### PR TITLE
Adds chromosome effects to Cryokinesis, Shocktouch, Chameleon, and Webbing mutations.

### DIFF
--- a/code/datums/mutations/chameleon.dm
+++ b/code/datums/mutations/chameleon.dm
@@ -7,6 +7,7 @@
 	text_gain_indication = "<span class='notice'>You feel one with your surroundings.</span>"
 	text_lose_indication = "<span class='notice'>You feel oddly exposed.</span>"
 	instability = 25
+	power_coeff = 1
 
 /datum/mutation/human/chameleon/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
@@ -16,7 +17,7 @@
 	RegisterSignal(owner, COMSIG_HUMAN_EARLY_UNARMED_ATTACK, PROC_REF(on_attack_hand))
 
 /datum/mutation/human/chameleon/on_life(delta_time, times_fired)
-	owner.alpha = max(owner.alpha - (12.5 * delta_time), 0)
+	owner.alpha = max(owner.alpha - (12.5 * (GET_MUTATION_POWER(src)) * delta_time), 0)
 
 /**
  * Resets the alpha of the host to the chameleon default if they move.

--- a/code/datums/mutations/cold.dm
+++ b/code/datums/mutations/cold.dm
@@ -24,9 +24,10 @@
 	desc = "Draws negative energy from the sub-zero void to freeze surrounding temperatures at subject's will."
 	quality = POSITIVE //upsides and downsides
 	text_gain_indication = "<span class='notice'>Your hand feels cold.</span>"
-	instability = 20
+	instability = 30
 	difficulty = 12
 	synchronizer_coeff = 1
+	energy_coeff = 1
 	power_path = /datum/action/cooldown/spell/pointed/projectile/cryo
 
 /datum/action/cooldown/spell/pointed/projectile/cryo

--- a/code/datums/mutations/cold.dm
+++ b/code/datums/mutations/cold.dm
@@ -34,7 +34,7 @@
 	name = "Cryobeam"
 	desc = "This power fires a frozen bolt at a target."
 	button_icon_state = "icebeam0"
-	cooldown_time = 15 SECONDS
+	cooldown_time = 16 SECONDS
 	spell_requirements = NONE
 	antimagic_flags = NONE
 

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -15,7 +15,7 @@
 	. = ..()
 	var/datum/action/cooldown/spell/touch/shock/to_modify =.
 
-	if(!istype(to_modify)) // null or invalid
+	if(!istype(to_modify)) /// null or invalid
 		return
 
 	if(GET_MUTATION_POWER(src) <= 1)
@@ -33,13 +33,14 @@
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 
+	///Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
+	///This var decides if the spell should chain, dictated by presence of power chromosome
 	var/chain = FALSE
-	//Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
-	//damage should do about 1 per limb
+	///Affects damage, should do about 1 per limb
 	var/zap_power = 7500
-	//range of tesla shock bounces
+	///Range of tesla shock bounces
 	var/zap_range = 7
-	//flags, Can only damage mobs, leaving out machine damage and energy generating flags as they have alot more impact
+	///flags that dictate what the tesla shock can interact with, Can only damage mobs, Cannot damage machines or generate energy
 	var/zap_flags = ZAP_MOB_DAMAGE
 
 	hand_path = /obj/item/melee/touch_attack/shock

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -15,7 +15,7 @@
 	. = ..()
 	var/datum/action/cooldown/spell/touch/shock/to_modify =.
 
-	if(!istype(to_modify)) /// null or invalid
+	if(!istype(to_modify)) // null or invalid
 		return
 
 	if(GET_MUTATION_POWER(src) <= 1)
@@ -33,7 +33,7 @@
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 
-	///Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
+	//Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
 	///This var decides if the spell should chain, dictated by presence of power chromosome
 	var/chain = FALSE
 	///Affects damage, should do about 1 per limb

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -8,6 +8,21 @@
 	text_lose_indication = "<span class='notice'>The energy in your hands subsides.</span>"
 	power_path = /datum/action/cooldown/spell/touch/shock
 	instability = 30
+	energy_coeff = 1
+	power_coeff = 1
+
+/datum/mutation/human/shock/modify()
+	. = ..()
+	var/datum/action/cooldown/spell/touch/shock/to_modify =.
+
+	if(!istype(to_modify)) // null or invalid
+		return
+
+	if(GET_MUTATION_POWER(src) <= 1)
+		to_modify.pwr_chrom = 0
+		return
+
+	to_modify.pwr_chrom = 1
 
 /datum/action/cooldown/spell/touch/shock
 	name = "Shock Touch"
@@ -17,6 +32,15 @@
 	cooldown_time = 10 SECONDS
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
+
+	var/pwr_chrom = 0
+	//Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
+	//damage should do 1 per limb
+	var/zap_power = 5000
+	//range
+	var/zap_range = 7
+	//flags
+	var/zap_flags = ZAP_MOB_DAMAGE
 
 	hand_path = /obj/item/melee/touch_attack/shock
 	draw_message = span_notice("You channel electricity into your hand.")
@@ -33,6 +57,8 @@
 				span_danger("[caster] electrocutes [victim]!"),
 				span_userdanger("[caster] electrocutes you!"),
 			)
+			if(pwr_chrom == 1)
+				tesla_zap(victim, zap_range, zap_power, zap_flags)
 			return TRUE
 
 	else if(isliving(victim))
@@ -42,6 +68,8 @@
 				span_danger("[caster] electrocutes [victim]!"),
 				span_userdanger("[caster] electrocutes you!"),
 			)
+			if(pwr_chrom == 1)
+				tesla_zap(victim, zap_range, zap_power, zap_flags)
 			return TRUE
 
 	to_chat(caster, span_warning("The electricity doesn't seem to affect [victim]..."))

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -36,7 +36,7 @@
 	var/chain = 0
 	//Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
 	//damage should do about 1 per limb
-	var/zap_power = 5000
+	var/zap_power = 7500
 	//range
 	var/zap_range = 7
 	//flags

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -35,7 +35,7 @@
 
 	var/chain = 0
 	//Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
-	//damage should do 1 per limb
+	//damage should do about 1 per limb
 	var/zap_power = 5000
 	//range
 	var/zap_range = 7

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -19,7 +19,7 @@
 		return
 
 	if(GET_MUTATION_POWER(src) <= 1)
-		to_modify.chain = FALSE
+		to_modify.chain = initial(to_modify.chain)
 		return
 
 	to_modify.chain = TRUE
@@ -37,9 +37,9 @@
 	//Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
 	//damage should do about 1 per limb
 	var/zap_power = 7500
-	//range of tesla shock
+	//range of tesla shock bounces
 	var/zap_range = 7
-	//flags, Only includes the flag that allows the shocks to damage mobs, leaving out structure damage and energy generating flags
+	//flags, Can only damage mobs, leaving out machine damage and energy generating flags as they have alot more impact
 	var/zap_flags = ZAP_MOB_DAMAGE
 
 	hand_path = /obj/item/melee/touch_attack/shock

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -19,10 +19,10 @@
 		return
 
 	if(GET_MUTATION_POWER(src) <= 1)
-		to_modify.pwr_chrom = 0
+		to_modify.chain = 0
 		return
 
-	to_modify.pwr_chrom = 1
+	to_modify.chain = 1
 
 /datum/action/cooldown/spell/touch/shock
 	name = "Shock Touch"
@@ -33,7 +33,7 @@
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 
-	var/pwr_chrom = 0
+	var/chain = 0
 	//Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
 	//damage should do 1 per limb
 	var/zap_power = 5000
@@ -57,8 +57,10 @@
 				span_danger("[caster] electrocutes [victim]!"),
 				span_userdanger("[caster] electrocutes you!"),
 			)
-			if(pwr_chrom == 1)
+			if(chain == 1)
 				tesla_zap(victim, zap_range, zap_power, zap_flags)
+				carbon_victim.visible_message(
+					span_danger("An arc of electricity explodes out of [victim]!"))
 			return TRUE
 
 	else if(isliving(victim))
@@ -68,8 +70,10 @@
 				span_danger("[caster] electrocutes [victim]!"),
 				span_userdanger("[caster] electrocutes you!"),
 			)
-			if(pwr_chrom == 1)
+			if(chain == 1)
 				tesla_zap(victim, zap_range, zap_power, zap_flags)
+				living_victim.visible_message(
+					span_danger("An arc of electricity explodes out of [victim]!"))
 			return TRUE
 
 	to_chat(caster, span_warning("The electricity doesn't seem to affect [victim]..."))

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -7,7 +7,7 @@
 	text_gain_indication = "<span class='notice'>You feel power flow through your hands.</span>"
 	text_lose_indication = "<span class='notice'>The energy in your hands subsides.</span>"
 	power_path = /datum/action/cooldown/spell/touch/shock
-	instability = 30
+	instability = 35
 	energy_coeff = 1
 	power_coeff = 1
 
@@ -29,7 +29,7 @@
 	desc = "Channel electricity to your hand to shock people with."
 	button_icon_state = "zap"
 	sound = 'sound/weapons/zapbang.ogg'
-	cooldown_time = 10 SECONDS
+	cooldown_time = 12 SECONDS
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -19,10 +19,10 @@
 		return
 
 	if(GET_MUTATION_POWER(src) <= 1)
-		to_modify.chain = 0
+		to_modify.chain = FALSE
 		return
 
-	to_modify.chain = 1
+	to_modify.chain = TRUE
 
 /datum/action/cooldown/spell/touch/shock
 	name = "Shock Touch"
@@ -33,13 +33,13 @@
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 
-	var/chain = 0
+	var/chain = FALSE
 	//Vars for zaps made when power chromosome is applied, ripped and toned down from reactive tesla armor code.
 	//damage should do about 1 per limb
 	var/zap_power = 7500
-	//range
+	//range of tesla shock
 	var/zap_range = 7
-	//flags
+	//flags, Only includes the flag that allows the shocks to damage mobs, leaving out structure damage and energy generating flags
 	var/zap_flags = ZAP_MOB_DAMAGE
 
 	hand_path = /obj/item/melee/touch_attack/shock
@@ -57,10 +57,9 @@
 				span_danger("[caster] electrocutes [victim]!"),
 				span_userdanger("[caster] electrocutes you!"),
 			)
-			if(chain == 1)
+			if(chain)
 				tesla_zap(victim, zap_range, zap_power, zap_flags)
-				carbon_victim.visible_message(
-					span_danger("An arc of electricity explodes out of [victim]!"))
+				carbon_victim.visible_message(span_danger("An arc of electricity explodes out of [victim]!"))
 			return TRUE
 
 	else if(isliving(victim))
@@ -70,10 +69,9 @@
 				span_danger("[caster] electrocutes [victim]!"),
 				span_userdanger("[caster] electrocutes you!"),
 			)
-			if(chain == 1)
+			if(chain)
 				tesla_zap(victim, zap_range, zap_power, zap_flags)
-				living_victim.visible_message(
-					span_danger("An arc of electricity explodes out of [victim]!"))
+				living_victim.visible_message(span_danger("An arc of electricity explodes out of [victim]!"))
 			return TRUE
 
 	to_chat(caster, span_warning("The electricity doesn't seem to affect [victim]..."))

--- a/code/datums/mutations/webbing.dm
+++ b/code/datums/mutations/webbing.dm
@@ -16,9 +16,9 @@
 		return
 
 	if(GET_MUTATION_ENERGY(src) == 1) //energetic chromosome outputs a value less than 1 when present, 1 by default
-		to_modify.webbing_time = (4 SECONDS)
+		to_modify.webbing_time = initial(to_modify.webbing_time)
 		return
-	to_modify.webbing_time = (2 SECONDS)
+	to_modify.webbing_time = 2 SECONDS
 
 /datum/mutation/human/webbing/on_acquiring(mob/living/carbon/human/owner)
 	if(..())

--- a/code/datums/mutations/webbing.dm
+++ b/code/datums/mutations/webbing.dm
@@ -6,6 +6,19 @@
 	text_gain_indication = "<span class='notice'>Your skin feels webby.</span>"
 	instability = 15
 	power_path = /datum/action/cooldown/spell/lay_genetic_web
+	energy_coeff = 1
+
+/datum/mutation/human/webbing/modify()
+	. = ..()
+	var/datum/action/cooldown/spell/lay_genetic_web/to_modify =.
+
+	if(!istype(to_modify)) // null or invalid
+		return
+
+	if(GET_MUTATION_ENERGY(src) == 1) //energetic chromosome outputs a value less than 1 when present, 1 by default
+		to_modify.webbing_time = (4 SECONDS)
+		return
+	to_modify.webbing_time = (2 SECONDS)
 
 /datum/mutation/human/webbing/on_acquiring(mob/living/carbon/human/owner)
 	if(..())


### PR DESCRIPTION
## About The Pull Request
https://www.youtube.com/watch?v=CPKeEeBNSH0
Cryokinesis instability up by 10 (from 20 to 30)
Cryokinesis base cooldown up by 1 second (from 15 to 16) now accepts energetic chromosomes (8 seconds when applied)

Shock touch instability up by 5 (from 30 to 35) now accepts both energetic and power chromosomes 

Shock touch cooldown up by 2 (from 10 to 12) (cooldown of 6 when energetic is applied)

If a power chromosome is applied Shock touch does a weak 7500 power (I`ve seen it hit from 5-7 damage) tesla shock with range of 7 when used on a viable target (extra damage does not apply to target, no you cant use it on yourself, no you cant use it on someone that is shock immune, yes you have to put yourself in harms way to apply the tesla shock.)

(The vars for the tesla shock can be edited by admins for events/abuse)

Chameleon now accepts power chromosomes to fully stealth about 3 seconds faster.

Webbing now accepts energetic chromosomes 

## Why It's Good For The Game
1. Geneticists needs something to do after they find mutations and chromosome farming can greatly expand the time that geneticists spend doing genetics.

2. Only 1 beneficial mutation uses power and energetic chromosomes and that is firebreath, (and arguably void magnet but nobody else uses that no matter how hard I try to get people to try it)

3. We have a whole chromosome system that most mutations cant even use and several mutations are unused because they are simply too weak or irrelevant for anyone to give a damn about them.

This pr kills 3 birds with one stone, geneticists will have more to do, the chromosome system will see more use, and the underused mutations will see more use rather than being bloat.
## Changelog

:cl:
add: Cryokinesis, Shocktouch, Chameleon, and Webbing mutations now have a higher potential
balance: Cryokinesis and Shock touch appear to be weaker and more unstable by default
/:cl:
