### PR TITLE
Removes unreachable organ forcemove override

### DIFF
--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -59,14 +59,6 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 			volume = reagent_vol,\
 			after_eat = CALLBACK(src, .proc/OnEatFrom))
 
-/obj/item/organ/forceMove(atom/destination, check_dest = TRUE)
-	if(check_dest && destination) //Nullspace is always a valid location for organs. Because reasons.
-		if(organ_flags & ORGAN_UNREMOVABLE && owner) //If this organ is unremovable, it should delete itself if it tries to be moved to anything besides a bodypart.
-			if(!isbodypart(destination) && !iscarbon(destination))
-				qdel(src)
-				return //Don't move it out of nullspace if it's deleted.
-	return ..()
-
 /*
  * Insert the organ into the select mob.
  *


### PR DESCRIPTION
## About The Pull Request

Removes an override of forcemove for unremovable organs

I do not think this code is reachable anymore. Organs don't really get forcemoved out of a mob's body without first removing it from the owner. Feel free to correct me and point me to where an organ is forcemoved from a body without `Remove()` being called first. 

## Why It's Good For The Game

Doesn't do anything?

## Changelog

:cl: Melbert
code: Unremovable organs that are forcemoved out of a mob with an owner no longer self terminate
/:cl:
