### PR TITLE
[NO GBP] Add a 2 second cooldown for ore bag balloon alerts

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -332,7 +332,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return FALSE
 
 	if(resolve_location.contents.len >= max_slots)
-		if(messages && user)
+		if(messages && user && !silent_for_user)
 			to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
 		return FALSE
 
@@ -342,7 +342,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		total_weight += thing.w_class
 
 	if(total_weight > max_total_storage)
-		if(messages && user)
+		if(messages && user && !silent_for_user)
 			to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
 		return FALSE
 

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -1,3 +1,5 @@
+#define ORE_BAG_BALOON_COOLDOWN (2 SECONDS)
+
 /*
  * These absorb the functionality of the plant bag, ore satchel, etc.
  * They use the use_to_pickup, quick_gather, and quick_empty functions
@@ -104,8 +106,11 @@
 	worn_icon_state = "satchel"
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
 	w_class = WEIGHT_CLASS_NORMAL
-	var/spam_protection = FALSE //If this is TRUE, the holder won't receive any messages when they fail to pick up ore through crossing it
+	///If this is TRUE, the holder won't receive any messages when they fail to pick up ore through crossing it
+	var/spam_protection = FALSE
 	var/mob/listeningTo
+	///Cooldown on balloon alerts when picking ore
+	COOLDOWN_DECLARE(ore_bag_balloon_cooldown)
 
 /obj/item/storage/bag/ore/Initialize(mapload)
 	. = ..()
@@ -161,7 +166,10 @@
 					continue
 	if(show_message)
 		playsound(user, SFX_RUSTLE, 50, TRUE)
+		if(!COOLDOWN_FINISHED(src, ore_bag_balloon_cooldown))
+			return
 
+		COOLDOWN_START(src, ore_bag_balloon_cooldown, ORE_BAG_BALOON_COOLDOWN)
 		if (box)
 			balloon_alert(user, "scoops ore into box")
 			user.visible_message(
@@ -533,3 +541,5 @@
 /obj/item/storage/bag/harpoon_quiver/PopulateContents()
 	for(var/i in 1 to 40)
 		new /obj/item/ammo_casing/caseless/harpoon(src)
+
+#undef ORE_BAG_BALOON_COOLDOWN


### PR DESCRIPTION

## About The Pull Request
And removes an extra `to_chat` message for when your ore bag is full and can't put ore in using the `silent_for_user` system.
## Why It's Good For The Game
I have been moving the chat messages that miners get bombarded every shift away from their chat bar and into balloon alerts with the goal of making the chat be a cleaner place for miners, as it is their only way to interact with the station while down at lavaland.

People have been complaining that it was too much, which is fair. I've been work on a mini rework on how ore bags function and a cleaner feedback with ore icons falling into the bag, but I'm just not happy with how it works now so I will restart on it.

Until I get that sorted, I added a 2 second cooldown on the balloon alerts for picking up ore as a middle ground, it provides good feedback for new players while not being as distracting.
## Changelog
:cl: Guillaume Prata
qol: Ore bag balloon alerts have a 2 second cooldown now and a spammy message (hopefully the last) it send to your chat about being full was removed
/:cl:
