### PR TITLE
Visually update containers when crafting

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -276,6 +276,7 @@
 							RG.volume -= amt
 							data = RG.data
 							RC.reagents.conditional_update(RC)
+							RC.update_appearance()
 							RG = locate(RG.type) in Deletion
 							RG.volume = amt
 							RG.data += data
@@ -285,6 +286,7 @@
 							amt -= RG.volume
 							RC.reagents.reagent_list -= RG
 							RC.reagents.conditional_update(RC)
+							RC.update_appearance()
 							RGNT = locate(RG.type) in Deletion
 							RGNT.volume += RG.volume
 							RGNT.data += RG.data

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -276,7 +276,7 @@
 							RG.volume -= amt
 							data = RG.data
 							RC.reagents.conditional_update(RC)
-							RC.update_appearance()
+							RC.update_appearance(UPDATE_ICON)
 							RG = locate(RG.type) in Deletion
 							RG.volume = amt
 							RG.data += data
@@ -286,7 +286,7 @@
 							amt -= RG.volume
 							RC.reagents.reagent_list -= RG
 							RC.reagents.conditional_update(RC)
-							RC.update_appearance()
+							RC.update_appearance(UPDATE_ICON)
 							RGNT = locate(RG.type) in Deletion
 							RGNT.volume += RG.volume
 							RGNT.data += RG.data


### PR DESCRIPTION
## About The Pull Request

Makes reagent containers update their appearance when crafting.
Fixes #69935, minor but annoying bug, especially when you are playing as chef.

## Changelog
:cl:
fix: Containers visually update after crafting.
/:cl:
