### PR TITLE
[NO GBP] More balloon alerts for guns + fixes a wrong alert

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -279,7 +279,7 @@
 		return FALSE
 	var/obj/item/bodypart/other_hand = shooter.has_hand_for_held_index(shooter.get_inactive_hand_index())
 	if(weapon_weight == WEAPON_HEAVY && (shooter.get_inactive_held_item() || !other_hand))
-		to_chat(shooter, span_warning("You need two hands to fire [src]!"))
+		balloon_alert(shooter, "need two hands!")
 		return FALSE
 	return TRUE
 

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -279,7 +279,7 @@
 		return FALSE
 	var/obj/item/bodypart/other_hand = shooter.has_hand_for_held_index(shooter.get_inactive_hand_index())
 	if(weapon_weight == WEAPON_HEAVY && (shooter.get_inactive_held_item() || !other_hand))
-		balloon_alert(shooter, "need two hands!")
+		balloon_alert(shooter, "use both hands!")
 		return FALSE
 	return TRUE
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -249,7 +249,7 @@
 
 	var/obj/item/bodypart/other_hand = user.has_hand_for_held_index(user.get_inactive_hand_index()) //returns non-disabled inactive hands
 	if(weapon_weight == WEAPON_HEAVY && (user.get_inactive_held_item() || !other_hand))
-		balloon_alert(user, "need two hands!")
+		balloon_alert(user, "use both hands!")
 		return
 	//DUAL (or more!) WIELDING
 	var/bonus_spread = 0

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -249,7 +249,7 @@
 
 	var/obj/item/bodypart/other_hand = user.has_hand_for_held_index(user.get_inactive_hand_index()) //returns non-disabled inactive hands
 	if(weapon_weight == WEAPON_HEAVY && (user.get_inactive_held_item() || !other_hand))
-		to_chat(user, span_warning("You need two hands to fire [src]!"))
+		balloon_alert(user, "need two hands!")
 		return
 	//DUAL (or more!) WIELDING
 	var/bonus_spread = 0

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -273,6 +273,7 @@
 		return
 	cover_open = !cover_open
 	to_chat(user, span_notice("You [cover_open ? "open" : "close"] [src]'s cover."))
+	balloon_alert(user, "cover [cover_open ? "opened" : "closed"]")
 	playsound(src, 'sound/weapons/gun/l6/l6_door.ogg', 60, TRUE)
 	update_appearance()
 
@@ -305,7 +306,7 @@
 
 /obj/item/gun/ballistic/automatic/l6_saw/attackby(obj/item/A, mob/user, params)
 	if(!cover_open && istype(A, mag_type))
-		balloon_alert(user, "close the cover!")
+		balloon_alert(user, "open the cover!")
 		return
 	..()
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -272,7 +272,6 @@
 	if(!user.canUseTopic(src))
 		return
 	cover_open = !cover_open
-	to_chat(user, span_notice("You [cover_open ? "open" : "close"] [src]'s cover."))
 	balloon_alert(user, "cover [cover_open ? "opened" : "closed"]")
 	playsound(src, 'sound/weapons/gun/l6/l6_door.ogg', 60, TRUE)
 	update_appearance()

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -33,7 +33,7 @@
 
 /obj/item/gun/ballistic/rifle/attackby(obj/item/A, mob/user, params)
 	if (!bolt_locked && !istype(A, /obj/item/stack/sheet/cloth))
-		to_chat(user, span_notice("The bolt is closed!"))
+		balloon_alert(user, "[bolt_wording] is closed!")
 		return
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Turns out I missed a few to_chats in #70398. Also I accidentally inverted one so it said close the cover instead of open it. Oops!
## Why It's Good For The Game

Same reason as the original PR, balloon alerts are handy for stuff you care about right now and not in 5 minutes. Also they should probably not tell you to do the opposite of what you actually need to do.
## Changelog
:cl: VexingRaven
fix: Fixed a few balloon alerts for guns and moved a few more chat messages to balloon alerts
/:cl:
