### PR TITLE
Freeze on anything using .proc/ until 515 is merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Fulpstation codebase
+## /fulp/station codebase
 
 [![Build Status](https://github.com/tgstation/tgstation/workflows/CI%20Suite/badge.svg)](https://github.com/tgstation/tgstation/actions?query=workflow%3A%22CI+Suite%22)
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/tgstation/tgstation.svg)](https://isitmaintained.com/project/tgstation/tgstation "Percentage of issues still open")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## /tg/station codebase
+## Fulpstation codebase
 
 [![Build Status](https://github.com/tgstation/tgstation/workflows/CI%20Suite/badge.svg)](https://github.com/tgstation/tgstation/actions?query=workflow%3A%22CI+Suite%22)
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/tgstation/tgstation.svg)](https://isitmaintained.com/project/tgstation/tgstation "Percentage of issues still open")


### PR DESCRIPTION
This PR is a notice that there's a freeze on things touching .proc/ stuff until https://github.com/tgstation/tgstation/pull/71161 is merged.

This is to avoid merge conflicts, so if you're planning on making a PR that uses it, you should probably wait. Opening the PR is fine but you'll have to update it after.

Notice: All PRs will have to be updated to Master for the work of https://github.com/tgstation/tgstation/pull/71177