### PR TITLE
Icebox's Lavaland ATs

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
@@ -12,7 +12,7 @@
 /obj/item/clothing/shoes/bronze,
 /obj/item/clothing/head/costume/bronze,
 /turf/open/floor/bronze{
-	initial_gas_mix = "TEMP=2.7"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/icemoon/surface)
 "m" = (
@@ -20,12 +20,12 @@
 	name = "empowered bronze spear"
 	},
 /turf/open/floor/bronze{
-	initial_gas_mix = "TEMP=2.7"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/icemoon/surface)
 "o" = (
 /turf/open/floor/bronze{
-	initial_gas_mix = "TEMP=2.7"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/icemoon/surface)
 "A" = (
@@ -66,7 +66,7 @@
 "L" = (
 /mob/living/simple_animal/hostile/megafauna/clockwork_defender,
 /turf/open/floor/bronze{
-	initial_gas_mix = "TEMP=2.7"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/icemoon/surface)
 "M" = (
@@ -95,7 +95,7 @@
 	},
 /obj/item/pen,
 /turf/open/floor/bronze{
-	initial_gas_mix = "TEMP=2.7"
+	initial_gas_mix = "LAVALAND_ATMOS"
 	},
 /area/icemoon/surface)
 


### PR DESCRIPTION

## About The Pull Request
Yeah so these tiles had a different gasmix than the basalt around it so I just changed it to be the lavaland gasmix at roundstart, tested, works.
![image](https://user-images.githubusercontent.com/73589390/201421548-b406492b-62ef-4d82-b86d-7192e8e7cad1.png)
## Why It's Good For The Game
Active Turf Bad
## Changelog
:cl:
fix: A few tiles on icebox's lavaland ruin aren't active turfs anymore.
/:cl:
