### PR TITLE
Crew members may now use the staff of change again. 

### DIFF
--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -44,21 +44,6 @@
 /obj/item/gun/magic/staff/change/unrestricted
 	allow_intruder_use = TRUE
 
-/obj/item/gun/magic/staff/change/pickup(mob/user)
-	. = ..()
-	if(!is_wizard_or_friend(user))
-		to_chat(user, span_hypnophrase("<span style='font-size: 24px'>You don't feel strong enough to properly wield this staff!</span>"))
-		balloon_alert(user, "you feel weak holding this staff")
-
-/obj/item/gun/magic/staff/change/on_intruder_use(mob/living/user, atom/target)
-	user.dropItemToGround(src, TRUE)
-	var/wabbajack_into = preset_wabbajack_type || pick(WABBAJACK_MONKEY, WABBAJACK_HUMAN, WABBAJACK_ANIMAL)
-	var/mob/living/new_body = user.wabbajack(wabbajack_into, preset_wabbajack_changeflag)
-	if(!new_body)
-		return
-
-	balloon_alert(new_body, "wabbajack, wabbajack!")
-
 /obj/item/gun/magic/staff/animate
 	name = "staff of animation"
 	desc = "An artefact that spits bolts of life-force which causes objects which are hit by it to animate and come to life! This magic doesn't affect machines."


### PR DESCRIPTION

## About The Pull Request

Quite a while ago somebody made it so that certain wizard staffs had different effects when wielded by nonwizards, for healing staffs it would make it work as if it were a healing beam. For wizards, it would polymorph the person holding it into either a monkey, a random human or an animal.  

This made it so that anyone that was shafted with an unserviceable animal form (or slime, holy fuck being slime sucks during wizard) would essentially be soft RR'd.  This amends this by returning the staff to how it originally worked, god bless.

## Why It's Good For The Game

Gives the crew a chance to hunt the wizard down in hopes of being restored into something that can be used, and gives the crew a reason to continue wizard rounds where a staff of change was used. 

I believe the original change has no place existing with the dynamic ruleset.

## Changelog

:cl:
balance: Crewmembers now know how to point the staff of change at others instead of themselves.
/:cl:
