### PR TITLE
Removes hard cap on number of refined anomaly cores and tweaks the refining process

### DIFF
--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -1,12 +1,3 @@
-// Max amounts of cores you can make
-#define MAX_CORES_BLUESPACE 8
-#define MAX_CORES_GRAVITATIONAL 8
-#define MAX_CORES_FLUX 8
-#define MAX_CORES_VORTEX 8
-#define MAX_CORES_PYRO 8
-#define MAX_CORES_HALLUCINATION 8
-#define MAX_CORES_BIOSCRAMBLER 8
-
 ///Defines for the different types of explosion a flux anomaly can have
 #define FLUX_NO_EXPLOSION 0
 #define FLUX_EXPLOSIVE 1

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -53,19 +53,6 @@ SUBSYSTEM_DEF(research)
 	//[88nodes * 5000points/node] / [1.5hr * 90min/hr * 60s/min]
 	//Around 450000 points max???
 
-	/// The global list of raw anomaly types that have been refined, for hard limits.
-	var/list/created_anomaly_types = list()
-	/// The hard limits of cores created for each anomaly type. For faster code lookup without switch statements.
-	var/list/anomaly_hard_limit_by_type = list(
-		/obj/item/assembly/signaler/anomaly/bluespace = MAX_CORES_BLUESPACE,
-		/obj/item/assembly/signaler/anomaly/pyro = MAX_CORES_PYRO,
-		/obj/item/assembly/signaler/anomaly/grav = MAX_CORES_GRAVITATIONAL,
-		/obj/item/assembly/signaler/anomaly/vortex = MAX_CORES_VORTEX,
-		/obj/item/assembly/signaler/anomaly/flux = MAX_CORES_FLUX,
-		/obj/item/assembly/signaler/anomaly/hallucination = MAX_CORES_HALLUCINATION,
-		/obj/item/assembly/signaler/anomaly/bioscrambler = MAX_CORES_BIOSCRAMBLER,
-	)
-
 	/// Lookup list for ordnance briefers.
 	var/list/ordnance_experiments
 	/// Lookup list for scipaper partners.

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -102,9 +102,6 @@
 	wanted_types = list(/obj/item/assembly/signaler/anomaly/bluespace = TRUE)
 
 /datum/bounty/item/science/ref_anomaly/can_get(obj/O)
-	var/anomaly_type = wanted_types[1]
-	if(SSresearch.created_anomaly_types[anomaly_type] >= SSresearch.anomaly_hard_limit_by_type[anomaly_type])
-		return FALSE
 	return TRUE
 
 /datum/bounty/item/science/ref_anomaly/flux

--- a/code/modules/research/anomaly/raw_anomaly.dm
+++ b/code/modules/research/anomaly/raw_anomaly.dm
@@ -82,10 +82,7 @@
  * * del_self - should we qdel(src)
  * * count_towards_limit - should we increment the amount of created cores on SSresearch
  */
-/obj/item/raw_anomaly_core/proc/create_core(newloc, del_self = FALSE, count_towards_limit = FALSE)
+/obj/item/raw_anomaly_core/proc/create_core(newloc, del_self = FALSE)
 	. = new anomaly_type(newloc)
-	if(count_towards_limit)
-		var/existing = SSresearch.created_anomaly_types[anomaly_type] || 0
-		SSresearch.created_anomaly_types[anomaly_type] = existing + 1
 	if(del_self)
 		qdel(src)

--- a/tgui/packages/tgui/interfaces/AnomalyRefinery.js
+++ b/tgui/packages/tgui/interfaces/AnomalyRefinery.js
@@ -61,8 +61,15 @@ const AnomalyRefineryContent = (props, context) => {
 
 const CoreCompressorContent = (props, context) => {
   const { act, data } = useBackend(context);
-  const { core, requiredRadius, gasList, valveReady, active, valvePresent } =
-    data;
+  const {
+    core,
+    requiredRadius,
+    implosionsLeft,
+    gasList,
+    valveReady,
+    active,
+    valvePresent,
+  } = data;
   return (
     <>
       <Stack.Item grow>
@@ -87,6 +94,9 @@ const CoreCompressorContent = (props, context) => {
               {requiredRadius
                 ? requiredRadius + ' tiles'
                 : 'Implosion not possible.'}
+            </LabeledList.Item>
+            <LabeledList.Item label={'Implosions Left'}>
+              {implosionsLeft}
             </LabeledList.Item>
           </LabeledList>
         </Section>


### PR DESCRIPTION
**About the pull request**
Addresses issue [#70248](https://github.com/tgstation/tgstation/issues/70248)

**The Problem**
Currently only 8 anomaly cores of each type can be refined in a round, The [HackerMD]( https://hackmd.io/@tgstation/r1tzxpwPL) imposed this limit to prevent players from creating too many powerful weapons such as the Phason , some MOD suite modules etc but the document didn't take into consideration how actual players can exploit this limitation 

1) If let's say 8 cult members broke into robotics & ordnance lab and refined 8 bluespace anomaly cores and built 8 Phasons to wreck havok in the station then if an 9th person decides to fight against these cult members by building Phason for himself to level the playing field cause u know fight fire with fire, he can't do that because of the build limit. He and everyone else who comes after him won't stand a chance against those people because they can't refine anymore cores of that type and will have to flee. 

2) If a Moron/Clown breaks into ordnance, refines 8 bluespace cores and throws 7 of them into space, down the trash chute basically gets rid of them in any way [Maybe give them for bounty] and keeps 1 for himself then everyone else in the station will be at his mercy cause now no one can refine any more cores

3) You have a server of let's say 50+ people and your saying only 8 of them can have fun or worse only one person [cause of the reasons i listed above]??. Hell no 

Basically, restricting a resource in a server where players come & go creates contention & chaos , like reserving only 8 slices of bread to feed the masses **NOT FUN!!!**

**The Solution**
Remove the hard cap & let players refine cores anywhere, anytime. Thats the first part of this PR it removes the hard limit on the number of cores that can be refined, and it also imposes a constant radius of 15 tiles for refining all core types. The refining process has been tweaked as described below

**Tweaking the anomaly refinery**
The refinery now benefits from upgraded parts in the following ways

  **1. Better scanning module:** The scanning module is required to scan/find & extract refined matter after imploding a core. Higher tier scanning modules will extract higher amounts of pure material from a smaller explosion, hence higher tier scanning modules will reduce the implosion radius required starting at 15 tiles for tier 1 all the way down to 6 tiles at tier 4, with a decrement of 3 tiles per higher tier

**2. Better manipulator:** The manipulator is responsible for repairing & resetting the internal electromagnetic field which is used to contain the explosion of TTV's. After every explosion & repair the manipulator gets used up and when it gets completely fried the user is required to deconstruct the machine & insert a new manipulator. 
Thus, a tier 1 manipulator will allow you to refine only 2 cores before you have to dismantle the machine & insert a new one while a tier 4 manipulator will allow you to implode 5 cores

**Why it's good for the game**
1) No hard cap on refined cores = more fun + better gameplay

2) Improving scanning modules will reduce the effort required to refine the core

3) Giving the manipulator some purpose inside the refinery is also good

**Change Log**
:cl:

del: hard cap on number of refined cores

add: better stock part upgrades for  anomaly refinery

qol: better scanning modules means easier refining

code: new purpose for manipulator

/:cl:
