### PR TITLE
Chunky fingers no longer blocks all mod PC use, instead will cause UI actions to fail (sometimes) 

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -228,9 +228,10 @@
 /obj/item/modular_computer/proc/fingers_check(mob/living/carbon/human/human_user)
 	if(human_user.check_chunky_fingers() && prob(75))
 		human_user.visible_message(
-			span_warning("[human_user] taps the screen of [src] repeatedly, the screen unchanging."),
+			span_warning("[human_user] taps [src] repeatedly, its screen unchanging."),
 			span_warning("Damn these [human_user.gloves ? "gloves, the" : "hands, my"] fingers are too big."),
 			span_hear("You hear frustrated tapping."),
+			vision_distance = COMBAT_MESSAGE_RANGE,
 		)
 		return TRUE
 

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -111,7 +111,7 @@
 
 	// Chunky fingers dropping our input
 	if(ishuman(usr) && fingers_check(usr))
-		return
+		return TRUE
 
 	switch(action)
 		if("PC_exit")

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -16,12 +16,6 @@
 	if(!user.can_read(src, READING_CHECK_LITERACY))
 		return
 
-	if(ishuman(user))
-		var/mob/living/carbon/human/human_user = user
-		if(human_user.check_chunky_fingers())
-			balloon_alert(human_user, "fingers are too big!")
-			return
-
 	// Robots don't really need to see the screen, their wireless connection works as long as computer is on.
 	if(!screen_on && !issilicon(user))
 		if(ui)
@@ -114,6 +108,10 @@
 	. = ..()
 	if(.)
 		return
+
+	if(ishuman(usr) && fingers_check(usr))
+		return
+
 
 	switch(action)
 		if("PC_exit")
@@ -220,3 +218,20 @@
 	if(physical)
 		return physical
 	return src
+
+/**
+ * Check for chunky fingers done before the computer (or any of its program)'s UIs are interacted with (UI act).
+ *
+ * Return TRUE to stop the UI act from continuing.
+ * Return FALSE to let the UI act happen.
+ */
+/obj/item/modular_computer/proc/fingers_check(mob/living/carbon/human/human_user)
+	if(human_user.check_chunky_fingers() && prob(75))
+		human_user.visible_message(
+			span_warning("[human_user] taps the screen of [src] repeatedly, the screen unchanging."),
+			span_warning("Damn these [human_user.gloves ? "gloves, the" : "hands, my"] fingers are too big."),
+			span_hear("You hear frustrated tapping."),
+		)
+		return TRUE
+
+	return FALSE

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -109,9 +109,9 @@
 	if(.)
 		return
 
+	// Chunky fingers dropping our input
 	if(ishuman(usr) && fingers_check(usr))
 		return
-
 
 	switch(action)
 		if("PC_exit")

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -225,6 +225,7 @@
 	if(.)
 		return
 
+	// Chunky fingers dropping our input
 	if(ishuman(usr) && computer.fingers_check(usr))
 		return
 

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -225,6 +225,9 @@
 	if(.)
 		return
 
+	if(ishuman(usr) && computer.fingers_check(usr))
+		return
+
 	if(computer)
 		switch(action)
 			if("PC_exit")

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -227,7 +227,7 @@
 
 	// Chunky fingers dropping our input
 	if(ishuman(usr) && computer.fingers_check(usr))
-		return
+		return TRUE
 
 	if(computer)
 		switch(action)


### PR DESCRIPTION
## About The Pull Request

- Chunky Fingers no longer blocks all modular PC viewing
- Instead, attempting to use a modular PR in any way (any UI act) will have an RNG chance (75% chance currently, same as MODsuit malfunctioning) from doing nothing. 

Closes #71180

## Why It's Good For The Game

I always thought it was a little silly that you could not even *view* a computer if you had gloves on. It is very annoying for engineers to have to take their gloves off just to check the CIMS interface.

So I decided to rework this mechanic. Chunky fingers will, instead of blocking you from viewing the PC wholesale, instead make it such that (on occasion) your inputs will be dropped. 

Engineers and stuff can view their tablets, PCs, and PDAs like normal, but actually using it will be a crapshoot. Just like real life, you can tap your phone all you want, but sometimes it will just do nothing, because the touch screen doesn't react to the glove's touch. 

Plus I think this is funnier?

![image](https://user-images.githubusercontent.com/51863163/201565208-fda7766d-1906-403c-85b3-92522c9e679c.png)

## Changelog

:cl: Melbert
balance: Chunky Fingers (insuls and hulk) no longer entirely block you from opening modular computers / PDAs. Have you ever actually tried to use a touch screen wearing gloves? Half of your swipes never do anything. So that's what happens instead. It adds a chance of randomly failing UI actions / inputs. And damn, this will be annoying. Just like real life. It'll immerse you. 
/:cl: