### PR TITLE
You can't wield two-handed items with chunky fingers. Bombsuits now give chunky fingers.

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -167,6 +167,11 @@
 			user.dropItemToGround(parent, force=TRUE)
 		to_chat(user, span_warning("You don't have enough intact hands."))
 		return
+	if(ishuman(user))
+		var/mob/living/carbon/human/potential_chunky_fingers_human = user
+		if(potential_chunky_fingers_human.check_chunky_fingers())
+			potential_chunky_fingers_human.balloon_alert(potential_chunky_fingers_human, "fingers are too big!")
+			return
 
 	// wield update status
 	if(SEND_SIGNAL(parent, COMSIG_TWOHANDED_WIELD, user) & COMPONENT_TWOHANDED_BLOCK_WIELD)

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -100,6 +100,7 @@
 	strip_delay = 70
 	equip_delay_other = 70
 	resistance_flags = NONE
+	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 
 /obj/item/clothing/head/utility/bomb_hood/security
 	icon_state = "bombsuit_sec"


### PR DESCRIPTION
## About The Pull Request

You can't wield two-handed items with chunky fingers. Bombsuits now give chunky fingers.

## Why It's Good For The Game

If this doesn't resolve e-lances existing completely melting every antagonist in the game, it's time to old yeller e-lances.

## Changelog
:cl:
balance: You can't wield two-handed items with chunky fingers. 
balance: Bombsuits now give chunky fingers.
/:cl: