### PR TITLE
You can no longer print cleavers at the autolathe.

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1435,17 +1435,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
-/datum/design/cleaver
-	name = "Butcher's Cleaver"
-	id = "cleaver"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 18000)
-	build_path = /obj/item/knife/butcher
-	category = list(
-		RND_CATEGORY_HACKED,
-		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SERVICE
-	)
-
 /datum/design/spraycan
 	name = "Spraycan"
 	id = "spraycan"


### PR DESCRIPTION
## About The Pull Request

You can no longer print cleavers at the autolathe.

## Why It's Good For The Game

Do you guys remember when strong weapons weren't mass producable every single shift with literally no downside or challenge to getting them? If you want to spam cleavers, invest in refills for the chef vending machine and also steal them from the chef.

## Changelog
:cl:
balance: You can no longer print cleavers at the autolathe.
/:cl: