### PR TITLE
Surgical saws and drills are now bulky.

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -121,7 +121,7 @@
 	item_flags = SURGICAL_TOOL
 	force = 15
 	demolition_mod = 0.5
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	attack_verb_continuous = list("drills")
 	attack_verb_simple = list("drill")
 	tool_behaviour = TOOL_DRILL
@@ -203,7 +203,7 @@
 	flags_1 = CONDUCT_1
 	item_flags = SURGICAL_TOOL
 	force = 15
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	throwforce = 9
 	throw_speed = 2
 	throw_range = 5


### PR DESCRIPTION
## About The Pull Request

Surgical saws and drills are now bulky.

## Why It's Good For The Game

Discourages greytiders rolling into medbay for the meta combat weaponry since they'll have a hard time carrying it around now.
Encourages inter-departmental cooperation by making the upgraded medical tools way better in comparison.

## Changelog
:cl:
balance: Surgical saws and drills are now bulky.
/:cl: