### PR TITLE
Fix crash of TGUI fax panel when there is no fax in the network.

### DIFF
--- a/tgui/packages/tgui/interfaces/Fax.tsx
+++ b/tgui/packages/tgui/interfaces/Fax.tsx
@@ -30,14 +30,16 @@ type FaxHistory = {
 export const Fax = (props, context) => {
   const { act } = useBackend(context);
   const { data } = useBackend<FaxData>(context);
-  const faxes = sortBy((sortFax: FaxInfo) => sortFax.fax_name)(
-    data.syndicate_network
-      ? data.faxes.filter((filterFax: FaxInfo) => filterFax.visible)
-      : data.faxes.filter(
-        (filterFax: FaxInfo) =>
-          filterFax.visible && !filterFax.syndicate_network
-      )
-  );
+  const faxes = data.faxes
+    ? sortBy((sortFax: FaxInfo) => sortFax.fax_name)(
+      data.syndicate_network
+        ? data.faxes.filter((filterFax: FaxInfo) => filterFax.visible)
+        : data.faxes.filter(
+          (filterFax: FaxInfo) =>
+            filterFax.visible && !filterFax.syndicate_network
+        )
+    )
+    : [];
   return (
     <Window width={340} height={540}>
       <Window.Content scrollable>
@@ -68,23 +70,27 @@ export const Fax = (props, context) => {
           </LabeledList.Item>
         </Section>
         <Section title="Send">
-          <Box mt={0.4}>
-            {faxes.map((fax: FaxInfo) => (
-              <Button
-                key={fax.fax_id}
-                title={fax.fax_name}
-                disabled={!data.has_paper}
-                color={fax.syndicate_network ? 'red' : 'blue'}
-                onClick={() =>
-                  act('send', {
-                    id: fax.fax_id,
-                    name: fax.fax_name,
-                  })
-                }>
-                {fax.fax_name}
-              </Button>
-            ))}
-          </Box>
+          {faxes.length !== 0 ? (
+            <Box mt={0.4}>
+              {faxes.map((fax: FaxInfo) => (
+                <Button
+                  key={fax.fax_id}
+                  title={fax.fax_name}
+                  disabled={!data.has_paper}
+                  color={fax.syndicate_network ? 'red' : 'blue'}
+                  onClick={() =>
+                    act('send', {
+                      id: fax.fax_id,
+                      name: fax.fax_name,
+                    })
+                  }>
+                  {fax.fax_name}
+                </Button>
+              ))}
+            </Box>
+          ) : (
+            "The fax couldn't detect any other faxes on the network."
+          )}
         </Section>
         <Section
           title="History"


### PR DESCRIPTION

## About The Pull Request

Thanks to @Bobbanz1 for letting me know about this error.
When designing faxes, I didn't foresee a situation where the fax list could be empty. This caused the TGUI panel to crash. In this PR I fixed this situation by checking for emptiness.
![FeUbGclCUq](https://user-images.githubusercontent.com/88540658/201709838-bb07c72f-4ee8-4db7-b17a-d9f82aae96a0.png)

## Changelog
:cl:
fix: Fix crash of TGUI fax panel when there is no fax in the network
/:cl:
