### PR TITLE
Fixes pick_weight()

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -419,7 +419,7 @@
 			list_to_pick[item] = 0
 		total += list_to_pick[item]
 
-	total = rand(0, total)
+	total = rand(1, total)
 	for(item in list_to_pick)
 		total -= list_to_pick[item]
 		if(total <= 0 && list_to_pick[item])


### PR DESCRIPTION

## About The Pull Request

Good lord, how many years was this proc mathematically broken in such a basic way?

Fixes #71271

The issue was that whoever wrote pick_weight either didn't know how rand() worked, how byond list indexing worked, or was high.

### Results from re-running the test procs given in the linked issue

Choosing from `list("a"=1, "b"=1)` (should be 50/50)
- A: 985 (49%)
- B: 1016 (51%)

Choosing from `list("a"=1, "b"=1, "c"=1, "d"=1, "e"=1, "f"=1, "g"=1, "h"=1)` (each letter should have 12.5%)
 - A: 268 (13%)
 - B: 256 (13%)
 - C: 249 (12%)
 - D: 272 (14%)
 - E: 242 (12%)
 - F: 240 (12%)
 - G: 237 (12%)
 - H: 237 (12%)

Choosing from `list("c"=1, "b"=1, "a"=1)` (should be 33/33/33)
 - C: 658 (33%)
 - B: 674 (34%)
 - A: 669 (33%)

Choosing from `list("a"=3, "b"=2, "c"=5`) (should be 30/20/50 -- note the bias towards "a" despite the large number of samples)
 - A: 603 (30%)
 - B: 400 (20%)
 - C: 998 (50%)

Choosing from `list("a"=0, "b"=1, "c"=1)` (should be 0/50/50 -- note that the bias towards "a" is instead shifted towards "b". The zero weight takes priority, apparently)
 - A: 0 (0%)
 - B: 993 (50%)
 - C: 1008 (50%)
## Why It's Good For The Game

Basic core procs working as expected
## Changelog
Not client facing unless people are crunching some meta really hard.
