### PR TITLE
Adding the ability to load the configuration of custom maps.

### DIFF
--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -92,7 +92,7 @@
 				"job_changes" = virtual_map.job_changes,
 				"library_areas" = virtual_map.library_areas,
 			)
-		if (else)
+		else
 			virtual_map = load_map_config()
 			virtual_map.map_name = input("Choose the name for the map", "Map Name") as null|text
 			if(isnull(virtual_map.map_name))

--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -13,25 +13,25 @@
 	set name = "Change Map"
 	var/list/maprotatechoices = list()
 	for (var/map in config.maplist)
-		var/datum/map_config/VM = config.maplist[map]
-		var/mapname = VM.map_name
-		if (VM == config.defaultmap)
+		var/datum/map_config/virtual_map = config.maplist[map]
+		var/mapname = virtual_map.map_name
+		if (virtual_map == config.defaultmap)
 			mapname += " (Default)"
 
-		if (VM.config_min_users > 0 || VM.config_max_users > 0)
+		if (virtual_map.config_min_users > 0 || virtual_map.config_max_users > 0)
 			mapname += " \["
-			if (VM.config_min_users > 0)
-				mapname += "[VM.config_min_users]"
+			if (virtual_map.config_min_users > 0)
+				mapname += "[virtual_map.config_min_users]"
 			else
 				mapname += "0"
 			mapname += "-"
-			if (VM.config_max_users > 0)
-				mapname += "[VM.config_max_users]"
+			if (virtual_map.config_max_users > 0)
+				mapname += "[virtual_map.config_max_users]"
 			else
 				mapname += "inf"
 			mapname += "\]"
 
-		maprotatechoices[mapname] = VM
+		maprotatechoices[mapname] = virtual_map
 	var/chosenmap = tgui_input_list(usr, "Choose a map to change to", "Change Map", sort_list(maprotatechoices)|"Custom")
 	if (isnull(chosenmap))
 		return
@@ -39,7 +39,7 @@
 	if(chosenmap == "Custom")
 		message_admins("[key_name_admin(usr)] is changing the map to a custom map")
 		log_admin("[key_name(usr)] is changing the map to a custom map")
-		var/datum/map_config/VM = new
+		var/datum/map_config/virtual_map = new
 
 		var/map_file = input("Pick file:", "Map File") as null|file
 		if(isnull(map_file))
@@ -79,42 +79,42 @@
 				fdel("data/custom_map_json/[config_file]")
 			if(!fcopy(config_file, "data/custom_map_json/[config_file]"))
 				return
-			if (VM.LoadConfig("data/custom_map_json/[config_file]", TRUE) != TRUE)
+			if (virtual_map.LoadConfig("data/custom_map_json/[config_file]", TRUE) != TRUE)
 				to_chat(src, span_warning("Failed to load config: [config_file]. Check that the fields are filled out correctly. \"map_path\": \"custom\" and \"map_file\": \"your_map_name.dmm\""))
 				return
 			json_value = list(
 				"version" = MAP_CURRENT_VERSION,
-				"map_name" = VM.map_name,
-				"map_path" = VM.map_path,
-				"map_file" = VM.map_file,
-				"shuttles" = VM.shuttles,
-				"traits" = VM.traits,
-				"job_changes" = VM.job_changes,
-				"library_areas" = VM.job_changes,
+				"map_name" = virtual_map.map_name,
+				"map_path" = virtual_map.map_path,
+				"map_file" = virtual_map.map_file,
+				"shuttles" = virtual_map.shuttles,
+				"traits" = virtual_map.traits,
+				"job_changes" = virtual_map.job_changes,
+				"library_areas" = virtual_map.library_areas,
 			)
-		if (config == "No" || isnull(config))
-			VM = load_map_config()
-			VM.map_name = input("Choose the name for the map", "Map Name") as null|text
-			if(isnull(VM.map_name))
-				VM.map_name = "Custom"
+		if (else)
+			virtual_map = load_map_config()
+			virtual_map.map_name = input("Choose the name for the map", "Map Name") as null|text
+			if(isnull(virtual_map.map_name))
+				virtual_map.map_name = "Custom"
 
 			var/shuttles = tgui_alert(usr,"Do you want to modify the shuttles?", "Map Shuttles", list("Yes", "No"))
 			if(shuttles == "Yes")
-				for(var/s in VM.shuttles)
+				for(var/s in virtual_map.shuttles)
 					var/shuttle = input(s, "Map Shuttles") as null|text
 					if(!shuttle)
 						continue
 					if(!SSmapping.shuttle_templates[shuttle])
 						to_chat(usr, span_warning("No such shuttle as '[shuttle]' exists, using default."))
 						continue
-					VM.shuttles[s] = shuttle
+					virtual_map.shuttles[s] = shuttle
 
 			json_value = list(
 				"version" = MAP_CURRENT_VERSION,
-				"map_name" = VM.map_name,
+				"map_name" = virtual_map.map_name,
 				"map_path" = CUSTOM_MAP_PATH,
 				"map_file" = "[map_file]",
-				"shuttles" = VM.shuttles,
+				"shuttles" = virtual_map.shuttles,
 			)
 
 		// If the file isn't removed text2file will just append.
@@ -122,14 +122,14 @@
 			fdel(PATH_TO_NEXT_MAP_JSON)
 		text2file(json_encode(json_value), PATH_TO_NEXT_MAP_JSON)
 
-		if(SSmapping.changemap(VM))
-			message_admins("[key_name_admin(usr)] has changed the map to [VM.map_name]")
+		if(SSmapping.changemap(virtual_map))
+			message_admins("[key_name_admin(usr)] has changed the map to [virtual_map.map_name]")
 			SSmapping.map_force_chosen = TRUE
 		fdel("data/custom_map_json/[config_file]")
 	else
-		var/datum/map_config/VM = maprotatechoices[chosenmap]
-		message_admins("[key_name_admin(usr)] is changing the map to [VM.map_name]")
-		log_admin("[key_name(usr)] is changing the map to [VM.map_name]")
-		if (SSmapping.changemap(VM))
-			message_admins("[key_name_admin(usr)] has changed the map to [VM.map_name]")
+		var/datum/map_config/virtual_map = maprotatechoices[chosenmap]
+		message_admins("[key_name_admin(usr)] is changing the map to [virtual_map.map_name]")
+		log_admin("[key_name(usr)] is changing the map to [virtual_map.map_name]")
+		if (SSmapping.changemap(virtual_map))
+			message_admins("[key_name_admin(usr)] has changed the map to [virtual_map.map_name]")
 			SSmapping.map_force_chosen = TRUE

--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -49,9 +49,10 @@
 			to_chat(src, span_warning("Filename must end in '.dmm': [map_file]"))
 			return
 
+		if(fexists("_maps/custom/[map_file]"))
+			fdel("_maps/custom/[map_file]")
 		if(!fcopy(map_file, "_maps/custom/[map_file]"))
 			return
-
 		// This is to make sure the map works so the server does not start without a map.
 		var/datum/parsed_map/M = new (map_file)
 		if(!M)
@@ -74,9 +75,11 @@
 			if(copytext("[config_file]", -5) != ".json")
 				to_chat(src, span_warning("Filename must end in '.json': [config_file]"))
 				return
-			if(!fcopy(config_file, "_maps/custom/[config_file]"))
+			if(fexists("data/custom_map_json/[config_file]"))
+				fdel("data/custom_map_json/[config_file]")
+			if(!fcopy(config_file, "data/custom_map_json/[config_file]"))
 				return
-			if (VM.LoadConfig("_maps/custom/[config_file]", TRUE) != TRUE)
+			if (VM.LoadConfig("data/custom_map_json/[config_file]", TRUE) != TRUE)
 				to_chat(src, span_warning("Failed to load config: [config_file]. Check that the fields are filled out correctly. \"map_path\": \"custom\" and \"map_file\": \"your_map_name.dmm\""))
 				return
 			json_value = list(
@@ -89,8 +92,7 @@
 				"job_changes" = VM.job_changes,
 				"library_areas" = VM.job_changes
 			)
-
-		if (config == "No")
+		if (config == "No" || isnull(config))
 			VM = load_map_config()
 			VM.map_name = input("Choose the name for the map", "Map Name") as null|text
 			if(isnull(VM.map_name))
@@ -123,6 +125,7 @@
 		if(SSmapping.changemap(VM))
 			message_admins("[key_name_admin(usr)] has changed the map to [VM.map_name]")
 			SSmapping.map_force_chosen = TRUE
+		fdel("data/custom_map_json/[config_file]")
 	else
 		var/datum/map_config/VM = maprotatechoices[chosenmap]
 		message_admins("[key_name_admin(usr)] is changing the map to [VM.map_name]")

--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -66,7 +66,7 @@
 
 		qdel(M)
 		var/config_file = null
-		var/json_value = list()
+		var/list/json_value = list()
 		var/config = tgui_alert(usr,"Would you like to upload an additional config for this map?", "Map Config", list("Yes", "No"))
 		if(config == "Yes")
 			config_file = input("Pick file:", "Config JSON File") as null|file
@@ -90,7 +90,7 @@
 				"shuttles" = VM.shuttles,
 				"traits" = VM.traits,
 				"job_changes" = VM.job_changes,
-				"library_areas" = VM.job_changes
+				"library_areas" = VM.job_changes,
 			)
 		if (config == "No" || isnull(config))
 			VM = load_map_config()
@@ -114,7 +114,7 @@
 				"map_name" = VM.map_name,
 				"map_path" = CUSTOM_MAP_PATH,
 				"map_file" = "[map_file]",
-				"shuttles" = VM.shuttles
+				"shuttles" = VM.shuttles,
 			)
 
 		// If the file isn't removed text2file will just append.


### PR DESCRIPTION
## About The Pull Request

By default, all custom maps are assigned one standard configuration. This option rather limits the possibilities for creating custom levels. For example, you can not use multilevel maps, because with this configuration will always be loaded only one level. With this PR I want to provide the ability to load a configuration file for a custom map similar to the standard map.json configs.
![ZpdpfZWq2V](https://user-images.githubusercontent.com/88540658/201946344-fdf8589c-0e20-475c-a9d8-b21c9ff32dd8.png)

## Why It's Good For The Game

Allows administrators to flexibly configure custom maps. For example for events, etc.

## Changelog
:cl:
admin: Adding the ability to load the configuration of custom maps
/:cl:
