### PR TITLE
Adds basic support for multiple byond versions to build scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,6 @@ libprof.so
 
 # Screenshot tests
 /artifacts
+
+# named byond versions config
+/tools/build/dm_versions.json

--- a/tools/build/README.md
+++ b/tools/build/README.md
@@ -32,3 +32,23 @@ tools/build/build --help
 We used to include compiled versions of the tgui JavaScript code in the Git repository so that the project could be compiled using BYOND only. These pre-compiled files tended to have merge conflicts for no good reason. Using a build script lets us avoid this problem, while keeping builds convenient for people who are not modifying tgui.
 
 This build script is based on [Juke Build](https://github.com/stylemistake/juke-build) - follow the link to read the documentation for the project and understand how it works and how to contribute.
+
+## Named byond versions
+
+If you have byond installations in non-standard locations or want to use few versions at once for testing you can fill in `dm_versions.json` file in this directory.
+Entries with "default" set to true will be used BEFORE byond installations in standard locations. Otherwise you need to pass `--dm-version={name}` to the build script to choose version you want to use.
+Example dm_versions.json file:
+```
+[
+  {
+    "name": "515.1594",
+    "path": "C:\\Repo\\ByondVersions\\515.1594_byond\\byond\\bin\\dm.exe",
+    "default": false
+  },
+  {
+    "name": "funny_version",
+    "path": "D:\\Repo\\ByondVersions\\514.1589_byond\\byond\\bin\\dm.exe",
+    "default": true
+  }
+]
+```

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -7,8 +7,10 @@
  */
 
 import fs from 'fs';
+import { get } from 'http';
+import { env } from 'process';
 import Juke from './juke/index.js';
-import { DreamDaemon, DreamMaker } from './lib/byond.js';
+import { DreamDaemon, DreamMaker, NamedVersionFile } from './lib/byond.js';
 import { yarn } from './lib/yarn.js';
 
 Juke.chdir('../..', import.meta.url);
@@ -33,6 +35,10 @@ export const PortParameter = new Juke.Parameter({
   type: 'string',
   alias: 'p',
 });
+
+export const DmVersionParameter = new Juke.Parameter({
+  type: 'string',
+})
 
 export const CiParameter = new Juke.Parameter({ type: 'boolean' });
 
@@ -59,7 +65,7 @@ export const DmMapsIncludeTarget = new Juke.Target({
 });
 
 export const DmTarget = new Juke.Target({
-  parameters: [DefineParameter],
+  parameters: [DefineParameter, DmVersionParameter],
   dependsOn: ({ get }) => [
     get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
   ],
@@ -70,21 +76,27 @@ export const DmTarget = new Juke.Target({
     'icons/**',
     'interface/**',
     `${DME_NAME}.dme`,
+    NamedVersionFile,
   ],
-  outputs: [
-    `${DME_NAME}.dmb`,
-    `${DME_NAME}.rsc`,
-  ],
+  outputs: ({ get }) => {
+    if(get(DmVersionParameter) != null)
+      return [] //Always rebuild when dm version is provided
+    return [
+      `${DME_NAME}.dmb`,
+      `${DME_NAME}.rsc`,
+    ]
+  },
   executes: async ({ get }) => {
     await DreamMaker(`${DME_NAME}.dme`, {
       defines: ['CBT', ...get(DefineParameter)],
       warningsAsErrors: get(WarningParameter).includes('error'),
+      namedDmVersion: get(DmVersionParameter),
     });
   },
 });
 
 export const DmTestTarget = new Juke.Target({
-  parameters: [DefineParameter],
+  parameters: [DefineParameter, DmVersionParameter],
   dependsOn: ({ get }) => [
     get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
   ],
@@ -93,10 +105,15 @@ export const DmTestTarget = new Juke.Target({
     await DreamMaker(`${DME_NAME}.test.dme`, {
       defines: ['CBT', 'CIBUILDING', ...get(DefineParameter)],
       warningsAsErrors: get(WarningParameter).includes('error'),
+      namedDmVersion: get(DmVersionParameter),
     });
     Juke.rm('data/logs/ci', { recursive: true });
+    const options = {
+      dmbFile : `${DME_NAME}.test.dmb`,
+      namedDmVersion: get(DmVersionParameter),
+    }
     await DreamDaemon(
-      `${DME_NAME}.test.dmb`,
+      options,
       '-close', '-trusted', '-verbose',
       '-params', 'log-directory=ci'
     );
@@ -113,7 +130,7 @@ export const DmTestTarget = new Juke.Target({
 });
 
 export const AutowikiTarget = new Juke.Target({
-  parameters: [DefineParameter],
+  parameters: [DefineParameter, DmVersionParameter],
   dependsOn: ({ get }) => [
     get(DefineParameter).includes('ALL_MAPS') && DmMapsIncludeTarget,
   ],
@@ -125,12 +142,18 @@ export const AutowikiTarget = new Juke.Target({
     await DreamMaker(`${DME_NAME}.test.dme`, {
       defines: ['CBT', 'AUTOWIKI', ...get(DefineParameter)],
       warningsAsErrors: get(WarningParameter).includes('error'),
+      namedDmVersion: get(DmVersionParameter),
     });
     Juke.rm('data/autowiki_edits.txt');
     Juke.rm('data/autowiki_files', { recursive: true });
     Juke.rm('data/logs/ci', { recursive: true });
+
+    const options = {
+      dmbFile: `${DME_NAME}.test.dmb`,
+      namedDmVersion: get(DmVersionParameter),
+    }
     await DreamDaemon(
-      `${DME_NAME}.test.dmb`,
+      options,
       '-close', '-trusted', '-verbose',
       '-params', 'log-directory=ci',
     );
@@ -253,10 +276,14 @@ export const BuildTarget = new Juke.Target({
 });
 
 export const ServerTarget = new Juke.Target({
-  dependsOn: [BuildTarget],
+  dependsOn: [BuildTarget, DmVersionParameter],
   executes: async ({ get }) => {
     const port = get(PortParameter) || '1337';
-    await DreamDaemon(`${DME_NAME}.dmb`, port, '-trusted');
+    const options = {
+      dmbFile: `${DME_NAME}.dmb`,
+      namedDmVersion: get(DmVersionParameter),
+    }
+    await DreamDaemon(options, port, '-trusted');
   },
 });
 

--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -79,8 +79,9 @@ export const DmTarget = new Juke.Target({
     NamedVersionFile,
   ],
   outputs: ({ get }) => {
-    if(get(DmVersionParameter) != null)
-      return [] //Always rebuild when dm version is provided
+    if (get(DmVersionParameter)) {
+      return []; // Always rebuild when dm version is provided
+    }
     return [
       `${DME_NAME}.dmb`,
       `${DME_NAME}.rsc`,

--- a/tools/build/lib/byond.js
+++ b/tools/build/lib/byond.js
@@ -66,7 +66,7 @@ const getDmPath = async (namedVersion) => {
 
 
 const getNamedByondVersionPath = (namedVersion) =>{
-  const all_entries = getMapFileContents(true)
+  const all_entries = getAllNamedDmVersions(true)
   const map_entry = all_entries.find(x => x.name === namedVersion);
   if(map_entry === undefined){
     Juke.logger.error(`No named byond version with name "${namedVersion}" found.`);
@@ -76,7 +76,7 @@ const getNamedByondVersionPath = (namedVersion) =>{
 }
 
 const getDefaultNamedByondVersionPath = () =>{
-  const all_entries = getMapFileContents(false)
+  const all_entries = getAllNamedDmVersions(false)
   const map_entry = all_entries.find(x => x.default == true);
   if(map_entry === undefined)
     return []
@@ -85,32 +85,32 @@ const getDefaultNamedByondVersionPath = () =>{
 
 
 /** @type {[{ name, path, default }]} */
-let mapFileContents;
+let namedDmVersionList;
 export const NamedVersionFile = "tools/build/dm_versions.json"
 
-const getMapFileContents = (throw_on_fail) => {
-  if(!mapFileContents){
+const getAllNamedDmVersions = (throw_on_fail) => {
+  if(!namedDmVersionList){
     if(!fs.existsSync(NamedVersionFile)){
       if(throw_on_fail){
         Juke.logger.error(`No byond version map file found.`);
         throw new Juke.ExitCode(1);
       }
-      mapFileContents = []
-      return mapFileContents;
+      namedDmVersionList = []
+      return namedDmVersionList;
     }
     try{
-      mapFileContents = JSON.parse(fs.readFileSync(NamedVersionFile));
+      namedDmVersionList = JSON.parse(fs.readFileSync(NamedVersionFile));
     }
     catch(err){
       if(throw_on_fail){
         Juke.logger.error(`Failed to parse byond version map file. ${err}`);
         throw new Juke.ExitCode(1);
       }
-      mapFileContents = []
-      return mapFileContents;
+      namedDmVersionList = []
+      return namedDmVersionList;
     }
   }
-  return mapFileContents;
+  return namedDmVersionList;
 }
 
 /**

--- a/tools/build/lib/byond.js
+++ b/tools/build/lib/byond.js
@@ -8,7 +8,11 @@ import { regQuery } from './winreg.js';
  */
 let dmPath;
 
-const getDmPath = async () => {
+const getDmPath = async (namedVersion) => {
+  // Use specific named version
+  if(namedVersion) {
+    return getNamedByondVersionPath(namedVersion);
+  }
   if (dmPath) {
     return dmPath;
   }
@@ -16,6 +20,7 @@ const getDmPath = async () => {
     // Search in array of paths
     const paths = [
       ...((process.env.DM_EXE && process.env.DM_EXE.split(',')) || []),
+      ...getDefaultNamedByondVersionPath(),
       'C:\\Program Files\\BYOND\\bin\\dm.exe',
       'C:\\Program Files (x86)\\BYOND\\bin\\dm.exe',
       ['reg', 'HKLM\\Software\\Dantom\\BYOND', 'installpath'],
@@ -58,15 +63,69 @@ const getDmPath = async () => {
   return dmPath;
 };
 
+
+
+const getNamedByondVersionPath = (namedVersion) =>{
+  const all_entries = getMapFileContents(true)
+  const map_entry = all_entries.find(x => x.name === namedVersion);
+  if(map_entry === undefined){
+    Juke.logger.error(`No named byond version with name "${namedVersion}" found.`);
+    throw new Juke.ExitCode(1);
+  }
+  return map_entry.path;
+}
+
+const getDefaultNamedByondVersionPath = () =>{
+  const all_entries = getMapFileContents(false)
+  const map_entry = all_entries.find(x => x.default == true);
+  if(map_entry === undefined)
+    return []
+  return [map_entry.path];
+}
+
+
+/** @type {[{ name, path, default }]} */
+let mapFileContents;
+export const NamedVersionFile = "tools/build/dm_versions.json"
+
+const getMapFileContents = (throw_on_fail) => {
+  if(!mapFileContents){
+    if(!fs.existsSync(NamedVersionFile)){
+      if(throw_on_fail){
+        Juke.logger.error(`No byond version map file found.`);
+        throw new Juke.ExitCode(1);
+      }
+      mapFileContents = []
+      return mapFileContents;
+    }
+    try{
+      mapFileContents = JSON.parse(fs.readFileSync(NamedVersionFile));
+    }
+    catch(err){
+      if(throw_on_fail){
+        Juke.logger.error(`Failed to parse byond version map file. ${err}`);
+        throw new Juke.ExitCode(1);
+      }
+      mapFileContents = []
+      return mapFileContents;
+    }
+  }
+  return mapFileContents;
+}
+
 /**
  * @param {string} dmeFile
  * @param {{
  *   defines?: string[];
  *   warningsAsErrors?: boolean;
+ *   namedDmVersion?: string;
  * }} options
  */
 export const DreamMaker = async (dmeFile, options = {}) => {
-  const dmPath = await getDmPath();
+  if(options.namedDmVersion !== null){
+    Juke.logger.info('Using named byond version:', options.namedDmVersion);
+  }
+  const dmPath = await getDmPath(options.namedDmVersion);
   // Get project basename
   const dmeBaseName = dmeFile.replace(/\.dme$/, '');
   // Make sure output files are writable
@@ -120,10 +179,17 @@ export const DreamMaker = async (dmeFile, options = {}) => {
   }
 };
 
-export const DreamDaemon = async (dmbFile, ...args) => {
-  const dmPath = await getDmPath();
+
+/**
+* @param {{
+*   dmbFile: string;
+*   namedDmVersion?: string;
+* }} options
+*/
+export const DreamDaemon = async (options, ...args) => {
+  const dmPath = await getDmPath(options.namedDmVersion);
   const baseDir = path.dirname(dmPath);
   const ddExeName = process.platform === 'win32' ? 'dreamdaemon.exe' : 'DreamDaemon';
   const ddExePath = baseDir === '.' ? ddExeName : path.join(baseDir, ddExeName);
-  return Juke.exec(ddExePath, [dmbFile, ...args]);
+  return Juke.exec(ddExePath, [options.dmbFile, ...args]);
 };


### PR DESCRIPTION
You can now specify few named versions in `tools/build/dm_versions.json` file and either set them as default (overriding anything but env vars) or just use them with new --dm-version parameter.

Makes juggling versions bit easier during testing. I'll look into adding support in sdmm so debugging is in line later.