### PR TITLE
Renews a bunch of old roundend new reports that got lost. Plus, some roundend report QoL for cult and revs.

### DIFF
--- a/code/__DEFINES/roundend.dm
+++ b/code/__DEFINES/roundend.dm
@@ -11,8 +11,6 @@
 #define STATION_EVACUATED 5
 /// The blob has reached critical mass and overtaken the station
 #define BLOB_WIN 8
-/// The station's nuke was detonated destroying the blob
-#define BLOB_NUKE 9
 /// The blob was destroyed by the crew
 #define BLOB_DESTROYED 10
 /// The cult managed to escape alive on the shuttle

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -946,37 +946,42 @@ SUBSYSTEM_DEF(job)
 ///////////////////////////////////
 /datum/controller/subsystem/job/proc/get_living_heads()
 	. = list()
-	for(var/mob/living/carbon/human/player as anything in GLOB.human_list)
-		if(player.stat != DEAD && (player.mind?.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
-			. += player.mind
-
+	for(var/datum/mind/head as anything in get_crewmember_minds())
+		if(!(head.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			continue
+		if(isnull(head.current) || head.current.stat == DEAD)
+			continue
+		. += mind
 
 ////////////////////////////
 //Keeps track of all heads//
 ////////////////////////////
 /datum/controller/subsystem/job/proc/get_all_heads()
 	. = list()
-	for(var/mob/living/carbon/human/player as anything in GLOB.human_list)
-		if(player.mind?.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
-			. += player.mind
+	for(var/datum/mind/head as anything in get_crewmember_minds())
+		if(head.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
+			. += mind
 
 //////////////////////////////////////////////
 //Keeps track of all living security members//
 //////////////////////////////////////////////
 /datum/controller/subsystem/job/proc/get_living_sec()
 	. = list()
-	for(var/mob/living/carbon/human/player as anything in GLOB.human_list)
-		if(player.stat != DEAD && (player.mind?.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY))
-			. += player.mind
+	for(var/datum/mind/head as anything in get_crewmember_minds())
+		if(!(head.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY))
+			continue
+		if(isnull(head.current) || head.current.stat == DEAD)
+			continue
+		. += mind
 
 ////////////////////////////////////////
 //Keeps track of all  security members//
 ////////////////////////////////////////
 /datum/controller/subsystem/job/proc/get_all_sec()
 	. = list()
-	for(var/mob/living/carbon/human/player as anything in GLOB.human_list)
-		if(player.mind?.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
-			. += player.mind
+	for(var/datum/mind/head as anything in get_crewmember_minds())
+		if(head.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
+			. += mind
 
 /datum/controller/subsystem/job/proc/JobDebug(message)
 	log_job_debug(message)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -949,14 +949,14 @@ SUBSYSTEM_DEF(job)
 			continue
 		if(isnull(head.current) || head.current.stat == DEAD)
 			continue
-		. += mind
+		. += head
 
 /// Returns a list of minds of all heads of staff
 /datum/controller/subsystem/job/proc/get_all_heads()
 	. = list()
 	for(var/datum/mind/head as anything in get_crewmember_minds())
 		if(head.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
-			. += mind
+			. += head
 
 /// Returns a list of minds of all security members who are alive
 /datum/controller/subsystem/job/proc/get_living_sec()
@@ -966,14 +966,14 @@ SUBSYSTEM_DEF(job)
 			continue
 		if(isnull(sec.current) || sec.current.stat == DEAD)
 			continue
-		. += mind
+		. += sec
 
 /// Returns a list of minds of all security members
 /datum/controller/subsystem/job/proc/get_all_sec()
 	. = list()
 	for(var/datum/mind/sec as anything in get_crewmember_minds())
 		if(sec.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
-			. += mind
+			. += sec
 
 /datum/controller/subsystem/job/proc/JobDebug(message)
 	log_job_debug(message)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -941,9 +941,7 @@ SUBSYSTEM_DEF(job)
 		living_mob.forceMove(toLaunch)
 		new /obj/effect/pod_landingzone(spawn_turf, toLaunch)
 
-///////////////////////////////////
-//Keeps track of all living heads//
-///////////////////////////////////
+/// Returns a list of minds of all heads of staff who are alive
 /datum/controller/subsystem/job/proc/get_living_heads()
 	. = list()
 	for(var/datum/mind/head as anything in get_crewmember_minds())
@@ -953,34 +951,28 @@ SUBSYSTEM_DEF(job)
 			continue
 		. += mind
 
-////////////////////////////
-//Keeps track of all heads//
-////////////////////////////
+/// Returns a list of minds of all heads of staff
 /datum/controller/subsystem/job/proc/get_all_heads()
 	. = list()
 	for(var/datum/mind/head as anything in get_crewmember_minds())
 		if(head.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
 			. += mind
 
-//////////////////////////////////////////////
-//Keeps track of all living security members//
-//////////////////////////////////////////////
+/// Returns a list of minds of all security members who are alive
 /datum/controller/subsystem/job/proc/get_living_sec()
 	. = list()
-	for(var/datum/mind/head as anything in get_crewmember_minds())
-		if(!(head.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY))
+	for(var/datum/mind/sec as anything in get_crewmember_minds())
+		if(!(sec.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY))
 			continue
-		if(isnull(head.current) || head.current.stat == DEAD)
+		if(isnull(sec.current) || sec.current.stat == DEAD)
 			continue
 		. += mind
 
-////////////////////////////////////////
-//Keeps track of all  security members//
-////////////////////////////////////////
+/// Returns a list of minds of all security members
 /datum/controller/subsystem/job/proc/get_all_sec()
 	. = list()
-	for(var/datum/mind/head as anything in get_crewmember_minds())
-		if(head.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
+	for(var/datum/mind/sec as anything in get_crewmember_minds())
+		if(sec.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
 			. += mind
 
 /datum/controller/subsystem/job/proc/JobDebug(message)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -45,6 +45,7 @@ SUBSYSTEM_DEF(ticker)
 	var/queue_delay = 0
 	var/list/queued_players = list() //used for join queues when the server exceeds the hard population cap
 
+	/// What is going to be reported to other stations at end of round?
 	var/news_report
 
 
@@ -555,46 +556,94 @@ SUBSYSTEM_DEF(ticker)
 	var/news_message
 	var/news_source = "Nanotrasen News Network"
 	var/decoded_station_name = html_decode(station_name()) //decode station_name to avoid minor_announce double encode
+
 	switch(news_report)
+		// The nuke was detonated on the syndicate recon outpost
 		if(NUKE_SYNDICATE_BASE)
-			news_message = "In a daring raid, the heroic crew of [decoded_station_name] detonated a nuclear device in the heart of a terrorist base."
+			news_message = "In a daring raid, the heroic crew of [decoded_station_name] \
+				detonated a nuclear device in the heart of a terrorist base."
+		// The station was destroyed by nuke ops
 		if(STATION_DESTROYED_NUKE)
-			news_message = "We would like to reassure all employees that the reports of a Syndicate backed nuclear attack on [decoded_station_name] are, in fact, a hoax. Have a secure day!"
+			news_message = "We would like to reassure all employees that the reports of a Syndicate \
+				backed nuclear attack on [decoded_station_name] are, in fact, a hoax. Have a secure day!"
+		// The station was evacuated (normal result)
 		if(STATION_EVACUATED)
+			// Had an emergency reason supplied to pass along
 			if(emergency_reason)
-				news_message = "[decoded_station_name] has been evacuated after transmitting the following distress beacon:\n\n[html_decode(emergency_reason)]"
+				news_message = "[decoded_station_name] has been evacuated after transmitting \
+					the following distress beacon:\n\n[html_decode(emergency_reason)]"
 			else
-				news_message = "The crew of [decoded_station_name] has been evacuated amid unconfirmed reports of enemy activity."
+				news_message = "The crew of [decoded_station_name] has been \
+					evacuated amid unconfirmed reports of enemy activity."
+		// A blob won
 		if(BLOB_WIN)
-			news_message = "[decoded_station_name] was overcome by an unknown biological outbreak, killing all crew on board. Don't let it happen to you! Remember, a clean work station is a safe work station."
-		if(BLOB_NUKE)
-			news_message = "[decoded_station_name] is currently undergoing decontanimation after a controlled burst of radiation was used to remove a biological ooze. All employees were safely evacuated prior, and are enjoying a relaxing vacation."
+			news_message = "[decoded_station_name] was overcome by an unknown biological outbreak, killing \
+				all crew on board. Don't let it happen to you! Remember, a clean work station is a safe work station."
+		// A blob was destroyed
 		if(BLOB_DESTROYED)
-			news_message = "[decoded_station_name] is currently undergoing decontamination procedures after the destruction of a biological hazard. As a reminder, any crew members experiencing cramps or bloating should report immediately to security for incineration."
+			news_message = "[decoded_station_name] is currently undergoing decontamination procedures \
+				after the destruction of a biological hazard. As a reminder, any crew members experiencing \
+				cramps or bloating should report immediately to security for incineration."
+		// A certain percentage of all cultists managed to escape at the end of round
 		if(CULT_ESCAPE)
 			news_message = "Security Alert: A group of religious fanatics have escaped from [decoded_station_name]."
+		// Cult was completely or almost completely wiped out
 		if(CULT_FAILURE)
-			news_message = "Following the dismantling of a restricted cult aboard [decoded_station_name], we would like to remind all employees that worship outside of the Chapel is strictly prohibited, and cause for termination."
+			news_message = "Following the dismantling of a restricted cult aboard [decoded_station_name], \
+				we would like to remind all employees that worship outside of the Chapel is strictly prohibited, \
+				and cause for termination."
+		// Cult summoned Nar'sie
 		if(CULT_SUMMON)
-			news_message = "Company officials would like to clarify that [decoded_station_name] was scheduled to be decommissioned following meteor damage earlier this year. Earlier reports of an unknowable eldritch horror were made in error."
+			news_message = "Company officials would like to clarify that [decoded_station_name] was scheduled \
+				to be decommissioned following meteor damage earlier this year. Earlier reports of an \
+				unknowable eldritch horror were made in error."
+		// Nuke detonated, but missed the station entirely
 		if(NUKE_MISS)
-			news_message = "The Syndicate have bungled a terrorist attack [decoded_station_name], detonating a nuclear weapon in empty space nearby."
+			news_message = "The Syndicate have bungled a terrorist attack [decoded_station_name], \
+				detonating a nuclear weapon in empty space nearby."
+		// All nuke ops got killed
 		if(OPERATIVES_KILLED)
-			news_message = "Repairs to [decoded_station_name] are underway after an elite Syndicate death squad was wiped out by the crew."
+			news_message = "Repairs to [decoded_station_name] are underway after an elite \
+				Syndicate death squad was wiped out by the crew."
+		// Nuke ops results inconclusive - Crew escaped without the disk, or nukies were left alive, or something
 		if(OPERATIVE_SKIRMISH)
-			news_message = "A skirmish between security forces and Syndicate agents aboard [decoded_station_name] ended with both sides bloodied but intact."
+			news_message = "A skirmish between security forces and Syndicate agents aboard [decoded_station_name] \
+				ended with both sides bloodied but intact."
+		// Revolution victory
 		if(REVS_WIN)
-			news_message = "Company officials have reassured investors that despite a union led revolt aboard [decoded_station_name] there will be no wage increases for workers."
+			news_message = "Company officials have reassured investors that despite a union led revolt \
+				aboard [decoded_station_name] there will be no wage increases for workers."
+		// Revolution defeat
 		if(REVS_LOSE)
-			news_message = "[decoded_station_name] quickly put down a misguided attempt at mutiny. Remember, unionizing is illegal!"
+			news_message = "[decoded_station_name] quickly put down a misguided attempt at mutiny. \
+				Remember, unionizing is illegal!"
+		// All wizards (plus apprentices) have been killed
 		if(WIZARD_KILLED)
-			news_message = "Tensions have flared with the Space Wizard Federation following the death of one of their members aboard [decoded_station_name]."
+			news_message = "Tensions have flared with the Space Wizard Federation following the death \
+				of one of their members aboard [decoded_station_name]."
+		// The station was nuked generically
 		if(STATION_NUKED)
-			news_message = "[decoded_station_name] activated its self-destruct device for unknown reasons. Attempts to clone the Captain for arrest and execution are underway."
+			// There was a blob on board, guess it was nuked to stop it
+			for(var/mob/camera/blob/overmind as anything in GLOB.overminds)
+				if(overmind.max_count < overmind.announcement_size)
+					continue
+
+				news_message = "[decoded_station_name] is currently undergoing decontanimation after a controlled \
+					burst of radiation was used to remove a biological ooze. All employees were safely evacuated prior, \
+					and are enjoying a relaxing vacation."
+				break
+			// A self destruct or something else
+			else
+				news_message = "[decoded_station_name] activated its self-destruct device for unknown reasons. \
+					Attempts to clone the Captain for arrest and execution are underway."
+		// The emergency escape shuttle was hijacked
 		if(SHUTTLE_HIJACK)
-			news_message = "During routine evacuation procedures, the emergency shuttle of [decoded_station_name] had its navigation protocols corrupted and went off course, but was recovered shortly after."
+			news_message = "During routine evacuation procedures, the emergency shuttle of [decoded_station_name] \
+				had its navigation protocols corrupted and went off course, but was recovered shortly after."
+		// A supermatter cascade triggered
 		if(SUPERMATTER_CASCADE)
-			news_message = "Officials are advising nearby colonies about a newly declared exclusion zone in the sector surrounding [decoded_station_name]."
+			news_message = "Officials are advising nearby colonies about a newly declared exclusion zone in \
+				the sector surrounding [decoded_station_name]."
 
 	if(news_message)
 		send2otherserver(news_source, news_message,"News_Report")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -624,14 +624,15 @@ SUBSYSTEM_DEF(ticker)
 		// The station was nuked generically
 		if(STATION_NUKED)
 			// There was a blob on board, guess it was nuked to stop it
-			for(var/mob/camera/blob/overmind as anything in GLOB.overminds)
-				if(overmind.max_count < overmind.announcement_size)
-					continue
+			if(length(GLOB.overminds))
+				for(var/mob/camera/blob/overmind as anything in GLOB.overminds)
+					if(overmind.max_count < overmind.announcement_size)
+						continue
 
-				news_message = "[decoded_station_name] is currently undergoing decontanimation after a controlled \
-					burst of radiation was used to remove a biological ooze. All employees were safely evacuated prior, \
-					and are enjoying a relaxing vacation."
-				break
+					news_message = "[decoded_station_name] is currently undergoing decontanimation after a controlled \
+						burst of radiation was used to remove a biological ooze. All employees were safely evacuated prior, \
+						and are enjoying a relaxing vacation."
+					break
 			// A self destruct or something else
 			else
 				news_message = "[decoded_station_name] activated its self-destruct device for unknown reasons. \
@@ -646,7 +647,7 @@ SUBSYSTEM_DEF(ticker)
 				the sector surrounding [decoded_station_name]."
 
 	if(news_message)
-		send2otherserver(news_source, news_message,"News_Report")
+		send2otherserver(news_source, news_message, "News_Report")
 
 /datum/controller/subsystem/ticker/proc/GetTimeLeft()
 	if(isnull(SSticker.timeLeft))

--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -73,7 +73,8 @@
 	var/has_ever_been_ai = FALSE
 	var/last_death = 0
 
-	/// Set by Into The Sunset command of the shuttle manipulator
+	/// Set by Into The Sunset command of the shuttle manipulator.
+	/// If TRUE, the mob will always be considered "escaped" if they are alive and not exiled.
 	var/force_escaped = FALSE
 
 	var/list/learned_recipes //List of learned recipe TYPES.

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -290,7 +290,11 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	// If it got to this part, just pick one high impact ruleset if it exists
 	for(var/datum/dynamic_ruleset/rule in executed_rules)
 		if(rule.flags & HIGH_IMPACT_RULESET)
-			return rule.round_result()
+			rule.round_result()
+			// One was set, so we're done here
+			if(Ssticker.news_report)
+				return
+
 	return ..()
 
 /datum/game_mode/dynamic/proc/send_intercept()

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -292,7 +292,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if(rule.flags & HIGH_IMPACT_RULESET)
 			rule.round_result()
 			// One was set, so we're done here
-			if(Ssticker.news_report)
+			if(SSticker.news_report)
 				return
 
 	return ..()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -273,7 +273,6 @@
 	weight = 2
 	cost = 20
 	requirements = list(90,90,90,80,60,40,30,20,10,10)
-	var/list/roundstart_wizards = list()
 
 /datum/dynamic_ruleset/roundstart/wizard/acceptable(population=0, threat=0)
 	if(GLOB.wizardstart.len == 0)
@@ -281,6 +280,17 @@
 		message_admins("Cannot accept Wizard ruleset. Couldn't find any wizard spawn points.")
 		return FALSE
 	return ..()
+
+/datum/dynamic_ruleset/roundstart/wizard/round_result()
+	var/existing_wizards = 0
+	var/dead_wizards = 0
+	for(var/datum/antagonist/wizard/wiz in GLOB.antagonists)
+		existing_wizards++
+		if(!considered_alive(wiz))
+			dead_wizards++
+
+	if(dead_wizards == existing_wizards)
+		SSticker.news_report = WIZARD_KILLED
 
 /datum/dynamic_ruleset/roundstart/wizard/pre_execute()
 	. = ..()
@@ -360,13 +370,25 @@
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/bloodcult/round_result()
-	..()
 	if(main_cult.check_cult_victory())
 		SSticker.mode_result = "win - cult win"
 		SSticker.news_report = CULT_SUMMON
-	else
-		SSticker.mode_result = "loss - staff stopped the cult"
-		SSticker.news_report = CULT_FAILURE
+		return
+
+	SSticker.mode_result = "loss - staff stopped the cult"
+
+	if(main_cult.size_at_maximum == 0)
+		CRASH("Cult team existed with a size_at_maximum of 0 at round end!")
+
+	// If more than a certain ratio of our cultists have escaped, give the "cult escape" resport.
+	// Otherwise, give the "cult failure" report.
+	var/ratio_to_be_considered_escaped = 0.5
+	var/escaped_cultists = 0
+	for(var/datum/mind/escapee as anything in main_cult.members)
+		if(considered_escaped(escapee))
+			escaped_cultists++
+
+	SSticker.news_report = (escaped_cultists / main_cult.size_at_maximum) >= ratio_to_be_considered_escaped ? CULT_ESCAPE : CULT_FAILURE
 
 //////////////////////////////////////////////
 //                                          //
@@ -431,10 +453,10 @@
 			SSticker.news_report = NUKE_SYNDICATE_BASE
 		if(NUKE_RESULT_NUKE_WIN)
 			SSticker.mode_result = "win - syndicate nuke"
-			SSticker.news_report = STATION_NUKED
+			SSticker.news_report = STATION_DESTROYED_NUKE
 		if(NUKE_RESULT_NOSURVIVORS)
 			SSticker.mode_result = "halfwin - syndicate nuke - did not evacuate in time"
-			SSticker.news_report = STATION_NUKED
+			SSticker.news_report = STATION_DESTROYED_NUKE
 		if(NUKE_RESULT_WRONG_STATION)
 			SSticker.mode_result = "halfwin - blew wrong station"
 			SSticker.news_report = NUKE_MISS

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -282,15 +282,17 @@
 	return ..()
 
 /datum/dynamic_ruleset/roundstart/wizard/round_result()
-	var/existing_wizards = 0
-	var/dead_wizards = 0
 	for(var/datum/antagonist/wizard/wiz in GLOB.antagonists)
-		existing_wizards++
-		if(!considered_alive(wiz.owner))
-			dead_wizards++
+		var/mob/living/real_wiz = wiz.owner?.current
+		if(isnull(real_wiz))
+			continue
 
-	if(dead_wizards == existing_wizards)
-		SSticker.news_report = WIZARD_KILLED
+		var/turf/wiz_location = get_turf(real_wiz)
+		// If this wiz is alive AND not in an away level, then we know not all wizards are dead and can leave entirely
+		if(considered_alive(wiz.owner) && wiz_location && !is_away_level(wiz_location.z))
+			return
+
+	SSticker.news_report = WIZARD_KILLED
 
 /datum/dynamic_ruleset/roundstart/wizard/pre_execute()
 	. = ..()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -286,7 +286,7 @@
 	var/dead_wizards = 0
 	for(var/datum/antagonist/wizard/wiz in GLOB.antagonists)
 		existing_wizards++
-		if(!considered_alive(wiz))
+		if(!considered_alive(wiz.owner))
 			dead_wizards++
 
 	if(dead_wizards == existing_wizards)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -202,14 +202,14 @@
 //Set result and news report here
 /datum/game_mode/proc/set_round_result()
 	SSticker.mode_result = "undefined"
+	// Something nuked the station - it wasn't nuke ops (they set their own via their rulset)
 	if(GLOB.station_was_nuked)
-		SSticker.news_report = STATION_DESTROYED_NUKE
-	if(EMERGENCY_ESCAPED_OR_ENDGAMED)
-		SSticker.news_report = STATION_EVACUATED
-		if(SSshuttle.emergency.is_hijacked())
-			SSticker.news_report = SHUTTLE_HIJACK
+		SSticker.news_report = STATION_NUKED
 	if(SSsupermatter_cascade.cascade_initiated)
 		SSticker.news_report = SUPERMATTER_CASCADE
+	// Only show this one if we have nothing better to show
+	if(EMERGENCY_ESCAPED_OR_ENDGAMED && !SSticker.news_report)
+		SSticker.news_report = SSshuttle.emergency?.is_hijacked() ? SHUTTLE_HIJACK : STATION_EVACUATED
 
 /// Mode specific admin panel.
 /datum/game_mode/proc/admin_panel()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -58,21 +58,28 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 
 	update_explanation_text()
 
-/datum/objective/proc/considered_escaped(datum/mind/M)
-	if(!considered_alive(M))
+/**
+ * Checks if the passed mind is considered "escaped".
+ *
+ * Escaped mobs are used to check certain antag objectives / results.
+ *
+ * Escaped includes minds with alive, non-exiled mobs generally.
+ */
+/proc/considered_escaped(datum/mind/escapee)
+	if(!considered_alive(escapee))
 		return FALSE
-	if(considered_exiled(M))
+	if(considered_exiled(escapee))
 		return FALSE
-	if(M.force_escaped)
+	if(escapee.force_escaped)
 		return TRUE
 	if(SSticker.force_ending || GLOB.station_was_nuked) // Just let them win.
 		return TRUE
 	if(SSshuttle.emergency.mode != SHUTTLE_ENDGAME)
 		return FALSE
-	var/area/current_area = get_area(M.current)
+	var/area/current_area = get_area(escapee.current)
 	if(!current_area || istype(current_area, /area/shuttle/escape/brig)) // Fails if they are in the shuttle brig
 		return FALSE
-	var/turf/current_turf = get_turf(M.current)
+	var/turf/current_turf = get_turf(escapee.current)
 	return current_turf.onCentCom() || current_turf.onSyndieBase()
 
 /datum/objective/proc/check_completion()

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -115,4 +115,3 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 ///Custom names for individuals in a team
 /datum/team/proc/antag_listing_name()
 	return name
-

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -135,6 +135,8 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 			if(autoplace_max_time && world.time >= autoplace_max_time)
 				place_blob_core(BLOB_RANDOM_PLACEMENT)
 		else
+			// If we get here, it means yes: the blob is kill
+			SSticker.news_report = BLOB_DESTROYED
 			qdel(src)
 	else if(!victory_in_progress && (blobs_legit.len >= blobwincount))
 		victory_in_progress = TRUE

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -309,6 +309,7 @@
 
 /datum/team/cult/add_member(datum/mind/new_member)
 	. = ..()
+	// A little hacky, but this checks that cult ghosts don't contribute to the size at maximum value.
 	if(is_unassigned_job(new_member.assigned_role))
 		return
 	size_at_maximum++

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -271,6 +271,8 @@
 
 	///Has narsie been summoned yet?
 	var/narsie_summoned = FALSE
+	///How large were we at max size.
+	var/size_at_maximum = 0
 
 /datum/team/cult/proc/check_size()
 	if(cult_ascendent)
@@ -304,6 +306,12 @@
 				mind.current.AddElement(/datum/element/cult_halo)
 		cult_ascendent = TRUE
 		log_game("The blood cult has ascended with [cultplayers] players.")
+
+/datum/team/cult/add_member(datum/mind/new_member)
+	. = ..()
+	if(is_unassigned_job(new_member.assigned_role))
+		return
+	size_at_maximum++
 
 /datum/team/cult/proc/make_image(datum/objective/sacrifice/sac_objective)
 	var/datum/job/job_of_sacrifice = sac_objective.target.assigned_role

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -869,7 +869,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 		to_chat(user, span_cultitalic("Your blood begins flowing into [src]. You must remain in place and conscious to maintain the forms of those summoned. This will hurt you slowly but surely..."))
 		var/obj/structure/emergency_shield/cult/weak/N = new(T)
 		new_human.key = ghost_to_spawn.key
-		new_human.mind?.add_antag_datum(/datum/antagonist/cult)
+		var/datum/antagonist/cult/created_cultist = new_human.mind?.add_antag_datum(/datum/antagonist/cult)
+		created_cultist?.silent = TRUE
 		to_chat(new_human, span_cultitalic("<b>You are a servant of the Geometer. You have been made semi-corporeal by the cult of Nar'Sie, and you are to serve them at all costs.</b>"))
 
 		while(!QDELETED(src) && !QDELETED(user) && !QDELETED(new_human) && (user in T))
@@ -885,7 +886,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 					span_cultlarge("Your link to the world fades. Your form breaks apart."))
 			for(var/obj/I in new_human)
 				new_human.dropItemToGround(I, TRUE)
+			new_human.mind?.remove_antag_datum(/datum/antagonist/cult)
 			new_human.dust()
+
 	else if(choice == "Ascend as a Dark Spirit")
 		affecting = user
 		affecting.add_atom_colour(RUNE_COLOR_DARKRED, ADMIN_COLOUR_PRIORITY)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -624,7 +624,7 @@
 
 	var/heads_report = "<b>Heads of Staff</b><br>"
 	heads_report += "<table cellspacing=5>"
-	for(var/datum/mind/N in SSjob.get_living_heads())
+	for(var/datum/mind/N as anything in SSjob.get_living_heads())
 		var/mob/M = N.current
 		if(M)
 			heads_report += "<tr><td><a href='?_src_=holder;[HrefToken()];adminplayeropts=[REF(M)]'>[M.real_name]</a>[M.client ? "" : " <i>(No Client)</i>"][M.stat == DEAD ? " <b><font color=red>(DEAD)</font></b>" : ""]</td>"

--- a/code/modules/events/ghost_role/pirates.dm
+++ b/code/modules/events/ghost_role/pirates.dm
@@ -456,7 +456,7 @@
 /datum/export/pirate/ransom/find_loot()
 	var/list/head_minds = SSjob.get_living_heads()
 	var/list/head_mobs = list()
-	for(var/datum/mind/M in head_minds)
+	for(var/datum/mind/M as anything in head_minds)
 		head_mobs += M.current
 	if(head_mobs.len)
 		return pick(head_mobs)


### PR DESCRIPTION
## About The Pull Request

A few roundend reports got lost from moving to dynamic and other prs. This PRs re-allows them to occur. Namely: "Wizard Killed" (lost in dynamic), "Blob nuked" (lost in dynamic), "Cult escaped" (lost in cult rework), and "Nuke Ops Victory" (station destroyed via nuke) (lost from, what I can see, an oversight / accidental swap of report values).

Additionally, small roundend report QOL for cult: Removes antag datums from spirit realm ghosts after being dusted, so they do not show up on the report. And in reverse, heads of staff who were dusted / destroyed in revolution rounds are now also shown in roundend reports.

## Why It's Good For The Game

Some of these reports are dead, which is is a shame because I think they're cool and fun. 

## Changelog

:cl: Melbert
qol: Successfully fending off a blob now has a cross station news report again. More pressing reports will take priority over it, though. 
qol: Successfully killing a wizard (and all of their apprentices) now has a cross station news report again. 
qol: If more than half of a cultist team manages to escape on the shuttle (rather than summoning Nar'sie), they will send a unique cross station news report. This is still a loss, by the way. Summon Nar'sie!
qol: Nuclear Operatives successfully nuking the station now has its unique cross station news report again, and no longer uses the generic "The station was nuked" report. 
qol: Nuking the station to stop a blob infection now has a unique cross station news report again. Good luck convincing admins to allow this.
qol: Cult ghosts from "Spirit Realm" no longer persist on the cult's team after being desummoned, meaning they will not show up on roundend report. 
qol: Heads of staff will now always show up on revolution roundend report - even if their body was fully destroyed. 
/:cl: