### PR TITLE
Makes some use of `CONDUCT_1` in grille and door attackby.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -925,7 +925,7 @@
 
 /obj/machinery/door/airlock/attackby(obj/item/C, mob/user, params)
 	if(!issilicon(user) && !isAdminGhostAI(user))
-		if(isElectrified() && shock(user, 75))
+		if(isElectrified() && (C.flags_1 & CONDUCT_1) && shock(user, 75))
 			return
 	add_fingerprint(user)
 

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -13,6 +13,7 @@
 	throwforce = 15
 	demolition_mod = 1.25
 	w_class = WEIGHT_CLASS_BULKY
+	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb_continuous = list("attacks", "chops", "cleaves", "tears", "lacerates", "cuts")
 	attack_verb_simple = list("attack", "chop", "cleave", "tear", "lacerate", "cut")

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -194,7 +194,6 @@
 
 /obj/structure/grille/attackby(obj/item/W, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
-	add_fingerprint(user)
 	if(istype(W, /obj/item/stack/rods) && broken)
 		if(shock(user, 90))
 			return
@@ -252,8 +251,10 @@
 			return
 //window placing end
 
-	else if(istype(W, /obj/item/shard) || !shock(user, 70))
-		return ..()
+	else if((W.flags_1 & CONDUCT_1) && shock(user, 70))
+		return
+
+	return ..()
 
 /obj/structure/grille/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)


### PR DESCRIPTION
## About The Pull Request

- Airlock attackby now uses `CONDUCT_1` to check if the mob should be shocked on attack
- Grille attackby now uses `CONDUCT_1` to check if the mob should be shocked on attack
- You don't leave a fingerprint on grilles you attack (?)
- Fire axe is now conductive (it's made of steel?)

## Why It's Good For The Game

- Consistency is nice.
   - If you have an item you don't expect to shock you, it shouldn't randomly zap you anyways.
   - Grilles are especially bad for this: It hard checked _glass shards_ when attacking, and _glass shards_ only. That's lame and nonsensical. All non-conductive weapons should resist a spark. 

## Changelog

:cl: Melbert
balance: Attacking a shocked door with an item that isn't conductive will not shock you.
balance: Attacking a shocked grille with any item that isn't conductive (not just glass shards) will not shock you.
balance: Attacking grilles with items no longer leaves behind a fingerprint on the grille (?).
balance: Fire axe is now conductive.
/:cl:
