### PR TITLE
Fixes lesser ashdrakes not being able to spit fire

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -360,7 +360,6 @@
 
 /mob/living/simple_animal/hostile/megafauna/dragon/lesser/Initialize(mapload)
 	. = ..()
-	fire_cone.Remove(src)
 	meteors.Remove(src)
 	mass_fire.Remove(src)
 	lava_swoop.cooldown_time = 20 SECONDS


### PR DESCRIPTION

## About The Pull Request
Fixes lesser ashdrakes not being able to spit fire
fixes https://github.com/tgstation/tgstation/issues/69877
## Why It's Good For The Game
their ability to do so was accidentally removed some time ago
## Changelog
:cl:
fix: lesser dragon form can now spit fire again
/:cl:
