### PR TITLE
Makes the Legion Staff of Storms normal sized

### DIFF
--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -944,7 +944,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	force = 20
 	damtype = BURN
 	hitsound = 'sound/weapons/taserhit.ogg'


### PR DESCRIPTION

## About The Pull Request
What it says on the tin
## Why It's Good For The Game
The staff of storms is a really cool tool, but the size limitation turns people off, so it's basically almost never used. If you want to use it as a weapon, you have to do lots of tedious hand management (you also can't easily store it while waiting for the charges to come back) for a weapon that's more of a gimmick than actually useful. Letting people fit it into their bags will probably see more people use it, and has minimal effect on balance outside of QoL.
## Changelog
:cl: 
balance: The Staff of Storms fits in backpacks now

/:cl:
