### PR TITLE
Lowers frequency of Docker Publish and Generate Documentation changes to lower throughput

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,10 +1,8 @@
 name: Docker Build
-
 on:
-  push:
-    branches:
-      - master
-
+  schedule:
+  - cron: "19 1 * * *"
+  workflow_dispatch:
 jobs:
   publish:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -1,11 +1,10 @@
 name: Generate documentation
 on:
-  push:
-    branches:
-    - master
+  schedule:
+  - cron: "44 */6 * * *"
+  workflow_dispatch:
 permissions:
   contents: read
-
 jobs:
   generate_documentation:
     permissions:


### PR DESCRIPTION
Docker Publish is now a nightly.

Generate Documentation now runs every 6 hours.

Both used to run every commit, and our CI is getting heavily bottlenecked. Need to ease some stress.