### PR TITLE
Fixes horrible CI times

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -84,6 +84,13 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	/// WARNING: Currently to use a density shortcircuiting this does not support dense turfs with special allow through function
 	var/pathing_pass_method = TURF_PATHING_PASS_DENSITY
 
+#ifdef UNIT_TESTS
+	/// For the area_contents list unit test
+	/// Allows us to know our area without needing to preassign it
+	/// Sorry for the mess
+	var/area/in_contents_of
+#endif
+
 /turf/vv_edit_var(var_name, new_value)
 	var/static/list/banned_edits = list(NAMEOF_STATIC(src, x), NAMEOF_STATIC(src, y), NAMEOF_STATIC(src, z))
 	if(var_name in banned_edits)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	/// WARNING: Currently to use a density shortcircuiting this does not support dense turfs with special allow through function
 	var/pathing_pass_method = TURF_PATHING_PASS_DENSITY
 
-#ifdef UNIT_TESTS
+#if defined(UNIT_TESTS) || defined(SPACEMAN_DMM)
 	/// For the area_contents list unit test
 	/// Allows us to know our area without needing to preassign it
 	/// Sorry for the mess

--- a/code/modules/unit_tests/area_contents.dm
+++ b/code/modules/unit_tests/area_contents.dm
@@ -4,27 +4,26 @@
 	priority = TEST_LONGER
 
 /datum/unit_test/area_contents/Run()
-	/// assoc list of turfs -> areas
-	var/list/turf_to_area = list()
 	// First, we check that there are no entries in more then one area
 	// That or duplicate entries
 	for(var/area/space in GLOB.areas)
 		for(var/turf/position as anything in space.get_contained_turfs())
 			if(!isturf(position))
 				TEST_FAIL("Found a [position.type] in [space.type]'s turf listing")
-			var/area/existing = turf_to_area[position]
-			if(existing == space)
-				TEST_FAIL("Found a duplicate turf [position.type] inside [space.type]'s turf listing")
-			else if(existing)
-				TEST_FAIL("Found a shared turf [position.type] between [space.type] and [existing.type]'s turf listings")
+
+			if(position.in_contents_of)
+				var/area/existing = position.in_contents_of
+				if(existing == space)
+					TEST_FAIL("Found a duplicate turf [position.type] inside [space.type]'s turf listing")
+				else
+					TEST_FAIL("Found a shared turf [position.type] between [space.type] and [existing.type]'s turf listings")
 
 			var/area/dream_spot = position.loc
 			if(dream_spot != space)
 				TEST_FAIL("Found a turf [position.type] which is IN [dream_spot.type], but is registered as being in [space.type]")
 
-			turf_to_area[position] = space
+			position.in_contents_of = space
 
 	for(var/turf/position in ALL_TURFS())
-		if(!turf_to_area[position])
+		if(!position.in_contents_of)
 			TEST_FAIL("Found a turf [position.type] inside [position.loc.type] that is NOT stored in any area's turf listing")
-


### PR DESCRIPTION

## About The Pull Request
Ok so like, I was using an assoc list in the unit test to map turfs to their tracked area parent.

This was foolish because unless the test fails we will be doing this for EVERY TURF IN THE GAME.

Assoc lists are red black tress, so insert time, more then just the list expansion cost, also just scales with the amount of keys, since we need to binary search them all to ensure we don't already exist.

This is really slow, and was costing us like actually 300 seconds or something.

I've switched to storing this information in just the turf. It should bring this down to like 6 seconds instead of 6 minutes.

Remember, assoc lists are dumb for high scales kids