### PR TITLE
[NO GBP] Corrects a word in power monitor UI

### DIFF
--- a/tgui/packages/tgui/interfaces/PowerMonitor.js
+++ b/tgui/packages/tgui/interfaces/PowerMonitor.js
@@ -60,7 +60,7 @@ export const PowerMonitorContent = (props, context) => {
               <Icon name="plug-circle-exclamation" size={2} />
             </Stack.Item>
             <Stack.Item>
-              <h1>No powernet found!</h1>
+              <h1>No APCs found!</h1>
             </Stack.Item>
           </Stack>
         </Dimmer>


### PR DESCRIPTION

## About The Pull Request
Changed one word in the power monitor ui when the apc list is empty so I can go to sleep at night without thinking about it

## Why It's Good For The Game
wrong meaning attached to an error message

## Changelog
:cl:
spellcheck: Corrected a miswording in the power monitor UI.
/:cl:
