### PR TITLE
Fixes a bug where chunky fingers were preventing roundstart PDA use

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -16,7 +16,7 @@
 	if(!user.can_read(src, READING_CHECK_LITERACY))
 		return
 
-	if(ishuman(user))
+	if(ishuman(user) && !allow_chunky)
 		var/mob/living/carbon/human/human_user = user
 		if(human_user.check_chunky_fingers())
 			balloon_alert(human_user, "fingers are too big!")


### PR DESCRIPTION

## About The Pull Request

Fixes #71180
#70422 Removed the !allow_chunky check introduced by #66358 ,I've re-added it.

I've tested this and can confirm PDAs are usable again while modular consoles remain unusable.
## Why It's Good For The Game

Fixes a rather frustrating bug
## Changelog
:cl:
fix: Roundstart PDAs can once again be used by people with chunky fingers.
/:cl:
