### PR TITLE
[Stations] Rotates the library consoles now that they have directional sprites

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -27378,13 +27378,8 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/wood,
 /obj/machinery/light_switch/directional/east,
-/obj/item/newspaper{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/machinery/computer/libraryconsole{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
@@ -80399,7 +80394,14 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/table/wood,
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/computer/libraryconsole,
+/obj/item/newspaper{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = -4;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "tEE" = (
@@ -91815,6 +91817,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"wqA" = (
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/turf/closed/wall,
+/area/station/commons/locker)
 "wqF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -92676,7 +92682,9 @@
 /area/station/cargo/warehouse)
 "wAe" = (
 /obj/structure/table,
-/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	dir = 1
+	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -146904,7 +146912,7 @@ oCP
 mfP
 xsS
 aOH
-oCP
+wqA
 oCP
 oCP
 wMo

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -91817,10 +91817,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"wqA" = (
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/turf/closed/wall,
-/area/station/commons/locker)
 "wqF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -146912,7 +146908,7 @@ oCP
 mfP
 xsS
 aOH
-wqA
+oCP
 oCP
 oCP
 wMo

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -60344,7 +60344,9 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "sBY" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	dir = 8
+	},
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15320,7 +15320,9 @@
 /area/station/science/ordnance/testlab)
 "fJi" = (
 /obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	dir = 8
+	},
 /obj/structure/noticeboard/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -42558,7 +42558,9 @@
 /area/station/maintenance/solars/starboard)
 "plU" = (
 /obj/structure/table,
-/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/sign/poster/official/here_for_your_safety{
 	pixel_y = -32


### PR DESCRIPTION

## About The Pull Request
Title.

## Why It's Good For The Game
This ain't it chief.
![image](https://user-images.githubusercontent.com/70232195/202206325-ac5e1a68-8a1c-4041-a219-ba837f4f624b.png)

We've had the dir sprites for awhile now, this just retroactively applies it to the station maps where it makes sense.

## Changelog

:cl: Jolly
fix: On most station maps, crew can now properly see the computer monitors for library consoles and the like. We don't know how you guys saw the screens before, but you did. Good on you, I suppose?
/:cl:

