### PR TITLE
Slightly adjust base pixel off-set for library consoles

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -28,6 +28,8 @@
 	icon_keyboard = null
 	circuit = /obj/item/circuitboard/computer/libraryconsole
 	desc = "Checked out books MUST be returned on time."
+	// This fixes consoles to be ON the tables, rather than their keyboards floating a bit
+	pixel_y = 8
 	///The current title we're searching for
 	var/title = ""
 	///The category we're searching for


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/70232195/202208894-95bcb3a9-9858-4f18-bca4-086054d1c925.png)
What it is currently vs

![image](https://user-images.githubusercontent.com/70232195/202208930-c34b985f-19b3-4875-a4bb-3e79439b2dfa.png)

7 works too but 8 is an even number and we love even.
The X off-set doesn't need to be set since the entire thing is weirdly symmetrical with NuTables.

## Changelog

:cl: Jolly
qol: Library Consoles and Book Management Consoles should no longer have their keyboards hanging over the edge of tables.
/:cl:

