### PR TITLE
Case consistency for the "Crew Manifest" pAi software

### DIFF
--- a/code/modules/pai/hud.dm
+++ b/code/modules/pai/hud.dm
@@ -97,7 +97,7 @@
 /atom/movable/screen/pai/crew_manifest
 	name = "Crew Manifest"
 	icon_state = "manifest"
-	required_software = "crew manifest"
+	required_software = "Crew Manifest"
 
 /atom/movable/screen/pai/crew_manifest/Click()
 	if(!..())


### PR DESCRIPTION
## About The Pull Request

A case inconsistency when the pAIs rework was done (#68241) broke the HUD toggle button used to display the Crew Manifest. While the software was installed by the pAi, it falsely displayed that it was not the case.

> You must download the required software to use this.

![image](https://user-images.githubusercontent.com/118366967/202476259-6d8493ca-f002-4c92-8afd-1e3e340ef546.png)

## Why It's Good For The Game

Toggle button didn't work. Now, it works.

## Changelog

:cl:
spellcheck: The pAI toggle button to quickly display the Crew Manifest works again.
/:cl:
