### PR TITLE
[NO GBP] Fixing some of my oversights with tape

### DIFF
--- a/code/modules/clothing/masks/muzzle.dm
+++ b/code/modules/clothing/masks/muzzle.dm
@@ -50,7 +50,7 @@
 
 /obj/item/clothing/mask/muzzle/tape/examine(mob/user)
 	. = ..()
-	. += "[span_notice("Target mouth and use it on someone to tape their mouth closed.")]"
+	. += "[span_notice("Use it on someone while not in combat mode!")]"
 
 /obj/item/clothing/mask/muzzle/tape/dropped(mob/living/user)
 	. = ..()
@@ -72,6 +72,7 @@
 		to_chat(attacker, span_notice("[victim] is already wearing somthing on their face."))
 		return
 	balloon_alert(attacker, "taping mouth...")
+	to_chat(victim, span_userdanger("[attacker] is attempting to tape your mouth closed!"))
 	if(!do_after(attacker, equip_delay_other, target = victim))
 		return
 	victim.equip_to_slot_if_possible(src, ITEM_SLOT_MASK)

--- a/code/modules/clothing/masks/muzzle.dm
+++ b/code/modules/clothing/masks/muzzle.dm
@@ -50,7 +50,7 @@
 
 /obj/item/clothing/mask/muzzle/tape/examine(mob/user)
 	. = ..()
-	. += "[span_notice("Use it on someone while not in combat mode!")]"
+	. += "[span_notice("Use it on someone while not in combat mode to tape their mouth closed!")]"
 
 /obj/item/clothing/mask/muzzle/tape/dropped(mob/living/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Tape pieces now have the correct examine tip. When you apply tape to someone they will now get a warning simmilar to trying to apply other clothing, this way you can't bypass the warning by using it on them directly.

## Why It's Good For The Game
Fixes oversights

## Changelog
:cl:
fix: Tape pieces have the correct examine tip.
fix: Applying tape pieces by using it on someone will now actually warn them.
/:cl:
