### PR TITLE
Hotkey-based inventory management now applies the click cooldown to prevent it from being abusable in combat scenarios.

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -367,7 +367,7 @@
 
 /// take the most recent item out of a slot or place held item in a slot
 
-/mob/living/carbon/human/proc/smart_equip_targeted(slot_type = ITEM_SLOT_BELT, slot_item_name = "belt")
+/mob/living/carbon/human/proc/smart_equip_targeted(slot_type = ITEM_SLOT_BELT, slot_item_name = "belt", delayed = TRUE)
 	if(incapacitated())
 		return
 	var/obj/item/thing = get_active_held_item()
@@ -397,5 +397,6 @@
 	var/obj/item/stored = real_location.contents[real_location.contents.len]
 	if(!stored || stored.on_found(src))
 		return
-	stored.attack_hand(src) // take out thing from item in storage slot
+	if(delayed && do_after(stored, 0.5 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE)))
+		stored.attack_hand(src) // take out thing from item in storage slot
 	return

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -399,5 +399,5 @@
 		return
 	stored.attack_hand(src) // take out thing from item in storage slot
 	if(delayed)
-		changeNext_move(CLICK_CD_MELEE)
+		changeNext_move(CLICK_CD_RANGE)
 	return

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -397,6 +397,7 @@
 	var/obj/item/stored = real_location.contents[real_location.contents.len]
 	if(!stored || stored.on_found(src))
 		return
-	if(delayed && do_after(stored, 0.5 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE)))
-		stored.attack_hand(src) // take out thing from item in storage slot
+	stored.attack_hand(src) // take out thing from item in storage slot
+	if(delayed)
+		changeNext_move(CLICK_CD_MELEE)
 	return

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -399,5 +399,5 @@
 		return
 	stored.attack_hand(src) // take out thing from item in storage slot
 	if(delayed)
-		changeNext_move(CLICK_CD_RANGE)
+		changeNext_move(CLICK_CD_MELEE)
 	return


### PR DESCRIPTION
## About The Pull Request

Hotkey-based inventory management now applies the click cooldown to prevent it from being abusable in combat scenarios. 

## Why It's Good For The Game

Players have been deploying unbelievable levels of abuse with these hotkeys having completely uncapped speeds.
I watched one cheater do automated inventory management using storage items and weirdly named empty pills to use as inventory delimiters.
Resolves people being able to have a baton hidden in their backpack and then activate and baton someone with it in 0.1 seconds without moving their mouse cursor off of their target.

Players should not be able to interact with their inventory faster than someone moving a mouse and clicking the left mouse button. This cripples the game balance and puts anyone with a worse internet connection, slower reaction speeds, or laggier computer at a distinct disadvantage against people who can macro their inventory management.

I can set up autohotkey so that I can withdraw a stun baton from my backpack, turn it on, and then click someone by just holding down a key and pressing M1 over someone. This shit needs to stop.

~~If a do_after() on hotkey management is too harsh, we can apply a combat click cooldown every time you use the hotkeys instead to discourage combat macro abuse.~~
Swapped it over to a click cooldown.

## Changelog
:cl:
balance: Hotkey-based inventory management now applies the click cooldown to prevent it from being abusable in combat scenarios. 
/:cl: