### PR TITLE
Unit Tests Overstuffing Reagent Containers with more than their defined volume

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -233,4 +233,5 @@
 	name = "Canned Laughter"
 	desc = "Just looking at this makes you want to giggle."
 	icon_state = "laughter"
+	volume = 50
 	list_reagents = list(/datum/reagent/consumable/laughter = 50)

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -171,6 +171,7 @@
 	name = "T-Borg's tonic water"
 	desc = "Quinine tastes funny, but at least it'll keep that Space Malaria away."
 	icon_state = "tonic"
+	volume = 50
 	list_reagents = list(/datum/reagent/consumable/tonic = 50)
 	drink_type = ALCOHOL
 
@@ -178,6 +179,7 @@
 	name = "soda water"
 	desc = "A can of soda water. Why not make a scotch and soda?"
 	icon_state = "sodawater"
+	volume = 50
 	list_reagents = list(/datum/reagent/consumable/sodawater = 50)
 
 /obj/item/reagent_containers/cup/soda_cans/lemon_lime

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -95,6 +95,7 @@
 #include "component_tests.dm"
 #include "confusion.dm"
 #include "connect_loc.dm"
+#include "container_sanity.dm"
 #include "crayons.dm"
 #include "create_and_destroy.dm"
 #include "dcs_get_id_from_elements.dm"

--- a/code/modules/unit_tests/container_sanity.dm
+++ b/code/modules/unit_tests/container_sanity.dm
@@ -3,8 +3,7 @@
 /datum/unit_test/reagent_container_sanity
 
 /datum/unit_test/reagent_container_sanity/Run()
-	var/list/all_containers = typesof(/obj/item/reagent_containers)
-	for(var/entry in all_containers)
+	for(var/entry in subtypesof(/obj/item/reagent_containers))
 		var/obj/item/reagent_containers/container = allocate(entry)
 		var/initialized_volume = 0
 		if(!length(container.list_reagents))

--- a/code/modules/unit_tests/container_sanity.dm
+++ b/code/modules/unit_tests/container_sanity.dm
@@ -1,0 +1,20 @@
+/// Test to ensure that all possible reagent containers have enough space to hold any reagents they spawn in with.
+/// A drink can with only 30 units of space should not be able to hold 50 units of drink, as an example.
+/datum/unit_test/reagent_container_sanity
+
+/datum/unit_test/reagent_container_sanity/Run()
+	var/list/all_containers = typesof(/obj/item/reagent_containers)
+	for(var/entry in all_containers)
+		var/obj/item/reagent_containers/container = allocate(entry)
+		var/initialized_volume = 0
+		if(!length(container.list_reagents))
+			continue
+
+		// Get the volume of the reagents in the container that we initialize with, must tally up all of the values in the associated list because checking it through
+		// the reagents datum will only ever return the maximum volume of the container when "overfull" (adding 120 units to a 100 unit beaker means you only get 100 units of stuff contained).
+		for(var/reagent in container.list_reagents)
+			initialized_volume += container.list_reagents[reagent]
+
+		if(initialized_volume > container.volume)
+			// include the path as well here since there's up to like five "hypospray" or "beaker" or "soda water" types that aren't distinct enough to be differentiated by name alone.
+			TEST_FAIL("[container] ([container.type]) has [initialized_volume] units of reagents, but only [container.volume] units of space.")


### PR DESCRIPTION
## About The Pull Request

Simple Unit Test that seeks to ensure that we don't put too much of a reagent in a container when the container doesn't have enough volume to accept all of it. Nothing bad would happen, but it's just silly really.

I also fixed all of the instances that this was broken in.
## Why It's Good For The Game

Prevents buggy regressions, such as those found in #71206.

```txt
[2022-11-18 03:32:30.736]     FAILURE #1: Canned Laughter (/obj/item/reagent_containers/cup/soda_cans/canned_laughter) has 50 units of reagents, but only 30 units of space. at code/modules/unit_tests/container_sanity.dm:21
 -     FAILURE #2: T-Borg's tonic water (/obj/item/reagent_containers/cup/soda_cans/tonic) has 50 units of reagents, but only 30 units of space. at code/modules/unit_tests/container_sanity.dm:21
 -     FAILURE #3: The soda water (/obj/item/reagent_containers/cup/soda_cans/sodawater) has 50 units of reagents, but only 30 units of space. at code/modules/unit_tests/container_sanity.dm:21
```
## Changelog

:cl:
fix: Canned Laughter, T-Borg's Tonic Water, and Soda Water cans should all come with the expected marketed 50 units of goodness, rather than cheaping out on materials for only 30 units of can volume.
/:cl:
