### PR TITLE
Unit tests radio, saymode, and language prefix keys

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -14,8 +14,8 @@
 #define RADIO_TOKEN_ENGINEERING ":e"
 
 #define RADIO_CHANNEL_COMMAND "Command"
-#define RADIO_KEY_COMMAND "m"
-#define RADIO_TOKEN_COMMAND ":m"
+#define RADIO_KEY_COMMAND "c"
+#define RADIO_TOKEN_COMMAND ":c"
 
 #define RADIO_CHANNEL_SCIENCE "Science"
 #define RADIO_KEY_SCIENCE "n"

--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -14,8 +14,8 @@
 #define RADIO_TOKEN_ENGINEERING ":e"
 
 #define RADIO_CHANNEL_COMMAND "Command"
-#define RADIO_KEY_COMMAND "c"
-#define RADIO_TOKEN_COMMAND ":c"
+#define RADIO_KEY_COMMAND "m"
+#define RADIO_TOKEN_COMMAND ":m"
 
 #define RADIO_CHANNEL_SCIENCE "Science"
 #define RADIO_KEY_SCIENCE "n"

--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -87,7 +87,7 @@
 
 
 /datum/saymode/holopad
-	key = "h"
+	key = "2"
 	mode = MODE_HOLOPAD
 
 /datum/saymode/holopad/handle_message(mob/living/user, message, datum/language/language)
@@ -98,7 +98,7 @@
 	return TRUE
 
 /datum/saymode/mafia
-	key = "j"
+	key = "1"
 	mode = MODE_MAFIA
 
 /datum/saymode/mafia/handle_message(mob/living/user, message, datum/language/language)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -209,7 +209,7 @@ Possible to do for anyone motivated enough:
 /obj/machinery/holopad/examine(mob/user)
 	. = ..()
 	if(isAI(user))
-		. += span_notice("The status display reads: Current projection range: <b>[holo_range]</b> units. Use :h to speak through the projection. Right-click to project or cancel a projection. Alt-click to hangup all active and incomming calls. Ctrl-click to end projection without jumping to your last location.")
+		. += span_notice("The status display reads: Current projection range: <b>[holo_range]</b> units. Use :2 to speak through the projection. Right-click to project or cancel a projection. Alt-click to hangup all active and incomming calls. Ctrl-click to end projection without jumping to your last location.")
 	else if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Current projection range: <b>[holo_range]</b> units.")
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -146,7 +146,7 @@
 	to_chat(src, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
 	to_chat(src, "To use something, simply click on it.")
 	to_chat(src, "For department channels, use the following say commands:")
-	to_chat(src, ":o - AI Private, :c - Command, :s - Security, :e - Engineering, :u - Supply, :v - Service, :m - Medical, :n - Science, :h - Holopad.")
+	to_chat(src, ":o - AI Private, :c - Command, :s - Security, :e - Engineering, :u - Supply, :v - Service, :m - Medical, :n - Science, :2 - Holopad.")
 	show_laws()
 	to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -118,6 +118,7 @@
 #include "hydroponics_validate_genes.dm"
 #include "inhands.dm"
 #include "keybinding_init.dm"
+#include "key_prefixes.dm"
 #include "knockoff_component.dm"
 #include "limbsanity.dm"
 #include "load_map_security.dm"

--- a/code/modules/unit_tests/key_prefixes.dm
+++ b/code/modules/unit_tests/key_prefixes.dm
@@ -16,7 +16,7 @@
 	var/list/radio_keys = list()
 
 	for(var/radio_key in GLOB.department_radio_keys)
-		if(radio_keys.Find(radio_key))
+		if(radio_key in radio_keys)
 			TEST_FAIL("[GLOB.department_radio_keys[radio_key]] radio channel has the same prefix key ([radio_key]) as [GLOB.department_radio_keys[radio_keys.Find(radio_key)]]")
 		radio_keys[radio_key] = GLOB.department_radio_keys[radio_key]
 

--- a/code/modules/unit_tests/key_prefixes.dm
+++ b/code/modules/unit_tests/key_prefixes.dm
@@ -18,7 +18,7 @@
 	for(var/radio_key in GLOB.department_radio_keys)
 		if(radio_keys.Find(radio_key))
 			TEST_FAIL("[GLOB.department_radio_keys[radio_key]] radio channel has the same prefix key ([radio_key]) as [GLOB.department_radio_keys[radio_keys.Find(radio_key)]]")
-		radio_keys[radio_key] = GLOB.department_radio_keys[radio_Key]
+		radio_keys[radio_key] = GLOB.department_radio_keys[radio_key]
 
 	for(var/datum/saymode/say_type as anything in subtypesof(/datum/saymode))
 		if(initial(say_type.key) in radio_keys)

--- a/code/modules/unit_tests/key_prefixes.dm
+++ b/code/modules/unit_tests/key_prefixes.dm
@@ -13,13 +13,14 @@
 	// Now radioes
 
 	// Assoc list of key:name (or type in the cases of saymodes)
-	var/list/radio_keys = GLOB.department_radio_keys.Copy()
+	var/list/radio_keys = list()
+
+	for(var/radio_key in GLOB.department_radio_keys)
+		if(radio_keys.Find(radio_key))
+			TEST_FAIL("[GLOB.department_radio_keys[radio_key]] radio channel has the same prefix key ([radio_key]) as [GLOB.department_radio_keys[radio_keys.Find(radio_key)]]")
+		radio_keys[radio_key] = GLOB.department_radio_keys[radio_Key]
 
 	for(var/datum/saymode/say_type as anything in subtypesof(/datum/saymode))
 		if(initial(say_type.key) in radio_keys)
 			TEST_FAIL("[say_type] saymode has the same prefix key ([initial(say_type.key)]) as [radio_keys[initial(say_type.key)]]")
 		radio_keys[initial(say_type.key)] = say_type
-
-	for(var/radio_key in GLOB.department_radio_keys)
-		if(radio_key in radio_keys)
-			TEST_FAIL("[GLOB.department_radio_keys[radio_key]] radio channel has the same prefix key ([radio_key]) as [radio_keys[radio_keys.Find(radio_key)]]")

--- a/code/modules/unit_tests/key_prefixes.dm
+++ b/code/modules/unit_tests/key_prefixes.dm
@@ -1,0 +1,25 @@
+/// A unit test to ensure radio and language prefix keys don't overlap
+/datum/unit_test/key_prefixes
+
+/datum/unit_test/key_prefixes/Run()
+	// Languages first
+	// Assoc list of key:lang type
+	var/list/language_keys = list()
+	for(var/datum/language/language_type as anything in subtypesof(/datum/language))
+		if(initial(language_type.key) in language_keys)
+			TEST_FAIL("[language_type] language has the same prefix key ([initial(language_type.key)]) as [language_keys[initial(language_type.key)]]")
+		language_keys[initial(language_type.key)] = language_type
+
+	// Now radioes
+
+	// Assoc list of key:name (or type in the cases of saymodes)
+	var/list/radio_keys = GLOB.department_radio_keys.Copy()
+
+	for(var/datum/saymode/say_type as anything in subtypesof(/datum/saymode))
+		if(initial(say_type.key) in radio_keys)
+			TEST_FAIL("[say_type] saymode has the same prefix key ([initial(say_type.key)]) as [radio_keys[initial(say_type.key)]]")
+		radio_keys[initial(say_type.key)] = say_type
+
+	for(var/radio_key in GLOB.department_radio_keys)
+		if(radio_key in radio_keys)
+			TEST_FAIL("[GLOB.department_radio_keys[radio_key]] radio channel has the same prefix key ([radio_key]) as [radio_keys[radio_keys.Find(radio_key)]]")


### PR DESCRIPTION
## About The Pull Request
This PR unit tests radio/saymode prefixes together, and language prefixes on their own, for any possible overlaps and duplicates

Moved mafia saymode key to :1 and holopad key to :2, we're running out of radio keys and i'm too afraid to move to 2-letter

## Why It's Good For The Game
1. Unit tests are good
2. https://github.com/tgstation/tgstation/pull/71326 this is bad

🆑 
spellcheck: Mafia changeling say prefix is now :1, and holopad say is now :2
/🆑 