### PR TITLE
Improves Readability/Documentation of SSTicker.force_ending

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -8,11 +8,14 @@ SUBSYSTEM_DEF(ticker)
 	flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME
 
-	var/current_state = GAME_STATE_STARTUP //state of current round (used by process()) Use the defines GAME_STATE_* !
-	var/force_ending = 0 //Round was ended by admin intervention
-	// If true, there is no lobby phase, the game starts immediately.
+	/// state of current round (used by process()) Use the defines GAME_STATE_* !
+	var/current_state = GAME_STATE_STARTUP
+	/// Boolean to track if round was ended by admin intervention or a "round-ending" event, like summoning Nar'Sie, a blob victory, the nuke going off, etc.
+	var/force_ending = FALSE
+	/// If TRUE, there is no lobby phase, the game starts immediately.
 	var/start_immediately = FALSE
-	var/setup_done = FALSE //All game setup done including mode post setup and
+	/// Boolean to track and check if our subsystem setup is done.
+	var/setup_done = FALSE
 
 	var/datum/game_mode/mode = null
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -162,7 +162,7 @@
 		if(tgui_alert(usr, "This will end the round, are you SURE you want to do this?", "Confirmation", list("Yes", "No")) == "Yes")
 			if(tgui_alert(usr, "Final Confirmation: End the round NOW?", "Confirmation", list("Yes", "No")) == "Yes")
 				message_admins(span_adminnotice("[key_name_admin(usr)] has ended the round."))
-				SSticker.force_ending = 1 //Yeah there we go APC destroyed mission accomplished
+				SSticker.force_ending = TRUE //Yeah there we go APC destroyed mission accomplished
 				return
 			else
 				message_admins(span_adminnotice("[key_name_admin(usr)] decided against ending the round."))

--- a/code/modules/admin/verbs/server.dm
+++ b/code/modules/admin/verbs/server.dm
@@ -77,7 +77,7 @@
 	if(confirm == "Cancel")
 		return
 	if(confirm == "Yes")
-		SSticker.force_ending = 1
+		SSticker.force_ending = TRUE
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "End Round") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/toggleooc()

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -201,7 +201,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 			main_objective.completed = TRUE
 	to_chat(world, "<B>[real_name] consumed the station in an unstoppable tide!</B>")
 	SSticker.news_report = BLOB_WIN
-	SSticker.force_ending = 1
+	SSticker.force_ending = TRUE
 
 /mob/camera/blob/Destroy()
 	QDEL_NULL(blobstrain)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -261,7 +261,7 @@
 
 ///Helper to set the round to end asap. Current usage Cult round end code
 /proc/ending_helper()
-	SSticker.force_ending = 1
+	SSticker.force_ending = TRUE
 
 /**
  * Selects cinematic to play as part of the cult end depending on the outcome then ends the round afterward


### PR DESCRIPTION
## About The Pull Request

Hey there,

force_ending was a boolean (with inconsistent usage, flip-flopping between using TRUE/FALSE and 1/0 variables), so let's just change it all over to the macros and call it a good day.

I also updated documentation of the variables in that "code block" in SSTicker while in the area because changing just one line made it look ugly. Some of the documentation was no longer current to it's... current use in code, so I updated those as well.
## Why It's Good For The Game

Pure code improvement, DMdocs are swell, and readability is kino.
## Changelog
Nothing here should affect players.
