### PR TITLE
Fixes regenerate organs carrying over organ damage

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -829,7 +829,7 @@
 	if(heal_flags & HEAL_TOX)
 		setToxLoss(0, FALSE, TRUE)
 	if(heal_flags & HEAL_OXY)
-		setToxLoss(0, FALSE, TRUE)
+		setOxyLoss(0, FALSE, TRUE)
 	if(heal_flags & HEAL_CLONE)
 		setCloneLoss(0, FALSE, TRUE)
 	if(heal_flags & HEAL_BRUTE)

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -221,46 +221,53 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 //Looking for brains?
 //Try code/modules/mob/living/carbon/brain/brain_item.dm
 
-/mob/living/proc/regenerate_organs()
-	return FALSE
-
-/mob/living/carbon/regenerate_organs()
+/**
+ * Recreates all of this mob's organs, and heals them to full.
+ */
+/mob/living/carbon/proc/regenerate_organs()
+	// Delegate to species if possible.
 	if(dna?.species)
 		dna.species.regenerate_organs(src)
+		// Species regenerate organs doesn't handling healing the organs here,
+		// it's more concerned with just putting the necessary organs back in.
+		for(var/obj/item/organ/organ as anything in internal_organs)
+			organ.setOrganDamage(0)
+		set_heartattack(FALSE)
 		return
 
+	// Default organ fixing handling
+	// May result in kinda cursed stuff for mobs which don't need these organs
+	var/obj/item/organ/internal/lungs/lungs = getorganslot(ORGAN_SLOT_LUNGS)
+	if(!lungs)
+		lungs = new()
+		lungs.Insert(src)
+	lungs.setOrganDamage(0)
+
+	var/obj/item/organ/internal/heart/heart = getorganslot(ORGAN_SLOT_HEART)
+	if(heart)
+		set_heartattack(FALSE)
 	else
-		var/obj/item/organ/internal/lungs/lungs = getorganslot(ORGAN_SLOT_LUNGS)
-		if(!lungs)
-			lungs = new()
-			lungs.Insert(src)
-		lungs.setOrganDamage(0)
+		heart = new()
+		heart.Insert(src)
+	heart.setOrganDamage(0)
 
-		var/obj/item/organ/internal/heart/heart = getorganslot(ORGAN_SLOT_HEART)
-		if(heart)
-			set_heartattack(FALSE)
-		else
-			heart = new()
-			heart.Insert(src)
-		heart.setOrganDamage(0)
+	var/obj/item/organ/internal/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
+	if(!tongue)
+		tongue = new()
+		tongue.Insert(src)
+	tongue.setOrganDamage(0)
 
-		var/obj/item/organ/internal/tongue/tongue = getorganslot(ORGAN_SLOT_TONGUE)
-		if(!tongue)
-			tongue = new()
-			tongue.Insert(src)
-		tongue.setOrganDamage(0)
+	var/obj/item/organ/internal/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
+	if(!eyes)
+		eyes = new()
+		eyes.Insert(src)
+	eyes.setOrganDamage(0)
 
-		var/obj/item/organ/internal/eyes/eyes = getorganslot(ORGAN_SLOT_EYES)
-		if(!eyes)
-			eyes = new()
-			eyes.Insert(src)
-		eyes.setOrganDamage(0)
-
-		var/obj/item/organ/internal/ears/ears = getorganslot(ORGAN_SLOT_EARS)
-		if(!ears)
-			ears = new()
-			ears.Insert(src)
-		ears.setOrganDamage(0)
+	var/obj/item/organ/internal/ears/ears = getorganslot(ORGAN_SLOT_EARS)
+	if(!ears)
+		ears = new()
+		ears.Insert(src)
+	ears.setOrganDamage(0)
 
 /obj/item/organ/proc/handle_failing_organs(delta_time)
 	return


### PR DESCRIPTION
## About The Pull Request

Fixes #71331
Fixes #71353

Funnily enough I tested this, but I also managed to break it with another PR

Species regenerate organs carries over organ damage if it's replacing an existing organ, or fully heals it if it isn't. 

Carbon regenerate organs does the former, but wants both. 

So, I just implemented some organ healing in carbon regenerate organs. Early return moment.

Also a copy paste error in fullyheal from oxyloss... Oops

## Why It's Good For The Game

Debug tools work

## Changelog

:cl: Melbert
fix: Fullheals heal organ damage and oxy again.
/:cl:

