### PR TITLE
i left a lock on the kilo whiteship door button because i copied it from starfury like a dumbass and this fixes it

### DIFF
--- a/_maps/shuttles/whiteship_kilo.dmm
+++ b/_maps/shuttles/whiteship_kilo.dmm
@@ -296,7 +296,6 @@
 	id = "ntms_exterior";
 	name = "NTMS-037 Mining Airlock Bolt Control";
 	normaldoorcontrol = 1;
-	req_access = list("syndicate_leader");
 	specialfunctions = 4
 	},
 /turf/open/floor/plating,


### PR DESCRIPTION

sorry for long PR name but it is what it is
## About The Pull Request
removes access lock from the kilo whiteship doorbolt button because it's a syndicate leader one and wont even accept agent IDs and im a dumbass

## Why It's Good For The Game
unobtainable ID on a doorbolt button for a whiteship is bad, especially when I added the lock by accident

## Changelog
:cl:
fix: your local space explorer has removed the locks from all kilo-class mining vessel mining airlock bolt control panels. please report any surviving instances to central command so said space explorer can be dispatched to do the same exact thing.
/:cl:
