### PR TITLE
Ensures external libraries can't be called by callbacks

### DIFF
--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -117,9 +117,11 @@
 	if (!object)
 		return
 
+#if DM_VERSION <= 514
 	if(istext(object) && object != GLOBAL_PROC)
 		to_chat(usr, "[object] may be an external library. Calling external libraries is disallowed.", confidential = TRUE)
 		return
+#endif
 
 	var/list/calling_arguments = arguments
 	if (length(args))
@@ -158,9 +160,11 @@
 	if (!object)
 		return
 
+#if DM_VERSION <= 514
 	if(istext(object) && object != GLOBAL_PROC)
 		to_chat(usr, "[object] may be an external library. Calling external libraries is disallowed.", confidential = TRUE)
 		return
+#endif
 
 	var/list/calling_arguments = arguments
 	if (length(args))

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -117,7 +117,7 @@
 	if (!object)
 		return
 
-	if(fexists(object))
+	if(istext(object) && object != GLOBAL_PROC)
 		to_chat(usr, "[object] may be an external library. Calling external libraries is disallowed.", confidential = TRUE)
 		return
 
@@ -158,7 +158,7 @@
 	if (!object)
 		return
 
-	if(fexists(object))
+	if(istext(object) && object != GLOBAL_PROC)
 		to_chat(usr, "[object] may be an external library. Calling external libraries is disallowed.", confidential = TRUE)
 		return
 

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -117,6 +117,10 @@
 	if (!object)
 		return
 
+	if(fexists(object))
+		to_chat(usr, "[object] may be an external library. Calling external libraries is disallowed.", confidential = TRUE)
+		return
+
 	var/list/calling_arguments = arguments
 	if (length(args))
 		if (length(arguments))
@@ -152,6 +156,10 @@
 				return world.push_usr(M, src)
 
 	if (!object)
+		return
+
+	if(fexists(object))
+		to_chat(usr, "[object] may be an external library. Calling external libraries is disallowed.", confidential = TRUE)
 		return
 
 	var/list/calling_arguments = arguments


### PR DESCRIPTION
## About The Pull Request

It is possible to create a callback whose `object` (the datum it tries to call) is a path to an external library. Needless to say, it's probably a bad idea to allow admins to call arbitrary external libraries. Var-edited callbacks won't be able to reach the point where the library is executed, but only because `WrapAdminProcCall` runtimes when trying to call `CanProcCall` on a string, but if there is some way to call a function that creates a non-varedited callback with an external library as its object, this PR prevents that. 

## Why It's Good For The Game

See above.

## Changelog

:cl:
admin: Admins are unable to invoke functions from external libraries using callbacks.
/:cl:
