### PR TITLE
Lowers the metabolization rate of nooartrium to 0.2 (while reviving someone)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -518,7 +518,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/obj/item/organ/internal/heart/heart = owner.getorganslot(ORGAN_SLOT_HEART)
 	if(!heart || heart.organ_flags & ORGAN_FAILING)
 		return ..()
-	metabolization_rate = 0.4 * REM
+	metabolization_rate = 0.2 * REM //Previously 0.35, which without REM multiplication amounted to 0.7 which was WAY, WAY TOO MUCH for a chemical this hard to get
 	ADD_TRAIT(owner, TRAIT_STABLEHEART, type)
 	ADD_TRAIT(owner, TRAIT_NOHARDCRIT, type)
 	ADD_TRAIT(owner, TRAIT_NOSOFTCRIT, type)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -518,7 +518,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/obj/item/organ/internal/heart/heart = owner.getorganslot(ORGAN_SLOT_HEART)
 	if(!heart || heart.organ_flags & ORGAN_FAILING)
 		return ..()
-	metabolization_rate = 0.2 * REM //Previously 0.35, which without REM multiplication amounted to 0.7 which was WAY, WAY TOO MUCH for a chemical this hard to get
+	metabolization_rate = 0.2 * REM
 	ADD_TRAIT(owner, TRAIT_STABLEHEART, type)
 	ADD_TRAIT(owner, TRAIT_NOHARDCRIT, type)
 	ADD_TRAIT(owner, TRAIT_NOSOFTCRIT, type)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -518,7 +518,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/obj/item/organ/internal/heart/heart = owner.getorganslot(ORGAN_SLOT_HEART)
 	if(!heart || heart.organ_flags & ORGAN_FAILING)
 		return ..()
-	metabolization_rate = 0.35
+	metabolization_rate = 0.4 * REM
 	ADD_TRAIT(owner, TRAIT_STABLEHEART, type)
 	ADD_TRAIT(owner, TRAIT_NOHARDCRIT, type)
 	ADD_TRAIT(owner, TRAIT_NOSOFTCRIT, type)


### PR DESCRIPTION
## About The Pull Request

I noticed that Nooartrium wasn't multiplying it's metabolism while reviving someone by REM whatsoever.
This, from what I can tell, results in nooartrium having a metabolism of 0.7, which for a massively difficult inverse wittel reagent doesn't seem very justified.

I also noticed the obscene metabolism while trying to use the chemical on a local server. It was blatantly unusable. (You can only inject 19.9u of Nooartrium at most and it rapidly damages your heart.)

This PR changes the weird value of metabolism from 0.35 to 0.2 and also multiplies it by REM in the code. This should result in a 0.2 metabolism while reviving someone instead of 0.7.

## Why It's Good For The Game

Doing all that only to get a chemical that metabolizes this quickly is plain obscene. (I've never seen this chemical being used anyways, this just might solve that.)

It's overdose is also rather low and it deals massive heart damage so I don't get the issue here. If you get a tier 3 cyberheart, wittel and make the complicated ingredients required for penthrite, you should be able to use it to great effect.

You can already revive yourself from the dead in numerous ways, especially strange reagent synthflesh smoke grenades. (Which are a pain to set up, but less of a pain than nooartrium is.) You could also just use one of the many antag revivals. Nooartrium doesn't heal you, either. Oh, right, it also slows you down a lot if your health is down in the dirt.

## Changelog

:cl:
balance: Nooartrium metabolizes much slower now.
/:cl:
