### PR TITLE
Inverse reagent purity fixed

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1634,6 +1634,38 @@
 	var/area/source_area = get_area(src)
 	return source_area?.airlock_wires ? new source_area.airlock_wires(src) : new /datum/wires/airlock(src)
 
+/**
+ * Completely deletes our existing electronics and then replaces them with an (almost) exact copy of copy_from.
+ * Sets autoclose to TRUE. (Copied from /turf/open/floor/rcd_act())
+ *
+ * Returns whether or not the operation was successful.
+ * Arguments:
+ * * copy_from - The electronics to copy from.
+ */
+/obj/machinery/door/airlock/proc/copy_electronics_from(obj/item/electronics/airlock/copy_from)
+	if(!copy_from)
+		return FALSE
+	if(!electronics)
+		return FALSE
+	QDEL_NULL(electronics) //We're starting over from scratch
+	electronics = new(src)
+	electronics.copy_access_from(copy_from)
+	if(electronics.one_access)
+		req_one_access = electronics.accesses
+	else
+		req_access = electronics.accesses
+	if(electronics.unres_sides)
+		unres_sides = electronics.unres_sides
+		unres_sensor = TRUE
+	if(electronics.passed_name)
+		name = sanitize(electronics.passed_name)
+	if(electronics.passed_cycle_id)
+		closeOtherId = electronics.passed_cycle_id
+		update_other_id()
+	autoclose = TRUE
+	update_appearance()
+	return TRUE
+
 #undef AIRLOCK_CLOSED
 #undef AIRLOCK_CLOSING
 #undef AIRLOCK_OPEN

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -107,3 +107,20 @@
 	if(holder)
 		return holder
 	return src
+
+/**
+ * Copies copy_from's access over to us.
+ *
+ * Returns whether or not the operation was successful.
+ * Arguments:
+ * * copy_from - The electronics to copy from.
+ */
+/obj/item/electronics/airlock/proc/copy_access_from(obj/item/electronics/airlock/copy_from)
+	if(!copy_from)
+		return FALSE
+	accesses = copy_from.accesses.Copy()
+	one_access = copy_from.one_access
+	unres_sides = copy_from.unres_sides
+	passed_name = copy_from.passed_name
+	passed_cycle_id = copy_from.passed_cycle_id
+	return TRUE

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -411,6 +411,23 @@
 			return TRUE
 	return FALSE
 
+/**
+ * Acts like a simplified, windoor version of /obj/machinery/door/airlock/proc/copy_electronics_from().
+ *
+ * Returns whether or not the operation was successful.
+ * Arguments:
+ * * copy_from - The electronics to copy from.
+ */
+/obj/machinery/door/window/proc/copy_access_from(obj/item/electronics/airlock/copy_from)
+	if(!copy_from)
+		return FALSE
+	name = copy_from.passed_name || initial(name)
+	if(copy_from.one_access)
+		req_one_access = copy_from.accesses.Copy()
+	else
+		req_access = copy_from.accesses.Copy()
+	autoclose = TRUE
+	update_appearance()
 
 /obj/machinery/door/window/brigdoor
 	name = "secure door"

--- a/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
+++ b/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
@@ -6,25 +6,34 @@
 	icon_state = "boris"
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/iron = 50, /datum/material/glass = 300)
-	var/recharging = FALSE
 	var/circuits = 5 //How many circuits the pseudocircuit has left
 	var/static/recycleable_circuits = typecacheof(list(
 		/obj/item/electronics/firelock,
 		/obj/item/electronics/airalarm,
 		/obj/item/electronics/firealarm,
 		/obj/item/electronics/apc,
-	))//A typecache of circuits consumable for material
+		/obj/item/electronics/airlock,
+	)) //A typecache of circuits consumable for material
+	var/obj/item/electronics/airlock/airlock_electronics //An internal set of airlock electronics used for copying access over to newly created ones
 
 /obj/item/electroadaptive_pseudocircuit/Initialize(mapload)
 	. = ..()
 	maptext = MAPTEXT(circuits)
+	add_item_action(/datum/action/item_action/pseudocircuit_access)
+	airlock_electronics = new(src)
+	airlock_electronics.name = "Access Control"
+	airlock_electronics.holder = src
+
+/obj/item/electroadaptive_pseudocircuit/Destroy()
+	. = ..()
+	QDEL_NULL(airlock_electronics)
 
 /obj/item/electroadaptive_pseudocircuit/examine(mob/user)
 	. = ..()
 	if(iscyborg(user))
 		. += "[span_notice("It has material for <b>[circuits]</b> circuit[circuits == 1 ? "" : "s"]. Use the pseudocircuit on existing circuits to gain material.")]\n"+\
-		"[span_notice("Serves as a substitute for <b>fire/air alarm</b>, <b>firelock</b>, and <b>APC</b> electronics.")]\n"+\
-		span_notice("It can also be used on an APC with no power cell to <b>fabricate a low-capacity cell</b> at a high power cost.")
+		"[span_notice("Serves as a substitute for <b>fire/air alarm</b>, <b>firelock</b>, <b>airlock</b>, and <b>APC</b> electronics.")]\n"+\
+		span_notice("It can also be used on an APC or light fixture with no power cell to <b>fabricate a low-capacity cell</b> at a high power cost.")
 
 /obj/item/electroadaptive_pseudocircuit/proc/adapt_circuit(mob/living/silicon/robot/R, circuit_cost = 0)
 	if(QDELETED(R) || !istype(R))
@@ -35,19 +44,12 @@
 	if(!R.cell.use(circuit_cost))
 		to_chat(R, span_warning("You don't have the energy for that (you need [display_energy(circuit_cost)].)"))
 		return
-	if(recharging)
-		to_chat(R, span_warning("[src] needs some time to recharge first."))
-		return
 	if(!circuits)
 		to_chat(R, span_warning("You need more material. Use [src] on existing simple circuits to break them down."))
 		return
 	playsound(R, 'sound/items/rped.ogg', 50, TRUE)
-	recharging = TRUE
 	circuits--
 	maptext = MAPTEXT(circuits)
-	icon_state = "[initial(icon_state)]_recharging"
-	var/recharge_time = min(600, circuit_cost * 5)  //40W of cost for one fabrication = 20 seconds of recharge time; this is to prevent spamming
-	addtimer(CALLBACK(src, PROC_REF(recharge)), recharge_time)
 	return TRUE //The actual circuit magic itself is done on a per-object basis
 
 /obj/item/electroadaptive_pseudocircuit/afterattack(atom/target, mob/living/user, proximity)
@@ -63,7 +65,10 @@
 	playsound(user, 'sound/items/deconstruct.ogg', 50, TRUE)
 	qdel(target)
 
-/obj/item/electroadaptive_pseudocircuit/proc/recharge()
-	playsound(src, 'sound/machines/chime.ogg', 25, TRUE)
-	recharging = FALSE
-	icon_state = initial(icon_state)
+/obj/item/electroadaptive_pseudocircuit/ui_action_click(mob/user, actiontype)
+	airlock_electronics.ui_interact(user)
+
+/datum/action/item_action/pseudocircuit_access
+	name = "Change Airlock Access"
+	icon_icon = 'icons/hud/radial.dmi'
+	button_icon_state = "access"

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -265,3 +265,33 @@
 	if(istype(atom, /obj/item/ai_module) && !stored) //If an admin wants a borg to upload laws, who am I to stop them? Otherwise, we can hint that it fails
 		to_chat(user, span_warning("This circuit board doesn't seem to have standard robot apparatus pin holes. You're unable to pick it up."))
 	return ..()
+
+/obj/item/borg/apparatus/material
+	name = "material manipulation apparatus"
+	desc = "A special apparatus for carrying and manipulating sheets of material. It's complicated circuitry allows for the precise construction of objects."
+	icon_state = "borg_material_apparatus"
+	storable = list(/obj/item/stack/sheet)
+
+/obj/item/borg/apparatus/material/Initialize(mapload)
+	update_appearance()
+	return ..()
+
+/obj/item/borg/apparatus/material/update_overlays()
+	. = ..()
+	var/mutable_appearance/arm = mutable_appearance(icon, "borg_material_apparatus_arm1")
+	if(stored)
+		stored.pixel_x = -3
+		stored.pixel_y = 0
+		if(!istype(stored, /obj/item/stack/sheet))
+			arm.icon_state = "borg_material_apparatus_arm2"
+		var/mutable_appearance/stored_copy = new /mutable_appearance(stored)
+		stored_copy.layer = FLOAT_LAYER
+		stored_copy.plane = FLOAT_PLANE
+		. += stored_copy
+	. += arm
+
+/obj/item/borg/apparatus/material/examine()
+	. = ..()
+	if(stored)
+		. += "The apparatus currently has [stored] secured."
+	. += span_notice(" <i>Alt-click</i> will drop the currently stored stack of materials. ")

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -696,6 +696,34 @@
 		if (C)
 			R.model.remove_module(C, TRUE)
 
+/obj/item/borg/upgrade/material_app
+	name = "material manipulation apparatus"
+	desc = "An engineering cyborg upgrade allowing for manipulation and usage of any material."
+	icon_state = "cyborg_upgrade3"
+	require_model = TRUE
+	model_type = list(/obj/item/robot_model/engineering, /obj/item/robot_model/saboteur)
+	model_flags = BORG_MODEL_ENGINEERING
+
+
+/obj/item/borg/upgrade/material_app/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		var/obj/item/borg/apparatus/material/M = locate() in R.model.modules
+		if(M)
+			to_chat(user, span_warning("This unit is already equipped with a material apparatus!"))
+			return FALSE
+
+		M = new(R.model)
+		R.model.basic_modules += M
+		R.model.add_module(M, FALSE, TRUE)
+
+/obj/item/borg/upgrade/material_app/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if (.)
+		var/obj/item/borg/apparatus/material/M = locate() in R.model.modules
+		if (M)
+			R.model.remove_module(M, TRUE)
+
 /obj/item/borg/upgrade/beaker_app
 	name = "beaker storage apparatus"
 	desc = "A supplementary beaker storage apparatus for medical cyborgs."

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -162,6 +162,14 @@
 			name = "near finished airlock assembly"
 			electronics = W
 
+	else if(istype(W, /obj/item/electroadaptive_pseudocircuit) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS)
+		var/obj/item/electroadaptive_pseudocircuit/pseudocircuit = W
+		user.visible_message(span_notice("[user] fabricates a circuit and places it into [src]."), \
+								span_notice("You adapt an airlock circuit and slot it into the assembly."))
+		state = AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER
+		name = "near finished airlock assembly"
+		electronics = new(src)
+		electronics.copy_access_from(pseudocircuit.airlock_electronics)
 
 	else if((W.tool_behaviour == TOOL_CROWBAR) && state == AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER )
 		user.visible_message(span_notice("[user] removes the electronics from the airlock assembly."), \

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -289,38 +289,12 @@
 			if(ispath(the_rcd.airlock_type, /obj/machinery/door/window))
 				to_chat(user, span_notice("You build a windoor."))
 				var/obj/machinery/door/window/new_window = new the_rcd.airlock_type(src, user.dir, the_rcd.airlock_electronics?.unres_sides)
-				if(the_rcd.airlock_electronics)
-					new_window.name = the_rcd.airlock_electronics.passed_name || initial(new_window.name)
-					if(the_rcd.airlock_electronics.one_access)
-						new_window.req_one_access = the_rcd.airlock_electronics.accesses.Copy()
-					else
-						new_window.req_access = the_rcd.airlock_electronics.accesses.Copy()
-				new_window.autoclose = TRUE
-				new_window.update_appearance()
+				new_window.copy_access_from(the_rcd.airlock_electronics)
 				return TRUE
 			to_chat(user, span_notice("You build an airlock."))
 			var/obj/machinery/door/airlock/new_airlock = new the_rcd.airlock_type(src)
 			new_airlock.electronics = new /obj/item/electronics/airlock(new_airlock)
-			if(the_rcd.airlock_electronics)
-				new_airlock.electronics.accesses = the_rcd.airlock_electronics.accesses.Copy()
-				new_airlock.electronics.one_access = the_rcd.airlock_electronics.one_access
-				new_airlock.electronics.unres_sides = the_rcd.airlock_electronics.unres_sides
-				new_airlock.electronics.passed_name = the_rcd.airlock_electronics.passed_name
-				new_airlock.electronics.passed_cycle_id = the_rcd.airlock_electronics.passed_cycle_id
-			if(new_airlock.electronics.one_access)
-				new_airlock.req_one_access = new_airlock.electronics.accesses
-			else
-				new_airlock.req_access = new_airlock.electronics.accesses
-			if(new_airlock.electronics.unres_sides)
-				new_airlock.unres_sides = new_airlock.electronics.unres_sides
-				new_airlock.unres_sensor = TRUE
-			if(new_airlock.electronics.passed_name)
-				new_airlock.name = sanitize(new_airlock.electronics.passed_name)
-			if(new_airlock.electronics.passed_cycle_id)
-				new_airlock.closeOtherId = new_airlock.electronics.passed_cycle_id
-				new_airlock.update_other_id()
-			new_airlock.autoclose = TRUE
-			new_airlock.update_appearance()
+			new_airlock.copy_electronics_from(the_rcd.airlock_electronics)
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			var/old_turf_name = name

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -787,7 +787,7 @@
 		added_purity = 0
 
 	if((reagent.inverse_chem_val > added_purity) && (reagent.inverse_chem))//Turns all of a added reagent into the inverse chem
-		add_reagent(reagent.inverse_chem, added_volume, FALSE, added_purity = 1-reagent.creation_purity)
+		add_reagent(reagent.inverse_chem, added_volume, FALSE, added_purity = reagent.get_inverse_purity())
 		var/datum/reagent/inverse_reagent = has_reagent(reagent.inverse_chem)
 		if(inverse_reagent.chemical_flags & REAGENT_SNEAKYNAME)
 			inverse_reagent.name = reagent.name//Negative effects are hidden

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -218,7 +218,7 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 				var/datum/reagent/inverse_reagent = GLOB.chemical_reagents_list[reagent.inverse_chem]
 				if(inverse_reagent.mass < lower_mass_range || inverse_reagent.mass > upper_mass_range)
 					in_range = FALSE
-				beakerContents.Add(list(list("name" = inverse_reagent.name, "volume" = round(reagent.volume, 0.01), "mass" = inverse_reagent.mass, "purity" = round(1-reagent.purity, 0.01)*100, "selected" = in_range, "color" = "#b60046", "type" = "Inverted")))
+				beakerContents.Add(list(list("name" = inverse_reagent.name, "volume" = round(reagent.volume, 0.01), "mass" = inverse_reagent.mass, "purity" = round(reagent.get_inverse_purity(), 0.01)*100, "selected" = in_range, "color" = "#b60046", "type" = "Inverted")))
 				data["peakHeight"] = max(data["peakHeight"], reagent.volume)
 				continue
 			if(reagent.mass < lower_mass_range || reagent.mass > upper_mass_range)
@@ -331,7 +331,7 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 			if(inverse_reagent.mass < lower_mass_range || inverse_reagent.mass > upper_mass_range)
 				continue
 			log += list(inverse_reagent.type = "Cannot purify inverted") //Might as well make it do something - just updates the reagent's name
-			beaker2.reagents.add_reagent(reagent.inverse_chem, volume, reagtemp = beaker1.reagents.chem_temp, added_purity = 1-reagent.purity)
+			beaker2.reagents.add_reagent(reagent.inverse_chem, volume, reagtemp = beaker1.reagents.chem_temp, added_purity = reagent.get_inverse_purity())
 			beaker1.reagents.remove_reagent(reagent.type, volume)
 			continue
 
@@ -397,7 +397,6 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 			continue
 		if(reagent.mass < lower_mass_range || reagent.mass > upper_mass_range)
 			continue
-		var/inverse_purity = 1-reagent.purity
-		time += (((reagent.mass * reagent.volume) + (reagent.mass * inverse_purity * 0.1)) * 0.0035) + 10 ///Roughly 10 - 30s?
+		time += (((reagent.mass * reagent.volume) + (reagent.mass * reagent.get_inverse_purity() * 0.1)) * 0.0035) + 10 ///Roughly 10 - 30s?
 	delay_time = (time * cms_coefficient)
 	return delay_time

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -246,6 +246,19 @@ Primarily used in reagents/reaction_agents
 	return creation_purity / normalise_num_to
 
 /**
+ * Gets the inverse purity of this reagent. Mostly used when converting from a normal reagent to it's inverse one.
+ *
+ * Arguments
+ * * purity - Overrides the purity used for determining the inverse purity.
+ */
+/datum/reagent/proc/get_inverse_purity(var/purity)
+	if(!inverse_chem || !inverse_chem_val)
+		return
+	if(!purity)
+		purity = src.purity
+	return min(1-inverse_chem_val + purity + 0.01, 1) //Gives inverse reactions a 1% purity threshold for being 100% pure to appease players with OCD.
+
+/**
  * Input a reagent_list, outputs pretty readable text!
  * Default output will be formatted as
  * * water, 5 | silicon, 6 | soup, 4 | space lube, 8

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -251,7 +251,7 @@ Primarily used in reagents/reaction_agents
  * Arguments
  * * purity - Overrides the purity used for determining the inverse purity.
  */
-/datum/reagent/proc/get_inverse_purity(var/purity)
+/datum/reagent/proc/get_inverse_purity(purity)
 	if(!inverse_chem || !inverse_chem_val)
 		return
 	if(!purity)

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -154,7 +154,7 @@
 		if((reaction_flags & REACTION_CLEAR_INVERSE) && reagent.inverse_chem)
 			if(reagent.inverse_chem_val > reagent.purity)
 				holder.remove_reagent(reagent.type, cached_volume, FALSE)
-				holder.add_reagent(reagent.inverse_chem, cached_volume, FALSE, added_purity = 1-cached_purity)
+				holder.add_reagent(reagent.inverse_chem, cached_volume, FALSE, added_purity = reagent.get_inverse_purity(cached_purity))
 				return
 
 /**

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1193,6 +1193,13 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_ENGINEERING
 	)
 
+/datum/design/borg_upgrade_material_app
+	name = "Material Apparatus"
+	id = "borg_upgrade_materialapp"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/material_app
+	materials = list(/datum/material/iron = 2000, /datum/material/gold = 500)
+
 /datum/design/borg_upgrade_beaker_app
 	name = "Secondary Beaker Storage"
 	id = "borg_upgrade_beakerapp"


### PR DESCRIPTION

## About The Pull Request

fixes #71356

This PR changes how inverse reagent purity is calculated in general. Read #71356 for more information as to why I'm doing this.

Inverse reagent purity is now calculated based on how close to the inverse reagent threshold you are. The closer you are to it while still being under it, the higher the purity.

Reagents sort of just explode if you get to a low enough purity so the previous system didn't work and for some chemicals the maximum purity could be as low as 25%! (super melatonin)

The inverse reagent conversion when being injected into a target also had it's purity completely broken. Those ones are affected even worse than reagents that are automatically converted into their inverse reagents after a reaction. (prohol)

Now you can get 100% pure inverse reagents as long as you make your recipes, well, good. This also adds a 1% threshold for 100% purity so that people can get 100% pure inverse reagents. (You physically couldn't get them otherwise.)
## Why It's Good For The Game

Being able to get 100% pure inverse reagents is rather nice, ya know?
This is a bugfix PR anyways.
## Changelog
:cl:
fix: You can now get 100% pure inverse reagents.
/:cl:
