### PR TITLE
Airlocks no longer run deny logic when depowered on bump

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -356,6 +356,9 @@
 		update_appearance()
 
 /obj/machinery/door/airlock/bumpopen(mob/living/user)
+	if(!hasPower())
+		return
+
 	if(issilicon(user) || !iscarbon(user))
 		return ..()
 


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

resolves https://github.com/tgstation/tgstation/issues/70180

## Changelog

:cl:
fix: Airlocks will no longer 'deny' entry when bumped while depowered
/:cl:
