### PR TITLE
prevent crushing mobs you cannot reach

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -663,7 +663,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 
 	. = FALSE
 
-	if(in_range(fatty, src))
+	if(Adjacent(fatty))
 		for(var/mob/living/L in get_turf(fatty))
 			var/was_alive = (L.stat != DEAD)
 			var/mob/living/carbon/C = L


### PR DESCRIPTION
See title

Resolves https://github.com/tgstation/tgstation/issues/69110

:cl:
fix: Vending machines will no longer crush you through windows!
/:cl:

vscode web editor sucks ass and didnt let me set pr body