### PR TITLE
Fixes liver failure metabolization, TRAIT_STABLELIVER and herignis.

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -596,7 +596,7 @@
 		return
 
 	reagents.end_metabolization(src, keep_liverless = TRUE) //Stops trait-based effects on reagents, to prevent permanent buffs
-	reagents.metabolize(src, delta_time, times_fired, can_overdose=FALSE, liverless = TRUE)
+	reagents.metabolize(src, delta_time, times_fired, can_overdose=TRUE, liverless = TRUE)
 
 	if(HAS_TRAIT(src, TRAIT_STABLELIVER) || HAS_TRAIT(src, TRAIT_NOMETABOLISM))
 		return

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -268,41 +268,41 @@ Basically, we fill the time between now and 2s from now with hands based off the
 //inverse
 /datum/reagent/inverse/hercuri
 	name = "Herignis"
-	description = "This reagent causes a dramatic raise in a patient's body temperature."
+	description = "This reagent causes a dramatic raise in the patient's body temperature. Overdosing makes the effect even stronger and causes severe liver damage."
 	ph = 0.8
 	tox_damage = 0
 	color = "#ff1818"
+	overdose_threshold = 25
+	reagent_weight = 0.6
 	taste_description = "heat! Ouch!"
 	addiction_types = list(/datum/addiction/medicine = 2.5)
-	data = list("method" = TOUCH)
-	///The method in which the reagent was exposed
-	var/method
-
-/datum/reagent/inverse/hercuri/expose_mob(mob/living/carbon/exposed_mob, methods=VAPOR, reac_volume)
-	method |= methods
-	data["method"] |= methods
-	..()
-
-/datum/reagent/inverse/hercuri/on_new(data)
-	. = ..()
-	if(!data)
-		return
-	method |= data["method"]
 
 /datum/reagent/inverse/hercuri/on_mob_life(mob/living/carbon/owner, delta_time, times_fired)
-	var/heating = rand(creation_purity * REM * 3, creation_purity * REM * 6)
-	if(method & INGEST)
-		owner.reagents?.chem_temp += heating * REM * delta_time
-	if(method & VAPOR)
-		owner.adjust_bodytemperature(heating * REM * delta_time * TEMPERATURE_DAMAGE_COEFFICIENT, 50)
-	if(method & INJECT)
-		if(!ishuman(owner))
-			return ..()
-		var/mob/living/carbon/human/human_mob = owner
-		human_mob.adjust_coretemperature(heating * REM * delta_time * TEMPERATURE_DAMAGE_COEFFICIENT, 50)
-	else
-		owner.adjust_fire_stacks(heating * 0.05)
-	..()
+	. = ..()
+	var/heating = rand(5, 25) * creation_purity * REM * delta_time
+	owner.reagents?.chem_temp += heating
+	owner.adjust_bodytemperature(heating * TEMPERATURE_DAMAGE_COEFFICIENT)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/human = owner
+	human.adjust_coretemperature(heating * TEMPERATURE_DAMAGE_COEFFICIENT)
+
+/datum/reagent/inverse/hercuri/expose_mob(mob/living/carbon/exposed_mob, methods=VAPOR, reac_volume)
+	. = ..()
+	if(!(methods & VAPOR))
+		return
+
+	exposed_mob.adjust_bodytemperature(reac_volume * TEMPERATURE_DAMAGE_COEFFICIENT)
+	exposed_mob.adjust_fire_stacks(reac_volume / 2)
+
+/datum/reagent/inverse/hercuri/overdose_process(mob/living/carbon/owner, delta_time, times_fired)
+	. = ..()
+	owner.adjustOrganLoss(ORGAN_SLOT_LIVER, 2 * REM * delta_time) //Makes it so you can't abuse it with pyroxadone very easily (liver dies from 25u unless it's fully upgraded)
+	var/heating = 10 * creation_purity * REM * delta_time * TEMPERATURE_DAMAGE_COEFFICIENT
+	owner.adjust_bodytemperature(heating) //hot hot
+	if(ishuman(owner))
+		var/mob/living/carbon/human/human = owner
+		human.adjust_coretemperature(heating)
 
 /datum/reagent/inverse/healing/tirimol
 	name = "Super Melatonin"//It's melatonin, but super!

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -93,9 +93,7 @@
 
 	if(!istype(liver_owner))
 		return
-	if(HAS_TRAIT(liver_owner, TRAIT_NOMETABOLISM)) //You don't even have a metabolism
-		return
-	if(organ_flags & ORGAN_FAILING) //If you do have a metabolism but your liver is failing then we use the liverless version of metabolize
+	if(organ_flags & ORGAN_FAILING || HAS_TRAIT(liver_owner, TRAIT_NOMETABOLISM)) //If  your liver is failing or you lack a metabolism then we use the liverless version of metabolize
 		liver_owner.reagents.metabolize(liver_owner, delta_time, times_fired, can_overdose=TRUE, liverless=TRUE)
 		return
 
@@ -104,7 +102,7 @@
 
 	var/provide_pain_message = HAS_NO_TOXIN
 	var/obj/belly = liver_owner.getorganslot(ORGAN_SLOT_STOMACH)
-	if(filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
+	if(filterToxins && !HAS_TRAIT(liver_owner, TRAIT_TOXINLOVER))
 		//handle liver toxin filtration
 		for(var/datum/reagent/toxin/toxin in liver_owner.reagents.reagent_list)
 			var/thisamount = liver_owner.reagents.get_reagent_amount(toxin.type)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -93,7 +93,7 @@
 
 	if(!istype(liver_owner))
 		return
-	if(organ_flags & ORGAN_FAILING || HAS_TRAIT(liver_owner, TRAIT_NOMETABOLISM)) //If  your liver is failing or you lack a metabolism then we use the liverless version of metabolize
+	if(organ_flags & ORGAN_FAILING || HAS_TRAIT(liver_owner, TRAIT_NOMETABOLISM)) //If your liver is failing or you lack a metabolism then we use the liverless version of metabolize
 		liver_owner.reagents.metabolize(liver_owner, delta_time, times_fired, can_overdose=TRUE, liverless=TRUE)
 		return
 

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -93,7 +93,10 @@
 
 	if(!istype(liver_owner))
 		return
-	if(organ_flags & ORGAN_FAILING || HAS_TRAIT(liver_owner, TRAIT_NOMETABOLISM))//can't process reagents with a failing liver
+	if(HAS_TRAIT(liver_owner, TRAIT_NOMETABOLISM)) //You don't even have a metabolism
+		return
+	if(organ_flags & ORGAN_FAILING) //If you do have a metabolism but your liver is failing then we use the liverless version of metabolize
+		liver_owner.reagents.metabolize(liver_owner, delta_time, times_fired, can_overdose=TRUE, liverless=TRUE)
 		return
 
 	// How much damage to inflict on our liver
@@ -125,7 +128,7 @@
 
 
 /obj/item/organ/internal/liver/handle_failing_organs(delta_time)
-	if(HAS_TRAIT(src, TRAIT_STABLELIVER) || HAS_TRAIT(src, TRAIT_NOMETABOLISM))
+	if(HAS_TRAIT(owner, TRAIT_STABLELIVER) || HAS_TRAIT(owner, TRAIT_NOMETABOLISM))
 		return
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

fixes #71012

This PR makes it so that a failing liver can still process reagents that don't need you to have a liver. You can now also overdose on liverless reagents while not having a liver. (Who coded this? I just want to talk.)

TRAIT_STABLELIVER and TRAIT_NOMETABOLISM work while you have a failing liver.

TRAIT_STABLELIVER prevents liver failure as it should.

It also fixes herignis not working and changes it's effects. (More potent.)

## Why It's Good For The Game

Major bugfix good.

## Changelog
:cl:
fix: Metabolization works for reagents that are meant to metabolize while your liver is failing.
fix: Higadrite, cordiolis hepatico and herignis work properly.
balance: Herignis is more potent and has an overdose threshold of 25u.
/:cl:
