### PR TITLE
Inverse reagent purity fixed (ATTEMPT 3 GIT WHY)

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -787,7 +787,7 @@
 		added_purity = 0
 
 	if((reagent.inverse_chem_val > added_purity) && (reagent.inverse_chem))//Turns all of a added reagent into the inverse chem
-		add_reagent(reagent.inverse_chem, added_volume, FALSE, added_purity = 1-reagent.creation_purity)
+		add_reagent(reagent.inverse_chem, added_volume, FALSE, added_purity = reagent.get_inverse_purity(reagent.creation_purity))
 		var/datum/reagent/inverse_reagent = has_reagent(reagent.inverse_chem)
 		if(inverse_reagent.chemical_flags & REAGENT_SNEAKYNAME)
 			inverse_reagent.name = reagent.name//Negative effects are hidden

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -218,7 +218,7 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 				var/datum/reagent/inverse_reagent = GLOB.chemical_reagents_list[reagent.inverse_chem]
 				if(inverse_reagent.mass < lower_mass_range || inverse_reagent.mass > upper_mass_range)
 					in_range = FALSE
-				beakerContents.Add(list(list("name" = inverse_reagent.name, "volume" = round(reagent.volume, 0.01), "mass" = inverse_reagent.mass, "purity" = round(1-reagent.purity, 0.01)*100, "selected" = in_range, "color" = "#b60046", "type" = "Inverted")))
+				beakerContents.Add(list(list("name" = inverse_reagent.name, "volume" = round(reagent.volume, 0.01), "mass" = inverse_reagent.mass, "purity" = round(reagent.get_inverse_purity(), 0.01)*100, "selected" = in_range, "color" = "#b60046", "type" = "Inverted")))
 				data["peakHeight"] = max(data["peakHeight"], reagent.volume)
 				continue
 			if(reagent.mass < lower_mass_range || reagent.mass > upper_mass_range)
@@ -331,7 +331,7 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 			if(inverse_reagent.mass < lower_mass_range || inverse_reagent.mass > upper_mass_range)
 				continue
 			log += list(inverse_reagent.type = "Cannot purify inverted") //Might as well make it do something - just updates the reagent's name
-			beaker2.reagents.add_reagent(reagent.inverse_chem, volume, reagtemp = beaker1.reagents.chem_temp, added_purity = 1-reagent.purity)
+			beaker2.reagents.add_reagent(reagent.inverse_chem, volume, reagtemp = beaker1.reagents.chem_temp, added_purity = reagent.get_inverse_purity())
 			beaker1.reagents.remove_reagent(reagent.type, volume)
 			continue
 
@@ -397,7 +397,6 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 			continue
 		if(reagent.mass < lower_mass_range || reagent.mass > upper_mass_range)
 			continue
-		var/inverse_purity = 1-reagent.purity
-		time += (((reagent.mass * reagent.volume) + (reagent.mass * inverse_purity * 0.1)) * 0.0035) + 10 ///Roughly 10 - 30s?
+		time += (((reagent.mass * reagent.volume) + (reagent.mass * reagent.get_inverse_purity() * 0.1)) * 0.0035) + 10 ///Roughly 10 - 30s?
 	delay_time = (time * cms_coefficient)
 	return delay_time

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -246,6 +246,19 @@ Primarily used in reagents/reaction_agents
 	return creation_purity / normalise_num_to
 
 /**
+ * Gets the inverse purity of this reagent. Mostly used when converting from a normal reagent to it's inverse one.
+ *
+ * Arguments
+ * * purity - Overrides the purity used for determining the inverse purity.
+ */
+/datum/reagent/proc/get_inverse_purity(purity)
+	if(!inverse_chem || !inverse_chem_val)
+		return
+	if(!purity)
+		purity = src.purity
+	return min(1-inverse_chem_val + purity + 0.01, 1) //Gives inverse reactions a 1% purity threshold for being 100% pure to appease players with OCD.
+
+/**
  * Input a reagent_list, outputs pretty readable text!
  * Default output will be formatted as
  * * water, 5 | silicon, 6 | soup, 4 | space lube, 8

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -154,7 +154,7 @@
 		if((reaction_flags & REACTION_CLEAR_INVERSE) && reagent.inverse_chem)
 			if(reagent.inverse_chem_val > reagent.purity)
 				holder.remove_reagent(reagent.type, cached_volume, FALSE)
-				holder.add_reagent(reagent.inverse_chem, cached_volume, FALSE, added_purity = 1-cached_purity)
+				holder.add_reagent(reagent.inverse_chem, cached_volume, FALSE, added_purity = reagent.get_inverse_purity(cached_purity))
 				return
 
 /**


### PR DESCRIPTION
## About The Pull Request

fixes #71356

This PR changes how inverse reagent purity is calculated in general. Read #71356 for more information as to why I'm doing this.

Inverse reagent purity is now calculated based on how close to the inverse reagent threshold you are. The closer you are to it while still being under it, the higher the purity.

Reagents sort of just explode if you get to a low enough purity so the previous system didn't work and for some chemicals the maximum purity could be as low as 25%! (super melatonin)

The inverse reagent conversion when being injected into a target also had it's purity completely broken. Those ones are affected even worse than reagents that are automatically converted into their inverse reagents after a reaction. (prohol)

Now you can get 100% pure inverse reagents as long as you make your recipes, well, good. This also adds a 1% threshold for 100% purity so that people can get 100% pure inverse reagents. (You physically couldn't get them otherwise.)

## Why It's Good For The Game

Being able to get 100% pure inverse reagents is rather nice, ya know?
This is a bugfix PR anyways.

## Changelog

:cl:
fix: You can now get 100% pure inverse reagents.
/:cl:
