### PR TITLE
Fix TGUI Dev Server on 514!

### DIFF
--- a/tgui/packages/tgui-dev-server/reloader.js
+++ b/tgui/packages/tgui-dev-server/reloader.js
@@ -66,7 +66,7 @@ export const findCacheRoot = async () => {
 
 const onCacheRootFound = (cacheRoot) => {
   logger.log(`found cache at '${cacheRoot}'`);
-  // Plant a dummy browser window file, we'll be using this to avoid world topic
+  // Plant a dummy browser window file, we'll be using this to avoid world topic. For byond 514.
   fs.closeSync(fs.openSync(cacheRoot + '/dummy', 'w'));
 };
 
@@ -98,7 +98,7 @@ export const reloadByondCache = async (bundleDir) => {
       './*.+(bundle|chunk|hot-update).*'
     );
     try {
-      // Plant a dummy browser window file, we'll be using this to avoid world topic
+      // Plant a dummy browser window file, we'll be using this to avoid world topic. For byond 515.
       fs.closeSync(fs.openSync(cacheDir + '/dummy', 'w'));
 
       for (let file of garbage) {

--- a/tgui/packages/tgui-dev-server/reloader.js
+++ b/tgui/packages/tgui-dev-server/reloader.js
@@ -66,6 +66,8 @@ export const findCacheRoot = async () => {
 
 const onCacheRootFound = (cacheRoot) => {
   logger.log(`found cache at '${cacheRoot}'`);
+  // Plant a dummy browser window file, we'll be using this to avoid world topic
+  fs.closeSync(fs.openSync(cacheRoot + '/dummy', 'w'));
 };
 
 export const reloadByondCache = async (bundleDir) => {


### PR DESCRIPTION

## About The Pull Request
Makes the dev server actually work on 514 again by reverting a removal in reloader.js!

#71161 didn't take into account that we still use 514 in their TGUI edits. Pain.
## Why It's Good For The Game
TGUI dev server works again, this is a good thing, I think!
## Changelog
Not player facing!
