### PR TITLE
Replaces some bad trait sources and updates two trait names

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -760,7 +760,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 ///stops someone from splashing their reagent_container on an object with this trait
 #define TRAIT_DO_NOT_SPLASH "do_not_splash"
 /// Marks an atom when the cleaning of it is first started, so that the cleaning overlay doesn't get removed prematurely
-#define CURRENTLY_CLEANING "currently_cleaning"
+#define TRAIT_CURRENTLY_CLEANING "currently_cleaning"
 
 // unique trait sources, still defines
 #define STATUE_MUTE "statue"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -758,7 +758,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Trait from [/datum/element/rust]. Its rusty and should be applying a special overlay to denote this.
 #define TRAIT_RUSTY "rust_trait"
 ///stops someone from splashing their reagent_container on an object with this trait
-#define DO_NOT_SPLASH "do_not_splash"
+#define TRAIT_DO_NOT_SPLASH "do_not_splash"
 /// Marks an atom when the cleaning of it is first started, so that the cleaning overlay doesn't get removed prematurely
 #define CURRENTLY_CLEANING "currently_cleaning"
 

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -88,8 +88,8 @@
  * * clean_target set this to false if the target should not be washed and if experience should not be awarded to the user
  */
 /datum/component/cleaner/proc/clean(datum/source, atom/target, mob/living/user, clean_target = TRUE)
-	if(!HAS_TRAIT(target, CURRENTLY_CLEANING)) //add the trait and overlay
-		ADD_TRAIT(target, CURRENTLY_CLEANING, REF(src))
+	if(!HAS_TRAIT(target, TRAIT_CURRENTLY_CLEANING)) //add the trait and overlay
+		ADD_TRAIT(target, TRAIT_CURRENTLY_CLEANING, REF(src))
 
 		// We need to update our planes on overlay changes
 		RegisterSignal(target, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(cleaning_target_moved))
@@ -128,7 +128,7 @@
 	target.cut_overlay(low_bubble)
 	target.cut_overlay(high_bubble)
 	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED)
-	REMOVE_TRAIT(target, CURRENTLY_CLEANING, REF(src))
+	REMOVE_TRAIT(target, TRAIT_CURRENTLY_CLEANING, REF(src))
 
 /datum/component/cleaner/proc/cleaning_target_moved(atom/movable/source, turf/old_turf, turf/new_turf, same_z_layer)
 	if(same_z_layer)

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -89,7 +89,7 @@
  */
 /datum/component/cleaner/proc/clean(datum/source, atom/target, mob/living/user, clean_target = TRUE)
 	if(!HAS_TRAIT(target, CURRENTLY_CLEANING)) //add the trait and overlay
-		ADD_TRAIT(target, CURRENTLY_CLEANING, src)
+		ADD_TRAIT(target, CURRENTLY_CLEANING, REF(src))
 
 		// We need to update our planes on overlay changes
 		RegisterSignal(target, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(cleaning_target_moved))
@@ -128,7 +128,7 @@
 	target.cut_overlay(low_bubble)
 	target.cut_overlay(high_bubble)
 	UnregisterSignal(target, COMSIG_MOVABLE_Z_CHANGED)
-	REMOVE_TRAIT(target, CURRENTLY_CLEANING, src)
+	REMOVE_TRAIT(target, CURRENTLY_CLEANING, REF(src))
 
 /datum/component/cleaner/proc/cleaning_target_moved(atom/movable/source, turf/old_turf, turf/new_turf, same_z_layer)
 	if(same_z_layer)

--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -172,7 +172,7 @@
 	if(SEND_SIGNAL(parent, COMSIG_TWOHANDED_WIELD, user) & COMPONENT_TWOHANDED_BLOCK_WIELD)
 		return // blocked wield from item
 	wielded = TRUE
-	ADD_TRAIT(parent,TRAIT_WIELDED,src)
+	ADD_TRAIT(parent, TRAIT_WIELDED, REF(src))
 	RegisterSignal(user, COMSIG_MOB_SWAP_HANDS, PROC_REF(on_swap_hands))
 	wield_callback?.Invoke(parent, user)
 
@@ -221,7 +221,7 @@
 	wielded = FALSE
 	UnregisterSignal(user, COMSIG_MOB_SWAP_HANDS)
 	SEND_SIGNAL(parent, COMSIG_TWOHANDED_UNWIELD, user)
-	REMOVE_TRAIT(parent,TRAIT_WIELDED,src)
+	REMOVE_TRAIT(parent, TRAIT_WIELDED, REF(src))
 	unwield_callback?.Invoke(parent, user)
 
 	// update item stats

--- a/code/modules/explorer_drone/loot.dm
+++ b/code/modules/explorer_drone/loot.dm
@@ -173,7 +173,7 @@ GLOBAL_LIST_INIT(adventure_loot_generator_index,generate_generator_index())
 	if(!cell.use(charge_per_use))
 		to_chat(user,span_warning("[src] battery ran dry!"))
 		return
-	ADD_TRAIT(user,TRAIT_IMMOBILIZED,src)
+	ADD_TRAIT(user, TRAIT_IMMOBILIZED, REF(src))
 	to_chat(user,span_notice("You begin to charge [src]"))
 	inhand_icon_state = "firelance_charging"
 	user.update_held_items()
@@ -186,7 +186,7 @@ GLOBAL_LIST_INIT(adventure_loot_generator_index,generate_generator_index())
 				turf_to_melt.Melt()
 	inhand_icon_state = initial(inhand_icon_state)
 	user.update_held_items()
-	REMOVE_TRAIT(user,TRAIT_IMMOBILIZED,src)
+	REMOVE_TRAIT(user, TRAIT_IMMOBILIZED, REF(src))
 
 /// Additional windup checks
 /obj/item/firelance/proc/windup_checks()

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -37,7 +37,7 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 
 /obj/machinery/chem_mass_spec/Initialize(mapload)
 	. = ..()
-	ADD_TRAIT(src, TRAIT_DO_NOT_SPLASH, type)
+	ADD_TRAIT(src, TRAIT_DO_NOT_SPLASH, INNATE_TRAIT)
 	if(mapload)
 		beaker2 = new /obj/item/reagent_containers/cup/beaker/large(src)
 

--- a/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_mass_spec.dm
@@ -37,7 +37,7 @@ This will not clean any inverted reagents. Inverted reagents will still be corre
 
 /obj/machinery/chem_mass_spec/Initialize(mapload)
 	. = ..()
-	ADD_TRAIT(src, DO_NOT_SPLASH, src.type)
+	ADD_TRAIT(src, TRAIT_DO_NOT_SPLASH, type)
 	if(mapload)
 		beaker2 = new /obj/item/reagent_containers/cup/beaker/large(src)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -82,7 +82,7 @@
 	mode_change_message(user)
 
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
-	if(HAS_TRAIT(target, DO_NOT_SPLASH))
+	if(HAS_TRAIT(target, TRAIT_DO_NOT_SPLASH))
 		return ..()
 	if(!user.combat_mode)
 		return ..()


### PR DESCRIPTION
## About The Pull Request

Traits should never use a hard reference as their trait source, if you want to use a "reference" to a datum use `REF()` instead, or it will cause hard deletes

Also renamed some traits which didn't use the "standard" scheme, because I saw it while regexing 

## Why It's Good For The Game

- Prevents some hard deletes
- Uses a less confusing naming scheme

## Changelog

Not necessary