### PR TITLE
Fixes some fractal soulstone naming issues.

### DIFF
--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -71,7 +71,7 @@
 
 	var/mob/living/simple_animal/shade/shade = locate() in src
 	if(shade)
-		// "(dull) soultone: Urist McCaptain"
+		// "(dull) soulstone: Urist McCaptain"
 		name = "[name]: [shade.real_name]"
 
 /obj/item/soulstone/update_desc(updates)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -9,6 +9,8 @@
 	desc = "A fragment of the legendary treasure known simply as the 'Soul Stone'. The shard still flickers with a fraction of the full artefact's power."
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = ITEM_SLOT_BELT
+	/// The base name of the soulstone, set to the initial name by default. Used in name updating
+	var/base_name
 	/// if TRUE, we can only be used once.
 	var/one_use = FALSE
 	/// Only used if one_use is TRUE. Whether it's used.
@@ -27,6 +29,8 @@
 	. = ..()
 	if(theme != THEME_HOLY)
 		RegisterSignal(src, COMSIG_BIBLE_SMACKED, PROC_REF(on_bible_smacked))
+	if(!base_name)
+		base_name = initial(name)
 
 /obj/item/soulstone/update_appearance(updates)
 	. = ..()
@@ -60,15 +64,15 @@
 
 /obj/item/soulstone/update_name(updates)
 	. = ..()
+	name = base_name
 	if(spent)
+		// "dull soulstone"
 		name = "dull [name]"
-		return
 
 	var/mob/living/simple_animal/shade/shade = locate() in src
 	if(shade)
+		// "(dull) soultone: Urist McCaptain"
 		name = "[name]: [shade.real_name]"
-	else
-		name = initial(name)
 
 /obj/item/soulstone/update_desc(updates)
 	. = ..()
@@ -548,6 +552,7 @@
 /obj/item/soulstone/anybody/chaplain/sparring/Initialize(mapload)
 	. = ..()
 	name = "[GLOB.deity]'s punishment"
+	base_name = name
 	desc = "A prison for those who lost [GLOB.deity]'s game."
 
 /obj/item/soulstone/anybody/mining


### PR DESCRIPTION
## About The Pull Request

Fixes #71378

Soulstone names didn't reset between name updates, so anything that caused one, caused the names to spiral out of control

I'd replace it with just `initial()`s, but some soulstones (namely, the "divine punishment") stone takes on a new name in initialized based on the chaplain's deity. 

So, I added a base name var, for use in the name updating.

## Why It's Good For The Game

Soultone: Shade of shade of shade of shade of...

## Changelog

:cl: Melbert
fix: Soulstone names should no longer become bizarre after repeated use. 
/:cl:

