### PR TITLE
Fixes absent spread_text instances 

### DIFF
--- a/code/datums/diseases/adrenal_crisis.dm
+++ b/code/datums/diseases/adrenal_crisis.dm
@@ -12,6 +12,7 @@
 	severity = DISEASE_SEVERITY_MEDIUM
 	disease_flags = CAN_CARRY|CAN_RESIST
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+	spread_text = "Organ failure"
 	visibility_flags = HIDDEN_PANDEMIC
 	bypasses_immunity = TRUE
 

--- a/code/datums/diseases/cold.dm
+++ b/code/datums/diseases/cold.dm
@@ -1,12 +1,13 @@
 /datum/disease/cold
 	name = "The Cold"
+	desc = "If left untreated the subject will contract the flu."
 	max_stages = 3
 	cure_text = "Rest & Spaceacillin"
 	cures = list(/datum/reagent/medicine/spaceacillin)
 	agent = "XY-rhinovirus"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	spreading_modifier = 0.5
-	desc = "If left untreated the subject will contract the flu."
+	spread_text = "Airborne"
 	severity = DISEASE_SEVERITY_NONTHREAT
 
 

--- a/code/datums/diseases/decloning.dm
+++ b/code/datums/diseases/decloning.dm
@@ -11,7 +11,7 @@
 	cures = list(/datum/reagent/medicine/rezadone)
 	disease_flags = CAN_CARRY|CAN_RESIST
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
-	spread_text = "Organic Meltdown"
+	spread_text = "Organic meltdown"
 	process_dead = TRUE
 
 /datum/disease/decloning/stage_act(delta_time, times_fired)

--- a/code/datums/diseases/decloning.dm
+++ b/code/datums/diseases/decloning.dm
@@ -11,6 +11,7 @@
 	cures = list(/datum/reagent/medicine/rezadone)
 	disease_flags = CAN_CARRY|CAN_RESIST
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+	spread_text = "Organic Meltdown"
 	process_dead = TRUE
 
 /datum/disease/decloning/stage_act(delta_time, times_fired)

--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -11,6 +11,7 @@
 	severity = "Dangerous!"
 	disease_flags = CAN_CARRY|CAN_RESIST
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
+	spread_text = "Organ Failure"
 	visibility_flags = HIDDEN_PANDEMIC
 	required_organs = list(/obj/item/organ/internal/heart)
 	bypasses_immunity = TRUE // Immunity is based on not having an appendix; this isn't a virus

--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -11,7 +11,7 @@
 	severity = "Dangerous!"
 	disease_flags = CAN_CARRY|CAN_RESIST
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
-	spread_text = "Organ Failure"
+	spread_text = "Organ failure"
 	visibility_flags = HIDDEN_PANDEMIC
 	required_organs = list(/obj/item/organ/internal/heart)
 	bypasses_immunity = TRUE // Immunity is based on not having an appendix; this isn't a virus


### PR DESCRIPTION

## About The Pull Request

spread_text dictates the readout next to "type" on a health analyzer's output. It was absent from some special diseases (and also the common cold), leading to the field being blank on the analyzer results.
## Why It's Good For The Game

Closes #71379.
## Changelog
:cl:
spellcheck: Adds spread text to some diseases that lacked it.
/:cl:
