### PR TITLE
Makes ruin blacklist file actually set from JSON

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -172,6 +172,9 @@
 	if ("minetype" in json)
 		minetype = json["minetype"]
 
+	if ("blacklist_file" in json)
+		blacklist_file = json["blacklist_file"]
+
 	allow_custom_shuttles = json["allow_custom_shuttles"] != FALSE
 
 	if ("job_changes" in json)


### PR DESCRIPTION
## About The Pull Request

Json was never checked for the blacklist file, meaning icebox didn't have any blacklisted ruins.

Now:
![image](https://user-images.githubusercontent.com/53777086/202890015-6d5df1ef-c03e-4392-857a-3ff317ffc2d3.png)

## Why It's Good For The Game

I broke icebox's blacklist by fixing lavalands, hopefully now both will work.

Fixes https://github.com/tgstation/tgstation/issues/71377

## Changelog

:cl:
fix: Icebox's blacklisted ruins works again.
/:cl: