### PR TITLE
Sign Language Hotfix

### DIFF
--- a/code/datums/components/sign_language.dm
+++ b/code/datums/components/sign_language.dm
@@ -42,8 +42,6 @@
 		stack_trace("Sign Language component added to [parent] ([parent?.type]) which is not a /mob/living/carbon subtype.")
 		return COMPONENT_INCOMPATIBLE
 	linked_action = new(src)
-	linked_action.Grant(parent)
-	linked_action.UpdateButtons()
 
 /datum/component/sign_language/Destroy()
 	QDEL_NULL(linked_action)
@@ -53,6 +51,8 @@
 	// Sign language is toggled on/off via adding/removing TRAIT_SIGN_LANG.
 	RegisterSignal(parent, SIGNAL_ADDTRAIT(TRAIT_SIGN_LANG), PROC_REF(enable_sign_language))
 	RegisterSignal(parent, SIGNAL_REMOVETRAIT(TRAIT_SIGN_LANG), PROC_REF(disable_sign_language))
+	linked_action.Grant(parent)
+	linked_action.UpdateButtons()
 
 /datum/component/sign_language/UnregisterFromParent()
 	disable_sign_language()


### PR DESCRIPTION
## About The Pull Request
This is a hot-fix for PR #71265

In PR #71265 there was a minor oversight, which caused a bug. The bug occurred when the Mute and Signer traits were added out-of-order, and the mob would be totally unable to talk. The bug was introduced accidentally when a late-change was added to the PR to have the component add an Action. The Action was responsible for toggling-on sign language if the mob was mute, but in this case was doing so before the neccesary signals were registered.

This PR fixes the bug by moving the Action's Grant call to after necessary signals.

## Why It's Good For The Game
Due to my oversight and some last-minute changes from maintainers, some people who spawn with Mute and Signer will be totally unable to communicate. This PR fixes the bug, which I noticed affects downstreams more than TG for some reason.

## Changelog
:cl: A.C.M.O.
fix: Fixed a bug that caused the Signer quirk to stop working as expected when used with the Mute quirk.
/:cl: