### PR TITLE
Corrects the name of Delta's Port Bow Solar's airlock

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -87085,7 +87085,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/engineering{
-	name = "Starboard Quarter Solar Access"
+	name = "Port Bow Solar Access"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1


### PR DESCRIPTION

## About The Pull Request

This airlock was called Starboard Quarter, its not starboard nor quarter.
## Why It's Good For The Game

Port Left, Starboard Right.
## Changelog
:cl:
fix: Delta's Port Bow Solar is now correctly labelled.
/:cl:
