### PR TITLE
Revert "Hotkey-based inventory management now applies the click cooldown to prevent it from being abusable in combat scenarios."

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -367,7 +367,7 @@
 
 /// take the most recent item out of a slot or place held item in a slot
 
-/mob/living/carbon/human/proc/smart_equip_targeted(slot_type = ITEM_SLOT_BELT, slot_item_name = "belt", delayed = TRUE)
+/mob/living/carbon/human/proc/smart_equip_targeted(slot_type = ITEM_SLOT_BELT, slot_item_name = "belt")
 	if(incapacitated())
 		return
 	var/obj/item/thing = get_active_held_item()
@@ -398,6 +398,4 @@
 	if(!stored || stored.on_found(src))
 		return
 	stored.attack_hand(src) // take out thing from item in storage slot
-	if(delayed)
-		changeNext_move(CLICK_CD_MELEE)
 	return


### PR DESCRIPTION
Reverts tgstation/tgstation#71325

I have changed my mind and I think instead drawing items from any inventory slot by hotkey or click should have a do after cooldown, possibly an animation so people can see items coming out. Thus removing the principle of surprise unless they use a stealthy item from say a pocket.

Backpacks should have a slower withdraw time than belts and suit storage/pocket slots

@Mothblocks thoughts