### PR TITLE
Logs / messages when uploads are made

### DIFF
--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -8,6 +8,9 @@
 /obj/machinery/computer/upload/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/gps, "Encrypted Upload")
+	if(!mapload)
+		log_silicon("\A [name] was created at [loc_name(src)].")
+		message_admins("\A [name] was created at [ADMIN_VERBOSEJMP(src)].")
 
 /obj/machinery/computer/upload/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/ai_module))


### PR DESCRIPTION
## About The Pull Request

Adds a `message_admins` and silicon log when an upload console is created

## Why It's Good For The Game

Helps admins keep track during AI upload wars.

## Changelog

:cl: Melbert
admin: AI uploads constructed midround will now give an admin message and log to silicon log
/:cl:

