### PR TITLE
More expanded multi-web support

### DIFF
--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -179,8 +179,9 @@
  * * message - The message to announce
  */
 /datum/component/experiment_handler/proc/announce_message_to_all(message)
-	for(var/experiment in GLOB.experiment_handlers)
-		var/datum/component/experiment_handler/experi_handler = experiment
+	for(var/datum/component/experiment_handler/experi_handler as anything in GLOB.experiment_handlers)
+		if(experi_handler.linked_web != linked_web)
+			continue
 		var/atom/movable/experi_parent = experi_handler.parent
 		experi_parent.say(message)
 
@@ -353,17 +354,22 @@
 	. = list(
 		"always_active" = config_flags & EXPERIMENT_CONFIG_ALWAYS_ACTIVE,
 		"has_start_callback" = !isnull(start_experiment_callback))
-	.["servers"] = list()
-	for (var/obj/machinery/rnd/server/server in get_available_servers())
+	.["techwebs"] = list()
+	for (var/datum/techweb/techwebs as anything in SSresearch.techwebs)
+		if(!length(techwebs.techweb_servers)) //no servers, we don't care
+			continue
+		var/obj/machinery/rnd/server = techwebs.techweb_servers[1] //get the first machine possible
+		if(!is_valid_z_level(get_turf(user), get_turf(server)))
+			continue
 		var/list/data = list(
 			name = server.name,
-			web_id = server.stored_research?.id,
-			web_org = server.stored_research?.organization,
-			location = get_area(server),
-			selected = !isnull(linked_web) && server.stored_research == linked_web,
-			ref = REF(server)
+			web_id = techwebs.id,
+			web_org = techwebs.organization,
+			selected = (techwebs == linked_web),
+			ref = REF(server),
+			all_servers = techwebs.techweb_servers,
 		)
-		.["servers"] += list(data)
+		.["techwebs"] += list(data)
 	.["experiments"] = list()
 	if (linked_web)
 		for (var/datum/experiment/experiment in linked_web.available_experiments)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -49,7 +49,7 @@ Nothing else in the console has ID requirements.
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link))
 		stored_research = SSresearch.science_tech
-		stored_research.consoles_accessing[src] = TRUE
+		stored_research.consoles_accessing += src
 
 /obj/machinery/computer/rdconsole/Destroy()
 	if(stored_research)
@@ -153,13 +153,14 @@ Nothing else in the console has ID requirements.
 
 /obj/machinery/computer/rdconsole/ui_assets(mob/user)
 	return list(
-		get_asset_datum(/datum/asset/spritesheet/research_designs)
+		get_asset_datum(/datum/asset/spritesheet/research_designs),
 	)
 
 // heavy data from this proc should be moved to static data when possible
 /obj/machinery/computer/rdconsole/ui_data(mob/user)
 	var/list/data = list()
 	data["stored_research"] = !!stored_research
+	data["locked"] = locked
 	if(!stored_research) //lack of a research node is all we care about.
 		return data
 	data += list(
@@ -172,7 +173,6 @@ Nothing else in the console has ID requirements.
 		"sec_protocols" = !(obj_flags & EMAGGED),
 		"t_disk" = null,
 		"d_disk" = null,
-		"locked" = locked,
 	)
 
 	if (t_disk)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -30,9 +30,14 @@
 	if(CONFIG_GET(flag/no_default_techweb_link))
 		stored_research = new /datum/techweb
 	SSresearch.servers |= src
+	stored_research.techweb_servers |= src
 	name += " [num2hex(rand(1,65535), -1)]" //gives us a random four-digit hex number as part of the name. Y'know, for fluff.
 
 /obj/machinery/rnd/server/Destroy()
+	if(stored_research)
+		stored_research.techweb_servers -= src
+	if(CONFIG_GET(flag/no_default_techweb_link))
+		QDEL_NULL(stored_research)
 	SSresearch.servers -= src
 	return ..()
 

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -7,6 +7,11 @@
  * on research consoles, servers, and disks. They are NOT global.
  */
 /datum/techweb
+	///The id/name of the whole Techweb viewable to players.
+	var/id = "Generic"
+	/// Organization name, used for display
+	var/organization = "Third-Party"
+
 	/// Already unlocked and all designs are now available. Assoc list, id = TRUE
 	var/list/researched_nodes = list()
 	/// Visible nodes, doesn't mean it can be researched. Assoc list, id = TRUE
@@ -25,12 +30,8 @@
 	var/list/deconstructed_items = list()
 	/// Available research points, type = number
 	var/list/research_points = list()
-	var/list/obj/machinery/computer/rdconsole/consoles_accessing = list()
-	var/id = "generic"
 	/// IC logs
 	var/list/research_logs = list()
-	/// Organization name, used for display
-	var/organization = "Third-Party"
 	/// Current per-second production, used for display only.
 	var/list/last_bitcoins = list()
 	/// Mutations discovered by genetics, this way they are shared and cant be destroyed by destroying a single console
@@ -41,6 +42,11 @@
 	var/list/available_experiments = list()
 	/// Completed experiments
 	var/list/completed_experiments = list()
+
+	///All RD consoles connected to this individual techweb.
+	var/list/obj/machinery/computer/rdconsole/consoles_accessing = list()
+	///All research servers connected to this individual techweb.
+	var/list/obj/machinery/rnd/server/techweb_servers = list()
 
 	/**
 	 * Assoc list of relationships with various partners
@@ -62,6 +68,7 @@
 	hidden_nodes = SSresearch.techweb_nodes_hidden.Copy()
 	initialize_published_papers()
 	return ..()
+
 /datum/techweb/admin
 	id = "ADMIN"
 	organization = "CentCom"
@@ -74,14 +81,6 @@
 	for(var/i in SSresearch.point_types)
 		research_points[i] = INFINITY
 	hidden_nodes = list()
-
-/datum/techweb/science //Global science techweb for RND consoles.
-	id = "SCIENCE"
-	organization = "Nanotrasen"
-
-/datum/techweb/bepis //Should contain only 1 BEPIS tech selected at random.
-	id = "EXPERIMENTAL"
-	organization = "Nanotrasen R&D"
 
 /datum/techweb/bepis/New(remove_tech = TRUE)
 	. = ..()
@@ -285,8 +284,7 @@
  */
 /datum/techweb/proc/add_experiments(list/experiment_list)
 	. = TRUE
-	for (var/experiment_type in experiment_list)
-		var/datum/experiment/experiment = experiment_type
+	for (var/datum/experiment/experiment as anything in experiment_list)
 		. = . && add_experiment(experiment)
 
 /**
@@ -331,11 +329,6 @@
 		var/datum/bank_account/science_department_bank_account = SSeconomy.get_dep_account(ACCOUNT_SCI)
 		science_department_bank_account?.adjust_money(SSeconomy.techweb_bounty)
 	return TRUE
-
-/datum/techweb/science/research_node(datum/techweb_node/node, force = FALSE, auto_adjust_cost = TRUE, get_that_dosh = TRUE) //When something is researched, triggers the proc for this techweb only
-	. = ..()
-	if(.)
-		node.on_research()
 
 /datum/techweb/proc/unresearch_node_id(id)
 	return unresearch_node(SSresearch.techweb_node_by_id(id))
@@ -523,3 +516,16 @@
 			handler.announce_message_to_all("The [experiment.name] has been completed!")
 
 	return TRUE
+
+/datum/techweb/science //Global science techweb for RND consoles.
+	id = "SCIENCE"
+	organization = "Nanotrasen"
+
+/datum/techweb/science/research_node(datum/techweb_node/node, force = FALSE, auto_adjust_cost = TRUE, get_that_dosh = TRUE) //When something is researched, triggers the proc for this techweb only
+	. = ..()
+	if(.)
+		node.on_research()
+
+/datum/techweb/bepis //Should contain only 1 BEPIS tech selected at random.
+	id = "EXPERIMENTAL"
+	organization = "Nanotrasen R&D"

--- a/tgui/packages/tgui/interfaces/ExperimentConfigure.js
+++ b/tgui/packages/tgui/interfaces/ExperimentConfigure.js
@@ -53,28 +53,26 @@ const ExperimentStageRow = (props) => {
 
 export const TechwebServer = (props, context) => {
   const { act, data } = useBackend(context);
-  const { servers } = props;
+  const { techwebs } = props;
 
-  return (
-    <Box m={1} className="ExperimentTechwebServer__Web">
+  return techwebs.map((server, index) => (
+    <Box key={index} m={1} className="ExperimentTechwebServer__Web">
       <Flex
         align="center"
         justify="space-between"
         className="ExperimentTechwebServer__WebHeader">
         <Flex.Item className="ExperimentTechwebServer__WebName">
-          {servers[0].web_id} / {servers[0].web_org}
+          {server.web_id} / {server.web_org}
         </Flex.Item>
         <Flex.Item>
           <Button
             onClick={() =>
-              servers[0].selected
+              server.selected
                 ? act('clear_server')
-                : act('select_server', { 'ref': servers[0].ref })
+                : act('select_server', { 'ref': server.ref })
             }
-            content={servers[0].selected ? 'Disconnect' : 'Connect'}
-            backgroundColor={
-              servers[0].selected ? 'good' : 'rgba(0, 0, 0, 0.4)'
-            }
+            content={server.selected ? 'Disconnect' : 'Connect'}
+            backgroundColor={server.selected ? 'good' : 'rgba(0, 0, 0, 0.4)'}
             className="ExperimentTechwebServer__ConnectButton"
           />
         </Flex.Item>
@@ -84,29 +82,25 @@ export const TechwebServer = (props, context) => {
           Connectivity to this web is maintained by the following servers...
         </span>
         <LabeledList>
-          {servers.map((server, index) => {
-            return (
-              <LabeledList.Item key={index} label={server.name}>
-                <i>Located in {server.location}</i>
-              </LabeledList.Item>
-            );
-          })}
+          {server.all_servers.map((individual_servers, new_index) => (
+            <Box key={new_index}>{individual_servers}</Box>
+          ))}
         </LabeledList>
       </Box>
     </Box>
-  );
+  ));
 };
 
 export const ExperimentConfigure = (props, context) => {
   const { act, data } = useBackend(context);
   const { always_active, has_start_callback } = data;
-  let servers = data.servers ?? [];
+  let techwebs = data.techwebs ?? [];
 
   const experiments = sortBy((exp) => exp.name)(data.experiments ?? []);
 
   // Group servers together by web
   let webs = new Map();
-  servers.forEach((x) => {
+  techwebs.forEach((x) => {
     if (x.web_id !== null) {
       if (!webs.has(x.web_id)) {
         webs.set(x.web_id, []);
@@ -127,13 +121,13 @@ export const ExperimentConfigure = (props, context) => {
                   : 'Found no available techwebs!'}
               </Box>
               {webs.size > 0 &&
-                Array.from(webs, ([techweb, servers]) => (
-                  <TechwebServer key={techweb} servers={servers} />
+                Array.from(webs, ([techweb, techwebs]) => (
+                  <TechwebServer key={techweb} techwebs={techwebs} />
                 ))}
             </Section>
           </Flex.Item>
           <Flex.Item mb={has_start_callback ? 1 : 0} grow={1}>
-            {servers.some((e) => e.selected) && (
+            {techwebs.some((e) => e.selected) && (
               <Section
                 title="Experiments"
                 className="ExperimentConfigure__ExperimentsContainer">

--- a/tgui/packages/tgui/interfaces/Techweb.js
+++ b/tgui/packages/tgui/interfaces/Techweb.js
@@ -92,30 +92,30 @@ export const Techweb = (props, context) => {
 };
 
 const TechwebStart = (props, context) => {
-  const { act, data } = useRemappedBackend(context);
+  const { act, data } = useBackend(context);
   const { locked, stored_research } = data;
-  return (
-    <>
-      {!!locked && (
-        <Modal width="15em" align="center" className="Techweb__LockedModal">
-          <div>
-            <b>Console Locked</b>
-          </div>
-          <Button icon="unlock" onClick={() => act('toggleLock')}>
-            Unlock
-          </Button>
-        </Modal>
-      )}
-      {!stored_research && (
-        <Modal width="25em" align="center" className="Techweb__LockedModal">
-          <div>
-            <b>No research techweb found, please synchronize the console.</b>
-          </div>
-        </Modal>
-      )}
-      <TechwebContent />
-    </>
-  );
+  if (locked) {
+    return (
+      <Modal width="15em" align="center" className="Techweb__LockedModal">
+        <div>
+          <b>Console Locked</b>
+        </div>
+        <Button icon="unlock" onClick={() => act('toggleLock')}>
+          Unlock
+        </Button>
+      </Modal>
+    );
+  }
+  if (!stored_research) {
+    return (
+      <Modal width="25em" align="center" className="Techweb__LockedModal">
+        <div>
+          <b>No research techweb found, please synchronize the console.</b>
+        </div>
+      </Modal>
+    );
+  }
+  return <TechwebContent />;
 };
 
 export const AppTechweb = (props, context) => {
@@ -124,17 +124,7 @@ export const AppTechweb = (props, context) => {
   return (
     <NtosWindow width={640} height={735}>
       <NtosWindow.Content scrollable>
-        {!!locked && (
-          <Modal width="15em" align="center" className="Techweb__LockedModal">
-            <div>
-              <b>Console Locked</b>
-            </div>
-            <Button icon="unlock" onClick={() => act('toggleLock')}>
-              Unlock
-            </Button>
-          </Modal>
-        )}
-        <TechwebContent />
+        <TechwebStart />
       </NtosWindow.Content>
     </NtosWindow>
   );


### PR DESCRIPTION
## About The Pull Request

This is a continuation of my previous PR https://github.com/tgstation/tgstation/pull/71070

That one tackled techwebs and syncing it to machines, this one primarily focuses on Generic techwebs and Experiment handlers.

### What it does

* Experiment handlers now only broadcast completed experiments over the node they're connected to
* RD consoles once again no longer bluescreen if not connected to a techweb
* RD servers now delete their techweb on deconstruction if they're the creator of it
* 'Generic' techwebs are now capitalized
* Experiment handlers now see all techwebs instead of all servers being listed under the same web, allowing there to have more than 1 techweb on the same Z level but not list it as the same. They don't show the location of the server anymore, I don't know if that's something that's wanted or not.

In-game screenshot:
![image](https://user-images.githubusercontent.com/53777086/202935208-21b1fa15-e41d-4f85-b954-619252ecd504.png)

## Why It's Good For The Game

Mostly the same reason as my previous PR, this opens up more ways to modularize techwebs and give more possibilities for ghost roles and downstreams.

## Changelog

:cl:
fix: Experisci handlers no longer show all servers as being on the same techweb if they aren't.
fix: RnD consoles no longer bluescreen if they aren't connected to a techweb, instead it will give an error message.
balance: Experisci handlers no longer show the location of RnD servers.
/:cl: