### PR TITLE
Halves the price of Malf Doomsday

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -139,7 +139,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /datum/ai_module/destructive/nuke_station
 	name = "Doomsday Device"
 	description = "Activate a weapon that will disintegrate all organic life on the station after a 450 second delay. Can only be used while on the station, will fail if your core is moved off station or destroyed."
-	cost = 130
+	cost = 70
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/nuke_station
 	unlock_text = "<span class='notice'>You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.</span>"


### PR DESCRIPTION
Yeah I used the webedit, wanna know why?

## About The Pull Request
- Sets the price of Malf AI Doomsday to 70, down from 130. This means Doomsday requires seven hacked APCs.

## Why It's Good For The Game
The Doomsday is in a weird spot.

Activating the Doomsday puts a target on your head, and sets pinpointers to your location. It automatically deactivates if you shunt or move off the Z-level, and requires you survive until full activation. For this reason, if you're planning on using the Doomsday, you will often lead into it with a borg machine, to bolster your numbers and give yourself a fighting chance.

Meanwhile, finding 13 extra APCs for the required points is very difficult if you're trying to get everything set up beforehand. So what ends up happening is you scrape together the few hidden APCs for the borg machine, and then take the APCs from the department the borg machine is dropped into, as it is stripped of humanoids that would notice blue Malf tells everywhere.

The culmination of all this is that it takes a rough 13 extra minutes after the machine is dropped (not including points spent for other powers needed to cripple tenacious crewmembers foiling your plans) to get the doomsday. Often by the time you unlock it, everyone is dead or borged, and what should be a desperate struggle between the station silicons and the remaining crew becomes "hurry up and wait". So I'm cutting the price by nearly half, to allow the Doomsday an earlier purchase.

## Changelog
:cl:
balance: The Malf AI Doomsday device now costs 70 points, down from 130.
/:cl: