### PR TITLE
Fixes the random shapeshift CI failure

### DIFF
--- a/code/modules/antagonists/heretic/magic/flesh_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/flesh_ascension.dm
@@ -22,7 +22,7 @@
 /datum/action/cooldown/spell/shapeshift/shed_human_form/do_shapeshift(mob/living/caster)
 	// When we transform into the worm, everyone nearby gets freaked out
 	for(var/mob/living/carbon/human/nearby_human in view(scare_radius, caster))
-		if(IS_HERETIC_OR_MONSTER(nearby_human))
+		if(IS_HERETIC_OR_MONSTER(nearby_human) || nearby_human == caster)
 			continue
 
 		// 25% chance to cause a trauma


### PR DESCRIPTION
The unit tests in order:

`/datum/action/cooldown/spell/shapeshift/shed_human_form` - Gives random trauma which includes mute trauma to the caster beacause they are not a heretic.
`/datum/action/cooldown/spell/shapeshift/slime_form` - Does not require speech to cast
`/datum/action/cooldown/spell/shapeshift/dragon` and following - Requires speech to cast and fails
