### PR TITLE
Fixes gas turbine scaling its output mix thermal energy, and prevents it from creating power from thermal energy it can't take.

### DIFF
--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -565,7 +565,7 @@
 	var/output_mix_heat_capacity = output_mix.heat_capacity()
 	if(!output_mix_heat_capacity)
 		return 0
-	output_mix.temperature = max((output_mix.temperature * output_mix_heat_capacity + work_done * output_mix.total_moles() * TURBINE_HEAT_CONVERSION_MULTIPLIER) / output_mix_heat_capacity, TCMB)
+	output_mix.temperature = max((output_mix.temperature * output_mix_heat_capacity + work_done * TURBINE_HEAT_CONVERSION_MULTIPLIER) / output_mix_heat_capacity, TCMB)
 	return work_done
 
 /obj/item/paper/guides/jobs/atmos/turbine

--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -565,6 +565,7 @@
 	var/output_mix_heat_capacity = output_mix.heat_capacity()
 	if(!output_mix_heat_capacity)
 		return 0
+	work_done = min(work_done, (output_mix_heat_capacity * output_mix.temperature - output_mix_heat_capacity * TCMB) / TURBINE_HEAT_CONVERSION_MULTIPLIER)
 	output_mix.temperature = max((output_mix.temperature * output_mix_heat_capacity + work_done * TURBINE_HEAT_CONVERSION_MULTIPLIER) / output_mix_heat_capacity, TCMB)
 	return work_done
 


### PR DESCRIPTION

## About The Pull Request
Removes errant mole scaling for the thermal energy loss of gases entering the turbine. Limits the amount of work it can do to only cool gas down to TCMB, preventing it from creating power from no thermal energy.
## Why It's Good For The Game
It was too silly when the turbine can cool a raging fire down to 2.7 Kelvin. Creating power from energy it can't take was also too silly.
## Changelog
:cl:
fix: Fix unnecessary mole scaling with gas turbine gas thermal energy loss from work done.
fix: The gas turbine no longer creates power from thermal energy it can't take.
/:cl:
