### PR TITLE
RND machines now use connect_techweb (automatically updates)

### DIFF
--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -21,7 +21,7 @@
 /obj/machinery/rnd/Initialize(mapload)
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link))
-		stored_research = SSresearch.science_tech
+		connect_techweb(SSresearch.science_tech)
 	wires = new /datum/wires/rnd(src)
 
 /obj/machinery/rnd/proc/connect_techweb(datum/techweb/new_techweb)


### PR DESCRIPTION
## About The Pull Request

``connect_techweb`` handles registering signals to the techweb it connects to for automatic updating on node researching, which is what is used when you multitool to connect something to it.
However, this wasn't used on its Initialize, meaning you had to connect it manually with a multitool to get the automatic updating functioning properly. This fixes that.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/71418
Techfabs work as intended now.

## Changelog

:cl:
fix: Techfabs now automatically update to researched designs again.
/:cl: