### PR TITLE
tissue hydration can now proc from your species' blood type being water (+plasma fixation doing the same for plasma)

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -453,6 +453,14 @@
 	else if(M.reagents.has_reagent(/datum/reagent/water, needs_metabolizing = FALSE))
 		M.reagents.remove_reagent(/datum/reagent/water, 0.5 * absorption_coeff)
 		. += power * 0.5
+	else if(ishuman(M))
+		var/mob/living/carbon/human/bloodyhooman = M
+		if(bloodyhooman.dna?.species?.exotic_blood == /datum/reagent/water/holywater && !(NOBLOOD in bloodyhooman.dna.species.species_traits) && bloodyhooman.blood_volume >= BLOOD_VOLUME_NORMAL + 0.5*absorption_coeff) //do NOT make this able to lower your water-blood level below BLOOD_VOLUME_NORMAL, or self-resp will be able to keep this active all the time on its own.
+			bloodyhooman.blood_volume -= 0.5*absorption_coeff
+			. += power * 0.75 //technically, if someone with holy water as their exotic blood has normal water in their bloodstream, the normal water will be prioritized over their holy water. that's an extreme edge case that would require way too much logic to cover properly, though.
+		else if(bloodyhooman.dna?.species?.exotic_blood == /datum/reagent/water && !(NOBLOOD in bloodyhooman.dna.species.species_traits) && bloodyhooman.blood_volume >= BLOOD_VOLUME_NORMAL + 0.5*absorption_coeff)
+			bloodyhooman.blood_volume -= 0.5*absorption_coeff
+			. += power * 0.5
 
 /datum/symptom/heal/water/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = 2 * actual_power
@@ -518,6 +526,10 @@
 			. += power * min(0.5, gases[/datum/gas/plasma][MOLES] * HEALING_PER_MOL)
 	if(M.reagents.has_reagent(/datum/reagent/toxin/plasma, needs_metabolizing = TRUE))
 		. += power * 0.75 //Determines how much the symptom heals if injected or ingested
+	else if(ishuman(M))
+		var/mob/living/carbon/human/bloodyhooman = M
+		if(bloodyhooman.dna?.species?.exotic_blood == /datum/reagent/toxin/plasma && !(NOBLOOD in bloodyhooman.dna.species.species_traits) && bloodyhooman.blood_volume > 0)
+			. += power * 0.75
 
 /datum/symptom/heal/plasma/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	var/heal_amt = 4 * actual_power


### PR DESCRIPTION
## About The Pull Request

The tissue hydration virus symptom can now check your "blood" itself for water, instead of merely your blood stream. If your species uses water (or holy water) as its "blood" and you have no water in your system, tissue hydration will consume your "blood" instead, provided that doing so wouldn't bring your blood volume below BLOOD_VOLUME_NORMAL.

Plasma fixation is now also triggered by your species using plasma as its "blood." Unlike tissue hydration, plasma fixation doesn't drain the reagent it checks for, so it won't drain your "blood" either. If you somehow manage to get plasma as your blood type, you've earned the passive healing, IMO.

None of this stacks with having water, holy water, or plasma in your bloodstream.

## Why It's Good For The Game

I think it's funny (and consistent).

And before someone suggests "let tissue hydration drain them to death!", allowing tissue hydration to bring your blood volume below BLOOD_VOLUME_NORMAL would let self-respiration (with its blood regeneration threshold met) keep tissue hydration triggered indefinitely and safely. Podpeople default to water as their blood type, so this is actually a feasible occurrence.

## Changelog

:cl: ATHATH
add: Humanoids of species with water or holy water for blood can now benefit from the tissue hydration symptom, provided that they have enough excess "blood" to feed it.
add: Humanoids of species with plasma for blood now trigger the effects of the plasma fixation symptom.
/:cl:
