### PR TITLE
icebox kitchen maints wiring fixed

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -28054,6 +28054,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "iCD" = (


### PR DESCRIPTION

## About The Pull Request
fixes #71416
![image](https://user-images.githubusercontent.com/54422837/203189234-77558af1-20de-4aa1-aaef-9d9ad5a9fd42.png)
## Why It's Good For The Game
having correctly wired maints at roundstart is good

## Changelog
:cl:

fix: icebox kitchen maints is now correctly wired
/:cl:
