### PR TITLE
Nerfs insulated gloves (by nerfing shocks)

### DIFF
--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -258,8 +258,8 @@
 		if(human_mob == caster)
 			continue
 		to_shock.Beam(human_mob, icon_state = "purple_lightning", time = 0.5 SECONDS)
-		if(!human_mob.can_block_magic(antimagic_flags))
-			human_mob.electrocute_act(shock_damage, to_shock, flags = SHOCK_NOGLOVES)
+		if(!human_mob.can_block_magic(antimagic_flags) && human_mob.electrocute_act(shock_damage, to_shock, flags = SHOCK_NOGLOVES))
+			human_mob.Paralyze(80)
 
 		do_sparks(4, FALSE, human_mob)
 		playsound(human_mob, 'sound/machines/defib_zap.ogg', 50, TRUE, -1)

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -259,7 +259,7 @@
 			continue
 		to_shock.Beam(human_mob, icon_state = "purple_lightning", time = 0.5 SECONDS)
 		if(!human_mob.can_block_magic(antimagic_flags) && human_mob.electrocute_act(shock_damage, to_shock, flags = SHOCK_NOGLOVES))
-			human_mob.Paralyze(80)
+			human_mob.Paralyze(8 SECONDS)
 
 		do_sparks(4, FALSE, human_mob)
 		playsound(human_mob, 'sound/machines/defib_zap.ogg', 50, TRUE, -1)

--- a/code/modules/hallucination/shock.dm
+++ b/code/modules/hallucination/shock.dm
@@ -37,12 +37,11 @@
 
 	hallucinator.playsound_local(get_turf(src), SFX_SPARKS, 100, TRUE)
 	hallucinator.adjustStaminaLoss(50)
-	hallucinator.Stun(4 SECONDS)
+	hallucinator.Knockdown(8 SECONDS)
 	hallucinator.do_jitter_animation(300) // Maximum jitter
 	hallucinator.adjust_jitter(20 SECONDS)
 
 	addtimer(CALLBACK(src, PROC_REF(reset_shock_animation)), 4 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(shock_drop)), 2 SECONDS)
 	QDEL_IN(src, 4 SECONDS)
 	return TRUE
 
@@ -55,9 +54,3 @@
 
 	hallucinator.client?.images -= electrocution_skeleton_anim
 	electrocution_skeleton_anim = null
-
-/datum/hallucination/shock/proc/shock_drop()
-	if(QDELETED(hallucinator))
-		return
-
-	hallucinator.Paralyze(6 SECONDS)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -386,7 +386,7 @@
 	//Knockdown
 	var/should_not_knockdown = ((flags & SHOCK_TESLA) && siemens_coeff <= 0.5) || (flags & SHOCK_NOSTUN)
 	if(!should_not_knockdown)
-		Knockdown(80 * siemens_coeff)
+		Knockdown(8 SECONDS * siemens_coeff)
 	//Jitter and other fluff.
 	do_jitter_animation(300)
 	adjust_jitter(20 SECONDS)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -384,8 +384,8 @@
 			var/mob/living/carbon/C = victim
 			C.electrocute_act(shock_damage*0.75, src, 1, flags)
 	//Knockdown
-	var/should_knockdown = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
-	if(should_knockdown)
+	var/should_not_knockdown = ((flags & SHOCK_TESLA) && siemens_coeff <= 0.5) || (flags & SHOCK_NOSTUN)
+	if(!should_not_knockdown)
 		Knockdown(80 * siemens_coeff)
 	//Jitter and other fluff.
 	do_jitter_animation(300)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -383,21 +383,15 @@
 		for(var/victim in shocking_queue)
 			var/mob/living/carbon/C = victim
 			C.electrocute_act(shock_damage*0.75, src, 1, flags)
-	//Stun
-	var/should_stun = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
-	if(should_stun)
-		Paralyze(40)
+	//Knockdown
+	var/should_knockdown = (!(flags & SHOCK_TESLA) || siemens_coeff > 0.5) && !(flags & SHOCK_NOSTUN)
+	if(should_knockdown)
+		Knockdown(80 * siemens_coeff)
 	//Jitter and other fluff.
 	do_jitter_animation(300)
 	adjust_jitter(20 SECONDS)
 	adjust_stutter(4 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(secondary_shock), should_stun), 2 SECONDS)
 	return shock_damage
-
-///Called slightly after electrocute act to apply a secondary stun.
-/mob/living/carbon/proc/secondary_shock(should_stun)
-	if(should_stun)
-		Paralyze(60)
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/helper)
 	if(on_fire)

--- a/code/modules/spells/spell_types/conjure_item/lighting_packet.dm
+++ b/code/modules/spells/spell_types/conjure_item/lighting_packet.dm
@@ -29,7 +29,7 @@
 	if(isliving(hit_atom))
 		var/mob/living/hit_living = hit_atom
 		if(!hit_living.can_block_magic() && hit_living.electrocute_act(80, src, flags = SHOCK_ILLUSION | SHOCK_NOGLOVES))
-			hit_living.Paralyze(80)
+			hit_living.Paralyze(8 SECONDS)
 	qdel(src)
 
 /obj/item/spellpacket/lightningbolt/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, quickstart = TRUE)

--- a/code/modules/spells/spell_types/conjure_item/lighting_packet.dm
+++ b/code/modules/spells/spell_types/conjure_item/lighting_packet.dm
@@ -28,8 +28,8 @@
 
 	if(isliving(hit_atom))
 		var/mob/living/hit_living = hit_atom
-		if(!hit_living.can_block_magic())
-			hit_living.electrocute_act(80, src, flags = SHOCK_ILLUSION)
+		if(!hit_living.can_block_magic() && hit_living.electrocute_act(80, src, flags = SHOCK_ILLUSION | SHOCK_NOGLOVES))
+			hit_living.Paralyze(80)
 	qdel(src)
 
 /obj/item/spellpacket/lightningbolt/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, quickstart = TRUE)


### PR DESCRIPTION
## About The Pull Request

The 8 second paralysis from being electrocuted has been replaced by an 8 second knockdown. The length of this knockdown can be reduced by having a low siemens coefficient (and it isn't applied at all if you're wearing insulated gloves or the like).

The Spell Packets wizard spell still hardstuns you if you're electrocuted by it, and it now has the SHOCK_NOGLOVES flag, like other shocks that don't enter your body through your arms.

Revenant light overloads also still hardstun, because it's hard for them to capitalize upon it and it's an important part of their kit.

The conditions for what does and doesn't cause a shock knockdown have been made slightly more clear in the code.

 I feel like I shouldn't have to explicitly say this, but if I know that if I don't, the comments will descend into a flame war: To be 100% clear, this PR does not actually make any direct changes to insulated gloves, and they still provide immunity to the damage and knockdowns of most shocks. The title of this PR was a joke to draw attention.

## Why It's Good For The Game

Being rendered helpless for 8 seconds because you dared to not rush for a form of shock immunity feels awful. You can still be dunked on for touching a shocked door (shovestun go brrr), but the kill (or handcuffing) isn't _as_ free as it was before.

The title was mostly a joke, but this could genuinely reduce the usage rate of insulated gloves, as the punishment for not getting them is now much less harsh.

Shocks knocking down instead of hardstunning could also allow me to re-merge liquid electricity and enriched liquid electricity in a future PR, as the latter would be much weaker.

Spell Packets still hardstuns because the hardstun from the illusory electrocution was, like, the entire point of the spell. I've given it the SHOCK_NOGLOVES flag because the electrocution comes from being hit in the chest by an enchanted packet of birdseed, not touching something with your hand.

This PR has been tested on a local test server.

## Changelog

:cl: ATHATH
balance: We've heard your complains about baton combat, and we have decided to address them by nerfing insulated gloves. The hardstun from being electrocuted is now a knockdown. This should reduce the demand for insulated gloves.
balance: The Spell Packets wizard spell still tazes you, though. It also ignores your gloves now, as the electrocution comes from being hit in the chest by an enchanted packet of birdseed, not touching something with your hand.
balance: Revenant light overloads also still hardstun, because it's hard for them to capitalize upon it and it's an important part of their kit.
/:cl: