### PR TITLE
Add development override configuration system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 ###Files and folders specified here will never be tracked.
 
+# Local overrides--you can use this to change the config for your dev environment (like setting up SQL) without worrying about committing it
+/config/dev_overrides.txt
+
 #Ignore everything in datafolder and subdirectories
 /data/**/*
 /tmp/**/*

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -84,6 +84,8 @@
 				for(var/J in legacy_configs)
 					LoadEntries(J)
 				break
+	if (fexists("[directory]/dev_overrides.txt"))
+		LoadEntries("dev_overrides.txt")
 	loadmaplist(CONFIG_MAPS_FILE)
 	LoadMOTD()
 	LoadPolicy()

--- a/config/dev_overrides_readme.txt
+++ b/config/dev_overrides_readme.txt
@@ -1,4 +1,4 @@
-# Rename this file to dev_overrides.txt in order to be able to add your own configuration
+# Make a new file named dev_overrides.txt in order to be able to add your own configuration
 # without worrying about committing. These are applied after config.txt.
 # You do not need this if you are a server operator! You should instead use the $include system.
 

--- a/config/dev_overrides_readme.txt
+++ b/config/dev_overrides_readme.txt
@@ -1,0 +1,5 @@
+# Rename this file to dev_overrides.txt in order to be able to add your own configuration
+# without worrying about committing. These are applied after config.txt.
+# You do not need this if you are a server operator! You should instead use the $include system.
+
+#STATIONNAME My Dev World


### PR DESCRIPTION
Config system will now load dev_overrides.txt automatically if it exists, but this file is in gitignore. I want to use this for configuring SQL and such easier.