### PR TITLE
Fix Flypeople food consumption

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -442,6 +442,15 @@ Behavior that's still missing from this component that original food items had t
 		if(after_eat)
 			after_eat.Invoke(eater, feeder, bitecount)
 
+		//Flypeople throw the food back up immediately
+		if(ishuman(eater))
+			var/mob/living/carbon/human/H = eater
+			if(isflyperson(H))
+				H.vomit(0, FALSE, FALSE, 2, TRUE, force=TRUE, purge_ratio = 0.67)
+				playsound(get_turf(H), 'sound/effects/splat.ogg', 50, TRUE)
+				H.visible_message(span_danger("[H] vomits on the floor!"), \
+					span_userdanger("You throw up on the floor!"))
+
 		return TRUE
 
 ///Checks whether or not the eater can actually consume the food

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -442,14 +442,12 @@ Behavior that's still missing from this component that original food items had t
 		if(after_eat)
 			after_eat.Invoke(eater, feeder, bitecount)
 
-		//Flypeople throw the food back up immediately
-		if(ishuman(eater))
-			var/mob/living/carbon/human/H = eater
-			if(isflyperson(H))
-				H.vomit(0, FALSE, FALSE, 2, TRUE, force=TRUE, purge_ratio = 0.67)
-				playsound(get_turf(H), 'sound/effects/splat.ogg', 50, TRUE)
-				H.visible_message(span_danger("[H] vomits on the floor!"), \
-					span_userdanger("You throw up on the floor!"))
+		//Invoke the eater's stomach's after_eat callback if valid
+		if(iscarbon(eater))
+			var/mob/living/carbon/C = eater
+			var/obj/item/organ/internal/stomach/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
+			if(istype(stomach))
+				stomach.after_eat(owner)
 
 		return TRUE
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -444,8 +444,8 @@ Behavior that's still missing from this component that original food items had t
 
 		//Invoke the eater's stomach's after_eat callback if valid
 		if(iscarbon(eater))
-			var/mob/living/carbon/C = eater
-			var/obj/item/organ/internal/stomach/stomach = C.getorganslot(ORGAN_SLOT_STOMACH)
+			var/mob/living/carbon/carbon_eater = eater
+			var/obj/item/organ/internal/stomach/stomach = carbon_eater.getorganslot(ORGAN_SLOT_STOMACH)
 			if(istype(stomach))
 				stomach.after_eat(owner)
 

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -156,14 +156,7 @@
 		if(isflyperson(H))
 			playsound(get_turf(src), 'sound/items/drink.ogg', 50, TRUE) //slurp
 			H.visible_message(span_alert("[H] extends a small proboscis into the vomit pool, sucking it with a slurping sound."))
-			if(reagents)
-				for(var/datum/reagent/R in reagents.reagent_list)
-					if (istype(R, /datum/reagent/consumable))
-						var/datum/reagent/consumable/nutri_check = R
-						if(nutri_check.nutriment_factor >0)
-							H.adjust_nutrition(nutri_check.nutriment_factor * nutri_check.volume)
-							reagents.remove_reagent(nutri_check.type,nutri_check.volume)
-			reagents.trans_to(H, reagents.total_volume, transfered_by = user)
+			reagents.trans_to(H, reagents.total_volume, transfered_by = user, methods = INGEST)
 			qdel(src)
 
 /obj/effect/decal/cleanable/vomit/old

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -138,16 +138,6 @@
 	name = odd_organ_name()
 	icon_state = pick("brain-x-d", "liver-x", "kidneys-x", "spinner-x", "lungs-x", "random_fly_1", "random_fly_2", "random_fly_3", "random_fly_4", "random_fly_5")
 
-/obj/item/organ/internal/stomach/fly/on_life(delta_time, times_fired)
-	if(locate(/datum/reagent/consumable) in reagents.reagent_list)
-		var/mob/living/carbon/body = owner
-		// we do not loss any nutrition as a fly when vomiting out food
-		body.vomit(0, FALSE, FALSE, 2, TRUE, force=TRUE, purge_ratio = 0.67)
-		playsound(get_turf(owner), 'sound/effects/splat.ogg', 50, TRUE)
-		body.visible_message(span_danger("[body] vomits on the floor!"), \
-					span_userdanger("You throw up on the floor!"))
-	return ..()
-
 /obj/item/organ/internal/appendix/fly
 	desc = "You have no idea what the hell this is, or how it manages to keep something alive in any capacity."
 

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -138,6 +138,15 @@
 	name = odd_organ_name()
 	icon_state = pick("brain-x-d", "liver-x", "kidneys-x", "spinner-x", "lungs-x", "random_fly_1", "random_fly_2", "random_fly_3", "random_fly_4", "random_fly_5")
 
+/obj/item/organ/internal/stomach/fly/after_eat(edible)
+	var/mob/living/carbon/body = owner
+	// we do not loss any nutrition as a fly when vomiting out food
+	body.vomit(0, FALSE, FALSE, 2, TRUE, force=TRUE, purge_ratio = 0.67)
+	playsound(get_turf(owner), 'sound/effects/splat.ogg', 50, TRUE)
+	body.visible_message(span_danger("[body] vomits on the floor!"), \
+				span_userdanger("You throw up on the floor!"))
+	return ..()
+
 /obj/item/organ/internal/appendix/fly
 	desc = "You have no idea what the hell this is, or how it manages to keep something alive in any capacity."
 

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -141,8 +141,8 @@
 /obj/item/organ/internal/stomach/fly/after_eat(edible)
 	var/mob/living/carbon/body = owner
 	ASSERT(istype(body))
-	// we do not loss any nutrition as a fly when vomiting out food
-	body.vomit(0, FALSE, FALSE, 2, TRUE, force=TRUE, purge_ratio = 0.67)
+	// we do not lose any nutrition as a fly when vomiting out food
+	body.vomit(lost_nutrition = 0, stun = FALSE, distance = 2, force = TRUE, purge_ratio = 0.67)
 	playsound(get_turf(owner), 'sound/effects/splat.ogg', 50, TRUE)
 	body.visible_message(
 		span_danger("[body] vomits on the floor!"),

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -140,11 +140,14 @@
 
 /obj/item/organ/internal/stomach/fly/after_eat(edible)
 	var/mob/living/carbon/body = owner
+	ASSERT(istype(body))
 	// we do not loss any nutrition as a fly when vomiting out food
 	body.vomit(0, FALSE, FALSE, 2, TRUE, force=TRUE, purge_ratio = 0.67)
 	playsound(get_turf(owner), 'sound/effects/splat.ogg', 50, TRUE)
-	body.visible_message(span_danger("[body] vomits on the floor!"), \
-				span_userdanger("You throw up on the floor!"))
+	body.visible_message(
+		span_danger("[body] vomits on the floor!"),
+		span_userdanger("You throw up on the floor!"),
+	)
 	return ..()
 
 /obj/item/organ/internal/appendix/fly

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -208,6 +208,7 @@
 /obj/item/organ/internal/stomach/get_availability(datum/species/owner_species)
 	return !(NOSTOMACH in owner_species.species_traits)
 
+///This gets called after the owner takes a bite of food
 /obj/item/organ/internal/stomach/proc/after_eat(atom/edible)
 	return
 

--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -208,6 +208,9 @@
 /obj/item/organ/internal/stomach/get_availability(datum/species/owner_species)
 	return !(NOSTOMACH in owner_species.species_traits)
 
+/obj/item/organ/internal/stomach/proc/after_eat(atom/edible)
+	return
+
 /obj/item/organ/internal/stomach/proc/handle_disgust(mob/living/carbon/human/disgusted, delta_time, times_fired)
 	var/old_disgust = disgusted.old_disgust
 	var/disgust = disgusted.disgust


### PR DESCRIPTION
## About The Pull Request

This PR fixes #70716 by having flypeople ingest vomited reagents into their stomach instead of directly modifying nutrition. To accomplish this, flypeople no longer vomit their entire stomach contents every life tick, which also fixes them vomiting immediately on spawn. Instead they vomit only after taking bites of food.

Since flypeople aren't currently metabolizing food the same way as other species there's a huge discrepancy in nutrition gained from food. For example, a human gets 37 nutrition from a slice of pizza and 270 nutrition from a whole margherita pizza, but a flyperson only gets 10 and 70 respectively, meaning they'd need to eat 4 entire margherita pizzas and slurp up the vomit to go from total starvation to being satiated again. With this change flypeople get ~190 nutrition from a whole margherita pizza.
## Why It's Good For The Game

Makes it easier for flypeople to stay satiated without having to consume mass amounts of food. Also makes it easier and more predictable to deal with flyperson interactions with other reagents getting in their stomach - for example, currently taking a happy pill causes flypeople to vomit due to the sugar.
## Changelog
:cl:
fix: Flypeople gain a comparable amount of nutrients from vomited food to other species (~70%, up from ~30%)
fix: Flypeople no longer vomit after drinking fluids
fix: Flypeople no longer vomit all contents of their stomach on spawn
code: Stomachs can now react to foods entering them by overriding the `after_eat` proc
/:cl:
