### PR TITLE
premium internals now increase the slots of your internals box

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -45,9 +45,9 @@
 /datum/station_trait/premium_internals_box
 	name = "Premium internals boxes"
 	trait_type = STATION_TRAIT_POSITIVE
-	weight = 10
+	weight = 5
 	show_in_report = TRUE
-	report_message = "The internals boxes for your crew have been filled with bonus equipment."
+	report_message = "The internals boxes for your crew have been upsized and filled with bonus equipment."
 	trait_to_give = STATION_TRAIT_PREMIUM_INTERNALS
 
 /datum/station_trait/bountiful_bounties

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -1101,5 +1101,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(!resolve_parent)
 		return
 
-	animate(resolve_parent, time = 1.5, loop = 0, transform = matrix().Scale(1.07, 0.9))
-	animate(time = 2, transform = null)
+	var/matrix/old_matrix = resolve_parent.transform
+	animate(resolve_parent, time = 1.5, loop = 0, transform = resolve_parent.transform.Scale(1.07, 0.9))
+	animate(time = 2, transform = old_matrix)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -563,8 +563,8 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 		new /datum/stack_recipe("extended oxygen tank box", /obj/item/storage/box/engitank), \
 		null, \
 
-		new /datum/stack_recipe("survival box", /obj/item/storage/box/survival), \
-		new /datum/stack_recipe("extended tank survival box", /obj/item/storage/box/survival/engineer), \
+		new /datum/stack_recipe("survival box", /obj/item/storage/box/survival/crafted), \
+		new /datum/stack_recipe("extended tank survival box", /obj/item/storage/box/survival/engineer/crafted), \
 		new /datum/stack_recipe("disk box", /obj/item/storage/box/disks), \
 		new /datum/stack_recipe("light tubes box", /obj/item/storage/box/lights/tubes), \
 		new /datum/stack_recipe("light bulbs box", /obj/item/storage/box/lights/bulbs), \

--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -13,6 +13,14 @@
 	/// What medipen should be present in this box?
 	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
 
+/obj/item/storage/box/survival/Initialize(mapload)
+	. = ..()
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
+		atom_storage.max_slots += 2
+		atom_storage.max_total_storage += 4
+		name = "large [name]"
+		transform = transform.Scale(1.25, 1)
+
 /obj/item/storage/box/survival/PopulateContents()
 	if(!isnull(mask_type))
 		new mask_type(src)

--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -12,16 +12,21 @@
 	var/internal_type = /obj/item/tank/internals/emergency_oxygen
 	/// What medipen should be present in this box?
 	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
+	/// Are we crafted?
+	var/crafted = FALSE
 
 /obj/item/storage/box/survival/Initialize(mapload)
 	. = ..()
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
-		atom_storage.max_slots += 2
-		atom_storage.max_total_storage += 4
-		name = "large [name]"
-		transform = transform.Scale(1.25, 1)
+	if(crafted || !HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
+		return
+	atom_storage.max_slots += 2
+	atom_storage.max_total_storage += 4
+	name = "large [name]"
+	transform = transform.Scale(1.25, 1)
 
 /obj/item/storage/box/survival/PopulateContents()
+	if(crafted)
+		return
 	if(!isnull(mask_type))
 		new mask_type(src)
 
@@ -106,6 +111,12 @@
 // Medical survival box
 /obj/item/storage/box/survival/medical
 	mask_type = /obj/item/clothing/mask/breath/medical
+
+/obj/item/storage/box/survival/crafted
+	crafted = TRUE
+
+/obj/item/storage/box/survival/engineer/crafted
+	crafted = TRUE
 
 //Mime spell boxes
 


### PR DESCRIPTION
## About The Pull Request
premium internals boxes from the station trait now get 2 more slots and have a slightly bigger sprite
also lowers the trait's weight a bit, making it equal to most other traits.
![image](https://user-images.githubusercontent.com/23585223/203337272-ea75ae4b-111e-4adb-8598-c9cba4c4e47b.png)


## Why It's Good For The Game
the main reason im doing this is because this trait messes with anything people wanna do to survival boxes, cause it takes up 2 slots, so you have to account for that whenever youre making a subtype that you wanna fill with more stuff, you cant really do that (currently an issue with the nukie medical pr)
the other reason is station traits should affect the gameplay a bit more than "wow i have 2 items i can normally get from an emergency toolbox", a larger box doesnt change that much but its something.

## Changelog
:cl:
balance: premium internals station trait now increases the slots of your internals box
/:cl:
