### PR TITLE
Stops tech disks from creating two techwebs & Adds more research logging

### DIFF
--- a/code/modules/research/research_disk.dm
+++ b/code/modules/research/research_disk.dm
@@ -8,9 +8,10 @@
 
 /obj/item/disk/tech_disk/Initialize(mapload)
 	. = ..()
+	if(!stored_research)
+		stored_research = new /datum/techweb
 	pixel_x = base_pixel_x + rand(-5, 5)
 	pixel_y = base_pixel_y + rand(-5, 5)
-	stored_research = new /datum/techweb
 
 /obj/item/disk/tech_disk/debug
 	name = "\improper CentCom technology disk"
@@ -18,8 +19,8 @@
 	custom_materials = null
 
 /obj/item/disk/tech_disk/debug/Initialize(mapload)
-	. = ..()
-	stored_research = new /datum/techweb/admin
+	stored_research = SSresearch.admin_tech
+	return ..()
 
 /obj/item/disk/tech_disk/major
 	name = "Reformatted technology disk"
@@ -28,8 +29,8 @@
 	custom_materials = list(/datum/material/iron=300, /datum/material/glass=100)
 
 /obj/item/disk/tech_disk/major/Initialize(mapload)
-	. = ..()
 	stored_research = new /datum/techweb/bepis
+	return ..()
 
 /obj/item/disk/tech_disk/spaceloot
 	name = "Old experimental technology disk"
@@ -38,5 +39,5 @@
 	custom_materials = list(/datum/material/iron=300, /datum/material/glass=100)
 
 /obj/item/disk/tech_disk/spaceloot/Initialize(mapload)
-	. = ..()
 	stored_research = new /datum/techweb/bepis(remove_tech = FALSE)
+	return ..()

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -91,6 +91,7 @@
 	update_node_status(BN)
 	if(remove_tech)
 		SSresearch.techweb_nodes_experimental -= bepis_id
+		log_research("[BN.display_name] has been universally unlocked through the BEPIS techweb's \"remove tech\" feature.")
 
 /datum/techweb/Destroy()
 	researched_nodes = null
@@ -296,7 +297,7 @@
 /datum/techweb/proc/complete_experiment(datum/experiment/completed_experiment)
 	available_experiments -= completed_experiment
 	completed_experiments[completed_experiment.type] = completed_experiment
-	log_research("[completed_experiment.name] ([completed_experiment.type]) has been completed on techweb id [id]")
+	log_research("[completed_experiment.name] ([completed_experiment.type]) has been completed on techweb [id]/[organization]")
 
 /datum/techweb/proc/printout_points()
 	return techweb_point_display_generic(research_points)
@@ -311,8 +312,9 @@
 	if(!force)
 		if(!available_nodes[node.id] || (auto_adjust_cost && (!can_afford(node.get_price(src)))) || !have_experiments_for_node(node))
 			return FALSE
+	var/node_cost = node.get_price(src)
 	if(auto_adjust_cost)
-		remove_point_list(node.get_price(src))
+		remove_point_list(node_cost)
 	researched_nodes[node.id] = TRUE //Add to our researched list
 	for(var/id in node.unlock_ids)
 		visible_nodes[id] = TRUE
@@ -328,6 +330,7 @@
 	if(get_that_dosh)
 		var/datum/bank_account/science_department_bank_account = SSeconomy.get_dep_account(ACCOUNT_SCI)
 		science_department_bank_account?.adjust_money(SSeconomy.techweb_bounty)
+	log_research("[id]/[organization] researched node [node.id] at the cost of [node_cost][get_that_dosh ? ", gaining [SSeconomy.techweb_bounty] for it." : ""]")
 	return TRUE
 
 /datum/techweb/proc/unresearch_node_id(id)

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -316,7 +316,7 @@
 	if(auto_adjust_cost)
 		var/node_cost = node.get_price(src)
 		remove_point_list(node_cost)
-		log_message += "at the cost of [node_cost]"
+		log_message += " at the cost of [node_cost]"
 	researched_nodes[node.id] = TRUE //Add to our researched list
 	for(var/id in node.unlock_ids)
 		visible_nodes[id] = TRUE
@@ -332,7 +332,7 @@
 	if(get_that_dosh)
 		var/datum/bank_account/science_department_bank_account = SSeconomy.get_dep_account(ACCOUNT_SCI)
 		science_department_bank_account?.adjust_money(SSeconomy.techweb_bounty)
-		log_message += "gaining [SSeconomy.techweb_bounty] to [science_department_bank_account] for it."
+		log_message += ", gaining [SSeconomy.techweb_bounty] to [science_department_bank_account] for it."
 	log_research(log_message)
 	return TRUE
 

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -91,7 +91,7 @@
 	update_node_status(BN)
 	if(remove_tech)
 		SSresearch.techweb_nodes_experimental -= bepis_id
-		log_research("[BN.display_name] has been universally unlocked through the BEPIS techweb's \"remove tech\" feature.")
+		log_research("[BN.display_name] has been removed from experimental nodes through the BEPIS techweb's \"remove tech\" feature.")
 
 /datum/techweb/Destroy()
 	researched_nodes = null
@@ -312,9 +312,11 @@
 	if(!force)
 		if(!available_nodes[node.id] || (auto_adjust_cost && (!can_afford(node.get_price(src)))) || !have_experiments_for_node(node))
 			return FALSE
-	var/node_cost = node.get_price(src)
+	var/log_message = "[id]/[organization] researched node [node.id]"
 	if(auto_adjust_cost)
+		var/node_cost = node.get_price(src)
 		remove_point_list(node_cost)
+		log_message += "at the cost of [node_cost]"
 	researched_nodes[node.id] = TRUE //Add to our researched list
 	for(var/id in node.unlock_ids)
 		visible_nodes[id] = TRUE
@@ -330,7 +332,8 @@
 	if(get_that_dosh)
 		var/datum/bank_account/science_department_bank_account = SSeconomy.get_dep_account(ACCOUNT_SCI)
 		science_department_bank_account?.adjust_money(SSeconomy.techweb_bounty)
-	log_research("[id]/[organization] researched node [node.id] at the cost of [node_cost][get_that_dosh ? ", gaining [SSeconomy.techweb_bounty] for it." : ""]")
+		log_message += "gaining [SSeconomy.techweb_bounty] to [science_department_bank_account] for it."
+	log_research(log_message)
 	return TRUE
 
 /datum/techweb/proc/unresearch_node_id(id)


### PR DESCRIPTION
## About The Pull Request

This hopes to stop floodings in SSresearch.techwebs by making tech disks not initialize techwebs twice each time, especially since techwebs never get deleted currently.

I also added some loggings to research because currently its only use is when completing an experiment.

## Why It's Good For The Game

Better logs for research stuff and prevents a flood of techwebs when trying to find one specific one in SSresearch's techweb list.
It would also slightly help with https://github.com/tgstation/tgstation/issues/71434 because I don't know what would cause this as bepis isn't logged.

## Changelog

:cl:
admin: Researching nodes and bepis unlocking stuff is now logged in research.
/:cl: