### PR TITLE
[NO GBP] Biogen power usage hotfix

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -206,7 +206,7 @@
 			qdel(object)
 			var/potential_biomass = max(1, nutriments) * productivity
 			while(processing && potential_biomass > 0)
-				use_power(active_power_usage * (1 SECONDS)) // Seconds needed here to convert time (in deciseconds) to seconds such that watts * seconds = joules
+				use_power(active_power_usage * (0.01 SECONDS)) // Seconds needed here to convert time (in deciseconds) to seconds such that watts * seconds = joules)
 				potential_biomass -= 1
 				biomass += 1
 				stoplag(2 / productivity)


### PR DESCRIPTION
## About The Pull Request

Fixes the active power usage for biogenerator (300kw -> 3kw active usage) because of wrong time conversion change in https://github.com/tgstation/tgstation/pull/71175

There is also another bug with biogen, that looks like a regression of some other PR as it wasn't there before the merge:
`build_path(drop_location(), amount)` ignores amount for non-stackable items. Not sure why it got broken.

## Changelog
:cl:
fix: biogenerator active power usage fix
/:cl:

