### PR TITLE
you get access to the next storage ui row 1 item earlier

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -853,7 +853,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		adjusted_contents = numbered_contents.len
 
 	var/columns = clamp(max_slots, 1, screen_max_columns)
-	var/rows = clamp(CEILING(adjusted_contents / columns, 1) + !(adjusted_contents % screen_max_columns), 1, screen_max_rows)
+	var/rows = clamp(CEILING(adjusted_contents / columns, 1) + (!(adjusted_contents % screen_max_columns) && adjusted_contents < max_slots), 1, screen_max_rows)
 
 	orient_item_boxes(rows, columns, numbered_contents)
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -853,7 +853,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		adjusted_contents = numbered_contents.len
 
 	var/columns = clamp(max_slots, 1, screen_max_columns)
-	var/rows = clamp(CEILING(adjusted_contents / columns, 1), 1, screen_max_rows)
+	var/rows = clamp(CEILING(adjusted_contents / columns, 1) + !(adjusted_contents % screen_max_columns), 1, screen_max_rows)
 
 	orient_item_boxes(rows, columns, numbered_contents)
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -852,8 +852,11 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		numbered_contents = process_numerical_display()
 		adjusted_contents = numbered_contents.len
 
+	//if the ammount of contents reaches some multiplier of the final column (and its not the last slot), let the player view an additional row
+	var/additional_row = (!(adjusted_contents % screen_max_columns) && adjusted_contents < max_slots)
+
 	var/columns = clamp(max_slots, 1, screen_max_columns)
-	var/rows = clamp(CEILING(adjusted_contents / columns, 1) + (!(adjusted_contents % screen_max_columns) && adjusted_contents < max_slots), 1, screen_max_rows)
+	var/rows = clamp(CEILING(adjusted_contents / columns, 1) + additional_row, 1, screen_max_rows)
 
 	orient_item_boxes(rows, columns, numbered_contents)
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -851,7 +851,6 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(numerical_stacking)
 		numbered_contents = process_numerical_display()
 		adjusted_contents = numbered_contents.len
-
 	//if the ammount of contents reaches some multiplier of the final column (and its not the last slot), let the player view an additional row
 	var/additional_row = (!(adjusted_contents % screen_max_columns) && adjusted_contents < max_slots)
 


### PR DESCRIPTION

## About The Pull Request
the next ui storage row spawns when your last row is full, rather than when theres enough items that its needed
![image](https://user-images.githubusercontent.com/23585223/203356246-afab63f8-a302-4f0c-a1ff-cadd45da32bc.png)
not when its full or missing slots though
![image](https://user-images.githubusercontent.com/23585223/203357844-14a4b80e-26dd-4814-98b9-1556e0a95e29.png)
![image](https://user-images.githubusercontent.com/23585223/203357904-54c499e5-8003-4bd2-a757-26bb6bc53e1d.png)


## Why It's Good For The Game
its annoying especially with the doctors special medkit, cause youll be storing stuff in it and if you take out enough items to where its just 7 left, the row closes and you need to go back to the backpacks storage ui to put stuff back in

## Changelog
:cl:
qol: you get access to the next storage ui row 1 item earlier
/:cl:
