### PR TITLE
Fix curd cheese being burned in microwave

### DIFF
--- a/code/game/objects/items/food/cheese.dm
+++ b/code/game/objects/items/food/cheese.dm
@@ -67,7 +67,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	rat_heal = 35
 
-/obj/item/food/curd_cheese/make_microwavable()
+/obj/item/food/cheese/curd_cheese/make_microwavable()
 	AddElement(/datum/element/microwavable, /obj/item/food/cheese/cheese_curds)
 
 /obj/item/food/cheese/cheese_curds


### PR DESCRIPTION
## About The Pull Request

Fixes #71391

## Changelog

:cl:
fix: Curd cheese can be microwaved again into cheese curds
/:cl:

