### PR TITLE
Fix roundstart seed and fish asset runtimes

### DIFF
--- a/code/modules/asset_cache/assets/fish.dm
+++ b/code/modules/asset_cache/assets/fish.dm
@@ -2,13 +2,15 @@
 	name = "fish"
 
 /datum/asset/spritesheet/fish/create_spritesheets()
+	var/list/id_list = list()
 	for (var/path in subtypesof(/obj/item/fish))
 		var/obj/item/fish/fish_type = path
 		var/fish_icon = initial(fish_type.icon)
 		var/fish_icon_state = initial(fish_type.icon_state)
 		var/id = sanitize_css_class_name("[fish_icon][fish_icon_state]")
-		if(sprites[id]) //no dupes
+		if(id in id_list) //no dupes
 			continue
+		id_list += id
 		Insert(id, fish_icon, fish_icon_state)
 
 

--- a/code/modules/asset_cache/assets/seeds.dm
+++ b/code/modules/asset_cache/assets/seeds.dm
@@ -2,11 +2,13 @@
 	name = "seeds"
 
 /datum/asset/spritesheet/seeds/create_spritesheets()
+	var/list/id_list = list()
 	for (var/path in subtypesof(/obj/item/seeds))
 		var/obj/item/seeds/seed_type = path
 		var/icon = initial(seed_type.icon)
 		var/icon_state = initial(seed_type.icon_state)
 		var/id = sanitize_css_class_name("[icon][icon_state]")
-		if(sprites[id]) //no dupes
+		if(id in id_list) //no dupes
 			continue
+		id_list += id
 		Insert(id, icon, icon_state)


### PR DESCRIPTION
## About The Pull Request

Fixes annoying roundstart runtimes coming from a wrong deduplication method. `sprites[id]` was empty at the time of the check and only got filled when it started actually building the spritesheet. Now it's tracked in a local variable.

No changelog update since it's not visible on the player side.