### PR TITLE
Changes Obsession resilience to require a lobotomy

### DIFF
--- a/code/datums/brain_damage/creepy_trauma.dm
+++ b/code/datums/brain_damage/creepy_trauma.dm
@@ -6,7 +6,7 @@
 	lose_text = "<span class='warning'>The voices in your head fall silent.</span>"
 	can_gain = TRUE
 	random_gain = FALSE
-	resilience = TRAUMA_RESILIENCE_SURGERY
+	resilience = TRAUMA_RESILIENCE_LOBOTOMY
 	var/mob/living/obsession
 	var/datum/objective/spendtime/attachedobsessedobj
 	var/datum/antagonist/obsessed/antagonist

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -66,7 +66,7 @@
 			var/mob/living/carbon/C = M
 			if(prob(10))
 				if(trauma_heal_severe)
-					C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_LOBOTOMY)
+					C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_SEVERE)
 				else
 					C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
 

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -66,7 +66,7 @@
 			var/mob/living/carbon/C = M
 			if(prob(10))
 				if(trauma_heal_severe)
-					C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_SEVERE)
+					C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_SURGERY)
 				else
 					C.cure_trauma_type(resilience = TRAUMA_RESILIENCE_BASIC)
 


### PR DESCRIPTION
## About The Pull Request

Obsessed is changed to require a lobotomy rather than brain surgery. Also nerfs Mind Restoration so it cannot remove deep-rooted traumas.

## Why It's Good For The Game

Obsessed has been well-known for some time as being surprise ganked by fairly low-key airborne healing viruses. Players are stripped of their antag status with no fanfare or consequence.

With this change the cure for obsessed will require a lobotomy, which will cause additional permanent brain traumas. This provides way more mechanically-informed RP than losing antag due to a friendly sneeze.

## Changelog

:cl:
balance: Obsessed has been bumped up to a Deep-Rooted Brain Trauma
balance: Mind Restoration can't remove deep-rooted traumas, making Obsessed unremovable by virusses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
