### PR TITLE
Fixes the identification section not appearing in PDAs and improves its appearance just a bit (while also fixing some runtimes)

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -59,21 +59,22 @@
 	data["device_theme"] = device_theme
 	data["login"] = list()
 
-	if(computer_id_slot)
-		var/stored_name = saved_identification
-		var/stored_title = saved_job
-		if(!stored_name)
-			stored_name = "Unknown"
-		if(!stored_title)
-			stored_title = "Unknown"
-		data["login"] = list(
-			IDName = saved_identification,
-			IDJob = saved_job,
-		)
-		data["proposed_login"] = list(
-			IDName = computer_id_slot.registered_name,
-			IDJob = computer_id_slot.assignment,
-		)
+	var/stored_name = saved_identification
+	var/stored_title = saved_job
+	if(!stored_name)
+		stored_name = "Unknown"
+	if(!stored_title)
+		stored_title = "Unknown"
+	data["login"] = list(
+		IDName = saved_identification,
+		IDJob = saved_job,
+	)
+
+	data["proposed_login"] = computer_id_slot ? list(
+		IDName = computer_id_slot.registered_name,
+		IDJob = computer_id_slot.assignment,
+	) : list()
+
 
 	data["removable_media"] = list()
 	if(inserted_disk)
@@ -166,18 +167,26 @@
 				if("Eject Disk")
 					if(!inserted_disk)
 						return
+
 					user.put_in_hands(inserted_disk)
 					inserted_disk = null
 					playsound(src, 'sound/machines/card_slide.ogg', 50)
+					return TRUE
+
 				if("intelliCard")
 					var/datum/computer_file/program/ai_restorer/airestore_app = locate() in stored_files
 					if(!airestore_app)
 						return
+
 					if(airestore_app.try_eject(user))
 						playsound(src, 'sound/machines/card_slide.ogg', 50)
+						return TRUE
+
 				if("ID")
 					if(RemoveID())
 						playsound(src, 'sound/machines/card_slide.ogg', 50)
+						return TRUE
+
 		if("PC_Imprint_ID")
 			saved_identification = computer_id_slot.registered_name
 			saved_job = computer_id_slot.assignment

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -57,23 +57,16 @@
 /obj/item/modular_computer/ui_data(mob/user)
 	var/list/data = get_header_data()
 	data["device_theme"] = device_theme
-	data["login"] = list()
 
-	var/stored_name = saved_identification
-	var/stored_title = saved_job
-	if(!stored_name)
-		stored_name = "Unknown"
-	if(!stored_title)
-		stored_title = "Unknown"
 	data["login"] = list(
-		IDName = saved_identification,
-		IDJob = saved_job,
+		IDName = saved_identification || "Unknown",
+		IDJob = saved_job || "Unknown",
 	)
 
-	data["proposed_login"] = computer_id_slot ? list(
-		IDName = computer_id_slot.registered_name,
-		IDJob = computer_id_slot.assignment,
-	) : list()
+	data["proposed_login"] = list(
+		IDName = computer_id_slot?.registered_name,
+		IDJob = computer_id_slot?.assignment,
+	)
 
 
 	data["removable_media"] = list()

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -1,7 +1,6 @@
 import { useBackend } from '../backend';
 import { Button, ColorBox, Stack, Section, Table } from '../components';
 import { NtosWindow } from '../layouts';
-import { logger } from '../logging';
 
 export const NtosMain = (props, context) => {
   const { act, data } = useBackend(context);
@@ -17,7 +16,6 @@ export const NtosMain = (props, context) => {
     proposed_login = [],
     pai,
   } = data;
-  logger.log(proposed_login ? proposed_login.IDName : '');
   return (
     <NtosWindow
       title={

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -85,12 +85,20 @@ export const NtosMain = (props, context) => {
           }>
           <Table>
             <Table.Row>
-              ID Name: {login.IDName}{' '}
-              {proposed_login.IDName ? '(' + proposed_login.IDName + ')' : ''}
+              ID Name:{' '}
+              {show_imprint
+                ? login.IDName +
+                ' ' +
+                (proposed_login.IDName ? '(' + proposed_login.IDName + ')' : '')
+                : proposed_login.IDName ?? ''}
             </Table.Row>
             <Table.Row>
-              Assignment: {login.IDJob}{' '}
-              {proposed_login.IDJob ? '(' + proposed_login.IDJob + ')' : ''}
+              Assignment:{' '}
+              {show_imprint
+                ? login.IDJob +
+                ' ' +
+                (proposed_login.IDJob ? '(' + proposed_login.IDJob + ')' : '')
+                : proposed_login.IDJob ?? ''}
             </Table.Row>
           </Table>
         </Section>

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -1,6 +1,7 @@
 import { useBackend } from '../backend';
 import { Button, ColorBox, Stack, Section, Table } from '../components';
 import { NtosWindow } from '../layouts';
+import { logger } from '../logging';
 
 export const NtosMain = (props, context) => {
   const { act, data } = useBackend(context);
@@ -12,11 +13,11 @@ export const NtosMain = (props, context) => {
     light_on,
     comp_light_color,
     removable_media = [],
-    cardholder,
     login = [],
     proposed_login = [],
     pai,
   } = data;
+  logger.log(proposed_login ? proposed_login.IDName : '');
   return (
     <NtosWindow
       title={
@@ -58,17 +59,17 @@ export const NtosMain = (props, context) => {
             </Stack>
           </Section>
         )}
-        {!!(cardholder && show_imprint) && (
-          <Section
-            title="User Login"
-            buttons={
-              <>
-                <Button
-                  icon="eject"
-                  content="Eject ID"
-                  disabled={!proposed_login.IDName}
-                  onClick={() => act('PC_Eject_Disk', { name: 'ID' })}
-                />
+        <Section
+          title="User Login"
+          buttons={
+            <>
+              <Button
+                icon="eject"
+                content="Eject ID"
+                disabled={!proposed_login.IDName}
+                onClick={() => act('PC_Eject_Disk', { name: 'ID' })}
+              />
+              {!!show_imprint && (
                 <Button
                   icon="dna"
                   content="Imprint ID"
@@ -79,18 +80,20 @@ export const NtosMain = (props, context) => {
                   }
                   onClick={() => act('PC_Imprint_ID', { name: 'ID' })}
                 />
-              </>
-            }>
-            <Table>
-              <Table.Row>
-                ID Name: {login.IDName} ({proposed_login.IDName})
-              </Table.Row>
-              <Table.Row>
-                Assignment: {login.IDJob} ({proposed_login.IDJob})
-              </Table.Row>
-            </Table>
-          </Section>
-        )}
+              )}
+            </>
+          }>
+          <Table>
+            <Table.Row>
+              ID Name: {login.IDName}{' '}
+              {proposed_login.IDName ? '(' + proposed_login.IDName + ')' : ''}
+            </Table.Row>
+            <Table.Row>
+              Assignment: {login.IDJob}{' '}
+              {proposed_login.IDJob ? '(' + proposed_login.IDJob + ')' : ''}
+            </Table.Row>
+          </Table>
+        </Section>
         {!!pai && (
           <Section title="pAI">
             <Table>


### PR DESCRIPTION
## About The Pull Request
Yeah so turns out that #71420 broke the display of the identification section in PDAs (and by extension, all modular (I guess not really modular anymore) computers), because it forgot to remove a now unused variable from the interface. However, while investigating this, I strolled upon many more bugs and other general unresponsiveness of the interface, so I went ahead and fixed those.

There's also no longer an empty set of `()` on both of the fields if there's no ID inside of the computer anymore, because that was stupid.

## Why It's Good For The Game
Bug bad, fix good. Multiple fix, even better.

## Changelog

:cl: GoldenAlpharex
fix: PDAs (and by extension, modular computers) now can see the ID section at the top of their main screen again, which means that PDAs can have IDs imprinted on them again.
fix: Fixes the ID section not displaying anything when there wasn't any ID inserted in it, even if it had an imprinted name and job.
fix: Fixes the "Eject ID" and "Imprint ID" buttons not being disabled when there's no ID in the computer/PDA.
fix: There's no longer any empty () by in the "ID Name" and "Assignment" fields of the ID section of computers when there's no ID in them.
/:cl: