### PR TITLE
Wall mounted vendors are no longer a Brand Intelligence liability

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -4,7 +4,6 @@
 	weight = 5
 	category = EVENT_CATEGORY_AI
 	description = "Vending machines will attack people until the Patient Zero is disabled."
-
 	min_players = 15
 	max_occurrences = 1
 	///Var used to determine vendor subtype if used for admin setup
@@ -17,6 +16,7 @@
 		var/list/vendors = list()
 		vendors += subtypesof(/obj/machinery/vending)
 		chosen_vendor = tgui_input_list(usr, "Vendor type must have at least one instance on the station for this to work!","Vendor Selector", vendors)
+
 /datum/round_event/brand_intelligence
 	announce_when = 21
 	end_when = 1000 //Ends when all vending machines are subverted anyway.
@@ -52,13 +52,13 @@
 	if(brand_event.chosen_vendor) //Attempt to search for vendors of the selected admin subtype
 		var/chosen_vendor = brand_event.chosen_vendor
 		for(var/obj/machinery/vending/vendor in GLOB.machines)
-			if(!is_station_level(vendor.z) || !istype(vendor, chosen_vendor))
+			if(!is_station_level(vendor.z) || !istype(vendor, chosen_vendor) || !vendor.density)
 				continue
 			vendingMachines.Add(vendor)
 		brand_event.chosen_vendor = null //Event has a max_occurences of 1 but juuust in case
 	if(!length(vendingMachines)) //If no vendors are in vendingMachines, setup defaults back to randomly selecting one.
 		for(var/obj/machinery/vending/vendor in GLOB.machines)
-			if(!is_station_level(vendor.z))
+			if(!is_station_level(vendor.z) || !vendor.density)
 				continue
 			vendingMachines.Add(vendor)
 	if(!length(vendingMachines)) //If somehow there are still no elligible vendors, give up.


### PR DESCRIPTION
## About The Pull Request

Wall mounted vendors (currently just the wallmed) are no longer able to be selected or spread to during the Brand Intelligence event. This is done by checking the density variable, rather than just excluding the wallmed, in case any other wall mounted vendors are implemented. 

Also, adds and removes empty lines that were bugging me.
## Why It's Good For The Game

Closes #71465.

Wall mounted vendors look wonky when they leave the wall due to their visual offset, and since they don't look like vending machines it can be a bit confusing. Less buggy vendors and more immersive slapstick comedy.

## Changelog
:cl:
fix: Wall mounted vendors can no longer receive brand intelligence.
/:cl:
