### PR TITLE
Fermentation and barrel refactoring

### DIFF
--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -157,3 +157,10 @@
 	volume = 20
 	falloff_distance = 2
 	falloff_exponent = 5
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/datum/looping_sound/boiling
+	mid_sounds = list('sound/effects/bubbles2.ogg' = 1)
+	mid_length = 7 SECONDS
+	volume = 25

--- a/code/datums/looping_sounds/machinery_sounds.dm
+++ b/code/datums/looping_sounds/machinery_sounds.dm
@@ -6,8 +6,6 @@
 	end_sound = 'sound/machines/shower/shower_end.ogg'
 	volume = 20
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /datum/looping_sound/supermatter
 	mid_sounds = list('sound/machines/sm/loops/calm.ogg' = 1)
 	mid_length = 60
@@ -17,16 +15,12 @@
 	falloff_distance = 5
 	vary = TRUE
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /datum/looping_sound/destabilized_crystal
 	mid_sounds = list('sound/machines/sm/loops/delamming.ogg' = 1)
 	mid_length = 60
 	volume = 55
 	extra_range = 15
 	vary = TRUE
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/looping_sound/hypertorus
 	mid_sounds = list('sound/machines/hypertorus/loops/hypertorus_nominal.ogg' = 1)
@@ -35,8 +29,6 @@
 	extra_range = 15
 	vary = TRUE
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /datum/looping_sound/generator
 	start_sound = 'sound/machines/generator/generator_start.ogg'
 	start_length = 4
@@ -44,8 +36,6 @@
 	mid_length = 4
 	end_sound = 'sound/machines/generator/generator_end.ogg'
 	volume = 40
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
 /datum/looping_sound/deep_fryer
@@ -56,15 +46,11 @@
 	end_sound = 'sound/machines/fryer/deep_fryer_emerge.ogg'
 	volume = 15
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 
 /datum/looping_sound/grill
 	mid_sounds = list('sound/machines/grill/grillsizzle.ogg' = 1)
 	mid_length = 18
 	volume = 50
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/looping_sound/oven
 	start_sound = 'sound/machines/oven/oven_loop_start.ogg' //my immersions
@@ -75,14 +61,10 @@
 	volume = 100
 	falloff_exponent = 4
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /datum/looping_sound/deep_fryer
 	mid_length = 2
 	mid_sounds = list('sound/machines/fryer/deep_fryer_1.ogg' = 1, 'sound/machines/fryer/deep_fryer_2.ogg' = 1)
 	volume = 30
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/looping_sound/microwave
 	start_sound = 'sound/machines/microwave/microwave-start.ogg'
@@ -92,15 +74,11 @@
 	end_sound = 'sound/machines/microwave/microwave-end.ogg'
 	volume = 90
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /datum/looping_sound/jackpot
 	mid_length = 11
 	mid_sounds = list('sound/machines/roulettejackpot.ogg' = 1)
 	volume = 85
 	vary = TRUE
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/looping_sound/server
 	mid_sounds = list(
@@ -119,8 +97,6 @@
 	volume = 50
 	ignore_walls = FALSE
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /datum/looping_sound/computer
 	start_sound = 'sound/machines/computer/computer_start.ogg'
 	start_length = 7.2 SECONDS
@@ -134,8 +110,6 @@
 	extra_range = -12
 	falloff_distance = 1 //Instant falloff after initial tile
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /datum/looping_sound/gravgen
 	mid_sounds = list('sound/machines/gravgen/gravgen_mid1.ogg' = 1, 'sound/machines/gravgen/gravgen_mid2.ogg' = 1, 'sound/machines/gravgen/gravgen_mid3.ogg' = 1, 'sound/machines/gravgen/gravgen_mid4.ogg' = 1)
 	mid_length = 1.8 SECONDS
@@ -144,21 +118,15 @@
 	falloff_distance = 5
 	falloff_exponent = 20
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /datum/looping_sound/firealarm
 	mid_sounds = list('sound/machines/FireAlarm1.ogg' = 1,'sound/machines/FireAlarm2.ogg' = 1,'sound/machines/FireAlarm3.ogg' = 1,'sound/machines/FireAlarm4.ogg' = 1)
 	mid_length = 2.4 SECONDS
 	volume = 75
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 /datum/looping_sound/gravgen/kinesis
 	volume = 20
 	falloff_distance = 2
 	falloff_exponent = 5
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /datum/looping_sound/boiling
 	mid_sounds = list('sound/effects/bubbles2.ogg' = 1)

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -1,6 +1,6 @@
 /obj/structure/fermenting_barrel
 	name = "wooden barrel"
-	desc = "A large wooden barrel. You can ferment fruits and such inside it, or just use it to hold liquid."
+	desc = "A large wooden barrel. You can ferment fruits and such inside it, or just use it to hold reagents."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "barrel"
 	density = TRUE
@@ -9,71 +9,135 @@
 	max_integrity = 300
 	var/open = FALSE
 	var/can_open = TRUE
-	var/speed_multiplier = 1 //How fast it distills. Defaults to 100% (1.0). Lower is better.
+	/// The amount of reagents that can be created from the contained products, used for validation
+	var/potential_volume = 0
+	/// Whether the fermentation is ongoing
+	var/fermenting = FALSE
+	/// The volume of the barrel sounds
+	var/sound_volume = 25
+	/// The sound of fermentation
+	var/datum/looping_sound/boiling/soundloop
+	var/lid_open_sound = 'sound/items/handling/cardboardbox_pickup.ogg'
+	var/lid_close_sound = 'sound/effects/footstep/woodclaw2.ogg'
 
 /obj/structure/fermenting_barrel/Initialize(mapload)
-	// Bluespace beakers, but without the portability or efficiency in circuits.
-	create_reagents(300, DRAINABLE)
 	. = ..()
+	create_reagents(600, DRAINABLE)
+	soundloop = new(src, fermenting)
+	soundloop.volume = sound_volume
+
+/obj/structure/fermenting_barrel/Destroy()
+	QDEL_NULL(soundloop)
+	return ..()
 
 /obj/structure/fermenting_barrel/examine(mob/user)
 	. = ..()
-	. += span_notice("It is currently [open?"open, letting you pour liquids in.":"closed, letting you draw liquids from the tap."]")
-
-/obj/structure/fermenting_barrel/proc/makeWine(obj/item/food/grown/fruit)
-	if(fruit.reagents)
-		fruit.reagents.trans_to(src, fruit.reagents.total_volume)
-	var/amount = fruit.seed.potency / 4
-	if(fruit.distill_reagent)
-		reagents.add_reagent(fruit.distill_reagent, amount)
+	if(open)
+		var/fruit_count = contents.len
+		if(fruit_count)
+			. += span_notice("It contains [fruit_count] fruits ready to be fermented.")
+		. += span_notice("It is currently open, letting you fill it with fruits or reagents.")
 	else
-		var/data = list()
-		data["names"] = list("[initial(fruit.name)]" = 1)
-		data["color"] = fruit.filling_color
-		data["boozepwr"] = fruit.wine_power
-		if(fruit.wine_flavor)
-			data["tastes"] = list(fruit.wine_flavor = 1)
-		else
-			data["tastes"] = list(fruit.tastes[1] = 1)
-		reagents.add_reagent(/datum/reagent/consumable/ethanol/fruit_wine, amount, data)
-	qdel(fruit)
-	playsound(src, 'sound/effects/bubbles.ogg', 50, TRUE)
+		. += span_notice("It is currently closed, letting it ferment fruits or draw reagents from its tap.")
 
-/obj/structure/fermenting_barrel/attackby(obj/item/I, mob/user, params)
-	var/obj/item/food/grown/fruit = I
-	if(istype(fruit))
-		if(!fruit.can_distill)
-			to_chat(user, span_warning("You can't distill this into anything..."))
-			return TRUE
-		else if(!user.transferItemToLoc(I,src))
-			to_chat(user, span_warning("[I] is stuck to your hand!"))
-			return TRUE
-		to_chat(user, span_notice("You place [I] into [src] to start the fermentation process."))
-		addtimer(CALLBACK(src, PROC_REF(makeWine), fruit), rand(80, 120) * speed_multiplier)
-		return TRUE
-	if(I)
-		if(I.is_refillable())
-			return FALSE //so we can refill them via their afterattack.
-	else
-		return ..()
+/obj/structure/fermenting_barrel/attackby(obj/item/object, mob/user, params)
+	if(open)
+		if(istype(object, /obj/item/food/grown))
+			if(insert_fruit(user, object))
+				balloon_alert(user, "added fruit")
+				return
+		if(istype(object, /obj/item/storage/bag/plants))
+			var/obj/item/storage/bag/plants/bag = object
+			var/inserted_fruits = 0
+			for(var/obj/item/food/grown/fruit in bag.contents)
+				if(!insert_fruit(user, fruit, bag))
+					break
+				inserted_fruits++
+			if(inserted_fruits)
+				balloon_alert(user, "added [inserted_fruits] fruits")
+	else if(object.is_refillable())
+		return //so we can refill them via their afterattack.
+	return ..()
 
 /obj/structure/fermenting_barrel/attack_hand(mob/user, list/modifiers)
 	if(!can_open)
 		return
-	open = !open
 	if(open)
-		reagents.flags &= ~(DRAINABLE)
-		reagents.flags |= REFILLABLE | TRANSPARENT
-		to_chat(user, span_notice("You open [src], letting you fill it."))
-	else
+		open = FALSE
 		reagents.flags |= DRAINABLE
 		reagents.flags &= ~(REFILLABLE | TRANSPARENT)
-		to_chat(user, span_notice("You close [src], letting you draw from its tap."))
-	update_appearance()
+		balloon_alert(user, "closed the lid")
+		playsound(src, lid_close_sound, sound_volume)
+		start_fermentation()
+	else
+		open = TRUE
+		reagents.flags &= ~(DRAINABLE)
+		reagents.flags |= REFILLABLE | TRANSPARENT
+		balloon_alert(user, "opened the lid")
+		playsound(src, lid_open_sound, sound_volume)
+		stop_fermentation()
+	update_appearance(UPDATE_ICON)
 
 /obj/structure/fermenting_barrel/update_icon_state()
 	icon_state = open ? "barrel_open" : "barrel"
 	return ..()
+
+/// Adds the fruit to the barrel to queue the fermentation
+/obj/structure/fermenting_barrel/proc/insert_fruit(mob/user, obj/item/food/grown/fruit, obj/item/storage/bag/plants/bag = null)
+	if(reagents.total_volume + potential_volume >= reagents.maximum_volume)
+		to_chat(user, span_warning("The barrel can't hold any more fruits!"))
+		return FALSE
+	if(!fruit.can_distill)
+		to_chat(user, span_warning("You can't distill this into anything!"))
+		return FALSE
+	if(bag)
+		if(!bag.atom_storage.attempt_remove(fruit, src))
+			to_chat(user, span_warning("Can't take the fruit from the bag!"))
+			return FALSE
+	else if (!user.transferItemToLoc(fruit, src))
+		to_chat(user, span_warning("[fruit] is stuck to your hand!"))
+		return FALSE
+	potential_volume += fruit.reagents.total_volume
+	return TRUE
+
+/// Starts the fermentation process
+/obj/structure/fermenting_barrel/proc/start_fermentation()
+	if(fermenting)
+		return
+	if(open)
+		return
+	if(reagents.total_volume >= reagents.maximum_volume)
+		return
+	if(!locate(/obj/item/food) in contents)
+		return
+	fermenting = TRUE
+	soundloop.start()
+	START_PROCESSING(SSobj, src)
+
+/// Ferments the next found fruit into wine
+/obj/structure/fermenting_barrel/proc/process_fermentation()
+	if(!fermenting)
+		return
+	if(open)
+		return stop_fermentation()
+	if(reagents.total_volume >= reagents.maximum_volume)
+		return stop_fermentation()
+	var/obj/item/food/grown/fruit = locate(/obj/item/food/grown) in contents
+	if(!fruit)
+		return stop_fermentation()
+	fruit.ferment()
+	fruit.reagents.trans_to(reagents, fruit.reagents.total_volume)
+	potential_volume -= fruit.reagents.total_volume
+	qdel(fruit)
+
+/// Stops the fermentation process
+/obj/structure/fermenting_barrel/proc/stop_fermentation()
+	fermenting = FALSE
+	soundloop.stop()
+	STOP_PROCESSING(SSobj, src)
+
+/obj/structure/fermenting_barrel/process(delta_time)
+	process_fermentation()
 
 /datum/crafting_recipe/fermenting_barrel
 	name = "Wooden Barrel"
@@ -82,8 +146,7 @@
 	time = 50
 	category = CAT_PRIMAL
 
-//lil gunpowder barrel fer pirates since it's a nice reagent holder
-
+/// Lil gunpowder barrel fer pirates since it's a nice reagent holder
 /obj/structure/fermenting_barrel/gunpowder
 	name = "gunpowder barrel"
 	desc = "A large wooden barrel for holding gunpowder. You'll need to take from this to load the cannons."
@@ -91,4 +154,4 @@
 
 /obj/structure/fermenting_barrel/gunpowder/Initialize(mapload)
 	. = ..()
-	reagents.add_reagent(/datum/reagent/gunpowder, 250)
+	reagents.add_reagent(/datum/reagent/gunpowder, 500)

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -90,10 +90,9 @@
 	if(!fruit.can_distill)
 		to_chat(user, span_warning("You can't distill this into anything!"))
 		return FALSE
-	if(bag)
-		if(!bag.atom_storage.attempt_remove(fruit, src))
-			to_chat(user, span_warning("Can't take the fruit from the bag!"))
-			return FALSE
+	if(bag && !bag.atom_storage.attempt_remove(fruit, src))
+		to_chat(user, span_warning("Can't take the fruit from the bag!"))
+		return FALSE
 	else if (!user.transferItemToLoc(fruit, src))
 		to_chat(user, span_warning("[fruit] is stuck to your hand!"))
 		return FALSE

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -42,10 +42,9 @@
 
 /obj/structure/fermenting_barrel/attackby(obj/item/object, mob/user, params)
 	if(open)
-		if(istype(object, /obj/item/food/grown))
-			if(insert_fruit(user, object))
-				balloon_alert(user, "added fruit")
-				return
+		if(istype(object, /obj/item/food/grown) && insert_fruit(user, object))
+			balloon_alert(user, "added fruit")
+			return
 		if(istype(object, /obj/item/storage/bag/plants))
 			var/obj/item/storage/bag/plants/bag = object
 			var/inserted_fruits = 0

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -35,7 +35,7 @@
 	if(open)
 		var/fruit_count = contents.len
 		if(fruit_count)
-			. += span_notice("It contains [fruit_count] fruits ready to be fermented.")
+			. += span_notice("It contains [fruit_count] [fruit_count % 10 == 1 && fruit_count % 100 != 11 ? "fruit" : "fruits"] ready to be fermented.")
 		. += span_notice("It is currently open, letting you fill it with fruits or reagents.")
 	else
 		. += span_notice("It is currently closed, letting it ferment fruits or draw reagents from its tap.")
@@ -54,7 +54,7 @@
 					break
 				inserted_fruits++
 			if(inserted_fruits)
-				balloon_alert(user, "added [inserted_fruits] fruits")
+				balloon_alert(user, "added [inserted_fruits] [inserted_fruits % 10 == 1 && inserted_fruits % 100 != 11 ? "fruit" : "fruits"]")
 	else if(object.is_refillable())
 		return //so we can refill them via their afterattack.
 	return ..()

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -35,7 +35,7 @@
 	if(open)
 		var/fruit_count = contents.len
 		if(fruit_count)
-			. += span_notice("It contains [fruit_count] [fruit_count % 10 == 1 && fruit_count % 100 != 11 ? "fruit" : "fruits"] ready to be fermented.")
+			. += span_notice("It contains [fruit_count] fruit\s ready to be fermented.")
 		. += span_notice("It is currently open, letting you fill it with fruits or reagents.")
 	else
 		. += span_notice("It is currently closed, letting it ferment fruits or draw reagents from its tap.")
@@ -54,7 +54,7 @@
 					break
 				inserted_fruits++
 			if(inserted_fruits)
-				balloon_alert(user, "added [inserted_fruits] [inserted_fruits % 10 == 1 && inserted_fruits % 100 != 11 ? "fruit" : "fruits"]")
+				balloon_alert(user, "added [inserted_fruits] fruit\s")
 	else if(object.is_refillable())
 		return //so we can refill them via their afterattack.
 	return ..()
@@ -125,8 +125,8 @@
 	if(!fruit)
 		return stop_fermentation()
 	fruit.ferment()
-	fruit.reagents.trans_to(reagents, fruit.reagents.total_volume)
 	potential_volume -= fruit.reagents.total_volume
+	fruit.reagents.trans_to(reagents, fruit.reagents.total_volume)
 	qdel(fruit)
 
 /// Stops the fermentation process

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -43,7 +43,7 @@
 /obj/structure/fermenting_barrel/attackby(obj/item/object, mob/user, params)
 	if(open)
 		if(istype(object, /obj/item/food/grown) && insert_fruit(user, object))
-			balloon_alert(user, "added fruit")
+			balloon_alert(user, "Added fruit")
 			return
 		if(istype(object, /obj/item/storage/bag/plants))
 			var/obj/item/storage/bag/plants/bag = object
@@ -53,7 +53,7 @@
 					break
 				inserted_fruits++
 			if(inserted_fruits)
-				balloon_alert(user, "added [inserted_fruits] fruit\s")
+				balloon_alert(user, "Added [inserted_fruits] fruit\s")
 	else if(object.is_refillable())
 		return //so we can refill them via their afterattack.
 	return ..()
@@ -65,14 +65,14 @@
 		open = FALSE
 		reagents.flags |= DRAINABLE
 		reagents.flags &= ~(REFILLABLE | TRANSPARENT)
-		balloon_alert(user, "closed the lid")
+		balloon_alert(user, "Closed the lid")
 		playsound(src, lid_close_sound, sound_volume)
 		start_fermentation()
 	else
 		open = TRUE
 		reagents.flags &= ~(DRAINABLE)
 		reagents.flags |= REFILLABLE | TRANSPARENT
-		balloon_alert(user, "opened the lid")
+		balloon_alert(user, "Opened the lid")
 		playsound(src, lid_open_sound, sound_volume)
 		stop_fermentation()
 	update_appearance(UPDATE_ICON)

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -84,7 +84,7 @@
 
 /// Adds the fruit to the barrel to queue the fermentation
 /obj/structure/fermenting_barrel/proc/insert_fruit(mob/user, obj/item/food/grown/fruit, obj/item/storage/bag/plants/bag = null)
-	if(reagents.total_volume + potential_volume >= reagents.maximum_volume)
+	if(reagents.total_volume + potential_volume > reagents.maximum_volume)
 		to_chat(user, span_warning("The barrel can't hold any more fruits!"))
 		return FALSE
 	if(!fruit.can_distill)

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -84,16 +84,16 @@
 /// Adds the fruit to the barrel to queue the fermentation
 /obj/structure/fermenting_barrel/proc/insert_fruit(mob/user, obj/item/food/grown/fruit, obj/item/storage/bag/plants/bag = null)
 	if(reagents.total_volume + potential_volume > reagents.maximum_volume)
-		to_chat(user, span_warning("The barrel can't hold any more fruits!"))
+		balloon_alert(user, "The barrel is full!")
 		return FALSE
 	if(!fruit.can_distill)
-		to_chat(user, span_warning("You can't distill this into anything!"))
+		balloon_alert(user, "Can't ferment this!")
 		return FALSE
 	if(bag && !bag.atom_storage.attempt_remove(fruit, src))
-		to_chat(user, span_warning("Can't take the fruit from the bag!"))
+		balloon_alert(user, "Can't take from the bag!")
 		return FALSE
 	else if (!user.transferItemToLoc(fruit, src))
-		to_chat(user, span_warning("[fruit] is stuck to your hand!"))
+		balloon_alert(user, "Can't take the fruit!")
 		return FALSE
 	potential_volume += fruit.reagents.total_volume
 	return TRUE

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -43,7 +43,7 @@
 /obj/structure/fermenting_barrel/attackby(obj/item/object, mob/user, params)
 	if(open)
 		if(istype(object, /obj/item/food/grown) && insert_fruit(user, object))
-			balloon_alert(user, "Added fruit")
+			balloon_alert(user, "added fruit")
 			return
 		if(istype(object, /obj/item/storage/bag/plants))
 			var/obj/item/storage/bag/plants/bag = object
@@ -53,7 +53,7 @@
 					break
 				inserted_fruits++
 			if(inserted_fruits)
-				balloon_alert(user, "Added [inserted_fruits] fruit\s")
+				balloon_alert(user, "added [inserted_fruits] fruit\s")
 	else if(object.is_refillable())
 		return //so we can refill them via their afterattack.
 	return ..()
@@ -65,14 +65,12 @@
 		open = FALSE
 		reagents.flags |= DRAINABLE
 		reagents.flags &= ~(REFILLABLE | TRANSPARENT)
-		balloon_alert(user, "Closed the lid")
 		playsound(src, lid_close_sound, sound_volume)
 		start_fermentation()
 	else
 		open = TRUE
 		reagents.flags &= ~(DRAINABLE)
 		reagents.flags |= REFILLABLE | TRANSPARENT
-		balloon_alert(user, "Opened the lid")
 		playsound(src, lid_open_sound, sound_volume)
 		stop_fermentation()
 	update_appearance(UPDATE_ICON)
@@ -84,16 +82,16 @@
 /// Adds the fruit to the barrel to queue the fermentation
 /obj/structure/fermenting_barrel/proc/insert_fruit(mob/user, obj/item/food/grown/fruit, obj/item/storage/bag/plants/bag = null)
 	if(reagents.total_volume + potential_volume > reagents.maximum_volume)
-		balloon_alert(user, "The barrel is full!")
+		balloon_alert(user, "it's full!")
 		return FALSE
 	if(!fruit.can_distill)
-		balloon_alert(user, "Can't ferment this!")
+		balloon_alert(user, "can't ferment this!")
 		return FALSE
 	if(bag && !bag.atom_storage.attempt_remove(fruit, src))
-		balloon_alert(user, "Can't take from the bag!")
+		balloon_alert(user, "can't take from bag!")
 		return FALSE
 	else if (!user.transferItemToLoc(fruit, src))
-		balloon_alert(user, "Can't take the fruit!")
+		balloon_alert(user, "can't take fruit!")
 		return FALSE
 	potential_volume += fruit.reagents.total_volume
 	return TRUE
@@ -106,7 +104,7 @@
 		return
 	if(reagents.total_volume >= reagents.maximum_volume)
 		return
-	if(!locate(/obj/item/food) in contents)
+	if(!(locate(/obj/item/food) in contents))
 		return
 	fermenting = TRUE
 	soundloop.start()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -74,6 +74,9 @@
 	seed.prepare_result(src)
 	transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5 //Makes the resulting produce's sprite larger or smaller based on potency!
 
+	if(seed.get_gene(/datum/plant_gene/trait/brewing))
+		ferment()
+
 /obj/item/food/grown/Destroy()
 	if(isatom(seed))
 		QDEL_NULL(seed)
@@ -101,6 +104,25 @@
 		to_chat(usr, span_warning("[src] needs to be dry before it can be ground up!"))
 		return
 	return TRUE
+
+/// Turns the nutriments and vitamins into the distill reagent or fruit wine
+/obj/item/food/grown/proc/ferment()
+	for(var/datum/reagent/reagent in reagents.reagent_list)
+		if(reagent.type != /datum/reagent/consumable/nutriment && reagent.type != /datum/reagent/consumable/nutriment/vitamin)
+			continue
+		if(distill_reagent)
+			reagents.add_reagent(distill_reagent, reagent.volume)
+		else
+			var/data = list()
+			data["names"] = list("[initial(name)]" = 1)
+			data["color"] = filling_color
+			data["boozepwr"] = wine_power
+			if(wine_flavor)
+				data["tastes"] = list(wine_flavor = 1)
+			else
+				data["tastes"] = list(tastes[1] = 1)
+			reagents.add_reagent(/datum/reagent/consumable/ethanol/fruit_wine, reagent.volume, data)
+		reagents.del_reagent(reagent.type)
 
 /obj/item/food/grown/on_grind()
 	. = ..()

--- a/code/modules/hydroponics/grown/sugarcane.dm
+++ b/code/modules/hydroponics/grown/sugarcane.dm
@@ -14,7 +14,7 @@
 	yield = 4
 	instability = 15
 	growthstages = 2
-	reagents_add = list(/datum/reagent/consumable/sugar = 0.25)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.04, /datum/reagent/consumable/sugar = 0.25)
 	mutatelist = list(/obj/item/seeds/bamboo)
 
 /obj/item/food/grown/sugarcane

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -277,11 +277,6 @@
 				data = list("blood_type" = "O-")
 			if(istype(grown_edible) && (rid == /datum/reagent/consumable/nutriment || rid == /datum/reagent/consumable/nutriment/vitamin))
 				data = grown_edible.tastes // apple tastes of apple.
-				//Handles the distillary trait, swaps nutriment and vitamins for that species brewable if it exists.
-				if(get_gene(/datum/plant_gene/trait/brewing) && grown_edible.distill_reagent)
-					T.reagents.add_reagent(grown_edible.distill_reagent, amount/2)
-					continue
-
 			T.reagents.add_reagent(rid, amount, data)
 
 		//Handles the juicing trait, swaps nutriment and vitamins for that species various juices if they exist. Mutually exclusive with distilling.


### PR DESCRIPTION
## About The Pull Request

The barrel was essentially a grinder that also added a lot of wine on top of other reagents. Now it converts only nutriment and vitamin into the wine.

Also the Auto-Distilling Composition plant gene didn't make fruit wine and gave only half of the distilled drink volume.

- Now the fermentation is consistent and it happens in one place - the `ferment()` proc of the plant. Both gene and barrel use it.
- Added some sounds and ballon alerts.
- Increased the barrel volume to 600, as other stationary reagent containers have even more.

https://user-images.githubusercontent.com/3625094/203582992-8d31cff6-15bd-416f-b2fb-c7a0f6cfbcb4.mp4

## Why It's Good For The Game

Barrels are cute, we should use them more.

## Changelog

:cl:
qol: barrel works with the plant bag now
balance: barrel volume increased to 600 units
fix: barrel now properly converts nutriments into wine
fix: added 4% nutriments to sugar cane, to allow rum creation
refactor: barrel logic and fermentation refactoring
/:cl:
