### PR TITLE
Fixes all modular computers being called "processing unit"

### DIFF
--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -14,8 +14,8 @@
 
 /obj/item/modular_computer/processor/UpdateDisplay()
 	. = ..()
-	//update the name with us
-	machinery_computer.name = name
+	//update our name to match the computer's
+	name = machinery_computer.name
 
 /obj/item/modular_computer/processor/Initialize(mapload)
 	if(!istype(loc, /obj/machinery/modular_computer))


### PR DESCRIPTION
## About The Pull Request
That's it, really. The processing unit was giving its name to the console, rather than it being the other way around.

## Why It's Good For The Game
It's nice when machines are named the way they're meant to be named.

## Changelog

:cl: GoldenAlpharex
fix: Modular computers will now no longer all be called "processing unit", and will all have their own unique names once again.
/:cl: