### PR TITLE
Fix allow_spawn check for Ashwalkers and Battlecruiser crew

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -228,7 +228,8 @@
 /obj/effect/mob_spawn/ghost_role/human/ash_walker/allow_spawn(mob/user, silent = FALSE)
 	if(!(user.key in team.players_spawned))//one per person unless you get a bonus spawn
 		return TRUE
-	to_chat(user, span_warning("<b>You have exhausted your usefulness to the Necropolis</b>."))
+	if(!silent)
+		to_chat(user, span_warning("You have exhausted your usefulness to the Necropolis."))
 	return FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/ash_walker/special(mob/living/carbon/human/spawned_human)

--- a/code/modules/mob_spawn/ghost_roles/space_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/space_roles.dm
@@ -120,7 +120,8 @@
 /obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/allow_spawn(mob/user, silent = FALSE)
 	if(!(user.ckey in antag_team.players_spawned))
 		return TRUE
-	to_chat(user, span_boldwarning("You have already used up your chance to roll as Battlecruiser."))
+	if(!silent)
+		to_chat(user, span_boldwarning("You have already used up your chance to roll as Battlecruiser."))
 	return FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/special(mob/living/spawned_mob, mob/possesser)


### PR DESCRIPTION

## About The Pull Request
Currently, if you fail the allow_spawn test for Ashwalkers or Battlecruiser Crew you will get the deny message even if the check was silent. Meaning every time you open the spawners menu you get "You have exhausted your usefulness to the Necropolis." or "You have already used up your chance to roll as Battlecruiser." All the other allow_spawn checks have a `!silent` check before sending the message so that they only show this message if the player actually clicks the spawner.

Also for some reason the ashwalker message is bold and it shouldn't be.
## Why It's Good For The Game
Consistency is good, as is not giving the player unnecessary chat messages.
## Changelog
:cl: VexingRaven
fix: Ashwalker Eggs and Battlecruiser spawners no longer give you a warning every time you open the spawn menu if you've already spawned as that role once.
spellcheck: Ashwalker Egg warning message for having already spawned once is no longer bolded for no reason.
/:cl:
