### PR TITLE
Basic Mob Carp Part IV: Revived Basic Mobs Look Alive

### DIFF
--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -122,6 +122,15 @@
 			transform = transform.Turn(180)
 		set_density(FALSE)
 
+/mob/living/basic/revive(full_heal_flags = NONE, excess_healing = 0, force_grab_ghost = FALSE)
+	. = ..()
+	if (!.)
+		return
+	icon_state = icon_living
+	if (flip_on_death)
+		transform = transform.Turn(180)
+	set_density(initial(density))
+
 /mob/living/basic/proc/melee_attack(atom/target)
 	src.face_atom(target)
 	if(SEND_SIGNAL(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, target) & COMPONENT_HOSTILE_NO_ATTACK)

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -77,6 +77,8 @@
 	var/icon_gib = null
 	///Flip the sprite upside down on death. Mostly here for things lacking custom dead sprites.
 	var/flip_on_death = FALSE
+	///Invert the mob's density on death. A usually dense mob will become passable, a passable one will become dense.
+	var/flip_density_on_death = TRUE
 
 	///If the mob can be spawned with a gold slime core. HOSTILE_SPAWN are spawned with plasma, FRIENDLY_SPAWN are spawned with blood.
 	var/gold_core_spawnable = NO_SPAWN
@@ -120,7 +122,8 @@
 		icon_state = icon_dead
 		if(flip_on_death)
 			transform = transform.Turn(180)
-		set_density(FALSE)
+		if (flip_density_on_death)
+			set_density(!density)
 
 /mob/living/basic/revive(full_heal_flags = NONE, excess_healing = 0, force_grab_ghost = FALSE)
 	. = ..()
@@ -129,7 +132,8 @@
 	icon_state = icon_living
 	if (flip_on_death)
 		transform = transform.Turn(180)
-	set_density(initial(density))
+	if (flip_density_on_death)
+		set_density(!density)
 
 /mob/living/basic/proc/melee_attack(atom/target)
 	src.face_atom(target)


### PR DESCRIPTION

## About The Pull Request

Fourth atomisation of #71421 
Pretty basic fix, if you revived basic mobs they'd retain their dead appearance forever (as well as losing density if they had it).
Now they don't do that.

There's still some work to do to get the Lazarus Injector to work with Basic Mobs because of how it changes behaviour, and we don't really have support for that yet. Probably important once it covers more pets because once Basic Mob Dogs is merged Ian will be temporarily impossible to revive with the injector (although strange reagent, wands, etc will still work fine).
I'll get to that eventually.

## Why It's Good For The Game

If something is alive it should look alive.

## Changelog
:cl:
fix: A revived basic mob will stand up again rather than inching around as a living corpse.
/:cl:
