### PR TITLE
Wirecarp mass PDA now edits the TARGET computer

### DIFF
--- a/code/modules/modular_computers/file_system/programs/wirecarp.dm
+++ b/code/modules/modular_computers/file_system/programs/wirecarp.dm
@@ -56,7 +56,7 @@
 			var/obj/item/modular_computer/target_tablet = locate(params["ref"]) in GLOB.TabletMessengers
 			if(!istype(target_tablet))
 				return
-			for(var/datum/computer_file/program/messenger/messenger_app in computer.stored_files)
+			for(var/datum/computer_file/program/messenger/messenger_app in target_tablet.stored_files)
 				messenger_app.spam_mode = !messenger_app.spam_mode
 
 /datum/computer_file/program/ntnetmonitor/ui_data(mob/user)


### PR DESCRIPTION
## About The Pull Request

Wirecarp's mass pda perms feature broke when I had switched 'target computer' for the host of the application instead, likely due to a copy paste error. This fixes that, allowing the RD to once again give people PDA perms.

## Why It's Good For The Game

Wirecarp now works as intended.

## Changelog

:cl:
fix: Wirecarp now lets you give people mass PDA perms again.
/:cl:
