### PR TITLE
Limits when Icebox's snow will alert you

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -306,6 +306,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// prevents xeno huggies implanting skeletons
 #define TRAIT_XENO_IMMUNE "xeno_immune"
 #define TRAIT_NAIVE "naive"
+/// always detect storms on icebox
+#define TRAIT_DETECT_STORM "detect_storm"
 #define TRAIT_PRIMITIVE "primitive"
 #define TRAIT_GUNFLIP "gunflip"
 /// Increases chance of getting special traumas, makes them harder to cure

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -179,8 +179,7 @@
 // the checks for if a mob should recieve alerts, returns TRUE if can
 /datum/weather/proc/can_get_alert(mob/player)
 	var/turf/mob_turf = get_turf(player)
-	if(mob_turf)
-		return TRUE
+	return !isnull(mob_turf)
 
 /**
  * Returns TRUE if the living mob can be affected by the weather

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -114,15 +114,7 @@
 	weather_duration = rand(weather_duration_lower, weather_duration_upper)
 	SSweather.processing |= src
 	update_areas()
-	for(var/z_level in impacted_z_levels)
-		for(var/mob/player as anything in SSmobs.clients_by_zlevel[z_level])
-			var/turf/mob_turf = get_turf(player)
-			if(!mob_turf)
-				continue
-			if(telegraph_message)
-				to_chat(player, telegraph_message)
-			if(telegraph_sound)
-				SEND_SOUND(player, sound(telegraph_sound))
+	send_alert(telegraph_message, telegraph_sound)
 	addtimer(CALLBACK(src, PROC_REF(start)), telegraph_duration)
 
 /**
@@ -138,15 +130,7 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_WEATHER_START(type))
 	stage = MAIN_STAGE
 	update_areas()
-	for(var/z_level in impacted_z_levels)
-		for(var/mob/player as anything in SSmobs.clients_by_zlevel[z_level])
-			var/turf/mob_turf = get_turf(player)
-			if(!mob_turf)
-				continue
-			if(weather_message)
-				to_chat(player, weather_message)
-			if(weather_sound)
-				SEND_SOUND(player, sound(weather_sound))
+	send_alert(weather_message, weather_sound)
 	if(!perpetual)
 		addtimer(CALLBACK(src, PROC_REF(wind_down)), weather_duration)
 
@@ -163,15 +147,7 @@
 	SEND_GLOBAL_SIGNAL(COMSIG_WEATHER_WINDDOWN(type))
 	stage = WIND_DOWN_STAGE
 	update_areas()
-	for(var/z_level in impacted_z_levels)
-		for(var/mob/player as anything in SSmobs.clients_by_zlevel[z_level])
-			var/turf/mob_turf = get_turf(player)
-			if(!mob_turf)
-				continue
-			if(end_message)
-				to_chat(player, end_message)
-			if(end_sound)
-				SEND_SOUND(player, sound(end_sound))
+	send_alert(end_message, end_sound)
 	addtimer(CALLBACK(src, PROC_REF(end)), end_duration)
 
 /**
@@ -188,6 +164,23 @@
 	stage = END_STAGE
 	SSweather.processing -= src
 	update_areas()
+
+// handles sending all alerts
+/datum/weather/proc/send_alert(alert_msg, alert_sfx)
+	for(var/z_level in impacted_z_levels)
+		for(var/mob/player as anything in SSmobs.clients_by_zlevel[z_level])
+			if(!can_get_alert(player))
+				continue
+			if(alert_msg)
+				to_chat(player, alert_msg)
+			if(alert_sfx)
+				SEND_SOUND(player, sound(alert_sfx))
+
+// the checks for if a mob should recieve alerts, returns TRUE if can
+/datum/weather/proc/can_get_alert(mob/player)
+	var/turf/mob_turf = get_turf(player)
+	if(mob_turf)
+		return TRUE
 
 /**
  * Returns TRUE if the living mob can be affected by the weather

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -27,3 +27,25 @@
 /datum/weather/snow_storm/weather_act(mob/living/L)
 	L.adjust_bodytemperature(-rand(5,15))
 
+
+// since snowstorm is on a station z level, add extra checks to not annoy everyone
+/datum/weather/snow_storm/can_get_alert(mob/player)
+	var/standard_check = ..()
+	// dont bother checking if theyre not on the station or wouldnt be able to see the alert anyways
+	if(!standard_check || !is_station_level(player.z))
+		return standard_check
+
+	if(isobserver(player))
+		return TRUE
+
+	if(istype(get_area(player), /area/mine))
+		return TRUE
+
+	if(player.mind?.assigned_role.title == JOB_SHAFT_MINER) // a good miner always senses a storm brewin.
+		return TRUE
+
+	for(var/area/snowarea in impacted_areas)
+		if(locate(snowarea) in view(player))
+			return TRUE
+
+	return FALSE

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -30,10 +30,11 @@
 
 // since snowstorm is on a station z level, add extra checks to not annoy everyone
 /datum/weather/snow_storm/can_get_alert(mob/player)
-	var/standard_check = ..()
-	// dont bother checking if theyre not on the station or wouldnt be able to see the alert anyways
-	if(!standard_check || !is_station_level(player.z))
-		return standard_check
+	if(!..())
+		return FALSE
+
+	if(!is_station_level(player.z))
+		return TRUE  // bypass checks
 
 	if(isobserver(player))
 		return TRUE

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -46,8 +46,8 @@
 		return TRUE
 
 
-	for(var/area/snowarea in impacted_areas)
-		if(locate(snowarea) in view(player))
+	for(var/area/snow_area in impacted_areas)
+		if(locate(snow_area) in view(player))
 			return TRUE
 
 	return FALSE

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -38,11 +38,12 @@
 	if(isobserver(player))
 		return TRUE
 
+	if(HAS_TRAIT(player, TRAIT_DETECT_STORM))
+		return TRUE
+
 	if(istype(get_area(player), /area/mine))
 		return TRUE
 
-	if(player.mind?.assigned_role.title == JOB_SHAFT_MINER) // a good miner always senses a storm brewin.
-		return TRUE
 
 	for(var/area/snowarea in impacted_areas)
 		if(locate(snowarea) in view(player))

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -26,6 +26,14 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_TOOL_ATOM_ACTED_PRIMARY(tool_behaviour), PROC_REF(on_analyze))
 
+/obj/item/analyzer/equipped(mob/user, slot, initial)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_DETECT_STORM, CLOTHING_TRAIT)
+
+/obj/item/analyzer/dropped(mob/user, silent)
+	. = ..()
+	REMOVE_TRAIT(user, TRAIT_DETECT_STORM, CLOTHING_TRAIT)
+
 /obj/item/analyzer/examine(mob/user)
 	. = ..()
 	. += span_notice("Right-click [src] to open the gas reference.")

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -17,6 +17,8 @@
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_CAR
 
+	mind_traits = list(TRAIT_DETECT_STORM)
+
 	display_order = JOB_DISPLAY_ORDER_SHAFT_MINER
 	bounty_types = CIV_JOB_MINE
 	departments_list = list(


### PR DESCRIPTION
## About The Pull Request
Limits when you get alerted to icebox, to when you would need to know it

When youre in a mining area
If you're a miner
and If you can see the snow outside
then it will alert you, otherwise it hides the alert
and ghosts always get alerted
## Why It's Good For The Game
Getting alerted about incoming storms is annoying when you're indoors for 80-100% of the shift, and just serves to clutter chat. Also, the way its set up is modular and can be applied to any other weather condition you'd want
## Changelog
:cl:
fix: limits how much you get alerted by icebox storms
/:cl:
