### PR TITLE
Fixes being able to get to centcomm and move through floors when in mechs/boxes

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -243,7 +243,7 @@
 */
 /atom/movable/proc/try_step_multiz(direction, z_move_flags = ZMOVE_FLIGHT_FLAGS)
 	if(direction == UP || direction == DOWN)
-		return zMove(direction)
+		return zMove(direction, null, z_move_flags)
 	return step(src, direction)
 
 /*

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -235,6 +235,18 @@
 	return TRUE
 
 /*
+ * Attempts to move using zMove if direction is UP or DOWN, step if not
+ *
+ * Args:
+ * direction: The direction to go
+ * z_move_flags: bitflags used for checks in zMove and can_z_move
+*/
+/atom/movable/proc/try_step_multiz(direction, z_move_flags = ZMOVE_FLIGHT_FLAGS)
+	if(direction == UP || direction == DOWN)
+		return zMove(direction)
+	return step(src, direction)
+
+/*
  * The core multi-z movement proc. Used to move a movable through z levels.
  * If target is null, it'll be determined by the can_z_move proc, which can potentially return null if
  * conditions aren't met (see z_move_flags defines in __DEFINES/movement.dm for info) or if dir isn't set.

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -168,7 +168,7 @@
 				amount = 25
 
 		can_move = world.time + amount
-		step(src, direction)
+		try_step_multiz(direction)
 	return
 
 /obj/effect/dummy/chameleon/Destroy()

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -32,7 +32,7 @@
 		return
 	move_delay = TRUE
 	var/oldloc = loc
-	step(src, direction)
+	try_step_multiz(direction);
 	if(oldloc != loc)
 		addtimer(CALLBACK(src, PROC_REF(ResetMoveDelay)), CONFIG_GET(number/movedelay/walk_delay) * move_speed_multiplier)
 	else

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -439,7 +439,10 @@
 		return
 	if(pixel_x != base_pixel_x || pixel_y != base_pixel_y)
 		animate(src, 0.2 SECONDS, pixel_x = base_pixel_y, pixel_y = base_pixel_y, flags = ANIMATION_PARALLEL)
-	Move(get_step_multiz(src, direction), direction)
+	if(direction == UP || direction == DOWN)
+		zMove(direction)
+	else
+		Move(get_step(src, direction))
 	COOLDOWN_START(src, move_cooldown, (direction in GLOB.cardinals) ? 0.1 SECONDS : 0.2 SECONDS)
 
 /obj/item/soulscythe/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -439,10 +439,7 @@
 		return
 	if(pixel_x != base_pixel_x || pixel_y != base_pixel_y)
 		animate(src, 0.2 SECONDS, pixel_x = base_pixel_y, pixel_y = base_pixel_y, flags = ANIMATION_PARALLEL)
-	if(direction == UP || direction == DOWN)
-		zMove(direction)
-	else
-		Move(get_step(src, direction))
+	try_step_multiz(direction)
 	COOLDOWN_START(src, move_cooldown, (direction in GLOB.cardinals) ? 0.1 SECONDS : 0.2 SECONDS)
 
 /obj/item/soulscythe/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -548,6 +548,12 @@
 	set name = "Move Down"
 	set category = "IC"
 
+	var/turf/current_turf = get_turf(src)
+	var/turf/below_turf = SSmapping.get_turf_below(current_turf)
+	if(!below_turf)
+		to_chat(src, span_warning("There's nowhere to go in that direction!"))
+		return
+
 	if(ismovable(loc)) //Inside an object, tell it we moved
 		var/atom/loc_atom = loc
 		return loc_atom.relaymove(src, DOWN)

--- a/code/modules/mod/mod_ai.dm
+++ b/code/modules/mod/mod_ai.dm
@@ -90,7 +90,7 @@
 		ADD_TRAIT(wearer, TRAIT_FORCED_STANDING, MOD_TRAIT)
 		addtimer(CALLBACK(src, PROC_REF(ai_fall)), AI_FALL_TIME, TIMER_UNIQUE | TIMER_OVERRIDE)
 	var/atom/movable/mover = wearer || src
-	return step(mover, direction)
+	return mover.try_step_multiz(direction)
 
 #undef MOVE_DELAY
 #undef WEARER_DELAY

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -95,9 +95,9 @@
 
 	if(trailer)
 		var/dir_to_move = get_dir(trailer.loc, loc)
-		var/did_move = step(src, direction)
+		var/did_move = try_step_multiz(direction)
 		if(did_move)
 			step(trailer, dir_to_move)
 		return did_move
 	after_move(direction)
-	return step(src, direction)
+	return try_step_multiz(direction)

--- a/code/modules/vehicles/mecha/mecha_movement.dm
+++ b/code/modules/vehicles/mecha/mecha_movement.dm
@@ -119,7 +119,7 @@
 
 	set_glide_size(DELAY_TO_GLIDE_SIZE(movedelay))
 	//Otherwise just walk normally
-	. = step(src,direction, dir)
+	. = try_step_multiz(direction)
 	if(phasing)
 		use_power(phasing_energy_drain)
 	if(strafe)


### PR DESCRIPTION

## About The Pull Request
Fixes #71484 - Adds a check to the down verb to make sure a z level exists below before trying to move.
Changes some step() in relay_move procs to use zMove instead if they have a direction of up/down, as this was causing you to be able to phase through floors if you were in a cardboard box/mech/etc
## Why It's Good For The Game
![dreamseeker_LuXqZUhvNg](https://user-images.githubusercontent.com/22856555/203672877-6b7da56c-494a-49dc-a8c8-13b15c2133eb.gif)
## Changelog
:cl:
fix: Fixed being able to move through floors and get to centcomm when moving up/down while inside mechs and similar movable objects.
/:cl:
