### PR TITLE
Caches Rust for Run Linters CI

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -30,6 +30,15 @@ jobs:
             ${{ runner.os }}-build-${{ secrets.CACHE_PURGE_KEY }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - name: Restore Rust cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-rust-${{ secrets.CACHE_PURGE_KEY }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ secrets.CACHE_PURGE_KEY }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Install Tools
         run: |
           pip3 install setuptools


### PR DESCRIPTION
## About The Pull Request

Hey there,

It's on the tin, we just cache the whole Rust installation to use over multiple workflows. Without this, it would take up to _five minutes per linters workflow run_ to install the whole fucking rust toolchain/crate dependencies (ref: https://github.com/san7890/bruhstation/actions/runs/3536980337/jobs/5936542571 ).

Now with the cache, it's now down to approximately one minute, thirty seconds after it's able to pull a cached rust installation (ref: https://github.com/san7890/bruhstation/actions/runs/3537002138/jobs/5936585526 ). More than half is very good, and frees up valuable Github Runners slots sooner!

I've also always seen linters as that rapid check to immediately call you out whenever you screw up in a PR, and it taking four minutes sorta lessens that immediate: "HEY, LISTEN!" aspect
