### PR TITLE
The clown car now crashes upon collision with a deer. Also fixes an unrelated bug with car keys I found while testing.

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -100,7 +100,7 @@
 
 /obj/vehicle/sealed/car/clowncar/Bump(atom/bumped)
 	. = ..()
-	if(isliving(bumped))
+	if(isliving(bumped) && !istype(bumped, /mob/living/simple_animal/deer))
 		if(ismegafauna(bumped))
 			return
 		var/mob/living/hittarget_living = bumped

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -98,6 +98,7 @@
 			if(inserted_key) //just in case there's an invalid key
 				inserted_key.forceMove(drop_location())
 			inserted_key = I
+			inserted_key.forceMove(src)
 		else
 			to_chat(user, span_warning("[I] seems to be stuck to your hand!"))
 		return
@@ -111,7 +112,6 @@
 		to_chat(user, span_warning("You must be driving [src] to remove [src]'s key!"))
 		return
 	to_chat(user, span_notice("You remove [inserted_key] from [src]."))
-	inserted_key.forceMove(drop_location())
 	if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		user.put_in_hands(inserted_key)
 	else


### PR DESCRIPTION

## About The Pull Request

Clown cars now crash into deer rather than sucking them up.

Removing the keys from a car would call forcemove, then place it in the user's inventory. For some reason, the inserted_key would be nulled during the forcemove, leading to a null.equip_to_best_slot being called and a runtime and not getting your key back.
## Why It's Good For The Game

https://en.wikipedia.org/wiki/Deer%E2%80%93vehicle_collisions

The natural enemy of the car is the deer.
## Changelog
:cl:
fix: you get your keys upon removing them from a car now!
balance: the clown car now crashes upon ramming into a deer, like god intended.
/:cl:
