### PR TITLE
Fixes being unable to open necropolis gate when behind it

### DIFF
--- a/code/datums/components/seethrough.dm
+++ b/code/datums/components/seethrough.dm
@@ -13,9 +13,11 @@
 	var/animation_time
 	///After we somehow moved (because ss13 is godless and does not respect anything), how long do we need to stand still to feel safe to setup our "behind" area again
 	var/perimeter_reset_timer
+	///Does this object let clicks from players its transparent to pass through it
+	var/clickthrough
 
 ///see_through_map is a define pointing to a specific map. It's basically defining the area which is considered behind. See see_through_maps.dm for a list of maps
-/datum/component/seethrough/Initialize(see_through_map = SEE_THROUGH_MAP_DEFAULT, target_alpha = 100, animation_time = 0.5 SECONDS, perimeter_reset_timer = 2 SECONDS)
+/datum/component/seethrough/Initialize(see_through_map = SEE_THROUGH_MAP_DEFAULT, target_alpha = 100, animation_time = 0.5 SECONDS, perimeter_reset_timer = 2 SECONDS, clickthrough = TRUE)
 	. = ..()
 
 	relative_turf_coords = GLOB.see_through_maps[see_through_map]
@@ -28,6 +30,7 @@
 	src.target_alpha = target_alpha
 	src.animation_time = animation_time
 	src.perimeter_reset_timer = perimeter_reset_timer
+	src.clickthrough = clickthrough
 
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(dismantle_perimeter))
 
@@ -102,8 +105,10 @@
 	var/image/user_overlay = new(parent)
 	user_overlay.loc = parent
 	user_overlay.override = TRUE
-	//Special plane so we can click through the overlay
-	SET_PLANE_EXPLICIT(user_overlay, SEETHROUGH_PLANE, parent)
+
+	if(clickthrough)
+		//Special plane so we can click through the overlay
+		SET_PLANE_EXPLICIT(user_overlay, SEETHROUGH_PLANE, parent)
 
 	//These are inherited, but we already use the atom's loc so we end up at double the pixel offset
 	user_overlay.pixel_x = 0

--- a/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
@@ -50,7 +50,7 @@
 	)
 
 	AddElement(/datum/element/connect_loc, loc_connections)
-	AddComponent(/datum/component/seethrough, SEE_THROUGH_MAP_DEFAULT_TWO_TALL, null, null, null, FALSE)
+	AddComponent(/datum/component/seethrough, SEE_THROUGH_MAP_DEFAULT_TWO_TALL, clickthrough = FALSE)
 
 /obj/structure/necropolis_gate/Destroy(force)
 	qdel(sight_blocker)

--- a/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/necropolis_gate.dm
@@ -50,7 +50,7 @@
 	)
 
 	AddElement(/datum/element/connect_loc, loc_connections)
-	AddComponent(/datum/component/seethrough, SEE_THROUGH_MAP_DEFAULT_TWO_TALL)
+	AddComponent(/datum/component/seethrough, SEE_THROUGH_MAP_DEFAULT_TWO_TALL, null, null, null, FALSE)
 
 /obj/structure/necropolis_gate/Destroy(force)
 	qdel(sight_blocker)


### PR DESCRIPTION

## About The Pull Request
Adds a new parameter to the seethrough component for if it should allow clickthrough when transparent (true by default), and sets it to false on the necropolis gate.
## Why It's Good For The Game
Fixes #71471 
Ashwalkers can't even leave their own base right now because it's impossible for them to open the door from inside.
## Changelog
:cl:
fix: Fixed being unable to open the necropolis gate when standing behind it
/:cl:
