### PR TITLE
Better RND logs & Experiment handheld connects to techwebs directly

### DIFF
--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -73,7 +73,7 @@
 	// on the map as the servers aren't initialized when the non-machines are initializing
 	if (!(config_flags & EXPERIMENT_CONFIG_NO_AUTOCONNECT))
 		var/list/found_servers = get_available_servers(parent)
-		var/obj/machinery/rnd/server/selected_server = found_servers.len ? found_servers[1] : null
+		var/obj/machinery/rnd/server/selected_server = length(found_servers) ? found_servers[1] : null
 		if (selected_server)
 			link_techweb(selected_server.stored_research)
 
@@ -297,7 +297,7 @@
 	if (!turf_source)
 		turf_source = get_turf(parent)
 	var/list/local_servers = list()
-	for (var/obj/machinery/rnd/server/server in SSresearch.servers)
+	for (var/obj/machinery/rnd/server/server as anything in SSresearch.servers)
 		var/turf/turf_server = get_turf(server)
 		if (!turf_source || !turf_server)
 			break
@@ -352,21 +352,20 @@
 
 /datum/component/experiment_handler/ui_data(mob/user)
 	. = list(
-		"always_active" = config_flags & EXPERIMENT_CONFIG_ALWAYS_ACTIVE,
-		"has_start_callback" = !isnull(start_experiment_callback))
+		"always_active" = (config_flags & EXPERIMENT_CONFIG_ALWAYS_ACTIVE),
+		"has_start_callback" = !isnull(start_experiment_callback),
+	)
 	.["techwebs"] = list()
 	for (var/datum/techweb/techwebs as anything in SSresearch.techwebs)
 		if(!length(techwebs.techweb_servers)) //no servers, we don't care
 			continue
-		var/obj/machinery/rnd/server = techwebs.techweb_servers[1] //get the first machine possible
-		if(!is_valid_z_level(get_turf(user), get_turf(server)))
+		if(!is_valid_z_level(get_turf(techwebs.techweb_servers[1]), get_turf(parent)))
 			continue
 		var/list/data = list(
-			name = server.name,
 			web_id = techwebs.id,
 			web_org = techwebs.organization,
 			selected = (techwebs == linked_web),
-			ref = REF(server),
+			ref = REF(techwebs),
 			all_servers = techwebs.techweb_servers,
 		)
 		.["techwebs"] += list(data)
@@ -392,9 +391,9 @@
 	switch (action)
 		if ("select_server")
 			. = TRUE
-			var/obj/machinery/rnd/server/server = locate(params["ref"])
-			if (server)
-				link_techweb(server.stored_research)
+			var/datum/techweb/new_techweb = locate(params["ref"])
+			if (new_techweb)
+				link_techweb(new_techweb)
 				return
 		if ("clear_server")
 			. = TRUE

--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -358,6 +358,8 @@
 	.["techwebs"] = list()
 	for (var/datum/techweb/techwebs as anything in SSresearch.techwebs)
 		if(!length(techwebs.techweb_servers)) //no servers, we don't care
+			if(techwebs == linked_web) //disconnect if OUR techweb lost their servers.
+				unlink_techweb()
 			continue
 		if(!is_valid_z_level(get_turf(techwebs.techweb_servers[1]), get_turf(parent)))
 			continue

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -24,13 +24,17 @@
 		connect_techweb(SSresearch.science_tech)
 	wires = new /datum/wires/rnd(src)
 
-/obj/machinery/rnd/proc/connect_techweb(datum/techweb/new_techweb)
-	stored_research = new_techweb
-
 /obj/machinery/rnd/Destroy()
-	stored_research = null
+	if(stored_research)
+		log_research("[src] disconnected from techweb [stored_research] (destroyed).")
+		stored_research = null
 	QDEL_NULL(wires)
 	return ..()
+
+/obj/machinery/rnd/proc/connect_techweb(datum/techweb/new_techweb)
+	if(stored_research)
+		log_research("[src] disconnected from techweb [stored_research] when connected to [new_techweb].")
+	stored_research = new_techweb
 
 /obj/machinery/rnd/proc/shock(mob/user, prb)
 	if(machine_stat & (BROKEN|NOPOWER)) // unpowered, no shock

--- a/tgui/packages/tgui/interfaces/ExperimentConfigure.js
+++ b/tgui/packages/tgui/interfaces/ExperimentConfigure.js
@@ -118,7 +118,7 @@ export const ExperimentConfigure = (props, context) => {
               <Box>
                 {webs.size > 0
                   ? 'Please select a techweb to connect to...'
-                  : 'Found no available techwebs!'}
+                  : 'Found no servers connected to a techweb!'}
               </Box>
               {webs.size > 0 &&
                 Array.from(webs, ([techweb, techwebs]) => (


### PR DESCRIPTION
## About The Pull Request

- Adds better feedback to the experiment handler's UI when it can't connect to a techweb
- Experiment handlers now refs techwebs directly, instead of servers, so if the server in question breaks there won't have some wonky stuff happening.
- Adds logs when rnd machines (so techfabs & servers) are disconnected from a techweb, either on the machine's destruction or when it gets linked to another techweb.
- Disconnects experiment handlers if the techweb they're connected to has no more research servers suddenly.

## Why It's Good For The Game

Better RnD logging, better user feedback, and connecting to techwebs directly instead of servers makes it more resilient to bugs.

## Changelog

:cl:
qol: Experiment handlers now give a more reasonable explanation for why they can't find a server.
admin: Machines being disconnected from techwebs is now logged in research.
/:cl: