### PR TITLE
Removes message admins for tram malfunction failing to run

### DIFF
--- a/code/modules/events/tram_malfunction.dm
+++ b/code/modules/events/tram_malfunction.dm
@@ -21,7 +21,6 @@
 		if(tram_ref.specific_lift_id == MAIN_STATION_TRAM)
 			return .
 
-	message_admins("Second pre-condition check for [name] failed, selecting new event.")
 	return FALSE
 
 /datum/round_event/tram_malfunction


### PR DESCRIPTION

## About The Pull Request
See title
## Why It's Good For The Game
Really not needed to know for admins, it's getting a little spammy
## Changelog
:cl: Tattle
admin: removed message_admins message for tram malfunction failing to run on maps that aren't tram
/:cl:
