### PR TITLE
the shocks from spell packets now have SHOCK_NOGLOVES

### DIFF
--- a/code/modules/spells/spell_types/conjure_item/lighting_packet.dm
+++ b/code/modules/spells/spell_types/conjure_item/lighting_packet.dm
@@ -29,7 +29,7 @@
 	if(isliving(hit_atom))
 		var/mob/living/hit_living = hit_atom
 		if(!hit_living.can_block_magic())
-			hit_living.electrocute_act(80, src, flags = SHOCK_ILLUSION)
+			hit_living.electrocute_act(80, src, flags = SHOCK_ILLUSION | SHOCK_NOGLOVES)
 	qdel(src)
 
 /obj/item/spellpacket/lightningbolt/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback, force = INFINITY, quickstart = TRUE)


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

Atomized from https://github.com/tgstation/tgstation/pull/71426.

The shocks come from you being hit in the chest by a packet of enchanted birdseed, not from touching something with your hands.

## Changelog

:cl: ATHATH
fix: The shocks from the spell packets spell are no longer blocked by insulated gloves.
/:cl:
