### PR TITLE
Remove explicit runtime check in monkey business test

### DIFF
--- a/code/modules/unit_tests/monkey_business.dm
+++ b/code/modules/unit_tests/monkey_business.dm
@@ -25,6 +25,3 @@
 			new /datum/ai_controller/monkey(monkey)
 		monkey.ai_controller.blackboard[BB_MONKEY_TARGET_MONKEYS] = TRUE
 	sleep(monkey_timer)
-	var/monkey_runtimes = GLOB.total_runtimes - start_runtimes
-	if(monkey_runtimes)
-		TEST_FAIL("Monkey Business caused [monkey_runtimes] runtimes")


### PR DESCRIPTION
I knew this was redundant at first but kept it anyway because I thought it was fine.

However, for some code I'm writing to make issues for flaky tests, this is going to be an issue. I'm making sure it can intelligently create collated issues for multiple failures (rather than generating an issue for every individual shapeshift failure, for instance), but also a more obviously titled issue if it's only one failure. With this assertion, it always guarantees multiple failures, and would make issues harder to read.

To be clear, runtimes during a test ALWAYS mean failure. This check was never necessary, I just didn't mind it.