### PR TITLE
Don't rerun "Show Screenshot Tests"

### DIFF
--- a/.github/workflows/show_screenshot_test_results.yml
+++ b/.github/workflows/show_screenshot_test_results.yml
@@ -11,7 +11,7 @@ on:
       - completed
 jobs:
   show_screenshot_test_results:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && github.event.workflow_run.run_attempt == 1"
     name: Show Screenshot Test Results
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
I don't want the tool to rerun flaky tests to rerun show screenshot test results, or else it will repeat the comment twice if it only fails on one map.