### PR TITLE
Wrench pda fix

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -409,6 +409,10 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		if(ishuman(loc))
 			var/mob/living/carbon/human/human_wearer = loc
 			human_wearer.sec_hud_set_ID()
+	if(inserted_pai == gone)
+		inserted_pai = null
+	if(inserted_disk == gone)
+		inserted_disk = null
 	return ..()
 
 // On-click handling. Turns on the computer if it's off and opens the GUI.
@@ -778,6 +782,10 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 /obj/item/modular_computer/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
 	tool.play_tool_sound(src, user, 20, volume=20)
+	internal_cell?.forceMove(drop_location())
+	computer_id_slot?.forceMove(drop_location())
+	inserted_disk?.forceMove(drop_location())
+	inserted_pai?.forceMove(drop_location())
 	new /obj/item/stack/sheet/iron(get_turf(loc), steel_sheet_cost)
 	user.balloon_alert(user, "disassembled")
 	relay_qdel()

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -365,6 +365,10 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 /obj/item/modular_computer/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	. = ..()
 
+	if(held_item?.tool_behaviour == TOOL_WRENCH)
+		context[SCREENTIP_CONTEXT_RMB] = "Deconstruct"
+		. = CONTEXTUAL_SCREENTIP_SET
+
 	if(computer_id_slot) // ID get removed first before pAIs
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove ID"
 		. = CONTEXTUAL_SCREENTIP_SET
@@ -375,7 +379,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	if(inserted_disk)
 		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Remove SSD"
 		. = CONTEXTUAL_SCREENTIP_SET
-
 	return . || NONE
 
 /obj/item/modular_computer/update_icon_state()
@@ -779,7 +782,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 
 	return ..()
 
-/obj/item/modular_computer/wrench_act(mob/living/user, obj/item/tool)
+/obj/item/modular_computer/wrench_act_secondary(mob/living/user, obj/item/tool)
 	. = ..()
 	tool.play_tool_sound(src, user, 20, volume=20)
 	internal_cell?.forceMove(drop_location())


### PR DESCRIPTION
## About The Pull Request

Fixes #71514 
Now when PDA's are deconstructed, the ID, PAI, computer disk, and battery cell  (if there are any inside) will all drop to the floor.
PDA's and modular computers that are destroyed have their behaviours unchanged, this is only for deconstruction.
Also gives deconstructing a screentip and sets it to wrench_act_secondary

## Why It's Good For The Game

oversight, screentips are good even if its for something you probably wont do

## Changelog

:cl:
qol: pdas have a wrench deconstruct screentip
fix: wrenching a pda no longer destroys all contents inside
/:cl:
