### PR TITLE
Remove cache purge key that has never worked and has meant that our cache has never worked

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -20,23 +20,21 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/SpacemanDMM
-          key: ${{ runner.os }}-spacemandmm-${{ secrets.CACHE_PURGE_KEY }}
+          key: ${{ runner.os }}-spacemandmm
       - name: Restore Yarn cache
         uses: actions/cache@v3
         with:
           path: tgui/.yarn/cache
-          key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ secrets.CACHE_PURGE_KEY }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Restore Rust cache
         uses: actions/cache@v3
         with:
           path: ~/.cargo
-          key: ${{ runner.os }}-rust-${{ secrets.CACHE_PURGE_KEY }}
+          key: ${{ runner.os }}-rust
           restore-keys: |
-            ${{ runner.os }}-build-${{ secrets.CACHE_PURGE_KEY }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Install Tools
@@ -76,7 +74,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/BYOND
-          key: ${{ runner.os }}-byond-${{ secrets.CACHE_PURGE_KEY }}
+          key: ${{ runner.os }}-byond
       - name: Compile All Maps
         run: |
           bash tools/ci/install_byond.sh
@@ -185,9 +183,8 @@ jobs:
         uses: actions/cache@v3
         with:
           path: tgui/.yarn/cache
-          key: ${{ runner.os }}-yarn-${{ secrets.CACHE_PURGE_KEY }}-${{ hashFiles('tgui/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ secrets.CACHE_PURGE_KEY }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - name: Compile


### PR DESCRIPTION
ci_suite.yml runs on your fork. This means you do not have access to secrets. Every user has had the purge key of blank.

WE have it set to something. Which means the master cache that every PR pulls from has been unable to match.

This means our cache has been at the max limit all this time, constantly clearing out old caches, and never reusing any.