### PR TITLE
mugs now default to spawning empty

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -169,8 +169,8 @@
 	icon_state = "mug_nt_empty"
 
 /obj/item/reagent_containers/cup/glass/mug/nanotrasen/update_icon_state()
+	. = ..()
 	icon_state = reagents.total_volume ? "mug_nt" : "mug_nt_empty"
-	return ..()
 
 /obj/item/reagent_containers/cup/glass/coffee_cup
 	name = "coffee cup"

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -142,7 +142,7 @@
 /obj/item/reagent_containers/cup/glass/mug // parent type is literally just so empty mug sprites are a thing
 	name = "mug"
 	desc = "A drink served in a classy mug."
-	icon_state = "tea"
+	icon_state = "tea_empty"
 	inhand_icon_state = "coffee"
 	spillable = TRUE
 


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/116288367/204053022-1344cfce-8b55-4907-83b1-30e4eeab137d.png)


## Why It's Good For The Game

the sprites wrong!!!!!!!!!!!!!! also the code comment says that the parent /glass_mug exists to have an empty sprite but the sprite doesn't start empty!

## Changelog

:cl:
fix: roundstart empty mugs now appear to be empty
fix: nanotrasen mug no longer becomes normal mug after you drink from it
/:cl:
