### PR TITLE
The pentaerythritol recipe no longer conflicts with the acetaldehyde recipe

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -736,7 +736,7 @@
 
 /datum/chemical_reaction/pentaerythritol
 	results = list(/datum/reagent/pentaerythritol = 2)
-	required_reagents = list(/datum/reagent/acetaldehyde = 1, /datum/reagent/toxin/formaldehyde = 3, /datum/reagent/water = 1, /datum/reagent/sodium = 1)
+	required_reagents = list(/datum/reagent/acetaldehyde = 1, /datum/reagent/toxin/formaldehyde = 3, /datum/reagent/lye = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
 
 /datum/chemical_reaction/acetaldehyde

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -736,7 +736,7 @@
 
 /datum/chemical_reaction/pentaerythritol
 	results = list(/datum/reagent/pentaerythritol = 2)
-	required_reagents = list(/datum/reagent/acetaldehyde = 1, /datum/reagent/toxin/formaldehyde = 3, /datum/reagent/water = 1 )
+	required_reagents = list(/datum/reagent/acetaldehyde = 1, /datum/reagent/toxin/formaldehyde = 3, /datum/reagent/water = 1, /datum/reagent/sodium = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
 
 /datum/chemical_reaction/acetaldehyde


### PR DESCRIPTION
## About The Pull Request

Replaces 1 part water with 1 part lye in the pentaerythritol recipe to separate it from the acetaldehyde recipe.

I literally googled pentaerythritol production and the first thing that comes up is acetaldehyde, formaldehyde and sodium hydroxide. As it turns out, lye is sodium hydroxide so I just replaced the water with that. (I know the reaction occurs in an aqueous solution, but shouldn't a lot of our reactions do that and yet they don't? Yeah...)

I tested the recipe in-game and the conflicts were resolved.
## Why It's Good For The Game

Bug fix good.
## Changelog
:cl:
fix: You can now make acetaldehyde without making pentaerythritol.
/:cl:
