### PR TITLE
Fax QoL: Reply button

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -65,11 +65,11 @@
 #define ADMIN_COORDJMP(src) "[src ? src.Admin_Coordinates_Readable(FALSE, TRUE) : "nonexistent location"]"
 #define ADMIN_VERBOSEJMP(src) "[src ? src.Admin_Coordinates_Readable(TRUE, TRUE) : "nonexistent location"]"
 #define ADMIN_INDIVIDUALLOG(user) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];individuallog=[REF(user)]'>LOGS</a>)"
-#define ADMIN_TAG(datum) "(<A href='?src=[REF(src)];[HrefToken(forceGlobal = TRUE)];tag_datum=[REF(datum)]'>TAG</a>)"
+#define ADMIN_TAG(datum) "(<a href='?src=[REF(src)];[HrefToken(forceGlobal = TRUE)];tag_datum=[REF(datum)]'>TAG</a>)"
 #define ADMIN_LUAVIEW(state) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];lua_state=[REF(state)]'>VIEW STATE</a>)"
 #define ADMIN_LUAVIEW_CHUNK(state, log_index) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];lua_state=[REF(state)];log_index=[log_index]'>VIEW CODE</a>)"
 /// Displays "(SHOW)" in the chat, when clicked it tries to show atom(paper). First you need to set the request_state variable to TRUE for the paper.
-#define ADMIN_SHOW_PAPER(atom) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];show_paper=[REF(atom)]'>SHOW</a>)"
+#define ADMIN_SHOW_PAPER(atom) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];show_paper=[REF(atom)]'>SHOW</a>)"
 #define ADMIN_FAX_REPLY(atom) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];reply_fax=[REF(atom)]'>RPLY</a>)"
 
 /atom/proc/Admin_Coordinates_Readable(area_name, admin_jump_ref)

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -70,6 +70,7 @@
 #define ADMIN_LUAVIEW_CHUNK(state, log_index) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];lua_state=[REF(state)];log_index=[log_index]'>VIEW CODE</a>)"
 /// Displays "(SHOW)" in the chat, when clicked it tries to show atom(paper). First you need to set the request_state variable to TRUE for the paper.
 #define ADMIN_SHOW_PAPER(atom) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];show_paper=[REF(atom)]'>SHOW</a>)"
+#define ADMIN_FAX_REPLY(atom) "(<a href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];reply_fax=[REF(atom)]'>RPLY</a>)"
 
 /atom/proc/Admin_Coordinates_Readable(area_name, admin_jump_ref)
 	var/turf/T = Safe_COORD_Location()

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -146,7 +146,7 @@
 		air_update_turf(FALSE, FALSE)
 	if(admins_warned && internal_heat < max_heat * 0.75)
 		admins_warned = FALSE
-		message_admins("Power sink at ([x],[y],[z] - <A HREF='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has cooled down and will not explode.")
+		message_admins("Power sink at ([x],[y],[z] - [ADMIN_JMP(src)]) has cooled down and will not explode.")
 	if(mode != OPERATING && internal_heat < MINIMUM_HEAT)
 		internal_heat = 0
 		STOP_PROCESSING(SSobj, src)
@@ -186,7 +186,7 @@
 	if(internal_heat > max_heat * ALERT / 100)
 		if (!admins_warned)
 			admins_warned = TRUE
-			message_admins("Power sink at ([x],[y],[z] - <A HREF='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>) has reached [ALERT]% of max heat. Explosion imminent.")
+			message_admins("Power sink at ([x],[y],[z] - [ADMIN_JMP(src)]) has reached [ALERT]% of max heat. Explosion imminent.")
 		playsound(src, 'sound/effects/screech.ogg', 100, TRUE, TRUE)
 
 	if(internal_heat >= max_heat)

--- a/code/modules/admin/admin_fax_panel.dm
+++ b/code/modules/admin/admin_fax_panel.dm
@@ -10,13 +10,16 @@
 
 	var/datum/fax_panel_interface/ui = new(usr)
 	ui.ui_interact(usr)
-	
+
 /// Admin Fax Panel. Tool for sending fax messages faster.
 /datum/fax_panel_interface
 	/// All faxes in from machinery list()
 	var/available_faxes = list()
 	/// List with available stamps
 	var/stamp_list = list()
+
+	/// The fax machine we're sending to
+	var/obj/machinery/fax/action_fax
 
 	/// Paper which admin edit and send.
 	var/obj/item/paper/fax_paper = new /obj/item/paper(null)
@@ -30,14 +33,14 @@
 	//Get all faxes, and save them to our list.
 	for(var/obj/machinery/fax/fax in GLOB.machines)
 		available_faxes += WEAKREF(fax)
-	
+
 	//Get all stamps
 	for(var/stamp in subtypesof(/obj/item/stamp))
 		var/obj/item/stamp/real_stamp = new stamp()
 		if(!istype(real_stamp, /obj/item/stamp/chameleon) && !istype(real_stamp, /obj/item/stamp/mod))
 			var/stamp_detail = real_stamp.get_writing_implement_details()
 			stamp_list += list(list(real_stamp.name, real_stamp.icon_state, stamp_detail["stamp_class"]))
-	
+
 	//Give our paper special status, to read everywhere.
 	fax_paper.request_state = TRUE
 
@@ -74,12 +77,12 @@
 
 	for(var/stamp in stamp_list)
 		data["stamps"] += list(stamp[1]) // send only names.
-	
+
 	for(var/datum/weakref/weakrefed_fax as anything in available_faxes)
 		var/obj/machinery/fax/another_fax = weakrefed_fax.resolve()
 		if(another_fax && istype(another_fax))
 			data["faxes"] += list(another_fax.fax_name)
-	
+
 	return data
 
 /datum/fax_panel_interface/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -88,12 +91,10 @@
 
 	if(!check_rights(R_ADMIN))
 		return
-	
-	var/obj/machinery/fax/action_fax
 
 	if(params["faxName"])
-		action_fax = get_fax_by_name(params["faxName"]) 
-	
+		action_fax = get_fax_by_name(params["faxName"])
+
 	switch(action)
 
 		if("follow")
@@ -101,20 +102,20 @@
 				usr.client?.admin_ghost()
 
 			usr.client?.admin_follow(action_fax)
-		
+
 		if("preview") // see saved variant
 			if(!fax_paper)
 				return
 			fax_paper.ui_interact(usr)
-		
+
 		if("save") // save paper
 			if(params["paperName"])
 				default_paper_name = params["paperName"]
 			if(params["fromWho"])
 				sending_fax_name = params["fromWho"]
-			
+
 			fax_paper.clear_paper()
-			var/stamp 
+			var/stamp
 			var/stamp_class
 
 			for(var/needed_stamp in stamp_list)
@@ -122,24 +123,24 @@
 					stamp = needed_stamp[2]
 					stamp_class = needed_stamp[3]
 					break
-			
+
 			fax_paper.name = "paper — [default_paper_name]"
 			fax_paper.add_raw_text(params["rawText"])
 
 			if(stamp)
 				fax_paper.add_stamp(stamp_class, params["stampX"], params["stampY"], params["stampAngle"], stamp)
-			
-			fax_paper.update_static_data(usr) // OK, it's work, and update UI. 
-			
+
+			fax_paper.update_static_data(usr) // OK, it's work, and update UI.
+
 		if("send")
 			//copy
 			var/obj/item/paper/our_fax = fax_paper.copy(/obj/item/paper)
 			our_fax.name = fax_paper.name
 			//send
 			action_fax.receive(our_fax, sending_fax_name)
-			message_admins("[key_name_admin(usr)] has send custom fax message to [action_fax.name][ADMIN_FLW(action_fax)][ADMIN_SHOW_PAPER(fax_paper)].")
-			log_admin("[key_name(usr)] has send custom fax message to [action_fax.name]")
-		
+			message_admins("[key_name_admin(usr)] has sent a custom fax message to [action_fax.name][ADMIN_FLW(action_fax)][ADMIN_SHOW_PAPER(fax_paper)].")
+			log_admin("[key_name(usr)] has sent a custom fax message to [action_fax.name]")
+
 		if("createPaper")
 			var/obj/item/paper/our_paper = fax_paper.copy(/obj/item/paper, usr.loc)
 			our_paper.name = fax_paper.name

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1747,3 +1747,10 @@
 		if(!paper_to_show)
 			return
 		paper_to_show.ui_interact(usr)
+
+	else if(href_list["reply_fax"])
+		if(!check_rights(R_ADMIN))
+			return
+
+		var/datum/fax_panel_interface/ui = new(usr)
+		ui.ui_interact(usr)

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -280,7 +280,7 @@
 			history_add("Send", params["name"])
 
 			GLOB.requests.fax_request(usr.client, "sent a fax message from [fax_name]/[fax_id] to [params["name"]]", fax_paper)
-			to_chat(GLOB.admins, span_adminnotice("[icon2html(src.icon, GLOB.admins)]<b><font color=green>FAX REQUEST: </font>[ADMIN_FULLMONTY(usr)]:</b> [span_linkify("sent a fax message from [fax_name]/[fax_id][ADMIN_FLW(src)] to [html_encode(params["name"])]")] [ADMIN_SHOW_PAPER(fax_paper)]"), confidential = TRUE)
+			to_chat(GLOB.admins, span_adminnotice("[icon2html(src.icon, GLOB.admins)]<b><font color=green>FAX REQUEST: </font>[ADMIN_FULLMONTY(usr)]:</b> [span_linkify("sent a fax message from [fax_name]/[fax_id][ADMIN_FLW(src)] to [html_encode(params["name"])]")] [ADMIN_SHOW_PAPER(fax_paper)] [ADMIN_FAX_REPLY(src.name)]"), confidential = TRUE)
 			log_fax(fax_paper, params["id"], params["name"])
 			loaded_item_ref = null
 			update_appearance()

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -268,7 +268,7 @@
 		if("send_special")
 			var/obj/item/paper/fax_paper = loaded_item_ref?.resolve()
 			if(!istype(fax_paper))
-				to_chat(usr, icon2html(src.icon, usr) + span_warning("Fax cannot send all above paper on this protected network, sorry."))
+				to_chat(usr, icon2html(src.icon, usr) + span_warning("Cannot send non-paper faxes on protected networks."))
 				return
 
 			fax_paper.request_state = TRUE
@@ -280,7 +280,10 @@
 			history_add("Send", params["name"])
 
 			GLOB.requests.fax_request(usr.client, "sent a fax message from [fax_name]/[fax_id] to [params["name"]]", fax_paper)
-			to_chat(GLOB.admins, span_adminnotice("[icon2html(src.icon, GLOB.admins)]<b><font color=green>FAX REQUEST: </font>[ADMIN_FULLMONTY(usr)]:</b> [span_linkify("sent a fax message from [fax_name]/[fax_id][ADMIN_FLW(src)] to [html_encode(params["name"])]")] [ADMIN_SHOW_PAPER(fax_paper)] [ADMIN_FAX_REPLY(src.name)]"), confidential = TRUE)
+			to_chat(GLOB.admins, \
+				span_adminnotice("[icon2html(src.icon, GLOB.admins)]<b><font color=green>FAX REQUEST: </font>[ADMIN_FULLMONTY(usr)]:</b> \
+				[span_linkify("sent a fax message from [fax_name]/[fax_id][ADMIN_FLW(src)] to [html_encode(params["name"])]")] \
+				[ADMIN_SHOW_PAPER(fax_paper)] [ADMIN_FAX_REPLY(src)]"), confidential = TRUE)
 			log_fax(fax_paper, params["id"], params["name"])
 			loaded_item_ref = null
 			update_appearance()


### PR DESCRIPTION
## About The Pull Request
Faxes to centcom now come with a reply fax button for admins.

BONUS: Removed some copypaste topic code

## Why It's Good For The Game
Easier for admins to respond to faxes without needing to search for the verb to open the admin fax panel.

## Changelog
:cl: Tattle
admin: faxes to centcom now come with a reply fax button
/:cl: