### PR TITLE
Only notify codeowners on non draft PRs

### DIFF
--- a/.github/workflows/codeowner_reviews.yml
+++ b/.github/workflows/codeowner_reviews.yml
@@ -1,7 +1,9 @@
 name: Codeowner Reviews
 
 # Controls when the workflow will run
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   assign-users:
@@ -12,8 +14,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so the job can access it
       - uses: actions/checkout@v3
 
-      #Parse the Codeowner file
+      #Parse the Codeowner file on non draft PRs
       - name: CodeOwnersParser
+        if: github.event.pull_request.draft == false
         id: CodeOwnersParser
         uses: tgstation/CodeOwnersParser@v1
 


### PR DESCRIPTION

## About The Pull Request
As requested by @Mothblocks the codeowner action will now only parse PRs that are not drafted.
This is done to align with Githubs default behavior of assigning codeowners.

The workflow will now also run when a PR is marked as ready for review (undrafted).
## Why It's Good For The Game
Annoys the codeowners less often
