### PR TITLE
Removes Bombgers

### DIFF
--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -9,7 +9,8 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/storage,
 	/obj/item/delivery,
 	/obj/item/his_grace,
-	/obj/item/transfer_valve,)))
+	/obj/item/transfer_valve,
+)))
 
 /obj/machinery/deepfryer
 	name = "deep fryer"

--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/storage,
 	/obj/item/delivery,
 	/obj/item/his_grace,
-	/obj/item/transfer_valve)))
+	/obj/item/transfer_valve,)))
 
 /obj/machinery/deepfryer
 	name = "deep fryer"

--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -8,7 +8,8 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/reagent_containers/condiment,
 	/obj/item/storage,
 	/obj/item/delivery,
-	/obj/item/his_grace)))
+	/obj/item/his_grace,
+	/obj/item/transfer_valve)))
 
 /obj/machinery/deepfryer
 	name = "deep fryer"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds TTVs to the oil frying blacklist so they can't be fried and concealed in food any more.

Fixes #71547 

## Why It's Good For The Game

God never intended for TTVs to be turned into easily concealed, explosively delicious food.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: TTV bombs can no longer be concealed inside food
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
