### PR TITLE
Undertile Element Logic Refactor, or Catwalks Aren't Affected by Ambient Occlusion Anymore

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(minor_mapping)
 		var/turf/T = pick_n_take(turfs)
 		var/obj/item/storage/backpack/satchel/flat/F = new(T)
 
-		SEND_SIGNAL(F, COMSIG_OBJ_HIDE, T.underfloor_accessibility < UNDERFLOOR_VISIBLE)
+		SEND_SIGNAL(F, COMSIG_OBJ_HIDE, T.underfloor_accessibility)
 		amount--
 
 /proc/find_exposed_wires()

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -307,12 +307,14 @@
 		net.add_plumber(src, dir)
 		net.add_plumber(plumbing, opposite_dir)
 
-/datum/component/plumbing/proc/hide(atom/movable/parent_obj, should_hide)
+/datum/component/plumbing/proc/hide(atom/movable/parent_obj, underfloor_accessibility)
 	SIGNAL_HANDLER
 
 	// If machine is unanchored, keep connector visible.
 	// This doesn't necessary map to `active`, so check parent.
 	var/atom/movable/parent_movable = parent
+
+	var/should_hide = !underfloor_accessibility
 
 	if(parent_movable.anchored || !should_hide)
 		tile_covered = should_hide

--- a/code/datums/elements/undertile.dm
+++ b/code/datums/elements/undertile.dm
@@ -19,6 +19,7 @@
 
 /datum/element/undertile/Attach(datum/target, invisibility_trait, invisibility_level = INVISIBILITY_MAXIMUM, tile_overlay, use_alpha = TRUE, use_anchor = FALSE)
 	. = ..()
+
 	if(!ismovable(target))
 		return ELEMENT_INCOMPATIBLE
 
@@ -30,37 +31,51 @@
 	src.use_alpha = use_alpha
 	src.use_anchor = use_anchor
 
+
 ///called when a tile has been covered or uncovered
-/datum/element/undertile/proc/hide(atom/movable/source, covered)
+/datum/element/undertile/proc/hide(atom/movable/source, underfloor_accessibility)
 	SIGNAL_HANDLER
 
-	source.invisibility = covered ? invisibility_level : 0
+	source.invisibility = underfloor_accessibility < UNDERFLOOR_VISIBLE ? invisibility_level : 0
 
 	var/turf/T = get_turf(source)
 
-	if(covered)
-		if(invisibility_trait)
-			ADD_TRAIT(source, invisibility_trait, ELEMENT_TRAIT(type))
+	if(underfloor_accessibility < UNDERFLOOR_INTERACTABLE)
+		SET_PLANE_IMPLICIT(source, FLOOR_PLANE) // We do this so that turfs that allow you to see what's underneath them don't have to be on the game plane (which causes ambient occlusion weirdness)
+
 		if(tile_overlay)
 			T.add_overlay(tile_overlay)
-		if(use_alpha)
-			source.alpha = ALPHA_UNDERTILE
+
 		if(use_anchor)
 			source.set_anchored(TRUE)
 
+		if(underfloor_accessibility < UNDERFLOOR_VISIBLE)
+			if(use_alpha)
+				source.alpha = ALPHA_UNDERTILE
+
+			if(invisibility_trait)
+				ADD_TRAIT(source, invisibility_trait, ELEMENT_TRAIT(type))
+
 	else
+		SET_PLANE_IMPLICIT(source, initial(source.plane))
+
 		if(invisibility_trait)
 			REMOVE_TRAIT(source, invisibility_trait, ELEMENT_TRAIT(type))
+
 		if(tile_overlay)
 			T.overlays -= tile_overlay
+
 		if(use_alpha)
-			source.alpha = 255
+			source.alpha = initial(source.alpha)
+
 		if(use_anchor)
 			source.set_anchored(FALSE)
 
-/datum/element/undertile/Detach(atom/movable/AM, visibility_trait, invisibility_level = INVISIBILITY_MAXIMUM)
+
+/datum/element/undertile/Detach(atom/movable/source, visibility_trait, invisibility_level = INVISIBILITY_MAXIMUM)
 	. = ..()
 
-	hide(AM, FALSE)
+	hide(source, UNDERFLOOR_INTERACTABLE)
+
 
 #undef ALPHA_UNDERTILE

--- a/code/game/objects/items/devices/pressureplates.dm
+++ b/code/game/objects/items/devices/pressureplates.dm
@@ -85,8 +85,8 @@
 		to_chat(user, span_notice("You turn [src] off."))
 
 ///Called from COMSIG_OBJ_HIDE to toggle the active part, because yeah im not making a special exception on the element to support it
-/obj/item/pressure_plate/proc/ToggleActive(datum/source, covered)
+/obj/item/pressure_plate/proc/ToggleActive(datum/source, underfloor_accessibility)
 	SIGNAL_HANDLER
 
-	active = covered
+	active = underfloor_accessibility < UNDERFLOOR_VISIBLE
 

--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -48,6 +48,8 @@
 		underfloor_accessibility = UNDERFLOOR_VISIBLE
 		layer = CATWALK_LAYER
 		icon_state = "[catwalk_type]_above"
+
+	levelupdate()
 	user.balloon_alert(user, "[!covered ? "cover removed" : "cover added"]")
 	tool.play_tool_sound(src)
 	update_appearance()

--- a/code/game/turfs/open/floor/catwalk_plating.dm
+++ b/code/game/turfs/open/floor/catwalk_plating.dm
@@ -13,7 +13,6 @@
 	baseturfs = /turf/open/floor/plating
 	floor_tile = /obj/item/stack/tile/catwalk_tile
 	layer = CATWALK_LAYER
-	plane = GAME_PLANE
 	footstep = FOOTSTEP_CATWALK
 	overfloor_placed = TRUE
 	underfloor_accessibility = UNDERFLOOR_VISIBLE
@@ -44,12 +43,10 @@
 	if(!covered)
 		underfloor_accessibility = UNDERFLOOR_INTERACTABLE
 		layer = TURF_LAYER
-		SET_PLANE_IMPLICIT(src, FLOOR_PLANE)
 		icon_state = "[catwalk_type]_below"
 	else
 		underfloor_accessibility = UNDERFLOOR_VISIBLE
 		layer = CATWALK_LAYER
-		SET_PLANE_IMPLICIT(src, GAME_PLANE)
 		icon_state = "[catwalk_type]_above"
 	user.balloon_alert(user, "[!covered ? "cover removed" : "cover added"]")
 	tool.play_tool_sound(src)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -466,7 +466,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/proc/levelupdate()
 	for(var/obj/O in src)
 		if(O.flags_1 & INITIALIZED_1)
-			SEND_SIGNAL(O, COMSIG_OBJ_HIDE, underfloor_accessibility < UNDERFLOOR_VISIBLE)
+			SEND_SIGNAL(O, COMSIG_OBJ_HIDE, underfloor_accessibility)
 
 // override for space turfs, since they should never hide anything
 /turf/open/space/levelupdate()

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -49,9 +49,9 @@
 /**
  * Called in Initialize(), set the showpipe var to true or false depending on the situation, calls update_icon()
  */
-/obj/machinery/atmospherics/components/proc/hide_pipe(datum/source, covered)
+/obj/machinery/atmospherics/components/proc/hide_pipe(datum/source, underfloor_accessibility)
 	SIGNAL_HANDLER
-	showpipe = !covered
+	showpipe = !!underfloor_accessibility
 	update_appearance()
 
 /obj/machinery/atmospherics/components/update_icon()


### PR DESCRIPTION
## About The Pull Request
It was bugging me how catwalks would just be stuck rendering on the game plane in order to be above the pipes and all the other underfloor objects, because it meant that they stood out due to being affected by ambient occlusion.

So I decided to change that, and the best change I could come up with, was to refactor the logic of `/datum/element/undertile` in order to actually allow us to do exactly what we wanted by having three different states of underfloor visibility, which in turn allowed me to slap everything that wasn't accessible on the floor plane rather than whatever plane they were on, effectively making it so catwalk tiles wouldn't need to be on the game plane anymore. :)

Also fixes https://github.com/tgstation/tgstation/issues/63590 while I'm at it :)

## Why It's Good For The Game
Seeing ambient occlusion on catwalks make them stand out in a jarring way, now that won't be the case anymore!

Now, instead, you get something like this, which _absolutely_ looks like it fits in!
![image](https://user-images.githubusercontent.com/58045821/204106823-95b77a6b-b9c1-4494-b2f8-3b586c42428c.png)


## Changelog

:cl: GoldenAlpharex
refactor: Refactored the way the undertile component works, to allow it to have a bit more granularity as to when it's meant to be covered, but still visible, like for catwalks!
fix: Catwalks no longer are affected by ambient occlusion, and now properly feel like actual floor tiles.
/:cl: