### PR TITLE
Makes Miner's Salve HUD screw not permanent.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -353,7 +353,7 @@
 
 /datum/reagent/medicine/mine_salve/on_mob_end_metabolize(mob/living/metabolizer)
 	. = ..()
-	metabolizer.apply_status_effect(/datum/status_effect/grouped/screwy_hud/fake_healthy, type)
+	metabolizer.remove_status_effect(/datum/status_effect/grouped/screwy_hud/fake_healthy, type)
 
 /datum/reagent/medicine/omnizine
 	name = "Omnizine"


### PR DESCRIPTION
## About The Pull Request

Does exactly what it says on the tin.

## Why It's Good For The Game

As of current, after the miner's salve metabolizes, it calls apply_status_effect again, which... Doesn't remove the fake health deal. This should fix that.

## Changelog

:cl:
fix: Makes Miner's Salve HUD screw not permanent.
/:cl: