### PR TITLE
Renames an incorrectly named bitfield

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -101,7 +101,7 @@ DEFINE_BITFIELD(foodtypes, list(
 /// Finger food can be eaten while walking / running around
 #define FOOD_FINGER_FOOD (1<<1)
 
-DEFINE_BITFIELD(food_types, list(
+DEFINE_BITFIELD(food_flags, list(
 	"FOOD_FINGER_FOOD" = FOOD_FINGER_FOOD,
 	"FOOD_IN_CONTAINER" = FOOD_IN_CONTAINER,
 ))


### PR DESCRIPTION
## About The Pull Request

`foodtypes` are the flags like `MEAT`
`food_flags` are flags like `FOOD_FINGER_FOOD`
`food_types` is... neither of these, the only vars named this are lists / typecaches for some basic mob behaviors. 

## Why It's Good For The Game

Good correct VV

## Changelog

:cl: Melbert
fix: VVing an edible comp's food flags pulls up the bitfield ui correctly
/:cl:
