### PR TITLE
Overhauls beach bar, adds griddle and oven to some ruins

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -381,16 +381,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "ba" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/peppermill,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 9
 	},
-/obj/item/knife/kitchen,
+/obj/machinery/oven,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bb" = (
@@ -626,6 +620,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bM" = (
@@ -633,6 +628,13 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/condiment/peppermill,
+/obj/item/knife/kitchen,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bN" = (
@@ -645,7 +647,7 @@
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bO" = (
 /obj/machinery/light/directional/south,
-/obj/machinery/vending/dinnerware,
+/obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/has_grav/deepstorage/kitchen)
 "bP" = (

--- a/_maps/RandomZLevels/TheBeach.dmm
+++ b/_maps/RandomZLevels/TheBeach.dmm
@@ -634,17 +634,13 @@
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "cd" = (
-/obj/effect/turf_decal/sand,
 /obj/machinery/vending/cola/starkist,
+/obj/effect/turf_decal/sand,
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "cf" = (
-/obj/effect/turf_decal/sand,
-/obj/structure/sign/poster/contraband/smoke{
-	pixel_y = -32
-	},
-/obj/machinery/vending/cigarette/beach,
-/turf/open/misc/beach/sand,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
 /area/awaymission/beach)
 "cg" = (
 /obj/effect/turf_decal/sand,
@@ -675,8 +671,8 @@
 /turf/open/floor/wood,
 /area/awaymission/beach)
 "cl" = (
+/obj/machinery/processor,
 /obj/structure/table/wood,
-/obj/item/reagent_containers/cup/glass/shaker,
 /turf/open/floor/wood,
 /area/awaymission/beach)
 "cn" = (
@@ -719,8 +715,9 @@
 /turf/open/floor/wood,
 /area/awaymission/beach)
 "cs" = (
-/obj/machinery/processor,
-/turf/open/floor/wood,
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/sand,
+/turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "ct" = (
 /obj/effect/turf_decal/stripes/white/corner,
@@ -805,8 +802,8 @@
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "cH" = (
-/obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/sand,
+/obj/structure/chair/stool/directional/north,
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "cI" = (
@@ -991,9 +988,10 @@
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "lx" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/misc/beach/sand,
+/obj/structure/table/wood,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/reagent_containers/cup/glass/shaker,
+/turf/open/floor/wood,
 /area/awaymission/beach)
 "lA" = (
 /obj/structure/table/wood,
@@ -1023,11 +1021,12 @@
 /turf/open/floor/wood,
 /area/awaymission/beach)
 "sG" = (
-/obj/structure/table/wood,
-/obj/item/clothing/glasses/sunglasses,
-/obj/item/reagent_containers/cup/glass/bottle/beer,
-/obj/item/reagent_containers/cup/glass/bottle/beer,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/sand,
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_y = -32
+	},
+/obj/machinery/vending/cigarette/beach,
+/turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "wr" = (
 /obj/item/toy/seashell{
@@ -1096,11 +1095,24 @@
 	},
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
+"FG" = (
+/obj/structure/table/wood,
+/obj/machinery/reagentgrinder,
+/turf/open/floor/wood,
+/area/awaymission/beach)
 "He" = (
 /obj/structure/fluff/beach_umbrella/syndi,
 /turf/open/misc/beach/coastline_t/sandwater_inner{
 	dir = 1
 	},
+/area/awaymission/beach)
+"HN" = (
+/obj/machinery/griddle,
+/turf/open/floor/wood,
+/area/awaymission/beach)
+"Jr" = (
+/obj/machinery/oven,
+/turf/open/floor/wood,
 /area/awaymission/beach)
 "Kg" = (
 /obj/item/flashlight/flare/torch{
@@ -1150,6 +1162,10 @@
 /obj/item/food/meat/slab/gorilla,
 /turf/open/misc/beach/sand,
 /area/awaymission/beach)
+"Sg" = (
+/obj/structure/sink/kitchen/directional/south,
+/turf/open/floor/wood,
+/area/awaymission/beach)
 "SR" = (
 /obj/machinery/food_cart,
 /turf/open/misc/beach/sand,
@@ -1158,6 +1174,11 @@
 /obj/structure/table/wood,
 /obj/item/storage/photo_album,
 /turf/open/floor/wood,
+/area/awaymission/beach)
+"Vn" = (
+/obj/effect/turf_decal/sand,
+/obj/structure/table/wood,
+/turf/open/misc/beach/sand,
 /area/awaymission/beach)
 "Vx" = (
 /obj/item/reagent_containers/cup/glass/bottle/wine{
@@ -6590,10 +6611,10 @@ aX
 aX
 ak
 ba
+ba
 cd
 aX
-ci
-bd
+co
 bd
 bd
 hw
@@ -6697,11 +6718,11 @@ bQ
 aX
 ak
 ba
-lx
+ba
+cs
 aX
-cj
-bd
-bd
+cn
+ck
 bd
 hw
 cH
@@ -6805,9 +6826,9 @@ bX
 ba
 ba
 ba
+cg
 aX
-ck
-bd
+cp
 bd
 bd
 cC
@@ -6912,9 +6933,9 @@ aX
 ak
 ba
 ba
+Vn
 aX
-cl
-bd
+cj
 bd
 bd
 cD
@@ -7019,9 +7040,9 @@ ak
 ak
 ba
 ba
+Vn
 aX
-sG
-bd
+ci
 bd
 bd
 mF
@@ -7125,10 +7146,10 @@ ba
 ba
 ba
 ba
-cf
+ba
+sG
 aX
-cn
-bd
+lx
 bd
 bd
 cE
@@ -7234,8 +7255,8 @@ ak
 ba
 ba
 aX
-co
-bd
+aX
+aX
 bd
 bd
 cF
@@ -7341,7 +7362,7 @@ ak
 ba
 ba
 aX
-cp
+cq
 bd
 bd
 bd
@@ -7448,9 +7469,9 @@ ba
 ba
 ba
 aX
-cq
+Jr
 bd
-bd
+FG
 bd
 Tr
 cH
@@ -7553,11 +7574,11 @@ bQ
 aX
 ak
 ba
-lx
+ba
 aX
+HN
 bd
-bd
-bd
+cf
 bd
 xA
 cH
@@ -7660,14 +7681,14 @@ aX
 aX
 ak
 ba
-cg
+ba
 aX
-cr
-cs
-cw
+Sg
 bd
-aX
-cI
+bd
+bd
+cf
+cH
 ba
 ak
 ak
@@ -7769,12 +7790,12 @@ ak
 ba
 ba
 aX
+cf
+cr
+cl
+cw
 aX
-aX
-aX
-aX
-aX
-ba
+cI
 ba
 ak
 ak
@@ -7875,12 +7896,12 @@ ak
 ak
 ba
 ba
-ba
-ba
-ba
-ba
-ba
-ba
+aX
+aX
+aX
+aX
+aX
+aX
 ba
 ba
 ak
@@ -7980,16 +8001,16 @@ ak
 ak
 ak
 ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
-ak
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
+ba
 ak
 ak
 ak

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -3224,6 +3224,7 @@
 "hS" = (
 /obj/structure/table,
 /obj/item/food/mint,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/cafeteria{
 	dir = 5;
 	heat_capacity = 1e+006
@@ -3416,8 +3417,7 @@
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "iq" = (
-/obj/structure/table,
-/obj/item/kitchen/rollingpin,
+/obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria{
 	dir = 5;
 	heat_capacity = 1e+006
@@ -7679,7 +7679,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("uo45air" = "Air Supply")
+	atmos_chambers = list("uo45air"="Air Supply")
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 1;
@@ -8587,7 +8587,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("uo45mix" = "Mix Chamber");
+	atmos_chambers = list("uo45mix"="Mix Chamber");
 	dir = 8
 	},
 /turf/open/floor/iron{
@@ -9549,7 +9549,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("uo45n2" = "Nitrogen Supply");
+	atmos_chambers = list("uo45n2"="Nitrogen Supply");
 	dir = 1
 	},
 /turf/open/floor/iron{
@@ -9594,7 +9594,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("uo45o2" = "Oxygen Supply");
+	atmos_chambers = list("uo45o2"="Oxygen Supply");
 	dir = 1
 	},
 /turf/open/floor/iron{
@@ -9681,7 +9681,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/atmos_control/fixed{
-	atmos_chambers = list("uo45air" = "Air Supply", "uo45mix" = "Mix Chamber", "uo45n2" = "Nitrogen Supply", "uo45o2" = "Oxygen Supply");
+	atmos_chambers = list("uo45air"="Air Supply","uo45mix"="Mix Chamber","uo45n2"="Nitrogen Supply","uo45o2"="Oxygen Supply");
 	dir = 4;
 	name = "Chamber Atmospherics Monitoring"
 	},
@@ -9856,7 +9856,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/atmos_control/fixed{
-	atmos_chambers = list("uo45waste", "uo45distro");
+	atmos_chambers = list("uo45waste","uo45distro");
 	dir = 4;
 	name = "Distribution and Waste Monitoring"
 	},
@@ -11217,6 +11217,13 @@
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
+"Ar" = (
+/obj/machinery/oven,
+/turf/open/floor/iron/cafeteria{
+	dir = 5;
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
 "AN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -47659,7 +47666,7 @@ gD
 gO
 hq
 hR
-hr
+iq
 iK
 je
 jA
@@ -48175,7 +48182,7 @@ gO
 hT
 gO
 gO
-gD
+dO
 jB
 jZ
 kv
@@ -48431,7 +48438,7 @@ gP
 hs
 hU
 ir
-dO
+Ar
 jf
 jC
 ka


### PR DESCRIPTION
## About The Pull Request
This PR adds modern cooking equipment (griddles, ovens) to ruins such as deep storage, underground, and tries to overhaul the beach biodome's bar, making it less boxy while making it more viable for cooking.

<details>
<summary>Beach Biodome</summary>

Before
![StrongDMM_ZBuhUoQs3E](https://user-images.githubusercontent.com/66234359/204110568-67e33e15-cb8a-42dc-80dd-390243ef4ed8.png)

After
![StrongDMM_D7TM3YbLjR](https://user-images.githubusercontent.com/66234359/204110675-275862f1-537d-4ed0-bfb9-3b17b1884b71.png)

</details>

<details>
<summary>Underground Outpost</summary>

Before
![image](https://user-images.githubusercontent.com/66234359/204112023-c9a47516-e8b5-4d80-ad77-b8ff98dd862b.png)


After
![StrongDMM_edNy9xHzce](https://user-images.githubusercontent.com/66234359/204111482-1ffacb17-fa35-463c-bde4-0a85d212cacd.png)

</details>

<details>
<summary>Deep Storage</summary>

Before
![StrongDMM_ahPa931xKG](https://user-images.githubusercontent.com/66234359/204112081-de94fea0-8c5c-4933-b445-7841818213a8.png)

After
![StrongDMM_2pvSv5RBpx](https://user-images.githubusercontent.com/66234359/204112088-51627aa1-2aa8-430c-9f54-186bb6a9ec81.png)

</details>

## Why It's Good For The Game
The kitchens on these ruins are kind of outdated, we don't use the microwave to grill stuff like meat anymore and this PR fixes this issue while making the beach's less boring and more viable for cooking.
## Changelog
:cl:
qol: Added griddles and ovens to ruins and away missions such as Deep Storage, Underground Outpost and Beach Biodome.
fix: Overhauled beach biodome bar, fixed stools facing the wrong direction, as well as making the bar less boxy.
/:cl:
