### PR TITLE
Photocopier now tells you if it can't charge you successfully.

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -246,6 +246,7 @@
 		if(!toner_cartridge) //someone removed the toner cartridge during printing lol.
 			break
 		if(attempt_charge(src, user) & COMPONENT_OBJ_CANCEL_CHARGE)
+			balloon_alert(user, "need to pay!")
 			break
 		addtimer(copy_cb, i SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(reset_busy)), i SECONDS)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -246,7 +246,7 @@
 		if(!toner_cartridge) //someone removed the toner cartridge during printing lol.
 			break
 		if(attempt_charge(src, user) & COMPONENT_OBJ_CANCEL_CHARGE)
-			balloon_alert(user, "can't find ID!")
+			balloon_alert(user, "can't charge to ID!")
 			break
 		addtimer(copy_cb, i SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(reset_busy)), i SECONDS)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -246,7 +246,7 @@
 		if(!toner_cartridge) //someone removed the toner cartridge during printing lol.
 			break
 		if(attempt_charge(src, user) & COMPONENT_OBJ_CANCEL_CHARGE)
-			balloon_alert(user, "can't charge to ID!")
+			balloon_alert(user, "insufficient funds!")
 			break
 		addtimer(copy_cb, i SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(reset_busy)), i SECONDS)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -246,7 +246,7 @@
 		if(!toner_cartridge) //someone removed the toner cartridge during printing lol.
 			break
 		if(attempt_charge(src, user) & COMPONENT_OBJ_CANCEL_CHARGE)
-			balloon_alert(user, "need to pay!")
+			balloon_alert(user, "can't find ID!")
 			break
 		addtimer(copy_cb, i SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(reset_busy)), i SECONDS)


### PR DESCRIPTION

## About The Pull Request

Closes #71466.

Photocopying your ass is fine and works well enough, but the comments to that report were correct that it provided no user feedback as to why it wasn't copying. This just adds a small balloon alert to the viewer so that they realize that they might have to have their card in their hand for it to run.

I toyed around with a few iterations of the message and I figured that one got the point across well, but if anyone has any better ideas that would be welcome as well. Not sure if we should just have it be a longer "Say" message.
## Why It's Good For The Game

User feedback when something fails is important!
## Changelog
:cl:
qol: The photocopier will now tell you when it's not able to find an ID to charge on your person.
/:cl:
