### PR TITLE
Small optimization for allowed lists

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -163,7 +163,7 @@
 
 //Allowed equipment lists for security vests.
 
-GLOBAL_LIST_INIT(detective_vest_allowed, typecacheof(list(
+GLOBAL_LIST_INIT(detective_vest_allowed, list(
 	/obj/item/ammo_box,
 	/obj/item/ammo_casing,
 	/obj/item/detective_scanner,
@@ -181,9 +181,9 @@ GLOBAL_LIST_INIT(detective_vest_allowed, typecacheof(list(
 	/obj/item/storage/belt/holster/detective,
 	/obj/item/storage/belt/holster/nukie,
 	/obj/item/storage/belt/holster/thermal,
-	)))
+))
 
-GLOBAL_LIST_INIT(security_vest_allowed, typecacheof(list(
+GLOBAL_LIST_INIT(security_vest_allowed, list(
 	/obj/item/ammo_box,
 	/obj/item/ammo_casing,
 	/obj/item/flashlight,
@@ -198,9 +198,9 @@ GLOBAL_LIST_INIT(security_vest_allowed, typecacheof(list(
 	/obj/item/storage/belt/holster/detective,
 	/obj/item/storage/belt/holster/nukie,
 	/obj/item/storage/belt/holster/thermal,
-	)))
+))
 
-GLOBAL_LIST_INIT(security_wintercoat_allowed, typecacheof(list(
+GLOBAL_LIST_INIT(security_wintercoat_allowed, list(
 	/obj/item/ammo_box,
 	/obj/item/ammo_casing,
 	/obj/item/gun/ballistic,
@@ -211,7 +211,7 @@ GLOBAL_LIST_INIT(security_wintercoat_allowed, typecacheof(list(
 	/obj/item/storage/belt/holster/detective,
 	/obj/item/storage/belt/holster/nukie,
 	/obj/item/storage/belt/holster/thermal,
-	)))
+))
 
 /// String for items placed into the left pocket.
 #define LOCATION_LPOCKET "in your left pocket"

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -112,7 +112,7 @@
 	helmet = new /obj/item/clothing/head/mod(src)
 	mod_parts += helmet
 	chestplate = new /obj/item/clothing/suit/mod(src)
-	chestplate.allowed += typecacheof(theme.allowed_suit_storage)
+	chestplate.allowed += theme.allowed_suit_storage
 	mod_parts += chestplate
 	gauntlets = new /obj/item/clothing/gloves/mod(src)
 	mod_parts += gauntlets


### PR DESCRIPTION
## About The Pull Request

Removes typecaching from allowed lists. 

`allowed` uses `is_type_in_list`, it's not a typecache.
Making it a typecache makes it scale very poorly. 

Before: 488 `istype`s
![image](https://user-images.githubusercontent.com/51863163/204115121-725ea813-3369-4eb5-9bd8-fd6b80efb5ca.png)

After: 5 `istype`s
![image](https://user-images.githubusercontent.com/51863163/204115127-65c17653-8c1e-406f-baf5-0a78c604d4b6.png)

You may ask "Why not make allowed lists typecaches instead, it's also faster than is type in list"
Yes, but it's a lot more work than just getting this out of the way, and plus you need to account for stuff like adding allowed lists together and meh. This is just easier. 

## Why It's Good For The Game

Code goes faster

## Changelog

:cl: Melbert
code: Cuts some uses of allowed list as a typecache. Allowed lists are not typecaches, don't make them typecaches
/:cl:

