### PR TITLE
Only log research when the MC is running (saves 0.4s of init time, but it depends on I/O)

### DIFF
--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -333,7 +333,11 @@
 		var/datum/bank_account/science_department_bank_account = SSeconomy.get_dep_account(ACCOUNT_SCI)
 		science_department_bank_account?.adjust_money(SSeconomy.techweb_bounty)
 		log_message += ", gaining [SSeconomy.techweb_bounty] to [science_department_bank_account] for it."
-	log_research(log_message)
+
+	// Avoid logging the same 300+ lines at the beginning of every round
+	if (MC_RUNNING())
+		log_research(log_message)
+
 	return TRUE
 
 /datum/techweb/proc/unresearch_node_id(id)


### PR DESCRIPTION
The recent R&D PR introduced a very large regression in init time performance, as this always logs 300+ lines every single round, from the station techwebs, CentCom techwebs, and more. This isn't helpful for developers or admins, so limits logs to only after the MC is running, which will mean user triggers.