### PR TITLE
Cleans up toolbox initializes

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -26,6 +26,7 @@
 
 /obj/item/storage/toolbox/Initialize(mapload)
 	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	if(has_latches)
 		if(prob(10))
 			latches = "double_latch"
@@ -39,10 +40,6 @@
 	. = ..()
 	if(has_latches)
 		. += latches
-
-/obj/item/storage/toolbox/Initialize(mapload)
-	. = ..()
-	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/toolbox/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] robusts [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -167,7 +167,7 @@
 	inhand_icon_state = "artistic_toolbox"
 	material_flags = NONE
 
-/obj/item/storage/toolbox/Initialize(mapload)
+/obj/item/storage/toolbox/fishing/Initialize(mapload)
 	. = ..()
 	// Can hold fishing rod despite the size
 	var/static/list/exception_cache = typecacheof(/obj/item/fishing_rod)


### PR DESCRIPTION
:cl:
fix: normal toolboxes can't hold fishing rods anymore
/:cl:
