### PR TITLE
Saves 0.1 seconds of init by not reacting reagents if something is created during MC init

### DIFF
--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -28,6 +28,6 @@
 #ifdef UNIT_TESTS
 #define TEST_ONLY_ASSERT(test, explanation) if(!(test)) {CRASH(explanation)}
 #else
-#define TEST_ONLY_ASSERT(test, explanation) ()
+#define TEST_ONLY_ASSERT(test, explanation) 
 #endif
 

--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -23,3 +23,11 @@
 /// It will only work for datums mind, for datum reasons
 /// : because of the embedded typecheck
 #define text_ref(datum) (isdatum(datum) ? (datum:cached_ref ||= "\ref[datum]") : ("\ref[datum]"))
+
+/// ASSERT(), but it only actually does anything during unit tests
+#ifdef UNIT_TESTS
+#define TEST_ONLY_ASSERT(test, explanation) if(!test) {CRASH(explanation)}
+#else
+#define TEST_ONLY_ASSERT(test, explanation) ()
+#endif
+

--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -26,7 +26,7 @@
 
 /// ASSERT(), but it only actually does anything during unit tests
 #ifdef UNIT_TESTS
-#define TEST_ONLY_ASSERT(test, explanation) if(!test) {CRASH(explanation)}
+#define TEST_ONLY_ASSERT(test, explanation) if(!(test)) {CRASH(explanation)}
 #else
 #define TEST_ONLY_ASSERT(test, explanation) ()
 #endif

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -861,6 +861,13 @@
 		if(!(has_changed_state()))
 			return FALSE
 
+#ifndef UNIT_TESTS
+	// We assert that reagents will not need to react before the map is fully loaded
+	// This is the best I can do, sorry :(
+	if(!MC_RUNNING())
+		return FALSE
+#endif
+
 	var/list/cached_reagents = reagent_list
 	var/list/cached_reactions = GLOB.chemical_reactions_list_reactant_index
 	var/datum/cached_my_atom = my_atom
@@ -966,6 +973,8 @@
 
 	if(.)
 		SEND_SIGNAL(src, COMSIG_REAGENTS_REACTED, .)
+
+	TEST_ONLY_ASSERT((!. || MC_RUNNING()), "We reacted during subsystem init, that shouldn't be happening!")
 
 /*
 * Main Reaction loop handler, Do not call this directly

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -974,7 +974,7 @@
 	if(.)
 		SEND_SIGNAL(src, COMSIG_REAGENTS_REACTED, .)
 
-	TEST_ONLY_ASSERT((!. || MC_RUNNING()), "We reacted during subsystem init, that shouldn't be happening!")
+	TEST_ONLY_ASSERT(!. || MC_RUNNING(), "We reacted during subsystem init, that shouldn't be happening!")
 
 /*
 * Main Reaction loop handler, Do not call this directly


### PR DESCRIPTION

## About The Pull Request

This is midlly fragile, but it doesn't fail tests, so it's fine.
