### PR TITLE
Fix Slap/Slam-ing tables

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -272,14 +272,14 @@
 	return
 
 /obj/item/hand_item/slapper/pre_attack_secondary(atom/target, mob/living/user, params)
-	if(!Adjacent(target) || !istype(target, /obj/structure/table))
+	if(!loc.Adjacent(target) || !istype(target, /obj/structure/table))
 		return ..()
 
 	slam_table(target, user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/hand_item/slapper/pre_attack(atom/target, mob/living/user, params)
-	if(!Adjacent(target) || !istype(target, /obj/structure/table))
+	if(!loc.Adjacent(target) || !istype(target, /obj/structure/table))
 		return ..()
 
 	slap_table(target, user)


### PR DESCRIPTION
when I added the Adjacent checks I forgot to check from the holders location not the items

closes https://github.com/tgstation/tgstation/issues/71574