### PR TITLE
Adds Type Paths to Duplicate APC Logging

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -173,7 +173,7 @@
 
 	if(area)
 		if(area.apc)
-			log_mapping("Duplicate APC created at [AREACOORD(src)]. Original at [AREACOORD(area.apc)].")
+			log_mapping("Duplicate APC created at [AREACOORD(src)] [area.type]. Original at [AREACOORD(area.apc)] [area.type].")
 		area.apc = src
 
 	update_appearance()


### PR DESCRIPTION

## About The Pull Request

Hey there,

Space Ruins all use the same name "Unexplored Location", and one of them is conflicting:

![image](https://user-images.githubusercontent.com/34697715/204362713-737a3ae0-3caa-4913-8db5-c247d4a0c540.png)

I have no fucking idea which one this is though, given that I took this screenshot a week ago. It doesn't fail unit tests since it's on a space ruins Z-Level, which are exempt from those checks. So, let's just at least put the type in the message so someone can figure it out sooner.
## Why It's Good For The Game

We shouldn't be having duplicate APCs, and this problem is very hard to fix right now. At least if I had a type, I would be much more able to tell which subtype of `/area/ruin/space` is fluking on us.
## Changelog
Nothing that affects players.
