### PR TITLE
Status effect process has SHOULD NOT OVERRIDE

### DIFF
--- a/code/datums/status_effects/_status_effect.dm
+++ b/code/datums/status_effects/_status_effect.dm
@@ -78,10 +78,11 @@
 		owner = null
 	return ..()
 
-// Status effect process. Handles adjusting it's duration and ticks.
+// Status effect process. Handles adjusting its duration and ticks.
 // If you're adding processed effects, put them in [proc/tick]
-// instead of extending / overriding ththe process() proc.
+// instead of extending / overriding the process() proc.
 /datum/status_effect/process(delta_time, times_fired)
+	SHOULD_NOT_OVERRIDE(TRUE)
 	if(QDELETED(owner))
 		qdel(src)
 		return


### PR DESCRIPTION
## About The Pull Request

Adds `SHOULD_NOT_OVERRIDE` to status effect process.

Nothing currently does it but another PR attempted it which is incorrect. 

## Why It's Good For The Game

Status effect subtypes shouldn't extend or override process. They can be `qdel`ed at the end, and not everything will handle it properly. 

Adding processed effects should be done in `tick`, with a set `tick_interval`.

## Changelog
 
Not necessary