### PR TITLE
Allows datum AI to switch to different movement datums

### DIFF
--- a/code/datums/ai/_ai_behavior.dm
+++ b/code/datums/ai/_ai_behavior.dm
@@ -23,6 +23,6 @@
 	controller.behavior_args -= type
 	if(behavior_flags & AI_BEHAVIOR_REQUIRE_MOVEMENT) //If this was a movement task, reset our movement target if necessary
 		if(!(behavior_flags & AI_BEHAVIOR_KEEP_MOVE_TARGET_ON_FINISH))
-			controller.current_movement_target = null
+			controller.set_movement_target(null)
 		if(!(behavior_flags & AI_BEHAVIOR_KEEP_MOVING_TOWARDS_TARGET_ON_FINISH))
 			controller.ai_movement.stop_moving_towards(controller)

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -61,6 +61,12 @@ multiple modular subtrees with behaviors
 	UnpossessPawn(FALSE)
 	return ..()
 
+///Sets the current movement target, with an optional param to override the movement behavior
+/datum/ai_controller/proc/set_movement_target(atom/target, datum/ai_movement/new_movement)
+	set_movement_target(target)
+	if(new_movement)
+		change_ai_movement_type(new_movement)
+
 ///Overrides the current ai_movement of this controller with a new one
 /datum/ai_controller/proc/change_ai_movement_type(datum/ai_movement/new_movement)
 	ai_movement = SSai_movement.movement_types[new_movement]

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -63,7 +63,7 @@ multiple modular subtrees with behaviors
 
 ///Sets the current movement target, with an optional param to override the movement behavior
 /datum/ai_controller/proc/set_movement_target(atom/target, datum/ai_movement/new_movement)
-	set_movement_target(target)
+	current_movement_target = target
 	if(new_movement)
 		change_ai_movement_type(new_movement)
 

--- a/code/datums/ai/_item_behaviors.dm
+++ b/code/datums/ai/_item_behaviors.dm
@@ -25,7 +25,7 @@
 /datum/ai_behavior/item_move_close_and_attack/setup(datum/ai_controller/controller, target_key, throw_count_key)
 	. = ..()
 	var/datum/weakref/target_ref = controller.blackboard[target_key]
-	controller.current_movement_target = target_ref?.resolve()
+	controller.set_movement_target(target_ref?.resolve())
 
 /datum/ai_behavior/item_move_close_and_attack/perform(delta_time, datum/ai_controller/controller, target_key, throw_count_key)
 	. = ..()

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -9,7 +9,7 @@
 	var/atom/target = weak_target?.resolve()
 	if(!target)
 		return FALSE
-	controller.current_movement_target = target
+	controller.set_movement_target(target)
 
 /datum/ai_behavior/basic_melee_attack/perform(delta_time, datum/ai_controller/controller, target_key, targetting_datum_key, hiding_location_key)
 	. = ..()
@@ -49,7 +49,7 @@
 	var/atom/target = weak_target?.resolve()
 	if(!target)
 		return FALSE
-	controller.current_movement_target = target
+	controller.set_movement_target(target)
 
 /datum/ai_behavior/basic_ranged_attack/perform(delta_time, datum/ai_controller/controller, target_key, targetting_datum_key, hiding_location_key)
 	. = ..()

--- a/code/datums/ai/cursed/cursed_subtrees.dm
+++ b/code/datums/ai/cursed/cursed_subtrees.dm
@@ -11,5 +11,5 @@
 	if(get_dist(curse_target, item_pawn) > CURSED_VIEW_RANGE)
 		controller.blackboard[BB_CURSE_TARGET] = null
 		return
-	controller.current_movement_target = curse_target
+	controller.set_movement_target(curse_target)
 	controller.queue_behavior(/datum/ai_behavior/item_move_close_and_attack/ghostly/cursed)

--- a/code/datums/ai/dog/dog_controller.dm
+++ b/code/datums/ai/dog/dog_controller.dm
@@ -86,7 +86,7 @@
 	var/mob/living/living_pawn = pawn
 	if(IS_DEAD_OR_INCAP(living_pawn))
 		return
-	current_movement_target = thrown_thing
+	set_movement_target(thrown_thing)
 	blackboard[BB_FETCH_TARGET] = thrown_thing
 	blackboard[BB_FETCH_DELIVER_TO] = throwing_datum.thrower
 	if(living_pawn.buckled)
@@ -272,7 +272,7 @@
 			if(pointed_item.obj_flags & ABSTRACT)
 				return
 			pawn.visible_message(span_notice("[pawn] follows [pointing_friend]'s gesture towards [pointed_movable] and barks excitedly!"))
-			current_movement_target = pointed_movable
+			set_movement_target(pointed_movable)
 			blackboard[BB_FETCH_TARGET] = pointed_movable
 			blackboard[BB_FETCH_DELIVER_TO] = pointing_friend
 			if(living_pawn.buckled)
@@ -280,7 +280,7 @@
 			queue_behavior(/datum/ai_behavior/fetch)
 		if(DOG_COMMAND_ATTACK)
 			pawn.visible_message(span_notice("[pawn] follows [pointing_friend]'s gesture towards [pointed_movable] and growls intensely!"))
-			current_movement_target = pointed_movable
+			set_movement_target(pointed_movable)
 			blackboard[BB_DOG_HARASS_TARGET] = WEAKREF(pointed_movable)
 			if(living_pawn.buckled)
 				queue_behavior(/datum/ai_behavior/resist)//in case they are in bed or something

--- a/code/datums/ai/dog/dog_subtrees.dm
+++ b/code/datums/ai/dog/dog_subtrees.dm
@@ -18,7 +18,7 @@
 	if(!controller.blackboard[BB_SIMPLE_CARRY_ITEM] && controller.blackboard[BB_FETCH_TARGET])
 		var/atom/movable/interact_target = controller.blackboard[BB_FETCH_TARGET]
 		if(in_range(living_pawn, interact_target) && (isturf(interact_target.loc)))
-			controller.current_movement_target = interact_target
+			controller.set_movement_target(interact_target)
 			if(IS_EDIBLE(interact_target))
 				controller.queue_behavior(/datum/ai_behavior/eat_snack)
 			else if(isitem(interact_target))
@@ -35,6 +35,6 @@
 			// if the return target isn't in sight, we'll just forget about it and carry the thing around
 			controller.blackboard[BB_FETCH_DELIVER_TO] = null
 			return
-		controller.current_movement_target = return_target
+		controller.set_movement_target(return_target)
 		controller.queue_behavior(/datum/ai_behavior/deliver_item)
 		return

--- a/code/datums/ai/generic/generic_behaviors.dm
+++ b/code/datums/ai/generic/generic_behaviors.dm
@@ -31,7 +31,7 @@
 
 /datum/ai_behavior/break_spine/setup(datum/ai_controller/controller, target_key)
 	. = ..()
-	controller.current_movement_target = controller.blackboard[target_key]
+	controller.set_movement_target(controller.blackboard[target_key])
 
 /datum/ai_behavior/break_spine/perform(delta_time, datum/ai_controller/controller, target_key)
 	var/mob/living/batman = controller.blackboard[target_key]
@@ -90,7 +90,7 @@
 	var/target = target_ref?.resolve()
 	if(!target)
 		return FALSE
-	controller.current_movement_target = target
+	controller.set_movement_target(target)
 
 /datum/ai_behavior/use_on_object/perform(delta_time, datum/ai_controller/controller, target_key)
 	. = ..()
@@ -119,7 +119,7 @@
 /datum/ai_behavior/give/setup(datum/ai_controller/controller, target_key)
 	. = ..()
 	var/datum/weakref/target_ref = controller.blackboard[target_key]
-	controller.current_movement_target = target_ref?.resolve()
+	controller.set_movement_target(target_ref?.resolve())
 
 /datum/ai_behavior/give/perform(delta_time, datum/ai_controller/controller, target_key)
 	. = ..()
@@ -186,7 +186,7 @@
 /datum/ai_behavior/consume/setup(datum/ai_controller/controller, target_key)
 	. = ..()
 	var/datum/weakref/target_ref = controller.blackboard[target_key]
-	controller.current_movement_target = target_ref?.resolve()
+	controller.set_movement_target(target_ref?.resolve())
 
 /datum/ai_behavior/consume/perform(delta_time, datum/ai_controller/controller, target_key, hunger_timer_key)
 	. = ..()
@@ -245,7 +245,7 @@
 		finish_action(controller, TRUE)
 		return
 
-	controller.current_movement_target = living_target
+	controller.set_movement_target(living_target)
 	attack(controller, living_target)
 
 /datum/ai_behavior/attack/finish_action(datum/ai_controller/controller, succeeded)
@@ -281,7 +281,7 @@
 		finish_action(controller, TRUE)
 		return
 
-	controller.current_movement_target = living_target
+	controller.set_movement_target(living_target)
 
 /datum/ai_behavior/follow/finish_action(datum/ai_controller/controller, succeeded)
 	. = ..()

--- a/code/datums/ai/hunting_behavior/hunting_behaviors.dm
+++ b/code/datums/ai/hunting_behavior/hunting_behaviors.dm
@@ -85,7 +85,7 @@
 /datum/ai_behavior/hunt_target/setup(datum/ai_controller/controller, hunting_target_key, hunting_cooldown_key)
 	. = ..()
 	var/datum/weakref/hunting_weakref = controller.blackboard[hunting_target_key]
-	controller.current_movement_target = hunting_weakref?.resolve()
+	controller.set_movement_target(hunting_weakref?.resolve())
 
 /datum/ai_behavior/hunt_target/perform(delta_time, datum/ai_controller/controller, hunting_target_key, hunting_cooldown_key)
 	. = ..()

--- a/code/datums/ai/making_your_ai.md
+++ b/code/datums/ai/making_your_ai.md
@@ -223,7 +223,7 @@ As before, let's take a look at a basic example of one:
 		finish_action(controller, TRUE)
 		return
 
-	controller.current_movement_target = living_target
+	controller.set_movement_target(living_target)
 
 /datum/ai_behavior/follow/finish_action(datum/ai_controller/controller, succeeded, follow_key, range_key)
 	. = ..()

--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -143,7 +143,7 @@
 /datum/ai_behavior/monkey_attack_mob/setup(datum/ai_controller/controller, target_key)
 	. = ..()
 	var/datum/weakref/target_ref = controller.blackboard[target_key]
-	controller.current_movement_target = target_ref?.resolve()
+	controller.set_movement_target(target_ref?.resolve())
 
 /datum/ai_behavior/monkey_attack_mob/perform(delta_time, datum/ai_controller/controller, target_key)
 	. = ..()
@@ -241,7 +241,7 @@
 /datum/ai_behavior/disposal_mob/setup(datum/ai_controller/controller, attack_target_key, disposal_target_key)
 	. = ..()
 	var/datum/weakref/target_ref = controller.blackboard[attack_target_key]
-	controller.current_movement_target = target_ref?.resolve()
+	controller.set_movement_target(target_ref?.resolve())
 
 /datum/ai_behavior/disposal_mob/finish_action(datum/ai_controller/controller, succeeded, attack_target_key, disposal_target_key)
 	. = ..()
@@ -259,7 +259,7 @@
 	var/mob/living/target = target_ref?.resolve()
 	var/mob/living/living_pawn = controller.pawn
 
-	controller.current_movement_target = target
+	controller.set_movement_target(target)
 
 	if(!target)
 		finish_action(controller, FALSE)
@@ -272,7 +272,7 @@
 
 	var/datum/weakref/disposal_ref = controller.blackboard[disposal_target_key]
 	var/obj/machinery/disposal/disposal = disposal_ref.resolve()
-	controller.current_movement_target = disposal
+	controller.set_movement_target(disposal)
 
 	if(!disposal)
 		finish_action(controller, FALSE)

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -147,7 +147,7 @@ have ways of interacting with a specific mob and control it.
 		return FALSE
 
 	blackboard[BB_MONKEY_PICKUPTARGET] = weapon
-	current_movement_target = weapon
+	set_movement_target(weapon)
 	if(pickpocket)
 		queue_behavior(/datum/ai_behavior/monkey_equip/pickpocket)
 	else

--- a/code/datums/ai/objects/vending_machines/vending_machine_behaviors.dm
+++ b/code/datums/ai/objects/vending_machines/vending_machine_behaviors.dm
@@ -7,7 +7,7 @@
 
 /datum/ai_behavior/vendor_crush/setup(datum/ai_controller/controller, target_key)
 	. = ..()
-	controller.current_movement_target = controller.blackboard[target_key]
+	controller.set_movement_target(controller.blackboard[target_key])
 
 
 /datum/ai_behavior/vendor_crush/perform(delta_time, datum/ai_controller/controller)

--- a/code/datums/ai/oldhostile/hostile_tameable.dm
+++ b/code/datums/ai/oldhostile/hostile_tameable.dm
@@ -180,7 +180,7 @@
 			CancelActions()
 			blackboard[BB_HOSTILE_ORDER_MODE] = HOSTILE_COMMAND_FOLLOW
 			blackboard[BB_FOLLOW_TARGET] = WEAKREF(commander)
-			current_movement_target = commander
+			set_movement_target(commander)
 			var/mob/living/living_pawn = pawn
 			if(living_pawn.buckled)
 				queue_behavior(/datum/ai_behavior/resist)//in case they are in bed or something
@@ -211,7 +211,7 @@
 
 	if(blackboard[BB_HOSTILE_ORDER_MODE] == HOSTILE_COMMAND_ATTACK)
 		pawn.visible_message(span_notice("[pawn] follows [pointing_friend]'s gesture towards [pointed_movable] and [blackboard[BB_HOSTILE_ATTACK_WORD]] intensely!"))
-		current_movement_target = pointed_movable
+		set_movement_target(pointed_movable)
 		blackboard[BB_ATTACK_TARGET] = WEAKREF(pointed_movable)
 		if(living_pawn.buckled)
 			queue_behavior(/datum/ai_behavior/resist)//in case they are in bed or something

--- a/code/datums/ai/robot_customer/robot_customer_behaviors.dm
+++ b/code/datums/ai/robot_customer/robot_customer_behaviors.dm
@@ -122,7 +122,7 @@
 /datum/ai_behavior/leave_venue/setup(datum/ai_controller/controller, venue_key)
 	. = ..()
 	var/datum/venue/attending_venue = controller.blackboard[venue_key]
-	controller.current_movement_target = attending_venue.restaurant_portal
+	controller.set_movement_target(attending_venue.restaurant_portal)
 
 /datum/ai_behavior/leave_venue/perform(delta_time, datum/ai_controller/controller, venue_key)
 	. = ..()

--- a/code/datums/ai/robot_customer/robot_customer_subtrees.dm
+++ b/code/datums/ai/robot_customer/robot_customer_subtrees.dm
@@ -15,7 +15,7 @@
 		controller.queue_behavior(/datum/ai_behavior/find_seat)
 		return SUBTREE_RETURN_FINISH_PLANNING
 
-	controller.current_movement_target = seat_marker
+	controller.set_movement_target(seat_marker)
 
 	if(!controller.blackboard[BB_CUSTOMER_CURRENT_ORDER]) //We haven't ordered yet even ordered yet. go on! go over there and go do it!
 		controller.queue_behavior(/datum/ai_behavior/order_food)

--- a/code/modules/mod/modules/module_pathfinder.dm
+++ b/code/modules/mod/modules/module_pathfinder.dm
@@ -109,7 +109,7 @@
 		return FALSE
 	var/datum/ai_controller/mod_ai = new /datum/ai_controller/mod(module.mod)
 	module.mod.ai_controller = mod_ai
-	mod_ai.current_movement_target = imp_in
+	mod_ai.set_movement_target(imp_in)
 	mod_ai.blackboard[BB_MOD_TARGET] = imp_in
 	mod_ai.blackboard[BB_MOD_IMPLANT] = src
 	module.mod.interaction_flags_item &= ~INTERACT_ITEM_ATTACK_HAND_PICKUP


### PR DESCRIPTION
## About The Pull Request

Allows basic mobs / datum AI to switch between movement datums. Useful if you need JPS in some moments, but simple obstacle avoidance in others

This isn't used anywhere yet, but is a building block for basic bots.

## Why It's Good For The Game

Allows us to pick the right tool for the job!

## Changelog

:cl: Capybara Holly
refactor: Datum AI can now switch to different movement datums in their behavior.
/:cl: