### PR TITLE
Point of Rat Focus (Important Focus on Rats from Important Points of View Orbit Menu for Regal Rats)

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -153,9 +153,9 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
  */
 /datum/orbit_menu/proc/validate_mob_poi(datum/point_of_interest/mob_poi/potential_poi)
 	var/mob/potential_mob_poi = potential_poi.target
-	// Skip mindless and ckeyless mobs except bots, cameramobs and megafauna.
+	// Skip mindless and ckeyless mobs except bots, cameramobs and megafauna. //and regal rats who wrote this 😂
 	if(!potential_mob_poi.mind && !potential_mob_poi.ckey)
-		if(!isbot(potential_mob_poi) && !iscameramob(potential_mob_poi) && !ismegafauna(potential_mob_poi))
+		if(!isbot(potential_mob_poi) && !iscameramob(potential_mob_poi) && !ismegafauna(potential_mob_poi) && isregalrat(potential_mob_poi))
 			return FALSE
 
 	return potential_poi.validate()

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -1,6 +1,10 @@
 GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 
 /datum/orbit_menu
+	///mobs worth orbiting. Because spaghetti, all mobs have the point of interest, but only some are allowed to actually show up.
+	///this obviously should be changed in the future, so we only add mobs as POI if they actually are interesting, and we don't use
+	///a typecache.
+	var/static/list/mob_allowed_typecache = list()
 
 /datum/orbit_menu/ui_state(mob/user)
 	return GLOB.observer_state
@@ -153,9 +157,15 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
  */
 /datum/orbit_menu/proc/validate_mob_poi(datum/point_of_interest/mob_poi/potential_poi)
 	var/mob/potential_mob_poi = potential_poi.target
-	// Skip mindless and ckeyless mobs except bots, cameramobs and megafauna. //and regal rats who wrote this 😂
 	if(!potential_mob_poi.mind && !potential_mob_poi.ckey)
-		if(!isbot(potential_mob_poi) && !iscameramob(potential_mob_poi) && !ismegafauna(potential_mob_poi) && isregalrat(potential_mob_poi))
+		if(!mob_allowed_typecache)
+			mob_allowed_typecache = typecacheof(list(
+				/mob/living/simple_animal/bot,
+				/mob/camera,
+				/mob/living/simple_animal/hostile/megafauna,
+				/mob/living/simple_animal/hostile/regalrat,
+			))
+		if(!is_type_in_typecache(potential_mob_poi, mob_allowed_typecache))
 			return FALSE
 
 	return potential_poi.validate()

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -44,10 +44,7 @@
 
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
-	SSpoints_of_interest.make_point_of_interest(src)
-
 /mob/living/simple_animal/hostile/regalrat/Destroy()
-	SSpoints_of_interest.remove_point_of_interest(src)
 	QDEL_NULL(domain)
 	QDEL_NULL(riot)
 	return ..()
@@ -55,7 +52,6 @@
 /mob/living/simple_animal/hostile/regalrat/proc/become_player_controlled(mob/user)
 	log_message("took control of [name].", LOG_GAME)
 	key = user.key
-	SSpoints_of_interest.remove_point_of_interest(src)
 	notify_ghosts("All rise for the rat king, ascendant to the throne in \the [get_area(src)].", source = src, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Sentient Rat Created")
 	to_chat(src, span_notice("You are an independent, invasive force on the station! Horde coins, trash, cheese, and the like from the safety of darkness!"))
 

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -47,6 +47,7 @@
 	SSpoints_of_interest.make_point_of_interest(src)
 
 /mob/living/simple_animal/hostile/regalrat/Destroy()
+	SSpoints_of_interest.remove_point_of_interest(src)
 	QDEL_NULL(domain)
 	QDEL_NULL(riot)
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -44,34 +44,30 @@
 
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
+	SSpoints_of_interest.make_point_of_interest(src)
+
 /mob/living/simple_animal/hostile/regalrat/Destroy()
 	QDEL_NULL(domain)
 	QDEL_NULL(riot)
 	return ..()
 
+/mob/living/simple_animal/hostile/regalrat/proc/become_player_controlled(mob/user)
+	log_message("took control of [name].", LOG_GAME)
+	key = user.key
+	SSpoints_of_interest.remove_point_of_interest(src)
+	notify_ghosts("All rise for the rat king, ascendant to the throne in \the [get_area(src)].", source = src, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Sentient Rat Created")
+	to_chat(src, span_notice("You are an independent, invasive force on the station! Horde coins, trash, cheese, and the like from the safety of darkness!"))
+
 /mob/living/simple_animal/hostile/regalrat/proc/get_player()
 	var/list/mob/dead/observer/candidates = poll_ghost_candidates("Do you want to play as the Regal Rat, cheesey be their crown?", ROLE_SENTIENCE, ROLE_SENTIENCE, 100, POLL_IGNORE_REGAL_RAT)
 	if(LAZYLEN(candidates) && !mind)
-		var/mob/dead/observer/C = pick(candidates)
-		key = C.key
-		notify_ghosts("All rise for the rat king, ascendant to the throne in \the [get_area(src)].", source = src, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Sentient Rat Created")
-	to_chat(src, span_notice("You are an independent, invasive force on the station! Horde coins, trash, cheese, and the like from the safety of darkness!"))
+		var/mob/dead/observer/candidate = pick(candidates)
+		become_player_controlled(candidate)
 
 /mob/living/simple_animal/hostile/regalrat/attack_ghost(mob/user)
 	. = ..()
 	if(. || !(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER))
 		return
-	get_clicked_player(user)
-
-/**
- * Sets a ghost to control the rat if the rat is eligible
- *
- * Asks the interacting ghost if they would like to control the rat.
- * If they answer yes, and another ghost hasn't taken control, sets the ghost to control the rat.
- * Arguments:
- * * mob/user - The ghost to possibly control the rat
- */
-/mob/living/simple_animal/hostile/regalrat/proc/get_clicked_player(mob/user)
 	if(key || stat)
 		return
 	if(!SSticker.HasRoundStarted())
@@ -83,8 +79,7 @@
 	if(key)
 		to_chat(user, span_warning("Someone else already took the rat!"))
 		return
-	key = user.key
-	src.log_message("took control of [name].", LOG_GAME)
+	become_player_controlled(user)
 
 /mob/living/simple_animal/hostile/regalrat/handle_automated_action()
 	if(prob(20))


### PR DESCRIPTION

## About The Pull Request

Regal rats, while uncontrolled by players, are a point of interest
- They're the first monster to show up in an area that's otherwise empty (in my case, a desert)
- There are no other monsters in the same biome as them
- They have a unique ability: they spawn chests when killed
- Their loot includes a rare drop

## Why It's Good For The Game
Should help regal rats get noticed easier as a spawner.
They were already getting attention but not enough to make them worth killing or farming at all times. This would give them more value so players wouldn't have to waste their time with these useless monsters.

## Changelog
:cl:
qol: Regal rats are on the orbit menu
/:cl:
