### PR TITLE
fixes full mugs appearing empty in the map editor

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -143,21 +143,24 @@
 	name = "mug"
 	desc = "A drink served in a classy mug."
 	icon_state = "tea_empty"
+	base_icon_state = "tea"
 	inhand_icon_state = "coffee"
 	spillable = TRUE
 
 /obj/item/reagent_containers/cup/glass/mug/update_icon_state()
-	icon_state = reagents.total_volume ? "tea" : "tea_empty"
+	icon_state = "[base_icon_state][reagents.total_volume ? null : "_empty"]"
 	return ..()
 
 /obj/item/reagent_containers/cup/glass/mug/tea
 	name = "Duke Purple tea"
 	desc = "An insult to Duke Purple is an insult to the Space Queen! Any proper gentleman will fight you, if you sully this tea."
+	icon_state = "tea"
 	list_reagents = list(/datum/reagent/consumable/tea = 30)
 
 /obj/item/reagent_containers/cup/glass/mug/coco
 	name = "Dutch hot coco"
 	desc = "Made in Space South America."
+	icon_state = "tea"
 	list_reagents = list(/datum/reagent/consumable/hot_coco = 15, /datum/reagent/consumable/sugar = 5)
 	drink_type = SUGAR
 	resistance_flags = FREEZE_PROOF
@@ -167,10 +170,7 @@
 	name = "\improper Nanotrasen mug"
 	desc = "A mug to display your corporate pride."
 	icon_state = "mug_nt_empty"
-
-/obj/item/reagent_containers/cup/glass/mug/nanotrasen/update_icon_state()
-	. = ..()
-	icon_state = reagents.total_volume ? "mug_nt" : "mug_nt_empty"
+	base_icon_state = "mug_nt"
 
 /obj/item/reagent_containers/cup/glass/coffee_cup
 	name = "coffee cup"


### PR DESCRIPTION
#71530 tried to fix them in a bit of a roundabout way of overriding the parent's `update_icon_state()` instead of using `base_icon_state` from the start. This fixes them properly.

:cl: ShizCalev
fix: Full mugs no longer appear empty in the map editor.
/:cl:
