### PR TITLE
Run CI, merge conflict checks, and 515 compat on "project branches"

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
     - master
+    - 'project/**'
   pull_request:
     branches:
     - master
+    - 'project/**'
 jobs:
   run_linters:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - 'project/**'
 jobs:
   triage:
     runs-on: ubuntu-20.04

--- a/.github/workflows/has_515_compatibility.yml
+++ b/.github/workflows/has_515_compatibility.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
     - master
+    - 'project/**'
 jobs:
   has_515_compatibility:
     name: Has 515 Compatibility


### PR DESCRIPTION
## About The Pull Request

Here introduces "project" branches. Branches designed for bit by bit contributions of large scale refactors and changes. PRs to these branches will show up on tracker like normal but won't apply to master until the project branch itself is done and merged in. This allows for much easier review and atomization without compromising master with temporary hacky code.

A maintainer will create a project branch on the repository, allowing any contributor to PR to it like normal. Very simple.

An example of this use can be seen in the basic bots PR. It is too large to be full sent as one PR, but doing it one bot at a time will result in a lot of bugs and copy and pasted code. This way, we can update bots one by one until they're all done, then full send it. 

This PR adjusts our CI (as well as merge conflict checks and 515 compatibility) to run on "`project/`" branches in addition to master.  

