### PR TITLE
Made geysers easier to find

### DIFF
--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -35,7 +35,7 @@
 	///Base chance of spawning flora
 	var/flora_spawn_chance = 2
 	///Base chance of spawning features
-	var/feature_spawn_chance = 0.1
+	var/feature_spawn_chance = 0.15
 	///Unique ID for this spawner
 	var/string_gen
 

--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -35,7 +35,7 @@
 	///Base chance of spawning flora
 	var/flora_spawn_chance = 2
 	///Base chance of spawning features
-	var/feature_spawn_chance = 0.15
+	var/feature_spawn_chance = 0.2
 	///Unique ID for this spawner
 	var/string_gen
 

--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -35,7 +35,7 @@
 	///Base chance of spawning flora
 	var/flora_spawn_chance = 2
 	///Base chance of spawning features
-	var/feature_spawn_chance = 0.2
+	var/feature_spawn_chance = 0.15
 	///Unique ID for this spawner
 	var/string_gen
 

--- a/code/datums/mapgen/Cavegens/IcemoonCaves.dm
+++ b/code/datums/mapgen/Cavegens/IcemoonCaves.dm
@@ -9,7 +9,7 @@
 						  /mob/living/simple_animal/hostile/asteroid/lobstrosity = 15)
 	weighted_flora_spawn_list = list(/obj/structure/flora/tree/pine/style_random = 2, /obj/structure/flora/rock/icy/style_random = 2, /obj/structure/flora/rock/pile/icy/style_random = 2, /obj/structure/flora/grass/both/style_random = 6, /obj/structure/flora/ash/chilly = 2)
 	///Note that this spawn list is also in the lavaland generator
-	weighted_feature_spawn_list = list(/obj/structure/geyser/wittel = 6, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 10, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
+	weighted_feature_spawn_list = list(/obj/structure/geyser/wittel = 10, /obj/structure/geyser/random = 2, /obj/structure/geyser/plasma_oxide = 10, /obj/structure/geyser/protozine = 10, /obj/structure/geyser/hollowwater = 10)
 
 /datum/map_generator/cave_generator/icemoon/surface
 	flora_spawn_chance = 4

--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -28,7 +28,7 @@
 
 	///Note that this spawn list is also in the icemoon generator
 	weighted_feature_spawn_list = list(
-		/obj/structure/geyser/wittel = 6,
+		/obj/structure/geyser/wittel = 10,
 		/obj/structure/geyser/random = 2,
 		/obj/structure/geyser/plasma_oxide = 10,
 		/obj/structure/geyser/protozine = 10,


### PR DESCRIPTION
## About The Pull Request

This PR raises the geyser spawn rate from 0.1 to 0.15 and increases the weight of wittel geysers to 10 which is the same as every other special geyser. (previously 6)

Wittel shouldn't be any less difficult to find than other geysers as all of the special geysers are equally powerful. Hyper-plasmium oxide can be used to make extremely powerful explosives that can go beyond maxcaps and hollow water + protozine can create an infinite amount of strange reagent.

I've subjected myself to going out of my way to visit lavaland/icemoon several times to get wittel and each time finding a single geyser takes about 5 minutes of my time. This, coupled with the fact you really don't have a lot of time to be wasting on looking for the geysers results in an unfun experience.

I understand geysers are sort of a necessary evil, however, they shouldn't be THIS difficult to find. Out of the 10 or so geysers I've found, only 1 has had wittel in it and it was next to a whelp portal which ended both me and my miner escort.

I've also hunted the entirety of lavaland with no luck. (Horrendous experience.)

I've dedicated entire rounds to this, by the way.
## Why It's Good For The Game

If you go out of your way to waste ages hunting for geysers, there should at least be a reward. That is, in the same round, not after 3 or more rounds as even megafauna gear isn't gatekept THAT hard.

You shouldn't have to waste this much of a miner's time (who is also going for megafauna gear) to get something that is arguably less powerful than what they get for less effort. Megafauna gear is also available every round and is attained via predictable methods.

This PR will also likely make geyser scanning a more comparable method of point gain to just mining.

Oh and not to mention that penthrite is available almost roundstart via luxpens. (It's a wittel chem.)
## Changelog
:cl:
balance: Geysers now spawn more often, especially wittel geysers.
/:cl:
