### PR TITLE
Disabled plumbing IV drip transfer control on injection.

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -245,6 +245,7 @@
 		if(!amount)
 			transfer_rate = MIN_IV_TRANSFER_RATE
 			visible_message(span_hear("[src] pings."))
+			update_appearance(UPDATE_ICON)
 			return
 
 		// If the human is losing too much blood, beep.

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -228,7 +228,7 @@
 	if(!drip_reagents)
 		return PROCESS_KILL
 
-	if(set_transfer_rate(MIN_IV_TRANSFER_RATE))
+	if(transfer_rate == 0)
 		return
 
 	// Give reagents

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -228,7 +228,7 @@
 	if(!drip_reagents)
 		return PROCESS_KILL
 
-	if(transfer_rate == 0)
+	if(set_transfer_rate(MIN_IV_TRANSFER_RATE))
 		return
 
 	// Give reagents
@@ -243,9 +243,8 @@
 		var/amount = min(transfer_rate * delta_time, drip_reagents.maximum_volume - drip_reagents.total_volume)
 		// If the beaker is full, ping
 		if(!amount)
-			transfer_rate = MIN_IV_TRANSFER_RATE
+			set_transfer_rate(MIN_IV_TRANSFER_RATE)
 			visible_message(span_hear("[src] pings."))
-			update_appearance(UPDATE_ICON)
 			return
 
 		// If the human is losing too much blood, beep.
@@ -295,9 +294,8 @@
 	if(attached)
 		visible_message(span_notice("[attached] is detached from [src]."))
 	SEND_SIGNAL(src, COMSIG_IV_DETACH, attached)
-	transfer_rate = MIN_IV_TRANSFER_RATE
+	set_transfer_rate(MIN_IV_TRANSFER_RATE)
 	attached = null
-	update_appearance(UPDATE_ICON)
 
 /// Get the reagents used by IV drip
 /obj/machinery/iv_drip/proc/get_reagents()
@@ -347,9 +345,8 @@
 		mode = IV_INJECTING
 		return
 	mode = !mode
-	transfer_rate = MIN_IV_TRANSFER_RATE
+	set_transfer_rate(MIN_IV_TRANSFER_RATE)
 	to_chat(usr, span_notice("The IV drip is now [mode ? "injecting" : "taking blood"]."))
-	update_appearance(UPDATE_ICON)
 
 /obj/machinery/iv_drip/examine(mob/user)
 	. = ..()

--- a/tgui/packages/tgui/interfaces/IVDrip.tsx
+++ b/tgui/packages/tgui/interfaces/IVDrip.tsx
@@ -113,24 +113,31 @@ export const IVDrip = (props, context) => {
               </LabeledList.Item>
             )}
             {!!data.connected &&
-              (!!data.containerAttached || data.useInternalStorage) && (
-                <LabeledList.Item
-                  label="Transfer Rate"
-                  buttons={'Units / Second'}>
-                  <Slider
-                    step={data.transferStep}
-                    my={1}
-                    value={data.transferRate}
-                    minValue={data.minInjectRate}
-                    maxValue={data.maxInjectRate}
-                    onDrag={(e, value) =>
-                      act('changeRate', {
-                        rate: value,
-                      })
-                    }
-                  />
+              (data.mode && data.useInternalStorage ? ( // Plumbing drip injects with the rate from network
+                <LabeledList.Item label="Transfer Rate">
+                  Controlled by the plumbing network
                 </LabeledList.Item>
-              )}
+              ) : (
+                ((!data.mode && data.useInternalStorage) || // Transfer rate controls always work for blood drawing
+                  !!data.containerAttached) && (
+                  <LabeledList.Item
+                    label="Transfer Rate"
+                    buttons={'Units / Second'}>
+                    <Slider
+                      step={data.transferStep}
+                      my={1}
+                      value={data.transferRate}
+                      minValue={data.minInjectRate}
+                      maxValue={data.maxInjectRate}
+                      onDrag={(e, value) =>
+                        act('changeRate', {
+                          rate: value,
+                        })
+                      }
+                    />
+                  </LabeledList.Item>
+                )
+              ))}
           </LabeledList>
         </Section>
       </Window.Content>


### PR DESCRIPTION
## About The Pull Request

Workaround for https://github.com/tgstation/tgstation/issues/71579

The injection rate of the automated IV drip is controlled by plumbing, but the UI transfer rate was still available.
It misled people because it did nothing.

Now there is a message saying that the transfer rate is managed by the network.

![image](https://user-images.githubusercontent.com/3625094/204649114-c3040529-ab69-4e30-a77d-7f9cdcd182cb.png)

## Why It's Good For The Game

It seems like a bug without this control disabled.

## Changelog

:cl:
fix: Automated IV drip transfer rate controls now unavailable on injection, since the transfer rate is managed by the plumbing network
/:cl:
