### PR TITLE
Fixes a misused flag operation from the noequip flag change

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
@@ -53,9 +53,8 @@
 	if(!ishuman(tongue_owner))
 		return
 	var/mob/living/carbon/human/human_receiver = tongue_owner
-	var/datum/species/rec_species = human_receiver.dna.species
-	if(!(rec_species.no_equip_flags & ITEM_SLOT_MASK))
-		rec_species.no_equip_flags += ITEM_SLOT_MASK
+	// Add mask to noequip flags
+	tongue_owner.dna.species.no_equip_flags |= ITEM_SLOT_MASK
 	var/obj/item/bodypart/head/head = human_receiver.get_bodypart(BODY_ZONE_HEAD)
 	head.unarmed_damage_low = 10 // Yeah, biteing is pretty weak, blame the monkey super-nerf
 	head.unarmed_damage_high = 15
@@ -67,8 +66,10 @@
 		return
 	var/mob/living/carbon/human/human_receiver = tongue_owner
 	var/datum/species/rec_species = human_receiver.dna.species
-	if(!(initial(rec_species.no_equip_flags) & ITEM_SLOT_MASK))
-		rec_species.no_equip_flags -= ITEM_SLOT_MASK
+	var/default_noequip_flags = initial(rec_species.no_equip_flags)
+	// Remove mask from noequip flags if we didn't already have it
+	if(!(default_noequip_flags & ITEM_SLOT_MASK))
+		rec_species.no_equip_flags &= ~ITEM_SLOT_MASK
 	var/obj/item/bodypart/head/head = human_receiver.get_bodypart(BODY_ZONE_HEAD)
 	head.unarmed_damage_low = initial(head.unarmed_damage_low)
 	head.unarmed_damage_high = initial(head.unarmed_damage_high)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///Bitfield for food types that the species absolutely hates, giving them even more disgust than disliked food. Meat is "toxic" to moths, for example.
 	var/toxic_food = TOXIC
 	///flags for inventory slots the race can't equip stuff to. Golems cannot wear jumpsuits, for example.
-	var/no_equip_flags
+	var/no_equip_flags = NONE
 	/// Allows the species to equip items that normally require a jumpsuit without having one equipped. Used by golems.
 	var/nojumpsuit = FALSE
 	///Affects the speech message, for example: Motharula flutters, "My speech message is flutters!"


### PR DESCRIPTION
## About The Pull Request

Don't add or subtract flags from other flags, that's a surefire way to screw things up. 

Bitflags should and, or, and/or negate. Not add or subtract.  

## Why It's Good For The Game

Things work correctly

## Changelog

:cl: Melbert
fix: There is less of a chance that the carp tongue bricks your ability to wear certain things when removed
/:cl:
