### PR TITLE
"Peek" launch mode for bluespace launchpads

### DIFF
--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -9,7 +9,7 @@
 	var/list/obj/machinery/launchpad/launchpads
 	var/maximum_pads = 4
 
-	var/list/peek_stack
+	var/list/peek_stack = list()
 
 /obj/machinery/computer/launchpad/Initialize(mapload)
 	launchpads = list()
@@ -190,10 +190,11 @@
 			var/checks = teleport_checks(current_pad)
 			if(!isnull(checks))
 				to_chat(usr, span_warning(checks))
+				return
 
 			current_pad.doteleport(usr, TRUE)
-			if(!length(peek_stack))  // dont pull multiple times
-				addtimer(CALLBACK(src, PROC_REF(peek_return)), 4 SECONDS)
+			if(!LAZYLEN(peek_stack))  // dont pull multiple times
+				addtimer(CALLBACK(src, PROC_REF(peek_return)), 3 SECONDS)
 			peek_stack += current_pad
 
 			. = TRUE
@@ -209,7 +210,9 @@
 		if(!isnull(checks))
 			to_chat(user, span_warning(checks))
 			continue
-		current_pad.doteleport(user, FALSE)
-		sleep(0.25 SECONDS)
+
+		// initializes pull on each pad without waiting for it to complete pulling
+		INVOKE_ASYNC(current_pad, TYPE_PROC_REF(/obj/machinery/launchpad, doteleport), user, FALSE)
+		sleep(0.25 SECONDS)  // adds some delay to not make it too epileptic/pull properly
 
 	peek_stack.Cut()

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -9,6 +9,8 @@
 	var/list/obj/machinery/launchpad/launchpads
 	var/maximum_pads = 4
 
+	var/list/peek_stack
+
 /obj/machinery/computer/launchpad/Initialize(mapload)
 	launchpads = list()
 	. = ..()
@@ -190,8 +192,24 @@
 				to_chat(usr, span_warning(checks))
 
 			current_pad.doteleport(usr, TRUE)
-			sleep(selected_id SECONDS)  // allows for cool relay tactics
-			current_pad.doteleport(usr, FALSE)
+			if(!length(peek_stack))  // dont pull multiple times
+				addtimer(CALLBACK(src, PROC_REF(peek_return)), 4 SECONDS)
+			peek_stack += current_pad
 
 			. = TRUE
 	. = TRUE
+
+
+/obj/machinery/computer/launchpad/proc/peek_return(user)
+	if(!length(peek_stack))
+		return
+
+	for(var/obj/machinery/launchpad/current_pad in reverseList(peek_stack))
+		var/checks = teleport_checks(current_pad)
+		if(!isnull(checks))
+			to_chat(user, span_warning(checks))
+			continue
+		current_pad.doteleport(user, FALSE)
+		sleep(0.25 SECONDS)
+
+	peek_stack.Cut()

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -9,7 +9,7 @@
 	var/list/obj/machinery/launchpad/launchpads
 	var/maximum_pads = 4
 
-	var/list/peek_stack = list()
+	var/list/peek_stack
 
 /obj/machinery/computer/launchpad/Initialize(mapload)
 	launchpads = list()
@@ -195,16 +195,17 @@
 			current_pad.doteleport(usr, TRUE)
 			if(!LAZYLEN(peek_stack))  // dont pull multiple times
 				addtimer(CALLBACK(src, PROC_REF(peek_return)), 3 SECONDS)
-			peek_stack += current_pad
+			LAZYADD(peek_stack, current_pad)
 
 			. = TRUE
 	. = TRUE
 
 
 /obj/machinery/computer/launchpad/proc/peek_return(user)
-	if(!length(peek_stack))
+	if(!LAZYLEN(peek_stack))
 		return
 
+	// we've confirmed the lazylist is a list, and can treat it as such
 	for(var/obj/machinery/launchpad/current_pad in reverseList(peek_stack))
 		var/checks = teleport_checks(current_pad)
 		if(!isnull(checks))
@@ -215,4 +216,4 @@
 		INVOKE_ASYNC(current_pad, TYPE_PROC_REF(/obj/machinery/launchpad, doteleport), user, FALSE)
 		sleep(0.25 SECONDS)  // adds some delay to not make it too epileptic/pull properly
 
-	peek_stack.Cut()
+	peek_stack = null

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -206,7 +206,7 @@
 		return
 
 	// we've confirmed the lazylist is a list, and can treat it as such
-	for(var/obj/machinery/launchpad/current_pad in reverseList(peek_stack))
+	for(var/obj/machinery/launchpad/current_pad as anything in reverseList(peek_stack))
 		var/checks = teleport_checks(current_pad)
 		if(!isnull(checks))
 			to_chat(user, span_warning(checks))

--- a/code/game/machinery/computer/launchpad_control.dm
+++ b/code/game/machinery/computer/launchpad_control.dm
@@ -183,4 +183,15 @@
 				to_chat(usr, span_warning(checks))
 
 			. = TRUE
+
+		if("peek")
+			var/checks = teleport_checks(current_pad)
+			if(!isnull(checks))
+				to_chat(usr, span_warning(checks))
+
+			current_pad.doteleport(usr, TRUE)
+			sleep(selected_id SECONDS)  // allows for cool relay tactics
+			current_pad.doteleport(usr, FALSE)
+
+			. = TRUE
 	. = TRUE

--- a/tgui/packages/tgui/interfaces/LaunchpadConsole.js
+++ b/tgui/packages/tgui/interfaces/LaunchpadConsole.js
@@ -207,6 +207,15 @@ export const LaunchpadControl = (props, context) => {
         <Grid.Column>
           <Button
             fluid
+            icon="up-down"
+            content="Peek"
+            textAlign="center"
+            onClick={() => act('peek')}
+          />
+        </Grid.Column>
+        <Grid.Column>
+          <Button
+            fluid
             icon="download"
             content="Pull"
             textAlign="center"


### PR DESCRIPTION

## About The Pull Request
This pr adds a new launch option for bluespace lauchpads called peek. What it will do is launch, wait 3 seconds, then pull you back. Additionaly, hitting peek on multiple pads sequentially will cause them to pull in reverse order, allowing you to utilize this with chained pads.
## Why It's Good For The Game
Launchpads are very hard to use effectively without a partner, as you can teleport yourself into danger with no way out. This will let you more easily trial-error coordinates without removing the risk factor, since you will still be in the area for 5-6 seconds, plenty of time to be spotted, shot at, die in space, etc. 
## Changelog
:cl:
add: bluespace launchpad peek mode
/:cl:
