### PR TITLE
Important heretic spell rebalancing

### DIFF
--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -322,3 +322,9 @@
 	desc = "Patient's skin has numerous small slashes and cuts, generating moderate blood loss."
 	examine_desc = "has a ton of small cuts"
 	occur_text = "is cut numerous times, leaving many small slashes."
+
+// Subtype for cleave (heretic spell)
+/datum/wound/slash/critical/cleave
+	name = "Burning Avulsion"
+	examine_desc = "is ruptured, spraying blood wildly"
+	clot_rate = 0.01

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -410,7 +410,7 @@
 	user.apply_status_effect(/datum/status_effect/protective_blades/recharging, null, 8, 30, 0.25 SECONDS, 1 MINUTES)
 
 	var/datum/action/cooldown/spell/pointed/projectile/furious_steel/steel_spell = locate() in user.actions
-	steel_spell?.cooldown_time /= 3
+	steel_spell?.cooldown_time /= 2
 
 /datum/heretic_knowledge/ultimate/blade_final/proc/on_eldritch_blade(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)
 	SIGNAL_HANDLER

--- a/code/modules/antagonists/heretic/magic/blood_cleave.dm
+++ b/code/modules/antagonists/heretic/magic/blood_cleave.dm
@@ -7,32 +7,28 @@
 	ranged_mousepointer = 'icons/effects/mouse_pointers/throw_target.dmi'
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 40 SECONDS
+	cooldown_time = 45 SECONDS
 
 	invocation = "CL'VE!"
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
-	cast_range = 9
+	cast_range = 4
 
 	/// The radius of the cleave effect
 	var/cleave_radius = 1
 	/// What type of wound we apply
-	var/wound_type = /datum/wound/slash/critical
+	var/wound_type = /datum/wound/slash/critical/cleave
 
 /datum/action/cooldown/spell/pointed/cleave/is_valid_target(atom/cast_on)
 	return ..() && ishuman(cast_on)
 
 /datum/action/cooldown/spell/pointed/cleave/cast(mob/living/carbon/human/cast_on)
 	. = ..()
-	var/list/mob/living/carbon/human/nearby = list()
-	for(var/mob/living/carbon/human/nearby_human in range(cleave_radius, cast_on))
-		nearby += nearby_human
-
-	for(var/mob/living/carbon/human/victim as anything in nearby)
+	for(var/mob/living/carbon/human/victim in range(cleave_radius, cast_on))
 		if(victim == owner || IS_HERETIC_OR_MONSTER(victim))
 			continue
-		if(victim.can_block_magic())
+		if(victim.can_block_magic(antimagic_flags))
 			victim.visible_message(
 				span_danger("[victim]'s flashes in a firey glow, but repels the blaze!"),
 				span_danger("Your body begins to flash a firey glow, but you are protected!!")

--- a/code/modules/antagonists/heretic/magic/blood_siphon.dm
+++ b/code/modules/antagonists/heretic/magic/blood_siphon.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/pointed/blood_siphon
 	name = "Blood Siphon"
-	desc = "A touch spell that heals your wounds while damaging the enemy. \
+	desc = "A targeted spell that heals your wounds while damaging the enemy. \
 		It has a chance to transfer wounds between you and your enemy."
 	background_icon_state = "bg_ecult"
 	icon_icon = 'icons/mob/actions/actions_ecult.dmi'
@@ -14,7 +14,7 @@
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = NONE
 
-	cast_range = 9
+	cast_range = 6
 
 /datum/action/cooldown/spell/pointed/blood_siphon/can_cast_spell(feedback = TRUE)
 	return ..() && isliving(owner)

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -9,7 +9,7 @@
 	sound = 'sound/weapons/guillotine.ogg'
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 30 SECONDS
+	cooldown_time = 60 SECONDS
 	invocation = "F'LSH'NG S'LV'R!"
 	invocation_type = INVOCATION_SHOUT
 
@@ -122,5 +122,9 @@
 			var/datum/antagonist/heretic_monster/monster = victim.mind?.has_antag_datum(/datum/antagonist/heretic_monster)
 			if(monster?.master == caster.mind)
 				return PROJECTILE_PIERCE_PHASE
+
+		if(victim.can_block_magic(MAGIC_RESISTANCE))
+			visible_message(span_warning("[src] drops to the ground and melts on contact [victim]!"))
+			return PROJECTILE_DELETE_WITHOUT_HITTING
 
 	return ..()

--- a/code/modules/antagonists/heretic/magic/rust_construction.dm
+++ b/code/modules/antagonists/heretic/magic/rust_construction.dm
@@ -2,8 +2,7 @@
 	name = "Rust Formation"
 	desc = "Transforms a rusted floor into a full wall of rust. Creating a wall underneath a mob will harm it."
 	background_icon_state = "bg_ecult"
-	icon_icon = 'icons/mob/actions/actions_ecult.dmi'
-	button_icon_state = "cleave"
+	button_icon_state = "shield"
 	ranged_mousepointer = 'icons/effects/mouse_pointers/throw_target.dmi'
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
 

--- a/code/modules/antagonists/heretic/magic/void_cold_cone.dm
+++ b/code/modules/antagonists/heretic/magic/void_cold_cone.dm
@@ -5,11 +5,10 @@
 		Additionally, objects hit will be frozen and can shatter, and ground hit will be iced over and slippery - \
 		though they may thaw shortly if used in room temperature."
 	background_icon_state = "bg_ecult"
-	icon_icon = 'icons/mob/actions/actions_ecult.dmi'
-	button_icon_state = "entropic_plume"
+	button_icon_state = "icebeam"
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 1 MINUTES
+	cooldown_time = 30 SECONDS
 
 	invocation = "FR'ZE!"
 	invocation_type = INVOCATION_SHOUT

--- a/code/modules/antagonists/heretic/magic/void_phase.dm
+++ b/code/modules/antagonists/heretic/magic/void_phase.dm
@@ -35,22 +35,8 @@
 	var/turf/source_turf = get_turf(owner)
 	var/turf/targeted_turf = get_turf(cast_on)
 
-	new /obj/effect/temp_visual/voidin(source_turf)
-	new /obj/effect/temp_visual/voidout(targeted_turf)
-
-	// We handle sounds here so we can disable vary
-	playsound(source_turf, 'sound/magic/voidblink.ogg', 60, FALSE)
-	playsound(targeted_turf, 'sound/magic/voidblink.ogg', 60, FALSE)
-
-	for(var/mob/living/living_mob in range(damage_radius, source_turf))
-		if(IS_HERETIC_OR_MONSTER(living_mob) || living_mob == owner)
-			continue
-		living_mob.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND)
-
-	for(var/mob/living/living_mob in range(damage_radius, targeted_turf))
-		if(IS_HERETIC_OR_MONSTER(living_mob) || living_mob == owner)
-			continue
-		living_mob.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND)
+	cause_aoe(source_turf, /obj/effect/temp_visual/voidin)
+	cause_aoe(targeted_turf, /obj/effect/temp_visual/voidout)
 
 	do_teleport(
 		owner,
@@ -59,6 +45,17 @@
 		no_effects = TRUE,
 		channel = TELEPORT_CHANNEL_MAGIC,
 	)
+
+/// Does the AOE effect of the blinka t the passed turf
+/datum/action/cooldown/spell/pointed/void_phase/proc/cause_aoe(turf/target_turf, effect_type = /obj/effect/temp_visual/voidin)
+	new effect_type(target_turf)
+	playsound(target_turf, 'sound/magic/voidblink.ogg', 60, FALSE)
+	for(var/mob/living/living_mob in range(damage_radius, target_turf))
+		if(IS_HERETIC_OR_MONSTER(living_mob) || living_mob == owner)
+			continue
+		if(living_mob.can_block_magic(antimagic_flags))
+			continue
+		living_mob.apply_damage(40, BRUTE, wound_bonus = CANT_WOUND)
 
 /obj/effect/temp_visual/voidin
 	icon = 'icons/effects/96x96.dmi'

--- a/code/modules/antagonists/heretic/magic/void_pull.dm
+++ b/code/modules/antagonists/heretic/magic/void_pull.dm
@@ -32,7 +32,7 @@
 	for(var/mob/living/nearby_living as anything in get_things_to_cast_on(cast_on, damage_radius))
 		nearby_living.apply_damage(30, BRUTE, wound_bonus = CANT_WOUND)
 
-/datum/action/cooldown/spell/aoe/void_pull/get_things_to_cast_on(atom/center, radius_override = 0)
+/datum/action/cooldown/spell/aoe/void_pull/get_things_to_cast_on(atom/center, radius_override = 1)
 	var/list/things = list()
 	for(var/mob/living/nearby_mob in view(radius_override || aoe_radius, center))
 		if(nearby_mob == owner || nearby_mob == center)
@@ -41,6 +41,8 @@
 		if(!isturf(nearby_mob.loc))
 			continue
 		if(IS_HERETIC_OR_MONSTER(nearby_mob))
+			continue
+		if(nearby_mob.can_block_magic(antimagic_flags))
 			continue
 
 		things += nearby_mob


### PR DESCRIPTION
## About The Pull Request

Nerfs
- Furious steel cooldown: 30s -> 60 seconds (when ascended: 10s -> 30s)
- Furious steel: Now affected by antimagic
- Cleave cooldown: 40s -> 45s
- Cleave range: 9 tiles -> 4 tiles
- Cleave wound: Now has natural clotting, changing the amount of blood loss from inf -> ~40% 
- Blood siphon range: 9 tiles -> 6 tiles
- Void Pull: Now affected by antimagic
- Void Phase: Now affected by antimagic

Buffs
- Void Blast cooldown: 60s -> 30s

Other
- Rust Formation now has a "distinct" icon
- Void Blast now has a "distinct" icon

## Why It's Good For The Game

A lot of these spells were extremely oppressive, and made it pretty much a joke to get away with anything. 
They were no-brainer choices, and as a result no one really pathed into anything else but these. 

- Furious Steel: 
   - Now that blade heretics have "realignment" in their repertoire, which offers them another counter for being hit by disablers or batons, this spell doesn't need to have such an insanely high uptime. The spell should be used for initiating and obtaining the lead in a combat, instead of having nigh-invulnerability for most periods. 
   - Additionally, antimagic protection was kind of missing, which was partially an oversight of it not being a `/magic` projectile.
 
- Cleave:
   - Cleave was by far the most absurd ability available bar none. This spell was guaranteed death in 30 seconds if the target had no way to stop the bloodflow immediately. AND it could be casted from across the screen. This brings cleave's range into midrange between you and the target, giving a lot more opportunity to be aware for the victim. 
   - Critical bleed wounds had a negative clotting rate, meaning that prior you would bleed to 0% from cleave if you didn't stop it. Not very fun, so with the default clotting rate it now stops at 60% blood flow - enough to be lethal if untreated, but doesn't completely tap you out
   - **Alternatives**: 
      - Keep the no clotting, make it a pure melee / touch spell. 
      - Reduce the cooldown, make it a projectile
      - Change it to be like a cool scythe attack that comes out of the caster and does a sweep

- Blood Siphon: 
   - This was primarily done to slot in better with Cleave's range decrease, encouraging more close range combat between the two. Getting point clicked from across the screen isn't fun.

- Void Pull and Phase:
   - Largely done for consistency. These are spells which cause damage, so anti-magic should stop the damage from the spells. 

- Void Blast
   - I have no idea why I made the cooldown so high on this, 1 minute made it almost worthless. 

TLDR: Instakill click spells from across the screen bad, invulnerability bad

## Changelog

:cl: Melbert
balance: Heretic: Furious Steel's cooldown has been doubled (30s -> 60s), and abides by antimagic
balance: Heretic: Cleave's cooldown has increased by 5s, range has been decreased to 4 tiles, and wound applied now has natural clotting
balance: Heretic: Blood Siphon's range has been decreased to 6 tiles
balance: Heretic: Void Pull and Phase abide by antimagic
balance: Heretic: Halved Void Blast's cooldown to 30s
qol: Heretic: Void Blast and Rust Formation now have distinct icons 
/:cl:
