### PR TITLE
Made it possible to exit the DNA scanner without help

### DIFF
--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -131,7 +131,7 @@
 	dump_inventory_contents(list(occupant))
 
 /obj/machinery/dna_infuser/relaymove(mob/living/user, direction)
-	if(user.stat)
+	if(user.stat || infusing)
 		return
 	open_machine()
 

--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -41,13 +41,10 @@
 	. += span_notice("Alt-click to eject the infusion source, if one is inside.")
 
 /obj/machinery/dna_infuser/interact(mob/user)
-	if(user == occupant)
-		balloon_alert(user, "can't reach!")
-		return
 	if(infusing)
 		balloon_alert(user, "not while it's on!")
 		return
-	if(occupant && infusing_from)
+	if(occupant && infusing_from && user != occupant)
 		balloon_alert(user, "starting DNA infusion...")
 		start_infuse()
 		return
@@ -132,6 +129,11 @@
 	open_machine(drop = FALSE)
 	//we set drop to false to manually call it with an allowlist
 	dump_inventory_contents(list(occupant))
+
+/obj/machinery/dna_infuser/relaymove(mob/living/user, direction)
+	if(user.stat)
+		return
+	open_machine()
 
 /obj/machinery/dna_infuser/attackby(obj/item/used, mob/user, params)
 	if(infusing)


### PR DESCRIPTION

## About The Pull Request

Currently, when placed inside of a DNA infuser, by yourself or by someone else, it's impossible to exit without help - trying to click on it simply prints a "can't reach!" message. This PR changes this behavior in a couple of ways:

- Clicking the DNA infuser from inside will always open it (you still can't turn it on from inside).
- Trying to move while inside will open the door, much like the DNA scanner and other, similar machines.
## Why It's Good For The Game

It feels odd that the DNA infuser is an impenetrable prison if you get shut inside of it - something it's fairly easy to do on your own. Geneticists probably shouldn't be able to permanently imprison someone, accidentally or on purpose, with a roundstart machine. These changes make the behavior more-or-less identical to the DNA scanner - this is likely more intuitive, given that the scanner exists in the same room as the infuser.
## Changelog
:cl:
fix: Made it possible to leave the DNA infuser on your own.
/:cl:
