### PR TITLE
Ephedrine no longer punishes you for making it pure

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -532,16 +532,16 @@
 	return TRUE
 
 /datum/reagent/medicine/ephedrine/overdose_process(mob/living/M, delta_time, times_fired)
-	if(DT_PROB(1 * normalise_creation_purity(), delta_time) && iscarbon(M))
+	if(DT_PROB(1 * (1 + creation_purity), delta_time) && iscarbon(M))
 		var/datum/disease/D = new /datum/disease/heart_failure
 		M.ForceContractDisease(D)
 		to_chat(M, span_userdanger("You're pretty sure you just felt your heart stop for a second there.."))
 		M.playsound_local(M, 'sound/effects/singlebeat.ogg', 100, 0)
 
-	if(DT_PROB(3.5 * normalise_creation_purity(), delta_time))
+	if(DT_PROB(3.5 * (1 + creation_purity), delta_time))
 		to_chat(M, span_notice("[pick("Your head pounds.", "You feel a tight pain in your chest.", "You find it hard to stay still.", "You feel your heart practically beating out of your chest.")]"))
 
-	if(DT_PROB(18 * normalise_creation_purity(), delta_time))
+	if(DT_PROB(18 * (1 + creation_purity), delta_time))
 		M.adjustToxLoss(1, 0)
 		M.losebreath++
 		. = TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -532,16 +532,16 @@
 	return TRUE
 
 /datum/reagent/medicine/ephedrine/overdose_process(mob/living/M, delta_time, times_fired)
-	if(DT_PROB(1 * (1 + normalise_creation_purity()), delta_time) && iscarbon(M))
+	if(DT_PROB(1 * (1 + (1-normalise_creation_purity())), delta_time) && iscarbon(M))
 		var/datum/disease/D = new /datum/disease/heart_failure
 		M.ForceContractDisease(D)
 		to_chat(M, span_userdanger("You're pretty sure you just felt your heart stop for a second there.."))
 		M.playsound_local(M, 'sound/effects/singlebeat.ogg', 100, 0)
 
-	if(DT_PROB(3.5 * (1 + normalise_creation_purity()), delta_time))
+	if(DT_PROB(3.5 * (1 + (1-normalise_creation_purity())), delta_time))
 		to_chat(M, span_notice("[pick("Your head pounds.", "You feel a tight pain in your chest.", "You find it hard to stay still.", "You feel your heart practically beating out of your chest.")]"))
 
-	if(DT_PROB(18 * (1 + normalise_creation_purity()), delta_time))
+	if(DT_PROB(18 * (1 + (1-normalise_creation_purity())), delta_time))
 		M.adjustToxLoss(1, 0)
 		M.losebreath++
 		. = TRUE

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -532,16 +532,16 @@
 	return TRUE
 
 /datum/reagent/medicine/ephedrine/overdose_process(mob/living/M, delta_time, times_fired)
-	if(DT_PROB(1 * (1 + creation_purity), delta_time) && iscarbon(M))
+	if(DT_PROB(1 * (1 + normalise_creation_purity()), delta_time) && iscarbon(M))
 		var/datum/disease/D = new /datum/disease/heart_failure
 		M.ForceContractDisease(D)
 		to_chat(M, span_userdanger("You're pretty sure you just felt your heart stop for a second there.."))
 		M.playsound_local(M, 'sound/effects/singlebeat.ogg', 100, 0)
 
-	if(DT_PROB(3.5 * (1 + creation_purity), delta_time))
+	if(DT_PROB(3.5 * (1 + normalise_creation_purity()), delta_time))
 		to_chat(M, span_notice("[pick("Your head pounds.", "You feel a tight pain in your chest.", "You find it hard to stay still.", "You feel your heart practically beating out of your chest.")]"))
 
-	if(DT_PROB(18 * (1 + creation_purity), delta_time))
+	if(DT_PROB(18 * (1 + normalise_creation_purity()), delta_time))
 		M.adjustToxLoss(1, 0)
 		M.losebreath++
 		. = TRUE


### PR DESCRIPTION
## About The Pull Request

According to the wiki, ephedrine's side effects are reduced by higher purity.

Well, I was looking into the code to see how that worked and while I was doing so I saw that the overdose side effects are instead increased by higher purity. This is, as far as I know, the only case of purity doing something negative. Purity is by design meant to make the effects of a reagent better for it's intended purpose, not worse.

Ephedrine no longer multiplies the chances for overdose effects by it's purity (1.33x at 100%) and instead has more severe side effects at low purity and less severe ones at high purity. (0.66x at 100%)
## Why It's Good For The Game

Well, it makes the wiki state correct information while simultaneously making a reagent adhere by the standards of how purity works. I don't see any reason as for why this wouldn't be good for the game.
## Changelog
:cl:
fix: Ephedrine now rewards you instead of punishing you for making it pure.
/:cl:
