### PR TITLE
Add baking and grilling results to the blackbox

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -174,3 +174,5 @@ DEFINE_BITFIELD(food_types, list(
 #define DEFAULT_MAX_ICE_CREAM_SCOOPS 3
 // the vertical distance in pixels from an ice cream scoop and another.
 #define ICE_CREAM_SCOOP_OFFSET 4
+
+#define BLACKBOX_LOG_FOOD_MADE(food) SSblackbox.record_feedback("tally", "food_made", 1, food)

--- a/code/__DEFINES/logging.dm
+++ b/code/__DEFINES/logging.dm
@@ -65,5 +65,3 @@
 //This is an external call, "true" and "false" are how rust parses out booleans
 #define WRITE_LOG(log, text) rustg_log_write(log, text, "true")
 #define WRITE_LOG_NO_FORMAT(log, text) rustg_log_write(log, text, "false")
-
-#define BLACKBOX_LOG_FOOD_MADE(food) SSblackbox.record_feedback("tally", "food_made", 1, food)

--- a/code/__DEFINES/logging.dm
+++ b/code/__DEFINES/logging.dm
@@ -65,3 +65,5 @@
 //This is an external call, "true" and "false" are how rust parses out booleans
 #define WRITE_LOG(log, text) rustg_log_write(log, text, "true")
 #define WRITE_LOG_NO_FORMAT(log, text) rustg_log_write(log, text, "false")
+
+#define BLACKBOX_LOG_FOOD_MADE(food) SSblackbox.record_feedback("tally", "food_made", 1, food)

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -68,9 +68,6 @@
 	var/obj/item/plate/oven_tray/used_tray = original_object.loc
 	var/atom/baked_result = new bake_result(used_tray)
 
-	if(positive_result)
-		SSblackbox.record_feedback("tally", "food_made", 1, baked_result.type)
-
 	if(who_baked_us)
 		ADD_TRAIT(baked_result, TRAIT_FOOD_CHEF_MADE, who_baked_us)
 
@@ -83,6 +80,7 @@
 
 	if(positive_result)
 		used_oven.visible_message(span_notice("You smell something great coming from [used_oven]."), blind_message = span_notice("You smell something great..."))
+		SSblackbox.record_feedback("tally", "food_made", 1, baked_result.type)
 	else
 		used_oven.visible_message(span_warning("You smell a burnt smell coming from [used_oven]."), blind_message = span_warning("You smell a burnt smell..."))
 	SEND_SIGNAL(parent, COMSIG_ITEM_BAKED, baked_result)

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -64,10 +64,12 @@
 
 ///Ran when an object finished baking
 /datum/component/bakeable/proc/finish_baking(atom/used_oven)
-
 	var/atom/original_object = parent
 	var/obj/item/plate/oven_tray/used_tray = original_object.loc
 	var/atom/baked_result = new bake_result(used_tray)
+
+	if(positive_result)
+		SSblackbox.record_feedback("tally", "food_made", 1, baked_result.type)
 
 	if(who_baked_us)
 		ADD_TRAIT(baked_result, TRAIT_FOOD_CHEF_MADE, who_baked_us)

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -80,7 +80,7 @@
 
 	if(positive_result)
 		used_oven.visible_message(span_notice("You smell something great coming from [used_oven]."), blind_message = span_notice("You smell something great..."))
-		SSblackbox.record_feedback("tally", "food_made", 1, baked_result.type)
+		BLACKBOX_LOG_FOOD_MADE(baked_result.type)
 	else
 		used_oven.visible_message(span_warning("You smell a burnt smell coming from [used_oven]."), blind_message = span_warning("You smell a burnt smell..."))
 	SEND_SIGNAL(parent, COMSIG_ITEM_BAKED, baked_result)

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -69,7 +69,6 @@
 
 ///Ran when an object finished grilling
 /datum/component/grillable/proc/finish_grilling(atom/grill_source)
-
 	var/atom/original_object = parent
 	var/atom/grilled_result
 
@@ -81,6 +80,9 @@
 		grilled_result = new cook_result(original_object.loc)
 		if(original_object.custom_materials)
 			grilled_result.set_custom_materials(original_object.custom_materials)
+
+	if(IS_EDIBLE(grilled_result))
+		SSblackbox.record_feedback("tally", "food_made", 1, grilled_result.type)
 
 	SEND_SIGNAL(parent, COMSIG_ITEM_GRILLED, grilled_result)
 	if(who_placed_us)

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -82,7 +82,7 @@
 			grilled_result.set_custom_materials(original_object.custom_materials)
 
 	if(IS_EDIBLE(grilled_result))
-		SSblackbox.record_feedback("tally", "food_made", 1, grilled_result.type)
+		BLACKBOX_LOG_FOOD_MADE(grilled_result.type)
 
 	SEND_SIGNAL(parent, COMSIG_ITEM_GRILLED, grilled_result)
 	if(who_placed_us)

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -49,7 +49,7 @@
 		result.reagents?.multiply_reagents(efficiency * CRAFTED_FOOD_BASE_REAGENT_MODIFIER)
 		source.reagents?.trans_to(result, source.reagents.total_volume)
 
-		SSblackbox.record_feedback("tally", "food_made", 1, result.type)
+		BLACKBOX_LOG_FOOD_MADE(result.type)
 
 	qdel(source)
 


### PR DESCRIPTION

## About The Pull Request
Adds baking and grilling results to the blackbox. Microwaved and crafted foods were being logged here, but the logging messages were lost when we got the grilling and baking components.

## Why It's Good For The Game
More food logging yeehaw

## Changelog
No player-facing changes
