### PR TITLE
misplaced psyker brains don't deal their brain damage twice

### DIFF
--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -30,7 +30,6 @@
 	to_chat(owner, span_userdanger("Your head hurts... It can't fit your brain!"))
 	owner.adjust_disgust(33 * delta_time)
 	applyOrganDamage(5 * delta_time, 199)
-	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5 * delta_time)
 
 /obj/item/bodypart/head/psyker
 	limb_id = BODYPART_ID_PSYKER


### PR DESCRIPTION
## About The Pull Request

psyker brains that aren't in psyker heads no longer take twice as much brain damage from that as intended

they also no longer straight up die due to that

## Why It's Good For The Game

it looks to me like fikou decided to change the proc he used to deal the brain damage, but forgot to remove his call to the proc he was previously using

## Changelog

:cl: ATHATH
fix: Psyker brains that aren't in psyker heads no longer take twice as much brain damage from that as intended, nor can they suffer complete brain death due to that.
/:cl: