### PR TITLE
Admins can now add footnotes to the roundstart command report

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -15,8 +15,8 @@ SUBSYSTEM_DEF(communications)
 
 	/// A list of footnote datums, to be added to the bottom of the roundstart command report.
 	var/list/command_report_footnotes = list()
-	/// Delays the roundstart threat report when true
-	var/block_command_report = FALSE
+	/// A counter of conditions that are blocking the command report from printing. Counter incremements up for every blocking condition, and de-incrememnts when it is complete.
+	var/block_command_report = 0
 
 /datum/controller/subsystem/communications/proc/can_announce(mob/living/user, is_silicon)
 	if(is_silicon && COOLDOWN_FINISHED(src, silicon_message_cooldown))

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -13,6 +13,9 @@ SUBSYSTEM_DEF(communications)
 	/// Are we trying to send a cross-station message that contains soft-filtered words? If so, flip to TRUE to extend the time admins have to cancel the message.
 	var/soft_filtering = FALSE
 
+	/// The footnote to be added to the bottom of the roundstart command report.
+	var/command_report_footnote
+
 /datum/controller/subsystem/communications/proc/can_announce(mob/living/user, is_silicon)
 	if(is_silicon && COOLDOWN_FINISHED(src, silicon_message_cooldown))
 		return TRUE

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -15,6 +15,8 @@ SUBSYSTEM_DEF(communications)
 
 	/// A list of footnote datums, to be added to the bottom of the roundstart command report.
 	var/list/command_report_footnotes = list()
+	/// Delays the roundstart threat report when true
+	var/block_command_report = FALSE
 
 /datum/controller/subsystem/communications/proc/can_announce(mob/living/user, is_silicon)
 	if(is_silicon && COOLDOWN_FINISHED(src, silicon_message_cooldown))

--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -13,8 +13,8 @@ SUBSYSTEM_DEF(communications)
 	/// Are we trying to send a cross-station message that contains soft-filtered words? If so, flip to TRUE to extend the time admins have to cancel the message.
 	var/soft_filtering = FALSE
 
-	/// The footnote to be added to the bottom of the roundstart command report.
-	var/command_report_footnote
+	/// A list of footnote datums, to be added to the bottom of the roundstart command report.
+	var/list/command_report_footnotes = list()
 
 /datum/controller/subsystem/communications/proc/can_announce(mob/living/user, is_silicon)
 	if(is_silicon && COOLDOWN_FINISHED(src, silicon_message_cooldown))

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -337,6 +337,8 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	generate_station_goals(greenshift)
 	. += generate_station_goal_report()
 	. += generate_station_trait_report()
+	if(SScommunications.command_report_footnote)
+		. += generate_report_footnote()
 
 	print_command_report(., "Central Command Status Summary", announce=FALSE)
 	if(greenshift)

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -298,6 +298,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	return ..()
 
 /datum/game_mode/dynamic/proc/send_intercept()
+	if(SScommunications.block_command_report) //If we don't want the report to be printed just yet, we put it off until it's ready
+		addtimer(CALLBACK(src, PROC_REF(send_intercept)), 10 SECONDS)
+		return
+
 	. = "<b><i>Nanotrasen Department of Intelligence Threat Advisory, Spinward Sector, TCD [time2text(world.realtime, "DDD, MMM DD")], [CURRENT_STATION_YEAR]:</i></b><hr>"
 	switch(round(shown_threat))
 		if(0 to 19)

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -337,7 +337,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	generate_station_goals(greenshift)
 	. += generate_station_goal_report()
 	. += generate_station_trait_report()
-	if(SScommunications.command_report_footnote)
+	if(length(SScommunications.command_report_footnotes))
 		. += generate_report_footnote()
 
 	print_command_report(., "Central Command Status Summary", announce=FALSE)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -99,10 +99,14 @@
 	return
 
 /datum/game_mode/proc/generate_report_footnote()
-	var/footnote_string = SScommunications.command_report_footnote
-	if(footnote_string != "")
-		return "<hr><b>Additional Notes: </b><BR>" + footnote_string
-	return
+	var/footnote_pile = ""
+
+	for(var/datum/command_footnote/footnote in SScommunications.command_report_footnotes)
+		footnote_pile += "[footnote.message]<BR>"
+		footnote_pile += "<i>[footnote.signature]</i><BR>"
+		footnote_pile += "<BR>"
+
+	return "<hr><b>Additional Notes: </b><BR><BR>" + footnote_pile
 
 /proc/reopen_roundstart_suicide_roles()
 	var/include_command = CONFIG_GET(flag/reopen_roundstart_suicide_roles_command_positions)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -98,6 +98,12 @@
 		return "<hr><b>Identified shift divergencies:</b><BR>" + trait_list_string
 	return
 
+/datum/game_mode/proc/generate_report_footnote()
+	var/footnote_string = SScommunications.command_report_footnote
+	if(footnote_string != "")
+		return "<hr><b>Additional Notes: </b><BR>" + footnote_string
+	return
+
 /proc/reopen_roundstart_suicide_roles()
 	var/include_command = CONFIG_GET(flag/reopen_roundstart_suicide_roles_command_positions)
 	var/list/reopened_jobs = list()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -119,6 +119,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/add_mob_ability,
 	/client/proc/remove_mob_ability,
 	/client/proc/command_report_footnote,
+	/client/proc/delay_command_report,
 	/datum/admins/proc/station_traits_panel,
 	))
 GLOBAL_PROTECT(admin_verbs_fun)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -118,6 +118,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/admin_away,
 	/client/proc/add_mob_ability,
 	/client/proc/remove_mob_ability,
+	/client/proc/command_report_footnote,
 	/datum/admins/proc/station_traits_panel,
 	))
 GLOBAL_PROTECT(admin_verbs_fun)

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -386,3 +386,15 @@
 	log_admin("[key_name(usr)] removed mob ability [ability_name] from mob [marked_mob].")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Remove Mob Ability") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/command_report_footnote()
+	set category = "Admin.Fun"
+	set name = "Command Report Footnote"
+	set desc = "Adds a footnote to the roundstart command report. "
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	SScommunications.command_report_footnote = tgui_input_text(usr, "What would you like your captive audience to know?", "P.S.")
+
+	if(SScommunications.command_report_footnote)
+		message_admins("[usr] has changed the command report footnote to: [SScommunications.command_report_footnote]")

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -404,7 +404,7 @@
 	command_report_footnote.signature = tgui_input_text(usr, "Whose signature will appear on this footnote?", "Also sign here, here, aaand here.")
 
 	if(!command_report_footnote.signature)
-		command_report_footnote.signature = "Anonymous"
+		command_report_footnote.signature = "Classified"
 
 	SScommunications.command_report_footnotes += command_report_footnote
 

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -395,7 +395,7 @@
 		return
 
 	var/datum/command_footnote/command_report_footnote = new /datum/command_footnote()
-	SScommunications.block_command_report = TRUE
+	SScommunications.block_command_report++ //Add a blocking condition to the counter until the inputs are done.
 
 	command_report_footnote.message = tgui_input_text(usr, "This message will be attached to the bottom of the roundstart threat report. Be sure to delay the roundstart report if you need extra time.", "P.S.")
 
@@ -408,7 +408,7 @@
 		command_report_footnote.signature = "Classified"
 
 	SScommunications.command_report_footnotes += command_report_footnote
-	SScommunications.block_command_report = FALSE
+	SScommunications.block_command_report--
 
 	message_admins("[usr] has added a footnote to the command report: [command_report_footnote.message], signed [command_report_footnote.signature]")
 
@@ -424,9 +424,9 @@
 	if(!check_rights(R_ADMIN))
 		return
 
-	if(SScommunications.block_command_report)
-		SScommunications.block_command_report = FALSE
+	if(SScommunications.block_command_report) //If it's anything other than 0, decrease. If 0, increase.
+		SScommunications.block_command_report--
 		message_admins("[usr] has enabled the roundstart command report.")
 	else
-		SScommunications.block_command_report = TRUE
+		SScommunications.block_command_report++
 		message_admins("[usr] has delayed the roundstart command report.")

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -387,14 +387,14 @@
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Remove Mob Ability") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/command_report_footnote()
-	set category = "Admin.Fun"
+	set category = "Admin.Events"
 	set name = "Command Report Footnote"
 	set desc = "Adds a footnote to the roundstart command report. "
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	SScommunications.command_report_footnote = tgui_input_text(usr, "What would you like your captive audience to know?", "P.S.")
+	SScommunications.command_report_footnote = tgui_input_text(usr, "This message will be attached to the bottom of the roundstart threat report. It will likely not be seen if the report has already been sent.", "P.S.")
 
 	if(SScommunications.command_report_footnote)
 		message_admins("[usr] has changed the command report footnote to: [SScommunications.command_report_footnote]")

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -389,12 +389,27 @@
 /client/proc/command_report_footnote()
 	set category = "Admin.Events"
 	set name = "Command Report Footnote"
-	set desc = "Adds a footnote to the roundstart command report. "
+	set desc = "Adds a footnote to the roundstart command report."
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	SScommunications.command_report_footnote = tgui_input_text(usr, "This message will be attached to the bottom of the roundstart threat report. It will likely not be seen if the report has already been sent.", "P.S.")
+	var/datum/command_footnote/command_report_footnote = new /datum/command_footnote()
 
-	if(SScommunications.command_report_footnote)
-		message_admins("[usr] has changed the command report footnote to: [SScommunications.command_report_footnote]")
+	command_report_footnote.message = tgui_input_text(usr, "This message will be attached to the bottom of the roundstart threat report. It will likely not be seen if the report has already been sent.", "P.S.")
+
+	if(!command_report_footnote.message)
+		return
+
+	command_report_footnote.signature = tgui_input_text(usr, "Whose signature will appear on this footnote?", "Also sign here, here, aaand here.")
+
+	if(!command_report_footnote.signature)
+		command_report_footnote.signature = "Anonymous"
+
+	SScommunications.command_report_footnotes += command_report_footnote
+
+	message_admins("[usr] has added a footnote to the command report: [command_report_footnote.message], signed [command_report_footnote.signature]")
+
+/datum/command_footnote
+	var/message
+	var/signature

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -395,8 +395,9 @@
 		return
 
 	var/datum/command_footnote/command_report_footnote = new /datum/command_footnote()
+	SScommunications.block_command_report = TRUE
 
-	command_report_footnote.message = tgui_input_text(usr, "This message will be attached to the bottom of the roundstart threat report. It will likely not be seen if the report has already been sent.", "P.S.")
+	command_report_footnote.message = tgui_input_text(usr, "This message will be attached to the bottom of the roundstart threat report. Be sure to delay the roundstart report if you need extra time.", "P.S.")
 
 	if(!command_report_footnote.message)
 		return
@@ -407,9 +408,25 @@
 		command_report_footnote.signature = "Classified"
 
 	SScommunications.command_report_footnotes += command_report_footnote
+	SScommunications.block_command_report = FALSE
 
 	message_admins("[usr] has added a footnote to the command report: [command_report_footnote.message], signed [command_report_footnote.signature]")
 
 /datum/command_footnote
 	var/message
 	var/signature
+
+/client/proc/delay_command_report()
+	set category = "Admin.Events"
+	set name = "Delay Command Report"
+	set desc = "Prevents the roundstart command report from being sent until toggled."
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	if(SScommunications.block_command_report)
+		SScommunications.block_command_report = FALSE
+		message_admins("[usr] has enabled the roundstart command report.")
+	else
+		SScommunications.block_command_report = TRUE
+		message_admins("[usr] has delayed the roundstart command report.")


### PR DESCRIPTION
## About The Pull Request

Admins now have a verb to add footnotes to the roundstart threat report. These messages can be signed, and multiple can be submitted at once.

![image](https://user-images.githubusercontent.com/28870487/205114744-32056a6d-3528-48b3-8365-14594cfc8d71.png)

(If no footnotes are submitted, the report does not display the "additional notes" section)

This ALSO adds a verb to delay the roundstart threat report indefinitely, to give some extra time. If you turn it off, be sure to toggle it back on when you're done!

## Why It's Good For The Game

Gives admins a way to set the tone for a shift, give IC advisory on stuff, bully the command players, or just add some flavor to the report.

We already give these chuckleheads enough platforms to shitpost from. What's one more?
## Changelog
:cl:
admin: new admin verb -- Command Report Footnote. Lets you attach a signed message to the roundstart command report. 
admin: new admin verb -- Delay Command Report. Lets you delay the roundstart command report indefinitely.
/:cl:
