### PR TITLE
Fixes unconciousness (typo)

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -793,7 +793,7 @@
 
 /datum/status_effect/ants/on_creation(mob/living/new_owner, amount_left)
 	if(isnum(amount_left) && new_owner.stat < HARD_CRIT)
-		if(new_owner.stat < UNCONSCIOUS) // Unconcious people won't get messages
+		if(new_owner.stat < UNCONSCIOUS) // Unconscious people won't get messages
 			to_chat(new_owner, span_userdanger("You're covered in ants!"))
 		ants_remaining += amount_left
 		RegisterSignal(new_owner, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(ants_washed))
@@ -802,7 +802,7 @@
 /datum/status_effect/ants/refresh(effect, amount_left)
 	var/mob/living/carbon/human/victim = owner
 	if(isnum(amount_left) && ants_remaining >= 1 && victim.stat < HARD_CRIT)
-		if(victim.stat < UNCONSCIOUS) // Unconcious people won't get messages
+		if(victim.stat < UNCONSCIOUS) // Unconscious people won't get messages
 			if(!prob(1)) // 99%
 				to_chat(victim, span_userdanger("You're covered in MORE ants!"))
 			else // 1%

--- a/code/modules/antagonists/blob/blobstrains/distributed_neurons.dm
+++ b/code/modules/antagonists/blob/blobstrains/distributed_neurons.dm
@@ -3,7 +3,7 @@
 	name = "Distributed Neurons"
 	description = "will do medium-low toxin damage and turns unconscious targets into blob zombies."
 	effectdesc = "will also produce fragile spores when killed.  Spores produced by factories are sentient."
-	shortdesc = "will do medium-low toxin damage and will kill any unconcious targets when attacked.  Spores produced by factories are sentient."
+	shortdesc = "will do medium-low toxin damage and will kill any unconscious targets when attacked.  Spores produced by factories are sentient."
 	analyzerdescdamage = "Does medium-low toxin damage and kills unconscious humans."
 	analyzerdesceffect = "Produces spores when killed.  Spores produced by factories are sentient."
 	color = "#E88D5D"

--- a/code/modules/mapfluff/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/puzzle.dm
@@ -313,7 +313,7 @@
 		return
 	var/mob/living/victim = target
 	var/mob/living/carbon/carbon_victim = victim
-	//Handcuffed or unconcious
+	//Handcuffed or unconscious
 	if(istype(carbon_victim) && carbon_victim.handcuffed || victim.stat != CONSCIOUS)
 		if(!puzzle_imprison(target))
 			to_chat(user,span_warning("[src] does nothing."))
@@ -321,7 +321,7 @@
 		to_chat(user,span_warning("You trap [victim] in the prison cube!"))
 		qdel(src)
 	else
-		to_chat(user,span_notice("[src] only accepts restrained or unconcious prisoners."))
+		to_chat(user,span_notice("[src] only accepts restrained or unconscious prisoners."))
 
 /proc/puzzle_imprison(mob/living/prisoner)
 	var/turf/T = get_turf(prisoner)

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -43,8 +43,8 @@
 	var/list/gorilla_overlays[GORILLA_TOTAL_LAYERS]
 	var/oogas = 0
 
-// Gorillas like to dismember limbs from unconcious mobs.
-// Returns null when the target is not an unconcious carbon mob; a list of limbs (possibly empty) otherwise.
+// Gorillas like to dismember limbs from unconscious mobs.
+// Returns null when the target is not an unconscious carbon mob; a list of limbs (possibly empty) otherwise.
 /mob/living/simple_animal/hostile/gorilla/proc/get_target_bodyparts(atom/hit_target)
 	if(!iscarbon(hit_target))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -206,7 +206,7 @@
 	return ..()
 
 
-///In addition to parent functionality, this will also turn the target into a small legion if they are unconcious.
+///In addition to parent functionality, this will also turn the target into a small legion if they are unconscious.
 /mob/living/simple_animal/hostile/megafauna/legion/AttackingTarget()
 	. = ..()
 	if(!. || !ishuman(target))

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -63,7 +63,7 @@
 	// Close UIs if mindless.
 	if(!client && !HAS_TRAIT(src, TRAIT_PRESERVE_UI_WITHOUT_CLIENT))
 		return UI_CLOSE
-	// Disable UIs if unconcious.
+	// Disable UIs if unconscious.
 	else if(stat)
 		return UI_DISABLED
 	// Update UIs if incapicitated but concious.

--- a/tgui/packages/tgui/interfaces/HypnoChair.js
+++ b/tgui/packages/tgui/interfaces/HypnoChair.js
@@ -31,7 +31,7 @@ export const HypnoChair = (props, context) => {
                 {data.occupant.stat === 0
                   ? 'Conscious'
                   : data.occupant.stat === 1
-                    ? 'Unconcious'
+                    ? 'Unconscious'
                     : 'Dead'}
               </LabeledList.Item>
             )}

--- a/tgui/packages/tgui/interfaces/ImplantChair.js
+++ b/tgui/packages/tgui/interfaces/ImplantChair.js
@@ -25,7 +25,7 @@ export const ImplantChair = (props, context) => {
                 {data.occupant.stat === 0
                   ? 'Conscious'
                   : data.occupant.stat === 1
-                    ? 'Unconcious'
+                    ? 'Unconscious'
                     : 'Dead'}
               </LabeledList.Item>
             )}


### PR DESCRIPTION

## About The Pull Request

Made a typo while doing a github search, but it still gave me results. This removes the "unconcious" typo from a few different places, including code comments, tgui interfaces, descriptions, etc.
## Why It's Good For The Game

Good spellign
## Changelog
:cl:
spellcheck: removes a bunch of instances of "unconcious" from the code.
/:cl:
