### PR TITLE
Adds surgery for fixing ears/hearing.

### DIFF
--- a/code/modules/surgery/ear_surgery.dm
+++ b/code/modules/surgery/ear_surgery.dm
@@ -47,10 +47,9 @@
 		span_notice("[user] successfully fixes [target]'s ears!"),
 		span_notice("[user] completes the surgery on [target]'s ears."),
 	)
-	display_pain(target, "Your head swims, but it seems like you can hear a little better now!")
-	target_ears.deaf = FALSE
+	display_pain(target, "Your head swims, but it seems like you can feel your hearing coming back!")
+	target_ears.deaf = (20) //deafness works off ticks, so this should work out to about 30-40s
 	target_ears.setOrganDamage(0)
-	target.adjust_dizzy_up_to(45 SECONDS, 60 SECONDS)
 	return ..()
 
 /datum/surgery_step/fix_ears/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/ear_surgery.dm
+++ b/code/modules/surgery/ear_surgery.dm
@@ -25,7 +25,6 @@
 /datum/surgery/ear_surgery/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/internal/ears/target_ears = target.getorganslot(ORGAN_SLOT_EARS)
 	if(!target_ears)
-		to_chat(user, span_warning("It's hard to do surgery on someone's ears when [target.p_they()] [target.p_do()]n't have any."))
 		return FALSE
 	return TRUE
 
@@ -49,9 +48,9 @@
 		span_notice("[user] completes the surgery on [target]'s ears."),
 	)
 	display_pain(target, "Your head swims, but it seems like you can hear a little better now!")
-	target_ears.deaf = (0)
+	target_ears.deaf = FALSE
 	target_ears.setOrganDamage(0)
-	target.adjust_dizzy_up_to(15 SECONDS, 30 SECONDS)
+	target.adjust_dizzy_up_to(45 SECONDS, 60 SECONDS)
 	return ..()
 
 /datum/surgery_step/fix_ears/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/ear_surgery.dm
+++ b/code/modules/surgery/ear_surgery.dm
@@ -1,0 +1,77 @@
+//Head surgery to fix the ears organ
+/datum/surgery/ear_surgery
+	name = "Ear surgery"
+	requires_bodypart_type = NONE
+	organ_to_manipulate = ORGAN_SLOT_EARS
+	possible_locs = list(BODY_ZONE_HEAD)
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/saw,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/fix_ears,
+		/datum/surgery_step/close,
+	)
+
+//fix ears
+/datum/surgery_step/fix_ears
+	name = "fix ears (hemostat)"
+	implements = list(
+		TOOL_HEMOSTAT = 100,
+		TOOL_SCREWDRIVER = 45,
+		/obj/item/pen = 25)
+	time = 64
+
+/datum/surgery/ear_surgery/can_start(mob/user, mob/living/carbon/target)
+	var/obj/item/organ/internal/ears/target_ears = target.getorganslot(ORGAN_SLOT_EARS)
+	if(!target_ears)
+		to_chat(user, span_warning("It's hard to do surgery on someone's ears when [target.p_they()] [target.p_do()]n't have any."))
+		return FALSE
+	return TRUE
+
+/datum/surgery_step/fix_ears/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(
+		user,
+		target,
+		span_notice("You begin to fix [target]'s ears..."),
+		span_notice("[user] begins to fix [target]'s ears."),
+		span_notice("[user] begins to perform surgery on [target]'s ears."),
+	)
+	display_pain(target, "You feel a dizzying pain in your head!")
+
+/datum/surgery_step/fix_ears/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	var/obj/item/organ/internal/ears/target_ears = target.getorganslot(ORGAN_SLOT_EARS)
+	display_results(
+		user,
+		target,
+		span_notice("You succeed in fixing [target]'s ears."),
+		span_notice("[user] successfully fixes [target]'s ears!"),
+		span_notice("[user] completes the surgery on [target]'s ears."),
+	)
+	display_pain(target, "Your head swims, but it seems like you can hear a little better now!")
+	target_ears.deaf = (0)
+	target_ears.setOrganDamage(0)
+	target.adjust_dizzy_up_to(15 SECONDS, 30 SECONDS)
+	return ..()
+
+/datum/surgery_step/fix_ears/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(target.getorgan(/obj/item/organ/internal/brain))
+		display_results(
+			user,
+			target,
+			span_warning("You accidentally stab [target] right in the brain!"),
+			span_warning("[user] accidentally stabs [target] right in the brain!"),
+			span_warning("[user] accidentally stabs [target] right in the brain!"),
+		)
+		display_pain(target, "You feel a visceral stabbing pain right through your head, into your brain!")
+		target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 70)
+	else
+		display_results(
+			user,
+			target,
+			span_warning("You accidentally stab [target] right in the brain! Or would have, if [target] had a brain."),
+			span_warning("[user] accidentally stabs [target] right in the brain! Or would have, if [target] had a brain."),
+			span_warning("[user] accidentally stabs [target] right in the brain!"),
+		)
+		display_pain(target, "You feel a visceral stabbing pain right through your head!") // dunno who can feel pain w/o a brain but may as well be consistent.
+	return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4532,6 +4532,7 @@
 #include "code\modules\surgery\coronary_bypass.dm"
 #include "code\modules\surgery\dental_implant.dm"
 #include "code\modules\surgery\dissection.dm"
+#include "code\modules\surgery\ear_surgery.dm"
 #include "code\modules\surgery\eye_surgery.dm"
 #include "code\modules\surgery\gastrectomy.dm"
 #include "code\modules\surgery\healing.dm"


### PR DESCRIPTION
## About The Pull Request

Adds surgery for fixing ears/hearing - this time without somehow bricking my entire fork trying to squash the merge commit out of there as I did with #71644. My apologies to the folks who reviewed and were sitting on the last one - I actually used a branch this time, so it shouldn't be a mess. 💀 

Apologies and thanks to @distributivgesetz and @Time-Green for review and comments on the earlier PR, this should integrate all of your feedback.

## Why It's Good For The Game

Consistency with eye surgery as a way of getting people access to the information they use to engage with the game, when getting people back to engaging with the game is the point of medical (and you don't always have chems or upgraded organ freezers for non-functional ears) is a good thing. 

## Changelog

:cl:
add: Adds ear surgery to repair damaged ears/deafness.
/:cl: