### PR TITLE
Fixes an armor logic typo in living mobs' bullet_act() (which may or may not have repercussions elsewhere)

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -63,7 +63,7 @@
 		var/armor_check = check_projectile_armor(def_zone, P, is_silent = TRUE)
 		armor_check = min(ARMOR_MAX_BLOCK, armor_check) //cap damage reduction at 90%
 		apply_damage(P.damage, P.damage_type, def_zone, armor_check, wound_bonus=P.wound_bonus, bare_wound_bonus=P.bare_wound_bonus, sharpness = P.sharpness, attack_direction = attack_direction)
-		apply_effects(P.stun, P.knockdown, P.unconscious, P.slur, P.stutter, P.eyeblur, P.drowsy, armor, P.stamina, P.jitter, P.paralyze, P.immobilize)
+		apply_effects(P.stun, P.knockdown, P.unconscious, P.slur, P.stutter, P.eyeblur, P.drowsy, armor_check, P.stamina, P.jitter, P.paralyze, P.immobilize)
 		if(P.dismemberment)
 			check_projectile_dismemberment(P, def_zone)
 	return . ? BULLET_ACT_HIT : BULLET_ACT_BLOCK


### PR DESCRIPTION
## About The Pull Request
Did you know that the on-hit extra effects of projectiles (e.g. .38 rubbershot's stamina, ebow bolts' stamina/knockdown/eyeblur) checked the atom-level armor datum `armor` instead of the actual `armor_check` variable (which actually uses `check_projectile_armor`) for projectile hits against living targets?

Problem code here is on lines 65 and 66.
https://github.com/tgstation/tgstation/blob/bb3e8748415de809c4852c7d4cc4902e5ca12779/code/modules/mob/living/living_defense.dm#L57-L69
This effectively made the effects from `apply_effects` ignore all armor. Including stamina from bullets/rubbershots/etc., which was... weird and seemingly unintentional?
## Why It's Good For The Game
Extra projectile effects now respect armor, like the rest of the projectile. (This may have repercussions, and if so, I'm sorry.)
## Changelog

:cl:
fix: Fixes a typo that meant auxiliary effects from projectiles (.38 rubber stamina, ebow stamina/knockdown/blur) checked a generally nonexistent armor value that was defined on a per-/atom level. As a consequence, such auxiliary effects from projectiles now actually respect the armored equipment of hit targets/limbs/etc. On living mobs that have armor equipped, anyway.
/:cl:
