### PR TITLE
Fixes random failure in cleanbot pathing

### DIFF
--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -25,11 +25,11 @@
 	// We're guarenteed that list will be the first list in pathfinding_finished's argset because of how callback handles the arguments list
 	var/datum/callback/await = CALLBACK(GLOBAL_PROC, /proc/pathfinding_finished, path)
 	if(!SSpathfinder.pathfind(caller, end, max_distance, mintargetdist, id, simulated_only, exclude, skip_first, diagonal_safety, await))
-		return null
+		return list()
 
 	UNTIL(length(path))
 	if(length(path) == 1 && path[1] == null || (QDELETED(caller) || QDELETED(end))) // It's trash, just hand back null to make it easy
-		return null
+		return list()
 	return path
 
 /// Uses funny pass by reference bullshit to take the path created by pathfinding, and insert it into a return list

--- a/code/__HELPERS/path.dm
+++ b/code/__HELPERS/path.dm
@@ -28,7 +28,7 @@
 		return null
 
 	UNTIL(length(path))
-	if(length(path) == 1 && path[1] == null) // It's trash, just hand back null to make it easy
+	if(length(path) == 1 && path[1] == null || (QDELETED(caller) || QDELETED(end))) // It's trash, just hand back null to make it easy
 		return null
 	return path
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1039,7 +1039,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 	var/list/path_images = active_hud_list[DIAG_PATH_HUD]
 	QDEL_LIST(path_images)
-	if(newpath)
+	if(length(newpath))
 		var/mutable_appearance/path_image = new /mutable_appearance()
 		path_image.icon = path_image_icon
 		path_image.icon_state = path_image_icon_state

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -293,12 +293,11 @@
 				return
 
 		if(target && path.len == 0 && (get_dist(src,target) > 1))
-			path = get_path_to(src, target, max_distance=30, mintargetdist=1, id=access_card)
+			set_path(get_path_to(src, target, max_distance=30, mintargetdist=1, id=access_card))
 			mode = BOT_MOVING
 			if(length(path) == 0)
 				add_to_ignore(target)
 				target = null
-				path = list()
 
 		if(path.len > 0 && target)
 			if(!bot_move(path[path.len]))

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -293,7 +293,7 @@
 				return
 
 		if(target && path.len == 0 && (get_dist(src,target) > 1))
-			set_path(get_path_to(src, target, max_distance=30, mintargetdist=1, id=access_card))
+			path = get_path_to(src, target, max_distance=30, mintargetdist=1, id=access_card)
 			mode = BOT_MOVING
 			if(length(path) == 0)
 				add_to_ignore(target)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -654,7 +654,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 					item = I
 					break
 		if(item)
-			if(!get_path_to(src, item)) // WHY DO WE DISREGARD THE PATH AHHHHHH
+			if(!length(get_path_to(src, item))) // WHY DO WE DISREGARD THE PATH AHHHHHH
 				item = null
 				continue
 			return item


### PR DESCRIPTION
## About The Pull Request

Ok so like, it used to be we would hand back our path immediately after get_path_to

What's happening now is the path is completed, and THEN we have to wait a tick before getting it back
So between the path finishing and our UNTIL resuming, our mob could be deleted

This resolves that issue, wrapping the UNTIL in some qdeleted checks to return a failure response

## Why It's Good For The Game

Fixes #71628. Also fixes #71493, ~~quit using = to set the path it's a setter for a reason 🗞️~~ I FUCKED UP JPS SHOULD RETURN AN EMPTY LIST ON FAILURE NOT NULL
