### PR TITLE
Rename organ decay proc for clarity and add medical roundstart tip

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -17,14 +17,14 @@
 /proc/cheap_hypotenuse(Ax, Ay, Bx, By)
 	return sqrt(abs(Ax - Bx) ** 2 + abs(Ay - By) ** 2) //A squared + B squared = C squared
 
-/** recursive_organ_check
+/** toggle_organ_decay
  * inputs: first_object (object to start with)
  * outputs:
  * description: A pseudo-recursive loop based off of the recursive mob check, this check looks for any organs held
  *  within 'first_object', toggling their frozen flag. This check excludes items held within other safe organ
  *  storage units, so that only the lowest level of container dictates whether we do or don't decompose
  */
-/proc/recursive_organ_check(atom/first_object)
+/proc/toggle_organ_decay(atom/first_object)
 
 	var/list/processing_list = list(first_object)
 	var/list/processed_list = list()

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -8,12 +8,12 @@
 	var/jones = FALSE
 
 /obj/structure/closet/secure_closet/freezer/Destroy()
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 	return ..()
 
 /obj/structure/closet/secure_closet/freezer/Initialize(mapload)
 	. = ..()
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 
 /obj/structure/closet/secure_closet/freezer/open(mob/living/user, force = FALSE)
 	if(opened || !can_open(user, force)) //dupe check just so we don't let the organs decay when someone fails to open the locker

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -18,12 +18,12 @@
 /obj/structure/closet/secure_closet/freezer/open(mob/living/user, force = FALSE)
 	if(opened || !can_open(user, force)) //dupe check just so we don't let the organs decay when someone fails to open the locker
 		return FALSE
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 	return ..()
 
 /obj/structure/closet/secure_closet/freezer/close(mob/living/user)
 	if(..()) //if we actually closed the locker
-		recursive_organ_check(src)
+		toggle_organ_decay(src)
 
 /obj/structure/closet/secure_closet/freezer/ex_act()
 	if(jones)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -181,22 +181,20 @@
 //Order is important, since we check source, we need to do the check whenever we have all the organs in the crate
 
 /obj/structure/closet/crate/freezer/open(mob/living/user, force = FALSE)
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 	..()
 
 /obj/structure/closet/crate/freezer/close()
 	..()
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 
 /obj/structure/closet/crate/freezer/Destroy()
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 	return ..()
 
 /obj/structure/closet/crate/freezer/Initialize(mapload)
 	. = ..()
-	recursive_organ_check(src)
-
-
+	toggle_organ_decay(src)
 
 /obj/structure/closet/crate/freezer/blood
 	name = "blood freezer"

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 /obj/structure/bodycontainer/Initialize(mapload)
 	. = ..()
 	GLOB.bodycontainers += src
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 
 /obj/structure/bodycontainer/Destroy()
 	GLOB.bodycontainers -= src
@@ -102,7 +102,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 /obj/structure/bodycontainer/deconstruct(disassembled = TRUE)
 	if (!(flags_1 & NODECONSTRUCT_1))
 		new /obj/item/stack/sheet/iron (loc, 5)
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 	qdel(src)
 
 /obj/structure/bodycontainer/container_resist_act(mob/living/user)
@@ -122,7 +122,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 		open()
 
 /obj/structure/bodycontainer/proc/open()
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 	playsound(src.loc, 'sound/items/deconstruct.ogg', 50, TRUE)
 	playsound(src, 'sound/effects/roll.ogg', 5, TRUE)
 	var/turf/T = get_step(src, dir)
@@ -146,7 +146,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 			else if(istype(AM, /obj/effect/dummy/phased_mob))
 				continue
 			AM.forceMove(src)
-	recursive_organ_check(src)
+	toggle_organ_decay(src)
 	update_appearance()
 
 /obj/structure/bodycontainer/get_remote_view_fullscreens(mob/user)

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -47,6 +47,7 @@ As a Janitor, if someone steals your janicart, you can instead use your space cl
 As a Janitor, mousetraps can be used to create bombs or booby-trap containers.
 As a Medical Cyborg, you can fully perform surgery and even augment people.
 As a Medical Doctor, almost every type of wound can be treated at least temporarily with gauze. When in doubt, wrap it up!
+As a Medical Doctor, corpses placed inside a freezer or morgue tray will have their organs frozen preventing decay. If you don't have time to revive multiple dead bodies, transfer them to the morgue temporarily!
 As a Medical Doctor, corpses with the "...and their soul has departed" description no longer have a ghost attached to them and can't be revived.
 As a Medical Doctor, Critical Slash wounds are one of the most dangerous conditions someone can have. Apply gauze, epipens, sutures, cauteries, whatever you can, as soon as possible!
 As a Medical Doctor, Saline-Glucose not only acts as a temporary boost to a patient's blood level, it also speeds blood regeneration! Perfect for drained patients!


### PR DESCRIPTION

## About The Pull Request
Renames `recursive_organ_check` to be `toggle_organ_decay` which better explains what the proc is doing.  Also adds a medical tip for new players so they are aware that morgue trays prevent organ decay.

## Why It's Good For The Game
I was actually going to code this as a feature, until I realized someone else had done it already.  They named their proc pretty poorly so I wanted to make sure nobody else made the same mistake as me. Also giving information to prevent organ decay is helpful for new doctors.

## Changelog
:cl:
qol: Add roundstart tip to let new doctors now that morgue trays and freezers prevent organ decay 
code: Renamed organ decay proc to be `toggle_organ_decay` instead of `recursive_organ_check`
/:cl:
