### PR TITLE
fixes negative forced gravity

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1842,11 +1842,13 @@
 		if(!length(forced_gravity))
 			SEND_SIGNAL(gravity_turf, COMSIG_TURF_HAS_GRAVITY, src, forced_gravity)
 
-		var/max_grav = 0
-		for(var/i in forced_gravity)//our gravity is the strongest return forced gravity we get
-			max_grav = max(max_grav, i)
-		//cut so we can reuse the list, this is ok since forced gravity movers are exceedingly rare compared to all other movement
-		return max_grav
+		var/positive_grav = 0
+		var/negative_grav = 0
+		for(var/gravity_influence as anything in forced_gravity)//our gravity is the strongest return forced gravity we get
+			positive_grav = max(positive_grav, gravity_influence)
+			negative_grav = min(negative_grav, gravity_influence)
+
+		return (positive_grav + negative_grav)
 
 	var/area/turf_area = gravity_turf.loc
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1844,7 +1844,7 @@
 
 		var/positive_grav = 0
 		var/negative_grav = 0
-		for(var/gravity_influence as anything in forced_gravity)//our gravity is the strongest return forced gravity we get
+		for(var/gravity_influence in forced_gravity)//our gravity is the strongest return forced gravity we get
 			positive_grav = max(positive_grav, gravity_influence)
 			negative_grav = min(negative_grav, gravity_influence)
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1844,7 +1844,10 @@
 
 		var/positive_grav = 0
 		var/negative_grav = 0
-		for(var/gravity_influence in forced_gravity)//our gravity is the strongest return forced gravity we get
+		//our gravity is sum of the most massive positive and negative numbers returned by the signal
+		//so that adding two forced_gravity elements with an effect size of 1 each doesnt add to 2 gravity
+		//but negative force gravity effects can cancel out positive ones
+		for(var/gravity_influence in forced_gravity)
 			positive_grav = max(positive_grav, gravity_influence)
 			negative_grav = min(negative_grav, gravity_influence)
 


### PR DESCRIPTION
## About The Pull Request
fixes #70875
i broke negative gravity with the tram pr by not setting max_grav to the first forced gravity return, so when it did max_grav = max(max_grav, i) it was max(0, -1).
but before it only worked if negative gravity was the first element of the forced_gravity_list, so i made it add the largest positive and largest negative numbers in the list as the return value, so now a forced gravity of +1 and -1 creates a net value of 0 gravity instead of 1, while keeping the behavior where 2 positive forced gravity elements dont add their gravities
## Why It's Good For The Game
fix
## Changelog
:cl:
fix: the atrocinator modsuit module's negative gravity now works again. have fun on the ceiling
/:cl:
