### PR TITLE
Fixes registersignal(s) sound manager runtime

### DIFF
--- a/code/datums/components/area_sound_manager.dm
+++ b/code/datums/components/area_sound_manager.dm
@@ -18,8 +18,16 @@
 
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(react_to_move))
 	RegisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(react_to_z_move))
-	RegisterSignal(parent, change_on, PROC_REF(handle_change))
-	RegisterSignal(parent, remove_on, PROC_REF(handle_removal))
+	// change on can be a list of signals
+	if(islist(change_on))
+		RegisterSignals(parent, change_on, PROC_REF(handle_change))
+	else if(!isnull(change_on))
+		RegisterSignal(parent, change_on, PROC_REF(handle_change))
+	// remove on can be a list of signals
+	if(islist(remove_on))
+		RegisterSignals(parent, remove_on, PROC_REF(handle_removal))
+	else if(!isnull(remove_on))
+		RegisterSignal(parent, remove_on, PROC_REF(handle_removal))
 
 /datum/component/area_sound_manager/Destroy(force, silent)
 	QDEL_NULL(our_loop)

--- a/code/datums/elements/weather_listener.dm
+++ b/code/datums/elements/weather_listener.dm
@@ -37,10 +37,14 @@
 	var/list/fitting_z_levels = SSmapping.levels_by_trait(weather_trait)
 	if(!(new_loc.z in fitting_z_levels))
 		return
-	var/datum/component/our_comp = source.AddComponent(/datum/component/area_sound_manager, playlist, list(), COMSIG_MOB_LOGOUT, fitting_z_levels)
-	our_comp.RegisterSignal(SSdcs, sound_change_signals, TYPE_PROC_REF(/datum/component/area_sound_manager, handle_change))
+	var/datum/component/our_comp = source.AddComponent(\
+		/datum/component/area_sound_manager, \
+		area_loop_pairs = playlist, \
+		remove_on = COMSIG_MOB_LOGOUT, \
+		acceptable_zs = fitting_z_levels, \
+	)
+	our_comp.RegisterSignals(SSdcs, sound_change_signals, TYPE_PROC_REF(/datum/component/area_sound_manager, handle_change))
 
 /datum/element/weather_listener/proc/handle_logout(datum/source)
 	SIGNAL_HANDLER
 	source.RemoveElement(/datum/element/weather_listener, weather_type, weather_trait, playlist)
-


### PR DESCRIPTION
## About The Pull Request

RegisterSignal no longer takes lists, so these needed to be updated

The element passed an empty list to the component (caused a runtime but not one you'd expect) and also registered a list to SSdcs incorrectly

Very cool

