### PR TITLE
Fixes a bug where ghosts spawning on the lower z layer would be double offset

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -12,7 +12,8 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	if(flags_1 & INITIALIZED_1)
 		stack_trace("Warning: [src]([type]) initialized multiple times!")
 	flags_1 |= INITIALIZED_1
-	SET_PLANE_IMPLICIT(src, plane)
+	// Initial is non standard here, but ghosts move before they get here so it's needed. this is a cold path too so it's ok
+	SET_PLANE_IMPLICIT(src, initial(plane))
 	tag = "mob_[next_mob_id++]"
 	add_to_mob_list()
 


### PR DESCRIPTION

## About The Pull Request

This code assumes they haven't been offset yet, and they very much have due to an abstract_move in their pre ..() initialize. Let's just use initial here it's a cold path so it's fineee