### PR TITLE
Fixes logging runtime from alien larva

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -123,12 +123,13 @@
 
 	if(gib_on_success)
 		new_xeno.visible_message(span_danger("[new_xeno] bursts out of [owner] in a shower of gore!"), span_userdanger("You exit [owner], your previous host."), span_hear("You hear organic matter ripping and tearing!"))
+		owner.investigate_log("has been gibbed by an alien larva.", INVESTIGATE_DEATHS)
 		owner.gib(TRUE)
 	else
 		new_xeno.visible_message(span_danger("[new_xeno] wriggles out of [owner]!"), span_userdanger("You exit [owner], your previous host."))
+		owner.log_message("had an alien larva within them escape (without being gibbed).", LOG_ATTACK, log_globally = FALSE)
 		owner.adjustBruteLoss(40)
 		owner.cut_overlay(overlay)
-	owner.investigate_log("has been gibbed by an alien larva.", INVESTIGATE_DEATHS)
 	qdel(src)
 
 


### PR DESCRIPTION
## About The Pull Request

Being gibbed deletes your mob, so calling `owner.investigate_log` after the gibbing caused a runtime on a successful gib.
It also wasn't entirely accurate, as it could reach that point without a gibbing.

## Changelog

:cl: Melbert
fix: Fixes a runtime when alien larva exploded their host that caused the larva organ to not be deleted afterwards.
/:cl:

