### PR TITLE
Fixes food holder screentip runtime

### DIFF
--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -275,7 +275,7 @@
 	SIGNAL_HANDLER
 
 	// only accept valid ingredients
-	if (!valid_ingredient(held_item))
+	if (isnull(held_item) || !valid_ingredient(held_item))
 		return NONE
 
 	context[SCREENTIP_CONTEXT_LMB] = "[screentip_verb] [held_item]"


### PR DESCRIPTION
## About The Pull Request

`held_item` isn't guaranteed to exist, and `valid_ingredient` does no null-checking, as it doesn't expect it to be passed a null item

Fixes it with a null check in the screentip

## Why It's Good For The Game

More minor runtimes

## Changelog

:cl: Melbert
fix: Fixed a runtime from hovering over stuff like bread with an empty hand. 
/:cl:
