### PR TITLE
Chaplain armor beacon now uses radial + previews possible armor sets, plus some choice beacon code cleanup.

### DIFF
--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -100,7 +100,7 @@
 	name = "augment beacon"
 	desc = "Summons augmentations. Can be used 3 times!"
 	uses = 3
-	company_source = "S.E.L.F"
+	company_source = "S.E.L.F."
 	company_message = span_bold("Item request received. Your package has been teleported, use the autosurgeon supplied to apply the upgrade.")
 
 /obj/item/choice_beacon/augments/generate_display_names()

--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -8,8 +8,9 @@
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 	/// How many uses this item has before being deleted
 	var/uses = 1
-
+	/// Used in the deployment message - What company is sending the equipment, flavor
 	var/company_source = "Central Command"
+	/// Used inthe deployment message - What is the company saying with their message, flavor
 	var/company_message = span_bold("Item request received. Your package is inbound, please stand back from the landing site.")
 
 /obj/item/choice_beacon/interact(mob/user)
@@ -63,7 +64,7 @@
 	podspawn(list(
 		"target" = get_turf(src),
 		"style" = STYLE_BLUESPACE,
-		"spawn" = choice,
+		"spawn" = choice_path,
 	))
 
 /obj/item/choice_beacon/ingredient
@@ -91,7 +92,7 @@
 	var/static/list/hero_item_list
 	if(!hero_item_list)
 		hero_item_list = list()
-		for(var/obj/item/storage/box/hero/box in typesof(/obj/item/storage/box/hero))
+		for(var/obj/item/storage/box/hero/box as anything in typesof(/obj/item/storage/box/hero))
 			hero_item_list[initial(box.name)] = box
 	return hero_item_list
 
@@ -122,7 +123,7 @@
 
 // just drops the box at their feet, "quiet" and "sneaky"
 /obj/item/choice_beacon/augments/spawn_option(obj/choice_path, mob/living/user)
-	new choice(get_turf(user))
+	new choice_path(get_turf(user))
 	playsound(src, 'sound/weapons/emitter2.ogg', 50, extrarange = SILENCED_SOUND_EXTRARANGE)
 
 /obj/item/choice_beacon/holy
@@ -169,6 +170,6 @@
 
 /obj/item/choice_beacon/holy/spawn_option(obj/choice_path, mob/living/user)
 	playsound(src, 'sound/effects/pray_chaplain.ogg', 40, TRUE)
-	SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
-	GLOB.holy_armor_type = choice
+	SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice_path]")
+	GLOB.holy_armor_type = choice_path
 	return ..()

--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -140,7 +140,7 @@
 /obj/item/choice_beacon/holy/open_options_menu(mob/living/user)
 	if(GLOB.holy_armor_type)
 		to_chat(user, span_warning("A selection has already been made."))
-		spawn_option(GLOB.holy_armor_type, user)
+		consume_use(GLOB.holy_armor_type, user)
 		return
 
 	// Not bothering to cache this stuff because it'll only even be used once

--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -6,140 +6,169 @@
 	inhand_icon_state = "radio"
 	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
+	/// How many uses this item has before being deleted
 	var/uses = 1
 
-/obj/item/choice_beacon/attack_self(mob/user)
-	if(canUseBeacon(user))
-		generate_options(user)
+	var/company_source = "Central Command"
+	var/company_message = span_bold("Item request received. Your package is inbound, please stand back from the landing site.")
 
-/obj/item/choice_beacon/proc/generate_display_names() // return the list that will be used in the choice selection. entries should be in (type.name = type) fashion. see choice_beacon/hero for how this is done.
+/obj/item/choice_beacon/interact(mob/user)
+	. = ..()
+	if(!can_use_beacon(user))
+		return
+
+	open_options_menu(user)
+
+/// Return the list that will be used in the choice selection.
+/// Entries should be in (type.name = type) fashion.
+/obj/item/choice_beacon/proc/generate_display_names()
 	return list()
 
-/obj/item/choice_beacon/proc/canUseBeacon(mob/living/user)
+/// Checks if this mob can use the beacon, returns TRUE if so or FALSE otherwise.
+/obj/item/choice_beacon/proc/can_use_beacon(mob/living/user)
 	if(user.canUseTopic(src, be_close = TRUE, no_dexterity = FALSE, no_tk = TRUE))
 		return TRUE
-	else
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 40, TRUE)
-		return FALSE
 
-/obj/item/choice_beacon/proc/generate_options(mob/living/M)
+	playsound(src, 'sound/machines/buzz-sigh.ogg', 40, TRUE)
+	return FALSE
+
+/// Opens a menu and allows the mob to pick an option from the list
+/obj/item/choice_beacon/proc/open_options_menu(mob/living/user)
 	var/list/display_names = generate_display_names()
 	if(!length(display_names))
 		return
-	var/choice = tgui_input_list(M, "Which item would you like to order?", "Select an Item", display_names)
-	if(isnull(choice))
+	var/choice = tgui_input_list(user, "Which item would you like to order?", "Select an Item", display_names)
+	if(isnull(choice) || isnull(display_names[choice]))
 		return
-	if(isnull(display_names[choice]))
-		return
-	if(!M.canUseTopic(src, be_close = TRUE, no_dexterity = FALSE, no_tk = TRUE))
+	if(!can_use_beacon(user))
 		return
 
-	spawn_option(display_names[choice],M)
-	uses--
-	if(!uses)
+	consume_use(display_names[choice], user)
+
+/// Consumes a use of the beacon, sending the user a message and creating their item in the process
+/obj/item/choice_beacon/proc/consume_use(obj/choice_path, mob/living/user)
+	to_chat(user, span_hear("You hear something crackle from the beacon for a moment before a voice speaks. \
+		\"Please stand by for a message from [company_source]. Message as follows: [company_message] Message ends.\""))
+
+	spawn_option(choice_path, user)
+	if(--uses <= 0)
+		do_sparks(3, source = src)
 		qdel(src)
-	else
-		to_chat(M, span_notice("[uses] use[uses > 1 ? "s" : ""] remaining on the [src]."))
+		return
 
-/obj/item/choice_beacon/proc/spawn_option(obj/choice,mob/living/M)
+	to_chat(user, span_notice("[uses] use[uses > 1 ? "s" : ""] remain[uses > 1 ? "" : "s"] on [src]."))
+
+/// Actually spawns the item selected by the user
+/obj/item/choice_beacon/proc/spawn_option(obj/choice_path, mob/living/user)
 	podspawn(list(
 		"target" = get_turf(src),
 		"style" = STYLE_BLUESPACE,
 		"spawn" = choice,
 	))
-	var/msg = span_danger("After making your selection, you notice a strange target on the ground. It might be best to step back!")
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		if(istype(H.ears, /obj/item/radio/headset))
-			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: [span_bold("Item request received. Your package is inbound, please stand back from the landing site.")] Message ends.\""
-	to_chat(M, msg)
 
 /obj/item/choice_beacon/ingredient
 	name = "ingredient delivery beacon"
 	desc = "Summon a box of ingredients to help you get started cooking."
 	icon_state = "gangtool-white"
+	company_source = "Sophronia Broadcasting"
+	company_message = span_bold("Please enjoy your Sophronia Broadcasting's 'Plasteel Chef' Ingredients Box, exactly as shown in the hit show!")
 
 /obj/item/choice_beacon/ingredient/generate_display_names()
-	var/list/ingredients = list()
-	for(var/V in subtypesof(/obj/item/storage/box/ingredients))
-		var/obj/item/storage/box/ingredients/A = V
-		ingredients[initial(A.theme_name)] = A
-	return ingredients
-
-/obj/item/choice_beacon/ingredient/spawn_option(obj/choice,mob/living/M)
-	new choice(get_turf(M))
-	to_chat(M, span_hear("You hear something crackle from the beacon for a moment before a voice speaks. \"Please stand by for a message from Sophronia Broadcasting. Message as follows: <b>Please enjoy your Sophronia Broadcasting's 'Plasteel Chef' Ingredients Box, exactly as shown in the hit show!</b> Message ends.\""))
+	var/static/list/ingredient_options
+	if(!ingredient_options)
+		ingredient_options = list()
+		for(var/obj/item/storage/box/ingredients/box as anything in subtypesof(/obj/item/storage/box/ingredients))
+			ingredient_options[initial(box.theme_name)] = box
+	return ingredient_options
 
 /obj/item/choice_beacon/hero
 	name = "heroic beacon"
 	desc = "To summon heroes from the past to protect the future."
+	company_source = "Sophronia Broadcasting"
+	company_message = span_bold("Please enjoy your Sophronia Broadcasting's 'History Comes Alive branded' Costume Set, exactly as shown in the hit show!")
 
 /obj/item/choice_beacon/hero/generate_display_names()
 	var/static/list/hero_item_list
 	if(!hero_item_list)
 		hero_item_list = list()
-		var/list/templist = typesof(/obj/item/storage/box/hero) //we have to convert type = name to name = type, how lovely!
-		for(var/V in templist)
-			var/atom/A = V
-			hero_item_list[initial(A.name)] = A
+		for(var/obj/item/storage/box/hero/box in typesof(/obj/item/storage/box/hero))
+			hero_item_list[initial(box.name)] = box
 	return hero_item_list
-
-/obj/item/choice_beacon/hero/spawn_option(obj/choice,mob/living/M)
-	new choice(get_turf(M))
-	to_chat(M, span_hear("You hear something crackle from the beacon for a moment before a voice speaks. \"Please stand by for a message from Sophronia Broadcasting. Message as follows: <b>Please enjoy your Sophronia Broadcasting's 'History Comes Alive branded' Costume Set, exactly as shown in the hit show!</b> Message ends.\""))
 
 /obj/item/choice_beacon/augments
 	name = "augment beacon"
 	desc = "Summons augmentations. Can be used 3 times!"
 	uses = 3
+	company_source = "S.E.L.F"
+	company_message = span_bold("Item request received. Your package has been teleported, use the autosurgeon supplied to apply the upgrade.")
 
 /obj/item/choice_beacon/augments/generate_display_names()
 	var/static/list/augment_list
 	if(!augment_list)
 		augment_list = list()
-		var/list/templist = list(
-		/obj/item/organ/internal/cyberimp/brain/anti_drop,
-		/obj/item/organ/internal/cyberimp/arm/toolset,
-		/obj/item/organ/internal/cyberimp/arm/surgery,
-		/obj/item/organ/internal/cyberimp/chest/thrusters,
-		/obj/item/organ/internal/lungs/cybernetic/tier3,
-		/obj/item/organ/internal/liver/cybernetic/tier3) //cyberimplants range from a nice bonus to fucking broken bullshit so no subtypesof
-		for(var/V in templist)
-			var/atom/A = V
-			augment_list[initial(A.name)] = A
+		// cyberimplants range from a nice bonus to fucking broken bullshit so no subtypesof
+		var/list/selectable_types = list(
+			/obj/item/organ/internal/cyberimp/brain/anti_drop,
+			/obj/item/organ/internal/cyberimp/arm/toolset,
+			/obj/item/organ/internal/cyberimp/arm/surgery,
+			/obj/item/organ/internal/cyberimp/chest/thrusters,
+			/obj/item/organ/internal/lungs/cybernetic/tier3,
+			/obj/item/organ/internal/liver/cybernetic/tier3,
+		)
+		for(var/obj/item/organ/organ as anything in selectable_types)
+			augment_list[initial(organ.name)] = organ
+
 	return augment_list
 
-/obj/item/choice_beacon/augments/spawn_option(obj/choice,mob/living/M)
-	new choice(get_turf(M))
-	to_chat(M, span_hear("You hear something crackle from the beacon for a moment before a voice speaks. \"Please stand by for a message from S.E.L.F. Message as follows: <b>Item request received. Your package has been transported, use the autosurgeon supplied to apply the upgrade.</b> Message ends.\""))
+// just drops the box at their feet, "quiet" and "sneaky"
+/obj/item/choice_beacon/augments/spawn_option(obj/choice_path, mob/living/user)
+	new choice(get_turf(user))
+	playsound(src, 'sound/weapons/emitter2.ogg', 50, extrarange = SILENCED_SOUND_EXTRARANGE)
 
 /obj/item/choice_beacon/holy
 	name = "armaments beacon"
 	desc = "Contains a set of armaments for the chaplain."
 
-/obj/item/choice_beacon/holy/canUseBeacon(mob/living/user)
-	if(user.mind && user.mind.holy_role)
+/obj/item/choice_beacon/holy/can_use_beacon(mob/living/user)
+	if(user.mind?.holy_role)
 		return ..()
-	else
-		playsound(src, 'sound/machines/buzz-sigh.ogg', 40, TRUE)
-		return FALSE
 
-/obj/item/choice_beacon/holy/generate_display_names()
-	var/static/list/holy_item_list
-	if(!holy_item_list)
-		holy_item_list = list()
-		var/list/templist = typesof(/obj/item/storage/box/holy)
-		for(var/V in templist)
-			var/atom/A = V
-			holy_item_list[initial(A.name)] = A
-	return holy_item_list
+	playsound(src, 'sound/machines/buzz-sigh.ogg', 40, TRUE)
+	return FALSE
 
-/obj/item/choice_beacon/holy/spawn_option(obj/choice,mob/living/M)
-	if(!GLOB.holy_armor_type)
-		..()
-		playsound(src, 'sound/effects/pray_chaplain.ogg', 40, TRUE)
-		SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
-		GLOB.holy_armor_type = choice
-	else
-		to_chat(M, span_warning("A selection has already been made. Self-Destructing..."))
+// Overrides generate options so that we can show a neat radial instead
+/obj/item/choice_beacon/holy/open_options_menu(mob/living/user)
+	if(GLOB.holy_armor_type)
+		to_chat(user, span_warning("A selection has already been made."))
+		spawn_option(GLOB.holy_armor_type, user)
 		return
+
+	// Not bothering to cache this stuff because it'll only even be used once
+	var/list/armament_names_to_images = list()
+	var/list/armament_names_to_typepaths = list()
+	for(var/obj/item/storage/box/holy/holy_box as anything in typesof(/obj/item/storage/box/holy))
+		var/box_name = initial(holy_box.name)
+		var/obj/item/preview_item = initial(holy_box.typepath_for_preview)
+		armament_names_to_typepaths[box_name] = holy_box
+		armament_names_to_images[box_name] = image(icon = initial(preview_item.icon), icon_state = initial(preview_item.icon_state))
+
+	var/chosen_name = show_radial_menu(
+		user = user,
+		anchor = src,
+		choices = armament_names_to_images,
+		custom_check = CALLBACK(src, .proc/can_use_beacon, user),
+		require_near = TRUE,
+	)
+	if(!can_use_beacon(user))
+		return
+	var/chosen_type = armament_names_to_typepaths[chosen_name]
+	if(!ispath(chosen_type, /obj/item/storage/box/holy))
+		return
+
+	consume_use(chosen_type, user)
+
+/obj/item/choice_beacon/holy/spawn_option(obj/choice_path, mob/living/user)
+	playsound(src, 'sound/effects/pray_chaplain.ogg', 40, TRUE)
+	SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
+	GLOB.holy_armor_type = choice
+	return ..()

--- a/code/game/objects/items/storage/boxes/clothes_boxes.dm
+++ b/code/game/objects/items/storage/boxes/clothes_boxes.dm
@@ -118,6 +118,9 @@
 
 /obj/item/storage/box/holy
 	name = "Templar Kit"
+	/// This item is used to generate a preview image for this set.
+	/// It could be any item, doesn't even necessarily need to be something in the kit
+	var/obj/item/typepath_for_preview = /obj/item/clothing/suit/chaplainsuit/armor/templar
 
 /obj/item/storage/box/holy/PopulateContents()
 	new /obj/item/clothing/head/helmet/chaplain(src)
@@ -125,6 +128,7 @@
 
 /obj/item/storage/box/holy/clock
 	name = "Forgotten kit"
+	typepath_for_preview = /obj/item/clothing/suit/chaplainsuit/armor/clock
 
 /obj/item/storage/box/holy/clock/PopulateContents()
 	new /obj/item/clothing/head/helmet/chaplain/clock(src)
@@ -132,6 +136,7 @@
 
 /obj/item/storage/box/holy/student
 	name = "Profane Scholar Kit"
+	typepath_for_preview = /obj/item/clothing/suit/chaplainsuit/armor/studentuni
 
 /obj/item/storage/box/holy/student/PopulateContents()
 	new /obj/item/clothing/suit/chaplainsuit/armor/studentuni(src)
@@ -139,6 +144,7 @@
 
 /obj/item/storage/box/holy/sentinel
 	name = "Stone Sentinel Kit"
+	typepath_for_preview = /obj/item/clothing/suit/chaplainsuit/armor/ancient
 
 /obj/item/storage/box/holy/sentinel/PopulateContents()
 	new /obj/item/clothing/suit/chaplainsuit/armor/ancient(src)
@@ -146,6 +152,7 @@
 
 /obj/item/storage/box/holy/witchhunter
 	name = "Witchhunter Kit"
+	typepath_for_preview = /obj/item/clothing/suit/chaplainsuit/armor/witchhunter
 
 /obj/item/storage/box/holy/witchhunter/PopulateContents()
 	new /obj/item/clothing/suit/chaplainsuit/armor/witchhunter(src)
@@ -153,6 +160,7 @@
 
 /obj/item/storage/box/holy/adept
 	name = "Divine Adept Kit"
+	typepath_for_preview = /obj/item/clothing/suit/chaplainsuit/armor/adept
 
 /obj/item/storage/box/holy/adept/PopulateContents()
 	new /obj/item/clothing/suit/chaplainsuit/armor/adept(src)
@@ -160,6 +168,7 @@
 
 /obj/item/storage/box/holy/follower
 	name = "Followers of the Chaplain Kit"
+	typepath_for_preview = /obj/item/clothing/suit/hooded/chaplain_hoodie/leader
 
 /obj/item/storage/box/holy/follower/PopulateContents()
 	new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
@@ -167,4 +176,3 @@
 	new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
 	new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
 	new /obj/item/clothing/suit/hooded/chaplain_hoodie/leader(src)
-

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -93,7 +93,7 @@
 	player_mind.active = TRUE
 	//if you want to add a fugitive with a special leader in the future, make this switch with the backstory
 	var/mob/living/carbon/human/S = gear_fugitive(leader, landing_turf, backstory)
-	var/obj/item/choice_beacon/augments/A = new(S)
+	var/obj/item/choice_beacon/augments/A = new(landing_turf)
 	S.put_in_hands(A)
 	new /obj/item/autosurgeon(landing_turf)
 

--- a/code/modules/instruments/items.dm
+++ b/code/modules/instruments/items.dm
@@ -251,23 +251,23 @@
 	var/static/list/instruments
 	if(!instruments)
 		instruments = list()
-		var/list/templist = list(/obj/item/instrument/violin,
-							/obj/item/instrument/piano_synth,
-							/obj/item/instrument/banjo,
-							/obj/item/instrument/guitar,
-							/obj/item/instrument/eguitar,
-							/obj/item/instrument/glockenspiel,
-							/obj/item/instrument/accordion,
-							/obj/item/instrument/trumpet,
-							/obj/item/instrument/saxophone,
-							/obj/item/instrument/trombone,
-							/obj/item/instrument/recorder,
-							/obj/item/instrument/harmonica,
-							/obj/item/instrument/piano_synth/headphones
-							)
-		for(var/V in templist)
-			var/atom/A = V
-			instruments[initial(A.name)] = A
+		var/list/possible_instruments = list(
+			/obj/item/instrument/violin,
+			/obj/item/instrument/piano_synth,
+			/obj/item/instrument/banjo,
+			/obj/item/instrument/guitar,
+			/obj/item/instrument/eguitar,
+			/obj/item/instrument/glockenspiel,
+			/obj/item/instrument/accordion,
+			/obj/item/instrument/trumpet,
+			/obj/item/instrument/saxophone,
+			/obj/item/instrument/trombone,
+			/obj/item/instrument/recorder,
+			/obj/item/instrument/harmonica,
+			/obj/item/instrument/piano_synth/headphones,
+		)
+		for(var/obj/item/instrument/instrument as anything in possible_instruments)
+			instruments[initial(instrument.name)] = instrument
 	return instruments
 
 /obj/item/instrument/musicalmoth


### PR DESCRIPTION
## About The Pull Request

- The chaplain choice beacon now uses a radial to select the armor set, instead of a list, giving the user a preview of what each looks like.

![image](https://user-images.githubusercontent.com/51863163/205417930-f5ceab11-6974-48a9-a871-abcb8228bcf2.png)

- Lots of additional cleanup to choice beacon code in general. Less copy pasted code.
   - All beacons now speak from the beacon with their message, instead of some going by "headset message". Soul removed

## Why It's Good For The Game

I always forgot when selecting my armor which looks like what, and choosing an ugly one is a pain since you only get one choice. This should help chaplains get the armor they actually want without needing to check the wiki. 

## Changelog

:cl: Melbert
qol: The chaplain's armament beacon now displays a radial instead of a text list, showing previews of what all the armor sets look like
qol: (Almost) all choice beacons now use a pod to send their item, instead of just magicking it under your feet
code: Cleaned up some choice beacon code. 
/:cl:
