### PR TITLE
Mining orders can no longer error and don't say they charge you

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -34,7 +34,11 @@
 	for(var/datum/orderable_item/item as anything in groceries)
 		things_to_order[item.item_path] = groceries[item]
 
-	var/datum/supply_pack/custom/mining_pack = new(purchaser, things_to_order)
+	var/datum/supply_pack/custom/mining_pack = new(
+		purchaser = purchaser, \
+		cost = get_total_cost(), \
+		contains = things_to_order,
+	)
 	var/datum/supply_order/new_order = new(
 		pack = mining_pack, \
 		orderer = purchaser, \
@@ -45,6 +49,7 @@
 		department_destination = null, \
 		coupon = null, \
 		charge_on_purchase = FALSE,
+		manifest_can_fail = FALSE,
 	)
 	if(ltsrbt_delivered)
 		var/obj/machinery/mining_ltsrbt/ltsrbt

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -63,8 +63,8 @@
 	paying_account,
 	department_destination,
 	coupon,
-	charge_on_purchase,
-	manifest_can_fail
+	charge_on_purchase = TRUE,
+	manifest_can_fail = TRUE,
 )
 	id = SSshuttle.order_number++
 	src.pack = pack

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -14,10 +14,12 @@
 	var/order_id = 0
 	var/errors = 0
 
-/obj/item/paper/fluff/jobs/cargo/manifest/Initialize(mapload, id, cost)
+/obj/item/paper/fluff/jobs/cargo/manifest/Initialize(mapload, id, cost, manifest_can_fail = TRUE)
 	. = ..()
 	order_id = id
 	order_cost = cost
+	if(!manifest_can_fail)
+		return
 
 	if(prob(MANIFEST_ERROR_CHANCE))
 		errors |= MANIFEST_ERROR_NAME
@@ -49,6 +51,8 @@
 	var/datum/supply_pack/pack
 	var/datum/bank_account/paying_account
 	var/obj/item/coupon/applied_coupon
+	///Boolean on whether the manifest can fail or not.
+	var/manifest_can_fail = TRUE
 
 /datum/supply_order/New(
 	datum/supply_pack/pack,
@@ -60,6 +64,7 @@
 	department_destination,
 	coupon,
 	charge_on_purchase,
+	manifest_can_fail
 )
 	id = SSshuttle.order_number++
 	src.pack = pack
@@ -71,6 +76,7 @@
 	src.department_destination = department_destination
 	src.applied_coupon = coupon
 	src.charge_on_purchase = charge_on_purchase
+	src.manifest_can_fail = manifest_can_fail
 
 /datum/supply_order/proc/generateRequisition(turf/T)
 	var/obj/item/paper/requisition_paper = new(T)
@@ -93,7 +99,7 @@
 	return requisition_paper
 
 /datum/supply_order/proc/generateManifest(obj/container, owner, packname, cost) //generates-the-manifests.
-	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest_paper = new(null, id, cost)
+	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest_paper = new(null, id, cost, manifest_can_fail)
 
 	var/station_name = (manifest_paper.errors & MANIFEST_ERROR_NAME) ? new_station_name() : station_name()
 

--- a/code/modules/cargo/packs/_packs.dm
+++ b/code/modules/cargo/packs/_packs.dm
@@ -90,7 +90,8 @@
 	crate_name = "shaft mining delivery crate"
 	access = list(ACCESS_MINING)
 
-/datum/supply_pack/custom/New(purchaser, list/given_contents)
+/datum/supply_pack/custom/New(purchaser, cost, list/contains)
 	. = ..()
 	name = "[purchaser]'s Mining Order"
-	contains = given_contents
+	src.cost = cost
+	src.contains = contains

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -153,7 +153,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				LAZYADD(goodies_by_buyer[spawning_order.paying_account], spawning_order)
 			var/reciever_message = "Cargo order #[spawning_order.id] has shipped."
 			if(spawning_order.charge_on_purchase)
-				reciever_message += "[price] credits have been charged to your bank account"
+				reciever_message += " [price] credits have been charged to your bank account"
 			paying_for_this.bank_card_talk(reciever_message)
 			SSeconomy.track_purchase(paying_for_this, price, spawning_order.pack.name)
 			var/datum/bank_account/department/cargo = SSeconomy.get_dep_account(ACCOUNT_CAR)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -151,7 +151,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			paying_for_this = spawning_order.paying_account
 			if(spawning_order.pack.goody)
 				LAZYADD(goodies_by_buyer[spawning_order.paying_account], spawning_order)
-			paying_for_this.bank_card_talk("Cargo order #[spawning_order.id] has shipped. [price] credits have been charged to your bank account.")
+			var/reciever_message = "Cargo order #[spawning_order.id] has shipped."
+			if(spawning_order.charge_on_purchase)
+				reciever_message += "[price] credits have been charged to your bank account"
+			paying_for_this.bank_card_talk(reciever_message)
 			SSeconomy.track_purchase(paying_for_this, price, spawning_order.pack.name)
 			var/datum/bank_account/department/cargo = SSeconomy.get_dep_account(ACCOUNT_CAR)
 			cargo.adjust_money(price - spawning_order.pack.get_cost()) //Cargo gets the handling fee
@@ -195,7 +198,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			for (var/item in our_order.pack.contains)
 				misc_contents[buyer] += item
 			misc_costs[buyer] += our_order.pack.cost
-			misc_order_num[buyer] = "[misc_order_num[buyer]]#[our_order.id]  "
+			misc_order_num[buyer] = "[misc_order_num[buyer]]#[our_order.id] "
 
 	for(var/I in miscboxes)
 		var/datum/supply_order/SO = new/datum/supply_order()


### PR DESCRIPTION
## About The Pull Request

- Mining orders now show the amount of mining points spent as the 'Cost' instead of a flat 240 credits

This is buying a single beacon
![image](https://user-images.githubusercontent.com/53777086/205418840-725b6b26-a863-4120-b7d0-d7000397ae3a.png)

- Mining orders now no longer have errors (including nothing being in the crate at all) because they can't be sent back for a full refund.

- Mining orders no longer say they charged you if they haven't.

![image](https://user-images.githubusercontent.com/53777086/205418862-696ef5cf-e103-4e8c-b0ce-4c6fbb64a269.png)

(ignore the lack of a space, that was fixed already)
![image](https://user-images.githubusercontent.com/53777086/205419458-5e37581e-4389-4628-9b22-1bc7e2d40a3b.png)

Fixes #71677

## Why It's Good For The Game

More consistency for Miners
Less misinformation displayed to users
Miners also will get their items that they paid for, because they can't send it back for a refund like the intended mechanic wants them to do.

## Changelog

:cl:
fix: Mining orders will no longer say they charged you credits.
qol: The cargo console now properly displays the amount of mining points used to purchase something.
qol: Mining orders no longer have manifest errors.
/:cl: