### PR TITLE
fixes a recursive bluespace body bag bypass

### DIFF
--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -10,6 +10,7 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/reagent_containers/condiment,
 	/obj/item/delivery,
 	/obj/item/his_grace,
+	/obj/item/bodybag/bluespace,
 )))
 
 /obj/machinery/deepfryer


### PR DESCRIPTION
## About The Pull Request

You can deepfry bluespace bodybags, then put them into a custom food and stack them into a bluespace body bag.
Since we dont want to bypass it we put the bluespace body bag into the backlist of oilfrying items.

## Why It's Good For The Game

No recursive bluespace body bag like its intented

## Changelog

:cl:
fix: fixes being able to stack deepfried bluespace body bags into bluespace body bag
/:cl:
