### PR TITLE
Stock part datums: Creates a framework for stock parts to not physically exist in the world

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -185,11 +185,12 @@
 	end_processing()
 	dump_inventory_contents()
 
-	// Don't delete the stock part singletons
-	for (var/atom/atom_part in component_parts)
-		qdel(atom_part)
+	if (!isnull(component_parts))
+		// Don't delete the stock part singletons
+		for (var/atom/atom_part in component_parts)
+			qdel(atom_part)
 
-	component_parts.Cut()
+		component_parts.Cut()
 
 	QDEL_NULL(circuit)
 	unset_static_power()

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -42,7 +42,7 @@
 		return
 
 	var/list/nice_list = list()
-	for(var/atom/component as anything in req_components)
+	for(var/component as anything in req_components)
 		if(!ispath(component))
 			stack_trace("An item in [src]'s req_components list is not a path!")
 			continue
@@ -63,24 +63,34 @@
 		return
 
 	req_component_names = list()
-	for(var/atom/component_path as anything in req_components)
+	for(var/component_path as anything in req_components)
 		if(!ispath(component_path))
 			continue
 
-		req_component_names[component_path] = initial(component_path.name)
+		var/component_name
 
 		if(ispath(component_path, /obj/item/stack))
 			var/obj/item/stack/stack_path = component_path
+			component_name = initial(stack_path.name)
 			if(initial(stack_path.singular_name))
 				req_component_names[component_path] = initial(stack_path.singular_name)
 				continue
+		else if(ispath(component_path, /datum/stock_part))
+			var/datum/stock_part/stock_part = component_path
+			component_path = initial(stock_part.physical_object_type)
+			ASSERT(ispath(component_path, /obj/item/stock_parts))
 
 		if(ispath(component_path, /obj/item/stock_parts))
 			var/obj/item/stock_parts/stock_part = component_path
+			component_name = initial(stock_part.name)
+
 			if(!specific_parts && initial(stock_part.base_name))
 				req_component_names[component_path] = initial(stock_part.base_name)
 			else
 				req_component_names[component_path] = initial(stock_part.name)
+
+		ASSERT(component_name)
+		req_component_names[component_path] = component_name
 
 /obj/structure/frame/machine/proc/get_req_components_amt()
 	var/amt = 0
@@ -182,8 +192,8 @@
 					to_chat(user, span_notice("You remove the circuit board."))
 				else
 					to_chat(user, span_notice("You remove the circuit board and other components."))
-					for(var/atom/movable/AM in components)
-						AM.forceMove(drop_location())
+					dump_contents()
+
 				desc = initial(desc)
 				req_components = null
 				components = null
@@ -228,9 +238,12 @@
 						new_machine.component_parts += circuit
 						new_machine.circuit = circuit
 
-						for(var/obj/new_part in src)
+						for (var/obj/new_part in src)
 							new_part.forceMove(new_machine)
-							new_machine.component_parts += new_part
+
+						new_machine.component_parts = components
+						components = null
+
 						new_machine.RefreshParts()
 
 						new_machine.on_construction()
@@ -281,33 +294,71 @@
 					replacer.play_rped_sound()
 				return
 
-			if(isitem(P) && get_req_components_amt())
-				for(var/I in req_components)
-					if(istype(P, I) && (req_components[I] > 0))
-						if(isstack(P))
-							var/obj/item/stack/S = P
-							var/used_amt = min(round(S.get_amount()), req_components[I])
+			for(var/stock_part_base in req_components)
+				var/stock_part_path
 
-							if(used_amt && S.use(used_amt))
-								var/obj/item/stack/NS = locate(S.merge_type) in components
+				if (ispath(stock_part_base, /obj/item))
+					stock_part_path = stock_part_base
+				else if (ispath(stock_part_base, /datum/stock_part))
+					var/datum/stock_part/stock_part_datum_type = stock_part_base
+					stock_part_path = initial(stock_part_datum_type.physical_object_type)
+				else
+					stack_trace("Bad stock part in req_components: [stock_part_base]")
+					continue
 
-								if(!NS)
-									NS = new S.merge_type(src, used_amt)
-									components += NS
-								else
-									NS.add(used_amt)
+				if (req_components[stock_part_path] == 0)
+					continue
 
-								req_components[I] -= used_amt
-								to_chat(user, span_notice("You add [P] to [src]."))
-							return
-						if(!user.transferItemToLoc(P, src))
-							break
+				if (!istype(P, stock_part_path))
+					continue
+
+				if(isstack(P))
+					var/obj/item/stack/S = P
+					var/used_amt = min(round(S.get_amount()), req_components[stock_part_path])
+
+					if(used_amt && S.use(used_amt))
+						var/obj/item/stack/NS = locate(S.merge_type) in components
+
+						if(!NS)
+							NS = new S.merge_type(src, used_amt)
+							components += NS
+						else
+							NS.add(used_amt)
+
+						req_components[stock_part_path] -= used_amt
 						to_chat(user, span_notice("You add [P] to [src]."))
-						components += P
-						req_components[I]--
-						return TRUE
-				to_chat(user, span_warning("You cannot add that to the machine!"))
-				return FALSE
+					return
+
+				// We might end up qdel'ing the part if it's a stock part datum.
+				// In practice, this doesn't have side effects to the name,
+				// but academically we should not be using an object after it's deleted.
+				var/part_name = "[P]"
+
+				if (ispath(stock_part_base, /datum/stock_part))
+					// We can't just reuse stock_part_path here or its singleton,
+					// or else putting ina tier 2 part will deconstruct to a tier 1 part.
+					var/stock_part_datum = GLOB.stock_part_datums_per_object[P.type]
+					if (isnull(stock_part_datum))
+						stack_trace("[P.type] does not have an associated stock part datum!")
+						continue
+
+					components += stock_part_datum
+
+					// We regenerate the stock parts on deconstruct.
+					// This technically means we lose unique qualities of the stock part, but
+					// it's worth it for how dramatically this simplifies the code.
+					// The only place I can see it affecting anything is like...RPG qualities. :P
+					qdel(P)
+				else if(user.transferItemToLoc(P, src))
+					components += P
+				else
+					break
+
+				to_chat(user, span_notice("You add [part_name] to [src]."))
+				req_components[stock_part_base]--
+				return TRUE
+			to_chat(user, span_warning("You cannot add that to the machine!"))
+			return FALSE
 	if(user.combat_mode)
 		return ..()
 
@@ -315,7 +366,18 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(state >= 2)
 			new /obj/item/stack/cable_coil(loc , 5)
-		for(var/X in components)
-			var/obj/item/I = X
-			I.forceMove(loc)
+
+		dump_contents()
 	..()
+
+/obj/structure/frame/machine/dump_contents()
+	for (var/component in components)
+		if (ismovable(component))
+			var/atom/movable/atom_component = component
+			atom_component.forceMove(drop_location())
+		else if (istype(component, /datum/stock_part))
+			var/datum/stock_part/stock_part_datum = component
+			var/physical_object_type = initial(stock_part_datum.physical_object_type)
+			new physical_object_type(drop_location())
+		else
+			stack_trace("Invalid component [component] was found in constructable frame")

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -42,7 +42,7 @@
 		return
 
 	var/list/nice_list = list()
-	for(var/component as anything in req_components)
+	for(var/component in req_components)
 		if(!ispath(component))
 			stack_trace("An item in [src]'s req_components list is not a path!")
 			continue
@@ -63,7 +63,7 @@
 		return
 
 	req_component_names = list()
-	for(var/component_path as anything in req_components)
+	for(var/component_path in req_components)
 		if(!ispath(component_path))
 			continue
 

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -67,30 +67,24 @@
 		if(!ispath(component_path))
 			continue
 
-		var/component_name
-
 		if(ispath(component_path, /obj/item/stack))
 			var/obj/item/stack/stack_path = component_path
-			component_name = initial(stack_path.name)
 			if(initial(stack_path.singular_name))
 				req_component_names[component_path] = initial(stack_path.singular_name)
-				continue
+			else
+				req_component_names[component_path] = initial(stack_path.name)
 		else if(ispath(component_path, /datum/stock_part))
 			var/datum/stock_part/stock_part = component_path
-			component_path = initial(stock_part.physical_object_type)
-			ASSERT(ispath(component_path, /obj/item/stock_parts))
+			var/obj/item/physical_object_type = initial(stock_part.physical_object_type)
 
-		if(ispath(component_path, /obj/item/stock_parts))
+			req_component_names[component_path] = initial(physical_object_type.name)
+		else if(ispath(component_path, /obj/item/stock_parts))
 			var/obj/item/stock_parts/stock_part = component_path
-			component_name = initial(stock_part.name)
 
 			if(!specific_parts && initial(stock_part.base_name))
 				req_component_names[component_path] = initial(stock_part.base_name)
 			else
 				req_component_names[component_path] = initial(stock_part.name)
-
-		ASSERT(component_name)
-		req_component_names[component_path] = component_name
 
 /obj/structure/frame/machine/proc/get_req_components_amt()
 	var/amt = 0

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -330,7 +330,7 @@
 
 				if (ispath(stock_part_base, /datum/stock_part))
 					// We can't just reuse stock_part_path here or its singleton,
-					// or else putting ina tier 2 part will deconstruct to a tier 1 part.
+					// or else putting in a tier 2 part will deconstruct to a tier 1 part.
 					var/stock_part_datum = GLOB.stock_part_datums_per_object[P.type]
 					if (isnull(stock_part_datum))
 						stack_trace("[P.type] does not have an associated stock part datum!")

--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -21,8 +21,8 @@
 	scan_level = 0
 	damage_coeff = 0
 	precision_coeff = 0
-	for(var/obj/item/stock_parts/scanning_module/P in component_parts)
-		scan_level += P.rating
+	for(var/datum/stock_part/scanning_module/scanning_module in component_parts)
+		scan_level += scanning_module.tier
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
 		precision_coeff = M.rating
 	for(var/obj/item/stock_parts/micro_laser/P in component_parts)

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -167,9 +167,10 @@ The console is located at computer/gulag_teleporter.dm
 	name = "labor camp teleporter (Machine Board)"
 	build_path = /obj/machinery/gulag_teleporter
 	req_components = list(
-							/obj/item/stack/ore/bluespace_crystal = 2,
-							/datum/stock_part/scanning_module,
-							/obj/item/stock_parts/manipulator)
+		/obj/item/stack/ore/bluespace_crystal = 2,
+		/datum/stock_part/scanning_module = 1,
+		/obj/item/stock_parts/manipulator = 1,
+	)
 	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
 
 /*  beacon that receives the teleported prisoner */

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -168,7 +168,7 @@ The console is located at computer/gulag_teleporter.dm
 	build_path = /obj/machinery/gulag_teleporter
 	req_components = list(
 							/obj/item/stack/ore/bluespace_crystal = 2,
-							/obj/item/stock_parts/scanning_module,
+							/datum/stock_part/scanning_module,
 							/obj/item/stock_parts/manipulator)
 	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
 

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -93,6 +93,12 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 
 		if(ispath(comp_path, /obj/item/stack))
 			machine.component_parts += new comp_path(machine, comp_amt)
+		else if (ispath(comp_path, /datum/stock_part))
+			for (var/_ in 1 to comp_amt)
+				var/stock_part_datum = GLOB.stock_part_datums[comp_path]
+				if (isnull(stock_part_datum))
+					CRASH("[comp_path] didn't have a matching stock part datum")
+				machine.component_parts += stock_part_datum
 		else
 			for(var/component in 1 to comp_amt)
 				machine.component_parts += new comp_path(machine)
@@ -106,18 +112,17 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 		return .
 
 	var/list/nice_list = list()
-	for(var/atom/component_path as anything in req_components)
+	for(var/component_path as anything in req_components)
 		if(!ispath(component_path))
 			continue
 
-		var/component_name = initial(component_path.name)
+		var/component_name
 		var/component_amount = req_components[component_path]
 
 		if(ispath(component_path, /obj/item/stack))
 			var/obj/item/stack/stack_path = component_path
 			if(initial(stack_path.singular_name))
 				component_name = initial(stack_path.singular_name) //e.g. "glass sheet" vs. "glass"
-
 		else if(ispath(component_path, /obj/item/stock_parts) && !specific_parts)
 			var/obj/item/stock_parts/stock_part = component_path
 			if(initial(stock_part.base_name))
@@ -126,6 +131,16 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 			var/obj/item/stock_parts/stock_part = component_path
 			if(initial(stock_part.name))
 				component_name = initial(stock_part.name)
+		else if(ispath(component_path, /datum/stock_part))
+			var/datum/stock_part/stock_part = component_path
+			var/obj/item/physical_object_type = initial(stock_part.physical_object_type)
+			if (initial(physical_object_type.name))
+				component_name = initial(physical_object_type.name)
+		else if(ispath(component_path, /atom))
+			var/atom/stock_part = component_path
+			component_name = initial(stock_part.name)
+		else
+			stack_trace("[component_path] was an invalid component")
 
 		nice_list += list("[component_amount] [component_name]\s")
 

--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -112,7 +112,7 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 		return .
 
 	var/list/nice_list = list()
-	for(var/component_path as anything in req_components)
+	for(var/component_path in req_components)
 		if(!ispath(component_path))
 			continue
 

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -967,7 +967,7 @@
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/dna_scannernew
 	req_components = list(
-		/obj/item/stock_parts/scanning_module = 1,
+		/datum/stock_part/scanning_module = 1,
 		/obj/item/stock_parts/matter_bin = 1,
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/stack/sheet/glass = 1,

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -263,7 +263,7 @@
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/scanner_gate
 	req_components = list(
-		/obj/item/stock_parts/scanning_module = 3)
+		/datum/stock_part/scanning_module = 3)
 
 /obj/item/circuitboard/machine/smes
 	name = "SMES"
@@ -615,7 +615,7 @@
 	build_path = /obj/machinery/piratepad/civilian
 	req_components = list(
 		/obj/item/stock_parts/card_reader = 1,
-		/obj/item/stock_parts/scanning_module = 1,
+		/datum/stock_part/scanning_module = 1,
 		/obj/item/stock_parts/micro_laser = 1
 	)
 
@@ -625,7 +625,7 @@
 	build_path = /obj/machinery/fax
 	req_components = list(
 		/obj/item/stock_parts/subspace/crystal = 1,
-		/obj/item/stock_parts/scanning_module = 1,
+		/datum/stock_part/scanning_module = 1,
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/stock_parts/manipulator = 1,)
 
@@ -750,7 +750,7 @@
 	var/custom_cost = 10
 	req_components = list(
 		/obj/item/healthanalyzer = 1,
-		/obj/item/stock_parts/scanning_module = 1)
+		/datum/stock_part/scanning_module = 1)
 
 /obj/item/circuitboard/machine/medical_kiosk/multitool_act(mob/living/user)
 	. = ..()
@@ -869,7 +869,7 @@
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/destructive_analyzer
 	req_components = list(
-		/obj/item/stock_parts/scanning_module = 1,
+		/datum/stock_part/scanning_module = 1,
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stock_parts/micro_laser = 1)
 
@@ -878,7 +878,7 @@
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/experimentor
 	req_components = list(
-		/obj/item/stock_parts/scanning_module = 1,
+		/datum/stock_part/scanning_module = 1,
 		/obj/item/stock_parts/manipulator = 2,
 		/obj/item/stock_parts/micro_laser = 2)
 
@@ -936,7 +936,7 @@
 	build_path = /obj/machinery/rnd/server
 	req_components = list(
 		/obj/item/stack/cable_coil = 2,
-		/obj/item/stock_parts/scanning_module = 1)
+		/datum/stock_part/scanning_module = 1)
 
 /obj/item/circuitboard/machine/techfab/department/science
 	name = "\improper Departmental Techfab - Science"
@@ -979,7 +979,7 @@
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/dna_infuser
 	req_components = list(
-		/obj/item/stock_parts/scanning_module = 1,
+		/datum/stock_part/scanning_module = 1,
 		/obj/item/stock_parts/matter_bin = 1,
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/stack/cable_coil = 2,
@@ -1249,7 +1249,7 @@
 		/obj/item/stock_parts/capacitor = 1,
 		/obj/item/stock_parts/manipulator = 1,
 		/obj/item/stock_parts/micro_laser = 1,
-		/obj/item/stock_parts/scanning_module = 1)
+		/datum/stock_part/scanning_module = 1)
 
 //Misc
 /obj/item/circuitboard/machine/sheetifier
@@ -1289,7 +1289,7 @@
 	build_path = /obj/machinery/hypnochair
 	req_components = list(
 		/obj/item/stock_parts/micro_laser = 2,
-		/obj/item/stock_parts/scanning_module = 2
+		/datum/stock_part/scanning_module = 2
 	)
 
 /obj/item/circuitboard/machine/plumbing_receiver
@@ -1309,7 +1309,7 @@
 	req_components = list(
 		/obj/item/stock_parts/matter_bin = 2,
 		/obj/item/stock_parts/micro_laser = 2,
-		/obj/item/stock_parts/scanning_module = 2
+		/datum/stock_part/scanning_module = 2
 	)
 
 /obj/item/circuitboard/machine/destructive_scanner
@@ -1327,7 +1327,7 @@
 	build_path = /obj/machinery/doppler_array
 	req_components = list(
 		/obj/item/stock_parts/micro_laser = 2,
-		/obj/item/stock_parts/scanning_module = 4)
+		/datum/stock_part/scanning_module = 4)
 
 /obj/item/circuitboard/machine/exoscanner
 	name = "Exoscanner"
@@ -1335,7 +1335,7 @@
 	build_path = /obj/machinery/exoscanner
 	req_components = list(
 		/obj/item/stock_parts/micro_laser = 4,
-		/obj/item/stock_parts/scanning_module = 4)
+		/datum/stock_part/scanning_module = 4)
 
 /obj/item/circuitboard/machine/exodrone_launcher
 	name = "Exploration Drone Launcher"
@@ -1343,14 +1343,14 @@
 	build_path = /obj/machinery/exodrone_launcher
 	req_components = list(
 		/obj/item/stock_parts/micro_laser = 4,
-		/obj/item/stock_parts/scanning_module = 4)
+		/datum/stock_part/scanning_module = 4)
 
 /obj/item/circuitboard/machine/ecto_sniffer
 	name = "Ectoscopic Sniffer"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/ecto_sniffer
 	req_components = list(
-		/obj/item/stock_parts/scanning_module = 1)
+		/datum/stock_part/scanning_module = 1)
 
 /obj/item/circuitboard/machine/anomaly_refinery
 	name = "Anomaly Refinery"
@@ -1358,7 +1358,7 @@
 	build_path = /obj/machinery/research/anomaly_refinery
 	req_components = list(
 		/obj/item/stack/sheet/plasteel = 15,
-		/obj/item/stock_parts/scanning_module = 1,
+		/datum/stock_part/scanning_module = 1,
 		/obj/item/stock_parts/manipulator = 1,
 		)
 
@@ -1368,7 +1368,7 @@
 	build_path = /obj/machinery/atmospherics/components/binary/tank_compressor
 	req_components = list(
 		/obj/item/stack/sheet/plasteel = 5,
-		/obj/item/stock_parts/scanning_module = 4,
+		/datum/stock_part/scanning_module = 4,
 		)
 
 /obj/item/circuitboard/machine/coffeemaker

--- a/code/modules/cargo/markets/market_telepad.dm
+++ b/code/modules/cargo/markets/market_telepad.dm
@@ -6,7 +6,7 @@
 		/obj/item/stack/ore/bluespace_crystal = 2,
 		/obj/item/stock_parts/subspace/ansible = 1,
 		/obj/item/stock_parts/micro_laser = 1,
-		/obj/item/stock_parts/scanning_module = 2)
+		/datum/stock_part/scanning_module = 2)
 	def_components = list(/obj/item/stack/ore/bluespace_crystal = /obj/item/stack/ore/bluespace_crystal/artificial)
 
 /obj/machinery/ltsrbt
@@ -51,8 +51,8 @@
 	. = ..()
 	recharge_time = base_recharge_time
 	// On tier 4 recharge_time should be 20 and by default it is 80 as scanning modules should be tier 1.
-	for(var/obj/item/stock_parts/scanning_module/scan in component_parts)
-		recharge_time -= scan.rating * 10
+	for(var/datum/stock_part/scanning_module/scanning_module in component_parts)
+		recharge_time -= scanning_module.tier * 10
 	recharge_cooldown = recharge_time
 
 	power_efficiency = 0

--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -100,8 +100,8 @@
 	for(var/obj/item/stock_parts/micro_laser/Laser in component_parts)
 		L += ((Laser.rating - 1) * PART_CASH_OFFSET_AMOUNT)
 	negative_cash_offset = L
-	for(var/obj/item/stock_parts/scanning_module/Scan in component_parts)
-		S += ((Scan.rating - 1) * 0.25)
+	for(var/datum/stock_part/scanning_module/scanning_module in component_parts)
+		S += ((scanning_module.tier - 1) * 0.25)
 	inaccuracy_percentage = (1.5 - S)
 
 /obj/machinery/rnd/bepis/update_icon_state()

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -112,8 +112,8 @@
 	resetTime = initial(resetTime)
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		resetTime = max(1, resetTime - M.rating)
-	for(var/obj/item/stock_parts/scanning_module/M in component_parts)
-		malfunction_probability_coeff += M.rating*2
+	for(var/datum/stock_part/scanning_module/scanning_module in component_parts)
+		malfunction_probability_coeff += scanning_module.tier * 2
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
 		malfunction_probability_coeff += M.rating
 

--- a/code/modules/research/stock_parts/stock_part_datum.dm
+++ b/code/modules/research/stock_parts/stock_part_datum.dm
@@ -1,0 +1,80 @@
+/// Represents the concept of a stock part.
+/// One is created for every stock part type for every level.
+/// Machines have these inside their component_parts.
+/// For example, scanning modules use /datum/stock_part/scanning_module.
+/// In machines, you can perform a loop through something like
+/// `for (var/datum/stock_part/scanning_module/part in component_parts)`
+/datum/stock_part
+	/// Better parts have higher tiers
+	var/tier
+
+	/// What object does this stock part refer to?
+	var/obj/item/physical_object_type
+
+	/// A single instance of the physical object type.
+	/// Used for icons, should never be moved out.
+	var/obj/item/physical_object_reference
+
+/datum/stock_part/New()
+	physical_object_reference = new physical_object_type
+
+/datum/stock_part/Destroy()
+	SHOULD_CALL_PARENT(FALSE)
+
+	// MBTODO: I know /obj/machinery/Destroy() requests this
+	// This should CRASH
+	return QDEL_HINT_LETMELIVE
+
+/// Returns the name of the physical object
+/datum/stock_part/proc/name()
+	return initial(physical_object_type.name)
+
+/// Map of physical stock part types to their /datum/stock_part
+GLOBAL_LIST_EMPTY_TYPED(stock_part_datums_per_object, /datum/stock_part)
+
+/// Map of stock part type to their singleton
+GLOBAL_LIST_INIT(stock_part_datums, generate_stock_part_datums())
+
+/proc/generate_stock_part_datums()
+	var/list/stock_part_datums = list()
+
+	for (var/datum/stock_part/stock_part_type as anything in subtypesof(/datum/stock_part))
+		var/singleton = new stock_part_type
+		stock_part_datums[stock_part_type] = singleton
+
+		// Relying on GLOB ordering here somewhat.
+		// If this changes, it'll error in CI.
+		GLOB.stock_part_datums_per_object[initial(stock_part_type.physical_object_type)] = singleton
+
+	return stock_part_datums
+
+/// Returns the energy rating of the stock part given a level.
+/// The higher this is, the more power machines with these parts will consume.
+/datum/stock_part/proc/energy_rating()
+	switch (tier)
+		if (1)
+			return 1
+		if (2)
+			return 3
+		if (3)
+			return 5
+		if (4)
+			return 10
+		else
+			CRASH("Invalid level given to energy_rating: [tier]")
+
+/datum/stock_part/scanning_module
+	tier = 1
+	physical_object_type = /obj/item/stock_parts/scanning_module
+
+/datum/stock_part/scanning_module/tier2
+	tier = 2
+	physical_object_type = /obj/item/stock_parts/scanning_module/adv
+
+/datum/stock_part/scanning_module/tier3
+	tier = 3
+	physical_object_type = /obj/item/stock_parts/scanning_module/phasic
+
+/datum/stock_part/scanning_module/tier4
+	tier = 4
+	physical_object_type = /obj/item/stock_parts/scanning_module/triphasic

--- a/code/modules/research/stock_parts/stock_part_datum.dm
+++ b/code/modules/research/stock_parts/stock_part_datum.dm
@@ -11,6 +11,12 @@
 	/// What object does this stock part refer to?
 	var/obj/item/physical_object_type
 
+	/// What's the base path that this stock part refers to?
+	/// For example, a tier 2 capacitor will have a physical_object_type
+	/// of /obj/item/capacitor/tier2, but a physical_object_base_type of
+	/// /obj/item/capacitor
+	var/obj/item/physical_object_base_type
+
 	/// A single instance of the physical object type.
 	/// Used for icons, should never be moved out.
 	var/obj/item/physical_object_reference
@@ -20,9 +26,7 @@
 
 /datum/stock_part/Destroy()
 	SHOULD_CALL_PARENT(FALSE)
-
-	// MBTODO: I know /obj/machinery/Destroy() requests this
-	// This should CRASH
+	stack_trace("[type] is trying to Destroy. It is a singleton, this should not be happening")
 	return QDEL_HINT_LETMELIVE
 
 /// Returns the name of the physical object
@@ -66,6 +70,7 @@ GLOBAL_LIST_INIT(stock_part_datums, generate_stock_part_datums())
 /datum/stock_part/scanning_module
 	tier = 1
 	physical_object_type = /obj/item/stock_parts/scanning_module
+	physical_object_base_type = /obj/item/stock_parts/scanning_module
 
 /datum/stock_part/scanning_module/tier2
 	tier = 2

--- a/code/modules/research/xenobiology/vatgrowing/microscope.dm
+++ b/code/modules/research/xenobiology/vatgrowing/microscope.dm
@@ -88,7 +88,7 @@
 	reqs = list(
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/stack/sheet/plastic = 1,
-		/obj/item/stock_parts/scanning_module = 1,
+		/datum/stock_part/scanning_module = 1,
 		/obj/item/flashlight = 1,
 	)
 	category = CAT_CHEMISTRY

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4377,6 +4377,7 @@
 #include "code\modules\research\ordnance\doppler_array.dm"
 #include "code\modules\research\ordnance\scipaper_partner.dm"
 #include "code\modules\research\ordnance\tank_compressor.dm"
+#include "code\modules\research\stock_parts\stock_part_datum.dm"
 #include "code\modules\research\techweb\__techweb_helpers.dm"
 #include "code\modules\research\techweb\_techweb.dm"
 #include "code\modules\research\techweb\_techweb_node.dm"


### PR DESCRIPTION
Currently, every stock part is created inside every machine on initialize. This is costing us about 300ms. This was likely done because a lot of similar code that I've been ripping out recently has been related to the singularity being a common source of destruction, so everything created its contents to be able to move later to reduce lag.

Unfortunately, machines are a lot more complicated than paper bins or decks of cards. They need to be able to exchange parts, but also the following pattern is very common:

```dm
// component_parts is sometimes, incorrectly, contents
for (var/obj/item/stock_parts/capacitor/C in component_parts)
```

That means the parts have to exist *somewhere*. I played with creating a single one and passing it immutably around component_parts, but it was a nightmare.

---

Instead, this PR creates `/datum/stock_part`, a singleton instance that maps to a specific part and tier. Machines specify their requirements using these stock part datums, which are not initialized, but should function exactly like normal stock parts.

Interface looks like this:

```dm
/datum/stock_part/scanning_module
	tier = 1
	physical_object_type = /obj/item/stock_parts/scanning_module
	physical_object_base_type = /obj/item/stock_parts/scanning_module

/datum/stock_part/scanning_module/tier2
	tier = 2
	physical_object_type = /obj/item/stock_parts/scanning_module/adv

/datum/stock_part/scanning_module/tier3
	tier = 3
	physical_object_type = /obj/item/stock_parts/scanning_module/phasic

/datum/stock_part/scanning_module/tier4
	tier = 4
	physical_object_type = /obj/item/stock_parts/scanning_module/triphasic
```

And to use:

```patch
- for (var/obj/item/stock_parts/capacitor/C in component_parts)
+ for (var/datum/stock_part/capacitor/C in component_parts)
```

```patch
req_components = list(
    /obj/item/stack/glass = 2,
-    /obj/item/stock_parts/capacitor = 1,
+    /datum/stock_part/capacitor = 1,
)
```

This PR currently only updates scanning modules. There are a very small handful of machines that actually use these, which makes them a good starting point for focusing on the system itself. After this PR is confirmed to be working and merged, I'll make PRs for every other core type.

Also, unlike paper bins, we do not hold onto the part that was put into the machine, it is completely deleted. This means that if the stock part has any unique qualities for whatever reason, they won't be preserved. Only thing I can think of is RPG stats but the code is very much made more complex with that support.

---

To maintainers: Hide whitespace mode recommended

![image](https://user-images.githubusercontent.com/35135081/205468403-288674ad-0363-4756-a691-65a6f08d17f4.png)

:cl:
fix: Fixed gulag teleporters not containing the correct parts.
/:cl: