### PR TITLE
Janitor can use wagon key to stab people

### DIFF
--- a/code/modules/vehicles/vehicle_key.dm
+++ b/code/modules/vehicles/vehicle_key.dm
@@ -26,6 +26,16 @@
 /obj/item/key/janitor
 	desc = "A keyring with a small steel key, and a pink fob reading \"Pussy Wagon\"."
 	icon_state = "keyjanitor"
+	force = 2
+	w_class = WEIGHT_CLASS_SMALL
+	throwforce = 9
+	hitsound = SFX_SWING_HIT
+	attack_verb_continuous = list("stubs", "pokes")
+	attack_verb_simple = list("stub", "poke")
+	sharpness = SHARP_EDGED
+	embedding = list("pain_mult" = 1, "embed_chance" = 30, "fall_chance" = 70)
+	wound_bonus = -1
+	bare_wound_bonus = 2
 
 /obj/item/key/janitor/suicide_act(mob/living/carbon/user)
 	switch(user.mind?.get_skill_level(/datum/skill/cleaning))


### PR DESCRIPTION

## About The Pull Request
The key can now be used to attack people by stabbing or throwing. I always thought it was weird how most other roles have starter weapons. Well the key's not a good weapon it's very weak but hey at least it's something.


## Why It's Good For The Game
Little details and fluff is always nice, being able to stab people with keys is pretty realistic, it's even used in self defense booklets! In general it is a real thing and weird that we couldn't do it in the first place. Being able to key people adds more realistic interaction that is not overpowered.


## Changelog



:cl:
add:  Key can now hurt people by stabbing or throwing.
code: changed the keys code to make it able to hurt ppl
/:cl:
