### PR TITLE
Adds card reader to autolathe

### DIFF
--- a/code/modules/research/designs/stock_parts_designs.dm
+++ b/code/modules/research/designs/stock_parts_designs.dm
@@ -379,7 +379,7 @@
 	name = "Card Reader"
 	desc = "A small magnetic card reader, used for devices that take and transmit holocredits."
 	id = "c-reader"
-	build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
 	materials = list(/datum/material/iron=50, /datum/material/glass=10)
 	build_path = /obj/item/stock_parts/card_reader
 	category = list(


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
It got removed from general protolathe designs, and it's a very basic roundstart part for useful machines (service and bounty stuff), I think having it be in autolathe is good as an alternative.
## Changelog
:cl:
qol: card readers can be printed from autolathes
/:cl:
