### PR TITLE
Canisters are purchasable at cargo again

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -142,14 +142,16 @@ SUBSYSTEM_DEF(shuttle)
 	while(length(pack_processing))
 		var/datum/supply_pack/pack = pack_processing[length(pack_processing)]
 		pack_processing.len--
-		if(!initial(pack.contains))
-			continue
 		if(ispath(pack, /datum/supply_pack))
 			pack = new pack
 
 		var/list/generated_packs = pack.generate_supply_packs()
 		if(generated_packs)
 			pack_processing += generated_packs
+			continue
+
+		//we have to create the pack before checking if it has 'contains' because generate_supply_packs manually sets it, therefore we cant check initial.
+		if(!pack.contains)
 			continue
 
 		supply_packs[pack.id] = pack


### PR DESCRIPTION
## About The Pull Request

Checking the initial pack's contains did not work for canisters because they were manually given a contains by ``generate_supply_packs()``, so they were skipped over when creating supply packs.

## Why It's Good For The Game

Canisters can now be ordered again.

Closes https://github.com/tgstation/tgstation/issues/71679

## Changelog

:cl:
fix: You can now order canisters again.
/:cl:
