### PR TITLE
Replace moveToNullspace in decal Destroy() to loc = null -- Saves 0.11s of init time

### DIFF
--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -61,5 +61,8 @@
 		var/turf/T = loc
 		T.RemoveElement(/datum/element/decal, icon, icon_state, dir, null, null, alpha, color, null, FALSE, null)
 #endif
-	moveToNullspace()
+	// Intentionally used over moveToNullspace(), which calls doMove(), which fires
+	// off an enormous amount of procs, signals, etc, that this temporary effect object
+	// never needs or affects.
+	loc = null
 	return QDEL_HINT_QUEUE


### PR DESCRIPTION
This calls Exited(), Entered(), etc etc etc etc, and it is not necessary for this. Was 119ms, now 9.