### PR TITLE
IV drip injects only to injectable things

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -150,8 +150,8 @@
 	if(!get_reagents())
 		to_chat(usr, span_warning("There's nothing attached to the IV drip!"))
 		return
-	if(!target.reagents)
-		to_chat(usr, span_warning("Target can't hold reagents!"))
+	if(!target.is_injectable(usr))
+		to_chat(usr, span_warning("Can't inject into this!"))
 		return
 	if(attached)
 		visible_message(span_warning("[attached] is detached from [src]."))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -57,7 +57,7 @@
 /obj/machinery/hydroponics/Initialize(mapload)
 	//ALRIGHT YOU DEGENERATES. YOU HAD REAGENT HOLDERS FOR AT LEAST 4 YEARS AND NONE OF YOU MADE HYDROPONICS TRAYS HOLD NUTRIENT CHEMS INSTEAD OF USING "Points".
 	//SO HERE LIES THE "nutrilevel" VAR. IT'S DEAD AND I PUT IT OUT OF IT'S MISERY. USE "reagents" INSTEAD. ~ArcaneMusic, accept no substitutes.
-	create_reagents(maxnutri)
+	create_reagents(maxnutri, INJECTABLE)
 	reagents.add_reagent(/datum/reagent/plantnutriment/eznutriment, 10) //Half filled nutrient trays for dirt trays to have more to grow with in prison/lavaland.
 	. = ..()
 

--- a/code/modules/reagents/chemistry/machinery/chem_separator.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_separator.dm
@@ -31,7 +31,7 @@
 
 /obj/structure/chem_separator/Initialize(mapload)
 	. = ..()
-	create_reagents(300, TRANSPARENT)
+	create_reagents(300, TRANSPARENT | INJECTABLE)
 	condenser = new()
 	soundloop = new(src, boiling)
 

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -36,7 +36,7 @@
 
 /obj/machinery/smoke_machine/Initialize(mapload)
 	. = ..()
-	create_reagents(REAGENTS_BASE_VOLUME)
+	create_reagents(REAGENTS_BASE_VOLUME, INJECTABLE)
 	AddComponent(/datum/component/plumbing/simple_demand)
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		reagents.maximum_volume += REAGENTS_BASE_VOLUME * B.rating
@@ -57,7 +57,7 @@
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		new_volume += REAGENTS_BASE_VOLUME * B.rating
 	if(!reagents)
-		create_reagents(new_volume)
+		create_reagents(new_volume, INJECTABLE)
 	reagents.maximum_volume = new_volume
 	if(new_volume < reagents.total_volume)
 		reagents.expose(loc, TOUCH) // if someone manages to downgrade it without deconstructing


### PR DESCRIPTION
## About The Pull Request

Previous PR https://github.com/tgstation/tgstation/pull/71217 made IV drip work with any containers which, after a while led to some undesired cases.

People could add reagents to medipens, making them free hypospray. Refilling extinguishers with things other than water. And just sabotaging pills, patches, etc.

Now IV drips inject only into injectable containers.

I added INJECTABLE flag to a few other things that were not originally injectable - hydroponic trays, smoke machine, chem separator. May later whitelist some other items that may be injectable by logic, but don't lead to undesired accidents.

![image](https://user-images.githubusercontent.com/3625094/205488795-c2482b44-6296-4514-81de-36a69b0dffad.png)

## Why It's Good For The Game

Free sleepy pens are not OK. 

## Changelog

:cl:
fix: IV drip now injects only into injectable things
/:cl:

