### PR TITLE
Oldstation suits to suit storage units

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -3581,7 +3581,6 @@
 /area/ruin/space/ancientstation/beta/supermatter)
 "lJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/space/nasavoid/old,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -3589,8 +3588,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/structure/closet,
-/obj/item/clothing/head/helmet/space/nasavoid/old,
+/obj/machinery/suit_storage_unit/void_old,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/engie)
 "lK" = (
@@ -3923,10 +3921,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/ancientstation/beta/mining)
 "mL" = (
-/obj/structure/closet,
-/obj/item/tank/jetpack/void,
-/obj/item/clothing/head/helmet/space/nasavoid/old,
-/obj/item/clothing/suit/space/nasavoid,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -3935,6 +3929,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/suit_storage_unit/void_old/jetpack,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/beta/mining)
 "mM" = (

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -126,6 +126,14 @@
 	storage_type = /obj/item/tank/jetpack/oxygen/harness
 	mod_type = /obj/item/mod/control/pre_equipped/nuclear
 
+/obj/machinery/suit_storage_unit/void_old
+	suit_type = /obj/item/clothing/suit/space/nasavoid/old
+	helmet_type = /obj/item/clothing/head/helmet/space/nasavoid/old
+	storage_type = /obj/item/tank/internals/oxygen/yellow
+
+/obj/machinery/suit_storage_unit/void_old/jetpack
+	storage_type = /obj/item/tank/jetpack/void
+
 /obj/machinery/suit_storage_unit/radsuit
 	name = "radiation suit storage unit"
 	suit_type = /obj/item/clothing/suit/utility/radiation


### PR DESCRIPTION
## About The Pull Request

Replaced a couple of lockers with void suits on oldstation with suit storage units with the same contents.

![image](https://user-images.githubusercontent.com/3625094/205521193-cacaec0b-4cf9-419b-a97f-e3f0c2249571.png)
![image](https://user-images.githubusercontent.com/3625094/205521220-1d347327-479e-4ec2-86b7-0a557046a869.png)


## Why It's Good For The Game

Space suits should be handled with care.

## Changelog

:cl:
qol: Charlie station stores space suits in proper storage
/:cl:

