### PR TITLE
Mining LTSRBT oversight fix

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -121,8 +121,8 @@ GLOBAL_LIST_EMPTY(order_console_products)
 			if(!purchase_items(used_id_card))
 				return
 			//So miners cant spam buy crates for a very low price
-			if(get_total_cost() < 200)
-				say("For the LTSRBT delivery order needs to cost more then 200 points!")
+			if(get_total_cost() < CARGO_CRATE_VALUE)
+				say("For the LTSRBT delivery order needs to cost more or equal to [CARGO_CRATE_VALUE] points!")
 				return
 			order_groceries(living_user, used_id_card, grocery_list, ltsrbt_delivered = (action == "ltsrbt_deliver"))
 			grocery_list.Cut()

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -122,7 +122,7 @@ GLOBAL_LIST_EMPTY(order_console_products)
 				return
 			//So miners cant spam buy crates for a very low price
 			if(get_total_cost() < CARGO_CRATE_VALUE)
-				say("For the LTSRBT delivery order needs to cost more or equal to [CARGO_CRATE_VALUE] points!")
+				say("For the delivery order needs to cost more or equal to [CARGO_CRATE_VALUE] points!")
 				return
 			order_groceries(living_user, used_id_card, grocery_list, ltsrbt_delivered = (action == "ltsrbt_deliver"))
 			grocery_list.Cut()

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -120,6 +120,10 @@ GLOBAL_LIST_EMPTY(order_console_products)
 				return
 			if(!purchase_items(used_id_card))
 				return
+			//So miners cant spam buy crates for a very low price
+			if(get_total_cost() < 200)
+				say("For the LTSRBT delivery order needs to cost more then 200 points!")
+				return
 			order_groceries(living_user, used_id_card, grocery_list, ltsrbt_delivered = (action == "ltsrbt_deliver"))
 			grocery_list.Cut()
 			COOLDOWN_START(src, order_cooldown, cooldown_time)

--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -2,8 +2,8 @@
 	category_index = CATEGORY_MINING
 
 /datum/orderable_item/mining/marker_beacon
-	item_path = /obj/item/stack/marker_beacon
-	cost_per_order = 10
+	item_path = /obj/item/stack/marker_beacon/ten
+	cost_per_order = 100
 
 /datum/orderable_item/mining/skeleton_key
 	item_path = /obj/item/skeleton_key


### PR DESCRIPTION
## About The Pull Request

With the mining ltsrbt miners can invest very low amount of points to get a free crate which they could then sell to cargo for the value the crate has, with some automating they could get a lot of credits. This PR prevents it by making sure the order for the mining ltsrbt delivery has more or equal to crate value. Also increases the amount of marker beacon miners can buy in a row from 1 to 10 to make things easier.

## Why It's Good For The Game

Oversight fix

## Changelog

:cl:
fix: fixes a oversight with mining ltsrbt which would allow them to spam buy crates for very low mining points
qol: Increases the amount of marker beacons you can buy in a row from 1 to 10
/:cl:
