### PR TITLE
Moves loot var to the abandoned crate itself, qdel_on_open now actually qdels on open instead of unlock

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -130,7 +130,7 @@
 		qdel(src)
 
 /obj/structure/closet/crate/secure/loot/proc/spawn_loot()
-	loot = rand(1,100) //100 different crates with varying chances of spawning
+	var/loot = rand(1,100) //100 different crates with varying chances of spawning
 	switch(loot)
 		if(1 to 5) //5% chance
 			new /obj/item/reagent_containers/cup/glass/bottle/rum(src)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -9,8 +9,9 @@
 	var/lastattempt = null
 	var/attempts = 10
 	var/codelen = 4
-	var/qdel_on_open = FALSE
+	var/qdel_on_unlock = FALSE
 	var/spawned_loot = FALSE
+	var/loot
 	tamperproof = 90
 
 	// Stop people from "diving into" the crate accidentally, and then detonating it.
@@ -24,6 +25,7 @@
 		var/dig = pick(digits)
 		code += dig
 		digits -= dig  //there are never matching digits in the answer
+	loot = rand(1,100) //100 different crates with varying chances of spawning
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/closet/crate/secure/loot/attack_hand(mob/user, list/modifiers)
@@ -45,9 +47,6 @@
 			if(input == code)
 				if(!spawned_loot)
 					spawn_loot()
-				if(qdel_on_open)
-					qdel(src)
-					return
 				tamperproof = 0 // set explosion chance to zero, so we dont accidently hit it with a multitool and instantly die
 				togglelock(user)
 			else if(!input || !sanitycheck || length(sanitised) != codelen)
@@ -119,6 +118,8 @@
 		return
 	if(tamperproof)
 		return
+	if(qdel_on_unlock)
+		qdel(src)
 	return ..()
 
 /obj/structure/closet/crate/secure/loot/deconstruct(disassembled = TRUE)
@@ -128,7 +129,6 @@
 	return ..()
 
 /obj/structure/closet/crate/secure/loot/proc/spawn_loot()
-	var/loot = rand(1,100) //100 different crates with varying chances of spawning
 	switch(loot)
 		if(1 to 5) //5% chance
 			new /obj/item/reagent_containers/cup/glass/bottle/rum(src)
@@ -219,7 +219,7 @@
 			new /obj/item/dnainjector/xraymut(src)
 		if(94)
 			new /mob/living/simple_animal/hostile/mimic/crate(src)
-			qdel_on_open = TRUE
+			qdel_on_unlock = TRUE
 		if(95)
 			new /obj/item/toy/plush/nukeplushie(src)
 		if(96)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -9,7 +9,7 @@
 	var/lastattempt = null
 	var/attempts = 10
 	var/codelen = 4
-	var/qdel_on_unlock = FALSE
+	var/qdel_on_open = FALSE
 	var/spawned_loot = FALSE
 	var/loot
 	tamperproof = 90
@@ -118,10 +118,6 @@
 		return
 	if(tamperproof)
 		return
-	if(qdel_on_unlock)
-		open(user, TRUE)
-		qdel(src)
-		return
 	return ..()
 
 /obj/structure/closet/crate/secure/loot/deconstruct(disassembled = TRUE)
@@ -129,6 +125,13 @@
 		boom()
 		return
 	return ..()
+
+/obj/structure/closet/crate/secure/loot/open(mob/living/user, force = FALSE)
+	. = ..()
+	if(qdel_on_open)
+		open(user, TRUE)
+		qdel(src)
+		return
 
 /obj/structure/closet/crate/secure/loot/proc/spawn_loot()
 	switch(loot)
@@ -221,7 +224,7 @@
 			new /obj/item/dnainjector/xraymut(src)
 		if(94)
 			new /mob/living/simple_animal/hostile/mimic/crate(src)
-			qdel_on_unlock = TRUE
+			qdel_on_open = TRUE
 		if(95)
 			new /obj/item/toy/plush/nukeplushie(src)
 		if(96)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -119,7 +119,9 @@
 	if(tamperproof)
 		return
 	if(qdel_on_unlock)
+		open(user, TRUE)
 		qdel(src)
+		return
 	return ..()
 
 /obj/structure/closet/crate/secure/loot/deconstruct(disassembled = TRUE)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -129,9 +129,7 @@
 /obj/structure/closet/crate/secure/loot/open(mob/living/user, force = FALSE)
 	. = ..()
 	if(qdel_on_open)
-		open(user, TRUE)
 		qdel(src)
-		return
 
 /obj/structure/closet/crate/secure/loot/proc/spawn_loot()
 	switch(loot)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -11,7 +11,6 @@
 	var/codelen = 4
 	var/qdel_on_open = FALSE
 	var/spawned_loot = FALSE
-	var/loot
 	tamperproof = 90
 
 	// Stop people from "diving into" the crate accidentally, and then detonating it.
@@ -25,7 +24,6 @@
 		var/dig = pick(digits)
 		code += dig
 		digits -= dig  //there are never matching digits in the answer
-	loot = rand(1,100) //100 different crates with varying chances of spawning
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/closet/crate/secure/loot/attack_hand(mob/user, list/modifiers)
@@ -132,6 +130,7 @@
 		qdel(src)
 
 /obj/structure/closet/crate/secure/loot/proc/spawn_loot()
+	loot = rand(1,100) //100 different crates with varying chances of spawning
 	switch(loot)
 		if(1 to 5) //5% chance
 			new /obj/item/reagent_containers/cup/glass/bottle/rum(src)


### PR DESCRIPTION
## About The Pull Request

This stupid var is should have been called "qdel_on_unlock". Now it actually triggers on open, and qdels AFTER all of the contents in the crate are gone. This prevents it from deleting its contents before it can dump them, which I'm assuming it has been doing since the dawn of time.

## Why It's Good For The Game

Closes #71718

Makes it so admins can set the loot for abandoned crates or peek into their contents, for whatever reason they may have. Also allows coders to choose which loot to recieve in the event that a bug like this needs debugging (again).
## Changelog
:cl: Rhials
fix: Earning the Mimic loot drop from an abandoned crate now properly spawns the mimic.
/:cl:
