### PR TITLE
fixes a regression on mining point cards' reusability

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -157,8 +157,8 @@
 
 /**********************Mining Point Card**********************/
 
-#define TO_USER_ID "To ID"
-#define TO_POINT_CARD "To Card"
+#define TO_USER_ID "Transfer Card → ID"
+#define TO_POINT_CARD "ID → Transfer Card"
 
 /obj/item/card/mining_point_card
 	name = "mining point transfer card"
@@ -175,9 +175,6 @@
 /obj/item/card/mining_point_card/attackby(obj/item/attacking_item, mob/user, params)
 	if(!isidcard(attacking_item))
 		return ..()
-	if(!points)
-		to_chat(user, span_alert("There's no points left on [src]."))
-		return
 	var/obj/item/card/id/attacking_id = attacking_item
 	balloon_alert(user, "starting transfer")
 	var/point_movement = tgui_alert(user, "To ID (from card) or to card (from ID)?", "Mining Points Transfer", list(TO_USER_ID, TO_POINT_CARD))


### PR DESCRIPTION
## About The Pull Request
Fixes a regression where mining point transfer cards that ran out of points stopped working despite being made to be reusable.
...Also makes the labels on the button slightly less painful to read, I think.
## Why It's Good For The Game
there's a reason they're labeled "reusable" in the description
![image](https://user-images.githubusercontent.com/31829017/205533182-f2f52914-d11c-4d2a-ab9c-402b44fe4fbe.png)

## Changelog
:cl:
fix: Mining point cards have slightly more readable buttons now, and also can be reused even after running out of points.
/:cl: