### PR TITLE
Roundend report has a meter for showing relative escape numbers

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -334,27 +334,27 @@
 	var/total_players = GLOB.joined_player_list.len
 	if(total_players)
 		/// the proportions used for the rendered list
-		var/barSections = list()
+		var/bar_sections = list()
 		parts+= "[FOURSPACES]Total Population: <B>[total_players]</B>"
 		if(station_evacuated)
 			parts += "<BR>[FOURSPACES]Evacuation Rate: <B>[popcount[POPCOUNT_ESCAPEES]] ([PERCENT(popcount[POPCOUNT_ESCAPEES]/total_players)]%)</B>"
 			parts += "[FOURSPACES](on emergency shuttle): <B>[popcount[POPCOUNT_SHUTTLE_ESCAPEES]] ([PERCENT(popcount[POPCOUNT_SHUTTLE_ESCAPEES]/total_players)]%)</B>"
 
-			barSections += list(
+			bar_sections += list(
 				popcount[POPCOUNT_ESCAPEES],
 				popcount[POPCOUNT_ESCAPEES] - popcount[POPCOUNT_SHUTTLE_ESCAPEES],  // non shuttle escapees
 			)
 
 		else
-			barSections += list(0, 0) // 0 escapees, those fields are empty
+			bar_sections += list(0, 0) // 0 escapees, those fields are empty
 
 		parts += "[FOURSPACES]Survival Rate: <B>[popcount[POPCOUNT_SURVIVORS]] ([PERCENT(popcount[POPCOUNT_SURVIVORS]/total_players)]%)</B>"
-		barSections += (popcount[POPCOUNT_SURVIVORS] - popcount[POPCOUNT_ESCAPEES])  // stranded
-		barSections += (total_players - popcount[POPCOUNT_SURVIVORS])  // dead
+		bar_sections += (popcount[POPCOUNT_SURVIVORS] - popcount[POPCOUNT_ESCAPEES]) // stranded
+		bar_sections += (total_players - popcount[POPCOUNT_SURVIVORS]) // dead
 
-		var/list/renderedBar = generate_aggregate_bar(ROUNDEND_BAR_SIZE, barSections, totalSize = total_players)
+		var/list/rendered_bar = generate_aggregate_bar(ROUNDEND_BAR_SIZE, bar_sections)
 
-		parts += "<B>( [join_color_list(renderedBar, ROUNDEND_BAR_COLOR)] )</B>"
+		parts += "<B>( [join_color_list(rendered_bar, ROUNDEND_BAR_COLOR)] )</B>"
 		parts += "<B>\
 			<span class=[ROUNDEND_BAR_COLOR[1]]>Shuttle</span>:\
 			<span class=[ROUNDEND_BAR_COLOR[2]]>No-Shuttle Escape</span>:\

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -340,9 +340,10 @@
 			parts += "<BR>[FOURSPACES]Evacuation Rate: <B>[popcount[POPCOUNT_ESCAPEES]] ([PERCENT(popcount[POPCOUNT_ESCAPEES]/total_players)]%)</B>"
 			parts += "[FOURSPACES](on emergency shuttle): <B>[popcount[POPCOUNT_SHUTTLE_ESCAPEES]] ([PERCENT(popcount[POPCOUNT_SHUTTLE_ESCAPEES]/total_players)]%)</B>"
 
-			barSections += list( \
-			popcount[POPCOUNT_ESCAPEES], \
-			popcount[POPCOUNT_ESCAPEES] - popcount[POPCOUNT_SHUTTLE_ESCAPEES])  // non shuttle escapees
+			barSections += list(
+				popcount[POPCOUNT_ESCAPEES],
+				popcount[POPCOUNT_ESCAPEES] - popcount[POPCOUNT_SHUTTLE_ESCAPEES],  // non shuttle escapees
+			)
 
 		else
 			barSections += list(0, 0) // 0 escapees, those fields are empty

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -5,7 +5,7 @@
 #define SERVER_LAST_ROUND "server last round"
 
 #define ROUNDEND_BAR_SIZE 20
-#define ROUNDEND_BAR_COLOR list("greentext", "medradio", "engradio", "redtext")  // using actual spans? heresey
+#define ROUNDEND_BAR_COLOR list("greentext", "info", "marooned", "redtext")  // using actual spans? heresey
 
 /datum/controller/subsystem/ticker/proc/gather_roundend_feedback()
 	gather_antag_data()
@@ -344,11 +344,23 @@
 			popcount[POPCOUNT_ESCAPEES], \
 			popcount[POPCOUNT_ESCAPEES] - popcount[POPCOUNT_SHUTTLE_ESCAPEES])  // non shuttle escapees
 
-		parts += "[FOURSPACES]Survival Rate: <B>[popcount[POPCOUNT_SURVIVORS]] ([PERCENT(popcount[POPCOUNT_SURVIVORS]/total_players)]%)</B>"
-		barSections += popcount[POPCOUNT_SURVIVORS] - popcount[POPCOUNT_ESCAPEES]  // stranded
+		else
+			barSections += list(0, 0) // 0 escapees, those fields are empty
 
-		var/list/renderedBar = generate_aggregate_bar(ROUNDEND_BAR_SIZE, barSections, total_size = total_players)
-		parts += "<B>[join_color_list(renderedBar, ROUNDEND_BAR_COLOR)]</B>"
+		parts += "[FOURSPACES]Survival Rate: <B>[popcount[POPCOUNT_SURVIVORS]] ([PERCENT(popcount[POPCOUNT_SURVIVORS]/total_players)]%)</B>"
+		barSections += (popcount[POPCOUNT_SURVIVORS] - popcount[POPCOUNT_ESCAPEES])  // stranded
+		barSections += (total_players - popcount[POPCOUNT_SURVIVORS])  // dead
+
+		to_chat(world, json_encode(barSections))
+		var/list/renderedBar = generate_aggregate_bar(ROUNDEND_BAR_SIZE, barSections, totalSize = total_players)
+		to_chat(world, json_encode(renderedBar))
+
+		parts += "<B>( [join_color_list(renderedBar, ROUNDEND_BAR_COLOR)] )</B>"
+		parts += "<B>\
+		<span class=[ROUNDEND_BAR_COLOR[1]]>Shuttle</span>:\
+		<span class=[ROUNDEND_BAR_COLOR[2]]>No-Shuttle Escape</span>:\
+		<span class=[ROUNDEND_BAR_COLOR[3]]>Stranded</span>:\
+		<span class=[ROUNDEND_BAR_COLOR[4]]>Dead</span></B>"
 
 		if(SSblackbox.first_death)
 			var/list/ded = SSblackbox.first_death

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -4,6 +4,9 @@
 #define PERSONAL_LAST_ROUND "personal last round"
 #define SERVER_LAST_ROUND "server last round"
 
+#define ROUNDEND_BAR_SIZE 20
+#define ROUNDEND_BAR_COLOR list("greentext", "medradio", "engradio", "redtext")  // using actual spans? heresey
+
 /datum/controller/subsystem/ticker/proc/gather_roundend_feedback()
 	gather_antag_data()
 	record_nuke_disk_location()
@@ -330,11 +333,23 @@
 	parts += "[FOURSPACES]Station Integrity: <B>[GLOB.station_was_nuked ? span_redtext("Destroyed") : "[popcount["station_integrity"]]%"]</B>"
 	var/total_players = GLOB.joined_player_list.len
 	if(total_players)
+		/// the proportions used for the rendered list
+		var/barSections = list()
 		parts+= "[FOURSPACES]Total Population: <B>[total_players]</B>"
 		if(station_evacuated)
 			parts += "<BR>[FOURSPACES]Evacuation Rate: <B>[popcount[POPCOUNT_ESCAPEES]] ([PERCENT(popcount[POPCOUNT_ESCAPEES]/total_players)]%)</B>"
 			parts += "[FOURSPACES](on emergency shuttle): <B>[popcount[POPCOUNT_SHUTTLE_ESCAPEES]] ([PERCENT(popcount[POPCOUNT_SHUTTLE_ESCAPEES]/total_players)]%)</B>"
+
+			barSections += list( \
+			popcount[POPCOUNT_ESCAPEES], \
+			popcount[POPCOUNT_ESCAPEES] - popcount[POPCOUNT_SHUTTLE_ESCAPEES])  // non shuttle escapees
+
 		parts += "[FOURSPACES]Survival Rate: <B>[popcount[POPCOUNT_SURVIVORS]] ([PERCENT(popcount[POPCOUNT_SURVIVORS]/total_players)]%)</B>"
+		barSections += popcount[POPCOUNT_SURVIVORS] - popcount[POPCOUNT_ESCAPEES]  // stranded
+
+		var/list/renderedBar = generate_aggregate_bar(ROUNDEND_BAR_SIZE, barSections, total_size = total_players)
+		parts += "<B>[join_color_list(renderedBar, ROUNDEND_BAR_COLOR)]</B>"
+
 		if(SSblackbox.first_death)
 			var/list/ded = SSblackbox.first_death
 			if(ded.len)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -356,10 +356,10 @@
 
 		parts += "<B>( [join_color_list(renderedBar, ROUNDEND_BAR_COLOR)] )</B>"
 		parts += "<B>\
-		<span class=[ROUNDEND_BAR_COLOR[1]]>Shuttle</span>:\
-		<span class=[ROUNDEND_BAR_COLOR[2]]>No-Shuttle Escape</span>:\
-		<span class=[ROUNDEND_BAR_COLOR[3]]>Stranded</span>:\
-		<span class=[ROUNDEND_BAR_COLOR[4]]>Dead</span></B>"
+			<span class=[ROUNDEND_BAR_COLOR[1]]>Shuttle</span>:\
+			<span class=[ROUNDEND_BAR_COLOR[2]]>No-Shuttle Escape</span>:\
+			<span class=[ROUNDEND_BAR_COLOR[3]]>Stranded</span>:\
+			<span class=[ROUNDEND_BAR_COLOR[4]]>Dead</span></B>"
 
 		if(SSblackbox.first_death)
 			var/list/ded = SSblackbox.first_death

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -817,3 +817,5 @@
 				return
 			qdel(query_update_everything_ranks)
 		qdel(query_check_everything_ranks)
+
+#undef ROUNDEND_BAR_SIZE

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -351,9 +351,7 @@
 		barSections += (popcount[POPCOUNT_SURVIVORS] - popcount[POPCOUNT_ESCAPEES])  // stranded
 		barSections += (total_players - popcount[POPCOUNT_SURVIVORS])  // dead
 
-		to_chat(world, json_encode(barSections))
 		var/list/renderedBar = generate_aggregate_bar(ROUNDEND_BAR_SIZE, barSections, totalSize = total_players)
-		to_chat(world, json_encode(renderedBar))
 
 		parts += "<B>( [join_color_list(renderedBar, ROUNDEND_BAR_COLOR)] )</B>"
 		parts += "<B>\

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1041,10 +1041,12 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		var/sectionRender = ""
 		var/repeatAmount = FLOOR(( section / totalSize ) * numSquares, 1)
 		if(repeatAmount < 1)
+			returnList += ""
 			continue
 		for(var/i in 1 to repeatAmount)
 			sectionRender += "#"
 		returnList += sectionRender
+		to_chat(world, json_encode(returnList))
 
 	if(listSum < totalSize)
 		var/sectionRender = ""
@@ -1057,12 +1059,14 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 // Returns new list that joins the first arg, while coloring each section by the associated span, repeating the last span if running out
 /proc/join_color_list(var/list/joined_list, var/list/span_list)
-	var/return_joined = ""
-	for(var/i in length(joined_list))
+	var/return_merged = ""
+	for(var/i in 1 to length(joined_list))
+		to_chat(world, i)
 		var/active_span = span_list[i] || span_list[length(span_list)]
-		return_joined += "<span class=[active_span]>[joined_list[i]]</span>"
-
-	return return_joined
+		to_chat(world, active_span)
+		return_merged += "<span class=[active_span]>[joined_list[i]]</span>"
+		to_chat(world, return_merged)
+	return return_merged
 
 /**
  * Formats a number to human readable form with the appropriate SI unit.

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1040,12 +1040,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 	for (var/section in sectionSize)
 		var/sectionRender = ""
 		var/repeatAmount = FLOOR((section / totalSize) * numSquares, 1)
-		if(repeatAmount < 1)
-			returnList += ""
-			continue
-		for(var/i in 1 to repeatAmount)
-			sectionRender += "#"
-		returnList += sectionRender
+		return_list += repeat_string(repeat_amount, "#")
 
 	if(listSum < totalSize)
 		var/sectionRender = ""

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1042,15 +1042,12 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 
 	for (var/section in section_size)
-		var/section_render = ""
 		var/repeat_amount = FLOOR((section / total_size) * num_squares, 1)
 		return_list += repeat_string(repeat_amount, "#")
 
 	if(listSum < total_size)
-		var/section_render = ""
-		for(var/i in 1 to ((total_size - listSum) / total_size) * num_squares)  // yep this is an eyesore
-			section_render += "_"
-		return_list += section_render
+		var/repeat_amount = ((total_size - listSum) / total_size) * num_squares // yep this is an eyesore
+		return_list += repeat_string(repeat_amount, "_")
 
 	return return_list
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1042,15 +1042,15 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 
 	for (var/section in section_size)
-		var/sectionRender = ""
-		var/repeatAmount = FLOOR((section / total_size) * num_squares, 1)
+		var/section_render = ""
+		var/repeat_amount = FLOOR((section / total_size) * num_squares, 1)
 		return_list += repeat_string(repeat_amount, "#")
 
 	if(listSum < total_size)
-		var/sectionRender = ""
+		var/section_render = ""
 		for(var/i in 1 to ((total_size - listSum) / total_size) * num_squares)  // yep this is an eyesore
-			sectionRender += "_"
-		return_list += sectionRender
+			section_render += "_"
+		return_list += section_render
 
 	return return_list
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1053,7 +1053,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 
 // Returns new list that joins the first arg, while coloring each section by the associated span, repeating the last span if running out
-/proc/join_color_list(var/list/joined_list, var/list/span_list)
+/proc/join_color_list(list/joined_list, list/span_list)
 	var/return_merged = ""
 	for(var/i in 1 to length(joined_list))
 		var/active_span = span_list[i] || span_list[length(span_list)]

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1039,7 +1039,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 
 	for (var/section in sectionSize)
 		var/sectionRender = ""
-		var/repeatAmount = FLOOR(( section / totalSize ) * numSquares, 1)
+		var/repeatAmount = FLOOR((section / totalSize) * numSquares, 1)
 		if(repeatAmount < 1)
 			returnList += ""
 			continue

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1046,7 +1046,6 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		for(var/i in 1 to repeatAmount)
 			sectionRender += "#"
 		returnList += sectionRender
-		to_chat(world, json_encode(returnList))
 
 	if(listSum < totalSize)
 		var/sectionRender = ""
@@ -1061,11 +1060,8 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 /proc/join_color_list(var/list/joined_list, var/list/span_list)
 	var/return_merged = ""
 	for(var/i in 1 to length(joined_list))
-		to_chat(world, i)
 		var/active_span = span_list[i] || span_list[length(span_list)]
-		to_chat(world, active_span)
 		return_merged += "<span class=[active_span]>[joined_list[i]]</span>"
-		to_chat(world, return_merged)
 	return return_merged
 
 /**

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1022,6 +1022,48 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		loadstring += i <= limit ? "█" : "░"
 	return "\[[loadstring]\]"
 
+
+/proc/generate_aggregate_bar(numSquares, list/sectionSize, totalSize=null)
+	var/list/returnList = list()
+
+	// calculate the sum of the entire list bc theres no builtin
+	var/listSum = 0
+	for(var/num in sectionSize)
+		if(!isnum(num))
+			continue
+		listSum += num
+
+	if(isnull(totalSize) || totalSize > listSum)
+		totalSize = listSum
+
+
+	for (var/section in sectionSize)
+		var/sectionRender = ""
+		var/repeatAmount = FLOOR(( section / totalSize ) * numSquares, 1)
+		if(repeatAmount < 1)
+			continue
+		for(var/i in 1 to repeatAmount)
+			sectionRender += "#"
+		returnList += sectionRender
+
+	if(listSum < totalSize)
+		var/sectionRender = ""
+		for(var/i in 1 to ((totalSize - listSum) / totalSize) * numSquares)  // yep this is an eyesore
+			sectionRender += "_"
+		returnList += sectionRender
+
+	return returnList
+
+
+// Returns new list that joins the first arg, while coloring each section by the associated span, repeating the last span if running out
+/proc/join_color_list(var/list/joined_list, var/list/span_list)
+	var/return_joined = ""
+	for(var/i in length(joined_list))
+		var/active_span = span_list[i] || span_list[length(span_list)]
+		return_joined += "<span class=[active_span]>[joined_list[i]]</span>"
+
+	return return_joined
+
 /**
  * Formats a number to human readable form with the appropriate SI unit.
  *

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1015,40 +1015,44 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 	catch
 		return null
 
-/proc/num2loadingbar(percent as num, numSquares = 20, reverse = FALSE)
+/proc/num2loadingbar(percent as num, num_squares = 20, reverse = FALSE)
 	var/loadstring = ""
-	for (var/i in 1 to numSquares)
-		var/limit = reverse ? numSquares - percent*numSquares : percent*numSquares
+	for (var/i in 1 to num_squares)
+		var/limit = reverse ? num_squares - percent*num_squares : percent*num_squares
 		loadstring += i <= limit ? "█" : "░"
 	return "\[[loadstring]\]"
 
 
-/proc/generate_aggregate_bar(numSquares, list/sectionSize, totalSize=null)
-	var/list/returnList = list()
+// num_squares determines the total size of the bar when the list is concatenated
+// section_size is a list of how much weight each section gets
+// total_size forces the sum of section_size to be at least what is passed, adding ___ padding at the end
+/// generates an aggregate bar, splitting up each section into a string and returning a list
+/proc/generate_aggregate_bar(num_squares, list/section_size, total_size=null)
+	var/list/return_list = list()
 
 	// calculate the sum of the entire list bc theres no builtin
 	var/listSum = 0
-	for(var/num in sectionSize)
+	for(var/num in section_size)
 		if(!isnum(num))
 			continue
 		listSum += num
 
-	if(isnull(totalSize) || totalSize > listSum)
-		totalSize = listSum
+	if(isnull(total_size) || total_size > listSum)
+		total_size = listSum
 
 
-	for (var/section in sectionSize)
+	for (var/section in section_size)
 		var/sectionRender = ""
-		var/repeatAmount = FLOOR((section / totalSize) * numSquares, 1)
+		var/repeatAmount = FLOOR((section / total_size) * num_squares, 1)
 		return_list += repeat_string(repeat_amount, "#")
 
-	if(listSum < totalSize)
+	if(listSum < total_size)
 		var/sectionRender = ""
-		for(var/i in 1 to ((totalSize - listSum) / totalSize) * numSquares)  // yep this is an eyesore
+		for(var/i in 1 to ((total_size - listSum) / total_size) * num_squares)  // yep this is an eyesore
 			sectionRender += "_"
-		returnList += sectionRender
+		return_list += sectionRender
 
-	return returnList
+	return return_list
 
 
 // Returns new list that joins the first arg, while coloring each section by the associated span, repeating the last span if running out


### PR DESCRIPTION

## About The Pull Request
Roundend report has a ascii bar for showing the relative number of people to escape on shuttle, escape on pod, be stranded, or die in the round

![image](https://user-images.githubusercontent.com/73374039/205536255-006be897-cb58-4fb8-ab8e-ceb02385a49e.png)
## Why It's Good For The Game
Fancy graphic, lets you see at a glance how much of a bloodbath the round was or how proactive people were at getting to the shuttle.
## Changelog
:cl:
add: roundend survival meter
/:cl:
