### PR TITLE
Defer creation of emergency power lights until needed -- Saves ~0.2s of init time

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -38,6 +38,9 @@
 	var/switchcount = 0
 	///Cell reference
 	var/obj/item/stock_parts/cell/cell
+	/// If TRUE, then cell is null, but one is pretending to exist.
+	/// This is to defer emergency cell creation unless necessary, as it is very expensive.
+	var/has_mock_cell = TRUE
 	///If true, this fixture generates a very weak cell at roundstart
 	var/start_with_cell = TRUE
 	///Currently in night shift mode?
@@ -85,8 +88,8 @@
 		var/obj/machinery/power/apc/temp_apc = our_area.apc
 		nightshift_enabled = temp_apc?.nightshift_lights
 
-	if(start_with_cell && !no_low_power)
-		cell = new/obj/item/stock_parts/cell/emergency_light(src)
+	if(!start_with_cell || no_low_power)
+		has_mock_cell = FALSE
 
 	RegisterSignal(src, COMSIG_LIGHT_EATER_ACT, PROC_REF(on_light_eater))
 	AddElement(/datum/element/atmos_sensitive, mapload)
@@ -264,6 +267,10 @@
 	update()
 
 /obj/machinery/light/get_cell()
+	if (has_mock_cell)
+		cell = new /obj/item/stock_parts/cell/emergency_light(src)
+		has_mock_cell = FALSE
+
 	return cell
 
 // examine verb
@@ -278,8 +285,8 @@
 			. += "The [fitting] is burnt out."
 		if(LIGHT_BROKEN)
 			. += "The [fitting] has been smashed."
-	if(cell)
-		. += "Its backup power charge meter reads [round((cell.charge / cell.maxcharge) * 100, 0.1)]%."
+	if(cell || has_mock_cell)
+		. += "Its backup power charge meter reads [has_mock_cell ? 100 : round((cell.charge / cell.maxcharge) * 100, 0.1)]%."
 
 
 
@@ -366,9 +373,11 @@
 			drop_light_tube()
 		new /obj/item/stack/cable_coil(loc, 1, "red")
 	transfer_fingerprints_to(new_light)
-	if(!QDELETED(cell))
-		new_light.cell = cell
-		cell.forceMove(new_light)
+
+	var/obj/item/stock_parts/cell/real_cell = get_cell()
+	if(!QDELETED(real_cell))
+		new_light.cell = real_cell
+		real_cell.forceMove(new_light)
 		cell = null
 	qdel(src)
 
@@ -415,23 +424,27 @@
 // returns whether this light has emergency power
 // can also return if it has access to a certain amount of that power
 /obj/machinery/light/proc/has_emergency_power(power_usage_amount)
-	if(no_low_power || !cell)
+	if(no_low_power || (!cell && !has_mock_cell))
 		return FALSE
+	if (has_mock_cell)
+		return status == LIGHT_OK
 	if(power_usage_amount ? cell.charge >= power_usage_amount : cell.charge)
 		return status == LIGHT_OK
+	return FALSE
 
 // attempts to use power from the installed emergency cell, returns true if it does and false if it doesn't
 /obj/machinery/light/proc/use_emergency_power(power_usage_amount = LIGHT_EMERGENCY_POWER_USE)
 	if(!has_emergency_power(power_usage_amount))
 		return FALSE
-	if(cell.charge > 300) //it's meant to handle 120 W, ya doofus
+	var/obj/item/stock_parts/cell/real_cell = get_cell()
+	if(real_cell.charge > 300) //it's meant to handle 120 W, ya doofus
 		visible_message(span_warning("[src] short-circuits from too powerful of a power cell!"))
 		burn_out()
 		return FALSE
-	cell.use(power_usage_amount)
+	real_cell.use(power_usage_amount)
 	set_light(
 		l_range = brightness * bulb_low_power_brightness_mul,
-		l_power = max(bulb_low_power_pow_min, bulb_low_power_pow_mul * (cell.charge / cell.maxcharge)),
+		l_power = max(bulb_low_power_pow_min, bulb_low_power_pow_mul * (real_cell.charge / real_cell.maxcharge)),
 		l_color = bulb_low_power_colour
 		)
 	return TRUE


### PR DESCRIPTION
Every light was creating a power cell. Creating a power cell creates reagents, creates appearances, updates the appearances to reflect its charge, etc etc. It's very expensive. Of the 293ms, 1,652 calls of cell/Initialize, 196ms of it was emergency_light/Initialize.

Defers it until necessary, `get_cell()` will produce the cell if it doesn't exist.

Closes https://github.com/tgstation/dev-cycles-initiative/issues/21