### PR TITLE
Windoors are vulnerable to a jaws of life

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -358,8 +358,8 @@
 		return turn(dir,180) & unres_sides
 	return ..()
 
-/obj/machinery/door/window/try_to_crowbar(obj/item/I, mob/user)
-	if(!hasPower())
+/obj/machinery/door/window/try_to_crowbar(obj/item/I, mob/user, forced = FALSE)
+	if(!hasPower() || forced)
 		if(density)
 			open(2)
 		else


### PR DESCRIPTION
## About The Pull Request
Windoors can be pried by a jaws of life now
## Why It's Good For The Game
Windoors are already immune to any kind of deconstruction outside of bashing it, so making it immune to the jaws of life as well seems excessive
## Changelog
:cl:
balance: jaws of life can pry windoors
/:cl:
