### PR TITLE
fixes shields with `breakable_by_damage` set to FALSE being unable to block attacks.

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -27,8 +27,6 @@
 	COOLDOWN_DECLARE(baton_bash)
 
 /obj/item/shield/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!breakable_by_damage)
-		return FALSE
 	if(transparent && (hitby.pass_flags & PASSGLASS))
 		return FALSE
 	if(attack_type == THROWN_PROJECTILE_ATTACK)
@@ -55,6 +53,8 @@
 	new shield_break_leftover(get_turf(src))
 
 /obj/item/shield/proc/on_shield_block(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", damage = 0, attack_type = MELEE_ATTACK)
+	if(!breakable_by_damage)
+		return TRUE
 	if (atom_integrity <= damage)
 		var/turf/owner_turf = get_turf(owner)
 		owner_turf.visible_message(span_warning("[hitby] destroys [src]!"))


### PR DESCRIPTION
## About The Pull Request
It removes a stupid check from `hit_reaction()` and adds another to `on_shield_block()`, simple as.

## Why It's Good For The Game
Consult the PR title. That's not what `breakable_by_damage` is supposed to do.

## Changelog

:cl:
fix: fixes shields that don't actually take damage from attacks (eg: adamantine shields) being unable to block said attacks.
/:cl:
