### PR TITLE
Inserted tongues and HUD implants no longer exist outside the body.

### DIFF
--- a/code/modules/surgery/organs/augments_eyes.dm
+++ b/code/modules/surgery/organs/augments_eyes.dm
@@ -16,7 +16,7 @@
 	var/HUD_trait = null
 
 /obj/item/organ/internal/cyberimp/eyes/hud/Insert(mob/living/carbon/eye_owner, special = 0, drop_if_replaced = FALSE)
-	..()
+	. = ..()
 	if(HUD_type)
 		var/datum/atom_hud/hud = GLOB.huds[HUD_type]
 		hud.show_to(eye_owner)
@@ -29,7 +29,7 @@
 		hud.hide_from(eye_owner)
 	if(HUD_trait)
 		REMOVE_TRAIT(eye_owner, HUD_trait, ORGAN_TRAIT)
-	..()
+	return ..()
 
 /obj/item/organ/internal/cyberimp/eyes/hud/medical
 	name = "Medical HUD implant"

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -51,7 +51,7 @@
 	return speech_args[SPEECH_MESSAGE]
 
 /obj/item/organ/internal/tongue/Insert(mob/living/carbon/tongue_owner, special = FALSE, drop_if_replaced = TRUE)
-	..()
+	. = ..()
 	ADD_TRAIT(tongue_owner, TRAIT_SPEAKS_CLEARLY, SPEAKING_FROM_TONGUE)
 	if (modifies_speech)
 		RegisterSignal(tongue_owner, COMSIG_MOB_SAY, PROC_REF(handle_speech))


### PR DESCRIPTION

## About The Pull Request

Fixes an odd bug reported in #71699. Due to a minor error, tongues and HUD implants, when inserted with organ manipulation, would _also_ drop on the floor. This was not duplication, as originally suggested, but was in fact the actual organ inserted. This could lead to _extremely_ odd behavior, where you could do things like steal someone's tongue and eat it later to remotely remove it from them. This no longer happens.
## Why It's Good For The Game

Organs should not exist outside of the body once they've been inserted. Mind you, it could be _interesting_ if there was an intentional way to do something like this (holding someone's organs hostage or something of the sort), but as a bug it's both obtrusive and confusing.
## Changelog
:cl:
fix: Fixed a bug that made certain inserted organs drop on the floor.
/:cl:
