### PR TITLE
Removing verbs from the simple_rotation component

### DIFF
--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -45,25 +45,10 @@
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(ExamineMessage))
 	RegisterSignal(parent, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, PROC_REF(on_requesting_context_from_item))
 
-/datum/component/simple_rotation/proc/AddVerbs()
-	var/obj/rotated_obj = parent
-	rotated_obj.verbs += /atom/movable/proc/SimpleRotateClockwise
-	rotated_obj.verbs += /atom/movable/proc/SimpleRotateCounterclockwise
-	if(!(rotation_flags & ROTATION_NO_FLIPPING))
-		rotated_obj.verbs += /atom/movable/proc/SimpleRotateFlip
-
-/datum/component/simple_rotation/proc/RemoveVerbs()
-	if(parent)
-		var/obj/rotated_obj = parent
-		rotated_obj.verbs -= /atom/movable/proc/SimpleRotateFlip
-		rotated_obj.verbs -= /atom/movable/proc/SimpleRotateClockwise
-		rotated_obj.verbs -= /atom/movable/proc/SimpleRotateCounterclockwise
-
 /datum/component/simple_rotation/proc/RemoveSignals()
 	UnregisterSignal(parent, list(COMSIG_CLICK_ALT, COMSIG_CLICK_ALT_SECONDARY, COMSIG_PARENT_EXAMINE, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM))
 
 /datum/component/simple_rotation/RegisterWithParent()
-	AddVerbs()
 	AddSignals()
 	. = ..()
 
@@ -74,7 +59,6 @@
 	return COMPONENT_NOTRANSFER
 
 /datum/component/simple_rotation/UnregisterFromParent()
-	RemoveVerbs()
 	RemoveSignals()
 	. = ..()
 
@@ -84,7 +68,6 @@
 	. = ..()
 
 /datum/component/simple_rotation/ClearFromParent()
-	RemoveVerbs()
 	return ..()
 
 /datum/component/simple_rotation/proc/ExamineMessage(datum/source, mob/user, list/examine_list)
@@ -155,30 +138,6 @@
 
 /datum/component/simple_rotation/proc/DefaultAfterRotation(mob/user, degrees)
 	return
-
-/atom/movable/proc/SimpleRotateClockwise()
-	set name = "Rotate Clockwise"
-	set category = "Object"
-	set src in oview(1)
-	var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)
-	if(rotcomp)
-		rotcomp.Rotate(usr, ROTATION_CLOCKWISE)
-
-/atom/movable/proc/SimpleRotateCounterclockwise()
-	set name = "Rotate Counter-Clockwise"
-	set category = "Object"
-	set src in oview(1)
-	var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)
-	if(rotcomp)
-		rotcomp.Rotate(usr, ROTATION_COUNTERCLOCKWISE)
-
-/atom/movable/proc/SimpleRotateFlip()
-	set name = "Flip"
-	set category = "Object"
-	set src in oview(1)
-	var/datum/component/simple_rotation/rotcomp = GetComponent(/datum/component/simple_rotation)
-	if(rotcomp)
-		rotcomp.Rotate(usr, ROTATION_FLIP)
 
 // maybe we don't need the item context proc but instead the hand one? since we don't need to check held_item
 /datum/component/simple_rotation/proc/on_requesting_context_from_item(atom/source, list/context, obj/item/held_item, mob/user)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -624,7 +624,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 						if(queued_p_flipped)
 							tube.setDir(turn(queued_p_dir, 45))
-							tube.SimpleRotateFlip()
+							var/datum/component/simple_rotation/rotcomp = tube.GetComponent(/datum/component/simple_rotation)
+							rotcomp?.Rotate(user, ROTATION_FLIP)
 
 						tube.add_fingerprint(usr)
 						if(mode & WRENCH_MODE)

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -623,9 +623,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 						tube.setDir(queued_p_dir)
 
 						if(queued_p_flipped)
-							tube.setDir(turn(queued_p_dir, 45))
-							var/datum/component/simple_rotation/rotcomp = tube.GetComponent(/datum/component/simple_rotation)
-							rotcomp?.Rotate(user, ROTATION_FLIP)
+							tube.setDir(turn(queued_p_dir, 45 + ROTATION_FLIP))
+							tube.AfterRotation(user, ROTATION_FLIP)
 
 						tube.add_fingerprint(usr)
 						if(mode & WRENCH_MODE)


### PR DESCRIPTION
## About The Pull Request
Likely the most trival issue from the [Dev Cycles Initiative](https://github.com/orgs/tgstation/projects/11) project: 

Closes https://github.com/tgstation/dev-cycles-initiative/issues/20

## Why It's Good For The Game
On the face of how useful they may seem, these verbs are basically surclassed by the more accessible click shortcuts, while also being an additional cost, which I cannot readily quantify on my subpar hardware, but likely to be but a smidge compared to loading the nukie outpost and wizard shuttle everytime rather than on demand, for example. 

## Changelog

:cl:
del: Removed object rotation related verbs, overwhelmingly overshadowed by the click shortcuts anyway.
/:cl:
