### PR TITLE
Crab Rangoon knows where its sprite is again

### DIFF
--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -659,6 +659,7 @@
 /obj/item/food/crab_rangoon
 	name = "Crab Rangoon"
 	desc = "Has many names, like crab puffs, cheese won'tons, crab dumplings? Whatever you call them, they're a fabulous blast of cream cheesy crab."
+	icon = 'icons/obj/food/meat.dmi'
 	icon_state = "crabrangoon"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 5, /datum/reagent/consumable/nutriment/protein = 7, /datum/reagent/consumable/nutriment/vitamin = 5)
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
## About The Pull Request

fixes #71736 
someone moved the crab rangoon sprite out of the huge food dmi into meat but didnt change the code

crab rangoon doesnt feel like a meat dish so i didnt move it into there but if thats what would be better its pretty trivial to do that

## Why It's Good For The Game

missing sprites bad

## Changelog

:cl:
fix: crab rangoon is not invisible
/:cl:

