### PR TITLE
Formats the name for get_targets

### DIFF
--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -146,10 +146,10 @@
 				continue
 
 			if(beacon.renamed)
-				targets[avoid_assoc_duplicate_keys("[beacon.name] ([get_area(beacon)])", area_index)] = beacon
+				targets[avoid_assoc_duplicate_keys("[beacon.name] ([format_text(get_area(beacon))])", area_index)] = beacon
 			else
 				var/area/area = get_area(beacon)
-				targets[avoid_assoc_duplicate_keys(area.name, area_index)] = beacon
+				targets[avoid_assoc_duplicate_keys(format_text(area.name), area_index)] = beacon
 
 		for (var/obj/item/implant/tracking/tracking_implant in GLOB.tracked_implants)
 			if (!tracking_implant.imp_in || !isliving(tracking_implant.loc) || !tracking_implant.allow_teleport)
@@ -160,12 +160,12 @@
 				continue
 
 			if (is_eligible(tracking_implant))
-				targets[avoid_assoc_duplicate_keys("[implanted.real_name] ([get_area(implanted)])", area_index)] = tracking_implant
+				targets[avoid_assoc_duplicate_keys("[implanted.real_name] ([format_text(get_area(implanted))])", area_index)] = tracking_implant
 	else
 		for (var/obj/machinery/teleport/station/station as anything in power_station.linked_stations)
 			if (is_eligible(station) && station.teleporter_hub)
 				var/area/area = get_area(station)
-				targets[avoid_assoc_duplicate_keys(area.name, area_index)] = station
+				targets[avoid_assoc_duplicate_keys(format_text(area.name), area_index)] = station
 
 	return targets
 


### PR DESCRIPTION

## About The Pull Request

This makes the  `get_targets` proc `get_format` to remove dumb stuff like \improper

![vars](https://cdn.discordapp.com/attachments/326831214667235328/1049391611076943882/image.png)

## Why It's Good For The Game

this breaks circuits since they set target assumes its the strong as is and not with the wierd stuff infront

## Changelog
:cl:
fix: Teleporters work properly now with circuits
/:cl:
