### PR TITLE
Prevent runtime in emp_act parent chain

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -67,7 +67,7 @@
 	update_current_power_usage()
 	update_appearance(UPDATE_ICON_STATE)
 
-/obj/machinery/rnd/server/emp_act()
+/obj/machinery/rnd/server/emp_act(severity)
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return


### PR DESCRIPTION
If you don't define severity it is passed through to the parent proc as null, this then causes a runtime.

Let this be a lesson on the dangers of **not** copying your parent procs args.
