### PR TITLE
Refactors achievements saving to allow for achievements to be saved more often, and not just when the server restarts

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -279,6 +279,10 @@
 	//stop collecting feedback during grifftime
 	SSblackbox.Seal()
 
+	// Send the roundend achievement queries so they get updated in one or two
+	// big queries rather than possibly over a hundred.
+	SSachievements.run_roundend_achievements_queries()
+
 	sleep(5 SECONDS)
 	ready_for_reboot = TRUE
 	standard_reboot()

--- a/code/controllers/subsystem/achievements.dm
+++ b/code/controllers/subsystem/achievements.dm
@@ -10,6 +10,14 @@ SUBSYSTEM_DEF(achievements)
 	var/list/datum/award/score/scores = list()
 	///List of all awards
 	var/list/datum/award/awards = list()
+	/// List of all currently queued up NON-ADDITIVE achievement query arguments (for roundend purposes).
+	var/list/achievement_query_arguments = list()
+	/// List of all currently queued up ADDITIVE achievement query arguments (for roundend purposes).
+	var/list/additive_achievement_query_arguments = list()
+	/// Are we done handling all of the achievements of roundend? This is so we
+	/// go back to individually updating the achievements again.
+	var/post_roundend = FALSE
+
 
 /datum/controller/subsystem/achievements/Initialize()
 	if(!SSdbcore.Connect())
@@ -26,7 +34,7 @@ SUBSYSTEM_DEF(achievements)
 		scores[T] = instance
 		awards[T] = instance
 
-	update_metadata()
+	// update_metadata()
 
 	for(var/i in GLOB.clients)
 		var/client/C = i
@@ -36,7 +44,7 @@ SUBSYSTEM_DEF(achievements)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/achievements/Shutdown()
-	save_achievements_to_db()
+	// save_achievements_to_db()
 
 /datum/controller/subsystem/achievements/proc/save_achievements_to_db()
 	var/list/cheevos_to_save = list()
@@ -72,3 +80,86 @@ SUBSYSTEM_DEF(achievements)
 
 	if(to_update.len)
 		SSdbcore.MassInsert(format_table_name("achievement_metadata"),to_update,duplicate_key = TRUE)
+
+
+/**
+ * Proc that updates an achievement's value in the database.
+ *
+ * Arguments:
+ * * ckey - The ckey of the player whose achievement we're updating.
+ * * achievement_key - The key of the achievement we're updating.
+ * * new_value (optional) - The new value for the achievement, defaulting to TRUE.
+ * * additive (optional) - Whether or not the achievement is additive, defaulting to `FALSE`.
+ * If set to `FALSE`, will simply overwrite the value on the database using the `new_value`.
+ * If set to `TRUE`, it will add `new_value` to the value already present in the database.
+ * You should only be setting this to `TRUE` for scores, achievements are binary.
+ */
+/datum/controller/subsystem/achievements/proc/update_achievement(ckey, achievement_key, new_value = TRUE, additive = FALSE)
+	if(!ckey || !achievement_key)
+		return
+
+	var/datum/db_query/query = SSdbcore.NewQuery(
+		"INSERT INTO [format_table_name("achievements")] (ckey, achievement_key, value) VALUES(:ckey, :achievement_key, :value) ON DUPLICATE KEY UPDATE value = [additive ? "value + " : ""]VALUES(value)",
+		list(
+			"ckey" = ckey,
+			"achievement_key" = achievement_key,
+			"value" = new_value,
+		)
+	)
+
+	query.Execute(async = TRUE)
+
+
+/**
+ * Proc that queues an update of an achievement in the database. If we're not currently
+ * in the part of roundend where many achievements are granted at once, the achievement
+ * will be updated instantly. If we are, the achievement update will be queued to be
+ * inserted in a MassInsert query a little later in the roundend process.
+ *
+ * Arguments:
+ * * ckey - The ckey of the player whose achievement we're updating.
+ * * achievement_key - The key of the achievement we're updating.
+ * * new_value (optional) - The new value for the achievement, defaulting to TRUE.
+ * * additive (optional) - Whether or not the achievement is additive, defaulting to `FALSE`.
+ * If set to `FALSE`, will simply overwrite the value on the database using the `new_value`.
+ * If set to `TRUE`, it will add `new_value` to the value already present in the database.
+ * You should only be setting this to `TRUE` for scores, achievements are binary.
+ */
+/datum/controller/subsystem/achievements/proc/queue_achievement_update(ckey, achievement_key, new_value = TRUE, additive = FALSE)
+	if(!ckey || !achievement_key)
+		return
+
+	if(SSticker.current_state != GAME_STATE_FINISHED || post_roundend)
+		update_achievement(ckey, achievement_key, new_value, additive)
+		return
+
+	var/datum/award/award = awards[achievement_key]
+
+	if(!award)
+		return
+
+	var/datum/award/score/score = scores[achievement_key]
+
+	if(score && score.additive)
+		additive_achievement_query_arguments += list(award.get_changed_rows(ckey, new_value))
+	else
+		achievement_query_arguments += list(award.get_changed_rows(ckey, new_value))
+
+
+/**
+ * Proc that runs the MassInsert queries for the roundend section of the round,
+ * to avoid running possibly hundreds of queries all at once when we're ending
+ * the round.
+ */
+/datum/controller/subsystem/achievements/proc/run_roundend_achievements_queries()
+	if(SSticker.current_state != GAME_STATE_FINISHED || post_roundend || !length(achievement_query_arguments))
+		return
+
+	post_roundend = TRUE
+
+	SSdbcore.MassInsert(format_table_name("achievements"), achievement_query_arguments, duplicate_key = TRUE, async = TRUE)
+
+	if(!length(additive_achievement_query_arguments))
+		return
+
+	SSdbcore.MassInsert(format_table_name("achievements"), achievement_query_arguments, duplicate_key = "\nON DUPLICATE KEY UPDATE value = value + VALUES(value)", async = TRUE)

--- a/code/datums/achievements/_achievement_data.dm
+++ b/code/datums/achievements/_achievement_data.dm
@@ -89,7 +89,7 @@
 
 		data[achievement_type] = value
 
-	SSachievements.update_achievement(owner_ckey, award.database_id, value, additive)
+	SSachievements.queue_achievement_update(owner_ckey, achievement_type, value, additive)
 
 
 ///Getter for the status/score of an achievement

--- a/code/datums/achievements/_achievement_data.dm
+++ b/code/datums/achievements/_achievement_data.dm
@@ -68,15 +68,29 @@
 
 	if(!SSachievements.achievements_enabled)
 		return
-	var/datum/award/A = SSachievements.awards[achievement_type]
+
+	var/datum/award/award = SSachievements.awards[achievement_type]
 	get_data(achievement_type) //Get the current status first if necessary
-	if(istype(A, /datum/award/achievement))
+	var/additive = FALSE
+
+	if(istype(award, /datum/award/achievement))
 		if(data[achievement_type]) //You already unlocked it so don't bother running the unlock proc
 			return
+
 		data[achievement_type] = TRUE
-		A.on_unlock(user) //Only on default achievement, as scores keep going up.
-	else if(istype(A, /datum/award/score))
-		data[achievement_type] += value
+		award.on_unlock(user) //Only on default achievement, as scores keep going up.
+
+	else if(istype(award, /datum/award/score))
+		var/datum/award/score/score = SSachievements.scores[achievement_type]
+		additive = score.additive
+
+		if(additive)
+			value = data[achievement_type] + value
+
+		data[achievement_type] = value
+
+	SSachievements.update_achievement(owner_ckey, award.database_id, value, additive)
+
 
 ///Getter for the status/score of an achievement
 /datum/achievement_data/proc/get_achievement_status(achievement_type)

--- a/code/datums/achievements/_achievement_data.dm
+++ b/code/datums/achievements/_achievement_data.dm
@@ -46,20 +46,21 @@
 	qdel(Query)
 
 	for(var/T in subtypesof(/datum/award))
-		var/datum/award/A = SSachievements.awards[T]
-		if(!A || !A.name) //Skip abstract achievements types
+		var/datum/award/award = SSachievements.awards[T]
+		if(!award || !award.name) //Skip abstract achievements types
 			continue
 		if(!data[T])
-			data[T] = A.parse_value(kv[A.database_id])
+			data[T] = award.parse_value(kv[award.database_id])
 			original_cached_data[T] = data[T]
 
 ///Updates local cache with db data for the given achievement type if it wasn't loaded yet.
 /datum/achievement_data/proc/get_data(achievement_type)
-	var/datum/award/A = SSachievements.awards[achievement_type]
-	if(!A.name)
+	var/datum/award/award = SSachievements.awards[achievement_type]
+	if(!award.name)
 		return FALSE
+
 	if(!data[achievement_type])
-		data[achievement_type] = A.load(owner_ckey)
+		data[achievement_type] = award.load(owner_ckey)
 		original_cached_data[achievement_type] = data[achievement_type]
 
 ///Unlocks an achievement of a specific type. achievement type is a typepath to the award, user is the mob getting the award, and value is an optional value to be used for defining a score to add to the leaderboard

--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -91,6 +91,11 @@
 	var/track_high_scores = TRUE
 	var/list/high_scores = list()
 
+	/// Are we additive? Basically, does granting this score increment its value,
+	/// rather than overwriting it?
+	var/additive = FALSE
+
+
 /datum/award/score/New()
 	. = ..()
 	if(track_high_scores)

--- a/code/datums/achievements/boss_scores.dm
+++ b/code/datums/achievements/boss_scores.dm
@@ -2,53 +2,64 @@
 	name = "Tendril Score"
 	desc = "Watch your step"
 	database_id = TENDRIL_CLEAR_SCORE
+	additive = TRUE
 
 /datum/award/score/boss_score
 	name = "Bosses Killed"
 	desc = "You've killed HOW many?"
 	database_id = BOSS_SCORE
+	additive = TRUE
 
 /datum/award/score/blood_miner_score
 	name = "Blood-Drunk Miners Killed"
 	desc = "You've killed HOW many?"
 	database_id = MINER_SCORE
+	additive = TRUE
 
 /datum/award/score/demonic_miner_score
 	name = "Demonic-Frost Miners Killed"
 	desc = "You've killed HOW many?"
 	database_id = FROST_MINER_SCORE
+	additive = TRUE
 
 /datum/award/score/bubblegum_score
 	name = "Bubblegums Killed"
 	desc = "You've killed HOW many?"
 	database_id = BUBBLEGUM_SCORE
+	additive = TRUE
 
 /datum/award/score/colussus_score
 	name = "Colossus Killed"
 	desc = "You've killed HOW many?"
 	database_id = COLOSSUS_SCORE
+	additive = TRUE
 
 /datum/award/score/drake_score
 	name = "Drakes Killed"
 	desc = "You've killed HOW many?"
 	database_id = DRAKE_SCORE
+	additive = TRUE
 
 /datum/award/score/hierophant_score
 	name = "Hierophants Killed"
 	desc = "You've killed HOW many?"
 	database_id = HIEROPHANT_SCORE
+	additive = TRUE
 
 /datum/award/score/legion_score
 	name = "Legions Killed"
 	desc = "You've killed HOW many?"
 	database_id = LEGION_SCORE
+	additive = TRUE
 
 /datum/award/score/swarmer_beacon_score
 	name = "Swarmer Beacons Killed"
 	desc = "You've killed HOW many?"
 	database_id = SWARMER_BEACON_SCORE
+	additive = TRUE
 
 /datum/award/score/wendigo_score
 	name = "Wendigos Killed"
 	desc = "You've killed HOW many?"
 	database_id = WENDIGO_SCORE
+	additive = TRUE

--- a/code/datums/achievements/misc_scores.dm
+++ b/code/datums/achievements/misc_scores.dm
@@ -3,12 +3,14 @@
 	name = "Hardcore random points"
 	desc = "Well, I might be a blind, deaf, crippled guy, but hey, at least I'm alive."
 	database_id = HARDCORE_RANDOM_SCORE
+	additive = TRUE
 
 ///How many maintenance pills did you eat?
 /datum/award/score/maintenance_pill
 	name = "Maintenance Pills Consumed"
 	desc = "Wait why?"
 	database_id = MAINTENANCE_PILL_SCORE
+	additive = TRUE
 
 ///How high of a score on the Intento did we get?
 /datum/award/score/intento_score

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1503,9 +1503,8 @@ GLOBAL_LIST_EMPTY(intento_players)
 	if(user && GLOB.intento_players[user.ckey] < score)
 		GLOB.intento_players[user.ckey] = score
 		var/award_status = user.client.get_award_status(/datum/award/score/intento_score)
-		var/award_score = score - award_status
-		if(award_score > 0)
-			user.client.give_award(/datum/award/score/intento_score, user, award_score)
+		if(score > award_status)
+			user.client.give_award(/datum/award/score/intento_score, user, score)
 
 	say("GAME OVER. Your score was [score]!")
 	playsound(src, 'sound/machines/synth_no.ogg', 50, FALSE)

--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -39,9 +39,8 @@
 	var/datum/venue/bar = SSrestaurant.all_venues[/datum/venue/bar]
 	var/award_score = bar.total_income
 	var/award_status = winner.get_award_status(/datum/award/score/bartender_tourist_score)
-	if(award_score - award_status > 0)
-		award_score -= award_status
-	winner.give_award(/datum/award/score/bartender_tourist_score, winner.mob, award_score)
+	if(award_score > award_status)
+		winner.give_award(/datum/award/score/bartender_tourist_score, winner.mob, award_score)
 
 
 /datum/outfit/job/bartender

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -52,8 +52,7 @@
 	var/award_score = restaurant.total_income
 	var/award_status = winner.get_award_status(/datum/award/score/chef_tourist_score)
 	if(award_score > award_status)
-		award_score -= award_status
-	winner.give_award(/datum/award/score/chef_tourist_score, winner.mob, award_score)
+		winner.give_award(/datum/award/score/chef_tourist_score, winner.mob, award_score)
 
 
 /datum/outfit/job/cook


### PR DESCRIPTION
## About The Pull Request
I was investigating why the achievements were only saved when the server was shutting down gracefully. Turns out it's because it's on `SSachievements.Shutdown()` only. So I decided to change that, to make it so they get saved as they happen, unless it's during the generation of all the roundend data (which is typically when a LOT of achievements are granted at once), where they'll all be sent at once in one big query.

I ended up refactoring a whole lot, and there's one or two things I haven't removed yet, just for the sake of "in the case I need it later in the PR", but I don't think that'll be the case.

I'm opening this PR now as a draft, because I'll need it to be test-merged to ensure that it really works, I tested the queries locally and also ran them on a test database, but it wasn't directly hooked into my test-server. I think it should all work fine, but in the event that it doesn't, it's better that it affects as little as possible.

I also was able to remove any usage of the `achievement_metadata` database table, as it didn't really do much that we didn't already have handled anywhere else.

### Todo
- [ ] Get rid of the `achievement_metadata` table for realsies.
- [ ] Create an admin verb to bring up the invalid achievements and give them the option to delete them.
- [ ] Get rid of the rest of the code I didn't remove yet.

## Why It's Good For The Game
Achievements won't be lost when the round restarts abnormally, or it crashes (unless you were getting the achievement as it was crashing).

Also gets rid of one basically unused table from the database (`achievement_metadata`), which was MEANT to help with getting rid of deprecated achievements, but that simply just didn't do it. I'm going to properly remove it from the schema once we're certain that getting rid of it won't break anything else (which it hopefully shouldn't).

## Changelog

:cl: GoldenAlpharex
refactor: Refactored the achievements subsystem to allow it to save achievement progress to the database in real time rather than only as the server is gracefully shutting down.
fix: Achievements no longer get lost when done during a round that ends in a crash or a TGS hard-restart.
server: Removes the achievement_metadata SQL table, because it's no longer useful for anything.
/:cl: