### PR TITLE
Landmines trigger when you step off of them, rather than onto them

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -5,6 +5,7 @@
 	anchored = TRUE
 	icon = 'icons/obj/weapons/items_and_weapons.dmi'
 	icon_state = "uglymine"
+	base_icon_state = "uglymine"
 	/// We manually check to see if we've been triggered in case multiple atoms cross us in the time between the mine being triggered and it actually deleting, to avoid a race condition with multiple detonations
 	var/triggered = FALSE
 	/// Can be set to FALSE if we want a short 'coming online' delay, then set to TRUE. Can still be set off by damage
@@ -12,43 +13,80 @@
 	/// If set, we default armed to FALSE and set it to TRUE after this long from initializing
 	var/arm_delay
 
+	/// Who's got their foot on the mine's pressure plate
+	/// Stepping on the mine will set this to the first mob who stepped over it
+	/// The mine will not detonate via movement unless the first mob steps off of it
+	var/datum/weakref/foot_on_mine
+
 /obj/effect/mine/Initialize(mapload)
 	. = ..()
 	if(arm_delay)
 		armed = FALSE
-		icon_state = "uglymine-inactive"
+		update_appearance(UPDATE_ICON_STATE)
 		addtimer(CALLBACK(src, PROC_REF(now_armed)), arm_delay)
+
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
+		COMSIG_ATOM_EXITED = PROC_REF(on_exited),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/effect/mine/examine(mob/user)
 	. = ..()
 	if(!armed)
-		. += span_info("\tIt appears to be inactive...")
+		. += span_info("It appears to be inactive...")
+
+	var/atom/movable/unlucky_sod = foot_on_mine?.resolve()
+	if(user == unlucky_sod)
+		. += span_bolddanger("The pressure plate is depressed. Any movement you make will set it off now.")
+	else if(!isnull(unlucky_sod))
+		. += span_danger("The pressure plate is depressed by [unlucky_sod]. Any move they make'll set it off now.")
+
+/obj/effect/mine/update_icon_state()
+	. = ..()
+	if(armed)
+		icon_state = base_icon_state
+	else
+		icon_state = "[base_icon_state]-inactive"
 
 /// The effect of the mine
 /obj/effect/mine/proc/mineEffect(mob/victim)
-	to_chat(victim, span_danger("*click*"))
+	return
 
 /// If the landmine was previously inactive, this beeps and displays a message marking it active
 /obj/effect/mine/proc/now_armed()
 	armed = TRUE
-	icon_state = "uglymine"
+	update_appearance(UPDATE_ICON_STATE)
 	playsound(src, 'sound/machines/nuke/angry_beep.ogg', 40, FALSE, -2)
 	visible_message(span_danger("\The [src] beeps softly, indicating it is now active."), vision_distance = COMBAT_MESSAGE_RANGE)
 
-/obj/effect/mine/proc/on_entered(datum/source, atom/movable/AM)
+/obj/effect/mine/proc/can_trigger(atom/movable/on_who)
+	if(triggered || !isturf(loc) || iseffect(on_who) || !armed)
+		return FALSE
+	return TRUE
+
+/obj/effect/mine/proc/on_entered(datum/source, atom/movable/arrived)
 	SIGNAL_HANDLER
 
-	if(triggered || !isturf(loc) || !armed)
+	if(!can_trigger(arrived))
+		return
+	if(arrived.movement_type & FLYING)
 		return
 
-	if(AM.movement_type & FLYING)
+	foot_on_mine = WEAKREF(arrived)
+	visible_message(span_danger("[icon2html(src, viewers(src))] *click*"))
+	playsound(src, 'sound/machines/click.ogg', 60, TRUE)
+
+/obj/effect/mine/proc/on_exited(datum/source, atom/movable/gone)
+	SIGNAL_HANDLER
+
+	if(!can_trigger(gone))
+		return
+	if(foot_on_mine && !IS_WEAKREF_OF(gone, foot_on_mine))
 		return
 
-	triggermine(AM)
+	triggermine(gone)
+	foot_on_mine = null
 
 /obj/effect/mine/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir)
 	. = ..()
@@ -56,8 +94,6 @@
 
 /// When something sets off a mine
 /obj/effect/mine/proc/triggermine(atom/movable/triggerer)
-	if(iseffect(triggerer))
-		return
 	if(triggered) //too busy detonating to detonate again
 		return
 	if(triggerer)
@@ -95,14 +131,14 @@
 	var/stun_time = 80
 
 /obj/effect/mine/stun/mineEffect(mob/living/victim)
-	if(isliving(victim))
+	if(isliving(victim) && Adjacent(victim))
 		victim.Paralyze(stun_time)
 
 /obj/effect/mine/kickmine
 	name = "kick mine"
 
 /obj/effect/mine/kickmine/mineEffect(mob/victim)
-	if(isliving(victim) && victim.client)
+	if(isliving(victim) && victim.client && Adjacent(victim))
 		to_chat(victim, span_userdanger("You have been kicked FOR NO REISIN!"))
 		qdel(victim.client)
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -60,6 +60,7 @@
 	playsound(src, 'sound/machines/nuke/angry_beep.ogg', 40, FALSE, -2)
 	visible_message(span_danger("\The [src] beeps softly, indicating it is now active."), vision_distance = COMBAT_MESSAGE_RANGE)
 
+/// Can this mine trigger on the passed movable?
 /obj/effect/mine/proc/can_trigger(atom/movable/on_who)
 	if(triggered || !isturf(loc) || iseffect(on_who) || !armed)
 		return FALSE
@@ -70,7 +71,11 @@
 
 	if(!can_trigger(arrived))
 		return
+	// Flying = can't step on a mine
 	if(arrived.movement_type & FLYING)
+		return
+	// Someone already on it
+	if(foot_on_mine?.resolve())
 		return
 
 	foot_on_mine = WEAKREF(arrived)
@@ -82,6 +87,7 @@
 
 	if(!can_trigger(gone))
 		return
+	// Check that the guy who's on it is stepping off
 	if(foot_on_mine && !IS_WEAKREF_OF(gone, foot_on_mine))
 		return
 


### PR DESCRIPTION
## About The Pull Request

Stepping onto a landmine will depress the pressure plate.
Making any further movement (releasing the pressure plate) will trigger the mine. 

Maybe you could escape with quick thinking? Maybe you can bait someone else into the detonation? Or maybe you can give a final warning to your compatriots? 

## Why It's Good For The Game

I think it's funny

![image](https://user-images.githubusercontent.com/51863163/205770869-84126f62-e9bf-43db-a879-878b325694a0.png)

## Changelog

:cl: Melbert
add: Landmines, rather than triggering when you step onto them, will now trigger when you step off of them. 
/:cl:
