### PR TITLE
[NO GBP] Fixes some dog behaviors

### DIFF
--- a/code/datums/ai/dog/dog_behaviors.dm
+++ b/code/datums/ai/dog/dog_behaviors.dm
@@ -133,7 +133,7 @@
 
 /datum/ai_behavior/play_dead/perform(delta_time, datum/ai_controller/controller)
 	. = ..()
-	var/mob/living/simple_animal/simple_pawn = controller.pawn
+	var/mob/living/basic/simple_pawn = controller.pawn
 	if(!istype(simple_pawn))
 		return
 
@@ -150,7 +150,7 @@
 
 /datum/ai_behavior/play_dead/finish_action(datum/ai_controller/controller, succeeded)
 	. = ..()
-	var/mob/living/simple_animal/simple_pawn = controller.pawn
+	var/mob/living/basic/simple_pawn = controller.pawn
 	if(!istype(simple_pawn) || simple_pawn.stat) // imagine actually dying while playing dead. hell, imagine being the kid waiting for your pup to get back up :(
 		return
 	controller.blackboard[BB_DOG_PLAYING_DEAD] = FALSE
@@ -163,7 +163,7 @@
 /// This behavior involves either eating a snack we can reach, or begging someone holding a snack
 /datum/ai_behavior/harass
 	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_MOVE_AND_PERFORM
-	required_distance = 3
+	required_distance = 1
 
 /datum/ai_behavior/harass/perform(delta_time, datum/ai_controller/controller)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

I somehow missed a `simple_animal` reference in the dog's play dead command. I also forgot there was a play dead command, heh.

Makes attack command's harass behavior less garbage by making the `required_distance` 1 as it always should have been. A higher than 1 required_distance would have made it never possible for the behavior to complete correctly, possibly being the cause of [this runtime](https://runtimes.moth.fans/runtime/%EF%BF%BD%15Lisa%20wants%20to%20perform%20action%20type%20%2Fdatum%2Fai_behavior%2Fharass%20which%20requires%20movement%2C%20but%20has%20no%20current%20movement%20target!%20(code%2Fdatums%2Fai%2F_ai_controller.dm%3A162)_______%2Fproc%2F_stack_trace) but I'm not sure since the runtime should have appeared before the refactor as well.
  * There's also a random silent failure where jps just gives up creating a path even if the dog and target are in a clear straight line with each other and cancels the action. As far as I could tell, it's an issue with the JPS ai movement, or the JPS movement datum since the target still exists and all. Dunno.
## Why It's Good For The Game

bugs
## Changelog
:cl:
fix: The dog's attack command is somewhat more reliable.
/:cl:
