### PR TITLE
Patches Admin_Teleport Location Logging Error

### DIFF
--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -115,11 +115,13 @@
 		log_admin("[key_name(usr)] teleported [key_name(src)] to nullspace")
 		moveToNullspace()
 	else
-		log_admin("[key_name(usr)] teleported [key_name(src)] to [AREACOORD(loc)]")
+		var/turf/location = get_turf(new_location)
+		log_admin("[key_name(usr)] teleported [key_name(src)] to [AREACOORD(location)]")
 		forceMove(new_location)
 
 /mob/admin_teleport(atom/new_location)
-	var/msg = "[key_name_admin(usr)] teleported [ADMIN_LOOKUPFLW(src)] to [isnull(new_location) ? "nullspace" : ADMIN_VERBOSEJMP(loc)]"
+	var/turf/location = get_turf(new_location)
+	var/msg = "[key_name_admin(usr)] teleported [ADMIN_LOOKUPFLW(src)] to [isnull(new_location) ? "nullspace" : ADMIN_VERBOSEJMP(location)]"
 	message_admins(msg)
 	admin_ticket_log(src, msg)
 	return ..()


### PR DESCRIPTION

## About The Pull Request
Hey there,

![image](https://user-images.githubusercontent.com/34697715/205855401-345d811c-b9be-48db-927c-10ef6b80f6b7.png)

This admin didn't actually send that player to the secret nullspace room, they sent them to somewhere stationside. This is because the logging in admin_teleport only reads the location of the current mob/atom's location, not the actual location of where they are going to. Silly error, but I've fixed it now.
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/205855414-75c562e3-919b-412c-8792-fa4031941939.png)

Logs being _correct_ is quite important, I feel.
## Changelog
:cl:
admin: Whenever you teleport an atom/mob using the Get function found in many admin utilities, rest assured that it will actually log the destination location of where you are teleporting that thing to- rather than the location they were pre-teleportation.
/:cl:
