### PR TITLE
RPED displays correct number of datum stock parts

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -1027,9 +1027,6 @@
 		else
 			part_count[component_name] = 1
 
-	for (var/datum/stock_part/stock_part in component_parts)
-		part_count[stock_part.name()] += 1
-
 	var/list/printed_components = list()
 
 	var/text = span_notice("It contains the following parts:")


### PR DESCRIPTION
**About the pull request**
RPED was counting stock parts & datum parts from #71693 twice causing incorrect results for devices which uses scanning modules like the R & D server which has only one scanning module though it displays 2 
![Pic 1](https://user-images.githubusercontent.com/110812394/205945202-492c4c27-e73e-4245-a643-d1cd785c1115.png)
Removing the extra for loop solved the problem
![Pic 2](https://user-images.githubusercontent.com/110812394/205945459-8dd9db9c-09cb-4992-b86c-6c354de14433.png)

 **Why its good for the game**
Correct Information

**Change Log**
:cl:
fix: incorrect part display information
/:cl:

