### PR TITLE
More sign subtypes

### DIFF
--- a/code/game/objects/structures/signs/signs_departments.dm
+++ b/code/game/objects/structures/signs/signs_departments.dm
@@ -37,6 +37,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/exam_room, 32)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/chemistry, 32)
 
+/obj/structure/sign/departments/chemistry/alt
+	sign_change_name = "Department - Medbay: Chemistry Alt"
+	icon_state = "chemistry2"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/chemistry/alt, 32)
+
 /obj/structure/sign/departments/chemistry/pharmacy
 	name = "\improper Pharmacy sign"
 	sign_change_name = "Department - Medbay: Pharmacy"
@@ -74,9 +80,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/engineering, 32)
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/science, 32)
 
 /obj/structure/sign/departments/science/alt
-	name = "\improper Science sign"
 	sign_change_name = "Department - Science Alt"
-	desc = "A sign labelling an area where research and science is performed."
 	icon_state = "science2"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/science/alt, 32)
@@ -88,6 +92,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/science/alt, 32)
 	icon_state = "xenobio"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/xenobio, 32)
+
+/obj/structure/sign/departments/xenobio/alt
+	sign_change_name = "Department - Science: Xenobiology Alt"
+	icon_state = "xenobio2"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/xenobio/alt, 32)
 
 /obj/structure/sign/departments/rndserver
 	name ="\improper R&D Server sign"
@@ -101,11 +111,23 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/rndserver, 32)
 
 /obj/structure/sign/departments/botany
 	name = "\improper Botany sign"
-	sign_change_name = "Department - Botany"
+	sign_change_name = "Department - Botany (Flower)"
 	desc = "A sign labelling an area as a place where plants are grown."
 	icon_state = "hydro1"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/botany, 32)
+
+/obj/structure/sign/departments/botany/alt1
+	sign_change_name = "Department - Botany (Tray)"
+	icon_state = "hydro2"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/botany/alt1, 32)
+
+/obj/structure/sign/departments/botany/alt2
+	sign_change_name = "Department - Botany (Watering Can)"
+	icon_state = "hydro3"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/botany/alt2, 32)
 
 /obj/structure/sign/departments/custodian
 	name = "\improper Janitor sign"
@@ -211,6 +233,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/telecomms, 32)
 
 /obj/structure/sign/departments/telecomms/alt
 	icon_state = "telecomms2"
+	sign_change_name = "Location - Telecommunications Alt"
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/departments/telecomms/alt, 32)
 

--- a/code/game/objects/structures/signs/signs_warning.dm
+++ b/code/game/objects/structures/signs/signs_warning.dm
@@ -16,7 +16,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning, 32)
 	name = "\improper SECURE AREA sign"
 	sign_change_name = "Warning - Secure Area"
 	desc = "A warning sign which reads 'SECURE AREA'."
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/secure_area, 32)
 
@@ -24,7 +23,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/secure_area, 32)
 	name = "\improper KEEP CLEAR: DOCKING AREA sign"
 	sign_change_name = "Warning - Docking Area"
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'."
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/docking, 32)
 
@@ -33,7 +31,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/docking, 32)
 	sign_change_name = "Warning - Biohazard"
 	desc = "A warning sign which reads 'BIOHAZARD'."
 	icon_state = "bio"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/biohazard, 32)
 
@@ -42,7 +39,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/biohazard, 32)
 	sign_change_name = "Warning - High Voltage"
 	desc = "A warning sign which reads 'HIGH VOLTAGE'."
 	icon_state = "shock"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/electric_shock, 32)
 
@@ -51,7 +47,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/electric_shock, 32)
 	sign_change_name = "Warning - Hard Vacuum"
 	desc = "A warning sign which reads 'HARD VACUUM AHEAD'."
 	icon_state = "space"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/vacuum, 32)
 
@@ -60,7 +55,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/vacuum, 32)
 	sign_change_name = "Warning - External Airlock"
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'."
 	layer = MOB_LAYER
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/vacuum/external, 32)
 
@@ -69,7 +63,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/vacuum/external, 32)
 	sign_change_name = "Warning - Disposals: Leads to Space"
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO SPACE'."
 	icon_state = "deathsposal"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/deathsposal, 32)
 
@@ -78,7 +71,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/deathsposal, 32)
 	sign_change_name = "Warning - Disposals: Leads to Morgue"
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO MORGUE'."
 	icon_state = "bodysposal"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/bodysposal, 32)
 
@@ -88,7 +80,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/bodysposal, 32)
 	desc = "A warning sign which reads 'DANGER: FIRE'."
 	icon_state = "fire"
 	resistance_flags = FIRE_PROOF
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/fire, 32)
 
@@ -98,7 +89,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/fire, 32)
 	desc = "A warning sign which reads 'NO SMOKING'."
 	icon_state = "nosmoking2"
 	resistance_flags = FLAMMABLE
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/no_smoking, 32)
 
@@ -107,16 +97,14 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/no_smoking, 32)
 	sign_change_name = "Warning - No Smoking Alt"
 	desc = "A warning sign which reads 'NO SMOKING'."
 	icon_state = "nosmoking"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/no_smoking/circle, 32)
 
 /obj/structure/sign/warning/yes_smoking/circle
 	name = "\improper YES SMOKING sign"
-	sign_change_name = "Warning - Yes Smoking Alt"
+	sign_change_name = "Warning - Yes Smoking"
 	desc = "A warning sign which reads 'YES SMOKING'."
 	icon_state = "yessmoking"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/yes_smoking/circle, 32)
 
@@ -125,7 +113,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/yes_smoking/circle, 32)
 	sign_change_name = "Warning - Radiation"
 	desc = "A warning sign alerting the user of potential radiation hazards."
 	icon_state = "radiation"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/radiation, 32)
 
@@ -133,7 +120,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/radiation, 32)
 	name = "\improper RADIOACTIVE AREA sign"
 	sign_change_name = "Warning - Radioactive Area"
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'."
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/radiation/rad_area, 32)
 
@@ -143,7 +129,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/radiation/rad_area, 32)
 	desc = "A sign that warns would-be travellers of hostile alien life in the vicinity."
 	icon = 'icons/obj/signs.dmi'
 	icon_state = "xeno_warning"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/xeno_mining, 32)
 
@@ -152,7 +137,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/xeno_mining, 32)
 	sign_change_name = "Warning - Engineering Safety Protocols"
 	desc = "A sign detailing the various safety protocols when working on-site to ensure a safe shift."
 	icon_state = "safety"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/engine_safety, 32)
 
@@ -161,7 +145,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/engine_safety, 32)
 	sign_change_name = "Warning - Explosives"
 	desc = "A warning sign which reads 'HIGH EXPLOSIVES'."
 	icon_state = "explosives"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/explosives, 32)
 
@@ -170,7 +153,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/explosives, 32)
 	sign_change_name = "Warning - Explosives Alt"
 	desc = "A warning sign which reads 'HIGH EXPLOSIVES'."
 	icon_state = "explosives2"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/explosives/alt, 32)
 
@@ -179,7 +161,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/explosives/alt, 32)
 	sign_change_name = "Warning - Testing Area"
 	desc = "A sign that warns of high-power testing equipment in the area."
 	icon_state = "testchamber"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/test_chamber, 32)
 
@@ -188,7 +169,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/test_chamber, 32)
 	sign_change_name = "Warning - Firing Range"
 	desc = "A sign reminding you to remain behind the firing line, and to wear ear protection."
 	icon_state = "firingrange"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/firing_range, 32)
 
@@ -197,7 +177,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/firing_range, 32)
 	sign_change_name = "Warning - Temp: Cold"
 	desc = "A sign that warns of extremely cold air in the vicinity."
 	icon_state = "cold"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/cold_temp, 32)
 
@@ -206,7 +185,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/cold_temp, 32)
 	sign_change_name = "Warning - Temp: Hot"
 	desc = "A sign that warns of extremely hot air in the vicinity."
 	icon_state = "heat"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/hot_temp, 32)
 
@@ -215,7 +193,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/hot_temp, 32)
 	sign_change_name = "Warning - Contaminated Air"
 	desc = "A sign that warns of dangerous particulates or gasses in the air, instructing you to wear internals."
 	icon_state = "gasmask"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/gas_mask, 32)
 
@@ -224,9 +201,16 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/gas_mask, 32)
 	sign_change_name = "Warning - Hazardous Chemicals sign"
 	desc = "A sign that warns of potentially reactive chemicals nearby, be they explosive, flamable, or acidic."
 	icon_state = "chemdiamond"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/chem_diamond, 32)
+
+/obj/structure/sign/warning/doors
+	name = "\improper BLAST DOORS sign"
+	sign_change_name = "Warning - Blast Doors"
+	desc = "A sign that shows there are doors here. There are doors everywhere!"
+	icon_state = "doors"
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/doors, 32)
 
 ////MISC LOCATIONS
 
@@ -235,7 +219,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/chem_diamond, 32)
 	sign_change_name = "Location - Escape Pods"
 	desc = "A warning sign which reads 'ESCAPE PODS'."
 	icon_state = "pods"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/pods, 32)
 
@@ -244,6 +227,5 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/pods, 32)
 	sign_change_name = "Location - Radstorm Shelter"
 	desc = "A warning sign which reads 'RADSTORM SHELTER'."
 	icon_state = "radshelter"
-	is_editable = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/warning/rad_shelter, 32)


### PR DESCRIPTION
## About The Pull Request
Adds new sign subtypes for use with in-game sign customization and the object tree while mapping. This expansion does not add new icons, it only adds subtypes for existing icons that are neglected.

An alternative telecomms sign subtype was given a `sign_change_name` variable so that it could be customized in-game.

Erased the "alt" from a "yes smoking" sign variable since there is only one type.

Variable sanitization in places where it would already inherit from the parent object.

The following sign subtypes have been added:
- Chemistry (alt)
- Xenobio (alt)
- Botany (alt1 and alt2)
- Warning: Blast Doors

## Why It's Good For The Game
The icons are already present, but now the signs are available to mappers without having to manually edit the `icon_state`. 
Players have more options when editing signs in-game.

## Changelog

:cl:
add: More options are now available when creating and editing signs.
/:cl: