### PR TITLE
Moves space initialization check to unit test - Saves 0.065s of init time

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -47,9 +47,10 @@
 	SHOULD_CALL_PARENT(FALSE)
 	air = space_gas
 
-	if(flags_1 & INITIALIZED_1)
-		stack_trace("Warning: [src]([type]) initialized multiple times!")
-	flags_1 |= INITIALIZED_1
+	if (PERFORM_ALL_TESTS(focus_only/multiple_space_initialization))
+		if(flags_1 & INITIALIZED_1)
+			stack_trace("Warning: [src]([type]) initialized multiple times!")
+		flags_1 |= INITIALIZED_1
 
 
 	// We make the assumption that the space plane will never be blacklisted, as an optimization

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -50,7 +50,7 @@
 	if (PERFORM_ALL_TESTS(focus_only/multiple_space_initialization))
 		if(flags_1 & INITIALIZED_1)
 			stack_trace("Warning: [src]([type]) initialized multiple times!")
-		flags_1 |= INITIALIZED_1
+	flags_1 |= INITIALIZED_1
 
 
 	// We make the assumption that the space plane will never be blacklisted, as an optimization

--- a/code/modules/unit_tests/focus_only_tests.dm
+++ b/code/modules/unit_tests/focus_only_tests.dm
@@ -15,5 +15,8 @@
 /// Checks that every icon sent to vending machines is valid
 /datum/unit_test/focus_only/invalid_vending_machine_icon_states
 
+/// Checks that space does not initialize multiple times
+/datum/unit_test/focus_only/multiple_space_initialization
+
 /// Checks that smoothing_groups and canSmoothWith are properly sorted in /atom/Initialize
 /datum/unit_test/focus_only/sorted_smoothing_groups


### PR DESCRIPTION
This hasn't been hit in a long time and this is an extremely hot proc, doing these checks in unit tests should catch any cases, though unlikely.

This has zero cost at runtime because `if (FALSE)` statically compiles out.