### PR TITLE
Makes palladium synthate catalyst easier to create

### DIFF
--- a/code/modules/reagents/chemistry/recipes/catalysts.dm
+++ b/code/modules/reagents/chemistry/recipes/catalysts.dm
@@ -7,7 +7,7 @@
 	mix_message = "The reaction evaporates slightly as the mixture solidifies"
 	mix_sound = 'sound/chemistry/catalyst.ogg'
 	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_UNIQUE | REACTION_TAG_CHEMICAL
-	required_temp = 300
+	required_temp = 200
 	optimal_temp = 500
 	overheat_temp = 800
 	optimal_ph_min = 5

--- a/code/modules/reagents/chemistry/recipes/catalysts.dm
+++ b/code/modules/reagents/chemistry/recipes/catalysts.dm
@@ -7,8 +7,8 @@
 	mix_message = "The reaction evaporates slightly as the mixture solidifies"
 	mix_sound = 'sound/chemistry/catalyst.ogg'
 	reaction_tags = REACTION_TAG_MODERATE | REACTION_TAG_UNIQUE | REACTION_TAG_CHEMICAL
-	required_temp = 320
-	optimal_temp = 600
+	required_temp = 300
+	optimal_temp = 500
 	overheat_temp = 800
 	optimal_ph_min = 5
 	optimal_ph_max = 6


### PR DESCRIPTION
## About The Pull Request

As it stands, Palladium synthate catalyst is extremely hard to make efficiently. The minimum temperature required for this reagent is set to 320K, but the issue is that Plasma, one of its ingredients, turns into gas around 323-324K. Not only that, but the optimal temperature is set to 600K, meaning even when its being made, it goes at a painfully slow rate. As a result, there is an extremely slim temperature margin in which this can be made without accidentally making plasma gas. 

This PR serves to fix that issue by lowering the minimal temperature threshold to 200K, and lowering the optimal temperature to 500K. While you still have to pay attention while making it, at least the margin for error is improved.

## Why It's Good For The Game

By making Palladium synthate catalyst easier to make, it expands more options for chemists to utilize this reagent, such as in plumbing loops or individual reactions.

## Changelog
:cl:
balance: Tweaks the minimal temperature threshold and optimal temperature for Palladium synthate catalyst.
/:cl:
