### PR TITLE
Fixes fake links in Adminwho that led to "no_feedback_link"

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -196,6 +196,9 @@ GLOBAL_PROTECT(href_token)
 	cached_feedback_link = feedback_query.item[1] || NO_FEEDBACK_LINK
 	qdel(feedback_query)
 
+	if (cached_feedback_link == NO_FEEDBACK_LINK) // Because we don't want to send fake clickable links.
+		return null
+
 	return cached_feedback_link
 
 /datum/admins/proc/check_for_rights(rights_required)


### PR DESCRIPTION
## About The Pull Request
Basically, sometimes, very rarely, it was possible for this to happen, when it shouldn't be happening. I was wondering for a little while what it was about, and then I finally downloaded my chat logs for a round and realized what was going on. It should no longer happen.

## Why It's Good For The Game
Clickable links that lead nowhere (and thus don't do anything) aren't very good for the game.

## Changelog

:cl: GoldenAlpharex
fix: There shouldn't be clickable names in Adminwho that don't do anything anymore.
/:cl: