### PR TITLE
Gives wizard fireball a heavy impact range.

### DIFF
--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -536,7 +536,7 @@
 	nodamage = FALSE
 
 	/// Heavy explosion range of the fireball
-	var/exp_heavy = 0
+	var/exp_heavy = 1
 	/// Light explosion range of the fireball
 	var/exp_light = 2
 	/// Fire radius of the fireball


### PR DESCRIPTION

## About The Pull Request
Wizard fireball will do do a 0, 1, 2 explosion, instead of 0, 0, 2. This causes a heavy impact on the epicenter.
## Why It's Good For The Game
Getting hit directly by a fireball should be a death sentence.
## Changelog
:cl:
balance: Wizard fireballs will have a heavy impact on the epicenter of the explosion.
/:cl:
