### PR TITLE
Getting hit by a nuclear particle will always irradiate you.

### DIFF
--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -27,7 +27,7 @@
 
 /obj/projectile/energy/nuclear_particle/on_hit(atom/target, blocked, pierce_hit)
 	if (ishuman(target))
-		radiation_pulse(target, max_range = 0, threshold = RAD_FULL_INSULATION)
+		radiation_pulse(target, max_range = 0, threshold = RAD_FULL_INSULATION, chance = 100)
 
 	..()
 

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -27,7 +27,7 @@
 
 /obj/projectile/energy/nuclear_particle/on_hit(atom/target, blocked, pierce_hit)
 	if (ishuman(target))
-		radiation_pulse(target, max_range = 0, threshold = RAD_FULL_INSULATION, chance = 100)
+		SSradiation.irradiate(target)
 
 	..()
 


### PR DESCRIPTION

## About The Pull Request
Makes nuclear particles directly irradiate people.
## Why It's Good For The Game
Getting hit by a nuclear particle should be a death sentence.
## Changelog
:cl:
balance: Nuclear particles will always irradiate you on hit.
/:cl:
