### PR TITLE
Biomass generation fixed (watermelons gave 4 biomass instead of 24)

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1317,10 +1317,11 @@
 
 /datum/reagents/proc/get_multiple_reagent_amounts(list/reagents)
 	var/list/cached_reagents = reagent_list
+	var/total_amount = 0
 	for(var/datum/reagent/cached_reagent as anything in cached_reagents)
 		if(cached_reagent.type in reagents)
-			return round(cached_reagent.volume, CHEMICAL_QUANTISATION_LEVEL)
-	return 0
+			total_amount += round(cached_reagent.volume, CHEMICAL_QUANTISATION_LEVEL)
+	return total_amount
 
 /// Get the purity of this reagent
 /datum/reagents/proc/get_reagent_purity(reagent)


### PR DESCRIPTION
## About The Pull Request

In the previous attempt to buff biogenerator in https://github.com/tgstation/tgstation/pull/71563 it started using `get_multiple_reagent_amounts()` proc which returned only the volume of the first found reagent.

100 potency watermelons have 4 vitamins and 20 nutriments, so this proc found 4 vitamins and returned only those.

Essentially, all this time biogen have been giving biomass for vitamins only, and for nutrments when the plant didn't have vitamins.

## Why It's Good For The Game

They have been suffering this whole time. And cursing me for nerfing biomass to abyss.

## Changelog

:cl:
fix: Biogenerator converts all plant nutriments into biomass, not just the first found one.
fix: Chef's kiss converts all food nutriments into love, not just the first found one.
/:cl:


