### PR TITLE
Frying an egg doesn't make it have twice more nutriments

### DIFF
--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -147,7 +147,7 @@
 	desc = "A fried egg. Would go well with a touch of salt and pepper."
 	icon = 'icons/obj/food/egg.dmi'
 	icon_state = "friedegg"
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/eggyolk = 2 , /datum/reagent/consumable/nutriment/vitamin = 2)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 3, /datum/reagent/consumable/eggyolk = 1 , /datum/reagent/consumable/nutriment/vitamin = 1)
 	bite_consumption = 1
 	tastes = list("egg" = 4)
 	foodtypes = MEAT | FRIED | BREAKFAST


### PR DESCRIPTION
## About The Pull Request

Essentially, right now a single fried egg is more filling than a steak.

Current egg conversion:
Raw egg - 4 white, 2 yolk
Boiled - 3 protein, 1 vitamin
Fried - 6 protein, 2 vitamin, 2 yolk

I made fried have 3 protein, 1 vitamin, 1 yolk.

This was probably forgotten when fried egg stopped being crafted from two raw eggs.

On this image you can see how nutritious fried egg is compared to other dishes made of raw eggs:
![image](https://user-images.githubusercontent.com/3625094/206625291-e89e29b9-b9e2-463d-92de-bcf42be6e4ba.png)

## Why It's Good For The Game

Only chicken are allowed to dupe eggs.

## Changelog

:cl:
fix: Fried egg reagents halved to meet the raw egg reagent amount
/:cl: