### PR TITLE
[NO GBP] Reswitched the base supermatter ray to be the original one.

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(sm_delam_list, list(
 
 	sm.add_filter(name = "ray", priority = 1, params = list(
 		type = "rays",
-		size = sm.internal_energy ? clamp((sm.damage/100) * sm.internal_energy, 50, 125) : 1,
+		size = clamp(sm.internal_energy / 30, 1, 125),
 		color = (sm.gas_heat_power_generation > 0.8 ? SUPERMATTER_RED : SUPERMATTER_COLOUR),
 		factor = clamp(sm.damage/600, 1, 10),
 		density = clamp(sm.damage/10, 12, 100)


### PR DESCRIPTION
## About The Pull Request
Fixes #71828 

I used the singulo and tesla ones, shouldve used the original one.

Original is here:
https://github.com/tgstation/tgstation/blob/fbf546847df34ccbb9da50963cc1898ee68e41a3/code/modules/power/supermatter/supermatter_glow.dm#L29

## Why It's Good For The Game
Restores it back to how the original coder wanted it.

## Changelog
:cl:
fix: fixed sm base ray needing damage to resize
/:cl:
