### PR TITLE
Fix circuitboards stock parts examine

### DIFF
--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -125,21 +125,19 @@ micro-manipulator, console screen, beaker, Microlaser, matter bin, power cells.
 				component_name = initial(stack_path.singular_name) //e.g. "glass sheet" vs. "glass"
 		else if(ispath(component_path, /obj/item/stock_parts) && !specific_parts)
 			var/obj/item/stock_parts/stock_part = component_path
-			if(initial(stock_part.base_name))
-				component_name = initial(stock_part.base_name)
+			component_name = initial(stock_part.base_name) || initial(stock_part.name)
 		else if(ispath(component_path, /obj/item/stock_parts))
 			var/obj/item/stock_parts/stock_part = component_path
-			if(initial(stock_part.name))
-				component_name = initial(stock_part.name)
+			component_name = initial(stock_part.name)
 		else if(ispath(component_path, /datum/stock_part))
 			var/datum/stock_part/stock_part = component_path
-			var/obj/item/physical_object_type = initial(stock_part.physical_object_type)
-			if (initial(physical_object_type.name))
-				component_name = initial(physical_object_type.name)
+			var/obj/item/stock_parts/physical_object_type = initial(stock_part.physical_object_type)
+			component_name = initial(physical_object_type.base_name) || initial(physical_object_type.name)
 		else if(ispath(component_path, /atom))
 			var/atom/stock_part = component_path
 			component_name = initial(stock_part.name)
-		else
+
+		if (isnull(component_name))
 			stack_trace("[component_path] was an invalid component")
 
 		nice_list += list("[component_amount] [component_name]\s")


### PR DESCRIPTION

## About The Pull Request
Fixes #71807. Wasn't always returning a component_name.

Don't you like that we can start out with such simple bugs before moving onto more integration?

## Changelog
:cl:
fix: Fixed circuitboards sometimes giving no name on examine.
/:cl:
