### PR TITLE
Natural booze

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -110,18 +110,27 @@
 	for(var/datum/reagent/reagent in reagents.reagent_list)
 		if(reagent.type != /datum/reagent/consumable/nutriment && reagent.type != /datum/reagent/consumable/nutriment/vitamin)
 			continue
+		var/purity = clamp(seed.lifespan/200 + seed.endurance/200, 0, 1)
+		var/quality_min = DRINK_NICE
+		var/quality_max = DRINK_FANTASTIC
+		var/quality = round(LERP(quality_min, quality_max, purity))
 		if(distill_reagent)
-			reagents.add_reagent(distill_reagent, reagent.volume)
+			var/data = list()
+			var/datum/reagent/consumable/ethanol/booze = distill_reagent
+			data["quality"] = quality
+			data["boozepwr"] = round(initial(booze.boozepwr) * purity)
+			reagents.add_reagent(distill_reagent, reagent.volume, data, added_purity = purity)
 		else
 			var/data = list()
 			data["names"] = list("[initial(name)]" = 1)
 			data["color"] = filling_color
-			data["boozepwr"] = wine_power
+			data["boozepwr"] = round(wine_power * purity)
+			data["quality"] = quality
 			if(wine_flavor)
 				data["tastes"] = list(wine_flavor = 1)
 			else
 				data["tastes"] = list(tastes[1] = 1)
-			reagents.add_reagent(/datum/reagent/consumable/ethanol/fruit_wine, reagent.volume, data)
+			reagents.add_reagent(/datum/reagent/consumable/ethanol/fruit_wine, reagent.volume, data, added_purity = purity)
 		reagents.del_reagent(reagent.type)
 
 /obj/item/food/grown/on_grind()

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -111,7 +111,7 @@
 		if(reagent.type != /datum/reagent/consumable/nutriment && reagent.type != /datum/reagent/consumable/nutriment/vitamin)
 			continue
 		var/purity = clamp(seed.lifespan/200 + seed.endurance/200, 0, 1)
-		var/quality_min = DRINK_NICE
+		var/quality_min = 0
 		var/quality_max = DRINK_FANTASTIC
 		var/quality = round(LERP(quality_min, quality_max, purity))
 		if(distill_reagent)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -38,7 +38,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 */
 
 /datum/reagent/consumable/ethanol/New(list/data)
-	if(data)
+	if(LAZYLEN(data))
 		if(data["quality"])
 			quality = data["quality"]
 			name = "Natural " + name

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -37,7 +37,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 91-100: Dangerously toxic - swift death
 */
 
-/datum/reagent/consumable/ethanol/New()
+/datum/reagent/consumable/ethanol/New(list/data)
+	if(data["quality"])
+		quality = data["quality"]
+		name = "Natural " + name
+	if(data["boozepwr"])
+		boozepwr = data["boozepwr"]
 	addiction_types = list(/datum/addiction/alcohol = 0.05 * boozepwr)
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -38,11 +38,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 */
 
 /datum/reagent/consumable/ethanol/New(list/data)
-	if(data["quality"])
-		quality = data["quality"]
-		name = "Natural " + name
-	if(data["boozepwr"])
-		boozepwr = data["boozepwr"]
+	if(data)
+		if(data["quality"])
+			quality = data["quality"]
+			name = "Natural " + name
+		if(data["boozepwr"])
+			boozepwr = data["boozepwr"]
 	addiction_types = list(/datum/addiction/alcohol = 0.05 * boozepwr)
 	return ..()
 

--- a/tgui/packages/tgui/interfaces/SeedExtractor.tsx
+++ b/tgui/packages/tgui/interfaces/SeedExtractor.tsx
@@ -108,7 +108,9 @@ export const SeedExtractor = (props, context) => {
               </Table.Cell>
               <Table.Cell collapsing p={1}>
                 <Tooltip
-                  content={'The health pool of the plant that delays death.'}>
+                  content={
+                    'The health pool of the plant that delays death. Affects fermentation quality.'
+                  }>
                   <Box
                     style={{ 'cursor': 'pointer' }}
                     onClick={(e) => setSortField('endurance')}>
@@ -118,7 +120,7 @@ export const SeedExtractor = (props, context) => {
               </Table.Cell>
               <Table.Cell collapsing p={1}>
                 <Tooltip
-                  content={`The age at which the plant starts decaying, in ${data.cycle_seconds} second long cycles.`}>
+                  content={`The age at which the plant starts decaying, in ${data.cycle_seconds} second long cycles. Affects fermentation quality.`}>
                   <Box
                     style={{ 'cursor': 'pointer' }}
                     onClick={(e) => setSortField('lifespan')}>


### PR DESCRIPTION
## About The Pull Request

Makes fermented booze take quality and power from the endurance and lifespan stats of the fruit.
These are the most neglected plant stats, and usually plants that have these high by default, do not have much nutriments.

This change makes fermented drinks a bit more desirable because your effort is reflected in their stats. And you get better mood buff by making them higher.

Fruit wine and other reagents get a "Natural" prefix when made through fermentation.

![image](https://user-images.githubusercontent.com/3625094/206508903-c3ff85d2-c904-4a12-ae23-422604d87edf.png)

I consider turning it into a more general solution so that dispensed drinks will also have purity and if the barman wants to aim for an absolute quality cocktail, he may want to cooperate with botany like chef does.

## Why It's Good For The Game

Fermented drinks are now a bit special compared to the free booze dispenser variants.

## Changelog

:cl:
add: Fermented drinks give mood buffs according to the stats of fermented fruit
/:cl:
