### PR TITLE
Reversed an unintentional change to golem trigger guard prices

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_golem.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_golem.dm
@@ -27,7 +27,7 @@
 
 /datum/orderable_item/golem/trigger_guard
 	item_path = /obj/item/borg/upgrade/modkit/trigger_guard
-	cost_per_order = 17500
+	cost_per_order = 1700
 
 /datum/orderable_item/golem/rnd_boards
 	item_path = /obj/item/storage/box/rndboards


### PR DESCRIPTION

## About The Pull Request

#71023 raised the price of golem trigger guards from 1700 to 17500, this was not documented and appears to be an unintentional change.
## Why It's Good For The Game

Golems should realistically be able to afford their own gear and accidental change bad.
## Changelog
:cl:
fix: The golem trigger guard scalping situation has improved and golems can now once again purchase trigger guards at market rate.
/:cl:
