### PR TITLE
Creates short-lived foam (and applies it to the Scrubber Overflow)

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -193,7 +193,7 @@
 
 
 // Short-lived foam
-/// A foam variant which dissapates quickly.
+/// A foam variant which dissipates quickly.
 /obj/effect/particle_effect/fluid/foam/short_life
 	lifetime = 1 SECONDS
 

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -192,6 +192,14 @@
 	SSfoam.queue_spread(foam)
 
 
+// Short-lived foam
+/// A foam variant which dissapates quickly.
+/obj/effect/particle_effect/fluid/foam/short_life
+	lifetime = 1 SECONDS
+
+/datum/effect_system/fluid_spread/foam/short
+	effect_type = /obj/effect/particle_effect/fluid/foam/short_life
+
 // Long lasting foam
 /// A foam variant which lasts for an extended amount of time.
 /obj/effect/particle_effect/fluid/foam/long_life

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -93,8 +93,6 @@
 		return TRUE //there's at least one. we'll let the codergods handle the rest with prob() i guess.
 	return FALSE
 
-
-
 /datum/round_event/scrubber_overflow/start()
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/vent as anything in scrubbers)
 		if(!vent.loc)
@@ -111,7 +109,7 @@
 		else
 			dispensed_reagent.add_reagent(pick(safer_chems), reagents_amount)
 
-		dispensed_reagent.create_foam(/datum/effect_system/fluid_spread/foam, reagents_amount)
+		dispensed_reagent.create_foam(/datum/effect_system/fluid_spread/foam/short, reagents_amount)
 
 		CHECK_TICK
 


### PR DESCRIPTION
## About The Pull Request
Creates a short-lived foam with a lifetime of 1 SECOND instead of the default 8 SECONDS to address some complaints about the scrubber overflow event overstaying its welcome. 

## Why It's Good For The Game
Fixes #69689 
Fixes #71830

## Changelog
:cl: Tattle
balance: the foam used in the scrubber overflow has a lifetime of 1s instead of 8s
/:cl: