### PR TITLE
Zombies now return from the dead

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -873,7 +873,7 @@
 		return FALSE
 
 	// And we can't heal them if they're missing their liver
-	if(!getorganslot(ORGAN_SLOT_LIVER))
+	if(!HAS_TRAIT(src, TRAIT_NOMETABOLISM) && !getorganslot(ORGAN_SLOT_LIVER))
 		return FALSE
 
 	return ..()


### PR DESCRIPTION
## About The Pull Request

Romerol was broken such that if you gave it to someone their corpse would turn into a zombie's corpse and stay dead.
This is because they were changed to use the `heal_and_revive` proc, which in turn checks if you have a liver.
Zombies don't have livers, so would never be revived.

## Why It's Good For The Game

People usually expect zombies to do this.

## Changelog

:cl:
fix: Romerol now successfully converts zombies into the living dead, rather than the uglier but still dead dead.
/:cl: