### PR TITLE
Fixes pinned module modsuit icons

### DIFF
--- a/code/modules/mod/mod_actions.dm
+++ b/code/modules/mod/mod_actions.dm
@@ -129,17 +129,16 @@
 /datum/action/item_action/mod/pinned_module/New(Target, obj/item/mod/module/linked_module, mob/user)
 	if(isAI(user))
 		ai_action = TRUE
+	button_icon = linked_module.icon
+	button_icon_state = linked_module.icon_state
 	..()
 	module = linked_module
 	name = "Activate [capitalize(linked_module.name)]"
 	desc = "Quickly activate [linked_module]."
-	button_icon = linked_module.icon
-	button_icon_state = linked_module.icon_state
-	RegisterSignal(linked_module, COMSIG_MODULE_ACTIVATED, PROC_REF(on_module_activate))
-	RegisterSignal(linked_module, COMSIG_MODULE_DEACTIVATED, PROC_REF(on_module_deactivate))
-	RegisterSignal(linked_module, COMSIG_MODULE_USED, PROC_REF(on_module_use))
+	RegisterSignals(linked_module, list(COMSIG_MODULE_ACTIVATED, COMSIG_MODULE_DEACTIVATED, COMSIG_MODULE_USED), PROC_REF(module_interacted_with))
 
 /datum/action/item_action/mod/pinned_module/Destroy()
+	UnregisterSignal(module, list(COMSIG_MODULE_ACTIVATED, COMSIG_MODULE_DEACTIVATED, COMSIG_MODULE_USED))
 	module.pinned_to -= pinner_ref
 	module = null
 	return ..()
@@ -173,17 +172,7 @@
 		current_button.add_overlay(cooldown_image)
 		addtimer(CALLBACK(current_button, TYPE_PROC_REF(/image, cut_overlay), cooldown_image), COOLDOWN_TIMELEFT(module, cooldown_timer))
 
-/datum/action/item_action/mod/pinned_module/proc/on_module_activate(datum/source)
+/datum/action/item_action/mod/pinned_module/proc/module_interacted_with(datum/source)
 	SIGNAL_HANDLER
 
-	build_all_button_icons()
-
-/datum/action/item_action/mod/pinned_module/proc/on_module_deactivate(datum/source)
-	SIGNAL_HANDLER
-
-	build_all_button_icons()
-
-/datum/action/item_action/mod/pinned_module/proc/on_module_use(datum/source)
-	SIGNAL_HANDLER
-
-	build_all_button_icons()
+	build_all_button_icons(UPDATE_BUTTON_OVERLAY|UPDATE_BUTTON_STATUS)

--- a/code/modules/mod/mod_actions.dm
+++ b/code/modules/mod/mod_actions.dm
@@ -159,9 +159,10 @@
 	module.on_select()
 
 /datum/action/item_action/mod/pinned_module/apply_button_overlay(atom/movable/screen/movable/action_button/current_button, force)
-	. = ..()
+	current_button.cut_overlays()
 	if(override)
-		return
+		return ..()
+
 	var/obj/item/mod/control/mod = target
 	if(module == mod.selected_module)
 		current_button.add_overlay(image(icon = 'icons/hud/radial.dmi', icon_state = "module_selected", layer = FLOAT_LAYER-0.1))
@@ -171,6 +172,7 @@
 		var/image/cooldown_image = image(icon = 'icons/hud/radial.dmi', icon_state = "module_cooldown")
 		current_button.add_overlay(cooldown_image)
 		addtimer(CALLBACK(current_button, TYPE_PROC_REF(/image, cut_overlay), cooldown_image), COOLDOWN_TIMELEFT(module, cooldown_timer))
+	return ..()
 
 /datum/action/item_action/mod/pinned_module/proc/module_interacted_with(datum/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

- `item_action/New` is where it item actions generate an icon based on the target if the icon is null. Pinned modules set up the icon **after** the parent call, so it went through to New, generated the icon, and THEN set its own icon.
   - Simply moves the icon setup to before the parent call to resolve this. 
- Also removes some copy and paste code. 

## Why It's Good For The Game

Icons look good
![image](https://user-images.githubusercontent.com/51863163/206623593-d6bbd4ea-5b5d-4365-aa08-d43d4fce0335.png)

## Changelog

:cl: Melbert
fix: Corrects the look of pinned modules
/:cl:
