### PR TITLE
Takes the Tram off of the game plane, to make everything on it look a lot less flat

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -929,7 +929,7 @@
 "asv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/glass/reinforced/tram,
+/turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "asw" = (
 /obj/machinery/computer/monitor{
@@ -12643,7 +12643,7 @@
 /obj/structure/fluff/tram_rail/floor{
 	dir = 1
 	},
-/turf/open/floor/glass/reinforced/tram,
+/turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "ezX" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -13478,7 +13478,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter Control Panel";
-	preset_destination_names = list("2" = "Hydroponics", "3" = "Kitchen")
+	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
 	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
@@ -23648,7 +23648,7 @@
 /obj/structure/fluff/tram_rail/floor,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/glass/reinforced/tram,
+/turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "iCA" = (
 /obj/structure/fluff{
@@ -26673,7 +26673,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/glass/reinforced/tram,
+/turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "jJO" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -30589,7 +30589,7 @@
 "kYX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/glass/reinforced/tram,
+/turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "kYZ" = (
 /obj/machinery/airalarm/server{
@@ -30601,10 +30601,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
-"kZb" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/glass/reinforced/tram,
-/area/station/hallway/primary/tram/right)
 "kZh" = (
 /turf/open/floor/eighties/red,
 /area/station/commons/fitness/recreation/entertainment)
@@ -56741,7 +56737,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter Control Panel";
-	preset_destination_names = list("2" = "Hydroponics", "3" = "Kitchen")
+	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
@@ -57746,7 +57742,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/glass/reinforced/tram,
+/turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "uIO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60528,7 +60524,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/fluff/tram_rail/floor,
 /obj/structure/cable,
-/turf/open/floor/glass/reinforced/tram,
+/turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "vKb" = (
 /obj/structure/lattice,
@@ -63576,7 +63572,7 @@
 "wQO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/fluff/tram_rail/floor,
-/turf/open/floor/glass/reinforced/tram,
+/turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "wQP" = (
 /turf/closed/wall,
@@ -175163,11 +175159,11 @@ wkz
 xHd
 xPU
 nXJ
-kZb
+iDv
 wQO
 oSW
 ezQ
-kZb
+iDv
 qsl
 aNP
 czl

--- a/code/game/objects/structures/fluff.dm
+++ b/code/game/objects/structures/fluff.dm
@@ -274,7 +274,7 @@
 	icon = 'icons/obj/tram_rails.dmi'
 	icon_state = "rail"
 	layer = TRAM_RAIL_LAYER
-	plane = GAME_PLANE
+	plane = FLOOR_PLANE
 	deconstructible = TRUE
 
 /obj/structure/fluff/tram_rail/floor

--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -781,7 +781,6 @@ GLOBAL_LIST_EMPTY(lifts)
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "titanium_yellow"
 	layer = TRAM_FLOOR_LAYER
-	plane = GAME_PLANE
 	base_icon_state = null
 	smoothing_flags = NONE
 	smoothing_groups = null

--- a/code/modules/industrial_lift/tram_override_objects.dm
+++ b/code/modules/industrial_lift/tram_override_objects.dm
@@ -26,7 +26,6 @@
 /turf/open/floor/glass/reinforced/tram
 	name = "tram bridge"
 	desc = "It shakes a bit when you step, but lets you cross between sides quickly!"
-	plane = GAME_PLANE
 	layer = TRAM_XING_LAYER
 
 /obj/machinery/door/window/tram


### PR DESCRIPTION
## About The Pull Request
That's about it. It being on the game plane sadly had the inherent issue of "no more ambient occlusion for anything that goes in it", which made it look jarring.

Sadly, because of this, I had to put regular iron floor tiles over the pipes/wires/disposals pipes on those crossings, but that's just further motivation for LT3 and I to work on some new glass plating and actual glass tiles so we can make this work properly again.

## Why It's Good For The Game
Muh ambient occlusion.

_Seriously, it just looks *SO* much better._
![image](https://user-images.githubusercontent.com/58045821/206630324-725131f1-d924-457c-b1db-78fc03a1cd92.png)


## Changelog

:cl: GoldenAlpharex
fix: Everything that goes on the tram should look a lot less flat now!
/:cl: