### PR TITLE
Biomass overlay thresholds use sine function

### DIFF
--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -132,7 +132,8 @@
 		. += mutable_appearance(icon, "[icon_state]_o_container")
 
 	if(biomass > 0)
-		var/biomass_level = min(ROUND_UP(7 * biomass / max_visual_biomass), 7)
+		var/biomass_volume_sin = sin(min(biomass/max_visual_biomass, 1) * 90)
+		var/biomass_level = ROUND_UP(biomass_volume_sin * 7)
 		. += mutable_appearance(icon, "[icon_state]_o_biomass_[biomass_level]")
 		. += emissive_appearance(icon, "[icon_state]_o_biomass_[biomass_level]", src)
 

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -132,7 +132,9 @@
 		. += mutable_appearance(icon, "[icon_state]_o_container")
 
 	if(biomass > 0)
+		// Get current biomass volume adjusted with sine function (more biomass = less frequent icon changes)
 		var/biomass_volume_sin = sin(min(biomass/max_visual_biomass, 1) * 90)
+		// Round up to get the corresponding overlay icon
 		var/biomass_level = ROUND_UP(biomass_volume_sin * 7)
 		. += mutable_appearance(icon, "[icon_state]_o_biomass_[biomass_level]")
 		. += emissive_appearance(icon, "[icon_state]_o_biomass_[biomass_level]", src)


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/3625094/206639477-c971dee0-3f0a-4fc8-beff-afb8709d0c6c.png)

In recent PRs, biogen cap got raised to 5000 units, which is far more than people usually have during most shifts.

This makes the biomass overlay icons pointless, because it will always have the same icon untill you go above 714 biomass, which is higher than the previous cap and more than anyone needs for normal tasks.

I made the overlay use sine interpolation to make the icon change faster at lower levels, but slower when the visual cap is near.

Linear thresholds (Old):
Min biomass at 1, 714, 1428, 2142, 2856, 3570, 4285

Sine thresholds (new):
Min biomass at 1, 440, 930, 1420, 1940, 2560, 3300 

![image](https://user-images.githubusercontent.com/3625094/206638496-87f47613-66f5-4027-9c1f-45fcbdd56962.png)

## Why It's Good For The Game

The icon was supposed to be an indicator that tells you - will you get enough leather or monkey cubes from biogen without even opening its UI.

When the cap got raised to 5000 it started telling whether you can make a ton of leather or a shit ton.

Now the indicator should be slightly more useful.

## Changelog

:cl:
qol: Biogenenerator biomass overlay uses sine instead of linear interpolation
/:cl:
