### PR TITLE
Fixed an improper proc ref.

### DIFF
--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -157,7 +157,7 @@
 		user = user,
 		anchor = src,
 		choices = armament_names_to_images,
-		custom_check = CALLBACK(src, .proc/can_use_beacon, user),
+		custom_check = CALLBACK(src, PROC_REF(can_use_beacon), user),
 		require_near = TRUE,
 	)
 	if(!can_use_beacon(user))


### PR DESCRIPTION

## About The Pull Request

I noticed that Linters was failing on another PR I opened, due to a proc ref in a single file being in the old format. I've set it to use PROC_REF() instead, which should fix this.
## Why It's Good For The Game

Linters errors are annoying, especially when they're not even related to your PR. Plus, these need to be in this format for future compatibility.
## Changelog
:cl:
code: Switched a single proc ref to the proper format.
/:cl:
