### PR TITLE
Fixes Linters (Three Month Old PR Edition)

### DIFF
--- a/code/modules/unit_tests/say.dm
+++ b/code/modules/unit_tests/say.dm
@@ -46,7 +46,7 @@
 	var/mob/host_mob
 
 /datum/unit_test/translate_language/Run()
-	host_mob = allocate(/mob/living/carbon/human)
+	host_mob = allocate(/mob/living/carbon/human/consistent)
 	var/surfer_quote = "surfing in the USA"
 
 	host_mob.grant_language(/datum/language/beachbum, spoken=TRUE, understood=FALSE) // can speak but can't understand
@@ -98,8 +98,8 @@
 	handle_hearing_result += hearing_args
 
 /datum/unit_test/speech/Run()
-	speaker = allocate(/mob/living/carbon/human)
-	listener = allocate(/mob/living/carbon/human)
+	speaker = allocate(/mob/living/carbon/human/consistent)
+	listener = allocate(/mob/living/carbon/human/consistent)
 	// Hear() requires a client otherwise it will early return
 	var/datum/client_interface/mock_client = new()
 	listener.mock_client = mock_client


### PR DESCRIPTION

## About The Pull Request

On the tin, we required usage of `/mob/living/carbon/human/consistent` sometime last month and linters were never reran on 48e36ef2c78dc1f19d2542f6e0181b6f8f4a1d2e (#69799), causing it to error out and skew.
## Why It's Good For The Game

CI is BROKEN I am going to SOB.
## Changelog
Nothing to concern players.
