### PR TITLE
Respawn Verb now alerts if respawning is disabled

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -744,10 +744,14 @@
 	set name = "Respawn"
 	set category = "OOC"
 
-	if (CONFIG_GET(flag/norespawn) && (!check_rights_for(usr.client, R_ADMIN) || tgui_alert(usr, "Respawn configs disabled. Do you want to use your permissions to circumvent it?", "Respawn", list("Yes", "No")) != "Yes"))
+	if (CONFIG_GET(flag/norespawn) && !check_rights_for(usr.client, R_ADMIN))
+		to_chat(usr, span_boldwarning("Respawning is not enabled!"))
 		return
 
-	if ((stat != DEAD || !( SSticker )))
+	if (check_rights_for(usr.client, R_ADMIN) && tgui_alert(usr, "Respawning is currently disabled, do you want to use your permissions to circumvent it?", "Respawn", list("Yes", "No")) != "Yes")
+		return
+
+	if (stat != DEAD)
 		to_chat(usr, span_boldnotice("You must be dead to use this!"))
 		return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -746,13 +746,13 @@
 
 	if (CONFIG_GET(flag/norespawn))
 		if (!check_rights_for(usr.client, R_ADMIN))
-			to_chat(usr, span_boldwarning("Respawning is not enabled!"))
+			to_chat(usr, span_boldnotice("Respawning is not enabled!"))
 			return
 		else if (tgui_alert(usr, "Respawning is currently disabled, do you want to use your permissions to circumvent it?", "Respawn", list("Yes", "No")) != "Yes")
 			return
 
 	if (stat != DEAD)
-		to_chat(usr, span_boldwarning("You must be dead to use this!"))
+		to_chat(usr, span_boldnotice("You must be dead to use this!"))
 		return
 
 	usr.log_message("used the respawn button.", LOG_GAME)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -752,7 +752,7 @@
 		return
 
 	if (stat != DEAD)
-		to_chat(usr, span_boldnotice("You must be dead to use this!"))
+		to_chat(usr, span_boldwarning("You must be dead to use this!"))
 		return
 
 	usr.log_message("used the respawn button.", LOG_GAME)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -744,12 +744,12 @@
 	set name = "Respawn"
 	set category = "OOC"
 
-	if (CONFIG_GET(flag/norespawn) && !check_rights_for(usr.client, R_ADMIN))
-		to_chat(usr, span_boldwarning("Respawning is not enabled!"))
-		return
-
-	if (check_rights_for(usr.client, R_ADMIN) && tgui_alert(usr, "Respawning is currently disabled, do you want to use your permissions to circumvent it?", "Respawn", list("Yes", "No")) != "Yes")
-		return
+	if (CONFIG_GET(flag/norespawn))
+		if (!check_rights_for(usr.client, R_ADMIN))
+			to_chat(usr, span_boldwarning("Respawning is not enabled!"))
+			return
+		else if (tgui_alert(usr, "Respawning is currently disabled, do you want to use your permissions to circumvent it?", "Respawn", list("Yes", "No")) != "Yes")
+			return
 
 	if (stat != DEAD)
 		to_chat(usr, span_boldwarning("You must be dead to use this!"))


### PR DESCRIPTION

## About The Pull Request
I'm not sure how it was before, but pressing the respawn verb if it's disabled will now alert non-admins if it's disabled.
I suggested for the verb to be unavailable completely if you can't respawn like this to avoid confusion with new players, but it was shrugged off.

Also fixes the grammorr a bit with admins trying to use it instead to bypass the config
## Why It's Good For The Game
:)
## Changelog
:cl:
fix: The respawn verb now alerts players if respawning is disabled
/:cl:
