### PR TITLE
Fixes FRAME cartridges

### DIFF
--- a/code/modules/modular_computers/computers/item/disks/virus_disk.dm
+++ b/code/modules/modular_computers/computers/item/disks/virus_disk.dm
@@ -120,14 +120,14 @@
 	telecrystal_stack.use(telecrystal_stack.amount)
 
 
-/obj/item/computer_disk/virus/frame/send_virus(obj/item/modular_computer/pda/target, mob/living/user)
+/obj/item/computer_disk/virus/frame/send_virus(obj/item/modular_computer/pda/source, obj/item/modular_computer/pda/target, mob/living/user)
 	. = ..()
 	if(!.)
 		return FALSE
 
 	charges--
-	var/lock_code = "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"
-	to_chat(user, span_notice("Success! The unlock code to the target is: [lock_code]"))
+	var/unlock_code = "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"
+	to_chat(user, span_notice("Success! The unlock code to the target is: [unlock_code]"))
 	var/datum/component/uplink/hidden_uplink = target.GetComponent(/datum/component/uplink)
 	if(!hidden_uplink)
 		var/datum/mind/target_mind
@@ -143,7 +143,8 @@
 				target_mind = user.mind
 			else
 				target_mind = pick(backup_players)
-		hidden_uplink = target.AddComponent(/datum/component/uplink, target_mind, enabled = TRUE, starting_tc = telecrystals, has_progression = TRUE)
+		hidden_uplink = target.AddComponent(/datum/component/uplink, target_mind, enabled = TRUE, starting_tc = telecrystals, has_progression = TRAIT_CAN_USE_FLIGHT_POTION)
+		hidden_uplink.unlock_code = unlock_code
 		hidden_uplink.uplink_handler.has_objectives = TRUE
 		hidden_uplink.uplink_handler.owner = target_mind
 		hidden_uplink.uplink_handler.can_take_objectives = FALSE

--- a/code/modules/modular_computers/computers/item/disks/virus_disk.dm
+++ b/code/modules/modular_computers/computers/item/disks/virus_disk.dm
@@ -143,7 +143,7 @@
 				target_mind = user.mind
 			else
 				target_mind = pick(backup_players)
-		hidden_uplink = target.AddComponent(/datum/component/uplink, target_mind, enabled = TRUE, starting_tc = telecrystals, has_progression = TRAIT_CAN_USE_FLIGHT_POTION)
+		hidden_uplink = target.AddComponent(/datum/component/uplink, target_mind, enabled = TRUE, starting_tc = telecrystals, has_progression = TRUE)
 		hidden_uplink.unlock_code = unlock_code
 		hidden_uplink.uplink_handler.has_objectives = TRUE
 		hidden_uplink.uplink_handler.owner = target_mind

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -180,7 +180,7 @@
 				if(sending_virus)
 					var/obj/item/computer_disk/virus/disk = computer.inserted_disk
 					if(istype(disk))
-						disk.send_virus(src, target, usr)
+						disk.send_virus(computer, target, usr)
 						return UI_UPDATE
 
 				send_message(usr, list(target))


### PR DESCRIPTION
## About The Pull Request

The NTmessenger has been passing along itself to the send_virus proc instead of the computer it is running on, which has caused runtimes, due to computer programs not having certain variables.  In addition, the send_virus override for the frame cartrdige was missing an argument. Lastly, the uplink code has not been actually assigned to the uplink, so once it has been closed, it stayed closed. These have been fixed.

I have checked the other viruses, they seem to be working even after my changes. 

## Why It's Good For The Game

Fixes #71843 
You can once again frame people, and maybe, tempt them.

## Changelog

:cl:
fix: F.R.A.M.E. cartridges work again
/:cl:
