### PR TITLE
Coupons now fit in wallets

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -18,6 +18,7 @@
 		/obj/item/holochip,
 		/obj/item/card,
 		/obj/item/clothing/mask/cigarette,
+		/obj/item/coupon,
 		/obj/item/flashlight/pen,
 		/obj/item/seeds,
 		/obj/item/stack/medical,


### PR DESCRIPTION

## About The Pull Request
Adds coupons to the list of items allowed in wallets. They're little pieces of paper, you'd commonly keep them in there!
## Why It's Good For The Game
They're a tiny item that are best suited to be kept in wallets when possible instead of taking up inventory space in a bag.
## Changelog
:cl: LT3
qol: Coupons can now be stored in wallets, freeing up inventory space.
/:cl:
