### PR TITLE
Sleeping status now considers being deaf

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -196,7 +196,7 @@
 			healing += 0.1
 
 		// sleeping in silence is always better
-		if(HAS_TRAIT(src, TRAIT_DEAF))
+		if(HAS_TRAIT(owner, TRAIT_DEAF))
 			healing += 0.1
 
 		// check for beds


### PR DESCRIPTION
## About The Pull Request

A bug in the sleeping status effect made it impossible to adjust the healing threshold with wearing earmuffs or being deaf alltogether, this PR fixes that issue

## Why It's Good For The Game
bug fix

## Changelog

:cl:
fix: wearing earmuffs or being deaf while being asleep will increase the healing threshold like its supposed to be
/:cl:
