### PR TITLE
Fixes reputation levels in the UI

### DIFF
--- a/tgui/packages/tgui/interfaces/Uplink/calculateReputationLevel.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/calculateReputationLevel.tsx
@@ -54,7 +54,7 @@ export const ranks: Rank[] = [
     gradient: veryGoodGradient,
   },
   {
-    minutesLessThan: 120,
+    minutesLessThan: 110,
     title: 'Glorious',
     gradient: ultraGoodGradient,
   },

--- a/tgui/packages/tgui/interfaces/Uplink/calculateReputationLevel.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/calculateReputationLevel.tsx
@@ -54,12 +54,12 @@ export const ranks: Rank[] = [
     gradient: veryGoodGradient,
   },
   {
-    minutesLessThan: 110,
+    minutesLessThan: 120,
     title: 'Glorious',
     gradient: ultraGoodGradient,
   },
   {
-    minutesLessThan: 130,
+    minutesLessThan: 140,
     title: 'Fabled',
     gradient: ultraGoodGradient,
   },


### PR DESCRIPTION

## About The Pull Request
Brings 'Legendary' up to 1400
![image](https://user-images.githubusercontent.com/37270891/206803638-7d0dfaa2-6ef8-4b8b-abf0-31dc846b41a3.png)

## Why It's Good For The Game
Final objectives unlock at 1400 reputation aka 140 minutes. Players seem to be getting confused about when final objectives actually unlock as most tend to think it's when they hit Legendary. This will make it more clear for them that hitting 'Legendary' will actually mean that you unlock final objectives (most of the time).

## Changelog
:cl:
qol: Changed the reputation cap of 'Legendary' on the UI to be at 1400 reputation. This is the point at which you unlock Final Objectives. This is purely a visual change.
/:cl:
