### PR TITLE
Fix TGUI latejoin menu not closing properly, properly this time

### DIFF
--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -24,7 +24,6 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 
 /datum/latejoin_menu/ui_interact(mob/dead/new_player/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
-
 	if(!ui)
 		// In case they reopen the GUI
 		user.jobs_menu_mounted = FALSE
@@ -112,8 +111,9 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 
 	return list("departments_static" = departments)
 
-/datum/latejoin_menu/ui_state(mob/user)
-	return GLOB.new_player_state
+// we can't use GLOB.new_player_state here since it also allows any admin to see the ui, which will cause runtimes
+/datum/latejoin_menu/ui_status(mob/user)
+	return isnewplayer(user) ? UI_INTERACTIVE : UI_CLOSE
 
 /datum/latejoin_menu/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
@@ -158,6 +158,7 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 
 			// SAFETY: AttemptLateSpawn has it's own sanity checks. This is perfectly safe.
 			owner.AttemptLateSpawn(params["job"])
+
 			return TRUE
 
 		if("viewpoll")

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -23,10 +23,8 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		user.jobs_menu_mounted = TRUE // Don't flood a user's chat if they open and close the UI.
 
 /datum/latejoin_menu/ui_interact(mob/dead/new_player/user, datum/tgui/ui)
-	if(!istype(user))
-		return
-
 	ui = SStgui.try_update_ui(user, src, ui)
+
 	if(!ui)
 		// In case they reopen the GUI
 		user.jobs_menu_mounted = FALSE
@@ -51,7 +49,7 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		switch(SSshuttle.emergency.mode)
 			if(SHUTTLE_ESCAPE)
 				data["shuttle_status"] = "The station has been evacuated."
-			if(SHUTTLE_CALL || SHUTTLE_DOCKED || SHUTTLE_IGNITING || SHUTTLE_ESCAPE)
+			if(SHUTTLE_CALL, SHUTTLE_DOCKED, SHUTTLE_IGNITING, SHUTTLE_ESCAPE)
 				if(!SSshuttle.canRecall())
 					data["shuttle_status"] = "The station is currently undergoing evacuation procedures."
 
@@ -158,7 +156,6 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 					tgui_alert(owner, "The server is full!", "Oh No!")
 					return TRUE
 
-			SStgui.close_user_uis(owner, src) // Bandaid fix cause ui_state doesn't react properly to spawning in.
 			// SAFETY: AttemptLateSpawn has it's own sanity checks. This is perfectly safe.
 			owner.AttemptLateSpawn(params["job"])
 			return TRUE


### PR DESCRIPTION

## About The Pull Request
Fixes issue in #71868

TGUI latejoin window stayed open because of an erroneous `isnewplayer` check in the latejoin's `ui_interact` which blocked `try_update_ui` from being called, therefore not letting the UI update its status.

also fixes dreamchecker warnings in latejoin menu code

## Why It's Good For The Game
bgug fix

## Changelog
No playerfacing changes.
