### PR TITLE
Fixes Duplicate Integrity Message for Mechas

### DIFF
--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -58,14 +58,21 @@
 	. = ..()
 	if(resistance_flags & ON_FIRE)
 		. += span_warning("It's on fire!")
-	var/healthpercent = atom_integrity/max_integrity * 100
-	switch(healthpercent)
+	. += generate_integrity_message()
+
+/// Returns a readable string of the vehicle's health for examining. Overridden by subtypes who want to be more verbose with their health messages.
+/obj/vehicle/proc/generate_integrity_message()
+	var/examine_text = ""
+	var/integrity = atom_integrity/max_integrity * 100
+	switch(integrity)
 		if(50 to 99)
-			. += "It looks slightly damaged."
+			examine_text = "It looks slightly damaged."
 		if(25 to 50)
-			. += "It appears heavily damaged."
+			examine_text = "It appears heavily damaged."
 		if(0 to 25)
-			. += span_warning("It's falling apart!")
+			examine_text = span_warning("It's falling apart!")
+
+	return examine_text
 
 /obj/vehicle/proc/is_key(obj/item/I)
 	return istype(I, key_type)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -430,18 +430,6 @@
 
 /obj/vehicle/sealed/mecha/examine(mob/user)
 	. = ..()
-	var/integrity = atom_integrity*100/max_integrity
-	switch(integrity)
-		if(85 to 100)
-			. += "It's fully intact."
-		if(65 to 85)
-			. += "It's slightly damaged."
-		if(45 to 65)
-			. += "It's badly damaged."
-		if(25 to 45)
-			. += "It's heavily damaged."
-		else
-			. += "It's falling apart."
 	if(LAZYLEN(flat_equipment))
 		. += "It's equipped with:"
 		for(var/obj/item/mecha_parts/mecha_equipment/ME as anything in flat_equipment)
@@ -460,6 +448,24 @@
 					continue
 				. += span_warning("It looks like you can hit the pilot directly if you target the center or above.")
 				break //in case user is holding two guns
+
+/obj/vehicle/sealed/mecha/generate_integrity_message()
+	var/examine_text = ""
+	var/integrity = atom_integrity*100/max_integrity
+
+	switch(integrity)
+		if(85 to 100)
+			examine_text = "It's fully intact."
+		if(65 to 85)
+			examine_text = "It's slightly damaged."
+		if(45 to 65)
+			examine_text = "It's badly damaged."
+		if(25 to 45)
+			examine_text = "It's heavily damaged."
+		else
+			examine_text = "It's falling apart."
+
+	return examine_text
 
 //processing internal damage, temperature, air regulation, alert updates, lights power use.
 /obj/vehicle/sealed/mecha/process(delta_time)


### PR DESCRIPTION
## About The Pull Request

Hey there,

This PR is just made to fix duplication of examination texts when you looked on a mecha, for example if something met a certain threshold, it would say "It's heavily damaged" twice when you examined it.

This PR just makes a new proc called on examine that's overridden by subtypes. I did it this way because mechas seemed to have their own logic/tiering system to determine how busted it was, and I didn't want to toy with the balance of the calculations should that matter.
## Why It's Good For The Game

Fixes #71684

![image](https://user-images.githubusercontent.com/34697715/206816123-9eb9150a-591d-4096-b8bd-02773c445328.png)

Better UX on examining, silly duplication.
## Changelog
:cl:
fix: When you examine a mecha, you should now no longer see two integrity messages.
/:cl:
