### PR TITLE
Add guideline against using the output of increment/decrement operators

### DIFF
--- a/.github/guides/STYLE.md
+++ b/.github/guides/STYLE.md
@@ -280,6 +280,26 @@ for (var/month in 1 to 12)
 for (var/i in reagents)
 ```
 
+### Don't abuse the increment/decrement operators
+`x++` and `++x` both will increment x, but the former will return x *before* it was incremented, while the latter will return x *after* it was incremented. Great if you want to be clever, or if you were a C programmer in the 70s, but it hurts the readability of code to anyone who isn't familiar with this. The convenience is not nearly good enough to justify this burden.
+
+```dm
+// Bad
+world.log << "You now have [++apples] apples."
+
+// Good
+apples++
+// apples += 1 - Allowed
+world.log << "You now have [apples] apples."
+
+// Bad
+world.log << "[apples--] apples left, taking one."
+
+// Good
+world.log << "[apples] apples left, taking one."
+apples--
+```
+
 ## Procs
 
 ### Getters and setters


### PR DESCRIPTION
@tgstation/commit-access 

I've been stopping contributors from doing this for a while but figured I would write it out in text so I don't have to repeat myself, and because a maintainer saw this and let it slide unfortunately.

In case it comes up, I explicitly do not mention `i++` in for loops, because to understand why that is technically using the output requires already very specialized knowledge of what each part of the for loop does. These are guidelines meant for contributors, not a place for us to show what we know.