### PR TITLE
Fixes Brain Trauma Forced Speech Triggering the World Filter

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -54,7 +54,7 @@
 	if(DT_PROB(1.5, delta_time))
 		owner.emote("drool")
 	else if(owner.stat == CONSCIOUS && DT_PROB(1.5, delta_time))
-		owner.say(pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"), forced = "brain damage")
+		owner.say(pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage"), forced = "brain damage", filterproof = TRUE)
 
 /datum/brain_trauma/mild/dumbness/on_lose()
 	REMOVE_TRAIT(owner, TRAIT_DUMB, TRAUMA_TRAIT)


### PR DESCRIPTION
## About The Pull Request
Fixes #71849

## Why It's Good For The Game
bug bad

## Changelog

:cl:
fix: Forced speech from brain damage will no longer trigger the world filter
/:cl:

