### PR TITLE
Makes the portable scrubber work in all cardinal directions

### DIFF
--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -60,6 +60,11 @@
 	excited = TRUE
 
 	var/atom/target = holding || get_turf(src)
+	if(!holding)
+		var/turf/target_turf = target
+		for(var/turf/adjacent_turf in target_turf.get_atmos_adjacent_turfs())
+			scrub(adjacent_turf.return_air())
+			return ..()
 	scrub(target.return_air())
 	return ..()
 

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -64,7 +64,7 @@
 		var/turf/target_turf = target
 		for(var/turf/adjacent_turf in target_turf.get_atmos_adjacent_turfs())
 			scrub(adjacent_turf.return_air())
-			return ..()
+		return ..()
 	scrub(target.return_air())
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request
Increase the working area of the portable scrubber to reach the four adjacent turfs in cardinal direction.
## Why It's Good For The Game
Increases the area of action of the normal portable scrubber so that it can be better at fixing atmos issues.
## Changelog
:cl:
balance: Increase the working area of the portable scrubber to reach the four adjacent turfs in cardinal direction.
/:cl:
