### PR TITLE
Improves description of the "Steal Heirloom" traitor objective.

### DIFF
--- a/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
@@ -13,7 +13,7 @@
 
 /datum/traitor_objective/destroy_heirloom
 	name = "Destroy %ITEM%, the family heirloom that belongs to %TARGET% the %JOB TITLE%"
-	description = "%TARGET% has been on our shitlist for a while and we want to show him we mean business. Find his %ITEM% and destroy it, you'll be rewarded handsomely for doing this"
+	description = "%TARGET% has been on our shitlist for a while and we want to show them we mean business. Find their %ITEM% and destroy it."
 
 	abstract_type = /datum/traitor_objective/destroy_heirloom
 


### PR DESCRIPTION

## About The Pull Request

Resolves #71898 

The description of the Steal Heirloom objective used he/him pronouns instead of the neutral they/them of every other traitor objective description. I've resolved this, and edited the description down slightly, as I felt it was needlessly wordy (none of the other objectives promise to "reward you handsomely", after all).
## Why It's Good For The Game

Removes an inaccuracy in objective text, and makes the description more in line with others. Consistency is good.
## Changelog
:cl:
spellcheck: Improved "Steal Heirloom" objective description.
/:cl:
