### PR TITLE
The removal of the Heretic antag no longer makes a sound.

### DIFF
--- a/code/modules/antagonists/heretic/magic/shadow_cloak.dm
+++ b/code/modules/antagonists/heretic/magic/shadow_cloak.dm
@@ -23,7 +23,8 @@
 	var/datum/status_effect/shadow_cloak/active_cloak
 
 /datum/action/cooldown/spell/shadow_cloak/Remove(mob/living/remove_from)
-	uncloak_mob(remove_from, show_message = FALSE)
+	if(active_cloak)
+		uncloak_mob(remove_from, show_message = FALSE)
 	return ..()
 
 /datum/action/cooldown/spell/shadow_cloak/is_valid_target(atom/cast_on)


### PR DESCRIPTION

## About The Pull Request

Resolves #71891 

Currently, when the Heretic antag datum is removed by an admin, it plays the sound of the shadow cloak spell ending. This a simple oversight that causes the user to be decloaked when the spell is removed from them - regardless of whether it's actually _active_. This PR checks first, so the sound will only play if the user is cloaked when they cease to be a heretic.
## Why It's Good For The Game

It shouldn't be given away audibly when someone has lost their antag status - it's meta knowledge that shouldn't be available in-game.
## Changelog
:cl:
fix: Admin removal of Heretic status no longer makes a sound.
/:cl:
