### PR TITLE
Adds the gaseous meteor wave

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -45,7 +45,7 @@
 		if("halloween")
 			wave_type = GLOB.meteorsSPOOKY
 		if("gaseous")
-			wave_type = GLOB.meteros_gaseous
+			wave_type = GLOB.meteors_gaseous
 		else
 			WARNING("Wave name of [wave_name] not recognised.")
 			kill()

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -44,6 +44,8 @@
 			wave_type = GLOB.meteorsC
 		if("halloween")
 			wave_type = GLOB.meteorsSPOOKY
+		if("gaseous")
+			wave_type = GLOB.meteros_gaseous
 		else
 			WARNING("Wave name of [wave_name] not recognised.")
 			kill()
@@ -91,3 +93,18 @@
 
 /datum/round_event/meteor_wave/meaty/announce(fake)
 	priority_announce("Meaty ores have been detected on collision course with the station.", "Oh crap, get the mop.", ANNOUNCER_METEORS)
+
+/datum/round_event_control/meteor_wave/gaseous
+	name = "Meteor Wave: Gaseous"
+	typepath =  /datum/round_event/meteor_wave/gaseous
+	weight = 5
+	min_players = 20
+	max_occurrences = 3
+	earliest_start = 10 MINUTES
+	description = "A wave of meteors filled with various gases"
+
+/datum/round_event/meteor_wave/gaseous
+	wave_name = "gaseous"
+
+/datum/round_event/meteor_wave/gaseous/announce(fake)
+	priority_announce("Gas filled chunk of rocks detected on collision course with the station.", "Save your breath.", ANNOUNCER_METEORS)

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(meteorsD, list(/obj/effect/meteor/medium=15, /obj/effect/meteor
 						  /obj/effect/meteor/banana=25, /obj/effect/meteor/meaty=10, /obj/effect/meteor/meaty/xeno=8, /obj/effect/meteor/emp = 30, \
 						  /obj/effect/meteor/cluster=20, /obj/effect/meteor/tunguska=1)) //for stray meteor event (bigger numbers for a bit finer weighting)
 
-GLOBAL_LIST_INIT(meteros_gaseous, list(/obj/effect/meteor/gaseous = 1))
+GLOBAL_LIST_INIT(meteors_gaseous, list(/obj/effect/meteor/gaseous = 1))
 
 ///////////////////////////////
 //Meteor spawning global procs

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -26,6 +26,8 @@ GLOBAL_LIST_INIT(meteorsD, list(/obj/effect/meteor/medium=15, /obj/effect/meteor
 						  /obj/effect/meteor/banana=25, /obj/effect/meteor/meaty=10, /obj/effect/meteor/meaty/xeno=8, /obj/effect/meteor/emp = 30, \
 						  /obj/effect/meteor/cluster=20, /obj/effect/meteor/tunguska=1)) //for stray meteor event (bigger numbers for a bit finer weighting)
 
+GLOBAL_LIST_INIT(meteros_gaseous, list(/obj/effect/meteor/gaseous = 1))
+
 ///////////////////////////////
 //Meteor spawning global procs
 ///////////////////////////////
@@ -510,5 +512,45 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 	. = ..()
 	meteorsound = pick('sound/hallucinations/im_here1.ogg','sound/hallucinations/im_here2.ogg')
 //////////////////////////
+
+/obj/effect/meteor/gaseous
+	name = "gas filled meteor"
+	dropamt = 1
+	threat = 10
+	hits = 10
+
+/obj/effect/meteor/gaseous/meteor_effect()
+	. = ..()
+
+	var/static/list/gases_to_spawn = list(
+		/datum/gas/nitrogen,
+		/datum/gas/oxygen,
+		/datum/gas/carbon_dioxide,
+		/datum/gas/plasma,
+		/datum/gas/nitrous_oxide,
+		/datum/gas/healium,
+		/datum/gas/freon,
+		/datum/gas/tritium,
+		/datum/gas/miasma,
+		/datum/gas/hydrogen,
+		/datum/gas/water_vapor,
+		/datum/gas/hypernoblium
+		)
+
+	var/list/picked_gases = list()
+	for(var/_ in 1 to rand(1, 3))
+		picked_gases += pick(gases_to_spawn)
+
+	var/datum/gas_mixture/mix_to_spawn = new
+	for(var/id in picked_gases)
+		mix_to_spawn.add_gas(id)
+		mix_to_spawn.gases[id][MOLES] = rand(3000, 7000)
+
+	mix_to_spawn.temperature = rand(20, 500)
+
+	var/turf/open/our_turf = get_turf(src)
+
+	our_turf.assume_air(mix_to_spawn)
+
 #undef DEFAULT_METEOR_LIFETIME
 #undef MAP_EDGE_PAD

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -534,8 +534,8 @@ GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
 		/datum/gas/miasma,
 		/datum/gas/hydrogen,
 		/datum/gas/water_vapor,
-		/datum/gas/hypernoblium
-		)
+		/datum/gas/hypernoblium,
+	)
 
 	var/list/picked_gases = list()
 	for(var/_ in 1 to rand(1, 3))


### PR DESCRIPTION

## About The Pull Request
Adds a new type of meteor wave, where the meteors are filled with random gases that are released once the meteor finish their runs.
## Why It's Good For The Game
It's a different type of atmospheric issue instead of the usually caused by atmos technicians. With the new changes to scrubber (PRd) and space heaters it's easier to fix those issues and it's important that they are caused also from sources outside the department, because in most cases you have either the fire caused by atmos traitor or the fire caused by atmos error.
## Changelog
:cl:
add: Adds the gaseous meteor wave where meteors are filled with gases that releases at the end of the meteor run
/:cl:
