### PR TITLE
Requires Run Linters before the rest of CI can run

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -8,6 +8,7 @@ on:
     branches:
     - master
     - 'project/**'
+
 jobs:
   run_linters:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
@@ -83,6 +84,37 @@ jobs:
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
 
+  test_windows:
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    name: Windows Build
+    runs-on: windows-latest
+    concurrency:
+      group: test_windows-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v3
+      - name: Restore Yarn cache
+        uses: actions/cache@v3
+        with:
+          path: tgui/.yarn/cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Compile
+        run: pwsh tools/ci/build.ps1
+        env:
+          DM_EXE: "C:\\byond\\bin\\dm.exe"
+      - name: Create artifact
+        run: |
+          md deploy
+          bash tools/deploy.sh ./deploy
+      - name: Deploy artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: deploy
+          path: deploy
+
   find_all_maps:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Find Maps to Test
@@ -93,6 +125,7 @@ jobs:
     concurrency:
       group: find_all_maps-${{ github.ref }}
       cancel-in-progress: true
+    needs: [run_linters, compile_all_maps, test_windows]
     steps:
       - uses: actions/checkout@v3
       - name: Find Maps
@@ -171,34 +204,3 @@ jobs:
         with:
           name: bad-screenshots
           path: artifacts/screenshot_comparisons
-
-  test_windows:
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    name: Windows Build
-    runs-on: windows-latest
-    concurrency:
-      group: test_windows-${{ github.ref }}
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v3
-      - name: Restore Yarn cache
-        uses: actions/cache@v3
-        with:
-          path: tgui/.yarn/cache
-          key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Compile
-        run: pwsh tools/ci/build.ps1
-        env:
-          DM_EXE: "C:\\byond\\bin\\dm.exe"
-      - name: Create artifact
-        run: |
-          md deploy
-          bash tools/deploy.sh ./deploy
-      - name: Deploy artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: deploy
-          path: deploy

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -68,6 +68,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Compile Maps
     runs-on: ubuntu-20.04
+    needs: run_linters
     concurrency:
       group: compile_all_maps-${{ github.ref }}
       cancel-in-progress: true
@@ -88,6 +89,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Windows Build
     runs-on: windows-latest
+    needs: run_linters
     concurrency:
       group: test_windows-${{ github.ref }}
       cancel-in-progress: true
@@ -125,7 +127,7 @@ jobs:
     concurrency:
       group: find_all_maps-${{ github.ref }}
       cancel-in-progress: true
-    needs: [run_linters, compile_all_maps, test_windows]
+    needs: run_linters
     steps:
       - uses: actions/checkout@v3
       - name: Find Maps


### PR DESCRIPTION

## About The Pull Request

Hey there,

This is just a small stop-guard I came up with. Recently, there's been an elevated amount of CI "clogging", which results in auto-merging of PRs only occurring roughly two hours after the auto-merge button (example: #71868, which took about two hours to merge between stylemistake first hitting the button and then waiting for enough runners to allow checks to pass) has been hit due to an excessive number of alloted GitHub runners taking up space. For example, let's say we're only allocated 15 runners for every single run. Each commit on a PR will require at least eleven separate runners going concurrently at its peak. Instead of endlessly throwing eleven runners at an issue, let's run the fastest one that will easily alert us to potential failures, and then go from there.

The key reason why this PR does it this way is that I recently noted is that even though linters were failing because it detected that the code would not compile (Run Linters uses Dreamchecker), we would still allocate runners to do the exact same thing! A good example of this on master is this CI run- Run Linters had already failed on it, but we still threw the entire kitchen sink at it anyways (https://github.com/tgstation/tgstation/actions/runs/3665153952). This means that even if one runner reported that it failed to build, we would still take up ten more runners (Compile All Maps, Windows Build, and the 8 Integration Tests all require the code to compile to run) and fail out at the compilation step over-and-over again. So, this PR just just prevents that excess chew.

Run Linters currently takes 1.5 minutes to run on master, and is a quick, rapid, and simple check to prevent unmergeable code from eating up resources needlessly. This does cause a concern that it effectively adds 1.5 minutes to the overall Continuous Integration Process, but I still think that it's more important to be able to not have all of our runners clogged out or needlessly allocated testing code that we already know won't work.

This is a good potential way to help triage this issue that is certainly extant. The issue isn't so much time, it's resources that we can lack for any number of reasons.