### PR TITLE
Pin autowiki to Ubuntu 20.04

### DIFF
--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   autowiki:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: "Check for AUTOWIKI_USERNAME"
       id: secrets_set


### PR DESCRIPTION
Autowiki uses ubuntu-latest, which does not have the libssl version it wants. GitHub recently increased these from 20.04 to 22.04. Yes this is extremely can-kicking and we will have to fix our stuff to use 22.04 eventually I'm just tired