### PR TITLE
Switching to a hunger-less species clears hunger moods

### DIFF
--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -114,6 +114,7 @@
 /// Handles mood given by nutrition
 /datum/mood/proc/handle_nutrition()
 	if (HAS_TRAIT(mob_parent, TRAIT_NOHUNGER))
+		clear_mood_event(MOOD_CATEGORY_NUTRITION)  // if you happen to switch species while hungry youre no longer hungy
 		return FALSE // no moods for nutrition
 	switch(mob_parent.nutrition)
 		if(NUTRITION_LEVEL_FULL to INFINITY)


### PR DESCRIPTION

## About The Pull Request
Adds an extra check for TRAIT_NOHUNGER to prevent hunger moods from appearing
## Why It's Good For The Game
If you happen to switch to a species without hunger while youre hungry, you have a permenant mood debuff, which doesnt make a lot of sense.
## Changelog
:cl:
fix: switching to species without hunger clears hunger moods
/:cl:
