### PR TITLE
lathes now print empty welders and extinguishers

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -83,14 +83,16 @@
 	if(!chem)
 		return
 	create_reagents(max_water, AMOUNT_VISIBLE)
-	if(starting_water)
-		reagents.add_reagent(chem, max_water)
+	reagents.add_reagent(chem, max_water)
 
 /obj/item/extinguisher/Initialize(mapload)
 	. = ..()
 	if(tank_holder_icon_state)
 		AddComponent(/datum/component/container_item/tank_holder, tank_holder_icon_state)
-	refill()
+	if(starting_water)
+		refill()
+	else if(chem)
+		create_reagents(max_water, AMOUNT_VISIBLE)
 
 /obj/item/extinguisher/advanced
 	name = "advanced fire extinguisher"

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -22,16 +22,25 @@
 	var/max_water = 50
 	/// Does the welder extinguisher start with water.
 	var/starting_water = TRUE
+	/// Cooldown between uses.
 	var/last_use = 1
+	/// Chem we use for our extinguishing.
 	var/chem = /datum/reagent/water
+	/// Can we actually fire currently?
 	var/safety = TRUE
+	/// Can we refill this at a water tank?
 	var/refilling = FALSE
+	/// What tank we need to refill this.
 	var/tanktype = /obj/structure/reagent_dispensers/watertank
+	/// something that should be replaced with base_icon_state
 	var/sprite_name = "fire_extinguisher"
-	var/power = 5 //Maximum distance launched water will travel
-	var/precision = FALSE //By default, turfs picked from a spray are random, set to 1 to make it always have at least one water effect per row
-	var/cooling_power = 2 //Sets the cooling_temperature of the water reagent datum inside of the extinguisher when it is refilled
-	/// Icon state when inside a tank holder
+	/// Maximum distance launched water will travel.
+	var/power = 5
+	/// By default, turfs picked from a spray are random, set to TRUE to make it always have at least one water effect per row.
+	var/precision = FALSE
+	/// Sets the cooling_temperature of the water reagent datum inside of the extinguisher when it is refilled.
+	var/cooling_power = 2
+	/// Icon state when inside a tank holder.
 	var/tank_holder_icon_state = "holder_extinguisher"
 
 /obj/item/extinguisher/empty

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -18,7 +18,10 @@
 	attack_verb_simple = list("slam", "whack", "bash", "thunk", "batter", "bludgeon", "thrash")
 	dog_fashion = /datum/dog_fashion/back
 	resistance_flags = FIRE_PROOF
+	/// The max amount of water this extinguisher can hold.
 	var/max_water = 50
+	/// Does the welder extinguisher start with water.
+	var/starting_water = TRUE
 	var/last_use = 1
 	var/chem = /datum/reagent/water
 	var/safety = TRUE
@@ -30,6 +33,9 @@
 	var/cooling_power = 2 //Sets the cooling_temperature of the water reagent datum inside of the extinguisher when it is refilled
 	/// Icon state when inside a tank holder
 	var/tank_holder_icon_state = "holder_extinguisher"
+
+/obj/item/extinguisher/empty
+	starting_water = FALSE
 
 /obj/item/extinguisher/mini
 	name = "pocket fire extinguisher"
@@ -46,6 +52,9 @@
 	max_water = 30
 	sprite_name = "miniFE"
 	dog_fashion = null
+
+/obj/item/extinguisher/mini/empty
+	starting_water = FALSE
 
 /obj/item/extinguisher/crafted
 	name = "Improvised cooling spray"
@@ -74,7 +83,8 @@
 	if(!chem)
 		return
 	create_reagents(max_water, AMOUNT_VISIBLE)
-	reagents.add_reagent(chem, max_water)
+	if(starting_water)
+		reagents.add_reagent(chem, max_water)
 
 /obj/item/extinguisher/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -39,6 +39,8 @@
 	var/status = TRUE
 	/// The max amount of fuel the welder can hold
 	var/max_fuel = 20
+	/// Do we start with fuel?
+	var/starting_fuel = TRUE
 	/// Whether or not we're changing the icon based on fuel left.
 	var/change_icons = TRUE
 	/// Used in process(), dictates whether or not we're calling STOP_PROCESSING whilst we're not welding.
@@ -56,7 +58,8 @@
 	AddElement(/datum/element/falling_hazard, damage = force, wound_bonus = wound_bonus, hardhat_safety = TRUE, crushes = FALSE, impact_sound = hitsound)
 
 	create_reagents(max_fuel)
-	reagents.add_reagent(/datum/reagent/fuel, max_fuel)
+	if(starting_fuel)
+		reagents.add_reagent(/datum/reagent/fuel, max_fuel)
 	update_appearance()
 
 /obj/item/weldingtool/update_icon_state()
@@ -318,6 +321,9 @@
 	else
 		return ""
 
+/obj/item/weldingtool/empty
+	starting_fuel = FALSE
+
 /obj/item/weldingtool/largetank
 	name = "industrial welding tool"
 	desc = "A slightly larger welder with a larger tank."
@@ -327,6 +333,9 @@
 
 /obj/item/weldingtool/largetank/flamethrower_screwdriver()
 	return
+
+/obj/item/weldingtool/largetank/empty
+	starting_fuel = FALSE
 
 /obj/item/weldingtool/largetank/cyborg
 	name = "integrated welding tool"
@@ -352,6 +361,9 @@
 
 /obj/item/weldingtool/mini/flamethrower_screwdriver()
 	return
+
+/obj/item/weldingtool/mini/empty
+	starting_fuel = FALSE
 
 /obj/item/weldingtool/abductor
 	name = "alien welding tool"

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -39,7 +39,7 @@
 	var/status = TRUE
 	/// The max amount of fuel the welder can hold
 	var/max_fuel = 20
-	/// Do we start with fuel?
+	/// Does the welder start with fuel.
 	var/starting_fuel = TRUE
 	/// Whether or not we're changing the icon based on fuel left.
 	var/change_icons = TRUE

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -79,7 +79,7 @@
 	id = "extinguisher"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 90)
-	build_path = /obj/item/extinguisher
+	build_path = /obj/item/extinguisher/empty
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ATMOSPHERICS
@@ -91,7 +91,7 @@
 	id = "pocketfireextinguisher"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 40)
-	build_path = /obj/item/extinguisher/mini
+	build_path = /obj/item/extinguisher/mini/empty
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ATMOSPHERICS

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -139,7 +139,7 @@
 	id = "welding_tool"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 70, /datum/material/glass = 20)
-	build_path = /obj/item/weldingtool
+	build_path = /obj/item/weldingtool/empty
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING
@@ -151,7 +151,7 @@
 	id = "mini_welding_tool"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 30, /datum/material/glass = 10)
-	build_path = /obj/item/weldingtool/mini
+	build_path = /obj/item/weldingtool/mini/empty
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING
@@ -1300,7 +1300,7 @@
 	id = "large_welding_tool"
 	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 70, /datum/material/glass = 60)
-	build_path = /obj/item/weldingtool/largetank
+	build_path = /obj/item/weldingtool/largetank/empty
 	category = list(
 		RND_CATEGORY_HACKED,
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING


### PR DESCRIPTION

## About The Pull Request
welders (other than experimental) printed by lathes now start with 0 fuel and have to be refueled with a welding tank
same with fire extinguishers

## Why It's Good For The Game
iron and glass dont create welding fuel or water, and it makes the tanks a bit more valuable

## Changelog
:cl:
add: lathes now print empty welders and extinguishers
/:cl:
