### PR TITLE
Makes the shadowperson legion corpse pill have enough mutation toxin to turn you

### DIFF
--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -202,7 +202,7 @@
 	desc = "I wouldn't eat this if I were you."
 	icon_state = "pill9"
 	color = "#454545"
-	list_reagents = list(/datum/reagent/mutationtoxin/shadow = 5)
+	list_reagents = list(/datum/reagent/mutationtoxin/shadow = 10)
 
 ///////////////////////////////////////// Psychologist inventory pills
 /obj/item/reagent_containers/pill/happinesspsych


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
the corpse is a rare enough, getting 2 to drop for its intended effect is basically impossible odds on lavaland
## Changelog
:cl:
fix: the pill dropped by the shadowperson legion corpse now has enough mutation toxin to work
/:cl:
