### PR TITLE
Adds an anonyminity wire to radios

### DIFF
--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -54,3 +54,4 @@
 #define WIRE_ZAP "High Voltage Circuit"
 #define WIRE_ZAP1 "High Voltage Circuit 1"
 #define WIRE_ZAP2 "High Voltage Circuit 2"
+#define WIRE_ANON "Voice Detection"

--- a/code/datums/wires/radio.dm
+++ b/code/datums/wires/radio.dm
@@ -30,6 +30,7 @@
 			R.set_anon(!R.anonymize)
 
 /datum/wires/radio/on_cut(wire, mend)
+	var/obj/item/radio/R = holder
 	if(wire == WIRE_ANON)
 		R.set_anon(!mend)
 
@@ -38,5 +39,5 @@
 	var/list/status = list()
 	status += "The broadcast light is [R.get_broadcasting() ? "on" : "off"]."
 	status += "The listening light is [R.get_listening() ? "on" : "off"]."
-	status += "The voice recognition chip is [anonymize ? "slightly buzzing" : "silent"]."
+	status += "The voice recognition chip is [R.anonymize ? "slightly buzzing" : "silent"]."
 	return status

--- a/code/datums/wires/radio.dm
+++ b/code/datums/wires/radio.dm
@@ -5,7 +5,8 @@
 /datum/wires/radio/New(atom/holder)
 	wires = list(
 		WIRE_SIGNAL,
-		WIRE_RX, WIRE_TX
+		WIRE_RX, WIRE_TX,
+		WIRE_ANON
 	)
 	..()
 
@@ -25,3 +26,17 @@
 			R.set_listening(!R.get_listening())
 		if(WIRE_TX)
 			R.set_broadcasting(!R.get_broadcasting())
+		if(WIRE_ANON)
+			R.set_anon(!R.anonymize)
+
+/datum/wires/radio/on_cut(wire, mend)
+	if(wire == WIRE_ANON)
+		R.set_anon(!mend)
+
+/datum/wires/radio/get_status()
+	var/obj/item/radio/R = holder
+	var/list/status = list()
+	status += "The broadcast light is [R.get_broadcasting() ? "on" : "off"]."
+	status += "The listening light is [R.get_listening() ? "on" : "off"]."
+	status += "The voice recognition chip is [anonymize ? "slightly buzzing" : "silent"]."
+	return status

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -38,6 +38,9 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	overlay_mic_idle = null
 	overlay_mic_active = null
 
+	/// on the go anominity seems excessive
+	anon_protect = TRUE
+
 /obj/item/radio/headset/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins putting \the [src]'s antenna up [user.p_their()] nose! It looks like [user.p_theyre()] trying to give [user.p_them()]self cancer!"))
 	return TOXLOSS

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -20,6 +20,7 @@
 /obj/item/radio/intercom/prison
 	name = "prison intercom"
 	desc = "A station intercom. It looks like it has been modified to not broadcast."
+	anon_protect = TRUE
 
 /obj/item/radio/intercom/prison/Initialize(mapload, ndir, building)
 	. = ..()
@@ -200,6 +201,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom, 26)
 	desc = "The command team's special extended-frequency intercom. Mostly just used for eavesdropping, gossiping about subordinates, and complaining about the higher-ups."
 	icon_state = "intercom_command"
 	freerange = TRUE
+	anon_protect = TRUE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/prison, 26)
 MAPPING_DIRECTIONAL_HELPERS(/obj/item/radio/intercom/chapel, 26)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -60,6 +60,8 @@
 
 	///makes anyone who is talking through this anonymous.
 	var/anonymize = FALSE
+	/// Prevents anomimity being set by wire manipulation
+	var/anon_protect = FALSE
 
 	/// Encryption key handling
 	var/obj/item/encryptionkey/keyslot
@@ -240,6 +242,13 @@
 		update_icon()
 	else if (!perform_update_icon)
 		should_update_icon = TRUE
+
+/// Setter for the anonimity of the speaker. Also checks for protection, but can be overriden with the force var
+/obj/item/radio/proc/set_anon(new_anon, force = FALSE)
+	if(anon_protect && !force)
+		visible_message("\The [src] beeps.")
+		return
+	anonymize = new_anon
 
 ///setter for the on var that sets both broadcasting and listening to off or whatever they were supposed to be
 /obj/item/radio/proc/set_on(new_on)


### PR DESCRIPTION

## About The Pull Request
Adds a hackable wire to set the anonymous status on most radios
excluding headsets, command, and prison radios
## Why It's Good For The Game
Anonymous radios are severely underutilized. The only non-admin method of obtaining one is the often-forgotten "confessions" radios in chapel, which most players will never use because of the frequency lock and that its intended use is very VERY rp heavy. 

Anonymity can be very powerful in the right hands too, delivering threats and advertising illegal business without fear of retribution.  
## Changelog
:cl:
add: Radio hacking wire for anonymity
add: Radios now have a hacking status display
/:cl:
