### PR TITLE
Non-humans no longer display "pale skin" examine message when not missing blood.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -236,7 +236,7 @@
 			msg += "[t_He] look[p_s()] extremely disgusted.\n"
 
 	var/apparent_blood_volume = blood_volume
-	if(skin_tone == "albino" && dna.species.use_skintones)
+	if(dna.species.use_skintones && skin_tone == "albino")
 		apparent_blood_volume -= 150 // enough to knock you down one tier
 	switch(apparent_blood_volume)
 		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -236,7 +236,7 @@
 			msg += "[t_He] look[p_s()] extremely disgusted.\n"
 
 	var/apparent_blood_volume = blood_volume
-	if(skin_tone == "albino")
+	if(skin_tone == "albino" && (dna.species.id == SPECIES_HUMAN || dna.species.id == SPECIES_FELINE))
 		apparent_blood_volume -= 150 // enough to knock you down one tier
 	switch(apparent_blood_volume)
 		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -236,7 +236,7 @@
 			msg += "[t_He] look[p_s()] extremely disgusted.\n"
 
 	var/apparent_blood_volume = blood_volume
-	if(skin_tone == "albino" && (dna.species.id == SPECIES_HUMAN || dna.species.id == SPECIES_FELINE))
+	if(skin_tone == "albino" && dna.species.use_skintones)
 		apparent_blood_volume -= 150 // enough to knock you down one tier
 	switch(apparent_blood_volume)
 		if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)


### PR DESCRIPTION
## About The Pull Request

Currently, some non-human characters will display the "They have pale skin." message on examine even when at full blood. This occurs because everyone, regardless of species, has a skin tone set, even if it isn't used. If this unused skin tone happens to be "albino", it will make examine text describe you as missing more blood than you really are (a feature of this skin tone).

This PR simply makes the check for albino skin also check if your species uses skintones, so that this doesn't happen.
## Why It's Good For The Game

Fixes a minor, confusing inconsistency. I've always wondered why my lizard characters seemed to be low on blood right when the round starts, and this PR removes that confusion.
## Changelog
:cl:
fix: Non-human characters will not sometimes display an incorrect level of blood loss on examine.
/:cl:
