### PR TITLE
Fix instant summons silent fail case

### DIFF
--- a/code/modules/spells/spell_types/self/summonitem.dm
+++ b/code/modules/spells/spell_types/self/summonitem.dm
@@ -120,7 +120,7 @@
 				var/obj/retrieved_item = item_to_retrieve.loc
 				// Can't bring anchored things
 				if(retrieved_item.anchored)
-					return
+					break
 				// Edge cases for moving certain machinery...
 				if(istype(retrieved_item, /obj/machinery/portable_atmospherics))
 					var/obj/machinery/portable_atmospherics/atmos_item = retrieved_item


### PR DESCRIPTION
## About The Pull Request

Continuation of #64862 (psst @optimumtact)

By using `break` once an anchored object is detected whatever containing object (or the mark itself) that was selected previously is teleported.

Currently instant summons is easily defeated by wrenched lockers, microwaves and more, with no notice to the wizard of why their item is not appearing. They also cannot bind the spell to anything new as a result. This PR seeks to fix that.

## Why It's Good For The Game

Fix good.

## Changelog
:cl:
fix: Instant summons spell now safely and reliably retrieves items from inside of anchored containers.
/:cl:
