### PR TITLE
turfs use integrity when burning/heated by atmos

### DIFF
--- a/code/game/objects/effects/effect_system/effect_shield.dm
+++ b/code/game/objects/effects/effect_system/effect_shield.dm
@@ -5,17 +5,17 @@
 	layer = ABOVE_NORMAL_TURF_LAYER
 	flags_1 = PREVENT_CLICK_UNDER_1
 	anchored = TRUE
-	var/old_heat_capacity
+	var/old_max_temperature
 
 /obj/effect/shield/Initialize(mapload)
 	. = ..()
 	var/turf/location = get_turf(src)
-	old_heat_capacity=location.heat_capacity
-	location.heat_capacity = INFINITY
+	old_max_temperature = location.max_temperature
+	location.max_temperature = INFINITY
 
 /obj/effect/shield/Destroy()
 	var/turf/location = get_turf(src)
-	location.heat_capacity=old_heat_capacity
+	location.max_temperature = old_max_temperature
 	return ..()
 
 /obj/effect/shield/singularity_act()

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -21,6 +21,7 @@
 	desc = "Effectively impervious to conventional methods of destruction."
 	icon = 'icons/turf/walls.dmi'
 	explosion_block = 50
+	resistance_flags = INDESTRUCTIBLE
 
 /turf/closed/indestructible/rust_heretic_act()
 	return

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -1,7 +1,6 @@
 /turf/open
 	plane = FLOOR_PLANE
-
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 20, ACID = 0)
+	max_integrity = 600
 	///negative for faster, positive for slower
 	var/slowdown = 0
 

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -1,5 +1,7 @@
 /turf/open
 	plane = FLOOR_PLANE
+
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 20, ACID = 0)
 	///negative for faster, positive for slower
 	var/slowdown = 0
 
@@ -47,6 +49,7 @@
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	tiled_dirt = TRUE
+	resistance_flags = INDESTRUCTIBLE
 
 /turf/open/indestructible/Melt()
 	to_be_destroyed = FALSE

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -15,7 +15,6 @@
 	canSmoothWith = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
 
 	thermal_conductivity = 0.04
-	heat_capacity = 10000
 	tiled_dirt = TRUE
 
 

--- a/code/game/turfs/open/floor/hull.dm
+++ b/code/game/turfs/open/floor/hull.dm
@@ -18,4 +18,4 @@
 	name = "exterior reinforced hull plating"
 	desc = "Extremely sturdy exterior hull plating that separates you from the uncaring vacuum of space."
 	icon_state = "reinforced_hull"
-	heat_capacity = INFINITY
+	max_temperature = INFINITY

--- a/code/game/turfs/open/floor/plating.dm
+++ b/code/game/turfs/open/floor/plating.dm
@@ -16,10 +16,10 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 
 	//Can this plating have reinforced floors placed ontop of it
-	var/attachment_holes = TRUE 
+	var/attachment_holes = TRUE
 
 	//Used for upgrading this into R-Plating
-	var/upgradable = TRUE 
+	var/upgradable = TRUE
 
 	/// If true, will allow tiles to replace us if the tile [wants to] [/obj/item/stack/tile/var/replace_plating].
 	/// And if our baseturfs are compatible.
@@ -191,7 +191,7 @@
 	icon_state = "r_plate-0"
 
 	thermal_conductivity = 0.025
-	heat_capacity = INFINITY
+	max_temperature = INFINITY
 
 	baseturfs = /turf/open/floor/plating
 	allow_replacement = FALSE

--- a/code/game/turfs/open/floor/reinforced_floor.dm
+++ b/code/game/turfs/open/floor/reinforced_floor.dm
@@ -7,7 +7,6 @@
 	thermal_conductivity = 0.025
 	heat_capacity = 1000
 	max_temperature = INFINITY
-	resistance_flags = INDESTRUCTIBLE
 	floor_tile = /obj/item/stack/rods
 	footstep = FOOTSTEP_PLATING
 	barefootstep = FOOTSTEP_HARD_BAREFOOT

--- a/code/game/turfs/open/floor/reinforced_floor.dm
+++ b/code/game/turfs/open/floor/reinforced_floor.dm
@@ -5,7 +5,9 @@
 	icon_state = "engine"
 	holodeck_compatible = TRUE
 	thermal_conductivity = 0.025
-	heat_capacity = INFINITY
+	heat_capacity = 1000
+	max_temperature = INFINITY
+	resistance_flags = INDESTRUCTIBLE
 	floor_tile = /obj/item/stack/rods
 	footstep = FOOTSTEP_PLATING
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
@@ -13,7 +15,6 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 	tiled_dirt = FALSE
 	rcd_proof = TRUE
-
 
 /turf/open/floor/engine/examine(mob/user)
 	. += ..()

--- a/code/game/turfs/open/misc.dm
+++ b/code/game/turfs/open/misc.dm
@@ -19,7 +19,6 @@
 	canSmoothWith = list(SMOOTH_GROUP_TURF_OPEN, SMOOTH_GROUP_OPEN_FLOOR)
 
 	thermal_conductivity = 0.04
-	heat_capacity = 10000
 	tiled_dirt = TRUE
 
 /turf/open/misc/attackby(obj/item/W, mob/user, params)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -5,6 +5,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	icon = 'icons/turf/floors.dmi'
 	vis_flags = VIS_INHERIT_ID // Important for interaction with and visualization of openspace.
 	luminosity = 1
+	uses_integrity = TRUE
 
 	/// Turf bitflags, see code/__DEFINES/flags.dm
 	var/turf_flags = NONE
@@ -26,6 +27,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	var/to_be_destroyed = 0
 	///The max temperature of the fire which it was subjected to
 	var/max_fire_temperature_sustained = 0
+
+	var/max_temperature = 1500
 
 	var/blocks_air = FALSE
 	// If this turf should initialize atmos adjacent turfs or not

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	///The max temperature of the fire which it was subjected to
 	var/max_fire_temperature_sustained = 0
 
-	var/max_temperature = 1500
+	var/max_temperature = 3500
 
 	var/blocks_air = FALSE
 	// If this turf should initialize atmos adjacent turfs or not

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -2,7 +2,7 @@
 	///used for temperature calculations in superconduction
 	var/thermal_conductivity = 0.05
 	///Amount of heat necessary to activate some atmos processes (there is a weird usage of this var because is compared directly to the temperature instead of heat energy)
-	var/heat_capacity = INFINITY //This should be opt in rather then opt out
+	var/heat_capacity = 1000 //This should be opt in rather then opt out
 	///Archived version of the temperature on a turf
 	var/temperature_archived
 	///All currently stored conductivities changes
@@ -122,10 +122,12 @@
 	return return_air()
 
 /turf/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
-	return (exposed_temperature >= heat_capacity || to_be_destroyed)
+	return (exposed_temperature >= max_temperature || to_be_destroyed)
 
 /turf/atmos_expose(datum/gas_mixture/air, exposed_temperature)
-	if(exposed_temperature >= heat_capacity)
+	if(exposed_temperature >= max_temperature && get_integrity() > 0)
+		take_damage((exposed_temperature - max_temperature) * 0.01, BURN, FIRE, FALSE)
+	if(get_integrity() <= 0)
 		to_be_destroyed = TRUE
 	if(to_be_destroyed && exposed_temperature >= max_fire_temperature_sustained)
 		max_fire_temperature_sustained = min(exposed_temperature, max_fire_temperature_sustained + heat_capacity / 4) //Ramp up to 100% yeah?


### PR DESCRIPTION

## About The Pull Request
Change the way open turfs handle heat exposure by changing the old heat_capacity to a proper temperature check and to make the turfs use integrity to check if the turf should be deleted.

Removed the INFINITE heat capacity of the reinforced floors, they can't be damaged by temperature.
## Why It's Good For The Game
Makes the turfs properly use integrity for their thermal exposure, heat capacity is no longer used to compare with a temperature and reinforced floors no longer have an infinite heat capacity that just wasted heat to space just to have an hacky way to prevent thermal damages.
## Changelog
:cl:
refactor: turfs use integrity instead of heat capacity to check for thermal damages. Player experience mostly unchanged (fires might burn through floors a bit faster now)
/:cl:
