### PR TITLE
Fixes cursed duffelbag's permanent curse (again), unit tests it.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -337,8 +337,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_CAN_SIGN_ON_COMMS "can_sign_on_comms"
 /// nobody can use martial arts on this mob
 #define TRAIT_MARTIAL_ARTS_IMMUNE "martial_arts_immune"
-/// You've been cursed with a living duffelbag, and can't have more added
-#define TRAIT_DUFFEL_CURSE_PROOF "duffel_cursed"
 /// Immune to being afflicted by time stop (spell)
 #define TRAIT_TIME_STOP_IMMUNE "time_stop_immune"
 /// Revenants draining you only get a very small benefit.
@@ -1011,4 +1009,3 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define SPEAKING_FROM_TONGUE "tongue"
 ///trait source that sign language should use
 #define SPEAKING_FROM_HANDS "hands"
-

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -203,8 +203,7 @@
 	var/filter_color = "#8a0c0ca1" //clarified args
 	var/new_name = pick(", eternally hungry", " of the glutton", " cursed with hunger", ", consumer of all", " of the feast")
 	master.AddElement(/datum/element/curse_announcement, "[master] is cursed with the curse of hunger!", filter_color, new_name, comp)
-	var/add_dropdel = FALSE //clarified boolean
-	comp.appliedComponents += master.AddComponent(/datum/component/curse_of_hunger, add_dropdel)
+	comp.appliedComponents += master.AddComponent(/datum/component/curse_of_hunger)
 	return newName //no spoilers!
 
 /datum/fantasy_affix/curse_of_hunger/remove(datum/component/fantasy/comp)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -361,7 +361,6 @@
 	icon_state = "duffel-curse"
 	inhand_icon_state = "duffel-curse"
 	slowdown = 2
-	item_flags = DROPDEL
 	max_integrity = 100
 
 /obj/item/storage/backpack/duffelbag/cursed/Initialize(mapload)

--- a/code/modules/spells/spell_types/touch/duffelbag_curse.dm
+++ b/code/modules/spells/spell_types/touch/duffelbag_curse.dm
@@ -41,7 +41,7 @@
 	victim.Knockdown(5 SECONDS)
 
 	// If someone's already cursed, don't try to give them another
-	if(HAS_TRAIT(victim, TRAIT_DUFFEL_CURSE_PROOF))
+	if(istype(victim.back, /obj/item/storage/backpack/duffelbag/cursed))
 		to_chat(caster, span_warning("The burden of [victim]'s duffel bag becomes too much, shoving them to the floor!"))
 		to_chat(victim, span_warning("The weight of this bag becomes overburdening!"))
 		return TRUE
@@ -53,8 +53,6 @@
 		span_danger("You feel something attaching itself to you, and a strong desire to discuss your [pick(elaborate_backstory)] at length!"),
 	)
 
-	// This duffelbag is now cuuuurrrsseed! Equip it on them
-	ADD_TRAIT(conjured_duffel, TRAIT_DUFFEL_CURSE_PROOF, CURSED_ITEM_TRAIT(conjured_duffel.name))
 	conjured_duffel.pickup(victim)
 	conjured_duffel.forceMove(victim)
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -116,6 +116,7 @@
 #include "heretic_rituals.dm"
 #include "holidays.dm"
 #include "human_through_recycler.dm"
+#include "hunger_curse.dm"
 #include "hydroponics_extractor_storage.dm"
 #include "hydroponics_harvest.dm"
 #include "hydroponics_self_mutations.dm"

--- a/code/modules/unit_tests/hunger_curse.dm
+++ b/code/modules/unit_tests/hunger_curse.dm
@@ -1,3 +1,5 @@
+/// Tests that the curse of hunger, from [/datum/component/curse_of_hunger],
+/// is properly added when equipped to the correct slot and removed when dropped / deleted
 /datum/unit_test/hunger_curse
 
 /datum/unit_test/hunger_curse/Run()

--- a/code/modules/unit_tests/hunger_curse.dm
+++ b/code/modules/unit_tests/hunger_curse.dm
@@ -1,0 +1,16 @@
+/datum/unit_test/hunger_curse
+
+/datum/unit_test/hunger_curse/Run()
+	var/mob/living/carbon/human/dummy = allocate(/mob/living/carbon/human/consistent)
+	var/obj/item/storage/backpack/duffelbag/cursed/cursed_bag = allocate(/obj/item/storage/backpack/duffelbag/cursed)
+
+	dummy.equip_to_appropriate_slot(cursed_bag)
+
+	TEST_ASSERT(HAS_TRAIT(cursed_bag, TRAIT_NODROP), "The cursed bag wasn't NODROP after being cursed!")
+	TEST_ASSERT(HAS_TRAIT(dummy, TRAIT_CLUMSY), "Dummy wasn't clumsy after being cursed!")
+	TEST_ASSERT(HAS_TRAIT(dummy, TRAIT_PACIFISM), "Dummy wasn't a pacifist after being cursed!")
+
+	QDEL_NULL(cursed_bag)
+
+	TEST_ASSERT(!HAS_TRAIT(dummy, TRAIT_CLUMSY), "Dummy was still clumsy after being cured of its curse!")
+	TEST_ASSERT(!HAS_TRAIT(dummy, TRAIT_PACIFISM), "Dummy was still a pacifist after being cured of its curse!")


### PR DESCRIPTION
## About The Pull Request

Curse of hunger did some funky stuff by checking for `slot_equipment_priority` (which ONLY BUCKETS use) and registering certain signals based on that

The signals they were using instead didn't pass the unequipper, so the curse never got removed on unequip. 

Replaced them with just equip and drop, as equipped and dropped work just fine for it.

Unit tests this.

## Why It's Good For The Game

Infinite curse of clumsy and pacifism is kinda bad

## Changelog

:cl: Melbert
fix: Dufflebag Curse no longer lasts forever after the bag is destroyed. 
fix: Dufflebag Cursing someone already afflicted properly doesn't try to add the curse again
/:cl:
