### PR TITLE
Addresses Edge-Case For SM Delamination Safety Message in Disposals

### DIFF
--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -34,7 +34,13 @@
 			continue
 		victim.playsound_local(victim_turf, 'sound/magic/charge.ogg')
 		if(victim.z == 0) //victim is inside an object, this is to maintain an old bug turned feature with lockers n shit i guess. tg issue #69687
-			to_chat(victim, span_boldannounce("You hold onto \the [victim.loc] as hard as you can, as reality distorts around you. You feel safe."))
+			var/message = ""
+			var/location = victim.loc
+			if(istype(location, /obj/structure/disposalholder)) // sometimes your loc can be a disposalsholder when you're inside a disposals type, so let's just pass a message that makes sense.
+				message = "You hear a lot of rattling in the disposals pipes around you as reality itself distorts. Yet, you feel safe."
+			else
+				message = "You hold onto \the [victim.loc] as hard as you can, as reality distorts around you. You feel safe."
+			to_chat(victim, span_boldannounce(message))
 			continue
 		to_chat(victim, span_boldannounce("You feel reality distort for a moment..."))
 		if (isliving(victim))

--- a/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/delamination_effects.dm
@@ -37,7 +37,7 @@
 			var/message = ""
 			var/location = victim.loc
 			if(istype(location, /obj/structure/disposalholder)) // sometimes your loc can be a disposalsholder when you're inside a disposals type, so let's just pass a message that makes sense.
-				message = "You hear a lot of rattling in the disposals pipes around you as reality itself distorts. Yet, you feel safe."
+				message = "You hear a lot of rattling in the disposal pipes around you as reality itself distorts. Yet, you feel safe."
 			else
 				message = "You hold onto \the [victim.loc] as hard as you can, as reality distorts around you. You feel safe."
 			to_chat(victim, span_boldannounce(message))


### PR DESCRIPTION

## About The Pull Request

Hey there,

Before it would say that "you hold onto disposalsholder" tightly, but since disposalsholder is an abstract object (lol), it just didn't make sense to players. So, I just addressed that edgecase in the portion when we send messages to player regarding their safety in relation to being in a metal tube preventing them from going insane.
## Why It's Good For The Game

Fixes #71949

![image](https://user-images.githubusercontent.com/34697715/207222647-4617e702-65c9-4439-9f5a-5620ec2ed0ae.png)
## Changelog
:cl:
fix: The message you get when attempting to escape an SM delamination by hiding in a disposals pipe should now make more sense.
/:cl:
