### PR TITLE
You can't break the quantum link on an inverter while it's still recharging, and attempting to do so will have unforeseen consequences

### DIFF
--- a/code/game/objects/items/devices/swapper.dm
+++ b/code/game/objects/items/devices/swapper.dm
@@ -1,6 +1,7 @@
 /obj/item/swapper
 	name = "quantum spin inverter"
-	desc = "An experimental device that is able to swap the locations of two entities by switching their particles' spin values. Must be linked to another device to function."
+	desc = "An experimental device that is able to swap the locations of two entities by switching their particles' spin values. Must be linked to another device to function. A warning label is printed on the back: \n\n\
+	WARNING: DO NOT ATTEMPT TO BREAK LINK WHILE RECHARGING"
 	icon = 'icons/obj/device.dmi'
 	icon_state = "swapper"
 	inhand_icon_state = "electronic"
@@ -70,7 +71,15 @@
 	if(!user.canUseTopic(src, be_close = TRUE, no_dexterity = TRUE, no_tk = FALSE, need_hands = !iscyborg(user)))
 		return
 	if(world.time < next_use)
-		to_chat(user, span_warning("[src] is still recharging."))
+		if(linked_swapper)
+			if(ishuman(user))
+				var/mob/living/carbon/human/homer = user
+				if(!isflyperson(user))
+					to_chat(homer, span_warning("You hear a buzzing in your ears as [src] sparks, attracting a passing fly which gets caught in the quantum flux field!"))
+					homer.set_species(/datum/species/fly)
+					homer.log_message("was turned into a [initial(species_to_transform.name)] through [src].", LOG_GAME)
+				else
+					to_chat(homer, span_warning("[src] sparks, but doesn't attract a fly this time, an error message on the device stating it's still charging and can't safely deconstruct the quantum flux field."))
 		return
 	to_chat(user, span_notice("You break the current quantum link."))
 	if(!QDELETED(linked_swapper))
@@ -112,9 +121,3 @@
 		if(ismob(B))
 			var/mob/M = B
 			to_chat(M, span_warning("[linked_swapper] activates, and you find yourself somewhere else."))
-			if(ishuman(M))
-				var/mob/living/carbon/human/homer = M
-				if(prob(1))
-					to_chat(M, span_hear("You hear a buzzing in your ears."))
-					homer.set_species(/datum/species/fly)
-					homer.log_message("was turned into a [initial(species_to_transform.name)] through [src].", LOG_GAME)

--- a/code/game/objects/items/devices/swapper.dm
+++ b/code/game/objects/items/devices/swapper.dm
@@ -69,6 +69,9 @@
 /obj/item/swapper/AltClick(mob/living/user)
 	if(!user.canUseTopic(src, be_close = TRUE, no_dexterity = TRUE, no_tk = FALSE, need_hands = !iscyborg(user)))
 		return
+	if(world.time < next_use)
+		to_chat(user, span_warning("[src] is still recharging."))
+		return
 	to_chat(user, span_notice("You break the current quantum link."))
 	if(!QDELETED(linked_swapper))
 		linked_swapper.linked_swapper = null

--- a/code/game/objects/items/devices/swapper.dm
+++ b/code/game/objects/items/devices/swapper.dm
@@ -112,3 +112,9 @@
 		if(ismob(B))
 			var/mob/M = B
 			to_chat(M, span_warning("[linked_swapper] activates, and you find yourself somewhere else."))
+			if(ishuman(M))
+				var/mob/living/carbon/human/homer = M
+				if(prob(1))
+					to_chat(M, span_hear("You hear a buzzing in your ears."))
+					homer.set_species(/datum/species/fly)
+					homer.log_message("was turned into a [initial(species_to_transform.name)] through [src].", LOG_GAME)


### PR DESCRIPTION
## About The Pull Request

You can't break the quantum link on an inverter while it's still recharging, and attempting to do so will have unforeseen consequences.

## Why It's Good For The Game

Effortless no recourse getaway tools are lame. There should be some risk. Throw the other end of the link somewhere dangerous or something and be creative.

## Changelog
:cl:
balance: You can't break the quantum link on an inverter while it's still recharging, and attempting to do so will have unforeseen consequences.
balance: Experimental teleporter technology has its' dangers, after all.
/:cl:
