### PR TITLE
The Indestructible objective energy guns protect their contents, preventing them from bricking

### DIFF
--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -70,6 +70,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/disabler/hos, /obj/item/ammo_casing/energy/laser/hos, /obj/item/ammo_casing/energy/ion/hos)
 	ammo_x_offset = 4
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 
 /obj/item/gun/energy/e_gun/dragnet
 	name = "\improper DRAGnet"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -46,6 +46,7 @@
 	ammo_x_offset = 3
 	selfcharge = 1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/antique)
 
 /obj/item/gun/energy/laser/captain/scattershot


### PR DESCRIPTION

## About The Pull Request

Stops the two objective firearms from having their contents destroyed by bombs. This isn't important for any other firearms, as they're all destroyed by those explosions rather than surviving them, only to have their contents deleted instead.

## Why It's Good For The Game

An everpresent consequence of oversimulation in firearms is that they're prone to stupid shit like this happening. Since you can't replace the power cell in these weapons, it just bricks the guns.

You can certainly replace the firing pin in the gun if that's destroyed, but I figured it would be better to just wholesale make this no longer a problem for these weapons.

## Changelog
:cl:
fix: Stops strong enough explosions from bricking the objective energy guns permanently.
/:cl:
