### PR TITLE
Fixes a Runtime in the TGUI Latejoin Menu

### DIFF
--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -34,7 +34,7 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		ui.open()
 
 /datum/latejoin_menu/proc/scream_at_player(mob/dead/new_player/player)
-	if(!player.jobs_menu_mounted)
+	if(istype(player) && !player.jobs_menu_mounted)
 		to_chat(player, span_notice("If the late join menu isn't showing, hold CTRL while clicking the join button!"))
 
 /datum/latejoin_menu/ui_data(mob/user)

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -26,8 +26,9 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		// In case they reopen the GUI
-		user.jobs_menu_mounted = FALSE
-		addtimer(CALLBACK(src, PROC_REF(scream_at_player), user), 5 SECONDS)
+		if(istype(user))
+			user.jobs_menu_mounted = FALSE
+			addtimer(CALLBACK(src, PROC_REF(scream_at_player), user), 5 SECONDS)
 
 		ui = new(user, src, "JobSelection", "Latejoin Menu")
 		ui.open()


### PR DESCRIPTION

## About The Pull Request

Hey, it's your favorite catgirl who fucks shit up, but this time fixing code that she didn't touch for once!
## Why It's Good For The Game

Less random runtimes when player latejoins good, yes?
## Changelog
Not player facing, barely noticeable in the first place, but still so goddamn annoying when testing and seeing it pop up in runtimes.
