### PR TITLE
Fixes forensics scanners breaking on scanning blood.

### DIFF
--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -113,20 +113,20 @@
 			det_data[DETSCAN_CATEGORY_FINGERS] = GET_ATOM_FINGERPRINTS(A)
 
 			// Only get reagents from non-mobs.
-			if(A.reagents && A.reagents.reagent_list.len)
+			for(var/datum/reagent/present_reagnet as anything in A.reagents?.reagent_list)
+				LAZYADD(det_data[DETSCAN_CATEGORY_DRINK], \
+					"Reagent: <font color='red'>[present_reagnet.name]</font> Volume: <font color='red'>[present_reagnet.volume]</font>")
 
-				for(var/datum/reagent/R in A.reagents.reagent_list)
-					LAZYADD(det_data[DETSCAN_CATEGORY_DRINK], \
-						"Reagent: <font color='red'>[R.name]</font> Volume: <font color='red'>[reagents[R.volume]]</font>")
+				// Get blood data from the blood reagent.
+				if(!istype(present_reagnet, /datum/reagent/blood))
+					continue
 
-					// Get blood data from the blood reagent.
-					if(istype(R, /datum/reagent/blood))
+				var/blood_DNA = present_reagnet.data["blood_DNA"]
+				var/blood_type = present_reagnet.data["blood_type"]
+				if(!blood_DNA || !blood_type)
+					continue
 
-						if(R.data["blood_DNA"] && R.data["blood_type"])
-							var/blood_DNA = R.data["blood_DNA"]
-							var/blood_type = R.data["blood_type"]
-							LAZYINITLIST(blood)
-							blood[blood_DNA] = blood_type
+				LAZYSET(blood, blood_DNA, blood_type)
 
 		if(istype(A, /obj/item/card/id))
 			var/obj/item/card/id/user_id = A

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -113,16 +113,16 @@
 			det_data[DETSCAN_CATEGORY_FINGERS] = GET_ATOM_FINGERPRINTS(A)
 
 			// Only get reagents from non-mobs.
-			for(var/datum/reagent/present_reagnet as anything in A.reagents?.reagent_list)
+			for(var/datum/reagent/present_reagent as anything in A.reagents?.reagent_list)
 				LAZYADD(det_data[DETSCAN_CATEGORY_DRINK], \
-					"Reagent: <font color='red'>[present_reagnet.name]</font> Volume: <font color='red'>[present_reagnet.volume]</font>")
+					"Reagent: <font color='red'>[present_reagent.name]</font> Volume: <font color='red'>[present_reagent.volume]</font>")
 
 				// Get blood data from the blood reagent.
-				if(!istype(present_reagnet, /datum/reagent/blood))
+				if(!istype(present_reagent, /datum/reagent/blood))
 					continue
 
-				var/blood_DNA = present_reagnet.data["blood_DNA"]
-				var/blood_type = present_reagnet.data["blood_type"]
+				var/blood_DNA = present_reagent.data["blood_DNA"]
+				var/blood_type = present_reagent.data["blood_type"]
 				if(!blood_DNA || !blood_type)
 					continue
 


### PR DESCRIPTION
## About The Pull Request

Fixes #71973

For some reason it attempted to append `[reagents[volume]]` to the string

`reagents` is 
A. not indexed by volume
B. not a list, but a reagent datum

Replaces it with just a readout of the reagent's volume, cleans up some associated code

## Why It's Good For The Game

Scanning blood is good and has important information

## Changelog

:cl: Melbert
fix: Detective Scanner can scan stuff that contains blood again.
/:cl:

