### PR TITLE
Invisible wall and chair spells can now be cast without open hands.

### DIFF
--- a/code/modules/spells/spell_types/conjure/invisible_chair.dm
+++ b/code/modules/spells/spell_types/conjure/invisible_chair.dm
@@ -5,7 +5,7 @@
 	overlay_icon_state = "bg_mime_border"
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
 	button_icon_state = "invisible_chair"
-	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
+	check_flags = AB_CHECK_CONSCIOUS
 	panel = "Mime"
 	sound = null
 

--- a/code/modules/spells/spell_types/conjure/invisible_wall.dm
+++ b/code/modules/spells/spell_types/conjure/invisible_wall.dm
@@ -5,7 +5,7 @@
 	overlay_icon_state = "bg_mime_border"
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
 	button_icon_state = "invisible_wall"
-	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
+	check_flags = AB_CHECK_CONSCIOUS
 	panel = "Mime"
 	sound = null
 

--- a/code/modules/spells/spell_types/self/forcewall.dm
+++ b/code/modules/spells/spell_types/self/forcewall.dm
@@ -49,7 +49,7 @@
 	overlay_icon_state = "bg_mime_border"
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
 	button_icon_state = "invisible_blockade"
-	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
+	check_flags = AB_CHECK_CONSCIOUS
 	panel = "Mime"
 	sound = null
 


### PR DESCRIPTION

## About The Pull Request
Allows mimes to "act" while their hands are blocked 
## Why It's Good For The Game
Mimes can be a little annoying, as a treat.
## Changelog
:cl:
balance: Invisible wall and chair spells can now be cast with hands blocked
/:cl:
