### PR TITLE
Splits the emag into two

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -269,3 +269,22 @@ GLOBAL_LIST_INIT(ai_employers, list(
 #define OBJECTIVE_WEIGHT_HUGE 20
 
 #define REVENANT_NAME_FILE "revenant_names.json"
+
+// EMAG ACCESS ZONE
+/// Access to all airlocks and firelocks
+#define EMAG_ACCESS_AIRLOCK (1 << 0)
+/// Borg and aibot frying
+#define EMAG_ACCESS_BOT_FRY (1 << 1)
+/// Dispenser and Vendor Extra options
+#define EMAG_ACCESS_DISPENSE (1 << 2)
+/// Specialized ID access checks (Lockers, Communication Console, Display cases, etc)
+#define EMAG_ACCESS_ID_CHECK (1 << 3)
+/// Directly makes the machine more hazardous (Recycler, Vape, Arcade, AI-bots)
+#define EMAG_ACCESS_HAZARD (1 << 4)
+/// Visual adjustments/lesser gameplay impact (Vape, Ethereals, Bar Sign)
+#define EMAG_ACCESS_VISUAL (1 << 5)
+/// Access to syndicate systems (Mod PC, Comms console, Fax Machine, Cargo Requests)
+#define EMAG_ACCESS_SYSTEMS (1 << 6)
+
+/// Defines how high the bits roll on the broken emag
+#define EMAG_ACCESS_TOTAL_CATEGORIES 6

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -176,6 +176,9 @@
 	/// How this atom should react to having its astar blocking checked
 	var/can_astar_pass = CANASTARPASS_DENSITY
 
+	/// the emag access required by an emag to trigger emag_act()
+	var/emag_required
+
 /**
  * Called when an atom is created in byond (built in engine proc)
  *

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -176,8 +176,6 @@
 	/// How this atom should react to having its astar blocking checked
 	var/can_astar_pass = CANASTARPASS_DENSITY
 
-	/// the emag access required by an emag to trigger emag_act()
-	var/emag_required
 
 /**
  * Called when an atom is created in byond (built in engine proc)
@@ -1007,14 +1005,6 @@
 /atom/proc/acid_act(acidpwr, acid_volume)
 	SEND_SIGNAL(src, COMSIG_ATOM_ACID_ACT, acidpwr, acid_volume)
 	return FALSE
-
-/**
- * Respond to an emag being used on our atom
- *
- * Default behaviour is to send [COMSIG_ATOM_EMAG_ACT] and return
- */
-/atom/proc/emag_act(mob/user, obj/item/card/emag/emag_card)
-	SEND_SIGNAL(src, COMSIG_ATOM_EMAG_ACT, user, emag_card)
 
 /**
  * Respond to narsie eating our atom

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -94,6 +94,9 @@
 	/// The degree of pressure protection that mobs in list/contents have from the external environment, between 0 and 1
 	var/contents_pressure_protection = 0
 
+	/// the emag access required by an emag to trigger emag_act()
+	var/emag_required
+
 /mutable_appearance/emissive_blocker
 
 /mutable_appearance/emissive_blocker/New()
@@ -1518,3 +1521,11 @@
 */
 /atom/movable/proc/keybind_face_direction(direction)
 	setDir(direction)
+
+/**
+ * Respond to an emag being used on our atom
+ *
+ * Default behaviour is to send [COMSIG_ATOM_EMAG_ACT] and return
+ */
+/atom/movable/proc/emag_act(mob/user, obj/item/card/emag/emag_card)
+	SEND_SIGNAL(src, COMSIG_ATOM_EMAG_ACT, user, emag_card)

--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -16,6 +16,8 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 
 	circuit = /obj/item/circuitboard/machine/announcement_system
 
+	emag_required = EMAG_ACCESS_VISUAL
+
 	var/obj/item/radio/headset/radio
 	var/arrival = "%PERSON has signed up as %RANK"
 	var/arrivalToggle = 1

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -14,6 +14,7 @@
 	armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 10, BIO = 0, FIRE = 90, ACID = 70)
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.02
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
+	emag_required = EMAG_ACCESS_ID_CHECK
 
 /obj/machinery/button/indestructible
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -4,6 +4,7 @@
 	icon_screen = "solar"
 	icon_keyboard = "power_key"
 	req_access = list(ACCESS_CE)
+	emag_required = EMAG_ACCESS_ID_CHECK
 	circuit = /obj/item/circuitboard/computer/apc_control
 	light_color = LIGHT_COLOR_YELLOW
 	var/obj/machinery/power/apc/active_apc //The APC we're using right now

--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -75,6 +75,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	icon_screen = "invaders"
 	light_color = LIGHT_COLOR_GREEN
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON|INTERACT_MACHINE_SET_MACHINE // we don't need to be literate to play video games fam
+	emag_required = EMAG_ACCESS_DISPENSE
 	var/list/prize_override
 
 /obj/machinery/computer/arcade/proc/Reset()

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -14,6 +14,8 @@
 	icon_screen = "comm"
 	icon_keyboard = "tech_key"
 	req_access = list(ACCESS_COMMAND)
+	// either id or system required
+	emag_required = EMAG_ACCESS_ID_CHECK | EMAG_ACCESS_SYSTEMS
 	circuit = /obj/item/circuitboard/computer/communications
 	light_color = LIGHT_COLOR_BLUE
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -23,6 +23,7 @@
 
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.2
+	emag_required = EMAG_ACCESS_AIRLOCK
 
 	var/visible = TRUE
 	var/operating = FALSE

--- a/code/game/machinery/fat_sucker.dm
+++ b/code/game/machinery/fat_sucker.dm
@@ -7,6 +7,7 @@
 	state_open = FALSE
 	density = TRUE
 	req_access = list(ACCESS_KITCHEN)
+	emag_required = EMAG_ACCESS_HAZARD
 	var/processing = FALSE
 	var/start_at = NUTRITION_LEVEL_WELL_FED
 	var/stop_at = NUTRITION_LEVEL_STARVING

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -27,6 +27,8 @@
 	light_range = 7
 	light_color = COLOR_VIVID_RED
 
+	emag_required = EMAG_ACCESS_HAZARD
+
 	//Trick to get the glowing overlay visible from a distance
 	luminosity = 1
 	//We want to use area sensitivity, let us

--- a/code/game/machinery/gulag_item_reclaimer.dm
+++ b/code/game/machinery/gulag_item_reclaimer.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "dorm_taken"
 	req_access = list(ACCESS_BRIG) //REQACCESS TO ACCESS ALL STORED ITEMS
+	emag_required = EMAG_ACCESS_ID_CHECK
 	density = FALSE
 
 	var/list/stored_items = list()

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -9,6 +9,7 @@
 	state_open = FALSE
 	circuit = /obj/item/circuitboard/machine/harvester
 	light_color = LIGHT_COLOR_BLUE
+	emag_required = EMAG_ACCESS_HAZARD
 	var/interval = 20
 	var/harvesting = FALSE
 	var/warming_up = FALSE

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -8,6 +8,8 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/limbgrower
 
+	emag_required = EMAG_ACCESS_SYSTEMS
+
 	/// The category of limbs we're browing in our UI.
 	var/selected_category = SPECIES_HUMAN
 	/// If we're currently printing something.

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -21,6 +21,9 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/medical_kiosk
 	payment_department = ACCOUNT_MED
+
+	emag_required = EMAG_ACCESS_VISUAL
+
 	var/obj/item/scanner_wand
 	/// How much it costs to use the kiosk by default.
 	var/default_price = 15          //I'm defaulting to a low price on this, but in the future I wouldn't have an issue making it more or less expensive.

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -33,6 +33,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	density = TRUE
 	desc = "A covered turret that shoots at its enemies."
 	req_access = list(ACCESS_SECURITY) /// Only people with Security access
+	emag_required = EMAG_ACCESS_HAZARD
 	power_channel = AREA_USAGE_EQUIP //drains power from the EQUIPMENT channel
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.15
 	max_integrity = 160 //the turret's health
@@ -858,6 +859,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	base_icon_state = "control"
 	density = FALSE
 	req_access = list(ACCESS_AI_UPLOAD)
+	emag_required = EMAG_ACCESS_ID_CHECK
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	/// Variable dictating if linked turrets are active and will shoot targets
 	var/enabled = TRUE

--- a/code/game/machinery/porta_turret/portable_turret_cover.dm
+++ b/code/game/machinery/porta_turret/portable_turret_cover.dm
@@ -11,6 +11,7 @@
 	density = FALSE
 	max_integrity = 80
 	use_power = NO_POWER_USE
+	emag_required = EMAG_ACCESS_HAZARD
 	var/obj/machinery/porta_turret/parent_turret = null
 
 /obj/machinery/porta_turret_cover/Destroy()

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -9,6 +9,9 @@
 	plane = ABOVE_GAME_PLANE
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/recycler
+
+	emag_required = EMAG_ACCESS_HAZARD
+
 	var/safety_mode = FALSE // Temporarily stops machine if it detects a mob
 	var/icon_name = "grinder-o"
 	var/bloody = FALSE

--- a/code/game/machinery/scan_gate.dm
+++ b/code/game/machinery/scan_gate.dm
@@ -24,6 +24,8 @@
 	icon_state = "scangate"
 	circuit = /obj/item/circuitboard/machine/scanner_gate
 
+	emag_required = EMAG_ACCESS_ID_CHECK
+
 	var/scanline_timer
 	///Internal timer to prevent audio spam.
 	var/next_beep = 0

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -116,6 +116,7 @@
 	anchored = FALSE
 	pressure_resistance = 2*ONE_ATMOSPHERE
 	req_access = list(ACCESS_ENGINEERING)
+	emag_required = EMAG_ACCESS_HAZARD  // uncontrollable gen is a hazard
 	max_integrity = 100
 	var/active = FALSE
 	var/list/deployed_shields
@@ -263,6 +264,7 @@
 	anchored = FALSE
 	density = TRUE
 	req_access = list(ACCESS_TELEPORTER)
+	emag_required = EMAG_ACCESS_HAZARD
 	flags_1 = CONDUCT_1
 	use_power = NO_POWER_USE
 	max_integrity = 300

--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -11,6 +11,7 @@
 
 	payment_department = ACCOUNT_MED
 	fair_market_price = 5
+	emag_required = EMAG_ACCESS_HAZARD
 
 	///How much chems is allowed to be in a patient at once, before we force them to wait for the reagent to process.
 	var/efficiency = 1

--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -24,6 +24,7 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/computer/slot_machine
 	light_color = LIGHT_COLOR_BROWN
+	emag_required = EMAG_ACCESS_HAZARD  // barely a hazard but eh
 	var/money = 3000 //How much money it has CONSUMED
 	var/plays = 0
 	var/working = FALSE

--- a/code/game/machinery/telecomms/computers/message.dm
+++ b/code/game/machinery/telecomms/computers/message.dm
@@ -16,6 +16,7 @@
 	name = "message monitor console"
 	desc = "Used to monitor the crew's PDA messages, as well as request console messages."
 	icon_screen = "comm_logs"
+	emag_required = EMAG_ACCESS_ID_CHECK  // im not 100% but i think this fits
 	circuit = /obj/item/circuitboard/computer/message_monitor
 	light_color = LIGHT_COLOR_GREEN
 	//Server linked to.

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -166,6 +166,7 @@ RSF
 	discriptor = "cookie-units"
 	action_type = "Fabricates"
 	cooldowndelay = 10 SECONDS
+	emag_required = EMAG_ACCESS_HAZARD
 	///Tracks whether or not the cookiesynth is about to print a poisoned cookie
 	var/toxin = FALSE //This might be better suited to some initialize fuckery, but I don't have a good "poisoned" sprite
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -944,6 +944,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	inhand_icon_state = null
 	w_class = WEIGHT_CLASS_TINY
 	flags_1 = IS_PLAYER_COLORABLE_1
+	emag_required = EMAG_ACCESS_VISUAL
 
 	/// The capacity of the vape.
 	var/chem_volume = 100

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -477,6 +477,7 @@
 	name = "Supply Console"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/computer/cargo
+	emag_required = EMAG_ACCESS_SYSTEMS
 	var/contraband = FALSE
 
 /obj/item/circuitboard/computer/cargo/multitool_act(mob/living/user)
@@ -506,6 +507,7 @@
 /obj/item/circuitboard/computer/cargo/express
 	name = "Express Supply Console"
 	build_path = /obj/machinery/computer/cargo/express
+	emag_required = EMAG_ACCESS_HAZARD
 
 /obj/item/circuitboard/computer/cargo/express/emag_act(mob/living/user)
 	if(!(obj_flags & EMAGGED))

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -17,6 +17,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	actions_types = list(/datum/action/item_action/toggle_paddles)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 50, ACID = 50)
+	emag_required = EMAG_ACCESS_HAZARD
 
 	var/obj/item/shockpaddles/paddle_type = /obj/item/shockpaddles
 	/// If the paddles are equipped (1) or on the defib (0)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -43,6 +43,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	force = 8
+	emag_required = EMAG_ACCESS_HAZARD  // boom
 
 	var/max_uses = 20
 	var/uses = 10

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -8,6 +8,7 @@
 	righthand_file = 'icons/mob/inhands/items/megaphone_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 	siemens_coefficient = 1
+	emag_required = EMAG_ACCESS_VISUAL
 	var/spamcheck = 0
 	var/list/voicespan = list(SPAN_COMMAND)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -18,6 +18,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=75, /datum/material/glass=25)
 	obj_flags = USES_TGUI
+	emag_required = EMAG_ACCESS_ID_CHECK
 
 	///if FALSE, broadcasting and listening dont matter and this radio shouldnt do anything
 	VAR_PRIVATE/on = TRUE

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -69,7 +69,7 @@
 	A.emag_act(user, src)
 
 /obj/item/card/emag/proc/can_emag(atom/target, mob/user)
-	if(emag_required && !(emag_access & emag_required))
+	if(target.emag_required && !(emag_access & target.emag_required))
 		to_chat(user, span_warning("The [target] cannot be affected by the [src]! A more specialized hacking device is required."))
 		return FALSE
 	return TRUE
@@ -127,31 +127,19 @@
 	var/reset_deviation = 5
 	/// uses tracked
 	var/current_use_loop = 0
-	/// how long until it re-rolls access
-	COOLDOWN_DECLARE(reset_after_time)
 
 /obj/item/card/emag/broken/Initialize(mapload)
 	. = ..()
-	START_PROCESSING(SSObj, src)
-
-/obj/item/card/emag/broken/Destroy(force)
-	STOP_PROCESSING(SSobj, src)
-	return ..()
-
-/obj/item/card/emag/broken/process(delta_time)
-	. = ..()
-	if(COOLDOWN_FINISHED(src, reset_after_time) || !emag_access)
-		roll_access()
-		COOLDOWN_START(src, reset_after_time, 5 MINUTES)
+	roll_access()
 
 /obj/item/card/emag/broken/proc/roll_access()
 	emag_access = rand(1, 2 ^ EMAG_ACCESS_TOTAL_CATEGORIES - 1)
 	audible_message("\The [src] buzzes quietly, shaking, before falling silent.")
 
-/obj/item/card/emag/can_emag(atom/target, mob/user)
+/obj/item/card/emag/broken/can_emag(atom/target, mob/user)
 	if(prob(50))
 		to_chat(user, span_warning("\The [src] sparks, but does nothing else."))
-		do_sparks(1, FALSE, A)
+		do_sparks(1, FALSE, src)
 		return
 	current_use_loop += 1
 	if(current_use_loop >= uses_to_reset + rand(-reset_deviation, reset_deviation))

--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -294,6 +294,7 @@
 	desc = "Releases a harmless blast that confuses most organics. For when the harm is JUST TOO MUCH."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "megaphone"
+	emag_required = EMAG_ACCESS_HAZARD
 	/// Harm alarm cooldown
 	COOLDOWN_DECLARE(alarm_cooldown)
 

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -8,6 +8,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/briefcase_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	req_access = list(ACCESS_ARMORY)
+	emag_required = EMAG_ACCESS_ID_CHECK
 	var/broken = FALSE
 	var/open = FALSE
 	var/icon_locked = "lockbox+l"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -31,6 +31,7 @@
 	throw_speed = 3
 	throw_range = 7
 	force = 0
+	emag_required = EMAG_ACCESS_HAZARD  // not playing around
 
 /*
  * Balloons

--- a/code/game/objects/structures/barsigns.dm
+++ b/code/game/objects/structures/barsigns.dm
@@ -8,6 +8,7 @@
 	integrity_failure = 0.5
 	armor = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 50, ACID = 50)
 	buildable_sign = FALSE
+	emag_required = EMAG_ACCESS_VISUAL
 
 	var/panel_open = FALSE
 	var/datum/barsign/chosen_sign

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -11,6 +11,7 @@
 	integrity_failure = 0.25
 	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 10, BIO = 0, FIRE = 70, ACID = 60)
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
+	emag_required = EMAG_ACCESS_ID_CHECK
 
 	/// The overlay for the closet's door
 	var/obj/effect/overlay/closet_door/door_obj

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -9,6 +9,7 @@
 	armor = list(MELEE = 30, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 0, FIRE = 70, ACID = 100)
 	max_integrity = 200
 	integrity_failure = 0.25
+	emag_required = EMAG_ACCESS_ID_CHECK
 	///The showpiece item inside the case
 	var/obj/item/showpiece = null
 	///This allows for showpieces that can only hold items if they're the same istype as this.

--- a/code/game/objects/structures/training_machine.dm
+++ b/code/game/objects/structures/training_machine.dm
@@ -20,6 +20,7 @@
 	can_buckle = TRUE
 	buckle_lying = 0
 	max_integrity = 200
+	emag_required = EMAG_ACCESS_HAZARD
 	///Is the machine moving? Setting this to FALSE will automatically call stop_moving()
 	var/moving = FALSE
 	///The distance the machine is allowed to roam from its starting point

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -73,6 +73,7 @@
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.02
 	power_channel = AREA_USAGE_ENVIRON
 	req_access = list(ACCESS_ATMOSPHERICS)
+	emag_required = EMAG_ACCESS_HAZARD
 	max_integrity = 250
 	integrity_failure = 0.33
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 90, ACID = 30)

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -15,6 +15,7 @@
 	circuit = /obj/item/circuitboard/computer/cargo/express
 	blockade_warning = "Bluespace instability detected. Delivery impossible."
 	req_access = list(ACCESS_CARGO)
+	emag_required = EMAG_ACCESS_HAZARD
 	is_express = TRUE
 	interface_type = "CargoExpress"
 

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -4,6 +4,7 @@
 	icon_screen = "supply"
 	circuit = /obj/item/circuitboard/computer/cargo
 	light_color = COLOR_BRIGHT_ORANGE
+	emag_required = EMAG_ACCESS_SYSTEMS
 
 	///Can the supply console send the shuttle back and forth? Used in the UI backend.
 	var/can_send = TRUE

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -2,6 +2,7 @@
 	name = "HUD"
 	desc = "A heads-up display that provides important info in (almost) real time."
 	flags_1 = null //doesn't protect eyes because it's a monocle, duh
+	emag_required = EMAG_ACCESS_VISUAL
 	var/hud_type = null
 	///Used for topic calls. Just because you have a HUD display doesn't mean you should be able to interact with stuff.
 	var/hud_trait = null

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -57,6 +57,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	visor_flags_cover = MASKCOVERSMOUTH
 	tint = 0
 	has_fov = FALSE
+	emag_required = EMAG_ACCESS_HAZARD
 	COOLDOWN_DECLARE(hailer_cooldown)
 	var/aggressiveness = AGGR_BAD_COP
 	var/overuse_cooldown = FALSE

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -52,6 +52,7 @@
 	equip_delay_other = 80
 	resistance_flags = NONE
 	actions_types = list(/datum/action/item_action/toggle_spacesuit)
+	emag_required = EMAG_ACCESS_HAZARD
 	var/temperature_setting = BODYTEMP_NORMAL /// The default temperature setting
 	var/obj/item/stock_parts/cell/cell = /obj/item/stock_parts/cell/high /// If this is a path, this gets created as an object in Initialize.
 	var/cell_cover_open = FALSE /// Status of the cell cover on the suit

--- a/code/modules/experisci/destructive_scanner.dm
+++ b/code/modules/experisci/destructive_scanner.dm
@@ -10,6 +10,7 @@
 	icon_state = "tube_open"
 	circuit = /obj/item/circuitboard/machine/destructive_scanner
 	layer = MOB_LAYER
+	emag_required = EMAG_ACCESS_HAZARD
 	var/scanning = FALSE
 
 /obj/machinery/destructive_scanner/Initialize(mapload)

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -33,6 +33,7 @@ GLOBAL_LIST_INIT(typecache_holodeck_linked_floorcheck_ok, typecacheof(list(/turf
 	name = "holodeck control console"
 	desc = "A computer used to control a nearby holodeck."
 	icon_screen = "holocontrol"
+	emag_required = EMAG_ACCESS_HAZARD
 
 	//new vars
 	///what area type this holodeck loads into. linked turns into the nearest instance of this area

--- a/code/modules/industrial_lift/crossing_signal.dm
+++ b/code/modules/industrial_lift/crossing_signal.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_EMPTY(tram_signals)
 	light_power = 1
 	light_color = COLOR_VIBRANT_LIME
 	luminosity = 1
+	emag_required = EMAG_ACCESS_VISUAL
 
 	/// green, amber, or red.
 	var/signal_state = XING_STATE_GREEN

--- a/code/modules/industrial_lift/elevator_button.dm
+++ b/code/modules/industrial_lift/elevator_button.dm
@@ -1,6 +1,7 @@
 /obj/item/assembly/control/elevator
 	name = "elevator controller"
 	desc = "A small device used to call elevators to the current floor."
+	emag_required = EMAG_ACCESS_HAZARD
 	/// A weakref to the lift_master datum we control
 	var/datum/weakref/lift_weakref
 

--- a/code/modules/industrial_lift/elevator_panel.dm
+++ b/code/modules/industrial_lift/elevator_panel.dm
@@ -23,6 +23,8 @@
 	// Indestructible until someone wants to make these constructible, with all the chaos that implies
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
+	emag_required = EMAG_ACCESS_HAZARD
+
 	/// Were we instantiated at mapload? Used to determine when we should link / throw errors
 	var/maploaded = FALSE
 

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -279,6 +279,7 @@
 	icon_keyboard = null
 	circuit = /obj/item/circuitboard/computer/libraryconsole
 	interface_type = "LibraryConsole"
+	emag_required = EMAG_ACCESS_HAZARD  // memetic hazard
 	///Can spawn secret lore item
 	var/can_spawn_lore = TRUE
 	///The screen we're currently on, sent to the ui

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -5,6 +5,7 @@
 	desc = "What could be inside?"
 	icon_state = "securecrate"
 	integrity_failure = 0 //no breaking open the crate
+	emag_required = EMAG_ACCESS_HAZARD  // to you
 	var/code = null
 	var/lastattempt = null
 	var/attempts = 10

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST(labor_sheet_values)
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	icon_state = "console"
 	density = FALSE
+	emag_required = EMAG_ACCESS_ID_CHECK
 	/// Connected stacking machine
 	var/obj/machinery/mineral/stacking_machine/laborstacker/stacking_machine
 	/// Needed to send messages to sec radio

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -13,6 +13,7 @@
 	speech_span = SPAN_ROBOT
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1
 	examine_cursor_icon = null
+	emag_required = EMAG_ACCESS_ID_CHECK
 	var/datum/ai_laws/laws = null//Now... THEY ALL CAN ALL HAVE LAWS
 	var/last_lawchange_announce = 0
 	var/list/alarms_to_show = list()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -27,6 +27,7 @@
 	light_system = MOVABLE_LIGHT
 	light_range = 3
 	light_power = 0.9
+	emag_required = EMAG_ACCESS_BOT_FRY
 
 	///Will other (noncommissioned) bots salute this bot?
 	var/commissioned = FALSE

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -29,6 +29,7 @@
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	siemens_coefficient = 0.5
 	alternate_worn_layer = HANDS_LAYER+0.1 //we want it to go above generally everything, but not hands
+	emag_required = EMAG_ACCESS_ID_CHECK
 	/// The MOD's theme, decides on some stuff like armor and statistics.
 	var/datum/mod_theme/theme = /datum/mod_theme
 	/// Looks of the MOD.

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -393,6 +393,7 @@
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 3
 	incompatible_modules = list(/obj/item/mod/module/dna_lock, /obj/item/mod/module/eradication_lock)
 	cooldown_time = 0.5 SECONDS
+	emag_required = EMAG_ACCESS_ID_CHECK
 	/// The DNA we lock with.
 	var/dna = null
 

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	max_integrity = 100
 	armor = list(MELEE = 0, BULLET = 20, LASER = 20, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
+	emag_required = EMAG_ACCESS_SYSTEMS
 
 	///The ID currently stored in the computer.
 	var/obj/item/card/id/computer_id_slot

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -11,7 +11,7 @@
 	icon_state = null
 
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.05
-	emag_access = EMAG_ACCESS_SYSTEMS
+	emag_required = EMAG_ACCESS_SYSTEMS
 	///The power cell, null by default as we use the APC we're in
 	var/internal_cell = null
 	///A flag that describes this device type

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -11,6 +11,7 @@
 	icon_state = null
 
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.05
+	emag_access = EMAG_ACCESS_SYSTEMS
 	///The power cell, null by default as we use the APC we're in
 	var/internal_cell = null
 	///A flag that describes this device type

--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -11,6 +11,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	worn_icon_state = "electronic"
+	emag_required = EMAG_ACCESS_ID_CHECK
 
 	/// Spam alert prevention
 	var/alert_cooldown

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -28,6 +28,7 @@
 	pull_force = 0
 	radio = /obj/item/radio/headset/silicon/pai
 	worn_slot_flags = ITEM_SLOT_HEAD
+	emag_required = EMAG_ACCESS_ID_CHECK
 
 	/// If someone has enabled/disabled the pAIs ability to holo
 	var/can_holo = TRUE

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -8,6 +8,7 @@
 	max_integrity = 100
 	pass_flags = PASSTABLE
 	circuit = /obj/item/circuitboard/machine/fax
+	emag_required = EMAG_ACCESS_SYSTEMS
 	/// The unique ID by which the fax will build a list of existing faxes.
 	var/fax_id
 	/// The name of the fax displayed in the list. Not necessarily unique to some EMAG jokes.

--- a/code/modules/paperwork/ticketmachine.dm
+++ b/code/modules/paperwork/ticketmachine.dm
@@ -13,6 +13,7 @@
 	maptext_x = 7
 	maptext_y = 10
 	layer = HIGH_OBJ_LAYER
+	emag_required = EMAG_ACCESS_VISUAL
 	///Increment the ticket number whenever the HOP presses his button
 	var/ticket_number = 0
 	///What ticket number are we currently serving?

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -17,6 +17,7 @@
 	damage_deflection = 10
 	resistance_flags = FIRE_PROOF
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON
+	emag_required = EMAG_ACCESS_ID_CHECK
 
 	///Range of the light emitted when on
 	var/light_on_range = 1.5

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -82,6 +82,7 @@
 	name = "\improper P.A.C.M.A.N.-type portable generator"
 	circuit = /obj/item/circuitboard/machine/pacman
 	power_gen = 5000
+	emag_required = EMAG_ACCESS_HAZARD
 	var/sheets = 0
 	var/max_sheets = 50
 	var/sheet_name = ""

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -8,6 +8,7 @@
 	anchored = FALSE
 	density = TRUE
 	req_access = list(ACCESS_ENGINE_EQUIP)
+	emag_required = EMAG_ACCESS_ID_CHECK  // suprisingly!
 	circuit = /obj/item/circuitboard/machine/emitter
 
 	use_power = NO_POWER_USE

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -9,6 +9,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb_continuous = list("pokes")
 	attack_verb_simple = list("poke")
+	emag_required = EMAG_ACCESS_ID_CHECK
 	var/fail_message = "invalid user!"
 	var/selfdestruct = FALSE // Explode when user check is failed.
 	var/force_replace = FALSE // Can forcefully replace other pins.

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -22,6 +22,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	circuit = /obj/item/circuitboard/machine/chem_dispenser
 	processing_flags = NONE
+	emag_required = EMAG_ACCESS_DISPENSE
 
 	var/obj/item/stock_parts/cell/cell
 	var/powerefficiency = 0.1

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -16,6 +16,7 @@
 	icon_state = "outlet"
 	density = TRUE
 	anchored = TRUE
+	emag_required = EMAG_ACCESS_HAZARD
 	var/active = FALSE
 	var/turf/target // this will be where the output objects are 'thrown' to.
 	var/obj/structure/disposalpipe/trunk/trunk // the attached pipe trunk

--- a/code/modules/research/anomaly/anomaly_refinery.dm
+++ b/code/modules/research/anomaly/anomaly_refinery.dm
@@ -18,6 +18,7 @@
 	base_icon_state = "explosive_compressor"
 	icon_state = "explosive_compressor"
 	density = TRUE
+	emag_required = EMAG_ACCESS_HAZARD  // how to kill scientists with their own bomb
 
 	/// The raw core inserted in the machine.
 	var/obj/item/raw_anomaly_core/inserted_core

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -23,6 +23,7 @@ Nothing else in the console has ID requirements.
 	icon_keyboard = "rd_key"
 	circuit = /obj/item/circuitboard/computer/rdconsole
 	req_access = list(ACCESS_RESEARCH) // Locking and unlocking the console requires research access
+	emag_required = EMAG_ACCESS_ID_CHECK  // ..unless youre a syndie
 	/// Reference to global science techweb
 	var/datum/techweb/stored_research
 	/// The stored technology disk, if present

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -115,6 +115,7 @@
 	icon_keyboard = "rd_key"
 	circuit = /obj/item/circuitboard/computer/rdservercontrol
 	req_access = list(ACCESS_RD)
+	emag_required = EMAG_ACCESS_ID_CHECK
 	var/list/servers = list()
 	///Connected techweb node the server is connected to.
 	var/datum/techweb/stored_research

--- a/code/modules/research/xenobiology/vatgrowing/vatgrower.dm
+++ b/code/modules/research/xenobiology/vatgrowing/vatgrower.dm
@@ -6,6 +6,7 @@
 	buffer = 300
 	///category for plumbing RCD
 	category = "Synthesizers"
+	emag_required = EMAG_ACCESS_VISUAL
 
 
 	///List of all microbiological samples in this soup.

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -13,6 +13,7 @@
 	icon_keyboard = "tech_key"
 	light_color = LIGHT_COLOR_CYAN
 	req_access = list()
+	emag_required = EMAG_ACCESS_ID_CHECK
 	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON|INTERACT_MACHINE_SET_MACHINE
 	/// ID of the attached shuttle
 	var/shuttleId

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -17,6 +17,7 @@
 	icon_screen = "shuttle"
 	icon_keyboard = "tech_key"
 	resistance_flags = INDESTRUCTIBLE
+	emag_required = EMAG_ACCESS_HAZARD
 	var/auth_need = 3
 	var/list/authorized = list()
 	var/list/acted_recently = list()
@@ -591,6 +592,7 @@
 	icon_state = "dorm_available"
 	light_color = LIGHT_COLOR_BLUE
 	density = FALSE
+	emag_required = EMAG_ACCESS_ID_CHECK
 
 /obj/machinery/computer/shuttle/pod/Initialize(mapload)
 	AddElement(/datum/element/update_icon_blocker)

--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -147,6 +147,7 @@
 	mode = "M-SHIELD"
 	processing_flags = START_PROCESSING_MANUALLY
 	subsystem_type = /datum/controller/subsystem/processing/fastprocess
+	emag_required = EMAG_ACCESS_HAZARD
 	var/kill_range = 14
 
 /obj/machinery/satellite/meteor_shield/proc/space_los(meteor)

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -227,6 +227,7 @@
 /obj/item/organ/internal/cyberimp/arm/toolset
 	name = "integrated toolset implant"
 	desc = "A stripped-down version of the engineering cyborg toolset, designed to be installed on subject's arm. Contain advanced versions of every tool."
+	emag_required = EMAG_ACCESS_HAZARD
 	items_to_create = list(
 		/obj/item/screwdriver/cyborg,
 		/obj/item/wrench/cyborg,

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -94,9 +94,10 @@
 	cost = 1
 
 /datum/uplink_item/device_tools/doorjack
-	name = "Airlock Authentication Override Card"
-	desc = "A specialized cryptographic sequencer specifically designed to override station airlock access codes. \
-			After hacking a certain number of airlocks, the device will require some time to recharge."
+	name = "Authentication Override Card"
+	desc = "This is a specialized cryptographic sequencer specifically designed to override access codes. \
+			It can also link devices to syndicate systems. \
+			After hacking a certain number of machines, the device will require some time to recharge."
 	item = /obj/item/card/emag/doorjack
 	cost = 3
 
@@ -194,8 +195,8 @@
 
 /datum/uplink_item/device_tools/emag
 	name = "Cryptographic Sequencer"
-	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \
-			in electronic devices, subverts intended functions, and easily breaks security mechanisms. Cannot be used to open airlocks."
+	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hazardous functions \
+			in electronic devices, and subverts intended functions,Cannot be used to unlock most devices."
 	progression_minimum = 20 MINUTES
 	item = /obj/item/card/emag
 	cost = 4

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -5,6 +5,7 @@
 	overlay_icon = "motorized_wheelchair_overlay"
 	foldabletype = null
 	max_integrity = 150
+	emag_required = EMAG_ACCESS_HAZARD  // how to kill old people
 	///How "fast" the wheelchair goes only affects ramming
 	var/speed = 2
 	///Self explanatory, ratio of how much power we use
@@ -35,7 +36,7 @@
 		speed += M.rating
 	var/chair_icon = "motorized_wheelchair[speed > delay_multiplier ? "_fast" : ""]"
 	if(icon_state != chair_icon)
-		wheels_overlay = image(icon, chair_icon + "_overlay", ABOVE_MOB_LAYER) 
+		wheels_overlay = image(icon, chair_icon + "_overlay", ABOVE_MOB_LAYER)
 
 	icon_state = chair_icon
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -64,6 +64,7 @@
 	payment_department = ACCOUNT_SRV
 	light_power = 0.5
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE
+	emag_required = EMAG_ACCESS_DISPENSE
 	/// Is the machine active (No sales pitches if off)!
 	var/active = 1
 	///Are we ready to vend?? Is it time??


### PR DESCRIPTION

## About The Pull Request
So first, every /atom has an emag_requried var which categorizes the type of emagging that happens.
Every emag now has an emag_access var, which is a bitflag var for each emag category.
The standard emag has bot frying, general safety hazard, visual, and vending machine/chem dispenser type unlocks,
while the doorjack (renamed access card) gets airlock, vending/chem, id checks, linking machines to syndie systems (cargo console, fax, modpc), and visual

and theres a broken emag that randomizes accesses every 5-15 uses and also doesnt work half the time anyways
## Why It's Good For The Game
The emag is kinda overpowered with how many things it can affect (90+), so splitting it into two will make it more interesting. The rng heavy emag is also going to be fun to use.
## Changelog
:cl:
balance: gave half the emag effects to doorjack
add: doorjack renamed access override card
add: broken emag, barely works and randomizes emag access but its cheaper
code: emag_required var, controls the access required by the users emag to trigger emag_act()
/:cl:
