### PR TITLE
Glass Maintenance station trait

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -338,7 +338,7 @@
 	name = "Glass Maintenance"
 	trait_type = STATION_TRAIT_POSITIVE
 	show_in_report = TRUE
-	weight = 5
+	weight = 4
 
 /datum/station_trait/glass_maint/New()
 	. = ..()

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -342,16 +342,14 @@
 
 /datum/station_trait/glass_maint/New()
 	. = ..()
-	report_message = pick(
-		"In an effort to reduce maintenance casualties, glass windows have been fitted in every door.",
+	report_message = pick("In an effort to reduce maintenance casualties, glass windows have been fitted in every door.",
 		"We had a spare engineer, so we had them put glass in all maintenance doors.",
 		"To commemorate our miners, we put glass in all the airlocks. Unfortunately, we ran out after completing maintenance.",
 		"In an effort to comply with Space Law section [rand(1,99999)].4, we have outfitted maintenence with glass windows.",
 		"An anomaly caused all the maintenance airlocks to get glass windows.",
 		"An intern went through and added glass to all the maintenance windows in their spare time.",
 		"In an effort to promote brand transparancy, we're adding glass to all maintenance doors effective immediately.",  // my proudest dad joke
-		"We over-ordered glass during construction, so maintenance gets glass windows."
-	)
+		"We over-ordered glass during construction, so maintenance gets glass windows.")
 
 /datum/station_trait/on_round_start()
 	for(var/area/station/maintenance/A in GLOB.areas)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -333,3 +333,30 @@
 		return
 	var/obj/item/organ/internal/cybernetic = new cybernetic_type()
 	cybernetic.Insert(spawned, special = TRUE, drop_if_replaced = FALSE)
+
+/datum/station_trait/glass_maint
+	name = "Glass Maintinance"
+	trait_type = STATION_TRAIT_POSITIVE
+	show_in_report = TRUE
+	weight = 5
+
+/datum/station_trait/glass_maint/New()
+	. = ..()
+	report_message = pick(
+		"In an effort to reduce maintenance casualties, glass windows have been fitted in every door.",
+		"We had a spare engineer, so we had them put glass in all maintenance doors.",
+		"To commemorate our miners, we put glass in all the airlocks. Unfortunately, we ran out after completing maintenance.",
+		"In an effort to comply with Space Law section [rand(1,99999)].4, we have outfitted maintenence with glass windows.",
+		"An anomaly caused all the maintenance airlocks to get glass windows.",
+		"An intern went through and added glass to all the maintenance windows in their spare time.",
+		"In an effort to promote brand transparancy, we're adding glass to all maintenance doors effective immediately.",  // my proudest dad joke
+		"We over-ordered glass during construction, so maintenance gets glass windows."
+	)
+
+/datum/station_trait/on_round_start()
+	for(var/area/station/maintenance/A in GLOB.areas)
+		for(var/turf/in_area as anything in A.get_contained_turfs())
+			for(var/obj/machinery/door/airlock/D in in_area)
+				D.opacity = FALSE
+				D.glass = TRUE
+				D.update_icon(ALL, 0)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -335,7 +335,7 @@
 	cybernetic.Insert(spawned, special = TRUE, drop_if_replaced = FALSE)
 
 /datum/station_trait/glass_maint
-	name = "Glass Maintinance"
+	name = "Glass Maintenance"
 	trait_type = STATION_TRAIT_POSITIVE
 	show_in_report = TRUE
 	weight = 5

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -352,9 +352,15 @@
 		"We over-ordered glass during construction, so maintenance gets glass windows.")
 
 /datum/station_trait/on_round_start()
-	for(var/area/station/maintenance/A in GLOB.areas)
-		for(var/turf/in_area as anything in A.get_contained_turfs())
-			for(var/obj/machinery/door/airlock/D in in_area)
-				D.opacity = FALSE
-				D.glass = TRUE
-				D.update_icon(ALL, 0)
+	for(var/area/station/maintenance/maint_area in GLOB.the_station_areas)
+		for(var/turf/maint_floor as anything in maint_area.get_contained_turfs())
+
+			if(istype(maint_floor, /turf/open/floor/plating/reinforced))  // keeps reinf status
+				maint_floor.ChangeTurf(/turf/open/floor/glass/reinforced)
+			else
+				maint_floor.ChangeTurf(/turf/open/floor/glass)
+
+			for(var/obj/machinery/door/airlock/affected_airlock in maint_floor)
+				affected_airlock.opacity = FALSE
+				affected_airlock.glass = TRUE
+				affected_airlock.update_icon(ALL)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -353,11 +353,7 @@
 
 	for(var/area/station/maintenance/maint_area in GLOB.the_station_areas)
 		for(var/turf/maint_floor as anything in maint_area.get_contained_turfs())
-
-			if(istype(maint_floor, /turf/open/floor/plating/reinforced))  // keeps reinf status
-				maint_floor.ChangeTurf(/turf/open/floor/glass/reinforced)
-			else
-				maint_floor.ChangeTurf(/turf/open/floor/glass)
+			maint_floor.ChangeTurf(/turf/open/floor/glass)
 
 			for(var/obj/machinery/door/airlock/affected_airlock in maint_floor)
 				affected_airlock.opacity = FALSE

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -342,14 +342,16 @@
 
 /datum/station_trait/glass_maint/New()
 	. = ..()
-	report_message = pick("In an effort to reduce maintenance casualties, glass windows have been fitted in every door.",
+	report_message = pick(
+		"In an effort to reduce maintenance casualties, glass windows have been fitted in every door.",
 		"We had a spare engineer, so we had them put glass in all maintenance doors.",
 		"To commemorate our miners, we put glass in all the airlocks. Unfortunately, we ran out after completing maintenance.",
-		"In an effort to comply with Space Law section [rand(1,99999)].4, we have outfitted maintenence with glass windows.",
+		"In an effort to comply with Space Law section [rand(1,99999)].4, we have outfitted maintenance with glass windows.",
 		"An anomaly caused all the maintenance airlocks to get glass windows.",
 		"An intern went through and added glass to all the maintenance windows in their spare time.",
-		"In an effort to promote brand transparancy, we're adding glass to all maintenance doors effective immediately.",  // my proudest dad joke
-		"We over-ordered glass during construction, so maintenance gets glass windows.")
+		"In an effort to promote brand transparency, we're adding glass to all maintenance doors effective immediately.",  // my proudest dad joke
+		"We over-ordered glass during construction, so maintenance gets glass windows.",
+	)
 
 	for(var/area/station/maintenance/maint_area in GLOB.the_station_areas)
 		for(var/turf/maint_floor as anything in maint_area.get_contained_turfs())

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -357,8 +357,12 @@
 
 	for(var/area/station/maintenance/maint_area in GLOB.areas)
 		for(var/turf/maint_floor as anything in maint_area.get_contained_turfs())
-			if(istype(maint_floor, /turf/open))
-				maint_floor.ChangeTurf(/turf/open/floor/glass, flags = CHANGETURF_INHERIT_AIR)
+
+			if(istype(maint_floor, /turf/closed))  // replace walls with fulltile windows to not space everything
+				new /obj/structure/window/reinforced/fulltile(maint_floor)
+				new /obj/structure/grille(maint_floor)  // some protection..
+
+			maint_floor.ChangeTurf(/turf/open/floor/glass, flags = CHANGETURF_INHERIT_AIR)
 
 			for(var/obj/machinery/door/airlock/affected_airlock in maint_floor)
 				var/obj/machinery/door/airlock/maintenance/glass/replacement_door = new(maint_floor)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -354,7 +354,6 @@
 	)
 
 /datum/station_trait/glass_maint/on_round_start()
-
 	for(var/area/station/maintenance/maint_area in GLOB.areas)
 		for(var/turf/maint_floor as anything in maint_area.get_contained_turfs())
 

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -351,7 +351,6 @@
 		"In an effort to promote brand transparancy, we're adding glass to all maintenance doors effective immediately.",  // my proudest dad joke
 		"We over-ordered glass during construction, so maintenance gets glass windows.")
 
-/datum/station_trait/on_round_start()
 	for(var/area/station/maintenance/maint_area in GLOB.the_station_areas)
 		for(var/turf/maint_floor as anything in maint_area.get_contained_turfs())
 

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -338,7 +338,7 @@
 	name = "Glass Maintenance"
 	trait_type = STATION_TRAIT_POSITIVE
 	show_in_report = TRUE
-	weight = 4
+	weight = 2
 
 /datum/station_trait/glass_maint/New()
 	. = ..()

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -353,11 +353,14 @@
 		"We over-ordered glass during construction, so maintenance gets glass windows.",
 	)
 
-	for(var/area/station/maintenance/maint_area in GLOB.the_station_areas)
+/datum/station_trait/glass_maint/on_round_start()
+
+	for(var/area/station/maintenance/maint_area in GLOB.areas)
 		for(var/turf/maint_floor as anything in maint_area.get_contained_turfs())
-			maint_floor.ChangeTurf(/turf/open/floor/glass)
+			if(istype(maint_floor, /turf/open))
+				maint_floor.ChangeTurf(/turf/open/floor/glass, flags = CHANGETURF_INHERIT_AIR)
 
 			for(var/obj/machinery/door/airlock/affected_airlock in maint_floor)
-				affected_airlock.opacity = FALSE
-				affected_airlock.glass = TRUE
-				affected_airlock.update_appearance(UPDATE_ICON)
+				var/obj/machinery/door/airlock/maintenance/glass/replacement_door = new(maint_floor)
+				replacement_door.name = affected_airlock.name
+				qdel(affected_airlock)

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -356,7 +356,6 @@
 /datum/station_trait/glass_maint/on_round_start()
 	for(var/area/station/maintenance/maint_area in GLOB.areas)
 		for(var/turf/maint_floor as anything in maint_area.get_contained_turfs())
-
 			if(istype(maint_floor, /turf/closed))  // replace walls with fulltile windows to not space everything
 				new /obj/structure/window/reinforced/fulltile(maint_floor)
 				new /obj/structure/grille(maint_floor)  // some protection..

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -358,4 +358,4 @@
 			for(var/obj/machinery/door/airlock/affected_airlock in maint_floor)
 				affected_airlock.opacity = FALSE
 				affected_airlock.glass = TRUE
-				affected_airlock.update_icon(ALL)
+				affected_airlock.update_appearance(UPDATE_ICON)


### PR DESCRIPTION

## About The Pull Request
Adds a station trait that makes all maintenance airlocks glass
## Why It's Good For The Game
Makes it harder for antags to hide bodies/runes/etc
## Changelog
:cl:
add: glass maint station trait
/:cl:
