### PR TITLE
shipping containers go above mobs

### DIFF
--- a/code/game/objects/structures/containers.dm
+++ b/code/game/objects/structures/containers.dm
@@ -8,6 +8,8 @@
 	bound_height = 32
 	density = TRUE
 	anchored = TRUE
+	layer = ABOVE_ALL_MOB_LAYER
+	plane = ABOVE_GAME_PLANE
 
 /obj/structure/shipping_container/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
![image](https://user-images.githubusercontent.com/23585223/207670501-ce9dbfba-0730-4c5c-81e9-e62490414257.png)
shipping containers no longer do this

## Why It's Good For The Game
refer to #71259 

## Changelog
:cl:
fix: shipping containers go above mobs
/:cl:
