### PR TITLE
Ignore codeowners that got previously removed from review

### DIFF
--- a/.github/workflows/codeowner_reviews.yml
+++ b/.github/workflows/codeowner_reviews.yml
@@ -27,3 +27,4 @@ jobs:
         with:
           separator: ' '
           users: ${{ steps.CodeOwnersParser.outputs.owners }}
+          ignoreRemovedUsers: true

--- a/code/__HELPERS/logging/_logging.dm
+++ b/code/__HELPERS/logging/_logging.dm
@@ -1,4 +1,4 @@
-//print a warning message to world.log
+///print a warning message to world.log
 #define WARNING(MSG) warning("[MSG] in [__FILE__] at line [__LINE__] src: [UNLINT(src)] usr: [usr].")
 /proc/warning(msg)
 	msg = "## WARNING: [msg]"


### PR DESCRIPTION

## About The Pull Request
**Only merge this after the following 2 PRs got merged!**
https://github.com/tgstation/RequestReviewFromUser/pull/5
https://github.com/tgstation/RequestReviewFromUser/pull/6

Makes it so that codeowners no longer get notified if they got removed from review previously in the PRs lifetime
Requested by @Mothblocks 
## Why It's Good For The Game
Apparently no means no and the action constantly re-adding you as owner after you remove yourself is annoying
## Changelog
