### PR TITLE
Replaces the direct central command contact from fax machines with nanotrasen departmental contacts

### DIFF
--- a/code/modules/admin/admin_fax_panel.dm
+++ b/code/modules/admin/admin_fax_panel.dm
@@ -24,7 +24,7 @@
 	/// Default name of fax. Used when field with fax name not edited.
 	var/sending_fax_name = "Secret"
 	/// Default name of paper. paper - bluh-bluh. Used when field with paper name not edited.
-	var/default_paper_name = "Standart Report"
+	var/default_paper_name = "Standard Report"
 
 /datum/fax_panel_interface/New()
 	//Get all faxes, and save them to our list.

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -50,7 +50,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	)
 	/// List with a fake-networks(not a fax actually), for request manager.
 	var/list/special_networks = list(
-		nanotrasen = list(fax_name = "Nanotrasen HR Deptartment", fax_id = "central_command", color = "teal", emag_needed = FALSE),
+		nanotrasen = list(fax_name = "NT HR Deptartment", fax_id = "central_command", color = "teal", emag_needed = FALSE),
 		syndicate = list(fax_name = "Sabotage Department", fax_id = "syndicate", color = "red", emag_needed = TRUE),
 	)
 

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -50,7 +50,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 	)
 	/// List with a fake-networks(not a fax actually), for request manager.
 	var/list/special_networks = list(
-		nanotrasen = list(fax_name = "NT HR Deptartment", fax_id = "central_command", color = "teal", emag_needed = FALSE),
+		nanotrasen = list(fax_name = "NT HR Department", fax_id = "central_command", color = "teal", emag_needed = FALSE),
 		syndicate = list(fax_name = "Sabotage Department", fax_id = "syndicate", color = "red", emag_needed = TRUE),
 	)
 

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -1,3 +1,5 @@
+GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department", "NT Complaint Department", "NT Customer Relations", "Nanotrasen Tech Support", "NT Internal Affairs Dept."))
+
 /obj/machinery/fax
 	name = "Fax Machine"
 	desc = "Bluespace technologies on the application of bureaucracy."
@@ -48,8 +50,8 @@
 	)
 	/// List with a fake-networks(not a fax actually), for request manager.
 	var/list/special_networks = list(
-		list(fax_name = "Central Command", fax_id = "central_command", color = "teal", emag_needed = FALSE),
-		list(fax_name = "Sabotage Department", fax_id = "syndicate", color = "red", emag_needed = TRUE),
+		nanotrasen = list(fax_name = "Nanotrasen HR Deptartment", fax_id = "central_command", color = "teal", emag_needed = FALSE),
+		syndicate = list(fax_name = "Sabotage Department", fax_id = "syndicate", color = "red", emag_needed = TRUE),
 	)
 
 /obj/machinery/fax/Initialize(mapload)
@@ -60,6 +62,7 @@
 		fax_name = "Unregistered fax " + fax_id
 	wires = new /datum/wires/fax(src)
 	register_context()
+	special_networks["nanotrasen"]["fax_name"] = GLOB.nt_fax_department
 
 /obj/machinery/fax/Destroy()
 	QDEL_NULL(loaded_item_ref)
@@ -234,7 +237,10 @@
 	data["syndicate_network"] = (syndicate_network || (obj_flags & EMAGGED))
 	data["has_paper"] = !!loaded_item_ref?.resolve()
 	data["fax_history"] = fax_history
-	data["special_faxes"] = special_networks
+	var/list/special_networks_data = list()
+	for(var/key in special_networks)
+		special_networks_data += list(special_networks[key])
+	data["special_faxes"] = special_networks_data
 	return data
 
 /obj/machinery/fax/ui_act(action, list/params)

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -1,4 +1,4 @@
-GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department", "NT Complaint Department", "NT Customer Relations", "Nanotrasen Tech Support", "NT Internal Affairs Dept."))
+GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department", "NT Complaint Department", "NT Customer Relations", "Nanotrasen Tech Support", "NT Internal Affairs Dept"))
 
 /obj/machinery/fax
 	name = "Fax Machine"

--- a/tgui/packages/tgui/interfaces/AdminFax.js
+++ b/tgui/packages/tgui/interfaces/AdminFax.js
@@ -91,8 +91,8 @@ export const FaxMainPanel = (props, context) => {
             icon="n"
             mr="7px"
             width="49%"
-            onClick={() => setPaperName('Central Command Report')}>
-            Central Command
+            onClick={() => setPaperName('Nanotrasen Offical Report')}>
+            Nanotrasen
           </Button>
           <Button
             icon="s"
@@ -117,8 +117,8 @@ export const FaxMainPanel = (props, context) => {
             icon="n"
             mr="7px"
             width="49%"
-            onClick={() => setFromWho('Central Command')}>
-            Central Command
+            onClick={() => setFromWho('Nanotrasen')}>
+            Nanotrasen
           </Button>
           <Button icon="s" width="49%" onClick={() => setFromWho('Syndicate')}>
             Syndicate


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does what it says on the tin, instead of being able to fax central command fax machines are linked to a randomly selected Nanotrasen department. Current options are as follows but more can be added if any creative ideas are provided.

- NT HR Department
- NT Legal Department
- NT Complaint Department
- NT Customer Relations
- Nanotrasen Tech Support
- NT Internal Affairs Dept

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Re-restricts contacting the top dogs at central command to people with a captain ID. Being able to contact central commands highest ranks from an IC perspective makes sense to be restricted to the captain only through the use of the communications console. The crew can instead contact what is likely an intern working in a specialized department.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Admin fax report names now default to standard report rather than standart.
del: Central Command can no longer be faxed directly from fax machines.
spellcheck: Replaced the ability to contact central command directly by being able to contact a randomly selected nanotrasen department.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
