### PR TITLE
removes extra turtleneck from research directors garment bag

### DIFF
--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -92,7 +92,6 @@
 	new /obj/item/clothing/under/rank/rnd/research_director/alt/skirt(src)
 	new /obj/item/clothing/under/rank/rnd/research_director/turtleneck(src)
 	new /obj/item/clothing/under/rank/rnd/research_director/turtleneck/skirt(src)
-	new /obj/item/clothing/under/rank/rnd/research_director/turtleneck(src)
 	new /obj/item/clothing/head/beret/science/rd(src)
 	new /obj/item/clothing/neck/cloak/rd(src)
 	new /obj/item/clothing/shoes/jackboots(src)


### PR DESCRIPTION
## About The Pull Request
was looking at all of the head of staff clothes to boggle at why head of security got so many when i noticed that the research director had two turtlenecks.

i could obviously not let this stand.

## Why It's Good For The Game

the research director doesnt deserve to own two, maybe even three turtleneck shirts

## Changelog

:cl:
fix: CentComm has noticed that the research director has been hoarding turtlenecks, corrective action has been taken
/:cl:


