### PR TITLE
Adds logging for stuffing people in crates/lockers/bodybags

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -556,6 +556,7 @@
 			else
 				O.forceMove(T)
 				close()
+			log_combat(user, O, "stuffed", addition = "inside of [src]")
 	else
 		O.forceMove(T)
 	return 1


### PR DESCRIPTION

## About The Pull Request

Stuffing people inside of thigs was unlogged, now it is.
## Why It's Good For The Game

Useful for admins so they actually know who hid a corpse in a locker for example.
## Changelog
:cl:
admin: Stuffing people inside lockers is now logged.
/:cl:
