### PR TITLE
Hot ice anime fires.

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -345,7 +345,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/hot_ice/on_applied(atom/source, amount, material_flags)
 	. = ..()
-	source.AddComponent(/datum/component/combustible_flooder, "plasma", amount*1.5, amount*0.2+300)
+	source.AddComponent(/datum/component/combustible_flooder, "plasma", amount*1.5, 5e5)
 
 /datum/material/hot_ice/on_removed(atom/source, amount, material_flags)
 	qdel(source.GetComponent(/datum/component/combustible_flooder))


### PR DESCRIPTION
Sets he temperature parameter for the combustible_flooder application on hot_ice is set to 5e5.
## About The Pull Request
The plasma released from hot ice combustion is now 500,000 Kelvin.
## Why It's Good For The Game
Anime fires are awesome. Could be an interesting heat source for the gas turbine.
## Changelog
:cl:
balance: Hot ice can release anime fires.
/:cl:
