### PR TITLE
Gives admins the ability to enable hostile environments at will.

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -468,7 +468,7 @@ SUBSYSTEM_DEF(shuttle)
 
 /datum/controller/subsystem/shuttle/proc/checkHostileEnvironment()
 	for(var/datum/d in hostile_environments)
-		if(!istype(d) || QDELETED(d))
+		if(QDELETED(d))
 			hostile_environments -= d
 	emergency_no_escape = hostile_environments.len
 

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -467,9 +467,9 @@ SUBSYSTEM_DEF(shuttle)
 		//Make all cargo consoles speak up
 
 /datum/controller/subsystem/shuttle/proc/checkHostileEnvironment()
-	for(var/datum/d in hostile_environments)
-		if(QDELETED(d))
-			hostile_environments -= d
+	for(var/datum/hostile_environment_source in hostile_environments)
+		if(QDELETED(hostile_environment_source))
+			hostile_environments -= hostile_environment_source
 	emergency_no_escape = hostile_environments.len
 
 	if(emergency_no_escape && (emergency.mode == SHUTTLE_IGNITING))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -63,6 +63,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/admin_cancel_shuttle, /*allows us to cancel the emergency shuttle, sending it back to centcom*/
 	/client/proc/admin_disable_shuttle, /*allows us to disable the emergency shuttle admin-wise so that it cannot be called*/
 	/client/proc/admin_enable_shuttle,  /*undoes the above*/
+	/client/proc/admin_hostile_environment, /*Allows admins to prevent the emergency shuttle from leaving, also lets admins clear hostile environments if theres one stuck*/
 	/client/proc/cmd_admin_direct_narrate, /*send text directly to a player with no padding. Useful for narratives and fluff-text*/
 	/client/proc/cmd_admin_world_narrate, /*sends text to all players with no padding*/
 	/client/proc/cmd_admin_local_narrate, /*sends text to all mobs within view of atom*/

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -265,8 +265,6 @@
 			message_admins(span_adminnotice("[key_name_admin(usr)] Disabled all current hostile environment sources"))
 			SSshuttle.hostile_environments.Cut()
 			SSshuttle.checkHostileEnvironment()
-		else
-			return
 
 /client/proc/toggle_nuke(obj/machinery/nuclearbomb/N in GLOB.nuke_list)
 	set category = "Admin.Events"

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -241,6 +241,33 @@
 	SSshuttle.emergency.setTimer(SSshuttle.last_call_time)
 	priority_announce("Warning: Emergency Shuttle uplink reestablished, shuttle enabled.", "Emergency Shuttle Uplink Alert", 'sound/misc/announce_dig.ogg')
 
+/client/proc/admin_hostile_environment()
+	set category = "Admin.Events"
+	set name = "Hostile Environment"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	switch(tgui_alert(usr, "Select an Option", "Hostie Environment Manager", list("Enable", "Disable", "Clear All")))
+		if("Enable")
+			if (SSshuttle.hostile_environments["Admin"] == TRUE)
+				to_chat(usr, span_warning("Error, admin hostile environment already enabled."))
+			else
+				message_admins(span_adminnotice("[key_name_admin(usr)] Enabled an admin hostile environment"))
+				SSshuttle.registerHostileEnvironment("Admin")
+		if("Disable")
+			if (!SSshuttle.hostile_environments["Admin"])
+				to_chat(usr, span_warning("Error, no admin hostile environment found."))
+			else
+				message_admins(span_adminnotice("[key_name_admin(usr)] Disabled the admin hostile environment"))
+				SSshuttle.clearHostileEnvironment("Admin")
+		if("Clear All")
+			message_admins(span_adminnotice("[key_name_admin(usr)] Disabled all current hostile environment sources"))
+			SSshuttle.hostile_environments.Cut()
+			SSshuttle.checkHostileEnvironment()
+		else
+			return
+
 /client/proc/toggle_nuke(obj/machinery/nuclearbomb/N in GLOB.nuke_list)
 	set category = "Admin.Events"
 	set name = "Toggle Nuke"

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -248,7 +248,7 @@
 	if(!check_rights(R_ADMIN))
 		return
 
-	switch(tgui_alert(usr, "Select an Option", "Hostie Environment Manager", list("Enable", "Disable", "Clear All")))
+	switch(tgui_alert(usr, "Select an Option", "Hostile Environment Manager", list("Enable", "Disable", "Clear All")))
 		if("Enable")
 			if (SSshuttle.hostile_environments["Admin"] == TRUE)
 				to_chat(usr, span_warning("Error, admin hostile environment already enabled."))


### PR DESCRIPTION

## About The Pull Request

Adds a new admin verb that allows admins to create a blob/revolution style hostile environment preventing the shuttle from leaving. Also allows admins to clear all hostile environments, I've had a blob hostile environment exist without a living blob in the past and its rather troublesome to debug live if you don't know what your doing.
## Why It's Good For The Game

Sometimes admins want to stop the crew from leaving but in a more thematic way then centcoms just not sending you an escape shuttle, especially if the shuttle is already called.
## Changelog
:cl:
admin: Admins can now enable a custom hostile environment that prevents the shuttle from leaving.
/:cl:
