### PR TITLE
Fixes HOS Beret (and all of its subtypes) having wrong path and thus not being armored

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -1112,7 +1112,7 @@
 	req_access = list("syndicate");
 	secure = 1
 	},
-/obj/item/clothing/head/hos/beret/syndicate,
+/obj/item/clothing/head/hats/hos/beret/syndicate,
 /obj/item/clothing/suit/armor/vest/capcarapace/syndicate,
 /obj/item/clothing/mask/gas/syndicate,
 /obj/item/clothing/under/syndicate,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -45428,7 +45428,7 @@
 /obj/item/clothing/head/beret/sec/navyofficer,
 /obj/item/clothing/head/beret/sec/navyofficer,
 /obj/item/clothing/head/beret/sec/navywarden,
-/obj/item/clothing/head/hos/beret/navyhos,
+/obj/item/clothing/head/hats/hos/beret/navyhos,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,

--- a/_maps/templates/battlecruiser_starfury.dmm
+++ b/_maps/templates/battlecruiser_starfury.dmm
@@ -2691,7 +2691,7 @@
 	},
 /obj/item/card/id/advanced/black/syndicate_command/captain_id/syndie_spare,
 /obj/item/clothing/head/hats/hos/syndicate,
-/obj/item/clothing/head/hos/beret/syndicate,
+/obj/item/clothing/head/hats/hos/beret/syndicate,
 /obj/item/clothing/under/syndicate/skirt,
 /obj/item/clothing/under/syndicate,
 /obj/item/storage/belt/military/assault,

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -90,7 +90,7 @@
 					/obj/item/clothing/head/beret/sec/navywarden,
 					/obj/item/clothing/under/rank/security/head_of_security/formal,
 					/obj/item/clothing/suit/jacket/hos/blue,
-					/obj/item/clothing/head/hos/beret/navyhos,
+					/obj/item/clothing/head/hats/hos/beret/navyhos,
 				)
 	crate_name = "security clothing crate"
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -146,7 +146,7 @@
 	name = "syndicate cap"
 	desc = "A black cap fit for a high ranking syndicate officer."
 
-/obj/item/clothing/head/hos/beret
+/obj/item/clothing/head/hats/hos/beret
 	name = "head of security's beret"
 	desc = "A robust beret for the Head of Security, for looking stylish while not sacrificing protection."
 	icon_state = "beret_badge"
@@ -154,12 +154,12 @@
 	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
 	greyscale_colors = "#39393f#FFCE5B"
 
-/obj/item/clothing/head/hos/beret/navyhos
+/obj/item/clothing/head/hats/hos/beret/navyhos
 	name = "head of security's formal beret"
 	desc = "A special beret with the Head of Security's insignia emblazoned on it. A symbol of excellence, a badge of courage, a mark of distinction."
 	greyscale_colors = "#3C485A#FFCE5B"
 
-/obj/item/clothing/head/hos/beret/syndicate
+/obj/item/clothing/head/hats/hos/beret/syndicate
 	name = "syndicate beret"
 	desc = "A black beret with thick armor padding inside. Stylish and robust."
 

--- a/code/modules/jobs/job_types/head_of_security.dm
+++ b/code/modules/jobs/job_types/head_of_security.dm
@@ -60,7 +60,7 @@
 	ears = /obj/item/radio/headset/heads/hos/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	gloves = /obj/item/clothing/gloves/color/black
-	head = /obj/item/clothing/head/hos/beret
+	head = /obj/item/clothing/head/hats/hos/beret
 	shoes = /obj/item/clothing/shoes/jackboots/sec
 	l_pocket = /obj/item/restraints/handcuffs
 	r_pocket = /obj/item/assembly/flash/handheld

--- a/code/modules/mafia/outfits.dm
+++ b/code/modules/mafia/outfits.dm
@@ -75,7 +75,7 @@
 	shoes = /obj/item/clothing/shoes/jackboots
 	suit = /obj/item/clothing/suit/armor/hos/trenchcoat
 	gloves = /obj/item/clothing/gloves/color/black
-	head = /obj/item/clothing/head/hos/beret
+	head = /obj/item/clothing/head/hats/hos/beret
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 
 /datum/outfit/mafia/warden

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -309,7 +309,7 @@
 	name = "Syndicate Ship Captain"
 	uniform = /obj/item/clothing/under/syndicate/combat
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace/syndicate
-	head = /obj/item/clothing/head/hos/beret/syndicate
+	head = /obj/item/clothing/head/hats/hos/beret/syndicate
 	ears = /obj/item/radio/headset/syndicate/alt/leader
 	r_pocket = /obj/item/knife/combat/survival
 	id = /obj/item/card/id/advanced/black/syndicate_command/captain_id

--- a/tools/UpdatePaths/Scripts/72024_hos_beret.txt
+++ b/tools/UpdatePaths/Scripts/72024_hos_beret.txt
@@ -1,1 +1,1 @@
-/obj/item/clothing/head/hos/beret/ : /obj/item/clothing/head/hats/hos/beret{@OLD}
+/obj/item/clothing/head/hos/beret : /obj/item/clothing/head/hats/hos/beret{@OLD}

--- a/tools/UpdatePaths/Scripts/72024_hos_beret.txt
+++ b/tools/UpdatePaths/Scripts/72024_hos_beret.txt
@@ -1,1 +1,1 @@
-/obj/item/clothing/head/hos/beret/ : /obj/item/clothing/head/hats/hos/beret/{@OLD}
+/obj/item/clothing/head/hos/beret/ : /obj/item/clothing/head/hats/hos/beret{@OLD}

--- a/tools/UpdatePaths/Scripts/72024_hos_beret.txt
+++ b/tools/UpdatePaths/Scripts/72024_hos_beret.txt
@@ -1,0 +1,1 @@
+/obj/item/clothing/head/hos/beret/ : /obj/item/clothing/head/hats/hos/beret/{@OLD}


### PR DESCRIPTION

## About The Pull Request
The HOS beret was not a subtype of his other hat and thus did not have it's properties. The same was true of all the subtypes of the HOS beret. 

## Why It's Good For The Game
This  is quite clearly unintended as the description of many of these berets state that they are armored. Additionally, the HOS's subordinates, the warden and regular sec officers, berets were armored and yet the HOS's was not. 

## Changelog

:cl:
fix: The HOS and syndicate berets have had their missing armor and strip delay readded
/:cl:

