### PR TITLE
Fixes Unwrenched Signs Having An Error Sign

### DIFF
--- a/code/game/objects/structures/signs/_signs.dm
+++ b/code/game/objects/structures/signs/_signs.dm
@@ -83,6 +83,7 @@
 	if(type != /obj/structure/sign/blank) //If it's still just a basic sign backing, we can (and should) skip some of the below variable transfers.
 		unwrenched_sign.name = name //Copy over the sign structure variables to the sign item we're creating when we unwrench a sign.
 		unwrenched_sign.desc = "[desc] It can be placed on a wall."
+		unwrenched_sign.icon = icon
 		unwrenched_sign.icon_state = icon_state
 		unwrenched_sign.sign_path = type
 		unwrenched_sign.set_custom_materials(custom_materials) //This is here so picture frames and wooden things don't get messed up.


### PR DESCRIPTION

## About The Pull Request

I think this code was first made with the assumption that every sign would be in the same DMI? Anyways, let's just ensure that it now works in modern code by also passing in a valid icon file as well to the non-descript "item sign".
## Why It's Good For The Game

Fixes #71920.
## Changelog
:cl:
fix: When you unwrench a flag, you should now no longer see the big flashy red ERROR sign.
/:cl:
