### PR TITLE
Log the food's type instead of the component's

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -276,7 +276,7 @@ Behavior that's still missing from this component that original food items had t
 
 	this_food.reagents.maximum_volume = ROUND_UP(this_food.reagents.maximum_volume) // Just because I like whole numbers for this.
 
-	SSblackbox.record_feedback("tally", "food_made", 1, type)
+	BLACKBOX_LOG_FOOD_MADE(this_food.type)
 
 ///Makes sure the thing hasn't been destroyed or fully eaten to prevent eating phantom edibles
 /datum/component/edible/proc/IsFoodGone(atom/owner, mob/living/feeder)


### PR DESCRIPTION

## About The Pull Request
Two year old bug that was filling the food_made table with /datum/component/edible instead of actual food
## Why It's Good For The Game
Means I don't have to parse two different tables instead of one convenient one
## Changelog
:cl: Tattle
fix: crafted foods are logged in the blackbox once more
/:cl:
