### PR TITLE
Fix SM activation spam.

### DIFF
--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -196,7 +196,7 @@
 	var/atom/atom_source = source
 	var/obj/machinery/power/supermatter_crystal/our_supermatter = parent // Why is this a component?
 	if(istype(our_supermatter))
-		our_supermatter.log_activation(who = atom_source)
+		our_supermatter.log_activation(who = hit_object)
 	if(isliving(hit_object))
 		hit_object.visible_message(span_danger("\The [hit_object] slams into \the [atom_source] inducing a resonance... [hit_object.p_their()] body starts to glow and burst into flames before flashing into dust!"),
 			span_userdanger("You slam into \the [atom_source] as your ears are filled with unearthly ringing. Your last thought is \"Oh, fuck.\""),

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -195,9 +195,7 @@
 	SIGNAL_HANDLER
 	var/atom/atom_source = source
 	var/obj/machinery/power/supermatter_crystal/our_supermatter = parent // Why is this a component?
-	if(!istype(our_supermatter))
-		our_supermatter = null // so we don't runtime on the next line....
-	if(our_supermatter?.has_been_powered)
+	if(istype(our_supermatter))
 		our_supermatter.log_activation(source = atom_source)
 	if(isliving(hit_object))
 		hit_object.visible_message(span_danger("\The [hit_object] slams into \the [atom_source] inducing a resonance... [hit_object.p_their()] body starts to glow and burst into flames before flashing into dust!"),
@@ -281,8 +279,7 @@
 			near_mob.show_message(span_hear("An unearthly ringing fills your ears, and you find your skin covered in new radiation burns."), MSG_AUDIBLE)
 	consume_returns(matter_increase, damage_increase)
 	var/obj/machinery/power/supermatter_crystal/our_crystal = parent
-	if(!our_crystal.has_been_powered)
-		our_crystal.log_activation(source = consumed_object)
+	our_crystal.log_activation(source = consumed_object)
 
 /datum/component/supermatter_crystal/proc/consume_returns(matter_increase = 0, damage_increase = 0)
 	if(consume_callback)

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -279,7 +279,8 @@
 			near_mob.show_message(span_hear("An unearthly ringing fills your ears, and you find your skin covered in new radiation burns."), MSG_AUDIBLE)
 	consume_returns(matter_increase, damage_increase)
 	var/obj/machinery/power/supermatter_crystal/our_crystal = parent
-	our_crystal.log_activation(who = consumed_object)
+	if(istype(parent))
+		our_crystal.log_activation(who = consumed_object)
 
 /datum/component/supermatter_crystal/proc/consume_returns(matter_increase = 0, damage_increase = 0)
 	if(consume_callback)

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -196,7 +196,7 @@
 	var/atom/atom_source = source
 	var/obj/machinery/power/supermatter_crystal/our_supermatter = parent // Why is this a component?
 	if(istype(our_supermatter))
-		our_supermatter.log_activation(source = atom_source)
+		our_supermatter.log_activation(who = atom_source)
 	if(isliving(hit_object))
 		hit_object.visible_message(span_danger("\The [hit_object] slams into \the [atom_source] inducing a resonance... [hit_object.p_their()] body starts to glow and burst into flames before flashing into dust!"),
 			span_userdanger("You slam into \the [atom_source] as your ears are filled with unearthly ringing. Your last thought is \"Oh, fuck.\""),
@@ -279,7 +279,7 @@
 			near_mob.show_message(span_hear("An unearthly ringing fills your ears, and you find your skin covered in new radiation burns."), MSG_AUDIBLE)
 	consume_returns(matter_increase, damage_increase)
 	var/obj/machinery/power/supermatter_crystal/our_crystal = parent
-	our_crystal.log_activation(source = consumed_object)
+	our_crystal.log_activation(who = consumed_object)
 
 /datum/component/supermatter_crystal/proc/consume_returns(matter_increase = 0, damage_increase = 0)
 	if(consume_callback)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -118,8 +118,8 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	///The key our internal radio uses
 	var/radio_key = /obj/item/encryptionkey/headset_eng
 
-	///Boolean used for logging if we've been powered
-	var/is_powered = FALSE
+	///Boolean used to log the first activation of the SM.
+	var/activation_logged = FALSE
 
 	///An effect we show to admins and ghosts the percentage of delam we're at
 	var/obj/effect/countdown/supermatter/countdown
@@ -583,9 +583,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	for(var/powergain_types in additive_power)
 		internal_energy += additive_power[powergain_types]
 	internal_energy = max(internal_energy, 0)
-	if(internal_energy && !is_powered)
-		stack_trace("Supermatter powered due to unknown causes. Internal energy factors: [json_encode(internal_energy_factors)]")
-		is_powered = TRUE // so we dont spam the log.
+	if(internal_energy && !activation_logged)
+		stack_trace("Supermatter powered for the first time without being logged. Internal energy factors: [json_encode(internal_energy_factors)]")
+		activation_logged = TRUE // so we dont spam the log.
 	return additive_power
 
 /** Log when the supermatter is activated for the first time.
@@ -597,7 +597,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
  * * how - A datum. How they powered it. Optional.
  */
 /obj/machinery/power/supermatter_crystal/proc/log_activation(who, how)
-	if(is_powered)
+	if(activation_logged)
 		return
 	if(!who)
 		CRASH("Supermatter activated by an unknown source")
@@ -608,7 +608,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	else
 		investigate_log("has been powered for the first time by [key_name(who)][how ? " with [how]" : ""].", INVESTIGATE_ENGINE)
 		message_admins("[src] [ADMIN_JMP(src)] has been powered for the first time by [ADMIN_FULLMONTY(who)][how ? " with [how]" : ""].")
-	is_powered = TRUE
+	activation_logged = TRUE
 
 /**
  * Perform calculation for the main zap power multiplier.

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -279,6 +279,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 
 	// PART 4: DAMAGE PROCESSING
 	temp_limit_factors = calculate_temp_limit()
+	damage_archived = damage
 	damage_factors = calculate_damage()
 	if(damage == 0) // Clear any in game forced delams if on full health.
 		set_delam(SM_DELAM_PRIO_IN_GAME, SM_DELAM_STRATEGY_PURGE)
@@ -597,7 +598,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
  * * how - A datum. How they powered it. Optional.
  */
 /obj/machinery/power/supermatter_crystal/proc/log_activation(who, how)
-	if(activation_logged)
+	if(activation_logged || disable_power_change)
 		return
 	if(!who)
 		CRASH("Supermatter activated by an unknown source")
@@ -722,7 +723,6 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	for (var/damage_type in additive_damage)
 		total_damage += additive_damage[damage_type]
 
-	damage_archived = damage
 	damage += total_damage
 	damage = max(damage, 0)
 	return additive_damage

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -119,7 +119,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/radio_key = /obj/item/encryptionkey/headset_eng
 
 	///Boolean used for logging if we've been powered
-	var/has_been_powered = FALSE
+	var/is_powered = FALSE
 
 	///An effect we show to admins and ghosts the percentage of delam we're at
 	var/obj/effect/countdown/supermatter/countdown
@@ -583,8 +583,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	for(var/powergain_types in additive_power)
 		internal_energy += additive_power[powergain_types]
 	internal_energy = max(internal_energy, 0)
-	if(internal_energy && !has_been_powered)
+	if(internal_energy && !is_powered)
 		stack_trace("Supermatter powered due to unknown causes. Internal energy factors: [json_encode(internal_energy_factors)]")
+		is_powered = TRUE // so we dont spam the log.
 	return additive_power
 
 /** Log when the supermatter is activated for the first time.
@@ -596,7 +597,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
  * * how - A datum. How they powered it. Optional.
  */
 /obj/machinery/power/supermatter_crystal/proc/log_activation(who, how)
-	if(has_been_powered)
+	if(is_powered)
 		return
 	if(!who)
 		CRASH("Supermatter activated by an unknown source")
@@ -607,7 +608,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	else
 		investigate_log("has been powered for the first time by [key_name(who)][how ? " with [how]" : ""].", INVESTIGATE_ENGINE)
 		message_admins("[src] [ADMIN_JMP(src)] has been powered for the first time by [ADMIN_FULLMONTY(who)][how ? " with [how]" : ""].")
-	has_been_powered = TRUE
+	is_powered = TRUE
 
 /**
  * Perform calculation for the main zap power multiplier.

--- a/code/modules/power/supermatter/supermatter_gas.dm
+++ b/code/modules/power/supermatter/supermatter_gas.dm
@@ -174,6 +174,7 @@ GLOBAL_LIST_INIT(sm_gas_behavior, init_sm_gas())
 		return
 	sm.absorbed_gasmix.gases[/datum/gas/miasma][MOLES] -= consumed_miasma
 	sm.external_power_trickle += consumed_miasma * MIASMA_POWER_GAIN
+	sm.log_activation("miasma absorption")
 
 /datum/sm_gas/freon
 	gas_path = /datum/gas/freon

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -21,7 +21,7 @@
 		if(kiss_power)
 			psy_coeff = 1
 		external_power_immediate += projectile.damage * bullet_energy + kiss_power
-		log_activation(cause = projectile.fired_from, source = projectile.firer)
+		log_activation(who = projectile.firer, how = projectile.fired_from)
 	else
 		external_damage_immediate += projectile.damage * bullet_energy
 		// Stop taking damage at emergency point, yell to players at danger point.
@@ -68,7 +68,7 @@
 			to_chat(user, span_danger("You extract a sliver from \the [src]. \The [src] begins to react violently!"))
 			new /obj/item/nuke_core/supermatter_sliver(src.drop_location())
 			external_power_trickle += 800
-			log_activation(source = scalpel, cause = user)
+			log_activation(who = user, how = scalpel)
 			scalpel.usesLeft--
 			if (!scalpel.usesLeft)
 				to_chat(user, span_notice("A tiny piece of \the [scalpel] falls off, rendering it useless!"))
@@ -96,7 +96,7 @@
 			set_delam(SM_DELAM_PRIO_IN_GAME, /datum/sm_delam/cascade)
 			external_damage_immediate += 100
 			external_power_trickle += 500
-			log_activation(source = destabilizing_crystal, cause = user)
+			log_activation(who = user, how = destabilizing_crystal)
 			qdel(destabilizing_crystal)
 		return
 

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -21,8 +21,7 @@
 		if(kiss_power)
 			psy_coeff = 1
 		external_power_immediate += projectile.damage * bullet_energy + kiss_power
-		if(!has_been_powered)
-			log_activation(cause = projectile.fired_from, source = projectile.firer)
+		log_activation(cause = projectile.fired_from, source = projectile.firer)
 	else
 		external_damage_immediate += projectile.damage * bullet_energy
 		// Stop taking damage at emergency point, yell to players at danger point.
@@ -31,22 +30,6 @@
 		if(damage_to_be > danger_point)
 			visible_message(span_notice("[src] compresses under stress, resisting further impacts!"))
 	return BULLET_ACT_HIT
-
-/obj/machinery/power/supermatter_crystal/proc/log_activation(source, cause)
-	var/fired_from_str = cause ? " with [cause]" : ""
-	investigate_log(
-		source \
-			? "has been powered for the first time by [key_name(source)][fired_from_str]." \
-			: "has been powered for the first time.",
-		INVESTIGATE_ENGINE
-	)
-	message_admins(
-		source \
-			? "[src] [ADMIN_JMP(src)] has been powered for the first time by [cause ? ADMIN_FULLMONTY(source) + (fired_from_str) : (cause ? source : "environmental factors")]." \
-			: "[src] [ADMIN_JMP(src)] has been powered for the first time."
-	)
-
-	has_been_powered = TRUE
 
 /obj/machinery/power/supermatter_crystal/singularity_act()
 	var/gain = 100
@@ -85,8 +68,7 @@
 			to_chat(user, span_danger("You extract a sliver from \the [src]. \The [src] begins to react violently!"))
 			new /obj/item/nuke_core/supermatter_sliver(src.drop_location())
 			external_power_trickle += 800
-			if(!has_been_powered)
-				log_activation(source = scalpel, cause = user)
+			log_activation(source = scalpel, cause = user)
 			scalpel.usesLeft--
 			if (!scalpel.usesLeft)
 				to_chat(user, span_notice("A tiny piece of \the [scalpel] falls off, rendering it useless!"))
@@ -114,8 +96,7 @@
 			set_delam(SM_DELAM_PRIO_IN_GAME, /datum/sm_delam/cascade)
 			external_damage_immediate += 100
 			external_power_trickle += 500
-			if(!has_been_powered)
-				log_activation(source = destabilizing_crystal, cause = user)
+			log_activation(source = destabilizing_crystal, cause = user)
 			qdel(destabilizing_crystal)
 		return
 


### PR DESCRIPTION
## About The Pull Request
Fixes #71921

Bug was because https://github.com/tgstation/tgstation/blob/19df98e0984924788a9bc3c6de4fea793d72b2d7/code/datums/components/supermatter_crystal.dm#L200 was flipped. BUT there are a bunch more implementation problems that we'll have to fix.

Did these so far:
- Moved the has_been_powered check into the function. DRY.
- Changed how the environment activation gets called since its not supposed to be tied to the zap logic but power logic.
- Fixed a mistaken arg which leads to the logs saying SM got activated by SM `06:36:03 [0x201f0f0] (208,78,1) || the anchored supermatter shard has been powered for the first time by [anchored supermatter shard].`
- ~~Really don't like how it doesn't verify that the power actually gets added before logging. Fixing that would be pretty difficult though.~~ Actually we can turn the current implementation to enforce people logging SM activations. Will do that instead.
- ~~var/source and var/cause is a bit weird and the doc that i added isn't helpful yet. The message also have bugs. Will fix.~~ 
Pretty small problem as it turns out, source is who did it and cause is how they did it. Kinda weird so I'm renaming em.
- ![image](https://user-images.githubusercontent.com/54709710/208033855-616605ef-090a-469b-9470-359f4a0e8c17.png)<br/>The picture above says environmental factor while it should be the hitting datum. I'll get rid of the ternary check and restructure the args to fix this.

A bit unrelated with the PR but i also moved the damage_archived updates outside the disable_damage check so we dont spam jannies.

## Why It's Good For The Game
See above.

## Changelog
:cl:
fix: fixed sm activation logging.
/:cl: