### PR TITLE
Makes machine frames tell you what non stack/stock parts are

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -89,6 +89,9 @@
 			var/obj/item/part = component_path
 
 			req_component_names[component_path] = initial(part.name)
+		else
+			stack_trace("Invalid component part [component_path] in [type], couldn't get its name")
+			req_component_names[component_path] = "[component_path] (this is a bug)"
 
 /obj/structure/frame/machine/proc/get_req_components_amt()
 	var/amt = 0

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -85,6 +85,10 @@
 				req_component_names[component_path] = initial(stock_part.base_name)
 			else
 				req_component_names[component_path] = initial(stock_part.name)
+		else if(ispath(component_path, /obj/item))
+			var/obj/item/part = component_path
+
+			req_component_names[component_path] = initial(part.name)
 
 /obj/structure/frame/machine/proc/get_req_components_amt()
 	var/amt = 0


### PR DESCRIPTION

## About The Pull Request

Adds in a missing case for machine frame req_component_names where the component is neither a stack nor a stock part

## Why It's Good For The Game

Knowing what a machine needs is very useful

## Changelog
:cl:
fix: Machine frames will no longer ask for "s" in place of some components
/:cl:
