### PR TITLE
Limits Miner Guardian Types

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -801,6 +801,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	used_message = "<span class='holoparasite'>This shard seems to have lost all its' power...</span>"
 	failure_message = "<span class='holoparasite bold'>The shard hasn't reacted at all. Maybe try again later...</span>"
 	ling_failure = "<span class='holoparasite bold'>The power of the shard seems to not react with your horrifying, mutated body.</span>"
+	possible_guardians = list("Charger", "Protector", "Ranged", "Standard", "Support")
 
 /obj/item/guardiancreator/miner/choose
 	random = FALSE


### PR DESCRIPTION

## About The Pull Request
limits the power miners the dusty shard can summon to
charger, protector, ranged, standard and support
this removes
assassin, chaos, explosive, lightning, gravitokinetic (+ dextrous but they already couldnt get that)

## Why It's Good For The Game
current miner guardians are filled with stuff like chaos, lightning or explosive which are griefy and collateral as hell while being practically useless on lavaland, so if the miner isnt antag, 1/2 of the time the power miner has to sit and just talk with them without being able to do anything because they are a liability that just gets them more damage
charger is very fast so it can avoid stuff and wear mobs down with the throws a bit
protector has like, 95% armor in its protective mode. it can be neat against projectile megafauna for blocking attacks
ranged can be used in actual combat as its ranged, and the scout mode is neat
support heals you, how cool.
standard can break rocks and is a classic

## Changelog
:cl:
balance: limits the power miners the dusty shard can summon to charger, protector, ranged, standard and support
/:cl:
