### PR TITLE
Rats will stop biting you if you die

### DIFF
--- a/code/datums/ai/basic_mobs/targetting_datums/dont_target_friends.dm
+++ b/code/datums/ai/basic_mobs/targetting_datums/dont_target_friends.dm
@@ -1,5 +1,7 @@
 /// Don't target an atom in our friends list (or turfs), anything else is fair game
 /datum/targetting_datum/not_friends
+	/// Stop regarding someone as a valid target once they pass this stat level, setting it to DEAD means you will happily attack corpses
+	var/attack_until_past_stat = HARD_CRIT
 
 ///Returns true or false depending on if the target can be attacked by the mob
 /datum/targetting_datum/not_friends/can_attack(mob/living/living_mob, atom/target)
@@ -12,12 +14,13 @@
 		var/mob/mob_target = target
 		if (mob_target.status_flags & GODMODE)
 			return FALSE
+		if (mob_target.stat > attack_until_past_stat)
+			return FALSE
 
 	if (living_mob.see_invisible < target.invisibility)
 		return FALSE
 	if (isturf(target.loc) && living_mob.z != target.z) // z check will always fail if target is in a mech
 		return FALSE
-
 	if (!living_mob.ai_controller) // How did you get here?
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Fixes #72029 although I am not sure it was a _bug_, there's a configurable target stat check on the "not one of my friends" targetting behaviour now and rats will cease attacking someone once they have died.
That said that just means they'll spread out, rats you are directly commanding won't automatically retarget unless you tell them to start making their own decisions again, so I don't think this quite does what the issue poster wanted.

## Why It's Good For The Game

This is how mobs usually work rather than brutalising a corpse indefinitely, so should be possible here.

## Changelog

:cl:
fix: Rats won't continue attacking someone they've been ordered to kill past the point of death.
/:cl:
