### PR TITLE
Fixes round end reputation formatting

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -258,7 +258,7 @@
 	result += objectives_text
 
 	if(uplink_handler)
-		result += "<br>The traitor had a total of [uplink_handler.progression_points] Reputation and [uplink_handler.telecrystals] Unused Telecrystals."
+		result += "<br>The traitor had a total of [DISPLAY_PROGRESSION(uplink_handler.progression_points)] Reputation and [uplink_handler.telecrystals] Unused Telecrystals."
 
 	var/special_role_text = lowertext(name)
 


### PR DESCRIPTION

## About The Pull Request

In the round end report, you can see the players accumulated reputation. However, it actually displayed raw progression points, which are much, much larger. This PR fixes that.

## Why It's Good For The Game

The game will accurately display the reputation you got as a traitor.

## Changelog

:cl:
fix: in the round end report, progression points are converted to reputation
/:cl:
