### PR TITLE
Prevent atmos runtimes during shuttle move

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -164,8 +164,7 @@
 	for(var/turf/border_turf as anything in border)
 		SSair.remove_from_active(border_turf)
 		for(var/turf/sub_turf as anything in border_turf.atmos_adjacent_turfs)
-			if(sub_turf.atmos_adjacent_turfs)
-				sub_turf.atmos_adjacent_turfs -= border_turf
+			sub_turf.atmos_adjacent_turfs?.Remove(border_turf)
 		border_turf.atmos_adjacent_turfs?.Cut()
 
 	// Accept cached maps, but don't save them automatically - we don't want

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -164,7 +164,8 @@
 	for(var/turf/border_turf as anything in border)
 		SSair.remove_from_active(border_turf)
 		for(var/turf/sub_turf as anything in border_turf.atmos_adjacent_turfs)
-			sub_turf.atmos_adjacent_turfs -= border_turf
+			if(sub_turf.atmos_adjacent_turfs)
+				sub_turf.atmos_adjacent_turfs -= border_turf
 		border_turf.atmos_adjacent_turfs?.Cut()
 
 	// Accept cached maps, but don't save them automatically - we don't want

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -163,9 +163,9 @@
 	// iterate over turfs in the border and clear them from active atmos processing
 	for(var/turf/border_turf as anything in border)
 		SSair.remove_from_active(border_turf)
-		for(var/turf/sub_turf as anything in turf_to_disable.atmos_adjacent_turfs)
+		for(var/turf/sub_turf as anything in border_turf.atmos_adjacent_turfs)
 			sub_turf.atmos_adjacent_turfs -= turf_to_disable
-		turf_to_disable.atmos_adjacent_turfs?.Cut()
+		border_turf.atmos_adjacent_turfs?.Cut()
 
 	// Accept cached maps, but don't save them automatically - we don't want
 	// ruins clogging up memory for the whole round.

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -164,7 +164,7 @@
 	for(var/turf/border_turf as anything in border)
 		SSair.remove_from_active(border_turf)
 		for(var/turf/sub_turf as anything in border_turf.atmos_adjacent_turfs)
-			sub_turf.atmos_adjacent_turfs -= turf_to_disable
+			sub_turf.atmos_adjacent_turfs -= border_turf
 		border_turf.atmos_adjacent_turfs?.Cut()
 
 	// Accept cached maps, but don't save them automatically - we don't want

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -159,9 +159,12 @@
 
 	var/list/border = block(locate(max(T.x-1, 1), max(T.y-1, 1),  T.z),
 							locate(min(T.x+width+1, world.maxx), min(T.y+height+1, world.maxy), T.z))
-	for(var/L in border)
-		var/turf/turf_to_disable = L
-		SSair.remove_from_active(turf_to_disable) //stop processing turfs along the border to prevent runtimes, we return it in initTemplateBounds()
+
+	// iterate over turfs in the border and clear them from active atmos processing
+	for(var/turf/border_turf as anything in border)
+		SSair.remove_from_active(border_turf)
+		for(var/turf/sub_turf as anything in turf_to_disable.atmos_adjacent_turfs)
+			sub_turf.atmos_adjacent_turfs -= turf_to_disable
 		turf_to_disable.atmos_adjacent_turfs?.Cut()
 
 	// Accept cached maps, but don't save them automatically - we don't want


### PR DESCRIPTION
During shuttle move we iterate over border turfs to clear their excited state and active groups, but we never actually cleared it from the opposite direction so the turfs bordering the border would still try to process with the border turfs and would then runtime.