### PR TITLE
Changes the amount of conveyor belts needed for a Clarke from 4 to 5

### DIFF
--- a/code/modules/vehicles/mecha/mecha_construction_paths.dm
+++ b/code/modules/vehicles/mecha/mecha_construction_paths.dm
@@ -413,7 +413,7 @@
 	return list(
 		list(
 			"key" = /obj/item/stack/conveyor,
-			"amount" = 4,
+			"amount" = 5,
 			"desc" = "The treads can be added using 4 sheets of conveyor belts.",
 			"forward_message" = "added tread systems",
 		),


### PR DESCRIPTION

## About The Pull Request

Increases the amount of conveyor belts needed for Clarke construction from 4 to 5, an negligible iron cost increase of about 1.5 sheets.

## Why It's Good For The Game

I understand the idea of it being an even number of belts. It implies symmetry. But it's just annoying to work with. Nearly every  other mech construction step in the game either asks for one of something, or a multiple of five. Protolathes and autolathes are best suited to print single items, or multiples of 5, 10, etc. This change would indirectly streamline the process of building the mech.

I'm so tired of hitting the x5 button to get the required conveyor belts in a stack and then having this single leftover belt with a MASSIVE sprite sitting around in the mech lab. I mean yeah I could send it down disposals and make it someone elses problem. But I'd rather just not have to deal with it in the first place.

## Changelog
:cl:
qol: Changed the number of Conveyor Belts required for a Clarke from 4 to 5 to match how most machines produce item stacks.
/:cl:
