### PR TITLE
Fixes secure briefcase and wall safes not sending icon update signals properly

### DIFF
--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -36,14 +36,9 @@
 	if(can_hack_open)
 		. += "The service panel is currently <b>[panel_open ? "unscrewed" : "screwed shut"]</b>."
 
-/obj/item/storage/secure/update_icon()
-	..()
-	if(!atom_storage)
-		return
-	if(atom_storage.locked)
-		icon_state = "[initial(icon_state)]_locked"
-	else
-		icon_state = "[initial(icon_state)]"
+/obj/item/storage/secure/update_icon_state()
+	. = ..()
+	icon_state = "[initial(icon_state)][atom_storage?.locked ? "_locked" : null]"
 
 /obj/item/storage/secure/tool_act(mob/living/user, obj/item/tool)
 	if(can_hack_open && atom_storage.locked)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -680,7 +680,7 @@
 	icon_state = "wall_safe_locked"
 	var/unlocked = FALSE
 
-/obj/item/storage/pod/update_icon()
+/obj/item/storage/pod/update_icon_state()
 	. = ..()
 	icon_state = "wall_safe[unlocked ? "" : "_locked"]"
 


### PR DESCRIPTION
#71788 used the wrong procs.

:cl: ShizCalev 
fix: Fixed secure briefcase and wall safes not sending icon update signals properly
/:cl:
