### PR TITLE
Adds message clarifying that you've been KICKED from the game when the keysend flood autokick triggers.

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -23,6 +23,7 @@
 			keysend_tripped = TRUE
 			next_keysend_trip_reset = world.time + (2 SECONDS)
 		else
+			to_chat(src, span_userdanger("Flooding keysends! This could have been caused by lag, or due to a plugged-in game controller. You have been disconnected from the server automatically."))
 			log_admin("Client [ckey] was just autokicked for flooding keysends; likely abuse but potentially lagspike.")
 			message_admins("Client [ckey] was just autokicked for flooding keysends; likely abuse but potentially lagspike.")
 			qdel(src)


### PR DESCRIPTION
:cl: ShizCalev
fix: There is now a message clarifying that you've been KICKED from the game when the keysend flood autokick triggers.
/:cl:

Since folks thought they were CRASHING and didn't know they were being KICKED #71980 / #70801