### PR TITLE
More Tracy gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,8 +217,14 @@ libaux*.so
 aux*.pdb
 
 # byond-tracy, we intentionally do not ship this and do not want to maintain it
+# https://github.com/mafemergency/byond-tracy/
 prof.dll
 libprof.so
+
+# Tracy can read source files when it is in the root folder, even without absolute paths.
+# If you're interested, run this hack:
+# https://gist.github.com/Mothblocks/db5462aa84d7d6b1d1b1276b820f62da
+Tracy.exe
 
 # JavaScript tools
 **/node_modules


### PR DESCRIPTION
Adds a link to byond-tracy in gitignore.

Adds Tracy.exe to gitignore, since if you have it in your root alongside [this hack to get file paths](https://gist.github.com/Mothblocks/db5462aa84d7d6b1d1b1276b820f62da), you can read sources within Tracy. If you just use the hack without configuring, then it'll work fine no matter where it is, but it's helpful for avoiding releasing your user directory or whatever if you share the files.