### PR TITLE
Fixes a rogue vent on deltastation brig

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2225,10 +2225,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/mob/living/basic/cockroach,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/basic/cockroach,
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
 "ayH" = (
@@ -5306,7 +5306,6 @@
 /area/station/security/office)
 "bla" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/mob/living/carbon/human/species/monkey,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
@@ -5318,6 +5317,7 @@
 	name = "virology camera";
 	network = list("ss13","medbay","virology")
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/virology)
 "blc" = (
@@ -8004,8 +8004,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bQy" = (
-/mob/living/basic/cockroach,
 /obj/effect/mapping_helpers/burnt_floor,
+/mob/living/basic/cockroach,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
 "bRe" = (
@@ -9531,8 +9531,8 @@
 /area/station/engineering/atmos/mix)
 "ciF" = (
 /obj/structure/window/reinforced/spawner/east,
-/mob/living/carbon/human/species/monkey,
 /obj/structure/flora/bush/sparsegrass,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "ciH" = (
@@ -10492,8 +10492,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "ctW" = (
-/mob/living/simple_animal/slime,
 /obj/structure/cable,
+/mob/living/simple_animal/slime,
 /turf/open/floor/circuit/green,
 /area/station/science/xenobiology)
 "cug" = (
@@ -16727,9 +16727,9 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/simple_animal/bot/secbot/beepsky/officer,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "dYj" = (
@@ -30029,10 +30029,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "hkR" = (
-/mob/living/basic/cockroach,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/mob/living/basic/cockroach,
 /turf/open/floor/wood,
 /area/station/service/library/abandoned)
 "hkU" = (
@@ -30092,11 +30092,11 @@
 /area/station/hallway/primary/central/aft)
 "hlG" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/human/species/monkey,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
 /obj/structure/cable,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "hlM" = (
@@ -36774,9 +36774,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "iWL" = (
-/mob/living/carbon/human/species/monkey,
 /obj/structure/flora/bush/flowers_pp,
 /obj/structure/flora/bush/sparsegrass,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "iWR" = (
@@ -38638,10 +38638,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/mob/living/simple_animal/sloth/citrus,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "jrA" = (
@@ -46492,10 +46492,10 @@
 /area/station/cargo/sorting)
 "lkE" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/human/species/monkey,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "lkL" = (
@@ -57326,11 +57326,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/library/abandoned)
 "nUR" = (
-/mob/living/basic/cockroach,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/basic/cockroach,
 /turf/open/floor/plating,
 /area/station/service/theater/abandoned)
 "nUT" = (
@@ -69250,11 +69250,11 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/trimline/white/warning{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "qRZ" = (
@@ -69653,8 +69653,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/structure/cable/layer3,
+/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "qYL" = (
@@ -70645,8 +70645,8 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/item/radio/intercom/directional/south,
+/mob/living/simple_animal/pet/cat/runtime,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
 "rlC" = (
@@ -88110,10 +88110,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "vxi" = (
@@ -89258,7 +89258,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -95611,9 +95613,9 @@
 "xoa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/mob/living/carbon/human/species/monkey,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/filled/warning,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "xop" = (
@@ -98429,10 +98431,10 @@
 /area/station/hallway/primary/central/fore)
 "xXq" = (
 /obj/structure/cable,
-/mob/living/simple_animal/hostile/carp/lia,
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 1
 	},
+/mob/living/simple_animal/hostile/carp/lia,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
 "xXt" = (


### PR DESCRIPTION
Fixes a rogue vent in deltastation brig entrance, which was facing downwards instead of upwards(where the pipes are)

## Why It's Good For The Game
So the gas can go trough the vent c:

:cl: Improvedname
fix: fixes deltastation vent at brig entrance
/:cl:

