### PR TITLE
Examining your uplink gives you the code

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -136,7 +136,7 @@
 	if(unlock_code)
 		examine_list += span_warning("The code to unlock it is [unlock_code].")
 	if(failsafe_code)
-		examine_list += span_warning("The failsafe code is [failsafe_code]")
+		examine_list += span_warning("The failsafe code is [failsafe_code].")
 
 /datum/component/uplink/proc/interact(datum/source, mob/user)
 	SIGNAL_HANDLER

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -134,11 +134,11 @@
 
 	if(user != owner)
 		return
-	examine_list += span_warning("[parent] contains your hidden uplink.")
-	if(unlock_code)
-		examine_list += span_warning("The code to unlock it is [unlock_code].")
+	examine_list += span_warning("[parent] contains your hidden uplink\
+	[unlock_code ? ", and the code to unlock it is [span_boldwarning(unlock_code)]" : null].")
+
 	if(failsafe_code)
-		examine_list += span_warning("The failsafe code is [failsafe_code].")
+		examine_list += span_warning("The failsafe code is [span_boldwarning(failsafe_code)].")
 
 /datum/component/uplink/proc/interact(datum/source, mob/user)
 	SIGNAL_HANDLER

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -73,6 +73,7 @@
 			purchase_log = GLOB.uplink_purchase_logs_by_key[owner]
 		else
 			purchase_log = new(owner, src)
+		RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 	src.lockable = lockable
 	src.active = enabled
 	if(!uplink_handler_override)
@@ -127,6 +128,15 @@
 
 	if(istype(item, /obj/item/stack/telecrystal))
 		load_tc(user, item)
+
+/datum/component/uplink/proc/on_examine(datum/souuce, mob/user, list/examine_list)
+	if(user != owner)
+		return
+	examine_list += span_warning("\The [parent] contains your hidden uplink.")
+	if(unlock_code)
+		examine_list += span_warning("The code to unlock it is [unlock_code].")
+	if(failsafe_code)
+		examine_list += span_warning("The failsafe code is [failsafe_code]")
 
 /datum/component/uplink/proc/interact(datum/source, mob/user)
 	SIGNAL_HANDLER

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -134,7 +134,7 @@
 
 	if(user != owner)
 		return
-	examine_list += span_warning("\The [parent] contains your hidden uplink.")
+	examine_list += span_warning("[parent] contains your hidden uplink.")
 	if(unlock_code)
 		examine_list += span_warning("The code to unlock it is [unlock_code].")
 	if(failsafe_code)

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -130,6 +130,8 @@
 		load_tc(user, item)
 
 /datum/component/uplink/proc/on_examine(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
 	if(user != owner)
 		return
 	examine_list += span_warning("\The [parent] contains your hidden uplink.")

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -135,7 +135,7 @@
 	if(user != owner)
 		return
 	examine_list += span_warning("[parent] contains your hidden uplink\
-	[unlock_code ? ", and the code to unlock it is [span_boldwarning(unlock_code)]" : null].")
+		[unlock_code ? ", the code to unlock it is [span_boldwarning(unlock_code)]" : null].")
 
 	if(failsafe_code)
 		examine_list += span_warning("The failsafe code is [span_boldwarning(failsafe_code)].")

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -129,7 +129,7 @@
 	if(istype(item, /obj/item/stack/telecrystal))
 		load_tc(user, item)
 
-/datum/component/uplink/proc/on_examine(datum/souuce, mob/user, list/examine_list)
+/datum/component/uplink/proc/on_examine(datum/source, mob/user, list/examine_list)
 	if(user != owner)
 		return
 	examine_list += span_warning("\The [parent] contains your hidden uplink.")


### PR DESCRIPTION

## About The Pull Request
If you're the "owner" of an uplink, you can examine it to get the code and possible failsafe code.
## Why It's Good For The Game
It can feel slow to pull up the traitor info menu when you forget what your code is
## Changelog
:cl:
qol: examine your uplink for code
/:cl:
