### PR TITLE
Right-clicking a Cigarette pack takes out a cigarette, while Alt-Clicking takes out a lighter (if there is one)

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -83,6 +83,9 @@
 
 	var/datum/weakref/modeswitch_action_ref
 
+	/// If true shows the contents of the storage in open_storage
+	var/display_contents = TRUE
+
 /datum/storage/New(atom/parent, max_slots, max_specific_storage, max_total_storage, numerical_stacking, allow_quick_gather, allow_quick_empty, collection_mode, attack_hand_interact)
 	boxes = new(null, src)
 	closer = new(null, src)
@@ -949,7 +952,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return FALSE
 
 	if(!quickdraw || to_show.get_active_held_item())
-		show_contents(to_show)
+		if(display_contents)
+			show_contents(to_show)
 
 		if(animated)
 			animate_parent()

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -218,13 +218,11 @@
 
 /obj/item/storage/fancy/cigarettes/Initialize(mapload)
 	. = ..()
-	atom_storage.quickdraw = TRUE
 	atom_storage.set_holdable(list(/obj/item/clothing/mask/cigarette, /obj/item/lighter))
 
 /obj/item/storage/fancy/cigarettes/examine(mob/user)
 	. = ..()
 
-	. += span_notice("Alt-click to extract contents.")
 	if(spawn_coupon)
 		. += span_notice("There's a coupon on the back of the pack! You can tear it off once it's empty.")
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -243,8 +243,7 @@
 
 /obj/item/storage/fancy/cigarettes/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
-	var/obj/item/lighter = locate(/obj/item/lighter) in contents
-	if(lighter)
+	if(locate(/obj/item/lighter) in contents)
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove lighter"
 	context[SCREENTIP_CONTEXT_RMB] = "Remove [contents_tag]"
 	return CONTEXTUAL_SCREENTIP_SET

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -228,9 +228,9 @@
 
 /obj/item/storage/fancy/cigarettes/AltClick(mob/user)
 	. = ..()
-	var/obj/item/lighting = locate(/obj/item/lighter) in contents
-	if(lighting)
-		quick_remove_item(lighting, user)
+	var/obj/item/lighter = locate(/obj/item/lighter) in contents
+	if(lighter)
+		quick_remove_item(lighter, user)
 	else
 		quick_remove_item(/obj/item/clothing/mask/cigarette, user)
 
@@ -243,9 +243,9 @@
 
 /obj/item/storage/fancy/cigarettes/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
-	var/obj/item/lighting = locate(/obj/item/lighter) in contents
-	if(lighting)
-		context[SCREENTIP_CONTEXT_ALT_RMB] = "Remove lighter"
+	var/obj/item/lighter = locate(/obj/item/lighter) in contents
+	if(lighter)
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Remove lighter"
 	context[SCREENTIP_CONTEXT_RMB] = "Remove [contents_tag]"
 	return CONTEXTUAL_SCREENTIP_SET
 

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -218,7 +218,36 @@
 
 /obj/item/storage/fancy/cigarettes/Initialize(mapload)
 	. = ..()
+	atom_storage.display_contents = FALSE
 	atom_storage.set_holdable(list(/obj/item/clothing/mask/cigarette, /obj/item/lighter))
+	register_context()
+
+/obj/item/storage/fancy/cigarettes/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	quick_remove_item(/obj/item/clothing/mask/cigarette, user)
+
+/obj/item/storage/fancy/cigarettes/AltClick(mob/user)
+	. = ..()
+	var/obj/item/lighting = locate(/obj/item/lighter) in contents
+	if(lighting)
+		quick_remove_item(lighting, user)
+	else
+		quick_remove_item(/obj/item/clothing/mask/cigarette, user)
+
+/// Removes an item from the packet if there is one
+/obj/item/storage/fancy/cigarettes/proc/quick_remove_item(obj/item/grabbies, mob/user)
+	var/obj/item/finger = locate(grabbies) in contents
+	if(finger)
+		atom_storage.attempt_remove(finger, drop_location())
+		user.put_in_hands(finger)
+
+/obj/item/storage/fancy/cigarettes/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	var/obj/item/lighting = locate(/obj/item/lighter) in contents
+	if(lighting)
+		context[SCREENTIP_CONTEXT_ALT_RMB] = "Remove lighter"
+	context[SCREENTIP_CONTEXT_RMB] = "Remove [contents_tag]"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/storage/fancy/cigarettes/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Right-clicking a Cigarette pack takes out a cigarette, while Alt-Clicking takes out a lighter. If there's no lighter, then it just takes out a cigarette instead.
## Why It's Good For The Game
Currently, if you put your lighter in the cigarette pack, then trying to fish it out requires you to take out the packet and mill through all the cigarettes until you get to the lighter.
This fixes that while still keeping the quick and easy functionality.

## Changelog
:cl: Wallem
qol: Smokers rejoice, you no longer need to mill through your cigarette packet to get your lighter out. Alt-Click a cigarette packet to extract a lighter from it, if you've put it in there. Right-Clicking will still take out a cigarette.
/:cl:
