### PR TITLE
Fixes medical scrubs not being adjustable

### DIFF
--- a/code/modules/clothing/under/jobs/medical.dm
+++ b/code/modules/clothing/under/jobs/medical.dm
@@ -78,7 +78,6 @@
 
 /obj/item/clothing/under/rank/medical/scrubs
 	name = "medical scrubs"
-	can_adjust = FALSE
 
 /obj/item/clothing/under/rank/medical/scrubs/blue
 	desc = "It's made of a special fiber that provides minor protection against biohazards. This one is in baby blue."


### PR DESCRIPTION

## About The Pull Request
I had on my list: "Make adjusted sprites for the medical scrubs." and to my surprise #69047 already added adjusted sprites for all the medical scrubs (thanks for saving 30 minutes of my day Imaginos16!), but not on the code side, this fixes that.
## Why It's Good For The Game
Adjusting jumpsuits is an important medbay feature IMO, this keeps new doctors from learning bad habits (fully stripping at stasis) from other doctors.
## Changelog
:cl: Guillaume Prata, Imaginos16
fix: You can now adjust medical scrubs for easier surgery on your fellow doctors.
/:cl:
