### PR TITLE
Implements Cooldown On Uploading Books to Newscaster

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -378,16 +378,8 @@
 			data["has_scanner"] = !!(scan)
 			data["has_cache"] = !!(scan?.cache)
 
-			var/cooldown_number = (COOLDOWN_TIMELEFT(src, newscaster_cooldown))
-			var/active_newscaster_cooldown = COOLDOWN_FINISHED(src, newscaster_cooldown)
-			data["active_newscaster_cooldown"] = active_newscaster_cooldown
-			var/tooltip_message = ""
-			if(active_newscaster_cooldown)
-				tooltip_message = "Upload your book to the newscaster's book club channel."
-			else
-				tooltip_message = "Please wait [DisplayTimeText(cooldown_number)] before uploading your book."
-
-			data["upload_tooltip_message"] = tooltip_message
+			data["cooldown_string"] = "[DisplayTimeText(COOLDOWN_TIMELEFT(src, newscaster_cooldown))]"
+			data["active_newscaster_cooldown"] = COOLDOWN_FINISHED(src, newscaster_cooldown)
 
 			if(scan?.cache)
 				data["cache_title"] = scan.cache.get_title()

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -248,7 +248,7 @@
 	var/duedate
 
 #define PRINTER_COOLDOWN (6 SECONDS)
-#define NEWSCASTER_COOLDOWN (60 SECONDS)
+#define NEWSCASTER_COOLDOWN (10 SECONDS)
 #define LIBRARY_NEWSFEED "Nanotrasen Book Club"
 //The different states the computer can be in, only send the info we need yeah?
 #define LIBRARY_INVENTORY 1

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -379,7 +379,7 @@
 			data["has_cache"] = !!(scan?.cache)
 
 			var/cooldown_number = (COOLDOWN_TIMELEFT(src, newscaster_cooldown))
-			var/active_newscaster_cooldown = !!(COOLDOWN_FINISHED(src, newscaster_cooldown))
+			var/active_newscaster_cooldown = COOLDOWN_FINISHED(src, newscaster_cooldown)
 			data["active_newscaster_cooldown"] = active_newscaster_cooldown
 			var/tooltip_message = ""
 			if(active_newscaster_cooldown)

--- a/tgui/packages/tgui/interfaces/LibraryConsole.js
+++ b/tgui/packages/tgui/interfaces/LibraryConsole.js
@@ -490,7 +490,7 @@ export const Upload = (props, context) => {
     can_db_request,
     has_cache,
     has_scanner,
-    upload_tooltip_message,
+    cooldown_string,
   } = data;
   const [uploadToDB, setUploadToDB] = useLocalState(context, 'UploadDB', false);
   if (!has_scanner) {
@@ -575,7 +575,13 @@ export const Upload = (props, context) => {
               <Button
                 disabled={!active_newscaster_cooldown}
                 fluid
-                tooltip={upload_tooltip_message}
+                tooltip={
+                  active_newscaster_cooldown
+                    ? "Send your book to the station's newscaster's channel."
+                    : 'Please wait ' +
+                    cooldown_string +
+                    ' before sending your book to the newscaster!'
+                }
                 tooltipPosition="top"
                 icon="newspaper"
                 content="Newscaster"

--- a/tgui/packages/tgui/interfaces/LibraryConsole.js
+++ b/tgui/packages/tgui/interfaces/LibraryConsole.js
@@ -483,12 +483,14 @@ export const SearchAndDisplay = (props, context) => {
 export const Upload = (props, context) => {
   const { act, data } = useBackend(context);
   const {
-    can_db_request,
-    has_scanner,
-    has_cache,
-    cache_title,
+    active_newscaster_cooldown,
     cache_author,
     cache_content,
+    cache_title,
+    can_db_request,
+    has_cache,
+    has_scanner,
+    upload_tooltip_message,
   } = data;
   const [uploadToDB, setUploadToDB] = useLocalState(context, 'UploadDB', false);
   if (!has_scanner) {
@@ -571,7 +573,10 @@ export const Upload = (props, context) => {
           <Stack>
             <Stack.Item grow>
               <Button
+                disabled={!active_newscaster_cooldown}
                 fluid
+                tooltip={upload_tooltip_message}
+                tooltipPosition="top"
                 icon="newspaper"
                 content="Newscaster"
                 fontSize="30px"


### PR DESCRIPTION

## About The Pull Request

Hey there,

Pretty much on the tin. We implement a cooldown on the backend for a set amount of time to prevent people spamming the newscaster channel with a shitload of books (rather than have absolutely no safeguards against it), and then pipe information to the UI for user feedback.
## Why It's Good For The Game

Fixes #71290

In case you weren't already aware, letting users absolutely wreck the shit out of player's chat via newscaster spam (all newscasters forcesay a message when something's uploaded to it) as well as just fill the shit up of a channel with various vulgarities isn't a really good thing.
## Changelog
:cl:
fix: To prevent spam, there is now a cooldown on being able to upload assorted books into the newscaster's channel feed.
/:cl:

Let me know if the cooldown seems too long, not hard to change.
