### PR TITLE
Guards against uplink failsafe code being the same as unlock code

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -419,15 +419,23 @@
 		unlock_note = "<B>Uplink Degrees:</B> [english_list(unlock_code)] ([P.name])."
 
 /datum/component/uplink/proc/generate_code()
-	if(istype(parent,/obj/item/modular_computer/pda))
-		return "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"
-	else if(istype(parent,/obj/item/radio))
-		return pick(GLOB.phonetic_alphabet)
-	else if(istype(parent,/obj/item/pen))
-		var/list/L = list()
+	var/returnable_code = ""
+
+	if(istype(parent, /obj/item/modular_computer/pda))
+		returnable_code = "[rand(100,999)] [pick(GLOB.phonetic_alphabet)]"
+
+	else if(istype(parent, /obj/item/radio))
+		returnable_code = pick(GLOB.phonetic_alphabet)
+
+	else if(istype(parent, /obj/item/pen))
+		returnable_code = list()
 		for(var/i in 1 to PEN_ROTATIONS)
-			L += rand(1, 360)
-		return L
+			returnable_code += rand(1, 360)
+
+	if(unlock_code == returnable_code)
+		return generate_code() // Not really a good idea to have the same code twice in a row (prevents failsafe code being the same as your unlock code)
+
+	return returnable_code
 
 /datum/component/uplink/proc/failsafe(mob/living/carbon/user)
 	if(!parent)

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -432,8 +432,16 @@
 		for(var/i in 1 to PEN_ROTATIONS)
 			returnable_code += rand(1, 360)
 
-	if(unlock_code == returnable_code)
-		return generate_code() // Not really a good idea to have the same code twice in a row (prevents failsafe code being the same as your unlock code)
+	if(!unlock_code) // assume the unlock_code is our "base" code that we don't want to duplicate, and if we don't have an unlock code, immediately return out of it since there's nothing to compare to.
+		return returnable_code
+
+	// duplicate checking, re-run the proc if we get a dupe to prevent the failsafe explodey code being the same as the unlock code.
+	if(islist(returnable_code))
+		if(english_list(returnable_code) == english_list(unlock_code)) // we pass english_list to the user anyways and for later processing, so we can just compare the english_list of the two lists.
+			return generate_code()
+
+	else if(unlock_code == returnable_code)
+		return generate_code()
 
 	return returnable_code
 


### PR DESCRIPTION

## About The Pull Request

There's probably a better way to do this to be honest, but I think it's silly for both to potentially be the same and this should work alright.
## Why It's Good For The Game

Fixes #71446.

I don't think the Syndicate is that stupid.
## Changelog
:cl:
fix: After a recent mishap with a high-ranking Syndicate operative, the uplink's unlock code and failsafe code (the one that makes it blow up if you say it) should never turn out to be the same.
/:cl:
