### PR TITLE
Traitor UI only shows Unlock/Failsafe Code if you have it

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -201,6 +201,8 @@
 		data["phrases"] = jointext(GLOB.syndicate_code_phrase, ", ")
 		data["responses"] = jointext(GLOB.syndicate_code_response, ", ")
 	data["theme"] = traitor_flavor["ui_theme"]
+	data["code"] = uplink?.unlock_code
+	data["failsafe_code"] = uplink?.failsafe_code
 	data["intro"] = traitor_flavor["introduction"]
 	data["allies"] = traitor_flavor["allies"]
 	data["goal"] = traitor_flavor["goal"]
@@ -208,18 +210,6 @@
 	if(uplink)
 		data["uplink_intro"] = traitor_flavor["uplink"]
 		data["uplink_unlock_info"] = uplink.unlock_text
-
-		var/unlock_code_string = ""
-		var/failsafe_code_string = ""
-		if(uplink.unlock_code)
-			unlock_code_string = "Code: [uplink.unlock_code]"
-
-		if(uplink.failsafe_code)
-			failsafe_code_string = "Failsafe: [uplink.failsafe_code]"
-
-		data["code"] = unlock_code_string
-		data["failsafe_code"] = failsafe_code_string
-
 	data["objectives"] = get_objectives()
 	return data
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -201,8 +201,6 @@
 		data["phrases"] = jointext(GLOB.syndicate_code_phrase, ", ")
 		data["responses"] = jointext(GLOB.syndicate_code_response, ", ")
 	data["theme"] = traitor_flavor["ui_theme"]
-	data["code"] = uplink?.unlock_code
-	data["failsafe_code"] = uplink?.failsafe_code
 	data["intro"] = traitor_flavor["introduction"]
 	data["allies"] = traitor_flavor["allies"]
 	data["goal"] = traitor_flavor["goal"]
@@ -210,6 +208,18 @@
 	if(uplink)
 		data["uplink_intro"] = traitor_flavor["uplink"]
 		data["uplink_unlock_info"] = uplink.unlock_text
+
+		var/unlock_code_string = ""
+		var/failsafe_code_string = ""
+		if(uplink.unlock_code)
+			unlock_code_string = "Code: [uplink.unlock_code]"
+
+		if(uplink.failsafe_code)
+			failsafe_code_string = "Failsafe: [uplink.failsafe_code]"
+
+		data["code"] = unlock_code_string
+		data["failsafe_code"] = failsafe_code_string
+
 	data["objectives"] = get_objectives()
 	return data
 

--- a/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
@@ -136,9 +136,9 @@ const UplinkSection = (props, context) => {
             <Stack.Item bold>
               {uplink_intro}
               <br />
-              <span style={goalstyle}>Code: {code}</span>
+              <span style={goalstyle}>{code}</span>
               <br />
-              <span style={badstyle}>Failsafe: {failsafe_code}</span>
+              <span style={badstyle}>{failsafe_code}</span>
             </Stack.Item>
             <Stack.Divider />
             <Stack.Item mt="1%">

--- a/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
@@ -136,9 +136,11 @@ const UplinkSection = (props, context) => {
             <Stack.Item bold>
               {uplink_intro}
               <br />
-              <span style={goalstyle}>{code}</span>
+              {code && <span style={goalstyle}>Code: {code}</span>}
               <br />
-              <span style={badstyle}>{failsafe_code}</span>
+              {failsafe_code && (
+                <span style={badstyle}>Failsafe: {failsafe_code}</span>
+              )}
             </Stack.Item>
             <Stack.Divider />
             <Stack.Item mt="1%">


### PR DESCRIPTION
## About The Pull Request

There are cases in which you don't have an unlock code (if the uplink is implanted in you from the start) and you obviously don't always start with with a failsafe code (need to buy it). So, let's only fill in this fields in the UI should they exist.

There might be something to be said about wanting to ensure that people remember that they can check this UI screen to find the failsafe code should they lose it later, and I wouldn't mind changing the string to be something like "Failsafe: None" in that case. However, I just think that keeping it as:

```txt
Code:
Failsafe:
```

is silly and should be changed somehow.
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/208604758-d7ff3ae9-e552-4dd2-998d-81715cd06ffc.png)

Note: That white box isn't part of the UI, that's a part of the edit I did to the screenshot in the area where the stuff... isn't? What was i thinking

I think the UI looks a lot cleaner for those cases when you just don't have anything.
## Changelog
:cl:
qol: The Traitor's Antagonist Panel's Unlock and Failsafe entries will only appear if there is an Unlock/Failsafe Code to display. 
/:cl:
