### PR TITLE
Resist calls cancel_camera

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1050,6 +1050,7 @@
 	changeNext_move(CLICK_CD_RESIST)
 
 	SEND_SIGNAL(src, COMSIG_LIVING_RESIST, src)
+	cancel_camera()
 	//resisting grabs (as if it helps anyone...)
 	if(!HAS_TRAIT(src, TRAIT_RESTRAINED) && pulledby)
 		log_combat(src, pulledby, "resisted grab")


### PR DESCRIPTION

## About The Pull Request
When resisting, it will call cancel_camera
## Why It's Good For The Game
Being able to quickly exit a camera view could be vital for survival, if you happen to be attacked while using one. The only ways to get out of a camera view are through the action icon and cancel camera verb, both very slow. This also has the side effect of giving ai a shortcut to viewing their satellite, and giving them a use for the resist verb in the first place.
## Changelog
:cl:
qol: you can resist out of camera views
/:cl:
