### PR TITLE
Fix adding mutations to advanced injectors not working without an occupant

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -1564,13 +1564,8 @@
 		// params["mutref"] - ATOM Ref of specific mutation to add to the injector
 		// params["advinj"] - Name of the advanced injector to add the mutation to
 		if("add_advinj_mut")
-			// GUARD CHECK - Can we genetically modify the occupant? Includes scanner
-			//  operational guard checks.
-			// This is needed because this operation can only be completed from the
-			//  genetic sequencer.
-			if(!can_modify_occupant())
+			if(!scanner_operational())
 				return
-
 			var/adv_inj = params["advinj"]
 
 			// GUARD CHECK - Make sure our advanced injector actually exists. This
@@ -1598,6 +1593,9 @@
 				return
 
 			var/bref = params["mutref"]
+			if(search_flag & SEARCH_OCCUPANT)
+				if(!can_modify_occupant())
+					return
 			// We've already made sure we can modify the occupant, so this is safe to
 			//  call
 			var/datum/mutation/human/HM = get_mut_by_ref(bref, search_flag)


### PR DESCRIPTION

## About The Pull Request

You couldnt add mutations to an advanced injector if there was no occupant inside the scanner
Now you can

## Why It's Good For The Game
Fixes #72099

## Changelog
:cl:
fix: You can now add mutations to advanced injectors without having an occupant inside
/:cl:
