### PR TITLE
View Sensor circuits now have a range modifier

### DIFF
--- a/code/modules/wiremod/components/sensors/view_sensor.dm
+++ b/code/modules/wiremod/components/sensors/view_sensor.dm
@@ -53,13 +53,10 @@
 			result.set_output(null)
 			return
 
-	var/range_val = range.value || 0
+	var/range_value = clamp(range.value, 0, maximum_range)
 	var/object_list = list()
 
-	if(range_val > maximum_range)
-		range_val = maximum_range
-
-	for(var/atom/movable/target in view(range_val, get_turf(parent.shell)))
+	for(var/atom/movable/target in view(range_value, get_turf(parent.shell)))
 		if(target.mouse_opacity == MOUSE_OPACITY_TRANSPARENT)
 			continue
 		if(target.invisibility > see_invisible)

--- a/code/modules/wiremod/components/sensors/view_sensor.dm
+++ b/code/modules/wiremod/components/sensors/view_sensor.dm
@@ -4,16 +4,17 @@
  * Returns all movable objects in view.
  */
 
-#define VIEW_SENSOR_RANGE 5
-
 /obj/item/circuit_component/view_sensor
 	display_name = "View Sensor"
-	desc = "Outputs a list with all movable objects in it's view. Requires a shell."
+	desc = "Outputs a list with all movable objects in it's view. Requires a shell. Max range of 5 tiles."
 	category = "Sensor"
 
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	power_usage_per_input = 10 //Normal components have 1
+
+	///Allows setting the range of the view sensor
+	var/datum/port/input/range
 
 	/// The result from the output
 	var/datum/port/output/result
@@ -21,8 +22,10 @@
 
 	var/see_invisible = SEE_INVISIBLE_LIVING
 	var/view_cooldown = 1 SECONDS
+	var/maximum_range = 5 //Variablised incase admins want to increase it.
 
 /obj/item/circuit_component/view_sensor/populate_ports()
+	range = add_input_port("Range", PORT_TYPE_NUMBER)
 	result = add_output_port("Result", PORT_TYPE_LIST(PORT_TYPE_ATOM))
 	cooldown = add_output_port("Scan On Cooldown", PORT_TYPE_SIGNAL)
 
@@ -50,9 +53,13 @@
 			result.set_output(null)
 			return
 
+	var/range_val = range.value || 0
 	var/object_list = list()
 
-	for(var/atom/movable/target in view(5, get_turf(parent.shell)))
+	if(range_val > maximum_range)
+		range_val = maximum_range
+
+	for(var/atom/movable/target in view(range_val, get_turf(parent.shell)))
 		if(target.mouse_opacity == MOUSE_OPACITY_TRANSPARENT)
 			continue
 		if(target.invisibility > see_invisible)
@@ -63,5 +70,3 @@
 
 	result.set_output(object_list)
 	TIMER_COOLDOWN_START(parent, COOLDOWN_CIRCUIT_VIEW_SENSOR, view_cooldown)
-
-#undef VIEW_SENSOR_RANGE

--- a/code/modules/wiremod/components/sensors/view_sensor.dm
+++ b/code/modules/wiremod/components/sensors/view_sensor.dm
@@ -25,7 +25,7 @@
 	var/maximum_range = 5 //Variablised incase admins want to increase it.
 
 /obj/item/circuit_component/view_sensor/populate_ports()
-	range = add_input_port("Range", PORT_TYPE_NUMBER)
+	range = add_input_port("Range", PORT_TYPE_NUMBER, default = maximum_range)
 	result = add_output_port("Result", PORT_TYPE_LIST(PORT_TYPE_ATOM))
 	cooldown = add_output_port("Scan On Cooldown", PORT_TYPE_SIGNAL)
 


### PR DESCRIPTION

## About The Pull Request

Adds the ability to use ranges between 0 and 5 for View Sensor circuits. Currently these nodes are locked to 5 tiles and it is rather difficult to limit the area this circuit effects either for speed reasons or otherwise. This PR makes it a simple variable that remains capped at 5, admins can raise the cap by modifying a variable.
## Why It's Good For The Game

I mostly use circuits as an admin, I can't for the life of me figure out how to make a shorter range AOE circuit although I imagine its possible by comparing x and y coordinates of things in the list and yourself this is far to finicky. Players can also utilize this to, for example check all objects on the tile the view sensor is on, "possible" at the moment but way to finicky compared to a 5 tiles.
## Changelog
:cl:
qol: You can now reduce the range of View Sensor circuits.
/:cl:
