### PR TITLE
Fixes access_view on goodies not being respected by anything other than department budget orders

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -238,7 +238,10 @@
 				if(!istype(account))
 					say("Invalid bank account.")
 					return
-
+				access = id_card.GetAccess()
+				if(pack.access_view && !(pack.access_view in access))
+					say("[id_card] lacks the requisite access for this purchase.")
+					return
 			var/reason = ""
 			if(requestonly && !self_paid)
 				reason = tgui_input_text(usr, "Reason", name)

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -238,7 +238,7 @@
 				if(!istype(account))
 					say("Invalid bank account.")
 					return
-				access = id_card.GetAccess()
+				var/list/access = id_card.GetAccess()
 				if(pack.access_view && !(pack.access_view in access))
 					say("[id_card] lacks the requisite access for this purchase.")
 					return


### PR DESCRIPTION
## About The Pull Request

Fixes access_view on goodies not being respected by anything other than department budget orders

## Why It's Good For The Game

Bugfix, per gitblame we simply never fixed this but we clearly intended it to work this way per the variable comment description and the fact we use it on the detective revolver

## Changelog
:cl:
fix: Fixes access_view on goodies not being respected by anything other than department budget orders
/:cl:
