### PR TITLE
Fixes final objectives not displaying UI buttons

### DIFF
--- a/tgui/packages/tgui/interfaces/Uplink/ObjectiveMenu.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/ObjectiveMenu.tsx
@@ -365,8 +365,8 @@ export const ObjectiveElement = (props: ObjectiveElementProps, context) => {
     handleAbort,
     canAbort,
     originalProgression,
-    grow,
     hideTcRep,
+    grow,
     finalObjective,
     ...rest
   } = props;
@@ -422,15 +422,7 @@ export const ObjectiveElement = (props: ObjectiveElementProps, context) => {
         </Box>
       </Flex.Item>
       <Flex.Item grow={grow} basis="content">
-        <Box
-          style={{
-            'border-bottom': hideTcRep
-              ? '2px solid rgba(0, 0, 0, 0.5)'
-              : undefined,
-          }}
-          className="UplinkObjective__Content"
-          height="100%"
-          mb={hideTcRep ? 2 : 0}>
+        <Box className="UplinkObjective__Content" height="100%">
           <Box>{description}</Box>
           {!hideTcRep && (
             <Box mt={1}>
@@ -447,9 +439,9 @@ export const ObjectiveElement = (props: ObjectiveElementProps, context) => {
         </Box>
       </Flex.Item>
       <Flex.Item>
-        {!hideTcRep && (
-          <Box className="UplinkObjective__Footer">
-            <Stack vertical>
+        <Box className="UplinkObjective__Footer">
+          <Stack vertical>
+            {!hideTcRep && (
               <Stack.Item>
                 <Stack align="center" justify="center">
                   <Box
@@ -547,12 +539,12 @@ export const ObjectiveElement = (props: ObjectiveElementProps, context) => {
                   </Box>
                 ) : null}
               </Stack.Item>
-              {!!uiButtons && !objectiveFinished && (
-                <Stack.Item>{uiButtons}</Stack.Item>
-              )}
-            </Stack>
-          </Box>
-        )}
+            )}
+            {!!uiButtons && !objectiveFinished && (
+              <Stack.Item>{uiButtons}</Stack.Item>
+            )}
+          </Stack>
+        </Box>
       </Flex.Item>
     </Flex>
   );

--- a/tgui/packages/tgui/interfaces/Uplink/PrimaryObjectiveMenu.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/PrimaryObjectiveMenu.tsx
@@ -68,7 +68,7 @@ export const PrimaryObjectiveMenu = (
                 telecrystalPenalty={0}
                 progressionReward={0}
                 originalProgression={0}
-                hideTcRep={1}
+                hideTcRep
                 canAbort={false}
                 grow={false}
                 finalObjective={false}


### PR DESCRIPTION

## About The Pull Request
See title

## Why It's Good For The Game
hideTcRep was hiding the entire footer. All it had to hide was the Stack.Item that contained the TC and reputation rewards.

Another PR was trying to fix this issue, but only by increasing the complexity of ObjectiveMenu code, which was unnecessary and would've made the code harder to maintain. Instead of asking them to basically rewrite their entire code, I decided it would be faster if I just remade it myself.

## Changelog
:cl:
fix: Fixed final objectives not displaying the UI buttons.
/:cl:
