### PR TITLE
Changes the default security delivery area to the Security Office

### DIFF
--- a/code/modules/cargo/department_order.dm
+++ b/code/modules/cargo/department_order.dm
@@ -191,6 +191,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 	name = "security order console"
 	circuit = /obj/item/circuitboard/computer/security_orders
 	department_delivery_areas = list(
+		/area/station/security/office,
 		/area/station/security/brig,
 		/area/station/security/brig/upper,
 	)


### PR DESCRIPTION

## About The Pull Request

The department security crates currently default to be opened in the Brig area. However, this causes issues with Icebox, as the Brig is in the basement, and the upper, main station level floor is called Brig Overlook. This caused several people I know, and myself, great confusion. I considered just swapping their priority in department_delivery_areas, but this would just push the problem to the future, for hypothetical maps that have the Brig Overlook as the secondary brig floor.

So instead I have decided to make the Security Office the default pick in department_delivery_areas. It is an iconic location, departmentless officers spawn there, and the security mail disposals is also found here (though cargo techs might use different mail methods). 

## Why It's Good For The Game

Its good to have the delivery areas more clear.

## Changelog

:cl:
qol: the security department delivery crates are now have to be opened in the security office, where the crates are delivered
/:cl:
