### PR TITLE
Removes armor from Det's fedora and jacket

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -94,7 +94,6 @@
 /obj/item/clothing/head/fedora/det_hat
 	name = "detective's fedora"
 	desc = "There's only one man who can sniff out the dirty stench of crime, and he's likely wearing this hat."
-	armor = list(MELEE = 25, BULLET = 5, LASER = 25, ENERGY = 35, BOMB = 0, BIO = 0, FIRE = 30, ACID = 50, WOUND = 5)
 	icon_state = "detective"
 	inhand_icon_state = "det_hat"
 	var/candy_cooldown = 0

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -98,7 +98,6 @@
 	inhand_icon_state = "det_suit"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|GROIN|ARMS
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 0, BIO = 0, FIRE = 0, ACID = 45)
 	cold_protection = CHEST|GROIN|ARMS
 	heat_protection = CHEST|GROIN|ARMS
 


### PR DESCRIPTION
## About The Pull Request
Just that, it removes armor from their jackets and fedora.
## Why It's Good For The Game
A lot of clothing has random armor values which bloat the system a lot.

Cutting on normal clothing that has armor for "balance" reasons would cut on a lot of this issues and help with player clarity.
A new player should see someone with helmet and expect their head to be protected, not the same with the detective's fedora, which has a hat with the same name, but no armor, freely available to the public. It's just confusing.

This PR would be a first step on cutting on clothes having random armor values.

As for everyone talking about detectives grabbing sec uniforms becoming the meta. Every other department has different armor values between their jobs, we don't make Engineers' suits fire proof because they can take one at Atmos, we don't make Cargo Tech's wintercoat have armor because they can take Miner's wintercoat to use.
I don't see why Detectives should be the exemption of the rule.
## Changelog
:cl: Guillaume Prata
balance: Detective's fedora and jackets have no armor now.
/:cl:
