### PR TITLE
Fixes Bar/Restaurant Bots Orders Sending Infinite Orders

### DIFF
--- a/code/modules/food_and_drinks/restaurant/generic_venues.dm
+++ b/code/modules/food_and_drinks/restaurant/generic_venues.dm
@@ -83,6 +83,7 @@
 	)
 
 /datum/venue/bar/get_food_appearance(order)
+	// we have to instantiate the object here because there's no current way to run initial() to read the typepath (unchangeable static variable).
 	var/datum/reagent/reagent_to_order = new order
 	// Default the icon to the fallback icon
 	var/glass_visual_icon = initial(reagent_to_order.fallback_icon)

--- a/code/modules/food_and_drinks/restaurant/generic_venues.dm
+++ b/code/modules/food_and_drinks/restaurant/generic_venues.dm
@@ -83,14 +83,14 @@
 	)
 
 /datum/venue/bar/get_food_appearance(order)
-	var/datum/reagent/reagent_to_order = order
+	var/datum/reagent/reagent_to_order = new order
 	// Default the icon to the fallback icon
 	var/glass_visual_icon = initial(reagent_to_order.fallback_icon)
 	var/glass_visual_icon_state = initial(reagent_to_order.fallback_icon_state)
 
 	// Look for a glass style based on this reagent type
 	for(var/potential_container in GLOB.glass_style_singletons)
-		var/datum/glass_style/draw_as = GLOB.glass_style_singletons[potential_container][initial(reagent_to_order.type)]
+		var/datum/glass_style/draw_as = GLOB.glass_style_singletons[potential_container][reagent_to_order.type]
 		if(isnull(draw_as))
 			continue
 

--- a/code/modules/food_and_drinks/restaurant/generic_venues.dm
+++ b/code/modules/food_and_drinks/restaurant/generic_venues.dm
@@ -83,14 +83,14 @@
 	)
 
 /datum/venue/bar/get_food_appearance(order)
-	var/datum/reagent/reagent_to_order = new order
+	var/datum/reagent/reagent_to_order = order
 	// Default the icon to the fallback icon
 	var/glass_visual_icon = initial(reagent_to_order.fallback_icon)
 	var/glass_visual_icon_state = initial(reagent_to_order.fallback_icon_state)
 
 	// Look for a glass style based on this reagent type
 	for(var/potential_container in GLOB.glass_style_singletons)
-		var/datum/glass_style/draw_as = GLOB.glass_style_singletons[potential_container][reagent_to_order.type]
+		var/datum/glass_style/draw_as = GLOB.glass_style_singletons[potential_container][initial(reagent_to_order.type)]
 		if(isnull(draw_as))
 			continue
 

--- a/code/modules/food_and_drinks/restaurant/generic_venues.dm
+++ b/code/modules/food_and_drinks/restaurant/generic_venues.dm
@@ -83,7 +83,7 @@
 	)
 
 /datum/venue/bar/get_food_appearance(order)
-	var/datum/reagent/reagent_to_order = order
+	var/datum/reagent/reagent_to_order = new order
 	// Default the icon to the fallback icon
 	var/glass_visual_icon = initial(reagent_to_order.fallback_icon)
 	var/glass_visual_icon_state = initial(reagent_to_order.fallback_icon_state)

--- a/code/modules/food_and_drinks/restaurant/generic_venues.dm
+++ b/code/modules/food_and_drinks/restaurant/generic_venues.dm
@@ -83,15 +83,14 @@
 	)
 
 /datum/venue/bar/get_food_appearance(order)
-	// we have to instantiate the object here because there's no current way to run initial() to read the typepath (unchangeable static variable).
-	var/datum/reagent/reagent_to_order = new order
+	var/datum/reagent/reagent_to_order = order
 	// Default the icon to the fallback icon
 	var/glass_visual_icon = initial(reagent_to_order.fallback_icon)
 	var/glass_visual_icon_state = initial(reagent_to_order.fallback_icon_state)
 
 	// Look for a glass style based on this reagent type
 	for(var/potential_container in GLOB.glass_style_singletons)
-		var/datum/glass_style/draw_as = GLOB.glass_style_singletons[potential_container][reagent_to_order.type]
+		var/datum/glass_style/draw_as = GLOB.glass_style_singletons[potential_container][reagent_to_order]
 		if(isnull(draw_as))
 			continue
 


### PR DESCRIPTION

## About The Pull Request

We didn't instantiate order (which was needed to read the type), so they would just spam new orders until the heat death of the universe. Very annoying.
## Why It's Good For The Game

Fixes #72023.
## Changelog
:cl:
fix: Bar/Restaurant Bots should no longer spam orders forever.
/:cl:
