### PR TITLE
fixes typo for insertion during organ manipulation

### DIFF
--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -143,7 +143,7 @@
 			span_notice("[user] begins to insert [tool] into [target]'s [parse_zone(target_zone)]."),
 			span_notice("[user] begins to insert something into [target]'s [parse_zone(target_zone)]."),
 		)
-		display_pain(target, "You can feel your something being placed in your [parse_zone(target_zone)]!")
+		display_pain(target, "You can feel something being placed in your [parse_zone(target_zone)]!")
 
 
 	else if(implement_type in implements_extract)


### PR DESCRIPTION

## About The Pull Request
**BEFORE:** 
display_pain(target, "You can feel your something being placed in your [parse_zone(target_zone)]!")
**AFTER:**
display_pain(target, "You can feel something being placed in your [parse_zone(target_zone)]!")
Removes lazy coding, improves visual fidelity

## Why It's Good For The Game
ugly


:cl:
spellcheck: drastically improves grammar for inserting something during organ manipulation
/:cl:
