### PR TITLE
Removes using right click to reset alarms because it's dumb, makes it use left click instead

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -59,8 +59,7 @@
 
 	AddElement( \
 		/datum/element/contextual_screentip_bare_hands, \
-		lmb_text = "Turn on", \
-		rmb_text = "Turn off", \
+		lmb_text = "Turn on/off", \
 	)
 
 /obj/machinery/firealarm/Destroy()
@@ -230,14 +229,10 @@
 		return
 	. = ..()
 	add_fingerprint(user)
-	alarm(user)
-
-/obj/machinery/firealarm/attack_hand_secondary(mob/user, list/modifiers)
-	if(buildstage != 2)
-		return ..()
-	add_fingerprint(user)
-	reset(user)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	if(my_area.fire)
+		reset(user)
+	else
+		alarm(user)
 
 /obj/machinery/firealarm/attack_ai(mob/user)
 	return attack_hand(user)


### PR DESCRIPTION
## About The Pull Request

Ok get this right, a fire alarm, can only be on or off.
It is binary.
So why in god's name, do we have two separate inputs, to turn it on and to turn it off?

I got rid of that and made it just use left click, if the alarm is active it will reset, if it's not it will trigger. Simple, sensible design.

## Why It's Good For The Game

Why complicate the control scheme for something so simple?

## Changelog

:cl:
qol: Fire alarms no longer use right click to be turned off, just use left click while they are on.
/:cl:
