### PR TITLE
Pride pin quirk + pins can be infinitely reskinned

### DIFF
--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -539,3 +539,26 @@
 	human_holder.add_mood_event("gamer_withdrawal", /datum/mood_event/gamer_withdrawal)
 
 #undef GAMING_WITHDRAWAL_TIME
+
+
+/datum/quirk/item_quirk/pride_pin
+	name = "Pride Pin"
+	desc = "Show off your pride with this changing pride pin!"
+	icon = "thumbtack"
+	value = 0
+	gain_text = "<span class='notice'>You feel fruity.</span>"
+	lose_text = "<span class='danger'>You feel only slightly less fruity than before.</span>"
+	medical_record_text = "Patient appears to be fruity."
+	var/pride_choice
+	var/pride_reskin
+
+/datum/quirk/item_quirk/pride_pin/add_unique()
+	var/obj/item/clothing/accessory/pride/pin = new(get_turf(quirk_holder))
+
+	pride_choice = quirk_holder.client?.prefs?.read_preference(/datum/preference/choiced/pride_pin) || assoc_to_keys(GLOB.pride_pin_reskins)[1]
+	pride_reskin = GLOB.pride_pin_reskins[pride_choice]
+
+	pin.current_skin = pride_choice
+	pin.icon_state = pride_reskin
+	
+	give_item_to_holder(pin, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -17,6 +17,7 @@
 
 	var/current_skin //Has the item been reskinned?
 	var/list/unique_reskin //List of options to reskin.
+	var/infinite_reskin = FALSE //If set to true, we can reskin this item as much as we want.
 
 	// Access levels, used in modules\jobs\access.dm
 	var/list/req_access
@@ -283,12 +284,12 @@
 	. = ..()
 	if(obj_flags & UNIQUE_RENAME)
 		. += span_notice("Use a pen on it to rename it or change its description.")
-	if(unique_reskin && !current_skin)
+	if(unique_reskin && (!current_skin || infinite_reskin))
 		. += span_notice("Alt-click it to reskin it.")
 
 /obj/AltClick(mob/user)
 	. = ..()
-	if(unique_reskin && !current_skin && user.canUseTopic(src, be_close = TRUE, no_dexterity = TRUE))
+	if(unique_reskin && (!current_skin || infinite_reskin) && user.canUseTopic(src, be_close = TRUE, no_dexterity = TRUE))
 		reskin_obj(user)
 
 /**
@@ -325,7 +326,7 @@
 /obj/proc/check_reskin_menu(mob/user)
 	if(QDELETED(src))
 		return FALSE
-	if(current_skin)
+	if(!infinite_reskin && current_skin)
 		return FALSE
 	if(!istype(user))
 		return FALSE

--- a/code/modules/client/preferences/pride_pin.dm
+++ b/code/modules/client/preferences/pride_pin.dm
@@ -1,0 +1,16 @@
+/datum/preference/choiced/pride_pin
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_key = "pride_pin"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/choiced/pride_pin/init_possible_values()
+	return assoc_to_keys(GLOB.pride_pin_reskins)
+
+/datum/preference/choiced/pride_pin/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Pride Pin" in preferences.all_quirks
+
+/datum/preference/choiced/pride_pin/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -463,17 +463,24 @@
 	SIGNAL_HANDLER
 	examine_list += "The dogtag has a listing of allergies : [display]"
 
+GLOBAL_LIST_INIT(pride_pin_reskins, list(
+	"Rainbow Pride" = "pride",
+	"Bisexual Pride" = "pride_bi",
+	"Pansexual Pride" = "pride_pan",
+	"Asexual Pride" = "pride_ace",
+	"Non-binary Pride" = "pride_enby",
+	"Transgender Pride" = "pride_trans",
+	"Intersex Pride" = "pride_intersex",
+	"Lesbian Pride" = "pride_lesbian",
+))
+
 /obj/item/clothing/accessory/pride
 	name = "pride pin"
-	desc = "A Nanotrasen Diversity & Inclusion Center-sponsored holographic pin to show off your sexuality, reminding the crew of their unwavering commitment to equity, diversity, and inclusion!"
+	desc = "A Nanotrasen Diversity & Inclusion Center-sponsored holographic pin to show off your pride, reminding the crew of their unwavering commitment to equity, diversity, and inclusion!"
 	icon_state = "pride"
 	obj_flags = UNIQUE_RENAME
-	unique_reskin = list("Rainbow Pride" = "pride",
-						"Bisexual Pride" = "pride_bi",
-						"Pansexual Pride" = "pride_pan",
-						"Asexual Pride" = "pride_ace",
-						"Non-binary Pride" = "pride_enby",
-						"Transgender Pride" = "pride_trans",
-						"Intersex Pride" = "pride_intersex",
-						"Lesbian Pride" = "pride_lesbian",
-						)
+	infinite_reskin = TRUE
+
+/obj/item/clothing/accessory/pride/Initialize(mapload)
+	. = ..()
+	unique_reskin = GLOB.pride_pin_reskins

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2735,6 +2735,7 @@
 #include "code\modules\client\preferences\pixel_size.dm"
 #include "code\modules\client\preferences\playtime_reward_cloak.dm"
 #include "code\modules\client\preferences\preferred_map.dm"
+#include "code\modules\client\preferences\pride_pin.dm"
 #include "code\modules\client\preferences\prisoner_crime.dm"
 #include "code\modules\client\preferences\random.dm"
 #include "code\modules\client\preferences\runechat.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/pride_pin.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/pride_pin.tsx
@@ -1,0 +1,6 @@
+import { FeatureChoiced, FeatureDropdownInput } from '../base';
+
+export const pride_pin: FeatureChoiced = {
+  name: 'Pride Pin',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION

## About The Pull Request

Neutral pride pin quirk added. Pride pins can be infinitely reskinned now. Changes "sexuality" to "pride" in description of pin.

## Why It's Good For The Game

Pride pins are cute and having to buy them every round is a chore. Pride pins are purely cosmetic and have no reason to be locked into only being reskinned once.

## Changelog

:cl:
add: Pride pin quirk!
qol: Pride pins can be infinitely reskinned now.
/:cl:
