### PR TITLE
lamps now use movable lighting instead of static lighting

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -256,7 +256,7 @@
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	force = 10
 	light_range = 5
-	light_system = STATIC_LIGHT
+	light_system = MOVABLE_LIGHT
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = CONDUCT_1
 	custom_materials = null


### PR DESCRIPTION

## About The Pull Request
they were on static lighting so tehy just didnt move with you

## Why It's Good For The Game
i have 0 idea why they were on static lighting

## Changelog
:cl:
fix: lamps now use movable lighting, so they light moves correctly
/:cl:
