### PR TITLE
Static light sources will attempt to follow the top atom

### DIFF
--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -79,7 +79,7 @@
 		return FALSE
 
 	LAZYADD(new_atom_host.light_sources, src)
-	if(ismovable(new_atom_host) && new_atom_host == source_atom)
+	if(ismovable(new_atom_host))
 		RegisterSignal(new_atom_host, COMSIG_MOVABLE_MOVED, PROC_REF(update_host_lights))
 	return TRUE
 
@@ -89,7 +89,7 @@
 		return FALSE
 
 	LAZYREMOVE(old_atom_host.light_sources, src)
-	if(ismovable(old_atom_host) && old_atom_host == source_atom)
+	if(ismovable(old_atom_host))
 		UnregisterSignal(old_atom_host, COMSIG_MOVABLE_MOVED)
 	return TRUE
 

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -79,6 +79,7 @@
 		return FALSE
 
 	LAZYADD(new_atom_host.light_sources, src)
+	//yes, we register the signal to the top atom too, this is intentional and ensures contained lighting updates properly
 	if(ismovable(new_atom_host))
 		RegisterSignal(new_atom_host, COMSIG_MOVABLE_MOVED, PROC_REF(update_host_lights))
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/71826
Probably fixes some other issue related to lighting but i didn't find any

## Why It's Good For The Game

Look, i know it's called STATIC lighting for a reason, and movement on it should be kept to a minimum, but this at least ensure that static lighting being carried around, if that happens for some reason, updates properly.

## Changelog

:cl:
fix: Static light sources update properly now when carried by a mob.
/:cl:
