### PR TITLE
Fixes some bad `investigate_log`s causing runtimes in somewhat important places

### DIFF
--- a/code/modules/atmospherics/machinery/portable/pump.dm
+++ b/code/modules/atmospherics/machinery/portable/pump.dm
@@ -89,7 +89,7 @@
 			on = FALSE
 			update_appearance()
 	else if(on && holding && direction == PUMP_OUT)
-		usr.investigate_log("started a transfer into [holding].", INVESTIGATE_ATMOS)
+		user.investigate_log("started a transfer into [holding].", INVESTIGATE_ATMOS)
 
 /obj/machinery/portable_atmospherics/pump/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -140,7 +140,7 @@
 			on = FALSE
 			update_appearance()
 	else if(on && holding)
-		usr.investigate_log("started a transfer into [holding].", INVESTIGATE_ATMOS)
+		user.investigate_log("started a transfer into [holding].", INVESTIGATE_ATMOS)
 
 /obj/machinery/portable_atmospherics/scrubber/ui_act(action, params)
 	. = ..()
@@ -221,4 +221,3 @@
 			on = FALSE
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 	return FALSE
-

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -405,8 +405,8 @@
 
 ///Logs, gibs and returns point values of whatever mob is unfortunate enough to get eaten.
 /mob/living/singularity_act()
-	usr.investigate_log("has been consumed by the singularity.", INVESTIGATE_ENGINE) //Oh that's where the clown ended up!
-	usr.investigate_log("has been gibbed by the singularity.", INVESTIGATE_DEATHS)
+	investigate_log("has been consumed by the singularity.", INVESTIGATE_ENGINE) //Oh that's where the clown ended up!
+	investigate_log("has been gibbed by the singularity.", INVESTIGATE_DEATHS)
 	gib()
 	return 20
 
@@ -435,7 +435,7 @@
 			if(4)
 				new /mob/living/simple_animal/hostile/construct/proteon/hostile(get_turf(src))
 	spawn_dust()
-	usr.investigate_log("has been gibbed by Nar'Sie.", INVESTIGATE_DEATHS)
+	investigate_log("has been gibbed by Nar'Sie.", INVESTIGATE_DEATHS)
 	gib()
 	return TRUE
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -219,7 +219,7 @@
 	return ..()
 
 /obj/machinery/rnd/production/proc/do_print(path, amount, list/matlist, notify_admins)
-	if(notify_admins)
+	if(notify_admins && ismob(usr))
 		usr.investigate_log("built [amount] of [path] at [src]([type]).", INVESTIGATE_RESEARCH)
 		message_admins("[ADMIN_LOOKUPFLW(usr)] has built [amount] of [path] at \a [src]([type]).")
 


### PR DESCRIPTION
## About The Pull Request

Fixes #72150 

```
[2022-12-21 19:35:38.178] runtime error: Cannot execute null.investigate log().
 - proc name: narsie act (/mob/living/narsie_act)
 -   source file: living_defense.dm,438
 -   usr: null
 -   src: Featherbottom (/mob/living/simple_animal/chicken)
 -   src.loc: the grass patch (147,154,2) (/turf/open/floor/grass)
 -   call stack:
 - Featherbottom (/mob/living/simple_animal/chicken): narsie act()
 ```

Removes `usr` from Nar'Sie act and Singularity act logs

I don't know why these were set to log in `usr`, when
A. `usr` is likely not the person getting gibbed
B. `usr` is unreliable 

Case in point: 
`usr` is some random person who probably helped invoke the Nar'sie rune (no idea how it choses), if they get deleted for whatever reason, `usr` seems to clear to `null` (?), which causes a `null` use and the above runtime

![image](https://user-images.githubusercontent.com/51863163/208999857-540d9caa-9df6-49b0-8f45-8b75973a32a4.png)

I also peeked around for other improper use of `usr` logs. Most of them were in `ui_act` code, which is whatever. Some where in places which had a passed user, so I replaced them. And one was in a place with no `user` passed, so I just added some sanity checking.

## Why It's Good For The Game

These are really bad places to runtime error

## Changelog

:cl: Melbert
fix: Nar'Sie will no longer bring upon the construct apocalypse when they encounter a chicken after one of the invokers were destroyed
fix: The Singularity should no longer stop gibbing people when whoever created it was destroyed
/:cl:
