### PR TITLE
Gives shadow jaunt users a warning before moving into a lit area

### DIFF
--- a/code/modules/spells/spell_types/jaunt/shadow_walk.dm
+++ b/code/modules/spells/spell_types/jaunt/shadow_walk.dm
@@ -77,7 +77,7 @@
 	. = ..()
 	if(loc != oldloc)
 		if(check_light_level(loc))
-			eject_jaunter(TRUE) //If the warning is already given and the cooldown is done, move them and eject them.
+			eject_jaunter(TRUE)
 
 /obj/effect/dummy/phased_mob/shadow/phased_check(mob/living/user, direction)
 	. = ..()
@@ -100,12 +100,11 @@
 
 	return ..()
 
-
 /**
  * Checks the light level. If above the minimum acceptable amount (0.2), returns TRUE.
  *
  * Checks the light level of a given location to see if it is too bright to
- * continue a jaunt in.
+ * continue a jaunt in. Returns FALSE if it's acceptably dark, and TRUE if it is too bright.
  *
  * * location_to_check - The location to have its light level checked.
  */
@@ -120,19 +119,18 @@
  * Checks if the user should recieve a warning that they're moving into light.
  *
  * Checks the cooldown for the warning message on moving into the light.
- * If the cooldown is complete, returns TRUE.
- * Used in relay_move/phased_check
+ * If the message has been displayed, and the cooldown (delay period) is complete, returns TRUE.
  */
 
 /obj/effect/dummy/phased_mob/shadow/proc/light_step_warning()
-	if(!light_alert_given) //To prevent you from accidentally flying into lit rooms.
+	if(!light_alert_given) //Give the user a warning that they're leaving the darkness
 		balloon_alert(jaunter, "leaving the shadows...")
 		light_alert_given = TRUE
-		COOLDOWN_START(src, light_step_cooldown, 1 SECONDS)
-		addtimer(CALLBACK(src, PROC_REF(reactivate_light_alert)), 1.5 SECONDS) //You get a .5 second window to bypass the warning before it comes back
+		COOLDOWN_START(src, light_step_cooldown, 0.75 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(reactivate_light_alert)), 1.25 SECONDS) //You get a .5 second window to bypass the warning before it comes back
 		return FALSE
 
-	if(!COOLDOWN_FINISHED(src, light_step_cooldown)) //If it's been 1 second since the warning was given, we continue
+	if(!COOLDOWN_FINISHED(src, light_step_cooldown))
 		return FALSE
 
 	light_alert_given = FALSE
@@ -141,8 +139,8 @@
 /**
  * Sets light_alert_given to false.
  *
- * Sets light_alert_given to false, making it pop up and intercept movement into light again.
- * Added in its own proc to reset the alert without having to call light_step_warning.
+ * Sets light_alert_given to false, making the light alert pop up and intercept movement once again.
+ * Added in its own proc to reset the alert without having to call light_step_warning().
  */
 
 /obj/effect/dummy/phased_mob/shadow/proc/reactivate_light_alert()

--- a/code/modules/spells/spell_types/jaunt/shadow_walk.dm
+++ b/code/modules/spells/spell_types/jaunt/shadow_walk.dm
@@ -54,7 +54,7 @@
 /obj/effect/dummy/phased_mob/shadow/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
-	COOLDOWN_START(src, light_step_cooldown, 3 SECONDS) //Kick-start the cooldown and give a grace period to allow for shadow dancing.
+	COOLDOWN_START(src, light_step_cooldown, 1 SECONDS) //Kick-start the cooldown and give a grace period to allow for shadow dancing.
 
 /obj/effect/dummy/phased_mob/shadow/Destroy()
 	STOP_PROCESSING(SSobj, src)
@@ -78,8 +78,6 @@
 	. = ..()
 	if(loc != oldloc)
 		if(check_light_level(loc))
-			if(!light_step_warning()) //Intercept to see if we should relay the move attempt or not.
-				return FALSE
 			eject_jaunter(TRUE) //If the warning is already given and the cooldown is done, move them and eject them.
 
 /obj/effect/dummy/phased_mob/shadow/phased_check(mob/living/user, direction)
@@ -122,7 +120,7 @@
 		COOLDOWN_START(src, light_step_cooldown, 1 SECONDS)
 		return FALSE
 
-	if(COOLDOWN_FINISHED(src, light_step_cooldown)) //If it's been 1 second since the warning was given, we continue
+	if(!COOLDOWN_FINISHED(src, light_step_cooldown)) //If it's been 1 second since the warning was given, we continue
 		return FALSE
 
 	light_alert_given = FALSE

--- a/code/modules/spells/spell_types/jaunt/shadow_walk.dm
+++ b/code/modules/spells/spell_types/jaunt/shadow_walk.dm
@@ -127,7 +127,7 @@
 		balloon_alert(jaunter, "leaving the shadows...")
 		light_alert_given = TRUE
 		COOLDOWN_START(src, light_step_cooldown, 0.75 SECONDS)
-		addtimer(CALLBACK(src, PROC_REF(reactivate_light_alert)), 1.25 SECONDS) //You get a .5 second window to bypass the warning before it comes back
+		addtimer(CALLBACK(src, PROC_REF(reactivate_light_alert)), 1 SECONDS) //You get a .5 second window to bypass the warning before it comes back
 		return FALSE
 
 	if(!COOLDOWN_FINISHED(src, light_step_cooldown))


### PR DESCRIPTION
## About The Pull Request

When using Shadow Jaunt, if you are about to walk onto a tile that will force you out of your jaunt, you will receive a warning and be held back for a moment. After the delay, you will have a window to continue moving into the light and leave your jaunt. If you need to get out of your jaunt sooner, you can manually exit the shadow jaunt with the action button.

https://user-images.githubusercontent.com/28870487/209010307-f8973e2d-b92d-4d2b-b0a1-3211a6eb034d.mp4

(It's a bit faster than shown in the video, just trust me)

It's not perfect, and with bad timing you might slip out of it anyways, but it's better than nothing. If you are intentionally trying to bypass a wall, you'll have to wait out the delay if you want to come out on the other side of it.

There's a few minor code changes to help facilitate this. check_light_level no longer ejects the jaunter on its own, instead returning true or false based on if the light level is above the acceptable amount. It also now receives a location to check the light level of, rather than strictly checking the location of the jaunt effect.

If this ends up being too clunky or restrictive, I'd be fine with changing the warning to a toggleable option on the Nightmare's HUD.
## Why It's Good For The Game

Shadow jaunt moves you very fast, and is difficult to move precisely in (especially when under the pressure of a tactical retreat). It's not uncommon for Nightmares to accidentally fling themselves past a wall in maintenance and be exposed in an unfavorable location. 

There are already so many ways for a Nightmare to be screwed over. Accidentally walking through a wall and dying is probably one of the lamest.
## Changelog
:cl: Rhials
qol: Shadow Jaunter users now receive a brief warning before walking into light and being forcibly un-jaunted.
/:cl:
