### PR TITLE
Fix briefcase in the MetaStation vault being useless and not having the surprisingly-extremely-good contents its supposed to

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10217,9 +10217,7 @@
 /area/station/security/office)
 "dOo" = (
 /obj/structure/safe,
-/obj/item/storage/secure/briefcase{
-	contents = newlist(/obj/item/clothing/suit/armor/vest,/obj/item/gun/ballistic/automatic/pistol,/obj/item/suppressor,/obj/item/melee/baton/telescopic,/obj/item/clothing/mask/balaclava,/obj/item/bodybag,/obj/item/soap/nanotrasen)
-	},
+/obj/item/storage/secure/briefcase/riches,
 /obj/item/storage/backpack/duffelbag/syndie/hitman,
 /obj/item/card/id/advanced/silver/reaper,
 /obj/item/lazarus_injector,

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -72,16 +72,3 @@
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 	new /obj/item/suppressor/specialoffer(src)
-
-/// A briefcase that contains various sought-after spoils
-/obj/item/storage/briefcase/riches
-
-/obj/item/storage/briefcase/riches/PopulateContents()
-	..()
-	new /obj/item/clothing/suit/armor/vest(src)
-	new /obj/item/gun/ballistic/automatic/pistol(src)
-	new /obj/item/suppressor(src)
-	new /obj/item/melee/baton/telescopic(src)
-	new /obj/item/clothing/mask/balaclava(src)
-	new /obj/item/bodybag(src)
-	new /obj/item/soap/nanotrasen(src)

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -72,3 +72,16 @@
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
 	new /obj/item/suppressor/specialoffer(src)
+
+/// A briefcase that contains various sought-after spoils
+/obj/item/storage/briefcase/riches
+
+/obj/item/storage/briefcase/riches/PopulateContents()
+	..()
+	new /obj/item/clothing/suit/armor/vest(src)
+	new /obj/item/gun/ballistic/automatic/pistol(src)
+	new /obj/item/suppressor(src)
+	new /obj/item/melee/baton/telescopic(src)
+	new /obj/item/clothing/mask/balaclava(src)
+	new /obj/item/bodybag(src)
+	new /obj/item/soap/nanotrasen(src)

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -153,6 +153,19 @@
 	for(var/iterator in 1 to 5)
 		new /obj/item/stack/spacecash/c1000(src)
 
+/// A briefcase that contains various sought-after spoils
+/obj/item/storage/secure/briefcase/riches
+
+/obj/item/storage/secure/briefcase/riches/PopulateContents()
+	..()
+	new /obj/item/clothing/suit/armor/vest(src)
+	new /obj/item/gun/ballistic/automatic/pistol(src)
+	new /obj/item/suppressor(src)
+	new /obj/item/melee/baton/telescopic(src)
+	new /obj/item/clothing/mask/balaclava(src)
+	new /obj/item/bodybag(src)
+	new /obj/item/soap/nanotrasen(src)
+
 ///Secure Safe
 /obj/item/storage/secure/safe
 	name = "secure safe"

--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -157,7 +157,6 @@
 /obj/item/storage/secure/briefcase/riches
 
 /obj/item/storage/secure/briefcase/riches/PopulateContents()
-	..()
 	new /obj/item/clothing/suit/armor/vest(src)
 	new /obj/item/gun/ballistic/automatic/pistol(src)
 	new /obj/item/suppressor(src)


### PR DESCRIPTION

## About The Pull Request
This was using `newlist`, which is both not supported but unfortunately also not linted for. This is the only case like it in maps.

Pretty surprisingly good contents, like a gun and a telescopic baton. I hope it doesn't turn into something like the captain's antique because that is cringe but at least the QM has no reason to take the baton now

## Changelog
:cl:
fix: The briefcase in the MetaStation vault now contains the (surprisingly good) spoils it's supposed to.
/:cl:
