### PR TITLE
allows admins to select pirate events

### DIFF
--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -16,12 +16,12 @@
 	for(var/datum/pirate_gang/possible_gang as anything in GLOB.pirate_gangs)
 		gang_choices[possible_gang.name] = possible_gang
 
-	var/datum/pirate_gang/chosen = tgui_input_list(usr, "Select pirate gang", "TICKETS TO THE SPONGEBOB MOVIE!!", gang_choices)
+	var/chosen = tgui_input_list(usr, "Select pirate gang", "TICKETS TO THE SPONGEBOB MOVIE!!", gang_choices)
 	if(!chosen)
 		return ADMIN_CANCEL_EVENT
 	if(chosen == "Random")
 		return //still do the event, but chosen_gang is still null, so it will pick from the choices
-	chosen_gang = gang_choices["chosen"]
+	chosen_gang = gang_choices["[chosen]"]
 
 /datum/round_event_control/pirates/preRunEvent()
 	if (!SSmapping.empty_space)

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -21,7 +21,7 @@
 		return ADMIN_CANCEL_EVENT
 	if(chosen == "Random")
 		return //still do the event, but chosen_gang is still null, so it will pick from the choices
-	chosen_gang = gang_choices["[chosen]"]
+	chosen_gang = gang_choices[chosen]
 
 /datum/round_event_control/pirates/preRunEvent()
 	if (!SSmapping.empty_space)


### PR DESCRIPTION
## About The Pull Request

i was messing with pirate gangs for a downstream and on testing found a small error in #71650 that meant that when admins selected pirate gangs, they just selected "chosen" instead of their pirate gang

also the chosen variable was extended from datum/pirate_gang instead of just being a variable, so i changed that too

## Why It's Good For The Game

admins should be able to spawn in specific pirates to harass the crew if they want instead of picking skeletons and getting silverscales

## Changelog

:cl:
fix: admins can now select pirate events correctly

/:cl:
