### PR TITLE
Fixes racks not crafting properly and deleting themselves

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -864,7 +864,7 @@
 	if(do_after(user, 50, target = user, progress=TRUE))
 		if(!user.temporarilyRemoveItemFromInventory(src))
 			return
-		var/obj/structure/rack/R = new /obj/structure/rack(loc)
+		var/obj/structure/rack/R = new /obj/structure/rack(get_turf(src))
 		user.visible_message("<span class='notice'>[user] assembles \a [R].\
 			</span>", span_notice("You assemble \a [R]."))
 		R.add_fingerprint(user)


### PR DESCRIPTION

## About The Pull Request

Rack parts now use get_turf instead of loc when being constructed from your hands. Loc would be the user rather than a valid location, and the rack parts would be consumed, meaning you lose your rack parts and get no rack. Loc is used in a few other places in the racks/tables file, but they all appear to be working fine other than this one instance.
## Why It's Good For The Game

We've gotta keep our stuff organized somehow, right?

Closes #72155
## Changelog
:cl: Rhials
fix: Racks now properly construct again
/:cl:
