### PR TITLE
Fixes Tinacusiate being impossible to make

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -64,9 +64,9 @@
 	overheat_temp = 500
 	optimal_ph_min = 5
 	optimal_ph_max = 10
-	determin_ph_range = 10
+	determin_ph_range = 4
 	temp_exponent_factor = 0.35
-	ph_exponent_factor = 0.5
+	ph_exponent_factor = 1
 	thermic_constant = 20
 	H_ion_release = 1.5
 	rate_up_lim = 3


### PR DESCRIPTION

## About The Pull Request
Since failchems were removed, tinacusiate has been impossible to make. While it's also the inverse of inacusiate, the values that determine chem purity that inacusiate has makes it practically impossible to push the purity much below the low 40s, let alone below 30% to make tinacusiate. This changes those values slightly so it's possible to make when purposefully doing so, but hard to get on accident.

## Why It's Good For The Game
Makes a chem that's basically a goof actually possible to synthesise.

## Changelog

:cl:
fix: Tinacusiate is now possible to make again.
/:cl:


