### PR TITLE
Fixes turfs on centcom getting weird atmos adjacent turfs.

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -534,7 +534,9 @@ SUBSYSTEM_DEF(air)
 		active.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, COLOR_VIBRANT_LIME)
 	#endif
 	active_turfs.Cut()
-	var/time = 0
+	// We compare this against turf.current cycle using <= to ensure O(n)
+	// It defaults to 0, so we start at -1
+	var/time = -1
 
 	for(var/turf/T as anything in ALL_TURFS())
 		if (!T.init_air)


### PR DESCRIPTION

## About The Pull Request

We compare the current_cycle var against time using <= But current_cycle defaults to 0, so when we compare with a 0, it breaks

Let's just start with -1 yeah?

Fixes #72170

This is an old bug, I got bullied about it and then just... forgot because my head is empty. Fixed now.