### PR TITLE
Pacifists can attack people with non-lethal weapons

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -182,7 +182,7 @@
 	if(item_flags & NOBLUDGEON)
 		return
 
-	if(force && HAS_TRAIT(user, TRAIT_PACIFISM))
+	if(damtype != STAMINA && force && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("You don't want to harm other living beings!"))
 		return
 

--- a/code/datums/martial/_martial.dm
+++ b/code/datums/martial/_martial.dm
@@ -13,6 +13,8 @@
 	var/display_combos = FALSE //shows combo meter if true
 	var/combo_timer = 6 SECONDS // period of time after which the combo streak is reset.
 	var/timerid
+	/// If set to true this style allows you to punch people despite being a pacifist (for instance Boxing, which does no damage)
+	var/pacifist_style = FALSE
 
 /datum/martial_art/proc/help_act(mob/living/A, mob/living/D)
 	return MARTIAL_ATTACK_INVALID

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -1,6 +1,7 @@
 /datum/martial_art/boxing
 	name = "Boxing"
 	id = MARTIALART_BOXING
+	pacifist_style = TRUE
 
 /datum/martial_art/boxing/disarm_act(mob/living/A, mob/living/D)
 	to_chat(A, span_warning("Can't disarm while boxing!"))

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1092,7 +1092,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 ///This proc handles punching damage. IMPORTANT: Our owner is the TARGET and not the USER in this proc. For whatever reason...
 /datum/species/proc/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
-	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) && !attacker_style?.pacifist_style)
 		to_chat(user, span_warning("You don't want to harm [target]!"))
 		return FALSE
 	if(target.check_block())


### PR DESCRIPTION
## About The Pull Request

Fixes #72054 
Allows pacifists to hit people with weapons which only do stamina damage.
Additionally, allows pacifists to participate in boxing which also only does stamina damage.
Is it pacifism to hit someone square in the face while wearing boxing gloves? I say, maybe.

## Why It's Good For The Game

Pacifists were feeling left out after not being invited to your pillow fights.
More seriously, they can use _guns_ which only do stamina damage so it makes sense that they can use melee implements too.
Boxing is fun.

## Changelog

:cl:
fix: Pacifists can now hit people with pillows and holographic weapons, as well as participate in boxing.
/:cl:
