### PR TITLE
Fixes some bad AddElements, Fixes incompatible element runtime error text

### DIFF
--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -52,11 +52,10 @@
 /datum/proc/_AddElement(list/arguments)
 	if(QDELING(src))
 		CRASH("We just tried to add an element to a qdeleted datum, something is fucked")
-	var/element_type = arguments[1]
 	var/datum/element/ele = SSdcs.GetElement(arguments)
 	arguments[1] = src
 	if(ele.Attach(arglist(arguments)) == ELEMENT_INCOMPATIBLE)
-		CRASH("Incompatible element [element_type] was assigned to a [type]! args: [json_encode(args)]")
+		CRASH("Incompatible element [ele.type] was assigned to a [type]! args: [json_encode(args)]")
 
 /**
  * Finds the singleton for the element type given and detaches it from src

--- a/code/datums/elements/_element.dm
+++ b/code/datums/elements/_element.dm
@@ -9,7 +9,7 @@
 	var/element_flags = NONE
 	/**
 	  * The index of the first attach argument to consider for duplicate elements
-	  * 
+	  *
 	  * All arguments from this index onwards (1 based) are hashed into the key to determine
 	  * if this is a new unique element or one already exists
 	  *
@@ -52,10 +52,11 @@
 /datum/proc/_AddElement(list/arguments)
 	if(QDELING(src))
 		CRASH("We just tried to add an element to a qdeleted datum, something is fucked")
+	var/element_type = arguments[1]
 	var/datum/element/ele = SSdcs.GetElement(arguments)
 	arguments[1] = src
 	if(ele.Attach(arglist(arguments)) == ELEMENT_INCOMPATIBLE)
-		CRASH("Incompatible [arguments[1]] assigned to a [type]! args: [json_encode(args)]")
+		CRASH("Incompatible element [element_type] was assigned to a [type]! args: [json_encode(args)]")
 
 /**
  * Finds the singleton for the element type given and detaches it from src

--- a/code/datums/elements/falling_hazard.dm
+++ b/code/datums/elements/falling_hazard.dm
@@ -74,7 +74,8 @@
 	if(!crushes_people)
 		return
 
-	poor_target.AddElement(/datum/element/squish, 30 SECONDS)
+	if(iscarbon(poor_target))
+		poor_target.AddElement(/datum/element/squish, 30 SECONDS)
 	poor_target.Paralyze(0.5 SECONDS * fall_damage) // For a piano, that would be 30 seconds
 
 	add_memory_in_range(poor_target, 7, MEMORY_VENDING_CRUSHED, list(DETAIL_PROTAGONIST = poor_target, DETAIL_WHAT_BY = src), story_value = STORY_VALUE_AMAZING, memory_flags = MEMORY_CHECK_BLINDNESS, protagonist_memory_flags = MEMORY_SKIP_UNCONSCIOUS)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -149,9 +149,9 @@
 		var/obj/item/food_item = new chosen(T)
 		ADD_TRAIT(food_item, TRAIT_FOOD_SILVER, INNATE_TRAIT)
 		if(prob(5))//Fry it!
-			AddElement(/datum/element/fried_item, rand(15, 60))
+			food_item.AddElement(/datum/element/fried_item, rand(15, 60))
 		if(prob(5))//Grill it!
-			AddElement(/datum/element/grilled_item, rand(30, 100))
+			food_item.AddElement(/datum/element/grilled_item, rand(30, 100))
 		if(prob(50))
 			for(var/j in 1 to rand(1, 3))
 				step(food_item, pick(NORTH,SOUTH,EAST,WEST))


### PR DESCRIPTION
## About The Pull Request

- `/datum/element/squish` cannot be applied to non-carbons, and the falling hazard element works on all livings. 
   - It seems like squish could easily be changed to apply to all livings, but out of scope. 
- `/datum/element/fried_item` and `/datum/element/griled_item` weren't being applied to the new item correctly
   - This one's my bad
- Changes "Incompatible element" `CRASH` to print the element type rather than the mob's name mistakenly 
   - I think this was intended, but always used the wrong arguments, and no one noticed?

## Why It's Good For The Game

Less runtimes, features work as expected, and a more clearer runtime for element errors

## Changelog

:cl: Melbert
fix: Silver foods correctly spawn things grilled and fried 
/:cl:
