### PR TITLE
Areas with power over-draw will now flicker the lights.

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -452,7 +452,7 @@
 	else if(excess < 0)
 		main_status = APC_LOW_POWER
 		for(var/obj/machinery/light/flickering_light in area)
-			breaked_light.flickering = TRUE // We don't need to unset, because it resets back to FALSE every time it flickers in light code
+			flickering_light.flickering = TRUE // We don't need to unset, because it resets back to FALSE every time it flickers in light code
 			CHECK_TICK
 	else
 		main_status = APC_HAS_POWER

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -451,6 +451,9 @@
 		main_status = APC_NO_POWER
 	else if(excess < 0)
 		main_status = APC_LOW_POWER
+		for(var/obj/machinery/light/flickering_light in area)
+			breaked_light.flickering = TRUE // We don't need to unset, because it resets back to FALSE every time it flickers in light code
+			CHECK_TICK
 	else
 		main_status = APC_HAS_POWER
 


### PR DESCRIPTION
## About The Pull Request

Areas with power over-draw will now flicker the lights.

## Why It's Good For The Game

Provides a realistic visual indicator to indicate to players when the room they're in is drawing too much power from the grid, along with improving the visuals on power loss.

## Changelog

:cl:
add: Areas with power over-draw will now flicker the lights.
/:cl: