### PR TITLE
Dead people are no longer counted as crew when determining if 65% of the station is revs for the auto-shuttle call

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -510,6 +510,8 @@
 	for (var/datum/mind/crewmember as anything in get_crewmember_minds())
 		if (crewmember.has_antag_datum(/datum/antagonist/enemy_of_the_revolution))
 			continue
+		if(crewmember.current && (isobserver(crewmember.current) || crewmember.current.stat == DEAD)) // if we have 60 dead nonrev crew, 2 alive crew, and 10 alive revs, it should qualify for the shuttle
+			continue
 
 		total_candidates += 1
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -510,7 +510,7 @@
 	for (var/datum/mind/crewmember as anything in get_crewmember_minds())
 		if (crewmember.has_antag_datum(/datum/antagonist/enemy_of_the_revolution))
 			continue
-		if(crewmember.current && (isobserver(crewmember.current) || crewmember.current.stat == DEAD)) // if we have 60 dead nonrev crew, 2 alive crew, and 10 alive revs, it should qualify for the shuttle
+		if(crewmember.current?.stat == DEAD) // if we have 60 dead nonrev crew, 2 alive crew, and 10 alive revs, it should qualify for the shuttle
 			continue
 
 		total_candidates += 1


### PR DESCRIPTION
## About The Pull Request

Dead people are no longer counted as crew when determining if 65% of the station is revs for the auto-shuttle call

## Why It's Good For The Game

Bugfix for the feature, admins were noticing the auto-call is never occuring and this is because the logic doesn't actually check alive crewmembers, it's only looking at the total crew count, dead and alive

a station with 60 dead non-rev crew, 10 alive revs, and 2 alive non-revs previously would not call the shuttle, but now it will

## Changelog

:cl:
fix: Dead people are no longer counted as crew when determining if 65% of the station is revs for the auto-shuttle call
/:cl:
