### PR TITLE
Make barstool on Emergency Bar buckleable

### DIFF
--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -213,7 +213,10 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "aN" = (
-/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/chair/stool/bar/directional/north{
+	can_buckle = 1;
+	name = "buckleable bar stool"
+	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1


### PR DESCRIPTION

## About Why It's Good For The Game The Pull Request
Fixes #71971

## Changelog
:cl: Tattle
fix: all of the barstools on the Emergency escape shuttle are equipped with a seatbelt
/:cl:
