### PR TITLE
Temporary antagonist disable pref

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -233,6 +233,10 @@
 			candidates.Remove(candidate_player)
 			continue
 
+		if (candidate_client.prefs.special_disable)
+			candidates.Remove(candidate_player)
+			continue
+
 		if (is_banned_from(candidate_player.ckey, list(antag_flag_override || antag_flag, ROLE_SYNDICATE)))
 			candidates.Remove(candidate_player)
 			continue

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -17,7 +17,7 @@
 		else if (!((antag_preference || antag_flag) in P.client.prefs.be_special) || is_banned_from(P.ckey, list(antag_flag_override || antag_flag, ROLE_SYNDICATE)))
 			candidates.Remove(P)
 		else if (P.client.prefs.special_disable)
-			candidates.Remove(p)
+			candidates.Remove(P)
 
 /datum/dynamic_ruleset/latejoin/ready(forced = 0)
 	if (forced)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -16,6 +16,8 @@
 			candidates.Remove(P)
 		else if (!((antag_preference || antag_flag) in P.client.prefs.be_special) || is_banned_from(P.ckey, list(antag_flag_override || antag_flag, ROLE_SYNDICATE)))
 			candidates.Remove(P)
+		else if (P.client.prefs.special_disable)
+			candidates.Remove(p)
 
 /datum/dynamic_ruleset/latejoin/ready(forced = 0)
 	if (forced)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -68,6 +68,9 @@
 		if (is_banned_from(M.ckey, list(antag_flag_override || antag_flag, ROLE_SYNDICATE)))
 			trimmed_list.Remove(M)
 			continue
+		if (M.client.prefs.special_disable)
+			trimmed_list.Remove(M)
+			continue
 		if (M.mind)
 			if (restrict_ghost_roles && (M.mind.assigned_role.title in GLOB.exp_specialmap[EXP_TYPE_SPECIAL])) // Are they playing a ghost role?
 				trimmed_list.Remove(M)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -333,11 +333,19 @@ GLOBAL_LIST_EMPTY(antagonists)
 	return ""
 
 /datum/antagonist/proc/enabled_in_preferences(datum/mind/M)
+	if(!M.current)
+		return
+	if(!M.current.client)
+		return
+
 	if(job_rank)
-		if(M.current && M.current.client && (job_rank in M.current.client.prefs.be_special))
-			return TRUE
-		else
+		if(M.current.client.prefs.special_disable)
 			return FALSE
+
+		if(job_rank in M.current.client.prefs.be_special)
+			return TRUE
+		return FALSE
+
 	return TRUE
 
 /// List of ["Command"] = CALLBACK(), user will be appeneded to callback arguments on execution

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -367,6 +367,8 @@
 			var/list/datum/mind/promotable = list()
 			var/list/datum/mind/nonhuman_promotable = list()
 			for(var/datum/mind/khrushchev in non_heads)
+				if(khrushchev.current.client.prefs.special_disable)
+					continue
 				if(khrushchev.current && !khrushchev.current.incapacitated() && !HAS_TRAIT(khrushchev.current, TRAIT_RESTRAINED) && khrushchev.current.client)
 					if((ROLE_REV_HEAD in khrushchev.current.client.prefs.be_special) || (ROLE_PROVOCATEUR in khrushchev.current.client.prefs.be_special))
 						if(ishuman(khrushchev.current))

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -17,6 +17,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//Antag preferences
 	var/list/be_special = list() //Special role selection
+	/// Global disable for all antags
+	var/special_disable = FALSE
 
 	/// Custom keybindings. Map of keybind names to keyboard inputs.
 	/// For example, by default would have "swap_hands" -> list("X")

--- a/code/modules/client/preferences/middleware/antags.dm
+++ b/code/modules/client/preferences/middleware/antags.dm
@@ -16,7 +16,7 @@
 		selected_antags += serialize_antag_name(antag)
 
 	data["selected_antags"] = selected_antags
-	data["special_disable"] = special_disable
+	data["special_disable"] = preferences.special_disable
 
 	var/list/antag_bans = get_antag_bans()
 	if (antag_bans.len)

--- a/code/modules/client/preferences/middleware/antags.dm
+++ b/code/modules/client/preferences/middleware/antags.dm
@@ -1,6 +1,7 @@
 /datum/preference_middleware/antags
 	action_delegations = list(
 		"set_antags" = PROC_REF(set_antags),
+		"set_disable" = PROC_REF(set_disable)
 	)
 
 /datum/preference_middleware/antags/get_ui_static_data(mob/user)
@@ -15,6 +16,7 @@
 		selected_antags += serialize_antag_name(antag)
 
 	data["selected_antags"] = selected_antags
+	data["special_disable"] = special_disable
 
 	var/list/antag_bans = get_antag_bans()
 	if (antag_bans.len)
@@ -55,6 +57,10 @@
 
 	// This is predicted on the client
 	return FALSE
+
+/datum/preference_middleware/antags/proc/set_disable(list/params)
+	var/enable = params["enable"]
+	preferences.special_disable = !!enable
 
 /datum/preference_middleware/antags/proc/get_antag_bans()
 	var/list/antag_bans = list()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -170,6 +170,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//general preferences
 	lastchangelog = savefile.get_entry("lastchangelog")
 	be_special = savefile.get_entry("be_special")
+	special_disable = savefile.get_entry("special_disable", FALSE)
 	default_slot = savefile.get_entry("default_slot")
 	chat_toggles = savefile.get_entry("chat_toggles")
 	toggles = savefile.get_entry("toggles")
@@ -208,6 +209,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	default_slot = sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
 	toggles = sanitize_integer(toggles, 0, (2**24)-1, initial(toggles))
 	be_special = sanitize_be_special(SANITIZE_LIST(be_special))
+	special_disable = !!special_disable
 	key_bindings = sanitize_keybindings(key_bindings)
 	favorite_outfits = SANITIZE_LIST(favorite_outfits)
 
@@ -251,6 +253,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	savefile.set_entry("lastchangelog", lastchangelog)
 	savefile.set_entry("be_special", be_special)
+	savefile.set_entry("special_disable", special_disable)
 	savefile.set_entry("default_slot", default_slot)
 	savefile.set_entry("toggles", toggles)
 	savefile.set_entry("chat_toggles", chat_toggles)

--- a/code/modules/events/creep_awakening.dm
+++ b/code/modules/events/creep_awakening.dm
@@ -13,6 +13,8 @@
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
 		if(!H.client || !(ROLE_OBSESSED in H.client.prefs.be_special))
 			continue
+		if(H.client.prefs.special_disable)
+			continue
 		if(H.stat == DEAD)
 			continue
 		if(!(H.mind.assigned_role.job_flags & JOB_CREW_MEMBER)) //only station jobs sans nonhuman roles, prevents ashwalkers trying to stalk with crewmembers they never met

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -275,7 +275,7 @@
 		return TRUE
 	// If they have antags enabled, they're potentially doing this on purpose instead of by accident. Notify admins if so.
 	var/has_antags = FALSE
-	if(client.prefs.be_special.len > 0)
+	if(client.prefs.be_special.len > 0 && !client.special_disable)
 		has_antags = TRUE
 	if(client.prefs.job_preferences.len == 0)
 		if(!ineligible_for_roles)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -275,7 +275,7 @@
 		return TRUE
 	// If they have antags enabled, they're potentially doing this on purpose instead of by accident. Notify admins if so.
 	var/has_antags = FALSE
-	if(client.prefs.be_special.len > 0 && !client.special_disable)
+	if(client.prefs.be_special.len > 0 && !client.prefs.special_disable)
 		has_antags = TRUE
 	if(client.prefs.job_preferences.len == 0)
 		if(!ineligible_for_roles)

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/AntagsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/AntagsPage.tsx
@@ -1,7 +1,15 @@
 import { binaryInsertWith } from 'common/collections';
 import { classes } from 'common/react';
 import { useBackend, useLocalState } from '../../backend';
-import { Box, Button, Divider, Flex, Section, Stack, Tooltip } from '../../components';
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  Section,
+  Stack,
+  Tooltip,
+} from '../../components';
 import { Antagonist, Category } from './antagonists/base';
 import { PreferencesMenuData } from './data';
 
@@ -94,6 +102,21 @@ const AntagSelection = (
           <Button color="bad" onClick={() => disableAntags(antagonistKeys)}>
             Disable All
           </Button>
+
+          {data.special_disable ? (
+            <Button
+              color="bad"
+              onclick={() => act('set_disable', { enable: true })}>
+              Re-enable antagonist functions
+            </Button>
+          ) : (
+            <Button
+              color="good"
+              onClick={() => act('set_disable', { enable: false })}>
+              Temporarily disable all antagonists
+            </Button>
+          )}
+          <Button color=""></Button>
         </>
       }>
       <Flex className={className} align="flex-end" wrap>
@@ -112,8 +135,8 @@ const AntagSelection = (
                   isBanned || daysLeft > 0
                     ? 'banned'
                     : predictedState.has(antagonist.key)
-                      ? 'on'
-                      : 'off'
+                    ? 'on'
+                    : 'off'
                 }`,
               ])}
               key={antagonist.key}>
@@ -134,15 +157,16 @@ const AntagSelection = (
                       isBanned
                         ? `You are banned from ${antagonist.name}.`
                         : antagonist.description.map((text, index) => {
-                          return (
-                            <div key={antagonist.key + index}>
-                              {text}
-                              {index !== antagonist.description.length - 1 && (
-                                <Divider />
-                              )}
-                            </div>
-                          );
-                        })
+                            return (
+                              <div key={antagonist.key + index}>
+                                {text}
+                                {index !==
+                                  antagonist.description.length - 1 && (
+                                  <Divider />
+                                )}
+                              </div>
+                            );
+                          })
                     }
                     position="bottom">
                     <Box

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/AntagsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/AntagsPage.tsx
@@ -116,7 +116,6 @@ const AntagSelection = (
               Temporarily disable all antagonists
             </Button>
           )}
-          <Button color=""></Button>
         </>
       }>
       <Flex className={className} align="flex-end" wrap>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -165,6 +165,7 @@ export type PreferencesMenuData = {
   antag_bans?: string[];
   antag_days_left?: Record<string, number>;
   selected_antags: string[];
+  special_disable: BooleanLike;
 
   active_slot: number;
   name_to_use: string;


### PR DESCRIPTION

## About The Pull Request
Adds a pref that temporarily disables all antagonist checks without modifying your underlying antagonist prefs 
## Why It's Good For The Game
Sometimes I don't want to be an antag, but if i go and hit disable all i have to remember which antags I like playing and go through to toggle each one manually. It takes way too much time when all I want is to guarenteed be a normal crewmember for a round or two.
## Changelog
:cl:
qol: added a global antag switch that doesnt modify your antag preferences
/:cl:
