### PR TITLE
Allows you to place plating adjacent to already existing plating (and some code improvement)

### DIFF
--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -14,34 +14,33 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		qdel(thing, force=TRUE)
 
 	if(turf_type)
-		var/turf/newT = ChangeTurf(turf_type, baseturf_type, flags)
-		SSair.remove_from_active(newT)
-		CALCULATE_ADJACENT_TURFS(newT, KILL_EXCITED)
+		var/turf/new_turf = ChangeTurf(turf_type, baseturf_type, flags)
+		SSair.remove_from_active(new_turf)
+		CALCULATE_ADJACENT_TURFS(new_turf, KILL_EXCITED)
 
-/turf/proc/copyTurf(turf/T)
-	if(T.type != type)
-		T.ChangeTurf(type)
-	if(T.icon_state != icon_state)
-		T.icon_state = icon_state
-	if(T.icon != icon)
-		T.icon = icon
+/turf/proc/copyTurf(turf/copy_to_turf)
+	if(copy_to_turf.type != type)
+		copy_to_turf.ChangeTurf(type)
+	if(copy_to_turf.icon_state != icon_state)
+		copy_to_turf.icon_state = icon_state
+	if(copy_to_turf.icon != icon)
+		copy_to_turf.icon = icon
 	if(color)
-		T.atom_colours = atom_colours.Copy()
-		T.update_atom_colour()
-	if(T.dir != dir)
-		T.setDir(dir)
-	return T
+		copy_to_turf.atom_colours = atom_colours.Copy()
+		copy_to_turf.update_atom_colour()
+	if(copy_to_turf.dir != dir)
+		copy_to_turf.setDir(dir)
+	return copy_to_turf
 
-/turf/open/copyTurf(turf/T, copy_air = FALSE)
+/turf/open/copyTurf(turf/open/copy_to_turf, copy_air = FALSE)
 	. = ..()
-	if (isopenturf(T))
+	if (isopenturf(copy_to_turf))
 		var/datum/component/wet_floor/slip = GetComponent(/datum/component/wet_floor)
 		if(slip)
-			var/datum/component/wet_floor/WF = T.AddComponent(/datum/component/wet_floor)
-			WF.InheritComponent(slip)
+			var/datum/component/wet_floor/new_wet_floor_component = copy_to_turf.AddComponent(/datum/component/wet_floor)
+			new_wet_floor_component.InheritComponent(slip)
 		if (copy_air)
-			var/turf/open/openTurf = T
-			openTurf.air.copy_from(air)
+			copy_to_turf.air.copy_from(air)
 
 //wrapper for ChangeTurf()s that you want to prevent/affect without overriding ChangeTurf() itself
 /turf/proc/TerraformTurf(path, new_baseturf, flags)
@@ -168,17 +167,17 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		. = ..() //If path == type this will return us, don't bank on making a new type
 		if (!.) // changeturf failed or didn't do anything
 			return
-		var/turf/open/newTurf = .
-		newTurf.air.copy_from(stashed_air)
-		newTurf.excited = stashed_state
-		newTurf.excited_group = stashed_group
+		var/turf/open/new_turf = .
+		new_turf.air.copy_from(stashed_air)
+		new_turf.excited = stashed_state
+		new_turf.excited_group = stashed_group
 		#ifdef VISUALIZE_ACTIVE_TURFS
 		if(stashed_state)
-			newTurf.add_atom_colour(COLOR_VIBRANT_LIME, TEMPORARY_COLOUR_PRIORITY)
+			new_turf.add_atom_colour(COLOR_VIBRANT_LIME, TEMPORARY_COLOUR_PRIORITY)
 		#endif
 		if(stashed_group)
 			if(stashed_group.should_display || SSair.display_all_groups)
-				stashed_group.display_turf(newTurf)
+				stashed_group.display_turf(new_turf)
 	else
 		SSair.remove_from_active(src) //Clean up wall excitement, and refresh excited groups
 		if(ispath(path,/turf/closed) || ispath(path,/turf/cordon))
@@ -239,7 +238,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		new_baseturfs = list(new_baseturfs)
 	flags = turf_area.PlaceOnTopReact(new_baseturfs, fake_turf_type, flags) // A hook so areas can modify the incoming args
 
-	var/turf/newT
+	var/turf/new_turf
 	if(flags & CHANGETURF_SKIP) // We haven't been initialized
 		if(flags_1 & INITIALIZED_1)
 			stack_trace("CHANGETURF_SKIP was used in a PlaceOnTop call for a turf that's initialized. This is a mistake. [src]([type])")
@@ -251,13 +250,13 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			var/list/old_baseturfs = baseturfs.Copy()
 			if(!isclosedturf(src))
 				old_baseturfs += type
-			newT = ChangeTurf(fake_turf_type, null, flags)
-			newT.assemble_baseturfs(initial(fake_turf_type.baseturfs)) // The baseturfs list is created like roundstart
-			if(!length(newT.baseturfs))
-				newT.baseturfs = list(baseturfs)
+			new_turf = ChangeTurf(fake_turf_type, null, flags)
+			new_turf.assemble_baseturfs(initial(fake_turf_type.baseturfs)) // The baseturfs list is created like roundstart
+			if(!length(new_turf.baseturfs))
+				new_turf.baseturfs = list(baseturfs)
 			// The old baseturfs are put underneath, and we sort out the unwanted ones
-			newT.baseturfs = baseturfs_string_list(old_baseturfs + (newT.baseturfs - GLOB.blacklisted_automated_baseturfs), newT)
-			return newT
+			new_turf.baseturfs = baseturfs_string_list(old_baseturfs + (new_turf.baseturfs - GLOB.blacklisted_automated_baseturfs), new_turf)
+			return new_turf
 		if(!length(baseturfs))
 			baseturfs = list(baseturfs)
 		if(!isclosedturf(src))
@@ -297,9 +296,9 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			target_baseturfs -= new_baseturfs & GLOB.blacklisted_automated_baseturfs
 			new_baseturfs += target_baseturfs
 
-	var/turf/newT = copytarget.copyTurf(src, copy_air)
-	newT.baseturfs = baseturfs_string_list(new_baseturfs, newT)
-	return newT
+	var/turf/new_turf = copytarget.copyTurf(src, copy_air)
+	new_turf.baseturfs = baseturfs_string_list(new_baseturfs, new_turf)
+	return new_turf
 
 
 //If you modify this function, ensure it works correctly with lateloaded map templates.
@@ -313,9 +312,8 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		CALCULATE_ADJACENT_TURFS(src, (!(ispath(oldType, /turf/closed) && isopenturf(src)) ? NORMAL_TURF : MAKE_ACTIVE))
 	//update firedoor adjacency
 	var/list/turfs_to_check = get_adjacent_open_turfs(src) | src
-	for(var/I in turfs_to_check)
-		var/turf/T = I
-		for(var/obj/machinery/door/firedoor/FD in T)
+	for(var/turf/check_turf in turfs_to_check)
+		for(var/obj/machinery/door/firedoor/FD in check_turf)
 			FD.CalculateAffectingAreas()
 
 	HandleTurfChange(src)
@@ -340,10 +338,9 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	var/energy = 0
 	var/heat_cap = 0
 
-	for(var/t in turf_list)
-		var/turf/open/T = t
+	for(var/turf/open/turf in turf_list)
 		//Cache?
-		var/datum/gas_mixture/turf/mix = T.air
+		var/datum/gas_mixture/turf/mix = turf.air
 		//"borrowing" this code from merge(), I need to play with the temp portion. Lets expand it out
 		//temperature = (giver.temperature * giver_heat_capacity + temperature * self_heat_capacity) / combined_heat_capacity
 		var/capacity = mix.heat_capacity()
@@ -359,11 +356,10 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	for(var/id in total_gases)
 		total_gases[id][MOLES] /= turflen
 
-	for(var/t in turf_list)
-		var/turf/open/T = t
-		T.air.copy_from(total)
-		T.update_visuals()
-		SSair.add_to_active(T)
+	for(var/turf/open/turf in turf_list)
+		turf.air.copy_from(total)
+		turf.update_visuals()
+		SSair.add_to_active(turf)
 
 /turf/proc/AttemptLatticeReplacement(amount = 2)
 	if(lattice_underneath)

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -34,13 +34,13 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 
 /turf/open/copyTurf(turf/open/copy_to_turf, copy_air = FALSE)
 	. = ..()
-	if (isopenturf(copy_to_turf))
-		var/datum/component/wet_floor/slip = GetComponent(/datum/component/wet_floor)
-		if(slip)
-			var/datum/component/wet_floor/new_wet_floor_component = copy_to_turf.AddComponent(/datum/component/wet_floor)
-			new_wet_floor_component.InheritComponent(slip)
-		if (copy_air)
-			copy_to_turf.air.copy_from(air)
+	ASSERT(istype(copy_to_turf, /turf/open))
+	var/datum/component/wet_floor/slip = GetComponent(/datum/component/wet_floor)
+	if(slip)
+		var/datum/component/wet_floor/new_wet_floor_component = copy_to_turf.AddComponent(/datum/component/wet_floor)
+		new_wet_floor_component.InheritComponent(slip)
+	if (copy_air)
+		copy_to_turf.air.copy_from(air)
 
 //wrapper for ChangeTurf()s that you want to prevent/affect without overriding ChangeTurf() itself
 /turf/proc/TerraformTurf(path, new_baseturf, flags)
@@ -361,10 +361,11 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		turf.update_visuals()
 		SSair.add_to_active(turf)
 
-/turf/proc/AttemptLatticeReplacement(amount = 2)
+/// Attempts to replace a tile with lattice. Amount is the amount of tiles to scrape away.
+/turf/proc/attempt_lattice_replacement(amount = 2)
 	if(lattice_underneath)
 		var/turf/new_turf = ScrapeAway(amount, flags = CHANGETURF_INHERIT_AIR)
 		if(!istype(new_turf, /turf/open/floor))
-			new /obj/structure/lattice(locate(x,y,z))
+			new /obj/structure/lattice(src)
 	else
 		ScrapeAway(amount, flags = CHANGETURF_INHERIT_AIR)

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -307,7 +307,6 @@
 		return
 	
 	playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
-	balloon_alert(user, "built a floor")
 	var/turf/open/floor/plating/new_plating = PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 	if(lattice)
 		qdel(lattice)

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -300,14 +300,14 @@
 /turf/open/proc/build_with_floor_tiles(obj/item/stack/tile/iron/used_tiles, user)
 	var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
 	if(!has_valid_support() && !lattice)
-		balloon_alert(user, "The plating is going to need some support! Place metal rods first.")
+		balloon_alert(user, "needs support, place rods")
 		return
 	if(!used_tiles.use(1))
-		balloon_alert(user, "You need one floor tile to build a floor!")
+		balloon_alert(user, "need a floor tile to build")
 		return
 	
 	playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
-	balloon_alert(user, "You build a floor.")
+	balloon_alert(user, "built a floor")
 	var/turf/open/floor/plating/new_plating = PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 	if(lattice)
 		qdel(lattice)

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -298,15 +298,24 @@
 /// Very similar to build_with_rods, this exists to allow consistent behavior between different types in terms of how
 /// Building floors works
 /turf/open/proc/build_with_floor_tiles(obj/item/stack/tile/iron/used_tiles, user)
-	var/obj/structure/lattice/soon_to_be_floor = locate(/obj/structure/lattice, src)
-	if(!soon_to_be_floor)
+	var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
+	if(!has_valid_support() && !lattice)
 		to_chat(user, span_warning("The plating is going to need some support! Place metal rods first."))
 		return
 	if(!used_tiles.use(1))
 		to_chat(user, span_warning("You need one floor tile to build a floor!"))
 		return
-
-	qdel(soon_to_be_floor)
+	
 	playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
 	to_chat(user, span_notice("You build a floor."))
-	PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+	var/turf/open/floor/plating/newplating = PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+	if(lattice)
+		qdel(lattice)
+	else
+		newplating.lattice_underneath = FALSE
+
+/turf/open/proc/has_valid_support()
+	for (var/direction in GLOB.cardinals)
+		if(istype(get_step(src, direction), /turf/open/floor))
+			return TRUE
+	return FALSE

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -300,10 +300,10 @@
 /turf/open/proc/build_with_floor_tiles(obj/item/stack/tile/iron/used_tiles, user)
 	var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
 	if(!has_valid_support() && !lattice)
-		balloon_alert(user, "needs support, place rods")
+		balloon_alert(user, "needs support, place rods!")
 		return
 	if(!used_tiles.use(1))
-		balloon_alert(user, "need a floor tile to build")
+		balloon_alert(user, "need a floor tile to build!")
 		return
 	
 	playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -300,19 +300,19 @@
 /turf/open/proc/build_with_floor_tiles(obj/item/stack/tile/iron/used_tiles, user)
 	var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
 	if(!has_valid_support() && !lattice)
-		to_chat(user, span_warning("The plating is going to need some support! Place metal rods first."))
+		balloon_alert(user, "The plating is going to need some support! Place metal rods first.")
 		return
 	if(!used_tiles.use(1))
-		to_chat(user, span_warning("You need one floor tile to build a floor!"))
+		balloon_alert(user, "You need one floor tile to build a floor!")
 		return
 	
 	playsound(src, 'sound/weapons/genhit.ogg', 50, TRUE)
-	to_chat(user, span_notice("You build a floor."))
-	var/turf/open/floor/plating/newplating = PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+	balloon_alert(user, "You build a floor.")
+	var/turf/open/floor/plating/new_plating = PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 	if(lattice)
 		qdel(lattice)
 	else
-		newplating.lattice_underneath = FALSE
+		new_plating.lattice_underneath = FALSE
 
 /turf/open/proc/has_valid_support()
 	for (var/direction in GLOB.cardinals)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -83,7 +83,7 @@
 			switch(rand(1, 3))
 				if(1)
 					if(!length(baseturfs) || !ispath(baseturfs[baseturfs.len-1], /turf/open/floor))
-						AttemptLatticeReplacement()
+						attempt_lattice_replacement()
 					else
 						ScrapeAway(2, flags = CHANGETURF_INHERIT_AIR)
 					if(prob(33))
@@ -235,7 +235,7 @@
 			if(prob(70))
 				sheer = TRUE
 			else if(prob(50) && (/turf/open/space in baseturfs))
-				AttemptLatticeReplacement()
+				attempt_lattice_replacement()
 	if(sheer)
 		if(has_tile())
 			remove_tile(null, TRUE, TRUE, TRUE)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -83,8 +83,7 @@
 			switch(rand(1, 3))
 				if(1)
 					if(!length(baseturfs) || !ispath(baseturfs[baseturfs.len-1], /turf/open/floor))
-						ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
-						ReplaceWithLattice()
+						AttemptLatticeReplacement()
 					else
 						ScrapeAway(2, flags = CHANGETURF_INHERIT_AIR)
 					if(prob(33))
@@ -236,7 +235,7 @@
 			if(prob(70))
 				sheer = TRUE
 			else if(prob(50) && (/turf/open/space in baseturfs))
-				ReplaceWithLattice()
+				AttemptLatticeReplacement()
 	if(sheer)
 		if(has_tile())
 			remove_tile(null, TRUE, TRUE, TRUE)

--- a/code/game/turfs/open/floor/reinforced_floor.dm
+++ b/code/game/turfs/open/floor/reinforced_floor.dm
@@ -65,7 +65,7 @@
 		if(EXPLODE_DEVASTATE)
 			if(prob(80))
 				if(!length(baseturfs) || !ispath(baseturfs[baseturfs.len-1], /turf/open/floor))
-					AttemptLatticeReplacement()
+					attempt_lattice_replacement()
 				else
 					ScrapeAway(2, flags = CHANGETURF_INHERIT_AIR)
 			else if(prob(50))
@@ -84,7 +84,7 @@
 				new floor_tile(src)
 				make_plating(TRUE)
 		else if(prob(30))
-			AttemptLatticeReplacement()
+			attempt_lattice_replacement()
 
 /turf/open/floor/engine/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)

--- a/code/game/turfs/open/floor/reinforced_floor.dm
+++ b/code/game/turfs/open/floor/reinforced_floor.dm
@@ -65,8 +65,7 @@
 		if(EXPLODE_DEVASTATE)
 			if(prob(80))
 				if(!length(baseturfs) || !ispath(baseturfs[baseturfs.len-1], /turf/open/floor))
-					ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
-					ReplaceWithLattice()
+					AttemptLatticeReplacement()
 				else
 					ScrapeAway(2, flags = CHANGETURF_INHERIT_AIR)
 			else if(prob(50))
@@ -85,7 +84,7 @@
 				new floor_tile(src)
 				make_plating(TRUE)
 		else if(prob(30))
-			ReplaceWithLattice()
+			AttemptLatticeReplacement()
 
 /turf/open/floor/engine/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -212,7 +212,7 @@
 /turf/open/space/rust_heretic_act()
 	return FALSE
 
-/turf/open/space/AttemptLatticeReplacement()
+/turf/open/space/attempt_lattice_replacement()
 	var/dest_x = destination_x
 	var/dest_y = destination_y
 	var/dest_z = destination_z

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -212,7 +212,7 @@
 /turf/open/space/rust_heretic_act()
 	return FALSE
 
-/turf/open/space/ReplaceWithLattice()
+/turf/open/space/AttemptLatticeReplacement()
 	var/dest_x = destination_x
 	var/dest_y = destination_y
 	var/dest_z = destination_z

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	var/overfloor_placed = FALSE
 	/// How accessible underfloor pieces such as wires, pipes, etc are on this turf. Can be HIDDEN, VISIBLE, or INTERACTABLE.
 	var/underfloor_accessibility = UNDERFLOOR_HIDDEN
+	/// If there is a lattice underneat this turf. Used for the attempt_lattice_replacement proc to determine if it should place lattice.
 	var/lattice_underneath = TRUE
 
 	// baseturfs can be either a list or a single turf type.

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -13,6 +13,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	var/overfloor_placed = FALSE
 	/// How accessible underfloor pieces such as wires, pipes, etc are on this turf. Can be HIDDEN, VISIBLE, or INTERACTABLE.
 	var/underfloor_accessibility = UNDERFLOOR_HIDDEN
+	var/lattice_underneath = TRUE
 
 	// baseturfs can be either a list or a single turf type.
 	// In class definition like here it should always be a single type.

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -237,7 +237,7 @@
 				toggle_magnet()
 				mode = BOT_REPAIRING
 				if(isplatingturf(F))
-					F.AttemptLatticeReplacement()
+					F.attempt_lattice_replacement()
 				else
 					F.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 				audible_message(span_danger("[src] makes an excited booping sound."))

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -237,7 +237,7 @@
 				toggle_magnet()
 				mode = BOT_REPAIRING
 				if(isplatingturf(F))
-					F.ReplaceWithLattice()
+					F.AttemptLatticeReplacement()
 				else
 					F.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 				audible_message(span_danger("[src] makes an excited booping sound."))

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -241,6 +241,7 @@ When dealing with security, you can often get your sentence negated entirely thr
 When fighting the Blob, you can hit it with an analyzer to check its chemical effects and the type of blob analyzed. Examining it with a research scanner or medical hud active will also reveal this information.
 When hacking doors, cutting and mending a "test light wire" will restore power to the door.
 When in doubt about technicial issues, clear your cache (byond launcher > cogwheel > preferences > game prefs), update your BYOND, and relog.
+When placing floor tiles in space, you don't need to place down lattice if there is a piece of plating nearby.
 Where the space map levels connect is randomized every round, but are otherwise kept consistent within rounds. Remember that they are not necessarily bidirectional!
 You can catch thrown items by toggling on your throw mode with an empty hand active.
 You can change the control scheme by pressing tab. One is WASD, the other is the arrow keys. Keep in mind that hotkeys are also changed with this.


### PR DESCRIPTION
## About The Pull Request

Allows you to place plating without placing down lattice as long as there's a valid supporting tile nearby (walls, plating, floors, etc.). Also fixes magical letter variables in turf code.

Mothblocks requested this.

https://user-images.githubusercontent.com/65363339/209391286-d2bded8e-1278-481b-9a48-00e9312a6e54.mp4



## Why It's Good For The Game

Reconstruction is tedious and expensive and this aims to make reconstruction less tedious and less expensive.

In order to place down plating currently, you require 0.75 metal minimum. 0.5 metal for the lattice rod underneath, and 0.25 for the floor tile. Adding a polished floor on tile is a full 1 metal per tile. Fixing two 5x5 rooms worth of explosions is a total of 50 metal currently. This effectively cuts the costs in half while making it more convenient to reconstruct. Note that when explosions destroy floor tiles it destroys metal, which is why the cost of reconstruction is important.

## Changelog

:cl:
balance: You can now place plating adjacent to already existing plating without having to place rods first.
/:cl:
