### PR TITLE
Fix cult ghost mark target

### DIFF
--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -288,6 +288,7 @@
 	name = "Blood Mark your Target"
 	desc = "Marks whatever you are orbiting for the entire cult to track."
 	button_icon_state = "cult_mark"
+	check_flags = NONE
 	/// The duration of the mark on the target
 	var/cult_mark_duration = 60 SECONDS
 	/// The cooldown between marks - the ability can be used in between cooldowns, but can't mark (only clear)


### PR DESCRIPTION

## About The Pull Request

Overrides the inherited check flags that included "is conscious" which ghosts aren't.

## Why It's Good For The Game

Fixes: #71786

## Changelog
:cl:
fix: Cult spirt realm ghost marking now works again.
/:cl:
