### PR TITLE
[NO GBP] fixes error in set armor rating

### DIFF
--- a/code/datums/armor/_atom_armor.dm
+++ b/code/datums/armor/_atom_armor.dm
@@ -19,4 +19,4 @@
 /// Helper to update the atom's armor to a new armor with the specified rating
 /atom/proc/set_armor_rating(damage_type, rating)
 	var/datum/armor/armor = get_armor()
-	set_armor(armor.generate_new_with_specific(list(damage_type = rating)))
+	set_armor(armor.generate_new_with_specific(list("[damage_type]" = rating)))


### PR DESCRIPTION
Resolves an issue where set armor rating didnt work because of the way byond handles list declarations