### PR TITLE
Fixes inability to declare war as nukies

### DIFF
--- a/code/datums/components/stationloving.dm
+++ b/code/datums/components/stationloving.dm
@@ -148,6 +148,8 @@
 		return FALSE
 	if (is_station_level(destination_turf.z))
 		return TRUE
+	if(atom_to_check.onSyndieBase())
+		return TRUE
 
 	var/area/destination_area = destination_turf.loc
 	if (is_centcom_level(destination_turf.z))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -444,9 +444,9 @@
 					return TRUE
 
 /**
- * Is the atom in any of the centcom syndicate areas
+ * Is the atom in any of the syndicate areas
  *
- * Either in the syndie base on centcom, or any of their shuttles
+ * Either in the syndie base, or any of their shuttles
  *
  * Also used in gamemode code for win conditions
  */

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -455,7 +455,7 @@
 	if(!current_turf)
 		return FALSE
 
-	if(!is_centcom_level(current_turf.z))//if not, don't bother
+	if(!is_reserved_level(current_turf.z))//if not, don't bother
 		return FALSE
 
 	if(istype(current_turf.loc, /area/shuttle/syndicate) || istype(current_turf.loc, /area/centcom/syndicate_mothership) || istype(current_turf.loc, /area/shuttle/assault_pod))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -988,6 +988,10 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	if(!check_rights(R_ADMIN))
 		return
 
+	if(SSticker.current_state != GAME_STATE_PLAYING)
+		to_chat(usr, span_warning("The game hasnt started yet!"))
+		return
+
 	var/list/choices = LAZY_TEMPLATE_KEY_LIST_ALL()
 	var/choice = tgui_input_list(usr, "Key?", "Lazy Loader", choices)
 	if(!choice)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/syndicate_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/syndicate_nuke.dm
@@ -6,7 +6,7 @@
 		if(DETONATION_HIT_STATION)
 			// And it was detonated by nuke ops
 			if(length(get_antag_minds(/datum/antagonist/nukeop)))
-				if(is_infiltrator_docked_at_centcom())
+				if(is_infiltrator_docked_at_syndiebase())
 					// And the ops escaped, they won!
 					return /datum/cinematic/nuke/ops_victory
 				else

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -503,6 +503,6 @@
 
 	for(var/datum/turf_reservation/loaded_area as anything in nukie_template.reservations)
 		var/infiltrator_turf = get_turf(infiltrator_port)
-		if(infiltrator_port in loaded_area.reserved_turfs)
+		if(infiltrator_turf in loaded_area.reserved_turfs)
 			return TRUE
 	return FALSE

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -361,7 +361,7 @@
 /datum/team/nuclear/proc/get_result()
 	var/shuttle_evacuated = EMERGENCY_ESCAPED_OR_ENDGAMED
 	var/disk_rescued = is_disk_rescued()
-	var/syndies_didnt_escape = !is_infiltrator_docked_at_centcom()
+	var/syndies_didnt_escape = !is_infiltrator_docked_at_syndiebase()
 	var/team_is_dead = are_all_operatives_dead()
 	var/station_was_nuked = GLOB.station_was_nuked
 	var/station_nuke_source = GLOB.station_nuke_source
@@ -494,8 +494,15 @@
 	return common_part + disk_report + challenge_report
 
 /// Returns whether or not syndicate operatives escaped.
-/proc/is_infiltrator_docked_at_centcom()
+/proc/is_infiltrator_docked_at_syndiebase()
 	var/obj/docking_port/mobile/infiltrator/infiltrator_port = SSshuttle.getShuttle("syndicate")
-	var/obj/docking_port/stationary/transit/infiltrator_dock = locate() in infiltrator_port.loc
 
-	return infiltrator_port && (is_centcom_level(infiltrator_port.z) || infiltrator_dock)
+	var/datum/lazy_template/nukie_base/nukie_template = GLOB.lazy_templates[LAZY_TEMPLATE_KEY_NUKIEBASE]
+	if(!nukie_template)
+		return FALSE // if its not even loaded, cant be docked
+
+	for(var/datum/turf_reservation/loaded_area as anything in nukie_template.reservations)
+		var/infiltrator_turf = get_turf(infiltrator_port)
+		if(infiltrator_port in loaded_area.reserved_turfs)
+			return TRUE
+	return FALSE

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -49,7 +49,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(!is_centcom_level(z))
+	if(!is_reserved_level(z))
 		to_chat(user, span_warning("Pods are one way!"))
 		return FALSE
 	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

War item checked for being on the CC zlevel which is no longer where the nukie base is loaded.
Instead it now checks for being in a reserved area, which it will be if loaded in __correctly__

fixes https://github.com/tgstation/tgstation/issues/72214

Also restricts loading lazy templates until the game has fully started, i've noticed that trying to load pregame has a tendency to get stuck in a runtime loop when SSicon_smoothing fires at the same time loading is occurring

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

War Good

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: War can once again be declared
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
