### PR TITLE
Researching now checks your techweb for availability

### DIFF
--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -109,8 +109,6 @@
 				to_chat(usr, span_boldwarning("Unauthorized Access. Please insert research ID card."))
 			return TRUE
 		if ("researchNode")
-			if(!SSresearch.science_tech.available_nodes[params["node_id"]])
-				return TRUE
 			research_node(params["node_id"], usr)
 			return TRUE
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -320,8 +320,6 @@ Nothing else in the console has ID requirements.
 				to_chat(usr, span_boldwarning("Unauthorized Access."))
 			return TRUE
 		if ("researchNode")
-			if(!SSresearch.science_tech.available_nodes[params["node_id"]])
-				return TRUE
 			research_node(params["node_id"], usr)
 			return TRUE
 		if ("ejectDisk")


### PR DESCRIPTION
## About The Pull Request

Currently RD consoles are hardcoded to check the Science techweb for an available node to research it, and your unique techweb (if it exists) is only checked for availability in ``research_node()``.

To fix this, I removed this snowflake check, since we're already checking what we need to, when we need to.

## Why It's Good For The Game

RD consoles now should be working as expected when using different research nodes (actually being able to research things Science hasn't already researched).

## Changelog

:cl:
fix: Researching now checks the techweb it's linked to for node availability, rather than only the Science one.
/:cl: