### PR TITLE
Fixes infinite replicapodspawns

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -204,7 +204,13 @@
 	podman.hardset_dna(null, null, null, podman.real_name, blood_type, new /datum/species/pod, features) // Discard SE's and UI's, podman cloning is inaccurate, and always make them a podman
 	podman.set_cloned_appearance()
 
-	podman.dna.species.exotic_blood = max(reagents_add) || /datum/reagent/water
+	//Get the most plentiful reagent, if there's none: get water
+	var/most_plentiful_reagent = list(/datum/reagent/water = 0)
+	for(var/reagent in reagents_add)
+		if(reagents_add[reagent] > most_plentiful_reagent[most_plentiful_reagent[1]])
+			most_plentiful_reagent = list("[reagent]" = reagents_add[reagent])
+
+	podman.dna.species.exotic_blood = most_plentiful_reagent[1]
 	investigate_log("[key_name(mind)] cloned as a podman via [src] in [parent]", INVESTIGATE_BOTANY)
 	parent.update_tray(user, 1)
 	return result


### PR DESCRIPTION
Max() was being used incorrectly here, it doesn't support assoc lists

This caused the pod to runtime and never go away if there were any reagents and gave infinite respawns

Closes #67182

https://user-images.githubusercontent.com/7501474/209433613-f63d3355-78d8-46be-9fce-9a612a75f4c3.mp4

:cl:
fix: replicapods no longer sometimes have infinite spawns
/:cl:

Also thanks to randomdudefromtherim for reporting this