### PR TITLE
Adds tripping. Watch your step!

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -32,8 +32,9 @@
 /mob/living/carbon/human/Move(NewLoc, direct)
 	var/old_dir = dir
 	. = ..()
-	if(shoes && body_position == STANDING_UP && loc == NewLoc && has_gravity(loc))
-		SEND_SIGNAL(shoes, COMSIG_SHOES_STEP_ACTION)
+	if(body_position == STANDING_UP)
+		if(shoes && loc == NewLoc && has_gravity(loc))
+			SEND_SIGNAL(shoes, COMSIG_SHOES_STEP_ACTION)
 		if(dir != old_dir && prob(1.25))
 			playsound(loc, 'sound/misc/slip.ogg', 50, TRUE, -3)
 			balloon_alert_to_viewers("tripped!")

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -30,9 +30,14 @@
 	return dna.species.negates_gravity(src) || ..()
 
 /mob/living/carbon/human/Move(NewLoc, direct)
+	var/old_dir = dir
 	. = ..()
 	if(shoes && body_position == STANDING_UP && loc == NewLoc && has_gravity(loc))
 		SEND_SIGNAL(shoes, COMSIG_SHOES_STEP_ACTION)
+		if(dir != old_dir && prob(1.25))
+			playsound(loc, 'sound/misc/slip.ogg', 50, TRUE, -3)
+			balloon_alert_to_viewers("tripped!")
+			Knockdown(0.6 SECONDS)
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)
 	if(movement_type & FLYING || HAS_TRAIT(src, TRAIT_FREE_FLOAT_MOVEMENT))

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -35,7 +35,7 @@
 	if(body_position == STANDING_UP)
 		if(shoes && loc == NewLoc && has_gravity(loc))
 			SEND_SIGNAL(shoes, COMSIG_SHOES_STEP_ACTION)
-		if(dir != old_dir && prob(1.25))
+		if(dir != old_dir && prob(1.25) && m_intent != MOVE_INTENT_WALK)
 			playsound(loc, 'sound/misc/slip.ogg', 50, TRUE, -3)
 			balloon_alert_to_viewers("tripped!")
 			Knockdown(0.6 SECONDS)


### PR DESCRIPTION
## About The Pull Request

When changing directions while moving, there is a 1.25% chance you will trip over for 0.6 seconds. Walking allows you to avoid this.

## Why It's Good For The Game

Discourages the un-fun and unenjoyable tactic of spam-switching tiles to make yourself impossible to hit, encouraging more brawls instead of dancing in combat, thereby making combat more lethal and faster for players.

## Changelog

:cl:
add: Adds tripping. Watch your step!
/:cl: