### PR TITLE
made xmas crackers tiny

### DIFF
--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/obj/holiday/christmas.dmi'
 	icon_state = "cracker"
 	desc = "Directions for use: Requires two people, one to pull each end."
+	w_class = WEIGHT_CLASS_TINY
 	/// The crack state of the toy. If set to TRUE, you can no longer crack it by attacking.
 	var/cracked = FALSE
 


### PR DESCRIPTION

## About The Pull Request
Xmas crackers are now tiny instead of normal sized. This also applies to the used crackers.
## Why It's Good For The Game
They look tiny (![image](https://user-images.githubusercontent.com/94711066/209444831-24d914cd-8be4-4cf9-b220-5890e29a8b9b.png)) and this makes them fit into trash bags. People just leave these things all over the floor and they're annoying to clean up when you can't stuff them in your trash bag.
## Changelog
:cl:
fix: xmas crackers are now tiny instead of normal sized
/:cl:
