### PR TITLE
Minor improvements to mining order console

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -1,5 +1,5 @@
 /obj/machinery/computer/order_console/mining
-	name = "mining equipment vendor"
+	name = "mining equipment order console"
 	desc = "An equipment shop for miners, points collected at an ore redemption machine can be spent here."
 	icon = 'icons/obj/machines/mining_machines.dmi'
 	icon_state = "mining"
@@ -40,16 +40,18 @@
 		contains = things_to_order,
 	)
 	var/datum/supply_order/new_order = new(
-		pack = mining_pack, \
-		orderer = purchaser, \
-		orderer_rank = "Mining Vendor", \
-		orderer_ckey = purchaser.ckey, \
-		reason = "", \
-		paying_account = card.registered_account, \
-		department_destination = null, \
-		coupon = null, \
+		pack = mining_pack,
+		orderer = purchaser,
+		orderer_rank = "Mining Vendor",
+		orderer_ckey = purchaser.ckey,
+		reason = "",
+		paying_account = card.registered_account,
+		department_destination = null,
+		coupon = null,
 		charge_on_purchase = FALSE,
 		manifest_can_fail = FALSE,
+		cost_type = "mp",
+		can_be_cancelled = FALSE,
 	)
 	if(ltsrbt_delivered)
 		var/obj/machinery/mining_ltsrbt/ltsrbt

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -102,6 +102,10 @@ GLOBAL_LIST_EMPTY(order_console_products)
 		return
 	var/mob/living/living_user = usr
 	switch(action)
+		if("add_one")
+			var/datum/orderable_item/wanted_item = locate(params["target"]) in GLOB.order_console_products
+			grocery_list[wanted_item] += 1
+			update_static_data(living_user)
 		if("cart_set")
 			//this is null if the action doesn't need it (purchase, quickpurchase)
 			var/datum/orderable_item/wanted_item = locate(params["target"]) in GLOB.order_console_products

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -39,6 +39,7 @@
 
 /datum/supply_order
 	var/id
+	var/cost_type
 	var/orderer
 	var/orderer_rank
 	var/orderer_ckey
@@ -53,6 +54,8 @@
 	var/obj/item/coupon/applied_coupon
 	///Boolean on whether the manifest can fail or not.
 	var/manifest_can_fail = TRUE
+	///Boolean on whether the manifest can be cancelled through cargo consoles.
+	var/can_be_cancelled = TRUE
 
 /datum/supply_order/New(
 	datum/supply_pack/pack,
@@ -65,8 +68,11 @@
 	coupon,
 	charge_on_purchase = TRUE,
 	manifest_can_fail = TRUE,
+	cost_type = "cr",
+	can_be_cancelled = TRUE,
 )
 	id = SSshuttle.order_number++
+	src.cost_type = cost_type
 	src.pack = pack
 	src.orderer = orderer
 	src.orderer_rank = orderer_rank
@@ -77,6 +83,7 @@
 	src.applied_coupon = coupon
 	src.charge_on_purchase = charge_on_purchase
 	src.manifest_can_fail = manifest_can_fail
+	src.can_be_cancelled = can_be_cancelled
 
 /datum/supply_order/proc/generateRequisition(turf/T)
 	var/obj/item/paper/requisition_paper = new(T)

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -120,12 +120,14 @@
 	data["cart"] = list()
 	for(var/datum/supply_order/SO in SSshuttle.shopping_list)
 		data["cart"] += list(list(
+			"cost_type" = SO.cost_type,
 			"object" = SO.pack.name,
 			"cost" = SO.pack.get_cost(),
 			"id" = SO.id,
 			"orderer" = SO.orderer,
 			"paid" = !isnull(SO.paying_account), //paid by requester
-			"dep_order" = SO.department_destination ? TRUE : FALSE
+			"dep_order" = !!SO.department_destination,
+			"can_be_cancelled" = SO.can_be_cancelled,
 		))
 
 	data["requests"] = list()
@@ -288,8 +290,8 @@
 				break
 		if("clear")
 			for(var/datum/supply_order/cancelled_order in SSshuttle.shopping_list)
-				if(cancelled_order.department_destination)
-					continue //don't cancel other department's orders
+				if(cancelled_order.department_destination || cancelled_order.can_be_cancelled)
+					continue //don't cancel other department's orders or orders that can't be cancelled
 				SSshuttle.shopping_list -= cancelled_order
 			. = TRUE
 		if("approve")

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -125,11 +125,14 @@
 	data["cart"] = list()
 	for(var/datum/supply_order/SO in SSshuttle.shopping_list)
 		data["cart"] += list(list(
+			"cost_type" = SO.cost_type,
 			"object" = SO.pack.name,
 			"cost" = SO.pack.get_cost(),
 			"id" = SO.id,
 			"orderer" = SO.orderer,
-			"paid" = !isnull(SO.paying_account) //paid by requester
+			"paid" = !isnull(SO.paying_account), //paid by requester
+			"dep_order" = !!SO.department_destination,
+			"can_be_cancelled" = SO.can_be_cancelled,
 		))
 
 	data["requests"] = list()
@@ -251,7 +254,10 @@
 					. = TRUE
 					break
 		if("clear")
-			SSshuttle.shopping_list.Cut()
+			for(var/datum/supply_order/cancelled_order in SSshuttle.shopping_list)
+				if(cancelled_order.department_destination || cancelled_order.can_be_cancelled)
+					continue //don't cancel other department's orders or orders that can't be cancelled
+				SSshuttle.shopping_list -= cancelled_order
 			. = TRUE
 		if("approve")
 			var/id = text2num(params["id"])

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -400,15 +400,15 @@ const CargoCart = (props, context) => {
               </Table.Cell>
               {(entry.dep_order && (
                 <Table.Cell collapsing textAlign="right">
-                  {formatMoney(entry.cost)} cr earned on delivery
+                  {formatMoney(entry.cost)} {entry.cost_type} earned on delivery
                 </Table.Cell>
               )) || (
                 <>
                   <Table.Cell collapsing textAlign="right">
-                    {formatMoney(entry.cost)} cr
+                    {formatMoney(entry.cost)} {entry.cost_type}
                   </Table.Cell>
                   <Table.Cell collapsing>
-                    {can_send && (
+                    {can_send && !!entry.can_be_cancelled && (
                       <Button
                         icon="minus"
                         onClick={() =>

--- a/tgui/packages/tgui/interfaces/ProduceConsole.js
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.js
@@ -59,9 +59,17 @@ const ShoppingTab = (props, context) => {
                     </Box>
                   </Stack.Item>
                   <Stack.Item mt={-0.5}>
+                    <Button
+                      icon="plus"
+                      onClick={() =>
+                        act('add_one', {
+                          target: item.ref,
+                        })
+                      }
+                    />
                     <NumberInput
                       animated
-                      value={(item.amt && item.amt) || 0}
+                      value={item.amt || 0}
                       width="41px"
                       minValue={0}
                       maxValue={20}
@@ -87,7 +95,7 @@ const ShoppingTab = (props, context) => {
 const CheckoutTab = (props, context) => {
   const { data, act } = useBackend(context);
   const { ltsrbt_available, forced_express, order_datums, total_cost } = data;
-  const checkout_list = order_datums.filter((food) => food && food.amt);
+  const checkout_list = order_datums.filter((food) => food && (food.amt || 0));
   return (
     <Stack vertical fill>
       <Stack.Item grow>
@@ -120,7 +128,7 @@ const CheckoutTab = (props, context) => {
                     </Stack.Item>
                     <Stack.Item mt={-0.5}>
                       <NumberInput
-                        value={(item.amt && item.amt) || 0}
+                        value={item.amt || 0}
                         width="41px"
                         minValue={0}
                         maxValue={(item.cost > 10 && 50) || 10}
@@ -219,7 +227,7 @@ export const ProduceConsole = (props, context) => {
   const [tabIndex, setTabIndex] = useLocalState(context, 'tab-index', 1);
   const TabComponent = TAB2NAME[tabIndex - 1].component();
   return (
-    <Window title="Produce Orders" width={500} height={400}>
+    <Window width={500} height={400}>
       <Window.Content>
         {!off_cooldown && <OrderSent />}
         <Stack vertical fill>
@@ -251,7 +259,9 @@ export const ProduceConsole = (props, context) => {
           </Stack.Item>
           <Section>
             <Stack grow>
-              <Stack.Item>Currently available balance: {points}</Stack.Item>
+              <Stack.Item>
+                Currently available balance: {points || 0}
+              </Stack.Item>
             </Stack>
           </Section>
           <Stack.Item grow>


### PR DESCRIPTION
## About The Pull Request

Mining order consoles are now called 'order console' instead of 'vendor'

Cargo orders through the mining vendor can no longer be cancelled ("clear" on the ntos cargo app no longer removes department orders too)

Cargo orders made with mining points now state 'mp' (for 'mining points') instead of 'cr' to the Cargo console.

The order consoles now have a '+' icon that will instantly add +1 item to your cart, so you don't have to manually type 1 each time.

The order console's UI name is now named after the machine, rather than being hardcoded to 'Produce Orders'

Also makes the UI resilient to breaking if the wearer doesn't have an ID equipped.

## Why It's Good For The Game

Better player-feedback and makes a better distinction between mining order console and normal vendors, as well as fixes some problems like Cargo just deleting people's mining points by deleting their unrefundable orders.

The + button was a suggestion in the comments here and thought it would just be a nice harmless inclusion.

The departmental order cancelling on the NTos cargo app and UI not breaking if you don't have an ID were just bonuses that I fixed while dealing with everything else.

## Changelog

:cl:
qol: Mining order consoles are now named 'order console'.
qol: Orders from said mining order consoles can now no longer be cancelled, and are listed as 'mp' (mining points) in the Cargo console instead of 'cr'.
qol: Order consoles now have a + button that will instantly add 1 of the item.
fix: Departmental orders can no longer be cancelled through the NTos cargo application.
fix: Wearing an ID will no longer break order consoles.
/:cl: