### PR TITLE
[NO GBP] Allows the metal hydrogen/elder atmosian armor to hold a MH axe

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -415,7 +415,13 @@
 	desc = "A classic suit of plate armour, highly effective at stopping melee attacks."
 	icon_state = "knight_green"
 	inhand_icon_state = null
-	allowed = list(/obj/item/nullrod, /obj/item/claymore, /obj/item/banner, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
+	allowed = list(
+		/obj/item/banner,
+		/obj/item/claymore,
+		/obj/item/nullrod,
+		/obj/item/tank/internals/emergency_oxygen,
+		/obj/item/tank/internals/plasmaman,
+		)
 
 /obj/item/clothing/suit/armor/riot/knight/yellow
 	icon_state = "knight_yellow"
@@ -515,6 +521,12 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+
+/obj/item/clothing/suit/armor/elder_atmosian/Initialize(mapload)
+	. = ..()
+	allowed += list(
+		/obj/item/fireaxe/metal_h2_axe,
+	)
 
 /datum/armor/armor_elder_atmosian
 	melee = 25


### PR DESCRIPTION

## About The Pull Request
Just this, the axe goes into the suit's `allowed_list`

Closes #72207

Also turned an allowed list into ABC order while there.
## Why It's Good For The Game
I forgot the suit existed when I reworked the MH axe on #69467.
It is just a flavorful thing to let it carry, and most players would expect to be allowed, as they are basically items on the same set.
## Changelog
:cl: Guillaume Prata
fix: Metal Hydrogen/Elder Atmosian suits can carry a MH Axe on its suit slot now.
/:cl:
