### PR TITLE
Gives Syndicate Lavaland means to repel invading megafauna

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2941,9 +2941,9 @@
 	name = "emergency megafauna combat closet";
 	desc = "A storage unit used to contain emergency combat gear, presumably for fighting megafauna."
 	},
-/obj/item/gun/energy/recharge/kinetic_accelerator/minebot,
-/obj/item/gun/energy/recharge/kinetic_accelerator/minebot,
-/obj/item/gun/energy/recharge/kinetic_accelerator/minebot,
+/obj/item/gun/energy/recharge/kinetic_accelerator,
+/obj/item/gun/energy/recharge/kinetic_accelerator,
+/obj/item/gun/energy/recharge/kinetic_accelerator,
 /obj/item/gun/energy/plasmacutter/adv,
 /obj/item/gun/energy/plasmacutter/adv,
 /obj/item/gun/energy/plasmacutter/adv,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2937,6 +2937,23 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/closet/syndicate{
+	name = "emergency megafauna combat closet";
+	desc = "A storage unit used to contain emergency combat gear, presumably for fighting megafauna."
+	},
+/obj/item/gun/energy/recharge/kinetic_accelerator/minebot,
+/obj/item/gun/energy/recharge/kinetic_accelerator/minebot,
+/obj/item/gun/energy/recharge/kinetic_accelerator/minebot,
+/obj/item/gun/energy/plasmacutter/adv,
+/obj/item/gun/energy/plasmacutter/adv,
+/obj/item/gun/energy/plasmacutter/adv,
+/obj/item/kinetic_crusher,
+/obj/item/kinetic_crusher,
+/obj/item/kinetic_crusher,
+/obj/item/paper{
+	default_raw_text = "This kit's been provided so you can fight off megafauna. DO NOT attempt to mine outside of the base, as that will result in contract termination. -Syndicate Command";
+	name = "memo"
+	},
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "wv" = (


### PR DESCRIPTION
## About The Pull Request
Gives Syndicate Lavaland a red closet (easy to notice) containing 3 PKAs, 3 kinetic crushers, and 3 plasmacutters. No upgrades, but you can most likely manage to defend the base against hostile lifeforms.
<img width="264" alt="image" src="https://user-images.githubusercontent.com/80979251/209476097-e1422dfb-9f82-40b7-963d-7ed5911b49a7.png">


## Why It's Good For The Game
Syndicate Lavaland should be able to repel or kill invading megafauna in dire emergencies, as otherwise a megafauna attack spells immediate doom for the base, or for Lavaland if whoever's running the 1/3 chance SM knows what they're doing.
It's been placed in a red Syndicate closet so it's easier to notice during an ongoing megafauna attack.

## Changelog
:cl:
add: The Syndicate has issued their lavaland-based research outposts with megafauna combat gear.
/:cl:
