### PR TITLE
The nuke ops base begins lazy loading as soon as the first hijack stage is completed so as to avoid upwards of 30 second delays on the shuttle docking after the timer hits 00:00 due to server lag.

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -181,8 +181,8 @@
 
 /obj/machinery/computer/emergency_shuttle/proc/increase_hijack_stage()
 	var/obj/docking_port/mobile/emergency/shuttle = SSshuttle.emergency
-	if(!shuttle.hijack_status) // Begin loading this early, otherwise we get an awkward 30 second delay on the 
-		SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
+	// Begin loading this early, otherwise we get an awkward 30 second delay on the 
+	SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
 	shuttle.hijack_status++
 	if(hijack_announce)
 		announce_hijack_stage()

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -181,6 +181,8 @@
 
 /obj/machinery/computer/emergency_shuttle/proc/increase_hijack_stage()
 	var/obj/docking_port/mobile/emergency/shuttle = SSshuttle.emergency
+	if(!shuttle.hijack_status) // Begin loading this early, otherwise we get an awkward 30 second delay on the 
+		SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
 	shuttle.hijack_status++
 	if(hijack_announce)
 		announce_hijack_stage()
@@ -545,7 +547,6 @@
 				// unless the shuttle is "hijacked"
 				var/destination_dock = "emergency_away"
 				if(is_hijacked() || elimination_hijack())
-					SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
 					destination_dock = "emergency_syndicate"
 					minor_announce("Corruption detected in \
 						shuttle navigation protocols. Please contact your \


### PR DESCRIPTION

## Why It's Good For The Game
Just got out of a manuel round where we were stuck on a shuttle at 00:00 for like 30 seconds because of the lazy loading being way, way too slow.
![dreamseeker_AZluZ0MgCq](https://user-images.githubusercontent.com/4081722/209479719-7be94786-e21a-45b9-81af-3b48f8906236.png)

Note that this doesn't fix the fact hijack greentexts don't work due to the lazy loading being off the CC Z-level, by the way.

## Changelog

:cl:
fix: The nuke ops base begins lazy loading as soon as the first hijack stage is completed so as to avoid upwards of 30 second delays on the shuttle docking after the timer hits 00:00 due to server lag.
/:cl:
