### PR TITLE
The burden level of Burdened Sect chaplains now updates properly when using mutadone to remove mutations

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		return
 	for(var/datum/mutation/human/HM in group)
 		if((HM.class in classes) && !(HM.mutadone_proof && mutadone))
-			force_lose(HM)
+			remove_mutation(HM)
 
 /datum/dna/proc/generate_unique_identity()
 	. = ""
@@ -648,7 +648,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 //Return the active mutation of a type if there is one
 /datum/dna/proc/get_mutation(A)
 	for(var/datum/mutation/human/HM in mutations)
-		if(HM.type == A)
+		if(istype(HM, A))
 			return HM
 
 /datum/dna/proc/check_block_string(mutation)


### PR DESCRIPTION

## About The Pull Request

Makes `remove_mutation_group()` call `remove_mutation()` rather than `force_lose()` directly, as this made it so no COMSIG_CARBON_LOSE_MUTATION signals would be sent. 
Also made the if check in `get_mutation()` just an `istype()` check because that's basically all it ever was. This way it works with typepaths and the mutation datums themselves.
## Why It's Good For The Game

The signal is used by the burdened sect to tell when a mutation is removed and lower the burden level accordingly. Since mutadone (indirectly) calls `remove_mutation_group()` rather than `remove_mutation()`, healing your mutations with it would send no such signal.
This caused the, perhaps notorious, issue of Burdened Sect chaplains being able to reach max burden by giving themselves negative mutations and then healing themselves with mutadone while keeping their burden level.
This made it so they would have all the benefits of their sect with no downsides and we don't want that, do we?
## Changelog
:cl:
fix: The burden level of Burdened Sect chaplains is now updated properly when their negative mutations are healed with mutadone
/:cl:
