### PR TITLE
that was the most boring 15 fucking minutes of my life, blocks revolutions and xenomorphs from occuring at the same time

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -500,6 +500,7 @@
 	cost = 10
 	minimum_players = 25
 	repeatable = TRUE
+	blocking_rules = list(/datum/dynamic_ruleset/latejoin/provocateur, /datum/dynamic_ruleset/roundstart/revs)
 	var/list/vents = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/xenomorph/execute()


### PR DESCRIPTION
Revolutions and Xenomorphs is the worst possible ruleset combo because all three sides cannot force the game to end without explicitly forcing themselves to lose, and one of the sides can't even quit playing to force the round to end.

This was the most boring 15 minutes of my life. I never want to experience that again. Nobody had fun that round.

:cl:
fix: Revolutions and Xenomorphs no longer mix in dynamic.
/:cl: