### PR TITLE
guardian death checks

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -97,7 +97,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	return ..()
 
 /// Setter for our summoner mob.
-/mob/living/simple_animal/hostile/guardian/proc/set_summoner(mob/to_who, different_person = FALSE)
+/mob/living/simple_animal/hostile/guardian/proc/set_summoner(mob/living/to_who, different_person = FALSE)
 	if(QDELETED(to_who))
 		qdel(src) //no gettin off scot-free pal.........
 		return
@@ -129,6 +129,8 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	RegisterSignal(to_who, COMSIG_LIVING_SHAPESHIFTED, PROC_REF(on_summoner_shapeshifted))
 	RegisterSignal(to_who, COMSIG_LIVING_UNSHAPESHIFTED, PROC_REF(on_summoner_unshapeshifted))
 	recall(forced = TRUE)
+	if(to_who.stat == DEAD)
+		on_summoner_death(to_who)
 
 /mob/living/simple_animal/hostile/guardian/proc/cut_summoner(different_person = FALSE)
 	if(is_deployed())

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -92,6 +92,8 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		used = FALSE
 
 /obj/item/guardiancreator/proc/spawn_guardian(mob/living/user, mob/dead/candidate, guardian_path)
+	if(QDELETED(user) || user.stat == DEAD)
+		return
 	var/list/guardians = user.get_all_linked_holoparasites()
 	if(length(guardians) && !allowmultiple)
 		to_chat(user, span_holoparasite("You already have a [mob_name]!") )


### PR DESCRIPTION
## About The Pull Request
if a guardian summoner is dead during the summoner setting process, we (the guardian) now kill ourselves since itd mean a guardian that cant die
to combat some fucked upness of it (if you inject a guardian and it only spawns after you died and then dusts you), the process of spawning a guardian from the playerside guardian creator stuff gets canceled if youre dead or dont exist

## Why It's Good For The Game
yeah that seems good

## Changelog
:cl:
fix: guardian spirits check for death before they add themselves to you
/:cl:
