### PR TITLE
Rescale SM health from 900 to 100, UI improvements, visual changes.

### DIFF
--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -57,7 +57,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 /atom/movable/plane_master_controller/transition_filter(name, time, list/new_params, easing, loop)
 	. = ..()
 	for(var/atom/movable/screen/plane_master/pm_iterator as anything in get_planes())
-		pm_iterator.transition_filter(name, time, new_params, easing, loop)
+		pm_iterator.transition_filter(name, new_params, time, easing, loop)
 
 ///Full override so we can just use filterrific
 /atom/movable/plane_master_controller/add_atom_colour(coloration, colour_priority)

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -43,7 +43,7 @@
 	if(!blob || isspaceturf(atom_source)) //does nothing in space
 		return
 	playsound(get_turf(atom_source), 'sound/effects/supermatter.ogg', 50, TRUE)
-	consume_returns(damage_increase = blob.get_integrity() * 0.5)
+	consume_returns(damage_increase = blob.get_integrity() * 0.05)
 	if(blob.get_integrity() > 100)
 		blob.visible_message(span_danger("\The [blob] strikes at \the [atom_source] and flinches away!"),
 			span_hear("You hear a loud crack as you are washed with a wave of heat."))
@@ -247,7 +247,7 @@
 		consumed_mob.dust(force = TRUE)
 		matter_increase += 100 * object_size
 		if(is_clown_job(consumed_mob.mind?.assigned_role))
-			damage_increase += rand(-300, 300) // HONK
+			damage_increase += rand(-30, 30) // HONK
 		consume_returns(matter_increase, damage_increase)
 	else if(consumed_object.flags_1 & SUPERMATTER_IGNORES_1)
 		return

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1597,7 +1597,15 @@
 /atom/proc/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	return
 
-/atom/proc/add_filter(name,priority,list/params)
+/** Add a filter to the atom.
+ * Can also be used to assert a filter's existence. I.E. update a filter regardless if it exists or not.
+ *
+ * Arguments:
+ * * name - Filter name
+ * * priority - Priority used when sorting the filter.
+ * * params - Parameters of the filter.
+ */
+/atom/proc/add_filter(name, priority, list/params)
 	LAZYINITLIST(filter_data)
 	var/list/copied_parameters = params.Copy()
 	copied_parameters["priority"] = priority
@@ -1614,20 +1622,40 @@
 		filters += filter(arglist(arguments))
 	UNSETEMPTY(filter_data)
 
-/atom/proc/transition_filter(name, time, list/new_params, easing, loop)
+/** Update a filter's parameter and animate this change. If the filter doesnt exist we won't do anything.
+ * Basically a [atom/proc/modify_filter] call but with animations. Unmodified filter parameters are kept.
+ *
+ * Arguments:
+ * * name - Filter name
+ * * new_params - New parameters of the filter
+ * * time - time arg of the BYOND animate() proc.
+ * * easing - easing arg of the BYOND animate() proc.
+ * * loop - loop arg of the BYOND animate() proc.
+ */
+/atom/proc/transition_filter(name, list/new_params, time, easing, loop)
 	var/filter = get_filter(name)
 	if(!filter)
 		return
-
-	var/list/old_filter_data = filter_data[name]
-
-	var/list/params = old_filter_data.Copy()
-	for(var/thing in new_params)
-		params[thing] = new_params[thing]
-
 	animate(filter, new_params, time = time, easing = easing, loop = loop)
-	for(var/param in params)
-		filter_data[name][param] = params[param]
+	modify_filter(name, new_params)
+
+/** Update a filter's parameter to the new one. If the filter doesnt exist we won't do anything.
+ *
+ * Arguments:
+ * * name - Filter name
+ * * new_params - New parameters of the filter
+ * * overwrite - TRUE means we replace the parameter list completely. FALSE means we only replace the things on new_params.
+ */
+/atom/proc/modify_filter(name, list/new_params, overwrite = FALSE)
+	var/filter = get_filter(name)
+	if(!filter)
+		return
+	if(overwrite)
+		filter_data[name] = new_params
+	else
+		for(var/thing in new_params)
+			filter_data[name][thing] = new_params[thing]
+	update_filters()
 
 /atom/proc/change_filter_priority(name, new_priority)
 	if(!filter_data || !filter_data[name])

--- a/code/game/objects/effects/countdown.dm
+++ b/code/game/objects/effects/countdown.dm
@@ -109,7 +109,7 @@
 	var/obj/machinery/power/supermatter_crystal/S = attached_to
 	if(!istype(S))
 		return
-	return "<div align='center' valign='middle' style='position:relative; top:0px; left:0px'>[round(S.get_integrity_percent(), 1)]%</div>"
+	return "<div align='center' valign='middle' style='position:relative; top:0px; left:0px'>[round(S.get_integrity_percent())]%</div>"
 
 /obj/effect/countdown/transformer
 	name = "transformer countdown"

--- a/code/modules/admin/view_variables/filterrific.dm
+++ b/code/modules/admin/view_variables/filterrific.dm
@@ -53,7 +53,7 @@
 			target.change_filter_priority(params["name"], new_priority)
 			. = TRUE
 		if("transition_filter_value")
-			target.transition_filter(params["name"], 4, params["new_data"])
+			target.transition_filter(params["name"], params["new_data"], 4)
 			. = TRUE
 		if("modify_filter_value")
 			var/list/old_filter_data = target.filter_data[params["name"]]
@@ -69,7 +69,7 @@
 		if("modify_color_value")
 			var/new_color = input(usr, "Pick new filter color", "Filteriffic Colors!") as color|null
 			if(new_color)
-				target.transition_filter(params["name"], 4, list("color" = new_color))
+				target.transition_filter(params["name"], list("color" = new_color), 4)
 				. = TRUE
 		if("modify_icon_value")
 			var/icon/new_icon = input("Pick icon:", "Icon") as null|icon

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -119,7 +119,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		// Display the supermatter crystal integrity
 		if(istype(atom_poi, /obj/machinery/power/supermatter_crystal))
 			var/obj/machinery/power/supermatter_crystal/crystal = atom_poi
-			misc[length(misc)]["extra"] = "Integrity: [crystal.get_integrity_percent()]%"
+			misc[length(misc)]["extra"] = "Integrity: [round(crystal.get_integrity_percent())]%"
 			continue
 		// Display the nuke timer
 		if(istype(atom_poi, /obj/machinery/nuclearbomb))

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -64,16 +64,16 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/list/waste_multiplier_factors
 
 	///The point at which we consider the supermatter to be [SUPERMATTER_STATUS_WARNING]
-	var/warning_point = 50
+	var/warning_point = 5
 	var/warning_channel = RADIO_CHANNEL_ENGINEERING
 	///The point at which we consider the supermatter to be [SUPERMATTER_STATUS_DANGER]
 	///Spawns anomalies when more damaged than this too.
-	var/danger_point = 550
+	var/danger_point = 60
 	///The point at which we consider the supermatter to be [SUPERMATTER_STATUS_EMERGENCY]
-	var/emergency_point = 675
+	var/emergency_point = 75
 	var/emergency_channel = null // Need null to actually broadcast, lol.
-	///The point at which we delam [SUPERMATTER_STATUS_DELAMINATING]
-	var/explosion_point = 900
+	///The point at which we delam [SUPERMATTER_STATUS_DELAMINATING].
+	var/explosion_point = 100
 	///Are we exploding?
 	var/final_countdown = FALSE
 	///A scaling value that affects the severity of explosions.
@@ -704,20 +704,20 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	additive_damage[SM_DAMAGE_EXTERNAL] = external_damage_immediate * clamp((emergency_point - damage) / emergency_point, 0, 1)
 	external_damage_immediate = 0
 
-	additive_damage[SM_DAMAGE_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 2400, 0, 1.5)
-	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 4000, 0, 1)
-	additive_damage[SM_DAMAGE_MOLES] = clamp((total_moles - MOLE_PENALTY_THRESHOLD) / 320, 0, 1)
+	additive_damage[SM_DAMAGE_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 240, 0, 0.15)
+	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 400, 0, 0.1)
+	additive_damage[SM_DAMAGE_MOLES] = clamp((total_moles - MOLE_PENALTY_THRESHOLD) / 32, 0, 0.1)
 
 	var/is_spaced = FALSE
 	if(isturf(src.loc))
 		var/turf/local_turf = src.loc
 		for (var/turf/open/space/turf in ((local_turf.atmos_adjacent_turfs || list()) + local_turf))
-			additive_damage[SM_DAMAGE_SPACED] = clamp(internal_energy * 0.00125, 0, 10)
+			additive_damage[SM_DAMAGE_SPACED] = clamp(internal_energy * 0.000125, 0, 1)
 			is_spaced = TRUE
 			break
 
 	if(total_moles > 0 && !is_spaced)
-		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 600, -1, 0)
+		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 60, -0.1, 0)
 
 	var/total_damage = 0
 	for (var/damage_type in additive_damage)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -705,9 +705,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	additive_damage[SM_DAMAGE_EXTERNAL] = external_damage_immediate * clamp((emergency_point - damage) / emergency_point, 0, 1)
 	external_damage_immediate = 0
 
-	additive_damage[SM_DAMAGE_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 240, 0, 0.15)
-	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 400, 0, 0.1)
-	additive_damage[SM_DAMAGE_MOLES] = clamp((total_moles - MOLE_PENALTY_THRESHOLD) / 32, 0, 0.1)
+	additive_damage[SM_DAMAGE_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 24000, 0, 0.15)
+	additive_damage[SM_DAMAGE_POWER] = clamp((internal_energy - POWER_PENALTY_THRESHOLD) / 40000, 0, 0.1)
+	additive_damage[SM_DAMAGE_MOLES] = clamp((total_moles - MOLE_PENALTY_THRESHOLD) / 3200, 0, 0.1)
 
 	var/is_spaced = FALSE
 	if(isturf(src.loc))
@@ -718,7 +718,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			break
 
 	if(total_moles > 0 && !is_spaced)
-		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 60, -0.1, 0)
+		additive_damage[SM_DAMAGE_HEAL_HEAT] = clamp((absorbed_gasmix.temperature - temp_limit) / 6000, -0.1, 0)
 
 	var/total_damage = 0
 	for (var/damage_type in additive_damage)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -419,9 +419,10 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		return SUPERMATTER_NORMAL
 	return SUPERMATTER_INACTIVE
 
+/// Returns the integrity percent of the Supermatter. No rounding made yet, round it yourself.
 /obj/machinery/power/supermatter_crystal/proc/get_integrity_percent()
 	var/integrity = damage / explosion_point
-	integrity = round(100 - integrity * 100, 0.01)
+	integrity = 100 - integrity * 100
 	integrity = integrity < 0 ? 0 : integrity
 	return integrity
 

--- a/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
@@ -108,8 +108,8 @@ GLOBAL_LIST_INIT(sm_delam_list, list(
 /// [/obj/machinery/power/supermatter_crystal/process_atmos]
 /datum/sm_delam/proc/lights(obj/machinery/power/supermatter_crystal/sm)
 	sm.set_light(
-		l_range = 4 + ROUND_UP(max(sm.internal_energy / 200, 25)),
-		l_power = 1 + ROUND_UP(max(sm.internal_energy/1000, 5)),
+		l_range = 4 + ROUND_UP(min(sm.internal_energy / 200, 25)),
+		l_power = 1 + ROUND_UP(min(sm.internal_energy/1000, 5)),
 		l_color = sm.gas_heat_power_generation > 0.8 ? SUPERMATTER_RED : SUPERMATTER_COLOUR,
 		l_on = !!sm.internal_energy,
 	)

--- a/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
@@ -51,14 +51,14 @@ GLOBAL_LIST_INIT(sm_delam_list, list(
 			playsound(sm, 'sound/machines/terminal_alert.ogg', 75)
 
 	if(sm.damage < sm.damage_archived) // Healing
-		sm.radio.talk_into(sm,"Crystalline hyperstructure returning to safe operating parameters. Integrity: [sm.get_integrity_percent()]%", sm.damage_archived >= sm.emergency_point ? sm.emergency_channel : sm.warning_channel)
+		sm.radio.talk_into(sm,"Crystalline hyperstructure returning to safe operating parameters. Integrity: [round(sm.get_integrity_percent(), 0.01)]%", sm.damage_archived >= sm.emergency_point ? sm.emergency_channel : sm.warning_channel)
 		return FALSE
 
 	if(sm.damage >= sm.emergency_point) // Taking damage, in emergency
-		sm.radio.talk_into(sm, "CRYSTAL DELAMINATION IMMINENT Integrity: [sm.get_integrity_percent()]%", sm.emergency_channel)
+		sm.radio.talk_into(sm, "CRYSTAL DELAMINATION IMMINENT Integrity: [round(sm.get_integrity_percent(), 0.01)]%", sm.emergency_channel)
 		sm.lastwarning = REALTIMEOFDAY - (SUPERMATTER_WARNING_DELAY / 2) // Cut the time to next announcement in half.
 	else // Taking damage, in warning
-		sm.radio.talk_into(sm, "Danger! Crystal hyperstructure integrity faltering! Integrity: [sm.get_integrity_percent()]%", sm.warning_channel)
+		sm.radio.talk_into(sm, "Danger! Crystal hyperstructure integrity faltering! Integrity: [round(sm.get_integrity_percent(), 0.01)]%", sm.warning_channel)
 
 	SEND_SIGNAL(sm, COMSIG_SUPERMATTER_DELAM_ALARM)
 	return TRUE

--- a/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(sm_delam_list, list(
 
 	sm.add_filter(name = "ray", priority = 1, params = list(
 		type = "rays",
-		size = clamp(sm.internal_energy / 30, 1, 125),
+		size = clamp(sm.internal_energy / 50, 1, 100),
 		color = (sm.gas_heat_power_generation > 0.8 ? SUPERMATTER_RED : SUPERMATTER_COLOUR),
 		factor = clamp(sm.damage / 10, 1, 10),
 		density = clamp(sm.damage, 12, 100)

--- a/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
@@ -108,8 +108,8 @@ GLOBAL_LIST_INIT(sm_delam_list, list(
 /// [/obj/machinery/power/supermatter_crystal/process_atmos]
 /datum/sm_delam/proc/lights(obj/machinery/power/supermatter_crystal/sm)
 	sm.set_light(
-		l_range = 4 + ROUND_UP(min(sm.internal_energy / 200, 25)),
-		l_power = 1 + ROUND_UP(min(sm.internal_energy/1000, 5)),
+		l_range = ROUND_UP(clamp(sm.internal_energy / 500, 4, 10)),
+		l_power = ROUND_UP(clamp(sm.internal_energy / 1000, 1, 5)),
 		l_color = sm.gas_heat_power_generation > 0.8 ? SUPERMATTER_RED : SUPERMATTER_COLOUR,
 		l_on = !!sm.internal_energy,
 	)

--- a/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/_sm_delam.dm
@@ -94,8 +94,8 @@ GLOBAL_LIST_INIT(sm_delam_list, list(
 		type = "rays",
 		size = clamp(sm.internal_energy / 30, 1, 125),
 		color = (sm.gas_heat_power_generation > 0.8 ? SUPERMATTER_RED : SUPERMATTER_COLOUR),
-		factor = clamp(sm.damage/600, 1, 10),
-		density = clamp(sm.damage/10, 12, 100)
+		factor = clamp(sm.damage / 10, 1, 10),
+		density = clamp(sm.damage, 12, 100)
 	))
 
 	// Filter animation persists even if the filter itself is changed externally.
@@ -108,8 +108,8 @@ GLOBAL_LIST_INIT(sm_delam_list, list(
 /// [/obj/machinery/power/supermatter_crystal/process_atmos]
 /datum/sm_delam/proc/lights(obj/machinery/power/supermatter_crystal/sm)
 	sm.set_light(
-		l_range = 4 + sm.internal_energy/200,
-		l_power = 1 + sm.internal_energy/1000,
+		l_range = 4 + ROUND_UP(max(sm.internal_energy / 200, 25)),
+		l_power = 1 + ROUND_UP(max(sm.internal_energy/1000, 5)),
 		l_color = sm.gas_heat_power_generation > 0.8 ? SUPERMATTER_RED : SUPERMATTER_COLOUR,
 		l_on = !!sm.internal_energy,
 	)

--- a/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
@@ -31,7 +31,7 @@
 /datum/sm_delam/singularity/filters(obj/machinery/power/supermatter_crystal/sm)
 	..()
 
-	sm.modify_filter(name = "ray", new_params=list(
+	sm.modify_filter(name = "ray", new_params = list(
 		color = SUPERMATTER_SINGULARITY_RAYS_COLOUR
 	))
 

--- a/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
@@ -93,7 +93,6 @@
 /datum/sm_delam/tesla/filters(obj/machinery/power/supermatter_crystal/sm)
 	..()
 
-	// override the ray from parent call.
 	sm.modify_filter(name = "ray", new_params = list(
 		color = SUPERMATTER_TESLA_COLOUR,
 	))

--- a/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/common_delams.dm
@@ -31,13 +31,8 @@
 /datum/sm_delam/singularity/filters(obj/machinery/power/supermatter_crystal/sm)
 	..()
 
-	// override the ray from parent call.
-	sm.add_filter(name = "ray", priority = 1, params=list(
-		type = "rays",
-		size = sm.internal_energy ? clamp((sm.damage/100) * sm.internal_energy, 50, 125) : 1,
-		color = SUPERMATTER_SINGULARITY_RAYS_COLOUR,
-		factor = clamp(sm.damage / 300, 1, 30),
-		density = clamp(sm.damage / 5, 12, 200)
+	sm.modify_filter(name = "ray", new_params=list(
+		color = SUPERMATTER_SINGULARITY_RAYS_COLOUR
 	))
 
 	sm.add_filter(name = "outline", priority = 2, params = list(
@@ -63,12 +58,8 @@
 	return list()
 
 /datum/sm_delam/singularity/lights(obj/machinery/power/supermatter_crystal/sm)
-	sm.set_light(
-		l_range = 4 + clamp(sm.damage/2, 10, 50),
-		l_power = 3,
-		l_color = SUPERMATTER_SINGULARITY_LIGHT_COLOUR,
-		l_on = !!sm.internal_energy,
-	)
+	..()
+	sm.set_light_color(SUPERMATTER_SINGULARITY_LIGHT_COLOUR)
 
 /// When we have too much power.
 /datum/sm_delam/tesla
@@ -103,12 +94,8 @@
 	..()
 
 	// override the ray from parent call.
-	sm.add_filter(name = "ray", priority = 1, params = list(
-		type = "rays",
-		size = sm.internal_energy ? clamp((sm.damage/100) * sm.internal_energy, 50, 125) : 1,
+	sm.modify_filter(name = "ray", new_params = list(
 		color = SUPERMATTER_TESLA_COLOUR,
-		factor = clamp(sm.damage/300, 1, 30),
-		density = clamp(sm.damage/5, 12, 200)
 	))
 
 	sm.add_filter(name = "icon", priority = 2, params = list(
@@ -122,12 +109,8 @@
 	sm.remove_filter(list("icon"))
 
 /datum/sm_delam/tesla/lights(obj/machinery/power/supermatter_crystal/sm)
-	sm.set_light(
-		l_range = 4 + clamp(sm.damage * sm.internal_energy, 50, 500),
-		l_power = 3,
-		l_color = SUPERMATTER_TESLA_COLOUR,
-		l_on = !!sm.internal_energy,
-	)
+	..()
+	sm.set_light_color(SUPERMATTER_TESLA_COLOUR)
 
 /// Default delam.
 /datum/sm_delam/explosive

--- a/code/modules/power/supermatter/supermatter_hit_procs.dm
+++ b/code/modules/power/supermatter/supermatter_hit_procs.dm
@@ -23,7 +23,7 @@
 		external_power_immediate += projectile.damage * bullet_energy + kiss_power
 		log_activation(who = projectile.firer, how = projectile.fired_from)
 	else
-		external_damage_immediate += projectile.damage * bullet_energy
+		external_damage_immediate += projectile.damage * bullet_energy * 0.1
 		// Stop taking damage at emergency point, yell to players at danger point.
 		// This isn't clean and we are repeating [/obj/machinery/power/supermatter_crystal/proc/calculate_damage], sorry for this.
 		var/damage_to_be = damage + external_damage_immediate * clamp((emergency_point - damage) / emergency_point, 0, 1)
@@ -94,7 +94,7 @@
 			user.investigate_log("attached [destabilizing_crystal] to a supermatter crystal.", INVESTIGATE_ENGINE)
 			to_chat(user, span_danger("\The [destabilizing_crystal] snaps onto \the [src]."))
 			set_delam(SM_DELAM_PRIO_IN_GAME, /datum/sm_delam/cascade)
-			external_damage_immediate += 100
+			external_damage_immediate += 10
 			external_power_trickle += 500
 			log_activation(who = user, how = destabilizing_crystal)
 			qdel(destabilizing_crystal)

--- a/tgui/packages/tgui/interfaces/Supermatter.tsx
+++ b/tgui/packages/tgui/interfaces/Supermatter.tsx
@@ -145,7 +145,7 @@ export const SupermatterContent = (props: SupermatterProps, context) => {
                         label={name + ' (∆)'}
                         labelWrap>
                         <Box color={amount > 0 ? 'green' : 'red'}>
-                          {toFixed(amount, 2)}
+                          {toFixed(amount, 2) + ' %'}
                         </Box>
                       </LabeledList.Item>
                     ))}

--- a/tgui/packages/tgui/interfaces/Supermatter.tsx
+++ b/tgui/packages/tgui/interfaces/Supermatter.tsx
@@ -132,8 +132,9 @@ export const SupermatterContent = (props: SupermatterProps, context) => {
                     good: [0.9, Infinity],
                     average: [0.5, 0.9],
                     bad: [-Infinity, 0.5],
-                  }}
-                />
+                  }}>
+                  {toFixed(integrity, 2)}
+                </ProgressBar>
               }
               detail={
                 !!integrity_factors.length && (
@@ -141,10 +142,10 @@ export const SupermatterContent = (props: SupermatterProps, context) => {
                     {integrity_factors.map(({ name, amount }) => (
                       <LabeledList.Item
                         key={name}
-                        label={'∆ ' + name}
+                        label={name + ' (∆)'}
                         labelWrap>
                         <Box color={amount > 0 ? 'green' : 'red'}>
-                          {toFixed(amount, 4)}
+                          {toFixed(amount, 2)}
                         </Box>
                       </LabeledList.Item>
                     ))}
@@ -174,7 +175,7 @@ export const SupermatterContent = (props: SupermatterProps, context) => {
                     {internal_energy_factors.map(({ name, amount }) => (
                       <LabeledList.Item
                         key={name}
-                        label={'∆ ' + name}
+                        label={name + ' (∆)'}
                         labelWrap>
                         <Box color={amount > 0 ? 'green' : 'red'}>
                           {toFixed(amount, 2) + ' MeV/cm3'}

--- a/tgui/packages/tgui/interfaces/Supermatter.tsx
+++ b/tgui/packages/tgui/interfaces/Supermatter.tsx
@@ -141,7 +141,7 @@ export const SupermatterContent = (props: SupermatterProps, context) => {
                     {integrity_factors.map(({ name, amount }) => (
                       <LabeledList.Item key={name} label={name} labelWrap>
                         <Box color={amount > 0 ? 'green' : 'red'}>
-                          {toFixed(amount, 2)}
+                          {toFixed(amount, 4)}
                         </Box>
                       </LabeledList.Item>
                     ))}

--- a/tgui/packages/tgui/interfaces/Supermatter.tsx
+++ b/tgui/packages/tgui/interfaces/Supermatter.tsx
@@ -139,7 +139,10 @@ export const SupermatterContent = (props: SupermatterProps, context) => {
                 !!integrity_factors.length && (
                   <LabeledList>
                     {integrity_factors.map(({ name, amount }) => (
-                      <LabeledList.Item key={name} label={name} labelWrap>
+                      <LabeledList.Item
+                        key={name}
+                        label={'∆ ' + name}
+                        labelWrap>
                         <Box color={amount > 0 ? 'green' : 'red'}>
                           {toFixed(amount, 4)}
                         </Box>
@@ -169,7 +172,10 @@ export const SupermatterContent = (props: SupermatterProps, context) => {
                 !!internal_energy_factors.length && (
                   <LabeledList>
                     {internal_energy_factors.map(({ name, amount }) => (
-                      <LabeledList.Item key={name} label={name} labelWrap>
+                      <LabeledList.Item
+                        key={name}
+                        label={'∆ ' + name}
+                        labelWrap>
                         <Box color={amount > 0 ? 'green' : 'red'}>
                           {toFixed(amount, 2) + ' MeV/cm3'}
                         </Box>

--- a/tgui/packages/tgui/interfaces/Supermatter.tsx
+++ b/tgui/packages/tgui/interfaces/Supermatter.tsx
@@ -133,7 +133,7 @@ export const SupermatterContent = (props: SupermatterProps, context) => {
                     average: [0.5, 0.9],
                     bad: [-Infinity, 0.5],
                   }}>
-                  {toFixed(integrity, 2)}
+                  {toFixed(integrity, 2) + ' %'}
                 </ProgressBar>
               }
               detail={


### PR DESCRIPTION
## About The Pull Request
Title.
Rescaling because i saw someone think that the number on the supermatter UI are actually the percent damage over time, which is wrong.

Added delta symbol to damage and energy since they actually denote change, not the actual value.

Chose the numbers that look good instead of doing a 1:1 rescale of the old one (i.e. im dividing or multiplying things by 10 instead of 9). In practice this means I'm lowering the damage cap but increasing damage over the board for atmos (since it's mostly divisors). Lowered the damage overall for external stuffs.

Picked the spirit of #71641 up, with my own modifications.

A bit of modification on the filter helpers to suit my needs. Added documentation because I'm awesome.

## Why It's Good For The Game
Should be self evident.

## Changelog
:cl:
code: rescaled supermatter health from 900 to 100.
balance: we didn't do a 1:1 rescale of the damage though, atmos based damage should be slightly higher across the board but have lower caps. All external damage is slightly lower.
code: made the less important parts of the visual supermatter effects same between different delams so we have an easier time changing the code.
qol: added a delta symbol to the SM UI on damage and energy breakdown to denote that they are actually changes instead of exact values.
/:cl: