### PR TITLE
Turns miming into a liver trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -451,6 +451,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_LAW_ENFORCEMENT_METABOLISM "law_enforcement_metabolism"
 #define TRAIT_CULINARY_METABOLISM "culinary_metabolism"
 #define TRAIT_COMEDY_METABOLISM "comedy_metabolism"
+#define TRAIT_FRENCH_METABOLISM "french_metabolism"
+#define TRAIT_BROKEN_VOW "broken_vow_of_silence"
 #define TRAIT_MEDICAL_METABOLISM "medical_metabolism"
 #define TRAIT_ENGINEER_METABOLISM "engineer_metabolism"
 #define TRAIT_ROYAL_METABOLISM "royal_metabolism"

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -719,6 +719,8 @@ GLOBAL_LIST_EMPTY(species_list)
 
 #define ISADVANCEDTOOLUSER(mob) (HAS_TRAIT(mob, TRAIT_ADVANCEDTOOLUSER) && !HAS_TRAIT(mob, TRAIT_DISCOORDINATED_TOOL_USER))
 
+#define ISMIMING(mob) (HAS_TRAIT(mob, TRAIT_FRENCH_METABOLISM) && !HAS_TRAIT(mob, TRAIT_BROKEN_VOW))
+
 #define IS_IN_STASIS(mob) (mob.has_status_effect(/datum/status_effect/grouped/stasis))
 
 /// Gets the client of the mob, allowing for mocking of the client.

--- a/code/datums/components/sign_language.dm
+++ b/code/datums/components/sign_language.dm
@@ -129,7 +129,7 @@
 	SIGNAL_HANDLER
 
 	var/mob/living/carbon/carbon_parent = parent
-	if(carbon_parent.mind?.miming)
+	if(ISMIMING(carbon_parent))
 		to_chat(carbon_parent, span_green("You stop yourself from signing in favor of the artform of mimery!"))
 		return COMPONENT_CANNOT_SPEAK
 

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -189,7 +189,7 @@
 	. = msg
 	if(!muzzle_ignore && user.is_muzzled() && emote_type & EMOTE_AUDIBLE)
 		return "makes a [pick("strong ", "weak ", "")]noise."
-	if(user.mind?.miming && message_mime)
+	if(ISMIMING(user) && message_mime)
 		. = message_mime
 	if(isalienadult(user) && message_alien)
 		. = message_alien
@@ -271,7 +271,7 @@
 			return FALSE
 		if(ishuman(user))
 			var/mob/living/carbon/human/loud_mouth = user
-			if(loud_mouth.mind?.miming) // vow of silence prevents outloud noises
+			if(ISMIMING(loud_mouth)) // vow of silence prevents outloud noises
 				return FALSE
 			if(!loud_mouth.getorganslot(ORGAN_SLOT_TONGUE))
 				return FALSE

--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -54,8 +54,6 @@
 	/// Martial art on this mind
 	var/datum/martial_art/martial_art
 	var/static/default_martial_art = new/datum/martial_art
-	/// Mime's vow of silence
-	var/miming = FALSE
 	/// List of antag datums on this mind
 	var/list/antag_datums
 	/// this mind's ANTAG_HUD should have this icon_state

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -257,18 +257,18 @@
 
 /obj/item/food/baguette/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
-	if (user.mind?.miming && held_item == src)
+	if (ISMIMING(user) && held_item == src)
 		context[SCREENTIP_CONTEXT_LMB] = "Toggle Swordplay"
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/food/baguette/examine(mob/user)
 	. = ..()
-	if(user.mind?.miming)
+	if(ISMIMING(user))
 		. += span_notice("You can wield this like a sword by using it in your hand.")
 
 /obj/item/food/baguette/attack_self(mob/user, modifiers)
 	. = ..()
-	if(!user.mind?.miming)
+	if(!ISMIMING(user))
 		return
 	if(fake_swordplay)
 		end_swordplay(user)

--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -149,7 +149,7 @@
 
 /obj/item/storage/box/mime/attack_hand(mob/user, list/modifiers)
 	..()
-	if(user.mind.miming)
+	if(ISMIMING(user))
 		alpha = 255
 
 /obj/item/storage/box/mime/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -16,6 +16,8 @@
 	paycheck = PAYCHECK_CREW
 	paycheck_department = ACCOUNT_SRV
 
+	liver_traits = list(TRAIT_FRENCH_METABOLISM)
+
 	display_order = JOB_DISPLAY_ORDER_MIME
 	departments_list = list(
 		/datum/job_department/service,
@@ -75,12 +77,6 @@
 
 	if(visualsOnly)
 		return
-
-	// Start our mime out with a vow of silence and the ability to break (or make) it
-	if(H.mind)
-		var/datum/action/cooldown/spell/vow_of_silence/vow = new(H.mind)
-		vow.Grant(H)
-		H.mind.miming = TRUE
 
 	var/datum/atom_hud/fan = GLOB.huds[DATA_HUD_FAN]
 	fan.show_to(H)

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -110,14 +110,13 @@
 			picked_spell_type = /datum/action/cooldown/spell/conjure_item/invisible_box
 
 	if(ispath(picked_spell_type))
-		// Gives the user a vow ability too, if they don't already have one
-		var/datum/action/cooldown/spell/vow_of_silence/vow = locate() in user.actions
-		if(!vow && user.mind)
-			vow = new(user.mind)
-			vow.Grant(user)
+		// Gives the user a mime liver if they don't have one already
+		var/obj/item/organ/internal/liver/liver = user.getorganslot(ORGAN_SLOT_LIVER)
+		if(liver)
+			liver.add_organ_trait(TRAIT_FRENCH_METABOLISM)
 
-		picked_spell_type = new picked_spell_type(user.mind || user)
-		picked_spell_type.Grant(user)
+			picked_spell_type = new picked_spell_type(liver)
+			picked_spell_type.Grant(user)
 
 		to_chat(user, span_warning("The book disappears into thin air."))
 		qdel(src)
@@ -137,6 +136,7 @@
 		return FALSE
 	if(user.incapacitated())
 		return FALSE
-	if(!user.mind)
+	//mimery is stored in the liver
+	if(!user.getorganslot(ORGAN_SLOT_LIVER))
 		return FALSE
 	return TRUE

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -262,9 +262,9 @@
 
 /datum/emote/living/laugh/get_sound(mob/living/user)
 	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.dna.species.id == SPECIES_HUMAN && (!H.mind || !H.mind.miming))
-			if(user.gender == FEMALE)
+		var/mob/living/carbon/human/human_user = user
+		if(human_user.dna.species.id == SPECIES_HUMAN && !ISMIMING(human_user))
+			if(human_user.gender == FEMALE)
 				return 'sound/voice/human/womanlaugh.ogg'
 			else
 				return pick('sound/voice/human/manlaugh1.ogg', 'sound/voice/human/manlaugh2.ogg')

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -389,7 +389,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		return FALSE
 
 	if(!can_speak())
-		if(mind?.miming)
+		if(ISMIMING(src))
 			to_chat(src, span_green("Your vow of silence prevents you from speaking!"))
 		else
 			to_chat(src, span_warning("You find yourself unable to speak!"))
@@ -398,7 +398,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	return TRUE
 
 /mob/living/can_speak(allow_mimes = FALSE)
-	if(!allow_mimes && mind?.miming)
+	if(!allow_mimes && ISMIMING(src))
 		return FALSE
 
 	if(HAS_TRAIT(src, TRAIT_MUTE))

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1790,7 +1790,7 @@
 	icon_state = "silencerglass"
 
 /datum/reagent/consumable/ethanol/silencer/on_mob_life(mob/living/carbon/drinker, delta_time, times_fired)
-	if(ishuman(drinker) && drinker.mind?.miming)
+	if(ishuman(drinker) && ISMIMING(drinker))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
 		drinker.heal_bodypart_damage(1 * REM * delta_time, 1 * REM * delta_time)
 		. = TRUE
@@ -2695,7 +2695,7 @@
 	icon_state = "blank_paper"
 
 /datum/reagent/consumable/ethanol/blank_paper/on_mob_life(mob/living/carbon/drinker, delta_time, times_fired)
-	if(ishuman(drinker) && drinker.mind?.miming)
+	if(ishuman(drinker) && ISMIMING(drinker))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
 		drinker.heal_bodypart_damage(1 * REM * delta_time, 1 * REM * delta_time)
 		. = TRUE

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -209,7 +209,7 @@
 	icon_state = "nothing"
 
 /datum/reagent/consumable/nothing/on_mob_life(mob/living/carbon/drinker, delta_time, times_fired)
-	if(ishuman(drinker) && drinker.mind?.miming)
+	if(ishuman(drinker) && ISMIMING(drinker))
 		drinker.set_silence_if_lower(MIMEDRINK_SILENCE_DURATION)
 		drinker.heal_bodypart_damage(1 * REM * delta_time, 1 * REM * delta_time)
 		. = TRUE

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -159,7 +159,7 @@
 		// No point in feedback here, as mindless mobs aren't players
 		return FALSE
 
-	if((spell_requirements & SPELL_REQUIRES_MIME_VOW) && !owner.mind?.miming)
+	if((spell_requirements & SPELL_REQUIRES_MIME_VOW) && !ISMIMING(owner))
 		// In the future this can be moved out of spell checks exactly
 		if(feedback)
 			to_chat(owner, span_warning("You must dedicate yourself to silence first!"))

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -10,16 +10,19 @@
 	school = SCHOOL_MIME
 	cooldown_time = 5 MINUTES
 
-	spell_requirements = SPELL_REQUIRES_HUMAN|SPELL_REQUIRES_MIND
+	spell_requirements = SPELL_REQUIRES_HUMAN
 	spell_max_level = 1
 
 /datum/action/cooldown/spell/vow_of_silence/cast(mob/living/carbon/human/cast_on)
 	. = ..()
-	cast_on.mind.miming = !cast_on.mind.miming
-	if(cast_on.mind.miming)
+	var/obj/item/organ/internal/liver/liver = cast_on.getorganslot(ORGAN_SLOT_LIVER)
+	//should never happen
+	if(!liver)
+		return
+	if(TRAIT_BROKEN_VOW in liver.organ_traits)
 		to_chat(cast_on, span_notice("You make a vow of silence."))
-		cast_on.clear_mood_event("vow")
+		liver.remove_organ_trait(TRAIT_BROKEN_VOW)
 	else
 		to_chat(cast_on, span_notice("You break your vow of silence."))
-		cast_on.add_mood_event("vow", /datum/mood_event/broken_vow)
+		liver.add_organ_trait(TRAIT_BROKEN_VOW)
 	cast_on.update_mob_action_buttons()

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -124,7 +124,7 @@
 		if(HAS_TRAIT(src, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 			. += "Fatty deposits and sprinkle residue, imply that this is the liver of someone in <em>security</em>."
 		if(HAS_TRAIT(src, TRAIT_CULINARY_METABOLISM))
-			. += "The high iron content and slight smell of garlic, implies that this is the liver of a <em>cook</em>."
+			. += "The high iron content and slight smell of garlic, imply that this is the liver of a <em>cook</em>."
 		if(HAS_TRAIT(src, TRAIT_COMEDY_METABOLISM))
 			. += "A smell of bananas, a slippery sheen and [span_clown("honking")] when depressed, imply that this is the liver of a <em>clown</em>."
 		if(HAS_TRAIT(src, TRAIT_FRENCH_METABOLISM))
@@ -134,13 +134,13 @@
 		if(HAS_TRAIT(src, TRAIT_MEDICAL_METABOLISM))
 			. += "Marks of stress and a faint whiff of medicinal alcohol, imply that this is the liver of a <em>medical worker</em>."
 		if(HAS_TRAIT(src, TRAIT_ENGINEER_METABOLISM))
-			. += "Signs of radiation exposure and space adaption, implies that this is the liver of an <em>engineer</em>."
+			. += "Signs of radiation exposure and space adaption, imply that this is the liver of an <em>engineer</em>."
 
 		// royal trumps pretender royal
 		if(HAS_TRAIT(src, TRAIT_ROYAL_METABOLISM))
-			. += "A rich diet of luxury food, suppleness from soft beds, implies that this is the liver of a <em>head of staff</em>."
+			. += "A rich diet of luxury food, suppleness from soft beds, imply that this is the liver of a <em>head of staff</em>."
 		else if(HAS_TRAIT(src, TRAIT_PRETENDER_ROYAL_METABOLISM))
-			. += "A diet of imitation caviar, and signs of insomnia, implies that this is the liver of <em>someone who wants to be a head of staff</em>."
+			. += "A diet of imitation caviar, and signs of insomnia, imply that this is the liver of <em>someone who wants to be a head of staff</em>."
 
 /obj/item/organ/internal/liver/before_organ_replacement(obj/item/organ/replacement)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

I didn't like how miming was stored in mind and caused bizarre checks for it, so i turned it into two separate organ traits - TRAIT_FRENCH_METABOLISM and TRAIT_BROKEN_VOW.
TRAIT_FRENCH_METABOLISM is always present, even if the vow is broken, and it grants you the vow of silence spell.
TRAIT_BROKEN_VOW only gets applied to the liver when your vow is broken. You'll still have the vow of silence action, but pretty much none of the benefits of french metabolism work.

Also, mime livers are always grayscaled.
![image](https://user-images.githubusercontent.com/82850673/209511622-4961fdd3-9a12-4c64-a44f-c2031b4153b5.png)

I thought about making TRAIT_FRENCH_METABOLISM only affect how reagents are metabolized, but the thought of an entire mime's essence being stored in the liver is so fucking funny.

## Why It's Good For The Game

It felt really weird how mimes were the odd job out in regards to metabolism, so i fixed that.

## Changelog

:cl:
refactor: Mimery is now stored in the liver, you can steal someone's liver and implant them to get the vow of silence and the benefits that come from it.
/:cl:
