### PR TITLE
throwing no longer gets canceled if theres a mob buckled to the thrown thing

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -147,7 +147,7 @@ SUBSYSTEM_DEF(throwing)
 				continue
 			if(obstacle.pass_flags_self & LETPASSTHROW)
 				continue
-			if (obstacle == actual_target || (obstacle.density && !(obstacle.flags_1 & ON_BORDER_1)))
+			if (obstacle == actual_target || (obstacle.density && !(obstacle.flags_1 & ON_BORDER_1) && !(obstacle in AM.buckled_mobs)))
 				finalize(TRUE, obstacle)
 				return
 


### PR DESCRIPTION

## About The Pull Request
throwing checks for dense obstacles on every tick of its path. a buckled mob is a dense obstacle, so it canceled throws! it no longer does that

## Why It's Good For The Game
this will be useful in the future (and for admins throwing people buckled on the shuttle into space)

## Changelog
:cl:
fix: throwing no longer gets canceled if theres a mob buckled to the thrown thing
/:cl:
