### PR TITLE
Fixes a bug where latejoin menu would display incorrect number of open slots

### DIFF
--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -82,7 +82,8 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 				department_data["open_slots"] = "∞"
 
 			if(department_data["open_slots"] != "∞")
-				department_data["open_slots"] += job_datum.total_positions - job_datum.current_positions
+				if(job_datum.total_positions - job_datum.current_positions > 0)
+					department_data["open_slots"] += job_datum.total_positions - job_datum.current_positions
 
 			department_jobs[job_datum.title] = job_data
 


### PR DESCRIPTION
## About The Pull Request

Fixes number of open slots being less than intended by simply adding an if statement that prevents negative numbers from being added to the total.
## Why It's Good For The Game

The number of department slots open will be accurate and there won't be any nonsense like a negative number of slots.

Fixes #72034
## Changelog
:cl:
spellcheck: fixed a bug where latejoin menu would display incorrect number of open slots
/:cl:
