### PR TITLE
[NO GBP] Transparent and timid kudzu mutations wont block light like they are supposed to

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -1,5 +1,8 @@
 /// Determines brightness of the light emitted by kudzu with the light mutation
 #define LIGHT_MUTATION_BRIGHTNESS 4
+/// Kudzu light states
+#define PASS_LIGHT 0
+#define BLOCK_LIGHT 1
 /// Determines the probability that the toxicity mutation will harm someone who passes through it
 #define TOXICITY_MUTATION_PROB 10
 /// Determines the impact radius of kudzu's explosive mutation
@@ -290,7 +293,7 @@
 	severity = SEVERITY_TRIVIAL
 
 /datum/spacevine_mutation/transparency/on_grow(obj/structure/spacevine/holder)
-	holder.set_opacity(0)
+	holder.light_state = PASS_LIGHT
 	holder.alpha = 125
 
 /datum/spacevine_mutation/oxy_eater
@@ -398,6 +401,7 @@
 //This specific mutation only covers floors instead of structures, items, mobs and cant tangle mobs
 /datum/spacevine_mutation/timid/on_birth(obj/structure/spacevine/holder)
 	SET_PLANE_IMPLICIT(holder, FLOOR_PLANE)
+	holder.light_state = PASS_LIGHT
 	holder.can_tangle = FALSE
 	return ..()
 
@@ -440,6 +444,8 @@
 	var/trait_flags = 0
 	/// Should atmos always process this tile
 	var/always_atmos_process = FALSE
+	/// The kudzu blocks light on default once it grows
+	var/light_state = BLOCK_LIGHT
 
 /obj/structure/spacevine/Initialize(mapload)
 	. = ..()
@@ -469,7 +475,7 @@
 	if(master)
 		master.VineDestroyed(src)
 	mutations = list()
-	set_opacity(0)
+	set_opacity(PASS_LIGHT)
 	if(has_buckled_mobs())
 		unbuckle_all_mobs(force=1)
 	return ..()
@@ -678,7 +684,7 @@
 	if(!energy)
 		src.icon_state = pick("Med1", "Med2", "Med3")
 		energy = 1
-		set_opacity(1)
+		set_opacity(light_state)
 	else
 		src.icon_state = pick("Hvy1", "Hvy2", "Hvy3")
 		energy = 2
@@ -761,6 +767,8 @@
 	return FALSE
 
 #undef LIGHT_MUTATION_BRIGHTNESS
+#undef PASS_LIGHT
+#undef BLOCK_LIGHT
 #undef TOXICITY_MUTATION_PROB
 #undef EXPLOSION_MUTATION_IMPACT_RADIUS
 #undef GAS_MUTATION_REMOVAL_MULTIPLIER


### PR DESCRIPTION
## About The Pull Request

Back in my old PR(https://github.com/tgstation/tgstation/pull/70306) I had forgotten to make timid kudzu not block light, I also found out that transparent kudzus are not supposed to block light.
This PR fixes those issues

## Why It's Good For The Game

Bug fix

## Changelog

:cl:
fix: transparent and timid kudzu mutations wont block light
/:cl:
