### PR TITLE
Reduces power consumption of mob electrocution by 90%.

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -411,7 +411,7 @@
 	var/drained_hp = victim.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
 	log_combat(source, victim, "electrocuted")
 
-	var/drained_energy = drained_hp*20
+	var/drained_energy = drained_hp * 2
 
 	if (isarea(power_source))
 		var/area/source_area = power_source


### PR DESCRIPTION

## About The Pull Request
Reduces the power consumption of mob electrocution by 90%.
## Why It's Good For The Game
People being able to create untraceable ghetto powersinks with 2 monkeys and a conveyor contraption is fucking dumb.
## Changelog
:cl:
balance: Mob electrocution consumes 90% less power.
/:cl:
