### PR TITLE
Converted nonhuman payday modifier into a config option.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -110,9 +110,9 @@
 
 /datum/config_entry/flag/enforce_human_authority_on_everyone //If non-human species are barred from joining as a head of staff, including jobs flagged as allowed for non-humans, ie. Quartermaster.
 
-/datum/config_entry/flag/enforce_nonhuman_wage_gap //If non-human species have their pay multiplied by the value of nonhuman_payday_mul.
+/datum/config_entry/flag/no_nonhuman_wage_gap //Prevents non-humans from having their pay multiplied.
 
-/datum/config_entry/number/nonhuman_payday_mul // Multipliers for non-human pay if the wage gap config is enabled.
+/datum/config_entry/number/nonhuman_payday_multiplier // Multiplier for non-human pay.
 	default = 0.75
 	min_val = 0
 	integer = FALSE

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -110,6 +110,13 @@
 
 /datum/config_entry/flag/enforce_human_authority_on_everyone //If non-human species are barred from joining as a head of staff, including jobs flagged as allowed for non-humans, ie. Quartermaster.
 
+/datum/config_entry/flag/enforce_nonhuman_wage_gap //If non-human species have their pay multiplied by the value of nonhuman_payday_mul.
+
+/datum/config_entry/number/nonhuman_payday_mul // Multipliers for non-human pay if the wage gap config is enabled.
+	default = 0.75
+	min_val = 0
+	integer = FALSE
+
 /datum/config_entry/flag/allow_latejoin_antagonists // If late-joining players can be traitor/changeling
 
 /datum/config_entry/number/shuttle_refuel_delay

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -110,7 +110,7 @@
 
 /datum/config_entry/flag/enforce_human_authority_on_everyone //If non-human species are barred from joining as a head of staff, including jobs flagged as allowed for non-humans, ie. Quartermaster.
 
-/datum/config_entry/flag/no_nonhuman_wage_gap //Prevents non-humans from having their pay multiplied.
+/datum/config_entry/flag/equal_nonhuman_wages //Prevents non-humans from having their pay multiplied.
 
 /datum/config_entry/number/nonhuman_payday_multiplier // Multiplier for non-human pay.
 	default = 0.75

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -192,7 +192,7 @@
 
 /mob/living/carbon/human/on_job_equipping(datum/job/equipping)
 	var/payday
-	if(CONFIG_GET(flag/no_nonhuman_wage_gap) || dna.species.id == SPECIES_HUMAN)
+	if(CONFIG_GET(flag/equal_nonhuman_wages) || dna.species.id == SPECIES_HUMAN)
 		payday = 1
 	else
 		payday = CONFIG_GET(number/nonhuman_payday_multiplier)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -192,10 +192,10 @@
 
 /mob/living/carbon/human/on_job_equipping(datum/job/equipping)
 	var/payday
-	if(!CONFIG_GET(flag/enforce_nonhuman_wage_gap) || dna.species.id == SPECIES_HUMAN)
+	if(CONFIG_GET(flag/no_nonhuman_wage_gap) || dna.species.id == SPECIES_HUMAN)
 		payday = 1
 	else
-		payday = CONFIG_GET(number/nonhuman_payday_mul)
+		payday = CONFIG_GET(number/nonhuman_payday_multiplier)
 	var/datum/bank_account/bank_account = new(real_name, equipping, payday)
 	bank_account.payday(STARTING_PAYCHECKS, TRUE)
 	account_id = bank_account.account_id

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -191,7 +191,12 @@
 	return
 
 /mob/living/carbon/human/on_job_equipping(datum/job/equipping)
-	var/datum/bank_account/bank_account = new(real_name, equipping, dna.species.payday_modifier)
+	var/payday
+	if(!CONFIG_GET(flag/enforce_nonhuman_wage_gap) || dna.species.id == SPECIES_HUMAN)
+		payday = 1
+	else
+		payday = CONFIG_GET(number/nonhuman_payday_mul)
+	var/datum/bank_account/bank_account = new(real_name, equipping, payday)
 	bank_account.payday(STARTING_PAYCHECKS, TRUE)
 	account_id = bank_account.account_id
 	bank_account.replaceable = FALSE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -115,8 +115,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/heatmod = 1
 	///multiplier for stun durations
 	var/stunmod = 1
-	///multiplier for money paid at payday
-	var/payday_modifier = 1
 	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
 	var/siemens_coeff = 1
 	///To use MUTCOLOR with a fixed color that's independent of the mcolor feature in DNA.

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -9,7 +9,6 @@
 	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
-	payday_modifier = 0.75
 	species_traits = list(
 		DYNCOLORS,
 		AGENDER,

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -15,7 +15,6 @@
 	disliked_food = GROSS | CLOTH | RAW
 	liked_food = SEAFOOD | ORANGES | BUGS | GORE
 	var/original_felinid = TRUE //set to false for felinids created by mass-purrbation
-	payday_modifier = 0.75
 	ass_image = 'icons/ass/asscat.png'
 	family_heirlooms = list(/obj/item/toy/cattoy)
 	examine_limb_id = SPECIES_HUMAN

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -15,7 +15,6 @@
 	toxic_food = NONE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/fly
-	payday_modifier = 0.75
 
 	mutanttongue = /obj/item/organ/internal/tongue/fly
 	mutantheart = /obj/item/organ/internal/heart/fly

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -24,7 +24,6 @@
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	mutant_organs = list(/obj/item/organ/internal/adamantine_resonator)
 	speedmod = 2
-	payday_modifier = 0.75
 	armor = 55
 	siemens_coeff = 0
 	no_equip_flags = ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING | ITEM_SLOT_SUITSTORE

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -16,7 +16,6 @@
 	disliked_food = GROSS | RAW | CLOTH | BUGS | GORE
 	liked_food = JUNKFOOD | FRIED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 1
 
 /datum/species/human/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.hairstyle = "Business Hair"

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -22,7 +22,6 @@
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
 	burnmod = 0.5 // = 1/2x generic burn damage
-	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_factions = list("slime")
 	species_language_holder = /datum/language_holder/jelly

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -24,7 +24,6 @@
 	mutanttongue = /obj/item/organ/internal/tongue/lizard
 	coldmod = 1.5
 	heatmod = 0.67
-	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_cookie = /obj/item/food/meat/slab
 	meat = /obj/item/food/meat/slab/human/mutant/lizard

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -45,7 +45,6 @@
 	dust_anim = "dust-m"
 	gib_anim = "gibbed-m"
 
-	payday_modifier = 1.5
 	ai_controlled_species = TRUE
 
 

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -23,7 +23,6 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/moth
 	wing_types = list(/obj/item/organ/external/wings/functional/moth/megamoth, /obj/item/organ/external/wings/functional/moth/mothra)
-	payday_modifier = 0.75
 	family_heirlooms = list(/obj/item/flashlight/lantern/heirloom_moth)
 
 	bodypart_overrides = list(

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -25,7 +25,6 @@
 	burnmod = 1.5
 	heatmod = 1.5
 	brutemod = 1.5
-	payday_modifier = 0.75
 	breathid = "plas"
 	disliked_food = FRUIT | CLOTH
 	liked_food = VEGETABLES

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -18,7 +18,6 @@
 
 	burnmod = 1.25
 	heatmod = 1.5
-	payday_modifier = 0.75
 	meat = /obj/item/food/meat/slab/human/mutant/plant
 	exotic_blood = /datum/reagent/water
 	disliked_food = MEAT | DAIRY | SEAFOOD | BUGS

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -122,11 +122,11 @@ PROTECT_ROLES_FROM_ANTAGONIST
 ## If non-human species are barred from joining as a head of staff, including jobs flagged as allowed for non-humans, ie. Quartermaster.
 #ENFORCE_HUMAN_AUTHORITY_ON_EVERYONE
 
-## If non-human species have their pay multiplied by the value of NONHUMAN_PAYDAY_MUL.
-#ENFORCE_NONHUMAN_WAGE_GAP
+## Prevents non-human species from having their pay cut.
+#NO_NONHUMAN_WAGE_GAP
 
-## Multiplier for non-humans' paycheck values. Only used if ENFORCE_NONHUMAN_WAGE_GAP is uncommented.
-NONHUMAN_PAYDAY_MUL 0.75
+## Multiplier for non-humans' paycheck values. Unused if NO_NONHUMAN_WAGE_GAP is uncommented.
+NONHUMAN_PAYDAY_MULTIPLIER 0.75
 
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -123,7 +123,7 @@ PROTECT_ROLES_FROM_ANTAGONIST
 #ENFORCE_HUMAN_AUTHORITY_ON_EVERYONE
 
 ## If non-human species have their pay multiplied by the value of NONHUMAN_PAYDAY_MUL.
-ENFORCE_NONHUMAN_WAGE_GAP
+#ENFORCE_NONHUMAN_WAGE_GAP
 
 ## Multiplier for non-humans' paycheck values. Only used if ENFORCE_NONHUMAN_WAGE_GAP is uncommented.
 NONHUMAN_PAYDAY_MUL 0.75

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -122,6 +122,12 @@ PROTECT_ROLES_FROM_ANTAGONIST
 ## If non-human species are barred from joining as a head of staff, including jobs flagged as allowed for non-humans, ie. Quartermaster.
 #ENFORCE_HUMAN_AUTHORITY_ON_EVERYONE
 
+## If non-human species have their pay multiplied by the value of NONHUMAN_PAYDAY_MUL.
+ENFORCE_NONHUMAN_WAGE_GAP
+
+## Multiplier for non-humans' paycheck values. Only used if ENFORCE_NONHUMAN_WAGE_GAP is uncommented.
+NONHUMAN_PAYDAY_MUL 0.75
+
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -123,7 +123,7 @@ PROTECT_ROLES_FROM_ANTAGONIST
 #ENFORCE_HUMAN_AUTHORITY_ON_EVERYONE
 
 ## Prevents non-human species from having their pay cut.
-#NO_NONHUMAN_WAGE_GAP
+#EQUAL_NONHUMAN_WAGES
 
 ## Multiplier for non-humans' paycheck values. Unused if NO_NONHUMAN_WAGE_GAP is uncommented.
 NONHUMAN_PAYDAY_MULTIPLIER 0.75


### PR DESCRIPTION

## About The Pull Request

The "payday modifier" var has been removed from species, and added as a pair of config options in game_options.txt instead:

`ENFORCE_NONHUMAN_WAGE_GAP`: Whether non-human characters should have their pay multiplied by some value. (Default: false)
`NONHUMAN_PAYDAY_MUL`: The multiplier for paychecks if the prior is set to true. (Default: 0.75)

Note that I've set the nonhuman wage gap's default to false. This is to fall in line with the "human authority" config options (non-humans can't be heads of staff) also defaulting to false, even if they're enabled on official tgstation servers. I can easily change this default if that's more desirable.

Note also that this does remove a small piece of unique behavior: the only species that didn't have its payday modifier set to 0.75 was monkeys, who very humorously received 1.5x the pay of humans. I thought that this was an obscure enough little joke that it wouldn't hurt things to cut it in favor of the new system. But, again, I could restore this easily enough if it's wanted.
## Why It's Good For The Game
Setting the payday multiplier for non-humans globally removes a lot of redundancy in species datums: since the same number was used everywhere anyway, there wasn't a lot of reason why it should be defined for individual species. If some downstream somewhere was setting up a very fine-grained sort of racism in pay for individual species... that's weird. I don't know what to say about that.

Having the wage gap's _existence_ as a config option is mostly good for downstreams and unofficial servers that don't want non-humans to be paid less than humans in the first place. On my own downstream, we had to individually override the payday modifiers for every species to accomplish this, which is a needless pain.

Making this a config option is _also_ in line with the already-existing config options for human supremacy - it's strange to have _part_ of your employer's racism be optional while another part is mandatory. It's nice to be able to disable that aspect altogether.

## Changelog
:cl:
del: Removed payday modifiers from species code.
config: Added new config settings for the non-human wage gap.
/:cl:
