### PR TITLE
Add lints for idiomatic balloon alert usage

### DIFF
--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -134,6 +134,8 @@
  * Attempts to charge a mob, user, an integer number of credits, total_cost, directly from an ID card/bank account.
  */
 /datum/component/payment/proc/handle_card(mob/living/user, obj/item/card/id/idcard, total_cost)
+	var/atom/atom_parent = parent
+
 	if(!idcard)
 		return FALSE
 	if(!idcard?.registered_account)
@@ -154,7 +156,7 @@
 				to_chat(user, span_warning("YOU MORON. YOU ABSOLUTE BAFOON. YOU INSUFFERABLE TOOL. YOU ARE POOR."))
 			if(PAYMENT_CLINICAL)
 				to_chat(user, span_warning("ID Card lacks funds. Aborting."))
-		user.balloon_alert(user, "Cost: [total_cost] credits.")
+		atom_parent.balloon_alert(user, "needs [total_cost] credit\s!")
 		return FALSE
 	target_acc.transfer_money(idcard.registered_account, total_cost, "Nanotrasen: Usage of Corporate Machinery")
 	log_econ("[total_cost] credits were spent on [parent] by [user] via [idcard.registered_account.account_holder]'s card.")

--- a/code/game/machinery/botlaunchpad.dm
+++ b/code/game/machinery/botlaunchpad.dm
@@ -42,7 +42,7 @@
 				bot_count += 1 // this counts the number of bots so we don't launch if there multiple bots.
 				possible_bot = ROI  // We don't change the launched_bot var here because we are not sure if there is another bot on the pad.
 			else
-				user?.balloon_alert(user, "There is an unidentified life form on the pad!")
+				user?.balloon_alert(user, "unidentified life form on the pad!")
 				return
 	if(bot_count == 1)
 		launched_bot = possible_bot
@@ -54,13 +54,13 @@
 		))
 		use_power(active_power_usage)
 	else
-		user?.balloon_alert(user, "There is more than one bot on the pad!")
+		user?.balloon_alert(user, "too many bots on the pad!")
 
 /obj/machinery/botpad/proc/recall(mob/living/user)
 	if(!launched_bot)
-		user?.balloon_alert(user, "No bots detected on the pad!")
+		user?.balloon_alert(user, "no bots detected on the pad!")
 		return
-	user?.balloon_alert(user, "Sending the bot back to its pad")
+	user?.balloon_alert(user, "bot sent back to pad")
 	launched_bot.call_bot(src,  get_turf(src))
 
 /obj/structure/closet/supplypod/botpod

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -49,7 +49,7 @@
 		return
 	id = change_id
 	to_chat(user, span_notice("You change the ID to [id]."))
-	balloon_alert(user, "ID changed")
+	balloon_alert(user, "id changed")
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/machinery/door/poddoor/crowbar_act(mob/living/user, obj/item/tool)

--- a/code/game/objects/items/botpad_remote.dm
+++ b/code/game/objects/items/botpad_remote.dm
@@ -25,7 +25,7 @@
 	if(connected_botpad)
 		connected_botpad.recall(user)
 		return
-	user?.balloon_alert(user, "Controller has no connected pad!")
+	user?.balloon_alert(user, "no connected pad!")
 	return
 
 /obj/item/botpad_remote/multitool_act(mob/living/user, obj/item/tool)
@@ -47,12 +47,12 @@
 
 /obj/item/botpad_remote/proc/try_launch(mob/living/user)
 	if(!connected_botpad)
-		user?.balloon_alert(user, "Controller has no connected pad!")
+		user?.balloon_alert(user, "no connected pad!")
 		return
 	if(connected_botpad.panel_open)
-		user?.balloon_alert(user, "Connected pad has its panel open! It won't work!")
+		user?.balloon_alert(user, "close the panel!")
 		return
 	if(!(locate(/mob/living/simple_animal/bot) in get_turf(connected_botpad)))
-		user?.balloon_alert(user, "No bots detected on the pad!")
+		user?.balloon_alert(user, "no bots detected on the pad!")
 		return
 	connected_botpad.launch(user)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -99,9 +99,9 @@
 /obj/item/grenade/chem_grenade/screwdriver_act(mob/living/user, obj/item/tool)
 	. = TRUE
 	if(dud_flags & GRENADE_USED)
-		balloon_alert(user, span_notice("resetting trigger..."))
+		balloon_alert(user, "resetting trigger...")
 		if (do_after(user, 2 SECONDS, src))
-			balloon_alert(user, span_notice("trigger reset"))
+			balloon_alert(user, "trigger reset")
 			dud_flags &= ~GRENADE_USED
 		return
 

--- a/code/game/objects/items/inspector.dm
+++ b/code/game/objects/items/inspector.dm
@@ -62,7 +62,7 @@
 	if(user.combat_mode)
 		return
 	cell_cover_open = !cell_cover_open
-	balloon_alert(user, "You [cell_cover_open ? "open" : "close"] the cell cover on \the [src].")
+	balloon_alert(user, "[cell_cover_open ? "opened" : "closed"] cell cover")
 	return TRUE
 
 /obj/item/inspector/attackby(obj/item/I, mob/user, params)
@@ -225,13 +225,13 @@
 		time_mode = INSPECTOR_TIME_MODE_FAST
 		message = "LIGHTNING FAST."
 
-	balloon_alert(user, "You turn the screw-like dial, setting the device's scanning speed to [message]")
+	balloon_alert(user, "scanning speed set to [message]")
 
 /obj/item/inspector/clown/proc/cycle_sound(mob/user)
 	print_sound_mode++
 	if(print_sound_mode > max_mode)
 		print_sound_mode = INSPECTOR_PRINT_SOUND_MODE_NORMAL
-	balloon_alert(user, "You turn the dial with holes in it, setting the device's bleep setting to [mode_names[print_sound_mode]] mode.")
+	balloon_alert(user, "bleep setting set to [mode_names[print_sound_mode]]")
 
 /obj/item/inspector/clown/create_slip()
 	var/obj/item/paper/fake_report/slip = new(get_turf(src))
@@ -324,7 +324,7 @@
 			time_mode = INSPECTOR_TIME_MODE_HONK
 			power_per_print = INSPECTOR_POWER_USAGE_HONK
 			message = "HONK!"
-	balloon_alert(user, "You turn the screw-like dial, setting the device's scanning speed to [message]")
+	balloon_alert(user, "scanning speed set to [message]")
 
 /**
  * Reports printed by fake N-spect scanner

--- a/code/game/objects/items/pillow.dm
+++ b/code/game/objects/items/pillow.dm
@@ -91,14 +91,14 @@
 	if(!pillow_trophy)
 		balloon_alert(user, "no tag!")
 		return
-	balloon_alert(user, span_notice("removing tag..."))
+	balloon_alert(user, "removing tag...")
 	if(!do_after(user, 2 SECONDS, src))
 		return
 	if(last_fighter)
 		pillow_trophy.desc = "a pillow tag taken from [last_fighter] after a gruesome pillow fight."
 	user.put_in_hands(pillow_trophy)
 	pillow_trophy = null
-	balloon_alert(user, span_notice("tag removed"))
+	balloon_alert(user, "tag removed")
 	playsound(user,'sound/items/poster_ripped.ogg', 50)
 	update_appearance()
 

--- a/code/game/objects/structures/crates_lockers/crates/syndicrate.dm
+++ b/code/game/objects/structures/crates_lockers/crates/syndicrate.dm
@@ -49,7 +49,7 @@
 ///overwrites default opening behavior until it is unlocked via the syndicrate key
 /obj/structure/closet/crate/syndicrate/can_open(mob/living/user, force = FALSE)
 	if(!created_items)
-		balloon_alert(user, "Locked!")
+		balloon_alert(user, "locked!")
 		return FALSE
 	return ..()
 

--- a/code/game/objects/structures/toiletbong.dm
+++ b/code/game/objects/structures/toiletbong.dm
@@ -28,10 +28,10 @@
 /obj/structure/toiletbong/attack_hand(mob/living/carbon/user)
 	. = ..()
 	if (!anchored)
-		user.balloon_alert(user, "Secure it first!")
+		user.balloon_alert(user, "secure it first!")
 		return
 	if (!LAZYLEN(contents))
-		user.balloon_alert(user, "It's empty!")
+		user.balloon_alert(user, "it's empty!")
 		return
 	user.visible_message(span_boldnotice("[user] takes a huge drag on the [src]."))
 	if (do_after(user, 2 SECONDS, target = src))
@@ -47,8 +47,7 @@
 			puff.start()
 			if (prob(5) && !emagged)
 				if(islizard(user))
-					to_chat(user, span_boldnotice("A hidden treat in the pipes!"))
-					user.balloon_alert(user, "A hidden treat in the pipes!")
+					user.balloon_alert(user, "a hidden treat!")
 					user.visible_message(span_danger("[user] fishes a mouse out of the pipes."))
 				else
 					to_chat(user, span_userdanger("There was something disgusting in the pipes!"))
@@ -98,7 +97,7 @@
 
 /obj/structure/toiletbong/emag_act(mob/user, obj/item/card/emag/emag_card)
 	playsound(src, 'sound/effects/fish_splash.ogg', 50)
-	user.balloon_alert(user, "Whoops!")
+	user.balloon_alert(user, "whoops!")
 	if(!emagged)
 		emagged = TRUE
 		smokeradius = 2

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -30,7 +30,7 @@
 	if(isopenspaceturf(rift_spawn_turf))
 		owner.balloon_alert(dragon, "needs stable ground!")
 		return
-	owner.balloon_alert(owner, "You begin to open a rift...")
+	owner.balloon_alert(owner, "opening rift...")
 	if(!do_after(owner, 10 SECONDS, target = owner))
 		return
 	if(locate(/obj/structure/carp_rift) in owner.loc)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -96,7 +96,7 @@
 /obj/item/soulstone/proc/attempt_exorcism(mob/exorcist)
 	if(IS_CULTIST(exorcist) || theme == THEME_HOLY)
 		return
-	balloon_alert(exorcist, span_notice("exorcising [src]..."))
+	balloon_alert(exorcist, "exorcising...")
 	playsound(src, 'sound/hallucinations/veryfar_noise.ogg', 40, TRUE)
 	if(!do_after(exorcist, 4 SECONDS, target = src))
 		return

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -81,7 +81,7 @@
 	if (secured)
 		balloon_alert(user, "scanning [scanning ? "disabled" : "enabled"]")
 	else
-		balloon_alert(user, span_warning("secure it first!"))
+		balloon_alert(user, "secure it first!")
 	toggle_scan()
 
 /obj/item/assembly/health/proc/get_status_tab_item(mob/living/carbon/source, list/items)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -49,9 +49,9 @@
 		return FALSE
 	if(user.combat_mode)
 		return FALSE
-	balloon_alert(user, "You start repairing the crack...")
+	balloon_alert(user, "repairing...")
 	if(tool.use_tool(src, user, 10 SECONDS, volume=30, amount=5))
-		balloon_alert(user, "You repaired the crack.")
+		balloon_alert(user, "repaired")
 		cracked = FALSE
 		update_appearance()
 

--- a/code/modules/mining/equipment/kheiral_cuffs.dm
+++ b/code/modules/mining/equipment/kheiral_cuffs.dm
@@ -63,7 +63,7 @@
 	if(id_card)
 		gps_name = id_card.registered_name
 	AddComponent(/datum/component/gps/kheiral_cuffs, "*[gps_name]'s Kheiral Link")
-	balloon_alert(user, "GPS activated")
+	balloon_alert(user, "gps activated")
 	ADD_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
 	gps_enabled = TRUE
 
@@ -73,7 +73,7 @@
 		return
 	if(on_wrist && far_from_home)
 		return
-	balloon_alert(user, "GPS de-activated")
+	balloon_alert(user, "gps de-activated")
 	REMOVE_TRAIT(user, TRAIT_MULTIZ_SUIT_SENSORS, REF(src))
 	gps_enabled = FALSE
 

--- a/code/modules/mod/mod_ai.dm
+++ b/code/modules/mod/mod_ai.dm
@@ -8,7 +8,7 @@
 	switch(interaction)
 		if(AI_TRANS_TO_CARD)
 			if(!ai)
-				balloon_alert(user, "no AI in suit!")
+				balloon_alert(user, "no ai in suit!")
 				return
 			balloon_alert(user, "transferring to card...")
 			if(!do_after(user, 5 SECONDS, target = src))
@@ -28,21 +28,21 @@
 			intAI.controlled_equipment = null
 			intAI.remote_control = null
 			balloon_alert(intAI, "transferred to a card")
-			balloon_alert(user, "AI transferred to card")
+			balloon_alert(user, "ai transferred to card")
 			ai = null
 
 		if(AI_TRANS_FROM_CARD) //Using an AI card to upload to the suit.
 			intAI = card.AI
 			if(!intAI)
-				balloon_alert(user, "no AI in card!")
+				balloon_alert(user, "no ai in card!")
 				return
 			if(ai)
-				balloon_alert(user, "already has AI!")
+				balloon_alert(user, "already has ai!")
 				return
 			if(intAI.deployed_shell) //Recall AI if shelled so it can be checked for a client
 				intAI.disconnect_shell()
 			if(intAI.stat || !intAI.client)
-				balloon_alert(user, "AI unresponsive!")
+				balloon_alert(user, "ai unresponsive!")
 				return
 			balloon_alert(user, "transferring to suit...")
 			if(!do_after(user, 5 SECONDS, target = src))
@@ -50,7 +50,7 @@
 				return
 			if(ai)
 				return
-			balloon_alert(user, "AI transferred to suit")
+			balloon_alert(user, "ai transferred to suit")
 			ai_enter_mod(intAI)
 			card.AI = null
 
@@ -135,7 +135,7 @@
 		return
 	var/mob/living/silicon/ai/ai = stored_ai.resolve()
 	if(!ai)
-		balloon_alert(user, "no AI!")
+		balloon_alert(user, "no ai!")
 		return
 	balloon_alert(user, "transferring to card...")
 	if(!do_after(user, 5 SECONDS, target = src) || !ai)
@@ -145,5 +145,5 @@
 	ai.forceMove(card)
 	card.AI = ai
 	ai.notify_ghost_cloning("You have been recovered from the wreckage!", source = card)
-	balloon_alert(user, "AI transferred to card")
+	balloon_alert(user, "ai transferred to card")
 	stored_ai = null

--- a/code/modules/mod/mod_construction.dm
+++ b/code/modules/mod/mod_construction.dm
@@ -196,7 +196,7 @@
 					balloon_alert(user, "boots added")
 					return
 				playsound(src, 'sound/machines/click.ogg', 30, TRUE)
-				balloon_alert(user, "You fit [part] onto [src].")
+				balloon_alert(user, "fit [part.name]")
 				boots = part
 				step = BOOTS_STEP
 			else if(part.tool_behaviour == TOOL_CROWBAR) //Deconstruct

--- a/code/modules/mod/modules/modules_maint.dm
+++ b/code/modules/mod/modules/modules_maint.dm
@@ -231,7 +231,7 @@
 	if(prob(min(num_sheets_dispensed * 2, 30)))
 		if(crisp_paper in mod.wearer.held_items)
 			mod.wearer.dropItemToGround(crisp_paper, force = TRUE)
-		crisp_paper.balloon_alert(mod.wearer, "PC LOAD LETTER!")
+		crisp_paper.balloon_alert(mod.wearer, UNLINT("PC LOAD LETTER!"))
 		crisp_paper.visible_message(span_warning("[crisp_paper] bursts into flames, it's too crisp!"))
 		crisp_paper.fire_act(1000, 100)
 

--- a/code/modules/pai/software.dm
+++ b/code/modules/pai/software.dm
@@ -160,13 +160,13 @@
 	if(!iscarbon(holder))
 		balloon_alert(src, "not being carried")
 		return FALSE
-	balloon_alert(src, "requesting DNA sample")
+	balloon_alert(src, "requesting dna sample")
 	if(tgui_alert(holder, "[src] is requesting a DNA sample from you. Will you allow it to confirm your identity?", "Checking DNA", list("Yes", "No")) != "Yes")
-		balloon_alert(src, "DNA sample refused")
+		balloon_alert(src, "dna sample refused!")
 		return FALSE
 	holder.visible_message(span_notice("[holder] presses [holder.p_their()] thumb against [src]."), span_notice("You press your thumb against [src]."), span_notice("[src] makes a sharp clicking sound as it extracts DNA material from [holder]."))
 	if(!holder.has_dna())
-		balloon_alert(src, "no DNA detected")
+		balloon_alert(src, "no dna detected!")
 		return FALSE
 	to_chat(src, span_boldannounce(("[holder]'s UE string: [holder.dna.unique_enzymes]")))
 	to_chat(src, span_notice("DNA [holder.dna.unique_enzymes == master_dna ? "matches" : "does not match"] our stored Master's DNA."))

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -50,7 +50,7 @@
 			balloon_alert(user, "remove the floor plating!")
 			return
 		if(terminal)
-			balloon_alert(user, "APC is already wired!")
+			balloon_alert(user, "already wired!")
 			return
 		if(!has_electronics)
 			balloon_alert(user, "no board to wire!")
@@ -154,7 +154,7 @@
 		user.visible_message(span_notice("[user.name] replaces the damaged APC frame with a new one."))
 		balloon_alert(user, "replacing damaged frame...")
 		if(do_after(user, 50, target = src))
-			balloon_alert(user, "APC frame replaced")
+			balloon_alert(user, "replaced frame")
 			qdel(attacking_object)
 			set_machine_stat(machine_stat & ~BROKEN)
 			atom_integrity = max_integrity
@@ -288,7 +288,7 @@
 	var/mob/living/silicon/robot/robot = user
 	if(aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai!=AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots))))
 		if(!loud)
-			balloon_alert(user, "APC has been disabled!")
+			balloon_alert(user, "it's disabled!")
 		return FALSE
 	return TRUE
 

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -217,7 +217,7 @@
 	else
 		if(allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && !malfhack && !remote_control_user)
 			locked = !locked
-			balloon_alert(user, "APC [ locked ? "locked" : "unlocked"]")
+			balloon_alert(user, locked ? "locked" : "unlocked")
 			update_appearance()
 			if(!locked)
 				ui_interact(user)

--- a/code/modules/research/anomaly/anomaly_refinery.dm
+++ b/code/modules/research/anomaly/anomaly_refinery.dm
@@ -125,7 +125,7 @@
 /obj/machinery/research/anomaly_refinery/emag_act(mob/user, obj/item/card/emag/emag_card)
 	. = ..()
 	if (obj_flags & EMAGGED)
-		balloon_alert(user, span_warning("already hacked!"))
+		balloon_alert(user, "already hacked!")
 		return
 
 	obj_flags |= EMAGGED

--- a/code/modules/research/ordnance/doppler_array.dm
+++ b/code/modules/research/ordnance/doppler_array.dm
@@ -56,7 +56,7 @@
 			inserted_disk = disk
 			return
 		else
-			balloon_alert(user, span_warning("[disk] is stuck to your hand."))
+			balloon_alert(user, "it's stuck to your hand!")
 			return ..()
 	return ..()
 

--- a/code/modules/research/ordnance/tank_compressor.dm
+++ b/code/modules/research/ordnance/tank_compressor.dm
@@ -51,10 +51,10 @@
 		var/obj/item/tank/tank_item = item
 		if(inserted_tank)
 			if(!eject_tank(user))
-				balloon_alert(user, span_warning("[inserted_tank] is stuck inside."))
+				balloon_alert(user, "it's stuck inside!")
 				return ..()
 		if(!user.transferItemToLoc(tank_item, src))
-			balloon_alert(user, span_warning("[tank_item] is stuck to your hand."))
+			balloon_alert(user, "it's stuck to your hand!")
 			return ..()
 		inserted_tank = tank_item
 		last_recorded_pressure = 0
@@ -67,7 +67,7 @@
 		if(user.transferItemToLoc(attacking_disk, src))
 			inserted_disk = attacking_disk
 		else
-			balloon_alert(user, span_warning("[attacking_disk] is stuck to your hand."))
+			balloon_alert(user, "it's stuck to your hand!")
 		return
 	return ..()
 

--- a/code/modules/wiremod/components/id/access_checker.dm
+++ b/code/modules/wiremod/components/id/access_checker.dm
@@ -62,7 +62,7 @@
 
 /obj/item/circuit_component/compare/access/ui_perform_action(mob/user, action)
 	if(length(required_accesses.connected_ports))
-		balloon_alert(user, "Disconnect port before manually configuring!")
+		balloon_alert(user, "disconnect port before manually configuring!")
 		return
 	interact(user)
 

--- a/code/modules/wiremod/shell/moneybot.dm
+++ b/code/modules/wiremod/shell/moneybot.dm
@@ -35,7 +35,7 @@
 		return
 	set_anchored(!anchored)
 	tool.play_tool_sound(src)
-	balloon_alert(user, "You [anchored?"secure":"unsecure"] [src].")
+	balloon_alert(user, anchored ? "secured" : "unsecured")
 	return TRUE
 
 

--- a/code/modules/wiremod/shell/scanner_gate.dm
+++ b/code/modules/wiremod/shell/scanner_gate.dm
@@ -22,7 +22,7 @@
 		return
 	set_anchored(!anchored)
 	tool.play_tool_sound(src)
-	balloon_alert(user, "You [anchored?"secure":"unsecure"] [src].")
+	balloon_alert(user, anchored ? "secured" : "unsecured")
 	return TRUE
 
 /obj/structure/scanner_gate_shell/proc/on_entered(datum/source, atom/movable/AM)

--- a/code/modules/wiremod/shell/server.dm
+++ b/code/modules/wiremod/shell/server.dm
@@ -20,5 +20,5 @@
 /obj/structure/server/wrench_act(mob/living/user, obj/item/tool)
 	set_anchored(!anchored)
 	tool.play_tool_sound(src)
-	balloon_alert(user, "You [anchored?"secure":"unsecure"] [src].")
+	balloon_alert(user, anchored ? "secured" : "unsecured")
 	return TRUE

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -284,7 +284,7 @@ fi;
 
 if $grep 'balloon_alert(.*span_)' $code_files; then
 	echo
-	echo 'e "${RED}ERROR: Balloon alerts should never contain spans.${NC}"'
+	echo -e "${RED}ERROR: Balloon alerts should never contain spans.${NC}"
 	st=1
 fi;
 

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -274,12 +274,27 @@ if $grep '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' $code_files; then
     echo -e "${RED}ERROR: Changed files contains a proc argument starting with 'var'.${NC}"
     st=1
 fi;
+
 part "balloon_alert sanity"
 if $grep 'balloon_alert\(".*"\)' $code_files; then
 	echo
 	echo -e "${RED}ERROR: Found a balloon alert with improper arguments.${NC}"
 	st=1
 fi;
+
+if $grep 'balloon_alert(.*span_)' $code_files; then
+	echo
+	echo 'e "${RED}ERROR: Balloon alerts should never contain spans.${NC}"'
+	st=1
+fi;
+
+part "balloon_alert idiomatic usage"
+if $grep 'balloon_alert\(.*?, ?"[A-Z]' $code_files; then
+	echo
+	echo -e "${RED}ERROR: Balloon alerts should not start with capital letters. This includes text like 'AI'. If this is a false positive, wrap the text in UNLINT().${NC}"
+	st=1
+fi;
+
 part "common spelling mistakes"
 if $grep -i 'centcomm' $code_files; then
 	echo


### PR DESCRIPTION
Adds lints for `balloon_alert(span_xxx(...))` (which is always wrong), and balloon alert where the first letter is a capital (which is usually wrong). Fixes everything that failed them. As a reminder, abbreviations like "AI" and "GPS" shouldn't be capitalized in a balloon alert.

In cases where this is intentional for flavor (there was one case), you can `UNLINT` like so:

```dm
balloon_alert(user, UNLINT("OMGWTFBBQ!!!"))
```

:cl:
qol: Several balloon alerts have been changed to be more consistent.
/:cl: