### PR TITLE
Sanity checks presents, fixing edge case with players getting any-item presents outside of Christmas

### DIFF
--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -104,6 +104,10 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 	desc = "It could be anything!"
 
 /obj/item/a_gift/anything/get_gift_type()
+	if(!check_holidays(CHRISTMAS))
+		name = "gift"
+		desc = "PRESENTS!!!! eek!"
+		return ..() // Fixes edge cases where people were getting christmas presents outside of the christmas week.
 	if(!GLOB.possible_gifts.len)
 		var/list/gift_types_list = subtypesof(/obj/item)
 		for(var/V in gift_types_list)


### PR DESCRIPTION
## About The Pull Request

Sanity checks presents, fixing edge case with players getting any-item presents outside of Christmas. Presents opened outside of Christmas will now only hold the standard gift pool

## Why It's Good For The Game

Fixes issues with players being able to get normally unobtainable items and stuff outside of the holiday seasons. Makes Christmas more special for the playerbase.

## Changelog
:cl:
fix: Sanity checks presents, fixing edge case with players getting any-item presents outside of Christmas
/:cl:
