### PR TITLE
Admin Subtype of Integrated Circuits

### DIFF
--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -732,4 +732,7 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 	return TRUE
 
 /obj/item/integrated_circuit/admin
+	name = "administrative circuit"
+	desc = "The components installed in here are far beyond your comprehension."
+
 	admin_only = TRUE

--- a/code/modules/wiremod/core/integrated_circuit.dm
+++ b/code/modules/wiremod/core/integrated_circuit.dm
@@ -730,3 +730,6 @@ GLOBAL_LIST_EMPTY_TYPED(integrated_circuits, /obj/item/integrated_circuit)
 	WRITE_FILE(temp_file, convert_to_json())
 	DIRECT_OUTPUT(saver, ftp(temp_file, "[display_name || "circuit"].json"))
 	return TRUE
+
+/obj/item/integrated_circuit/admin
+	admin_only = TRUE


### PR DESCRIPTION

## About The Pull Request

Simply adds an admin only subtype of the integrated circuit because I spawn a lot and this'll save me 30 or so seconds each time I do.
## Why It's Good For The Game

When creating a new admin circuit from scratch being able to skip VVing it to change the admin_only var would save a bit of time.
## Changelog
:cl:
admin: Integrated Circuits now have an admin only subtype, functionally the same as VVed regular circuits.
/:cl:
