### PR TITLE
Adds a helper for base_pixel sets in typepaths that ensures the offset is autoapplied to pixel_x/y

### DIFF
--- a/code/__DEFINES/visual_helpers.dm
+++ b/code/__DEFINES/visual_helpers.dm
@@ -1,6 +1,15 @@
+/// Use this to set the base and ACTUAL pixel offsets of an object at the same time
+/// You should always use this for pixel setting in typepaths, unless you want the map display to look different from in game
 #define SET_BASE_PIXEL(x, y) \
 	pixel_x = x; \
 	base_pixel_x = x; \
 	pixel_y = y; \
 	base_pixel_y = y;
 
+/// Helper define, sets JUST base pixel offsets
+#define _SET_BASE_PIXEL_NO_OFFSET(x, y) \
+	base_pixel_x = x; \
+	base_pixel_y = y;
+
+/// Much like [SET_BASE_PIXEL], except it will not effect pixel offsets in mapping programs
+#define SET_BASE_PIXEL_NOMAP(x, y) MAP_SWITCH(SET_BASE_PIXEL(x, y), _SET_BASE_PIXEL_NO_OFFSET(x, y))

--- a/code/__DEFINES/visual_helpers.dm
+++ b/code/__DEFINES/visual_helpers.dm
@@ -1,0 +1,6 @@
+#define SET_BASE_PIXEL(x, y) \
+	pixel_x = x; \
+	base_pixel_x = x; \
+	pixel_y = y; \
+	base_pixel_y = y;
+

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -121,6 +121,7 @@
 	/// A luminescence-shifted value of the last color calculated for chatmessage overlays
 	var/chat_color_darkened
 
+	// Use SET_BASE_PIXEL(x, y) to set these in typepath definitions, it'll handle pixel_x and y for you
 	///Default pixel x shifting for the atom's icon.
 	var/base_pixel_x = 0
 	///Default pixel y shifting for the atom's icon.

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -70,10 +70,7 @@
 	 */
 	var/pixels_per_unit = 24
 
-	pixel_x = 11
-	pixel_y = 10
-	base_pixel_x = 11
-	base_pixel_y = 10
+	SET_BASE_PIXEL(11, 10)
 
 	custom_price = PAYCHECK_CREW
 
@@ -340,10 +337,7 @@
 	icon_state = "19x19"
 	width = 19
 	height = 19
-	pixel_x = 7
-	pixel_y = 7
-	base_pixel_x = 7
-	base_pixel_y = 7
+	SET_BASE_PIXEL(7, 7)
 	framed_offset_x = 7
 	framed_offset_y = 7
 
@@ -352,10 +346,7 @@
 	icon_state = "23x19"
 	width = 23
 	height = 19
-	pixel_x = 5
-	pixel_y = 7
-	base_pixel_x = 5
-	base_pixel_y = 7
+	SET_BASE_PIXEL(5, 7)
 	framed_offset_x = 5
 	framed_offset_y = 7
 
@@ -364,10 +355,7 @@
 	icon_state = "23x23"
 	width = 23
 	height = 23
-	pixel_x = 5
-	pixel_y = 5
-	base_pixel_x = 5
-	base_pixel_y = 5
+	SET_BASE_PIXEL(5, 5)
 	framed_offset_x = 5
 	framed_offset_y = 5
 
@@ -377,10 +365,7 @@
 	icon_state = "24x24"
 	width = 24
 	height = 24
-	pixel_x = 4
-	pixel_y = 4
-	base_pixel_x = 4
-	base_pixel_y = 4
+	SET_BASE_PIXEL(4, 4)
 	framed_offset_x = 4
 	framed_offset_y = 4
 
@@ -390,10 +375,7 @@
 	icon_state = "24x24" //The vending spritesheet needs the icons to be 32x32. We'll set the actual icon on Initialize.
 	width = 36
 	height = 24
-	pixel_x = -4
-	pixel_y = 4
-	base_pixel_x = -4
-	base_pixel_y = 4
+	SET_BASE_PIXEL(-4, 4)
 	framed_offset_x = 14
 	framed_offset_y = 4
 	pixels_per_unit = 20
@@ -413,10 +395,7 @@
 	icon_state = "24x24" //Ditto
 	width = 45
 	height = 27
-	pixel_x = -8
-	pixel_y = 2
-	base_pixel_x = -8
-	base_pixel_y = 2
+	SET_BASE_PIXEL(-8, 2)
 	framed_offset_x = 9
 	framed_offset_y = 4
 	pixels_per_unit = 18

--- a/code/modules/cargo/gondolapod.dm
+++ b/code/modules/cargo/gondolapod.dm
@@ -13,10 +13,7 @@
 	icon = 'icons/obj/supplypods.dmi'
 	icon_state = "gondola"
 	icon_living = "gondola"
-	pixel_x = -16//2x2 sprite
-	base_pixel_x = -16
-	pixel_y = -5
-	base_pixel_y = -5
+	SET_BASE_PIXEL(-16, -5) //2x2 sprite
 	layer = TABLE_LAYER//so that deliveries dont appear underneath it
 	loot = list(/obj/effect/decal/cleanable/blood/gibs, /obj/item/stack/sheet/animalhide/gondola = 2, /obj/item/food/meat/slab/gondola = 2)
 	//Gondolas aren't affected by cold.

--- a/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
@@ -136,10 +136,7 @@
 	icon_state = "lily_pad"
 	layer = BELOW_MOB_LAYER
 	plane = GAME_PLANE
-	pixel_x = -32
-	base_pixel_x = -32
-	pixel_y = -32
-	base_pixel_y = -32
+	SET_BASE_PIXEL(-32, -32)
 	duration = 30
 
 /mob/living/simple_animal/hostile/jungle/leaper/Initialize(mapload)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mook.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mook.dm
@@ -14,10 +14,8 @@
 	icon_living = "mook"
 	icon_dead = "mook_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	pixel_x = -16
-	base_pixel_x = -16
-	pixel_y = -8
-	base_pixel_y = -8
+	SET_BASE_PIXEL(-16, -8)
+
 	maxHealth = 45
 	health = 45
 	melee_damage_lower = 30
@@ -221,10 +219,7 @@
 	icon_state = "mook_leap_cloud"
 	layer = BELOW_MOB_LAYER
 	plane = GAME_PLANE
-	pixel_x = -16
-	base_pixel_x = -16
-	pixel_y = -16
-	base_pixel_y = -16
+	SET_BASE_PIXEL(-16, -16)
 	duration = 10
 
 #undef MOOK_ATTACK_NEUTRAL

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -18,10 +18,8 @@
 	health = 100
 	melee_damage_lower = 30
 	melee_damage_upper = 30
-	pixel_x = -16
-	base_pixel_x = -16
-	pixel_y = -14
-	base_pixel_y = -14
+	SET_BASE_PIXEL(-16, -14)
+
 	minimum_distance = 3
 	move_to_delay = 20
 	vision_range = 9

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -48,10 +48,7 @@
 	achievement_type = /datum/award/achievement/boss/legion_kill
 	crusher_achievement_type = /datum/award/achievement/boss/legion_crusher
 	score_achievement_type = /datum/award/score/legion_score
-	pixel_x = -32
-	base_pixel_x = -32
-	pixel_y = -16
-	base_pixel_y = -16
+	SET_BASE_PIXEL(-32, -16)
 	maptext_height = 96
 	maptext_width = 96
 	loot = list(/obj/item/stack/sheet/bone = 3)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -216,6 +216,7 @@
 #include "code\__DEFINES\uplink.dm"
 #include "code\__DEFINES\vehicles.dm"
 #include "code\__DEFINES\verb_manager.dm"
+#include "code\__DEFINES\visual_helpers.dm"
 #include "code\__DEFINES\vv.dm"
 #include "code\__DEFINES\wall_dents.dm"
 #include "code\__DEFINES\weather.dm"


### PR DESCRIPTION

## About The Pull Request

This was an issue on wallening and I figured I should fix it at the root 
Look ma I'm upstreaming
