### PR TITLE
afterattack now returns a flag if it's reasonable to suspect the user intends to act on an item

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -290,6 +290,7 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 /// Used for the swap hands/drop tutorials to know when you might just be trying to do something normally.
 /// Does not necessarily imply success, or even that it did hit an item, just intent.
 // This is intentionally not (1 << 0) because some stuff currently erroneously returns TRUE/FALSE for afterattack.
+// Doesn't need to be set if proximity flag is FALSE.
 #define AFTERATTACK_PROCESSED_ITEM (1 << 1)
 
 //Autofire component

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -286,6 +286,12 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 /// Proceed with the attack chain, but don't call the normal methods.
 #define SECONDARY_ATTACK_CONTINUE_CHAIN 3
 
+/// Flag for when /afterattack potentially acts on an item.
+/// Used for the swap hands/drop tutorials to know when you might just be trying to do something normally.
+/// Does not necessarily imply success, or even that it did hit an item, just intent.
+// This is intentionally not (1 << 0) because some stuff currently erroneously returns TRUE/FALSE for afterattack.
+#define AFTERATTACK_PROCESSED_ITEM (1 << 1)
+
 //Autofire component
 /// Compatible firemode is in the gun. Wait until it's held in the user hands.
 #define AUTOFIRE_STAT_IDLE (1<<0)

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -390,6 +390,10 @@
 #define COMSIG_ITEM_ATTACK_SECONDARY "item_pre_attack_secondary"
 ///from base of obj/item/afterattack(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"
+	/// Flag for when /afterattack potentially acts on an item.
+	/// Used for the swap hands/drop tutorials to know when you might just be trying to do something normally.
+	/// Does not necessarily imply success, or even that it did hit an item, just intent.
+	#define COMPONENT_AFTERATTACK_PROCESSED_ITEM (1<<0)
 ///from base of obj/item/afterattack_secondary(): (atom/target, mob/user, proximity_flag, click_parameters)
 #define COMSIG_ITEM_AFTERATTACK_SECONDARY "item_afterattack_secondary"
 ///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, params)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -282,9 +282,10 @@
  * * click_parameters - is the params string from byond [/atom/proc/Click] code, see that documentation.
  */
 /obj/item/proc/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters)
+	. = NONE
+	. |= SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters)
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_AFTERATTACK, target, src, proximity_flag, click_parameters)
-	return NONE
+	return .
 
 /**
  * Called at the end of the attack chain if the user right-clicked.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -59,7 +59,7 @@
 		if (after_attack_secondary_result == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN || after_attack_secondary_result == SECONDARY_ATTACK_CONTINUE_CHAIN)
 			return TRUE
 
-	return afterattack(target, user, TRUE, params)
+	return afterattack(target, user, TRUE, params) == TRUE
 
 /// Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.
 /obj/item/proc/attack_self(mob/user, modifiers)
@@ -271,7 +271,9 @@
 		return ..()
 
 /**
- * Last proc in the [/obj/item/proc/melee_attack_chain]
+ * Last proc in the [/obj/item/proc/melee_attack_chain].
+ * Returns a bitfield containing AFTERATTACK_PROCESSED_ITEM if the user is likely intending to use this item on another item.
+ * Some consumers currently return TRUE to mean "processed". These are not consistent and should be taken with a grain of salt.
  *
  * Arguments:
  * * atom/target - The thing that was hit
@@ -282,6 +284,7 @@
 /obj/item/proc/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	SEND_SIGNAL(src, COMSIG_ITEM_AFTERATTACK, target, user, proximity_flag, click_parameters)
 	SEND_SIGNAL(user, COMSIG_MOB_ITEM_AFTERATTACK, target, src, proximity_flag, click_parameters)
+	return NONE
 
 /**
  * Called at the end of the attack chain if the user right-clicked.

--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -179,9 +179,11 @@
 				focus.do_attack_animation(target, null, focus)
 		else if(isgun(I)) //I've only tested this with guns, and it took some doing to make it work
 			. = I.afterattack(target, tk_user, 0, params)
+		. |= AFTERATTACK_PROCESSED_ITEM
 
 	user.changeNext_move(CLICK_CD_MELEE)
 	update_appearance()
+	return .
 
 /obj/item/tk_grab/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -69,12 +69,14 @@
 	SIGNAL_HANDLER
 	if(!proximity_flag)
 		return
+	. |= COMPONENT_AFTERATTACK_PROCESSED_ITEM
 	var/clean_target
 	if(pre_clean_callback)
 		clean_target = pre_clean_callback?.Invoke(source, target, user)
 		if(clean_target == DO_NOT_CLEAN)
-			return
+			return .
 	INVOKE_ASYNC(src, PROC_REF(clean), source, target, user, clean_target) //signal handlers can't have do_afters inside of them
+	return .
 
 /**
  * Cleans something using this cleaner.

--- a/code/datums/components/igniter.dm
+++ b/code/datums/components/igniter.dm
@@ -26,6 +26,7 @@
 	if(!proximity_flag)
 		return
 	do_igniter(target)
+	return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 
 /datum/component/igniter/proc/hostile_attackingtarget(mob/living/simple_animal/hostile/attacker, atom/target, success)
 	SIGNAL_HANDLER

--- a/code/datums/components/reagent_refiller.dm
+++ b/code/datums/components/reagent_refiller.dm
@@ -44,6 +44,8 @@
 /datum/component/reagent_refiller/proc/refill()
 	SIGNAL_HANDLER
 
+	. |= COMPONENT_AFTERATTACK_PROCESSED_ITEM
+
 	var/obj/item/reagent_containers/container = parent
 	var/refill = container.reagents.get_master_reagent_id()
 	var/amount = min((container.amount_per_transfer_from_this + container.reagents.total_volume), container.reagents.total_volume)

--- a/code/datums/components/summoning.dm
+++ b/code/datums/components/summoning.dm
@@ -39,6 +39,7 @@
 	if(!proximity_flag)
 		return
 	do_spawn_mob(get_turf(target), user)
+	return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 
 /datum/component/summoning/proc/hostile_attackingtarget(mob/living/simple_animal/hostile/attacker, atom/target, success)
 	SIGNAL_HANDLER

--- a/code/datums/elements/easily_fragmented.dm
+++ b/code/datums/elements/easily_fragmented.dm
@@ -30,3 +30,5 @@
 	if(prob(break_chance))
 		user.visible_message(span_danger("[user]'s [item.name] snap[item.p_s()] into tiny pieces in [user.p_their()] hand."))
 		item.deconstruct(disassembled = FALSE)
+
+	return COMPONENT_AFTERATTACK_PROCESSED_ITEM

--- a/code/datums/elements/food/dunkable.dm
+++ b/code/datums/elements/food/dunkable.dm
@@ -23,14 +23,16 @@
 		return
 	var/obj/item/reagent_containers/container = target // the container we're trying to dunk into
 	if(istype(container) && container.reagent_flags & DUNKABLE) // container should be a valid target for dunking
+		. = COMPONENT_AFTERATTACK_PROCESSED_ITEM
 		if(!container.is_drainable())
 			to_chat(user, span_warning("[container] is unable to be dunked in!"))
-			return
+			return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 		var/obj/item/I = source // the item that has the dunkable element
 		if(container.reagents.trans_to(I, dunk_amount, transfered_by = user)) //if reagents were transfered, show the message
 			to_chat(user, span_notice("You dunk \the [I] into \the [container]."))
-			return
+			return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 		if(!container.reagents.total_volume)
 			to_chat(user, span_warning("[container] is empty!"))
 		else
 			to_chat(user, span_warning("[I] is full!"))
+		return COMPONENT_AFTERATTACK_PROCESSED_ITEM

--- a/code/datums/elements/knockback.dm
+++ b/code/datums/elements/knockback.dm
@@ -36,6 +36,7 @@
 	if(!proximity_flag)
 		return
 	do_knockback(target, user, get_dir(source, target))
+	return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 
 /// triggered after a hostile simplemob attacks something
 /datum/element/knockback/proc/hostile_attackingtarget(mob/living/simple_animal/hostile/attacker, atom/target, success)

--- a/code/datums/elements/lifesteal.dm
+++ b/code/datums/elements/lifesteal.dm
@@ -32,6 +32,7 @@
 	if(!proximity_flag)
 		return
 	do_lifesteal(user, target)
+	return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 
 /datum/element/lifesteal/proc/hostile_attackingtarget(mob/living/simple_animal/hostile/attacker, atom/target, success)
 	SIGNAL_HANDLER

--- a/code/datums/elements/light_eater.dm
+++ b/code/datums/elements/light_eater.dm
@@ -123,7 +123,7 @@
 	if(!proximity)
 		return NONE
 	eat_lights(target, source)
-	return NONE
+	return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 
 /**
  * Called when a source object is used to block a thrown object, projectile, or attack

--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -22,3 +22,4 @@
 	var/turf/turf_above = get_step_multiz(target, UP)
 	if(turf_above?.z == user.z)
 		INVOKE_ASYNC(source, TYPE_PROC_REF(/obj/item, handle_openspace_click), turf_above, user, user.CanReach(turf_above, source), click_parameters)
+	return COMPONENT_AFTERATTACK_PROCESSED_ITEM

--- a/code/datums/elements/venomous.dm
+++ b/code/datums/elements/venomous.dm
@@ -41,6 +41,7 @@
 	if(!proximity_flag)
 		return
 	add_reagent(target)
+	return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 
 /datum/element/venomous/proc/hostile_attackingtarget(mob/living/simple_animal/hostile/attacker, atom/target, success)
 	SIGNAL_HANDLER

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -872,6 +872,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	. = ..()
 	if(range_check(A,user))
 		pre_attack(A, user)
+		return . | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/construction/rcd/arcd/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
 	if(range_check(target,user))

--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -119,13 +119,17 @@ RSF
 	if(cooldown > world.time)
 		return
 	. = ..()
-	if(!proximity || !is_allowed(A))
-		return
+	if(!proximity)
+		return .
+	. |= AFTERATTACK_PROCESSED_ITEM
+	if (!is_allowed(A))
+		return .
 	if(use_matter(dispense_cost, user))//If we can charge that amount of charge, we do so and return true
 		playsound(loc, 'sound/machines/click.ogg', 10, TRUE)
 		var/atom/meme = new to_dispense(get_turf(A))
 		to_chat(user, span_notice("[action_type] [meme.name]..."))
 		cooldown = world.time + cooldowndelay
+	return .
 
 ///A helper proc. checks to see if we can afford the amount of charge that is passed, and if we can docs the charge from our base, and returns TRUE. If we can't we return FALSE
 /obj/item/rsf/proc/use_matter(charge, mob/user)

--- a/code/game/objects/items/broom.dm
+++ b/code/game/objects/items/broom.dm
@@ -52,6 +52,7 @@
 	if(!proximity)
 		return
 	sweep(user, A)
+	return . | AFTERATTACK_PROCESSED_ITEM
 
 /**
  * Attempts to push up to BROOM_PUSH_LIMIT atoms from a given location the user's faced direction

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1390,7 +1390,7 @@
 	if(isidcard(target))
 		theft_target = WEAKREF(target)
 		ui_interact(user)
-		return
+		return AFTERATTACK_PROCESSED_ITEM
 
 	return ..()
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -237,6 +237,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	else
 		to_chat(user, span_warning("[src] is full!"))
 
+	return AFTERATTACK_PROCESSED_ITEM
+
 /obj/item/clothing/mask/cigarette/update_icon_state()
 	. = ..()
 	if(lit)

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -144,10 +144,11 @@
 	to_chat(user, span_warning("The soap has ran out of chemicals"))
 
 /obj/item/soap/nanotrasen/cyborg/afterattack(atom/target, mob/user, proximity)
+	. = isitem(target) ? AFTERATTACK_PROCESSED_ITEM : NONE
 	if(uses <= 0)
 		to_chat(user, span_warning("No good, you need to recharge!"))
-		return
-	return ..()
+		return .
+	return ..() | .
 
 /obj/item/soap/attackby_storage_insert(datum/storage, atom/storage_holder, mob/living/user)
 	return !user?.combat_mode  // only cleans a storage item if on combat

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -266,11 +266,8 @@
 	var/static/regex/crayon_regex = new /regex(@"[^\w!?,.=&%#+/\-]", "ig")
 	return lowertext(crayon_regex.Replace(text, ""))
 
-/obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity, params)
-	. = ..()
-	if(!proximity || !check_allowed_items(target))
-		return
-
+/// Attempts to color the target. Returns how many charges were used.
+/obj/item/toy/crayon/proc/use_on(atom/target, mob/user, params)
 	var/static/list/punctuation = list("!","?",".",",","/","+","-","=","%","#","&")
 	var/istagger = HAS_TRAIT(user, TRAIT_TAGGER)
 
@@ -283,13 +280,13 @@
 		if (istagger)
 			cost *= 0.5
 	if(check_empty(user, cost))
-		return
+		return 0
 
 	if(istype(target, /obj/effect/decal/cleanable))
 		target = target.loc
 
 	if(!isValidSurface(target))
-		return
+		return 0
 
 	var/drawing = drawtype
 	switch(drawtype)
@@ -361,11 +358,11 @@
 
 	if(!instant)
 		if(!do_after(user, 50, target = target))
-			return
+			return 0
 
 	var/charges_used = use_charges(user, cost)
 	if(!charges_used)
-		return
+		return 0
 	. = charges_used
 
 	if(length(text_buffer))
@@ -418,6 +415,22 @@
 	for(var/t in affected_turfs)
 		reagents.trans_to(t, ., volume_multiplier, transfered_by = user, methods = TOUCH)
 	check_empty(user)
+	return .
+
+/obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity, params)
+	. = ..()
+
+	if(!proximity)
+		return .
+
+	if (isitem(target))
+		. |= AFTERATTACK_PROCESSED_ITEM
+
+	if (!check_allowed_items(target))
+		return .
+
+	use_on(target, user, params)
+	return .
 
 /obj/item/toy/crayon/attack(mob/M, mob/user)
 	if(edible && (M == user))
@@ -665,16 +678,13 @@
 		. += "It is empty."
 	. += span_notice("Alt-click [src] to [ is_capped ? "take the cap off" : "put the cap on"]. Right-click a colored object to match its existing color.")
 
-/obj/item/toy/crayon/spraycan/afterattack(atom/target, mob/user, proximity, params)
-	if(!proximity)
-		return
-
+/obj/item/toy/crayon/spraycan/use_on(atom/target, mob/user, params)
 	if(is_capped)
 		balloon_alert(user, "take the cap off first!")
-		return
+		return 0
 
 	if(check_empty(user))
-		return
+		return 0
 
 	if(iscarbon(target))
 		if(pre_noise || post_noise)
@@ -697,7 +707,7 @@
 		var/fraction = min(1, . / reagents.maximum_volume)
 		reagents.expose(C, VAPOR, fraction * volume_multiplier)
 
-		return
+		return .
 
 	if(ismob(target) && (HAS_TRAIT(target, TRAIT_SPRAY_PAINTABLE)))
 		if(actually_paints)
@@ -735,9 +745,9 @@
 		if(pre_noise || post_noise)
 			playsound(user.loc, 'sound/effects/spray.ogg', 5, TRUE, 5)
 		user.visible_message(span_notice("[user] coats [target] with spray paint!"), span_notice("You coat [target] with spray paint."))
-		return
+		return 0
 
-	. = ..()
+	return ..()
 
 /obj/item/toy/crayon/spraycan/afterattack_secondary(atom/target, mob/user, proximity, params)
 	if(!proximity)
@@ -793,16 +803,25 @@
 	charges = -1
 
 /obj/item/toy/crayon/spraycan/borg/afterattack(atom/target,mob/user,proximity, params)
-	var/diff = ..()
+	if (!proximity)
+		return
+
+	if (isitem(target))
+		. = AFTERATTACK_PROCESSED_ITEM
+
+	if (!check_allowed_items(target))
+		return .
+
+	var/diff = use_on(target, user, params)
 	if(!iscyborg(user))
 		to_chat(user, span_notice("How did you get this?"))
 		qdel(src)
-		return FALSE
+		return .
 
 	var/mob/living/silicon/robot/borgy = user
 
 	if(!diff)
-		return
+		return .
 	// 25 is our cost per unit of paint, making it cost 25 energy per
 	// normal tag, 50 per window, and 250 per attack
 	var/cost = diff * 25
@@ -810,6 +829,8 @@
 	// it's free.
 	if(borgy.cell)
 		borgy.cell.use(cost)
+
+	return .
 
 /obj/item/toy/crayon/spraycan/hellcan
 	name = "hellcan"

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -40,6 +40,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!check_sprite(target))
 		return
 	if(active_dummy)//I now present you the blackli(f)st

--- a/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
+++ b/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
@@ -54,6 +54,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!is_type_in_typecache(target, recycleable_circuits))
 		return
 	circuits++

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -25,6 +25,7 @@
 	. = ..()
 	if(!check_allowed_items(target, not_inside = TRUE))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(istype(target, /obj/structure/projected_forcefield))
 		var/obj/structure/projected_forcefield/F = target
 		if(F.generator == src)

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -68,7 +68,7 @@
 	balloon_alert(user, "switch [scanning ? "on" : "off"]")
 
 /obj/item/geiger_counter/afterattack(atom/target, mob/living/user, params)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 
 	if (user.combat_mode)
 		return

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -68,7 +68,8 @@
 	balloon_alert(user, "switch [scanning ? "on" : "off"]")
 
 /obj/item/geiger_counter/afterattack(atom/target, mob/living/user, params)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 
 	if (user.combat_mode)
 		return

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -70,7 +70,7 @@
 			. += span_notice("A class <b>[diode.rating]</b> laser diode is installed. It is <i>screwed</i> in place.")
 
 /obj/item/laser_pointer/afterattack(atom/target, mob/living/user, flag, params)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	laser_act(target, user, params)
 
 /obj/item/laser_pointer/proc/laser_act(atom/target, mob/living/user, params)

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -70,7 +70,8 @@
 			. += span_notice("A class <b>[diode.rating]</b> laser diode is installed. It is <i>screwed</i> in place.")
 
 /obj/item/laser_pointer/afterattack(atom/target, mob/living/user, flag, params)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	laser_act(target, user, params)
 
 /obj/item/laser_pointer/proc/laser_act(atom/target, mob/living/user, params)

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -212,4 +212,5 @@
 	. = ..()
 	if(!can_see(user, target, 15))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	atmos_scan(user, (target.return_analyzable_air() ? target : get_turf(target)))

--- a/code/game/objects/items/dna_probe.dm
+++ b/code/game/objects/items/dna_probe.dm
@@ -31,18 +31,21 @@
 /obj/item/dna_probe/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	if(!proximity_flag || !target)
-		return
+		return .
+
+	if (isitem(target))
+		. |= AFTERATTACK_PROCESSED_ITEM
 
 	if((allowed_scans & DNA_PROBE_SCAN_PLANTS) && istype(target, /obj/machinery/hydroponics))
 		var/obj/machinery/hydroponics/hydro_tray = target
 		if(!hydro_tray.myseed)
-			return
+			return .
 		if(stored_dna_plants[hydro_tray.myseed.type])
 			to_chat(user, span_notice("Plant data already present in local storage."))
-			return
+			return .
 		if(hydro_tray.plant_status != HYDROTRAY_PLANT_HARVESTABLE) // So it's bit harder.
 			to_chat(user, span_alert("Plant needs to be ready to harvest to perform full data scan.")) //Because space dna is actually magic
-			return
+			return .
 		stored_dna_plants[hydro_tray.myseed.type] = TRUE
 		to_chat(user, span_notice("Plant data added to local storage."))
 
@@ -54,10 +57,10 @@
 			var/mob/living/living_target = target
 			if(stored_dna_animal[living_target.type])
 				to_chat(user, span_alert("Animal data already present in local storage."))
-				return
+				return .
 			if(!(living_target.mob_biotypes & MOB_ORGANIC))
 				to_chat(user, span_alert("No compatible DNA detected."))
-				return
+				return .
 			stored_dna_animal[living_target.type] = TRUE
 			to_chat(user, span_notice("Animal data added to local storage."))
 
@@ -65,10 +68,10 @@
 		var/mob/living/carbon/human/human_target = target
 		if(stored_dna_human[human_target.dna.unique_identity])
 			to_chat(user, span_notice("Humanoid data already present in local storage."))
-			return
+			return .
 		if(!(human_target.mob_biotypes & MOB_ORGANIC))
 			to_chat(user, span_alert("No compatible DNA detected."))
-			return
+			return .
 		stored_dna_human[human_target.dna.unique_identity] = TRUE
 		to_chat(user, span_notice("Humanoid data added to local storage."))
 

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -53,7 +53,7 @@
 
 /obj/item/card/emagfake/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if (!proximity)
+	if (!proximity_flag)
 		return
 	. |= AFTERATTACK_PROCESSED_ITEM
 	playsound(src, 'sound/items/bikehorn.ogg', 50, TRUE)

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -51,8 +51,11 @@
 		user.visible_message(span_notice("[user] shows you: [icon2html(src, viewers(user))] [name]."), span_notice("You show [src]."))
 	add_fingerprint(user)
 
-/obj/item/card/emagfake/afterattack()
+/obj/item/card/emagfake/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
+	if (!proximity)
+		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	playsound(src, 'sound/items/bikehorn.ogg', 50, TRUE)
 
 /obj/item/card/emag/Initialize(mapload)
@@ -67,6 +70,7 @@
 	var/atom/A = target
 	if(!proximity && prox_check)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!can_emag(target, user))
 		return
 	log_combat(user, A, "attempted to emag")

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -178,20 +178,21 @@
 	// Make it so the extinguisher doesn't spray yourself when you click your inventory items
 	if (target.loc == user)
 		return
-	//TODO; Add support for reagents in water.
+
+	. |= AFTERATTACK_PROCESSED_ITEM
 
 	if(refilling)
 		refilling = FALSE
-		return
+		return .
 	if (!safety)
 
 
 		if (src.reagents.total_volume < 1)
 			balloon_alert(user, "it's empty!")
-			return
+			return .
 
 		if (world.time < src.last_use + 12)
-			return
+			return .
 
 		src.last_use = world.time
 
@@ -231,6 +232,8 @@
 
 		//Make em move dat ass, hun
 		move_particles(water_particles)
+
+	return .
 
 //Particle movement loop
 /obj/item/extinguisher/proc/move_particles(list/particles)

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -71,7 +71,7 @@
 		. += "+lit"
 
 /obj/item/flamethrower/afterattack(atom/target, mob/user, flag)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	if(flag)
 		return // too close
 	if(ishuman(user))

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -71,7 +71,8 @@
 		. += "+lit"
 
 /obj/item/flamethrower/afterattack(atom/target, mob/user, flag)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(flag)
 		return // too close
 	if(ishuman(user))

--- a/code/game/objects/items/grenades/_grenade.dm
+++ b/code/game/objects/items/grenades/_grenade.dm
@@ -249,3 +249,4 @@
 	. = ..()
 	if(active)
 		user.throw_item(target)
+		return . | AFTERATTACK_PROCESSED_ITEM

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -89,15 +89,18 @@
 		return
 	if(!flag)
 		return
+
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if(bomb_target != user && HAS_TRAIT(user, TRAIT_PACIFISM) && isliving(bomb_target))
 		to_chat(user, span_warning("You don't want to harm other living beings!"))
-		return
+		return .
 
 	to_chat(user, span_notice("You start planting [src]. The timer is set to [det_time]..."))
 
 	if(do_after(user, 30, target = bomb_target))
 		if(!user.temporarilyRemoveItemFromInventory(src))
-			return
+			return .
 		target = bomb_target
 		active = TRUE
 
@@ -120,6 +123,8 @@
 		target.add_overlay(plastic_overlay)
 		to_chat(user, span_notice("You plant the bomb. Timer counting down from [det_time]."))
 		addtimer(CALLBACK(src, PROC_REF(detonate)), det_time*10)
+
+	return .
 
 /obj/item/grenade/c4/proc/shout_syndicate_crap(mob/player)
 	if(!player)

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -473,7 +473,8 @@
 	var/cheek_kiss
 
 /obj/item/hand_item/kisser/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(HAS_TRAIT(user, TRAIT_GARLIC_BREATH))
 		kiss_type = /obj/projectile/kiss/french
 

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -473,7 +473,7 @@
 	var/cheek_kiss
 
 /obj/item/hand_item/kisser/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	if(HAS_TRAIT(user, TRAIT_GARLIC_BREATH))
 		kiss_type = /obj/projectile/kiss/french
 

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -36,33 +36,35 @@
 	. = ..()
 	if(!proximity_flag)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!check_allowed_items(target, not_inside = TRUE))
-		return
+		return .
 	var/turf/target_turf = get_turf(target)
 	var/obj/structure/holosign/target_holosign = locate(holosign_type) in target_turf
 	if(target_holosign)
 		qdel(target_holosign)
-		return
+		return .
 	if(target_turf.is_blocked_turf(TRUE)) //can't put holograms on a tile that has dense stuff
-		return
+		return .
 	if(holocreator_busy)
 		to_chat(user, span_notice("[src] is busy creating a hologram."))
-		return
+		return .
 	if(LAZYLEN(signs) >= max_signs)
 		balloon_alert(user, "max capacity!")
-		return
+		return .
 	playsound(loc, 'sound/machines/click.ogg', 20, TRUE)
 	if(creation_time)
 		holocreator_busy = TRUE
 		if(!do_after(user, creation_time, target = target))
 			holocreator_busy = FALSE
-			return
+			return .
 		holocreator_busy = FALSE
 		if(LAZYLEN(signs) >= max_signs)
-			return
+			return .
 		if(target_turf.is_blocked_turf(TRUE)) //don't try to sneak dense stuff on our tile during the wait.
-			return
+			return .
 	target_holosign = new holosign_type(get_turf(target), src)
+	return .
 
 /obj/item/holosign_creator/attack(mob/living/carbon/human/M, mob/user)
 	return

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -224,6 +224,7 @@
 		user.dropItemToGround(src)
 	if(proximity_flag)
 		consume_everything(target)
+		return . | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/melee/supermatter_sword/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	..()

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -129,5 +129,6 @@
 		return
 	if(!isturf(target) || !isobj(target))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(target.color != initial(target.color))
 		target.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -161,6 +161,7 @@
 	if(!istype(user))
 		return
 	Fire(user, target)
+	return AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/pneumatic_cannon/proc/Fire(mob/living/user, atom/target)
 	if(!istype(user) && !target)

--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -339,6 +339,7 @@
 	. = ..()
 	if(staffcooldown + staffwait > world.time)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	user.visible_message(span_notice("[user] chants deeply and waves [user.p_their()] staff!"))
 	if(do_after(user, 2 SECONDS, src))
 		target.add_atom_colour(conversion_color, WASHABLE_COLOUR_PRIORITY) //wololo

--- a/code/game/objects/items/robot/items/food.dm
+++ b/code/game/objects/items/robot/items/food.dm
@@ -123,17 +123,17 @@
 		var/mob/living/silicon/robot/robot_user = user
 		if(!robot_user.cell.use(12))
 			to_chat(user, span_warning("Not enough power."))
-			return FALSE
+			return AFTERATTACK_PROCESSED_ITEM
 	switch(mode)
 		if(DISPENSE_LOLLIPOP_MODE, DISPENSE_ICECREAM_MODE)
 			if(!proximity)
-				return FALSE
+				return AFTERATTACK_PROCESSED_ITEM
 			dispense(target, user)
 		if(THROW_LOLLIPOP_MODE)
 			shootL(target, user, click_params)
 		if(THROW_GUMBALL_MODE)
 			shootG(target, user, click_params)
-	return ..()
+	return ..() | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/borg/lollipop/attack_self(mob/living/user)
 	switch(mode)

--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -190,6 +190,7 @@
 	. = ..()
 	if(!proximity_flag || !iscyborg(user))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(mode == "draw")
 		if(is_type_in_list(target, charge_machines))
 			var/obj/machinery/target_machine = target

--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -348,17 +348,18 @@
 /obj/item/reagent_containers/borghypo/borgshaker/afterattack(obj/target, mob/user, proximity)
 	. = ..()
 	if(!proximity)
-		return
+		return .
 	if(!selected_reagent)
 		balloon_alert(user, "no reagent selected!")
-		return
+		return .
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(target.is_refillable())
 		if(!stored_reagents.has_reagent(selected_reagent.type, amount_per_transfer_from_this))
 			balloon_alert(user, "not enough [selected_reagent.name]!")
-			return
+			return .
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
 			balloon_alert(user, "[target] is full!")
-			return
+			return .
 
 		// This is the in-between where we're storing the reagent we're going to pour into the container
 		// because we cannot specify a singular reagent to transfer in trans_to
@@ -368,6 +369,7 @@
 
 		shaker.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
 		balloon_alert(user, "[amount_per_transfer_from_this] unit\s poured")
+	return .
 
 /obj/item/reagent_containers/borghypo/borgshaker/hacked
 	name = "cyborg shaker"

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -62,6 +62,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
 		if(charged)
 			charged = FALSE
@@ -72,6 +73,7 @@
 			var/turf/target = get_turf(A)
 			vortex(target,user)
 			addtimer(CALLBACK(src, PROC_REF(recharge)), 100)
+	return .
 
 /obj/item/mjollnir
 	name = "Mjolnir"

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -159,14 +159,15 @@
 	. = ..()
 	if(!proximity || !HAS_TRAIT(src, TRAIT_WIELDED) || !istype(AM))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(AM.resistance_flags & INDESTRUCTIBLE) //due to the lich incident of 2021, embedding grenades inside of indestructible structures is forbidden
-		return
+		return .
 	if(ismob(AM))
 		var/mob/mob_target = AM
 		if(mob_target.status_flags & GODMODE) //no embedding grenade phylacteries inside of ghost poly either
-			return
+			return .
 	if(iseffect(AM)) //and no accidentally wasting your moment of glory on graffiti
-		return
+		return .
 	user.say("[war_cry]", forced="spear warcry")
 	if(isliving(user))
 		var/mob/living/living_user = user
@@ -177,6 +178,7 @@
 		if(!QDELETED(living_user))
 			living_user.set_resting(new_resting = FALSE, silent = TRUE, instant = TRUE)
 	qdel(src)
+	return .
 
 //GREY TIDE
 /obj/item/spear/grey_tide

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -46,9 +46,11 @@
 	if(!istype(target))
 		return
 
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if(target.embedding && target.embedding == conferred_embed)
 		to_chat(user, span_warning("[target] is already coated in [src]!"))
-		return
+		return .
 
 	user.visible_message(span_notice("[user] begins wrapping [target] with [src]."), span_notice("You begin wrapping [target] with [src]."))
 	playsound(user, 'sound/items/duct_tape_rip.ogg', 50, TRUE)
@@ -61,11 +63,11 @@
 			to_chat(user, span_notice("You turn [target] into [O] with [src]."))
 			QDEL_NULL(target)
 			user.put_in_hands(O)
-			return
+			return .
 
 		if(target.embedding && target.embedding == conferred_embed)
 			to_chat(user, span_warning("[target] is already coated in [src]!"))
-			return
+			return .
 
 		target.embedding = conferred_embed
 		target.updateEmbedding()
@@ -75,6 +77,8 @@
 		if(isgrenade(target))
 			var/obj/item/grenade/sticky_bomb = target
 			sticky_bomb.sticky = TRUE
+
+	return .
 
 /obj/item/stack/sticky_tape/super
 	name = "super sticky tape"

--- a/code/game/objects/items/stacks/wrap.dm
+++ b/code/game/objects/items/stacks/wrap.dm
@@ -111,6 +111,7 @@
 		return
 
 	if(isitem(target))
+		. |= AFTERATTACK_PROCESSED_ITEM
 		var/obj/item/item = target
 		if(!item.can_be_package_wrapped())
 			balloon_alert(user, "can't be wrapped!")

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -191,7 +191,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	if(!proximity)
 		return
 	if(SEND_SIGNAL(bible_smacked, COMSIG_BIBLE_SMACKED, user, proximity) & COMSIG_END_BIBLE_CHAIN)
-		return
+		return . | AFTERATTACK_PROCESSED_ITEM
 	if(isfloorturf(bible_smacked))
 		if(user.mind && (user.mind.holy_role))
 			var/area/current_area = get_area(bible_smacked)
@@ -204,16 +204,19 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 
 	if(user?.mind?.holy_role)
 		if(bible_smacked.reagents && bible_smacked.reagents.has_reagent(/datum/reagent/water)) // blesses all the water in the holder
+			. |= AFTERATTACK_PROCESSED_ITEM
 			bible_smacked.balloon_alert(user, "blessed")
 			var/water2holy = bible_smacked.reagents.get_reagent_amount(/datum/reagent/water)
 			bible_smacked.reagents.del_reagent(/datum/reagent/water)
 			bible_smacked.reagents.add_reagent(/datum/reagent/water/holywater,water2holy)
 		if(bible_smacked.reagents && bible_smacked.reagents.has_reagent(/datum/reagent/fuel/unholywater)) // yeah yeah, copy pasted code - sue me
+			. |= AFTERATTACK_PROCESSED_ITEM
 			bible_smacked.balloon_alert(user, "purified")
 			var/unholy2clean = bible_smacked.reagents.get_reagent_amount(/datum/reagent/fuel/unholywater)
 			bible_smacked.reagents.del_reagent(/datum/reagent/fuel/unholywater)
 			bible_smacked.reagents.add_reagent(/datum/reagent/water/holywater,unholy2clean)
 		if(istype(bible_smacked, /obj/item/storage/book/bible) && !istype(bible_smacked, /obj/item/storage/book/bible/syndicate))
+			. |= AFTERATTACK_PROCESSED_ITEM
 			bible_smacked.balloon_alert(user, "converted")
 			var/obj/item/storage/book/bible/B = bible_smacked
 			B.name = name
@@ -221,6 +224,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 			B.inhand_icon_state = inhand_icon_state
 
 	if(istype(bible_smacked, /obj/item/cult_bastard) && !IS_CULTIST(user))
+		. |= AFTERATTACK_PROCESSED_ITEM
 		var/obj/item/cult_bastard/sword = bible_smacked
 		bible_smacked.balloon_alert(user, "exorcising...")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,TRUE)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -147,7 +147,7 @@
 /obj/item/reagent_containers/spray/mister/afterattack(obj/target, mob/user, proximity)
 	if(target.loc == loc) //Safety check so you don't fill your mister with mutagen or something and then blast yourself in the face with it
 		return
-	..()
+	return ..()
 
 //Janitor tank
 /obj/item/watertank/janitor
@@ -327,8 +327,7 @@
 	if(AttemptRefill(target, user))
 		return
 	if(nozzle_mode == EXTINGUISHER)
-		..()
-		return
+		return ..()
 	var/Adj = user.Adjacent(target)
 	if(nozzle_mode == RESIN_LAUNCHER)
 		if(Adj)

--- a/code/game/objects/items/taster.dm
+++ b/code/game/objects/items/taster.dm
@@ -13,6 +13,8 @@
 	if(!proximity)
 		return
 
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if(!O.reagents)
 		to_chat(user, span_notice("[src] cannot taste [O], since [O.p_they()] [O.p_have()] have no reagents."))
 	else if(O.reagents.total_volume == 0)

--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -300,8 +300,12 @@
 	. = ..()
 	if(!sliver)
 		return
-	if(proximity && ismovable(O) && O != sliver)
+	if (!proximity)
+		return
+	. |= AFTERATTACK_PROCESSED_ITEM
+	if(ismovable(O) && O != sliver)
 		Consume(O, user)
+	return .
 
 /obj/item/hemostat/supermatter/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum) // no instakill supermatter javelins
 	if(sliver)

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -156,17 +156,22 @@
 	if(!proximity)
 		return
 
-	if(isOn() && !QDELETED(attacked_atom) && isliving(attacked_atom)) // can't ignite something that doesn't exist
-		handle_fuel_and_temps(1, user)
-		var/mob/living/attacked_mob = attacked_atom
-		if(attacked_mob.ignite_mob())
-			message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(attacked_mob)] on fire with [src] at [AREACOORD(user)]")
-			user.log_message("set [key_name(attacked_mob)] on fire with [src].", LOG_ATTACK)
+	if(isOn())
+		. |= AFTERATTACK_PROCESSED_ITEM
+		if (!QDELETED(attacked_atom) && isliving(attacked_atom)) // can't ignite something that doesn't exist
+			handle_fuel_and_temps(1, user)
+			var/mob/living/attacked_mob = attacked_atom
+			if(attacked_mob.ignite_mob())
+				message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(attacked_mob)] on fire with [src] at [AREACOORD(user)]")
+				user.log_message("set [key_name(attacked_mob)] on fire with [src].", LOG_ATTACK)
 
 	if(!status && attacked_atom.is_refillable())
+		. |= AFTERATTACK_PROCESSED_ITEM
 		reagents.trans_to(attacked_atom, reagents.total_volume, transfered_by = user)
 		to_chat(user, span_notice("You empty [src]'s fuel tank into [attacked_atom]."))
 		update_appearance()
+
+	return .
 
 /obj/item/weldingtool/attack_qdeleted(atom/attacked_atom, mob/user, proximity)
 	. = ..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -871,7 +871,7 @@
 	damtype = STAMINA //maybe someday we can add stuffing rocks (or perhaps ore?) into snowballs to make them deal brute damage
 
 /obj/item/toy/snowball/afterattack(atom/target as mob|obj|turf|area, mob/user)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	if(user.dropItemToGround(src))
 		throw_at(target, throw_range, throw_speed)
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -871,7 +871,8 @@
 	damtype = STAMINA //maybe someday we can add stuffing rocks (or perhaps ore?) into snowballs to make them deal brute damage
 
 /obj/item/toy/snowball/afterattack(atom/target as mob|obj|turf|area, mob/user)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(user.dropItemToGround(src))
 		throw_at(target, throw_range, throw_speed)
 

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -1093,6 +1093,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	if(!proximity_flag || !(isclosedturf(target) || isitem(target) || ismachinery(target) || isstructure(target) || isvehicle(target)))
 		return
 	slash(target, user, params)
+	return AFTERATTACK_PROCESSED_ITEM
 
 /// triggered on wield of two handed item
 /obj/item/highfrequencyblade/proc/on_wield(obj/item/source, mob/user)

--- a/code/game/objects/structures/deployable_turret.dm
+++ b/code/game/objects/structures/deployable_turret.dm
@@ -269,7 +269,7 @@
 	add_fingerprint(user)
 
 /obj/item/gun_control/afterattack(atom/targeted_atom, mob/user, flag, params)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	var/modifiers = params2list(params)
 	var/obj/machinery/deployable_turret/E = user.buckled
 	E.calculated_projectile_vars = calculate_projectile_angle_and_pixel_offsets(user, targeted_atom, modifiers)

--- a/code/game/objects/structures/deployable_turret.dm
+++ b/code/game/objects/structures/deployable_turret.dm
@@ -269,7 +269,8 @@
 	add_fingerprint(user)
 
 /obj/item/gun_control/afterattack(atom/targeted_atom, mob/user, flag, params)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	var/modifiers = params2list(params)
 	var/obj/machinery/deployable_turret/E = user.buckled
 	E.calculated_projectile_vars = calculate_projectile_angle_and_pixel_offsets(user, targeted_atom, modifiers)

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -216,17 +216,20 @@
 	. = ..()
 	if(flag)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!ScientistCheck(user))
-		return
+		return .
 	if(!console)
 		to_chat(user, span_warning("The device is not linked to console!"))
-		return
+		return .
 
 	switch(mode)
 		if(GIZMO_SCAN)
 			scan(target, user)
 		if(GIZMO_MARK)
 			mark(target, user)
+
+	return .
 
 /obj/item/abductor/gizmo/proc/scan(atom/target, mob/living/user)
 	if(ishuman(target))
@@ -275,9 +278,11 @@
 	. = ..()
 	if(flag)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!AbductorCheck(user))
-		return
+		return .
 	radio_off(target, user)
+	return .
 
 /obj/item/abductor/silencer/proc/radio_off(atom/target, mob/living/user)
 	if( !(user in (viewers(7,target))) )
@@ -321,7 +326,7 @@
 	to_chat(user, span_notice("You switch the device to [mode==MIND_DEVICE_MESSAGE? "TRANSMISSION": "COMMAND"] MODE"))
 
 /obj/item/abductor/mind_device/afterattack(atom/target, mob/living/user, flag, params)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	if(!ScientistCheck(user))
 		return
 

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -326,7 +326,8 @@
 	to_chat(user, span_notice("You switch the device to [mode==MIND_DEVICE_MESSAGE? "TRANSMISSION": "COMMAND"] MODE"))
 
 /obj/item/abductor/mind_device/afterattack(atom/target, mob/living/user, flag, params)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!ScientistCheck(user))
 		return
 

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -216,7 +216,6 @@
 	. = ..()
 	if(flag)
 		return
-	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!ScientistCheck(user))
 		return .
 	if(!console)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -553,6 +553,7 @@
 		if(channeling)
 			to_chat(user, span_cultitalic("You are already invoking twisted construction!"))
 			return
+		. |= AFTERATTACK_PROCESSED_ITEM
 		var/turf/T = get_turf(target)
 		if(istype(target, /obj/item/stack/sheet/iron))
 			var/obj/item/stack/sheet/candidate = target
@@ -631,7 +632,7 @@
 		else
 			to_chat(user, span_warning("The spell will not work on [target]!"))
 			return
-		..()
+		return . | ..()
 
 /obj/item/melee/blood_magic/construction/proc/check_menu(mob/user)
 	if(!istype(user))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -622,6 +622,8 @@ Striking a noncultist, however, will tear their flesh."}
 		to_chat(user, span_warning("\The [src] can only transport items!"))
 		return
 
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	var/list/cultists = list()
 	for(var/datum/mind/M as anything in get_antag_minds(/datum/antagonist/cult))
 		if(M.current && M.current.stat != DEAD)
@@ -855,7 +857,7 @@ Striking a noncultist, however, will tear their flesh."}
 		angle = get_angle(user, A)
 	else
 		qdel(src)
-		return
+		return . | AFTERATTACK_PROCESSED_ITEM
 	charging = TRUE
 	INVOKE_ASYNC(src, PROC_REF(charge), user)
 	if(do_after(user, 9 SECONDS, target = user))

--- a/code/modules/antagonists/traitor/objectives/bug_room.dm
+++ b/code/modules/antagonists/traitor/objectives/bug_room.dm
@@ -154,6 +154,7 @@
 		return
 	if(!user.Adjacent(target))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	var/result = SEND_SIGNAL(src, COMSIG_TRAITOR_BUG_PRE_PLANTED_OBJECT, target)
 	if(!(result & COMPONENT_FORCE_PLACEMENT))
 		if(result & COMPONENT_FORCE_FAIL_PLACEMENT || !istype(target, target_object_type))

--- a/code/modules/antagonists/traitor/objectives/demoralise_graffiti.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_graffiti.dm
@@ -112,6 +112,8 @@
 		user.balloon_alert(user, "already busy!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if (!proximity || !check_allowed_items(target) || !isliving(user))
 		return
 

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -330,8 +330,13 @@ Moving interrupts
 // We aim at something distant.
 /obj/item/chisel/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if(!proximity_flag && !sculpting && prepared_block && ismovable(target) && prepared_block.completion == 0)
+	if(!proximity_flag)
+		return .
+
+	if (!sculpting && prepared_block && ismovable(target) && prepared_block.completion == 0)
 		prepared_block.set_target(target,user)
+
+	return . | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/chisel/proc/start_sculpting(mob/living/user)
 	to_chat(user,span_notice("You start sculpting [prepared_block]."),type=MESSAGE_TYPE_INFO)

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
@@ -9,6 +9,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	var/obj/machinery/portable_atmospherics/atmos_device = target_object
 	if(istype(atmos_device))
 		if(atmos_device.nob_crystal_inserted)

--- a/code/modules/cargo/universal_scanner.dm
+++ b/code/modules/cargo/universal_scanner.dm
@@ -61,11 +61,13 @@
 	. = ..()
 	if(!istype(object) || !proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(scanning_mode == SCAN_EXPORTS)
 		export_scan(object, user)
-		return
+		return .
 	if(scanning_mode == SCAN_PRICE_TAG)
 		price_tag(target = object, user = user)
+	return .
 
 /obj/item/universal_scanner/attackby(obj/item/attacking_item, mob/user, params)
 	. = ..()

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -352,6 +352,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	var/datum/export_report/ex = export_item_and_contents(I, delete_unsold = selling, dry_run = !selling)
 	var/price = 0
 	for(var/x in ex.total_amount)
@@ -364,6 +365,8 @@
 			new /obj/item/holochip(get_turf(user),true_price)
 	else
 		to_chat(user, span_warning("There is no export value for [I] or any items within it."))
+
+	return .
 
 /obj/item/clothing/neck/beads
 	name = "plastic bead necklace"

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -13,6 +13,7 @@
 	if(!proximity || loc == I)
 		return
 	evidencebagEquip(I, user)
+	return . | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/evidencebag/attackby(obj/item/I, mob/user, params)
 	if(evidencebagEquip(I, user))

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -72,7 +72,7 @@
 /obj/item/detective_scanner/afterattack(atom/A, mob/user, params)
 	. = ..()
 	scan(A, user)
-	return FALSE
+	return . | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/detective_scanner/proc/scan(atom/A, mob/user)
 	set waitfor = FALSE

--- a/code/modules/events/wizard/rpgloot.dm
+++ b/code/modules/events/wizard/rpgloot.dm
@@ -26,12 +26,16 @@
 	if(!proximity || !istype(target))
 		return
 
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	target.AddComponent(/datum/component/fantasy, upgrade_amount, null, null, can_backfire, TRUE)
 
 	uses -= 1
 	if(!uses)
 		visible_message(span_warning("[src] vanishes, its magic completely consumed from the fortification."))
 		qdel(src)
+
+	return .
 
 /obj/item/upgradescroll/unlimited
 	name = "unlimited foolproof item fortification scroll"

--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -98,10 +98,14 @@
  */
 /datum/component/experiment_handler/proc/ignored_handheld_experiment_attempt(datum/source, atom/target, mob/user, proximity_flag, params)
 	SIGNAL_HANDLER
-	if (!proximity_flag || (selected_experiment == null && !(config_flags & EXPERIMENT_CONFIG_ALWAYS_ACTIVE)))
+	if (!proximity_flag)
 		return
+	. |= COMPONENT_AFTERATTACK_PROCESSED_ITEM
+	if (selected_experiment == null && !(config_flags & EXPERIMENT_CONFIG_ALWAYS_ACTIVE)))
+		return .
 	playsound(user, 'sound/machines/buzz-sigh.ogg', 25)
 	to_chat(user, span_notice("[target] is not related to your currently selected experiment."))
+	return .
 
 /**
  * Checks that an experiment can be run using the provided target, used for preventing the cancellation of the attack chain inappropriately

--- a/code/modules/experisci/experiment/handlers/experiment_handler.dm
+++ b/code/modules/experisci/experiment/handlers/experiment_handler.dm
@@ -101,7 +101,7 @@
 	if (!proximity_flag)
 		return
 	. |= COMPONENT_AFTERATTACK_PROCESSED_ITEM
-	if (selected_experiment == null && !(config_flags & EXPERIMENT_CONFIG_ALWAYS_ACTIVE)))
+	if (selected_experiment == null && !(config_flags & EXPERIMENT_CONFIG_ALWAYS_ACTIVE))
 		return .
 	playsound(user, 'sound/machines/buzz-sigh.ogg', 25)
 	to_chat(user, span_notice("[target] is not related to your currently selected experiment."))

--- a/code/modules/explorer_drone/loot.dm
+++ b/code/modules/explorer_drone/loot.dm
@@ -164,7 +164,7 @@ GLOBAL_LIST_INIT(adventure_loot_generator_index,generate_generator_index())
 	return cell
 
 /obj/item/firelance/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	if(!HAS_TRAIT(src,TRAIT_WIELDED))
 		to_chat(user,span_notice("You need to wield [src] in two hands before you can fire it."))
 		return

--- a/code/modules/explorer_drone/loot.dm
+++ b/code/modules/explorer_drone/loot.dm
@@ -164,7 +164,8 @@ GLOBAL_LIST_INIT(adventure_loot_generator_index,generate_generator_index())
 	return cell
 
 /obj/item/firelance/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!HAS_TRAIT(src,TRAIT_WIELDED))
 		to_chat(user,span_notice("You need to wield [src] in two hands before you can fire it."))
 		return

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -193,12 +193,12 @@
 		return BEAM_CANCEL_DRAW
 
 /obj/item/fishing_rod/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 
 	/// Reel in if able
 	if(currently_hooked_item)
 		reel(user)
-		return
+		return .
 
 	/// If the line to whatever that is is clear and we're not already busy, try fishing in it
 	if(!casting && !currently_hooked_item && !proximity_flag && CheckToolReach(user, target, cast_range))
@@ -214,6 +214,8 @@
 		cast_projectile.impacted = list(user = TRUE)
 		cast_projectile.preparePixelProjectile(target, user)
 		cast_projectile.fire()
+
+	return .
 
 /// Called by hook projectile when hitting things
 /obj/item/fishing_rod/proc/hook_hit(atom/atom_hit_by_hook_projectile)

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -193,7 +193,8 @@
 		return BEAM_CANCEL_DRAW
 
 /obj/item/fishing_rod/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 
 	/// Reel in if able
 	if(currently_hooked_item)

--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -85,12 +85,15 @@
 	if(!ismovable(target))
 		return
 
+	. |= COMPONENT_AFTERATTACK_PROCESSED_ITEM
+
 	if(isobj(target))
 		var/obj/object_target = target
 		if(!(object_target.obj_flags & CAN_BE_HIT))
-			return
+			return .
 
 	INVOKE_ASYNC(src, PROC_REF(after_attack_effect), source, target, user)
+	return .
 
 /*
  * Effects done when we hit people with our plant, AFTER the attack is done.

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -478,9 +478,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 /obj/item/analyzer/hilbertsanalyzer/afterattack(atom/target, mob/user, proximity)
 	. = ..()
 	if(istype(target, /obj/item/hilbertshotel))
+		. |= AFTERATTACK_PROCESSED_ITEM
 		if(!proximity)
 			to_chat(user, span_warning("It's to far away to scan!"))
-			return
+			return .
 		var/obj/item/hilbertshotel/sphere = target
 		if(sphere.activeRooms.len)
 			to_chat(user, "Currently Occupied Rooms:")
@@ -494,6 +495,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 				to_chat(user, roomnumber)
 		else
 			to_chat(user, "No vacated rooms.")
+		return .
 
 /obj/effect/landmark/lift_id/hilbert
 	specific_lift_id = HILBERT_TRAM

--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -12,17 +12,20 @@
 	. = ..()
 	if (!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	var/obj/item/organ/internal/monster_core/target_core = target_organ
 	if (!istype(target_core, /obj/item/organ/internal/monster_core))
 		balloon_alert(user, "invalid target!")
-		return
+		return .
 
 	if (!target_core.preserve())
 		balloon_alert(user, "organ decayed!")
-		return
+		return .
 
 	balloon_alert(user, "organ stabilized")
 	qdel(src)
+	return .
 
 /**
  * Useful organs which drop as loot from a mining creature.
@@ -137,6 +140,7 @@
 	if (!proximity_flag)
 		return
 	try_apply(target, user)
+	return . | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/organ/internal/monster_core/attack_self(mob/user)
 	if (!user.canUseTopic(src, be_close = TRUE, no_dexterity = FALSE, no_tk = TRUE))

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -33,7 +33,8 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 		to_chat(user, span_notice("You link the extraction pack to the beacon system."))
 
 /obj/item/extraction_pack/afterattack(atom/movable/A, mob/living/carbon/human/user, flag, params)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!beacon)
 		to_chat(user, span_warning("[src] is not linked to a beacon, and cannot be used!"))
 		return

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 		to_chat(user, span_notice("You link the extraction pack to the beacon system."))
 
 /obj/item/extraction_pack/afterattack(atom/movable/A, mob/living/carbon/human/user, flag, params)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	if(!beacon)
 		to_chat(user, span_warning("[src] is not linked to a beacon, and cannot be used!"))
 		return

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -100,7 +100,7 @@
 	to_chat(user, span_notice("You [blink_activated ? "enable" : "disable"] the blink function on [src]."))
 
 /obj/item/hierophant_club/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	// If our target is the beacon and the hierostaff is next to the beacon, we're trying to pick it up.
 	if((target == beacon) && target.Adjacent(src))
 		return
@@ -842,6 +842,7 @@
 	. = ..()
 	if(timer > world.time)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(is_type_in_typecache(target, banned_turfs))
 		return
 	if(target in view(user.client.view, get_turf(user)))
@@ -1089,7 +1090,7 @@
 	user.log_message("has dispelled a storm at [AREACOORD(user_turf)].", LOG_GAME)
 
 /obj/item/storm_staff/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	if(!thunder_charges)
 		balloon_alert(user, "needs to charge!")
 		return

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -100,7 +100,8 @@
 	to_chat(user, span_notice("You [blink_activated ? "enable" : "disable"] the blink function on [src]."))
 
 /obj/item/hierophant_club/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	// If our target is the beacon and the hierostaff is next to the beacon, we're trying to pick it up.
 	if((target == beacon) && target.Adjacent(src))
 		return
@@ -1090,7 +1091,8 @@
 	user.log_message("has dispelled a storm at [AREACOORD(user_turf)].", LOG_GAME)
 
 /obj/item/storm_staff/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!thunder_charges)
 		balloon_alert(user, "needs to charge!")
 		return

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -329,6 +329,7 @@
 /obj/item/food/deadmouse/afterattack(obj/target, mob/living/user, proximity_flag)
 	. = ..()
 	if(proximity_flag && reagents && target.is_open_container())
+		. |= AFTERATTACK_PROCESSED_ITEM
 		// is_open_container will not return truthy if target.reagents doesn't exist
 		var/datum/reagents/target_reagents = target.reagents
 		var/trans_amount = reagents.maximum_volume - reagents.total_volume * (4 / 3)
@@ -336,7 +337,7 @@
 			to_chat(user, span_notice("You dip [src] into [target]."))
 		else
 			to_chat(user, span_warning("That's a terrible idea."))
-		return
+		return .
 
 /obj/item/food/deadmouse/moldy
 	name = "moldy dead mouse"

--- a/code/modules/ninja/ninja_explosive.dm
+++ b/code/modules/ninja/ninja_explosive.dm
@@ -42,10 +42,11 @@
 	if(!IS_SPACE_NINJA(ninja))
 		to_chat(ninja, span_notice("While it appears normal, you can't seem to detonate the charge."))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if (!check_loc(ninja))
-		return
+		return .
 	detonator = WEAKREF(ninja)
-	return ..()
+	return . | ..()
 
 /obj/item/grenade/c4/ninja/detonate(mob/living/lanced_by)
 	if(!check_loc(detonator.resolve())) // if its moved, deactivate the c4

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -40,6 +40,9 @@
 	. = ..()
 	if(!proximity)
 		return
+
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if(!mode) //if it's off, give up.
 		return
 
@@ -98,6 +101,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!iscyborg(user))
 		return
 

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -160,8 +160,14 @@
 
 /obj/item/pen/afterattack(obj/O, mob/living/user, proximity)
 	. = ..()
+
+	if (!proximity)
+		return .
+
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	//Changing name/description of items. Only works if they have the UNIQUE_RENAME object flag set
-	if(isobj(O) && proximity && (O.obj_flags & UNIQUE_RENAME))
+	if(isobj(O) && (O.obj_flags & UNIQUE_RENAME))
 		var/penchoice = tgui_input_list(user, "What would you like to edit?", "Pen Setting", list("Rename", "Description", "Reset"))
 		if(QDELETED(O) || !user.canUseTopic(O, be_close = TRUE))
 			return

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -125,6 +125,8 @@
 	return TRUE
 
 /obj/item/camera/afterattack(atom/target, mob/user, flag)
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if (disk)
 		if(ismob(target))
 			if (disk.record)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -490,7 +490,8 @@
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
 /obj/item/turret_control/afterattack(atom/targeted_atom, mob/user, proxflag, clickparams)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	var/obj/machinery/power/emitter/emitter = user.buckled
 	emitter.setDir(get_dir(emitter,targeted_atom))
 	user.setDir(emitter.dir)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -490,7 +490,7 @@
 	ADD_TRAIT(src, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 
 /obj/item/turret_control/afterattack(atom/targeted_atom, mob/user, proxflag, clickparams)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	var/obj/machinery/power/emitter/emitter = user.buckled
 	emitter.setDir(get_dir(emitter,targeted_atom))
 	user.setDir(emitter.dir)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -210,8 +210,8 @@
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/gun/afterattack(atom/target, mob/living/user, flag, params)
-	. = ..()
-	return fire_gun(target, user, flag, params)
+	..()
+	return fire_gun(target, user, flag, params) | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/gun/proc/fire_gun(atom/target, mob/living/user, flag, params)
 	if(QDELETED(target))

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -291,11 +291,13 @@
 
 
 /obj/item/gun/ballistic/automatic/l6_saw/afterattack(atom/target as mob|obj|turf, mob/living/user as mob|obj, flag, params)
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if(cover_open)
 		balloon_alert(user, "close the cover!")
 		return
 	else
-		. = ..()
+		. |= ..()
 		update_appearance()
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -44,6 +44,7 @@
 	update_appearance()
 
 /obj/item/gun/ballistic/bow/afterattack(atom/target, mob/living/user, flag, params, passthrough = FALSE)
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!chambered)
 		return
 	if(!drawn)

--- a/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -302,6 +302,7 @@
 	return ..()
 
 /obj/item/gun/energy/beam_rifle/afterattack(atom/target, mob/living/user, flag, params, passthrough = FALSE)
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(flag) //It's adjacent, is the user, or is on the user's person
 		if(target in user.contents) //can't shoot stuff inside us.
 			return

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -34,6 +34,7 @@
 	..()
 
 /obj/item/gun/magic/wand/afterattack(atom/target, mob/living/user)
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!charges)
 		shoot_with_empty_chamber(user)
 		return
@@ -47,7 +48,7 @@
 				no_den_usage = 0
 		zap_self(user)
 	else
-		. = ..()
+		. |= ..()
 	update_appearance()
 
 

--- a/code/modules/projectiles/guns/special/blastcannon.dm
+++ b/code/modules/projectiles/guns/special/blastcannon.dm
@@ -111,6 +111,8 @@
 	return TRUE
 
 /obj/item/gun/blastcannon/afterattack(atom/target, mob/user, flag, params)
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if((!bomb && bombcheck) || !target || (get_dist(get_turf(target), get_turf(user)) <= 2))
 		return ..()
 

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -24,6 +24,7 @@
 	. = ..()
 	if(proximity_flag)
 		if(isgun(target))
+			. |= AFTERATTACK_PROCESSED_ITEM
 			var/obj/item/gun/G = target
 			var/obj/item/firing_pin/old_pin = G.pin
 			if(old_pin && (force_replace || old_pin.pin_removeable))
@@ -36,11 +37,13 @@
 
 			if(!G.pin)
 				if(!user.temporarilyRemoveItemFromInventory(src))
-					return
+					return .
 				gun_insert(user, G)
 				to_chat(user, span_notice("You insert [src] into [G]."))
 			else
 				to_chat(user, span_notice("This firearm already has a firing pin installed."))
+
+			return .
 
 /obj/item/firing_pin/emag_act(mob/user)
 	if(obj_flags & EMAGGED)

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -294,7 +294,8 @@
 	return ..()
 
 /obj/item/thermometer/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(target.reagents)
 		if(!user.transferItemToLoc(src, target))
 			return .

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -81,6 +81,7 @@
 /obj/item/ph_paper/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(!is_reagent_container(target))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	var/obj/item/reagent_containers/cont = target
 	if(used == TRUE)
 		to_chat(user, span_warning("[src] has already been used!"))
@@ -116,6 +117,7 @@
 	. = ..()
 	if(!is_reagent_container(target))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	var/obj/item/reagent_containers/cont = target
 	if(LAZYLEN(cont.reagents.reagent_list) == null)
 		return
@@ -188,17 +190,21 @@
 /obj/item/burner/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	if(lit)
+		. |= AFTERATTACK_PROCESSED_ITEM
 		if(is_reagent_container(target))
 			var/obj/item/reagent_containers/container = target
 			container.reagents.expose_temperature(get_temperature())
 			to_chat(user, span_notice("You heat up the [src]."))
 			playsound(user.loc, 'sound/chemistry/heatdam.ogg', 50, TRUE)
-			return
+			return .
 	else if(isitem(target))
 		var/obj/item/item = target
 		if(item.heat > 1000)
+			. |= AFTERATTACK_PROCESSED_ITEM
 			set_lit(TRUE)
 			user.visible_message(span_notice("[user] lights up the [src]."))
+
+	return .
 
 /obj/item/burner/update_icon_state()
 	. = ..()
@@ -288,13 +294,14 @@
 	return ..()
 
 /obj/item/thermometer/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 	if(target.reagents)
 		if(!user.transferItemToLoc(src, target))
-			return
+			return .
 		attached_to_reagents = target.reagents
 		to_chat(user, span_notice("You add the [src] to the [target]."))
 		ui_interact(usr, null)
+	return .
 
 /obj/item/thermometer/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -70,6 +70,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(istype(target, /obj/structure/reagent_dispensers)) //A dispenser. Transfer FROM it TO us.
 
 		if(!target.reagents.total_volume)
@@ -152,6 +153,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(isturf(target))
 		if(!reagents.has_reagent(/datum/reagent/consumable/salt, 2))
 			to_chat(user, span_warning("You don't have enough salt to make a pile!"))
@@ -367,7 +369,7 @@
 /obj/item/reagent_containers/condiment/pack/afterattack(obj/target, mob/user , proximity)
 	if(!proximity)
 		return
-
+	. |= AFTERATTACK_PROCESSED_ITEM
 	//You can tear the bag open above food to put the condiments on it, obviously.
 	if(IS_EDIBLE(target))
 		if(!reagents.total_volume)
@@ -383,7 +385,7 @@
 			src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
 			qdel(src)
 			return
-	. = ..()
+	return . | ..()
 
 /// Handles reagents getting added to the condiment pack.
 /obj/item/reagent_containers/condiment/pack/proc/on_reagent_add(datum/reagents/reagents)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -100,7 +100,12 @@
 
 /obj/item/reagent_containers/cup/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
-	if((!proximity_flag) || !check_allowed_items(target, target_self = TRUE))
+	if(!proximity_flag)
+		return
+
+	. |= AFTERATTACK_PROCESSED_ITEM
+
+	if(!check_allowed_items(target, target_self = TRUE))
 		return
 
 	if(!spillable)

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -287,6 +287,8 @@
 	return ..()
 
 /obj/item/reagent_containers/cup/glass/waterbottle/afterattack(obj/target, mob/living/user, proximity)
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if(cap_on && (target.is_refillable() || target.is_drainable() || (reagents.total_volume && !user.combat_mode)))
 		to_chat(user, span_warning("You must remove the cap before you can do that!"))
 		return
@@ -297,7 +299,7 @@
 			to_chat(user, span_warning("[other_bottle] has a cap firmly twisted on!"))
 			return
 
-	return ..()
+	return . | ..()
 
 // heehoo bottle flipping
 /obj/item/reagent_containers/cup/glass/waterbottle/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -15,6 +15,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!target.reagents)
 		return
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -59,6 +59,7 @@
 	. = ..()
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!dissolvable || !target.is_refillable())
 		return
 	if(target.is_drainable() && !target.reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -30,6 +30,8 @@
 	if(istype(target, /obj/structure/sink) || istype(target, /obj/structure/mop_bucket/janitorialcart) || istype(target, /obj/machinery/hydroponics))
 		return
 
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if((target.is_drainable() && !target.is_refillable()) && (get_dist(src, target) <= 1) && can_fill_from_container)
 		if(!target.reagents.total_volume)
 			to_chat(user, span_warning("[target] is empty."))
@@ -220,7 +222,7 @@
 /obj/item/reagent_containers/spray/pepper/afterattack(atom/A as mob|obj, mob/user)
 	if (A.loc == user)
 		return
-	. = ..()
+	return ..() | AFTERATTACK_PROCESSED_ITEM
 
 //water flower
 /obj/item/reagent_containers/spray/waterflower
@@ -309,7 +311,7 @@
 	// Make it so the bioterror spray doesn't spray yourself when you click your inventory items
 	if (A.loc == user)
 		return
-	. = ..()
+	return ..() | AFTERATTACK_PROCESSED_ITEM
 
 /obj/item/reagent_containers/spray/chemsprayer/spray(atom/A, mob/user)
 	var/direction = get_dir(src, A)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -41,7 +41,8 @@
 	return TRUE
 
 /obj/item/reagent_containers/syringe/afterattack(atom/target, mob/user, proximity)
-	. = ..() | AFTERATTACK_PROCESSED_ITEM
+	. = ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 
 	if (!try_syringe(target, user, proximity))
 		return

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -41,7 +41,7 @@
 	return TRUE
 
 /obj/item/reagent_containers/syringe/afterattack(atom/target, mob/user, proximity)
-	. = ..()
+	. = ..() | AFTERATTACK_PROCESSED_ITEM
 
 	if (!try_syringe(target, user, proximity))
 		return

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -53,8 +53,10 @@ Slimecrossing Items
 	return ret
 
 /obj/item/camera/rewind/afterattack(atom/target, mob/user, flag)
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if(!on || !pictures_left || !isturf(target.loc))
-		return
+		return .
 
 	if(user == target)
 		to_chat(user, span_notice("You take a selfie!"))
@@ -64,7 +66,7 @@ Slimecrossing Items
 	to_chat(target, span_boldnotice("You'll remember this moment forever!"))
 
 	target.AddComponent(/datum/component/dejavu, 2)
-	.=..()
+	return . | ..()
 
 
 
@@ -76,10 +78,12 @@ Slimecrossing Items
 	pictures_max = 1
 
 /obj/item/camera/timefreeze/afterattack(atom/target, mob/user, flag)
+	. |= AFTERATTACK_PROCESSED_ITEM
+
 	if(!on || !pictures_left || !isturf(target.loc))
-		return
+		return .
 	new /obj/effect/timestop(get_turf(target), 2, 50, list(user))
-	. = ..()
+	return . | ..()
 
 //Hypercharged slime cell - Charged Yellow
 /obj/item/stock_parts/cell/high/slime_hypercharged

--- a/code/modules/research/xenobiology/crossbreeding/_potions.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_potions.dm
@@ -14,6 +14,7 @@ Slimecrossing Potions
 /obj/item/slimepotion/extract_cloner/afterattack(obj/item/target, mob/user , proximity)
 	if(!proximity)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(is_reagent_container(target))
 		return ..(target, user, proximity)
 	if(istype(target, /obj/item/slimecross))
@@ -116,12 +117,13 @@ Slimecrossing Potions
 	if(!istype(C))
 		to_chat(user, span_warning("The potion can only be used on clothing!"))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(istype(C, /obj/item/clothing/suit/space))
 		to_chat(user, span_warning("The [C] is already pressure-resistant!"))
-		return ..()
+		return . | ..()
 	if(C.min_cold_protection_temperature == SPACE_SUIT_MIN_TEMP_PROTECT && C.clothing_flags & STOPSPRESSUREDAMAGE)
 		to_chat(user, span_warning("The [C] is already pressure-resistant!"))
-		return ..()
+		return . | ..()
 	to_chat(user, span_notice("You slather the blue gunk over the [C], making it airtight."))
 	C.name = "pressure-resistant [C.name]"
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
@@ -132,6 +134,7 @@ Slimecrossing Potions
 	uses--
 	if(!uses)
 		qdel(src)
+	return .
 
 //Enhancer potion - Charged Cerulean
 /obj/item/slimepotion/enhancer/max
@@ -159,6 +162,7 @@ Slimecrossing Potions
 	if(!istype(C))
 		to_chat(user, span_warning("You can't coat this with lavaproofing fluid!"))
 		return ..()
+	. |= AFTERATTACK_PROCESSED_ITEM
 	to_chat(user, span_notice("You slather the red gunk over the [C], making it lavaproof."))
 	C.name = "lavaproof [C.name]"
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
@@ -170,6 +174,7 @@ Slimecrossing Potions
 	uses--
 	if(!uses)
 		qdel(src)
+	return .
 
 //Revival potion - Charged Grey
 /obj/item/slimepotion/slime_reviver

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -889,6 +889,7 @@
 	if(!istype(C))
 		to_chat(user, span_warning("The potion can only be used on objects!"))
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(SEND_SIGNAL(C, COMSIG_SPEED_POTION_APPLIED, src, user) & SPEED_POTION_STOP)
 		return
 	if(isitem(C))
@@ -927,6 +928,7 @@
 	if(!uses)
 		qdel(src)
 		return
+	. |= AFTERATTACK_PROCESSED_ITEM
 	if(!istype(C))
 		to_chat(user, span_warning("The potion can only be used on clothing!"))
 		return

--- a/code/modules/wiremod/shell/scanner.dm
+++ b/code/modules/wiremod/shell/scanner.dm
@@ -58,4 +58,5 @@
 	attacker.set_output(user)
 	attacking.set_output(target)
 	signal.set_output(COMPONENT_SIGNAL)
+	return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -38,6 +38,7 @@
 		if(ishuman(target))
 			try_to_zombie_infect(target)
 		else
+			. |= AFTERATTACK_PROCESSED_ITEM
 			check_feast(target, user)
 
 /proc/try_to_zombie_infect(mob/living/carbon/human/target)


### PR DESCRIPTION
Necessary for #72292 to work effectively, and probably not very useful out of that context. Split out of its own PR because this is long and boring.

I want to make sure that we're catching actual mistakes there, and not just experiencing side effects of how shitty the attack chain is.