### PR TITLE
Fixes emissives, starlight, and a filterrific bug

### DIFF
--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -22,15 +22,13 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"size" = 1
 		)
 	),
-	/* Not supported because making a proper matrix editor on the frontend would be a huge dick pain.
-		Uncomment if you ever implement it
+	// Not implenmented, but if this isn't uncommented some windows will just error
 	"color" = list(
 		"defaults" = list(
 			"color" = matrix(),
 			"space" = FILTER_COLOR_RGB
 		)
 	),
-	*/
 	"displace" = list(
 		"defaults" = list(
 			"x" = 0,

--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -23,6 +23,9 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 		)
 	),
 	// Not implenmented, but if this isn't uncommented some windows will just error
+	// Needs either a proper matrix editor, or just a hook to our existing one 
+	// Issue is filterrific assumes variables will have the same value type if they share the same name, which this violates
+	// Gotta refactor this sometime
 	"color" = list(
 		"defaults" = list(
 			"color" = matrix(),

--- a/code/__HELPERS/filters.dm
+++ b/code/__HELPERS/filters.dm
@@ -22,7 +22,7 @@ GLOBAL_LIST_INIT(master_filter_info, list(
 			"size" = 1
 		)
 	),
-	// Not implenmented, but if this isn't uncommented some windows will just error
+	// Not implemented, but if this isn't uncommented some windows will just error
 	// Needs either a proper matrix editor, or just a hook to our existing one 
 	// Issue is filterrific assumes variables will have the same value type if they share the same name, which this violates
 	// Gotta refactor this sometime

--- a/code/__HELPERS/lighting.dm
+++ b/code/__HELPERS/lighting.dm
@@ -14,7 +14,7 @@
 	var/mutable_appearance/blocker = new()
 	blocker.icon = make_blocker.icon
 	blocker.icon_state = make_blocker.icon_state
-	blocker.layer = make_blocker.layer
+	blocker.layer = FLOAT_LAYER 
 	blocker.appearance_flags |= make_blocker.appearance_flags | EMISSIVE_APPEARANCE_FLAGS
 	blocker.dir = make_blocker.dir
 	blocker.color = GLOB.em_block_color

--- a/code/__HELPERS/lighting.dm
+++ b/code/__HELPERS/lighting.dm
@@ -14,7 +14,7 @@
 	var/mutable_appearance/blocker = new()
 	blocker.icon = make_blocker.icon
 	blocker.icon_state = make_blocker.icon_state
-	blocker.layer = FLOAT_LAYER 
+	// blocker.layer = FLOAT_LAYER // Implied, FLOAT_LAYER is default for appearances
 	blocker.appearance_flags |= make_blocker.appearance_flags | EMISSIVE_APPEARANCE_FLAGS
 	blocker.dir = make_blocker.dir
 	blocker.color = GLOB.em_block_color

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -177,8 +177,11 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if(!ambientsounds)
 		ambientsounds = GLOB.ambience_assoc[ambience_index]
 
-	if(area_flags & AREA_USES_STARLIGHT)
-		static_lighting = CONFIG_GET(flag/starlight)
+	if(area_flags & AREA_USES_STARLIGHT && CONFIG_GET(flag/starlight))
+		// Areas lit by starlight are not supposed to be fullbright 4head
+		base_lighting_alpha = 0
+		base_lighting_color = null
+		static_lighting = TRUE
 
 	if(requires_power)
 		luminosity = 0


### PR DESCRIPTION
## About The Pull Request
[Fixes emissive lighting, we never actually used the thing's layer, should have just been using float layers anyhow](https://github.com/tgstation/tgstation/commit/2af035d48742eb4337dbfabed699a9acef67d883)

[Fixes starlight not disabling fullbright](https://github.com/tgstation/tgstation/commit/7a4e3f0c9abacaf944a4be801d2d99daa72e9c50)

It used to, but tivi messed it up with area lighting. makes maps like kilo look WAY worse then they should (I stole this slightly from kapu)

[Fixes filterrific erroring when editing something with a color matrix](https://github.com/tgstation/tgstation/commit/72dfd4fd8fe4755858568ab7d80e31e146f49ea5)

It's not supported right now, mostly becuase it would require reworking
how filterrifc works out what window type to use, but at least this way
I can mess with the emissive plane without needing to recompile or do it
manually

## Why It's Good For The Game

Makes starlight actually pretty instead of just fullbright + the windows glow a bit, emissives working is good actually, and filterrific not being annoying makes me happy.

## Changelog
:cl:
fix: Starlight will actually show now, instead of just being replaced by fullbright most of the time
fix: Emissive lighting will once again work. Sorry lads
/:cl:
