### PR TITLE
Drone dispensers now tell you how much material they need per drone.

### DIFF
--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -125,6 +125,8 @@
 
 /obj/machinery/drone_dispenser/examine(mob/user)
 	. = ..()
+	if (iron_cost > 0 || glass_cost > 0)
+		. += span_notice("It needs [iron_cost] iron and [glass_cost] glass to produce one drone shell.")
 	if((mode == DRONE_RECHARGING) && !machine_stat && recharging_text)
 		. += span_warning("[recharging_text]")
 

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -128,8 +128,8 @@
 	var/material_requirement_string = "It needs "
 	if (iron_cost > 0)
 		material_requirement_string += "[iron_cost] iron "
-	if (iron_cost > 0 && glass_cost > 0)
-		material_requirement_string += "and "
+		if (glass_cost > 0)
+			material_requirement_string += "and "
 	if (glass_cost > 0)
 		material_requirement_string += "[glass_cost] glass "
 	if (iron_cost > 0 || glass_cost > 0)

--- a/code/game/machinery/droneDispenser.dm
+++ b/code/game/machinery/droneDispenser.dm
@@ -125,8 +125,16 @@
 
 /obj/machinery/drone_dispenser/examine(mob/user)
 	. = ..()
+	var/material_requirement_string = "It needs "
+	if (iron_cost > 0)
+		material_requirement_string += "[iron_cost] iron "
+	if (iron_cost > 0 && glass_cost > 0)
+		material_requirement_string += "and "
+	if (glass_cost > 0)
+		material_requirement_string += "[glass_cost] glass "
 	if (iron_cost > 0 || glass_cost > 0)
-		. += span_notice("It needs [iron_cost] iron and [glass_cost] glass to produce one drone shell.")
+		material_requirement_string += "to produce one drone shell."
+		. += span_notice(material_requirement_string)
 	if((mode == DRONE_RECHARGING) && !machine_stat && recharging_text)
 		. += span_warning("[recharging_text]")
 


### PR DESCRIPTION

## About The Pull Request

Does what the title says, when you inspect a drone dispenser that has a material requirement it tells you what that material requirement is.
## Why It's Good For The Game

Played a round earlier today where I wanted to fill a drone dispenser and I had to work out how many materials it needed by just inserting a boatload and seeing how much got used. It makes a lot more sense if you know form the outset.
## Changelog
:cl:
qol: Drone dispensers now tell you how much material they need per drone.
/:cl:
