### PR TITLE
CTF downtown's red hat store's beret is now red again rather than green.

### DIFF
--- a/_maps/map_files/CTF/downtown.dmm
+++ b/_maps/map_files/CTF/downtown.dmm
@@ -91,7 +91,7 @@
 /obj/structure/rack{
 	resistance_flags = 64
 	},
-/obj/item/clothing/head/helmet/space/beret{
+/obj/item/clothing/head/beret/sec{
 	name = "red beret"
 	},
 /turf/open/floor/carpet/red,


### PR DESCRIPTION

## About The Pull Request

At some point this beret was made green. I've made it red again so its consistent with the hat store's theme.
## Why It's Good For The Game

Green is not a shade of red
## Changelog
:cl:
fix: CTF downtown's red hat store's beret is now red again rather than green.
/:cl:
