### PR TITLE
Fixes clothing not showing armor

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -286,7 +286,7 @@
 		how_cool_are_your_threads += "</span>"
 		. += how_cool_are_your_threads.Join()
 
-	if(armor.has_any_armor() || flags_cover & HEADCOVERSMOUTH || flags_cover & PEPPERPROOF)
+	if(get_armor().has_any_armor() || (flags_cover & (HEADCOVERSMOUTH|PEPPERPROOF)))
 		. += span_notice("It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes.")
 
 /obj/item/clothing/Topic(href, href_list)
@@ -295,6 +295,7 @@
 	if(href_list["list_armor"])
 		var/list/readout = list("<span class='notice'><u><b>PROTECTION CLASSES</u></b>")
 
+		var/datum/armor/armor = get_armor()
 		var/added_damage_header = FALSE
 		for(var/damage_key in ARMOR_LIST_DAMAGE())
 			var/rating = armor.get_rating(damage_key)


### PR DESCRIPTION

## About The Pull Request

So the linter didn't detect usage of a private var for some reason.
We never want to directly access the armor var because ideally its null unless being used
## Why It's Good For The Game

Inspecting armor should work
SpacemanDMM should also work, but i'unno
## Changelog
:cl:
fix: You can inspect armor again
/:cl:
