### PR TITLE
modules attached to active modsuits act as if the suit was activated, removed modules properly unequip themselves

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -554,6 +554,8 @@
 /obj/item/mod/control/proc/uninstall(obj/item/mod/module/old_module, deleting = FALSE)
 	modules -= old_module
 	complexity -= old_module.complexity
+	if(wearer)
+		old_module.on_unequip()
 	if(active)
 		old_module.on_suit_deactivation(deleting = deleting)
 		if(old_module.active)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -545,7 +545,8 @@
 	new_module.on_install()
 	if(wearer)
 		new_module.on_equip()
-
+	if(active)
+		new_module.on_suit_activation()
 	if(user)
 		balloon_alert(user, "[new_module] added")
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE, SILENCED_SOUND_EXTRARANGE)


### PR DESCRIPTION
this seems neat for backend even if players cant use it right now
also bug fix

🆑
fix: modsuit modules that act on wearer setting/unsetting now properly unequip if removed from suit
/:cl: