### PR TITLE
adds navigate_destination for the janitor's closet on metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15143,6 +15143,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/effect/landmark/navigate_destination/janitor,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "fGb" = (


### PR DESCRIPTION

## About The Pull Request
Adds a /obj/effect/landmark/navigate_destination/janitor to the entrance of the custodial closet on metastation, making it show up when you use the navigate verb.
![image](https://user-images.githubusercontent.com/94711066/209895099-2ed152b1-5ec9-422f-b08e-faa96ad60a05.png)
![image](https://user-images.githubusercontent.com/94711066/209894802-78177429-56b9-4d61-bb99-e406c62f24a9.png)
![image](https://user-images.githubusercontent.com/94711066/209894835-a0792daa-c28e-45bf-a2a7-a0f063cd46c8.png)
## Why It's Good For The Game
Metastation has the most well-hidden janitor closet, tucked away in maintenance. I've seen many intern janitors struggle to find it and get their equipment. With this at least the ones who know about the navigate verb will be able to find it by themselves.
## Changelog
:cl:
qol: the metastation custodial closet can now be found using the navigate verb
/:cl:
