### PR TITLE
Remove duplicate chaplain armor datums

### DIFF
--- a/code/modules/clothing/suits/chaplainsuits.dm
+++ b/code/modules/clothing/suits/chaplainsuits.dm
@@ -27,15 +27,6 @@
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
 //Suits
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
-
 /obj/item/clothing/suit/chaplainsuit/holidaypriest
 	name = "holiday priest"
 	desc = "This is a nice holiday, my son."
@@ -43,15 +34,6 @@
 	inhand_icon_state = "w_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
-
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
 
 /obj/item/clothing/suit/chaplainsuit/nun
 	name = "nun robe"
@@ -61,15 +43,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HANDS
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
-
 /obj/item/clothing/suit/chaplainsuit/bishoprobe
 	name = "bishop's robes"
 	desc = "Glad to see the tithes you collected were well spent."
@@ -78,15 +51,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
-
 /obj/item/clothing/suit/chaplainsuit/armor/studentuni
 	name = "student robe"
 	desc = "The uniform of a bygone institute of learning."
@@ -94,30 +58,12 @@
 	inhand_icon_state = null
 	body_parts_covered = ARMS|CHEST
 
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
-
 /obj/item/clothing/suit/chaplainsuit/armor/witchhunter
 	name = "witchunter garb"
 	desc = "This worn outfit saw much use back in the day."
 	icon_state = "witchhunter"
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
 
 /obj/item/clothing/suit/hooded/chaplainsuit/monkhabit
 	name = "monk's habit"
@@ -129,15 +75,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	hoodtype = /obj/item/clothing/head/hooded/monkhabit
 
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
-
 /obj/item/clothing/head/hooded/monkhabit
 	name = "monk's hood"
 	desc = "For when a man wants to cover up his tonsure."
@@ -148,15 +85,6 @@
 	body_parts_covered = HEAD
 	flags_inv = HIDEHAIR|HIDEEARS
 
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
-
 /obj/item/clothing/suit/chaplainsuit/monkrobeeast
 	name = "eastern monk's robes"
 	desc = "Best combined with a shaved head."
@@ -164,15 +92,6 @@
 	inhand_icon_state = null
 	body_parts_covered = GROIN|LEGS
 	flags_inv = HIDEJUMPSUIT
-
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
 
 /obj/item/clothing/suit/chaplainsuit/whiterobe
 	name = "white robe"
@@ -182,15 +101,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
-
 /obj/item/clothing/suit/chaplainsuit/clownpriest
 	name = "Robes of the Honkmother"
 	desc = "Meant for a clown of the cloth."
@@ -199,15 +109,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEJUMPSUIT
 	allowed = list(/obj/item/megaphone/clown, /obj/item/soap, /obj/item/food/pie/cream, /obj/item/bikehorn, /obj/item/bikehorn/golden, /obj/item/bikehorn/airhorn, /obj/item/instrument/bikehorn, /obj/item/reagent_containers/cup/soda_cans/canned_laughter, /obj/item/toy/crayon, /obj/item/toy/crayon/spraycan, /obj/item/toy/crayon/spraycan/lubecan, /obj/item/grown/bananapeel, /obj/item/food/grown/banana)
-
-/datum/armor/chaplainsuit_armor
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-	wound = 20
 
 /obj/item/clothing/head/helmet/chaplain/clock
 	name = "forgotten helmet"
@@ -236,14 +137,6 @@
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 	slowdown = 0
 	clothing_flags = NONE
-
-/datum/armor/chaplain_clock
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
 
 /obj/item/clothing/head/helmet/chaplain
 	name = "crusader helmet"
@@ -275,14 +168,6 @@
 	slowdown = 0
 	clothing_flags = NONE
 
-/datum/armor/helmet_chaplain
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-
 /obj/item/clothing/head/helmet/chaplain/cage
 	name = "cage"
 	desc = "A cage that restrains the will of the self, allowing one to see the profane world for what it is."
@@ -291,41 +176,17 @@
 	inhand_icon_state = null
 	worn_y_offset = 7
 
-/datum/armor/helmet_chaplain
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-
 /obj/item/clothing/head/helmet/chaplain/ancient
 	name = "ancient helmet"
 	desc = "None may pass!"
 	icon_state = "knight_ancient"
 	inhand_icon_state = null
 
-/datum/armor/helmet_chaplain
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-
 /obj/item/clothing/suit/chaplainsuit/armor/ancient
 	name = "ancient armour"
 	desc = "Defend the treasure..."
 	icon_state = "knight_ancient"
 	inhand_icon_state = null
-
-/datum/armor/helmet_chaplain
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
 
 /obj/item/clothing/head/helmet/chaplain/witchunter_hat
 	name = "witchunter hat"
@@ -335,14 +196,6 @@
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEEYES
 
-/datum/armor/helmet_chaplain
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-
 /obj/item/clothing/head/helmet/chaplain/adept
 	name = "adept hood"
 	desc = "Its only heretical when others do it."
@@ -351,27 +204,11 @@
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
 
-/datum/armor/helmet_chaplain
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
-
 /obj/item/clothing/suit/chaplainsuit/armor/adept
 	name = "adept robes"
 	desc = "The ideal outfit for burning the unfaithful."
 	icon_state = "crusader"
 	inhand_icon_state = null
-
-/datum/armor/helmet_chaplain
-	melee = 50
-	bullet = 10
-	laser = 10
-	energy = 10
-	fire = 80
-	acid = 80
 
 /obj/item/clothing/suit/chaplainsuit/armor/crusader
 	name = "Crusader's Armour"
@@ -394,26 +231,8 @@
 /obj/item/clothing/suit/chaplainsuit/armor/crusader/red
 	icon_state = "crusader-red"
 
-/datum/armor/armor_crusader
-	melee = 50
-	bullet = 50
-	laser = 50
-	energy = 50
-	bomb = 60
-	fire = 60
-	acid = 60
-
 /obj/item/clothing/suit/chaplainsuit/armor/crusader/blue
 	icon_state = "crusader-blue"
-
-/datum/armor/armor_crusader
-	melee = 50
-	bullet = 50
-	laser = 50
-	energy = 50
-	bomb = 60
-	fire = 60
-	acid = 60
 
 /obj/item/clothing/suit/hooded/chaplain_hoodie
 	name = "follower hoodie"
@@ -426,15 +245,6 @@
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 	hoodtype = /obj/item/clothing/head/hooded/chaplain_hood
 
-/datum/armor/armor_crusader
-	melee = 50
-	bullet = 50
-	laser = 50
-	energy = 50
-	bomb = 60
-	fire = 60
-	acid = 60
-
 /obj/item/clothing/head/hooded/chaplain_hood
 	name = "follower hood"
 	desc = "Hood made for acolytes of the chaplain."
@@ -444,15 +254,6 @@
 	body_parts_covered = HEAD
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
 
-/datum/armor/armor_crusader
-	melee = 50
-	bullet = 50
-	laser = 50
-	energy = 50
-	bomb = 60
-	fire = 60
-	acid = 60
-
 /obj/item/clothing/suit/hooded/chaplain_hoodie/leader
 	name = "leader hoodie"
 	desc = "Now you're ready for some 50 dollar bling water."
@@ -460,28 +261,10 @@
 	inhand_icon_state = null
 	hoodtype = /obj/item/clothing/head/hooded/chaplain_hood/leader
 
-/datum/armor/armor_crusader
-	melee = 50
-	bullet = 50
-	laser = 50
-	energy = 50
-	bomb = 60
-	fire = 60
-	acid = 60
-
 /obj/item/clothing/head/hooded/chaplain_hood/leader
 	name = "leader hood"
 	desc = "I mean, you don't /have/ to seek bling water. I just think you should."
 	icon_state = "chaplain_hood_leader"
-
-/datum/armor/armor_crusader
-	melee = 50
-	bullet = 50
-	laser = 50
-	energy = 50
-	bomb = 60
-	fire = 60
-	acid = 60
 
 /obj/item/clothing/suit/chaplainsuit/shrinehand
 	name = "shrinehand robe"


### PR DESCRIPTION

## About The Pull Request
Fixes #72348 

Caused by #71986  Looks like they used some type of regex to mass c/p multiple duplicate armor values across many items.

## Why It's Good For The Game
Less c/p code.

## Changelog
Not needed.
