### PR TITLE
Prevent basicmobs from attacking mobs inside indestructible objects

### DIFF
--- a/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
+++ b/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
@@ -19,7 +19,7 @@
 	var/stat_attack = CONSCIOUS
 
 /datum/targetting_datum/basic/can_attack(mob/living/living_mob, atom/the_target)
-	if(isturf(the_target) || !the_target) // bail out on invalids
+	if(isturf(the_target) || !the_target || isitem(the_target.loc)) // bail out on invalids
 		return FALSE
 
 	if(ismob(the_target)) //Target is in godmode, ignore it.

--- a/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
+++ b/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
@@ -19,8 +19,13 @@
 	var/stat_attack = CONSCIOUS
 
 /datum/targetting_datum/basic/can_attack(mob/living/living_mob, atom/the_target)
-	if(isturf(the_target) || !the_target || isitem(the_target.loc)) // bail out on invalids
+	if(isturf(the_target) || !the_target) // bail out on invalids
 		return FALSE
+
+	if(isobj(the_target.loc))
+		var/obj/container = the_target.loc
+		if(container.resistance_flags & INDESTRUCTIBLE)
+			return FALSE
 
 	if(ismob(the_target)) //Target is in godmode, ignore it.
 		var/mob/M = the_target


### PR DESCRIPTION
## About The Pull Request

Targetting datum for basicmobs now calls targets inside indestructibles invalid

## Why It's Good For The Game

Fixes #72250

## Changelog
:cl:
fix: Basicmobs can no longer shoot mobs inside indestructibles
/:cl:
