### PR TITLE
Standardizes NtosPay with other NTos apps

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosPay.tsx
+++ b/tgui/packages/tgui/interfaces/NtosPay.tsx
@@ -17,38 +17,40 @@ type Transactions = {
 let name_to_token, money_to_send, token;
 
 export const NtosPay = (props, context) => {
+  return (
+    <NtosWindow width={495} height={655}>
+      <NtosWindow.Content>
+        <NtosPayContent />
+      </NtosWindow.Content>
+    </NtosWindow>
+  );
+};
+
+export const NtosPayContent = (props, context) => {
   const { data } = useBackend<Data>(context);
   const { name } = data;
 
   if (!name) {
     return (
-      <NtosWindow width={512} height={130}>
-        <NtosWindow.Content>
-          <NoticeBox>
-            You need to insert your ID card into the card slot in order to use
-            this application.
-          </NoticeBox>
-        </NtosWindow.Content>
-      </NtosWindow>
+      <NoticeBox>
+        You need to insert your ID card into the card slot in order to use this
+        application.
+      </NoticeBox>
     );
   }
 
   return (
-    <NtosWindow width={495} height={655}>
-      <NtosWindow.Content>
-        <Stack fill vertical>
-          <Stack.Item>
-            <Introduction />
-          </Stack.Item>
-          <Stack.Item>
-            <TransferSection />
-          </Stack.Item>
-          <Stack.Item grow>
-            <TransactionHistory />
-          </Stack.Item>
-        </Stack>
-      </NtosWindow.Content>
-    </NtosWindow>
+    <Stack fill vertical>
+      <Stack.Item>
+        <Introduction />
+      </Stack.Item>
+      <Stack.Item>
+        <TransferSection />
+      </Stack.Item>
+      <Stack.Item grow>
+        <TransactionHistory />
+      </Stack.Item>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
## About The Pull Request

Ntos apps are generally split between 'app' and 'appContent' in their TGUI interfaces. This is done to add the ability to use the app's UI both with and without NtOS, or two NtOS apps sharing the same UI; though that's a rarer case (example: Newscaster, R&D console, Atmos alarm), so it's important to keep this standardized.

## Why It's Good For The Game

Consistency with other NtOS apps, makes the app more accessible for coders and makes the UI not break if used anywhere outside of the NtOS environment.

## Changelog

No player-facing changes.