### PR TITLE
fixes pellet clouds dealing insane wounds (probably?)

### DIFF
--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -318,7 +318,7 @@
 					if(armor_factor > 0)
 						if(initial(P.weak_against_armour) && armor_factor >= 0)
 							armor_factor *= ARMOR_WEAKENED_MULTIPLIER
-						damage_dealt *= armor_factor
+						damage_dealt *= max(0, 1 - armor_factor*0.01)
 
 					hit_part.painless_wound_roll(wound_type, damage_dealt, w_bonus, bw_bonus, initial(P.sharpness))
 


### PR DESCRIPTION
## About The Pull Request
pellet clouds multiplied the wound roll they do by your amount of armor instead of decreasing it
this meant that while they did normal stuff to someone naked
![image](https://user-images.githubusercontent.com/23585223/209995707-0371be35-9f24-410b-a441-e06ab9b054ba.png)
they did this to nukies
![image](https://user-images.githubusercontent.com/23585223/209995733-026c1c52-ae65-4860-b68d-890391451b9d.png)
and they did this to something like the admin modsuit
![image](https://user-images.githubusercontent.com/23585223/209995678-08715ac0-5be7-4e05-b750-e1f94d33f394.png)


## Why It's Good For The Game
nukies no longer get hit by 1 stray pellet and lose all their blood

## Changelog
:cl:
fix: fixed pellet clouds (buckshot, improv shells) dealing insane wounds to armored people
/:cl:
