### PR TITLE
you can now use armor examines to check wounding armor

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -44,7 +44,7 @@
 #define ARMOR_ALL "all_damage_types"
 
 /// Armor values that are used for damage
-#define ARMOR_LIST_DAMAGE(...) list(BIO, BOMB, BULLET, ENERGY, LASER, MELEE)
+#define ARMOR_LIST_DAMAGE(...) list(BIO, BOMB, BULLET, ENERGY, LASER, MELEE, WOUND)
 
 /// Armor values that are used for durability
 #define ARMOR_LIST_DURABILITY(...) list(ACID, FIRE)


### PR DESCRIPTION

## About The Pull Request
what the title says, the armor tag shows you wounding armor

## Why It's Good For The Game
wound armor is invisible to players without code diving, i dont think thats great if we let people see the other armor values

## Changelog
:cl:
qol: examining armor tags now shows you the wound armor value
/:cl:
