### PR TITLE
Small changes to some card-related debug verbs

### DIFF
--- a/code/controllers/subsystem/tcgsetup.dm
+++ b/code/controllers/subsystem/tcgsetup.dm
@@ -145,6 +145,10 @@ SUBSYSTEM_DEF(trading_card_game)
 			if(!cached_cards[pack.series][pack_rarity])
 				toReturn += "[pack.type] does not have the required rarity [pack_rarity]\n"
 		qdel(pack)
+
+	if(!length(toReturn))
+		toReturn += "No errors found in cardpack rarities. "
+
 	return toReturn
 
 ///Checks the global card list for cards that don't override all the default values of the card datum
@@ -166,6 +170,10 @@ SUBSYSTEM_DEF(trading_card_game)
 			if(shouldAdd)
 				toReturn += toAdd
 	qdel(thing)
+
+	if(!length(toReturn))
+		toReturn += "No errors found in cardpack datums."
+
 	return toReturn
 
 ///Used to test open a large amount of cardpacks

--- a/code/controllers/subsystem/tcgsetup.dm
+++ b/code/controllers/subsystem/tcgsetup.dm
@@ -171,7 +171,7 @@ SUBSYSTEM_DEF(trading_card_game)
 	return toReturn
 
 ///Used to test open a large amount of cardpacks
-/datum/controller/subsystem/trading_card_game/proc/checkCardDistribution(cardPack, batchSize, batchCount, guaranteed)
+/datum/controller/subsystem/trading_card_game/proc/check_card_distribution(cardPack, batchSize, batchCount, guaranteed)
 	var/totalCards = 0
 	//Gotta make this look like an associated list so the implicit "does this exist" checks work proper later
 	var/list/cardsByCount = list("" = 0)

--- a/code/controllers/subsystem/tcgsetup.dm
+++ b/code/controllers/subsystem/tcgsetup.dm
@@ -146,9 +146,6 @@ SUBSYSTEM_DEF(trading_card_game)
 				toReturn += "[pack.type] does not have the required rarity [pack_rarity]\n"
 		qdel(pack)
 
-	if(!length(toReturn))
-		toReturn += "No errors found in cardpack rarities. "
-
 	return toReturn
 
 ///Checks the global card list for cards that don't override all the default values of the card datum
@@ -170,9 +167,6 @@ SUBSYSTEM_DEF(trading_card_game)
 			if(shouldAdd)
 				toReturn += toAdd
 	qdel(thing)
-
-	if(!length(toReturn))
-		toReturn += "No errors found in cardpack datums."
 
 	return toReturn
 

--- a/code/controllers/subsystem/tcgsetup.dm
+++ b/code/controllers/subsystem/tcgsetup.dm
@@ -124,9 +124,9 @@ SUBSYSTEM_DEF(trading_card_game)
 			message_admins(toPrint.name)
 
 ///Checks the passed type list for missing raritys, or raritys out of bounds
-/datum/controller/subsystem/trading_card_game/proc/checkCardpacks(cardPackList)
+/datum/controller/subsystem/trading_card_game/proc/check_cardpacks(card_pack_list)
 	var/toReturn = ""
-	for(var/cardPack in cardPackList)
+	for(var/cardPack in card_pack_list)
 		var/obj/item/cardpack/pack = new cardPack()
 		//Lets see if someone made a type yeah?
 		if(!cached_cards[pack.series])
@@ -149,7 +149,7 @@ SUBSYSTEM_DEF(trading_card_game)
 	return toReturn
 
 ///Checks the global card list for cards that don't override all the default values of the card datum
-/datum/controller/subsystem/trading_card_game/proc/checkCardDatums()
+/datum/controller/subsystem/trading_card_game/proc/check_card_datums()
 	var/toReturn = ""
 	var/datum/thing = new()
 	for(var/series in cached_cards)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -665,7 +665,7 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as null|num
 	var/guar = input("Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system") as null|num
 
-	if(pack && batchSize && batchCount) //Not having any one of this will cause a runtime
+	if(pack && batchSize && batchCount) //Not having any one of these will cause a runtime
 		SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
 
 /client/proc/print_cards()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -660,12 +660,13 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	if(!SStrading_card_game.loaded)
 		message_admins("The card subsystem is not currently loaded")
 		return
-	var/pack = input("Which pack should we test?", "You fucked it didn't you") as null|anything in sort_list(SStrading_card_game.card_packs)
-	var/batchCount = input("How many times should we open it?", "Don't worry, I understand") as null|num
-	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as null|num
-	var/guar = input("Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system") as null|num
 
-	if(pack && batchSize && batchCount) //Not having any one of these will cause a runtime
+	var/pack = input("Which pack should we test?", "You fucked it didn't you") as null|anything in sort_list(SStrading_card_game.card_packs)
+	var/batchCount = input("How many times should we open it?", "Don't worry, I understand") as num
+	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as num
+	var/guar = input("Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system") as num
+
+	if(pack)
 		SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
 
 /client/proc/print_cards()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -665,7 +665,7 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as null|num
 	var/guar = input("Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system") as null|num
 
-	if(pack || !batchSize || !batchCount) //Not having any one of this will cause a runtime
+	if(pack && batchSize && batchCount) //Not having any one of this will cause a runtime
 		SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
 
 /client/proc/print_cards()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -660,7 +660,6 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	if(!SStrading_card_game.loaded)
 		message_admins("The card subsystem is not currently loaded")
 		return
-
 	var/pack = input("Which pack should we test?", "You fucked it didn't you") as null|anything in sort_list(SStrading_card_game.card_packs)
 	var/batchCount = input("How many times should we open it?", "Don't worry, I understand") as num
 	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as num

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -665,7 +665,7 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as null|num
 	var/guar = input("Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system") as null|num
 
-	if(pack)
+	if(pack || !batchSize || !batchCount) //Not having any one of this will cause a runtime
 		SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
 
 /client/proc/print_cards()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -664,7 +664,9 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	var/batchCount = input("How many times should we open it?", "Don't worry, I understand") as null|num
 	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as null|num
 	var/guar = input("Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system") as null|num
-	SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
+
+	if(pack)
+		SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
 
 /client/proc/print_cards()
 	set name = "Print Cards"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -661,12 +661,13 @@ GLOBAL_PROTECT(admin_verbs_poll)
 		message_admins("The card subsystem is not currently loaded")
 		return
 	var/pack = input("Which pack should we test?", "You fucked it didn't you") as null|anything in sort_list(SStrading_card_game.card_packs)
+	if(!pack)
+		return
 	var/batchCount = input("How many times should we open it?", "Don't worry, I understand") as num
 	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as num
 	var/guar = input("Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system") as num
 
-	if(pack)
-		SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
+	SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
 
 /client/proc/print_cards()
 	set name = "Print Cards"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -647,8 +647,8 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	if(!SStrading_card_game.loaded)
 		message_admins("The card subsystem is not currently loaded")
 		return
-	var/message = SStrading_card_game.checkCardpacks(SStrading_card_game.card_packs)
-	message += SStrading_card_game.checkCardDatums()
+	var/message = SStrading_card_game.check_cardpacks(SStrading_card_game.card_packs)
+	message += SStrading_card_game.check_card_datums()
 	if(message)
 		message_admins(message)
 	else
@@ -669,7 +669,7 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	var/batch_size = tgui_input_number(usr, "How many cards per batch?", "I hope you remember to check the validation")
 	var/guar = tgui_input_number(usr, "Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system")
 
-	SStrading_card_game.checkCardDistribution(pack, batch_size, batch_count, guar)
+	SStrading_card_game.check_card_distribution(pack, batch_size, batch_count, guar)
 
 /client/proc/print_cards()
 	set name = "Print Cards"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -662,12 +662,12 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	if(!SStrading_card_game.loaded)
 		message_admins("The card subsystem is not currently loaded")
 		return
-	var/pack = input("Which pack should we test?", "You fucked it didn't you") as null|anything in sort_list(SStrading_card_game.card_packs)
+	var/pack = tgui_input_list(usr, "Which pack should we test?", "You fucked it didn't you", sort_list(SStrading_card_game.card_packs))
 	if(!pack)
 		return
-	var/batchCount = input("How many times should we open it?", "Don't worry, I understand") as num
-	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as num
-	var/guar = input("Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system") as num
+	var/batchCount = tgui_input_number(usr, "How many times should we open it?", "Don't worry, I understand")
+	var/batchSize = tgui_input_number(usr, "How many cards per batch?", "I hope you remember to check the validation")
+	var/guar = tgui_input_number(usr, "Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system")
 
 	SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -651,6 +651,8 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	message += SStrading_card_game.checkCardDatums()
 	if(message)
 		message_admins(message)
+	else
+		message_admins("No errors found in card rarities or overrides.")
 
 /client/proc/test_cardpack_distribution()
 	set name = "Test Cardpack Distribution"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -665,11 +665,11 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	var/pack = tgui_input_list(usr, "Which pack should we test?", "You fucked it didn't you", sort_list(SStrading_card_game.card_packs))
 	if(!pack)
 		return
-	var/batchCount = tgui_input_number(usr, "How many times should we open it?", "Don't worry, I understand")
-	var/batchSize = tgui_input_number(usr, "How many cards per batch?", "I hope you remember to check the validation")
+	var/batch_count = tgui_input_number(usr, "How many times should we open it?", "Don't worry, I understand")
+	var/batch_size = tgui_input_number(usr, "How many cards per batch?", "I hope you remember to check the validation")
 	var/guar = tgui_input_number(usr, "Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system")
 
-	SStrading_card_game.checkCardDistribution(pack, batchSize, batchCount, guar)
+	SStrading_card_game.checkCardDistribution(pack, batch_size, batch_count, guar)
 
 /client/proc/print_cards()
 	set name = "Print Cards"

--- a/code/modules/unit_tests/card_mismatch.dm
+++ b/code/modules/unit_tests/card_mismatch.dm
@@ -2,5 +2,5 @@
 
 /datum/unit_test/card_mismatch/Run()
 	var/message = SStrading_card_game.check_cardpacks(SStrading_card_game.card_packs)
-	message += SStrading_card_game.check_card_distribution()
+	message += SStrading_card_game.check_card_datums()
 	TEST_ASSERT(!message, message)

--- a/code/modules/unit_tests/card_mismatch.dm
+++ b/code/modules/unit_tests/card_mismatch.dm
@@ -1,6 +1,6 @@
 /datum/unit_test/card_mismatch
 
 /datum/unit_test/card_mismatch/Run()
-	var/message = SStrading_card_game.checkCardpacks(SStrading_card_game.card_packs)
-	message += SStrading_card_game.checkCardDatums()
+	var/message = SStrading_card_game.check_cardpacks(SStrading_card_game.card_packs)
+	message += SStrading_card_game.check_card_distribution()
 	TEST_ASSERT(!message, message)


### PR DESCRIPTION
## About The Pull Request

Test Card Distribution debug verb has been altered slightly to prevent runtimes. Backing out of any one of the menus would send null as an argument, and cause a runtime. 

The Validate Cards verb now returns a message if no errors are found. I kept mistakenly clicking this verb thinking it was the Cardpack Distribution one, and would get confused whenever nothing happened. Now it returns a message!

Also converts some of the stuff I touch into snake case because pretty code is nice.

## Why It's Good For The Game

Closes #66987. Feedback for the random debug buttons I accidentally click is good.
## Changelog
:cl: Rhials
fix: backing out of the Test Card Packs debug menu will no longer cause a runtime
fix: Validate Cards debug verb now gives feedback if no errors are detected.
/:cl:
