### PR TITLE
Projectile hits on mobs are logged globally

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -336,7 +336,7 @@
 			log_combat(logged_mob, L, "shot", src, "from inside [firing_vehicle][logging_mobs.len > 1 ? " with multiple occupants" : null][reagent_note ? " and contained [reagent_note]" : null]")
 		return BULLET_ACT_HIT
 
-	L.log_message("has been shot by [firer] with [src][reagent_note ? " containing [reagent_note]" : null]", LOG_VICTIM, color="orange", log_globally=FALSE)
+	L.log_message("has been shot by [firer] with [src][reagent_note ? " containing [reagent_note]" : null]", LOG_VICTIM, color="orange")
 	return BULLET_ACT_HIT
 
 /obj/projectile/proc/vol_by_damage()


### PR DESCRIPTION
## About The Pull Request
The log_message for projectile victims wasn't being logged globally. It wasn't being logged elsewhere (for cannons at least, presumably for any non-vehicle non-mob firer), so it should be logged globally here.

## Why It's Good For The Game
Fixes #72336

## Changelog
:cl: Tattle
fix: projectile hits on mobs are logged globally
/:cl:
