### PR TITLE
Fixes dualsabers getting covered in blood

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -63,6 +63,9 @@
 	set_light_on(TRUE)
 
 
+/obj/item/dualsaber/add_blood_DNA(list/blood_DNA_to_add)
+	return FALSE
+
 /// Triggered on unwield of two handed item
 /// switch hitsounds
 /obj/item/dualsaber/proc/on_unwield(obj/item/source, mob/living/carbon/user)


### PR DESCRIPTION
Fixes #72338

:cl: ShizCalev
fix: Dual sabers will no longer get covered in blood when attacking someone.
/:cl:
