### PR TITLE
Fixes a oversight with cummerbund. closes #72357

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -482,13 +482,6 @@
 		/obj/item/clothing/mask/luchador
 		))
 
-/obj/item/storage/belt/cummerbund
-	name = "cummerbund"
-	desc = "A pleated sash that pairs well with a suit jacket."
-	icon_state = "cummerbund"
-	inhand_icon_state = null
-	worn_icon_state = "cummerbund"
-
 /obj/item/storage/belt/military
 	name = "chest rig"
 	desc = "A set of tactical webbing worn by Syndicate boarding parties."
@@ -769,6 +762,13 @@
 	name = "yellow fannypack"
 	icon_state = "fannypack_yellow"
 	worn_icon_state = "fannypack_yellow"
+
+/obj/item/storage/belt/fannypack/cummerbund
+	name = "cummerbund"
+	desc = "A pleated sash that pairs well with a suit jacket."
+	icon_state = "cummerbund"
+	inhand_icon_state = null
+	worn_icon_state = "cummerbund"
 
 /obj/item/storage/belt/sabre
 	name = "sabre sheath"

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -178,7 +178,7 @@
 	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/clothing/under/dress/wedding_dress,
 					/obj/item/clothing/under/suit/tuxedo,
-					/obj/item/storage/belt/cummerbund,
+					/obj/item/storage/belt/fannypack/cummerbund,
 					/obj/item/clothing/head/costume/weddingveil,
 					/obj/item/bouquet,
 					/obj/item/bouquet/sunflower,

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -220,7 +220,7 @@
 		/obj/item/clothing/under/dress/wedding_dress = 1,
 		/obj/item/clothing/under/suit/tuxedo = 1,
 		/obj/item/clothing/head/costume/weddingveil = 1,
-		/obj/item/storage/belt/cummerbund = 1,
+		/obj/item/storage/belt/fannypack/cummerbund = 1,
 		/obj/item/clothing/suit/costume/drfreeze_coat = 1,
 		/obj/item/clothing/under/costume/drfreeze = 1,
 		/obj/item/clothing/head/costume/drfreezehat = 1,

--- a/tools/UpdatePaths/Scripts/72373_Cummerbund.txt
+++ b/tools/UpdatePaths/Scripts/72373_Cummerbund.txt
@@ -1,0 +1,1 @@
+/obj/item/storage/belt/cummerbund : /obj/item/storage/belt/fannypack/cummerbund{@OLD}


### PR DESCRIPTION
Turns cummerbund from a full 7 slot belt for any item into a fannypack subtype(which holds 3 items)
Fixes https://github.com/tgstation/tgstation/issues/72357

why is this good for the game?
(That way we dont have powercreeps rushing an all purpose belt 24/7)

:cl: Improvedname
fix: fixes cummerbunds holding 7 items instead of 3(as fannypacks do)
/:cl: