### PR TITLE
Fixes layering between tram bridge, pipes, and cables

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -952,7 +952,7 @@
 "asv" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced/tram,
 /area/station/hallway/primary/tram/left)
 "asw" = (
 /obj/machinery/computer/monitor{
@@ -12620,7 +12620,7 @@
 /obj/structure/fluff/tram_rail/floor{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced/tram,
 /area/station/hallway/primary/tram/right)
 "ezX" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -23568,7 +23568,7 @@
 /obj/structure/fluff/tram_rail/floor,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced/tram,
 /area/station/hallway/primary/tram/left)
 "iCA" = (
 /obj/structure/fluff{
@@ -26582,7 +26582,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced/tram,
 /area/station/hallway/primary/tram/center)
 "jJO" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -30481,7 +30481,7 @@
 "kYX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced/tram,
 /area/station/hallway/primary/tram/center)
 "kYZ" = (
 /obj/machinery/airalarm/server{
@@ -33428,6 +33428,10 @@
 /obj/machinery/suit_storage_unit/medical,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"mdW" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/glass/reinforced/tram,
+/area/station/hallway/primary/tram/right)
 "mdY" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron,
@@ -57587,7 +57591,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced/tram,
 /area/station/hallway/primary/tram/left)
 "uIO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60403,7 +60407,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/fluff/tram_rail/floor,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced/tram,
 /area/station/hallway/primary/tram/center)
 "vKb" = (
 /obj/structure/lattice,
@@ -63480,7 +63484,7 @@
 "wQO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/fluff/tram_rail/floor,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced/tram,
 /area/station/hallway/primary/tram/right)
 "wQP" = (
 /turf/closed/wall,
@@ -174996,11 +175000,11 @@ wkz
 xHd
 xPU
 nXJ
-iDv
+mdW
 wQO
 oSW
 ezQ
-iDv
+mdW
 qsl
 aNP
 czl

--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -111,7 +111,9 @@
 #define HIGH_TURF_LAYER 2.03
 #define TURF_PLATING_DECAL_LAYER 2.031
 #define TURF_DECAL_LAYER 2.039 //Makes turf decals appear in DM how they will look inworld.
-#define ABOVE_OPEN_TURF_LAYER 2.04
+#define DISPOSAL_PIPE_LAYER 2.04
+#define WIRE_LAYER 2.041
+#define ABOVE_OPEN_TURF_LAYER 2.042
 
 //WALL_PLANE layers
 #define CLOSED_TURF_LAYER 2.05
@@ -120,9 +122,7 @@
 #define BULLET_HOLE_LAYER 2.06
 #define ABOVE_NORMAL_TURF_LAYER 2.08
 #define LATTICE_LAYER 2.2
-#define DISPOSAL_PIPE_LAYER 2.3
 #define GAS_PIPE_HIDDEN_LAYER 2.35 //layer = initial(layer) + piping_layer / 1000 in atmospherics/update_icon() to determine order of pipe overlap
-#define WIRE_LAYER 2.4
 #define TRAM_XING_LAYER 2.41
 #define TRAM_RAIL_LAYER 2.42
 #define TRAM_FLOOR_LAYER 2.43

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -17,6 +17,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 	icon = 'icons/obj/power_cond/layer_cable.dmi'
 	icon_state = "l2-1-2-4-8-node"
 	color = CABLE_HEX_COLOR_YELLOW
+	plane = FLOOR_PLANE
 	layer = WIRE_LAYER //Above hidden pipes, GAS_PIPE_HIDDEN_LAYER
 	anchored = TRUE
 	obj_flags = CAN_BE_HIT

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -10,6 +10,7 @@
 	dir = NONE // dir will contain dominant direction for junction pipes
 	max_integrity = 200
 	armor_type = /datum/armor/structure_disposalpipe
+	plane = FLOOR_PLANE
 	layer = DISPOSAL_PIPE_LAYER // slightly lower than wires and other pipes
 	damage_deflection = 10
 	var/dpdir = NONE // bitmask of pipe directions


### PR DESCRIPTION

## About The Pull Request
Fixes the cover up job of https://github.com/tgstation/tgstation/pull/71858 throwing iron tiles instead of the tram bridge to get ambient occlusion working.

Puts the pipes and wires on an appropriate plane and layer so they can co-exist with the tram bridge without screwing with the tram's shading.

![tramlayers1](https://user-images.githubusercontent.com/83487515/210128789-4d57493e-5bd9-444d-bc2e-3b9c2209b47a.png)
![tramlayers2](https://user-images.githubusercontent.com/83487515/210128798-4e283498-a831-431a-b039-e1cdc751d909.png)
## Why It's Good For The Game
#71858 was a temporary fix for the bridge until a permanent solution was found.
## Changelog
:cl: LT3
fix: Disposal pipes and cable wires now co-exist with the tram bridge
/:cl:
