### PR TITLE
Origami kit buff

### DIFF
--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -61,16 +61,17 @@
 	cost = 4
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
+// Low progression cost
+
 /datum/uplink_item/stealthy_weapons/origami_kit
 	name = "Boxed Origami Kit"
 	desc = "This box contains a guide on how to craft masterful works of origami, allowing you to transform normal pieces of paper into \
 			perfectly aerodynamic (and potentially lethal) paper airplanes."
 	item = /obj/item/storage/box/syndie_kit/origami_bundle
+	progression_minimum = 10 MINUTES
 	cost = 4
 	surplus = 0
 	purchasable_from = ~UPLINK_NUKE_OPS //clown ops intentionally left in, because that seems like some s-tier shenanigans.
-
-// Low progression cost
 
 // Medium progression cost
 

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -61,18 +61,16 @@
 	cost = 4
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
-// Low progression cost
-
 /datum/uplink_item/stealthy_weapons/origami_kit
 	name = "Boxed Origami Kit"
 	desc = "This box contains a guide on how to craft masterful works of origami, allowing you to transform normal pieces of paper into \
 			perfectly aerodynamic (and potentially lethal) paper airplanes."
-	progression_minimum = 15 MINUTES
 	item = /obj/item/storage/box/syndie_kit/origami_bundle
-	cost = 14
+	cost = 4
 	surplus = 0
 	purchasable_from = ~UPLINK_NUKE_OPS //clown ops intentionally left in, because that seems like some s-tier shenanigans.
 
+// Low progression cost
 
 // Medium progression cost
 


### PR DESCRIPTION

## About The Pull Request
Lowers cost of Boxed Origami Kit to 4 TC, lowers progression time requirement to 10 minutes from 15.
## Why It's Good For The Game
This item directly competes against the 3 TC boxed throwing kit, which contains 2 reinforced bolas, 2 dangerous paper planes and 4 highly lethal shurikens. at a monstrous 14 TC, which is 1 TC more than the insane sleeping carp, origami is one of the worst things you can possibly ever buy from a uplink. This change brings the TC cost down to match the power level of this item.
## Changelog
:cl:
balance: Origami kit costs 4 from 14, and is available at 100 reputation from 150.
/:cl:
