### PR TITLE
Food reactions no longer occur inside of harvested plants. Fixes being able to produce hundreds of candy corn every few seconds with 5 minutes in Botany.

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -23,6 +23,7 @@
 	thermic_constant = 0
 	H_ion_release = 0
 	reaction_tags = REACTION_TAG_FOOD | REACTION_TAG_EASY
+	plant_react = FALSE
 
 /datum/chemical_reaction/food/tofu
 	required_reagents = list(/datum/reagent/consumable/soymilk = 10)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -934,6 +934,8 @@
 						matching_container = TRUE
 				if (isliving(cached_my_atom) && !reaction.mob_react) //Makes it so certain chemical reactions don't occur in mobs
 					matching_container = FALSE
+				if (istype(cached_my_atom, /obj/item/food/grown) && !reaction.plant_react)
+					matching_container = FALSE
 				if(!reaction.required_other)
 					matching_other = TRUE
 

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -21,6 +21,8 @@
 
 	///Determines if a chemical reaction can occur inside a mob
 	var/mob_react = TRUE
+	///Determines if a chemical reaction can occur inside harvested plants. Used to stop food items from being mass produced on harvest by crops.
+	var/plant_react = TRUE
 	///The message shown to nearby people upon mixing, if applicable
 	var/mix_message = "The solution begins to bubble."
 	///The sound played upon mixing, if applicable


### PR DESCRIPTION
## About The Pull Request

# this doesn't touch other reactions, only those that cause food items to be spawned on the ground

Food reactions no longer occur inside of harvested plants. Fixes being able to produce hundreds of candy corn every few seconds with 5 minutes in Botany.

## Why It's Good For The Game

While it's immensely funny that botanists can grow plants that spawn approximately 10000 candycorn every minute or so, this is generally regarded as not great for server performance. Botanists will need to actually extract the fruits of their labor first before mixing them to produce the end product.

## Changelog

:cl:
fix: Food reactions no longer occur inside of harvested plants. Fixes being able to produce hundreds of candy corn every few seconds with 5 minutes in Botany.
/:cl:
