### PR TITLE
Boxes created through the crafting menu no longer spawn with their contents full

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -184,6 +184,9 @@
 				I = new R.result (get_turf(a.loc), R.result_amount || 1)
 			else
 				I = new R.result (get_turf(a.loc))
+				if(istype(I, /obj/item/storage))
+					for(var/obj/item/thing in I)
+						qdel(thing)
 			I.CheckParts(parts, R)
 			if(send_feedback)
 				SSblackbox.record_feedback("tally", "object_crafted", 1, I.type)

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -184,7 +184,7 @@
 				I = new R.result (get_turf(a.loc), R.result_amount || 1)
 			else
 				I = new R.result (get_turf(a.loc))
-				if(istype(I, /obj/item/storage))
+				if(I.atom_storage)
 					for(var/obj/item/thing in I)
 						qdel(thing)
 			I.CheckParts(parts, R)


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Since the contents weren't emptied you could get infinite beakers, donk pockets, chicken nuggets etc. by making and remaking a box over and over.
Fixes  #72385.
## Why It's Good For The Game

Bugfix. The world does not deserve infinite chicken nuggets yet
## Changelog
:cl:
fix: Boxes created through the crafting menu no longer spawn with their contents full
/:cl:
