### PR TITLE
Keeps gc_destroyed from getting updated on every step thru the gc queue.

### DIFF
--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -30,6 +30,13 @@
 #define GC_QUEUE_HARDDELETE 3 //! short queue for things that hard delete instead of going thru the gc subsystem, this is purely so if they *can* softdelete, they will soft delete rather then wasting time with a hard delete.
 #define GC_QUEUE_COUNT 3 //! Number of queues, used for allocating the nested lists. Don't forget to increase this if you add a new queue stage
 
+
+// Defines for the ssgarbage queue items
+#define GC_QUEUE_ITEM_QUEUE_TIME 1 //! Time this item entered the queue
+#define GC_QUEUE_ITEM_REF 2 //! Ref to the item
+#define GC_QUEUE_ITEM_GCD_DESTROYED 3 //! Item's gc_destroyed var value. Used to detect ref reuse.
+#define GC_QUEUE_ITEM_INDEX_COUNT 3 //! Number of item indexes, used for allocating the nested lists. Don't forget to increase this if you add a new queue item index
+
 // Defines for the time an item has to get its reference cleaned before it fails the queue and moves to the next.
 #define GC_FILTER_QUEUE (1 SECONDS)
 #define GC_CHECK_QUEUE (5 MINUTES)

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -166,21 +166,22 @@ SUBSYSTEM_DEF(garbage)
 	//Normally this isn't expensive, but the gc queue can grow to 40k items, and that gets costly/causes overrun.
 	for (var/i in 1 to length(queue))
 		var/list/L = queue[i]
-		if (length(L) < 2)
+		if (length(L) < GC_QUEUE_ITEM_INDEX_COUNT)
 			count++
 			if (MC_TICK_CHECK)
 				return
 			continue
 
-		var/GCd_at_time = L[1]
-		if(GCd_at_time > cut_off_time)
+		var/queued_at_time = L[GC_QUEUE_ITEM_QUEUE_TIME]
+		var/GCd_at_time = L[GC_QUEUE_ITEM_GCD_DESTROYED]
+		if(queued_at_time > cut_off_time)
 			break // Everything else is newer, skip them
 		count++
 
 #ifdef EXPERIMENT_515_QDEL_HARD_REFERENCE
-		var/datum/D = L[2]
+		var/datum/D = L[GC_QUEUE_ITEM_REF]
 #else
-		var/refID = L[2]
+		var/refID = L[GC_QUEUE_ITEM_REF]
 		var/datum/D
 		D = locate(refID)
 #endif
@@ -267,18 +268,19 @@ SUBSYSTEM_DEF(garbage)
 	if (level > GC_QUEUE_COUNT)
 		HardDelete(D)
 		return
-	var/gctime = world.time
+	var/queue_time = world.time
 
 #ifdef EXPERIMENT_515_QDEL_HARD_REFERENCE
 	var/refid = D
 #else
 	var/refid = text_ref(D)
 #endif
-
-	D.gc_destroyed = gctime
+	if (D.gc_destroyed <= 0)
+		D.gc_destroyed = queue_time
+	
 	var/list/queue = queues[level]
 
-	queue[++queue.len] = list(gctime, refid) // not += for byond reasons
+	queue[++queue.len] = list(queue_time, refid, D.gc_destroyed) // not += for byond reasons
 
 //this is mainly to separate things profile wise.
 /datum/controller/subsystem/garbage/proc/HardDelete(datum/D)


### PR DESCRIPTION
Keeps gc_destroyed from getting updated on every step thru the gc queue.

Fixes logic that assumed gc_destroyed is the time the object first qdel'ed. it used to get updated on each stage of the garbage controller and there are 3 stages.

Added list index defines for the inner gc item list.