### PR TITLE
Add config for station traits

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -339,6 +339,8 @@
 
 /datum/config_entry/flag/allow_random_events // Enables random events mid-round when set
 
+/datum/config_entry/flag/forbid_station_traits
+
 /datum/config_entry/number/events_min_time_mul // Multipliers for random events minimal starting time and minimal players amounts
 	default = 1
 	min_val = 0

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -26,6 +26,9 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 ///Rolls for the amount of traits and adds them to the traits list
 /datum/controller/subsystem/processing/station/proc/SetupTraits()
+	if (CONFIG_GET(flag/forbid_station_traits))
+		return
+
 	if (fexists(FUTURE_STATION_TRAITS_FILE))
 		var/forced_traits_contents = file2text(FUTURE_STATION_TRAITS_FILE)
 		fdel(FUTURE_STATION_TRAITS_FILE)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -135,6 +135,9 @@ DYNAMIC_CONFIG_ENABLED
 ## Comment this out to disable random events during the round.
 ALLOW_RANDOM_EVENTS
 
+## Uncomment this to disable station traits.
+#FORBID_STATION_TRAITS
+
 ## Multiplier for earliest start time of dangerous events.
 ## Set to 0 to make dangerous events avaliable from round start.
 EVENTS_MIN_TIME_MUL 1


### PR DESCRIPTION

## About The Pull Request
Adds a config for station traits. Extremely annoyed of testing locally and having all the lights break or spawning in the shuttle puking or whatever.

## Changelog
:cl:
admin: Added config for disabling station traits
/:cl:
