### PR TITLE
Scarves can begin surgeries.

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -221,6 +221,10 @@
 	greyscale_config_worn = /datum/greyscale_config/scarf_worn
 	flags_1 = IS_PLAYER_COLORABLE_1
 
+/obj/item/clothing/neck/scarf/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/surgery_initiator)
+
 /obj/item/clothing/neck/scarf/black
 	name = "black scarf"
 	greyscale_colors = "#4A4A4B#4A4A4B"
@@ -275,6 +279,10 @@
 	greyscale_config_worn = /datum/greyscale_config/large_scarf_worn
 	flags_1 = IS_PLAYER_COLORABLE_1
 
+/obj/item/clothing/neck/large_scarf/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/surgery_initiator)
+
 /obj/item/clothing/neck/large_scarf/red
 	name = "large red scarf"
 	greyscale_colors = "#8A2908#A06D66"
@@ -293,6 +301,10 @@
 	greyscale_colors = "#B40000#545350"
 	armor_type = /datum/armor/large_scarf_syndie
 
+/obj/item/clothing/neck/large_scarf/syndie/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/surgery_initiator)
+
 /obj/item/clothing/neck/infinity_scarf
 	name = "infinity scarf"
 	icon_state = "infinity_scarf"
@@ -302,6 +314,10 @@
 	greyscale_config = /datum/greyscale_config/infinity_scarf
 	greyscale_config_worn = /datum/greyscale_config/infinity_scarf_worn
 	flags_1 = IS_PLAYER_COLORABLE_1
+
+/obj/item/clothing/neck/infinity_scarf/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/surgery_initiator)
 
 /obj/item/clothing/neck/petcollar
 	name = "pet collar"

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -301,10 +301,6 @@
 	greyscale_colors = "#B40000#545350"
 	armor_type = /datum/armor/large_scarf_syndie
 
-/obj/item/clothing/neck/large_scarf/syndie/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/surgery_initiator)
-
 /obj/item/clothing/neck/infinity_scarf
 	name = "infinity scarf"
 	icon_state = "infinity_scarf"


### PR DESCRIPTION

## About The Pull Request
Adds the surgery initiator component to 3 types of scarves: neck/scarf, neck/large_scarf and neck/infinity_scarf. 
## Why It's Good For The Game
Heads of staff get cloaks that can begin surgery, and everyone can wear bedsheets to begin surgery, now scarf wearers can be included in the gang of being able to begin surgery on non-moths with their neck wear.
## Changelog
:cl:
add: Scarves can now begin surgery.
/:cl:
