### PR TITLE
Adds misisng contrabrand loot spawns to deltastation contrabrand locker

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -55483,6 +55483,8 @@
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "nyC" = (


### PR DESCRIPTION
Adds Missing contrabrand loot spawns which streamlines delta more with all the other maps right now.

:cl: Improvedname
fix: Adds missing contrabrand spawners to deltastation locker
/:cl:

