### PR TITLE
Minor detectives spawn with a candy cigarette and apple juice filled flask

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -117,6 +117,7 @@
 	icon_state = "detective"
 	inhand_icon_state = "det_hat"
 	var/candy_cooldown = 0
+	var/flask = /obj/item/reagent_containers/cup/glass/flask/det
 	dog_fashion = /datum/dog_fashion/head/detective
 
 /datum/armor/fedora_det_hat
@@ -133,7 +134,7 @@
 
 	create_storage(type = /datum/storage/pockets/small/fedora/detective)
 
-	new /obj/item/reagent_containers/cup/glass/flask/det(src)
+	new flask(src)
 
 /obj/item/clothing/head/fedora/det_hat/examine(mob/user)
 	. = ..()
@@ -150,6 +151,9 @@
 		candy_cooldown = world.time+1200
 	else
 		to_chat(user, span_warning("You just took a candy corn! You should wait a couple minutes, lest you burn through your stash."))
+
+/obj/item/clothing/head/fedora/det_hat/minor
+	flask = /obj/item/reagent_containers/cup/glass/flask/det/minor
 
 //Mime
 /obj/item/clothing/head/beret

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -117,8 +117,9 @@
 	icon_state = "detective"
 	inhand_icon_state = "det_hat"
 	var/candy_cooldown = 0
-	var/flask = /obj/item/reagent_containers/cup/glass/flask/det
 	dog_fashion = /datum/dog_fashion/head/detective
+	//Path for the flask that spawns inside their hat roundstart
+	var/flask_path = /obj/item/reagent_containers/cup/glass/flask/det
 
 /datum/armor/fedora_det_hat
 	melee = 25
@@ -134,7 +135,7 @@
 
 	create_storage(type = /datum/storage/pockets/small/fedora/detective)
 
-	new flask(src)
+	new flask_path(src)
 
 /obj/item/clothing/head/fedora/det_hat/examine(mob/user)
 	. = ..()
@@ -153,7 +154,7 @@
 		to_chat(user, span_warning("You just took a candy corn! You should wait a couple minutes, lest you burn through your stash."))
 
 /obj/item/clothing/head/fedora/det_hat/minor
-	flask = /obj/item/reagent_containers/cup/glass/flask/det/minor
+	flask_path = /obj/item/reagent_containers/cup/glass/flask/det/minor
 
 //Mime
 /obj/item/clothing/head/beret

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -118,7 +118,7 @@
 	inhand_icon_state = "det_hat"
 	var/candy_cooldown = 0
 	dog_fashion = /datum/dog_fashion/head/detective
-	//Path for the flask that spawns inside their hat roundstart
+	///Path for the flask that spawns inside their hat roundstart
 	var/flask_path = /obj/item/reagent_containers/cup/glass/flask/det
 
 /datum/armor/fedora_det_hat

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -73,6 +73,12 @@
 		)
 	implants = list(/obj/item/implant/mindshield)
 
+/datum/outfit/job/detective/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	if (H.age < AGE_MINOR)
+		mask = /obj/item/clothing/mask/cigarette/candy
+		head = /obj/item/clothing/head/fedora/det_hat/minor
+
 /datum/outfit/job/detective/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	var/obj/item/clothing/mask/cigarette/cig = H.wear_mask

--- a/code/modules/jobs/job_types/detective.dm
+++ b/code/modules/jobs/job_types/detective.dm
@@ -73,9 +73,9 @@
 		)
 	implants = list(/obj/item/implant/mindshield)
 
-/datum/outfit/job/detective/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/detective/pre_equip(mob/living/carbon/human/human, visualsOnly = FALSE)
 	. = ..()
-	if (H.age < AGE_MINOR)
+	if (human.age < AGE_MINOR)
 		mask = /obj/item/clothing/mask/cigarette/candy
 		head = /obj/item/clothing/head/fedora/det_hat/minor
 

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -461,6 +461,9 @@
 	icon_state = "detflask"
 	list_reagents = list(/datum/reagent/consumable/ethanol/whiskey = 30)
 
+/obj/item/reagent_containers/cup/glass/flask/det/minor
+	list_reagents = list(/datum/reagent/consumable/applejuice = 30)
+
 /obj/item/reagent_containers/cup/glass/mug/britcup
 	name = "cup"
 	desc = "A cup with the british flag emblazoned on it."

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -555,6 +555,7 @@
 		/obj/item/clothing/glasses/regular/kim = 1,
 		/obj/item/reagent_containers/cup/glass/flask/det = 2,
 		/obj/item/storage/fancy/cigarettes = 5,
+		/obj/item/storage/fancy/cigarettes/cigpack_candy = 5,
 		)
 	premium = list(
 		/obj/item/clothing/head/flatcap = 1,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -556,7 +556,7 @@
 		/obj/item/reagent_containers/cup/glass/flask/det = 2,
 		/obj/item/storage/fancy/cigarettes = 5,
 		/obj/item/storage/fancy/cigarettes/cigpack_candy = 5,
-		)
+	)
 	premium = list(
 		/obj/item/clothing/head/flatcap = 1,
 		)


### PR DESCRIPTION
## About The Pull Request

If a detective joins who is 20 or younger their cigarette is changed for a candy one and their flask is filled with apple juice. Also adds candy cigarettes' to the detective vendor.

## Why It's Good For The Game

Minor crew members are unable to use cigarette vendors or acquire alcohol in game without effectively committing a crime, it doesn't make sense for minor detectives to spawn with them. I also think that minor characters trying to obtain narcotics can be a pretty entertaining RP starter as a overall harmless crime and something that requires interaction with other members of the crew.

## Changelog
:cl:
add: Minor detectives now spawn with a candy cigarette and a flask full of apple juice.
balance: Candy Cigarettes added to the detective vendor.
fix: Minor detectives no longer spawn with real cigarettes or real alcohol, you'll need to ask you colleagues to buy you some, hopefully they wont arrest you for trying.
/:cl:
