### PR TITLE
Fixes runtime when an airlock is qdel'd while an AI is hacking it.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -636,6 +636,11 @@
 		aiHacking = TRUE
 		to_chat(user, span_warning("Airlock AI control has been blocked. Beginning fault-detection."))
 		sleep(5 SECONDS)
+
+
+		if(QDELETED(src))
+			to_chat(user, span_warning("Connection lost! Unable to hack airlock."))
+			return
 		if(canAIControl(user))
 			to_chat(user, span_notice("Alert cancelled. Airlock control has been restored without our assistance."))
 			aiHacking = FALSE
@@ -646,8 +651,18 @@
 			return
 		to_chat(user, span_notice("Fault confirmed: airlock control wire disabled or cut."))
 		sleep(2 SECONDS)
+
+
+		if(QDELETED(src))
+			to_chat(user, span_warning("Connection lost! Unable to hack airlock."))
+			return
 		to_chat(user, span_notice("Attempting to hack into airlock. This may take some time."))
 		sleep(20 SECONDS)
+
+
+		if(QDELETED(src))
+			to_chat(user, span_warning("Connection lost! Unable to hack airlock."))
+			return
 		if(canAIControl(user))
 			to_chat(user, span_notice("Alert cancelled. Airlock control has been restored without our assistance."))
 			aiHacking = FALSE
@@ -658,6 +673,11 @@
 			return
 		to_chat(user, span_notice("Upload access confirmed. Loading control program into airlock software."))
 		sleep(17 SECONDS)
+
+
+		if(QDELETED(src))
+			to_chat(user, span_warning("Connection lost! Unable to hack airlock."))
+			return
 		if(canAIControl(user))
 			to_chat(user, span_notice("Alert cancelled. Airlock control has been restored without our assistance."))
 			aiHacking = FALSE
@@ -668,10 +688,20 @@
 			return
 		to_chat(user, span_notice("Transfer complete. Forcing airlock to execute program."))
 		sleep(5 SECONDS)
+
+
+		if(QDELETED(src))
+			to_chat(user, span_warning("Connection lost! Unable to hack airlock."))
+			return
 		//disable blocked control
 		aiControlDisabled = AI_WIRE_HACKED
 		to_chat(user, span_notice("Receiving control information from airlock."))
 		sleep(1 SECONDS)
+
+
+		if(QDELETED(src))
+			to_chat(user, span_warning("Connection lost! Unable to hack airlock."))
+			return
 		//bring up airlock dialog
 		aiHacking = FALSE
 		if(user)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/6209658/210278385-d5ebbe62-a079-4c2f-8b36-d620a6121264.png)

hack() uses a bunch of sleeps, sanity check.

:cl: ShizCalev
fix: Fixed a minor runtime which occurred when an airlock got deleted if an AI was actively hacking it. 
/:cl:
