### PR TITLE
Fixes vulerabilities in The Syndicate's security software

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -721,6 +721,11 @@
 /obj/machinery/attack_ai(mob/user)
 	if(!(interaction_flags_machine & INTERACT_MACHINE_ALLOW_SILICON) && !isAdminGhostAI(user))
 		return FALSE
+	if(!(ROLE_SYNDICATE in user.faction))
+		if((ACCESS_SYNDICATE in req_access) || (ACCESS_SYNDICATE_LEADER in req_access) || (ACCESS_SYNDICATE in req_one_access) || (ACCESS_SYNDICATE_LEADER in req_one_access))
+			return FALSE
+		if((onSyndieBase() && loc != user))
+			return FALSE
 	if(iscyborg(user))// For some reason attack_robot doesn't work
 		return attack_robot(user)
 	return _try_interact(user)

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -14,6 +14,11 @@
 	if(issilicon(accessor))
 		if(ispAI(accessor))
 			return FALSE
+		if(!(ROLE_SYNDICATE in accessor.faction))
+			if((ACCESS_SYNDICATE in req_access) || (ACCESS_SYNDICATE_LEADER in req_access) || (ACCESS_SYNDICATE in req_one_access) || (ACCESS_SYNDICATE_LEADER in req_one_access))
+				return FALSE
+			if(onSyndieBase() && loc != accessor)
+				return FALSE
 		return TRUE //AI can do whatever it wants
 	if(isAdminGhostAI(accessor))
 		//Access can't stop the abuse

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1187,6 +1187,8 @@
 		return FALSE
 	if(is_away_level(T.z))
 		return FALSE
+	if(onSyndieBase() && !(ROLE_SYNDICATE in user.faction))
+		return FALSE
 	if(user != null && src == user)
 		return FALSE
 	if(invisibility || alpha == 0)//cloaked

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -13,11 +13,6 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags_1 = NODECONSTRUCT_1
 
-/obj/machinery/computer/shuttle/syndicate/allowed(mob/M)
-	if(issilicon(M) && !(ROLE_SYNDICATE in M.faction))
-		return FALSE
-	return ..()
-
 /obj/machinery/computer/shuttle/syndicate/launch_check(mob/user)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
Fixes #72420

:cl: ShizCalev
fix: Crew AIs can no longer interact with ANY syndicate machinery (ie shuttle computers, buttons, ect.)
fix: Crew AIs can no longer attempt to track mobs on the syndicate base to determine the gamemode. 
/:cl:
