### PR TITLE
Fixes nulls in gulag reclaimer storage

### DIFF
--- a/code/game/machinery/gulag_item_reclaimer.dm
+++ b/code/game/machinery/gulag_item_reclaimer.dm
@@ -9,6 +9,11 @@
 	var/list/stored_items = list()
 	var/obj/machinery/gulag_teleporter/linked_teleporter = null
 
+/obj/machinery/gulag_item_reclaimer/handle_atom_del(atom/deleting_atom)
+	for(var/person in stored_items)
+		stored_items[person] -= deleting_atom
+	return ..()
+
 /obj/machinery/gulag_item_reclaimer/Destroy()
 	for(var/i in contents)
 		var/obj/item/I = i


### PR DESCRIPTION
```
[2022-12-03 21:21:48.250] runtime error: Cannot execute null.forceMove().
 - proc name: drop items (/obj/machinery/gulag_item_reclaimer/proc/drop_items)
 -   source file: gulag_item_reclaimer.dm,86
 -   usr: Seth Deces (/mob/living/carbon/human)
 -   src: the equipment reclaimer statio... (/obj/machinery/gulag_item_reclaimer)
 -   usr.loc: the floor (94,162,2) (/turf/open/floor/iron/dark)
 -   src.loc: the floor (94,162,2) (/turf/open/floor/iron/dark)
 -   call stack:
 - the equipment reclaimer statio... (/obj/machinery/gulag_item_reclaimer): drop items(Seth Deces (/mob/living/carbon/human))
 - the equipment reclaimer statio... (/obj/machinery/gulag_item_reclaimer): ui act("release_items", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/default (/datum/ui_state/default))
 - /datum/tgui (/datum/tgui): on act message("release_items", /list (/list), /datum/ui_state/default (/datum/ui_state/default))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): Invoke()
 - world: push usr(Seth Deces (/mob/living/carbon/human), /datum/callback/verb_callback (/datum/callback/verb_callback))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - Verb Manager (/datum/controller/subsystem/verb_manager): run verb queue()
 - Verb Manager (/datum/controller/subsystem/verb_manager): fire(0)
 - Verb Manager (/datum/controller/subsystem/verb_manager): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 
```

:cl: ShizCalev
fix: Fixed the gulag item reclaimer sometimes not giving you all your items back.
/:cl:
