### PR TITLE
Added positive moodlet for petting mothroach

### DIFF
--- a/code/modules/mob/living/basic/vermin/mothroach.dm
+++ b/code/modules/mob/living/basic/vermin/mothroach.dm
@@ -56,6 +56,12 @@
 		return
 	else
 		playsound(loc, 'sound/voice/moth/scream_moth.ogg', 50, TRUE)
+		if("help")
+		user.visible_message(span_notice("[user] pets [src]."), span_notice("You rest your hand on the [src]'s head for a moment."))
+		if(flags_1 & HOLOGRAM_1)
+			return
+		user.add_mood_event(REF(src), /datum/mood_event/pet_animal, src)
+		return
 
 /mob/living/basic/mothroach/attackby(obj/item/attacking_item, mob/living/user, params)
 	. = ..()

--- a/code/modules/mob/living/basic/vermin/mothroach.dm
+++ b/code/modules/mob/living/basic/vermin/mothroach.dm
@@ -57,13 +57,22 @@
 	else
 		playsound(loc, 'sound/voice/moth/scream_moth.ogg', 50, TRUE)
 
-/mob/living/basic/mothroach/attack_hand(mob/living/carbon/human/user, list/modifiers)
-	if("help")
-	user.visible_message(span_notice("[user] pets [src]."), span_notice("You rest your hand on the [src]'s head for a moment."))
-	if(flags_1 & HOLOGRAM_1)
-		return
-	user.add_mood_event(REF(src), /datum/mood_event/pet_animal, src)
-	return
+/mob/living/basic/mothroach/attack_hand(mob/living/carbon/human/userM)
+. = ..()
+	switch(userM.a_intent)
+		if("help")
+			habby(TRUE, userM)
+		if("harm")
+			habby(FALSE, userM)
+
+/mob/living/basic/mothroach/proc/habby(change, mob/userM)
+	if(change)
+		if(userM && stat != DEAD)
+			userM.visible_message(span_notice("[userM] pets [src]."), span_notice("You rest your hand on the [src]'s head for a moment."))
+			if(flags_1 & HOLOGRAM_1)
+				return
+			userM.add_mood_event(REF(src), /datum/mood_event/pet_animal, src)
+			return
 
 /mob/living/basic/mothroach/attackby(obj/item/attacking_item, mob/living/user, params)
 	. = ..()

--- a/code/modules/mob/living/basic/vermin/mothroach.dm
+++ b/code/modules/mob/living/basic/vermin/mothroach.dm
@@ -56,12 +56,14 @@
 		return
 	else
 		playsound(loc, 'sound/voice/moth/scream_moth.ogg', 50, TRUE)
-		if("help")
-		user.visible_message(span_notice("[user] pets [src]."), span_notice("You rest your hand on the [src]'s head for a moment."))
-		if(flags_1 & HOLOGRAM_1)
-			return
-		user.add_mood_event(REF(src), /datum/mood_event/pet_animal, src)
+
+/mob/living/basic/mothroach/attack_hand(mob/living/carbon/human/user, list/modifiers)
+	if("help")
+	user.visible_message(span_notice("[user] pets [src]."), span_notice("You rest your hand on the [src]'s head for a moment."))
+	if(flags_1 & HOLOGRAM_1)
 		return
+	user.add_mood_event(REF(src), /datum/mood_event/pet_animal, src)
+	return
 
 /mob/living/basic/mothroach/attackby(obj/item/attacking_item, mob/living/user, params)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

If a player uses their hands with help intent on a mothroach, then they will gain a positive moodlet. This works in a similar way to gaining one from petting a corgi. It will not gain a moodlet if you use your hands in any other intent than help.
## Why It's Good For The Game

There's not much reason to purchase a mothroach other than it's cute. Adding a positive moodlet for petting, like the corgi has, gives at least some mechanical reason for its existence.
## Changelog
:cl:
add: Added positive moodlet when the player pets a mothroach
/:cl:
