### PR TITLE
Makes the juice of death berries poisonous, like poison berry's

### DIFF
--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -74,6 +74,7 @@
 	icon_state = "deathberrypile"
 	bite_consumption_mod = 3
 	foodtypes = FRUIT | TOXIC
+	juice_results = list(/datum/reagent/consumable/poisonberryjuice = 0)
 	tastes = list("death-berry" = 1)
 	distill_reagent = null
 	wine_power = 50


### PR DESCRIPTION
## About The Pull Request

Found out poison berry juice existed from the wiki and code diving, however, only poison berries juice into it. Death berries, despite their stronger poison, juice into normal berry juice instead. This changes that to have death berries also juice into poisoned juice.

## Why It's Good For The Game

Mostly a consistency change, it doesn't make sense for the berry with the stronger poison to not juice into something poisonous as well, when a berry that's less poisonous does do so. For transparency's sake, this will make the death berry marginally stronger, as with plant traits you can get the juiced reagent inside of a plant without juicing it.

## Changelog

:cl:
fix: Death berry juice is poisonous now, like poison berry's
/:cl:
