### PR TITLE
The worst PR you've ever seen. Admins can now modify beer nukes to contain custom reagents.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -467,7 +467,7 @@ GLOBAL_VAR(station_nuke_source)
 	var/turf/our_turf = get_turf(src)
 	message_admins("\The [src] at [ADMIN_VERBOSEJMP(our_turf)] was disarmed by [disarmer ? ADMIN_LOOKUPFLW(disarmer) : "an unknown user"].")
 	if(disarmer)
-		disarmer.log_message("disarmed \the [src].", LOG_GAME)
+		disarmer.log_message("disarmed the [src].", LOG_GAME)
 
 	detonation_timer = null
 	SSsecurity_level.set_level(previous_level)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -467,7 +467,7 @@ GLOBAL_VAR(station_nuke_source)
 	var/turf/our_turf = get_turf(src)
 	message_admins("\The [src] at [ADMIN_VERBOSEJMP(our_turf)] was disarmed by [disarmer ? ADMIN_LOOKUPFLW(disarmer) : "an unknown user"].")
 	if(disarmer)
-		disarmer.log_message("disarmed the [src].", LOG_GAME)
+		disarmer.log_message("disarmed [src].", LOG_GAME)
 
 	detonation_timer = null
 	SSsecurity_level.set_level(previous_level)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -466,7 +466,8 @@ GLOBAL_VAR(station_nuke_source)
 /obj/machinery/nuclearbomb/proc/disarm_nuke(mob/disarmer)
 	var/turf/our_turf = get_turf(src)
 	message_admins("\The [src] at [ADMIN_VERBOSEJMP(our_turf)] was disarmed by [disarmer ? ADMIN_LOOKUPFLW(disarmer) : "an unknown user"].")
-	disarmer.log_message("disarmed \the [src].", LOG_GAME)
+	if(disarmer)
+		disarmer.log_message("disarmed \the [src].", LOG_GAME)
 
 	detonation_timer = null
 	SSsecurity_level.set_level(previous_level)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
@@ -61,10 +61,6 @@
 
 /obj/machinery/nuclearbomb/beer/really_actually_explode(detonation_status)
 	disarm_nuke()
-	if (flood_reagent != initial(flood_reagent))
-		var/datum/round_event_control/scrubber_overflow/custom/event = locate(/datum/round_event_control/scrubber_overflow/custom) in SSevents.control
-		event.custom_reagent = flood_reagent
-		event.runEvent()
-	else
-		var/datum/round_event_control/event = locate(/datum/round_event_control/scrubber_overflow/beer) in SSevents.control
-		event.runEvent()
+	var/datum/round_event_control/scrubber_overflow/custom/event = locate(/datum/round_event_control/scrubber_overflow/custom) in SSevents.control
+	event.custom_reagent = flood_reagent
+	event.runEvent()

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
@@ -5,6 +5,8 @@
 	proper_bomb = FALSE
 	/// The keg located within the beer nuke.
 	var/obj/structure/reagent_dispensers/beerkeg/keg
+	/// Reagent that is produced once the nuke detonates.
+	var/datum/reagent/flood_reagent = /datum/reagent/consumable/ethanol/beer
 
 /obj/machinery/nuclearbomb/beer/Initialize(mapload)
 	. = ..()
@@ -50,7 +52,7 @@
 /obj/machinery/nuclearbomb/beer/proc/local_foam()
 	var/datum/reagents/tmp_holder = new/datum/reagents(1000)
 	tmp_holder.my_atom = src
-	tmp_holder.add_reagent(/datum/reagent/consumable/ethanol/beer, 100)
+	tmp_holder.add_reagent(flood_reagent, 100)
 
 	var/datum/effect_system/fluid_spread/foam/foam = new
 	foam.set_up(200, holder = src, location = get_turf(src), carry = tmp_holder)
@@ -59,5 +61,10 @@
 
 /obj/machinery/nuclearbomb/beer/really_actually_explode(detonation_status)
 	disarm_nuke()
-	var/datum/round_event_control/event = locate(/datum/round_event_control/scrubber_overflow/beer) in SSevents.control
-	event.runEvent()
+	if (flood_reagent != /datum/reagent/consumable/ethanol/beer)
+		var/datum/round_event_control/scrubber_overflow/custom/event = locate(/datum/round_event_control/scrubber_overflow/custom) in SSevents.control
+		event.custom_reagent = flood_reagent
+		event.runEvent()
+	else
+		var/datum/round_event_control/event = locate(/datum/round_event_control/scrubber_overflow/beer) in SSevents.control
+		event.runEvent()

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
@@ -6,7 +6,7 @@
 	/// The keg located within the beer nuke.
 	var/obj/structure/reagent_dispensers/beerkeg/keg
 	/// Reagent that is produced once the nuke detonates.
-	var/datum/reagent/flood_reagent = /datum/reagent/consumable/ethanol/beer
+	var/flood_reagent = /datum/reagent/consumable/ethanol/beer
 
 /obj/machinery/nuclearbomb/beer/Initialize(mapload)
 	. = ..()
@@ -61,7 +61,7 @@
 
 /obj/machinery/nuclearbomb/beer/really_actually_explode(detonation_status)
 	disarm_nuke()
-	if (flood_reagent != /datum/reagent/consumable/ethanol/beer)
+	if (flood_reagent != initial(flood_reagent))
 		var/datum/round_event_control/scrubber_overflow/custom/event = locate(/datum/round_event_control/scrubber_overflow/custom) in SSevents.control
 		event.custom_reagent = flood_reagent
 		event.runEvent()

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -137,6 +137,7 @@ Runs the event
 	SSblackbox.record_feedback("tally", "event_ran", 1, "[E]")
 	return E
 
+///Used for the beer nuke/custom reagent floods which broadcast a different name to their actual event name
 /datum/round_event_control/proc/annouce_name(random)
 	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
 

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -132,10 +132,13 @@ Runs the event
 		log_game("Random Event triggering: [name] ([typepath]).")
 
 	if(alert_observers)
-		deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
+		annouce_name(random)
 
 	SSblackbox.record_feedback("tally", "event_ran", 1, "[E]")
 	return E
+
+/datum/round_event_control/proc/annouce_name(random)
+	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
 
 //Returns the component for the listener
 /datum/round_event_control/proc/stop_random_event()

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -132,13 +132,13 @@ Runs the event
 		log_game("Random Event triggering: [name] ([typepath]).")
 
 	if(alert_observers)
-		annouce_name(random)
+		announce_deadchat(random)
 
 	SSblackbox.record_feedback("tally", "event_ran", 1, "[E]")
 	return E
 
-///Used for the beer nuke/custom scrubber overflow which broadcast a different name to their actual event name
-/datum/round_event_control/proc/annouce_name(random)
+///Annouces the event name to deadchat, override this if what an event should show to deadchat is different to its event name.
+/datum/round_event_control/proc/announce_deadchat(random)
 	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
 
 //Returns the component for the listener

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -137,7 +137,7 @@ Runs the event
 	SSblackbox.record_feedback("tally", "event_ran", 1, "[E]")
 	return E
 
-///Used for the beer nuke/custom reagent floods which broadcast a different name to their actual event name
+///Used for the beer nuke/custom scrubber overflow which broadcast a different name to their actual event name
 /datum/round_event_control/proc/annouce_name(random)
 	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
 

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -139,26 +139,17 @@
 	danger_chance = 30
 	reagents_amount = 150
 
-/datum/round_event_control/scrubber_overflow/beer // Used when the beer nuke "detonates"
-	name = "Scrubber Overflow: Beer"
-	typepath = /datum/round_event/scrubber_overflow/beer
-	weight = 0
-	max_occurrences = 0
-	description = "The scrubbers release a tide of boozy froth."
-
-/datum/round_event/scrubber_overflow/beer
-	overflow_probability = 100
-	forced_reagent = /datum/reagent/consumable/ethanol/beer
-	reagents_amount = 100
-
-/datum/round_event_control/scrubber_overflow/custom
+/datum/round_event_control/scrubber_overflow/custom //Used for the beer nuke as well as admin abuse
 	name = "Scrubber Overflow: Custom"
 	typepath = /datum/round_event/scrubber_overflow/custom
 	weight = 0
 	max_occurrences = 0
 	description = "The scrubbers release a tide of custom froth."
 	///Reagent thats going to be flooded.
-	var/custom_reagent
+	var/datum/reagent/custom_reagent
+
+/datum/round_event_control/scrubber_overflow/custom/annouce_name(random)
+	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>Scrubber Overflow: [initial(custom_reagent.name)]</b>", message_type=DEADCHAT_ANNOUNCEMENT)
 
 /datum/round_event_control/scrubber_overflow/custom/admin_setup(mob/admin)
 	if(!check_rights(R_FUN))
@@ -169,7 +160,7 @@
 
 /datum/round_event/scrubber_overflow/custom
 	overflow_probability = 100
-	forced_reagent = /datum/reagent/lube/superlube
+	forced_reagent = /datum/reagent/consumable/ethanol/beer
 	reagents_amount = 100
 
 /datum/round_event/scrubber_overflow/custom/start()

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -156,9 +156,9 @@
 	typepath = /datum/round_event/scrubber_overflow/custom
 	weight = 0
 	max_occurrences = 0
-	description = "The scrubbers release a tide of custom froth"
+	description = "The scrubbers release a tide of custom froth."
 	///Reagent thats going to be flooded.
-	var/datum/reagent/custom_reagent
+	var/custom_reagent
 
 /datum/round_event_control/scrubber_overflow/custom/admin_setup(mob/admin)
 	if(!check_rights(R_FUN))
@@ -175,4 +175,4 @@
 /datum/round_event/scrubber_overflow/custom/start()
 	var/datum/round_event_control/scrubber_overflow/custom/event_controller = control
 	forced_reagent = event_controller.custom_reagent
-	. = ..()
+	return ..()

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -151,3 +151,27 @@
 	forced_reagent = /datum/reagent/consumable/ethanol/beer
 	reagents_amount = 100
 
+/datum/round_event_control/scrubber_overflow/custom
+	name = "Scrubber Overflow: Custom"
+	typepath = /datum/round_event/scrubber_overflow/custom
+	weight = 0
+	max_occurrences = 0
+	description = "The scrubbers release a tide of custom froth"
+	var/datum/reagent/custom_reagent
+
+/datum/round_event_control/scrubber_overflow/custom/admin_setup(mob/admin)
+	if(!check_rights(R_FUN))
+		return
+	custom_reagent = tgui_input_list(usr, "Choose a reagent to flood.", "Choose a reagent.", sort_list(subtypesof(/datum/reagent), /proc/cmp_typepaths_asc))
+	if (isnull(custom_reagent))
+		return ADMIN_CANCEL_EVENT
+
+/datum/round_event/scrubber_overflow/custom
+	overflow_probability = 100
+	forced_reagent = /datum/reagent/consumable/ethanol/beer
+	reagents_amount = 100
+
+/datum/round_event/scrubber_overflow/custom/start()
+	var/datum/round_event_control/scrubber_overflow/custom/event_controller = control
+	forced_reagent = event_controller.custom_reagent
+	. = ..()

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -148,7 +148,7 @@
 	///Reagent thats going to be flooded.
 	var/datum/reagent/custom_reagent
 
-/datum/round_event_control/scrubber_overflow/custom/annouce_name(random)
+/datum/round_event_control/scrubber_overflow/custom/announce_deadchat(random)
 	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>Scrubber Overflow: [initial(custom_reagent.name)]</b>", message_type=DEADCHAT_ANNOUNCEMENT)
 
 /datum/round_event_control/scrubber_overflow/custom/admin_setup(mob/admin)

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -157,6 +157,7 @@
 	weight = 0
 	max_occurrences = 0
 	description = "The scrubbers release a tide of custom froth"
+	///Reagent thats going to be flooded
 	var/datum/reagent/custom_reagent
 
 /datum/round_event_control/scrubber_overflow/custom/admin_setup(mob/admin)

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -157,7 +157,7 @@
 	weight = 0
 	max_occurrences = 0
 	description = "The scrubbers release a tide of custom froth"
-	///Reagent thats going to be flooded
+	///Reagent thats going to be flooded.
 	var/datum/reagent/custom_reagent
 
 /datum/round_event_control/scrubber_overflow/custom/admin_setup(mob/admin)

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -169,7 +169,7 @@
 
 /datum/round_event/scrubber_overflow/custom
 	overflow_probability = 100
-	forced_reagent = /datum/reagent/consumable/ethanol/beer
+	forced_reagent = /datum/reagent/lube/superlube
 	reagents_amount = 100
 
 /datum/round_event/scrubber_overflow/custom/start()


### PR DESCRIPTION
## About The Pull Request

The reagent that is produced when a beer nuke detonates is now customizable by admins, Allowing for horrific creations like mutation toxin floods, changing the entire stations flooring to carpets or lubing every single turf. Also allows admins to trigger this at will using trigger event, but you can't blame the crew if you do that.
## Why It's Good For The Game

I have on a few occasions wished I could modify the beer nuke to have a custom reagent for events, this allows for it. In general this is a pretty hilarious tool for the admin arsenal that I'm sure other admins will come up with funny use cases for.
## Changelog
:cl:
fix: Beer nukes no longer runtime on detonation.
admin: Admins can now modify what reagent beer nukes produce, now your parties can be alcohol free!
admin: Admins can now creature custom reagent scrubber overflows, TC trade 20TC for superlube flood?
/:cl:
