### PR TITLE
Removes Thunderdome Showtime Button Off Window

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5005,10 +5005,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
-"xG" = (
-/obj/machinery/button/showtime,
-/turf/closed/indestructible/fakeglass,
-/area/centcom/tdome/administration)
 "xN" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
@@ -52365,7 +52361,7 @@ IG
 IG
 IG
 It
-xG
+Pj
 Xn
 Sz
 Sz


### PR DESCRIPTION

## About The Pull Request

![image](https://user-images.githubusercontent.com/34697715/210458954-08e73e91-6d77-4dd4-b6fa-ef9fcfae9c29.png)

This wasn't even in the template version of the thunderdome, so any time an admin would reload the thunderdome, it wouldn't show up again. It's just silly to have buttons on windows regardless of context. (if you actually used this, just toggle `Admin AI Interaction` and hit the button yourself or something).
## Why It's Good For The Game

It doesn't look good on a window, I promise you.
## Changelog
:cl:
fix: There is no longer a button on a window at the CentCom Thunderdome.
/:cl:
