### PR TITLE
Alien closets deconstruct into alien alloy

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -14,7 +14,7 @@
 	name = "strange closet"
 	desc = "It looks alien!"
 	icon_state = "alien"
-
+	material_drop = /obj/item/stack/sheet/mineral/abductor
 
 /obj/structure/closet/gimmick
 	name = "administrative supply closet"


### PR DESCRIPTION

## About The Pull Request
The other day I found a rare alien locker in maint, hooray! Deconstructed it to get the alloy, and was instead met with iron. Booo. 
## Why It's Good For The Game
Alien lockers should deconstruct into the mineral used to craft them.
## Changelog
:cl: Tattle
fix: alien closets now deconstruct into alien alloy
/:cl:
