### PR TITLE
Fix inconsistent runtime spam from baseturf on startup

### DIFF
--- a/code/game/turfs/baseturfs.dm
+++ b/code/game/turfs/baseturfs.dm
@@ -118,6 +118,8 @@
 /// If found, returns how deep it is for use in other baseturf procs, or null if it cannot be found.
 /// For example, this number can be passed into ScrapeAway to scrape everything until that point.
 /turf/proc/depth_to_find_baseturf(baseturf_type)
+	if(!islist(baseturfs))
+		return baseturfs == baseturf_type ? 1 : null
 	var/index = baseturfs.Find(baseturf_type)
 	if (index == 0)
 		return null


### PR DESCRIPTION

## About The Pull Request
Fixes #72382

A baseturf can be a list or a single turf type.  The code was only checking if it was a list and caused a shit ton of runtime errors on master when starting a server.

## Why It's Good For The Game
No more runtime spam on startup.

## Changelog
:cl:
fix: Fix inconsistent runtime spam from baseturf on startup
/:cl:
