### PR TITLE
Adjusts Reagent Holder Code To Ignore Reagent Container

### DIFF
--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -124,7 +124,7 @@
 	SIGNAL_HANDLER
 
 	// This is for stuff like adding flour from a flour sack into a bowl, we handle the transfer of the reagent elsewhere, but we shouldn't regard it beyond some user feedback.
-	if (iistype(ingredient, /obj/item/reagent_containers))
+	if (istype(ingredient, /obj/item/reagent_containers))
 		attacker.balloon_alert(attacker, "transferring...")
 		return
 

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -123,17 +123,12 @@
 /datum/component/customizable_reagent_holder/proc/customizable_attack(datum/source, obj/ingredient, mob/attacker, silent = FALSE, force = FALSE)
 	SIGNAL_HANDLER
 
-	// This is for stuff like adding flour from a flour sack into a bowl, we handle the transfer of the reagent elsewhere, but we shouldn't regard it beyond some user feedback.
-	if (istype(ingredient, /obj/item/reagent_containers))
-		attacker.balloon_alert(attacker, "transferring...")
+	if (istype(ingredient, /obj/item/reagent_containers) && !valid_ingredient(ingredient))
+		if (ingredient.is_drainable()) // special message to handle the edgecase of adding flour from a beaker into a bowl or something like that
+			attacker.balloon_alert(attacker, "transferring...")
 		return
 
 	if (!valid_ingredient(ingredient))
-		attacker.balloon_alert(attacker, "doesn't go on that!")
-	if (!valid_ingredient(ingredient))
-		if (istype(ingredient, /obj/item/reagent_containers))
-			attacker.balloon_alert(attacker, "transferring...")
-			return
 		attacker.balloon_alert(attacker, "doesn't go on that!")
 		return
 

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -130,6 +130,11 @@
 
 	if (!valid_ingredient(ingredient))
 		attacker.balloon_alert(attacker, "doesn't go on that!")
+	if (!valid_ingredient(ingredient))
+		if (istype(ingredient, /obj/item/reagent_containers))
+			attacker.balloon_alert(attacker, "transferring...")
+			return
+		attacker.balloon_alert(attacker, "doesn't go on that!")
 		return
 
 	if (LAZYLEN(ingredients) >= max_ingredients)

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -123,12 +123,10 @@
 /datum/component/customizable_reagent_holder/proc/customizable_attack(datum/source, obj/ingredient, mob/attacker, silent = FALSE, force = FALSE)
 	SIGNAL_HANDLER
 
-	if (istype(ingredient, /obj/item/reagent_containers) && !valid_ingredient(ingredient))
-		if (ingredient.is_drainable()) // special message to handle the edgecase of adding flour from a beaker into a bowl or something like that
-			attacker.balloon_alert(attacker, "transferring...")
-		return
-
 	if (!valid_ingredient(ingredient))
+		if (ingredient.is_drainable()) // For stuff like adding flour from a flour sack into a bowl, we handle the transfer of the reagent elsewhere, but we shouldn't regard it beyond some user feedback.
+			attacker.balloon_alert(attacker, "transferring...")
+			return
 		attacker.balloon_alert(attacker, "doesn't go on that!")
 		return
 

--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -123,6 +123,11 @@
 /datum/component/customizable_reagent_holder/proc/customizable_attack(datum/source, obj/ingredient, mob/attacker, silent = FALSE, force = FALSE)
 	SIGNAL_HANDLER
 
+	// This is for stuff like adding flour from a flour sack into a bowl, we handle the transfer of the reagent elsewhere, but we shouldn't regard it beyond some user feedback.
+	if (iistype(ingredient, /obj/item/reagent_containers))
+		attacker.balloon_alert(attacker, "transferring...")
+		return
+
 	if (!valid_ingredient(ingredient))
 		attacker.balloon_alert(attacker, "doesn't go on that!")
 		return


### PR DESCRIPTION

## About The Pull Request

We shouldn't try to add the reagent container itself as an ingredient, so let's ignore that. I believe the actual reagent adding is handled well elsewhere, we just need to ignore the case here.
## Why It's Good For The Game

Fixes #72270

Confusing user feedback is never good.
## Changelog
:cl:
fix: You should now no longer get a confusing message whenever you try to add flour from a flour sack into a bowl.
/:cl:
