### PR TITLE
Bumps TGUI Bluescreen Copyright Year to 2563

### DIFF
--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -646,7 +646,7 @@ Thank you for your cooperation.
 </marquee>
 <div id="FatalError__stack" class="FatalError__stack"></div>
 <div class="FatalError__footer">
-Nanotrasen (c) 2525-2562
+Nanotrasen (c) 2525-2563
 </div>
 </div>
 


### PR DESCRIPTION
I wish there was a way to sync this to the `CURRENT_STATION_YEAR` macro but that doesn't really work for this file unfortunately.

:cl:
code: Nanotrasen has updated the copyright on their NToS Software to be valid for the New Year! (It's 2563 now!)
/:cl: