### PR TITLE
Fixes seeing rotation failed message ballons at distance

### DIFF
--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -110,6 +110,8 @@
 
 /datum/component/simple_rotation/proc/CanBeRotated(mob/user, degrees, silent=FALSE)
 	var/obj/rotated_obj = parent
+	if(!rotated_obj.Adjacent(user))
+		silent = TRUE
 
 	if(rotation_flags & ROTATION_REQUIRE_WRENCH)
 		if(!isliving(user))


### PR DESCRIPTION
Fixes #72460
:cl: ShizCalev
fix: You'll no longer see rotation failed messages when clicking on something far away.
/:cl:
