### PR TITLE
Adds test assertion to ensure armor vars never regress

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -265,6 +265,7 @@
 
 	if(uses_integrity)
 		atom_integrity = max_integrity
+	TEST_ONLY_ASSERT((!armor || istype(armor)), "[type] has an armor that contains an invalid value at intialize")
 
 	// apply materials properly from the default custom_materials value
 	// This MUST come after atom_integrity is set above, as if old materials get removed,


### PR DESCRIPTION
Well, github didn't provide the template for this PR so have a cake instead 🍰 

Preventing accidental regressions is good.