### PR TITLE
datum stock part fixes

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -289,14 +289,22 @@
 								if(QDELETED(incoming_stack))
 									break
 					if(!QDELETED(part)) //If we're a stack and we merged we might not exist anymore
-						components += part
-						part.forceMove(src)
+						var/stock_part_datum = GLOB.stock_part_datums_per_object[part.type]
+						if (!isnull(stock_part_datum))
+							components += stock_part_datum
+							qdel(part)
+						else
+							components += part
+							part.forceMove(src)
 					to_chat(user, span_notice("You add [part] to [src]."))
 				if(added_components.len)
 					replacer.play_rped_sound()
 				return
 
 			for(var/stock_part_base in req_components)
+				if (req_components[stock_part_base] == 0)
+					continue
+
 				var/stock_part_path
 
 				if (ispath(stock_part_base, /obj/item))
@@ -306,9 +314,6 @@
 					stock_part_path = initial(stock_part_datum_type.physical_object_type)
 				else
 					stack_trace("Bad stock part in req_components: [stock_part_base]")
-					continue
-
-				if (req_components[stock_part_path] == 0)
 					continue
 
 				if (!istype(P, stock_part_path))


### PR DESCRIPTION
## About The Pull Request
The issues

1. RPED is not converting `obj/item/stock_parts/scanning_module` into `datum/stock_part/scanning_module` before adding it into the constructable frame's `component_parts `causing any for loop construct like 
```
 for(var/datum/stock_part/scanning_module/scanning_module in component_parts)
  //do stuff 
```
to fail for example in the BEPIS machine

https://user-images.githubusercontent.com/110812394/210534328-35317784-2f55-482a-b50f-8bdea0c8cd66.mp4

2. You can add infinite amount of scanning modules to an constructable machine frame. Even if that that machine requires just 1 scanning module(say for anomaly refinery) you can keep on adding scanning modules to that frame forever. Happens only when you manually put the part in by hand

https://user-images.githubusercontent.com/110812394/210534406-0c2b7f3d-31c7-4271-9d21-b902fda432e0.mp4




## Why It's Good For The Game
This fixes the above mentioned bugs

## Changelog
:cl:
fix: check for stock parts that can be added to a machine frame by hand
fix: RPED converts stock parts into datum parts before inserting it into a machine frame only if possible. e.g. for scanning modules
/:cl:
