### PR TITLE
Fix: Goliath Infusion Organ Set Bonus

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -13,11 +13,11 @@
 
 /datum/status_effect/organ_set_bonus/goliath/enable_bonus()
 	. = ..()
-	ADD_TRAIT(src, TRAIT_LAVA_IMMUNE, REF(src))
+	ADD_TRAIT(owner, TRAIT_LAVA_IMMUNE, REF(src))
 
 /datum/status_effect/organ_set_bonus/goliath/disable_bonus()
 	. = ..()
-	REMOVE_TRAIT(src, TRAIT_LAVA_IMMUNE, REF(src))
+	REMOVE_TRAIT(owner, TRAIT_LAVA_IMMUNE, REF(src))
 
 ///goliath eyes, simple night vision
 /obj/item/organ/internal/eyes/night_vision/goliath


### PR DESCRIPTION
## About The Pull Request

This PR fixes a bug that caused the Goliath infusion of the DNA Infuser to stop working as expected. The bugs stops the lava "organ set bonus" from fully taking effect, add the "lava immunity" trait does not get added to the mob. The bug is caused by a minor developer oversight in `/datum/status_effect/organ_set_bonus/goliath/enable_bonus()` wherein it attempts to add `TRAIT_LAVA_IMMUNE` to the status effect rather than to the Mob.

To fix the bug, the single change in this PR adds the trait to the mob, allowing the trait to enable lava immunity as expected.

## Why It's Good For The Game

This PR fixes a bug that prevented players from receiving all of the benefits from the Goliath Infusion Set Bonus (all four Goliath organs) after infusing via putting 4 Goliaths into the DNA Infuser. The set bonus includes lava immunity, which now works as expected after the change.

## Changelog

:cl: A.C.M.O.
fix: Fixed the DNA Infuser's Goliaths infusion, which was not properly granting its organ set bonus. Having all 4 goliath organs infused now makes you lava-proof as expected.
/:cl:
