### PR TITLE
Removing an organ from a autosurgeon now correctly updates its overlays + 2 more bonus autosurgeon fixes

### DIFF
--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -123,6 +123,7 @@
 
 		to_chat(user, span_notice("You remove the [stored_organ] from [src]."))
 		screwtool.play_tool_sound(src)
+		update_appearance()
 	return TRUE
 
 /obj/item/autosurgeon/medical_hud

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -119,10 +119,14 @@
 		var/atom/drop_loc = user.drop_location()
 		for(var/atom/movable/stored_implant as anything in src)
 			stored_implant.forceMove(drop_loc)
+			to_chat(user, span_notice("You remove the [stored_organ] from [src]."))
 			stored_organ = null
 
-		to_chat(user, span_notice("You remove the [stored_organ] from [src]."))
 		screwtool.play_tool_sound(src)
+		if (uses)
+			uses--
+		if(uses == 0)
+			desc = "[initial(desc)] Looks like it's been used up."
 		update_appearance()
 	return TRUE
 

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -125,9 +125,9 @@
 		screwtool.play_tool_sound(src)
 		if (uses)
 			uses--
-		if(uses == 0)
+		if(!uses)
 			desc = "[initial(desc)] Looks like it's been used up."
-		update_appearance()
+		update_appearance(UPDATE_ICON)
 	return TRUE
 
 /obj/item/autosurgeon/medical_hud


### PR DESCRIPTION
## About The Pull Request

Removing an organ from an auto-surgeon with a screwdriver didn't call update_appearance() and thus it kept its overlay as if it was full.

BONUS ROUND:

Fixes single use autosurgeons not consuming uses when their implant is removed, this was a bug introduced by #68379
Autosurgeons now actually tell you what organ was removed from them.

## Why It's Good For The Game

Fixes a bug and makes the overlay a trustable marker of if an auto-surgeon is full or not.
Also more bug fixes
## Changelog
:cl:
fix: Autosurgeon overlays now correctly update when removing organs.
fix: Autosurgeons now say what organ is removed from them when screwdrivered.
fix: Single use auto-surgeons cannot be reloaded again.
/:cl:
