### PR TITLE
adds contextual screentip for stealing access with the agent id

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1603,7 +1603,7 @@
 	if(isitem(target))
 		context[SCREENTIP_CONTEXT_RMB] = "Scan for access"
 		return CONTEXTUAL_SCREENTIP_SET
-	return NONE
+	return .
 
 /// A special variant of the classic chameleon ID card which accepts all access.
 /obj/item/card/id/advanced/chameleon/black

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1329,6 +1329,7 @@
 	chameleon_card_action.chameleon_name = "ID Card"
 	chameleon_card_action.initialize_disguises()
 	add_item_action(chameleon_card_action)
+	register_item_context()
 
 /obj/item/card/id/advanced/chameleon/Destroy()
 	theft_target = null
@@ -1592,6 +1593,17 @@
 			set_new_account(user)
 			return
 	return ..()
+
+/obj/item/card/id/advanced/chameleon/add_item_context(obj/item/source, list/context, atom/target, mob/living/user,)
+	. = ..()
+
+	if(ishuman(target))
+		context[SCREENTIP_CONTEXT_RMB] = "Copy access"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(isitem(target))
+		context[SCREENTIP_CONTEXT_RMB] = "Scan for access"
+		return CONTEXTUAL_SCREENTIP_SET
+	return NONE
 
 /// A special variant of the classic chameleon ID card which accepts all access.
 /obj/item/card/id/advanced/chameleon/black

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1597,6 +1597,8 @@
 /obj/item/card/id/advanced/chameleon/add_item_context(obj/item/source, list/context, atom/target, mob/living/user,)
 	. = ..()
 
+	if(!in_range(user, target))
+		return .
 	if(ishuman(target))
 		context[SCREENTIP_CONTEXT_RMB] = "Copy access"
 		return CONTEXTUAL_SCREENTIP_SET


### PR DESCRIPTION
## About The Pull Request

the agent id or chameleon id has a good feature that lets you steal accesses from other people but often people are a bit confused on how, so i've added a item_context screentip that means that when you hover over someone while holding the agent id it will let you know that you can steal accesses with a right mouse button input

similarly, i've added one for when it hovers over any item that says "scan for access" because checking to see if it is an object with an ID inside of it every single time that you hover over any item seems expensive.

## Why It's Good For The Game

screentips are good, if someone has taken your agent id the new action buttons at the top are already giving the game away so it having its own screentips isnt a huge detriment
also prevents people from trying to left mouse click present their illicit id to someone, which while funny, is pretty suspicious!

## Changelog

:cl:
qol: agent id now has screentips when you can attempt to steal access for it
/:cl:

