### PR TITLE
Makes a few previously microwave only cooking options also doable in an oven

### DIFF
--- a/code/game/objects/items/food/cheese.dm
+++ b/code/game/objects/items/food/cheese.dm
@@ -84,6 +84,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 	rat_heal = 35
 
+/obj/item/food/cheese/curd_cheese/make_bakeable()
+	AddComponent(/datum/component/bakeable, /obj/item/food/cheese/cheese_curds, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
+
 /obj/item/food/cheese/curd_cheese/make_microwaveable()
 	AddElement(/datum/element/microwavable, /obj/item/food/cheese/cheese_curds)
 

--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -26,6 +26,9 @@
 	decomp_req_handle = TRUE //so laid eggs can actually become chickens
 	var/static/chick_count = 0 //I copied this from the chicken_count (note the "en" in there) variable from chicken code.
 
+/obj/item/food/egg/make_bakeable()
+	AddComponent(/datum/component/bakeable, /obj/item/food/boiledegg, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
+
 /obj/item/food/egg/make_microwaveable()
 	AddElement(/datum/element/microwavable, /obj/item/food/boiledegg)
 
@@ -33,6 +36,9 @@
 	food_reagents = list(/datum/reagent/consumable/eggrot = 10, /datum/reagent/consumable/mold = 10)
 	foodtypes = GROSS
 	preserved_food = TRUE
+
+/obj/item/food/egg/rotten/make_bakeable()
+	AddComponent(/datum/component/bakeable, /obj/item/food/boiledegg/rotten, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
 
 /obj/item/food/egg/rotten/make_microwaveable()
 	AddElement(/datum/element/microwavable, /obj/item/food/boiledegg/rotten)

--- a/code/game/objects/items/food/packaged.dm
+++ b/code/game/objects/items/food/packaged.dm
@@ -156,6 +156,9 @@
 	/// What type of ready-donk are we warmed into?
 	var/warm_type = /obj/item/food/ready_donk/warm
 
+/obj/item/food/ready_donk/make_bakeable()
+	AddComponent(/datum/component/bakeable, warm_type, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
+
 /obj/item/food/ready_donk/make_microwaveable()
 	AddElement(/datum/element/microwavable, warm_type)
 

--- a/code/game/objects/items/food/salad.dm
+++ b/code/game/objects/items/food/salad.dm
@@ -70,6 +70,9 @@
 	tastes = list("rice" = 1)
 	foodtypes = GRAIN | RAW
 
+/obj/item/food/uncooked_rice/make_bakeable()
+	AddComponent(/datum/component/bakeable, /obj/item/food/boiledrice, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
+
 /obj/item/food/uncooked_rice/make_microwaveable()
 	AddElement(/datum/element/microwavable, /obj/item/food/boiledrice)
 

--- a/code/game/objects/items/food/spaghetti.dm
+++ b/code/game/objects/items/food/spaghetti.dm
@@ -23,6 +23,9 @@
 	icon_state = "spaghetti"
 	tastes = list("pasta" = 1)
 
+/obj/item/food/spaghetti/make_bakeable()
+	AddComponent(/datum/component/bakeable, /obj/item/food/spaghetti/boiledspaghetti, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
+
 /obj/item/food/spaghetti/raw/make_microwaveable()
 	AddElement(/datum/element/microwavable, /obj/item/food/spaghetti/boiledspaghetti)
 

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -300,6 +300,7 @@ GLOBAL_LIST_INIT(sinew_recipes, list ( \
 /obj/item/stack/sheet/wethide/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/microwavable, /obj/item/stack/sheet/leather)
+	AddComponent(/datum/component/bakeable, /obj/item/stack/sheet/leather, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
 
 /obj/item/stack/sheet/wethide/should_atmos_process(datum/gas_mixture/air, exposed_temperature)
 	return (exposed_temperature > drying_threshold_temperature)

--- a/code/modules/hydroponics/grown/aloe.dm
+++ b/code/modules/hydroponics/grown/aloe.dm
@@ -26,5 +26,8 @@
 	juice_results = list(/datum/reagent/consumable/aloejuice = 0)
 	distill_reagent = /datum/reagent/consumable/ethanol/tequila
 
+/obj/item/food/grown/aloe/make_bakeable()
+	AddComponent(/datum/component/bakeable, /obj/item/stack/medical/aloe/fresh, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
+
 /obj/item/food/grown/aloe/make_microwaveable()
 	AddElement(/datum/element/microwavable, /obj/item/stack/medical/aloe/fresh)

--- a/code/modules/hydroponics/grown/onion.dm
+++ b/code/modules/hydroponics/grown/onion.dm
@@ -65,6 +65,9 @@
 	gender = PLURAL
 	w_class = WEIGHT_CLASS_TINY
 
+/obj/item/food/onion_slice/make_bakeable()
+	AddComponent(/datum/component/bakeable, /obj/item/food/onionrings, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
+
 /obj/item/food/onion_slice/make_microwaveable()
 	AddElement(/datum/element/microwavable, /obj/item/food/onionrings)
 


### PR DESCRIPTION

## About The Pull Request

Make the following list of things that can only be cooked in the microwave currently also able to be cooked in an oven:

Uncooked rice
Raw spaghetti

Wet leather (YUM!)

Aloe
Onion slices
Cheese curds
Eggs, rotten or not
Ready donk
## Why It's Good For The Game

We've already got stuff that's microwave-oven interchangeable (donk pockets), sometimes you don't have a microwave and you're just locked out of more than a few recipes because something that could easily be made in an oven isn't coded to be. The simple solution is just not have that be the case.
## Changelog
:cl:
qol: A few recipes that were microwave only (like boiling rice, heating ready donk, so on) can now also be made in an oven
/:cl:
