### PR TITLE
Fixes Honorbound Sect not correctly granting the 'Declare Evil' spell

### DIFF
--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -24,8 +24,8 @@
 
 	//signal that checks for dishonorable attacks
 	RegisterSignal(owner, COMSIG_MOB_CLICKON, PROC_REF(attack_honor))
-	var/datum/action/cooldown/spell/pointed/declare_evil = new(src)
-	declare_evil.Grant(owner)
+	var/datum/action/cooldown/spell/pointed/declare_evil/declare = new(src)
+	declare.Grant(owner)
 	return ..()
 
 /datum/brain_trauma/special/honorbound/on_lose(silent)


### PR DESCRIPTION

## About The Pull Request

Variable was accidentally typecasted to /pointed, not /pointed/declare_evil, and thus granted the base type.

## Why It's Good For The Game

Bugfix

## Changelog
:cl:
fix: Fixes Honorbound Sect not granting the right spell
/:cl:
