### PR TITLE
Adds a warning to view runtimes under extreme circumstances

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -802,7 +802,7 @@
 		if(GLOB.total_runtimes >= 100000)
 			warning = "There are a TON of runtimes, clicking any button (especially \"linear\") WILL LIKELY crash the server"
 		// Not using TGUI alert, because it's view runtimes, stuff is probably broken
-		alert(usr, "[warning]. Proceed with caution.", "HEED THIS WARNING CAREFULLY MORTAL")
+		alert(usr, "[warning]. Proceed with caution. If you really need to see the runtimes, download the runtime log and view it in a text editor.", "HEED THIS WARNING CAREFULLY MORTAL")
 
 /client/proc/pump_random_event()
 	set category = "Debug"

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -795,6 +795,15 @@
 
 	GLOB.error_cache.show_to(src)
 
+	// The runtime viewer has the potential to crash the server if there's a LOT of runtimes
+	// this has happened before, multiple times, so we'll just leave an alert on it
+	if(GLOB.total_runtimes >= 50000) // arbitrary number, I don't know when exactly it happens
+		var/warning = "There are a lot of runtimes, clicking any button (especially \"linear\") can have the potential to lag or crash the server"
+		if(GLOB.total_runtimes >= 100000)
+			warning = "There are a TON of runtimes, clicking any button (especially \"linear\") WILL LIKELY crash the server"
+		// Not using TGUI alert, because it's view runtimes, stuff is probably broken
+		alert(usr, "[warning]. Proceed with caution.", "HEED THIS WARNING CAREFULLY MORTAL")
+
 /client/proc/pump_random_event()
 	set category = "Debug"
 	set name = "Pump Random Event"


### PR DESCRIPTION
## About The Pull Request

View runtimes will warn the user if the server's experience a large amount of runtime errors

![image](https://user-images.githubusercontent.com/51863163/210738346-a8240e96-4138-4fd3-9e53-95b97e6674e7.png)

- Why not fix the runtimes?

We're not perfect
- Why not make the runtime viewer not crash the server?

I don't even know why it does it, someone else can accomplish that

- Why not find the exact threshold which it happens?

That's a waste of an afternoon

- Why not stop them from opening it wholesale?

Seeing the number is still kinda useful

- Admin Issue

Maintainers have crashed servers too 

## Why It's Good For The Game

Maybe admins will stop crashing the game

## Changelog

:cl: Melbert
admin: Adds a warning to "View Runtimes" informing you (yes, you) that it can (and will) crash the server if you attempt to render 100,000 runtimes into the UI at once
/:cl:
