### PR TITLE
Fix Pip for Bootstrap

### DIFF
--- a/tools/bootstrap/python39._pth
+++ b/tools/bootstrap/python39._pth
@@ -1,6 +1,0 @@
-python39.zip
-.
-..\..\..
-
-# Uncomment to run site.main() automatically
-import site

--- a/tools/bootstrap/python39._pth
+++ b/tools/bootstrap/python39._pth
@@ -1,4 +1,4 @@
-python37.zip
+python39.zip
 .
 ..\..\..
 

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -50,7 +50,7 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python37._pth" $PythonDir `
+	Copy-Item "$Bootstrap/python39._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -49,8 +49,13 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
+	$PthVArr = $PythonVersion.Split(".")
+	$PthVStr = "python$($PthVArr[0])$($PthVArr[1])"
+	Write-Output "Generating PATH descriptor."
+	New-Item "$Cache/$PthVStr._pth" | Out-Null
+	Set-Content "$Cache/$PthVStr._pth" "$PthVStr.zip`n.`n..\..\..`nimport site`n"
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Bootstrap/python39._pth" $PythonDir `
+	Copy-Item "$Cache/$PthVStr._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive

--- a/tools/bootstrap/python_.ps1
+++ b/tools/bootstrap/python_.ps1
@@ -49,13 +49,13 @@ if (!(Test-Path $PythonExe -PathType Leaf)) {
 
 	[System.IO.Compression.ZipFile]::ExtractToDirectory($Archive, $PythonDir)
 
-	$PthVArr = $PythonVersion.Split(".")
-	$PthVStr = "python$($PthVArr[0])$($PthVArr[1])"
+	$PythonVersionArray = $PythonVersion.Split(".")
+	$PythonVersionString = "python$($PythonVersionArray[0])$($PythonVersionArray[1])"
 	Write-Output "Generating PATH descriptor."
-	New-Item "$Cache/$PthVStr._pth" | Out-Null
-	Set-Content "$Cache/$PthVStr._pth" "$PthVStr.zip`n.`n..\..\..`nimport site`n"
+	New-Item "$Cache/$PythonVersionString._pth" | Out-Null
+	Set-Content "$Cache/$PythonVersionString._pth" "$PythonVersionString.zip`n.`n..\..\..`nimport site`n"
 	# Copy a ._pth file without "import site" commented, so pip will work
-	Copy-Item "$Cache/$PthVStr._pth" $PythonDir `
+	Copy-Item "$Cache/$PythonVersionString._pth" $PythonDir `
 		-ErrorAction Stop
 
 	Remove-Item $Archive


### PR DESCRIPTION
## YOU NEED TO UPDATE FROM MASTER DELETE YOUR .CACHE DIRECTORY AFTER THIS IS MERGED

Mothblocks forgot to update the bootstrap script to the new python version when they changed the python dependency version

That path descriptor file is now automatically generated during bootstrap, which will prevent this issue from happening again in the future, unless they change the path descriptor format