### PR TITLE
Fixes boring changeling gameplay by making shrieks not work while ventcrawling.

### DIFF
--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -10,6 +10,9 @@
 //A flashy ability, good for crowd control and sowing chaos.
 /datum/action/changeling/resonant_shriek/sting_action(mob/user)
 	..()
+	if(user.movement_type & VENTCRAWLING)
+		to_chat(user, span_notice("We must exit the pipes before we can shriek, otherwise it would just reverberate down the pipes ineffectually!"))
+		return FALSE
 	for(var/mob/living/M in get_hearers_in_view(4, user))
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
@@ -41,6 +44,9 @@
 
 /datum/action/changeling/dissonant_shriek/sting_action(mob/user)
 	..()
+	if(user.movement_type & VENTCRAWLING)
+		to_chat(user, span_notice("We must exit the pipes before we can shriek, otherwise it would just reverberate down the pipes ineffectually!"))
+		return FALSE
 	empulse(get_turf(user), 2, 5, 1)
 	for(var/obj/machinery/light/L in range(5, usr))
 		L.on = TRUE

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -11,7 +11,7 @@
 /datum/action/changeling/resonant_shriek/sting_action(mob/user)
 	..()
 	if(user.movement_type & VENTCRAWLING)
-		to_chat(user, span_notice("We must exit the pipes before we can shriek, otherwise it would just reverberate down the pipes ineffectually!"))
+		user.balloon_alert(user, "can't shriek in pipes!")
 		return FALSE
 	for(var/mob/living/M in get_hearers_in_view(4, user))
 		if(iscarbon(M))
@@ -45,7 +45,7 @@
 /datum/action/changeling/dissonant_shriek/sting_action(mob/user)
 	..()
 	if(user.movement_type & VENTCRAWLING)
-		to_chat(user, span_notice("We must exit the pipes before we can shriek, otherwise it would just reverberate down the pipes ineffectually!"))
+		user.balloon_alert(user, "can't shriek in pipes!")
 		return FALSE
 	empulse(get_turf(user), 2, 5, 1)
 	for(var/obj/machinery/light/L in range(5, usr))


### PR DESCRIPTION
## About The Pull Request

Fixes boring changeling gameplay by making shrieks not work while ventcrawling.

## Why It's Good For The Game

Changelings can just sit in a vent EMPing over and over again. If you cook them with superheated gas in the pipes, they can just revive inside the pipes and start doing it again. This fixes that.

## Changelog
:cl:
fix: Fixes boring changeling gameplay by making shrieks not work while ventcrawling.
/:cl: