### PR TITLE
Fix a runtime in logging

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -336,7 +336,7 @@
 			log_combat(logged_mob, L, "shot", src, "from inside [firing_vehicle][logging_mobs.len > 1 ? " with multiple occupants" : null][reagent_note ? " and contained [reagent_note]" : null]")
 		return BULLET_ACT_HIT
 
-	L.log_message("has been shot by [firer] with [src][reagent_note ? " containing [reagent_note]" : null]", LOG_VICTIM, color="orange")
+	L.log_message("has been shot by [firer] with [src][reagent_note ? " containing [reagent_note]" : null]", LOG_ATTACK, color="orange")
 	return BULLET_ACT_HIT
 
 /obj/projectile/proc/vol_by_damage()


### PR DESCRIPTION
## About The Pull Request
Turns out #72362 created a runtime that put the logs for getting hit by a projectile into LOG_GAME instead of LOG_ATTACK because LOG_VICTIM isn't recognized by log_message.

## Why It's Good For The Game
Fix a runtime I created, oops!

## Changelog

:cl: Tattle
fix: fixed a few things
/:cl: