### PR TITLE
Update stamina in carbon updatehealth

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -518,6 +518,7 @@
 		total_burn += (BP.burn_dam * BP.body_damage_coeff)
 	set_health(round(maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute, DAMAGE_PRECISION))
 	update_stat()
+	update_stamina()
 	if(((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD*2) && stat == DEAD )
 		become_husk(BURN)
 	med_hud_set_health()

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -104,7 +104,6 @@
 /mob/living/carbon/adjustStaminaLoss(amount, updating_stamina, forced, required_biotype)
 	. = ..()
 	if(amount > 0)
-		update_stamina()
 		stam_regen_start_time = world.time + STAMINA_REGEN_BLOCK_TIME
 
 /**

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -28,9 +28,8 @@
 		stop_sound_channel(CHANNEL_HEARTBEAT)
 	else
 
-		if(staminaloss > 0 && stam_regen_start_time <= world.time)
-			adjustStaminaLoss(-INFINITY, null, FALSE)
-			update_stamina()
+		if(getStaminaLoss() > 0 && stam_regen_start_time <= world.time)
+			adjustStaminaLoss(-INFINITY)
 		var/bprv = handle_bodyparts(delta_time, times_fired)
 		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
 			updatehealth()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -317,7 +317,6 @@
 	adjustStaminaLoss(-stamina, FALSE)
 	if(updating_health)
 		updatehealth()
-		update_stamina()
 
 /// damage MANY bodyparts, in random order
 /mob/living/proc/take_overall_damage(brute = 0, burn = 0, stamina = 0, updating_health = TRUE, required_bodytype)
@@ -326,7 +325,6 @@
 	adjustStaminaLoss(stamina, FALSE)
 	if(updating_health)
 		updatehealth()
-		update_stamina()
 
 ///heal up to amount damage, in a given order
 /mob/living/proc/heal_ordered_damage(amount, list/damage_types)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -842,7 +842,7 @@
 	if(heal_flags & HEAL_BURN)
 		setFireLoss(0, FALSE, TRUE)
 	if(heal_flags & HEAL_STAM)
-		setStaminaLoss(0, FALSE, TRUE)
+		setStaminaLoss(0, forced = TRUE) // update stamina now. updatehealth isn't guaranteed to update stamina for us
 
 	// I don't really care to keep this under a flag
 	set_nutrition(NUTRITION_LEVEL_FED + 50)
@@ -2523,4 +2523,3 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	message_admins(span_adminnotice("[key_name_admin(admin)] gave a guardian spirit controlled by [guardian_client || "AI"] to [src]."))
 	log_admin("[key_name(admin)] gave a guardian spirit controlled by [guardian_client] to [src].")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Give Guardian Spirit")
-

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -842,7 +842,7 @@
 	if(heal_flags & HEAL_BURN)
 		setFireLoss(0, FALSE, TRUE)
 	if(heal_flags & HEAL_STAM)
-		setStaminaLoss(0, forced = TRUE) // update stamina now. updatehealth isn't guaranteed to update stamina for us
+		setStaminaLoss(0, FALSE, TRUE)
 
 	// I don't really care to keep this under a flag
 	set_nutrition(NUTRITION_LEVEL_FED + 50)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -737,7 +737,6 @@
 
 	if(owner && need_mob_update) //some of the metabolized reagents had effects on the mob that requires some updates.
 		owner.updatehealth()
-		owner.update_stamina()
 	update_total()
 
 /*
@@ -832,7 +831,6 @@
 		need_mob_update += metabolize_reagent(owner, reagent, delta_time, times_fired, can_overdose = TRUE)
 	if(owner && need_mob_update) //some of the metabolized reagents had effects on the mob that requires some updates.
 		owner.updatehealth()
-		owner.update_stamina()
 	update_total()
 
 /**


### PR DESCRIPTION
## About The Pull Request

`living/updatehealth` calls update stamina, but `carbon/updatehealth` does not. Why? I'm not entirely sure.

But there's some bugs going around with people in infinite stamcrit. I don't 100% know the reproduction steps, just people are yelling at me. This is pretty much solely because `update_stamina` isn't being called when it should. 

Investigating it further, I found that MOST manual update stamina calls could be lumped into updatehealth.

It is, unfortunately, putting more proc calls into updatehealth, which is a shame, because it's pretty hot, but there are a lot of circumstances where people forget and it causes problems. 

## Why It's Good For The Game

Getting stuck in infinite stamcrit is bad. 

## Changelog

:cl: Melbert
fix: People should be stuck in infinite stamcrit less often. 
/:cl: