### PR TITLE
Unwacks immovable rod in hyperspace

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -85,7 +85,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	special_target = specific_target
 	loopy_rod ||= force_looping
 
-	ADD_TRAIT(TRAIT_FREE_HYPERSPACE_MOVEMENT, INNATE_TRAIT)
+	ADD_TRAIT(src, TRAIT_FREE_HYPERSPACE_MOVEMENT, INNATE_TRAIT)
 
 	SSpoints_of_interest.make_point_of_interest(src)
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -85,6 +85,8 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	special_target = specific_target
 	loopy_rod ||= force_looping
 
+	ADD_TRAIT(TRAIT_FREE_HYPERSPACE_MOVEMENT, INNATE_TRAIT)
+
 	SSpoints_of_interest.make_point_of_interest(src)
 
 	RegisterSignal(src, COMSIG_ATOM_ENTERING, PROC_REF(on_entering_atom))


### PR DESCRIPTION
closes #72497

Immovable rods, including wizard, will ignore the hyperspace drift

:cl:
fix: fixes wizard rod form infinitely travelling in hyperspace
/:cl:
