### PR TITLE
Remove tab indent size from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@ root = true
 
 [*]
 indent_style = tab
-indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
We don't allow tab alignment anyway so this serves literally zero purpose. It's not our place to set this kind of requirement in editorconfig. It doesn't even match GitHub's tab size.