### PR TITLE
Adds multiple chat highlights

### DIFF
--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -26,14 +26,14 @@ const saveChatToStorage = async (store) => {
   const messages = chatRenderer.messages
     .slice(fromIndex)
     .map((message) => serializeMessage(message));
-  storage.set('chat-state-cm', state);
-  storage.set('chat-messages-cm', messages);
+  storage.set('chat-state', state);
+  storage.set('chat-messages', messages);
 };
 
 const loadChatFromStorage = async (store) => {
   const [state, messages] = await Promise.all([
-    storage.get('chat-state-cm'),
-    storage.get('chat-messages-cm'),
+    storage.get('chat-state'),
+    storage.get('chat-messages'),
   ]);
   // Discard incompatible versions
   if (state && state.version <= 4) {

--- a/tgui/packages/tgui-panel/chat/replaceInTextNode.js
+++ b/tgui/packages/tgui-panel/chat/replaceInTextNode.js
@@ -7,42 +7,119 @@
 /**
  * Replaces text matching a regular expression with a custom node.
  */
-export const replaceInTextNode = (regex, createNode) => (node) => {
+const regexParseNode = (params) => {
+  const { node, regex, createNode, captureAdjust } = params;
   const text = node.textContent;
   const textLength = text.length;
+  let nodes;
+  let new_node;
   let match;
   let lastIndex = 0;
   let fragment;
   let n = 0;
+  let count = 0;
   // eslint-disable-next-line no-cond-assign
   while ((match = regex.exec(text))) {
     n += 1;
+    // Safety check to prevent permanent
+    // client crashing
+    if (++count > 9999) {
+      return {};
+    }
     // Lazy init fragment
     if (!fragment) {
       fragment = document.createDocumentFragment();
     }
-    const matchText = match[0];
+    // Lazy init nodes
+    if (!nodes) {
+      nodes = [];
+    }
+    const matchText = captureAdjust ? captureAdjust(match[0]) : match[0];
     const matchLength = matchText.length;
-    const matchIndex = match.index;
+    // If matchText is set to be a substring nested within the original
+    // matched text make sure to properly offset the index
+    const matchIndex = match.index + match[0].indexOf(matchText);
     // Insert previous unmatched chunk
     if (lastIndex < matchIndex) {
-      fragment.appendChild(
-        document.createTextNode(text.substring(lastIndex, matchIndex))
-      );
+      new_node = document.createTextNode(text.substring(lastIndex, matchIndex));
+      nodes.push(new_node);
+      fragment.appendChild(new_node);
     }
     lastIndex = matchIndex + matchLength;
     // Create a wrapper node
-    fragment.appendChild(createNode(matchText));
+    new_node = createNode(matchText);
+    nodes.push(new_node);
+    fragment.appendChild(new_node);
   }
   if (fragment) {
     // Insert the remaining unmatched chunk
     if (lastIndex < textLength) {
-      fragment.appendChild(
-        document.createTextNode(text.substring(lastIndex, textLength))
-      );
+      new_node = document.createTextNode(text.substring(lastIndex, textLength));
+      nodes.push(new_node);
+      fragment.appendChild(new_node);
     }
     // Commit the fragment
     node.parentNode.replaceChild(fragment, node);
+  }
+
+  return {
+    nodes: nodes,
+    n: n,
+  };
+};
+
+/**
+ * Replace text of a node with custom nades if they match
+ * a regex expression or are in a word list
+ */
+export const replaceInTextNode = (regex, words, createNode) => (node) => {
+  let nodes;
+  let result;
+  let n = 0;
+
+  if (regex) {
+    result = regexParseNode({
+      node: node,
+      regex: regex,
+      createNode: createNode,
+    });
+    nodes = result.nodes;
+    n += result.n;
+  }
+
+  if (words) {
+    let i = 0;
+    let wordRegexStr = '(';
+    for (let word of words) {
+      // Capture if the word is at the beginning, end, middle,
+      // or by itself in a message
+      wordRegexStr += `^${word}\\W|\\W${word}\\W|\\W${word}$|^${word}$`;
+      // Make sure the last character for the expression is NOT '|'
+      if (++i !== words.length) {
+        wordRegexStr += '|';
+      }
+    }
+    wordRegexStr += ')';
+    const wordRegex = new RegExp(wordRegexStr, 'gi');
+    if (regex && nodes) {
+      for (let a_node of nodes) {
+        result = regexParseNode({
+          node: a_node,
+          regex: wordRegex,
+          createNode: createNode,
+          captureAdjust: (str) => str.replace(/^\W|\W$/g, ''),
+        });
+        n += result.n;
+      }
+    } else {
+      result = regexParseNode({
+        node: node,
+        regex: wordRegex,
+        createNode: createNode,
+        captureAdjust: (str) => str.replace(/^\W|\W$/g, ''),
+      });
+      n += result.n;
+    }
   }
   return n;
 };
@@ -71,6 +148,7 @@ const createHighlightNode = (text) => {
 export const highlightNode = (
   node,
   regex,
+  words,
   createNode = createHighlightNode
 ) => {
   if (!createNode) {
@@ -82,9 +160,9 @@ export const highlightNode = (
     const node = childNodes[i];
     // Is a text node
     if (node.nodeType === 3) {
-      n += replaceInTextNode(regex, createNode)(node);
+      n += replaceInTextNode(regex, words, createNode)(node);
     } else {
-      n += highlightNode(node, regex, createNode);
+      n += highlightNode(node, regex, words, createNode);
     }
   }
   return n;
@@ -118,7 +196,7 @@ export const linkifyNode = (node) => {
   return n;
 };
 
-const linkifyTextNode = replaceInTextNode(URL_REGEX, (text) => {
+const linkifyTextNode = replaceInTextNode(URL_REGEX, null, (text) => {
   const node = document.createElement('a');
   node.href = text;
   node.textContent = text;

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -11,9 +11,9 @@ import { Box, Button, ColorBox, Divider, Dropdown, Flex, Input, LabeledList, Num
 import { ChatPageSettings } from '../chat';
 import { rebuildChat, saveChatToDisk } from '../chat/actions';
 import { THEMES } from '../themes';
-import { changeSettingsTab, updateSettings } from './actions';
-import { FONTS, SETTINGS_TABS } from './constants';
-import { selectActiveTab, selectSettings } from './selectors';
+import { changeSettingsTab, updateSettings, addHighlightSetting, removeHighlightSetting, updateHighlightSetting } from './actions';
+import { SETTINGS_TABS, FONTS, MAX_HIGHLIGHT_SETTINGS } from './constants';
+import { selectActiveTab, selectSettings, selectHighlightSettings, selectHighlightSettingById } from './selectors';
 
 export const SettingsPanel = (props, context) => {
   const activeTab = useSelector(context, selectActiveTab);
@@ -43,22 +43,17 @@ export const SettingsPanel = (props, context) => {
       <Stack.Item grow={1} basis={0}>
         {activeTab === 'general' && <SettingsGeneral />}
         {activeTab === 'chatPage' && <ChatPageSettings />}
+        {activeTab === 'textHighlight' && <TextHighlightSettings />}
       </Stack.Item>
     </Stack>
   );
 };
 
 export const SettingsGeneral = (props, context) => {
-  const {
-    theme,
-    fontFamily,
-    fontSize,
-    lineHeight,
-    highlightText,
-    highlightColor,
-    matchWord,
-    matchCase,
-  } = useSelector(context, selectSettings);
+  const { theme, fontFamily, fontSize, lineHeight } = useSelector(
+    context,
+    selectSettings
+  );
   const dispatch = useDispatch(context);
   const [freeFont, setFreeFont] = useLocalState(context, 'freeFont', false);
   return (
@@ -157,62 +152,41 @@ export const SettingsGeneral = (props, context) => {
         </LabeledList.Item>
       </LabeledList>
       <Divider />
-      <Box>
-        <Flex mb={1} color="label" align="baseline">
-          <Flex.Item grow={1}>Highlight text (comma separated):</Flex.Item>
-          <Flex.Item shrink={0}>
-            <ColorBox mr={1} color={highlightColor} />
-            <Input
-              width="5em"
-              monospace
-              placeholder="#ffffff"
-              value={highlightColor}
-              onInput={(e, value) =>
-                dispatch(
-                  updateSettings({
-                    highlightColor: value,
-                  })
-                )
-              }
+      <Button icon="save" onClick={() => dispatch(saveChatToDisk())}>
+        Save chat log
+      </Button>
+    </Section>
+  );
+};
+
+const TextHighlightSettings = (props, context) => {
+  const highlightSettings = useSelector(context, selectHighlightSettings);
+  const dispatch = useDispatch(context);
+  return (
+    <Section fill scrollable>
+      <Section level={2} p={0}>
+        <Flex direction="column">
+          {highlightSettings.map((id, i) => (
+            <TextHighlightSetting
+              key={i}
+              id={id}
+              mb={i + 1 === highlightSettings.length ? 0 : '10px'}
             />
-          </Flex.Item>
+          ))}
+          {highlightSettings.length < MAX_HIGHLIGHT_SETTINGS && (
+            <Flex.Item>
+              <Button
+                color="transparent"
+                icon="plus"
+                content="Add Highlight Setting"
+                onClick={() => {
+                  dispatch(addHighlightSetting());
+                }}
+              />
+            </Flex.Item>
+          )}
         </Flex>
-        <TextArea
-          height="3em"
-          value={highlightText}
-          onChange={(e, value) =>
-            dispatch(
-              updateSettings({
-                highlightText: value,
-              })
-            )
-          }
-        />
-        <Button.Checkbox
-          checked={matchWord}
-          tooltipPosition="bottom-start"
-          tooltip="Not compatible with punctuation."
-          onClick={() =>
-            dispatch(
-              updateSettings({
-                matchWord: !matchWord,
-              })
-            )
-          }>
-          Match word
-        </Button.Checkbox>
-        <Button.Checkbox
-          checked={matchCase}
-          onClick={() =>
-            dispatch(
-              updateSettings({
-                matchCase: !matchCase,
-              })
-            )
-          }>
-          Match case
-        </Button.Checkbox>
-      </Box>
+      </Section>
       <Divider />
       <Box>
         <Button icon="check" onClick={() => dispatch(rebuildChat())}>
@@ -222,10 +196,110 @@ export const SettingsGeneral = (props, context) => {
           Can freeze the chat for a while.
         </Box>
       </Box>
-      <Divider />
-      <Button icon="save" onClick={() => dispatch(saveChatToDisk())}>
-        Save chat log
-      </Button>
     </Section>
+  );
+};
+
+const TextHighlightSetting = (props, context) => {
+  const { id, ...rest } = props;
+  const highlightSettingById = useSelector(context, selectHighlightSettingById);
+  const dispatch = useDispatch(context);
+  const {
+    highlightColor,
+    highlightText,
+    highlightWholeMessage,
+    matchWord,
+    matchCase,
+  } = highlightSettingById[id];
+  return (
+    <Flex.Item {...rest}>
+      <Flex mb={1} color="label" align="baseline">
+        <Flex.Item grow={1}>
+          <Button
+            content="Highlight words:"
+            color="transparent"
+            icon="times"
+            onClick={() =>
+              dispatch(
+                removeHighlightSetting({
+                  id: id,
+                })
+              )
+            }
+          />
+        </Flex.Item>
+        <Flex.Item shrink={0}>
+          <Button.Checkbox
+            checked={highlightWholeMessage}
+            content="Highlight Whole Message"
+            mr="5px"
+            onClick={() =>
+              dispatch(
+                updateHighlightSetting({
+                  id: id,
+                  highlightWholeMessage: !highlightWholeMessage,
+                })
+              )
+            }
+          />
+          <Button.Checkbox
+            content="Match word"
+            checked={matchWord}
+            tooltipPosition="bottom-start"
+            tooltip="Not compatible with punctuation. Overriden if regex is used."
+            onClick={() =>
+              dispatch(
+                updateHighlightSetting({
+                  id: id,
+                  matchWord: !matchWord,
+                })
+              )
+            }
+          />
+          <Button.Checkbox
+            content="Match case"
+            checked={matchCase}
+            onClick={() =>
+              dispatch(
+                updateHighlightSetting({
+                  id: id,
+                  matchCase: !matchCase,
+                })
+              )
+            }
+          />
+        </Flex.Item>
+        <Flex.Item shrink={0}>
+          <ColorBox mr={1} color={highlightColor} />
+          <Input
+            width="5em"
+            monospace
+            placeholder="#ffffff"
+            value={highlightColor}
+            onInput={(e, value) =>
+              dispatch(
+                updateHighlightSetting({
+                  id: id,
+                  highlightColor: value,
+                })
+              )
+            }
+          />
+        </Flex.Item>
+      </Flex>
+      <TextArea
+        height="3em"
+        value={highlightText}
+        placeholder="Separate terms with commas, i.e. (term1, term2, term3)"
+        onChange={(e, value) =>
+          dispatch(
+            updateHighlightSetting({
+              id: id,
+              highlightText: value,
+            })
+          )
+        }
+      />
+    </Flex.Item>
   );
 };

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -164,7 +164,7 @@ const TextHighlightSettings = (props, context) => {
   const dispatch = useDispatch(context);
   return (
     <Section fill scrollable>
-      <Section level={2} p={0}>
+      <Section p={0}>
         <Flex direction="column">
           {highlightSettings.map((id, i) => (
             <TextHighlightSetting

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -163,7 +163,7 @@ const TextHighlightSettings = (props, context) => {
   const highlightSettings = useSelector(context, selectHighlightSettings);
   const dispatch = useDispatch(context);
   return (
-    <Section fill scrollable>
+    <Section fill scrollable height="200px">
       <Section p={0}>
         <Flex direction="column">
           {highlightSettings.map((id, i) => (
@@ -214,9 +214,9 @@ const TextHighlightSetting = (props, context) => {
   return (
     <Flex.Item {...rest}>
       <Flex mb={1} color="label" align="baseline">
-        <Flex.Item grow={1}>
+        <Flex.Item grow>
           <Button
-            content="Highlight words:"
+            content="Delete"
             color="transparent"
             icon="times"
             onClick={() =>
@@ -228,10 +228,11 @@ const TextHighlightSetting = (props, context) => {
             }
           />
         </Flex.Item>
-        <Flex.Item shrink={0}>
+        <Flex.Item>
           <Button.Checkbox
             checked={highlightWholeMessage}
-            content="Highlight Whole Message"
+            content="Whole Message"
+            tooltip="If this option is selected, the entire message will be highlighted in yellow."
             mr="5px"
             onClick={() =>
               dispatch(
@@ -242,11 +243,13 @@ const TextHighlightSetting = (props, context) => {
               )
             }
           />
+        </Flex.Item>
+        <Flex.Item>
           <Button.Checkbox
-            content="Match word"
+            content="Exact"
             checked={matchWord}
             tooltipPosition="bottom-start"
-            tooltip="Not compatible with punctuation. Overriden if regex is used."
+            tooltip="If this option is selected, only exact matches (no extra letters before or after) will trigger. Not compatible with punctuation. Overriden if regex is used."
             onClick={() =>
               dispatch(
                 updateHighlightSetting({
@@ -256,8 +259,11 @@ const TextHighlightSetting = (props, context) => {
               )
             }
           />
+        </Flex.Item>
+        <Flex.Item>
           <Button.Checkbox
-            content="Match case"
+            content="Case"
+            tooltip="If this option is selected, the highlight will be case-sensitive."
             checked={matchCase}
             onClick={() =>
               dispatch(
@@ -290,7 +296,7 @@ const TextHighlightSetting = (props, context) => {
       <TextArea
         height="3em"
         value={highlightText}
-        placeholder="Separate terms with commas, i.e. (term1, term2, term3)"
+        placeholder="Put words to highlight here. Separate terms with commas, i.e. (term1, term2, term3)"
         onChange={(e, value) =>
           dispatch(
             updateHighlightSetting({

--- a/tgui/packages/tgui-panel/settings/actions.js
+++ b/tgui/packages/tgui-panel/settings/actions.js
@@ -5,9 +5,22 @@
  */
 
 import { createAction } from 'common/redux';
+import { createHighlightSetting } from './model';
 
 export const updateSettings = createAction('settings/update');
 export const loadSettings = createAction('settings/load');
 export const changeSettingsTab = createAction('settings/changeTab');
 export const toggleSettings = createAction('settings/toggle');
 export const openChatSettings = createAction('settings/openChatTab');
+export const addHighlightSetting = createAction(
+  'settings/addHighlightSetting',
+  () => ({
+    payload: createHighlightSetting(),
+  })
+);
+export const removeHighlightSetting = createAction(
+  'settings/removeHighlightSetting'
+);
+export const updateHighlightSetting = createAction(
+  'settings/updateHighlightSetting'
+);

--- a/tgui/packages/tgui-panel/settings/constants.js
+++ b/tgui/packages/tgui-panel/settings/constants.js
@@ -9,6 +9,11 @@ export const SETTINGS_TABS = [
     id: 'general',
     name: 'General',
   },
+
+  {
+    id: 'textHighlight',
+    name: 'Text Highlights',
+  },
   {
     id: 'chatPage',
     name: 'Chat Tabs',
@@ -30,3 +35,5 @@ export const FONTS = [
   'Courier New',
   'Lucida Console',
 ];
+
+export const MAX_HIGHLIGHT_SETTINGS = 10;

--- a/tgui/packages/tgui-panel/settings/middleware.js
+++ b/tgui/packages/tgui-panel/settings/middleware.js
@@ -6,7 +6,7 @@
 
 import { storage } from 'common/storage';
 import { setClientTheme } from '../themes';
-import { loadSettings, updateSettings } from './actions';
+import { loadSettings, updateSettings, addHighlightSetting, removeHighlightSetting, updateHighlightSetting } from './actions';
 import { selectSettings } from './selectors';
 import { FONTS_DISABLED } from './constants';
 
@@ -32,7 +32,13 @@ export const settingsMiddleware = (store) => {
         store.dispatch(loadSettings(settings));
       });
     }
-    if (type === updateSettings.type || type === loadSettings.type) {
+    if (
+      type === updateSettings.type ||
+      type === loadSettings.type ||
+      type === addHighlightSetting.type ||
+      type === removeHighlightSetting.type ||
+      type === updateHighlightSetting.type
+    ) {
       // Set client theme
       const theme = payload?.theme;
       if (theme) {

--- a/tgui/packages/tgui-panel/settings/model.js
+++ b/tgui/packages/tgui-panel/settings/model.js
@@ -1,0 +1,20 @@
+/**
+ * @file
+ */
+import { createUuid } from 'common/uuid';
+
+export const createHighlightSetting = (obj) => ({
+  id: createUuid(),
+  highlightText: '',
+  highlightColor: '#ffdd44',
+  highlightWholeMessage: true,
+  matchWord: false,
+  matchCase: false,
+  ...obj,
+});
+
+export const createDefaultHighlightSetting = (obj) =>
+  createHighlightSetting({
+    id: 'default',
+    ...obj,
+  });

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -4,8 +4,11 @@
  * @license MIT
  */
 
-import { changeSettingsTab, loadSettings, openChatSettings, toggleSettings, updateSettings } from './actions';
-import { FONTS, SETTINGS_TABS } from './constants';
+import { changeSettingsTab, loadSettings, openChatSettings, toggleSettings, updateSettings, addHighlightSetting, removeHighlightSetting, updateHighlightSetting } from './actions';
+import { createDefaultHighlightSetting } from './model';
+import { SETTINGS_TABS, FONTS, MAX_HIGHLIGHT_SETTINGS } from './constants';
+
+const defaultHighlightSetting = createDefaultHighlightSetting();
 
 const initialState = {
   version: 1,
@@ -14,10 +17,14 @@ const initialState = {
   lineHeight: 1.2,
   theme: 'light',
   adminMusicVolume: 0.5,
+  // Keep these two state vars for compatibility with other servers
   highlightText: '',
   highlightColor: '#ffdd44',
-  matchWord: false,
-  matchCase: false,
+  // END compatibility state vars
+  highlightSettings: [defaultHighlightSetting.id],
+  highlightSettingById: {
+    [defaultHighlightSetting.id]: defaultHighlightSetting,
+  },
   view: {
     visible: false,
     activeTab: SETTINGS_TABS[0].id,
@@ -37,11 +44,34 @@ export const settingsReducer = (state = initialState, action) => {
     if (!payload?.version) {
       return state;
     }
+
     delete payload.view;
-    return {
+    const nextState = {
       ...state,
       ...payload,
     };
+    // Lazy init the list for compatibility reasons
+    if (!nextState.highlightSettings) {
+      nextState.highlightSettings = [defaultHighlightSetting.id];
+      nextState.highlightSettingById[defaultHighlightSetting.id] =
+        defaultHighlightSetting;
+    }
+    // Compensating for mishandling of default highlight settings
+    else if (!nextState.highlightSettingById[defaultHighlightSetting.id]) {
+      nextState.highlightSettings = [
+        defaultHighlightSetting.id,
+        ...nextState.highlightSettings,
+      ];
+      nextState.highlightSettingById[defaultHighlightSetting.id] =
+        defaultHighlightSetting;
+    }
+    // Update the highlight settings for default highlight
+    // settings compatibility
+    const highlightSetting =
+      nextState.highlightSettingById[defaultHighlightSetting.id];
+    highlightSetting.highlightColor = nextState.highlightColor;
+    highlightSetting.highlightText = nextState.highlightText;
+    return nextState;
   }
   if (type === toggleSettings.type) {
     return {
@@ -71,6 +101,75 @@ export const settingsReducer = (state = initialState, action) => {
         activeTab: tabId,
       },
     };
+  }
+  if (type === addHighlightSetting.type) {
+    const highlightSetting = payload;
+    if (state.highlightSettings.length >= MAX_HIGHLIGHT_SETTINGS) {
+      return state;
+    }
+    return {
+      ...state,
+      highlightSettings: [...state.highlightSettings, highlightSetting.id],
+      highlightSettingById: {
+        ...state.highlightSettingById,
+        [highlightSetting.id]: highlightSetting,
+      },
+    };
+  }
+  if (type === removeHighlightSetting.type) {
+    const { id } = payload;
+    const nextState = {
+      ...state,
+      highlightSettings: [...state.highlightSettings],
+      highlightSettingById: {
+        ...state.highlightSettingById,
+      },
+    };
+    if (id === defaultHighlightSetting.id) {
+      nextState.highlightSettings[defaultHighlightSetting.id] =
+        defaultHighlightSetting;
+    } else {
+      delete nextState.highlightSettingById[id];
+      nextState.highlightSettings = nextState.highlightSettings.filter(
+        (sid) => sid !== id
+      );
+      if (!nextState.highlightSettings.length) {
+        nextState.highlightSettings.push(defaultHighlightSetting.id);
+        nextState.highlightSettingById[defaultHighlightSetting.id] =
+          defaultHighlightSetting;
+      }
+    }
+    return nextState;
+  }
+  if (type === updateHighlightSetting.type) {
+    const { id, ...settings } = payload;
+    const nextState = {
+      ...state,
+      highlightSettings: [...state.highlightSettings],
+      highlightSettingById: {
+        ...state.highlightSettingById,
+      },
+    };
+
+    // Transfer this data from the default highlight setting
+    // so they carry over to other servers
+    if (id === defaultHighlightSetting.id) {
+      if (settings.highlightText) {
+        nextState.highlightText = settings.highlightText;
+      }
+      if (settings.highlightColor) {
+        nextState.highlightColor = settings.highlightColor;
+      }
+    }
+
+    if (nextState.highlightSettingById[id]) {
+      nextState.highlightSettingById[id] = {
+        ...nextState.highlightSettingById[id],
+        ...settings,
+      };
+    }
+
+    return nextState;
   }
   return state;
 };

--- a/tgui/packages/tgui-panel/settings/selectors.js
+++ b/tgui/packages/tgui-panel/settings/selectors.js
@@ -6,3 +6,7 @@
 
 export const selectSettings = (state) => state.settings;
 export const selectActiveTab = (state) => state.settings.view.activeTab;
+export const selectHighlightSettings = (state) =>
+  state.settings.highlightSettings;
+export const selectHighlightSettingById = (state) =>
+  state.settings.highlightSettingById;


### PR DESCRIPTION

## About The Pull Request
This PR is a CM port from https://github.com/cmss13-devs/cmss13/pull/2162 and https://github.com/cmss13-devs/cmss13/pull/2214

allows you to make up to 10 unique chat highlights, toggle if they highlight the whole message, and you can use regex in them!

![image](https://user-images.githubusercontent.com/66756236/211043329-463bde95-ecad-4cf3-b7c5-9fb5c50be74a.png)


## Why It's Good For The Game
makes the chat highlight system much more versatile with multiple highlights and regex

makes it more subtle, if you want, by toggling off the whole message highlighting

## Changelog
:cl: stanalbatross, thedonkified
add: added the ability to make up to 10 individual highlights in tgchat, customise their colours, and toggle if they highlight the whole message or not. Ported from CM.
add: you can now use regex for text highlighting. The syntax is /[regex expression]/, eg /dog[0-9]/. There are no quantifiers, but you can use capture groups. The regex must read a minimum of two characters.
/:cl:
