### PR TITLE
PORT: Sparks and lasers no longer count towards turf's lumcount value

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -10,6 +10,9 @@
 ///Is a movable light source attached to another movable (its loc), meaning that the lighting component should go one level deeper.
 #define LIGHT_ATTACHED (1<<0)
 
+///This light doesn't affect turf's lumcount calculations. Set to 1<<15 to ignore conflicts
+#define LIGHT_NO_LUMCOUNT (1<<15)
+
 //Bay lighting engine shit, not in /code/modules/lighting because BYOND is being shit about it
 /// frequency, in 1/10ths of a second, of the lighting process
 #define LIGHTING_INTERVAL       5

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -435,7 +435,7 @@
 	else // Lost the [LIGHT_ATTACHED] property
 		overlay_lighting_flags &= ~LIGHTING_ATTACHED
 		set_parent_attached_to(null)
-	if(new_value & LIGHT_NO_LUMCOUNT)
+	if(old_flags & LIGHT_NO_LUMCOUNT)
 		if(!(movable_parent.light_flags & LIGHT_NO_LUMCOUNT)) //Gained the NO_LUMCOUNT property
 			overlay_lighting_flags |= LIGHT_NO_LUMCOUNT
 			//Recalculate affecting

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -20,6 +20,7 @@
 	light_range = 2
 	light_power = 0.5
 	light_color = LIGHT_COLOR_FIRE
+	light_flags = LIGHT_NO_LUMCOUNT
 
 /obj/effect/particle_effect/sparks/Initialize(mapload)
 	..()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -13,6 +13,7 @@
 	light_range = 1
 	light_power = 1
 	light_color = COLOR_SOFT_RED
+	light_flags = LIGHT_NO_LUMCOUNT
 	ricochets_max = 50 //Honk!
 	ricochet_chance = 80
 	reflectable = REFLECT_NORMAL


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/BeeStation/BeeStation-Hornet/pull/6092

all credit to original PR author I just copy pasted

## Why It's Good For The Game

Same reasoning as described in the original PR, figured id port it over

as a bonus, sparks wont interfere either with things that need darkness so thats nice

fun fact nightmare has a mechanic to dodge projectiles in the dark, but since lasers acted as a light source this bassicly didnt work. fixes that

![nightdodge](https://user-images.githubusercontent.com/36102060/211061471-11f888b1-ef83-4a1f-8739-f7d766b35be8.gif)


## Changelog
:cl: PowerfulBacon
code: Overlay light sources can be set to not count towards get_lumcount calculations
code: Lasers and sparks no longer count towards get_lumcount calculations.
balance: Nightmares will now dodge lasers
/:cl:
