### PR TITLE
You can use right click microwaves again.

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -328,7 +328,7 @@
 		if(!length(ingredients))
 			balloon_alert(user, "it's empty!")
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		cook()
+		cook(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/microwave/ui_interact(mob/user)


### PR DESCRIPTION
## About The Pull Request

I noticed this while testing something locally, ``cook()`` on secondary attack was never setting user, so checking for TRAIT_CURSED on them would runtime.

## Why It's Good For The Game

When the machine interaction works!

## Changelog

:cl:
fix: You can right-click microwaves again.
/:cl: