### PR TITLE
Allows Panic Bunker Interview Window To Be Closed

### DIFF
--- a/tgui/packages/tgui/interfaces/Interview.js
+++ b/tgui/packages/tgui/interfaces/Interview.js
@@ -50,7 +50,10 @@ export const Interview = (props, context) => {
   };
 
   return (
-    <Window width={500} height={600} canClose={is_admin}>
+    <Window
+      width={500}
+      height={600}
+      canClose={is_admin || status === 'interview_approved'}>
       <Window.Content scrollable>
         {(!read_only && (
           <Section title="Welcome!">


### PR DESCRIPTION
## About The Pull Request

Allows players who have their interview approved to close out the interview window, because otherwise it's a fucked thing that you can't close even after you get reconnected to the server after five seconds.

![image](https://user-images.githubusercontent.com/34697715/211100231-c97284e7-feee-4dcc-8882-ae50695eff44.png)

this was a webedit because my git was fucked due to the python bootstrapping thing

## Why It's Good For The Game

Closes #71752

Let's be nice to the new people, no?

## Changelog
:cl:
fix: New players connecting via an active Panic Bunker Interview System can now close out the window once they have their interview approved by an admin.
/:cl:
