### PR TITLE
Hilbert tram caller button links to Hilbert tram

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -1448,7 +1448,8 @@
 /obj/structure/table/reinforced/rglass,
 /obj/machinery/button/tram{
 	id = "right_part_hilbert";
-	pixel_y = 4
+	pixel_y = 4;
+	lift_id = "tram_hilbert"
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/72518
## Changelog
:cl: LT3
fix: Hilbert's tram call button is now linked to the correct tram
/:cl:
