### PR TITLE
Basic Mob Refactor and Bad Pattern Avoidance: Removes Temp and Atmos and Sentience type vars, enforces considering them

### DIFF
--- a/code/__DEFINES/basic_mobs.dm
+++ b/code/__DEFINES/basic_mobs.dm
@@ -12,4 +12,4 @@
 #define NO_SENTIENCE_POSSIBILITY (1<<5)
 
 /// typical atmos requirements you'd expect most mobs who have atmos requirements at all to have.
-#define BASIC_ATMOS_REQUIREMENTS list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
+#define BASIC_ATMOS_REQUIREMENTS string_assoc_list(list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0))

--- a/code/__DEFINES/basic_mobs.dm
+++ b/code/__DEFINES/basic_mobs.dm
@@ -12,4 +12,4 @@
 #define NO_SENTIENCE_POSSIBILITY (1<<5)
 
 /// typical atmos requirements you'd expect most mobs who have atmos requirements at all to have.
-#define BASIC_ATMOS_REQUIREMENTS string_assoc_list(list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0))
+GLOBAL_LIST_INIT(basic_atmos_requirements, string_assoc_list(list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)))

--- a/code/__DEFINES/basic_mobs.dm
+++ b/code/__DEFINES/basic_mobs.dm
@@ -8,8 +8,16 @@
 #define NO_ATMOS_REQUIREMENTS (1<<3)
 /// fails unit tests if the mob has no temperature limits yet doesn't have this flag
 #define NO_TEMP_SENSITIVITY (1<<4)
-/// fails unit tests if the mob has no possibility of sentience yet doesn't have this flag
-#define NO_SENTIENCE_POSSIBILITY (1<<5)
 
 /// typical atmos requirements you'd expect most mobs who have atmos requirements at all to have.
 GLOBAL_LIST_INIT(basic_atmos_requirements, string_assoc_list(list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)))
+
+/// this proc must be inherited or basic_mob_flags has a flag to bypass. used to ensure people don't forget things like atmos requirements.
+#define MUST_INHERIT_OR_FLAG(issue, flag) \
+	do { \
+		SHOULD_CALL_PARENT(FALSE); \
+		if(basic_mob_flags & flag) { \
+			return \
+		}; \
+		CRASH("[issue] unconsidered! Either flag it as exempt or inherit the [issue] proc."); \
+	} while (0)

--- a/code/__DEFINES/basic_mobs.dm
+++ b/code/__DEFINES/basic_mobs.dm
@@ -4,4 +4,12 @@
 #define DEL_ON_DEATH (1<<0)
 #define FLIP_ON_DEATH (1<<1)
 #define UNDENSIFY_ON_DEATH (1<<2)
+/// fails unit tests if the mob has no atmos requirements yet doesn't have this flag
+#define NO_ATMOS_REQUIREMENTS (1<<3)
+/// fails unit tests if the mob has no temperature limits yet doesn't have this flag
+#define NO_TEMP_SENSITIVITY (1<<4)
+/// fails unit tests if the mob has no possibility of sentience yet doesn't have this flag
+#define NO_SENTIENCE_POSSIBILITY (1<<5)
 
+/// typical atmos requirements you'd expect most mobs who have atmos requirements at all to have.
+#define BASIC_ATMOS_REQUIREMENTS list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -46,6 +46,12 @@
 ///from base of element/bane/activate(): (item/weapon, mob/user)
 #define COMSIG_LIVING_BANED "living_baned"
 
+/// from /obj/item/slimepotion/slime/sentience/attack(): (datum/target, obj/sentience_source, sentience_biotypes, mob/user, try_sentience)
+#define COMSIG_LIVING_SENTIENCEPOTION "living_sentiencepotion"
+/// from base of /obj/item/slimepotion/slime/sentience/proc/try_sentience(): (datum/source, mob/possible_creator)
+/// specifically when guaranteed to be sentient
+#define COMSIG_LIVING_GIVEN_SENTIENCE "living_sentiencepotioned"
+
 /// from base of mob/living/updatehealth()
 #define COMSIG_LIVING_HEALTH_UPDATE "living_health_update"
 ///from base of mob/living/death(): (gibbed)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -316,13 +316,6 @@
 #define SLIME_FRIENDSHIP_STAY 3 //Min friendship to order it to stay
 #define SLIME_FRIENDSHIP_ATTACK 8 //Min friendship to order it to attack
 
-//Sentience types, to prevent things like sentience potions from giving bosses sentience
-#define SENTIENCE_ORGANIC 1
-#define SENTIENCE_ARTIFICIAL 2
-#define SENTIENCE_HUMANOID 3
-#define SENTIENCE_MINEBOT 4
-#define SENTIENCE_BOSS 5
-
 //Mob AI Status
 #define POWER_RESTORATION_OFF 0
 #define POWER_RESTORATION_START 1

--- a/code/datums/elements/atmos_requirements.dm
+++ b/code/datums/elements/atmos_requirements.dm
@@ -20,9 +20,6 @@
 	src.atmos_requirements = atmos_requirements
 	src.unsuitable_atmos_damage = unsuitable_atmos_damage
 	RegisterSignal(target, COMSIG_LIVING_HANDLE_BREATHING, PROC_REF(on_non_stasis_life))
-	#ifdef UNIT_TESTS
-	ADD_TRAIT(target, TRAIT_UNIT_TESTS(/datum/element/atmos_requirements), TRAIT_SOURCE_UNIT_TESTS)
-	#endif
 
 /datum/element/atmos_requirements/Detach(datum/target)
 	. = ..()

--- a/code/datums/elements/atmos_requirements.dm
+++ b/code/datums/elements/atmos_requirements.dm
@@ -20,6 +20,9 @@
 	src.atmos_requirements = atmos_requirements
 	src.unsuitable_atmos_damage = unsuitable_atmos_damage
 	RegisterSignal(target, COMSIG_LIVING_HANDLE_BREATHING, PROC_REF(on_non_stasis_life))
+	#ifdef UNIT_TESTS
+	ADD_TRAIT(target, TRAIT_UNIT_TESTS(/datum/element/atmos_requirements), TRAIT_SOURCE_UNIT_TESTS)
+	#endif
 
 /datum/element/atmos_requirements/Detach(datum/target)
 	. = ..()

--- a/code/datums/elements/basic_body_temp_sensitive.dm
+++ b/code/datums/elements/basic_body_temp_sensitive.dm
@@ -32,9 +32,6 @@
 		src.heat_damage = heat_damage
 
 	RegisterSignal(target, COMSIG_LIVING_LIFE, PROC_REF(on_life))
-	#ifdef UNIT_TESTS
-	ADD_TRAIT(target, TRAIT_UNIT_TESTS(/datum/element/basic_body_temp_sensitive), TRAIT_SOURCE_UNIT_TESTS)
-	#endif
 
 /datum/element/basic_body_temp_sensitive/Detach(datum/source)
 	if(source)

--- a/code/datums/elements/basic_body_temp_sensitive.dm
+++ b/code/datums/elements/basic_body_temp_sensitive.dm
@@ -32,6 +32,9 @@
 		src.heat_damage = heat_damage
 
 	RegisterSignal(target, COMSIG_LIVING_LIFE, PROC_REF(on_life))
+	#ifdef UNIT_TESTS
+	ADD_TRAIT(target, TRAIT_UNIT_TESTS(/datum/element/basic_body_temp_sensitive), TRAIT_SOURCE_UNIT_TESTS)
+	#endif
 
 /datum/element/basic_body_temp_sensitive/Detach(datum/source)
 	if(source)

--- a/code/datums/elements/sentience_possible.dm
+++ b/code/datums/elements/sentience_possible.dm
@@ -16,9 +16,6 @@
 	var/mob/living/living_target = target
 	biotypes = living_target.mob_biotypes
 	RegisterSignal(target, COMSIG_LIVING_SENTIENCEPOTION, PROC_REF(on_sentiencepotion))
-	#ifdef UNIT_TESTS
-	ADD_TRAIT(target, TRAIT_UNIT_TESTS(/datum/element/sentience_possible), TRAIT_SOURCE_UNIT_TESTS)
-	#endif
 
 /datum/element/sentience_possible/Detach(datum/target)
 	if(target)

--- a/code/datums/elements/sentience_possible.dm
+++ b/code/datums/elements/sentience_possible.dm
@@ -1,0 +1,33 @@
+/**
+ * ### Sentience possible element!
+ *
+ * Makes a mob sentient when a sentience item is used on them and it's of the correct biotype
+ */
+/datum/element/sentience_possible
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	///sentience for robots won't work on organic creatures. this biotype from the mob is checked with the sentience biotype
+	var/biotypes
+
+/datum/element/sentience_possible/Attach(datum/target)
+	. = ..()
+	if(!isliving(target))
+		return ELEMENT_INCOMPATIBLE
+	var/mob/living/living_target = target
+	biotypes = living_target.mob_biotypes
+	RegisterSignal(target, COMSIG_LIVING_SENTIENCEPOTION, PROC_REF(on_sentiencepotion))
+	#ifdef UNIT_TESTS
+	ADD_TRAIT(target, TRAIT_UNIT_TESTS(/datum/element/sentience_possible), TRAIT_SOURCE_UNIT_TESTS)
+	#endif
+
+/datum/element/sentience_possible/Detach(datum/target)
+	if(target)
+		UnregisterSignal(target, COMSIG_LIVING_SENTIENCEPOTION)
+	return ..()
+
+/datum/element/sentience_possible/proc/on_sentiencepotion(datum/target, obj/sentience_source, sentience_biotypes, mob/user, try_sentience)
+	SIGNAL_HANDLER
+	if(!(biotypes & sentience_biotypes))
+		to_chat(user, span_warning("[sentience_source] won't work on [target]."))
+		return
+	INVOKE_ASYNC(try_sentience, user, target)

--- a/code/modules/events/ghost_role/sentience.dm
+++ b/code/modules/events/ghost_role/sentience.dm
@@ -89,7 +89,8 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 
 		SA.grant_all_languages(TRUE, FALSE, FALSE)
 
-		SA.sentience_act()
+		//no user, which is why sentiencepotioned should be checking for that
+		SEND_SIGNAL(SA, COMSIG_LIVING_GIVEN_SENTIENCE, null)
 
 		SA.maxHealth = max(SA.maxHealth, 200)
 		SA.health = SA.maxHealth

--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -23,7 +23,7 @@
 	///Injector malf?
 	var/malfunctioning = FALSE
 	///So you can't revive boss monsters or robots with it
-	var/revive_type = SENTIENCE_ORGANIC
+	var/rejected_biotypes = MOB_EPIC|MOB_ROBOTIC
 
 /obj/item/lazarus_injector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
@@ -34,7 +34,7 @@
 		return
 
 	var/mob/living/simple_animal/target_animal = target
-	if(target_animal.sentience_type != revive_type)
+	if(target_animal.mob_biotypes & rejected_biotypes)
 		to_chat(user, span_info("[src] does not work on this sort of creature."))
 		return
 	if(target_animal.stat != DEAD)

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -27,7 +27,6 @@
 	attack_verb_continuous = "drills"
 	attack_verb_simple = "drill"
 	attack_sound = 'sound/weapons/circsawhit.ogg'
-	sentience_type = SENTIENCE_MINEBOT
 	speak_emote = list("states")
 	wanted_objects = list(/obj/item/stack/ore/diamond, /obj/item/stack/ore/gold, /obj/item/stack/ore/silver,
 						  /obj/item/stack/ore/plasma, /obj/item/stack/ore/uranium, /obj/item/stack/ore/iron,
@@ -43,7 +42,7 @@
 
 /mob/living/simple_animal/hostile/mining_drone/Initialize(mapload)
 	. = ..()
-
+	AddElement(/datum/element/sentience_possible)
 	AddElement(/datum/element/footstep, FOOTSTEP_OBJ_ROBOT, 1, -6, sound_vary = TRUE)
 
 	stored_gun = new(src)
@@ -63,13 +62,15 @@
 
 	SetCollectBehavior()
 
+	RegisterSignal(src, COMSIG_LIVING_GIVEN_SENTIENCE, PROC_REF(on_sentience_potioned))
+
 /mob/living/simple_animal/hostile/mining_drone/Destroy()
 	QDEL_NULL(stored_gun)
 	for (var/datum/action/innate/minedrone/action in actions)
 		qdel(action)
 	return ..()
 
-/mob/living/simple_animal/hostile/mining_drone/sentience_act()
+/mob/living/simple_animal/hostile/mining_drone/on_sentience_potioned(datum/source, mob/possible_creator)
 	..()
 	check_friendly_fire = 0
 
@@ -307,11 +308,16 @@
 	desc = "Can be used to grant sentience to minebots. It's incompatible with minebot armor and melee upgrades, and will override them."
 	icon_state = "door_electronics"
 	icon = 'icons/obj/module.dmi'
-	sentience_type = SENTIENCE_MINEBOT
 	var/base_health_add = 5 //sentient minebots are penalized for beign sentient; they have their stats reset to normal plus these values
 	var/base_damage_add = 1 //this thus disables other minebot upgrades
 	var/base_speed_add = 1
 	var/base_cooldown_add = 10 //base cooldown isn't reset to normal, it's just added on, since it's not practical to disable the cooldown module
+
+/obj/item/slimepotion/slime/sentience/mining/attack(mob/living/dumb_mob, mob/user)
+	if(!istype(dumb_mob, /mob/living/simple_animal/hostile/mining_drone))
+		balloon_alert(user, "only works on minebots!")
+		return
+	. = ..()
 
 /obj/item/slimepotion/slime/sentience/mining/after_success(mob/living/user, mob/living/simple_animal/simple_mob)
 	if(!istype(simple_mob, /mob/living/simple_animal/hostile/mining_drone))

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -97,11 +97,18 @@
 
 	if(speak_emote)
 		speak_emote = string_list(speak_emote)
-	add_environment_elements()
+	add_atmos_element()
+	add_temp_sensitivity_element()
+	if(!(status_flags & GODMODE)) //don't let people possess godmode stuff like ghost of poly
+		AddElement(/datum/element/sentience_possible)
 
-/// Proc for adding/overriding temperature and atmos elements, as a lot of mobs have spaceworthy subtypes. **Do not call parent!**
-/mob/living/basic/proc/add_environment_elements()
-	SHOULD_CALL_PARENT(FALSE)
+/// Wrapper for adding/overriding atmos requirements element. **Do not call parent!**
+/mob/living/basic/proc/add_atmos_element()
+	MUST_INHERIT_OR_FLAG("atmos requirements", NO_ATMOS_REQUIREMENTS)
+
+/// Wrapper for adding/overriding temperature element. **Do not call parent!**
+/mob/living/basic/proc/add_temp_sensitivity_element()
+	MUST_INHERIT_OR_FLAG("temp sensitivity", NO_TEMP_SENSITIVITY)
 
 /mob/living/basic/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -97,10 +97,10 @@
 
 	if(speak_emote)
 		speak_emote = string_list(speak_emote)
-	AddEnvironmentElements()
+	add_environment_elements()
 
 /// Proc for adding/overriding temperature and atmos elements, as a lot of mobs have spaceworthy subtypes. **Do not call parent!**
-/mob/living/basic/proc/AddEnvironmentElements()
+/mob/living/basic/proc/add_environment_elements()
 	SHOULD_CALL_PARENT(FALSE)
 
 /mob/living/basic/Life(delta_time = SSMOBS_DT, times_fired)

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -80,22 +80,6 @@
 
 	///If the mob can be spawned with a gold slime core. HOSTILE_SPAWN are spawned with plasma, FRIENDLY_SPAWN are spawned with blood.
 	var/gold_core_spawnable = NO_SPAWN
-	///Sentience type, for slime potions. SHOULD BE AN ELEMENT BUT I DONT CARE ABOUT IT FOR NOW
-	var/sentience_type = SENTIENCE_ORGANIC
-
-	///Leaving something at 0 means it's off - has no maximum.
-	var/list/habitable_atmos = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
-	///This damage is taken when atmos doesn't fit all the requirements above. Set to 0 to avoid adding the atmos_requirements element.
-	var/unsuitable_atmos_damage = 1
-
-	///Minimal body temperature without receiving damage
-	var/minimum_survivable_temperature = 250
-	///Maximal body temperature without receiving damage
-	var/maximum_survivable_temperature = 350
-	///This damage is taken when the body temp is too cold. Set both this and unsuitable_heat_damage to 0 to avoid adding the basic_body_temp_sensitive element.
-	var/unsuitable_cold_damage = 1
-	///This damage is taken when the body temp is too hot. Set both this and unsuitable_cold_damage to 0 to avoid adding the basic_body_temp_sensitive element.
-	var/unsuitable_heat_damage = 1
 
 /mob/living/basic/Initialize(mapload)
 	. = ..()
@@ -113,14 +97,11 @@
 
 	if(speak_emote)
 		speak_emote = string_list(speak_emote)
+	AddEnvironmentElements()
 
-	if(unsuitable_atmos_damage != 0)
-		//String assoc list returns a cached list, so this is like a static list to pass into the element below.
-		habitable_atmos = string_assoc_list(habitable_atmos)
-		AddElement(/datum/element/atmos_requirements, habitable_atmos, unsuitable_atmos_damage)
-
-	if(unsuitable_cold_damage != 0 && unsuitable_heat_damage != 0)
-		AddElement(/datum/element/basic_body_temp_sensitive, minimum_survivable_temperature, maximum_survivable_temperature, unsuitable_cold_damage, unsuitable_heat_damage)
+/// Proc for adding/overriding temperature and atmos elements, as a lot of mobs have spaceworthy subtypes. **Do not call parent!**
+/mob/living/basic/proc/AddEnvironmentElements()
+	SHOULD_CALL_PARENT(FALSE)
 
 /mob/living/basic/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()

--- a/code/modules/mob/living/basic/farm_animals/rabbit.dm
+++ b/code/modules/mob/living/basic/farm_animals/rabbit.dm
@@ -31,8 +31,6 @@
 	attack_verb_continuous = "kicks"
 	attack_verb_simple = "kick"
 	butcher_results = list(/obj/item/food/meat/slab = 1)
-	unsuitable_cold_damage = 0.5 // Cold damage is 0.5 here to account for low health on the rabbit.
-	unsuitable_heat_damage = 0.5 // Heat damage is 0.5 here to account for low health on the rabbit.
 	ai_controller = /datum/ai_controller/basic_controller/rabbit
 	/// passed to animal_varity as the prefix icon.
 	var/icon_prefix = "rabbit"
@@ -44,6 +42,10 @@
 	AddElement(/datum/element/animal_variety, icon_prefix, pick("brown", "black", "white"), TRUE)
 	if(prob(20)) // bunny
 		name = "bunny"
+
+/mob/living/basic/rabbit/AddEnvironmentElements()
+	AddElement(/datum/element/atmos_requirements, BASIC_ATMOS_REQUIREMENTS, 1)
+	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 0.5, 0.5)
 
 /datum/ai_controller/basic_controller/rabbit
 	blackboard = list(
@@ -102,14 +104,14 @@
 	icon_dead = "space_rabbit_white_dead"
 	icon_prefix = "space_rabbit"
 	ai_controller = /datum/ai_controller/basic_controller/rabbit/easter/space
-	unsuitable_atmos_damage = 0 // Zero because we are meant to survive in space.
-	minimum_survivable_temperature = 0 // Minimum Allowable Body Temp, zero because we are meant to survive in space and we have a fucking RABBIT SPACE MASK.
-	maximum_survivable_temperature = 1500 // Maximum Allowable Body Temp, 1500 because we might overheat and die in said RABBIT SPACE MASK.
-	unsuitable_cold_damage = 0 // Zero because we are meant to survive in space.
+
+/mob/living/basic/rabbit/easter/space/AddEnvironmentElements()
+	//no atmos, suspiciously high temperature to take damage
+	AddElement(/datum/element/basic_body_temp_sensitive, 0, 1500, 0, 0.5)
 
 /datum/ai_controller/basic_controller/rabbit/easter/space
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/random_speech/rabbit/easter/space,
 		/datum/ai_planning_subtree/find_nearest_thing_which_attacked_me_to_flee,
 		/datum/ai_planning_subtree/flee_target,
-		)
+	)

--- a/code/modules/mob/living/basic/farm_animals/rabbit.dm
+++ b/code/modules/mob/living/basic/farm_animals/rabbit.dm
@@ -43,8 +43,10 @@
 	if(prob(20)) // bunny
 		name = "bunny"
 
-/mob/living/basic/rabbit/add_environment_elements()
+/mob/living/basic/rabbit/add_atmos_element()
 	AddElement(/datum/element/atmos_requirements, GLOB.basic_atmos_requirements, 1)
+
+/mob/living/basic/rabbit/add_temp_sensitivity_element()
 	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 0.5, 0.5)
 
 /datum/ai_controller/basic_controller/rabbit
@@ -105,8 +107,12 @@
 	icon_prefix = "space_rabbit"
 	ai_controller = /datum/ai_controller/basic_controller/rabbit/easter/space
 
-/mob/living/basic/rabbit/easter/space/add_environment_elements()
-	//no atmos, suspiciously high temperature to take damage
+/mob/living/basic/rabbit/easter/space/add_atmos_element()
+	//no atmos
+	return
+
+/mob/living/basic/rabbit/easter/space/add_temp_sensitivity_element()
+	//far greater temp ranges and can survive space
 	AddElement(/datum/element/basic_body_temp_sensitive, 0, 1500, 0, 0.5)
 
 /datum/ai_controller/basic_controller/rabbit/easter/space

--- a/code/modules/mob/living/basic/farm_animals/rabbit.dm
+++ b/code/modules/mob/living/basic/farm_animals/rabbit.dm
@@ -43,8 +43,8 @@
 	if(prob(20)) // bunny
 		name = "bunny"
 
-/mob/living/basic/rabbit/AddEnvironmentElements()
-	AddElement(/datum/element/atmos_requirements, BASIC_ATMOS_REQUIREMENTS, 1)
+/mob/living/basic/rabbit/add_environment_elements()
+	AddElement(/datum/element/atmos_requirements, GLOB.basic_atmos_requirements, 1)
 	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 0.5, 0.5)
 
 /datum/ai_controller/basic_controller/rabbit
@@ -105,7 +105,7 @@
 	icon_prefix = "space_rabbit"
 	ai_controller = /datum/ai_controller/basic_controller/rabbit/easter/space
 
-/mob/living/basic/rabbit/easter/space/AddEnvironmentElements()
+/mob/living/basic/rabbit/easter/space/add_environment_elements()
 	//no atmos, suspiciously high temperature to take damage
 	AddElement(/datum/element/basic_body_temp_sensitive, 0, 1500, 0, 0.5)
 

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -3,9 +3,6 @@
 
 	combat_mode = TRUE
 	faction = list("mining")
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = 0
-	maximum_survivable_temperature = INFINITY
 
 /mob/living/basic/mining/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/basic/pets/dog.dm
+++ b/code/modules/mob/living/basic/pets/dog.dm
@@ -52,8 +52,8 @@
 	AddElement(/datum/element/befriend_petting, tamed_reaction = "%SOURCE% licks at %TARGET% in a friendly manner!", untamed_reaction = "%SOURCE% fixes %TARGET% with a look of betrayal.")
 	AddComponent(/datum/component/obeys_commands, pet_commands)
 
-/mob/living/basic/pet/dog/AddEnvironmentElements()
-	AddElement(/datum/element/atmos_requirements, BASIC_ATMOS_REQUIREMENTS, 1)
+/mob/living/basic/pet/dog/add_environment_elements()
+	AddElement(/datum/element/atmos_requirements, GLOB.basic_atmos_requirements, 1)
 	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 1, 1)
 
 /mob/living/basic/pet/dog/proc/update_dog_speech(datum/ai_planning_subtree/random_speech/speech)
@@ -749,7 +749,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	. = ..()
 	ADD_TRAIT(src, TRAIT_AI_BAGATTACK, INNATE_TRAIT)
 
-/mob/living/basic/pet/dog/corgi/puppy/void/AddEnvironmentElements()
+/mob/living/basic/pet/dog/corgi/puppy/void/add_environment_elements()
 	//no atmos sensitivity, very cold temp range
 	AddElement(/datum/element/basic_body_temp_sensitive, TCMB, T0C + 40, 1, 1)
 

--- a/code/modules/mob/living/basic/pets/dog.dm
+++ b/code/modules/mob/living/basic/pets/dog.dm
@@ -52,6 +52,10 @@
 	AddElement(/datum/element/befriend_petting, tamed_reaction = "%SOURCE% licks at %TARGET% in a friendly manner!", untamed_reaction = "%SOURCE% fixes %TARGET% with a look of betrayal.")
 	AddComponent(/datum/component/obeys_commands, pet_commands)
 
+/mob/living/basic/pet/dog/AddEnvironmentElements()
+	AddElement(/datum/element/atmos_requirements, BASIC_ATMOS_REQUIREMENTS, 1)
+	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 1, 1)
+
 /mob/living/basic/pet/dog/proc/update_dog_speech(datum/ai_planning_subtree/random_speech/speech)
 	speech.speak = string_list(list("YAP", "Woof!", "Bark!", "AUUUUUU"))
 	speech.emote_hear = string_list(list("barks!", "woofs!", "yaps.","pants."))
@@ -740,13 +744,14 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	icon_dead = "void_puppy_dead"
 	nofur = TRUE
 	held_state = "void_puppy"
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = TCMB
-	maximum_survivable_temperature = T0C + 40
 
 /mob/living/basic/pet/dog/corgi/puppy/void/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_AI_BAGATTACK, INNATE_TRAIT)
+
+/mob/living/basic/pet/dog/corgi/puppy/void/AddEnvironmentElements()
+	//no atmos sensitivity, very cold temp range
+	AddElement(/datum/element/basic_body_temp_sensitive, TCMB, T0C + 40, 1, 1)
 
 /mob/living/basic/pet/dog/corgi/puppy/void/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)
 	return 1 //Void puppies can navigate space.

--- a/code/modules/mob/living/basic/pets/dog.dm
+++ b/code/modules/mob/living/basic/pets/dog.dm
@@ -52,8 +52,10 @@
 	AddElement(/datum/element/befriend_petting, tamed_reaction = "%SOURCE% licks at %TARGET% in a friendly manner!", untamed_reaction = "%SOURCE% fixes %TARGET% with a look of betrayal.")
 	AddComponent(/datum/component/obeys_commands, pet_commands)
 
-/mob/living/basic/pet/dog/add_environment_elements()
+/mob/living/basic/pet/dog/add_atmos_element()
 	AddElement(/datum/element/atmos_requirements, GLOB.basic_atmos_requirements, 1)
+
+/mob/living/basic/pet/dog/add_temp_sensitivity_element()
 	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 1, 1)
 
 /mob/living/basic/pet/dog/proc/update_dog_speech(datum/ai_planning_subtree/random_speech/speech)
@@ -749,8 +751,12 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	. = ..()
 	ADD_TRAIT(src, TRAIT_AI_BAGATTACK, INNATE_TRAIT)
 
-/mob/living/basic/pet/dog/corgi/puppy/void/add_environment_elements()
-	//no atmos sensitivity, very cold temp range
+/mob/living/basic/pet/dog/corgi/puppy/void/add_atmos_element()
+	//no atmos sensitivity
+	return
+
+/mob/living/basic/pet/dog/corgi/puppy/void/add_temp_sensitivity_element()
+	//very cold temp range
 	AddElement(/datum/element/basic_body_temp_sensitive, TCMB, T0C + 40, 1, 1)
 
 /mob/living/basic/pet/dog/corgi/puppy/void/Process_Spacemove(movement_dir = 0, continuous_move = FALSE)

--- a/code/modules/mob/living/basic/ruin_defender/stickman.dm
+++ b/code/modules/mob/living/basic/ruin_defender/stickman.dm
@@ -16,15 +16,16 @@
 	attack_sound = 'sound/weapons/punch1.ogg'
 	combat_mode = TRUE
 	faction = list("stickman")
-	unsuitable_atmos_damage = 7.5
-	unsuitable_cold_damage = 7.5
-	unsuitable_heat_damage = 7.5
 
 	ai_controller = /datum/ai_controller/basic_controller/stickman
 
 /mob/living/basic/stickman/Initialize(mapload)
 	. = ..()
 	new /obj/effect/temp_visual/paper_scatter(get_turf(src))
+	// i will never understand why this mob has atmos requirements on a space ruin
+	// which lets people blatantly cheese it but whatever
+	AddElement(/datum/element/atmos_requirements, BASIC_ATMOS_REQUIREMENTS, 7.5)
+	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 7.5, 7.5)
 
 /datum/ai_controller/basic_controller/stickman
 	blackboard = list(

--- a/code/modules/mob/living/basic/ruin_defender/stickman.dm
+++ b/code/modules/mob/living/basic/ruin_defender/stickman.dm
@@ -24,7 +24,7 @@
 	new /obj/effect/temp_visual/paper_scatter(get_turf(src))
 	// i will never understand why this mob has atmos requirements on a space ruin
 	// which lets people blatantly cheese it but whatever
-	AddElement(/datum/element/atmos_requirements, BASIC_ATMOS_REQUIREMENTS, 7.5)
+	AddElement(/datum/element/atmos_requirements, GLOB.basic_atmos_requirements, 7.5)
 	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 7.5, 7.5)
 
 /datum/ai_controller/basic_controller/stickman

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -18,6 +18,7 @@
 	icon_living = "base"
 	icon_dead = "base_dead"
 	icon_gib = "carp_gib"
+	basic_mob_flags = NO_ATMOS_REQUIREMENTS
 	gold_core_spawnable = HOSTILE_SPAWN
 	mob_biotypes = MOB_ORGANIC | MOB_BEAST
 	movement_type = FLYING
@@ -40,9 +41,6 @@
 	butcher_results = list(/obj/item/food/fishmeat/carp = 2, /obj/item/stack/sheet/animalhide/carp = 1)
 	greyscale_config = /datum/greyscale_config/carp
 	ai_controller = /datum/ai_controller/basic_controller/carp
-	habitable_atmos = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	minimum_survivable_temperature = 0
-	maximum_survivable_temperature = 1500
 
 	/// Cytology cells you can swab from this creature
 	var/cell_line = CELL_LINE_TABLE_CARP
@@ -100,6 +98,9 @@
 		on_tamed(tamer, FALSE)
 	else
 		AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/meat), tame_chance = 10, bonus_tame_chance = 5, after_tame = CALLBACK(src, PROC_REF(on_tamed)))
+
+/mob/living/basic/carp/AddEnvironmentElements()
+	AddElement(/datum/element/basic_body_temp_sensitive, 0, 1500, 0, 1)
 
 /// Tell the elements and the blackboard what food we want to eat
 /mob/living/basic/carp/proc/setup_eating()

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -99,7 +99,10 @@
 	else
 		AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/meat), tame_chance = 10, bonus_tame_chance = 5, after_tame = CALLBACK(src, PROC_REF(on_tamed)))
 
-/mob/living/basic/carp/add_environment_elements()
+/mob/living/basic/carp/add_atmos_element()
+	return
+
+/mob/living/basic/carp/add_temp_sensitivity_element()
 	AddElement(/datum/element/basic_body_temp_sensitive, 0, 1500, 0, 1)
 
 /// Tell the elements and the blackboard what food we want to eat

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -99,7 +99,7 @@
 	else
 		AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/meat), tame_chance = 10, bonus_tame_chance = 5, after_tame = CALLBACK(src, PROC_REF(on_tamed)))
 
-/mob/living/basic/carp/AddEnvironmentElements()
+/mob/living/basic/carp/add_environment_elements()
 	AddElement(/datum/element/basic_body_temp_sensitive, 0, 1500, 0, 1)
 
 /// Tell the elements and the blackboard what food we want to eat

--- a/code/modules/mob/living/basic/syndicate/syndicate.dm
+++ b/code/modules/mob/living/basic/syndicate/syndicate.dm
@@ -14,7 +14,6 @@
 	icon_dead = "syndicate_dead"
 	icon_gib = "syndicate_gib"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	maxHealth = 100
 	health = 100
 	basic_mob_flags = DEL_ON_DEATH
@@ -26,12 +25,9 @@
 	attack_verb_simple = "punch"
 	attack_sound = 'sound/weapons/punch1.ogg'
 	combat_mode = TRUE
-	unsuitable_atmos_damage = 7.5
-	unsuitable_cold_damage = 7.5
-	unsuitable_heat_damage = 7.5
 	faction = list(ROLE_SYNDICATE)
 	ai_controller = /datum/ai_controller/basic_controller/syndicate
-	
+
 	var/loot = list(/obj/effect/mob_spawn/corpse/human/syndicatesoldier)
 
 /mob/living/basic/syndicate/Initialize(mapload)
@@ -39,16 +35,23 @@
 	if(LAZYLEN(loot))
 		AddElement(/datum/element/death_drops, loot)
 	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_SHOE)
+	AddElement(/datum/element/sentience_possible)
+
+/mob/living/basic/syndicate/AddEnvironmentElements()
+	AddElement(/datum/element/atmos_requirements, BASIC_ATMOS_REQUIREMENTS, 7.5)
+	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 7.5, 7.5)
 
 /mob/living/basic/syndicate/space
 	icon_state = "syndicate_space"
 	icon_living = "syndicate_space"
 	name = "Syndicate Commando"
+	basic_mob_flags = NO_ATMOS_REQUIREMENTS | NO_TEMP_SENSITIVITY
 	maxHealth = 170
 	health = 170
 	loot = list(/obj/effect/gibspawner/human)
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = 0
+
+/mob/living/basic/syndicate/space/AddEnvironmentElements()
+	return
 
 /mob/living/basic/syndicate/space/Initialize(mapload)
 	. = ..()
@@ -84,10 +87,12 @@
 	icon_state = "syndicate_space_knife"
 	icon_living = "syndicate_space_knife"
 	name = "Syndicate Commando"
+	basic_mob_flags = NO_ATMOS_REQUIREMENTS | NO_TEMP_SENSITIVITY
 	maxHealth = 170
 	health = 170
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = 0
+
+/mob/living/basic/syndicate/melee/space/AddEnvironmentElements()
+	return
 
 /mob/living/basic/syndicate/melee/space/Initialize(mapload)
 	. = ..()
@@ -121,10 +126,9 @@
 	icon_state = "syndicate_space_sword"
 	icon_living = "syndicate_space_sword"
 	name = "Syndicate Commando"
+	basic_mob_flags = NO_ATMOS_REQUIREMENTS | NO_TEMP_SENSITIVITY
 	maxHealth = 170
 	health = 170
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = 0
 	projectile_deflect_chance = 50
 	var/obj/effect/light_emitter/red_energy_sword/sord
 
@@ -133,6 +137,10 @@
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	sord = new(src)
 	set_light(4)
+
+/mob/living/basic/syndicate/melee/sword/space/AddEnvironmentElements()
+	return
+
 /mob/living/basic/syndicate/melee/sword/space/Destroy()
 	QDEL_NULL(sord)
 	return ..()
@@ -167,15 +175,17 @@
 	icon_state = "syndicate_space_pistol"
 	icon_living = "syndicate_space_pistol"
 	name = "Syndicate Commando"
+	basic_mob_flags = NO_ATMOS_REQUIREMENTS | NO_TEMP_SENSITIVITY
 	maxHealth = 170
 	health = 170
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = 0
 
 /mob/living/basic/syndicate/ranged/space/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	set_light(4)
+
+/mob/living/basic/syndicate/ranged/space/AddEnvironmentElements()
+	return
 
 /mob/living/basic/syndicate/ranged/space/stormtrooper
 	icon_state = "syndicate_stormtrooper_pistol"
@@ -199,15 +209,17 @@
 	icon_state = "syndicate_space_smg"
 	icon_living = "syndicate_space_smg"
 	name = "Syndicate Commando"
+	basic_mob_flags = NO_ATMOS_REQUIREMENTS | NO_TEMP_SENSITIVITY
 	maxHealth = 170
 	health = 170
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = 0
 
 /mob/living/basic/syndicate/ranged/smg/space/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	set_light(4)
+
+/mob/living/basic/syndicate/ranged/smg/space/AddEnvironmentElements()
+	return
 
 /mob/living/basic/syndicate/ranged/smg/space/stormtrooper
 	icon_state = "syndicate_stormtrooper_smg"
@@ -226,16 +238,18 @@
 	icon_state = "syndicate_space_shotgun"
 	icon_living = "syndicate_space_shotgun"
 	name = "Syndicate Commando"
+	basic_mob_flags = NO_ATMOS_REQUIREMENTS | NO_TEMP_SENSITIVITY
 	maxHealth = 170
 	health = 170
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = 0
 	speed = 1
 
 /mob/living/basic/syndicate/ranged/shotgun/space/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	set_light(4)
+
+/mob/living/basic/syndicate/ranged/shotgun/space/AddEnvironmentElements()
+	return
 
 /mob/living/basic/syndicate/ranged/shotgun/space/stormtrooper
 	icon_state = "syndicate_stormtrooper_shotgun"
@@ -254,11 +268,7 @@
 	pass_flags = PASSTABLE | PASSMOB
 	combat_mode = TRUE
 	mob_biotypes = MOB_ROBOTIC
-	basic_mob_flags = DEL_ON_DEATH
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = 0
-	maximum_survivable_temperature = 700
-	unsuitable_cold_damage = 0
+	basic_mob_flags = DEL_ON_DEATH | NO_ATMOS_REQUIREMENTS
 	health = 25
 	maxHealth = 25
 	melee_damage_lower = 15
@@ -284,3 +294,7 @@
 	. = ..()
 	AddElement(/datum/element/simple_flying)
 	AddComponent(/datum/component/swarming)
+
+/mob/living/basic/viscerator/AddEnvironmentElements()
+	//no atmos requirements, can burn
+	AddElement(/datum/element/basic_body_temp_sensitive, 0, 700, 0, 1)

--- a/code/modules/mob/living/basic/syndicate/syndicate.dm
+++ b/code/modules/mob/living/basic/syndicate/syndicate.dm
@@ -35,10 +35,11 @@
 	if(LAZYLEN(loot))
 		AddElement(/datum/element/death_drops, loot)
 	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_SHOE)
-	AddElement(/datum/element/sentience_possible)
 
-/mob/living/basic/syndicate/add_environment_elements()
+/mob/living/basic/syndicate/add_atmos_element()
 	AddElement(/datum/element/atmos_requirements, GLOB.basic_atmos_requirements, 7.5)
+
+/mob/living/basic/syndicate/add_temp_sensitivity_element()
 	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 7.5, 7.5)
 
 /mob/living/basic/syndicate/space
@@ -50,7 +51,10 @@
 	health = 170
 	loot = list(/obj/effect/gibspawner/human)
 
-/mob/living/basic/syndicate/space/add_environment_elements()
+/mob/living/basic/syndicate/space/add_atmos_element()
+	return
+
+/mob/living/basic/syndicate/space/add_temp_sensitivity_element()
 	return
 
 /mob/living/basic/syndicate/space/Initialize(mapload)
@@ -91,7 +95,10 @@
 	maxHealth = 170
 	health = 170
 
-/mob/living/basic/syndicate/melee/space/add_environment_elements()
+/mob/living/basic/syndicate/melee/space/add_atmos_element()
+	return
+
+/mob/living/basic/syndicate/melee/space/add_temp_sensitivity_element()
 	return
 
 /mob/living/basic/syndicate/melee/space/Initialize(mapload)
@@ -138,7 +145,10 @@
 	sord = new(src)
 	set_light(4)
 
-/mob/living/basic/syndicate/melee/sword/space/add_environment_elements()
+/mob/living/basic/syndicate/melee/sword/space/add_atmos_element()
+	return
+
+/mob/living/basic/syndicate/melee/sword/space/space/add_temp_sensitivity_element()
 	return
 
 /mob/living/basic/syndicate/melee/sword/space/Destroy()
@@ -184,7 +194,10 @@
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	set_light(4)
 
-/mob/living/basic/syndicate/ranged/space/add_environment_elements()
+/mob/living/basic/syndicate/ranged/space/add_atmos_element()
+	return
+
+/mob/living/basic/syndicate/ranged/space/add_temp_sensitivity_element()
 	return
 
 /mob/living/basic/syndicate/ranged/space/stormtrooper
@@ -218,7 +231,10 @@
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	set_light(4)
 
-/mob/living/basic/syndicate/ranged/smg/space/add_environment_elements()
+/mob/living/basic/syndicate/ranged/smg/space/add_atmos_element()
+	return
+
+/mob/living/basic/syndicate/ranged/smg/space/add_temp_sensitivity_element()
 	return
 
 /mob/living/basic/syndicate/ranged/smg/space/stormtrooper
@@ -248,7 +264,10 @@
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	set_light(4)
 
-/mob/living/basic/syndicate/ranged/shotgun/space/add_environment_elements()
+/mob/living/basic/syndicate/ranged/shotgun/space/add_atmos_element()
+	return
+
+/mob/living/basic/syndicate/ranged/shotgun/space/add_temp_sensitivity_element()
 	return
 
 /mob/living/basic/syndicate/ranged/shotgun/space/stormtrooper
@@ -295,6 +314,8 @@
 	AddElement(/datum/element/simple_flying)
 	AddComponent(/datum/component/swarming)
 
-/mob/living/basic/viscerator/add_environment_elements()
-	//no atmos requirements, can burn
+/mob/living/basic/viscerator/add_atmos_element()
+	return
+
+/mob/living/basic/viscerator/add_temp_sensitivity_element()
 	AddElement(/datum/element/basic_body_temp_sensitive, 0, 700, 0, 1)

--- a/code/modules/mob/living/basic/syndicate/syndicate.dm
+++ b/code/modules/mob/living/basic/syndicate/syndicate.dm
@@ -37,8 +37,8 @@
 	AddElement(/datum/element/footstep, footstep_type = FOOTSTEP_MOB_SHOE)
 	AddElement(/datum/element/sentience_possible)
 
-/mob/living/basic/syndicate/AddEnvironmentElements()
-	AddElement(/datum/element/atmos_requirements, BASIC_ATMOS_REQUIREMENTS, 7.5)
+/mob/living/basic/syndicate/add_environment_elements()
+	AddElement(/datum/element/atmos_requirements, GLOB.basic_atmos_requirements, 7.5)
 	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 7.5, 7.5)
 
 /mob/living/basic/syndicate/space
@@ -50,7 +50,7 @@
 	health = 170
 	loot = list(/obj/effect/gibspawner/human)
 
-/mob/living/basic/syndicate/space/AddEnvironmentElements()
+/mob/living/basic/syndicate/space/add_environment_elements()
 	return
 
 /mob/living/basic/syndicate/space/Initialize(mapload)
@@ -91,7 +91,7 @@
 	maxHealth = 170
 	health = 170
 
-/mob/living/basic/syndicate/melee/space/AddEnvironmentElements()
+/mob/living/basic/syndicate/melee/space/add_environment_elements()
 	return
 
 /mob/living/basic/syndicate/melee/space/Initialize(mapload)
@@ -138,7 +138,7 @@
 	sord = new(src)
 	set_light(4)
 
-/mob/living/basic/syndicate/melee/sword/space/AddEnvironmentElements()
+/mob/living/basic/syndicate/melee/sword/space/add_environment_elements()
 	return
 
 /mob/living/basic/syndicate/melee/sword/space/Destroy()
@@ -184,7 +184,7 @@
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	set_light(4)
 
-/mob/living/basic/syndicate/ranged/space/AddEnvironmentElements()
+/mob/living/basic/syndicate/ranged/space/add_environment_elements()
 	return
 
 /mob/living/basic/syndicate/ranged/space/stormtrooper
@@ -218,7 +218,7 @@
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	set_light(4)
 
-/mob/living/basic/syndicate/ranged/smg/space/AddEnvironmentElements()
+/mob/living/basic/syndicate/ranged/smg/space/add_environment_elements()
 	return
 
 /mob/living/basic/syndicate/ranged/smg/space/stormtrooper
@@ -248,7 +248,7 @@
 	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
 	set_light(4)
 
-/mob/living/basic/syndicate/ranged/shotgun/space/AddEnvironmentElements()
+/mob/living/basic/syndicate/ranged/shotgun/space/add_environment_elements()
 	return
 
 /mob/living/basic/syndicate/ranged/shotgun/space/stormtrooper
@@ -295,6 +295,6 @@
 	AddElement(/datum/element/simple_flying)
 	AddComponent(/datum/component/swarming)
 
-/mob/living/basic/viscerator/AddEnvironmentElements()
+/mob/living/basic/viscerator/add_environment_elements()
 	//no atmos requirements, can burn
 	AddElement(/datum/element/basic_body_temp_sensitive, 0, 700, 0, 1)

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -25,10 +25,6 @@
 	basic_mob_flags = DEL_ON_DEATH
 	faction = list("hostile", FACTION_MAINT_CREATURES)
 
-	unsuitable_atmos_damage = 0
-	minimum_survivable_temperature = 270
-	maximum_survivable_temperature = INFINITY
-
 	ai_controller = /datum/ai_controller/basic_controller/cockroach
 
 	var/cockroach_cell_line = CELL_LINE_TABLE_COCKROACH

--- a/code/modules/mob/living/basic/vermin/frog.dm
+++ b/code/modules/mob/living/basic/vermin/frog.dm
@@ -35,8 +35,6 @@
 	worn_slot_flags = ITEM_SLOT_HEAD
 	head_icon = 'icons/mob/clothing/head/pets_head.dmi'
 
-	habitable_atmos = list("min_oxy" = 3, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 15, "min_co2" = 0, "max_co2" = 15, "min_n2" = 0, "max_n2" = 0)
-
 	ai_controller = /datum/ai_controller/basic_controller/frog
 
 	var/stepped_sound = 'sound/effects/huuu.ogg'
@@ -66,6 +64,8 @@
 	AddElement(/datum/element/venomous, poison_type, poison_per_bite)
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_FROG, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
+	AddElement(/datum/element/atmos_requirements, list("min_oxy" = 3, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 15, "min_co2" = 0, "max_co2" = 15, "min_n2" = 0, "max_n2" = 0), 1)
+	AddElement(/datum/element/basic_body_temp_sensitive, 250, 350, 1, 1)
 
 /mob/living/basic/frog/proc/on_entered(datum/source, AM as mob|obj)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -13,7 +13,6 @@
 	maxbodytemp = INFINITY
 	minbodytemp = 0
 	has_unlimited_silicon_privilege = TRUE
-	sentience_type = SENTIENCE_ARTIFICIAL
 	status_flags = NONE //no default canpush
 	pass_flags = PASSFLAPS
 	verb_say = "states"
@@ -194,6 +193,8 @@
 
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_BOTS_GLITCHED))
 		randomize_language_if_on_station()
+	AddElement(/datum/element/sentience_possible)
+	RegisterSignal(src, COMSIG_LIVING_GIVEN_SENTIENCE, PROC_REF(on_sentience_potioned))
 
 /mob/living/simple_animal/bot/Destroy()
 	if(path_hud)
@@ -1029,7 +1030,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 	if(paicard && (!client || stat == DEAD))
 		ejectpai(0)
 
-/mob/living/simple_animal/bot/sentience_act()
+/mob/living/simple_animal/bot/on_sentience_potioned(datum/source, mob/possible_creator)
+	..()
 	faction -= "silicon"
 
 /mob/living/simple_animal/bot/proc/set_path(list/newpath)

--- a/code/modules/mob/living/simple_animal/friendly/robot_customer.dm
+++ b/code/modules/mob/living/simple_animal/friendly/robot_customer.dm
@@ -13,7 +13,6 @@
 	AIStatus = AI_OFF
 	del_on_death = TRUE
 	mob_biotypes = MOB_ROBOTIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_ARTIFICIAL
 	ai_controller = /datum/ai_controller/robot_customer
 	unsuitable_atmos_damage = 0
 	minbodytemp = 0
@@ -21,12 +20,12 @@
 	var/clothes_set = "amerifat_clothes"
 	var/datum/atom_hud/hud_to_show_on_hover
 
-
 /mob/living/simple_animal/robot_customer/Initialize(mapload, datum/customer_data/customer_data = /datum/customer_data/american, datum/venue/attending_venue = SSrestaurant.all_venues[/datum/venue/restaurant])
 	ADD_TRAIT(src, TRAIT_NOMOBSWAP, INNATE_TRAIT) //dont push me bitch
 	ADD_TRAIT(src, TRAIT_NO_TELEPORT, INNATE_TRAIT) //dont teleport me bitch
 	ADD_TRAIT(src, TRAIT_STRONG_GRABBER, INNATE_TRAIT) //strong arms bitch
 	AddElement(/datum/element/footstep, FOOTSTEP_OBJ_ROBOT, 1, -6, sound_vary = TRUE)
+	AddElement(/datum/element/sentience_possible)
 	var/datum/customer_data/customer_info = SSrestaurant.all_customers[customer_data]
 	clothes_set = pick(customer_info.clothing_sets)
 	ai_controller = customer_info.ai_controller_used

--- a/code/modules/mob/living/simple_animal/friendly/trader.dm
+++ b/code/modules/mob/living/simple_animal/friendly/trader.dm
@@ -45,7 +45,6 @@
 	combat_mode = TRUE
 	move_resist = MOVE_FORCE_STRONG
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	speed = 0
 	stat_attack = HARD_CRIT
 	robust_searching = TRUE

--- a/code/modules/mob/living/simple_animal/heretic_monsters.dm
+++ b/code/modules/mob/living/simple_animal/heretic_monsters.dm
@@ -140,7 +140,6 @@
 	pull_force = MOVE_FORCE_OVERPOWERING
 	movement_type = GROUND
 	mob_size = MOB_SIZE_HUGE
-	sentience_type = SENTIENCE_BOSS
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	mob_biotypes = MOB_ORGANIC|MOB_EPIC
 	obj_damage = 200

--- a/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
@@ -5,7 +5,6 @@
 	stat_attack = HARD_CRIT
 	status_flags = 0
 	combat_mode = TRUE
-	sentience_type = SENTIENCE_BOSS
 	gender = NEUTER
 	var/list/boss_abilities = list() //list of /datum/action/boss
 	var/datum/boss_active_timed_battle/atb

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -21,7 +21,6 @@
 	attack_sound = 'sound/weapons/circsawhit.ogg'
 	combat_mode = TRUE
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	loot = list(/obj/effect/mob_spawn/corpse/human/cat_butcher, /obj/item/circular_saw)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 7.5
@@ -29,6 +28,10 @@
 	check_friendly_fire = 1
 	status_flags = CANPUSH
 	del_on_death = 1
+
+/mob/living/simple_animal/hostile/cat_butcherer/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/cat_butcherer/AttackingTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
@@ -23,7 +23,6 @@
 	aggro_vision_range = 9
 	turns_per_move = 5
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	faction = list(ROLE_WIZARD)
 	footstep_type = FOOTSTEP_MOB_SHOE
 	weather_immunities = list(TRAIT_LAVA_IMMUNE, TRAIT_ASHSTORM_IMMUNE)
@@ -32,6 +31,10 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	loot = list(/obj/effect/decal/remains/human)
 	del_on_death = TRUE
+
+/mob/living/simple_animal/hostile/dark_wizard/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sentience_possible)
 
 /obj/projectile/temp/earth_bolt
 	name = "earth bolt"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -4,7 +4,6 @@
 	health = 1000
 	maxHealth = 1000
 	combat_mode = TRUE
-	sentience_type = SENTIENCE_BOSS
 	environment_smash = ENVIRONMENT_SMASH_RWALLS
 	mob_biotypes = MOB_ORGANIC|MOB_EPIC
 	obj_damage = 400

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
@@ -21,7 +21,6 @@
 	throw_message = "passes through the smokey body of"
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
-	sentience_type = SENTIENCE_BOSS
 	layer = LARGE_MOB_LAYER
 	plane = GAME_PLANE_UPPER_FOV_HIDDEN
 	var/mob/living/set_target

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -19,7 +19,6 @@
 	stat_attack = HARD_CRIT
 	layer = LARGE_MOB_LAYER
 	plane = GAME_PLANE_UPPER_FOV_HIDDEN
-	sentience_type = SENTIENCE_BOSS
 	var/chosen_attack = 1
 	var/list/attack_action_types = list()
 	var/can_talk = FALSE
@@ -212,7 +211,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	playsound(loc,'sound/effects/phasein.ogg', 200, 0, 50, TRUE, TRUE)
 	if(boosted)
 		mychild.key = elitemind.key
-		mychild.sentience_act()
+		SEND_SIGNAL(mychild, COMSIG_LIVING_GIVEN_SENTIENCE, null)
 		notify_ghosts("\A [mychild] has been awakened in \the [get_area(src)]!", source = mychild, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Lavaland Elite awakened")
 	mychild.log_message("has been awakened by [key_name(activator)]!", LOG_GAME, color="#960000")
 	icon_state = "tumor_popped"
@@ -367,7 +366,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	. = ..()
 	if(istype(target, /mob/living/simple_animal/hostile/asteroid/elite) && proximity_flag)
 		var/mob/living/simple_animal/hostile/asteroid/elite/E = target
-		if(E.stat != DEAD || E.sentience_type != SENTIENCE_BOSS || !E.key)
+		if(E.stat != DEAD || !(E.mob_biotypes & MOB_EPIC) || !E.key)
 			user.visible_message(span_notice("It appears [E] is unable to be revived right now.  Perhaps try again later."))
 			return
 		E.faction = list("[REF(user)]")
@@ -379,7 +378,6 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		E.maxHealth = E.maxHealth * 0.4
 		E.health = E.maxHealth
 		E.desc = "[E.desc]  However, this one appears appears less wild in nature, and calmer around people."
-		E.sentience_type = SENTIENCE_ORGANIC
 		qdel(src)
 	else
 		to_chat(user, span_info("[src] only works on the corpse of a sentient lavaland elite."))

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -264,7 +264,6 @@
 	maxbodytemp = INFINITY
 	layer = MOB_LAYER
 	del_on_death = TRUE
-	sentience_type = SENTIENCE_BOSS
 	loot = list(/obj/item/organ/internal/monster_core/regenerative_core/legion = 3, /obj/effect/mob_spawn/corpse/human/legioninfested = 5)
 	move_to_delay = 14
 	vision_range = 5

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -30,6 +30,7 @@
 	if(crusher_loot)
 		AddElement(/datum/element/crusher_loot, crusher_loot, crusher_drop_mod, del_on_death)
 	AddElement(/datum/element/mob_killed_tally, "mobs_killed_mining")
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/asteroid/Aggro()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
@@ -7,7 +7,6 @@
 	icon_dead = null
 	icon_gib = "syndicate_gib"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	speak_chance = 0
 	turns_per_move = 5
 	speed = 0
@@ -31,6 +30,10 @@
 	del_on_death = TRUE
 	dodging = TRUE
 	footstep_type = FOOTSTEP_MOB_SHOE
+
+/mob/living/simple_animal/hostile/nanotrasen/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/nanotrasen/screaming
 	icon_state = "nanotrasen"

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -28,6 +28,7 @@
 		var/datum/action/innate/creature/teleport/teleport = new(src)
 		teleport.Grant(src)
 	add_cell_sample()
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/netherworld/add_cell_sample()
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_NETHER, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 0)

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -6,7 +6,6 @@
 	icon_living = "piratemelee"
 	icon_dead = "pirate_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	speak_chance = 0
 	turns_per_move = 5
 	response_help_continuous = "pushes"
@@ -29,6 +28,9 @@
 	del_on_death = 1
 	faction = list("pirate")
 
+/mob/living/simple_animal/hostile/pirate/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/pirate/melee
 	name = "Pirate Swashbuckler"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/spaceman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/spaceman.dm
@@ -6,7 +6,6 @@
 	icon_dead = "old_dead"
 	icon_gib = "clown_gib"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	gender = MALE
 	turns_per_move = 5
 	response_disarm_continuous = "gently pushes aside"
@@ -27,6 +26,10 @@
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	del_on_death = 0
 	footstep_type = FOOTSTEP_MOB_SHOE
+
+/mob/living/simple_animal/hostile/retaliate/spaceman/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/retaliate/nanotrasenpeace //this should be in a different file
 	name = "\improper Nanotrasen Private Security Officer"
@@ -51,13 +54,16 @@
 	attack_sound = 'sound/weapons/punch1.ogg'
 	faction = list("nanotrasenprivate")
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	combat_mode = TRUE
 	loot = list(/obj/effect/mob_spawn/corpse/human/nanotrasensoldier)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 7.5
 	status_flags = CANPUSH
 	search_objects = 1
+
+/mob/living/simple_animal/hostile/retaliate/nanotrasenpeace/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/retaliate/nanotrasenpeace/Aggro()
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -7,7 +7,6 @@
 	icon_dead = "russianmelee_dead"
 	icon_gib = "syndicate_gib"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	speak_chance = 0
 	turns_per_move = 5
 	speed = 0
@@ -30,6 +29,9 @@
 
 	footstep_type = FOOTSTEP_MOB_SHOE
 
+/mob/living/simple_animal/hostile/russian/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/russian/ranged
 	icon_state = "russianranged"

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -71,6 +71,7 @@
 	// Set creator
 	if(creator)
 		src.creator = creator
+	RegisterSignal(src, COMSIG_LIVING_GIVEN_SENTIENCE, PROC_REF(on_sentience_potioned))
 
 /mob/living/simple_animal/hostile/netherworld/statue/add_cell_sample()
 	return
@@ -144,7 +145,8 @@
 	. = ..()
 	return . - creator
 
-/mob/living/simple_animal/hostile/netherworld/statue/sentience_act()
+/mob/living/simple_animal/hostile/netherworld/statue/on_sentience_potioned(datum/source, mob/possible_creator)
+	..()
 	faction -= FACTION_NEUTRAL
 
 // Statue powers

--- a/code/modules/mob/living/simple_animal/hostile/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wizard.dm
@@ -6,7 +6,6 @@
 	icon_living = "wizard"
 	icon_dead = "wizard_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	speak_chance = 0
 	turns_per_move = 3
 	speed = 0
@@ -55,6 +54,7 @@
 	blink.spell_requirements &= ~(SPELL_REQUIRES_HUMAN|SPELL_REQUIRES_WIZARD_GARB|SPELL_REQUIRES_MIND)
 	blink.outer_tele_radius = 3
 	blink.Grant(src)
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/wizard/Destroy()
 	QDEL_NULL(fireball)

--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -5,7 +5,6 @@
 	icon_state = "zombie"
 	icon_living = "zombie"
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
-	sentience_type = SENTIENCE_HUMANOID
 	speak_chance = 0
 	stat_attack = HARD_CRIT //braains
 	maxHealth = 100
@@ -28,6 +27,7 @@
 /mob/living/simple_animal/hostile/zombie/Initialize(mapload)
 	. = ..()
 	INVOKE_ASYNC(src, PROC_REF(setup_visuals))
+	AddElement(/datum/element/sentience_possible)
 
 /mob/living/simple_animal/hostile/zombie/proc/setup_visuals()
 	var/datum/job/job = SSjob.GetJob(zombiejob)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -992,12 +992,12 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 	color = "#FFFFFF77"
 	speak_chance = 20
 	status_flags = GODMODE
-	sentience_type = SENTIENCE_BOSS //This is so players can't mindswap into ghost poly to become a literal god
 	incorporeal_move = INCORPOREAL_MOVE_BASIC
 	butcher_results = list(/obj/item/ectoplasm = 1)
 
 /mob/living/simple_animal/parrot/poly/ghost/Initialize(mapload)
 	memory_saved = TRUE //At this point nothing is saved
+	// very specific comment here to tell you /datum/element/sentience_possible is not here ON PURPOSE. this is a godmode creature
 	. = ..()
 
 /mob/living/simple_animal/parrot/poly/ghost/handle_automated_speech()

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -997,7 +997,6 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 
 /mob/living/simple_animal/parrot/poly/ghost/Initialize(mapload)
 	memory_saved = TRUE //At this point nothing is saved
-	// very specific comment here to tell you /datum/element/sentience_possible is not here ON PURPOSE. this is a godmode creature
 	. = ..()
 
 /mob/living/simple_animal/parrot/poly/ghost/handle_automated_speech()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -129,9 +129,6 @@
 
 	var/datum/component/spawner/nest
 
-	///Sentience type, for slime potions.
-	var/sentience_type = SENTIENCE_ORGANIC
-
 	///List of things spawned at mob's loc when it dies.
 	var/list/loot = list()
 	///Causes mob to be deleted on death, useful for mobs that spawn lootable corpses.
@@ -214,6 +211,7 @@
 		unsuitable_cold_damage = unsuitable_atmos_damage
 	if(isnull(unsuitable_heat_damage))
 		unsuitable_heat_damage = unsuitable_atmos_damage
+	RegisterSignal(src, COMSIG_LIVING_GIVEN_SENTIENCE, PROC_REF(on_sentience_potioned))
 
 /mob/living/simple_animal/Life(delta_time = SSMOBS_DT, times_fired)
 	. = ..()
@@ -563,7 +561,8 @@
 		REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, RESTING_TRAIT)
 	return ..()
 
-/mob/living/simple_animal/proc/sentience_act() //Called when a simple animal gains sentience via gold slime potion
+/mob/living/simple_animal/proc/on_sentience_potioned(datum/source, mob/possible_creator) //Called when a simple animal gains sentience via gold slime potion
+	SIGNAL_HANDLER
 	toggle_ai(AI_OFF) // To prevent any weirdness.
 	can_have_ai = FALSE
 

--- a/code/modules/spells/spell_types/pointed/dominate.dm
+++ b/code/modules/spells/spell_types/pointed/dominate.dm
@@ -28,7 +28,7 @@
 		return FALSE
 	if(animal.stat == DEAD)
 		return FALSE
-	if(animal.sentience_type != SENTIENCE_ORGANIC)
+	if(animal.mob_biotypes & MOB_ORGANIC)
 		return FALSE
 	if("cult" in animal.faction)
 		return FALSE

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -74,6 +74,9 @@
 /// A trait source when adding traits through unit tests
 #define TRAIT_SOURCE_UNIT_TESTS "unit_tests"
 
+/// A unit testing trait
+#define TRAIT_UNIT_TESTS(type) "[type]"
+
 #include "ablative_hud.dm"
 #include "achievements.dm"
 #include "anchored_mobs.dm"
@@ -82,6 +85,7 @@
 #include "autowiki.dm"
 #include "barsigns.dm"
 #include "baseturfs.dm"
+#include "basic_mob_complexity.dm"
 #include "bespoke_id.dm"
 #include "binary_insert.dm"
 #include "bloody_footprints.dm"
@@ -147,8 +151,8 @@
 #include "ntnetwork_tests.dm"
 #include "nuke_cinematic.dm"
 #include "objectives.dm"
-#include "orderable_items.dm"
 #include "operating_table.dm"
+#include "orderable_items.dm"
 #include "outfit_sanity.dm"
 #include "paintings.dm"
 #include "pills.dm"
@@ -174,8 +178,8 @@
 #include "screenshot_humanoids.dm"
 #include "screenshot_husk.dm"
 #include "screenshot_saturnx.dm"
-#include "security_officer_distribution.dm"
 #include "security_levels.dm"
+#include "security_officer_distribution.dm"
 #include "serving_tray.dm"
 #include "simple_animal_freeze.dm"
 #include "siunit.dm"

--- a/code/modules/unit_tests/basic_mob_complexity.dm
+++ b/code/modules/unit_tests/basic_mob_complexity.dm
@@ -5,7 +5,7 @@
 /datum/unit_test/basic_mob_complexity/Run()
 	var/list/bmob_paths = subtypesof(/mob/living/basic)
 
-	for(var/bmob_path as anything in basic_mob_paths)
+	for(var/bmob_path as anything in bmob_paths)
 		var/mob/living/basic/bmob = allocate(bmob_path)
 
 		//consider atmos

--- a/code/modules/unit_tests/basic_mob_complexity.dm
+++ b/code/modules/unit_tests/basic_mob_complexity.dm
@@ -1,0 +1,39 @@
+/// Tests that all basic mobs created have not forgotten the many complexities in a mob.
+/// I'm doing this because it is a very easy pattern to fall into where you make variables for components and conditionally add them.
+/datum/unit_test/basic_mob_complexity
+
+/datum/unit_test/basic_mob_complexity/Run()
+	var/list/bmob_paths = subtypesof(/mob/living/basic)
+
+	for(var/bmob_path as anything in basic_mob_paths)
+		var/mob/living/basic/bmob = allocate(bmob_path)
+
+		//consider atmos
+		var/no_atmos_flag = bmob.basic_mob_flags & NO_ATMOS_REQUIREMENTS
+		var/has_atmos_requirements = HAS_TRAIT(bmob, TRAIT_UNIT_TESTS(/datum/element/atmos_requirements))
+		if(no_atmos_flag)
+			if(has_atmos_requirements)
+				TEST_FAIL("basic mob \"[bmob_path]\" flags that it has no atmos, yet it has atmos requirements.")
+		else
+			if(!has_atmos_requirements)
+				TEST_FAIL("basic mob \"[bmob_path]\" has atmos requirements despite being flagged otherwise.")
+
+		//consider temperature
+		var/no_temperature_flagged = bmob.basic_mob_flags & NO_TEMP_SENSITIVITY
+		var/has_temperature_sensitivity = HAS_TRAIT(bmob, TRAIT_UNIT_TESTS(/datum/element/basic_body_temp_sensitive))
+		if(no_temperature_flagged)
+			if(has_temperature_sensitivity)
+				TEST_FAIL("basic mob \"[bmob_path]\" flags that it has no temp sensitivity, yet it has temp sensitivity.")
+		else
+			if(!has_temperature_sensitivity)
+				TEST_FAIL("basic mob \"[bmob_path]\" has temp sensitivity despite being flagged otherwise.")
+
+		//consider sentient potion
+		var/no_sentience_flagged = bmob.basic_mob_flags & NO_SENTIENCE_POSSIBILITY
+		var/has_sentience_possibility = HAS_TRAIT(bmob, TRAIT_UNIT_TESTS(/datum/element/sentience_possible))
+		if(no_sentience_flagged)
+			if(has_sentience_possibility)
+				TEST_FAIL("basic mob \"[bmob_path]\" flags that it has no sentience possibility, yet it has sentience possibility.")
+		else
+			if(!has_sentience_possibility)
+				TEST_FAIL("basic mob \"[bmob_path]\" has sentience possibility despite being flagged otherwise.")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1138,6 +1138,7 @@
 #include "code\datums\elements\ridable.dm"
 #include "code\datums\elements\rust.dm"
 #include "code\datums\elements\selfknockback.dm"
+#include "code\datums\elements\sentience_possible.dm"
 #include "code\datums\elements\series.dm"
 #include "code\datums\elements\simple_flying.dm"
 #include "code\datums\elements\skittish.dm"


### PR DESCRIPTION
## About The Pull Request

fixes #37793

Recently, a pr #71817 attempted to fix the fact that a lot of basic mobs have accidentally been implemented without proper environmental values, but they did it in a way very antithetical to basic mobs, they made them
🤮 DEFAULT 🤮 VARIABLES 🤮 
We're trying to avoid bloating basic mobs like that, it goes against the reason we're componentizing this behavior in the first place. It could have a valid reason, basic mobs... HAVE VARIABLES, obviously, but in this case it was setting default behavior for atmos component because people were forgetting to add it. The answer to forgetting is not bloating our variables, it is forcing contributors to consider environmental factors the mob is either immune or weak to with unit testing!

- Adds unit tests to make sure you've either flagged a mob as non-temp/atmos/sentience OR you have given them the correct components.
- Componentizes sentience options, as I thought that was relevant, but I need to revisit that as it isn't copying behavior from the old right now well, letting mobs not intended to be sentienced get sentienced.

- [ ] Reconsider removing sentience defines for now or think of a different solution for flag checking

## Why It's Good For The Game

Removes needless variables for things that may or may not be on the mob at the base level of basic mobs, godobjecting the tree.

## Changelog
:cl:
refactor: Refactors environment behavior for some mobs, report any mobs that shouldn't be surviving in space but are and vice versa. Or things that shouldn't be able to be sentienced by a potion. Sorry in advance...
/:cl:
