### PR TITLE
Fixes prefilled drinking glasses, and small carton icon

### DIFF
--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -780,7 +780,7 @@
 /area/awaymission/cabin)
 "cK" = (
 /obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/cup/glass/sillycup/smallcarton{
+/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton{
 	pixel_y = 4
 	},
 /turf/open/floor/wood,

--- a/code/datums/components/takes_reagent_appearance.dm
+++ b/code/datums/components/takes_reagent_appearance.dm
@@ -12,6 +12,8 @@
  * An example usage is bartender mixed drinks - each reagent gets its own fancy drink sprite
  */
 /datum/component/takes_reagent_appearance
+	/// The type to compare against the glass_style's required_container_type. The parent's type by default.
+	var/base_container_type
 	/// Icon file when attached to the item
 	var/icon_pre_change
 	/// Icon state when attached to the item
@@ -24,6 +26,7 @@
 /datum/component/takes_reagent_appearance/Initialize(
 	datum/callback/on_icon_changed,
 	datum/callback/on_icon_reset,
+	base_container_type,
 )
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
@@ -37,6 +40,8 @@
 
 	src.on_icon_changed = on_icon_changed
 	src.on_icon_reset = on_icon_reset
+
+	src.base_container_type = base_container_type || parent.type
 
 /datum/component/takes_reagent_appearance/Destroy()
 	QDEL_NULL(on_icon_changed)
@@ -154,4 +159,4 @@
 	if(isnull(main_reagent))
 		return null
 
-	return GLOB.glass_style_singletons[parent.type][main_reagent.type]
+	return GLOB.glass_style_singletons[base_container_type][main_reagent.type]

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
@@ -111,7 +111,7 @@
 
 /datum/crafting_recipe/smallcarton
 	name = "Small Carton"
-	result = /obj/item/reagent_containers/cup/glass/sillycup/smallcarton
+	result = /obj/item/reagent_containers/cup/glass/smallcarton
 	time = 10
 	reqs = list(/obj/item/stack/sheet/cardboard = 1)
 	category = CAT_CONTAINERS

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_drink.dm
@@ -111,7 +111,7 @@
 
 /datum/crafting_recipe/smallcarton
 	name = "Small Carton"
-	result = /obj/item/reagent_containers/cup/glass/smallcarton
+	result = /obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton
 	time = 10
 	reqs = list(/obj/item/stack/sheet/cardboard = 1)
 	category = CAT_CONTAINERS

--- a/code/modules/reagents/reagent_containers/cups/_glass_datum.dm
+++ b/code/modules/reagents/reagent_containers/cups/_glass_datum.dm
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(glass_style_singletons, create_glass_styles())
 	icon = 'icons/obj/drinks/shot_glasses.dmi'
 
 /datum/glass_style/juicebox
-	required_container_type = /obj/item/reagent_containers/cup/glass/sillycup/smallcarton
+	required_container_type = /obj/item/reagent_containers/cup/glass/smallcarton
 	icon = 'icons/obj/drinks/boxes.dmi'
 	/// This style changes the "drink type" of the container it's placed it as well, it's like food types
 	var/drink_type = NONE

--- a/code/modules/reagents/reagent_containers/cups/_glass_datum.dm
+++ b/code/modules/reagents/reagent_containers/cups/_glass_datum.dm
@@ -73,7 +73,7 @@ GLOBAL_LIST_INIT(glass_style_singletons, create_glass_styles())
 	icon = 'icons/obj/drinks/shot_glasses.dmi'
 
 /datum/glass_style/juicebox
-	required_container_type = /obj/item/reagent_containers/cup/glass/smallcarton
+	required_container_type = /obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton
 	icon = 'icons/obj/drinks/boxes.dmi'
 	/// This style changes the "drink type" of the container it's placed it as well, it's like food types
 	var/drink_type = NONE

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -18,9 +18,18 @@
 	//the screwdriver cocktail can make a drinking glass into the world's worst screwdriver. beautiful.
 	toolspeed = 25
 
+	/// The type to compare to glass_style.required_container type, or null to use class type.
+	/// This allows subtypes to utilize parent styles.
+	var/base_container_type = null
+
 /obj/item/reagent_containers/cup/glass/drinkingglass/Initialize(mapload, vol)
 	. = ..()
-	AddComponent(/datum/component/takes_reagent_appearance, CALLBACK(src, PROC_REF(on_glass_change)), CALLBACK(src, PROC_REF(on_glass_reset)))
+	AddComponent( \
+		/datum/component/takes_reagent_appearance, \
+		CALLBACK(src, PROC_REF(on_glass_change)), \
+		CALLBACK(src, PROC_REF(on_glass_reset)), \
+		base_container_type = base_container_type, \
+	)
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/on_reagent_change(datum/reagents/holder, ...)
 	. = ..()
@@ -70,6 +79,13 @@
 		desc = "The challenge is not taking as many as you can, but guessing what it is before you pass out."
 	else
 		desc = "A shot glass - the universal symbol for bad decisions."
+
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled
+	base_container_type = /obj/item/reagent_containers/cup/glass/drinkingglass
+
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/Initialize(mapload, vol)
+	. = ..()
+	update_appearance()
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/filled/soda
 	name = "Soda Water"

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -85,7 +85,7 @@
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/filled/Initialize(mapload, vol)
 	. = ..()
-	update_appearance()
+	update_appearance(UPDATE_ICON)
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/filled/soda
 	name = "Soda Water"

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -85,7 +85,7 @@
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/filled/Initialize(mapload, vol)
 	. = ..()
-	update_appearance(UPDATE_ICON)
+	update_appearance()
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/filled/soda
 	name = "Soda Water"

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -366,29 +366,28 @@
 	icon_state = reagents.total_volume ? "water_cup" : "water_cup_e"
 	return ..()
 
-/obj/item/reagent_containers/cup/glass/smallcarton
+/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton
 	name = "small carton"
 	desc = "A small carton, intended for holding drinks."
 	icon = 'icons/obj/drinks/boxes.dmi'
 	icon_state = "juicebox"
-	volume = 15 //I figure if you have to craft these it should at least be slightly better than something you can get for free from a watercooler
-	spillable = TRUE
-	isGlass = FALSE
+	volume = 15
+	drink_type = NONE
 
-/obj/item/reagent_containers/cup/glass/smallcarton/Initialize(mapload, vol)
+/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton/Initialize(mapload, vol)
 	. = ..()
 	AddComponent(/datum/component/takes_reagent_appearance, CALLBACK(src, PROC_REF(on_box_change)), CALLBACK(src, PROC_REF(on_box_reset)))
 
 /// Having our icon state change changes our food type
-/obj/item/reagent_containers/cup/glass/smallcarton/proc/on_box_change(datum/glass_style/juicebox/style)
+/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton/proc/on_box_change(datum/glass_style/juicebox/style)
 	if(!istype(style))
 		return
 	drink_type = style.drink_type
 
-/obj/item/reagent_containers/cup/glass/smallcarton/proc/on_box_reset()
+/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton/proc/on_box_reset()
 	drink_type = NONE
 
-/obj/item/reagent_containers/cup/glass/smallcarton/smash(atom/target, mob/thrower, ranged = FALSE)
+/obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton/smash(atom/target, mob/thrower, ranged = FALSE)
 	if(bartender_check(target) && ranged)
 		return
 	SplashReagents(target, ranged, override_spillable = TRUE)

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -366,27 +366,29 @@
 	icon_state = reagents.total_volume ? "water_cup" : "water_cup_e"
 	return ..()
 
-/obj/item/reagent_containers/cup/glass/sillycup/smallcarton
+/obj/item/reagent_containers/cup/glass/smallcarton
 	name = "small carton"
 	desc = "A small carton, intended for holding drinks."
 	icon = 'icons/obj/drinks/boxes.dmi'
 	icon_state = "juicebox"
 	volume = 15 //I figure if you have to craft these it should at least be slightly better than something you can get for free from a watercooler
+	spillable = TRUE
+	isGlass = FALSE
 
-/obj/item/reagent_containers/cup/glass/sillycup/smallcarton/Initialize(mapload, vol)
+/obj/item/reagent_containers/cup/glass/smallcarton/Initialize(mapload, vol)
 	. = ..()
 	AddComponent(/datum/component/takes_reagent_appearance, CALLBACK(src, PROC_REF(on_box_change)), CALLBACK(src, PROC_REF(on_box_reset)))
 
 /// Having our icon state change changes our food type
-/obj/item/reagent_containers/cup/glass/sillycup/smallcarton/proc/on_box_change(datum/glass_style/juicebox/style)
+/obj/item/reagent_containers/cup/glass/smallcarton/proc/on_box_change(datum/glass_style/juicebox/style)
 	if(!istype(style))
 		return
 	drink_type = style.drink_type
 
-/obj/item/reagent_containers/cup/glass/sillycup/smallcarton/proc/on_box_reset()
+/obj/item/reagent_containers/cup/glass/smallcarton/proc/on_box_reset()
 	drink_type = NONE
 
-/obj/item/reagent_containers/cup/glass/sillycup/smallcarton/smash(atom/target, mob/thrower, ranged = FALSE)
+/obj/item/reagent_containers/cup/glass/smallcarton/smash(atom/target, mob/thrower, ranged = FALSE)
 	if(bartender_check(target) && ranged)
 		return
 	SplashReagents(target, ranged, override_spillable = TRUE)


### PR DESCRIPTION
## About The Pull Request

Fixes #72468

Fixes a few drink container issues:
- The `/obj/item/reagent_containers/cup/glass/drinkingglass/filled` subtypes runtimed whenever their reagents changed because of the strict way that `/datum/component/takes_reagent_appearance` compares container types.
  - `/datum/component/takes_reagent_appearance` now allows for an alternate type to check against `glass_style.required_container_type` via a var called `base_container_type`. The filled glasses now set this var to the main drinking glass type.
- As well, filled glasses didn't have their appearance set up to match the corresponding glass style. Thus, the `/obj/item/reagent_containers/cup/glass/drinkingglass/filled` type now updates its appearance on initialization.

- Seperately, the small carton's appearance broke if you put a reagent in that doesn't match a glass style, reverting to the "water_cup" icon state which doesn't exist in the boxes.dmi file. This is because it was a subtype of sillycup, but there is nothing gained as far as I can see from that type relationship, so the small carton was repathed to `/obj/item/reagent_containers/cup/glass/smallcarton`.

### Tested all 3 users of takes_reagent_appearance:
![image](https://user-images.githubusercontent.com/1185434/211126024-872d29db-9f15-4ee9-a7da-c45e66c2413b.png)
## Why It's Good For The Game

Runtime fix, fixed visuals.
## Changelog
:cl:
fix: The small carton no longer randomly disappears.
fix: Pre-filled bottles of cola & nuka cola, and glasses of soda now have the correct sprite.
/:cl:
