### PR TITLE
Better cyborg creation logging

### DIFF
--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -92,7 +92,7 @@
 	cooldown_timer = world.time + cooldown_duration
 	update_appearance()
 
-	playsound(src.loc, 'sound/items/welder.ogg', 5 SECONDS, TRUE)
+	playsound(src.loc, 'sound/items/welder.ogg', 50, TRUE)
 	victim.emote("scream") // It is painful
 	victim.adjustBruteLoss(max(0, 80 - victim.getBruteLoss())) // Hurt the human, don't try to kill them though.
 

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -105,7 +105,7 @@
 
 	// So he can't jump out the gate right away.
 	new_borg.SetLockdown()
-	if(masterAI)
+	if(masterAI && new_borg.connected_ai != masterAI)
 		new_borg.set_connected_ai(masterAI)
 		new_borg.lawsync()
 		new_borg.lawupdate = TRUE

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -61,7 +61,7 @@
 		var/mob/living/carbon/human/victim = entering_thing
 		if((transform_standing || victim.body_position == LYING_DOWN) && move_dir == EAST)
 			entering_thing.forceMove(drop_location())
-			do_transform(victim)
+			do_transform(entering_thing)
 
 /obj/machinery/transformer/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -84,7 +84,7 @@
 		return
 
 	if(!transform_dead && victim.stat == DEAD)
-		playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 5 SECONDS, FALSE)
+		playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 		return
 
 	// Activate the cooldown

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -24,7 +24,7 @@
 	/// The visual countdown effect
 	var/obj/effect/countdown/transformer/countdown
 	/// Who the master AI is that created this factory
-	var/mob/living/silicon/ai/masterAI
+	var/mob/living/silicon/ai/master_ai
 
 /obj/machinery/transformer/Initialize(mapload)
 	. = ..()
@@ -105,11 +105,11 @@
 
 	// So he can't jump out the gate right away.
 	new_borg.SetLockdown()
-	if(masterAI && new_borg.connected_ai != masterAI)
-		new_borg.set_connected_ai(masterAI)
+	if(master_ai && new_borg.connected_ai != master_ai)
+		new_borg.set_connected_ai(master_ai)
 		new_borg.lawsync()
 		new_borg.lawupdate = TRUE
-		log_silicon("[key_name(new_borg)] resynced to [key_name(masterAI)]")
+		log_silicon("[key_name(new_borg)] resynced to [key_name(master_ai)]")
 	addtimer(CALLBACK(src, PROC_REF(unlock_new_robot), new_borg), 5 SECONDS)
 
 /obj/machinery/transformer/proc/unlock_new_robot(mob/living/silicon/robot/new_borg)

--- a/code/game/machinery/transformer.dm
+++ b/code/game/machinery/transformer.dm
@@ -2,24 +2,31 @@
 	name = "\improper Automatic Robotic Factory 5000"
 	desc = "A large metallic machine with an entrance and an exit. A sign on \
 		the side reads, 'human go in, robot come out'. The human must be \
-		lying down and alive. Has to cooldown between each use."
+		lying down and alive. Has a cooldown between each use."
 	icon = 'icons/obj/recycling.dmi'
 	icon_state = "separator-AO1"
 	layer = ABOVE_ALL_MOB_LAYER // Overhead
 	plane = ABOVE_GAME_PLANE
 	density = FALSE
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 5
-	var/transform_dead = 0
-	var/transform_standing = 0
-	var/cooldown_duration = 600 // 1 minute
-	var/cooldown = 0
+	/// Whether this machine transforms dead mobs into cyborgs
+	var/transform_dead = FALSE
+	/// Whether this machine transforms standing mobs into cyborgs
+	var/transform_standing = FALSE
+	/// How long we have to wait between processing mobs
+	var/cooldown_duration = 60 SECONDS
+	/// Whether we're on cooldown
+	var/cooldown = FALSE
+	/// How long until the next mob can be processed
 	var/cooldown_timer
+	/// The created cyborg's cell chage
 	var/robot_cell_charge = 5000
+	/// The visual countdown effect
 	var/obj/effect/countdown/transformer/countdown
+	/// Who the master AI is that created this factory
 	var/mob/living/silicon/ai/masterAI
 
 /obj/machinery/transformer/Initialize(mapload)
-	// On us
 	. = ..()
 	new /obj/machinery/conveyor/auto(locate(x - 1, y, z), WEST)
 	new /obj/machinery/conveyor/auto(loc, WEST)
@@ -43,24 +50,22 @@
 		icon_state = initial(icon_state)
 	return ..()
 
-/obj/machinery/transformer/Bumped(atom/movable/AM)
-	if(cooldown == 1)
+/obj/machinery/transformer/Bumped(atom/movable/entering_thing)
+	if(cooldown)
 		return
 
 	// Crossed didn't like people lying down.
-	if(ishuman(AM))
+	if(ishuman(entering_thing))
 		// Only humans can enter from the west side, while lying down.
-		var/move_dir = get_dir(loc, AM.loc)
-		var/mob/living/carbon/human/H = AM
-		if((transform_standing || H.body_position == LYING_DOWN) && move_dir == EAST)// || move_dir == WEST)
-			AM.forceMove(drop_location())
-			do_transform(AM)
-
+		var/move_dir = get_dir(loc, entering_thing.loc)
+		var/mob/living/carbon/human/victim = entering_thing
+		if((transform_standing || victim.body_position == LYING_DOWN) && move_dir == EAST)
+			entering_thing.forceMove(drop_location())
+			do_transform(victim)
 
 /obj/machinery/transformer/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	// Allows items to go through,
-	// to stop them from blocking the conveyor belt.
+	// Allows items to go through to stop them from blocking the conveyor belt.
 	if(!ishuman(mover))
 		if(get_dir(src, mover) == EAST)
 			return
@@ -71,43 +76,45 @@
 		cooldown = FALSE
 		update_appearance()
 
-/obj/machinery/transformer/proc/do_transform(mob/living/carbon/human/H)
+/obj/machinery/transformer/proc/do_transform(mob/living/carbon/human/victim)
 	if(machine_stat & (BROKEN|NOPOWER))
 		return
-	if(cooldown == 1)
+
+	if(cooldown)
 		return
 
-	if(!transform_dead && H.stat == DEAD)
-		playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
+	if(!transform_dead && victim.stat == DEAD)
+		playsound(src.loc, 'sound/machines/buzz-sigh.ogg', 5 SECONDS, FALSE)
 		return
 
 	// Activate the cooldown
-	cooldown = 1
+	cooldown = TRUE
 	cooldown_timer = world.time + cooldown_duration
 	update_appearance()
 
-	playsound(src.loc, 'sound/items/welder.ogg', 50, TRUE)
-	H.emote("scream") // It is painful
-	H.adjustBruteLoss(max(0, 80 - H.getBruteLoss())) // Hurt the human, don't try to kill them though.
+	playsound(src.loc, 'sound/items/welder.ogg', 5 SECONDS, TRUE)
+	victim.emote("scream") // It is painful
+	victim.adjustBruteLoss(max(0, 80 - victim.getBruteLoss())) // Hurt the human, don't try to kill them though.
 
 	// Sleep for a couple of ticks to allow the human to see the pain
 	sleep(0.5 SECONDS)
 
 	use_power(active_power_usage) // Use a lot of power.
-	var/mob/living/silicon/robot/R = H.Robotize()
-	R.cell = new /obj/item/stock_parts/cell/upgraded/plus(R, robot_cell_charge)
+	var/mob/living/silicon/robot/new_borg = victim.Robotize()
+	new_borg.cell = new /obj/item/stock_parts/cell/upgraded/plus(new_borg, robot_cell_charge)
 
 	// So he can't jump out the gate right away.
-	R.SetLockdown()
+	new_borg.SetLockdown()
 	if(masterAI)
-		R.set_connected_ai(masterAI)
-		R.lawsync()
-		R.lawupdate = TRUE
-	addtimer(CALLBACK(src, PROC_REF(unlock_new_robot), R), 50)
+		new_borg.set_connected_ai(masterAI)
+		new_borg.lawsync()
+		new_borg.lawupdate = TRUE
+		log_silicon("[key_name(new_borg)] resynced to [key_name(masterAI)]")
+	addtimer(CALLBACK(src, PROC_REF(unlock_new_robot), new_borg), 5 SECONDS)
 
-/obj/machinery/transformer/proc/unlock_new_robot(mob/living/silicon/robot/R)
+/obj/machinery/transformer/proc/unlock_new_robot(mob/living/silicon/robot/new_borg)
 	playsound(src.loc, 'sound/machines/ping.ogg', 50, FALSE)
 	sleep(3 SECONDS)
-	if(R)
-		R.SetLockdown(FALSE)
-		R.notify_ai(AI_NOTIFICATION_NEW_BORG)
+	if(new_borg)
+		new_borg.SetLockdown(FALSE)
+		new_borg.notify_ai(AI_NOTIFICATION_NEW_BORG)

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /datum/action/innate/ai/Grant(mob/living/L)
 	. = ..()
 	if(!isAI(owner))
-		WARNING("AI action [name] attempted to grant itself to non-AI mob [L.real_name] ([L.key])!")
+		WARNING("AI action [name] attempted to grant itself to non-AI mob [key_name(L)]!")
 		qdel(src)
 	else
 		owner_AI = owner
@@ -96,12 +96,12 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /datum/action/innate/ai/ranged/adjust_uses(amt, silent)
 	uses += amt
 	if(!silent && uses)
-		to_chat(owner, span_notice("[name] now has <b>[uses]</b> use[uses > 1 ? "s" : ""] remaining."))
+		to_chat(owner, span_notice("[name] now has <b>[uses]</b> use\s remaining."))
 	if(!uses)
 		if(initial(uses) > 1) //no need to tell 'em if it was one-use anyway!
 			to_chat(owner, span_warning("[name] has run out of uses!"))
 		Remove(owner)
-		QDEL_IN(src, 100) //let any active timers on us finish up
+		QDEL_IN(src, 10 SECONDS) //let any active timers on us finish up
 
 /// The base module type, which holds info about each ability.
 /datum/ai_module
@@ -116,7 +116,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	/// If the module gives a passive upgrade, use this. Mutually exclusive with power_type.
 	var/upgrade = FALSE
 	/// Text shown when an ability is unlocked
-	var/unlock_text = "<span class='notice'>Hello World!</span>"
+	var/unlock_text = span_notice("Hello World!")
 	/// Sound played when an ability is unlocked
 	var/unlock_sound
 
@@ -139,11 +139,12 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /// Doomsday Device: Starts the self-destruct timer. It can only be stopped by killing the AI completely.
 /datum/ai_module/destructive/nuke_station
 	name = "Doomsday Device"
-	description = "Activate a weapon that will disintegrate all organic life on the station after a 450 second delay. Can only be used while on the station, will fail if your core is moved off station or destroyed."
+	description = "Activate a weapon that will disintegrate all organic life on the station after a 450 second delay. \
+		Can only be used while on the station, will fail if your core is moved off station or destroyed."
 	cost = 130
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/nuke_station
-	unlock_text = "<span class='notice'>You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.</span>"
+	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
 
 /datum/action/innate/ai/nuke_station
 	name = "Doomsday Device"
@@ -346,12 +347,13 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /// Hostile Station Lockdown: Locks, bolts, and electrifies every airlock on the station. After 90 seconds, the doors reset.
 /datum/ai_module/destructive/lockdown
 	name = "Hostile Station Lockdown"
-	description = "Overload the airlock, blast door and fire control networks, locking them down. Caution! This command also electrifies all airlocks. The networks will automatically reset after 90 seconds, briefly \
-	opening all doors on the station."
+	description = "Overload the airlock, blast door and fire control networks, locking them down. \
+		Caution! This command also electrifies all airlocks. The networks will automatically reset after 90 seconds, briefly \
+		opening all doors on the station."
 	cost = 30
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/lockdown
-	unlock_text = "<span class='notice'>You upload a sleeper trojan into the door control systems. You can send a signal to set it off at any time.</span>"
+	unlock_text = span_notice("You upload a sleeper trojan into the door control systems. You can send a signal to set it off at any time.")
 	unlock_sound = 'sound/machines/boltsdown.ogg'
 
 /datum/action/innate/ai/lockdown
@@ -371,7 +373,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	if(C)
 		C.post_status("alert", "lockdown")
 
-	minor_announce("Hostile runtime detected in door controllers. Isolation lockdown protocols are now in effect. Please remain calm.","Network Alert:", TRUE)
+	minor_announce("Hostile runtime detected in door controllers. Isolation lockdown protocols are now in effect. Please remain calm.", "Network Alert:", TRUE)
 	to_chat(owner, span_danger("Lockdown initiated. Network reset in 90 seconds."))
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(minor_announce),
 		"Automatic system reboot complete. Have a secure day.",
@@ -383,7 +385,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	description = "Overrides a machine's programming, causing it to rise up and attack everyone except other machines. Four uses per purchase."
 	cost = 30
 	power_type = /datum/action/innate/ai/ranged/override_machine
-	unlock_text = "<span class='notice'>You procure a virus from the Space Dark Web and distribute it to the station's machines.</span>"
+	unlock_text = span_notice("You procure a virus from the Space Dark Web and distribute it to the station's machines.")
 	unlock_sound = 'sound/machines/airlock_alien_prying.ogg'
 
 /datum/action/innate/ai/ranged/override_machine
@@ -392,8 +394,8 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	button_icon_state = "override_machine"
 	uses = 4
 	ranged_mousepointer = 'icons/effects/mouse_pointers/override_machine_target.dmi'
-	enable_text = "<span class='notice'>You tap into the station's powernet. Click on a machine to animate it, or use the ability again to cancel.</span>"
-	disable_text = "<span class='notice'>You release your hold on the powernet.</span>"
+	enable_text = span_notice("You tap into the station's powernet. Click on a machine to animate it, or use the ability again to cancel.")
+	disable_text = span_notice("You release your hold on the powernet.")
 
 /datum/action/innate/ai/ranged/override_machine/New()
 	. = ..()
@@ -436,7 +438,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	cost = 25
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/destroy_rcds
-	unlock_text = "<span class='notice'>After some improvisation, you rig your onboard radio to be able to send a signal to detonate all RCDs.</span>"
+	unlock_text = span_notice("After some improvisation, you rig your onboard radio to be able to send a signal to detonate all RCDs.")
 	unlock_sound = 'sound/items/timer.ogg'
 
 /datum/action/innate/ai/destroy_rcds
@@ -444,7 +446,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	desc = "Detonate all non-cyborg RCDs on the station."
 	button_icon_state = "detonate_rcds"
 	uses = 1
-	cooldown_period = 100
+	cooldown_period = 10 SECONDS
 
 /datum/action/innate/ai/destroy_rcds/Activate()
 	for(var/I in GLOB.rcd_list)
@@ -460,7 +462,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	description = "Overheats an electrical machine, causing a small explosion and destroying it. Two uses per purchase."
 	cost = 20
 	power_type = /datum/action/innate/ai/ranged/overload_machine
-	unlock_text = "<span class='notice'>You enable the ability for the station's APCs to direct intense energy into machinery.</span>"
+	unlock_text = span_notice("You enable the ability for the station's APCs to direct intense energy into machinery.")
 	unlock_sound = 'sound/effects/comfyfire.ogg' //definitely not comfy, but it's the closest sound to "roaring fire" we have
 
 /datum/action/innate/ai/ranged/overload_machine
@@ -469,8 +471,8 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	button_icon_state = "overload_machine"
 	uses = 2
 	ranged_mousepointer = 'icons/effects/mouse_pointers/overload_machine_target.dmi'
-	enable_text = "<span class='notice'>You tap into the station's powernet. Click on a machine to detonate it, or use the ability again to cancel.</span>"
-	disable_text = "<span class='notice'>You release your hold on the powernet.</span>"
+	enable_text = span_notice("You tap into the station's powernet. Click on a machine to detonate it, or use the ability again to cancel.")
+	disable_text = span_notice("You release your hold on the powernet.")
 
 /datum/action/innate/ai/ranged/overload_machine/New()
 	..()
@@ -516,7 +518,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	description = "Attempts to overload the lighting circuits on the station, destroying some bulbs. Three uses per purchase."
 	cost = 15
 	power_type = /datum/action/innate/ai/blackout
-	unlock_text = "<span class='notice'>You hook into the powernet and route bonus power towards the station's lighting.</span>"
+	unlock_text = span_notice("You hook into the powernet and route bonus power towards the station's lighting.")
 	unlock_sound = SFX_SPARKS
 
 /datum/action/innate/ai/blackout
@@ -550,7 +552,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	description = "Emit a debilitatingly percussive auditory blast through the station intercoms. Does not overpower hearing protection. Two uses per purchase."
 	cost = 20
 	power_type = /datum/action/innate/ai/honk
-	unlock_text = "<span class='notice'>You upload a sinister sound file into every intercom...</span>"
+	unlock_text = span_notice("You upload a sinister sound file into every intercom...")
 	unlock_sound = 'sound/items/airhorn.ogg'
 
 /datum/action/innate/ai/honk
@@ -581,7 +583,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	cost = 100
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/place_transformer
-	unlock_text = "<span class='notice'>You make contact with Space Amazon and request a robotics factory for delivery.</span>"
+	unlock_text = span_notice("You make contact with Space Amazon and request a robotics factory for delivery.")
 	unlock_sound = 'sound/machines/ping.ogg'
 
 /datum/action/innate/ai/place_transformer
@@ -595,7 +597,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /datum/action/innate/ai/place_transformer/New()
 	..()
 	for(var/i in 1 to 3)
-		var/image/I = image("icon"='icons/turf/overlays.dmi')
+		var/image/I = image("icon" = 'icons/turf/overlays.dmi')
 		LAZYADD(turfOverlays, I)
 
 /datum/action/innate/ai/place_transformer/Activate()
@@ -651,12 +653,12 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /// Air Alarm Safety Override: Unlocks the ability to enable flooding on all air alarms.
 /datum/ai_module/utility/break_air_alarms
 	name = "Air Alarm Safety Override"
-	description = "Gives you the ability to disable safeties on all air alarms. This will allow you to use the environmental mode Flood, which disables scrubbers as well as pressure checks on vents. \
-	Anyone can check the air alarm's interface and may be tipped off by their nonfunctionality."
+	description = "Gives you the ability to disable safeties on all air alarms. This will allow you to use the environmental mode Flood, \
+		which disables scrubbers as well as pressure checks on vents. Anyone can check the air alarm's interface and may be tipped off by their nonfunctionality."
 	one_purchase = TRUE
 	cost = 50
 	power_type = /datum/action/innate/ai/break_air_alarms
-	unlock_text = "<span class='notice'>You remove the safety overrides on all air alarms, but you leave the confirm prompts open. You can hit 'Yes' at any time... you bastard.</span>"
+	unlock_text = span_notice("You remove the safety overrides on all air alarms, but you leave the confirm prompts open. You can hit 'Yes' at any time... you bastard.")
 	unlock_sound = 'sound/effects/space_wind.ogg'
 
 /datum/action/innate/ai/break_air_alarms
@@ -676,11 +678,13 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /// Thermal Sensor Override: Unlocks the ability to disable all fire alarms from doing their job.
 /datum/ai_module/utility/break_fire_alarms
 	name = "Thermal Sensor Override"
-	description = "Gives you the ability to override the thermal sensors on all fire alarms. This will remove their ability to scan for fire and thus their ability to alert."
+	description = "Gives you the ability to override the thermal sensors on all fire alarms. \
+		This will remove their ability to scan for fire and thus their ability to alert."
 	one_purchase = TRUE
 	cost = 25
 	power_type = /datum/action/innate/ai/break_fire_alarms
-	unlock_text = "<span class='notice'>You replace the thermal sensing capabilities of all fire alarms with a manual override, allowing you to turn them off at will.</span>"
+	unlock_text = span_notice("You replace the thermal sensing capabilities of all fire alarms with a manual override, \
+		allowing you to turn them off at will.")
 	unlock_sound = 'sound/machines/FireAlarm1.ogg'
 
 /datum/action/innate/ai/break_fire_alarms
@@ -705,11 +709,12 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /// Disable Emergency Lights
 /datum/ai_module/utility/emergency_lights
 	name = "Disable Emergency Lights"
-	description = "Cuts emergency lights across the entire station. If power is lost to light fixtures, they will not attempt to fall back on emergency power reserves."
+	description = "Cuts emergency lights across the entire station. If power is lost to light fixtures, \
+		they will not attempt to fall back on emergency power reserves."
 	cost = 10
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/emergency_lights
-	unlock_text = "<span class='notice'>You hook into the powernet and locate the connections between light fixtures and their fallbacks.</span>"
+	unlock_text = span_notice("You hook into the powernet and locate the connections between light fixtures and their fallbacks.")
 	unlock_sound = SFX_SPARKS
 
 /datum/action/innate/ai/emergency_lights
@@ -730,11 +735,12 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /// Reactivate Camera Network: Reactivates up to 30 cameras across the station.
 /datum/ai_module/utility/reactivate_cameras
 	name = "Reactivate Camera Network"
-	description = "Runs a network-wide diagnostic on the camera network, resetting focus and re-routing power to failed cameras. Can be used to repair up to 30 cameras."
+	description = "Runs a network-wide diagnostic on the camera network, resetting focus and re-routing power to failed cameras. \
+		Can be used to repair up to 30 cameras."
 	cost = 10
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/reactivate_cameras
-	unlock_text = "<span class='notice'>You deploy nanomachines to the cameranet.</span>"
+	unlock_text = span_notice("You deploy nanomachines to the cameranet.")
 	unlock_sound = 'sound/items/wirecutter.ogg'
 
 /datum/action/innate/ai/reactivate_cameras
@@ -774,7 +780,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	//This used to have motion sensing as well, but testing quickly revealed that giving it to the whole cameranet is PURE HORROR.
 	cost = 35 //Decent price for omniscience!
 	upgrade = TRUE
-	unlock_text = "<span class='notice'>OTA firmware distribution complete! Cameras upgraded: CAMSUPGRADED. Light amplification system online.</span>"
+	unlock_text = span_notice("OTA firmware distribution complete! Cameras upgraded: CAMSUPGRADED. Light amplification system online.")
 	unlock_sound = 'sound/items/rped.ogg'
 
 /datum/ai_module/upgrade/upgrade_cameras/upgrade(mob/living/silicon/ai/AI)
@@ -782,19 +788,19 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	AI.update_sight()
 
 	var/upgraded_cameras = 0
-	for(var/obj/machinery/camera/C as anything in GLOB.cameranet.cameras)
-		var/obj/structure/camera_assembly/assembly = C.assembly_ref?.resolve()
+	for(var/obj/machinery/camera/camera as anything in GLOB.cameranet.cameras)
+		var/obj/structure/camera_assembly/assembly = camera.assembly_ref?.resolve()
 		if(assembly)
 			var/upgraded = FALSE
 
-			if(!C.isXRay())
-				C.upgradeXRay(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_xray_firmware_active and clean up isxray()
+			if(!camera.isXRay())
+				camera.upgradeXRay(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_xray_firmware_active and clean up isxray()
 				//Update what it can see.
-				GLOB.cameranet.updateVisibility(C, 0)
+				GLOB.cameranet.updateVisibility(camera, 0)
 				upgraded = TRUE
 
-			if(!C.isEmpProof())
-				C.upgradeEmpProof(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_emp_firmware_active and clean up isemp()
+			if(!camera.isEmpProof())
+				camera.upgradeEmpProof(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_emp_firmware_active and clean up isemp()
 				upgraded = TRUE
 
 			if(upgraded)
@@ -807,7 +813,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	description = "Improves the power and health of all AI turrets. This effect is permanent. Upgrade is done immediately upon purchase."
 	cost = 30
 	upgrade = TRUE
-	unlock_text = "<span class='notice'>You establish a power diversion to your turrets, upgrading their health and damage.</span>"
+	unlock_text = span_notice("You establish a power diversion to your turrets, upgrading their health and damage.")
 	unlock_sound = 'sound/items/rped.ogg'
 
 /datum/ai_module/upgrade/upgrade_turrets/upgrade(mob/living/silicon/ai/AI)
@@ -819,10 +825,11 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /// Enhanced Surveillance: Enables AI to hear conversations going on near its active vision.
 /datum/ai_module/upgrade/eavesdrop
 	name = "Enhanced Surveillance"
-	description = "Via a combination of hidden microphones and lip reading software, you are able to use your cameras to listen in on conversations. Upgrade is done immediately upon purchase."
+	description = "Via a combination of hidden microphones and lip reading software, \
+		you are able to use your cameras to listen in on conversations. Upgrade is done immediately upon purchase."
 	cost = 30
 	upgrade = TRUE
-	unlock_text = "<span class='notice'>OTA firmware distribution complete! Cameras upgraded: Enhanced surveillance package online.</span>"
+	unlock_text = span_notice("OTA firmware distribution complete! Cameras upgraded: Enhanced surveillance package online.")
 	unlock_sound = 'sound/items/rped.ogg'
 
 /datum/ai_module/upgrade/eavesdrop/upgrade(mob/living/silicon/ai/AI)
@@ -832,17 +839,17 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /// Unlock Mech Domination: Unlocks the ability to dominate mechs. Big shocker, right?
 /datum/ai_module/upgrade/mecha_domination
 	name = "Unlock Mech Domination"
-	description = "Allows you to hack into a mech's onboard computer, shunting all processes into it and ejecting any occupants. Once uploaded to the mech, it is impossible to leave.\
-	Do not allow the mech to leave the station's vicinity or allow it to be destroyed. Upgrade is done immediately upon purchase."
+	description = "Allows you to hack into a mech's onboard computer, shunting all processes into it and ejecting any occupants. \
+		Once uploaded to the mech, it is impossible to leave. Do not allow the mech to leave the station's vicinity or allow it to be destroyed. \
+		Upgrade is done immediately upon purchase."
 	cost = 30
 	upgrade = TRUE
-	unlock_text = "<span class='notice'>Virus package compiled. Select a target mech at any time. <b>You must remain on the station at all times. Loss of signal will result in total system lockout.</b></span>"
+	unlock_text = span_notice("Virus package compiled. Select a target mech at any time. <b>You must remain on the station at all times. \
+		Loss of signal will result in total system lockout.</b>")
 	unlock_sound = 'sound/mecha/nominal.ogg'
 
 /datum/ai_module/upgrade/mecha_domination/upgrade(mob/living/silicon/ai/AI)
 	AI.can_dominate_mechs = TRUE //Yep. This is all it does. Honk!
-
-
 
 /datum/ai_module/upgrade/voice_changer
 	name = "Voice Changer"
@@ -866,18 +873,27 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	voice_changer_machine.ui_interact(usr)
 
 /obj/machinery/ai_voicechanger
-	icon = 'icons/obj/machines/nuke_terminal.dmi'
 	name = "Voice Changer"
+	icon = 'icons/obj/machines/nuke_terminal.dmi'
 	icon_state = "nuclearbomb_base"
+	/// The AI this voicechanger belongs to
 	var/mob/living/silicon/ai/owner
+	/// Whether this AI is speaking loudly (bigger text)
 	var/loudvoice = FALSE
-	var/say_verb //verb used when voicechanger is on
-	var/say_name //name used when voicechanger is on
-	var/say_span //span used when voicechanger is on
-	var/changing_voice = FALSE //TRUE if the AI is changing its voice
-	var/prev_loud // saved loudvoice state, used to restore after a voice change
-	var/prev_verbs // saved verb state, used to restore after a voice change
-	var/prev_span // saved span state, used to restore after a voice change
+	// Verb used when voicechanger is on
+	var/say_verb
+	/// Name used when voicechanger is on
+	var/say_name
+	/// Span used when voicechanger is on
+	var/say_span
+	/// TRUE if the AI is changing its voice
+	var/changing_voice = FALSE
+	/// Saved loudvoice state, used to restore after a voice change
+	var/prev_loud
+	/// Saved verb state, used to restore after a voice change
+	var/prev_verbs
+	/// Saved span state, used to restore after a voice change
+	var/prev_span
 
 /obj/machinery/ai_voicechanger/Initialize(mapload)
 	. = ..()
@@ -905,7 +921,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 
 /obj/machinery/ai_voicechanger/ui_data(mob/user)
 	var/list/data = list()
-	data["voices"] = list("normal",SPAN_ROBOT,SPAN_YELL,SPAN_CLOWN) //manually adding this since i dont see other option
+	data["voices"] = list("normal", SPAN_ROBOT, SPAN_YELL, SPAN_CLOWN) //manually adding this since i dont see other option
 	data["loud"] = loudvoice
 	data["on"] = changing_voice
 	data["say_verb"] = say_verb

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -58,10 +58,10 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	/// If applicable, the time in deciseconds we have to wait before using any more modules
 	var/cooldown_period
 
-/datum/action/innate/ai/Grant(mob/living/L)
+/datum/action/innate/ai/Grant(mob/living/player)
 	. = ..()
 	if(!isAI(owner))
-		WARNING("AI action [name] attempted to grant itself to non-AI mob [key_name(L)]!")
+		WARNING("AI action [name] attempted to grant itself to non-AI mob [key_name(player)]!")
 		qdel(src)
 	else
 		owner_AI = owner
@@ -790,21 +790,23 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	var/upgraded_cameras = 0
 	for(var/obj/machinery/camera/camera as anything in GLOB.cameranet.cameras)
 		var/obj/structure/camera_assembly/assembly = camera.assembly_ref?.resolve()
-		if(assembly)
-			var/upgraded = FALSE
+		if(!assembly)
+			continue
 
-			if(!camera.isXRay())
-				camera.upgradeXRay(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_xray_firmware_active and clean up isxray()
-				//Update what it can see.
-				GLOB.cameranet.updateVisibility(camera, 0)
-				upgraded = TRUE
+		var/upgraded = FALSE
 
-			if(!camera.isEmpProof())
-				camera.upgradeEmpProof(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_emp_firmware_active and clean up isemp()
-				upgraded = TRUE
+		if(!camera.isXRay())
+			camera.upgradeXRay(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_xray_firmware_active and clean up isxray()
+			//Update what it can see.
+			GLOB.cameranet.updateVisibility(camera, 0)
+			upgraded = TRUE
 
-			if(upgraded)
-				upgraded_cameras++
+		if(!camera.isEmpProof())
+			camera.upgradeEmpProof(TRUE) //if this is removed you can get rid of camera_assembly/var/malf_emp_firmware_active and clean up isemp()
+			upgraded = TRUE
+
+		if(upgraded)
+			upgraded_cameras++
 	unlock_text = replacetext(unlock_text, "CAMSUPGRADED", "<b>[upgraded_cameras]</b>") //This works, since unlock text is called after upgrade()
 
 /// AI Turret Upgrade: Increases the health and damage of all turrets.

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -612,7 +612,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 		return
 	var/turf/T = get_turf(owner_AI.eyeobj)
 	var/obj/machinery/transformer/conveyor = new(T)
-	conveyor.masterAI = owner
+	conveyor.master_ai = owner
 	playsound(T, 'sound/effects/phasein.ogg', 100, TRUE)
 	owner_AI.can_shunt = FALSE
 	to_chat(owner, span_warning("You are no longer able to shunt your core to APCs."))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -80,6 +80,9 @@
 	diag_hud_set_borgcell()
 	logevent("System brought online.")
 
+	log_silicon("New cyborg [key_name(src)] created with [connected_ai ? "master AI: [key_name(connected_ai)]" : "no master AI"]")
+	log_current_laws()
+
 	alert_control = new(src, list(ALARM_ATMOS, ALARM_FIRE, ALARM_POWER, ALARM_CAMERA, ALARM_BURGLAR, ALARM_MOTION), list(z))
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_TRIGGERED, PROC_REF(alarm_triggered))
 	RegisterSignal(alert_control.listener, COMSIG_ALARM_LISTENER_CLEARED, PROC_REF(alarm_cleared))

--- a/code/modules/mob/living/silicon/robot/robot_defines.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defines.dm
@@ -1,9 +1,9 @@
-/***************************************************************************************
+/*
  * # robot_defines
  *
  * Definitions for /mob/living/silicon/robot and its children, including AI shells.
  *
- ***************************************************************************************/
+ */
 
 /mob/living/silicon/robot
 	name = "Cyborg"
@@ -26,13 +26,15 @@
 	light_system = MOVABLE_LIGHT_DIRECTIONAL
 	light_on = FALSE
 
+
 	//AI shell
 	var/shell = FALSE
 	var/deployed = FALSE
 	var/mob/living/silicon/ai/mainframe = null
 	var/datum/action/innate/undeployment/undeployment_action = new
 
-// ------------------------------------------ Parts
+
+	// Parts
 	var/custom_name = ""
 	var/braintype = "Cyborg"
 	var/obj/item/mmi/mmi = null
@@ -54,7 +56,8 @@
 
 	var/mutable_appearance/eye_lights
 
-// ------------------------------------------ Hud
+
+	// Hud
 	var/atom/movable/screen/inv1 = null
 	var/atom/movable/screen/inv2 = null
 	var/atom/movable/screen/inv3 = null
@@ -73,14 +76,16 @@
 	var/sight_mode = 0
 	hud_possible = list(ANTAG_HUD, DIAG_STAT_HUD, DIAG_HUD, DIAG_BATT_HUD, DIAG_TRACK_HUD)
 
-// ------------------------------------------ Modules (tool slots)
+
+	// Modules (tool slots)
 	var/obj/item/module_active = null
 	held_items = list(null, null, null) //we use held_items for the module holding, because that makes sense to do!
 
 	///For checking which modules are disabled or not.
 	var/disabled_modules
 
-// ------------------------------------------ Status
+
+	// Status
 	var/mob/living/silicon/ai/connected_ai = null
 
 	var/opened = FALSE
@@ -111,7 +116,8 @@
 	///Ionpulse effect.
 	var/datum/effect_system/trail_follow/ion/ion_trail
 
-// ------------------------------------------ Misc
+
+	// Misc
 	var/toner = 0
 	var/tonermax = 40
 
@@ -124,16 +130,14 @@
 	///What types of mobs are allowed to ride/buckle to this mob
 	var/static/list/can_ride_typecache = typecacheof(/mob/living/carbon/human)
 	can_buckle = TRUE
-	buckle_lying = 0
+	buckle_lying = FALSE
 
 	/// the last health before updating - to check net change in health
 	var/previous_health
 	/// Station alert datum for showing alerts UI
 	var/datum/station_alert/alert_control
 
-/***************************************************************************************
- *                          Defining specific kinds of robots
- ***************************************************************************************/
+// Defining specific kinds of robots
 ///This is the subtype that gets created by robot suits. It's needed so that those kind of borgs don't have a useless cell in them
 /mob/living/silicon/robot/nocell
 	cell = null
@@ -190,9 +194,9 @@
 	scrambledcodes = TRUE // These are rogue borgs.
 	ionpulse = TRUE
 	var/playstyle_string = "<span class='big bold'>You are a Syndicate assault cyborg!</span><br>\
-							<b>You are armed with powerful offensive tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
-							Your cyborg LMG will slowly produce ammunition from your power supply, and your operative pinpointer will find and locate fellow nuclear operatives. \
-							<i>Help the operatives secure the disk at all costs!</i></b>"
+		<b>You are armed with powerful offensive tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
+		Your cyborg LMG will slowly produce ammunition from your power supply, and your operative pinpointer will find and locate fellow nuclear operatives. \
+		<i>Help the operatives secure the disk at all costs!</i></b>"
 	set_model = /obj/item/robot_model/syndicate
 	cell = /obj/item/stock_parts/cell/hyper
 	radio = /obj/item/radio/borg/syndicate
@@ -204,22 +208,22 @@
 /mob/living/silicon/robot/model/syndicate/medical
 	icon_state = "synd_medical"
 	playstyle_string = "<span class='big bold'>You are a Syndicate medical cyborg!</span><br>\
-						<b>You are armed with powerful medical tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
-						Your hypospray will produce Restorative Nanites, a wonder-drug that will heal most types of bodily damages, including clone and brain damage. It also produces morphine for offense. \
-						Your defibrillator paddles can revive operatives through their suits, or can be used on harm intent to shock enemies! \
-						Your energy saw functions as a circular saw, but can be activated to deal more damage, and your operative pinpointer will find and locate fellow nuclear operatives. \
-						<i>Help the operatives secure the disk at all costs!</i></b>"
+		<b>You are armed with powerful medical tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
+		Your hypospray will produce Restorative Nanites, a wonder-drug that will heal most types of bodily damages, including clone and brain damage. It also produces morphine for offense. \
+		Your defibrillator paddles can revive operatives through their suits, or can be used on harm intent to shock enemies! \
+		Your energy saw functions as a circular saw, but can be activated to deal more damage, and your operative pinpointer will find and locate fellow nuclear operatives. \
+		<i>Help the operatives secure the disk at all costs!</i></b>"
 	set_model = /obj/item/robot_model/syndicate_medical
 
 /mob/living/silicon/robot/model/syndicate/saboteur
 	icon_state = "synd_engi"
 	playstyle_string = "<span class='big bold'>You are a Syndicate saboteur cyborg!</span><br>\
-						<b>You are armed with robust engineering tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
-						Your destination tagger will allow you to stealthily traverse the disposal network across the station \
-						Your welder will allow you to repair the operatives' exosuits, but also yourself and your fellow cyborgs \
-						Your cyborg chameleon projector allows you to assume the appearance and registered name of a Nanotrasen engineering borg, and undertake covert actions on the station \
-						Be aware that almost any physical contact or incidental damage will break your camouflage \
-						<i>Help the operatives secure the disk at all costs!</i></b>"
+		<b>You are armed with robust engineering tools to aid you in your mission: help the operatives secure the nuclear authentication disk. \
+		Your destination tagger will allow you to stealthily traverse the disposal network across the station \
+		Your welder will allow you to repair the operatives' exosuits, but also yourself and your fellow cyborgs \
+		Your cyborg chameleon projector allows you to assume the appearance and registered name of a Nanotrasen engineering borg, and undertake covert actions on the station \
+		Be aware that almost any physical contact or incidental damage will break your camouflage \
+		<i>Help the operatives secure the disk at all costs!</i></b>"
 	set_model = /obj/item/robot_model/saboteur
 
 /mob/living/silicon/robot/model/syndicate/kiltborg

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -119,35 +119,35 @@
 	if(notransform)
 		return
 	notransform = TRUE
-	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot(loc)
+	var/mob/living/silicon/robot/new_borg = new /mob/living/silicon/robot(loc)
 
-	R.gender = gender
-	R.invisibility = 0
+	new_borg.gender = gender
+	new_borg.invisibility = 0
 
 	if(client)
-		R.updatename(client)
+		new_borg.updatename(client)
 
 	if(mind) //TODO //TODO WHAT
 		if(!transfer_after)
 			mind.active = FALSE
-		mind.transfer_to(R)
+		mind.transfer_to(new_borg)
 	else if(transfer_after)
-		R.key = key
+		new_borg.key = key
 
-	if(R.mmi)
-		R.mmi.name = "[initial(R.mmi.name)]: [real_name]"
-		if(R.mmi.brain)
-			R.mmi.brain.name = "[real_name]'s brain"
-		if(R.mmi.brainmob)
-			R.mmi.brainmob.real_name = real_name //the name of the brain inside the cyborg is the robotized human's name.
-			R.mmi.brainmob.name = real_name
+	if(new_borg.mmi)
+		new_borg.mmi.name = "[initial(new_borg.mmi.name)]: [real_name]"
+		if(new_borg.mmi.brain)
+			new_borg.mmi.brain.name = "[real_name]'s brain"
+		if(new_borg.mmi.brainmob)
+			new_borg.mmi.brainmob.real_name = real_name //the name of the brain inside the cyborg is the robotized human's name.
+			new_borg.mmi.brainmob.name = real_name
 
-	R.job = JOB_CYBORG
-	R.notify_ai(AI_NOTIFICATION_NEW_BORG)
+	new_borg.job = JOB_CYBORG
+	new_borg.notify_ai(AI_NOTIFICATION_NEW_BORG)
 
-	. = R
-	if(R.ckey && is_banned_from(R.ckey, JOB_CYBORG))
-		INVOKE_ASYNC(R, TYPE_PROC_REF(/mob/living/silicon/robot, replace_banned_cyborg))
+	. = new_borg
+	if(new_borg.ckey && is_banned_from(new_borg.ckey, JOB_CYBORG))
+		INVOKE_ASYNC(new_borg, TYPE_PROC_REF(/mob/living/silicon/robot, replace_banned_cyborg))
 	qdel(src)
 
 /mob/living/Robotize(delete_items = 0, transfer_after = TRUE)


### PR DESCRIPTION
## About The Pull Request
A bunch of code improvements (better variable names, SECONDS defines, autodocs etc) plus more logging for newly-created cyborgs. Also cyborgs do not re-sync if they're already synced to the malf AI. 

## Why It's Good For The Game
Related to #44349 , we want to make sure we know who's synced to who. 

## Changelog

:cl: Tattle
admin: cyborg creation details (synced AI and default laws) are now logged
/:cl: