### PR TITLE
Fix antags being revealed by hallucinations

### DIFF
--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -31,7 +31,7 @@
 
 		for(var/datum/mind/crew_mind in get_crewmember_minds())
 			if(crew_mind.current)
-				humans += existing_human
+				humans += crew_mind.current
 		speaker = pick(humans)
 
 	// Time to generate a message.

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -28,11 +28,10 @@
 	var/is_radio = !speaker || force_radio
 	if(is_radio)
 		var/list/humans = list()
-		for(var/mob/living/carbon/human/existing_human in GLOB.alive_mob_list)
-			// these roles usually have special names that can reveal antags
-			if(IS_WIZARD(existing_human) || IS_NUKE_OP(existing_human) || IS_SPACE_NINJA(existing_human))
-				continue
-			humans += existing_human
+
+		for(var/datum/mind/crew_mind in get_crewmember_minds())
+			if(crew_mind.current)
+				humans += existing_human
 		speaker = pick(humans)
 
 	// Time to generate a message.

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -29,6 +29,9 @@
 	if(is_radio)
 		var/list/humans = list()
 		for(var/mob/living/carbon/human/existing_human in GLOB.alive_mob_list)
+			// these roles usually have special names that can reveal antags
+			if(IS_WIZARD(existing_human) || IS_NUKE_OP(existing_human) || IS_SPACE_NINJA(existing_human))
+				continue
 			humans += existing_human
 		speaker = pick(humans)
 


### PR DESCRIPTION

## About The Pull Request
Fixes #41127

People under the effects of hallucinations would occasionally see nuke op or wizard names in the radio log which would reveal their antag status.

## Why It's Good For The Game
Less cheap exploits, one more bug off the tracker.

## Changelog
:cl:
fix: Fix antags being revealed by hallucinations
/:cl:
