### PR TITLE
Fixes Cooking Menu Bluescreen when the user's species has TRAIT_NOHUNGER

### DIFF
--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -573,17 +573,18 @@ const FoodtypeContent = (props) => {
         {type.toLowerCase()}
       </Stack.Item>
       <Stack.Item>
-        {type === 'Can Make' ? (
-          craftableCount
-        ) : diet.liked_food.includes(type) ? (
-          <Icon name="face-laugh-beam" color={'good'} />
-        ) : diet.disliked_food.includes(type) ? (
-          <Icon name="face-tired" color={'average'} />
-        ) : (
-          diet.toxic_food.includes(type) && (
-            <Icon name="skull-crossbones" color={'bad'} />
-          )
-        )}
+        {type === 'Can Make'
+          ? craftableCount
+          : diet &&
+          (diet.liked_food.includes(type) ? (
+            <Icon name="face-laugh-beam" color={'good'} />
+          ) : diet.disliked_food.includes(type) ? (
+            <Icon name="face-tired" color={'average'} />
+          ) : (
+            diet.toxic_food.includes(type) && (
+              <Icon name="skull-crossbones" color={'bad'} />
+            )
+          ))}
       </Stack.Item>
     </Stack>
   );

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -564,6 +564,23 @@ const MaterialContent = (props, context) => {
 
 const FoodtypeContent = (props) => {
   const { type, diet, craftableCount } = props;
+  let iconName = '',
+    iconColor = '';
+
+  // We use iconName in the return to see if this went through.
+  if (type !== 'Can Make' && diet) {
+    if (diet.liked_food.includes(type)) {
+      iconName = 'face-laugh-beam';
+      iconColor = 'good';
+    } else if (diet.disliked_food.includes(type)) {
+      iconName = 'face-tired';
+      iconColor = 'average';
+    } else if (diet.toxic_food.includes(type)) {
+      iconName = 'skull-crossbones';
+      iconColor = 'bad';
+    }
+  }
+
   return (
     <Stack>
       <Stack.Item width="14px" textAlign="center">
@@ -575,16 +592,7 @@ const FoodtypeContent = (props) => {
       <Stack.Item>
         {type === 'Can Make'
           ? craftableCount
-          : diet &&
-          (diet.liked_food.includes(type) ? (
-            <Icon name="face-laugh-beam" color={'good'} />
-          ) : diet.disliked_food.includes(type) ? (
-            <Icon name="face-tired" color={'average'} />
-          ) : (
-            diet.toxic_food.includes(type) && (
-              <Icon name="skull-crossbones" color={'bad'} />
-            )
-          ))}
+          : iconName && <Icon name={iconName} color={iconColor} />}
       </Stack.Item>
     </Stack>
   );


### PR DESCRIPTION
## About The Pull Request
It bluescreened because it was expecting the `diet` variable to always be an associative list (or dictionaries, or whatever JavaScript/TypeScript calls them), when the proc that would return a species' diet could also return `null` if the species had `TRAIT_NOHUNGER`.

This simply makes it so it skips checking the diet for the menu to be opened.

In the future, it could still be a good idea to change the proc to always return a non-null, as species that don't have hungers can sometimes still eat, so that should probably be addressed. But it's a bit out of scope for this quick bugfix.

## Why It's Good For The Game
Being able to cook is good, even if you might not necessarily be able to enjoy that food yourself.

## Changelog

:cl: GoldenAlpharex
fix: Species that don't suffer from hunger can now properly open the cooking menu.
/:cl: