### PR TITLE
Allows admins to skip some paper sanitization

### DIFF
--- a/code/modules/admin/admin_fax_panel.dm
+++ b/code/modules/admin/admin_fax_panel.dm
@@ -113,11 +113,6 @@
 			if(params["fromWho"])
 				sending_fax_name = params["fromWho"]
 
-			if(params["advancedHTML"])
-				fax_paper.sanitize_text = FALSE
-			else
-				fax_paper.sanitize_text = TRUE
-
 			fax_paper.clear_paper()
 			var/stamp
 			var/stamp_class
@@ -129,7 +124,7 @@
 					break
 
 			fax_paper.name = "paper — [default_paper_name]"
-			fax_paper.add_raw_text(params["rawText"])
+			fax_paper.add_raw_text(params["rawText"], advanced_html = TRUE)
 
 			if(stamp)
 				fax_paper.add_stamp(stamp_class, params["stampX"], params["stampY"], params["stampAngle"], stamp)
@@ -139,13 +134,11 @@
 		if("send")
 			//copy
 			var/obj/item/paper/our_fax = fax_paper.copy(/obj/item/paper)
-			if(!fax_paper.sanitize_text)
-				our_fax.sanitize_text = FALSE
 			our_fax.name = fax_paper.name
 			//send
 			action_fax.receive(our_fax, sending_fax_name)
-			message_admins("[key_name_admin(usr)] has send custom fax message to [action_fax.name][ADMIN_FLW(action_fax)][ADMIN_SHOW_PAPER(fax_paper)].")
-			log_admin("[key_name(usr)] has send custom fax message to [action_fax.name]")
+			message_admins("[key_name_admin(usr)] has sent a custom fax message to [action_fax.name][ADMIN_FLW(action_fax)][ADMIN_SHOW_PAPER(fax_paper)].")
+			log_admin("[key_name(usr)] has sent a custom fax message to [action_fax.name]")
 
 		if("createPaper")
 			var/obj/item/paper/our_paper = fax_paper.copy(/obj/item/paper, usr.loc)

--- a/code/modules/admin/admin_fax_panel.dm
+++ b/code/modules/admin/admin_fax_panel.dm
@@ -10,7 +10,7 @@
 
 	var/datum/fax_panel_interface/ui = new(usr)
 	ui.ui_interact(usr)
-	
+
 /// Admin Fax Panel. Tool for sending fax messages faster.
 /datum/fax_panel_interface
 	/// All faxes in from machinery list()
@@ -30,14 +30,14 @@
 	//Get all faxes, and save them to our list.
 	for(var/obj/machinery/fax/fax in GLOB.machines)
 		available_faxes += WEAKREF(fax)
-	
+
 	//Get all stamps
 	for(var/stamp in subtypesof(/obj/item/stamp))
 		var/obj/item/stamp/real_stamp = new stamp()
 		if(!istype(real_stamp, /obj/item/stamp/chameleon) && !istype(real_stamp, /obj/item/stamp/mod))
 			var/stamp_detail = real_stamp.get_writing_implement_details()
 			stamp_list += list(list(real_stamp.name, real_stamp.icon_state, stamp_detail["stamp_class"]))
-	
+
 	//Give our paper special status, to read everywhere.
 	fax_paper.request_state = TRUE
 
@@ -74,12 +74,12 @@
 
 	for(var/stamp in stamp_list)
 		data["stamps"] += list(stamp[1]) // send only names.
-	
+
 	for(var/datum/weakref/weakrefed_fax as anything in available_faxes)
 		var/obj/machinery/fax/another_fax = weakrefed_fax.resolve()
 		if(another_fax && istype(another_fax))
 			data["faxes"] += list(another_fax.fax_name)
-	
+
 	return data
 
 /datum/fax_panel_interface/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -88,12 +88,12 @@
 
 	if(!check_rights(R_ADMIN))
 		return
-	
+
 	var/obj/machinery/fax/action_fax
 
 	if(params["faxName"])
-		action_fax = get_fax_by_name(params["faxName"]) 
-	
+		action_fax = get_fax_by_name(params["faxName"])
+
 	switch(action)
 
 		if("follow")
@@ -101,20 +101,25 @@
 				usr.client?.admin_ghost()
 
 			usr.client?.admin_follow(action_fax)
-		
+
 		if("preview") // see saved variant
 			if(!fax_paper)
 				return
 			fax_paper.ui_interact(usr)
-		
+
 		if("save") // save paper
 			if(params["paperName"])
 				default_paper_name = params["paperName"]
 			if(params["fromWho"])
 				sending_fax_name = params["fromWho"]
-			
+
+			if(params["advancedHTML"])
+				fax_paper.sanitize_text = FALSE
+			else
+				fax_paper.sanitize_text = TRUE
+
 			fax_paper.clear_paper()
-			var/stamp 
+			var/stamp
 			var/stamp_class
 
 			for(var/needed_stamp in stamp_list)
@@ -122,24 +127,26 @@
 					stamp = needed_stamp[2]
 					stamp_class = needed_stamp[3]
 					break
-			
+
 			fax_paper.name = "paper — [default_paper_name]"
 			fax_paper.add_raw_text(params["rawText"])
 
 			if(stamp)
 				fax_paper.add_stamp(stamp_class, params["stampX"], params["stampY"], params["stampAngle"], stamp)
-			
-			fax_paper.update_static_data(usr) // OK, it's work, and update UI. 
-			
+
+			fax_paper.update_static_data(usr) // OK, it's work, and update UI.
+
 		if("send")
 			//copy
 			var/obj/item/paper/our_fax = fax_paper.copy(/obj/item/paper)
+			if(!fax_paper.sanitize_text)
+				our_fax.sanitize_text = FALSE
 			our_fax.name = fax_paper.name
 			//send
 			action_fax.receive(our_fax, sending_fax_name)
 			message_admins("[key_name_admin(usr)] has send custom fax message to [action_fax.name][ADMIN_FLW(action_fax)][ADMIN_SHOW_PAPER(fax_paper)].")
 			log_admin("[key_name(usr)] has send custom fax message to [action_fax.name]")
-		
+
 		if("createPaper")
 			var/obj/item/paper/our_paper = fax_paper.copy(/obj/item/paper, usr.loc)
 			our_paper.name = fax_paper.name

--- a/tgui/packages/tgui/interfaces/AdminFax.js
+++ b/tgui/packages/tgui/interfaces/AdminFax.js
@@ -17,7 +17,6 @@ export const FaxMainPanel = (props, context) => {
 
   const [fax, setFax] = useLocalState(context, 'fax', '');
   const [saved, setSaved] = useLocalState(context, 'saved', false);
-  const [advancedHTML, setHTML] = useLocalState(context, 'advancedHTML', false);
   const [paperName, setPaperName] = useLocalState(context, 'paperName', '');
   const [fromWho, setFromWho] = useLocalState(context, 'fromWho', '');
   const [rawText, setRawText] = useLocalState(context, 'rawText', '');
@@ -217,13 +216,11 @@ export const FaxMainPanel = (props, context) => {
                 stampY: stampCoordY,
                 stampAngle: stampAngle,
                 fromWho: fromWho,
-                advancedHTML: advancedHTML,
               });
             }}>
             Save
           </Button>
           <Button
-            mr="9px"
             disabled={!saved}
             icon="circle-plus"
             onClick={() =>
@@ -232,12 +229,6 @@ export const FaxMainPanel = (props, context) => {
               })
             }>
             Create paper
-          </Button>
-          <Button
-            color={advancedHTML ? 'green' : 'red'}
-            icon="code"
-            onClick={() => setHTML(!advancedHTML)}>
-            Advanced HTML
           </Button>
         </Box>
       </Section>

--- a/tgui/packages/tgui/interfaces/AdminFax.js
+++ b/tgui/packages/tgui/interfaces/AdminFax.js
@@ -17,6 +17,7 @@ export const FaxMainPanel = (props, context) => {
 
   const [fax, setFax] = useLocalState(context, 'fax', '');
   const [saved, setSaved] = useLocalState(context, 'saved', false);
+  const [advancedHTML, setHTML] = useLocalState(context, 'advancedHTML', false);
   const [paperName, setPaperName] = useLocalState(context, 'paperName', '');
   const [fromWho, setFromWho] = useLocalState(context, 'fromWho', '');
   const [rawText, setRawText] = useLocalState(context, 'rawText', '');
@@ -199,7 +200,7 @@ export const FaxMainPanel = (props, context) => {
                 faxName: fax,
               })
             }>
-            Send fax
+            Send
           </Button>
           <Button
             icon="floppy-disk"
@@ -216,11 +217,13 @@ export const FaxMainPanel = (props, context) => {
                 stampY: stampCoordY,
                 stampAngle: stampAngle,
                 fromWho: fromWho,
+                advancedHTML: advancedHTML,
               });
             }}>
-            Save changes
+            Save
           </Button>
           <Button
+            mr="9px"
             disabled={!saved}
             icon="circle-plus"
             onClick={() =>
@@ -229,6 +232,12 @@ export const FaxMainPanel = (props, context) => {
               })
             }>
             Create paper
+          </Button>
+          <Button
+            color={advancedHTML ? 'green' : 'red'}
+            icon="code"
+            onClick={() => setHTML(!advancedHTML)}>
+            Advanced HTML
           </Button>
         </Box>
       </Section>

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -40,6 +40,7 @@ type PaperInput = {
   font?: string;
   color?: string;
   bold?: boolean;
+  advanced_html?: boolean;
 };
 
 type StampInput = {
@@ -512,6 +513,7 @@ export class PreviewView extends Component<PreviewViewProps> {
       const fontColor = value.color || default_pen_color;
       const fontFace = value.font || default_pen_font;
       const fontBold = value.bold || false;
+      const advancedHtml = value.advanced_html || false;
 
       let processingOutput = this.formatAndProcessRawText(
         rawText,
@@ -520,7 +522,8 @@ export class PreviewView extends Component<PreviewViewProps> {
         paper_color,
         fontBold,
         fieldCount,
-        readOnly
+        readOnly,
+        advancedHtml
       );
 
       output += processingOutput.text;
@@ -647,7 +650,8 @@ export class PreviewView extends Component<PreviewViewProps> {
     paperColor: string,
     bold: boolean,
     fieldCounter: number = 0,
-    forceReadonlyFields: boolean = false
+    forceReadonlyFields: boolean = false,
+    advanced_html: boolean = false
   ): FieldCreationReturn => {
     // First lets make sure it ends in a new line
     const { data } = useBackend<PaperContext>(this.context);
@@ -656,13 +660,8 @@ export class PreviewView extends Component<PreviewViewProps> {
     // Second, parse the text using markup
     const parsedText = this.runMarkedDefault(rawText);
 
-    let sanitizedText = '';
     // Third, we sanitize the text of html
-    if (data.sanitize_text) {
-      sanitizedText = sanitizeText(parsedText);
-    } else {
-      sanitizedText = parsedText;
-    }
+    const sanitizedText = sanitizeText(parsedText, advanced_html);
 
     // Fourth we replace the [__] with fields
     const fieldedText = this.createFields(

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -29,6 +29,7 @@ type PaperContext = {
   default_pen_font: string;
   default_pen_color: string;
   signature_font: string;
+  sanitize_text: boolean;
 
   // ui_data
   held_item_details?: WritingImplement;
@@ -649,13 +650,19 @@ export class PreviewView extends Component<PreviewViewProps> {
     forceReadonlyFields: boolean = false
   ): FieldCreationReturn => {
     // First lets make sure it ends in a new line
+    const { data } = useBackend<PaperContext>(this.context);
     rawText += rawText[rawText.length] === '\n' ? '\n' : '\n\n';
 
     // Second, parse the text using markup
     const parsedText = this.runMarkedDefault(rawText);
 
+    let sanitizedText = '';
     // Third, we sanitize the text of html
-    const sanitizedText = sanitizeText(parsedText);
+    if (data.sanitize_text) {
+      sanitizedText = sanitizeText(parsedText);
+    } else {
+      sanitizedText = parsedText;
+    }
 
     // Fourth we replace the [__] with fields
     const fieldedText = this.createFields(

--- a/tgui/packages/tgui/sanitize.js
+++ b/tgui/packages/tgui/sanitize.js
@@ -45,21 +45,35 @@ const defTag = [
   'ul',
 ];
 
+// Advanced HTML tags that we can trust admins (but not players) with
+const advTag = ['img'];
+
 const defAttr = ['class', 'style'];
 
 /**
  * Feed it a string and it should spit out a sanitized version.
  *
  * @param {string} input
+ * @param {boolean} advHtml
  * @param {array} tags
  * @param {array} forbidAttr
+ * @param {array} advTags
  */
-export const sanitizeText = (input, tags = defTag, forbidAttr = defAttr) => {
+export const sanitizeText = (
+  input,
+  advHtml,
+  tags = defTag,
+  forbidAttr = defAttr,
+  advTags = advTag
+) => {
   // This is VERY important to think first if you NEED
   // the tag you put in here.  We are pushing all this
   // though dangerouslySetInnerHTML and even though
   // the default DOMPurify kills javascript, it dosn't
   // kill href links or such
+  if (advHtml) {
+    tags = tags.concat(advTags);
+  }
   return DOMPurify.sanitize(input, {
     ALLOWED_TAGS: tags,
     FORBID_ATTR: forbidAttr,


### PR DESCRIPTION
## About The Pull Request
This PR allows admins with R_FUN to create paper that doesn't sanitize as much HTML as the default, player-accessible paper. Specifically, the ability for admins with R_FUN to add images that papercode would normally sanitise via HTML img tags.

## Why It's Good For The Game
I'd like to make some fancy papers to send as faxes, but the current sanitization doesn't allow for images.

![image](https://user-images.githubusercontent.com/41448081/211176186-c33d611d-8ac3-4683-bef8-10016e34eaf4.png)

This was a fax I threw together in a few minutes after making the logo
## Changelog
:cl:
admins: Admins with the appropriate permissions can now use HTML image tags in paper and faxes.
/:cl:
