### PR TITLE
Basic mobs don't become dense upon death

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -28,8 +28,8 @@
 ///AI flags
 /// Don't move if being pulled
 #define STOP_MOVING_WHEN_PULLED (1<<0)
-/// Don't act if you're dead
-#define STOP_ACTING_WHILE_DEAD	(1<<1)
+/// Continue processing even if dead
+#define CAN_ACT_WHILE_DEAD	(1<<1)
 
 //Base Subtree defines
 

--- a/code/__DEFINES/basic_mobs.dm
+++ b/code/__DEFINES/basic_mobs.dm
@@ -3,5 +3,5 @@
 ///Basic mob flags
 #define DEL_ON_DEATH (1<<0)
 #define FLIP_ON_DEATH (1<<1)
-#define UNDENSIFY_ON_DEATH (1<<2)
+#define REMAIN_DENSE_WHILE_DEAD (1<<2)
 

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -8,7 +8,7 @@ multiple modular subtrees with behaviors
 	///The atom this controller is controlling
 	var/atom/pawn
 	///Bitfield of traits for this AI to handle extra behavior
-	var/ai_traits = STOP_ACTING_WHILE_DEAD
+	var/ai_traits
 	///Current actions planned to be performed by the AI in the upcoming plan
 	var/list/planned_behaviors
 	///Current actions being performed by the AI.
@@ -120,10 +120,12 @@ multiple modular subtrees with behaviors
 	if(!continue_processing_when_client && mob_pawn.client)
 		final_status = AI_STATUS_OFF
 
-	if(ai_traits & STOP_ACTING_WHILE_DEAD)
-		RegisterSignal(pawn, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_changed))
-		if(mob_pawn.stat == DEAD)
-			final_status = AI_STATUS_OFF
+	if(ai_traits & CAN_ACT_WHILE_DEAD)
+		return final_status
+
+	RegisterSignal(pawn, COMSIG_MOB_STATCHANGE, PROC_REF(on_stat_changed))
+	if(mob_pawn.stat == DEAD)
+		final_status = AI_STATUS_OFF
 
 	return final_status
 

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -8,7 +8,7 @@ multiple modular subtrees with behaviors
 	///The atom this controller is controlling
 	var/atom/pawn
 	///Bitfield of traits for this AI to handle extra behavior
-	var/ai_traits
+	var/ai_traits = NONE
 	///Current actions planned to be performed by the AI in the upcoming plan
 	var/list/planned_behaviors
 	///Current actions being performed by the AI.

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -149,7 +149,7 @@
 	icon_state = icon_dead
 	if(basic_mob_flags & FLIP_ON_DEATH)
 		transform = transform.Turn(180)
-	if(basic_mob_flags & UNDENSIFY_ON_DEATH)
+	if(!(basic_mob_flags & REMAIN_DENSE_WHILE_DEAD))
 		set_density(FALSE)
 
 /mob/living/basic/revive(full_heal_flags = NONE, excess_healing = 0, force_grab_ghost = FALSE)
@@ -163,7 +163,7 @@
 	icon_state = icon_living
 	if(basic_mob_flags & FLIP_ON_DEATH)
 		transform = transform.Turn(180)
-	if(basic_mob_flags & UNDENSIFY_ON_DEATH)
+	if(!(basic_mob_flags & REMAIN_DENSE_WHILE_DEAD))
 		set_density(initial(density))
 
 /mob/living/basic/proc/melee_attack(atom/target, list/modifiers)

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_ai.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_ai.dm
@@ -5,7 +5,7 @@
 		BB_BASIC_MOB_TIPPER = null,
 	)
 
-	ai_traits = STOP_MOVING_WHEN_PULLED | STOP_ACTING_WHILE_DEAD
+	ai_traits = STOP_MOVING_WHEN_PULLED
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(

--- a/code/modules/mob/living/basic/farm_animals/pig.dm
+++ b/code/modules/mob/living/basic/farm_animals/pig.dm
@@ -51,7 +51,7 @@
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction(),
 	)
 
-	ai_traits = STOP_MOVING_WHEN_PULLED | STOP_ACTING_WHILE_DEAD
+	ai_traits = STOP_MOVING_WHEN_PULLED
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 

--- a/code/modules/mob/living/basic/farm_animals/rabbit.dm
+++ b/code/modules/mob/living/basic/farm_animals/rabbit.dm
@@ -50,7 +50,7 @@
 		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction(),
 	)
-	ai_traits = STOP_MOVING_WHEN_PULLED | STOP_ACTING_WHILE_DEAD
+	ai_traits = STOP_MOVING_WHEN_PULLED
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(

--- a/code/modules/mob/living/basic/farm_animals/sheep.dm
+++ b/code/modules/mob/living/basic/farm_animals/sheep.dm
@@ -85,7 +85,7 @@
 		BB_BASIC_MOB_FLEEING = TRUE,
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/ignore_faction(),
 	)
-	ai_traits = STOP_MOVING_WHEN_PULLED | STOP_ACTING_WHILE_DEAD
+	ai_traits = STOP_MOVING_WHEN_PULLED
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(

--- a/code/modules/mob/living/basic/vermin/axolotl.dm
+++ b/code/modules/mob/living/basic/vermin/axolotl.dm
@@ -36,6 +36,6 @@
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 /datum/ai_controller/basic_controller/axolotl
-	ai_traits = STOP_MOVING_WHEN_PULLED | STOP_ACTING_WHILE_DEAD
+	ai_traits = STOP_MOVING_WHEN_PULLED
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -57,7 +57,7 @@
 		BB_PET_TARGETTING_DATUM = new /datum/targetting_datum/not_friends(),
 	)
 
-	ai_traits = STOP_MOVING_WHEN_PULLED | STOP_ACTING_WHILE_DEAD
+	ai_traits = STOP_MOVING_WHEN_PULLED
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(

--- a/code/modules/mob/living/basic/vermin/mothroach.dm
+++ b/code/modules/mob/living/basic/vermin/mothroach.dm
@@ -67,7 +67,7 @@
 /datum/ai_controller/basic_controller/mothroach
 	blackboard = list()
 
-	ai_traits = STOP_MOVING_WHEN_PULLED | STOP_ACTING_WHILE_DEAD
+	ai_traits = STOP_MOVING_WHEN_PULLED
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -357,7 +357,7 @@
 		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic(), // Use this to find people to run away from
 	)
 
-	ai_traits = STOP_MOVING_WHEN_PULLED | STOP_ACTING_WHILE_DEAD
+	ai_traits = STOP_MOVING_WHEN_PULLED
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(
@@ -401,7 +401,7 @@
 		BB_LOW_PRIORITY_HUNTING_TARGET = null, // cable
 	)
 
-	ai_traits = STOP_MOVING_WHEN_PULLED | STOP_ACTING_WHILE_DEAD
+	ai_traits = STOP_MOVING_WHEN_PULLED
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(


### PR DESCRIPTION
## About The Pull Request

In #72260 what was previously a var became a flag, which was a sensible change, however this inverted the default behaviour.
In virtually all cases we want dead mobs to _stop_ being dense, this added a requirement for the flag to be present for that to happen and then didn't add the flag to any mobs.

Rather than add this to every mob I inverted the function of the flag.
My reasoning here is that _simple_ mobs seemingly never required this behaviour, basic mobs are probably going to need it rarely if ever, and including it in `basic_mob_flags` by default seems messy and easy to leave off when setting other flags (plus #72524 implies to me we want to avoid adding more default values).

Setting this manually on each mob seems kind of silly as a requirement going forward and I can't think of a way we'd unit test for people forgetting.

For the same reason I did the same thing with the `STOP_ACTING_WHILE_DEAD` flag I added to the AI controller in a recent PR, the flag should denote unusual behaviour not the default.

## Why It's Good For The Game

It looks really odd when you're constantly shuffling places with dead mobs, they're not supposed to do that.
It's tedious to add `STOP_ACTING_WHILE_DEAD` to every AI controller when that should be an obvious default assumption.

## Changelog

:cl:
fix: Dead basic mobs are no longer "dense" objects and can be stepped on.
/:cl:
