### PR TITLE
Restores 3-tone vote notfication chime

### DIFF
--- a/code/datums/votes/_vote_datum.dm
+++ b/code/datums/votes/_vote_datum.dm
@@ -10,7 +10,7 @@
 	/// If supplied, an override question will be displayed instead of the name of the vote.
 	var/override_question
 	/// The sound effect played to everyone when this vote is initiated.
-	var/vote_sound = 'sound/misc/bloop.ogg'
+	var/vote_sound = 'sound/misc/announce_dig.ogg'
 	/// A list of default choices we have for this vote.
 	var/list/default_choices
 	/// Does the name of this vote contain the word "vote"?


### PR DESCRIPTION

## About The Pull Request
When SSvote was refactored and votes were made into their own datums, the vote notification chime we were using was lost in the process. This restores it.
## Why It's Good For The Game
Three upward tones does a good job at catching your attention for map (or any other) votes.
## Changelog
:cl: LT3
soundadd: The 3-tone chime for vote notifications has returned
/:cl:
