### PR TITLE
Add signal override back as a runtime

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -220,7 +220,7 @@
 /// Registers multiple signals to the same proc.
 /datum/proc/RegisterSignals(datum/target, list/signal_types, proctype, override = FALSE)
 	for (var/signal_type in signal_types)
-		RegisterSignal(target, signal_type, proctype)
+		RegisterSignal(target, signal_type, proctype, override)
 
 /**
  * Stop listening to a given signal from target

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -201,7 +201,9 @@
 	var/list/lookup = (target.comp_lookup ||= list())
 
 	if(!override && target_procs[signal_type])
-		log_signal("[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Proc: [proctype]")
+		var/override_message = "[signal_type] overridden. Use override = TRUE to suppress this warning.\nTarget: [target] ([target.type]) Proc: [proctype]"
+		log_signal(override_message)
+		stack_trace(override_message)
 
 	target_procs[signal_type] = proctype
 	var/list/looked_up = lookup[signal_type]

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -175,9 +175,12 @@
 	UnregisterSignal(small_sprite, COMSIG_ACTION_TRIGGER)
 
 /mob/living/simple_animal/hostile/space_dragon/revive(full_heal_flags = NONE, excess_healing = 0, force_grab_ghost = FALSE)
+	var/was_dead = stat == DEAD
 	. = ..()
 	add_dragon_overlay()
-	RegisterSignal(small_sprite, COMSIG_ACTION_TRIGGER, PROC_REF(add_dragon_overlay))
+
+	if (was_dead)
+		RegisterSignal(small_sprite, COMSIG_ACTION_TRIGGER, PROC_REF(add_dragon_overlay))
 
 /**
  * Allows space dragon to choose its own name.


### PR DESCRIPTION
We're not seeing this on CI and I'm not seeing it on my local DD logs unless I go out of my way to check. Keeping separate file means it's easy to go through, but this indicates a bug that needs to be fixed and so it should still be in runtime.

Doesn't revert #70034, as it still keeps log_signal.