### PR TITLE
Light Replacer cleanup and afterattack improvement

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -27,6 +27,9 @@
 // examines you when you're holding it in your hand, you will be discovered.
 //
 
+#define GLASS_SHEET_USES 5
+#define LIGHTBULB_COST 1
+#define BULB_SHARDS_REQUIRED 4
 
 /obj/item/lightreplacer
 
@@ -46,16 +49,10 @@
 
 	var/max_uses = 20
 	var/uses = 10
-	// How much to increase per each glass?
-	var/increment = 5
-	// How much to take from the glass?
-	var/decrement = 1
 	var/charge = 1
 
-	// Eating used bulbs gives us bulb shards
+	// Eating used bulbs gives us bulb shards. Requires BULB_SHARDS_MAXIMUM to produce a new light.
 	var/bulb_shards = 0
-	// when we get this many shards, we get a free bulb.
-	var/shards_required = 4
 
 	// whether it is "bluespace powered" (can be used at a range)
 	var/bluespace_toggle = FALSE
@@ -71,8 +68,8 @@
 		if(uses >= max_uses)
 			to_chat(user, span_warning("[src.name] is full."))
 			return
-		else if(G.use(decrement))
-			AddUses(increment)
+		else if(G.use(LIGHTBULB_COST))
+			AddUses(GLASS_SHEET_USES)
 			to_chat(user, span_notice("You insert a piece of glass into \the [src.name]. You have [uses] light\s remaining."))
 			return
 		else
@@ -84,7 +81,7 @@
 			return
 		if(!user.temporarilyRemoveItemFromInventory(W))
 			return
-		AddUses(round(increment*0.75))
+		AddUses(round(GLASS_SHEET_USES*0.75))
 		to_chat(user, span_notice("You insert a shard of glass into \the [src]. You have [uses] light\s remaining."))
 		qdel(W)
 		return
@@ -164,10 +161,10 @@
 
 /obj/item/lightreplacer/proc/AddShards(amount = 1, user)
 	bulb_shards += amount
-	var/new_bulbs = round(bulb_shards / shards_required)
+	var/new_bulbs = round(bulb_shards / BULB_SHARDS_REQUIRED)
 	if(new_bulbs > 0)
 		AddUses(new_bulbs)
-	bulb_shards = bulb_shards % shards_required
+	bulb_shards = bulb_shards % BULB_SHARDS_REQUIRED
 	if(new_bulbs != 0)
 		to_chat(user, span_notice("\The [src] fabricates a new bulb from the broken glass it has stored. It now has [uses] uses."))
 		playsound(src.loc, 'sound/machines/ding.ogg', 50, TRUE)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -109,20 +109,21 @@
 		var/replaced_something = TRUE
 
 		for(var/obj/item/item_to_check in storage_to_empty.contents)
-			if(istype(item_to_check, /obj/item/light))
-				var/obj/item/light/found_light = item_to_check
-				found_lightbulbs = TRUE
-				if(src.uses >= max_uses)
-					break
-				if(found_light.status == LIGHT_OK)
-					replaced_something = TRUE
-					add_uses(1)
-					qdel(found_light)
+			if(!istype(item_to_check, /obj/item/light))
+				continue
+			var/obj/item/light/found_light = item_to_check
+			found_lightbulbs = TRUE
+			if(src.uses >= max_uses)
+				break
+			if(found_light.status == LIGHT_OK)
+				replaced_something = TRUE
+				add_uses(1)
+				qdel(found_light)
 
-				else if(found_light.status == LIGHT_BROKEN || found_light.status == LIGHT_BURNED)
-					replaced_something = TRUE
-					add_shards(1, user)
-					qdel(found_light)
+			else if(found_light.status == LIGHT_BROKEN || found_light.status == LIGHT_BURNED)
+				replaced_something = TRUE
+				add_shards(1, user)
+				qdel(found_light)
 
 		if(!found_lightbulbs)
 			to_chat(user, span_warning("\The [storage_to_empty] contains no bulbs."))

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -62,77 +62,77 @@
 	. = ..()
 	. += status_string()
 
-/obj/item/lightreplacer/attackby(obj/item/W, mob/user, params)
+/obj/item/lightreplacer/attackby(obj/item/insert, mob/user, params)
 
-	if(istype(W, /obj/item/stack/sheet/glass))
-		var/obj/item/stack/sheet/glass/G = W
+	if(istype(insert, /obj/item/stack/sheet/glass))
+		var/obj/item/stack/sheet/glass/glass_to_insert = insert
 		if(uses >= max_uses)
 			to_chat(user, span_warning("[src.name] is full."))
 			return
-		else if(G.use(LIGHTBULB_COST))
+		else if(glass_to_insert.use(LIGHTBULB_COST))
 			add_uses(GLASS_SHEET_USES)
 			to_chat(user, span_notice("You insert a piece of glass into \the [src.name]. You have [uses] light\s remaining."))
 			return
 		else
 			to_chat(user, span_warning("You need one sheet of glass to replace lights!"))
 
-	if(istype(W, /obj/item/shard))
+	if(istype(insert, /obj/item/shard))
 		if(uses >= max_uses)
 			to_chat(user, span_warning("\The [src] is full."))
 			return
-		if(!user.temporarilyRemoveItemFromInventory(W))
+		if(!user.temporarilyRemoveItemFromInventory(insert))
 			return
 		add_uses(round(GLASS_SHEET_USES*0.75))
 		to_chat(user, span_notice("You insert a shard of glass into \the [src]. You have [uses] light\s remaining."))
-		qdel(W)
+		qdel(insert)
 		return
 
-	if(istype(W, /obj/item/light))
-		var/obj/item/light/L = W
-		if(L.status == 0) // LIGHT OKAY
+	if(istype(insert, /obj/item/light))
+		var/obj/item/light/light_to_insert = insert
+		if(light_to_insert.status == 0) // LIGHT OKAY
 			if(uses < max_uses)
-				if(!user.temporarilyRemoveItemFromInventory(W))
+				if(!user.temporarilyRemoveItemFromInventory(insert))
 					return
 				add_uses(1)
-				qdel(L)
+				qdel(light_to_insert)
 		else
-			if(!user.temporarilyRemoveItemFromInventory(W))
+			if(!user.temporarilyRemoveItemFromInventory(insert))
 				return
-			to_chat(user, span_notice("You insert [L] into \the [src]."))
+			to_chat(user, span_notice("You insert [light_to_insert] into \the [src]."))
 			add_shards(1, user)
-			qdel(L)
+			qdel(light_to_insert)
 		return
 
-	if(istype(W, /obj/item/storage))
-		var/obj/item/storage/S = W
+	if(istype(insert, /obj/item/storage))
+		var/obj/item/storage/storage_to_empty = insert
 		var/found_lightbulbs = FALSE
 		var/replaced_something = TRUE
 
-		for(var/obj/item/I in S.contents)
-			if(istype(I, /obj/item/light))
-				var/obj/item/light/L = I
+		for(var/obj/item/item_to_check in storage_to_empty.contents)
+			if(istype(item_to_check, /obj/item/light))
+				var/obj/item/light/found_light = item_to_check
 				found_lightbulbs = TRUE
 				if(src.uses >= max_uses)
 					break
-				if(L.status == LIGHT_OK)
+				if(found_light.status == LIGHT_OK)
 					replaced_something = TRUE
 					add_uses(1)
-					qdel(L)
+					qdel(found_light)
 
-				else if(L.status == LIGHT_BROKEN || L.status == LIGHT_BURNED)
+				else if(found_light.status == LIGHT_BROKEN || found_light.status == LIGHT_BURNED)
 					replaced_something = TRUE
 					add_shards(1, user)
-					qdel(L)
+					qdel(found_light)
 
 		if(!found_lightbulbs)
-			to_chat(user, span_warning("\The [S] contains no bulbs."))
+			to_chat(user, span_warning("\The [storage_to_empty] contains no bulbs."))
 			return
 
 		if(!replaced_something && src.uses == max_uses)
 			to_chat(user, span_warning("\The [src] is full!"))
 			return
 
-		to_chat(user, span_notice("You fill \the [src] with lights from \the [S]. " + status_string() + ""))
+		to_chat(user, span_notice("You fill \the [src] with lights from \the [storage_to_empty]. " + status_string() + ""))
 
 /obj/item/lightreplacer/emag_act()
 	if(obj_flags & EMAGGED)

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -148,19 +148,17 @@
 	. = ..()
 	if(!can_use(user))
 		balloon_alert(user, "no more lights!")
+		return
 
 	if(!proximity && !bluespace_toggle)
 		return
 
 	if(!isturf(target))
 		if(istype(target, /obj/machinery/light))
-			if(!proximity)
-				if(bluespace_toggle)
-					if(replace_light(target, user))
-						user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
-						playsound(src, 'sound/items/pshoom.ogg', 40, 1)
-				else
-					balloon_alert(user, "get closer!")
+			if(!proximity && bluespace_toggle)
+				if(replace_light(target, user))
+					user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
+					playsound(src, 'sound/items/pshoom.ogg', 40, 1)
 		return
 
 	for(var/atom/target_atom in target)
@@ -202,19 +200,19 @@
 		add_uses(1)
 		charge = 1
 
-/obj/item/lightreplacer/proc/replace_light(obj/machinery/light/target, mob/living/U)
+/obj/item/lightreplacer/proc/replace_light(obj/machinery/light/target, mob/living/user)
 
 	if(!istype(target)) //Confirm that it's a light we're testing, because afterattack runs this for everything on a given turf and will runtime
 		return
 
 	if(target.status != LIGHT_OK)
-		if(can_use(U))
-			if(!Use(U))
+		if(can_use(user))
+			if(!Use(user))
 				return FALSE
-			to_chat(U, span_notice("You replace \the [target.fitting] with \the [src]."))
+			to_chat(user, span_notice("You replace \the [target.fitting] with \the [src]."))
 
 			if(target.status != LIGHT_EMPTY)
-				add_shards(1, U)
+				add_shards(1, user)
 				target.status = LIGHT_EMPTY
 				target.update()
 
@@ -232,10 +230,10 @@
 			return TRUE
 
 		else
-			to_chat(U, span_warning("\The [src]'s refill light blinks red."))
+			to_chat(user, span_warning("\The [src]'s refill light blinks red."))
 			return FALSE
 	else
-		to_chat(U, span_warning("There is a working [target.fitting] already inserted!"))
+		to_chat(user, span_warning("There is a working [target.fitting] already inserted!"))
 		return FALSE
 
 /obj/item/lightreplacer/proc/Emag()

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -166,6 +166,9 @@
 			balloon_alert(user, "no more lights!")
 			return
 		replace_light(target_atom, user)
+		if(bluespace_toggle)
+			user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
+			playsound(src, 'sound/items/pshoom.ogg', 40, 1)
 
 /obj/item/lightreplacer/update_icon_state()
 	icon_state = "[initial(icon_state)][(obj_flags & EMAGGED ? "-emagged" : "")]"

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -32,10 +32,8 @@
 #define BULB_SHARDS_REQUIRED 4
 
 /obj/item/lightreplacer
-
 	name = "light replacer"
 	desc = "A device to automatically replace lights. Refill with broken or working light bulbs, or sheets of glass."
-
 	icon = 'icons/obj/janitor.dmi'
 	icon_state = "lightreplacer"
 	inhand_icon_state = "electronic"
@@ -158,9 +156,9 @@
 		if(istype(target, /obj/machinery/light))
 			if(!proximity)
 				if(bluespace_toggle)
-					user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
-					playsound(src, 'sound/items/pshoom.ogg', 40, 1)
-					replace_light(target, user)
+					if(replace_light(target, user))
+						user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
+						playsound(src, 'sound/items/pshoom.ogg', 40, 1)
 				else
 					balloon_alert(user, "get closer!")
 		return
@@ -206,10 +204,13 @@
 
 /obj/item/lightreplacer/proc/replace_light(obj/machinery/light/target, mob/living/U)
 
+	if(!istype(target)) //Confirm that it's a light we're testing, because afterattack runs this for everything on a given turf and will runtime
+		return
+
 	if(target.status != LIGHT_OK)
 		if(can_use(U))
 			if(!Use(U))
-				return
+				return FALSE
 			to_chat(U, span_notice("You replace \the [target.fitting] with \the [src]."))
 
 			if(target.status != LIGHT_EMPTY)
@@ -228,14 +229,14 @@
 			target.on = target.has_power()
 			target.update()
 			qdel(L2)
-			return
+			return TRUE
 
 		else
 			to_chat(U, span_warning("\The [src]'s refill light blinks red."))
-			return
+			return FALSE
 	else
 		to_chat(U, span_warning("There is a working [target.fitting] already inserted!"))
-		return
+		return FALSE
 
 /obj/item/lightreplacer/proc/Emag()
 	obj_flags ^= EMAGGED
@@ -265,3 +266,7 @@
 
 /obj/item/lightreplacer/blue/emag_act()
 	return  // balancing against longrange explosions
+
+#undef GLASS_SHEET_USES
+#undef LIGHTBULB_COST
+#undef BULB_SHARDS_REQUIRED

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -45,7 +45,7 @@
 			return
 	if(istype(O, /obj/item/lightreplacer))
 		var/obj/item/lightreplacer/L = O
-		if(state == FLOODLIGHT_NEEDS_LIGHTS && L.CanUse(user))
+		if(state == FLOODLIGHT_NEEDS_LIGHTS && L.can_use(user))
 			L.Use(user)
 			to_chat(user, span_notice("You put lights in [src]."))
 			new /obj/machinery/power/floodlight(loc)

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -306,7 +306,7 @@
 	//Light replacer code
 	if(istype(tool, /obj/item/lightreplacer))
 		var/obj/item/lightreplacer/replacer = tool
-		replacer.ReplaceLight(src, user)
+		replacer.replace_light(src, user)
 		return
 
 	// attempt to insert light


### PR DESCRIPTION

## About The Pull Request

Makes a few code improvements to the light replacer.

* increment, decrement, and bulb shards were three values unnecessarily stored as vars on the light replacer. They are now defines, as they were static values either way.
* Autodocs variables on the light replacer.
* Everything uses snake case, and the single-character vars have all been smote from existence.
* Changes some 0/1 use to FALSE/TRUE

In addition to this cleanup, the afterattack chain has been cleaned up a lot. It now allows you to click on either the light, OR the turf under it to replace a light. As a bonus, you now get some balloon alerts when trying to replace lights while empty.
## Why It's Good For The Game

Closes #72557.

Cleans up the code I had to shuffle through to do so.
## Changelog
:cl: Rhials
qol: the light replacer now allows you to click on either the light, or the floor beneath it, to refill lights.
code: light replacer code is now a bit prettier.
/:cl:
