### PR TITLE
Fixes the orebag module runtiming when removed while the MOD control is still being worn

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -183,6 +183,10 @@
 /obj/item/mod/module/orebag/on_unequip()
 	UnregisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED)
 
+/obj/item/mod/module/orebag/on_uninstall(deleting = FALSE)
+	if(mod && mod.wearer) // We need to do this in the event that the module is uninstalled while the MOD control is still being worn.
+		UnregisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED)
+
 /obj/item/mod/module/orebag/proc/ore_pickup(atom/movable/source, atom/old_loc, dir, forced)
 	SIGNAL_HANDLER
 


### PR DESCRIPTION
## About The Pull Request
Basically, it wasn't unregistering a signal on its wearer when uninstalled when the MOD control it used to be into was still being worn, which meant that every time the wearer would move (MODsuit equipped or not), it would cause a runtime from trying to access `null.wearer` (as it's no longer in a MODsuit).

Which led to tens of thousands of runtimes during certain rounds.

Now it won't runtime anymore.

## Why It's Good For The Game
Runtimes are bad, especially when there's tens of thousands of them caused by one or two instances of an item.

## Changelog

:cl: GoldenAlpharex
fix: The ore bag MOD will no longer cause runtimes every time its original wearer moves after it was removed from their MODsuit, while it was still being worn.
/:cl: