### PR TITLE
Sec Helmets Protect Against Flashes

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/head/helmet
 	name = "helmet"
-	desc = "Standard Security gear. Protects the head from impacts."
+	desc = "Standard Security gear. Protects the head from impacts. Flashproof."
 	icon = 'icons/obj/clothing/head/helmet.dmi'
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "helmet"
@@ -12,6 +12,7 @@
 	max_heat_protection_temperature = HELMET_MAX_TEMP_PROTECT
 	strip_delay = 60
 	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT
+	flash_protect = FLASH_PROTECTION_FLASH
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR
 
@@ -63,9 +64,10 @@
 
 /obj/item/clothing/head/helmet/alt
 	name = "bulletproof helmet"
-	desc = "A bulletproof combat helmet that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
+	desc = "A bulletproof combat helmet that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent. Flashproof."
 	icon_state = "helmetalt"
 	inhand_icon_state = "helmet"
+	flash_protect = FLASH_PROTECTION_FLASH
 	armor_type = /datum/armor/helmet_alt
 	dog_fashion = null
 
@@ -165,8 +167,9 @@
 
 /obj/item/clothing/head/helmet/toggleable/riot
 	name = "riot helmet"
-	desc = "It's a helmet specifically designed to protect against close range attacks."
+	desc = "It's a helmet specifically designed to protect against close range attacks. Flashproof."
 	icon_state = "riot"
+	flash_protect = FLASH_PROTECTION_FLASH
 	inhand_icon_state = "riot_helmet"
 	toggle_message = "You pull the visor down on"
 	alt_toggle_message = "You push the visor up on"


### PR DESCRIPTION
About The Pull Request:

Gives Sec Helmets Flash protection akin to a non-hud pair of sec sunglasses (e.g. flash protection level 1) They do not, however, protect against the ears ringing from a flashbang.

Why It's Good For The Game:

There's been a good few rounds I've latejoined as secoff and was unable to find any HUDglasses or sunglasses, but there are nearly always a few helmets remaining unused. This PR attempts to act as a possible fallback for secoffs who are unable to get sunglasses but still not be vulnrable to flashes. The helmet does not come with a sec HUD, as I felt that would motivate people to steal them for that purpose, but because there are easier, and more legal ways to get flash protection, I generally don't think this PR will cause a spike in helmet theft.

Changelog 🆑 QOL: Gives Security Standard, Bulletproof, and Riot helmets basic flash protection. /🆑