### PR TITLE
Uses RegisterSignals for lists of signals, instead of RegisterSignal.

### DIFF
--- a/code/datums/components/admin_popup.dm
+++ b/code/datums/components/admin_popup.dm
@@ -16,7 +16,7 @@
 
 	create_notice()
 
-	RegisterSignal(
+	RegisterSignals(
 		ticket,
 		list(
 			COMSIG_ADMIN_HELP_MADE_INACTIVE,

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -97,7 +97,7 @@
 		return
 	if(listeningTo)
 		UnregisterSignal(listeningTo, signalCache)
-	RegisterSignal(user, signalCache, PROC_REF(disrupt))
+	RegisterSignals(user, signalCache, PROC_REF(disrupt))
 	listeningTo = user
 
 /obj/item/borg_chameleon/proc/deactivate(mob/living/silicon/robot/user)

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -120,7 +120,7 @@
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/Insert(special = FALSE, drop_if_replaced = TRUE)
 	. = ..()
-	RegisterSignal(owner, signalCache, PROC_REF(on_signal))
+	RegisterSignals(owner, signalCache, PROC_REF(on_signal))
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/proc/on_signal(datum/source, amount)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

Uses RegisterSignals instead of RegisterSignal when registering to a list of signals.

## Why It's Good For The Game

Less error messages, RegisterSignals is meant to be used for lists.

## Changelog

Nothing player-facing.