### PR TITLE
Fix pickle jar crafting

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -501,7 +501,7 @@
 	name = "pickles"
 	desc = "A jar for containing pickles."
 	spawn_type = /obj/item/food/pickle
-	spawn_count = 5
+	spawn_count = 10
 	contents_tag = "pickle"
 	fold_result = null
 	custom_materials = list(/datum/material/glass = 2000)

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -303,6 +303,12 @@
 	result = /obj/item/storage/fancy/pickles_jar
 	category = CAT_MISCFOOD
 
+/datum/crafting_recipe/food/pickles_jar/on_craft_completion(mob/user, atom/result)
+	. = ..()
+	var/obj/item/storage/fancy/pickles_jar/jar = result
+	var/obj/item/reagent_containers/cup/beaker/large/B = locate() in jar.contents
+	qdel(B)
+
 /datum/crafting_recipe/food/springroll
 	name = "Spring roll"
 	reqs = list(

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -306,8 +306,7 @@
 /datum/crafting_recipe/food/pickles_jar/on_craft_completion(mob/user, atom/result)
 	. = ..()
 	var/obj/item/storage/fancy/pickles_jar/jar = result
-	var/obj/item/reagent_containers/cup/beaker/large/B = locate() in jar.contents
-	qdel(B)
+	qdel(locate(/obj/item/reagent_containers/cup/beaker/large) in jar.contents)
 
 /datum/crafting_recipe/food/springroll
 	name = "Spring roll"


### PR DESCRIPTION
## About The Pull Request

Fixes #72568 but  not the underlying bug here. also pulls pickles made in line with the cost
![afbeelding](https://user-images.githubusercontent.com/36102060/211295436-0d654d27-bfbc-4e9b-815a-d0161e9fbc8a.png)


## Why It's Good For The Game

The large beaker is used in the process it should not be added to the pickle jar, the reason for the post-qdel instead of fixing the underlying root is because this seems for some part intended, in the extend that the parts get added to the finished craft. if that isn't supposed to be the case I could rework it a bit so that reagent containers dont get added but this will very likely cause bugs in other crafting recipes

## Changelog
:cl:
fix: Pickle crafting no longer gives an empty beaker
fix: Pickle crafting costs/gives 10 cucumbers/pickles
/:cl:
