### PR TITLE
RCDs can build computer & machine frames on tiles containing directional windows

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -537,13 +537,13 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	if(rcd_results["mode"] == RCD_MACHINE || rcd_results["mode"] == RCD_COMPUTER || rcd_results["mode"] == RCD_FURNISHING)
 		var/turf/target_turf = get_turf(A)
 		//ignore all directional windows on the turf
-		var/static/list/ignore_types = list(/obj/structure/window, /obj/structure/window/reinforced)
-		var/list/directional_windows = list()
+		var/static/list/ignored_atoms = list(/obj/structure/window, /obj/structure/window/reinforced)
+		var/list/ignored_content = list()
 		for(var/atom/movable/movable_content in target_turf)
-			if(is_type_in_list(movable_content, ignore_types))
-				directional_windows += movable_content
-
-		if(target_turf.is_blocked_turf(exclude_mobs = TRUE, source_atom = null, ignore_atoms = directional_windows))
+			if(is_type_in_list(movable_content, ignored_atoms))
+				ignored_content += movable_content
+		//check if the machine can fit on this turf
+		if(target_turf.is_blocked_turf(exclude_mobs = TRUE, source_atom = null, ignore_atoms = ignored_content))
 			playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
 			qdel(rcd_effect)
 			return FALSE

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -536,7 +536,14 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 		return FALSE
 	if(rcd_results["mode"] == RCD_MACHINE || rcd_results["mode"] == RCD_COMPUTER || rcd_results["mode"] == RCD_FURNISHING)
 		var/turf/target_turf = get_turf(A)
-		if(target_turf.is_blocked_turf(exclude_mobs = TRUE))
+
+		var/static/list/ignore_types = list(/obj/structure/window, /obj/structure/window/reinforced)
+		var/list/directional_windows = list()
+		for(var/atom/movable/movable_content in target_turf)
+			if(is_type_in_list(movable_content, ignore_types))
+				directional_windows += movable_content
+
+		if(target_turf.is_blocked_turf(exclude_mobs = TRUE, source_atom = null, ignore_atoms = directional_windows))
 			playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
 			qdel(rcd_effect)
 			return FALSE

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -536,7 +536,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 		return FALSE
 	if(rcd_results["mode"] == RCD_MACHINE || rcd_results["mode"] == RCD_COMPUTER || rcd_results["mode"] == RCD_FURNISHING)
 		var/turf/target_turf = get_turf(A)
-
+		//ignore all directional windows on the turf
 		var/static/list/ignore_types = list(/obj/structure/window, /obj/structure/window/reinforced)
 		var/list/directional_windows = list()
 		for(var/atom/movable/movable_content in target_turf)


### PR DESCRIPTION
## About The Pull Request

If a turf has a directional window or a reinforced directional window it now won't stop, you from making a machine/computer frame on that turf with the RCD

Fixes #59507

## Changelog

:cl:
fix: Directional windows won't block construction of machine & compute frames by the RCD
/:cl: