### PR TITLE
Makes the worn_icons unit test test against worn GAGS configs, instead of regular GAGS configs

### DIFF
--- a/code/modules/unit_tests/worn_icons.dm
+++ b/code/modules/unit_tests/worn_icons.dm
@@ -29,7 +29,7 @@
 			continue
 
 
-		if(initial(item_path.greyscale_colors) && initial(item_path.greyscale_config)) //GAGS has its own unit test.
+		if(initial(item_path.greyscale_colors) && initial(item_path.greyscale_config_worn)) //GAGS has its own unit test.
 			continue
 
 		var/worn_icon = initial(item_path.worn_icon) //override icon file. where our sprite is contained if set. (ie modularity stuff)


### PR DESCRIPTION
## About The Pull Request
It wasn't testing against the right thing, and whilst it doesn't really matter currently, if in the future there's items with worn GAGS configs but no regular GAGS config, they'll be grateful that this doesn't fail.

## Why It's Good For The Game
Stronger unit test good.

## Changelog

:cl: GoldenAlpharex
code: Made the worn_icons unit test check the worn GAGS config rather than the normal one.
/:cl: