### PR TITLE
Client DC Checking for new_player

### DIFF
--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -3,8 +3,12 @@
 		return
 
 	if(CONFIG_GET(flag/use_exp_tracking))
-		client.set_exp_from_db()
-		client.set_db_player_flags()
+		client?.set_exp_from_db()
+		client?.set_db_player_flags()
+		if(!client)
+			// client disconnected during one of the db queries
+			return FALSE
+
 	if(!mind)
 		mind = new /datum/mind(key)
 		mind.active = TRUE
@@ -38,6 +42,8 @@
 
 	var/datum/asset/asset_datum = get_asset_datum(/datum/asset/simple/lobby)
 	asset_datum.send(client)
+	if(!client) // client disconnected during asset transit
+		return FALSE
 
 	// The parent call for Login() may do a bunch of stuff, like add verbs.
 	// Delaying the register_for_interview until the very end makes sure it can clean everything up

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -1,5 +1,7 @@
 /**
- * Run when a client is put in this mob or reconnets to byond and their client was on this mob
+ * Run when a client is put in this mob or reconnets to byond and their client was on this mob.
+ * Anything that sleeps can result in the client reference being dropped, due to byond using that sleep to handle a client disconnect.
+ * You can save a lot of headache if you make Login use SHOULD_NOT_SLEEP, but that would require quite a bit of refactoring how Login code works.
  *
  * Things it does:
  * * Adds player to player_list


### PR DESCRIPTION

## About The Pull Request

Don't you love seeing this
```
[2023-01-08 19:43:47.400] runtime error: Cannot execute null.set db player flags().
 - proc name: Login (/mob/dead/new_player/Login)
 -   source file: login.dm,7
 -   usr: (src)
 -   src: xxx (/mob/dead/new_player)
 -   src.loc: null
 -   call stack:
 - xxx (/mob/dead/new_player): Login()
 - 
[2023-01-08 19:43:47.453] runtime error: Cannot execute null.set db player flags().
 - proc name: Login (/mob/dead/new_player/Login)
 -   source file: login.dm,7
 -   usr: (src)
 -   src: xxx (/mob/dead/new_player)
 -   src.loc: null
 -   call stack:
 - xxx (/mob/dead/new_player): Login()
 - 
[2023-01-08 19:43:47.573] runtime error: Tried to set a mind's current var to a qdeleted mob, what the fuck
 - proc name: set current (/datum/mind/proc/set_current)
 -   source file: _mind.dm,140
 -   usr: xxx (/mob/dead/new_player)
 -   src: /datum/mind (/datum/mind)
 -   usr.loc: null
 -   call stack:
 - /datum/mind (/datum/mind): set current(Phaseu (/mob/dead/new_player))
 - xxx (/mob/dead/new_player): Login()
 - 
[2023-01-08 19:43:47.573] runtime error: Cannot read null.holder
 - proc name: Login (/mob/dead/new_player/Login)
 -   source file: login.dm,14
 -   usr: (src)
 -   src: xxx (/mob/dead/new_player)
 -   src.loc: null
 -   call stack:
 - xxx (/mob/dead/new_player): Login()
```
I dont.
## Why It's Good For The Game

Less runtimes.
## Changelog
