### PR TITLE
Fix for plasmamen potentially spawning without internals, suits, etc

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1015,8 +1015,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(!outfit_important_for_life)
 		return
 
-	outfit_important_for_life= new()
-	outfit_important_for_life.equip(human_to_equip)
+	human_to_equip.equipOutfit(outfit_important_for_life)
 
 /**
  * Species based handling for irradiation

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -120,6 +120,8 @@
 /datum/species/plasmaman/pre_equip_species_outfit(datum/job/job, mob/living/carbon/human/equipping, visuals_only = FALSE)
 	if(job.plasmaman_outfit)
 		equipping.equipOutfit(job.plasmaman_outfit, visuals_only)
+	else 
+		give_important_for_life(equipping)
 	equipping.open_internals(equipping.get_item_for_held_index(2))
 
 /datum/species/plasmaman/random_name(gender,unique,lastname)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -118,7 +118,7 @@
 	. = ..()
 
 /datum/species/plasmaman/pre_equip_species_outfit(datum/job/job, mob/living/carbon/human/equipping, visuals_only = FALSE)
-	if(job.plasmaman_outfit)
+	if(job?.plasmaman_outfit)
 		equipping.equipOutfit(job.plasmaman_outfit, visuals_only)
 	else 
 		give_important_for_life(equipping)


### PR DESCRIPTION
## About The Pull Request

Currently there is a proc, 'give_important_for_life', which was unused except in some downstreams, that was not working properly. It was meant to be used for ensuring plasmamen get their gear upon spawning.

Fixed the issue with that proc and added it as a safety measure for plasmamen who spawn without race-specific job outfits for whatever reason (usually because one was not defined for that job). Also handles plasmamen whose jobs are set to null for whatever reason (event spawners perhaps?)

## Why It's Good For The Game

Fixes a proc that was bugged. Now plasmamen should get the generic plasmamen outfit if their job does not specify a plasmamen version, thus no more immediate combustion!

Fixes #60382 it would seem, tested and no issues were found.

## Changelog

:cl:
fix: fixed give_important_for_life proc in species.dm, which is supposed to be used to help ensure plasmamen (and potentially other races) are always spawned with internals and such
fix: fixed issue where plasmamen who are spawned without a plasmaman-specific job outfit could spawn without internals and a suit, and just start dying immediately
/:cl:
