### PR TITLE
RPED proximity Bug Fix

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -203,7 +203,6 @@
 						return
 				//install board
 				if(install_board(target_board, user, FALSE))
-					user.Beam(src, icon_state = "rped_upgrade", time = 5)
 					replacer.play_rped_sound()
 					//attack this frame again with the rped so it can install stock parts since its now in state 3
 					attackby(replacer, user, params)

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -55,9 +55,6 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 	if(!ismachinery(attacked_object) && !istype(attacked_object, /obj/structure/frame/machine))
 		return ..()
 
-	if(adjacent)
-		return ..()
-
 	if(ismachinery(attacked_object))
 		var/obj/machinery/attacked_machinery = attacked_object
 
@@ -70,6 +67,8 @@ If you create T5+ please take a pass at mech_fabricator.dm. The parts being good
 		return
 
 	var/obj/structure/frame/machine/attacked_frame = attacked_object
+	if(!adjacent && !works_from_distance)
+		return
 	// no point attacking the frame with the rped if the frame doesn't have wiring or it doesn't have components & rped has no circuitboard to offer as an component.
 	if(attacked_frame.state == 1 || (!attacked_frame.components && !has_an_circuitboard()))
 		return


### PR DESCRIPTION
## About The Pull Request

Made a small mistake in my previous PR #72540 that allowed the normal RPED to behave like an BRPED when installing stock parts in an incomplete machine frame. Didn't check correctly for the proximity flag. That's fixed now

## Changelog

:cl:
fix: normal RPED from behaving like an BRPED when installing stock parts in an incomplete machine frame
/:cl: