### PR TITLE
[NO GBP] Fixes a runtime caused by basic ghost mobs

### DIFF
--- a/code/modules/mob/living/basic/retaliate/ghost.dm
+++ b/code/modules/mob/living/basic/retaliate/ghost.dm
@@ -68,14 +68,14 @@
 			ghost_facial_hairstyle = random_facial_hairstyle()
 			ghost_facial_hair_color = ghost_hair_color
 
-	if(!isnull(ghost_hairstyle))
+	if(!isnull(ghost_hairstyle) && ghost_hairstyle != "Bald") //Bald hairstyle and the Shaved facial hairstyle lack an associated sprite and will not properly generate hair, and just cause runtimes.
 		var/datum/sprite_accessory/hair_style = GLOB.hairstyles_list[ghost_hairstyle] //We use the hairstyle name to get the sprite accessory, which we copy the icon_state from.
 		ghost_hair = mutable_appearance('icons/mob/species/human/human_face.dmi', "[hair_style.icon_state]", -HAIR_LAYER)
 		ghost_hair.alpha = 200
 		ghost_hair.color = ghost_hair_color
 		add_overlay(ghost_hair)
 
-	if(!isnull(ghost_facial_hairstyle))
+	if(!isnull(ghost_facial_hairstyle) && ghost_facial_hairstyle != "Shaved")
 		var/datum/sprite_accessory/facial_hair_style = GLOB.facial_hairstyles_list[ghost_facial_hairstyle]
 		ghost_facial_hair = mutable_appearance('icons/mob/species/human/human_face.dmi', "[facial_hair_style.icon_state]", -HAIR_LAYER)
 		ghost_facial_hair.alpha = 200


### PR DESCRIPTION

## About The Pull Request

Fixes a runtime that was causing the CI to fail. The Bald hairstyle and Shaved facial hairstyle had no associated sprites in the hairstyle global lists. This would cause a runtime when trying to generate the hair/beard sprite.

Bonus behind-the-scenes picture of the debug process:

![image](https://user-images.githubusercontent.com/28870487/211610958-fa7432a2-d848-4757-9ae1-e2f91d573ac3.png)
## Why It's Good For The Game

I get scared every time Fikou pings me and this will make him stop.
## Changelog
:cl:
fix: Bald/Shaved ghosts will no longer cause a runtime and spawn without a name.
/:cl:
