### PR TITLE
Add contextual screen tips for APCs

### DIFF
--- a/code/modules/power/apc/apc_contextual_tips.dm
+++ b/code/modules/power/apc/apc_contextual_tips.dm
@@ -1,0 +1,56 @@
+/obj/machinery/power/apc/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	if (isnull(held_item))
+		if (opened == APC_COVER_CLOSED)
+			context[SCREENTIP_CONTEXT_RMB] = locked ? "Unlock" : "Lock"
+		else if (opened == APC_COVER_OPENED && cell)
+			context[SCREENTIP_CONTEXT_LMB] = "Remove cell"
+
+	else if(held_item.tool_behaviour == TOOL_CROWBAR)
+		if (opened == APC_COVER_CLOSED)
+			context[SCREENTIP_CONTEXT_LMB] = "Open the cover"
+		else if ((opened == APC_COVER_OPENED && has_electronics == APC_ELECTRONICS_SECURED) && !(machine_stat & BROKEN))
+			context[SCREENTIP_CONTEXT_LMB] = "Close and lock"
+		else if (machine_stat & BROKEN|(machine_stat & EMAGGED| malfhack))
+			context[SCREENTIP_CONTEXT_LMB] = "Remove damaged board"
+		else
+			context[SCREENTIP_CONTEXT_LMB] = "Remove board"
+
+	else if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
+		if (opened == APC_COVER_CLOSED)
+			context[SCREENTIP_CONTEXT_LMB] = panel_open ? "Unexpose wires" : "Expose wires"
+		else if (cell && opened == APC_COVER_OPENED)
+			context[SCREENTIP_CONTEXT_LMB] = "Remove cell"
+		else if (has_electronics == APC_ELECTRONICS_INSTALLED)
+			context[SCREENTIP_CONTEXT_LMB] = "Fasten the board"
+		else if (has_electronics == APC_ELECTRONICS_SECURED)
+			context[SCREENTIP_CONTEXT_LMB] = "Unfasten the board"
+
+	else if(held_item.tool_behaviour == TOOL_WIRECUTTER)
+		if (terminal && opened == APC_COVER_OPENED)
+			context[SCREENTIP_CONTEXT_LMB] = "Dismantle wire terminal"
+
+	else if(held_item.tool_behaviour == TOOL_WELDER)
+		if (opened == APC_COVER_OPENED && !has_electronics)
+			context[SCREENTIP_CONTEXT_LMB] = "Disassemble the APC"
+
+	else if(istype(held_item, /obj/item/stock_parts/cell) && opened == APC_COVER_OPENED)
+		context[SCREENTIP_CONTEXT_LMB] = "Insert Cell"
+
+	else if(istype(held_item, /obj/item/stack/cable_coil) && opened == APC_COVER_OPENED)
+		context[SCREENTIP_CONTEXT_LMB] = "Create wire terminal"
+
+	else if(istype(held_item, /obj/item/electronics/apc) && opened == APC_COVER_OPENED)
+		context[SCREENTIP_CONTEXT_LMB] = "Insert board"
+
+	else if(istype(held_item, /obj/item/electroadaptive_pseudocircuit) && opened == APC_COVER_OPENED)
+		if (!has_electronics)
+			context[SCREENTIP_CONTEXT_LMB] = "Insert an APC board"
+		else if(!cell)
+			context[SCREENTIP_CONTEXT_LMB] = "Insert a cell"
+
+	else if(istype(held_item, /obj/item/wallframe/apc))
+		context[SCREENTIP_CONTEXT_LMB] = "Replace damaged frame"
+
+	return CONTEXTUAL_SCREENTIP_SET

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -190,6 +190,8 @@
 
 	addtimer(CALLBACK(src, PROC_REF(update)), 5)
 
+	register_context()
+
 	///This is how we test to ensure that mappers use the directional subtypes of APCs, rather than use the parent and pixel-shift it themselves.
 	if(abs(offset_old) != APC_PIXEL_OFFSET)
 		log_mapping("APC: ([src]) at [AREACOORD(src)] with dir ([dir] | [uppertext(dir2text(dir))]) has pixel_[dir & (WEST|EAST) ? "x" : "y"] value [offset_old] - should be [dir & (SOUTH|EAST) ? "-" : ""][APC_PIXEL_OFFSET]. Use the directional/ helpers!")

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -23,10 +23,9 @@
 	if(!opened || has_electronics != APC_ELECTRONICS_INSTALLED)
 		return
 	if(terminal)
-		balloon_alert(user, "disconnect the wires first!")
+		balloon_alert(user, "disconnect wires first!")
 		return
 	crowbar.play_tool_sound(src)
-	balloon_alert(user, "removing the board")
 	if(!crowbar.use_tool(src, user, 50))
 		return
 	if(has_electronics != APC_ELECTRONICS_INSTALLED)
@@ -60,10 +59,10 @@
 
 	if(!opened)
 		if(obj_flags & EMAGGED)
-			balloon_alert(user, "the interface is broken!")
+			balloon_alert(user, "interface is broken!")
 			return
 		toggle_panel_open()
-		balloon_alert(user, "wires are [panel_open ? "exposed" : "unexposed"]")
+		balloon_alert(user, "wires [panel_open ? "exposed" : "unexposed"]")
 		update_appearance()
 		return
 
@@ -175,9 +174,9 @@
 		return
 
 	if(opened)
-		balloon_alert(user, "must close the cover to swipe!")
+		balloon_alert(user, "close the cover first!")
 	else if(panel_open)
-		balloon_alert(user, "must close the panel first!")
+		balloon_alert(user, "close the panel first!")
 	else if(machine_stat & (BROKEN|MAINT))
 		balloon_alert(user, "nothing happens!")
 	else
@@ -209,9 +208,9 @@
 	if(obj_flags & EMAGGED)
 		balloon_alert(user, "interface is broken!")
 	else if(opened)
-		balloon_alert(user, "must close the cover to swipe!")
+		balloon_alert(user, "close the cover first!")
 	else if(panel_open)
-		balloon_alert(user, "must close the panel!")
+		balloon_alert(user, "close the panel first!")
 	else if(machine_stat & (BROKEN|MAINT))
 		balloon_alert(user, "nothing happens!")
 	else

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4171,6 +4171,7 @@
 #include "code\modules\power\tracker.dm"
 #include "code\modules\power\apc\apc_appearance.dm"
 #include "code\modules\power\apc\apc_attack.dm"
+#include "code\modules\power\apc\apc_contextual_tips.dm"
 #include "code\modules\power\apc\apc_main.dm"
 #include "code\modules\power\apc\apc_malf.dm"
 #include "code\modules\power\apc\apc_mapping.dm"


### PR DESCRIPTION

## About The Pull Request
And makes some improvements on their balloon alerts.

The code has a lot of if/else nonsense, I followed how other big chains of screen tips work now but maybe it can be smoothed out, I put the code on it's own DM so we don't need to stare at that wall while dealing with other APC code.
## Why It's Good For The Game
APC is definitely the worst offender on construction being a mess.
I personally like that it is a complicated machine that needs multiple pieces to build/repair, but the bad user experience of doing that just can't be excused.
Need to memorize multiple steps, a sequence of tools, you have "traps" you can get caught into by using the wrong tool, using crowbar at the wrong time and locking the access cover or engiborgs using a screwdriver and ejecting the cell as examples.

Now you will know what will happen before you misuse tool and you will get hints about what each tool does to the APC, even if it is not the right step at the moment, as a balloon alert will explain why the attempt failed.
## Changelog
:cl: Guillaume Prata
qol: APCs have contextual screen tips now.
/:cl:
