### PR TITLE
Headpikes now use proper grammar when referencing their spear type

### DIFF
--- a/code/game/objects/structures/headpike.dm
+++ b/code/game/objects/structures/headpike.dm
@@ -40,7 +40,7 @@
 	return ..()
 
 /obj/structure/headpike/update_name()
-	name = "[victim.real_name] on a [spear]"
+	name = "[victim.real_name] on a [spear.name]"
 	return ..()
 
 /obj/structure/headpike/update_overlays()


### PR DESCRIPTION

## About The Pull Request

When creating a name for the headpike structure, the spear name is now used, rather than just a reference to the spear itself. This led to funky grammar and ruined immersion etc etc.
## Why It's Good For The Game

Closes #72583.
## Changelog
:cl:
spellcheck: Head-spears are now named properly when using alternate spear types.
/:cl:
