### PR TITLE
Mothroach DNA infusion

### DIFF
--- a/code/game/machinery/dna_infuser/infuser_entries.dm
+++ b/code/game/machinery/dna_infuser/infuser_entries.dm
@@ -161,7 +161,7 @@ GLOBAL_LIST_INIT(infuser_entries, prepare_entries())
 /datum/infuser_entry/mothroach
 	name = "Mothroach"
 	infuse_mob_name = "Mothroach"
-	desc = "So first they mixed moth and roach dna to make mothroaches, and now we mix mothroach dna with humanoids to make mothmen hybrid?"
+	desc = "So first they mixed moth and roach DNA to make mothroaches, and now we mix mothroach DNA with humanoids to make mothmen hybrids?"
 	threshold_desc = NO_THRESHOLD
 	qualities = list(
 		"eyes weak to bright lights",

--- a/code/game/machinery/dna_infuser/infuser_entries.dm
+++ b/code/game/machinery/dna_infuser/infuser_entries.dm
@@ -45,12 +45,12 @@ GLOBAL_LIST_INIT(infuser_entries, prepare_entries())
 	)
 	/// organs that the machine could spit out in relation
 	var/list/output_organs = list(
+		/obj/item/organ/internal/appendix/fly,
 		/obj/item/organ/internal/eyes/fly,
-		/obj/item/organ/internal/tongue/fly,
 		/obj/item/organ/internal/heart/fly,
 		/obj/item/organ/internal/lungs/fly,
 		/obj/item/organ/internal/stomach/fly,
-		/obj/item/organ/internal/appendix/fly,
+		/obj/item/organ/internal/tongue/fly,
 	)
 	///message the target gets while being infused
 	var/infusion_desc = "fly-like"
@@ -71,8 +71,8 @@ GLOBAL_LIST_INIT(infuser_entries, prepare_entries())
 	)
 	output_organs = list(
 		/obj/item/organ/internal/eyes/night_vision/rat,
-		/obj/item/organ/internal/stomach/rat,
 		/obj/item/organ/internal/heart/rat,
+		/obj/item/organ/internal/stomach/rat,
 		/obj/item/organ/internal/tongue/rat,
 	)
 	infusion_desc = "skittish"
@@ -92,10 +92,10 @@ GLOBAL_LIST_INIT(infuser_entries, prepare_entries())
 		/mob/living/basic/carp,
 	)
 	output_organs = list(
-		/obj/item/organ/internal/lungs/carp,
-		/obj/item/organ/internal/tongue/carp,
 		/obj/item/organ/internal/brain/carp,
 		/obj/item/organ/internal/heart/carp,
+		/obj/item/organ/internal/lungs/carp,
+		/obj/item/organ/internal/tongue/carp,
 	)
 	infusion_desc = "nomadic"
 
@@ -151,9 +151,31 @@ GLOBAL_LIST_INIT(infuser_entries, prepare_entries())
 		/mob/living/simple_animal/hostile/asteroid/goliath,
 	)
 	output_organs = list(
-		/obj/item/organ/internal/eyes/night_vision/goliath,
-		/obj/item/organ/internal/lungs/lavaland/goliath,
-		/obj/item/organ/internal/heart/goliath,
 		/obj/item/organ/internal/brain/goliath,
+		/obj/item/organ/internal/eyes/night_vision/goliath,
+		/obj/item/organ/internal/heart/goliath,
+		/obj/item/organ/internal/lungs/lavaland/goliath,
 	)
 	infusion_desc = "armored tendril-like"
+
+/datum/infuser_entry/mothroach
+	name = "Mothroach"
+	infuse_mob_name = "Mothroach"
+	desc = "So first they mixed moth and roach dna to make mothroaches, and now we mix mothroach dna with humanoids to make mothmen hybrid?"
+	threshold_desc = NO_THRESHOLD
+	qualities = list(
+		"eyes weak to bright lights",
+		"you flutter when you talk",
+		"wings that can't even carry your body weight",
+		"i hope it was worth it",
+	)
+	input_obj_or_mob = list(
+		/mob/living/basic/mothroach,
+	)
+	output_organs = list(
+		/obj/item/organ/external/antennae,
+		/obj/item/organ/external/wings/moth,
+		/obj/item/organ/internal/eyes/moth,
+		/obj/item/organ/internal/tongue/moth,
+	)
+	infusion_desc = "fluffy"


### PR DESCRIPTION

## About The Pull Request
It has 4 organ options, all default ones from Mothpeople.
Moth eyes: Weak to flash
Moth tongue: Makes you flutter when you talk
Moth antennae: Makes you weaker to noogies
Moth wings: Just normal moth wings

Also ABC'd some lists while there.
## Why It's Good For The Game
I love the infuser and want more content to it, even if this one is mostly memery...
A fun side of the DNA infuser is making a mish mash of species organs into someone, the moth organs are mostly downsides but people still like how they look, win-win.
## Changelog
:cl: Guillaume Prata
add: Mothroach DNA infusion. For better or worse, anyone can get closer to being a Moth person now!
/:cl:
