### PR TITLE
Deadchat controlled mobs/objects now appear in the orbit menu.

### DIFF
--- a/code/datums/components/deadchat_control.dm
+++ b/code/datums/components/deadchat_control.dm
@@ -26,7 +26,8 @@
 	var/deadchat_mode
 	/// In DEMOCRACY_MODE, this is how long players have to vote on an input. In ANARCHY_MODE, this is how long between inputs for each unique player.
 	var/input_cooldown
-
+	///Set to true if a point of interest was created for an object, and needs to be removed if deadchat control is removed. Needed for preventing objects from having two points of interest.
+	var/generated_point_of_interest = FALSE
 	/// Callback invoked when this component is Destroy()ed to allow the parent to return to a non-deadchat controlled state.
 	var/datum/callback/on_removal
 
@@ -46,12 +47,17 @@
 			stack_trace("deadchat_control component added to [parent.type] with both democracy and anarchy modes enabled.")
 		timerid = addtimer(CALLBACK(src, PROC_REF(democracy_loop)), input_cooldown, TIMER_STOPPABLE | TIMER_LOOP)
 	notify_ghosts("[parent] is now deadchat controllable!", source = parent, action = NOTIFY_ORBIT, header="Something Interesting!")
+	if(!ismob(parent) && !SSpoints_of_interest.is_valid_poi(parent))
+		SSpoints_of_interest.make_point_of_interest(parent)
+		generated_point_of_interest = TRUE
 
 /datum/component/deadchat_control/Destroy(force, silent)
 	on_removal?.Invoke()
 	inputs = null
 	orbiters = null
 	ckey_to_cooldown = null
+	if(generated_point_of_interest)
+		SSpoints_of_interest.remove_point_of_interest(parent)
 	return ..()
 
 /datum/component/deadchat_control/proc/deadchat_react(mob/source, message)

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -4,7 +4,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 	///mobs worth orbiting. Because spaghetti, all mobs have the point of interest, but only some are allowed to actually show up.
 	///this obviously should be changed in the future, so we only add mobs as POI if they actually are interesting, and we don't use
 	///a typecache.
-	var/static/list/mob_allowed_typecache = list()
+	var/static/list/mob_allowed_typecache
 
 /datum/orbit_menu/ui_state(mob/user)
 	return GLOB.observer_state
@@ -49,6 +49,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 
 	var/list/alive = list()
 	var/list/antagonists = list()
+	var/list/deadchat_controlled = list()
 	var/list/dead = list()
 	var/list/ghosts = list()
 	var/list/misc = list()
@@ -60,13 +61,18 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		var/mob/mob_poi = new_mob_pois[name]
 
 		var/poi_ref = REF(mob_poi)
+
+		var/number_of_orbiters = length(mob_poi.get_all_orbiters())
+
 		serialized["ref"] = poi_ref
 		serialized["full_name"] = name
+		if(number_of_orbiters)
+			serialized["orbiters"] = number_of_orbiters
+
+		if(mob_poi.GetComponent(/datum/component/deadchat_control))
+			deadchat_controlled += list(serialized)
 
 		if(isobserver(mob_poi))
-			var/number_of_orbiters = length(mob_poi.get_all_orbiters())
-			if (number_of_orbiters)
-				serialized["orbiters"] = number_of_orbiters
 			ghosts += list(serialized)
 			continue
 
@@ -77,10 +83,6 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 		if(isnull(mob_poi.mind))
 			npcs += list(serialized)
 			continue
-
-		var/number_of_orbiters = length(mob_poi.get_all_orbiters())
-		if(number_of_orbiters)
-			serialized["orbiters"] = number_of_orbiters
 
 		var/datum/mind/mind = mob_poi.mind
 		var/was_antagonist = FALSE
@@ -111,6 +113,16 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 	for(var/name in new_other_pois)
 		var/atom/atom_poi = new_other_pois[name]
 
+		// Deadchat Controlled objects are orbitable
+		if(atom_poi.GetComponent(/datum/component/deadchat_control))
+			var/number_of_orbiters = length(atom_poi.get_all_orbiters())
+			deadchat_controlled += list(list(
+				"ref" = REF(atom_poi),
+				"full_name" = name,
+				"orbiters" = number_of_orbiters,
+			))
+			continue
+
 		misc += list(list(
 			"ref" = REF(atom_poi),
 			"full_name" = name,
@@ -137,6 +149,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 	return list(
 		"alive" = alive,
 		"antagonists" = antagonists,
+		"deadchat_controlled" = deadchat_controlled,
 		"dead" = dead,
 		"ghosts" = ghosts,
 		"misc" = misc,
@@ -151,7 +164,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
  * Helper POI validation function passed as a callback to various SSpoints_of_interest procs.
  *
  * Provides extended validation above and beyond standard, limiting mob POIs without minds or ckeys
- * unless they're mobs, camera mobs or megafauna.
+ * unless they're mobs, camera mobs or megafauna. Also allows exceptions for mobs that are deadchat controlled.
  *
  * If they satisfy that requirement, falls back to default validation for the POI.
  */
@@ -165,7 +178,7 @@ GLOBAL_DATUM_INIT(orbit_menu, /datum/orbit_menu, new)
 				/mob/living/simple_animal/hostile/megafauna,
 				/mob/living/simple_animal/hostile/regalrat,
 			))
-		if(!is_type_in_typecache(potential_mob_poi, mob_allowed_typecache))
+		if(!is_type_in_typecache(potential_mob_poi, mob_allowed_typecache) && !potential_mob_poi.GetComponent(/datum/component/deadchat_control))
 			return FALSE
 
 	return potential_poi.validate()

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -166,12 +166,12 @@ const ObservableContent = (props, context) => {
           />
         );
       })}
-      <ObservableSection color="blue" section={alive} title="Alive" />
       <ObservableSection
         color="purple"
         section={deadchat_controlled}
         title="Deadchat Controlled"
       />
+      <ObservableSection color="blue" section={alive} title="Alive" />
       <ObservableSection section={dead} title="Dead" />
       <ObservableSection section={ghosts} title="Ghosts" />
       <ObservableSection section={misc} title="Misc" />

--- a/tgui/packages/tgui/interfaces/Orbit/index.tsx
+++ b/tgui/packages/tgui/interfaces/Orbit/index.tsx
@@ -34,6 +34,7 @@ const ObservableSearch = (props, context) => {
   const {
     alive = [],
     antagonists = [],
+    deadchat_controlled = [],
     dead = [],
     ghosts = [],
     misc = [],
@@ -67,7 +68,9 @@ const ObservableSearch = (props, context) => {
       // Sorts descending by orbiters
       sortBy<Observable>((observable) => -(observable.orbiters || 0)),
       // Makes a single Observables list for an easy search
-    ])([alive, antagonists, dead, ghosts, misc, npcs].flat())[0];
+    ])(
+      [alive, antagonists, deadchat_controlled, dead, ghosts, misc, npcs].flat()
+    )[0];
 
     if (mostRelevant !== undefined) {
       act('orbit', {
@@ -138,6 +141,7 @@ const ObservableContent = (props, context) => {
   const {
     alive = [],
     antagonists = [],
+    deadchat_controlled = [],
     dead = [],
     ghosts = [],
     misc = [],
@@ -163,6 +167,11 @@ const ObservableContent = (props, context) => {
         );
       })}
       <ObservableSection color="blue" section={alive} title="Alive" />
+      <ObservableSection
+        color="purple"
+        section={deadchat_controlled}
+        title="Deadchat Controlled"
+      />
       <ObservableSection section={dead} title="Dead" />
       <ObservableSection section={ghosts} title="Ghosts" />
       <ObservableSection section={misc} title="Misc" />

--- a/tgui/packages/tgui/interfaces/Orbit/types.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/types.ts
@@ -5,6 +5,7 @@ export type AntagGroup = [string, Antags];
 export type OrbitData = {
   alive: Observable[];
   antagonists: Antags;
+  deadchat_controlled: Observable[];
   dead: Observable[];
   ghosts: Observable[];
   misc: Observable[];


### PR DESCRIPTION
## About The Pull Request

Remake of #72621

When a mob/object is granted deadchat control either by an admin or the Ian's Adventure station trait it will now become orbitable and will appear in its own section in the orbit menu. Deadchat controlled objects will now also show a count of how many ghosts are orbiting it.

Also fixes #72340
## Why It's Good For The Game

I've seen Ian's adventure roll a lot with no ghosts interacting with it, I believe this is because theres no real indication that its rolled unless you observe roundstart. Additionally I think this is useful to draw more attention to ghost chat controlled things for admins.
## Changelog
:cl:
fix: AI eyes, megafauna and robots will appear in the orbit menu NPC section again.
qol: Everything deadchat controlled will now be highlighted in the orbit menu.
/:cl: