### PR TITLE
Fixes a runtime with BotKeeper and observers

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -213,6 +213,8 @@
 		return TRUE
 	if(!(bot_cover_flags & BOT_COVER_LOCKED)) // Unlocked.
 		return TRUE
+	if(isdead(user)) //These shouldn't be able to manipulate bots, and will runtime if passed down any further.
+		return FALSE
 
 	var/obj/item/card/id/used_id = id || user.get_idcard(TRUE)
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -213,7 +213,7 @@
 		return TRUE
 	if(!(bot_cover_flags & BOT_COVER_LOCKED)) // Unlocked.
 		return TRUE
-	if(isdead(user)) //These shouldn't be able to manipulate bots, and will runtime if passed down any further.
+	if(!istype(user)) // Non-living mobs shouldn't be manipulating bots (like observes using the botkeeper UI).
 		return FALSE
 
 	var/obj/item/card/id/used_id = id || user.get_idcard(TRUE)


### PR DESCRIPTION

## About The Pull Request

Viewing the botkeeper app on an open computer as an observer would cause a runtime. check_access runtimes when passed something that isn't a mob/living, so an observer who opens the UI would be passed into check_access for every bot on station, causing runtimes.

![image](https://user-images.githubusercontent.com/28870487/211671642-7461229d-16e0-42c4-a64f-35f8d95a65c7.png)
## Why It's Good For The Game

This runtime fix was brought to you by [https://runtimes.moth.fans/runtime/](https://runtimes.moth.fans/runtime)
## Changelog
:cl:
fix: viewing the botkeeper app as an observer will no longer runtime.
/:cl:
