### PR TITLE
fixes a way to kill colossus with no work

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -133,8 +133,11 @@
 		qdel(src)
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/projectile/P)
-	visible_message(span_danger("The [P.name] is repelled by [name]'s girth!"))
-	return BULLET_ACT_BLOCK
+	if(istype(P, /obj/projectile/colossus))
+		return BULLET_ACT_FORCE_PIERCE
+	else
+		visible_message(span_danger("The [P.name] is repelled by [name]'s girth!"))
+		return BULLET_ACT_BLOCK
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	vision_range = 9

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -133,7 +133,7 @@
 		qdel(src)
 
 /mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/projectile/P)
-	if(istype(P, /obj/projectile/colossus))
+	if(stat == DEAD)
 		return BULLET_ACT_FORCE_PIERCE
 	else
 		visible_message(span_danger("The [P.name] is repelled by [name]'s girth!"))


### PR DESCRIPTION

## About The Pull Request
like the old body chair method, but better

grab a dead goldgrub, run up to a colossus, and start shooting! It will block the colossi's bolts as they're direct hit or whatever, while you can shoot over the grub! Walk in a straight line firing your KA with the grub pulled behind you for a quick easy kill

this PR prevents that by making the bolts pierce the grub, and hit you!
## Why It's Good For The Game
no more easy colossus kills via goldgrub
## Changelog
:cl:
fix: you can nolonger use a goldgrub as a shield to kill colossus
/:cl:
