### PR TITLE
Fixes borg sprites not updating when light is turned on

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -345,6 +345,7 @@
 		if(!eye_lights)
 			eye_lights = new()
 		if(lamp_enabled || lamp_doom)
+			eye_lights.icon_state = "[model.special_light_key ? "[model.special_light_key]":"[model.cyborg_base_icon]"]_l"
 			set_light_range(max(MINIMUM_USEFUL_LIGHT_RANGE, lamp_intensity))
 			set_light_color(lamp_doom ? COLOR_RED : lamp_color) //Red for doomsday killborgs, borg's choice otherwise
 			SET_PLANE_EXPLICIT(eye_lights, ABOVE_LIGHTING_PLANE, src) //glowy eyes

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -345,7 +345,7 @@
 		if(!eye_lights)
 			eye_lights = new()
 		if(lamp_enabled || lamp_doom)
-			eye_lights.icon_state = "[model.special_light_key ? "[model.special_light_key]":"[model.cyborg_base_icon]"]_l"
+			eye_lights.icon_state = "[model.special_light_key ? "[model.special_light_key]" : "[model.cyborg_base_icon]"]_l"
 			set_light_range(max(MINIMUM_USEFUL_LIGHT_RANGE, lamp_intensity))
 			set_light_color(lamp_doom ? COLOR_RED : lamp_color) //Red for doomsday killborgs, borg's choice otherwise
 			SET_PLANE_EXPLICIT(eye_lights, ABOVE_LIGHTING_PLANE, src) //glowy eyes


### PR DESCRIPTION

## About The Pull Request
Fixes borg sprites not updating when the light is turned on
Fixes #71036
## Why It's Good For The Game
When a cyborgs light is on the sprite should match it
![image](https://user-images.githubusercontent.com/71794877/211858464-81083421-dd40-41b2-9a12-d5deba79d966.png)
## Changelog
:cl:

fix: Cyborgs turning their lights on and off can now be seen doing so.

/:cl:
