### PR TITLE
Adds atmos holofans to Metastation's ordnance lab.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3932,14 +3932,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/burnchamber)
-"bqy" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 6
-	},
-/obj/structure/table,
-/obj/item/clipboard,
-/turf/open/floor/iron/white,
-/area/station/science/ordnance/office)
 "bqJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56534,6 +56526,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"tVv" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 6
+	},
+/obj/structure/table,
+/obj/item/clipboard,
+/obj/item/holosign_creator/atmos,
+/obj/item/holosign_creator/atmos,
+/turf/open/floor/iron/white,
+/area/station/science/ordnance/office)
 "tVP" = (
 /obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark,
@@ -102189,7 +102191,7 @@ fnh
 mMX
 moF
 klT
-bqy
+tVv
 svS
 dKC
 lMW


### PR DESCRIPTION

## About The Pull Request
Adds atmos holofans to Metastation's ordnance lab.

## Why It's Good For The Game
Metastation's ordnance lab lacks atmos holofans, while other maps have atmos holofans in ordnance. This fixes a consistency
issue. 
## Changelog
:cl:
add: Added atmos holofans to metastation's ordnance lab.
/:cl:
