### PR TITLE
Fixes a bad argument for onwear comp

### DIFF
--- a/code/datums/components/onwear_mood.dm
+++ b/code/datums/components/onwear_mood.dm
@@ -7,7 +7,7 @@
 	/// what slots it needs to be equipped to to work
 	var/slot_equip
 
-/datum/component/onwear_mood/Initialize(datum/mood_event/saved_event, examine_string, slot_equip = ITEM_SLOT_ON_BODY)
+/datum/component/onwear_mood/Initialize(datum/mood_event/saved_event_type, examine_string, slot_equip = ITEM_SLOT_ON_BODY)
 
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE


### PR DESCRIPTION
## About The Pull Request

Everywhere used `saved_event_type` but the parameters, causing runtime

## Why It's Good For The Game

Runtimes bad

## Changelog

:cl: Melbert
fix: Fixed not getting moodlet from freshly laundered clothing
/:cl:
