### PR TITLE
Fixes durability tags not showing their class

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -314,7 +314,7 @@
 			if(!added_durability_header)
 				readout += "\n<b>DURABILITY (I-X)</b>"
 				added_damage_header = TRUE
-			readout += "\n[armor_to_protection_name(durability_key)] [armor_to_protection_class(durability_key)]"
+			readout += "\n[armor_to_protection_name(durability_key)] [armor_to_protection_class(rating)]"
 
 		if(flags_cover & HEADCOVERSMOUTH || flags_cover & PEPPERPROOF)
 			var/list/things_blocked = list()


### PR DESCRIPTION
## About The Pull Request

Copy paste error. `armor_to_protection_class` should take a number, the armor rating. 

## Why It's Good For The Game

Runtimes bad

## Changelog

:cl: Melbert
fix: Fixed durability tags not showing their ratings
/:cl:
