### PR TITLE
Fixes calling on_death on null organ runtime

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -339,7 +339,7 @@
 			return
 		for(var/obj/item/organ/internal/organ as anything in internal_organs)
 			// On-death is where organ decay is handled
-			organ.on_death(delta_time, times_fired)
+			organ?.on_death(delta_time, times_fired) // organ can be null due to reagent metabolization
 			// We need to re-check the stat every organ, as one of our others may have revived us
 			if(stat != DEAD)
 				break

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -339,7 +339,7 @@
 			return
 		for(var/obj/item/organ/internal/organ as anything in internal_organs)
 			// On-death is where organ decay is handled
-			organ?.on_death(delta_time, times_fired) // organ can be null due to reagent metabolization
+			organ?.on_death(delta_time, times_fired) // organ can be null due to reagent metabolization causing organ shuffling
 			// We need to re-check the stat every organ, as one of our others may have revived us
 			if(stat != DEAD)
 				break


### PR DESCRIPTION

## About The Pull Request

https://runtimes.moth.fans/runtime/Cannot%20execute%20null.on%20death()._______%2Fmob%2Fliving%2Fcarbon%2Fproc%2Fhandle_organs

There's a pattern in this proc that wasn't implemented in #70635, and that is that organ is not guaranteed to exist (can be null due to some types of reagent metabolization?). Anyways, this would just cause this runtime:

```txt
[2023-01-05 05:45:23.541] runtime error: Cannot execute null.on death().
 - proc name: handle organs (/mob/living/carbon/proc/handle_organs)
 -   source file: life.dm,343
 -   usr: null
 -   src: Unknown (/mob/living/carbon/human/species/monkey)
 -   src.loc: the floor (51,185,2) (/turf/open/floor/iron/chapel)
 -   call stack:
 - Unknown (/mob/living/carbon/human/species/monkey): handle organs(2, 4585)
 - Unknown (/mob/living/carbon/human/species/monkey): Life(2, 4585)
 - Unknown (/mob/living/carbon/human/species/monkey): Life(2, 4585)
 - Mobs (/datum/controller/subsystem/mobs): fire(0)
 - Mobs (/datum/controller/subsystem/mobs): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```

Since the assumption elsewhere is that organ can indeed be null, let's just apply that to the runtiming line in question.
## Why It's Good For The Game

Less runtimes due to expected behavior.
## Changelog
Nothing that should affect players.
