### PR TITLE
VV outfits now ignore cached_ref

### DIFF
--- a/code/modules/clothing/outfits/vv_outfit.dm
+++ b/code/modules/clothing/outfits/vv_outfit.dm
@@ -46,7 +46,7 @@
 
 /proc/collect_vv(obj/item/I)
 	//Temporary/Internal stuff, do not copy these.
-	var/static/list/ignored_vars = list("vars","x","y","z","plane","layer","override","animate_movement","pixel_step_size","screen_loc","fingerprintslast","tip_timer")
+	var/static/list/ignored_vars = list("vars","x","y","z","plane","layer","override","animate_movement","pixel_step_size","screen_loc","fingerprintslast","tip_timer","cached_ref")
 
 	if(istype(I) && I.datum_flags & DF_VAR_EDITED)
 		var/list/vedits = list()

--- a/code/modules/clothing/outfits/vv_outfit.dm
+++ b/code/modules/clothing/outfits/vv_outfit.dm
@@ -46,7 +46,20 @@
 
 /proc/collect_vv(obj/item/item)
 	//Temporary/Internal stuff, do not copy these.
-	var/static/list/ignored_vars = list("vars","x","y","z","plane","layer","override","animate_movement","pixel_step_size","screen_loc","fingerprintslast","tip_timer","cached_ref","datum_flags")
+	var/static/list/ignored_vars = list(
+		NAMEOF(item, animate_movement),
+		NAMEOF(item, cached_ref),
+		NAMEOF(item, datum_flags),
+		NAMEOF(item, fingerprintslast),
+		NAMEOF(item, layer),
+		NAMEOF(item, plane),
+		NAMEOF(item, screen_loc),
+		NAMEOF(item, tip_timer),
+		NAMEOF(item, vars),
+		NAMEOF(item, x),
+		NAMEOF(item, y),
+		NAMEOF(item, z),
+	)
 
 	if(istype(item) && item.datum_flags & DF_VAR_EDITED)
 		var/list/vedits = list()

--- a/code/modules/clothing/outfits/vv_outfit.dm
+++ b/code/modules/clothing/outfits/vv_outfit.dm
@@ -10,7 +10,7 @@
 	equipping_mob.delete_equipment() //Applying VV to wrong objects is not reccomended.
 	return ..()
 
-/datum/outfit/varedit/proc/set_equipement_by_slot(slot,item_path)
+/datum/outfit/varedit/proc/set_equipment_by_slot(slot,item_path)
 	switch(slot)
 		if(ITEM_SLOT_ICLOTHING)
 			uniform = item_path
@@ -44,113 +44,113 @@
 			r_pocket = item_path
 
 
-/proc/collect_vv(obj/item/I)
+/proc/collect_vv(obj/item/item)
 	//Temporary/Internal stuff, do not copy these.
-	var/static/list/ignored_vars = list("vars","x","y","z","plane","layer","override","animate_movement","pixel_step_size","screen_loc","fingerprintslast","tip_timer","cached_ref")
+	var/static/list/ignored_vars = list("vars","x","y","z","plane","layer","override","animate_movement","pixel_step_size","screen_loc","fingerprintslast","tip_timer","cached_ref","datum_flags")
 
-	if(istype(I) && I.datum_flags & DF_VAR_EDITED)
+	if(istype(item) && item.datum_flags & DF_VAR_EDITED)
 		var/list/vedits = list()
-		for(var/varname in I.vars)
-			if(!I.can_vv_get(varname))
+		for(var/varname in item.vars)
+			if(!item.can_vv_get(varname))
 				continue
 			if(varname in ignored_vars)
 				continue
-			var/vval = I.vars[varname]
+			var/vval = item.vars[varname]
 			//Does it even work ?
-			if(vval == initial(I.vars[varname]))
+			if(vval == initial(item.vars[varname]))
 				continue
 			//Only text/numbers and icons variables to make it less weirdness prone.
 			if(!istext(vval) && !isnum(vval) && !isicon(vval))
 				continue
-			vedits[varname] = I.vars[varname]
+			vedits[varname] = item.vars[varname]
 		return vedits
 
 /mob/living/carbon/human/proc/copy_outfit()
-	var/datum/outfit/varedit/O = new
+	var/datum/outfit/varedit/outfit = new
 
 	//Copy equipment
 	var/list/result = list()
 	var/list/slots_to_check = list(ITEM_SLOT_ICLOTHING,ITEM_SLOT_BACK,ITEM_SLOT_OCLOTHING,ITEM_SLOT_BELT,ITEM_SLOT_GLOVES,ITEM_SLOT_FEET,ITEM_SLOT_HEAD,ITEM_SLOT_MASK,ITEM_SLOT_NECK,ITEM_SLOT_EARS,ITEM_SLOT_EYES,ITEM_SLOT_ID,ITEM_SLOT_SUITSTORE,ITEM_SLOT_LPOCKET,ITEM_SLOT_RPOCKET)
-	for(var/s in slots_to_check)
-		var/obj/item/I = get_item_by_slot(s)
-		var/vedits = collect_vv(I)
+	for(var/slot in slots_to_check)
+		var/obj/item/item = get_item_by_slot(slot)
+		var/vedits = collect_vv(item)
 		if(vedits)
-			result["[s]"] = vedits
-		if(istype(I))
-			O.set_equipement_by_slot(s,I.type)
+			result["[slot]"] = vedits
+		if(istype(item))
+			outfit.set_equipment_by_slot(slot, item.type)
 
 	//Copy access
-	O.stored_access = list()
+	outfit.stored_access = list()
 	var/obj/item/id_slot = get_item_by_slot(ITEM_SLOT_ID)
 	if(id_slot)
-		O.stored_access |= id_slot.GetAccess()
+		outfit.stored_access |= id_slot.GetAccess()
 		var/obj/item/card/id/ID = id_slot.GetID()
 		if(ID)
 			if(ID.registered_name == real_name)
-				O.update_id_name = TRUE
+				outfit.update_id_name = TRUE
 			if(ID.trim)
-				O.id_trim = ID.trim.type
+				outfit.id_trim = ID.trim.type
 	//Copy hands
 	if(held_items.len >= 2) //Not in the mood to let outfits transfer amputees
 		var/obj/item/left_hand = held_items[1]
 		var/obj/item/right_hand = held_items[2]
 		if(istype(left_hand))
-			O.l_hand = left_hand.type
+			outfit.l_hand = left_hand.type
 			var/vedits = collect_vv(left_hand)
 			if(vedits)
 				result["LHAND"] = vedits
 		if(istype(right_hand))
-			O.r_hand = right_hand.type
+			outfit.r_hand = right_hand.type
 			var/vedits = collect_vv(left_hand)
 			if(vedits)
 				result["RHAND"] = vedits
-	O.vv_values = result
+	outfit.vv_values = result
 	//Copy backpack contents if exist.
 	var/obj/item/backpack = get_item_by_slot(ITEM_SLOT_BACK)
 	if(istype(backpack) && backpack.atom_storage)
 		var/list/bp_stuff = list()
 		var/list/typecounts = list()
 		backpack.atom_storage.return_inv(bp_stuff, FALSE)
-		for(var/obj/item/I in bp_stuff)
-			if(typecounts[I.type])
-				typecounts[I.type] += 1
+		for(var/obj/item/backpack_item in bp_stuff)
+			if(typecounts[backpack_item.type])
+				typecounts[backpack_item.type] += 1
 			else
-				typecounts[I.type] = 1
-		O.backpack_contents = typecounts
+				typecounts[backpack_item.type] = 1
+		outfit.backpack_contents = typecounts
 		//TODO : Copy varedits from backpack stuff too.
 	//Copy implants
-	O.implants = list()
-	for(var/obj/item/implant/I in implants)
-		O.implants |= I.type
+	outfit.implants = list()
+	for(var/obj/item/implant/implant in implants)
+		outfit.implants |= implant.type
 	//Copy to outfit cache
 	var/outfit_name = stripped_input(usr,"Enter the outfit name")
-	O.name = outfit_name
-	GLOB.custom_outfits += O
+	outfit.name = outfit_name
+	GLOB.custom_outfits += outfit
 	to_chat(usr,"Outfit registered, use select equipment to equip it.")
 
-/datum/outfit/varedit/post_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/varedit/post_equip(mob/living/carbon/human/human, visualsOnly)
 	. = ..()
 	//Apply VV
 	for(var/slot in vv_values)
 		var/list/edits = vv_values[slot]
-		var/obj/item/I
+		var/obj/item/item
 		switch(slot)
 			if("LHAND")
-				I = H.held_items[1]
+				item = human.held_items[1]
 			if("RHAND")
-				I = H.held_items[2]
+				item = human.held_items[2]
 			else
-				I = H.get_item_by_slot(text2num(slot))
+				item = human.get_item_by_slot(text2num(slot))
 		for(var/vname in edits)
-			I.vv_edit_var(vname,edits[vname])
+			item.vv_edit_var(vname,edits[vname])
 	//Apply access
-	var/obj/item/id_slot = H.get_item_by_slot(ITEM_SLOT_ID)
+	var/obj/item/id_slot = human.get_item_by_slot(ITEM_SLOT_ID)
 	if(id_slot)
 		var/obj/item/card/id/card = id_slot.GetID()
 		if(istype(card))
 			card.add_access(stored_access, mode = FORCE_ADD_ALL)
 		if(update_id_name)
-			card.registered_name = H.real_name
+			card.registered_name = human.real_name
 			card.update_label()
 			card.update_icon()
 


### PR DESCRIPTION
It's been almost 2 years since I've touched anything related to Byond or SS13.
So, let me see if I still remember how to do this.

## About The Pull Request
VV outfits go through every item with the `DF_VAR_EDITED` tag and serialize every case of text, number, or icon that differs from their `initial` value. While normally an object reference is skipped, `cached_ref` is stored as text.
The whole method of comparing against `initial` is problematic, as a lot of stuff performs initialization and immediately changes values from what their `initial` was; and saving the outfit picks that up as an "edit".

I suppose what I did here was a band-aid fix. Not confident enough to try to fix the underlying problem yet.
I also changed some bad variable names while I was there; not sure what's the memo about doing that, these days.

## Why It's Good For The Game

fixes #72519
(does not fix the other issue linked to it; I'd rather keep this atomic to vv outfits)
## Changelog

:cl: Trigg
fix: Admins - Saving a VV outfit will no longer save their cached_ref variable, which caused problems when the game tried to use that cache on another round. Existing broken outfits will need to be loaded and saved again.
/:cl:
