### PR TITLE
Fixes Shake_Camera Being Passed Non-Mob References

### DIFF
--- a/code/datums/actions/mobs/charge.dm
+++ b/code/datums/actions/mobs/charge.dm
@@ -166,7 +166,7 @@
 	living_target.apply_damage(damage_dealt, BRUTE, wound_bonus = CANT_WOUND)
 	playsound(get_turf(living_target), 'sound/effects/meteorimpact.ogg', 100, TRUE)
 	shake_camera(living_target, 4, 3)
-	if(ismob(source))
+	if(isliving(source))
 		shake_camera(source, 2, 3)
 
 /datum/action/cooldown/mob_cooldown/charge/basic_charge

--- a/code/datums/actions/mobs/charge.dm
+++ b/code/datums/actions/mobs/charge.dm
@@ -166,7 +166,8 @@
 	living_target.apply_damage(damage_dealt, BRUTE, wound_bonus = CANT_WOUND)
 	playsound(get_turf(living_target), 'sound/effects/meteorimpact.ogg', 100, TRUE)
 	shake_camera(living_target, 4, 3)
-	shake_camera(source, 2, 3)
+	if(ismob(source))
+		shake_camera(source, 2, 3)
 
 /datum/action/cooldown/mob_cooldown/charge/basic_charge
 	name = "Basic Charge"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -143,7 +143,8 @@
 ///Duration isn't taken as a strict limit, since we don't trust our coders to not make things feel shitty. So it's more like a soft cap.
 /proc/shake_camera(mob/M, duration, strength=1)
 	if(!istype(M))
-		stack_trace("Called shake_camera on a non-mob: [M.type].")
+		if(!isnull(M)) // No real need to spam the logs with nulls when we can help it
+			stack_trace("Called shake_camera on a non-mob: [M.type].")
 		return
 	if(!M.client || duration < 1)
 		return

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -142,7 +142,10 @@
 ///Takes the mob to shake, the time span to shake for, and the amount of tiles we're allowed to shake by in tiles
 ///Duration isn't taken as a strict limit, since we don't trust our coders to not make things feel shitty. So it's more like a soft cap.
 /proc/shake_camera(mob/M, duration, strength=1)
-	if(!istype(M) || !M.client || duration < 1)
+	if(!istype(M))
+		stack_trace("Called shake_camera on a non-mob: [M.type].")
+		return
+	if(!M.client || duration < 1)
 		return
 	var/client/C = M.client
 	var/oldx = C.pixel_x

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -142,10 +142,9 @@
 ///Takes the mob to shake, the time span to shake for, and the amount of tiles we're allowed to shake by in tiles
 ///Duration isn't taken as a strict limit, since we don't trust our coders to not make things feel shitty. So it's more like a soft cap.
 /proc/shake_camera(mob/M, duration, strength=1)
-	if(!istype(M))
-		stack_trace("Called shake_camera on a non-mob: [M.type].")
-		return
-	if(!M.client || duration < 1)
+	if(!M || !M.client || duration < 1)
+		if(!istype(M))
+			stack_trace("Called shake_camera on a non-mob: [M.type].")
 		return
 	var/client/C = M.client
 	var/oldx = C.pixel_x

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -142,9 +142,10 @@
 ///Takes the mob to shake, the time span to shake for, and the amount of tiles we're allowed to shake by in tiles
 ///Duration isn't taken as a strict limit, since we don't trust our coders to not make things feel shitty. So it's more like a soft cap.
 /proc/shake_camera(mob/M, duration, strength=1)
-	if(!M || !M.client || duration < 1)
-		if(!istype(M))
-			stack_trace("Called shake_camera on a non-mob: [M.type].")
+	if(!istype(M))
+		stack_trace("Called shake_camera on a non-mob: [M.type].")
+		return
+	if(!M.client || duration < 1)
 		return
 	var/client/C = M.client
 	var/oldx = C.pixel_x

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -142,7 +142,7 @@
 ///Takes the mob to shake, the time span to shake for, and the amount of tiles we're allowed to shake by in tiles
 ///Duration isn't taken as a strict limit, since we don't trust our coders to not make things feel shitty. So it's more like a soft cap.
 /proc/shake_camera(mob/M, duration, strength=1)
-	if(!M || !istype(M) || !M.client || duration < 1)
+	if(!istype(M) || !M.client || duration < 1)
 		return
 	var/client/C = M.client
 	var/oldx = C.pixel_x

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -142,7 +142,7 @@
 ///Takes the mob to shake, the time span to shake for, and the amount of tiles we're allowed to shake by in tiles
 ///Duration isn't taken as a strict limit, since we don't trust our coders to not make things feel shitty. So it's more like a soft cap.
 /proc/shake_camera(mob/M, duration, strength=1)
-	if(!M || !M.client || duration < 1)
+	if(!M || !istype(M) || !M.client || duration < 1)
 		return
 	var/client/C = M.client
 	var/oldx = C.pixel_x


### PR DESCRIPTION

## About The Pull Request

https://tgstation13.download/parsed-logs/manuel/data/logs/2023/01/09/round-197882/runtime.txt

Something weird was going on here:

```txt
The following runtime has occurred 15 time(s).
runtime error: undefined variable /turf/open/floor/iron/white/var/client
proc name: shake camera (/proc/shake_camera)
  source file: mob_helpers.dm,145
  usr: Eats-The-Mice (/mob/living/carbon/human)
  src: null
```

It's clear that something was passing in a non-mob reference to shake_camera (which is reliant on having a client), causing this proc to fail. I could only find one instance in the code where it could pass in a non-mob reference to this proc, which I patched out appropriately. I also threw in an `istype()` for good measure just in case I missed something.
## Why It's Good For The Game

YOU CAN'T SHAKE SOMETHING THAT DOESN'T EXIST!!!
## Changelog
Nothing that concerns players.
