### PR TITLE
Fixes issue where mob biotype requirements were always being ignored when applying reagent based tox and oxy damage to mobs

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -86,8 +86,8 @@
 		return
 	adjustFireLoss(diff, updating_health, forced, required_bodytype)
 
-/mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
-	if(required_biotype && !(mob_biotypes & required_biotype))
+/mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype = MOB_ORGANIC)
+	if(!(mob_biotypes & required_biotype))
 		return
 	if(!forced && HAS_TRAIT(src, TRAIT_TOXINLOVER)) //damage becomes healing and healing becomes damage
 		amount = -amount

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -181,10 +181,10 @@
 /mob/living/proc/getOxyLoss()
 	return oxyloss
 
-/mob/living/proc/adjustOxyLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
+/mob/living/proc/adjustOxyLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype = MOB_ORGANIC)
 	if(!forced && (status_flags & GODMODE))
 		return
-	if(required_biotype && !(mob_biotypes & required_biotype))
+	if(!(mob_biotypes & required_biotype))
 		return
 	. = oxyloss
 	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)


### PR DESCRIPTION
## About The Pull Request

When testing for plasmaman reagent stuff I noticed that oddly plasmamen were still taking toxloss damage from plasma in cases they shouldn't, since they are `MOB_MINERAL` and toxins affect `MOB_ORGANIC`.

```
/datum/reagent
	/// The affected biotype, if the reagent damages/heals generic damage (Toxin/Oxygen) of an affected mob.
	/// See "Mob bio-types flags" in /code/_DEFINES/mobs.dm
	var/affected_biotype = MOB_ORGANIC
```
```
/datum/reagent/toxin/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
	if(toxpwr && affected_mob.health > health_required)
		affected_mob.adjustToxLoss(toxpwr * REM * normalise_creation_purity() * delta_time, FALSE, required_biotype = affected_biotype)
		. = TRUE
	..()
```
It should be the case that non-organics do not take tox damage from toxins that only target organics. But they still were.
My hunch was that the cause is this in /code/__DEFINES/mobs.dm, and that seems the case after testing:

```
//Mob bio-types flags
#define MOB_ORGANIC (1 << 0)
```
```
/mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
	if(required_biotype && !(mob_biotypes & required_biotype))
```

I'm not sure if this is intentional or not but it seems like a big oversight to me. Like the initial coder thought they were sanity checking an object not being null, but it's a bitflag not an obj... Made a small change so that it works now.

## Why It's Good For The Game

Fixes a bug. Gets rid of unexpected behavior. If anyone tries to add a future reagent that only affects a certain type of mob biology, now it will actually work how they think it will. It took a lot of head scratching for me to realize what the problem was and I don't want anyone else to go through that!

## Changelog

:cl:
fix: fixed mob biotypes being ignored when applying toxin damage and oxyloss 
/:cl:
