### PR TITLE
Fix chem dispensers not reverting upgrade chems if stock parts are downgraded

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -426,6 +426,8 @@
 	for(var/datum/stock_part/manipulator/manipulator in component_parts)
 		if (manipulator.tier > 3)
 			dispensable_reagents |= upgrade_reagents
+		else
+			dispensable_reagents -= upgrade_reagents
 		parts_rating += manipulator.tier
 	powerefficiency = round(newpowereff, 0.01)
 


### PR DESCRIPTION
When stock parts were downgraded, the chem dispenser kept its upgrade chems.

## Changelog
:cl:
fix: Fixed chem dispensers keeping their upgrade chemicals even after stock parts were downgraded.
/:cl:
