### PR TITLE
Fix circuit component menu search crashing on regex terms (fixes #72211)

### DIFF
--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/ComponentMenu.js
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/ComponentMenu.js
@@ -74,8 +74,8 @@ export class ComponentMenu extends Component {
         if (currentSearch !== '') {
           const result = val.name
             .toLowerCase()
-            .search(currentSearch.toLowerCase());
-          return result !== -1;
+            .includes(currentSearch.toLowerCase());
+          return result !== false;
         }
         return selectedTab === 'All' || selectedTab === val.category;
       }


### PR DESCRIPTION
## About The Pull Request

Fixes #72211

The search menu used the `.search()` function to search, which expects a regex. This caused errors when a user entered an unmatched regex thing such as `{`. I do not believe we need regex search for this so I changed it to normal text search.

## Why It's Good For The Game

Less errors when users use the UIs

## Changelog

:cl:
fix: Fixed integrated circuit component menu search crashing on certain symbols being entered.
/:cl:
