### PR TITLE
Fixes space tiles with z-layer destinations from tile placements

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -114,6 +114,8 @@
 	return attack_hand(user, modifiers)
 
 /turf/open/space/proc/CanBuildHere()
+	if(destination_z)
+		return FALSE
 	return TRUE
 
 /turf/open/space/handle_slip()


### PR DESCRIPTION

## About The Pull Request
Now you cannot place tiles/build on space tiles with z-layer destinations. Hopefully doesn't break anything I overlooked.
## Why It's Good For The Game
Fixes #72673
## Changelog
:cl:
fix: Fixes being able to place things on space tiles with a z-layer destination.
/:cl:
