### PR TITLE
Fixes abductors being unable to use stun batons. Retargets baton chunky finger check to explicitly check for HULKS

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -37,8 +37,6 @@
 	var/stun_animation = TRUE
 	/// Whether the stun attack is logged. Only relevant for abductor batons, which have different modes.
 	var/log_stun_attack = TRUE
-	/// Boolean on whether people with chunky fingers can use this baton.
-	var/chunky_finger_usable = FALSE
 
 	/// The context to show when the baton is active and targetting a living thing
 	var/context_living_target_active = "Stun"
@@ -123,11 +121,9 @@
 	if(clumsy_check(user, target))
 		return BATON_ATTACK_DONE
 
-	if(!chunky_finger_usable && ishuman(user))
-		var/mob/living/carbon/human/potential_chunky_finger_human = user
-		if(potential_chunky_finger_human.check_chunky_fingers() && user.is_holding(src))
-			balloon_alert(potential_chunky_finger_human, "fingers are too big!")
-			return BATON_ATTACK_DONE
+	if(HAS_TRAIT(user, TRAIT_HULK) && user.is_holding(src))
+		balloon_alert(user, "fingers are too big!")
+		return BATON_ATTACK_DONE
 
 	if(!active || LAZYACCESS(modifiers, RIGHT_CLICK))
 		return BATON_DO_NORMAL_ATTACK

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -469,7 +469,6 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	knockdown_time = 14 SECONDS
 	on_stun_sound = 'sound/weapons/egloves.ogg'
 	affect_cyborg = TRUE
-	chunky_finger_usable = TRUE
 
 	var/mode = BATON_STUN
 


### PR DESCRIPTION
Fixes #72585

:cl: ShizCalev
balance: People with big meaty hands have suddenly remembered how to hit people with sticks again! (stun batons work if you have chunky fingers.) Hulks can still not use stunbatons.
/:cl:
