### PR TITLE
Admin Request: Force Event panel no longer filters by tab when searching

### DIFF
--- a/tgui/packages/tgui/interfaces/ForceEvent.tsx
+++ b/tgui/packages/tgui/interfaces/ForceEvent.tsx
@@ -123,7 +123,7 @@ export const EventSection = (props, context) => {
   const preparedEvents = paginateEvents(
     events.filter((event) => {
       // remove events not in the category you're looking at
-      if (event.category !== category.name) {
+      if (!searchQuery && event.category !== category.name) {
         return false;
       }
       // remove events not being searched for, if a search is active
@@ -135,12 +135,10 @@ export const EventSection = (props, context) => {
     EVENT_PAGE_ITEMS
   );
 
+  const sectionTitle = searchQuery ? 'Searching...' : category.name + ' Events';
+
   return (
-    <Section
-      scrollable
-      fill
-      title={category.name + ' Events'}
-      buttons={<PanelOptions />}>
+    <Section scrollable fill title={sectionTitle} buttons={<PanelOptions />}>
       <Stack vertical>
         {preparedEvents.map((eventPage, i) => (
           <Stack.Item key={i}>


### PR DESCRIPTION

## About The Pull Request

Before, you would search  "Abductors", but would only find it if that tab was active. Now, searching disables tab filtering.

![image](https://user-images.githubusercontent.com/40974010/212409920-b0ba2a3b-5115-455f-9bd5-ac95ed1dcbc0.png)

## Why It's Good For The Game

If you search, you probably want results that include the search, lol.

## Changelog
:cl:
admin: Force Event no longer filters by tab when searching.
/:cl:
