### PR TITLE
fixes computers spamming fingers are too big warning. also fixes exploit when using programs w/ fingers that are too big.

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -16,12 +16,6 @@
 	if(!user.can_read(src, READING_CHECK_LITERACY))
 		return
 
-	if(ishuman(user) && !allow_chunky)
-		var/mob/living/carbon/human/human_user = user
-		if(human_user.check_chunky_fingers())
-			balloon_alert(human_user, "fingers are too big!")
-			return
-
 	// Robots don't really need to see the screen, their wireless connection works as long as computer is on.
 	if(!screen_on && !issilicon(user))
 		if(ui)
@@ -102,6 +96,12 @@
 	. = ..()
 	if(.)
 		return
+
+	if(ishuman(usr) && !allow_chunky) //in /datum/computer_file/program/ui_act() too
+		var/mob/living/carbon/human/human_user = usr
+		if(human_user.check_chunky_fingers())
+			balloon_alert(human_user, "fingers are too big!")
+			return TRUE
 
 	switch(action)
 		if("PC_exit")

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -218,6 +218,12 @@
 	if(.)
 		return
 
+	if(ishuman(usr) && !computer.allow_chunky) //in /obj/item/modular_computer/ui_act() too
+		var/mob/living/carbon/human/human_user = usr
+		if(human_user.check_chunky_fingers())
+			computer.balloon_alert(human_user, "fingers are too big!")
+			return TRUE
+
 	if(computer)
 		switch(action)
 			if("PC_exit")


### PR DESCRIPTION
Fixes #72153

:cl: ShizCalev
fix: You'll no longer constantly be spammed with messages if your fingers are too big to interact with a computer's keyboard.
fix: You can no longer interact with programs that were previously opened on a computer if your fingers are too big to use the keyboard.
fix: You can now look at computer screens even if your fingers are too big to use the keyboard.
/:cl:
