### PR TITLE
Ethereals(and other NO_HUNGER carbons with blood) Can now regenerate blood.

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -31,6 +31,10 @@
 			nutrition_ratio *= 1.25
 		adjust_nutrition(-nutrition_ratio * HUNGER_FACTOR * delta_time)
 		blood_volume = min(blood_volume + (BLOOD_REGEN_FACTOR * nutrition_ratio * delta_time), BLOOD_VOLUME_NORMAL)
+	
+	//blood regen for the hungerless
+	if(blood_volume < BLOOD_VOLUME_NORMAL && HAS_TRAIT(src, TRAIT_NOHUNGER))
+		blood_volume = min(blood_volume + (BLOOD_REGEN_FACTOR * 1.25 * delta_time), BLOOD_VOLUME_NORMAL) //optimal saitety/nutition assumed
 
 	//Effects of bloodloss
 	var/word = pick("dizzy","woozy","faint")


### PR DESCRIPTION

## About The Pull Request
Fixes #62492 by giving a method for no hunger mobs to get blood

## Why It's Good For The Game
Bugs are bad, bugs that make bloodloss more painful are more bad

## Changelog
:cl:
fix: Ethereals and other hungerless species will now regenerate blood.
/:cl:
