### PR TITLE
Canisters that have their shielding power run out will correctly update their atmos state

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -572,6 +572,8 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 			protected_contents = TRUE
 		else
 			shielding_powered = FALSE
+			SSair.start_processing_machine(src)
+			investigate_log("shielding turned off due to power loss")
 
 ///return the icon_state component for the canister's indicator light based on its current pressure reading
 /obj/machinery/portable_atmospherics/canister/proc/get_pressure_state(air_pressure)


### PR DESCRIPTION

## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/72138
## Why It's Good For The Game
Bug bad

## Changelog
:cl:
fix: Canisters no longer keep their shielding when their shielding cell fails
/:cl:
