### PR TITLE
Fiox firebots extinguishing themselves while also not on fire (fixes #71390)

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -253,8 +253,6 @@
 
 //Look for burning people or turfs around the bot
 /mob/living/simple_animal/bot/firebot/process_scan(atom/scan_target)
-	if(scan_target == src)
-		return src
 	if(!is_burning(scan_target))
 		return null
 


### PR DESCRIPTION
## About The Pull Request

Fixes #71390

Firebots returned themselves if they found themselves in the `process_scan()` override. The override usually checks to see if the found target is on fire, to then extinguish it. This leads to the firebots attempting to constantly extinguish themselves.

I'm not sure why this behaviour was here, as the other bots don't seem to return themselves in their `process_scan()` overrides. If someone has any insights on why this should be here and I should fix it differently, go ahead. The only alternative I see right now would be to return `null` on finding that the current scan object is `src`, which would shorten the program path a little.

## Why It's Good For The Game

Firebots extinguish people on fire instead of themselves.

## Changelog

:cl:
fix: Firebots no longer attempt to extinguish themselves constantly
/:cl:

