### PR TITLE
Makes datum stock parts work for Stock parts Experiment purposes 2: Electric Boogaloo

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -249,7 +249,7 @@
 		/obj/machinery/chem_heater = 3,
 		/obj/machinery/power/emitter = 3
 	)
-	required_stock_part = /datum/stock_part/micro_laser/high
+	required_stock_part = /obj/item/stock_parts/micro_laser/high
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_capacitors
 	name = "Advanced Capacitors Benchmark"
@@ -265,7 +265,7 @@
 		/obj/machinery/chem_dispenser/drinks = 3, /*actually having only the chem dispenser works for scanning soda/booze dispensers but im not quite sure how would i go about actually pointing that out w/o these two lines*/
 		/obj/machinery/chem_dispenser/drinks/beer = 3
 	)
-	required_stock_part = /datum/stock_part/capacitor/adv
+	required_stock_part = /obj/item/stock_parts/capacitor/adv
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier2_scanmodules
 	name = "Advanced Scanning Modules Calibration"
@@ -278,7 +278,7 @@
 		/obj/machinery/piratepad/civilian = 2,
 		/obj/machinery/rnd/bepis = 3
 	)
-	required_stock_part = /datum/stock_part/scanning_module/adv
+	required_stock_part = /obj/item/stock_parts/scanning_module/adv
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/tier3_cells
 	name = "Power Cells Capacity Test"
@@ -306,7 +306,7 @@
 		/obj/machinery/chem_heater = 2,
 		/obj/machinery/chem_mass_spec = 3
 	)
-	required_stock_part = /datum/stock_part/micro_laser/ultra
+	required_stock_part = /obj/item/stock_parts/micro_laser/ultra
 
 /datum/experiment/scanning/random/mecha_damage_scan
 	name = "Exosuit Materials 1: Stress Failure Test"

--- a/code/modules/experisci/experiment/types/scanning_machinery.dm
+++ b/code/modules/experisci/experiment/types/scanning_machinery.dm
@@ -33,7 +33,9 @@
 	name = "Machinery Pinpoint Stock Parts Scanning Experiment"
 	description = "Base experiment for scanning machinery with specific parts"
 	exp_tag = "Scan"
-	///Which stock part are we looking for in the machine
+	///Which stock part are we looking for in the machine.
+	///We use obj instead of datum here, as some stock parts aren't datumised, and in datumised ones
+	///we can just look for the physical_object_reference to match up the requirement.
 	var/obj/item/stock_parts/required_stock_part = /obj/item/stock_parts
 
 /datum/experiment/scanning/points/machinery_pinpoint_scan/check_progress()


### PR DESCRIPTION
## About The Pull Request
Fixes #72694
#72559 changed the requirements for pinpoint machine scanning experiments to datums on accident, so to hopefully prevent further mishaps I've commented the var further.

## Why This Speaks Volumes On The State Of Experi-Sci (Or Sybil RnD)
![image](https://user-images.githubusercontent.com/75863639/212465375-256fc9be-ef1f-4619-88cb-fb372b47ddc4.png)
____
![image](https://user-images.githubusercontent.com/75863639/212465379-dc48f1ab-6790-497b-b353-4bb8090feccb.png)


## Changelog
:cl:
fix: pinpoint machine scanning experiments work again (again)
/:cl:
