### PR TITLE
RPED Part Exchange Fix

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -1021,11 +1021,12 @@
 							if (isnull(stock_part_datum))
 								CRASH("[secondary_part] ([secondary_part.type]) did not have a stock part datum (was trying to find [primary_part_base])")
 							component_parts += stock_part_datum
+							part_list -= secondary_part //have to manually remove cause we are no longer refering replacer_tool.contents
 							qdel(secondary_part)
 						else
 							component_parts += secondary_part
 							secondary_part.forceMove(src)
-							part_list -= secondary_part //have to manually remove cause we are no longer refering replacer_tool.contents & forceMove wont remove it from th list
+							part_list -= secondary_part //have to manually remove cause we are no longer refering replacer_tool.contents
 
 				component_parts -= primary_part_base
 


### PR DESCRIPTION
## About The Pull Request

RPED wasn't removing the stock part from its sorted list after exchanging it causing bugs like 1 femto manipulator replacing 2 manipulators in the techfab and qdeling that part twice

## Changelog

:cl:
fix: properly remove the stock part from the RPED after exchanging it
/:cl: