### PR TITLE
Cell chargers now tell you what cell type is inside the charger.

### DIFF
--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -27,7 +27,7 @@
 
 /obj/machinery/cell_charger/examine(mob/user)
 	. = ..()
-	. += "There's [charging ? "a" : "no"] cell in the charger."
+	. += "There's [charging ? "\a [charging]" : "no cell"] in the charger."
 	if(charging)
 		. += "Current charge: [round(charging.percent(), 1)]%."
 	if(in_range(user, src) || isobserver(user))


### PR DESCRIPTION

## About The Pull Request

Simply makes the line that tells you that theres a cell inside a charger in a cell chargers description now tells you the type of cell inside of it.
## Why It's Good For The Game

Slight improvement to ease of use of the cell charger.
Wasn't certain what cell type was in a charger during a round at a glance and I thought this would be useful rather than referring to all cells as a generic "cell"
## Changelog
:cl:
qol: Inspecting a cell charger now tells you the type of cell in it.
/:cl:
