### PR TITLE
Fixes ERT Headsets not starting with their key

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -314,7 +314,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	name = "\improper CentCom bowman headset"
 	desc = "A headset especially for emergency response personnel. Protects ears from flashbangs."
 	icon_state = "cent_headset_alt"
-	keyslot = null
+	keyslot2 = null
 
 /obj/item/radio/headset/headset_cent/alt/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
fixes an accident and assigns the second keyslot to null instead of the first which removed the ability for ERT's to communicate.

## Why It's Good For The Game

Having comms when you're sent in somewhere deadly is a good thing

## Changelog
:cl:
fix: ERT Headsets have the proper key
/:cl:
