### PR TITLE
Fixes the Crab 17 exploding when someone swipes too early.

### DIFF
--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -65,6 +65,10 @@
 	return TRUE
 
 /obj/structure/checkoutmachine/attackby(obj/item/attacking_item, mob/user, params)
+	if(!canwalk)
+		balloon_alert(user, "not ready to accept transactions!")
+		return
+
 	if(check_if_finished())
 		qdel(src)
 		return
@@ -79,16 +83,12 @@
 
 		return
 
-	if(!canwalk)
-		to_chat(user, span_warning("Space-Coin only accepts transactions while mobile!"))
-		return
-
 	if(!card.registered_account)
-		to_chat(user, span_warning("This card does not have a registered account!"))
+		balloon_alert(user, "card has no registered account!")
 		return
 
 	if(!card.registered_account.being_dumped)
-		to_chat(user, span_warning("It appears that your funds are safe from draining!"))
+		balloon_alert(user, "funds are already safe!")
 		return
 
 	to_chat(user, span_warning("You quickly cash out your funds to a more secure banking location. Funds are safu.")) // This is a reference and not a typo


### PR DESCRIPTION
## About The Pull Request

This bug has personally inconvenienced me one too many times, so I decided to take a swing at it myself. I didn't expect the fix to be as straightforward as it ended up being.

You could get the Crab 17 to do its "all bank accounts are safe, let's explode the checkout machine" check by swiping during the setup animation. This would be before the list of accounts to rob was actually set up, meaning the check would succeed and the checkout machine would be deleted. Nobody would be able to pull money from their accounts, and with no checkout machine to fix things or automatically resolve the problem after a while, all crew bank accounts would be rendered inaccessible.

Now, if the checkout machine isn't mobile (completely set up, done animating, and ready to cause problems) it will reject your swipe BEFORE checking the bank account list. No more premature explosions, no more headaches.

This also balloonifies most of the Crab-17 checkout machine messages.
## Why It's Good For The Game

Closes #58933, putting a long-standing source of headaches to rest.
## Changelog
:cl:
fix: Swiping the Crab-17 checkout machine too early will no longer instantly explode it and lock everyone out of their bank accounts.
/:cl:
