### PR TITLE
Ceremonial blades can't wound

### DIFF
--- a/code/modules/religion/sparring/ceremonial_gear.dm
+++ b/code/modules/religion/sparring/ceremonial_gear.dm
@@ -16,6 +16,7 @@
 	custom_materials = list(/datum/material/iron = 12000)  //Defaults to an Iron blade.
 	force = 2 //20
 	throwforce = 1 //10
+	wound_bonus = CANT_WOUND // bad for sparring
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")


### PR DESCRIPTION

## About The Pull Request

Ceremonial blades can't wound anymore.

## Why It's Good For The Game

The blades, that have bad stats unless you're currently in a sparring match, apply wounding fairly often. Since it's a slash weapon, it applies a bleeding wound, which is just terrible for sparring for any amount of time since you'll need bloodbags. This made... anything else a better option.

## Changelog
:cl:
balance: Ceremonial blades no longer wound.
/:cl:
