### PR TITLE
[No GBP] Uranium, Diamonds, and Bananium now properly visually stack in techfabs

### DIFF
--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
@@ -22,14 +22,26 @@ const MATERIAL_ICONS: Record<string, [number, string][]> = {
     [17, 'sheet-gold_2'],
     [34, 'sheet-gold_3'],
   ],
-  'diamond': [[0, 'sheet-diamond']],
+  'diamond': [
+    [0, 'sheet-diamond'],
+    [17, 'sheet-diamond_2'],
+    [34, 'sheet-diamond_3'],
+  ],
   'plasma': [
     [0, 'sheet-plasma'],
     [17, 'sheet-plasma_2'],
     [34, 'sheet-plasma_3'],
   ],
-  'uranium': [[0, 'sheet-uranium']],
-  'bananium': [[0, 'sheet-bananium']],
+  'uranium': [
+    [0, 'sheet-uranium'],
+    [17, 'sheet-uranium_2'],
+    [34, 'sheet-uranium_3'],
+  ],
+  'bananium': [
+    [0, 'sheet-bananium'],
+    [17, 'sheet-bananium_2'],
+    [34, 'sheet-bananium_3'],
+  ],
   'titanium': [
     [0, 'sheet-titanium'],
     [17, 'sheet-titanium_2'],


### PR DESCRIPTION
## About The Pull Request
Makes the little icons at the bottom of the techfabs update for the mats that previously didn't have the ability to stack.
## Why It's Good For The Game
Fixes a thing I didn't realize needed to be fixed with #72652

![image](https://user-images.githubusercontent.com/66052067/212499641-cffa2f55-24f6-416d-9c47-1cce0100a4c8.png)

Closes #72702
## Changelog
:cl: Wallem
fix: Uranium, Diamonds, and Bananium now update visually in the techfab UI
/:cl:
