### PR TITLE
Unironically removes the atmos and black beret

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -406,12 +406,6 @@
 	greyscale_colors = "#FFBC30"
 	flags_1 = NONE
 
-/obj/item/clothing/head/beret/atmos
-	name = "atmospheric beret"
-	desc = "While \"pipes\" and \"style\" might not rhyme, this beret sure makes you feel like they should!"
-	greyscale_colors = "#FFDE15"
-	flags_1 = NONE
-
 //Cargo
 /obj/item/clothing/head/beret/cargo
 	name = "cargo beret"

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -419,15 +419,6 @@
 	desc = "You got red text today kid, but it doesn't mean you have to like it."
 	icon_state = "curator"
 
-//Miscellaneous
-/obj/item/clothing/head/beret/black
-	name = "black beret"
-	desc = "A black beret, perfect for war veterans and dark, brooding, anti-hero mimes."
-	icon_state = "beret"
-	greyscale_config = /datum/greyscale_config/beret
-	greyscale_config_worn = /datum/greyscale_config/beret/worn
-	greyscale_colors = "#3f3c40"
-
 /obj/item/clothing/head/beret/durathread
 	name = "durathread beret"
 	desc = "A beret made from durathread, its resilient fibers provide some protection to the wearer."

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -14,6 +14,7 @@
 				/obj/item/clothing/head/wig/natural = 4,
 				/obj/item/clothing/head/costume/fancy = 4,
 				/obj/item/clothing/head/beanie = 8,
+				/obj/item/clothing/head/beret = 3,
 				/obj/item/clothing/mask/bandana = 3,
 				/obj/item/clothing/mask/bandana/striped = 3,
 				/obj/item/clothing/mask/bandana/skull = 3,

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -14,7 +14,6 @@
 				/obj/item/clothing/head/wig/natural = 4,
 				/obj/item/clothing/head/costume/fancy = 4,
 				/obj/item/clothing/head/beanie = 8,
-				/obj/item/clothing/head/beret/black = 3,
 				/obj/item/clothing/mask/bandana = 3,
 				/obj/item/clothing/mask/bandana/striped = 3,
 				/obj/item/clothing/mask/bandana/skull = 3,

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -14,7 +14,7 @@
 				/obj/item/clothing/head/wig/natural = 4,
 				/obj/item/clothing/head/costume/fancy = 4,
 				/obj/item/clothing/head/beanie = 8,
-				/obj/item/clothing/head/beret = 3,
+				/obj/item/clothing/head/beret = 5,
 				/obj/item/clothing/mask/bandana = 3,
 				/obj/item/clothing/mask/bandana/striped = 3,
 				/obj/item/clothing/mask/bandana/skull = 3,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -127,7 +127,6 @@
 		/obj/item/clothing/suit/hooded/wintercoat/engineering/atmos = 3,
 		/obj/item/clothing/under/rank/engineering/atmospheric_technician = 3,
 		/obj/item/clothing/under/rank/engineering/atmospheric_technician/skirt = 3,
-		/obj/item/clothing/head/beret/atmos = 3,
 		/obj/item/clothing/shoes/sneakers/black = 3,
 		)
 	refill_canister = /obj/item/vending_refill/wardrobe/atmos_wardrobe


### PR DESCRIPTION
## About The Pull Request

Removes atmos berets

## Why It's Good For The Game
Berets shouldn't be thrown into every job, it's milsim circlejerking dressup shit that creeps out of our milsim containment jobs (security) and into other innocent jobs. There is absolutely no reason for this job to have a beret just straight up. Can we add unique hats to the game, not the same one recolored every way to Sunday? That's my problem. We don't have unique clothes, we have a billion types of beret when the BASE BERET TYPE has `IS_PLAYER_COLORABLE_1` so ANYONE can color it. So again, why do we have the atmos beret? To clog the wardrobe, a vending machine added specifically because we couldn't stop clogging the original locker atmos techs spawned in?

The black beret has the same problem: recolored item when you can get the item of any color

## Changelog
:cl:
del: Atmospherics beret and black beret
/:cl:
