### PR TITLE
Rearrange the cruise shuttle bridge

### DIFF
--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -45,11 +45,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/white,
-/obj/item/pen/blue,
 /obj/machinery/light/directional/north,
+/obj/machinery/computer/med_data,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "dQ" = (
@@ -76,11 +73,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/computer/station_alert{
-	desc = "Used to access the shuttle's automated alert system.";
-	dir = 1;
-	name = "ship alert console"
-	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/head/collectable/welding,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "en" = (
@@ -147,11 +141,8 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/red,
-/obj/item/pen/red,
 /obj/machinery/light/directional/north,
+/obj/machinery/computer/secure_data,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "jT" = (
@@ -203,9 +194,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/red,
+/obj/item/pen/red,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "lJ" = (
@@ -320,9 +312,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/collectable/welding{
-	pixel_y = 5
+/obj/machinery/computer/station_alert{
+	desc = "Used to access the shuttle's automated alert system.";
+	dir = 8;
+	name = "ship alert console"
 	},
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
@@ -408,9 +401,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/computer/med_data{
-	dir = 8
-	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/white,
+/obj/item/pen/blue,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "sW" = (
@@ -564,7 +558,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -572,7 +565,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/item/reactive_armour_shell,
+/obj/machinery/modular_computer/console/preset/research{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "zm" = (
@@ -607,9 +602,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/modular_computer/console/preset/research{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -617,6 +609,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/item/reactive_armour_shell,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "BB" = (


### PR DESCRIPTION

## About The Pull Request
Rearranges the tables/consoles on the bridge of the NTSS Independence so the tables actually reachable.
![image](https://user-images.githubusercontent.com/10399117/212530671-ac87a0fa-e5b8-450f-9b72-b9f62231dbe5.png)

## Why It's Good For The Game

IUnreachable tables bad

## Changelog


:cl:
fix: The tables on the bridge of the NTSS Independence are now usable. Fancy!
/:cl: