### PR TITLE
Renames Datum Parts above tier 1 accordingly to their tier.

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1389,6 +1389,6 @@
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/reagent_containers/cup/beaker = 2,
 		/datum/stock_part/water_recycler = 1,
-		/datum/stock_part/capacitor/tier4 = 1,
-		/datum/stock_part/micro_laser/tier4 = 2,
+		/datum/stock_part/capacitor/tier2 = 1,
+		/datum/stock_part/micro_laser/tier2 = 2,
 	)

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -6,7 +6,7 @@
 	build_path = /obj/machinery/bsa/back //No freebies!
 	specific_parts = TRUE
 	req_components = list(
-		/datum/stock_part/capacitor/quadratic = 5,
+		/datum/stock_part/capacitor/tier4 = 5,
 		/obj/item/stack/cable_coil = 2)
 
 /obj/item/circuitboard/machine/bsa/front
@@ -15,7 +15,7 @@
 	build_path = /obj/machinery/bsa/front
 	specific_parts = TRUE
 	req_components = list(
-		/datum/stock_part/manipulator/femto = 5,
+		/datum/stock_part/manipulator/tier4 = 5,
 		/obj/item/stack/cable_coil = 2)
 
 /obj/item/circuitboard/machine/bsa/middle
@@ -32,8 +32,8 @@
 	build_path = /obj/machinery/dna_vault //No freebies!
 	specific_parts = TRUE
 	req_components = list(
-		/datum/stock_part/capacitor/super = 5,
-		/datum/stock_part/manipulator/pico = 5,
+		/datum/stock_part/capacitor/tier3 = 5,
+		/datum/stock_part/manipulator/tier3 = 5,
 		/obj/item/stack/cable_coil = 2)
 
 //Engineering
@@ -648,9 +648,9 @@
 	build_path = /obj/machinery/chem_dispenser/fullupgrade
 	specific_parts = TRUE
 	req_components = list(
-		/datum/stock_part/matter_bin/bluespace = 2,
-		/datum/stock_part/capacitor/quadratic = 2,
-		/datum/stock_part/manipulator/femto = 2,
+		/datum/stock_part/matter_bin/tier4 = 2,
+		/datum/stock_part/capacitor/tier4 = 2,
+		/datum/stock_part/manipulator/tier4 = 2,
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/stock_parts/cell/bluespace = 1,
 	)
@@ -659,9 +659,9 @@
 	build_path = /obj/machinery/chem_dispenser/mutagensaltpeter
 	specific_parts = TRUE
 	req_components = list(
-		/datum/stock_part/matter_bin/bluespace = 2,
-		/datum/stock_part/capacitor/quadratic = 2,
-		/datum/stock_part/manipulator/femto = 2,
+		/datum/stock_part/matter_bin/tier4 = 2,
+		/datum/stock_part/capacitor/tier4 = 2,
+		/datum/stock_part/manipulator/tier4 = 2,
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/stock_parts/cell/bluespace = 1,
 	)
@@ -673,9 +673,9 @@
 	build_path = /obj/machinery/chem_dispenser/abductor
 	specific_parts = TRUE
 	req_components = list(
-		/datum/stock_part/matter_bin/bluespace = 2,
-		/datum/stock_part/capacitor/quadratic = 2,
-		/datum/stock_part/manipulator/femto = 2,
+		/datum/stock_part/matter_bin/tier4 = 2,
+		/datum/stock_part/capacitor/tier4 = 2,
+		/datum/stock_part/manipulator/tier4 = 2,
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/stock_parts/cell/bluespace = 1,
 	)
@@ -781,7 +781,7 @@
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/limbgrower
 	req_components = list(
-		/datum/stock_part/manipulator/femto  = 1,
+		/datum/stock_part/manipulator/tier4  = 1,
 		/obj/item/reagent_containers/cup/beaker/bluespace = 2,
 		/obj/item/stack/sheet/glass = 1)
 
@@ -803,8 +803,8 @@
 /obj/item/circuitboard/machine/sleeper/fullupgrade
 	build_path = /obj/machinery/sleeper/syndie/fullupgrade
 	req_components = list(
-		/datum/stock_part/matter_bin/bluespace = 1,
-		/datum/stock_part/manipulator/femto = 1,
+		/datum/stock_part/matter_bin/tier4 = 1,
+		/datum/stock_part/manipulator/tier4 = 1,
 		/obj/item/stack/cable_coil = 1,
 		/obj/item/stack/sheet/glass = 2)
 
@@ -1034,9 +1034,9 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks/fullupgrade
 	build_path = /obj/machinery/chem_dispenser/drinks/fullupgrade
 	req_components = list(
-		/datum/stock_part/matter_bin/bluespace = 2,
-		/datum/stock_part/capacitor/quadratic = 2,
-		/datum/stock_part/manipulator/femto = 2,
+		/datum/stock_part/matter_bin/tier4 = 2,
+		/datum/stock_part/capacitor/tier4 = 2,
+		/datum/stock_part/manipulator/tier4 = 2,
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/stock_parts/cell/bluespace = 1,
 	)
@@ -1049,9 +1049,9 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer/fullupgrade
 	build_path = /obj/machinery/chem_dispenser/drinks/beer/fullupgrade
 	req_components = list(
-		/datum/stock_part/matter_bin/bluespace = 2,
-		/datum/stock_part/capacitor/quadratic = 2,
-		/datum/stock_part/manipulator/femto = 2,
+		/datum/stock_part/matter_bin/tier4 = 2,
+		/datum/stock_part/capacitor/tier4 = 2,
+		/datum/stock_part/manipulator/tier4 = 2,
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/stock_parts/cell/bluespace = 1,
 	)
@@ -1278,8 +1278,8 @@
 		/datum/stock_part/micro_laser = 1,
 		/obj/item/stock_parts/cell/infinite/abductor = 1)
 	def_components = list(
-		/datum/stock_part/capacitor = /datum/stock_part/capacitor/quadratic,
-		/datum/stock_part/micro_laser = /datum/stock_part/micro_laser/quadultra)
+		/datum/stock_part/capacitor = /datum/stock_part/capacitor/tier4,
+		/datum/stock_part/micro_laser = /datum/stock_part/micro_laser/tier4)
 
 /obj/item/circuitboard/machine/hypnochair
 	name = "Enhanced Interrogation Chamber"
@@ -1389,6 +1389,6 @@
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/reagent_containers/cup/beaker = 2,
 		/datum/stock_part/water_recycler = 1,
-		/datum/stock_part/capacitor/adv = 1,
-		/datum/stock_part/micro_laser/high = 2,
+		/datum/stock_part/capacitor/tier4 = 1,
+		/datum/stock_part/micro_laser/tier4 = 2,
 	)

--- a/code/modules/research/stock_parts/stock_part_datum.dm
+++ b/code/modules/research/stock_parts/stock_part_datum.dm
@@ -72,15 +72,15 @@ GLOBAL_LIST_INIT(stock_part_datums, generate_stock_part_datums())
 	physical_object_type = /obj/item/stock_parts/scanning_module
 	physical_object_base_type = /obj/item/stock_parts/scanning_module
 
-/datum/stock_part/scanning_module/adv
+/datum/stock_part/scanning_module/tier2
 	tier = 2
 	physical_object_type = /obj/item/stock_parts/scanning_module/adv
 
-/datum/stock_part/scanning_module/phasic
+/datum/stock_part/scanning_module/tier3
 	tier = 3
 	physical_object_type = /obj/item/stock_parts/scanning_module/phasic
 
-/datum/stock_part/scanning_module/triphasic
+/datum/stock_part/scanning_module/tier4
 	tier = 4
 	physical_object_type = /obj/item/stock_parts/scanning_module/triphasic
 
@@ -89,15 +89,15 @@ GLOBAL_LIST_INIT(stock_part_datums, generate_stock_part_datums())
 	physical_object_type = /obj/item/stock_parts/capacitor
 	physical_object_base_type = /obj/item/stock_parts/capacitor
 
-/datum/stock_part/capacitor/adv
+/datum/stock_part/capacitor/tier2
 	tier = 2
 	physical_object_type = /obj/item/stock_parts/capacitor/adv
 
-/datum/stock_part/capacitor/super
+/datum/stock_part/capacitor/tier3
 	tier = 3
 	physical_object_type = /obj/item/stock_parts/capacitor/super
 
-/datum/stock_part/capacitor/quadratic
+/datum/stock_part/capacitor/tier4
 	tier = 4
 	physical_object_type = /obj/item/stock_parts/capacitor/quadratic
 
@@ -106,15 +106,15 @@ GLOBAL_LIST_INIT(stock_part_datums, generate_stock_part_datums())
 	physical_object_type = /obj/item/stock_parts/manipulator
 	physical_object_base_type = /obj/item/stock_parts/manipulator
 
-/datum/stock_part/manipulator/nano
+/datum/stock_part/manipulator/tier2
 	tier = 2
 	physical_object_type = /obj/item/stock_parts/manipulator/nano
 
-/datum/stock_part/manipulator/pico
+/datum/stock_part/manipulator/tier3
 	tier = 3
 	physical_object_type = /obj/item/stock_parts/manipulator/pico
 
-/datum/stock_part/manipulator/femto
+/datum/stock_part/manipulator/tier4
 	tier = 4
 	physical_object_type = /obj/item/stock_parts/manipulator/femto
 
@@ -123,15 +123,15 @@ GLOBAL_LIST_INIT(stock_part_datums, generate_stock_part_datums())
 	physical_object_type = /obj/item/stock_parts/micro_laser
 	physical_object_base_type = /obj/item/stock_parts/micro_laser
 
-/datum/stock_part/micro_laser/high
+/datum/stock_part/micro_laser/tier2
 	tier = 2
 	physical_object_type = /obj/item/stock_parts/micro_laser/high
 
-/datum/stock_part/micro_laser/ultra
+/datum/stock_part/micro_laser/tier3
 	tier = 3
 	physical_object_type = /obj/item/stock_parts/micro_laser/ultra
 
-/datum/stock_part/micro_laser/quadultra
+/datum/stock_part/micro_laser/tier4
 	tier = 4
 	physical_object_type = /obj/item/stock_parts/micro_laser/quadultra
 
@@ -140,15 +140,15 @@ GLOBAL_LIST_INIT(stock_part_datums, generate_stock_part_datums())
 	physical_object_type = /obj/item/stock_parts/matter_bin
 	physical_object_base_type = /obj/item/stock_parts/matter_bin
 
-/datum/stock_part/matter_bin/adv
+/datum/stock_part/matter_bin/tier2
 	tier = 2
 	physical_object_type = /obj/item/stock_parts/matter_bin/adv
 
-/datum/stock_part/matter_bin/super
+/datum/stock_part/matter_bin/tier3
 	tier = 3
 	physical_object_type = /obj/item/stock_parts/matter_bin/super
 
-/datum/stock_part/matter_bin/bluespace
+/datum/stock_part/matter_bin/tier4
 	tier = 4
 	physical_object_type = /obj/item/stock_parts/matter_bin/bluespace
 


### PR DESCRIPTION
## About The Pull Request

Renames datum parts above tier 1 to their base name + their tier for example `/datum/stock_part/matter_bin/bluespace` is renamed to just `/datum/stock_part/matter_bin/tier4`

## Why It's Good For The Game

Shorter consistent names across all parts improves readability, makes it easier for grep and also was requested in #72559

## Changelog

:cl:
refactor: renames datum parts above tier 1 accordingly to their tier
/:cl: