### PR TITLE
Fix ordance bomb site being a safe teleport area after surviving the heretic minigame

### DIFF
--- a/code/game/area/areas/station.dm
+++ b/code/game/area/areas/station.dm
@@ -1362,6 +1362,7 @@
 /area/station/science/ordnance/bomb
 	name = "\improper Ordnance Bomb Site"
 	icon_state = "ord_boom"
+	area_flags = BLOBS_ALLOWED | UNIQUE_AREA | CULT_PERMITTED
 
 /area/station/science/genetics
 	name = "\improper Genetics Lab"


### PR DESCRIPTION

## About The Pull Request
Fixes #72732

Ordance bomb site was considered a safe location to teleport to after the heretic shadow minigame.  This was obviously a really bad idea, due to it being in the vacuum of space on top of a person being put to sleep for a minute before having to wakeup.

## Why It's Good For The Game
No more instadeath after surviving the heretic minigame.

## Changelog
:cl:
fix: Fix ordance bomb site being a safe teleport area after surviving the heretic minigame
/:cl:
