### PR TITLE
Magnitis is more aggressive, uses throw_at instead of Move at higher stages

### DIFF
--- a/code/datums/diseases/magnitis.dm
+++ b/code/datums/diseases/magnitis.dm
@@ -54,7 +54,6 @@
 				to_chat(affected_mob, span_danger("You query upon the nature of miracles."))
 			if(DT_PROB(4, delta_time))
 				to_chat(affected_mob, span_danger("You feel a powerful shock course through your body."))
-				do_sparks(5, FALSE, src)
 				for(var/obj/nearby_object in orange(6, affected_mob))
 					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue

--- a/code/datums/diseases/magnitis.dm
+++ b/code/datums/diseases/magnitis.dm
@@ -28,7 +28,6 @@
 					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
 					var/move_dir = get_dir(nearby_object, affected_mob)
-					nearby_object.throw_at(get_step(nearby_object, move_dir), move_dir)
 				for(var/mob/living/silicon/nearby_silicon in orange(2, affected_mob))
 					if(isAI(nearby_silicon))
 						continue
@@ -38,21 +37,19 @@
 			if(DT_PROB(1, delta_time))
 				to_chat(affected_mob, span_danger("You feel a strong shock course through your body."))
 			if(DT_PROB(1, delta_time))
-				to_chat(affected_mob, span_danger("You feel like clowning around."))
+				to_chat(affected_mob, span_danger("Your hair stands on end."))
 			if(DT_PROB(2, delta_time))
 				for(var/obj/nearby_object in orange(4, affected_mob))
 					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
 					for(var/i in 1 to rand(1, 2))
-						var/move_dir = get_dir(nearby_object, affected_mob)
-						if(!nearby_object.Move(get_step(nearby_object, move_dir), move_dir))
+						if(!nearby_object.throw_at(affected_mob, 4, 4))
 							break
 				for(var/mob/living/silicon/nearby_silicon in orange(4, affected_mob))
 					if(isAI(nearby_silicon))
 						continue
 					for(var/i in 1 to rand(1, 2))
-						var/move_dir = get_dir(nearby_silicon, affected_mob)
-						if(!nearby_silicon.Move(get_step(nearby_silicon, move_dir), move_dir))
+						if(!nearby_silicon.throw_at(affected_mob, 4, 4))
 							break
 		if(4)
 			if(DT_PROB(1, delta_time))
@@ -64,13 +61,12 @@
 					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
 					for(var/i in 1 to rand(1, 3))
-						var/move_dir = get_dir(nearby_object, affected_mob)
-						if(!nearby_object.Move(get_step(nearby_object, move_dir), move_dir))
+						if(!nearby_object.throw_at(nearby_object, 6, 5))
 							break
 				for(var/mob/living/silicon/nearby_silicon in orange(6, affected_mob))
 					if(isAI(nearby_silicon))
 						continue
 					for(var/i in 1 to rand(1, 3))
 						var/move_dir = get_dir(nearby_silicon, affected_mob)
-						if(!nearby_silicon.Move(get_step(nearby_silicon, move_dir), move_dir))
+						if(!nearby_silicon.throw_at(affected_mob, 6, 3))
 							break

--- a/code/datums/diseases/magnitis.dm
+++ b/code/datums/diseases/magnitis.dm
@@ -54,6 +54,7 @@
 				to_chat(affected_mob, span_danger("You query upon the nature of miracles."))
 			if(DT_PROB(4, delta_time))
 				to_chat(affected_mob, span_danger("You feel a powerful shock course through your body."))
+				do_sparks(5, FALSE, src)
 				for(var/obj/nearby_object in orange(6, affected_mob))
 					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue

--- a/code/datums/diseases/magnitis.dm
+++ b/code/datums/diseases/magnitis.dm
@@ -22,12 +22,13 @@
 	switch(stage)
 		if(2)
 			if(DT_PROB(1, delta_time))
-				to_chat(affected_mob, span_danger("You feel a slight shock course through your body."))
+				to_chat(affected_mob, span_danger("Your skin tingles with energy."))
 			if(DT_PROB(1, delta_time))
 				for(var/obj/nearby_object in orange(2, affected_mob))
 					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
 					var/move_dir = get_dir(nearby_object, affected_mob)
+					nearby_object.Move(get_step(nearby_object, move_dir), move_dir)
 				for(var/mob/living/silicon/nearby_silicon in orange(2, affected_mob))
 					if(isAI(nearby_silicon))
 						continue
@@ -35,38 +36,31 @@
 					nearby_silicon.Move(get_step(nearby_silicon, move_dir), move_dir)
 		if(3)
 			if(DT_PROB(1, delta_time))
-				to_chat(affected_mob, span_danger("You feel a strong shock course through your body."))
-			if(DT_PROB(1, delta_time))
 				to_chat(affected_mob, span_danger("Your hair stands on end."))
 			if(DT_PROB(2, delta_time))
+				to_chat(affected_mob, span_danger("You feel a light shock course through your body."))
 				for(var/obj/nearby_object in orange(4, affected_mob))
 					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
 					for(var/i in 1 to rand(1, 2))
-						if(!nearby_object.throw_at(affected_mob, 4, 4))
-							break
+						nearby_object.throw_at(affected_mob, 4, 3)
 				for(var/mob/living/silicon/nearby_silicon in orange(4, affected_mob))
 					if(isAI(nearby_silicon))
 						continue
 					for(var/i in 1 to rand(1, 2))
-						if(!nearby_silicon.throw_at(affected_mob, 4, 4))
-							break
+						nearby_silicon.throw_at(affected_mob, 4, 3)
 		if(4)
-			if(DT_PROB(1, delta_time))
-				to_chat(affected_mob, span_danger("You feel a powerful shock course through your body."))
 			if(DT_PROB(1, delta_time))
 				to_chat(affected_mob, span_danger("You query upon the nature of miracles."))
 			if(DT_PROB(4, delta_time))
+				to_chat(affected_mob, span_danger("You feel a powerful shock course through your body."))
 				for(var/obj/nearby_object in orange(6, affected_mob))
 					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
 					for(var/i in 1 to rand(1, 3))
-						if(!nearby_object.throw_at(nearby_object, 6, 5))
-							break
+						nearby_object.throw_at(affected_mob, 6, 5) // I really wanted to use addtimers to stagger out when everything gets thrown but it would probably cause a lot of lag.
 				for(var/mob/living/silicon/nearby_silicon in orange(6, affected_mob))
 					if(isAI(nearby_silicon))
 						continue
 					for(var/i in 1 to rand(1, 3))
-						var/move_dir = get_dir(nearby_silicon, affected_mob)
-						if(!nearby_silicon.throw_at(affected_mob, 6, 3))
-							break
+						nearby_silicon.throw_at(affected_mob, 6, 5)

--- a/code/datums/diseases/magnitis.dm
+++ b/code/datums/diseases/magnitis.dm
@@ -28,7 +28,7 @@
 					if(nearby_object.anchored || !(nearby_object.flags_1 & CONDUCT_1))
 						continue
 					var/move_dir = get_dir(nearby_object, affected_mob)
-					nearby_object.Move(get_step(nearby_object, move_dir), move_dir)
+					nearby_object.throw_at(get_step(nearby_object, move_dir), move_dir)
 				for(var/mob/living/silicon/nearby_silicon in orange(2, affected_mob))
 					if(isAI(nearby_silicon))
 						continue

--- a/code/game/objects/items/RTD.dm
+++ b/code/game/objects/items/RTD.dm
@@ -246,7 +246,7 @@
 
 					//infer available overlays on the floor to recreate them to the best extent
 					QDEL_LIST(design_overlays)
-					var/floor_designs = floor.managed_overlays
+					floor_designs = floor.managed_overlays
 					if(isnull(floor_designs))
 						floor_designs = list()
 					else if(!islist(floor_designs))

--- a/code/game/objects/items/RTD.dm
+++ b/code/game/objects/items/RTD.dm
@@ -246,7 +246,7 @@
 
 					//infer available overlays on the floor to recreate them to the best extent
 					QDEL_LIST(design_overlays)
-					floor_designs = floor.managed_overlays
+					var/floor_designs = floor.managed_overlays
 					if(isnull(floor_designs))
 						floor_designs = list()
 					else if(!islist(floor_designs))


### PR DESCRIPTION
## About The Pull Request

I got this disease yesterday and was super disappointed by the actual effects. Rather than suffer an unending waves of metal objects being thrown at my head, I noticed that stuff on the bridge kept getting disorganized, shrugged, and moved on.

Now, stages 3/4 of Magnitis will use throw_at instead of just moving objects to the infectee. This can hurt or even kill the victim in extreme cases. Remember to duck!

The messages about electrical shocks will now appear when a magnetic pulse occurs. Some of the disease messages have been slightly altered to fit this. 

Also, while we're on the subject -- Is there a joke behind Magnitis' agent "Fukkos Miracos"? Why does Magnitis make you ponder upon the nature of miracles? Why did it make you feel like "clowning around"? This stuff was written over a decade ago and I get the feeling it's referencing something that is beyond me.
## Why It's Good For The Game

Gives an old disease a bit of a facelift. Makes it more _dynamic_ and _engaging_.
## Changelog
:cl: Rhials
balance: The Magnitis disease will now hurl objects at infectees at higher stages. Watch your head!
/:cl:
