### PR TITLE
Drag any valid dead mob into the infuser

### DIFF
--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -195,9 +195,8 @@
 	if(!state_open || !is_valid_infusion(target, user))
 		return
 
-	if(iscarbon(target) && ishuman(target))
-		infusing_from = target
-		infusing_from.forceMove(src)
+	infusing_from = target
+	infusing_from.forceMove(src)
 
 /obj/machinery/dna_infuser/proc/is_valid_infusion(atom/movable/target, mob/user)
 	if(user.stat != CONSCIOUS || HAS_TRAIT(user, TRAIT_UI_BLOCKED) || !Adjacent(user) || !user.Adjacent(target) || !ISADVANCEDTOOLUSER(user))


### PR DESCRIPTION
## About The Pull Request

Fixes #72738

I added an unnecessary carbon human check for the mob being dragged into the infuser even though that validation was already done above

Again to make the infuser work you have to
1. Make sure the infuser is open & empty(no occupant no infusion target inside)
2. Drag your mob(Your infusion target) into the machine
3. Then make someone/yourself enter the machine and have someone else close it from the outside & turn it on

## Changelog
:cl:
fix: Drag the correct valid mob into the machine
/:cl: