### PR TITLE
Adds the eyepatch to the Autodrobe

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -55,6 +55,7 @@
 				/obj/item/clothing/suit/costume/dracula = 1,
 				/obj/item/clothing/under/costume/draculass = 1,
 				/obj/item/clothing/suit/costume/gothcoat = 1,
+				/obj/item/clothing/glasses/eyepatch = 1,
 			),
 		),
 		list(


### PR DESCRIPTION

## About The Pull Request
Adds the eyepatch to the Autodrobe costume vendor. 

https://user-images.githubusercontent.com/102489377/212571492-a8f7f747-3ad7-4623-a546-f62cdae9bbdf.mp4
## Why It's Good For The Game
The eyepatch was previously only available on Metastation and Kilostation, this change will allow people to stylize their characters and bug the admins less.
## Changelog 
🆑 
add: Added the eyepatch to the Autodrobe.
/🆑 
