### PR TITLE
Trying to grab something restricted by HAUL gauntlets now has a Balloon alert.

### DIFF
--- a/code/datums/components/strong_pull.dm
+++ b/code/datums/components/strong_pull.dm
@@ -37,6 +37,7 @@ Basically, the items they pull cannot be pulled (except by the puller)
 /datum/component/strong_pull/proc/reject_further_pulls(datum/source, mob/living/puller)
 	SIGNAL_HANDLER
 	if(puller != parent) //for increasing grabs, you need to have a valid pull. thus, parent should be able to pull the same object again
+		strongpulling.balloon_alert(puller, "gripped too strong!")
 		return COMSIG_ATOM_CANT_PULL
 
 /*

--- a/code/datums/components/strong_pull.dm
+++ b/code/datums/components/strong_pull.dm
@@ -37,7 +37,7 @@ Basically, the items they pull cannot be pulled (except by the puller)
 /datum/component/strong_pull/proc/reject_further_pulls(datum/source, mob/living/puller)
 	SIGNAL_HANDLER
 	if(puller != parent) //for increasing grabs, you need to have a valid pull. thus, parent should be able to pull the same object again
-		strongpulling.balloon_alert(puller, "gripped too strong!")
+		strongpulling.balloon_alert(puller, "gripped too tightly!")
 		return COMSIG_ATOM_CANT_PULL
 
 /*


### PR DESCRIPTION

## About The Pull Request

Part of #72710 that I think is useful to be PRed even if the original is closed. When you try to grab someone or something restrained by HAUL gauntlets theres now a balloon alert telling you that its gripped too strongly, rather than no indication at all.
## Why It's Good For The Game

There being no player facing indication to attempting to steal an item being pulled by HAUL gauntlets seemed odd to me as without the feedback its easy to mistake it for just missing the grab.
## Changelog
:cl:
qol: Theres now a visual indicator when you attempt to grab an object or person restrained by the HAUL gauntlets.
/:cl:
