### PR TITLE
Fixing compile issue regarding Maintenance adapted eyes introduced by #72700

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -563,7 +563,7 @@
 	ADD_TRAIT(adapted, TRAIT_UNNATURAL_RED_GLOWY_EYES, ORGAN_TRAIT)
 
 /obj/item/organ/internal/eyes/night_vision/maintenance_adapted/on_life(delta_time, times_fired)
-	if(!HAS_TRAIT(owner, TRAIT_BLIND) && isturf(owner.loc) && owner.has_light_nearby(light_amount=0.5)) //we allow a little more than usual so we can produce light from the adapted eyes
+	if(!owner.is_blind() && isturf(owner.loc) && owner.has_light_nearby(light_amount=0.5)) //we allow a little more than usual so we can produce light from the adapted eyes
 		to_chat(owner, span_danger("Your eyes! They burn in the light!"))
 		applyOrganDamage(10) //blind quickly
 		playsound(owner, 'sound/machines/grill/grillsizzle.ogg', 50)


### PR DESCRIPTION

## About The Pull Request

#72700 made reference to a trait that doesn't actually exist, I've swapped it out with the correct thingy.
## Why It's Good For The Game

To be honest its not, this fix allows the code to compile which means we will continue playing this god forsaken game.
## Changelog
:cl:
fix: Maintenance adapted eyes no-longer prevent the game from compiling
/:cl:
