### PR TITLE
Log status display changes

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -769,12 +769,12 @@
 		if("message")
 			status_signal.data["top_text"] = data1
 			status_signal.data["bottom_text"] = data2
-			message_admins("[key_name(usr)] [ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[data1] [data2]\" [loc_name(usr)]")
+			message_admins("[key_name(usr)][ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[data1] [data2]\" [loc_name(usr)]")
 			log_game("[key_name(usr)] has changed the station status display message to \"[data1] [data2]\" [loc_name(usr)]")
 
 		if("alert")
 			status_signal.data["picture_state"] = data1
-			message_admins("[key_name(usr)] [ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[data1]\" [loc_name(usr)]")
+			message_admins("[key_name(usr)][ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[data1]\" [loc_name(usr)]")
 			log_game("[key_name(usr)] has changed the station status display message to \"[data1]\" [loc_name(usr)]")
 
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -769,8 +769,14 @@
 		if("message")
 			status_signal.data["top_text"] = data1
 			status_signal.data["bottom_text"] = data2
+			message_admins("[key_name(usr)] [ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[data1] [data2]\" [loc_name(usr)]")
+			log_game("[key_name(usr)] has changed the station status display message to \"[data1] [data2]\" [loc_name(usr)]")
+
 		if("alert")
 			status_signal.data["picture_state"] = data1
+			message_admins("[key_name(usr)] [ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[data1]\" [loc_name(usr)]")
+			log_game("[key_name(usr)] has changed the station status display message to \"[data1]\" [loc_name(usr)]")
+
 
 	frequency.post_signal(src, status_signal)
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -769,12 +769,10 @@
 		if("message")
 			status_signal.data["top_text"] = data1
 			status_signal.data["bottom_text"] = data2
-			message_admins("[key_name(usr)][ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[data1] [data2]\" [loc_name(usr)]")
 			log_game("[key_name(usr)] has changed the station status display message to \"[data1] [data2]\" [loc_name(usr)]")
 
 		if("alert")
 			status_signal.data["picture_state"] = data1
-			message_admins("[key_name(usr)][ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[data1]\" [loc_name(usr)]")
 			log_game("[key_name(usr)] has changed the station status display message to \"[data1]\" [loc_name(usr)]")
 
 

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -45,6 +45,8 @@
  */
 /datum/computer_file/program/status/proc/post_message(upper, lower)
 	post_status("message", upper, lower)
+	message_admins("[key_name(usr)] [ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[upper] [lower]\" [loc_name(usr)]")
+	log_game("[key_name(usr)] has changed the station status display message to \"[upper] [lower]\" [loc_name(usr)]")
 
 /**
  * Post a picture to status displays
@@ -58,6 +60,9 @@
 		post_status(picture)
 	else
 		post_status("alert", picture)
+
+	message_admins("[key_name(usr)] [ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[picture]\" [loc_name(usr)]")
+	log_game("[key_name(usr)] has changed the station status display message to \"[picture]\" [loc_name(usr)]")
 
 /datum/computer_file/program/status/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -45,7 +45,7 @@
  */
 /datum/computer_file/program/status/proc/post_message(upper, lower)
 	post_status("message", upper, lower)
-	message_admins("[key_name(usr)] [ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[upper] [lower]\" [loc_name(usr)]")
+	message_admins("[key_name(usr)][ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[upper] [lower]\" [loc_name(usr)]")
 	log_game("[key_name(usr)] has changed the station status display message to \"[upper] [lower]\" [loc_name(usr)]")
 
 /**
@@ -61,7 +61,7 @@
 	else
 		post_status("alert", picture)
 
-	message_admins("[key_name(usr)] [ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[picture]\" [loc_name(usr)]")
+	message_admins("[key_name(usr)][ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[picture]\" [loc_name(usr)]")
 	log_game("[key_name(usr)] has changed the station status display message to \"[picture]\" [loc_name(usr)]")
 
 /datum/computer_file/program/status/ui_act(action, list/params, datum/tgui/ui)

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -45,7 +45,6 @@
  */
 /datum/computer_file/program/status/proc/post_message(upper, lower)
 	post_status("message", upper, lower)
-	message_admins("[key_name(usr)][ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[upper] [lower]\" [loc_name(usr)]")
 	log_game("[key_name(usr)] has changed the station status display message to \"[upper] [lower]\" [loc_name(usr)]")
 
 /**
@@ -61,7 +60,6 @@
 	else
 		post_status("alert", picture)
 
-	message_admins("[key_name(usr)][ADMIN_LOOKUPFLW(usr)][ADMIN_SMITE(usr)] has changed the station status display message to \"[picture]\" [loc_name(usr)]")
 	log_game("[key_name(usr)] has changed the station status display message to \"[picture]\" [loc_name(usr)]")
 
 /datum/computer_file/program/status/ui_act(action, list/params, datum/tgui/ui)


### PR DESCRIPTION

## About The Pull Request
Changing the status displays creates an entry in game.log of who did it, and from where.
## Why It's Good For The Game
Seeing "LOL PENIS" on the status displays with no way to track it gets old after a while.
## Changelog
:cl: LT3
admin: Changing the station status displays now generates a log entry
/:cl:
