### PR TITLE
Uplink unlock code exclusion for lizards

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -27,6 +27,8 @@
 	var/datum/uplink_handler/uplink_handler
 	/// Code to unlock the uplink.
 	var/unlock_code
+	/// Excluded codes for lizard compatibility
+	var/list/excluded_codes = list("Foxtrot", "Oscar", "Sierra", "Whiskey", "X-ray")
 	/// Used for pen uplink
 	var/list/previous_attempts
 
@@ -443,6 +445,11 @@
 		returnable_code = list()
 		for(var/i in 1 to PEN_ROTATIONS)
 			returnable_code += rand(1, 360)
+
+	// check if the generated code is on the exclusion list. if it is, roll a new one.
+	for(var/code in 1 to excluded_codes.len)
+		if(returnable_code == excluded_codes[code])
+			return generate_code()
 
 	if(!unlock_code) // assume the unlock_code is our "base" code that we don't want to duplicate, and if we don't have an unlock code, immediately return out of it since there's nothing to compare to.
 		return returnable_code

--- a/strings/phonetic_alphabet.txt
+++ b/strings/phonetic_alphabet.txt
@@ -12,13 +12,13 @@ Kilo
 Lima
 Mike
 November
-Oscar
+October
 Papa
 Quebec
 Romeo
 Tango
 Uniform
 Victor
-Whiskey
+Waterloo
 Yankee
 Zulu

--- a/strings/phonetic_alphabet.txt
+++ b/strings/phonetic_alphabet.txt
@@ -16,9 +16,11 @@ Oscar
 Papa
 Quebec
 Romeo
+Sierra
 Tango
 Uniform
 Victor
 Whiskey
+X-ray
 Yankee
 Zulu

--- a/strings/phonetic_alphabet.txt
+++ b/strings/phonetic_alphabet.txt
@@ -12,13 +12,13 @@ Kilo
 Lima
 Mike
 November
-October
+Oscar
 Papa
 Quebec
 Romeo
 Tango
 Uniform
 Victor
-Waterloo
+Whiskey
 Yankee
 Zulu

--- a/strings/phonetic_alphabet.txt
+++ b/strings/phonetic_alphabet.txt
@@ -16,11 +16,9 @@ Oscar
 Papa
 Quebec
 Romeo
-Sierra
 Tango
 Uniform
 Victor
 Whiskey
-X-ray
 Yankee
 Zulu


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/71967 without touching the strings file this time.

Lizards can't use uplink codes that have S, X, or KS, so on uplink setup these letters are excluded when generating the unlock code.

## Changelog
:cl: LT3
fix: Lizardsss can now pronounce all the unlock codesss for uplinksss
/:cl:
