### PR TITLE
Fixes Ethereal revival

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -485,7 +485,7 @@
 		. += shine
 
 /obj/structure/ethereal_crystal/proc/heal_ethereal()
-	ethereal_heart.owner.revive(HEAL_ALL)
+	ethereal_heart.owner.heal_and_revive(0)
 	to_chat(ethereal_heart.owner, span_notice("You burst out of the crystal with vigour... </span><span class='userdanger'>But at a cost."))
 	var/datum/brain_trauma/picked_trauma
 	if(prob(10)) //10% chance for a severe trauma


### PR DESCRIPTION

## About The Pull Request

As of now reviving as an ethereal have multiple unintended effects - brain trauma not applying, healing any previously ailment the person might've had (including other traumas), negating cooldown on crystalization (infinite revivals) and healing organs.
Esentially meaning Ethereals can revive infinitely with no downside. Most of this caused by the revival proc reseting the heart and other organs. 
This PR fixes it.

Revival will now give appropriate trauma, will not reset revival cooldown and will not heal organ decay.

## Why It's Good For The Game

Closes #71630

## Changelog
:cl:
fix: fixed Ethereal revival
/:cl:
