### PR TITLE
You no longer have to sacrifice your soul to give a mouse sentience.

### DIFF
--- a/code/datums/components/tameable.dm
+++ b/code/datums/components/tameable.dm
@@ -46,7 +46,7 @@
 	atom_parent.balloon_alert(attacker, "fed")
 	if(unique || !already_friends(attacker))
 		if(prob(current_tame_chance)) //note: lack of feedback message is deliberate, keep them guessing!
-			on_tame(attacker, food)
+			on_tame(source, attacker, food)
 		else
 			current_tame_chance += bonus_tame_chance
 
@@ -61,7 +61,7 @@
 	return living_parent.faction.Find(REF(potential_friend))
 
 ///Ran once taming succeeds
-/datum/component/tameable/proc/on_tame(mob/living/tamer, atom/food)
+/datum/component/tameable/proc/on_tame(datum/source, mob/living/tamer, atom/food)
 	SIGNAL_HANDLER
 	after_tame?.Invoke(tamer, food)//Run custom behavior if needed
 


### PR DESCRIPTION
## About The Pull Request

Some Manuel shift I didn't take note of the round ID for.

A player ahelps because they LITERALLY VANISH. They think it's a genetic meltdown. I check the logs and I don't think it is.

The player mentions they got attacked by a mouse just before they died. I check the logs and what do we have, but the same game tick the player gets yeeted into the void that a mouse gains sentience.

```
    Line 11801: [2023-01-17 23:39:00.036] ACCESS: Mob Login: Cheeseromancer/(Lemmiwinks) was assigned to a /mob/living/basic/mouse/white
    Line 11802: [2023-01-17 23:39:00.052] GAME: Cheeseromancer/(Lemmiwinks) Client Cheeseromancer/(Lemmiwinks) has taken ownership of mob Lemmiwinks(/mob/living/basic/mouse/white) (Medbay Treatment Center (155,85,2))
    Line 11804: [2023-01-17 23:39:00.068] ACCESS: Mob Login: Super17andre/(Carter Wolfe) was assigned to a /mob/dead/observer
    Line 11806: [2023-01-17 23:39:00.111] GAME: Cheeseromancer/(Lemmiwinks) has gained antag datum �Sentient Creature(/datum/antagonist/sentient_creature).
```

There's other chatter IC about sentience potions, which narrows down the investigation.

Long story short, 20 month ago arm couldn't code and 20 month ago maintainers couldn't review code. On this blessed day, we're all complicit.

`on_tame` signal handler proc. Without source parameter. Signal handler. Without source parameter.

![image](https://user-images.githubusercontent.com/24975989/213057552-feb1c0c4-9119-4ea2-85f0-04ff5db8ae74.png)

This leads to your classic offset-by-1 arg error. The signal's source is the mouse. The tamer is the player that used the intelligence potion. There is no food. But because the signal handler omits source, the tamer is the mouse and the food is the tamer. Makes perfect sense in my head.

The food then, obviously, gets qdeleted in the later after_tame callback invocation. Meaning the player using the sentience potion gets sent to the Shadow Realm with no log entries suggesting cause of death.

Add in the missing source param, pass the source arg in the really, really bad signal handler proc being called directly. And we feex.

![image](https://user-images.githubusercontent.com/24975989/213058176-5a4ecb74-756a-46ef-b83b-fc61df8364c6.png)
## Why It's Good For The Game

Players being randomly qdeleted leads to admins crying. In the future I'm going to log qdeletions of cliented mobs. March. Because I have time off work then.
## Changelog
:cl:
fix: Mice given sentience through intelligence potions no longer immediately consume the body and soul of the person whom uplifted them.
/:cl:
