### PR TITLE
Fixes disguised morph movespeed bug

### DIFF
--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -127,7 +127,7 @@
 	multiplicative_slowdown = 5
 
 /datum/movespeed_modifier/morph_disguised
-	multiplicative_slowdown = 1
+	multiplicative_slowdown = -1
 
 /datum/movespeed_modifier/auto_wash
 	multiplicative_slowdown = 3


### PR DESCRIPTION

## About The Pull Request

Morph is described as this in the antag panel: "While morphed, you move faster, but are unable to attack creatures or eat anything." This is how it has worked as long as I have played, but at somepoint in the past this was broken. I was able to track down the source of this issue easier with admin powers, finally back to squash my own bug report.

## Why It's Good For The Game

Fixes #61693

## Changelog
:cl:
fix: Morphs now properly move faster when disguised rather than slowing down.
/:cl:
