### PR TITLE
adds a goose for the tram to hit

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -32890,6 +32890,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"lQG" = (
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
+/turf/open/floor/glass/reinforced/tram,
+/area/station/hallway/primary/tram/left)
 "lQM" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port/central)
@@ -158830,7 +158834,7 @@ iMR
 wpP
 wVw
 tep
-tep
+lQG
 klT
 aRN
 dDG


### PR DESCRIPTION

## About The Pull Request

there's no birdboat on tramstation. this puts birdboat on tramstation in a spot where it is highly likely to die within the first thirty seconds of the round
## Why It's Good For The Game

i was going to put it literally anywhere else but then a maintainer said

![image](https://user-images.githubusercontent.com/12202230/213110531-216b45d3-f0e5-4806-aad6-71d2b6e82a54.png)

this is a joke pr and you can close it but tram needs birdboat
## Changelog

![image](https://user-images.githubusercontent.com/12202230/213110861-e6f1e71b-d284-44a5-9b26-ca3c8aeb8f84.png)
:cl:
add: a goose for the tram to run over
/:cl:
