### PR TITLE
Adds an FOV cone to biohoods

### DIFF
--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -12,6 +12,10 @@
 	resistance_flags = ACID_PROOF
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 
+/obj/item/clothing/head/bio_hood/Initialize()
+	. = ..()
+	AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
+
 /datum/armor/head_bio_hood
 	bio = 100
 	fire = 30


### PR DESCRIPTION
## About The Pull Request

Fixes players bypassing the gas mask FOV restrictions with an equivalent head item that does everything the mask does without an FOV

## Why It's Good For The Game

Fixes players bypassing intended mechanics.

## Changelog
:cl:
fix: Fixes players bypassing the gas mask FOV restrictions with biohoods that do almost everything the mask does without an FOV
/:cl: