### PR TITLE
Stack traces when a cliented or ckeyed mob is Destroy()ed.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -24,7 +24,13 @@
  *
  * Parent call
  */
-/mob/Destroy()//This makes sure that mobs with clients/keys are not just deleted from the game.
+/mob/Destroy()
+	if(client)
+		stack_trace("Mob with client has been deleted.")
+
+	if(ckey)
+		stack_trace("Mob without client but with associated ckey has been deleted.")
+
 	remove_from_mob_list()
 	remove_from_dead_mob_list()
 	remove_from_alive_mob_list()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -27,8 +27,7 @@
 /mob/Destroy()
 	if(client)
 		stack_trace("Mob with client has been deleted.")
-
-	if(ckey)
+	else if(ckey)
 		stack_trace("Mob without client but with associated ckey has been deleted.")
 
 	remove_from_mob_list()

--- a/code/modules/unit_tests/metabolizing.dm
+++ b/code/modules/unit_tests/metabolizing.dm
@@ -51,15 +51,15 @@
 	var/mob/living/carbon/human/syringe_user = allocate(/mob/living/carbon/human/consistent)
 	var/mob/living/carbon/human/pill_syringe_user = allocate(/mob/living/carbon/human/consistent)
 
-	var/datum/mind/pill_mind = new /datum/mind("Mothcocks")
+	var/datum/mind/pill_mind = new /datum/mind(null)
 	pill_mind.active = TRUE
 	pill_mind.transfer_to(pill_user)
 
-	var/datum/mind/syringe_mind = new /datum/mind("Mothcocks")
+	var/datum/mind/syringe_mind = new /datum/mind(null)
 	syringe_mind.active = TRUE
 	syringe_mind.transfer_to(syringe_user)
 
-	var/datum/mind/pill_syringe_mind = new /datum/mind("Mothcocks")
+	var/datum/mind/pill_syringe_mind = new /datum/mind(null)
 	pill_syringe_mind.active = TRUE
 	pill_syringe_mind.transfer_to(pill_syringe_user)
 


### PR DESCRIPTION

## About The Pull Request

One thing that repeatedly pops up in admin channels is investigating causes of death when a player just vanishes from the game. These are almost universally qdeletion issues.

9 years ago `/mob/Destroy()` was commented with:
`//This makes sure that mobs with clients/keys are not just deleted from the game.`

Whatever code may have existed back then has long since been replaced.

**I consider that Destroy()ing a cliented or ckeyed mob is a runtime error case.**

Code which may result in deleting a mob should handle removing and/or reassigning any client or ckey - or call generic procs that do so - prior to destruction. This should ideally result in a clear log trail that allows admins to see what happened. Where this isn't the case, a stack trace will now be available to help narrow down the cause of qdeletion so an issue report can be made, and so admins have SOME info to investigate on.

An example of where this would help catch bugs is #72782 - It was clearly unintended behaviour to qdel the mob in the first place and this stack trace would have immediately highlighted exactly where the death came from.
```
[2023-01-18 12:44:40.415] runtime error: Mob with client has been deleted. (code/modules/mob/mob.dm:29)
 - proc name:  stack trace (/proc/_stack_trace)
 -   source file: stack_trace.dm,4
 -   usr: Julia Watson (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (111,143,2) (/turf/open/floor/iron)
 -   call stack:
 -  stack trace("Mob with client has been delet...", "code/modules/mob/mob.dm", 29)
 - Julia Watson (/mob/living/carbon/human): Destroy(0)
 - Julia Watson (/mob/living/carbon/human): Destroy(0)
 - Julia Watson (/mob/living/carbon/human): Destroy(0)
 - Julia Watson (/mob/living/carbon/human): Destroy(0)
 - qdel(Julia Watson (/mob/living/carbon/human), 0)
 - the mouse (/mob/living/basic/mouse): try consume cheese(Julia Watson (/mob/living/carbon/human))
 - the mouse (/mob/living/basic/mouse): tamed(the mouse (/mob/living/basic/mouse), Julia Watson (/mob/living/carbon/human))
 - /datum/callback (/datum/callback): Invoke(the mouse (/mob/living/basic/mouse), Julia Watson (/mob/living/carbon/human))
 - /datum/component/tameable (/datum/component/tameable): on tame(the mouse (/mob/living/basic/mouse), Julia Watson (/mob/living/carbon/human))
 - the mouse (/mob/living/basic/mouse):  SendSignal("simplemob_sentiencepotion", /list (/list))
 - the intelligence potion (/obj/item/slimepotion/slime/sentience): attack(the mouse (/mob/living/basic/mouse), Julia Watson (/mob/living/carbon/human), "icon-x=16;icon-y=7;left=1;butt...")
 - the mouse (/mob/living/basic/mouse): attackby(the intelligence potion (/obj/item/slimepotion/slime/sentience), Julia Watson (/mob/living/carbon/human), "icon-x=16;icon-y=7;left=1;butt...")
 - the intelligence potion (/obj/item/slimepotion/slime/sentience): melee attack chain(Julia Watson (/mob/living/carbon/human), the mouse (/mob/living/basic/mouse), "icon-x=16;icon-y=7;left=1;butt...")
 - Julia Watson (/mob/living/carbon/human): ClickOn(the mouse (/mob/living/basic/mouse), "icon-x=16;icon-y=7;left=1;butt...")
 - the mouse (/mob/living/basic/mouse): Click(the floor (112,143,2) (/turf/open/floor/iron), "mapwindow.map", "icon-x=16;icon-y=7;left=1;butt...")
 - 
```
See also #67300.

An example of where this would help identify causes of death where previously there were none - Scenarios that were fixed by #62949 and #66104 caused administrative headaches figuring out causes of death when players in exploding crates just got literally fucking qdeleted. Which was pretty trivial for players to do to other players.

Issue reports can be made and bugs can be fixed as we go along.

There are examples of quote "false positives" unquote.

Right click -> Delete, which can be used on any atom.
```
[2023-01-18 11:40:54.597] runtime error: Mob without client but with associated ckey has been deleted. (code/modules/mob/mob.dm:32)
 - proc name:  stack trace (/proc/_stack_trace)
 -   source file: stack_trace.dm,4
 -   usr: Norah Rader (/mob/dead/observer)
 -   src: null
 -   usr.loc: the floor (109,143,2) (/turf/open/floor/iron)
 -   call stack:
 -  stack trace("Mob without client but with as...", "code/modules/mob/mob.dm", 32)
 - Fulton Enderly (/mob/dead/observer): Destroy(0)
 - Fulton Enderly (/mob/dead/observer): Destroy(0)
 - qdel(Fulton Enderly (/mob/dead/observer), 0)
 - Timberpoes (/client): admin delete(Fulton Enderly (/mob/dead/observer))
 - Timberpoes (/client): Delete(Fulton Enderly (/mob/dead/observer))
```
 
Admin gibself
```
[2023-01-18 11:41:17.635] runtime error: Mob with client has been deleted. (code/modules/mob/mob.dm:29)
 - proc name:  stack trace (/proc/_stack_trace)
 -   source file: stack_trace.dm,4
 -   usr: Norah Rader (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (109,145,2) (/turf/open/floor/iron)
 -   call stack:
 -  stack trace("Mob with client has been delet...", "code/modules/mob/mob.dm", 29)
 - Norah Rader (/mob/living/carbon/human): Destroy(0)
 - Norah Rader (/mob/living/carbon/human): Destroy(0)
 - Norah Rader (/mob/living/carbon/human): Destroy(0)
 - Norah Rader (/mob/living/carbon/human): Destroy(0)
 - qdel(Norah Rader (/mob/living/carbon/human), 0)
 - Norah Rader (/mob/living/carbon/human): gib(1, 1, 1, 0)
 - Norah Rader (/mob/living/carbon/human): gib(1, 1, 1, 0)
 - Timberpoes (/client): Gibself()
```

Over time these stack traces can be checked for how well the true cause of death is logged, and whether there is a better procedure for deleting cliented/ckeyed mobs than just qdel(target).
## Why It's Good For The Game

qdeletion of cliented or ckeyed mobs is death and often lacks any specific logging.

This obfuscates bugs and hinders admin investigation.

stack_tracing highlights where this happens, revealing the previously obfuscated bugs more clearly. It also provides relevant information on a cause of death that can allow admin investigation to take place despite the absence of logging.
## Changelog
:cl:
admin: When a player-owned mob is deleted from the game world, a stack trace is now dropped in the runtime logs. This allows admins and coders to investigate these issues easier.
/:cl:
