### PR TITLE
Fixes lazy loading antag maps locking world start

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -853,6 +853,8 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 /datum/controller/subsystem/mapping/proc/lazy_load_template(template_key, force = FALSE)
 	RETURN_TYPE(/datum/turf_reservation)
+
+	UNTIL(initialized)
 	var/static/lazy_loading = FALSE
 	UNTIL(!lazy_loading)
 

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -17,11 +17,6 @@
 	/// Type path for the associated job datum.
 	var/role_job = /datum/job/abductor_agent
 
-/datum/antagonist/abductor/New()
-	// lets get the loading started now, but don't block waiting for it
-	INVOKE_ASYNC(SSmapping, TYPE_PROC_REF(/datum/controller/subsystem/mapping, lazy_load_template), LAZY_TEMPLATE_KEY_ABDUCTOR_SHIPS)
-	return ..()
-
 /datum/antagonist/abductor/get_preview_icon()
 	var/mob/living/carbon/human/dummy/consistent/scientist = new
 	var/mob/living/carbon/human/dummy/consistent/agent = new

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -25,11 +25,6 @@
 	/// The amount of limited discounts that the team get
 	var/discount_limited_amount = 10
 
-/datum/antagonist/nukeop/New()
-	if(send_to_spawnpoint) // lets get the loading started now, but don't block waiting for it
-		INVOKE_ASYNC(SSmapping, TYPE_PROC_REF(/datum/controller/subsystem/mapping, lazy_load_template), LAZY_TEMPLATE_KEY_NUKIEBASE)
-	return ..()
-
 /datum/antagonist/nukeop/proc/equip_op()
 	if(!ishuman(owner.current))
 		return

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -21,11 +21,6 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	var/wiz_age = WIZARD_AGE_MIN /* Wizards by nature cannot be too young. */
 	show_to_ghosts = TRUE
 
-/datum/antagonist/wizard/New()
-	if(move_to_lair) // kick off loading of your lair, if you want to be moved to it
-		INVOKE_ASYNC(SSmapping, TYPE_PROC_REF(/datum/controller/subsystem/mapping, lazy_load_template), LAZY_TEMPLATE_KEY_WIZARDDEN)
-	return ..()
-
 /datum/antagonist/wizard_minion
 	name = "Wizard Minion"
 	antagpanel_category = "Wizard"


### PR DESCRIPTION
So the core issue here is antag datums are also created during preference spritesheet generation and when first opening admin panels. This could happen before mapping subsystem initialized and is ready for lazy loading. If this didn't actually lock the whole ss initialization it would also mean they are always loaded. I'll leave finding proper early load points for someone else if they're are necessary but New isn't it.