### PR TITLE
RMB Multitooling tcomms machines unlinks or links from buffer

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -255,3 +255,16 @@
 	if(issilicon(user) || in_range(user, src))
 		return TRUE
 	return FALSE
+
+/obj/machinery/telecomms/multitool_act_secondary(mob/living/user, obj/item/tool)
+	var/obj/item/multitool/multitool = tool
+	var/obj/machinery/telecomms/telecomms_machine = multitool.buffer
+	if(QDELETED(multitool.buffer)||!multitool.buffer || !istype(telecomms_machine) || telecomms_machine == src) //sanity + user sanity
+		return FALSE
+	if(multitool.buffer in links)
+		to_chat(user, span_notice("Unlinked [telecomms_machine] ([telecomms_machine.id]) from the [src]."))
+		remove_link(multitool.buffer,user)
+	else
+		to_chat(user, span_notice("Linked [telecomms_machine] ([telecomms_machine.id]) to the [src]."))
+		add_new_link(multitool.buffer,user)
+	return TRUE

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -259,7 +259,7 @@
 /obj/machinery/telecomms/multitool_act_secondary(mob/living/user, obj/item/tool)
 	var/obj/item/multitool/multitool = tool
 	var/obj/machinery/telecomms/telecomms_machine = multitool.buffer
-	if(QDELETED(multitool.buffer)||!multitool.buffer || !istype(telecomms_machine) || telecomms_machine == src) //sanity + user sanity
+	if(QDELETED(multitool.buffer) || !multitool.buffer || !istype(telecomms_machine) || telecomms_machine == src) //sanity + user sanity
 		return FALSE
 	if(multitool.buffer in links)
 		to_chat(user, span_notice("Unlinked [telecomms_machine] ([telecomms_machine.id]) from the [src]."))

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -106,6 +106,12 @@ GLOBAL_LIST_EMPTY(telecomms_list)
 	. = ..()
 	soundloop = new(src, on)
 	GLOB.telecomms_list += src
+	var/static/list/multitool_tips = list(
+		TOOL_MULTITOOL = list(
+			SCREENTIP_CONTEXT_RMB = "Link/Unlink from multitool buffer",
+		)
+	)
+	AddElement(/datum/element/contextual_screentip_tools, multitool_tips)
 	if(mapload && autolinkers.len)
 		return INITIALIZE_HINT_LATELOAD
 


### PR DESCRIPTION

## About The Pull Request

Adds a contextual multitool tooltip saying "Link/Unlink from multitool buffer" to tcomms machines
Rightclicking a tcomms machine with a multitool (with a tcomms machine in the buffer);
Links if the buffer was not found in the targets links
Unlinks if the buffer was found in the targets links

## Why It's Good For The Game

Way smoother and easier to connect tcomms machines instead of opening tgui like 15 times and pressing a button

## Changelog
:cl:
qol: Multitooling a telecommunications machine with RMB links or unlinks it to the machine in the multitools buffer
/:cl:
