### PR TITLE
You can no longer climb ladders from anchored buckleables

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -94,6 +94,9 @@
 	if(going_up ? !up : !down)
 		balloon_alert(user, "can't go any further [going_up ? "up" : "down"]")
 		return
+	if(user.buckled && user.buckled.anchored)
+		balloon_alert(user, "buckled to something anchored!")
+		return
 	if(travel_time)
 		INVOKE_ASYNC(src, PROC_REF(start_travelling), user, going_up)
 	else


### PR DESCRIPTION

## About The Pull Request
This PR prevents you from climbing ladders while buckled to something that is anchored. You can still climb while buckled to non-anchored things like wheelchairs or people.
Fixes #72691
## Why It's Good For The Game
Consistency
## Changelog
:cl: Ryll/Shaps
fix: You can no longer climb ladders while buckled to an anchored object
/:cl:
