### PR TITLE
Fixes Weird Circle-Fill Exceeding Bounds on Tram Console

### DIFF
--- a/tgui/packages/tgui/interfaces/TramControl.js
+++ b/tgui/packages/tgui/interfaces/TramControl.js
@@ -93,12 +93,12 @@ export const TramControl = (props, context) => {
             color={getDestColor(dest)}
             circular
             compact
-            height={5}
-            width={5}
+            height={4.9}
+            width={4.9}
             tooltipPosition="top"
             tooltip={COLOR2BLURB[getDestColor(dest)]}
             onClick={() => setTransitIndex(destinations.indexOf(dest))}>
-            <Icon ml={-2.1} mt={0.55} fontSize="60px" name="circle-o" />
+            <Icon ml={-2.1} fontSize="60px" name="circle-o" />
           </Button>
           {(destinations.length - 1 !== destinations.indexOf(dest) && (
             <Section title=" " mt={-7.3} ml={10} mr={-6.1} />


### PR DESCRIPTION

## About The Pull Request

Hey there, do you spot the issue here?

![image](https://user-images.githubusercontent.com/34697715/213350665-edc232be-e380-421e-b96a-b93945eedb33.png)

I'm not sure when this cropped up, but it appears to have been recently since it really irritated me when I first saw it. After a bit of toying around with the UI, I dropped both the height/width variables of the "fill" into the circle (the icon itself has thick enough boundaries to where it doesn't seem weird), as well as excising the `mt` variable, as any value I threw into it would always have some weirdness. Please do tell me if I shouldn't have axed it, but I don't really see any ill effect (and quite the opposite actually).
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/213350674-3e01b90d-b097-41a9-a374-61144245dcaf.png)

It's not as frustrating to look at anymore! Hopefully this isn't some sort of weird localized issue, but I much prefer these results.
## Changelog
:cl:
fix: Nanotrasen has pushed an update to their Transit System Consoles, which just makes sure the buttons look visually appropriate.
/:cl:

(i doubt players would notice though)
