### PR TITLE
RTD fits in toolbelt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -53,6 +53,7 @@
 		/obj/item/clothing/gloves,
 		/obj/item/construction/rcd,
 		/obj/item/construction/rld,
+		/obj/item/construction/rtd,
 		/obj/item/crowbar,
 		/obj/item/extinguisher/mini,
 		/obj/item/flashlight,


### PR DESCRIPTION
## About The Pull Request

RTD fits in toolbelt.

## Why It's Good For The Game

Don't give me rapid construction devices that don't fit in my toolbelt, that's lame!

## Changelog

:cl: Melbert
qol: RTD fits in toolbelts. 
/:cl:

