### PR TITLE
Changes a wall on runtimestation to a reinforced one

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -1123,9 +1123,9 @@
 	dir = 8;
 	dwidth = 3;
 	height = 15;
-	shuttle_id = "arrival_stationary";
 	name = "arrivals";
 	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	shuttle_id = "arrival_stationary";
 	width = 7
 	},
 /turf/open/floor/engine,
@@ -1212,10 +1212,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"ey" = (
-/obj/machinery/status_display/supply,
-/turf/closed/wall,
-/area/station/cargo/storage)
 "ez" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -1247,8 +1243,8 @@
 	dir = 8;
 	dwidth = 2;
 	height = 13;
-	shuttle_id = "ferry_home";
 	name = "port bay 2";
+	shuttle_id = "ferry_home";
 	width = 5
 	},
 /turf/open/space/basic,
@@ -1278,8 +1274,8 @@
 	dir = 4;
 	dwidth = 4;
 	height = 7;
-	shuttle_id = "cargo_home";
 	name = "Cargo Bay";
+	shuttle_id = "cargo_home";
 	width = 12
 	},
 /turf/open/space/basic,
@@ -1428,8 +1424,8 @@
 	dir = 2;
 	dwidth = 11;
 	height = 15;
-	shuttle_id = "whiteship_home";
 	name = "SS13: Auxiliary Dock, Station-Port";
+	shuttle_id = "whiteship_home";
 	width = 28
 	},
 /turf/open/space/basic,
@@ -1480,8 +1476,8 @@
 	dir = 2;
 	dwidth = 9;
 	height = 25;
-	shuttle_id = "emergency_home";
 	name = "Runtimestation emergency evac bay";
+	shuttle_id = "emergency_home";
 	width = 29
 	},
 /turf/open/space/basic,
@@ -2068,8 +2064,8 @@
 /area/station/construction)
 "tG" = (
 /obj/docking_port/stationary/random{
-	shuttle_id = "pod_lavaland";
-	name = "lavaland"
+	name = "lavaland";
+	shuttle_id = "pod_lavaland"
 	},
 /turf/open/space/basic,
 /area/space)
@@ -8739,7 +8735,7 @@ aa
 aa
 aa
 et
-ey
+fB
 fh
 fh
 fh


### PR DESCRIPTION
## About The Pull Request

One of the walls in the Runtimestation cargo bay was, amongst all of the reinforced walls used everywhere else on the station, a regular, normal wall. I noticed it a few months ago and now compulsively check up on it every time I open runtime for testing. I think it's time to finally put it to rest.

I don't know if this was put here for any particular reason. I'm assuming it's just a goof that went unnoticed because it was covered by a cargo screen.

![image](https://user-images.githubusercontent.com/28870487/213507536-269ffc97-5fd5-43db-a80b-b2962f387fe5.png)
## Why It's Good For The Game

Consistency in mapping.

Reduces the number of lines in the runtimestation.dmm file by a total of four. That's an improvement to efficiency on some microscopic, imperceptible scale, right?
## Changelog
:cl:
fix: a wall covered by a screen on runtimestation has been modified into a reinforced wall.
/:cl:
