### PR TITLE
Clarifies That Wire Terminals Are Inputs.

### DIFF
--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -6,7 +6,7 @@
 /obj/machinery/power/terminal
 	name = "terminal"
 	icon_state = "term"
-	desc = "It's an underfloor wiring terminal for power equipment."
+	desc = "It's an underfloor wiring terminal, used to draw power from the grid."
 	layer = WIRE_TERMINAL_LAYER //a bit above wires
 	var/obj/machinery/power/master = null
 


### PR DESCRIPTION

## About The Pull Request
Rewrites the wiring terminal's description to clarify that it's the input for both of it's use cases.
Yes, this is sincerely a problem spacemen have. And it pains me.

If we ever *do* get machines that use wiring terminals as an output, this'll need some minor revisiting.
## Why It's Good For The Game
I'd like it if Engineering actually provided power instead of succumbing to a Three Stooges Sketch trying to "fix" it.
Also explains it better to new players.
## Changelog
:cl:
spellcheck: Wire Terminals' Description now informs the player that they're an input.
/:cl:
