### PR TITLE
Amended pet carrier examine to include release command

### DIFF
--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -53,7 +53,7 @@
 	else
 		. += span_notice("It has nothing inside.")
 	if(user.canUseTopic(src))
-		. += span_notice("Activate it in your hand to [open ? "close" : "open"] its door.")
+		. += span_notice("Activate it in your hand to [open ? "close" : "open"] its door. Click-drag onto floor to release its occupants.")
 		if(!open)
 			. += span_notice("Alt-click to [locked ? "unlock" : "lock"] its door.")
 


### PR DESCRIPTION
## About The Pull Request

Added a small piece of text to the examine string, under usable and noticeable, to inform players on how to release pets from the pet carrier.

## Why It's Good For The Game

I am a relative new/returning player and have noticed there was no way to know how to release pets once they're inside. This helps people that want to carry their pets around in the carrier 🙂

## Changelog
:cl:
spellcheck: small amendment on pet carrier
/:cl:
