### PR TITLE
monophobia blind fix

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -168,9 +168,10 @@
 		stress = max(stress - (2 * delta_time), 0)
 
 /datum/brain_trauma/severe/monophobia/proc/check_alone()
+	var/check_radius = 7
 	if(owner.is_blind())
-		return TRUE
-	for(var/mob/M in oview(owner, 7))
+		check_radius = 1
+	for(var/mob/M in oview(owner, check_radius))
 		if(!isliving(M)) //ghosts ain't people
 			continue
 		if(istype(M, /mob/living/simple_animal/pet) || istype(M, /mob/living/basic/pet) || M.ckey)


### PR DESCRIPTION

## About The Pull Request
Doll with monophobia and blindness dont die from being "alone" while someone in 1 tile radius.   
## Why It's Good For The Game
maybe if blind and with monophobia die from heart attack while he in the crowd its funny, but too inescapable situation.
## Changelog
:cl: Winter Schock
fix: Blind doll with monophobia dont get stress while someone in 1 tile range
/:cl:
