### PR TITLE
Fixes Deep Frier Runtime on Deconstruct

### DIFF
--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -62,7 +62,8 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 
 /obj/machinery/deepfryer/deconstruct(disassembled)
 	// This handles nulling out frying via exited
-	frying.forceMove(drop_location())
+	if(frying)
+		frying.forceMove(drop_location())
 	return ..()
 
 /obj/machinery/deepfryer/RefreshParts()


### PR DESCRIPTION
## About The Pull Request

Via https://tgstation13.org/parsed-logs/sybil/data/logs/2023/01/20/round-198547/runtime.condensed.txt

```txt
The following runtime has occurred 1 time(s).
runtime error: Cannot execute null.forceMove().
proc name: deconstruct (/obj/machinery/deepfryer/deconstruct)
  source file: deep_fryer.dm,65
  usr: null
  src: the deep fryer (/obj/machinery/deepfryer)
  src.loc: space (143,123,2) (/turf/open/space)
```

The frying var being null is the default state of this machinery. Shouldn't runtime out of deconstruct() for something so silly. Let's just check against it.
## Why It's Good For The Game

LET ME DECONSTRUCT THE DEEPFRIER ARRRRRGHHH
## Changelog
:cl:
fix: Deconstructing deep friers should now work properly.
/:cl:
