### PR TITLE
You can no longer pull out pH Indicator Strips from across the room (COOL GIF INSIDE)

### DIFF
--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -43,7 +43,7 @@
 
 /obj/item/ph_booklet/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	var/mob/living/user = usr
-	if(!isliving(user))
+	if(!isliving(user) || !Adjacent(user))
 		return
 	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		return


### PR DESCRIPTION

## About The Pull Request

Basically, everytime you clicked and dragged the pH Indicator Booklet using mouse_drop behavior, it would give you one of the strips it had. Neat behavior, right? However, this worked at any range.

![brainpower](https://user-images.githubusercontent.com/34697715/213631227-fc0d6bf2-887f-4096-8e4b-7ebd488e9bdd.gif)
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/213629514-f108e41e-0df4-410a-bc6c-443e64867ace.png)

this can not possibly be real. we need to nerf this overpowered exploit. chemist powergamers must kneel.
## Changelog
:cl:
fix: Spacemen with a clear lack of genetics powers can no longer bend space and time to pull out pH indicator strips.
/:cl:
thank you to kelly harshman for telling me about this. sorry i had to kill off the parlor trick but the gif was too cool.