### PR TITLE
Allow illiterate people to play slots

### DIFF
--- a/code/game/machinery/slotmachine.dm
+++ b/code/game/machinery/slotmachine.dm
@@ -24,6 +24,7 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/computer/slot_machine
 	light_color = LIGHT_COLOR_BROWN
+	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON|INTERACT_MACHINE_SET_MACHINE // don't need to be literate to play slots
 	var/money = 3000 //How much money it has CONSUMED
 	var/plays = 0
 	var/working = FALSE


### PR DESCRIPTION
## About The Pull Request
When I coded the illiterate quirk I wanted to allow certain machines to be excluded.  Arcade machines and security cameras both are more of a visual type of machine that already have this exclusion.  Slot machines should also fall into that category.

## Why It's Good For The Game
Consistency.

![covid-covid19](https://user-images.githubusercontent.com/5195984/213676629-67f84aed-0078-456b-be2e-dc7185def683.gif)

## Changelog
:cl:
qol: Allow illiterate people to play slot machines
/:cl:
