### PR TITLE
Being wet no longer causes you to be EXTRA flammable

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -47,8 +47,8 @@
 				continue
 
 			var/cur_stacks = stacks
-			adjust_stacks(-enemy_effect.stacks * enemy_effect.stack_modifier / stack_modifier)
-			enemy_effect.adjust_stacks(-cur_stacks * stack_modifier / enemy_effect.stack_modifier)
+			adjust_stacks(-abs(enemy_effect.stacks * enemy_effect.stack_modifier / stack_modifier))
+			enemy_effect.adjust_stacks(-abs(cur_stacks * stack_modifier / enemy_effect.stack_modifier))
 			if(enemy_effect.stacks <= 0)
 				qdel(enemy_effect)
 


### PR DESCRIPTION
## About The Pull Request
Making it a separate PR because I think that's a very funny fuckup, who knows, maybe one of the fuckups of the year, even.

Being wet no longer causes you to be even more flammable, and instead properly lets you dry up instead of catching on fire even faster when receiving fire stacks.

What caused this was that there was some double-negatives happening, which meant that both fire and wet stacks would be increased together when both were present at once, rather than both being reduced and one of the two cancelling out the other.

## Why It's Good For The Game
Being wet shouldn't make you go up in flames faster. Now it will actually protect you from flames according to your amount of wet stacks, as intended.

## Changelog

:cl: GoldenAlpharex
fix: Being wet no longer causes you to be EXTRA flammable, and instead properly protects you from catching on fire. If you're wet enough, of course.
/:cl: