### PR TITLE
Water will now make you wet

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -47,8 +47,8 @@
 				continue
 
 			var/cur_stacks = stacks
-			adjust_stacks(-enemy_effect.stacks * enemy_effect.stack_modifier / stack_modifier)
-			enemy_effect.adjust_stacks(-cur_stacks * stack_modifier / enemy_effect.stack_modifier)
+			adjust_stacks(-abs(enemy_effect.stacks * enemy_effect.stack_modifier / stack_modifier))
+			enemy_effect.adjust_stacks(-abs(cur_stacks * stack_modifier / enemy_effect.stack_modifier))
 			if(enemy_effect.stacks <= 0)
 				qdel(enemy_effect)
 

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -47,8 +47,8 @@
 				continue
 
 			var/cur_stacks = stacks
-			adjust_stacks(-abs(enemy_effect.stacks * enemy_effect.stack_modifier / stack_modifier))
-			enemy_effect.adjust_stacks(-abs(cur_stacks * stack_modifier / enemy_effect.stack_modifier))
+			adjust_stacks(-enemy_effect.stacks * enemy_effect.stack_modifier / stack_modifier)
+			enemy_effect.adjust_stacks(-cur_stacks * stack_modifier / enemy_effect.stack_modifier)
 			if(enemy_effect.stacks <= 0)
 				qdel(enemy_effect)
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -230,19 +230,34 @@
 		new /obj/item/stack/sheet/wethide(get_turf(HH), HH.amount)
 		qdel(HH)
 
-/*
+
+/// How many wet stacks you get per units of water when it's applied by touch.
+#define WATER_TO_WET_STACKS_FACTOR_TOUCH 0.5
+/// How many wet stacks you get per unit of water when it's applied by vapor. Much less effective than by touch, of course.
+#define WATER_TO_WET_STACKS_FACTOR_VAPOR 0.1
+
+
+/**
  * Water reaction to a mob
  */
-
-/datum/reagent/water/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)//Splashing people with water can help put them out!
+/datum/reagent/water/expose_mob(mob/living/exposed_mob, methods = TOUCH, reac_volume)//Splashing people with water can help put them out!
 	. = ..()
 	if(methods & TOUCH)
 		exposed_mob.extinguish_mob() // extinguish removes all fire stacks
+		exposed_mob.adjust_wet_stacks(reac_volume * WATER_TO_WET_STACKS_FACTOR_TOUCH) // Water makes you wet, at a 50% water-to-wet-stacks ratio. Which, in turn, gives you some mild protection from being set on fire!
+
 	if(methods & VAPOR)
+		exposed_mob.adjust_wet_stacks(reac_volume * WATER_TO_WET_STACKS_FACTOR_VAPOR) // Spraying someone with water with the hope to put them out is just simply too funny to me not to add it.
+
 		if(!isfelinid(exposed_mob))
 			return
+
 		exposed_mob.incapacitate(1) // startles the felinid, canceling any do_after
 		exposed_mob.add_mood_event("watersprayed", /datum/mood_event/watersprayed)
+
+
+#undef WATER_TO_WET_STACKS_FACTOR_TOUCH
+#undef WATER_TO_WET_STACKS_FACTOR_VAPOR
 
 
 /datum/reagent/water/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -165,7 +165,7 @@
 #include "range_return.dm"
 #include "rcd.dm"
 #include "reagent_id_typos.dm"
-#include "reagent_mod_expose.dm"
+#include "reagent_mob_expose.dm"
 #include "reagent_mod_procs.dm"
 #include "reagent_names.dm"
 #include "reagent_recipe_collisions.dm"

--- a/code/modules/unit_tests/reagent_mob_expose.dm
+++ b/code/modules/unit_tests/reagent_mob_expose.dm
@@ -29,9 +29,9 @@
 	TEST_ASSERT(human.fire_stacks > 1, "Human fire stacks did not increase after life tick")
 
 	// TOUCH
-	dropper.reagents.add_reagent(/datum/reagent/water, 1)
+	dropper.reagents.add_reagent(/datum/reagent/water, 5)
 	dropper.afterattack(human, human, TRUE)
-	TEST_ASSERT_EQUAL(human.fire_stacks, 0, "Human still has fire stacks after touching water")
+	TEST_ASSERT(human.fire_stacks < 0, "Human still has fire stacks after touching water")
 
 	// VAPOR
 	TEST_ASSERT_NULL(human.has_status_effect(/datum/status_effect/drowsiness), "Human is drowsy at the start of testing")
@@ -39,6 +39,11 @@
 	drink.reagents.add_reagent(/datum/reagent/nitrous_oxide, 10)
 	drink.reagents.trans_to(human, 10, methods = VAPOR)
 	TEST_ASSERT_NOTNULL(human.has_status_effect(/datum/status_effect/drowsiness), "Human is not drowsy after exposure to vapors")
+	drink.reagents.clear_reagents()
+	drink.reagents.add_reagent(/datum/reagent/water, 10)
+	var/old_fire_stacks = human.fire_stacks
+	drink.reagents.trans_to(human, 10, methods = VAPOR)
+	TEST_ASSERT(human.fire_stacks < old_fire_stacks, "Human does not get wetter after being exposed to water by vapors")
 
 	// PATCH
 	human.health = 100


### PR DESCRIPTION
## About The Pull Request
Water, when exposed to a mob either via `TOUCH` or `VAPOR` application, will now apply wet stacks to said mob according to the amount of water used. For touch application, the ratio is 0.5 wet stack per unit of water, whereas for vapor application (so for foam and sprays), that ratio is lowered to 0.1 wet stack per unit of water. Yes, that would mean that you could now put someone out by spraying enough water at them with a spray bottle (usually around 50-150u), and I think that is quite simply hilarious.

As a reminder, wet stacks decay slowly over time, however obviously raising your fire stacks (so being exposed to something that's on fire, for instance) will speed up that decay, once https://github.com/tgstation/tgstation/pull/72843 is merged. I separated them in two PRs because honestly the fact that being wet made you more flammable just sounds like a fuckup of the year if I've ever heard one.

I also updated the unit test of water's `expose_mob()` proc, to check that wet stacks were being applied properly, hopefully making sure that there's no regression on that part in the future.

## Why It's Good For The Game
The number one thing you think of when you think of the word wet is water. Water should make you wet, it only makes sense.

## Changelog

:cl: GoldenAlpharex
balance: Water now makes you wet on touch and vapor application, with vapor being much less effective than touch. Yes, that means you can now spend two minutes putting someone out with a spray bottle full of water!
/:cl: