### PR TITLE
Makes nautical directions a proc

### DIFF
--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -4,6 +4,15 @@
 // #define EAST 4
 // #define WEST 8
 
+/// North direction in nautical directions
+#define FORE 1
+/// South direction in nautical directions
+#define AFT 2
+/// East direction in nautical directions
+#define STARBOARD 4
+/// West direction in nautical directions
+#define PORT 8
+
 /// North direction as a string "[1]"
 #define TEXT_NORTH "[NORTH]"
 /// South direction as a string "[2]"

--- a/code/__DEFINES/directional.dm
+++ b/code/__DEFINES/directional.dm
@@ -5,13 +5,13 @@
 // #define WEST 8
 
 /// North direction in nautical directions
-#define FORE 1
+#define FORE NORTH
 /// South direction in nautical directions
-#define AFT 2
+#define AFT SOUTH
 /// East direction in nautical directions
-#define STARBOARD 4
+#define STARBOARD EAST
 /// West direction in nautical directions
-#define PORT 8
+#define PORT WEST
 
 /// North direction as a string "[1]"
 #define TEXT_NORTH "[NORTH]"

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -6,6 +6,8 @@
  * angle2text
  * worldtime2text
  * text2dir_extended & dir2text_short
+ * dir2nautical
+ * nautical2dir
  */
 
 
@@ -37,35 +39,7 @@
 		if(SOUTHWEST)
 			return "southwest"
 		else
-	return
-
-//Turns a direction into a nautical direction
-/proc/dir2nautical(direction)
-	switch(direction)
-		if(NORTH)
-			return "fore"
-		if(SOUTH)
-			return "aft"
-		if(EAST)
-			return "starboard"
-		if(WEST)
-			return "port"
-		else
-	return
-
-//Turns a nautical direction into a direction
-/proc/nautical2dir(direction)
-	switch(uppertext(direction))
-		if("FORE")
-			return NORTH
-		if("AFT")
-			return SOUTH
-		if("STARBOARD")
-			return EAST
-		if("PORT")
-			return WEST
-		else
-	return
+			CRASH("Tried to convert dir [direction] to text, but received unrecognised direction.")
 
 //Turns text into proper directions
 /proc/text2dir(direction)
@@ -87,7 +61,35 @@
 		if("SOUTHWEST")
 			return SOUTHWEST
 		else
-	return
+			CRASH("Tried to convert text [direction] to dir, but received unrecognised direction.")
+
+//Turns a direction into a nautical direction
+/proc/dir2nautical(direction)
+	switch(direction)
+		if(NORTH)
+			return "fore"
+		if(SOUTH)
+			return "aft"
+		if(EAST)
+			return "starboard"
+		if(WEST)
+			return "port"
+		else
+			CRASH("Tried to convert dir [direction] to nautical, but received unrecognised direction.")
+
+//Turns a nautical direction into a direction
+/proc/nautical2dir(direction)
+	switch(uppertext(direction))
+		if("FORE")
+			return NORTH
+		if("AFT")
+			return SOUTH
+		if("STARBOARD")
+			return EAST
+		if("PORT")
+			return WEST
+		else
+			CRASH("Tried to convert nautical [direction] to dir, but received unrecognised direction.")
 
 //Converts an angle (degrees) into a ss13 direction
 GLOBAL_LIST_INIT(modulo_angle_to_dir, list(NORTH,NORTHEAST,EAST,SOUTHEAST,SOUTH,SOUTHWEST,WEST,NORTHWEST))

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -39,6 +39,34 @@
 		else
 	return
 
+//Turns a direction into a nautical direction
+/proc/dir2nautical(direction)
+	switch(direction)
+		if(NORTH)
+			return "fore"
+		if(SOUTH)
+			return "aft"
+		if(EAST)
+			return "starboard"
+		if(WEST)
+			return "port"
+		else
+	return
+
+//Turns a nautical direction into a direction
+/proc/nautical2dir(direction)
+	switch(uppertext(direction))
+		if("FORE")
+			return NORTH
+		if("AFT")
+			return SOUTH
+		if("STARBOARD")
+			return EAST
+		if("PORT")
+			return WEST
+		else
+	return
+
 //Turns text into proper directions
 /proc/text2dir(direction)
 	switch(uppertext(direction))

--- a/code/modules/events/sandstorm.dm
+++ b/code/modules/events/sandstorm.dm
@@ -52,22 +52,7 @@
 	else
 		start_side = pick(GLOB.cardinals)
 
-	var/start_side_text = "unknown"
-	switch(start_side)
-		if(NORTH)
-			start_side_text = "fore"
-		if(SOUTH)
-			start_side_text = "aft"
-		if(EAST)
-			start_side_text = "starboard"
-		if(WEST)
-			start_side_text = "port"
-		else
-			stack_trace("Sandstorm event given [start_side] as unrecognized direction. Cancelling event...")
-			kill()
-			return
-
-	priority_announce("A large wave of space dust is approaching from the [start_side_text] side of the station. \
+	priority_announce("A large wave of space dust is approaching from the [dir2nautical(start_side)] side of the station. \
 		Impact is expected in the next two minutes. All employees are encouranged to assist in repairs and damage mitigation if possible.", "Collision Emergency Alert")
 
 /datum/round_event/sandstorm/tick()


### PR DESCRIPTION

## About The Pull Request
Adds two new procs: dir2nautical and nautical2dir for converting between integer directions and their nautical text equivalent.
## Why It's Good For The Game
Deduplication of code. Instead of having these functions in each event that uses it, they can just call the proc instead. It will be used by more than one event now that we have directional code.
## Changelog
:cl: LT3
refactor: Nautical direction conversion gets its own set of procs
/:cl:
