### PR TITLE
Adds a Burn Medkit to Mining Vendor

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_consumables.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_consumables.dm
@@ -13,6 +13,11 @@
 	item_path = /obj/item/storage/medkit/brute
 	cost_per_order = 600
 
+/datum/orderable_item/consumables/medkit_fire
+	item_path = /obj/item/storage/medkit/fire
+	desc = "For emergency magmatic burn relief."
+	cost_per_order = 700
+
 /datum/orderable_item/consumables/whiskey
 	item_path = /obj/item/reagent_containers/cup/glass/bottle/whiskey
 	cost_per_order = 100


### PR DESCRIPTION

## About The Pull Request

Adds a burn medkit to the mining vendor. Since burn damage is slightly harder to deal with on lavaland, I've made it price slightly higher than the brute medkit.
## Why It's Good For The Game

With the addition of vileworms and bileworms, both dealing burn damage, along with the already hazardously flammable nature of lavaland, its about time miners had access to a burn medkit instead of having to use an expensive medipen to heal the damage.
## Changelog
:cl:
add: Burn Medkit to Mining Vendor
/:cl:
