### PR TITLE
Using fishnets will make fishing easier

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -28,6 +28,12 @@ GLOBAL_LIST_INIT(preset_fish_sources,init_fishing_configurations())
 	var/catalog_description
 	/// Background image name from /datum/asset/simple/fishing_minigame
 	var/background = "fishing_background_default"
+	/// The types of socks that count as "fishnets" for making fishing spot difficulty lower
+	var/list/static/fishing_nets = list(
+		"Knee-high (Fishnet)",
+		"Stockings (Fishnet)",
+		"Thigh-high (Fishnet)",
+	)
 
 /// Can we fish in this spot at all. Returns DENIAL_REASON or null if we're good to go
 /datum/fish_source/proc/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman)
@@ -76,6 +82,12 @@ GLOBAL_LIST_INIT(preset_fish_sources,init_fishing_configurations())
 
 	. += additive_mod
 	. *= multiplicative_mod
+
+	if(iscarbon(fisherman))
+		var/mob/living/carbon/human/highly_experienced_fisherman
+		if(highly_experienced_fisherman.socks in fishing_nets)
+			message_admins("[highly_experienced_fisherman] has just started fishing while wearing fishnets, how skilled of them.")
+			. += FAV_BAIT_DIFFICULTY_MOD
 
 /// In case you want more complex rules for specific spots
 /datum/fish_source/proc/roll_reward(obj/item/fishing_rod/rod, mob/fisherman)

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(preset_fish_sources,init_fishing_configurations())
 	. *= multiplicative_mod
 
 	if(iscarbon(fisherman))
-		var/mob/living/carbon/human/highly_experienced_fisherman
+		var/mob/living/carbon/human/highly_experienced_fisherman = fisherman
 		if(highly_experienced_fisherman.socks in fishing_nets)
 			message_admins("[highly_experienced_fisherman] has just started fishing while wearing fishnets, how skilled of them.")
 			. += FAV_BAIT_DIFFICULTY_MOD

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -69,6 +69,12 @@ GLOBAL_LIST_INIT(preset_fish_sources,init_fishing_configurations())
 				. += DISLIKED_BAIT_DIFFICULTY_MOD
 				break
 
+	// Checks if our fisherman is wearing fishnets, these logically make fishing easier.
+	if(iscarbon(fisherman))
+		var/mob/living/carbon/human/highly_experienced_fisherman = fisherman
+		if(highly_experienced_fisherman.socks in fishing_nets)
+			. += FAV_BAIT_DIFFICULTY_MOD
+
 	// Matching/not matching fish traits and equipment
 	var/list/fish_traits = fish_list_properties[caught_fish][NAMEOF(caught_fish, fishing_traits)]
 
@@ -82,12 +88,6 @@ GLOBAL_LIST_INIT(preset_fish_sources,init_fishing_configurations())
 
 	. += additive_mod
 	. *= multiplicative_mod
-
-	if(iscarbon(fisherman))
-		var/mob/living/carbon/human/highly_experienced_fisherman = fisherman
-		if(highly_experienced_fisherman.socks in fishing_nets)
-			message_admins("[highly_experienced_fisherman] has just started fishing while wearing fishnets, how skilled of them.")
-			. += FAV_BAIT_DIFFICULTY_MOD
 
 /// In case you want more complex rules for specific spots
 /datum/fish_source/proc/roll_reward(obj/item/fishing_rod/rod, mob/fisherman)


### PR DESCRIPTION

## About The Pull Request

Wearing any of the three kinds of fishnet socks options will lower fishing difficultly equivalent to that of using bait.

![image](https://user-images.githubusercontent.com/82386923/213843636-eed92dd9-327b-40d0-9e57-e731cf3e2b6a.png)

Note that this admin log will not be in the final version, its just there to show me that it worked.

![image](https://user-images.githubusercontent.com/82386923/213843643-d5ece4cc-9691-4185-8898-c143e57c97a9.png)
## Why It's Good For The Game

Fishnets are a practical tool for catching fish, why else would they be called **fish** **nets**?
## Changelog
:cl:
add: Wearing fishnets will lower fishing difficulty
/:cl:
