### PR TITLE
Inspecting a trading card or card hologram now shows the full card art in chat.

### DIFF
--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -15,6 +15,8 @@
 	var/flipped = FALSE
 	///Has this card been "tapped"? AKA, is it horizontal?
 	var/tapped = FALSE
+	///Cached icon used for inspecting the card
+	var/icon/cached_flat_icon
 
 /obj/item/tcgcard/Initialize(mapload, datum_series, datum_id)
 	. = ..()
@@ -61,7 +63,14 @@
 	name_chaser += "Power/Resolve: [data_holder.power]/[data_holder.resolve]"
 	if(data_holder.rules) //This can sometimes be empty
 		name_chaser += "Ruleset: [data_holder.rules]"
+	name_chaser += list("[icon2html(get_cached_flat_icon(), user, extra_classes = "hugeicon")]")
+
 	return name_chaser
+
+/obj/item/tcgcard/proc/get_cached_flat_icon()
+	if(!cached_flat_icon)
+		cached_flat_icon = getFlatIcon(src)
+	return cached_flat_icon
 
 GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -63,7 +63,7 @@
 	name_chaser += "Power/Resolve: [data_holder.power]/[data_holder.resolve]"
 	if(data_holder.rules) //This can sometimes be empty
 		name_chaser += "Ruleset: [data_holder.rules]"
-	name_chaser += list("[icon2html(get_cached_flat_icon(), user, extra_classes = "hugeicon")]")
+	name_chaser += list("[icon2html(get_cached_flat_icon(), user, "extra_classes" = "hugeicon")]")
 
 	return name_chaser
 

--- a/code/game/objects/items/tcg/tcg_machines.dm
+++ b/code/game/objects/items/tcg/tcg_machines.dm
@@ -34,7 +34,8 @@
 			update_appearance()
 			current_summon = new summon_type(locate(x + summon_offset_x, y + summon_offset_y, z))
 			current_summon.template = card_template
-			current_summon.load_model(current_card)
+			current_summon.card_ref = current_card
+			current_summon.load_model()
 		else
 			to_chat(user, span_notice("The [src] smartly rejects the non-creature card."))
 			current_card = null
@@ -108,6 +109,8 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 
 	///Holds all the default details of the card.
 	var/datum/card/template
+	///Holds a reference to the card itself.
+	var/obj/item/tcgcard/card_ref
 
 	///Power statistics for the hologram, stored seperately to the template as they can be modified.
 	var/summon_power
@@ -131,7 +134,7 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 	///Color of the holograms produced.
 	var/team_color = "#77abff"
 
-/obj/structure/trading_card_summon/proc/load_model(obj/item/tcgcard/current_card)
+/obj/structure/trading_card_summon/proc/load_model()
 
 	hologram = new(loc)
 
@@ -148,13 +151,13 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 
 
 /obj/structure/trading_card_summon/get_name_chaser(mob/user, list/name_chaser = list())
-
 	name_chaser += "Faction: [template.faction]"
 	name_chaser += "Cost: [template.summoncost]"
 	name_chaser += "Type: [template.cardtype] - [template.cardsubtype]"
 	name_chaser += "Power/Resolve: [summon_power]/[summon_resolve]"
 	if(template.rules) //This can sometimes be empty
 		name_chaser += "Ruleset: [template.rules]"
+	name_chaser += list("[icon2html(card_ref.get_cached_flat_icon(), user, extra_classes = "hugeicon")]")
 	return name_chaser
 
 /obj/structure/trading_card_summon/update_overlays()

--- a/code/game/objects/items/tcg/tcg_machines.dm
+++ b/code/game/objects/items/tcg/tcg_machines.dm
@@ -157,7 +157,7 @@ GLOBAL_LIST_EMPTY(tcgcard_machine_radial_choices)
 	name_chaser += "Power/Resolve: [summon_power]/[summon_resolve]"
 	if(template.rules) //This can sometimes be empty
 		name_chaser += "Ruleset: [template.rules]"
-	name_chaser += list("[icon2html(card_ref.get_cached_flat_icon(), user, extra_classes = "hugeicon")]")
+	name_chaser += list("[icon2html(card_ref.get_cached_flat_icon(), user, "extra_classes" = "hugeicon")]")
 	return name_chaser
 
 /obj/structure/trading_card_summon/update_overlays()

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -802,6 +802,10 @@ em {
   font-size: 2.5em;
 }
 
+.hugeicon {
+  font-size: 5em;
+}
+
 .memo {
   color: #638500;
   text-align: center;

--- a/tgui/packages/tgui-panel/styles/goon/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-light.scss
@@ -834,6 +834,10 @@ h2.alert {
   font-size: 2.5em;
 }
 
+.hugeicon {
+  font-size: 5em;
+}
+
 .memo {
   color: #638500;
   text-align: center;


### PR DESCRIPTION

## About The Pull Request

Does what it says in the title, example below.

![image](https://user-images.githubusercontent.com/40036527/213866406-903a3049-faf8-4f90-b91c-365573a8df6b.png)
## Why It's Good For The Game

TGC cards get shrunk down whenever you place them, making their card art very difficult to make out in a lot of cases, by doing this you can now view the full card art by inspecting the card rather than needing to pick it up.

Placed Ian card for reference 
![image](https://user-images.githubusercontent.com/40036527/213866537-cdbd48df-ca6f-4a56-803c-c43f552611f1.png)
## Changelog
:cl:
qol: Inspecting a trading card or card hologram will now let you see the full enlarged card art.
/:cl:
