### PR TITLE
Lowers the price of Kheiral Cuffs to 750 points

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -88,7 +88,7 @@
 
 /datum/orderable_item/mining/kheiralcuffs
 	item_path = /obj/item/kheiral_cuffs
-	cost_per_order = 2000
+	cost_per_order = 750
 
 /datum/orderable_item/mining/bhop
 	item_path = /obj/item/clothing/shoes/bhop


### PR DESCRIPTION

## About The Pull Request
What it says on the tin
## Why It's Good For The Game
I've gotten some critique on the cuffs saying that for a tool mostly for new players who might be more prone to dying in lavaland, they're far too expensive, and I'd have to agree. For a much lower price you could easily get far more equipment that instead of just being useful if you die, would _prevent_ you from dying, and you'd still have points to spare. Not to mention the fact that they don't always work, as you might get gibbed by a megafauna or something like that, which would turn off the cuff.
Taking all of this into account, a far lower price seems fair to me.

If the price is too low, I can raise it to something like 900 if the maintainers request it.
## Changelog
:cl: Wallem
balance: Kheiral Cuffs now cost 750 mining points instead of 2000.
/:cl:
