### PR TITLE
RPG Loot: A stat panel replacement

### DIFF
--- a/tgui/packages/tgui/interfaces/LootPanel.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel.tsx
@@ -1,0 +1,59 @@
+import { useBackend, useLocalState } from '../backend';
+import { Window } from '../layouts';
+import { Box, Icon, Input, Section, Stack, Tooltip } from '../components';
+import { capitalizeAll, createSearch } from 'common/string';
+
+type Data = {
+  contents: Atom[];
+};
+
+type Atom = {
+  ref: string;
+  name: string;
+  image: string;
+};
+
+export const LootPanel = (props, context) => {
+  const { act, data } = useBackend<Data>(context);
+  const { contents = [] } = data;
+  const [searchText, setSearchText] = useLocalState(context, 'searchText', '');
+  const filteredContents = contents.filter(
+    createSearch(searchText, (atom: Atom) => atom.name)
+  );
+
+  return (
+    <Window height={250} width={180} title="Contents">
+      <Window.Content>
+        <Section
+          buttons={
+            <Input
+              autoFocus
+              onInput={(event, value) => setSearchText(value)}
+              placeholder="Search"
+              width="11rem"
+            />
+          }
+          fill
+          scrollable
+          title={<Icon name="search" />}>
+          <Stack fill wrap>
+            {filteredContents.map((atom, index) => (
+              <Stack.Item key={index} m={1}>
+                <Tooltip content={capitalizeAll(atom.name)}>
+                  <Box
+                    onClick={() => act('grab', { ref: atom.ref })}
+                    style={{
+                      border: 'thin solid #212121',
+                      background: 'black',
+                    }}>
+                    <img src={atom.image} />
+                  </Box>
+                </Tooltip>
+              </Stack.Item>
+            ))}
+          </Stack>
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION

## About The Pull Request
Very rough draft - it's working, but not cleanly. Don't want to spend time on the change if the response is overly negative (but I like it so)

This makes it so that alt-clicking a turf opens a TGUI window instead of generating the icons for the stat panel.

![dreamseeker_fUj2hCZsUH](https://user-images.githubusercontent.com/42397676/213908689-91c4dc02-bf6d-40b3-9fe2-3b509a85c805.gif)
## Why It's Good For The Game
Short answer? Hate the state panel. Wish I could get rid of it entirely. But I use it for turf contents, and I thought I could replace its functionality elsewhere (in a better format).

Also, it's a loot panel dude, you can now properly loot corpses, the ground contents are searchable and the ui can easily be expanded upon.
## Changelog
:cl:
refactor: Alt clicking now opens a TGUI window that displays the turf contents.
/:cl:
