### PR TITLE
Prisoners no longer spawn with backpacks

### DIFF
--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -55,6 +55,7 @@
 	uniform = /obj/item/clothing/under/rank/prisoner
 	belt = null
 	ears = null
+	back = null
 	shoes = /obj/item/clothing/shoes/sneakers/orange
 
 /datum/outfit/job/prisoner/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION

## About The Pull Request

Sets prisoner backpack slot to null
## Why It's Good For The Game

Security don't have to run around stunning all the prisoners to take their backpacks at roundstart

Prisoners still have pockets in their jumpsuits

Prisoners can still get backpacks if they really wanted to by using the biogenerator
## Changelog
:cl:
balance: Prisoners no longer spawn with backpacks
/:cl:
