### PR TITLE
Vendors now tip in the opposite direction when struck from inside of a wall

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -615,6 +615,11 @@
 	else
 		. = ..()
 		if(tiltable && !tilted && I.force)
+			if(isclosedturf(get_turf(user))) //If the attacker is inside of a wall, immediately fall in the other direction, with no chance for goodies.
+				var/opposite_direction = REVERSE_DIR(get_dir(src, user))
+				var/target = get_step(src, opposite_direction)
+				tilt(get_turf(target))
+				return
 			switch(rand(1, 100))
 				if(1 to 5)
 					freebie(user, 3)
@@ -668,7 +673,7 @@
 
 	. = FALSE
 
-	if(Adjacent(fatty) && isopenturf(get_turf(fatty)))
+	if(Adjacent(fatty))
 		for(var/mob/living/L in get_turf(fatty))
 			var/was_alive = (L.stat != DEAD)
 			var/mob/living/carbon/C = L

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -668,7 +668,7 @@
 
 	. = FALSE
 
-	if(Adjacent(fatty))
+	if(Adjacent(fatty) && isopenturf(get_turf(fatty)))
 		for(var/mob/living/L in get_turf(fatty))
 			var/was_alive = (L.stat != DEAD)
 			var/mob/living/carbon/C = L


### PR DESCRIPTION
## About The Pull Request

When someone standing on a closed turf strikes a vendor, the vendor will now instantly tip over, in the _opposite_ direction. This will provide no chance for goodies, meaning you cannot build walls on top of yourself and abuse this for free stuff.

https://user-images.githubusercontent.com/28870487/213960163-e520d6fc-ab3f-4b56-9fcb-ca9859b11631.mp4
## Why It's Good For The Game

Leaving your jaunt in a wall and having some unexpected piece of machinery blocking you in is a very common occurrence, whether it be while playing nightmare, wizard, or heretic. If it's a console or machine, you just bash it down with whatever you have handy, but if that machinery happens to be a vendor, you're screwed. 

This should preserve the risk/reward of hitting vendors for free stuff, without fucking over people who unexpectedly jaunt into a bad position.

Most importantly -- Vendors can't crush people through walls. That doesn't make any sense! They don't even move onto your tile!

Closes #72873.
## Changelog
:cl:
balance: Hitting a vendor from inside a wall will cause it to fall away from you, rather than crushing you without being able to move to your tile.
/:cl:
