### PR TITLE
Adds Axolotls to List of Cytology Creatures

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -51,6 +51,7 @@
 #define CELL_LINE_TABLE_NETHER "cell_line_nether_table"
 #define CELL_LINE_TABLE_GLUTTON "cell_line_glutton_table"
 #define CELL_LINE_TABLE_FROG	"cell_line_frog_table"
+#define CELL_LINE_TABLE_AXOLOTL	"cell_line_axolotl_table"
 #define CELL_LINE_TABLE_WALKING_MUSHROOM "cell_line_walking_mushroom_table"
 #define CELL_LINE_TABLE_QUEEN_BEE "cell_line_bee_queen_table"
 #define CELL_LINE_TABLE_LEAPER	"cell_line_leaper_table"

--- a/code/_globalvars/lists/xenobiology.dm
+++ b/code/_globalvars/lists/xenobiology.dm
@@ -69,6 +69,7 @@ GLOBAL_LIST_INIT_TYPED(cell_line_tables, /list, list(
 
 	CELL_LINE_TABLE_GLUTTON = list(/datum/micro_organism/cell_line/clown/glutton = 1),
 	CELL_LINE_TABLE_FROG = list(/datum/micro_organism/cell_line/frog = 1),
+	CELL_LINE_TABLE_AXOLOTL = list(/datum/micro_organism/cell_line/axolotl = 1),
 	CELL_LINE_TABLE_WALKING_MUSHROOM = list(/datum/micro_organism/cell_line/walking_mushroom = 1),
 	CELL_LINE_TABLE_QUEEN_BEE = list(/datum/micro_organism/cell_line/queen_bee = 1),
 	CELL_LINE_TABLE_LEAPER = list(/datum/micro_organism/cell_line/leaper = 1),

--- a/code/_globalvars/lists/xenobiology.dm
+++ b/code/_globalvars/lists/xenobiology.dm
@@ -81,6 +81,7 @@ GLOBAL_LIST_INIT_TYPED(cell_line_tables, /list, list(
 		/datum/micro_organism/cell_line/queen_bee = 1,
 		/datum/micro_organism/cell_line/snake = 1,
 		/datum/micro_organism/cell_line/walking_mushroom = 2,
+		/datum/micro_organism/cell_line/axolotl = 1
 	)
 ))
 

--- a/code/modules/mob/living/basic/vermin/axolotl.dm
+++ b/code/modules/mob/living/basic/vermin/axolotl.dm
@@ -34,6 +34,7 @@
 /mob/living/basic/axolotl/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
+	AddElement(/datum/element/swabable, CELL_LINE_TABLE_AXOLOTL, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 
 /datum/ai_controller/basic_controller/axolotl
 	ai_traits = STOP_MOVING_WHEN_PULLED

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -596,7 +596,7 @@
 		/datum/reagent/toxin/carpotoxin = -3,
 		/datum/reagent/toxin/bungotoxin = -3,
 		/datum/reagent/toxin/spore = -3,
-		/datum/reagent/toxin/plantbgone = -2, //GAY FROGS
+		/datum/reagent/toxin/plantbgone = -2, //GAY AXOLOTLS
 		/datum/reagent/drying_agent = -2,
 		/datum/reagent/consumable/mold = -2,
 		/datum/reagent/toxin = -1)

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -563,7 +563,7 @@
 	resulting_atoms = list(/mob/living/simple_animal/hostile/retaliate/clown/longface = 1)
 
 /datum/micro_organism/cell_line/frog
-	desc = "amphibian cells"
+	desc = "anura amphibian cells"
 	required_reagents = list(/datum/reagent/consumable/nutriment/protein)
 
 	supplementary_reagents = list(
@@ -582,6 +582,27 @@
 
 	virus_suspectibility = 0.5
 	resulting_atoms = list(/mob/living/basic/frog = 1)
+
+/datum/micro_organism/cell_line/axolotl
+	desc = "caudata amphibian cells"
+	required_reagents = list(/datum/reagent/consumable/nutriment/protein)
+
+	supplementary_reagents = list(
+		/datum/reagent/ants = 3,
+		/datum/reagent/consumable/eggwhite= 2,
+		/datum/reagent/consumable/nutriment/vitamin = 1,)
+
+	suppressive_reagents = list(
+		/datum/reagent/toxin/carpotoxin = -3,
+		/datum/reagent/toxin/bungotoxin = -3,
+		/datum/reagent/toxin/spore = -3,
+		/datum/reagent/toxin/plantbgone = -2, //GAY FROGS
+		/datum/reagent/drying_agent = -2,
+		/datum/reagent/consumable/mold = -2,
+		/datum/reagent/toxin = -1)
+
+	virus_suspectibility = 0.5
+	resulting_atoms = list(/mob/living/basic/axolotl = 1)
 
 /datum/micro_organism/cell_line/walking_mushroom
 	desc = "motile fungal hyphae"

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -589,15 +589,17 @@
 
 	supplementary_reagents = list(
 		/datum/reagent/ants = 3,
-		/datum/reagent/consumable/eggwhite= 2,
+		/datum/reagent/liquidgibs = 2,
+		/datum/reagent/consumable/salt = 1,
+		/datum/reagent/consumable/eggwhite= 1,
 		/datum/reagent/consumable/nutriment/vitamin = 1,)
 
 	suppressive_reagents = list(
-		/datum/reagent/toxin/carpotoxin = -3,
+		/datum/reagent/ammonia = -3,
 		/datum/reagent/toxin/bungotoxin = -3,
 		/datum/reagent/toxin/spore = -3,
 		/datum/reagent/toxin/plantbgone = -2, //GAY AXOLOTLS
-		/datum/reagent/drying_agent = -2,
+		/datum/reagent/drying_agent = -4,
 		/datum/reagent/consumable/mold = -2,
 		/datum/reagent/toxin = -1)
 


### PR DESCRIPTION
## About The Pull Request
Adds axolotls to list of cytology creatures. Edits the name of the cells for frogs by changing to "anura amphibian cells" and for axolotls, "caudata amphibian cells." These mean both "frog" and "salamander" amphibian cells respectively. Also makes axolotls swabbable, adds their cell lines to fern's list, and they are now distinguishable from the frog's reagent lists.
## Why It's Good For The Game
Adding more thing to cytology is always good. Frogs could be grown but not axolotls despite them coming from the same place and are amphibians. Adds more ways to get axolotls and another reason why you should do cytology.

Reinforces the PR ([https://github.com/tgstation/tgstation/pull/72922](url)) I added for amphibian cytology.
## Changelog
:cl:
add: Axolotl lovers rejoice! I added axolotls to cytology and as such are now swabbable.
add: Frog cells are now named "anura amphibian cells." This literally means "frog amphibian cells."
add: Axolotl are "caudata amphibian cells." This literally means "salamander amphibian cells."
/:cl:
