### PR TITLE
Implements Instrument UI Interaction When Laying Down

### DIFF
--- a/code/modules/instruments/songs/editor.dm
+++ b/code/modules/instruments/songs/editor.dm
@@ -115,7 +115,7 @@
 		updateDialog(usr) // make sure updates when complete
 
 /datum/song/Topic(href, href_list)
-	if(!usr.canUseTopic(parent, be_close = TRUE, no_dexterity = FALSE, no_tk = FALSE, need_hands = FALSE))
+	if(!usr.canUseTopic(parent, be_close = TRUE, no_dexterity = FALSE, no_tk = FALSE, need_hands = FALSE, floor_okay = TRUE))
 		usr << browse(null, "window=instrument")
 		usr.unset_machine()
 		return


### PR DESCRIPTION
## About The Pull Request
Adds floor_okay = TRUE tag to the song editor dm. Basically a small QoL to allow you to initiate your song if you were say, slipped by a 100 potency banana and wanted to continue playing your song while waiting to get back up. The change allows you to actually interact with instrument UI while laying down.
## Why It's Good For The Game
Took a bit of searching but I find that this QoL feature really made a big impact to me at least. You can play your instrument on the floor while laying down. It makes sense to me that you should be physically able to strum a guitar or press keys when you're on the floor as you already are able to play anyway by starting the instrument standing up and then laying down. This just cuts out the need to have to stand up to re-interact with the UI if you say, got slipped or lost both your legs in a tragic accident. Also allows you to chill on a bed and play without having to get up, I guess. This might be a minor gameplay change to some but for those who play instruments the entire round for others to enjoy, this is a huge QoL.
## Changelog
:cl:
qol: Musicians rejoice! You can now interact with the instrument UI while laying down.
/:cl:
