### PR TITLE
Fix BUCKET_POS for ticklags with non-integer reciprocals

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,7 +1,7 @@
 /// Controls how many buckets should be kept, each representing a tick. (1 minutes worth)
 #define BUCKET_LEN (world.fps*1*60)
 /// Helper for getting the correct bucket for a given timer
-#define BUCKET_POS(timer) (((round((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN) || BUCKET_LEN)
+#define BUCKET_POS(timer) (((ROUND_UP((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN) || BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
 #define TIMER_MAX(timer_ss) (timer_ss.head_offset + TICKS2DS(BUCKET_LEN + timer_ss.practical_offset - 1))
 /// Max float with integer precision


### PR DESCRIPTION
## About The Pull Request
If the ticklag setting has a non-integer reciprocal, like 0.4, timers will be inserted into the past because the fractional component gets rounded down. This is bad.

Change originally made on a Bay codebase but it should work here too. Probably no real impact on mainline TG servers because the commonly-used ticklags like 0.2, 0.25, 0.33333, 0.5, etc. have integer reciprocals, so dividing by them always just multiplies by an integer.

## Why It's Good For The Game
Inserting timers into a bucket in the past (behind the `practical_offset`) causes a warning/unexpected behavior and should probably be avoided; the best fix I can think of for it is just rounding up so that it's placed in the closest *future* bucket.