### PR TITLE
Add clown firing pin to techweb

### DIFF
--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -163,6 +163,17 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
 
+/datum/design/clown_firing_pin
+	name = "Hilarious Firing Pin"
+	id = "clown_firing_pin"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 300, /datum/material/bananium = 500)
+	build_path = /obj/item/firing_pin/clown
+	category = list(
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SERVICE
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SERVICE
+
 /datum/design/mesons
 	name = "Optical Meson Scanners"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1099,6 +1099,7 @@
 		"mech_honker",
 		"mech_mousetrap_mortar",
 		"mech_punching_face",
+		"clown_firing_pin",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 


### PR DESCRIPTION
## About The Pull Request
This adds the clown firing pin to the `Clown Technology` node.

## Why It's Good For The Game

Clown technode should have all the funny clown items.  The firing pin is something you get from cargo, but I think it's okay to have it as a techweb item since it requires `bananium` which is one of the rarest ores in the game.

## Changelog
:cl:
qol: Add clown firing pin to techweb
/:cl:
