### PR TITLE
Add mining scanners to techweb

### DIFF
--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -203,7 +203,7 @@
 
 /datum/design/mining_scanner_advanced
 	name = "Advanced Mining Scanner"
-	id = "mining_scanner_advanced"
+	id = "mining_scanner_adv"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/glass = 500, /datum/material/iron = 500, /datum/material/silver = 1000, /datum/material/uranium = 1000)
 	build_path = /obj/item/t_scanner/adv_mining_scanner

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -201,14 +201,3 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_CARGO
 
-/datum/design/mining_scanner_advanced
-	name = "Advanced Mining Scanner"
-	id = "mining_scanner_adv"
-	build_type = PROTOLATHE | AWAY_LATHE
-	materials = list(/datum/material/glass = 500, /datum/material/iron = 500, /datum/material/silver = 1000, /datum/material/uranium = 1000)
-	build_path = /obj/item/t_scanner/adv_mining_scanner
-	category = list(
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MINING
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_CARGO
-

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -189,3 +189,26 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MINING
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/mining_scanner
+	name = "Mining Scanner"
+	id = "mining_scanner"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/glass = 500, /datum/material/iron = 500, /datum/material/silver = 1000)
+	build_path = /obj/item/t_scanner/adv_mining_scanner/lesser
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MINING
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO
+
+/datum/design/mining_scanner_advanced
+	name = "Advanced Mining Scanner"
+	id = "mining_scanner_advanced"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/glass = 500, /datum/material/iron = 500, /datum/material/silver = 1000, /datum/material/uranium = 1000)
+	build_path = /obj/item/t_scanner/adv_mining_scanner
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MINING
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO
+

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1390,7 +1390,6 @@
 		"hypermod",
 		"jackhammer",
 		"plasmacutter_adv",
-		"mining_scanner_adv",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	discount_experiments = list(/datum/experiment/scanning/random/material/hard/one = 5000)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1376,6 +1376,7 @@
 		"rangemod",
 		"superresonator",
 		"triggermod",
+		"mining_scanner",
 	)//e a r l y    g a  m e)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
@@ -1389,6 +1390,7 @@
 		"hypermod",
 		"jackhammer",
 		"plasmacutter_adv",
+		"mining_scanner_adv",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	discount_experiments = list(/datum/experiment/scanning/random/material/hard/one = 5000)


### PR DESCRIPTION
## About The Pull Request
This adds basic mining scanners to the `Mining Technology` node

## Why It's Good For The Game

A mining scanner is a basic tool, much like mesons or a bag.

It should be available to any person who wishes to mine for ore.  There are a limited number of them on the station that can run out and this is a good way to encourage more people to mine since it's apart of the basic kit.

## Changelog
:cl:
qol: Add mining scanners to techweb
/:cl:
