### PR TITLE
Add bluespace shelter capsule to techweb

### DIFF
--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -189,3 +189,14 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_MINING
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/survival_capsule
+	name = "Bluespace Shelter Capsule"
+	id = "survival_capsule"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/titanium = 20000, /datum/material/glass = 10000, /datum/material/silver = 5000, /datum/material/bluespace = 1000)
+	build_path = /obj/item/survivalcapsule
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MINING
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -706,6 +706,7 @@
 		"swapper",
 		"triphasic_scanning",
 		"wormholeprojector",
+		"survival_capsule",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 	discount_experiments = list(/datum/experiment/scanning/points/machinery_tiered_scan/tier3_variety = 5000)


### PR DESCRIPTION

## About The Pull Request
This adds the bluespace shelter capsule to the `Miniaturized Bluespace Research` node.

## Why It's Good For The Game
More ways for people to create and use items.

## Changelog
:cl:
qol: Add bluespace shelter capsule to techweb
/:cl:
