### PR TITLE
Add advanced fire extinguisher to techweb

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -116,6 +116,9 @@
 	sprite_name = "foam_extinguisher"
 	precision = TRUE
 
+/obj/item/extinguisher/advanced/empty
+	starting_water = FALSE
+
 /obj/item/extinguisher/suicide_act(mob/living/carbon/user)
 	if (!safety && (reagents.total_volume >= 1))
 		user.visible_message(span_suicide("[user] puts the nozzle to [user.p_their()] mouth. It looks like [user.p_theyre()] trying to extinguish the spark of life!"))

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -8,7 +8,7 @@
 	id = "adv_fire_extinguisher"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/titanium = 500, /datum/material/gold = 500)
-	build_path = /obj/item/extinguisher/advanced
+	build_path = /obj/item/extinguisher/advanced/empty
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
 	)

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -3,6 +3,17 @@
 /////////////////Tools///////////////////
 /////////////////////////////////////////
 
+/datum/design/fire_extinguisher_advanced
+	name = "Advanced Fire Extinguisher"
+	id = "adv_fire_extinguisher"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/titanium = 500, /datum/material/gold = 500)
+	build_path = /obj/item/extinguisher/advanced
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+
 /datum/design/handdrill
 	name = "Hand Drill"
 	desc = "A small electric hand drill with an interchangeable screwdriver and bolt bit"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1443,6 +1443,7 @@
 		"mechanicalpinches",
 		"rangedanalyzer",
 		"searingtool",
+		"adv_fire_extinguisher",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	discount_experiments = list(/datum/experiment/scanning/random/material/hard/one = 5000)


### PR DESCRIPTION
## About The Pull Request
This adds the advanced fire extinguisher to the `Experimental Tools` node.

## Why It's Good For The Game

There are several advanced engineering tools in this node.  This is an item that is considered a better version of a regular fire extinguisher for atmos techs.  It makes sense to put this with the other upgraded tools in techweb, since ya know, it's technically an advanced version.  It does spawn empty, so it needs to be refilled with a foam tank dispenser.

## Changelog
:cl:
qol: Add advanced fire extinguisher to techweb
/:cl:
