### PR TITLE
Add monkey mind helmet to techweb

### DIFF
--- a/code/modules/research/designs/electronics_designs.dm
+++ b/code/modules/research/designs/electronics_designs.dm
@@ -27,6 +27,17 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_SERVICE
 
+/datum/design/monkey_mind
+	name = "Monkey Mind Magnification Helmet"
+	id = "monkey_mind"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 2000, /datum/material/glass = 1000, /datum/material/bananium = 500)
+	build_path = /obj/item/clothing/head/helmet/monkey_sentience
+	category = list(
+		RND_CATEGORY_AI + RND_SUBCATEGORY_AI_MISC
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+
 /datum/design/ai_cam_upgrade
 	name = "AI Surveillance Software Update"
 	desc = "A software package that will allow an artificial intelligence to 'hear' from its cameras via lip reading."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -878,6 +878,7 @@
 	prereq_ids = list("neural_programming", "robotics")
 	design_ids = list(
 		"mmi_posi",
+		"monkey_mind",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 


### PR DESCRIPTION

## About The Pull Request
This adds the monkey mind magnification helmet to the `Advanced Robotics Research` node. (_requires bananium_) 

## Why It's Good For The Game
More ways for people to create and use items.

## Changelog
:cl:
qol: Add monkey mind helmet to techweb
/:cl:
