### PR TITLE
Add pickaxe to basic tools techweb

### DIFF
--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -12,7 +12,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
-	custom_materials = list(/datum/material/iron=2000) //one sheet, but where can you make them?
+	custom_materials = list(/datum/material/iron=2000)
 	tool_behaviour = TOOL_MINING
 	toolspeed = 1
 	usesound = list('sound/effects/picaxe1.ogg', 'sound/effects/picaxe2.ogg', 'sound/effects/picaxe3.ogg')

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -26,6 +26,17 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_CARGO
 
+/datum/design/pickaxe
+	name = "Pickaxe"
+	id = "pickaxe"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = 2000)
+	build_path = /obj/item/pickaxe
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MINING
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO
+
 /datum/design/drill
 	name = "Mining Drill"
 	desc = "Yours is the drill that will pierce through the rock walls."

--- a/code/modules/research/designs/mining_designs.dm
+++ b/code/modules/research/designs/mining_designs.dm
@@ -29,7 +29,7 @@
 /datum/design/pickaxe
 	name = "Pickaxe"
 	id = "pickaxe"
-	build_type = PROTOLATHE | AWAY_LATHE
+	build_type = PROTOLATHE | AWAY_LATHE | AUTOLATHE
 	materials = list(/datum/material/iron = 2000)
 	build_path = /obj/item/pickaxe
 	category = list(

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -250,6 +250,7 @@
 		"wirebrush",
 		"wirecutters",
 		"wrench",
+		"pickaxe",
 	)
 
 /datum/techweb_node/basic_medical


### PR DESCRIPTION
## About The Pull Request
Adds the pickaxe to basic tools techweb that can be printed the cargo lathe or autolathe.

## Why It's Good For The Game

This is a basic mining tool and should be available at roundstart.

It wasn't possible to create pickaxes, despite it being a T1 item.  It should be as easy to make as a shovel since these usually are mapped together.  I was tempted to put this into mining technology, but that already has advanced drills that are T2 versions of the pickaxe.

## Changelog
:cl:
qol: Add pickaxe to basic tools techweb
/:cl:
