### PR TITLE
Fix flaky test report bot

### DIFF
--- a/tools/pull_request_hooks/rerunFlakyTests.js
+++ b/tools/pull_request_hooks/rerunFlakyTests.js
@@ -190,7 +190,7 @@ async function getExistingIssueId(graphql, context, title) {
   }
 
   const foundInBody = openFlakyTestIssues.find((issue) =>
-    issue.body.contains(`<!-- ${TITLE_BOT_HEADER}${exactTitle} -->`)
+    issue.body.includes(`<!-- ${TITLE_BOT_HEADER}${exactTitle} -->`)
   );
   if (foundInBody !== undefined) {
     return foundInBody.number;


### PR DESCRIPTION
It's `includes` in JavaScript, not `contains`. Not sure how I missed this one