### PR TITLE
Improves/Abstracts Suicide A Bit More

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -82,14 +82,16 @@
 	visible_message(span_danger(get_visible_suicide_message()), span_userdanger(get_visible_suicide_message()), span_hear(get_blind_suicide_message()))
 
 /// Returns a subtype-specific flavorful string pertaining to this exact living mob's ending their own life to those who can see it (visible message).
-/// If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
+/// We don't return the raw string because of src memes sadly. If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
 /mob/living/proc/get_visible_suicide_message()
-	return "[src] begins to fall down. It looks like [p_theyve()] lost the will to live."
+	var/string = "[src] begins to fall down. It looks like [p_theyve()] lost the will to live."
+	return string
 
 /// Returns an appropriate string for what people who lack visibility hear when this mob kills itself.
-/// If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
+/// We don't return the raw string because of src memes sadly. If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
 /mob/living/proc/get_blind_suicide_message()
-	return "You hear something hitting the floor."
+	var/string = "You hear something hitting the floor."
+	return string
 
 /// Inserts logging in both the mob's logs and the investigate log pertaining to their death. Suicide tool is the object we used to commit suicide, if one was held and used (presently only humans use this arg).
 /mob/living/proc/suicide_log(obj/item/suicide_tool)

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -77,15 +77,17 @@
 	death(FALSE)
 	ghostize(FALSE)
 
-/// Send all suicide-related messages out to the world. message_type is a string macro that you can use to change out the dispatched suicide message if you desire that.
+/// Send all suicide-related messages out to the world. message_type can be used to change out the dispatched suicide message depending on the suicide context.
 /mob/living/proc/send_applicable_messages(message_type)
 	visible_message(span_danger(get_visible_suicide_message()), span_userdanger(get_visible_suicide_message()), span_hear(get_blind_suicide_message()))
 
 /// Returns a subtype-specific flavorful string pertaining to this exact living mob's ending their own life to those who can see it (visible message).
+/// If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
 /mob/living/proc/get_visible_suicide_message()
 	return "[src] begins to fall down. It looks like [p_theyve()] lost the will to live."
 
-/// Returns an appropriate string for what people who lack visibility hear when this mob kills itself. Return an empty string if it's impossible to hear.
+/// Returns an appropriate string for what people who lack visibility hear when this mob kills itself.
+/// If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
 /mob/living/proc/get_blind_suicide_message()
 	return "You hear something hitting the floor."
 

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -82,16 +82,14 @@
 	visible_message(span_danger(get_visible_suicide_message()), span_userdanger(get_visible_suicide_message()), span_hear(get_blind_suicide_message()))
 
 /// Returns a subtype-specific flavorful string pertaining to this exact living mob's ending their own life to those who can see it (visible message).
-/// We don't return the raw string because of src memes sadly. If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
+/// If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
 /mob/living/proc/get_visible_suicide_message()
-	var/string = "[src] begins to fall down. It looks like [p_theyve()] lost the will to live."
-	return string
+	return "[src] begins to fall down. It looks like [p_theyve()] lost the will to live."
 
 /// Returns an appropriate string for what people who lack visibility hear when this mob kills itself.
-/// We don't return the raw string because of src memes sadly. If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
+/// If you don't want a message, prefer to override send_applicable_messages() on your subtype instead.
 /mob/living/proc/get_blind_suicide_message()
-	var/string = "You hear something hitting the floor."
-	return string
+	return "You hear something hitting the floor."
 
 /// Inserts logging in both the mob's logs and the investigate log pertaining to their death. Suicide tool is the object we used to commit suicide, if one was held and used (presently only humans use this arg).
 /mob/living/proc/suicide_log(obj/item/suicide_tool)

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -199,6 +199,16 @@
 			if(TOXLOSS)
 				adjustToxLoss(damage_to_apply)
 
+/// Returns a subtype-specific flavorful string pertaining to this exact living mob's ending their own life to those who can see it (visible message).
+/mob/living/proc/get_visible_suicide_message()
+	var/string = "[src] begins to fall down. It looks like [p_theyve()] lost the will to live."
+	return string
+
+/// Returns an appropriate string for what people who lack visibility hear when this mob kills itself. Return an empty string if it's impossible to hear.
+/mob/living/proc/get_blind_suicide_message()
+	var/string = "You hear something hitting the floor."
+	return string
+
 /// We re-use a few messages in several contexts, so let's minimize some nasty footprint in the verbs.
 /mob/living/proc/dispatch_message_from_tree(type)
 	switch(type)

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -83,13 +83,11 @@
 
 /// Returns a subtype-specific flavorful string pertaining to this exact living mob's ending their own life to those who can see it (visible message).
 /mob/living/proc/get_visible_suicide_message()
-	var/string = "[src] begins to fall down. It looks like [p_theyve()] lost the will to live."
-	return string
+	return "[src] begins to fall down. It looks like [p_theyve()] lost the will to live."
 
 /// Returns an appropriate string for what people who lack visibility hear when this mob kills itself. Return an empty string if it's impossible to hear.
 /mob/living/proc/get_blind_suicide_message()
-	var/string = "You hear something hitting the floor."
-	return string
+	return "You hear something hitting the floor."
 
 /// Inserts logging in both the mob's logs and the investigate log pertaining to their death. Suicide tool is the object we used to commit suicide, if one was held and used (presently only humans use this arg).
 /mob/living/proc/suicide_log(obj/item/suicide_tool)

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -1,22 +1,3 @@
-/// Defines for all the types of messages we can dispatch, since there are a few that are re-used in different contexts (like generic messages, mechanical)
-#define ALIEN_SUICIDE_MESSAGE "alien message"
-#define BRAIN_SUICIDE_MESSAGE "brain message"
-#define GENERIC_SUICIDE_MESSAGE "generic message"
-#define HUMAN_BRAIN_DAMAGE_SUICIDE_MESSAGE "brain damaged message"
-#define HUMAN_COMBAT_MODE_SUICIDE_MESSAGE "combat mode message"
-#define HUMAN_DEFAULT_MODE_SUICIDE_MESSAGE "default mode message"
-#define MECHANICAL_SUICIDE_MESSAGE "mechanical message"
-#define PAI_SUICIDE_MESSAGE "pai message"
-
-/// Proc that handles changing the suiciding var on the mob in question, as well as additional operations to ensure that everything goes smoothly when we're certain that this person is going to kill themself.
-/// suicide_state is a boolean, to match the suiciding/suicided var.
-/mob/proc/set_suicide(suicide_state)
-	suiciding = suicide_state
-	if(suicide_state)
-		add_to_mob_suicide_list()
-	else
-		remove_from_mob_suicide_list()
-
 /// Verb to simply kill yourself (in a very visual way to all players) in game! How family-friendly. Can be governed by a series of multiple checks (i.e. confirmation, is it allowed in this area, etc.) which are
 /// handled and called by the proc this verb invokes. It's okay to block this, because we typically always give mobs in-game the ability to Ghost out of their current mob irregardless of context. This, in contrast,
 /// can have as many different checks as you desire to prevent people from doing the deed to themselves.
@@ -34,6 +15,15 @@
 	set_suicide(TRUE)
 	send_applicable_messages()
 	final_checkout()
+
+/// Proc that handles changing the suiciding var on the mob in question, as well as additional operations to ensure that everything goes smoothly when we're certain that this person is going to kill themself.
+/// suicide_state is a boolean, to match the suiciding/suicided var.
+/mob/proc/set_suicide(suicide_state)
+	suiciding = suicide_state
+	if(suicide_state)
+		add_to_mob_suicide_list()
+	else
+		remove_from_mob_suicide_list()
 
 /// Sends a TGUI Alert to the person attempting to commit suicide. Returns TRUE if they confirm they want to die, FALSE otherwise. Check can_suicide here as well.
 /mob/living/proc/suicide_alert()
@@ -141,12 +131,3 @@
 		if(DEAD)
 			to_chat(src, span_warning("You're already dead!"))
 	return FALSE
-
-#undef ALIEN_SUICIDE_MESSAGE
-#undef BRAIN_SUICIDE_MESSAGE
-#undef GENERIC_SUICIDE_MESSAGE
-#undef HUMAN_BRAIN_DAMAGE_SUICIDE_MESSAGE
-#undef HUMAN_COMBAT_MODE_SUICIDE_MESSAGE
-#undef HUMAN_DEFAULT_MODE_SUICIDE_MESSAGE
-#undef MECHANICAL_SUICIDE_MESSAGE
-#undef PAI_SUICIDE_MESSAGE

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -214,7 +214,7 @@
 	var/string = "You hear something hitting the floor."
 	return string
 
-/mob/living/carbon/human/dispatch_message_from_tree(type)
+/mob/living/carbon/human/send_applicable_messages()
 	var/suicide_message = ""
 	switch(type)
 		if(HUMAN_BRAIN_DAMAGE_SUICIDE_MESSAGE) // god damn this message is fucking stupid
@@ -240,7 +240,7 @@
 				"[src] is hugging [p_them()]self to death! It looks like [p_theyre()] trying to commit suicide.",
 			))
 
-	visible_message(span_danger("[suicide_message]"), span_userdanger("[suicide_message]"))
+	visible_message(span_danger(suicide_message), span_userdanger(suicide_message), span_hear(get_blind_suicide_message()))
 
 /// Checks if we are in a valid state to suicide (not already suiciding, capable of actually killing ourselves, area checks, etc.) Returns TRUE if we can suicide, FALSE if we can not.
 /mob/living/proc/can_suicide()

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -48,8 +48,7 @@
 	visible_message(span_danger(get_visible_suicide_message()), span_userdanger(get_visible_suicide_message()))
 
 /mob/living/brain/get_visible_suicide_message()
-	var/string = "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
-	return string
+	return "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
 
 /mob/living/brain/apply_suicide_damage() // we don't really care about applying damage to the brain mob and is just needless work.
 	return FALSE

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -43,15 +43,13 @@
 	QDEL_NULL(stored_dna)
 	return ..()
 
-/mob/living/brain/handle_suicide()
-
+/// Override parent here because... the blind message doesn't really work given what's happen when a brain suicides. Can't hear a brain going grey. So, we omit the "blind" message.
+/mob/living/brain/send_applicable_messages()
+	visible_message(span_danger(get_visible_suicide_message()), span_userdanger(get_visible_suicide_message()))
 
 /mob/living/brain/get_visible_suicide_message()
 	var/string = "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
 	return string
-
-/mob/living/brain/get_blind_suicide_message()
-	return null
 
 /mob/living/brain/ex_act() //you cant blow up brainmobs because it makes transfer_to() freak out when borgs blow up.
 	return FALSE

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -51,6 +51,9 @@
 	var/string = "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
 	return string
 
+/mob/living/brain/apply_suicide_damage() // we don't really care about applying damage to the brain mob and is just needless work.
+	return FALSE
+
 /mob/living/brain/ex_act() //you cant blow up brainmobs because it makes transfer_to() freak out when borgs blow up.
 	return FALSE
 

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -50,7 +50,7 @@
 /mob/living/brain/get_visible_suicide_message()
 	return "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
 
-/mob/living/brain/apply_suicide_damage() // we don't really care about applying damage to the brain mob and is just needless work.
+/mob/living/brain/apply_suicide_damage(obj/item/suicide_tool, damage_type = NONE) // we don't really care about applying damage to the brain mob and is just needless work.
 	return FALSE
 
 /mob/living/brain/ex_act() //you cant blow up brainmobs because it makes transfer_to() freak out when borgs blow up.

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -48,8 +48,7 @@
 	visible_message(span_danger(get_visible_suicide_message()), span_userdanger(get_visible_suicide_message()))
 
 /mob/living/brain/get_visible_suicide_message()
-	var/string = "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
-	return string
+	return "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
 
 /mob/living/brain/apply_suicide_damage(obj/item/suicide_tool, damage_type = NONE) // we don't really care about applying damage to the brain mob and is just needless work.
 	return FALSE

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -43,6 +43,15 @@
 	QDEL_NULL(stored_dna)
 	return ..()
 
+/mob/living/brain/handle_suicide()
+
+
+/mob/living/brain/get_visible_suicide_message()
+	var/string = "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
+	return string
+
+/mob/living/brain/get_blind_suicide_message()
+	return null
 
 /mob/living/brain/ex_act() //you cant blow up brainmobs because it makes transfer_to() freak out when borgs blow up.
 	return FALSE

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -48,7 +48,8 @@
 	visible_message(span_danger(get_visible_suicide_message()), span_userdanger(get_visible_suicide_message()))
 
 /mob/living/brain/get_visible_suicide_message()
-	return "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
+	var/string = "[src]'s brain is growing dull and lifeless. [p_they(TRUE)] look[p_s()] like [p_theyve()] lost the will to live."
+	return string
 
 /mob/living/brain/apply_suicide_damage(obj/item/suicide_tool, damage_type = NONE) // we don't really care about applying damage to the brain mob and is just needless work.
 	return FALSE

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -110,10 +110,12 @@ Des: Removes all infected images from the alien.
 	return TRUE
 
 /mob/living/carbon/alien/get_visible_suicide_message()
-	return "[src] is thrashing wildly! It looks like [p_theyre()] trying to commit suicide."
+	var/string = "[src] is thrashing wildly! It looks like [p_theyre()] trying to commit suicide."
+	return string
 
 /mob/living/carbon/alien/get_blind_suicide_message()
-	return "You hear thrashing."
+	var/string = "You hear thrashing."
+	return string
 
 /mob/living/carbon/alien/proc/alien_evolve(mob/living/carbon/alien/new_xeno)
 	visible_message(

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -109,6 +109,14 @@ Des: Removes all infected images from the alien.
 		return FALSE
 	return TRUE
 
+/mob/living/carbon/alien/get_visible_suicide_message()
+	var/string = "[src] is thrashing wildly! It looks like [p_theyre()] trying to commit suicide."
+	return string
+
+/mob/living/carbon/alien/get_blind_suicide_message()
+	var/string = "You hear thrashing."
+	return string
+
 /mob/living/carbon/alien/proc/alien_evolve(mob/living/carbon/alien/new_xeno)
 	visible_message(
 		span_alertalien("[src] begins to twist and contort!"),

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -110,12 +110,10 @@ Des: Removes all infected images from the alien.
 	return TRUE
 
 /mob/living/carbon/alien/get_visible_suicide_message()
-	var/string = "[src] is thrashing wildly! It looks like [p_theyre()] trying to commit suicide."
-	return string
+	return "[src] is thrashing wildly! It looks like [p_theyre()] trying to commit suicide."
 
 /mob/living/carbon/alien/get_blind_suicide_message()
-	var/string = "You hear thrashing."
-	return string
+	return "You hear thrashing."
 
 /mob/living/carbon/alien/proc/alien_evolve(mob/living/carbon/alien/new_xeno)
 	visible_message(

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -73,3 +73,17 @@
 			continue
 		part.drop_limb()
 		part.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
+
+/mob/living/carbon/set_suicide(suicide_state) //you thought that box trick was pretty clever, didn't you? well now hardmode is on, boyo.
+	. = ..()
+	var/obj/item/organ/internal/brain/userbrain = getorganslot(ORGAN_SLOT_BRAIN)
+	if(userbrain)
+		userbrain.suicided = suicide_state
+
+/mob/living/carbon/can_suicide()
+	if(!..())
+		return FALSE
+	if(!(mobility_flags & MOBILITY_USE)) //just while I finish up the new 'fun' suiciding verb. This is to prevent metagaming via suicide
+		to_chat(src, span_warning("You can't commit suicide whilst immobile! (You can type Ghost instead however)."))
+		return FALSE
+	return TRUE

--- a/code/modules/mob/living/carbon/human/human_suicide.dm
+++ b/code/modules/mob/living/carbon/human/human_suicide.dm
@@ -1,0 +1,85 @@
+/// This file handles anything related to suicide related to humans, as it's a bit more involved/complex than suicide on any other type of mob.
+
+/mob/living/carbon/human/handle_suicide()
+	if(!suicide_alert())
+		return
+
+	set_suicide(TRUE) //need to be called before calling suicide_act as fuck knows what suicide_act will do with your suicide
+
+	var/obj/item/held_item = get_active_held_item()
+	var/damage_type = SEND_SIGNAL(src, COMSIG_HUMAN_SUICIDE_ACT) || held_item?.suicide_act(src)
+
+	if(damage_type)
+		if(apply_suicide_damage(held_item, damage_type))
+			final_checkout(held_item, apply_damage = FALSE)
+		return
+
+	// if no specific item or damage type we want to deal, default to doing the deed with our own bare hands.
+	if(combat_mode)
+		send_applicable_messages(HUMAN_COMBAT_MODE_SUICIDE_MESSAGE)
+	else
+		var/obj/item/organ/internal/brain/userbrain = getorgan(/obj/item/organ/internal/brain)
+		if(userbrain?.damage >= 75)
+			send_applicable_messages(HUMAN_BRAIN_DAMAGE_SUICIDE_MESSAGE)
+		else
+			send_applicable_messages(HUMAN_DEFAULT_MODE_SUICIDE_MESSAGE)
+
+	final_checkout(held_item, do_damage)
+
+/mob/living/carbon/human/apply_suicide_damage(obj/item/suicide_tool, damage_type = NONE)
+	// if we don't have any damage_type passed in, default to parent.
+	if(damage_type == NONE)
+		return ..()
+
+	if(damage_type & SHAME)
+		adjustStaminaLoss(200)
+		set_suicide(FALSE)
+		add_mood_event("shameful_suicide", /datum/mood_event/shameful_suicide)
+		return FALSE
+
+	if(damage_type & MANUAL_SUICIDE_NONLETHAL)
+		set_suicide(FALSE)
+		return FALSE
+
+	if(damage_type & MANUAL_SUICIDE) // Assume that the suicide tool will handle the death.
+		suicide_log(suicide_tool)
+		return FALSE
+
+	if(damage_type & (BRUTELOSS | FIRELOSS | OXYLOSS | TOXLOSS))
+		handle_suicide_damage_spread(damage_type)
+		return TRUE
+
+	return ..() //if all else fails, hope parent accounts for it or just do whatever damage that parent prescribes.
+
+/// Any "special" suicide messages are handled by the related item that the mob uses to kill itself. This is just messages for when it's done with the bare hands.
+/mob/living/carbon/human/send_applicable_messages(message_type)
+	var/suicide_message = ""
+	switch(message_type)
+		if(HUMAN_BRAIN_DAMAGE_SUICIDE_MESSAGE) // god damn this message is fucking stupid
+			suicide_message = "[src] pulls both arms outwards in front of [p_their()] chest and pumps them behind [p_their()] back, repeats this motion in a smaller range of motion \
+			down to [p_their()] hips two times once more all while sliding [p_their()] legs in a faux walking motion, claps [p_their()] hands together \
+			in front of [p_them()] while both [p_their()] knees knock together, pumps [p_their()] arms downward, pronating [p_their()] wrists and abducting \
+			[p_their()] fingers outward while crossing [p_their()] legs back and forth, repeats this motion again two times while keeping [p_their()] shoulders low \
+			and hunching over, does finger guns with right hand and left hand bent on [p_their()] hip while looking directly forward and putting [p_their()] left leg forward then \
+			crossing [p_their()] arms and leaning back a little while bending [p_their()] knees at an angle! It looks like [p_theyre()] trying to commit suicide."
+
+		if(HUMAN_COMBAT_MODE_SUICIDE_MESSAGE)
+			suicide_message = pick(list(
+				"[src] is attempting to bite [p_their()] tongue off! It looks like [p_theyre()] trying to commit suicide.",
+				"[src] is holding [p_their()] breath! It looks like [p_theyre()] trying to commit suicide.",
+				"[src] is jamming [p_their()] thumbs into [p_their()] eye sockets! It looks like [p_theyre()] trying to commit suicide.",
+				"[src] is twisting [p_their()] own neck! It looks like [p_theyre()] trying to commit suicide.",
+			))
+
+		if(HUMAN_DEFAULT_MODE_SUICIDE_MESSAGE)
+			suicide_message = pick(list(
+				"[src] is getting too high on life! It looks like [p_theyre()] trying to commit suicide.",
+				"[src] is high-fiving [p_them()]self to death! It looks like [p_theyre()] trying to commit suicide.",
+				"[src] is hugging [p_them()]self to death! It looks like [p_theyre()] trying to commit suicide.",
+			))
+
+	visible_message(span_danger(suicide_message), span_userdanger(suicide_message), span_hear(get_blind_suicide_message()))
+
+/mob/living/carbon/human/suicide_log(obj/item/suicide_tool)
+	investigate_log("has died from committing suicide[suicide_tool ? " with [suicide_tool]" : ""].", INVESTIGATE_DEATHS)
+	log_message("(job: [src.job ? "[src.job]" : "None"]) committed suicide", LOG_ATTACK)

--- a/code/modules/mob/living/carbon/human/human_suicide.dm
+++ b/code/modules/mob/living/carbon/human/human_suicide.dm
@@ -1,4 +1,8 @@
 /// This file handles anything related to suicide related to humans, as it's a bit more involved/complex than suicide on any other type of mob.
+/// Defines for all the types of messages we can dispatch.
+#define HUMAN_BRAIN_DAMAGE_SUICIDE_MESSAGE "brain damaged message"
+#define HUMAN_COMBAT_MODE_SUICIDE_MESSAGE "combat mode message"
+#define HUMAN_DEFAULT_MODE_SUICIDE_MESSAGE "default mode message"
 
 /mob/living/carbon/human/handle_suicide()
 	if(!suicide_alert())
@@ -24,7 +28,7 @@
 		else
 			send_applicable_messages(HUMAN_DEFAULT_MODE_SUICIDE_MESSAGE)
 
-	final_checkout(held_item, do_damage)
+	final_checkout(held_item, apply_damage = TRUE)
 
 /mob/living/carbon/human/apply_suicide_damage(obj/item/suicide_tool, damage_type = NONE)
 	// if we don't have any damage_type passed in, default to parent.
@@ -83,3 +87,7 @@
 /mob/living/carbon/human/suicide_log(obj/item/suicide_tool)
 	investigate_log("has died from committing suicide[suicide_tool ? " with [suicide_tool]" : ""].", INVESTIGATE_DEATHS)
 	log_message("(job: [src.job ? "[src.job]" : "None"]) committed suicide", LOG_ATTACK)
+
+#undef HUMAN_BRAIN_DAMAGE_SUICIDE_MESSAGE
+#undef HUMAN_COMBAT_MODE_SUICIDE_MESSAGE
+#undef HUMAN_DEFAULT_MODE_SUICIDE_MESSAGE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -243,10 +243,12 @@
 	return ..()
 
 /mob/living/silicon/ai/get_visible_suicide_message()
-	return "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
+	var/string = "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
+	return string
 
 /mob/living/silicon/ai/get_blind_suicide_message()
-	return "You hear a long, hissing electronic whine."
+	var/string = "You hear a long, hissing electronic whine."
+	return string
 
 /// Removes all malfunction-related abilities from the AI
 /mob/living/silicon/ai/proc/remove_malf_abilities()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -242,12 +242,6 @@
 		ai_voicechanger = null
 	return ..()
 
-/mob/living/silicon/ai/get_visible_suicide_message()
-	return "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
-
-/mob/living/silicon/ai/get_blind_suicide_message()
-	return "You hear a long, hissing electronic whine."
-
 /// Removes all malfunction-related abilities from the AI
 /mob/living/silicon/ai/proc/remove_malf_abilities()
 	QDEL_NULL(modules_action)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -242,6 +242,14 @@
 		ai_voicechanger = null
 	return ..()
 
+/mob/living/silicon/ai/get_visible_suicide_message()
+	var/string = "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
+	return string
+
+/mob/living/silicon/ai/get_blind_suicide_message()
+	var/string = "You hear a long, hissing electronic whine."
+	return string
+
 /// Removes all malfunction-related abilities from the AI
 /mob/living/silicon/ai/proc/remove_malf_abilities()
 	QDEL_NULL(modules_action)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -243,12 +243,10 @@
 	return ..()
 
 /mob/living/silicon/ai/get_visible_suicide_message()
-	var/string = "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
-	return string
+	return "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
 
 /mob/living/silicon/ai/get_blind_suicide_message()
-	var/string = "You hear a long, hissing electronic whine."
-	return string
+	return "You hear a long, hissing electronic whine."
 
 /// Removes all malfunction-related abilities from the AI
 /mob/living/silicon/ai/proc/remove_malf_abilities()

--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -11,3 +11,9 @@
 	diag_hud_set_health()
 	update_health_hud()
 	return ..()
+
+/mob/living/silicon/get_visible_suicide_message()
+	return "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
+
+/mob/living/silicon/get_blind_suicide_message()
+	return "You hear a long, hissing electronic whine."

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -101,6 +101,14 @@
 		modularInterface.saved_job = "Cyborg"
 	return ..()
 
+/mob/living/silicon/robot/set_suicide(suicide_state)
+	. = ..()
+	if(mmi)
+		if(mmi.brain)
+			mmi.brain.suicided = suicide_state
+		if(mmi.brainmob)
+			mmi.brainmob.suiciding = suicide_state
+
 /mob/living/silicon/robot/get_visible_suicide_message()
 	var/string = "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
 	return string

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -110,10 +110,12 @@
 			mmi.brainmob.suiciding = suicide_state
 
 /mob/living/silicon/robot/get_visible_suicide_message()
-	return "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
+	var/string = "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
+	return string
 
 /mob/living/silicon/robot/get_blind_suicide_message()
-	return "You hear a long, hissing electronic whine."
+	var/string = "You hear a long, hissing electronic whine."
+	return string
 
 /**
  * Sets the tablet theme and icon

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -110,12 +110,10 @@
 			mmi.brainmob.suiciding = suicide_state
 
 /mob/living/silicon/robot/get_visible_suicide_message()
-	var/string = "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
-	return string
+	return "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
 
 /mob/living/silicon/robot/get_blind_suicide_message()
-	var/string = "You hear a long, hissing electronic whine."
-	return string
+	return "You hear a long, hissing electronic whine."
 
 /**
  * Sets the tablet theme and icon

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -109,12 +109,6 @@
 		if(mmi.brainmob)
 			mmi.brainmob.suiciding = suicide_state
 
-/mob/living/silicon/robot/get_visible_suicide_message()
-	return "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
-
-/mob/living/silicon/robot/get_blind_suicide_message()
-	return "You hear a long, hissing electronic whine."
-
 /**
  * Sets the tablet theme and icon
  *

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -101,6 +101,13 @@
 		modularInterface.saved_job = "Cyborg"
 	return ..()
 
+/mob/living/silicon/robot/get_visible_suicide_message()
+	var/string = "[src] is powering down. It looks like [p_theyre()] trying to commit suicide."
+	return string
+
+/mob/living/silicon/robot/get_blind_suicide_message()
+	var/string = "You hear a long, hissing electronic whine."
+	return string
 
 /**
  * Sets the tablet theme and icon

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -169,10 +169,12 @@
 	location.visible_message(span_danger(get_visible_suicide_message()), null, span_hear(get_blind_suicide_message())) // null in the second arg here because we're sending from the turf
 
 /mob/living/silicon/robot/get_visible_suicide_message()
-	return "[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""
+	var/string = "[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""
+	return string
 
 /mob/living/silicon/robot/get_blind_suicide_message()
-	return "[src] bleeps electronically."
+	var/string = "[src] bleeps electronically."
+	return string
 
 /mob/living/silicon/pai/emag_act(mob/user)
 	handle_emag(user)

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -163,18 +163,18 @@
 	GLOB.pai_list.Remove(src)
 	return ..()
 
-// Need to override parent here because we have a special message to dispatch... FUCK
-/mob/living/silicon/pai/handle_suicide()
-	if(!suicide_alert())
-		return
-
-	set_suicide(TRUE)
-
-	// send out the visible message from the turf because the pAI could be anywhere on a person's body. i hate it here.
+// Need to override parent here because the message we dispatch is turf-based, not based on the location of the object because that could be fuckin anywhere
+/mob/living/silicon/pai/send_applicable_messages()
 	var/turf/location = get_turf(src)
-	location.visible_message(span_notice("[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""), null, \
-	span_notice("[src] bleeps electronically."))
-	final_checkout()
+	location.visible_message(span_danger(get_visible_suicide_message()), null, span_hear(get_blind_suicide_message())) // null in the second arg here because we're sending from the turf
+
+/mob/living/silicon/robot/get_visible_suicide_message()
+	var/string = "[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""
+	return string
+
+/mob/living/silicon/robot/get_blind_suicide_message()
+	var/string = "[src] bleeps electronically."
+	return string
 
 /mob/living/silicon/pai/emag_act(mob/user)
 	handle_emag(user)

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -163,6 +163,19 @@
 	GLOB.pai_list.Remove(src)
 	return ..()
 
+// Need to override parent here because we have a special message to dispatch... FUCK
+/mob/living/silicon/pai/handle_suicide()
+	if(!suicide_alert())
+		return
+
+	set_suicide(TRUE)
+
+	// send out the visible message from the turf because the pAI could be anywhere on a person's body. i hate it here.
+	var/turf/location = get_turf(src)
+	location.visible_message(span_notice("[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""), null, \
+	span_notice("[src] bleeps electronically."))
+	final_checkout()
+
 /mob/living/silicon/pai/emag_act(mob/user)
 	handle_emag(user)
 

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -168,10 +168,10 @@
 	var/turf/location = get_turf(src)
 	location.visible_message(span_danger(get_visible_suicide_message()), null, span_hear(get_blind_suicide_message())) // null in the second arg here because we're sending from the turf
 
-/mob/living/silicon/robot/get_visible_suicide_message()
+/mob/living/silicon/pai/get_visible_suicide_message()
 	return "[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""
 
-/mob/living/silicon/robot/get_blind_suicide_message()
+/mob/living/silicon/pai/get_blind_suicide_message()
 	return "[src] bleeps electronically."
 
 /mob/living/silicon/pai/emag_act(mob/user)

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -169,12 +169,10 @@
 	location.visible_message(span_danger(get_visible_suicide_message()), null, span_hear(get_blind_suicide_message())) // null in the second arg here because we're sending from the turf
 
 /mob/living/silicon/robot/get_visible_suicide_message()
-	var/string = "[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""
-	return string
+	return "[src] flashes a message across its screen, \"Wiping core files. Please acquire a new personality to continue using pAI device functions.\""
 
 /mob/living/silicon/robot/get_blind_suicide_message()
-	var/string = "[src] bleeps electronically."
-	return string
+	return "[src] bleeps electronically."
 
 /mob/living/silicon/pai/emag_act(mob/user)
 	handle_emag(user)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3823,6 +3823,7 @@
 #include "code\modules\mob\living\carbon\human\human_movement.dm"
 #include "code\modules\mob\living\carbon\human\human_say.dm"
 #include "code\modules\mob\living\carbon\human\human_stripping.dm"
+#include "code\modules\mob\living\carbon\human\human_suicide.dm"
 #include "code\modules\mob\living\carbon\human\human_update_icons.dm"
 #include "code\modules\mob\living\carbon\human\init_signals.dm"
 #include "code\modules\mob\living\carbon\human\inventory.dm"


### PR DESCRIPTION
## About The Pull Request

Basically all of the heavy lifting was done in #72919, but we do a few key things here that I wasn't able to do then because it was just fucking massive.

Player Facing Changes:
* hear_blind arg is now a default state and must be specifically overridden. Pretty much every mob that wasn't a pAI or alien was lacking this, so let's toss it in as a default now. Let me know if the generic message I put in for /mob/living sucks and we can go from there.

Code Side Changes:
* suicide.dm now only contains code pertinent to the suicide verb, and all subtype proc-overrides have been moved to an appropriate file pertinent to that subtype.
* suicide.dm has also been organized a bit more to aid the previous change.
* There is only one suicide verb now, implemented on /mob/living. All the verb does is invoke the handle_suicide() proc, which does all of the lifting.
* Leaning into *mumble mumble* object-oriented philosophy, the message we send to the world on suicide is handled on subtype procs, rather than be in the huge fuck-off message tree I implemented in the earlier PR. It definitely makes the visible_message() proc not hard to read IMO. This also means that we can take up a less footprint when we re-use certain suicide messages (i.e. Silicon), which is nifty too.

i'm probably forgetting something but that's all of the big ones
## Why It's Good For The Game

There is now a very, very common framework for how suicide works across all living mobs, and it's much easier to override how suicide is handled. Certain subtypes do their own bullshit thing, but it's quite easy to account for this on that case-by-case basis. The overall code takes up a much less footprint that just makes it look nicer.
## Changelog
:cl:
qol: Some mob suicides now have a message that shows to blind people or people that didn't actually witness the suicide, pretty cool.
/:cl:
