### PR TITLE
Basic Mobs Now Actually Have A Deathgasp

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -28,8 +28,8 @@
 	var/message_AI = ""
 	/// Message displayed if the user is a monkey.
 	var/message_monkey = ""
-	/// Message to display if the user is a simple_animal.
-	var/message_simple = ""
+	/// Message to display if the user is a simple_animal or basic mob.
+	var/message_animal_or_basic = ""
 	/// Message with %t at the end to allow adding params to the message, like for mobs doing an emote relatively to something else.
 	var/message_param = ""
 	/// Whether the emote is visible and/or audible bitflag
@@ -201,8 +201,8 @@
 		. = message_AI
 	else if(ismonkey(user) && message_monkey)
 		. = message_monkey
-	else if(isanimal(user) && message_simple)
-		. = message_simple
+	else if(isanimal_or_basicmob(user) && message_animal_or_basic)
+		. = message_animal_or_basic
 
 /**
  * Replaces the %t in the message in message_param by params.

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -118,8 +118,9 @@
 /datum/emote/living/deathgasp/run_emote(mob/living/user, params, type_override, intentional)
 	if(!is_type_in_typecache(user, mob_type_allowed_typecache))
 		return
-	if(user.death_message)
-		message_animal_or_basic = user.death_message
+	var/custom_message = user.death_message
+	if(custom_message)
+		message_animal_or_basic = custom_message
 	. = ..()
 	message_animal_or_basic = initial(message_animal_or_basic)
 	if(. && user.death_sound)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -110,7 +110,7 @@
 	message_alien = "lets out a waning guttural screech, and collapses onto the floor..."
 	message_larva = "lets out a sickly hiss of air and falls limply to the floor..."
 	message_monkey = "lets out a faint chimper as it collapses and stops moving..."
-	message_simple = "stops moving..."
+	message_animal_or_basic = "stops moving..."
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE | EMOTE_IMPORTANT
 	cooldown = (15 SECONDS)
 	stat_allowed = HARD_CRIT
@@ -119,9 +119,9 @@
 	if(!is_type_in_typecache(user, mob_type_allowed_typecache))
 		return
 	if(user.death_message)
-		message_simple = user.death_message
+		message_animal_or_basic = user.death_message
 	. = ..()
-	message_simple = initial(message_simple)
+	message_animal_or_basic = initial(message_animal_or_basic)
 	if(. && user.death_sound)
 		if(!user.can_speak() || user.oxyloss >= 50)
 			return //stop the sound if oxyloss too high/cant speak


### PR DESCRIPTION
## About The Pull Request

Pretty obviously an oversight since we only checked for simple_animal for this, but should also factor in the fact that we could now be a basic mob.

Actually I tested it on Sybil just now and deathgasps just never worked. We were setting death_message for... I guess when they die? It's just fucked but it works on my local now. blurgh
## Why It's Good For The Game

Ported simple animals that are now basic mobs were able to deathgasp this time last year. Silly that they aren't able to do that now.
## Changelog
:cl:
fix: Basic Mobs are now able to deathgasp.
/:cl:

Let me know if the new variable name for the string is cringe, I just settled on that since it mirrored the type of check we run in select_message_type().
