### PR TITLE
changes regular asteroid digResult to regular sand instead of basalt sand

### DIFF
--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -21,7 +21,7 @@
 	/// Probability floor has a different icon state
 	var/floor_variance = 20
 	/// Itemstack to drop when dug by a shovel
-	var/obj/item/stack/digResult = /obj/item/stack/ore/glass
+	var/obj/item/stack/dig_result = /obj/item/stack/ore/glass
 	/// Whether the turf has been dug or not
 	var/dug = FALSE
 	/// Icon state to use when broken
@@ -42,7 +42,7 @@
 /// Drops itemstack when dug and changes icon
 /turf/open/misc/asteroid/proc/getDug()
 	dug = TRUE
-	new digResult(src, 5)
+	new dig_result(src, 5)
 	if (prob(worm_chance))
 		new /obj/item/food/bait/worm(src)
 	icon_state = "[base_icon_state]_dug"
@@ -114,7 +114,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 	icon_state = "basalt"
 	base_icon_state = "basalt"
 	floor_variance = 15
-	digResult = /obj/item/stack/ore/glass/basalt
+	dig_result = /obj/item/stack/ore/glass/basalt
 	broken_state = "basalt_dug"
 
 /turf/open/misc/asteroid/basalt/getDug()
@@ -177,7 +177,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 	planetary_atmos = TRUE
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null
-	digResult = /obj/item/stack/sheet/mineral/snow
+	dig_result = /obj/item/stack/sheet/mineral/snow
 	var/burnt = FALSE
 
 /turf/open/misc/asteroid/snow/burn_tile()

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -21,7 +21,7 @@
 	/// Probability floor has a different icon state
 	var/floor_variance = 20
 	/// Itemstack to drop when dug by a shovel
-	var/obj/item/stack/digResult = /obj/item/stack/ore/glass/basalt
+	var/obj/item/stack/digResult = /obj/item/stack/ore/glass
 	/// Whether the turf has been dug or not
 	var/dug = FALSE
 	/// Icon state to use when broken

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -47,7 +47,7 @@
 	icon_state = "wasteland"
 	base_icon_state = "wasteland"
 	baseturfs = /turf/open/misc/asteroid/basalt/wasteland
-	digResult = /obj/item/stack/ore/glass/basalt
+	dig_result = /obj/item/stack/ore/glass/basalt
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
 	slowdown = 0.5
 	floor_variance = 30


### PR DESCRIPTION
## About The Pull Request
makes it so the regular sand gives you regular sand when you dig up regular sand
also changes the var name because fikou asked nicely

## Why It's Good For The Game
lavaland already uses a basalt variant did we forget that asteroids exist in space too or something
![image](https://user-images.githubusercontent.com/9276171/214567563-48fa89e8-25e4-410d-839a-39b2472466dc.png)


## Changelog
:cl: MMMiracles
fix: Regular asteroid turfs now dig up regular asteroid sand instead of the basalt variant from Lavaland.
/:cl:
i don't know why this was changed or when or by who and i don't care i just find it weird it was done in the first place since lavaland uses its own variant anyway.
