### PR TITLE
Fixes strange reagent spawning plants when added to trays

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1124,7 +1124,7 @@
 /obj/machinery/hydroponics/proc/spawnplant() // why would you put strange reagent in a hydro tray you monster I bet you also feed them blood
 	var/list/livingplants = list(/mob/living/simple_animal/hostile/tree, /mob/living/simple_animal/hostile/killertomato)
 	var/chosen = pick(livingplants)
-	var/mob/living/simple_animal/hostile/C = new chosen
+	var/mob/living/simple_animal/hostile/C = new chosen(get_turf(src))
 	C.faction = list("plants")
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## About The Pull Request

Strange reagent is supposed to spawn pine trees and killer tomatoes when added to hydroponics trays (with plants in them), but it didn't have a location to do it, runtiming instead.

## Why It's Good For The Game

Makes the funny work, fixing the described runtime.

fixes #72963 

## Changelog

:cl:
fix: Strange reagent once again spawns angry plants when added to hydroponics trays!
/:cl:
