### PR TITLE
RD Has access to the AI SAT on Deltastation

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -35563,6 +35563,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "iFp" = (


### PR DESCRIPTION
## About The Pull Request
Fixes access on a door in engineering on deltastation that was preventing the RD from reaching the AI SAT.
## Why It's Good For The Game
The RD should have access to their job on delta.
![image](https://user-images.githubusercontent.com/66163761/214718212-619dbdfa-c57c-4f33-b250-2124eb00dca1.png)
This door in engineering no longer blocks their path.
## Changelog
:cl:
fix: RD has access to the AI SAT on deltastation
/:cl:
