### PR TITLE
Improves APC "Grid Check" Error UI-Side

### DIFF
--- a/tgui/packages/tgui/interfaces/Apc.js
+++ b/tgui/packages/tgui/interfaces/Apc.js
@@ -66,7 +66,7 @@ const ApcContent = (props, context) => {
   const adjustedCellChange = data.powerCellStatus / 100;
   if (data.failTime > 0) {
     return (
-      <NoticeBox textAlign="center" info mb={0}>
+      <NoticeBox info textAlign="center" mb={0}>
         <b>
           <h3>SYSTEM FAILURE</h3>
         </b>

--- a/tgui/packages/tgui/interfaces/Apc.js
+++ b/tgui/packages/tgui/interfaces/Apc.js
@@ -66,16 +66,21 @@ const ApcContent = (props, context) => {
   const adjustedCellChange = data.powerCellStatus / 100;
   if (data.failTime > 0) {
     return (
-      <NoticeBox>
+      <NoticeBox textAlign="center" info mb={0}>
         <b>
           <h3>SYSTEM FAILURE</h3>
         </b>
-        <i>I/O regulators malfunction detected! Waiting for system reboot...</i>
+        I/O regulators have malfunctioned! <br />
+        Awaiting system reboot.
         <br />
-        Automatic reboot in {data.failTime} seconds...
+        Executing software reboot in {data.failTime} seconds...
+        <br />
+        <br />
         <Button
           icon="sync"
           content="Reboot Now"
+          tooltip="Force an interface reset."
+          tooltipPosition="bottom"
           onClick={() => act('reboot')}
         />
       </NoticeBox>


### PR DESCRIPTION

## About The Pull Request

This has always felt a bit sad in quality to me, so I decided to just change up the notice a bit to make it look nicer. The italics are redundant since NoticeBox CSS makes all of it's text italicized... yeah... so I just got rid of them.
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/214732339-681db61b-e509-4675-9d3d-18adc0dccd14.png)

I think it looks a bit nicer personally.
## Changelog
:cl:
qol: The error message that shows up when APCs fail due to a Grid Check (powernet failure) looks a little bit nicer now.
/:cl:
