### PR TITLE
Returns limited stock for traitor discounts

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -66,7 +66,7 @@
 				if((uplink_handler.assigned_role in item.restricted_roles) || (uplink_handler.assigned_species in item.restricted_species))
 					uplink_items += item
 					continue
-		uplink_handler.extra_purchasable += create_uplink_sales(uplink_sale_count, /datum/uplink_category/discounts, -1, uplink_items)
+		uplink_handler.extra_purchasable += create_uplink_sales(uplink_sale_count, /datum/uplink_category/discounts, 1, uplink_items)
 
 	if(give_objectives)
 		forge_traitor_objectives()


### PR DESCRIPTION
## About The Pull Request

While checking old PRs to debug something (someone bought 5 crab phones, this might have been fixed by a recent PR though), I have discovered that before progression traitor has been added, Traitor discounts used to have a limited stock of one per item. However, right now it is infinite. I have asked @Watermelon914 to look over my findings, and they agreed that it must have been an oversight. I have restored the original value.

If the current state of discounts turned out to be more desirable, or on further investigation this turns out to be not an oversight, I can close this.

Further proofs: #22429 added discounts, they meant to be one time purchase.
#44027 added infinite discounts, limited to nuke ops.

## Why It's Good For The Game

Being able to buy ten syndie bombs for 2 TC each was probably not intended, nor is creating General Beepsky at such a big fraction of the intended cost, or buying two clown cars at round start amount of TC, or handing out 10 ebows or sleeping carp scrolls.

Unintended mass purchasing of items feels more like an exploit than a fun gimmick.

## Changelog

:cl:
fix: Traitors discounts stocks are once again limited to one item
/:cl:
