### PR TITLE
Made the operating computer display alternative steps.

### DIFF
--- a/tgui/packages/tgui/interfaces/OperatingComputer.js
+++ b/tgui/packages/tgui/interfaces/OperatingComputer.js
@@ -102,7 +102,7 @@ const PatientStateView = (props, context) => {
                 </>
               )}
             </LabeledList.Item>
-            {!!data.alternative_step && (
+            {procedure.alternative_step && (
               <LabeledList.Item label="Alternative Step">
                 {procedure.alternative_step}
                 {procedure.alt_chems_needed && (


### PR DESCRIPTION

## About The Pull Request

Apparently, operating computers are meant to display an alternative step when the current step is repeatable - due to a bug, however, this seems to have never worked. This PR fixes this.

![image](https://user-images.githubusercontent.com/105025397/214975329-fe8a5c96-3c54-4b7a-986d-2427b2986fd6.png)
## Why It's Good For The Game

Repeatable steps not telling you what the next step is can cause major confusion for those not familiar with surgery. While I think every repeatable step _currently_ comes before using a cautery, this need not always be the case. This improves operating computer quality of life.
## Changelog
:cl:
fix: Operating computers can now display alternative steps during repeatable surgery steps.
/:cl:
