### PR TITLE
Syndicate Bomb Core Payloads Can Only Be Triggered via the Bomb

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -107,7 +107,7 @@
 /obj/machinery/syndicatebomb/Destroy()
 	QDEL_NULL(wires)
 	QDEL_NULL(countdown)
-	end_processing()a
+	end_processing()
 	return ..()
 
 /obj/machinery/syndicatebomb/examine(mob/user)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -13,27 +13,37 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	processing_flags = START_PROCESSING_MANUALLY
 	subsystem_type = /datum/controller/subsystem/processing/fastprocess
-
 	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_OFFLINE
-
 	use_power = NO_POWER_USE
+
+	/// What is the lowest amount of time we can set the timer to?
 	var/minimum_timer = SYNDIEBOMB_MIN_TIMER_SECONDS
+	/// What is the highest amount of time we can set the timer to?
+	var/maximum_timer = 100 MINUTES
+	/// What is the default amount of time we set the timer to?
 	var/timer_set = SYNDIEBOMB_MIN_TIMER_SECONDS
-	var/maximum_timer = 60000
-
+	/// Can we be unanchored?
 	var/can_unanchor = TRUE
-
-	var/open_panel = FALSE //are the wires exposed?
-	var/active = FALSE //is the bomb counting down?
-	var/obj/item/bombcore/payload = /obj/item/bombcore/syndicate
+	/// Are the wires exposed?
+	var/open_panel = FALSE
+	/// Is the bomb counting down?
+	var/active = FALSE
+	/// What sound do we make as we beep down the timer?
 	var/beepsound = 'sound/items/timer.ogg'
-	var/delayedbig = FALSE //delay wire pulsed?
-	var/delayedlittle = FALSE //activation wire pulsed?
-	var/obj/effect/countdown/syndicatebomb/countdown
-
-	var/next_beep
-	var/detonation_timer
+	/// Is the delay wire pulsed?
+	var/delayedbig = FALSE
+	/// Is the activation wire pulsed?
+	var/delayedlittle = FALSE
+	/// Should we just tell the payload to explode now? Usually triggered by an event (like cutting the wrong wire)
 	var/explode_now = FALSE
+	/// The timer for the bomb.
+	var/detonation_timer
+	/// When do we beep next?
+	var/next_beep
+	/// Reference to the bomb core inside the bomb, which is the part that actually explodes.
+	var/obj/item/bombcore/payload = /obj/item/bombcore/syndicate
+	/// The countdown that'll show up to ghosts regarding the bomb's timer.
+	var/obj/effect/countdown/syndicatebomb/countdown
 
 /obj/machinery/syndicatebomb/proc/try_detonate(ignore_active = FALSE)
 	. = (payload in src) && (active || ignore_active)
@@ -97,7 +107,7 @@
 /obj/machinery/syndicatebomb/Destroy()
 	QDEL_NULL(wires)
 	QDEL_NULL(countdown)
-	end_processing()
+	end_processing()a
 	return ..()
 
 /obj/machinery/syndicatebomb/examine(mob/user)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -25,7 +25,7 @@
 
 	var/open_panel = FALSE //are the wires exposed?
 	var/active = FALSE //is the bomb counting down?
-	var/obj/item/bombcore/payload = /obj/item/bombcore
+	var/obj/item/bombcore/payload = /obj/item/bombcore/syndicate
 	var/beepsound = 'sound/items/timer.ogg'
 	var/delayedbig = FALSE //delay wire pulsed?
 	var/delayedlittle = FALSE //activation wire pulsed?
@@ -47,6 +47,9 @@
 /obj/machinery/syndicatebomb/atom_destruction()
 	if(!try_detonate())
 		..()
+
+/obj/machinery/syndicatebomb/ex_act(severity, target)
+	return
 
 /obj/machinery/syndicatebomb/process()
 	if(!active)
@@ -99,6 +102,8 @@
 
 /obj/machinery/syndicatebomb/examine(mob/user)
 	. = ..()
+	. += {"The patented external shell design is resistant to "probably all" forms of external explosive compression, protecting the electronically-trigged bomb core from accidental early detonation."}
+	. += "A small window reveals some information about the payload: [payload.desc]."
 	. += {"A digital display on it reads "[seconds_remaining()]"."}
 
 /obj/machinery/syndicatebomb/update_icon_state()
@@ -273,7 +278,7 @@
 /obj/machinery/syndicatebomb/self_destruct
 	name = "self-destruct device"
 	desc = "Do not taunt. Warranty invalid if exposed to high temperature. Not suitable for agents under 3 years of age."
-	payload = /obj/item/bombcore/large
+	payload = /obj/item/bombcore/syndicate/large
 	can_unanchor = FALSE
 
 ///Bomb Cores///
@@ -298,7 +303,6 @@
 /obj/item/bombcore/ex_act(severity, target) // Little boom can chain a big boom.
 	detonate()
 
-
 /obj/item/bombcore/burn()
 	detonate()
 	..()
@@ -316,6 +320,24 @@
 //Note: the machine's defusal is mostly done from the wires code, this is here if you want the core itself to do anything.
 
 ///Bomb Core Subtypes///
+
+/// Subtype for the bomb cores found inside syndicate bombs, which will not detonate due to explosion/burning.
+/obj/item/bombcore/syndicate
+	name = "Donk Co. Super-Stable Bomb Payload"
+	desc = "After a string of unwanted detonations, this payload has been specifically redesigned to not explode unless triggered electronically by a bomb shell."
+
+/obj/item/bombcore/syndicate/ex_act(severity, target)
+	return
+
+/obj/item/bombcore/syndicate/burn()
+	return ..()
+
+/obj/item/bombcore/syndicate/large
+	name = "Donk Co. Super-Stable Bomb Payload XL"
+	range_heavy = 5
+	range_medium = 10
+	range_light = 20
+	range_flame = 20
 
 /obj/item/bombcore/training
 	name = "dummy payload"


### PR DESCRIPTION
## About The Pull Request

Basically, you can't extract the bomb core, slap a 10-second c4 on it/on the shell/and run off having triggered an incredibly powerful explosion. This is accomplished by having the syndicate bomb override ex_act (it will be deleted if the explosion goes off), as well as the payload itself being subtyped into something resistant to bombs and burning.

In-universe, this is described as the shell being quite resistant to forms of external explosive force- but if any explosive force comes from within the bomb's shell: kabloom. The bombcore itself has been redesigned (in a rare moment of non-ineptude) by Donk Co., who has redesigned the bomb core payload from the ground up- meaning that it can only be detonated electronically by an impulse from the bomb machinery. Cutting the wrong wire and attempting to get rid of the bomb by hitting it with an axe or something will still cause it to blow up, but you know how those things can be.
## Why It's Good For The Game

I feel like the point of the syndicate bomb is to be a threat for the crew to match up against. I want a clown in bomb squad gear to head out to the site and sweat trying to figure out which wire it is, until.... KA-BLHONK: red mist. Or, I want some "helpful" assistant to interrupt someone's session by going "I KNOW WHAT WIRE IT IS", and having those odds of either blowing everyone around them up or actually saving the day.

Being able to detonate something that was balanced and designed to have _at least_ one minute and a half in **10 SECONDS** is just so injurious to the game. You can buy a shitload of these bombs, extract the cores, slap c4 on it and go around the station doling out some serious explosions. You can run into medbay, wrench it down, slap a c4 on it AND NO ONE CAN DO ANYTHING ABOUT IT! They can't cut wires, they can't figure it out to save the day, all they can do is run. Running from danger is fine and acceptable, but it's just completely stacked against the crew in a way that I feel needs to be rectified somehow.

I like the idea of purposefully fucking with the wires on the spot so you sacrificially kill everyone, that feels quite fair to me. I just simply don't like the fact that you can waltz around the station punching huge gaps in the hull (remember, putting c4 on the bomb core itself would cause it to go kabloom) with nearly nothing as far as risk. It's way too rewarding for something very easy to accomplish (there's a reason why it's 90 seconds- it's not meant to be easy to accomplish).

This doesn't affect base bombcore behavior, just the explodey ones that come standard in syndicate bombs.
## Changelog
:cl:
balance: After an unfortunate event occuring when some nuclear operatives took the ship to a Fireworks Store, the Syndicate have re-engineered their bomb cores to only explode when electronically triggered by the bomb shell itself. The payload inside a standard syndicate bomb can not be exploded with another explosion, you must keep it in the bomb machinery for it to actually do some explodey stuff.
/:cl:
