### PR TITLE
Nuclear PDAs work on nukie base, basic programs now available

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -318,8 +318,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		if(response == "Yes")
 			turn_on(user)
 
-/obj/item/modular_computer/emag_act(mob/user)
-	if(!enabled)
+/obj/item/modular_computer/emag_act(mob/user, forced)
+	if(!enabled && !forced)
 		to_chat(user, span_warning("You'd need to turn the [src] on first."))
 		return FALSE
 	obj_flags |= EMAGGED //Mostly for consistancy purposes; the programs will do their own emag handling

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -253,7 +253,6 @@
 /obj/item/modular_computer/pda/nukeops
 	name = "nuclear pda"
 	device_theme = "syndicate"
-	has_pda_programs = TRUE
 	comp_light_luminosity = 6.3 //matching a flashlight
 	light_color = COLOR_RED
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -264,13 +264,7 @@
 
 /obj/item/modular_computer/pda/nukeops/Initialize(mapload)
 	. = ..()
-	obj_flags |= EMAGGED //Mostly for consistency purposes; the programs will do their own emag handling
-	var/newemag = FALSE
-	for(var/datum/computer_file/program/app in stored_files)
-		if(!istype(app))
-			continue
-		if(app.run_emag())
-			newemag = TRUE
+	src.emag_act(forced = TRUE)
 	var/datum/computer_file/program/messenger/msg = locate() in stored_files
 	if(msg)
 		msg.invisible = TRUE

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -253,23 +253,28 @@
 /obj/item/modular_computer/pda/nukeops
 	name = "nuclear pda"
 	device_theme = "syndicate"
-	has_pda_programs = FALSE
+	has_pda_programs = TRUE
 	comp_light_luminosity = 6.3 //matching a flashlight
 	light_color = COLOR_RED
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#a80001#5C070F#000000"
-
+	long_ranged = TRUE
 	starting_programs = list(
-		/datum/computer_file/program/ntnetdownload/syndicate,
 		/datum/computer_file/program/radar/fission360,
 	)
 
-/obj/item/modular_computer/pda/nukeops/emag_act(mob/user)
-	if(!enabled)
-		to_chat(user, span_warning("You'd need to turn the [src] on first."))
-		return FALSE
-	to_chat(user, span_notice("You swipe \the [src]. It's screen briefly shows a message reading \"MEMORY CODE INJECTION DETECTED AND SUCCESSFULLY QUARANTINED\"."))
-	return FALSE
+/obj/item/modular_computer/pda/nukeops/Initialize(mapload)
+	. = ..()
+	obj_flags |= EMAGGED //Mostly for consistency purposes; the programs will do their own emag handling
+	var/newemag = FALSE
+	for(var/datum/computer_file/program/app in stored_files)
+		if(!istype(app))
+			continue
+		if(app.run_emag())
+			newemag = TRUE
+	var/datum/computer_file/program/messenger/msg = locate() in stored_files
+	if(msg)
+		msg.invisible = TRUE
 
 /**
  * Silicon PDA

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -264,7 +264,7 @@
 
 /obj/item/modular_computer/pda/nukeops/Initialize(mapload)
 	. = ..()
-	src.emag_act(forced = TRUE)
+	emag_act(forced = TRUE)
 	var/datum/computer_file/program/messenger/msg = locate() in stored_files
 	if(msg)
 		msg.invisible = TRUE

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -177,24 +177,3 @@
 /datum/computer_file/program/ntnetdownload/kill_program(forced)
 	abort_file_download()
 	return ..()
-
-////////////////////////
-//Syndicate Downloader//
-////////////////////////
-
-/// This app only lists programs normally found in the emagged section of the normal downloader app
-
-/datum/computer_file/program/ntnetdownload/syndicate
-	filename = "syndownloader"
-	filedesc = "Software Download Tool"
-	program_icon_state = "generic"
-	extended_desc = "This program allows downloads of software from shared Syndicate repositories"
-	requires_ntnet = FALSE
-	ui_header = "downloader_finished.gif"
-	tgui_id = "NtosNetDownloader"
-	emagged = TRUE
-
-/datum/computer_file/program/ntnetdownload/syndicate/on_start()
-	. = ..()
-	main_repo = SSmodular_computers.available_antag_software
-	antag_repo = null


### PR DESCRIPTION
## About The Pull Request
Nuclear PDAs now start with all the standard PDA programs + Fission 360. Their NT Software Hub starts emagged, so they still have access to all syndicate programs. Additionally, Nuclear PDAs are now long-ranged, allowing operatives to download ~~donksoft arcade~~ useful programs while still on base.

Default programs:
![image](https://user-images.githubusercontent.com/44104681/215008172-4dca93c6-cc34-4f2b-a1f0-4d6edd6842e9.png)

Hidden from others on Messenger (so as to not give the ops away):
![image](https://user-images.githubusercontent.com/44104681/215008406-253ea396-51ab-4619-8293-7553a60797fb.png)

Downloading illegal programs while on base:
![image](https://user-images.githubusercontent.com/44104681/215008685-96ffe1fb-da0d-4b5a-8392-5d4a8ca05819.png)

Fixes #72977
## Why It's Good For The Game
Loneops no longer waste over 1/5th of their TC when buying Detomatix, an edge case related to midround traitors is resolved, and new nukies can use the Detomatix with their starting PDA, rather than This One Specific PDA Hidden In A Locker, which is more intuitive.
## Changelog
:cl: Vladoricious
qol: Nuclear PDAs now actually work like a PDA should, with the power to download normal programs and delete them too. The nerds over at Cybersun even installed a new "Why Fy Dry Ver", allowing you to download your programs while still on the base!
fix: As a result, Lone Ops will no longer get scammed out of over 1/5th of their TC when buying the Detomatix cartridge and Midround Traitors with stolen Nuclear PDAs will not be denied an uplink.
/:cl:
