### PR TITLE
Adds wings from potion of flight for fly persons in game.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -15,6 +15,7 @@
 	toxic_food = NONE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/fly
+	wing_types = list(/obj/item/organ/external/wings/functional/fly)
 	payday_modifier = 0.75
 
 	mutanttongue = /obj/item/organ/internal/tongue/fly

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -196,3 +196,9 @@
 	name = "megamoth wings"
 	desc = "Don't get murderous."
 	sprite_accessory_override = /datum/sprite_accessory/wings/megamoth
+
+//fly wings for flies
+/obj/item/organ/external/wings/functional/fly
+	name = "fly wings"
+	desc = "Fly as a fly."
+	sprite_accessory_override = /datum/sprite_accessory/wings/fly

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -197,7 +197,7 @@
 	desc = "Don't get murderous."
 	sprite_accessory_override = /datum/sprite_accessory/wings/megamoth
 
-//fly wings for flies
+///fly wings, which relate to flies.
 /obj/item/organ/external/wings/functional/fly
 	name = "fly wings"
 	desc = "Fly as a fly."


### PR DESCRIPTION
## About The Pull Request
So, i was kinda surprised that there are no fly wings in game, when their sprite was already made. So it adds wings from strange elixir (potion of flight) for fly persons. Not much to discuss, i guess.
## Why It's Good For The Game
Wings for flies.
## Changelog
:cl:
add: Wings for fly persons from flight potion
/:cl:
