### PR TITLE
Fixes a bad assignment of parent in spirit holding component

### DIFF
--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -81,8 +81,7 @@
 
 	// Now that all of the important things are in place for our spirit, it's time for them to choose their name.
 	var/valid_input_name = custom_name(awakener)
-	if(parent && valid_input_name)
-		parent = valid_input_name
+	if(valid_input_name)
 		bound_spirit.fully_replace_character_name(null, "The spirit of [valid_input_name]")
 
 	attempting_awakening = FALSE


### PR DESCRIPTION
## About The Pull Request

`parent` is a reference to the datum parent of the component, but this was assigning it to a string for some reason?

I just removed it. It doesn't seem to be doing anything anyways

~~I was going to make parent a private variable but too many things access it for some weird reason. Kinda wack~~

## Why It's Good For The Game

Bad code

## Changelog

:cl: Melbert
fix: Maybe fixes some issues with spirit holding, particularly relating to it being in-exorcism-able.
/:cl:
