### PR TITLE
eswords now have a demoliton_mod of 1.5x

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -29,7 +29,7 @@
 	resistance_flags = FIRE_PROOF
 	wound_bonus = -10
 	bare_wound_bonus = 20
-	demolition_mod = 2 //2x damage to objects
+	demolition_mod = 1.5 //1.5x damage to objects, robots, etc.
 	item_flags = NO_BLOOD_ON_ITEM
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	var/saber_color = "green"

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -29,6 +29,7 @@
 	resistance_flags = FIRE_PROOF
 	wound_bonus = -10
 	bare_wound_bonus = 20
+	demolition_mod = 2 //2x damage to objects
 	item_flags = NO_BLOOD_ON_ITEM
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	var/saber_color = "green"

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -10,6 +10,7 @@
 	light_power = 1
 	light_on = FALSE
 	bare_wound_bonus = 20
+	demolition_mod = 2 //2x damage to objects
 	stealthy_audio = TRUE
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NO_BLOOD_ON_ITEM

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -10,7 +10,7 @@
 	light_power = 1
 	light_on = FALSE
 	bare_wound_bonus = 20
-	demolition_mod = 2 //2x damage to objects
+	demolition_mod = 1.5 //1.5x damage to objects, robots, etc.
 	stealthy_audio = TRUE
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NO_BLOOD_ON_ITEM

--- a/code/modules/unit_tests/mecha_damage.dm
+++ b/code/modules/unit_tests/mecha_damage.dm
@@ -25,7 +25,7 @@
 	// Get a sample "melee" weapon.
 	// The energy axe is chosen here due to having a high base force, to make sure we get over the equipment DT.
 	var/obj/item/dummy_melee = allocate(/obj/item/melee/energy/axe)
-	var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100), DAMAGE_PRECISION)
+	var/expected_melee_damage = round(dummy_melee.force * (1 - expected_melee_armor / 100) * dummy_melee.demolition_mod, DAMAGE_PRECISION)
 
 	// Get a sample laser weapon.
 	// The captain's laser gun here is chosen primarily because it deals more damage than normal lasers.


### PR DESCRIPTION
## About The Pull Request

most energy sword-like weapons have had their demolition_mod increased to 1.5x (from 1x). energy scalpels did not receive this buff, as they're easily crew-accessible and I don't want to deal with a balance flamewar.

this affects damage vs. robots, objects, structures, etc.

the melee part of the mecha damage unit test now accounts for demolition_mod.

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/42606352/215234868-f2a61911-99ca-4326-8f43-632e6236b0dc.png)


## Changelog

:cl: ATHATH
balance: Most energy sword-like weapons have had their demolition_mod increased to 1.5x (from 1x). This affects damage vs. robots, objects, structures, etc. Energy scalpels did not receive this buff.
/:cl: