### PR TITLE
Optimizes changing z level as a ghost by something like 85%

### DIFF
--- a/code/__HELPERS/stat_tracking.dm
+++ b/code/__HELPERS/stat_tracking.dm
@@ -36,6 +36,6 @@
 
 	output += "key, cost, count"
 	for (var/key in costs)
-		output += "[replacetext(key, ",", "")], [replacetext(costs[key], ",", "")], [replacetext(counts[key], ",", "")]"
+		output += "[replacetext(key, ",", "")], [costs[key]], [counts[key]]"
 
 	rustg_file_write(output.Join("\n"), "[GLOB.log_directory]/[filename]")

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -143,8 +143,6 @@
 			continue
 
 		var/visual_offset = plane.offset - new_offset
-		// we get like 47 -> 42 from just no AO/displace on lower levels. 39 with no FOV blocking
-		// 31 with only barebones lower planes
 
 		// Basically uh, if we're showing something down X amount of levels, or up any amount of levels
 		if(multiz_boundary != MULTIZ_PERFORMANCE_DISABLE && (visual_offset > multiz_boundary || visual_offset < 0))

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -29,14 +29,6 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 /mob/dead/canUseStorage()
 	return FALSE
 
-/mob/dead/abstract_move(atom/destination)
-	var/turf/old_turf = get_turf(src)
-	var/turf/new_turf = get_turf(destination)
-	if (old_turf?.z != new_turf?.z)
-		var/same_z_layer = (GET_TURF_PLANE_OFFSET(old_turf) == GET_TURF_PLANE_OFFSET(new_turf))
-		on_changed_z_level(old_turf, new_turf, same_z_layer)
-	return ..()
-
 /mob/dead/get_status_tab_items()
 	. = ..()
 	if(SSticker.HasRoundStarted())

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -113,11 +113,6 @@ All ShuttleMove procs go here
 
 // Called on atoms after everything has been moved
 /atom/movable/proc/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
-	var/turf/newT = get_turf(src)
-	if (newT.z != oldT.z)
-		var/same_z_layer = (GET_TURF_PLANE_OFFSET(oldT) == GET_TURF_PLANE_OFFSET(newT))
-		on_changed_z_level(oldT, newT, same_z_layer)
-
 	if(light)
 		update_light()
 	if(rotation)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Optimizes hud image addition/removal on z change

We were doing a lot of repeated work here, not to mention all the proc calls.
So I pushed the "operate on loops" behavior into its own proc, so I could ensure we only do some of this stuff once

This plus some removal of safeties saves 75% of the cost of z level transitions as a ghost

Prevents double on_changed_z_level calls from ghosts and shuttles

Reacting to z changes used to be done off doMove or one of those children, timber moved it to Moved, but did not remove the calls that assumed things like abstract_move wouldn't trigger it

This means that moving up/down as a ghost was causing a double call of the whole z move stack. Suprised this never broke anything tbh

Makes csv stat tracking actually encode numbers properly, cleans up an indev comment from plane group code

## Why It's Good For The Game

Speed, and fixes
