### PR TITLE
Corrects the description of the Exotic Seed Crate

### DIFF
--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -57,7 +57,7 @@
 
 /datum/supply_pack/organic/exoticseeds
 	name = "Exotic Seeds Crate"
-	desc = "Any entrepreneuring botanist's dream. Contains fourteen different seeds, \
+	desc = "Any entrepreneuring botanist's dream. Contains twelve different seeds, \
 		including one replica-pod seed and two mystery seeds!"
 	cost = CARGO_CRATE_VALUE * 3
 	access_view = ACCESS_HYDROPONICS


### PR DESCRIPTION
## About The Pull Request

Changes the description for the Exotic Seed Crate from advertising that it contains fourteen seeds to twelve seeds.

## Why It's Good For The Game

The crate's description says that it contains fourteen seeds, when it only contains twelve.  Changing the description to reflect the actual number of seeds will help buyers not to feel scammed.

## Changelog

:cl:
spellcheck: After one false advertising lawsuit too many, Nanotrasen has changed the sales pitch of the 'Exotic Seed Crate' to correctly reflect that it only contains twelve seeds.
/:cl: