### PR TITLE
Underwear Update (Sanity edition)

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -793,9 +793,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 ///Proc that will randomise the underwear (i.e. top, pants and socks) of a species' associated mob,
 /// but will not update the body right away.
 /datum/species/proc/randomize_active_underwear_only(mob/living/carbon/human/human_mob)
-	human_mob.undershirt = random_undershirt(human_mob.gender)
-	human_mob.underwear = random_underwear(human_mob.gender)
-	human_mob.socks = random_socks(human_mob.gender)
+	return
 
 ///Proc that will randomise the underwear (i.e. top, pants and socks) of a species' associated mob
 /datum/species/proc/randomize_active_underwear(mob/living/carbon/human/human_mob)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -162,6 +162,11 @@
 
 	return to_add
 
+/datum/species/dullahan/randomize_active_underwear_only(mob/living/carbon/human/human_mob)
+	human_mob.undershirt = random_undershirt(human_mob.gender)
+	human_mob.underwear = random_underwear(human_mob.gender)
+	human_mob.socks = random_socks(human_mob.gender)
+
 /obj/item/organ/internal/brain/dullahan
 	decoy_override = TRUE
 	organ_flags = NONE
@@ -273,3 +278,4 @@
 			owner.gib()
 	owner = null
 	return ..()
+

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -92,3 +92,8 @@
 		))
 
 	return to_add
+
+/datum/species/human/randomize_active_underwear_only(mob/living/carbon/human/human_mob)
+	human_mob.undershirt = random_undershirt(human_mob.gender)
+	human_mob.underwear = random_underwear(human_mob.gender)
+	human_mob.socks = random_socks(human_mob.gender)

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -108,6 +108,11 @@
 
 	return to_add
 
+/datum/species/vampire/randomize_active_underwear_only(mob/living/carbon/human/human_mob)
+	human_mob.undershirt = random_undershirt(human_mob.gender)
+	human_mob.underwear = random_underwear(human_mob.gender)
+	human_mob.socks = random_socks(human_mob.gender)
+
 // Vampire blood is special, so it needs to be handled with its own entry.
 /datum/species/vampire/create_pref_blood_perks()
 	var/list/to_add = list()

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -23,6 +23,14 @@
 		return FALSE
 	return ..()
 
+/obj/item/bodypart/chest/on_removal()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/undie_haver = owner
+		undie_haver.underwear = "Nude"
+		undie_haver.undershirt = "Nude"
+
+	..()
+
 /obj/item/bodypart/chest/Destroy()
 	QDEL_NULL(cavity_item)
 	return ..()
@@ -303,6 +311,12 @@
 	unarmed_damage_low = 2
 	unarmed_damage_high = 15
 	unarmed_stun_threshold = 10
+
+/obj/item/bodypart/leg/on_removal()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/sock_haver = owner
+		sock_haver.socks = "Nude"
+	..()
 
 /obj/item/bodypart/leg/left
 	name = "left leg"


### PR DESCRIPTION

## About The Pull Request
Two changes to underwear/undershirts/socks work:

Randomly spawned species will not be given underwear unless they are a human, felinid, dullahan, or vampire.
This does not effect character creation,

Losing your torso will cause you to loose your undershirt and underpants. You can put more on at a dresser if you'd like.
Losing a leg will make you loose your socks (sad)
## Why It's Good For The Game
I tried to spawn in some naked android for an event and they had underwear on and it made me mad. This problem is consistent about just about every race expect for felinids and humans,
Also when a human gets auged, they now get to show off their sexy new robot chest without going to a dresser. I think this kinda stuff should have been in since day one,
## Changelog
:cl: itseasytosee
del: You are less likely to see underwear in places it logically should not be.
/:cl:
