### PR TITLE
Renames Antagonist UI Button "Antag" -> "Special Role"

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -132,7 +132,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 /datum/action/antag_info/New(Target)
 	. = ..()
-	name += " [target]"
+	name = "Open [target] Information:"
 
 /datum/action/antag_info/Trigger(trigger_flags)
 	. = ..()

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -126,7 +126,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 //button for antags to review their descriptions/info
 /datum/action/antag_info
-	name = "Open Antag Information:"
+	name = "Open Special Role Information:"
 	button_icon_state = "round_end"
 	show_to_observers = FALSE
 


### PR DESCRIPTION

## About The Pull Request

Renames the button from referring to the special role as an antagonist.

## Why It's Good For The Game

A new player rolled ERT, read "Antag", and went hog wild. We can spend however long debating if they were faithfully confused by naming or not, but regardless the antagonist datum is for more than just antagonists at this point, and it fits much better to refer to them as this instead.

## Changelog
:cl:
spellcheck: Renamed the Antagonist Info button slightly.
/:cl:
