### PR TITLE
Fixes an edge case where you can get incurable plasma damage, & fixes healing sources that don't have biotype restrictions not working if the mob doesn't have the MOB_ORGANIC biotype

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -278,7 +278,7 @@
 			itemUser.adjustBruteLoss(-1.5)
 			itemUser.adjustFireLoss(-1.5)
 			itemUser.adjustToxLoss(-1.5, forced = TRUE) //Because Slime People are people too
-			itemUser.adjustOxyLoss(-1.5)
+			itemUser.adjustOxyLoss(-1.5, forced = TRUE)
 			itemUser.adjustStaminaLoss(-1.5)
 			itemUser.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1.5)
 			itemUser.adjustCloneLoss(-0.5) //Becasue apparently clone damage is the bastion of all health

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -318,7 +318,7 @@
 		if(!IS_ORGANIC_LIMB(burn_limb))
 			robo_parts += burn_limb
 
-	burn_human.adjustToxLoss(15)
+	burn_human.adjustToxLoss(15, required_biotype = MOB_ORGANIC) // This is from plasma, so it should obey plasma biotype requirements
 	burn_human.adjustFireLoss(25)
 	if(plasma_parts.len)
 		var/obj/item/bodypart/burn_limb = pick(plasma_parts) //using the above-mentioned list to get a choice of limbs

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -345,7 +345,6 @@
 	if(!plasma_parts.len && !robo_parts.len) //a person with no potential organic limbs left AND no robotic limbs, time to turn them into a plasmaman
 		burn_human.ignite_mob()
 		burn_human.set_species(/datum/species/plasmaman)
-		burn_human.adjustToxLoss(-burn_human.getToxLoss()) // clear the toxin damage after turning into a plasmaman
 		burn_human.visible_message(span_warning("[burn_human] bursts into a brilliant purple flame as [burn_human.p_their()] entire body is that of a skeleton!"), \
 			span_userdanger("Your senses numb as all of your remaining flesh is turned into a purple slurry, sloshing off your body and leaving only your bones to show in a vibrant purple!"))
 

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -344,8 +344,8 @@
 			span_userdanger("You scream out in pain as your [burn_limb.plaintext_zone] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
 	if(!plasma_parts.len && !robo_parts.len) //a person with no potential organic limbs left AND no robotic limbs, time to turn them into a plasmaman
 		burn_human.ignite_mob()
-		burn_human.adjustToxLoss(-burn_human.getToxLoss()) // To make sure that we clear the toxin damage before turning into a plasmaman
 		burn_human.set_species(/datum/species/plasmaman)
+		burn_human.adjustToxLoss(-burn_human.getToxLoss()) // clear the toxin damage after turning into a plasmaman
 		burn_human.visible_message(span_warning("[burn_human] bursts into a brilliant purple flame as [burn_human.p_their()] entire body is that of a skeleton!"), \
 			span_userdanger("Your senses numb as all of your remaining flesh is turned into a purple slurry, sloshing off your body and leaving only your bones to show in a vibrant purple!"))
 

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -344,6 +344,7 @@
 			span_userdanger("You scream out in pain as your [burn_limb.plaintext_zone] melts down to the bone, leaving an eerie plasma-like glow where flesh used to be!"))
 	if(!plasma_parts.len && !robo_parts.len) //a person with no potential organic limbs left AND no robotic limbs, time to turn them into a plasmaman
 		burn_human.ignite_mob()
+		burn_human.adjustToxLoss(-burn_human.getToxLoss()) // To make sure that we clear the toxin damage before turning into a plasmaman
 		burn_human.set_species(/datum/species/plasmaman)
 		burn_human.visible_message(span_warning("[burn_human] bursts into a brilliant purple flame as [burn_human.p_their()] entire body is that of a skeleton!"), \
 			span_userdanger("Your senses numb as all of your remaining flesh is turned into a purple slurry, sloshing off your body and leaving only your bones to show in a vibrant purple!"))

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -86,8 +86,8 @@
 		return
 	adjustFireLoss(diff, updating_health, forced, required_bodytype)
 
-/mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
-	if(!(mob_biotypes & required_biotype))
+/mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype = MOB_ORGANIC)
+	if(!forced && !(mob_biotypes & required_biotype))
 		return
 	if(!forced && HAS_TRAIT(src, TRAIT_TOXINLOVER)) //damage becomes healing and healing becomes damage
 		amount = -amount

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -86,7 +86,7 @@
 		return
 	adjustFireLoss(diff, updating_health, forced, required_bodytype)
 
-/mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype = MOB_ORGANIC)
+/mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
 	if(!(mob_biotypes & required_biotype))
 		return
 	if(!forced && HAS_TRAIT(src, TRAIT_TOXINLOVER)) //damage becomes healing and healing becomes damage

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -446,6 +446,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(C.hud_used)
 		C.hud_used.update_locked_slots()
 
+	if(inherent_biotypes & MOB_MINERAL && !(old_species.inherent_biotypes & MOB_MINERAL)) // if the mob was previously not of the MOB_MINERAL biotype when changing to MOB_MINERAL
+		C.adjustToxLoss(-C.getToxLoss(), forced = TRUE) // clear the organic toxin damage upon turning into a MOB_MINERAL, as they are now immune
 
 	C.mob_biotypes = inherent_biotypes
 

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -61,8 +61,6 @@
 /datum/species/plasmaman/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	. = ..()
 	C.set_safe_hunger_level()
-	if(!(old_species.inherent_biotypes & MOB_MINERAL)) // if the mob was previously not of the plasmaman biotype
-		C.adjustToxLoss(-C.getToxLoss(), forced = TRUE) // clear the organic toxin damage upon turning into a plasmaman, as they are now immune
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	var/atmos_sealed = TRUE

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -62,7 +62,7 @@
 	. = ..()
 	C.set_safe_hunger_level()
 	if(!(old_species.inherent_biotypes & MOB_MINERAL)) // if the mob was previously not of the plasmaman biotype
-		C.adjustToxLoss(-C.getToxLoss()) // clear the organic toxin damage before turning into a plasmaman, as they are now immune
+		C.adjustToxLoss(-C.getToxLoss()) // clear the organic toxin damage upon turning into a plasmaman, as they are now immune
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	var/atmos_sealed = TRUE

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -61,6 +61,8 @@
 /datum/species/plasmaman/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	. = ..()
 	C.set_safe_hunger_level()
+	if(!(old_species.inherent_biotypes & MOB_MINERAL)) // if the mob was previously not of the plasmaman biotype
+		C.adjustToxLoss(-C.getToxLoss()) // clear the organic toxin damage before turning into a plasmaman, as they are now immune
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	var/atmos_sealed = TRUE

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -62,7 +62,7 @@
 	. = ..()
 	C.set_safe_hunger_level()
 	if(!(old_species.inherent_biotypes & MOB_MINERAL)) // if the mob was previously not of the plasmaman biotype
-		C.adjustToxLoss(-C.getToxLoss()) // clear the organic toxin damage upon turning into a plasmaman, as they are now immune
+		C.adjustToxLoss(-C.getToxLoss(), forced = TRUE) // clear the organic toxin damage upon turning into a plasmaman, as they are now immune
 
 /datum/species/plasmaman/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	var/atmos_sealed = TRUE

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -181,7 +181,7 @@
 /mob/living/proc/getOxyLoss()
 	return oxyloss
 
-/mob/living/proc/adjustOxyLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype = MOB_ORGANIC)
+/mob/living/proc/adjustOxyLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
 	if(!forced && (status_flags & GODMODE))
 		return
 	if(!(mob_biotypes & required_biotype))

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -181,10 +181,10 @@
 /mob/living/proc/getOxyLoss()
 	return oxyloss
 
-/mob/living/proc/adjustOxyLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
+/mob/living/proc/adjustOxyLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype = MOB_ORGANIC)
 	if(!forced && (status_flags & GODMODE))
 		return
-	if(!(mob_biotypes & required_biotype))
+	if(!forced && !(mob_biotypes & required_biotype))
 		return
 	. = oxyloss
 	oxyloss = clamp((oxyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)

--- a/code/modules/projectiles/guns/special/medbeam.dm
+++ b/code/modules/projectiles/guns/special/medbeam.dm
@@ -146,8 +146,8 @@
 		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 	target.adjustBruteLoss(-4)
 	target.adjustFireLoss(-4)
-	target.adjustToxLoss(-1)
-	target.adjustOxyLoss(-1)
+	target.adjustToxLoss(-1, forced = TRUE)
+	target.adjustOxyLoss(-1, forced = TRUE)
 	return
 
 /obj/item/gun/medbeam/proc/on_beam_release(mob/living/target)


### PR DESCRIPTION
## About The Pull Request

Fixes #72962

The plasma river applies toxins damage to a mob as it transforms individual limbs into plasmaman ones. 
Once all limbs have been transformed, the mob's species changes to plasmaman. 

This currently leads to incurable toxin damage as antitoxin drugs do not work on plasmamen. Made it so that upon transforming fully, the toxin damage is cleared.

Also fixed an issue where healing sources that do not have a required_biotype parameter (e.g. `adjustToxLoss(-5)` vs `adjustToxLoss(-5, required biotype=whatever)`) will not work on mobs that do not have the `MOB_ORGANIC` biotype (e.g. plasmamen) due to it defaulting to `MOB_ORGANIC`. For now those use the `forced` param to accomplish this.

## Why It's Good For The Game

Incurable damage is no good.

## Changelog

:cl:
fix: fixed getting incurable tox damage when fully transformed into a plasmaman via plasma rivers
fix: fixed rod of asclepius/medibeam etc not being able to heal tox damage despite not having biotype restrictions
/:cl:
