### PR TITLE
Changes the hypno flash to work on unconscious people

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1158,6 +1158,8 @@
 		return TRUE
 	if(IsSleeping())
 		return TRUE
+	if(IsUnconscious())
+		return TRUE
 	if(HAS_TRAIT(src, TRAIT_DUMB))
 		return TRUE
 	if(mob_mood.sanity < SANITY_UNSTABLE)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1156,9 +1156,7 @@
 		return FALSE
 	if(has_status_effect(/datum/status_effect/hallucination))
 		return TRUE
-	if(IsSleeping())
-		return TRUE
-	if(IsUnconscious())
+	if(IsSleeping() || IsUnconscious())
 		return TRUE
 	if(HAS_TRAIT(src, TRAIT_DUMB))
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

The hypno flash is a really fun and flavourful item that is both strong while allowing for gimmicks. However, personally, I've always been a bit confused as to what counted for hypnosis, until looking into the specifics. I also know that I'm probably not alone in this, because various people have told me over the years that sleep doesn't work, while it definitely does. This PR hopes to change this by somewhat buffing the hypno flash, by making unconsciousness work for hypnosis.

## Why It's Good For The Game

Unconsciousness looks very similar to sleep, and in a lot of cases it is really just the same effect... except for hypnosis, where there is no effect on unconscious people. Personally, I don't think this is the best UX and it limits the options there are for hypnotising people, which is a shame, as I think it's very interesting. This may or may not be too strong (think using the hypno flash with the micro-laser), but I still think this is preferable to only working with sleep specifically or hypnosis, might warrant a TC up if people otherwise agree with the change. Also, just to note, unconsciousness is also still separate from crit. This does not let you hypnotise people for free because they're in crit.

## Changelog

:cl:
balance: The hypnotic flash now works on unconscious people (not crit), one of us, one of us!
/:cl:
