### PR TITLE
[WEBEDIT INCOMING]Allows any atom that is not an effect to increase supermatter matter power on consumption.

### DIFF
--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -264,7 +264,7 @@
 			var/obj/item/consumed_item = consumed_object
 			object_size = consumed_item.w_class
 			matter_increase += 70 * object_size
-		else
+		else if(!isliving(consumed_object))
 			matter_increase += min(0.5 * consumed_object.max_integrity, 4000)
 
 	//Some poor sod got eaten, go ahead and irradiate people nearby.

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -259,10 +259,13 @@
 				message_admins("[atom_source] has consumed [consumed_object], [suspicion] [ADMIN_JMP(atom_source)].")
 			atom_source.investigate_log("has consumed [consumed_object] - [suspicion].", INVESTIGATE_ENGINE)
 		qdel(consumed_object)
-	if(!iseffect(consumed_object) && isitem(consumed_object))
-		var/obj/item/consumed_item = consumed_object
-		object_size = consumed_item.w_class
-		matter_increase += 70 * object_size
+	if(!iseffect(consumed_object))
+		if(isitem(consumed_object))
+			var/obj/item/consumed_item = consumed_object
+			object_size = consumed_item.w_class
+			matter_increase += 70 * object_size
+		else
+			matter_increase += min(0.5 * consumed_object.max_integrity, 4000)
 
 	//Some poor sod got eaten, go ahead and irradiate people nearby.
 	radiation_pulse(atom_source, max_range = 6, threshold = 1.2 / max(object_size, 1), chance = 10 * object_size)

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -265,7 +265,7 @@
 			object_size = consumed_item.w_class
 			matter_increase += 70 * object_size
 		else if(!isliving(consumed_object))
-			matter_increase += min(0.5 * consumed_object.max_integrity, 4000)
+			matter_increase += min(0.5 * consumed_object.max_integrity, 1000)
 
 	//Some poor sod got eaten, go ahead and irradiate people nearby.
 	radiation_pulse(atom_source, max_range = 6, threshold = 1.2 / max(object_size, 1), chance = 10 * object_size)

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -259,12 +259,12 @@
 				message_admins("[atom_source] has consumed [consumed_object], [suspicion] [ADMIN_JMP(atom_source)].")
 			atom_source.investigate_log("has consumed [consumed_object] - [suspicion].", INVESTIGATE_ENGINE)
 		qdel(consumed_object)
-	if(!iseffect(consumed_object))
+	if(!iseffect(consumed_object) && !isliving(consumed_object))
 		if(isitem(consumed_object))
 			var/obj/item/consumed_item = consumed_object
 			object_size = consumed_item.w_class
 			matter_increase += 70 * object_size
-		else if(!isliving(consumed_object))
+		else
 			matter_increase += min(0.5 * consumed_object.max_integrity, 1000)
 
 	//Some poor sod got eaten, go ahead and irradiate people nearby.


### PR DESCRIPTION
If the consumed_object does not pass the isitem check, then it increases the matter_increase by half of consumed_object.max_integrity, capped at 1000.
# WEBEDIT INFORMATION
This is indeed a webedit, but I tested the changes on local.

## About The Pull Request
If the atom is not an item, the matter power increase will be half of the object's max integrity, up to a maximum of 1GeV (in case some object has an absurd amount of integrity).
## Why It's Good For The Game
When a physical object gets consumed by the supermatter, people expect it to do what it does for items, to give it trickled power over time. It's confusing when it doesn't increase the power.
## Changelog
:cl:
fix: Objects that are not items can increase supermatter power on consumption.
/:cl:
