### PR TITLE
Minor improvement to blast door construction.

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -101,6 +101,7 @@
 				req_one_access = board.accesses
 			else
 				req_access = board.accesses
+			balloon_alert(user, "electronics added")
 			to_chat(user, span_notice("You add [W] to the button."))
 
 		if(!device && !board && W.tool_behaviour == TOOL_WRENCH)
@@ -163,14 +164,15 @@
 	if(panel_open)
 		if(device || board)
 			if(device)
-				device.forceMove(drop_location())
+				user.put_in_hands(device)
 				device = null
 			if(board)
-				board.forceMove(drop_location())
+				user.put_in_hands(board)
 				req_access = list()
 				req_one_access = list()
 				board = null
 			update_appearance()
+			balloon_alert(user, "electronics removed")
 			to_chat(user, span_notice("You remove electronics from the button frame."))
 
 		else
@@ -178,6 +180,7 @@
 				skin = "launcher"
 			else
 				skin = "doorctrl"
+			balloon_alert(user, "swapped button style")
 			to_chat(user, span_notice("You change the button frame's front panel."))
 		return
 

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -143,6 +143,15 @@
 /obj/machinery/button/attack_robot(mob/user)
 	return attack_ai(user)
 
+/obj/machinery/button/examine(mob/user)
+	. = ..()
+	if(panel_open && device)
+		. += span_notice("There is \a [device] inside, which could be removed with an <b>empty hand</b>.")
+	if(panel_open && board)
+		. += span_notice("There is \a [board] inside, which could be removed with an <b>empty hand</b>.")
+	if(panel_open && !board && !device)
+		. += span_notice("There is nothing currently installed in \the [src].")
+
 /obj/machinery/button/proc/setup_device()
 	if(id && istype(device, /obj/item/assembly/control))
 		var/obj/item/assembly/control/A = device

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -147,11 +147,11 @@
 	. = ..()
 	if(!panel_open)
 		return
-	if(panel_open && device)
+	if(device)
 		. += span_notice("There is \a [device] inside, which could be removed with an <b>empty hand</b>.")
-	if(panel_open && board)
+	if(board)
 		. += span_notice("There is \a [board] inside, which could be removed with an <b>empty hand</b>.")
-	if(panel_open && !board && !device)
+	if(!board && !device)
 		. += span_notice("There is nothing currently installed in \the [src].")
 
 /obj/machinery/button/proc/setup_device()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -145,6 +145,8 @@
 
 /obj/machinery/button/examine(mob/user)
 	. = ..()
+	if(!panel_open)
+		return
 	if(panel_open && device)
 		. += span_notice("There is \a [device] inside, which could be removed with an <b>empty hand</b>.")
 	if(panel_open && board)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -113,6 +113,7 @@
 	if(panel_open)
 		if(deconstruction == BLASTDOOR_FINISHED)
 			. += span_notice("The maintenance panel is opened and the electronics could be <b>pried</b> out.")
+			. += span_notice("\The [src] could be calibrated to a blast door controller ID with a <b>multitool</b>.")
 		else if(deconstruction == BLASTDOOR_NEEDS_ELECTRONICS)
 			. += span_notice("The <i>electronics</i> are missing and there are some <b>wires</b> sticking out.")
 		else if(deconstruction == BLASTDOOR_NEEDS_WIRES)

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -3,9 +3,10 @@
 	desc = "A small electronic device able to control a blast door remotely."
 	icon_state = "control"
 	attachable = TRUE
+	/// The ID of the blast door electronics to match to the ID of the blast door being used.
 	var/id = null
-	var/can_change_id = 0
-	var/cooldown = FALSE //Door cooldowns
+	/// Cooldown of the door's controller. Updates when pressed (activate())
+	var/cooldown = FALSE
 	var/sync_doors = TRUE
 
 /obj/item/assembly/control/examine(mob/user)
@@ -18,6 +19,7 @@
 	if(!change_id || QDELETED(user) || QDELETED(src) || !usr.canUseTopic(src, be_close = TRUE, no_dexterity = FALSE, no_tk = TRUE))
 		return
 	id = change_id
+	balloon_alert(user, "ID:[id]")
 	to_chat(user, span_notice("You change the ID to [id]."))
 
 /obj/item/assembly/control/activate()

--- a/code/modules/assembly/doorcontrol.dm
+++ b/code/modules/assembly/doorcontrol.dm
@@ -19,7 +19,7 @@
 	if(!change_id || QDELETED(user) || QDELETED(src) || !usr.canUseTopic(src, be_close = TRUE, no_dexterity = FALSE, no_tk = TRUE))
 		return
 	id = change_id
-	balloon_alert(user, "ID:[id]")
+	balloon_alert(user, "id changed")
 	to_chat(user, span_notice("You change the ID to [id]."))
 
 /obj/item/assembly/control/activate()


### PR DESCRIPTION
## About The Pull Request

This PR does some QOL tweaks to blast doors and their construction. Namely, adding some balloon alerts to the whole construction process (adding, removing electronics, adjusting their electronics IDs).

Additionally, adds some extra examine text to an open blast door by explaining that you can multitool it to adjust the ID, and that it must match that of the blast electronics to be added to a wall frame.

Adjusts a forcedrop to a `move_to_hands` because it's 2023 and we trust that users can hold things during a attack_hand proc.

Also adds some description to button frames as well to guide them that they can install and remove electronics and boards while open.

I'm gonna be real, this needs a LOT more work than this to be up to code  standards, but this was what I could pull off in the 30 minutes before I need to sleep while away on business, but it's a start nonetheless.

## Why It's Good For The Game

Button frame code is practically ancient, yet it's still widely used to this day. It needs some real polish more than this, but for now this will at least make the construction process more intuitive and clear.

Also to that guy who I said I would do this about a month ago I'M SORRY I'VE BEEN TRAPPED IN THE **_SUPERMAX WAGE CAGE_** I CAN PROVE IT

~~Wait what do you mean you need to make player made blast doors through the CRAFTING UI WHAT THE FUUUUUUUU~~

## Changelog

:cl:
qol: Improves feedback on buttons as well as the blast door electronics so that installing your very own blast doors is less tedious.
/:cl: