### PR TITLE
Updates Offer/Give Code To Ignore Abstract Items

### DIFF
--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -362,7 +362,8 @@
 		return
 
 	var/obj/item/offered_item = get_active_held_item()
-	if(!offered_item)
+	// if it's an abstract item, should consider it to be non-existent (unless it's a HAND_ITEM, which means it's an obj/item that is just a representation of our hand)
+	if(!offered_item || ((offered_item.item_flags & ABSTRACT) && !(offered_item.item_flags & HAND_ITEM)))
 		to_chat(src, span_warning("You're not holding anything to offer!"))
 		return
 


### PR DESCRIPTION

## About The Pull Request

Hey there,

![image](https://user-images.githubusercontent.com/34697715/215311889-3f6072b7-2c9e-4d85-8c02-37e45e75c10c.png)

I think it's a bit silly to get an alert that that says "you are being offered the off-hand", but it's also just silly to get any abstract items that you literally shouldn't be able to obtain in this manner (even if they end up deleting itself). So, let's update the code to have a check for this (as well as allow potential "hand items", like when you wanna offer your hand for someone to drag you along) so it doesn't happen.
## Why It's Good For The Game

It's an abstract item, it shouldn't be considered to be an actual extant item that can be given to people (seeing an alert with the off-hand icon made me laugh a bit). Should still work with everything else that needs it.
## Changelog
:cl:
fix: You now should no longer be able to accidentally offer someone your "off-hand" item, since it's an abstract thing that shouldn't be considered a physical entity.
/:cl:
