### PR TITLE
Purchasing weapon goodie packs require weapon permits, rather than actually being a head of security (includes other small changes)

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -180,7 +180,7 @@ GLOBAL_LIST_INIT(detective_vest_allowed, list(
 	/obj/item/tank/internals/plasmaman,
 	/obj/item/storage/belt/holster/detective,
 	/obj/item/storage/belt/holster/nukie,
-	/obj/item/storage/belt/holster/thermal,
+	/obj/item/storage/belt/holster/energy,
 ))
 
 GLOBAL_LIST_INIT(security_vest_allowed, list(
@@ -197,7 +197,7 @@ GLOBAL_LIST_INIT(security_vest_allowed, list(
 	/obj/item/tank/internals/plasmaman,
 	/obj/item/storage/belt/holster/detective,
 	/obj/item/storage/belt/holster/nukie,
-	/obj/item/storage/belt/holster/thermal,
+	/obj/item/storage/belt/holster/energy,
 ))
 
 GLOBAL_LIST_INIT(security_wintercoat_allowed, list(
@@ -210,7 +210,7 @@ GLOBAL_LIST_INIT(security_wintercoat_allowed, list(
 	/obj/item/restraints/handcuffs,
 	/obj/item/storage/belt/holster/detective,
 	/obj/item/storage/belt/holster/nukie,
-	/obj/item/storage/belt/holster/thermal,
+	/obj/item/storage/belt/holster/energy,
 ))
 
 /// String for items placed into the left pocket.

--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -31,11 +31,11 @@
 		/obj/item/gun/energy/laser/thermal
 		))
 
-/obj/item/storage/belt/holster/thermal
-	name = "thermal shoulder holsters"
-	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Meant to hold a twinned pair of thermal pistols, but can fit several kinds of energy handguns as well."
+/obj/item/storage/belt/holster/energy
+	name = "energy shoulder holsters"
+	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Designed to hold energy weaponry."
 
-/obj/item/storage/belt/holster/thermal/Initialize(mapload)
+/obj/item/storage/belt/holster/energy/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 2
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
@@ -44,13 +44,26 @@
 		/obj/item/gun/energy/disabler,
 		/obj/item/gun/energy/dueling,
 		/obj/item/food/grown/banana,
-		/obj/item/gun/energy/laser/thermal
+		/obj/item/gun/energy/laser/thermal,
+		/obj/item/gun/energy/recharge/ebow,
 		))
 
-/obj/item/storage/belt/holster/thermal/PopulateContents()
+/obj/item/storage/belt/holster/energy/thermal
+	name = "thermal shoulder holsters"
+	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Meant to hold a twinned pair of thermal pistols, but can fit several kinds of energy handguns as well."
+
+/obj/item/storage/belt/holster/energy/thermal/PopulateContents()
 	generate_items_inside(list(
 		/obj/item/gun/energy/laser/thermal/inferno = 1,
 		/obj/item/gun/energy/laser/thermal/cryo = 1,
+	),src)
+
+/obj/item/storage/belt/holster/energy/disabler
+	desc = "A rather plain pair of shoulder holsters with a bit of insulated padding inside. Designed to hold energy weaponry. A production stamp indicates that it was shipped with a disabler."
+
+/obj/item/storage/belt/holster/energy/disabler/PopulateContents()
+	generate_items_inside(list(
+		/obj/item/gun/energy/disabler = 1,
 	),src)
 
 /obj/item/storage/belt/holster/detective

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -8,35 +8,35 @@
 	name = ".38 DumDum Speedloader"
 	desc = "Contains one speedloader of .38 DumDum ammunition, good for embedding in soft targets."
 	cost = PAYCHECK_CREW * 2
-	access_view = ACCESS_BRIG
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/ammo_box/c38/dumdum)
 
 /datum/supply_pack/goody/match38
 	name = ".38 Match Grade Speedloader"
 	desc = "Contains one speedloader of match grade .38 ammunition, perfect for showing off trickshots."
 	cost = PAYCHECK_CREW * 2
-	access_view = ACCESS_BRIG
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/ammo_box/c38/match)
 
 /datum/supply_pack/goody/rubber
 	name = ".38 Rubber Speedloader"
 	desc = "Contains one speedloader of bouncy rubber .38 ammunition, for when you want to bounce your shots off anything and everything."
 	cost = PAYCHECK_CREW * 1.5
-	access_view = ACCESS_BRIG
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/ammo_box/c38/match/bouncy)
 
 /datum/supply_pack/goody/mars_single
 	name = "Colt Detective Special Single-Pack"
 	desc = "The HoS took your gun and your badge? No problem! Just pay the absurd taxation fee and you too can be reunited with the lethal power of a .38!"
 	cost = PAYCHECK_CREW * 40 //they really mean a premium here
-	access_view = ACCESS_DETECTIVE
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/ballistic/revolver/c38/detective)
 
 /datum/supply_pack/goody/stingbang
 	name = "Stingbang Single-Pack"
 	desc = "Contains one \"stingbang\" grenade, perfect for playing meanhearted pranks."
 	cost = PAYCHECK_COMMAND * 2.5
-	access_view = ACCESS_BRIG
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/grenade/stingbang)
 
 /datum/supply_pack/goody/Survivalknives_single
@@ -52,26 +52,40 @@
 	access_view = ACCESS_ARMORY
 	contains = list(/obj/item/gun/ballistic/shotgun/automatic/combat, /obj/item/storage/belt/bandolier)
 
+/datum/supply_pack/goody/disabler_single
+	name = "Disabler Single-Pack"
+	desc = "Contains one disabler, the nonlethal workhorse of Nanotrasen security everywehere. Comes in a energy holster, just in case you happen to have an extra disabler."
+	cost = PAYCHECK_COMMAND * 3
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/storage/belt/holster/energy/disabler)
+
 /datum/supply_pack/goody/energy_single
 	name = "Energy Gun Single-Pack"
 	desc = "Contains one energy gun, capable of firing both nonlethal and lethal blasts of light."
 	cost = PAYCHECK_COMMAND * 12
-	access_view = ACCESS_ARMORY
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/energy/e_gun)
+
+/datum/supply_pack/goody/laser_single
+	name = "Laser Gun Single-Pack"
+	desc = "Contains one laser gun, the lethal workhorse of Nanotrasen security everywehere."
+	cost = PAYCHECK_COMMAND * 6
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/gun/energy/laser)
 
 /datum/supply_pack/goody/hell_single
 	name = "Hellgun Kit Single-Pack"
 	desc = "Contains one hellgun degradation kit, an old pattern of laser gun infamous for its ability to horribly disfigure targets with burns. Technically violates the Space Geneva Convention when used on humanoids."
 	cost = PAYCHECK_CREW * 2
-	access_view = ACCESS_ARMORY
+	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/weaponcrafting/gunkit/hellgun)
 
 /datum/supply_pack/goody/thermal_single
 	name = "Thermal Pistol Holster Single-Pack"
 	desc = "Contains twinned thermal pistols in a holster, ready for use in the field."
 	cost = PAYCHECK_COMMAND * 15
-	access_view = ACCESS_ARMORY
-	contains = list(/obj/item/storage/belt/holster/thermal)
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/storage/belt/holster/energy/thermal)
 
 /datum/supply_pack/goody/sologamermitts
 	name = "Insulated Gloves Single-Pack"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -343,7 +343,7 @@
 	desc = "Contains a pair of holsters each with two experimental thermal pistols, \
 		using nanites as the basis for their ammo."
 	cost = CARGO_CRATE_VALUE * 7
-	contains = list(/obj/item/storage/belt/holster/thermal = 2)
+	contains = list(/obj/item/storage/belt/holster/energy/thermal = 2)
 	crate_name = "thermal pistol crate"
 
 /datum/supply_pack/security/armory/wt550


### PR DESCRIPTION
## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/72750

This makes it so that you need a weapon permit to be able to purchase and open weapon goodie packs. The only one that still needs armory access is combat shotguns.

In addition:

You can buy disablers and lasers as goodie packs. Disablers come with a holster to stow your gun in, and also allow a security officer the ability to stow two disablers in the holster if they choose to buy another.

Energy holsters (what were just thermal holsters) can also store mini ebows because I just kind of forgot about them the first time around, oops!

## Why It's Good For The Game

The roles that have ACCESS_WEAPON are already expected to have weaponry available to them in one form or another.  Many of these roles may want to utilize the goodie system in order to acquire a brand new weapon, or replace a lost one. Since they still need to A) get money, in one way or another, and B) get cargo to fulfil their order, the added restriction of needing the presence of a head of staff to get a weapon Is overly much.

Many of the roles that couldn't buy the goodie packs could buy the full crates at a larger lump payment, but at a bulk discount. This isn't a meaningful restriction, but more likely an oversight from a bit of code that wasn't working for some time, because, when the system was first implemented, personal purchases were expected to bypass access restriction due to their increased markup.

This _still_ restricts weapon access as a whole by preventing roles not expected to have weapons from getting weapons. You would still need to go get a weapon permit from somewhere.

Additional stuff:
I noticed I couldn't get lasers and disablers as goodies and I thought that was weird, especially since I could get hellgun kits as goodies. So I added them, following the pattern somewhat. 

I literally should have added mini ebow to the energy holster, I fucked up.

## Changelog
:cl:
balance: You can purchase weapons via the goodie system if you have a weapon permit.
add: You can purchase lasers and disablers as goodies. The latter comes with a holster you can stick on your armor vest and store your extra disabler as security.
qol: You can store mini ebows in energy holsters. Oops.
/:cl:
