### PR TITLE
Malfunctioning AIs whos brain is removed from the core and rehomed in another core will retain their law 0.

### DIFF
--- a/code/game/objects/structures/ai_core.dm
+++ b/code/game/objects/structures/ai_core.dm
@@ -352,6 +352,10 @@
 		ai_mob = new /mob/living/silicon/ai(loc, laws, the_brainmob)
 		laws = null //we're giving the new AI this datum, so let's not delete it when we qdel(src) 5 lines from now
 
+	var/datum/antagonist/malf_ai/malf_datum = IS_MALF_AI(ai_mob)
+	if(malf_datum)
+		malf_datum.add_law_zero()
+
 	if(core_mmi.force_replace_ai_name)
 		ai_mob.fully_replace_character_name(ai_mob.name, core_mmi.replacement_ai_name())
 	if(core_mmi.braintype == "Android")


### PR DESCRIPTION

## About The Pull Request

Currently if you are able to deconstruct a malfunctioning AI, such as through methods that gib AIs, rehoming the AI in a new core results in it losing its law 0, but it retains its antagonist datum and combat upgrades. This is due to the law 0 only being generated when the AIs gains the antag datum, I've made it so that when a brain with the malfunctioning AI datum is inserted into an AI core it will re-produce its law 0. 
## Why It's Good For The Game

"Exploit"(?) that could be used to de-malf AIs patched and should cause less confusion for malf AI players since they wont end up in a situation where they have no law 0 but have all other malf AI components.
## Changelog
:cl:
fix: Removing a malf AIs brain and inserting it into a new core no-longer clears its zeroth law
/:cl:
