### PR TITLE
Carp won't eat an empty space station

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -2,7 +2,7 @@
 	name = "Carp Migration"
 	typepath = /datum/round_event/carp_migration
 	weight = 15
-	min_players = 2
+	min_players = 12
 	earliest_start = 10 MINUTES
 	max_occurrences = 6
 	category = EVENT_CATEGORY_ENTITIES


### PR DESCRIPTION
## About The Pull Request

I saw complaints in a few places that after changes to make them try to come inside, Carp Migration would fuck up marathon servers or other rounds where people playing with very low population.
Trivial fix: Now the event won't trigger if there are less than 12 players, rather than the previous completely pointless requirement of two players (why would it be unacceptable for carp to haunt the solar panels if there was only one player?)

## Why It's Good For The Game

Carp aren't individually very dangerous but if there's more of them than there are you it can be a problem. The maintenance issues also add up if you're playing a really long round with no people in it to do a construction project.

## Changelog

:cl:
balance: The carp migration event won't trigger if there are fewer than 12 players.
/:cl:
