### PR TITLE
Frankenstein's Monster Quirk

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -634,6 +634,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_INTROVERT "introvert"
 #define TRAIT_ANXIOUS "anxious"
 #define TRAIT_SMOKER "smoker"
+/// Doesn't get moodlets about whose limbs or bodyparts they get, or even have.
+#define TRAIT_FRANKENSTEIN "frankenstein"
 
 /// Gives you the Shifty Eyes quirk, rarely making people who examine you think you examined them back even when you didn't
 #define TRAIT_SHIFTY_EYES "shifty_eyes"

--- a/code/datums/quirks/positive_quirks.dm
+++ b/code/datums/quirks/positive_quirks.dm
@@ -292,3 +292,13 @@
 
 /datum/quirk/item_quirk/signer/remove()
 	qdel(quirk_holder.GetComponent(/datum/component/sign_language))
+
+/datum/quirk/frankensteins_monster
+	name = "Frankenstein's Monster"
+	desc = "You're very open-minded about medical malpractice. You don't have particular opinions about whose limbs or bodyparts you get, or even have."
+	icon = "user-doctor"
+	value = 1
+	mob_trait = TRAIT_FRANKENSTEIN
+	gain_text = span_notice("You have a mild wish to become Frankenstein's monster.")
+	lose_text = span_danger("You can no longer remember whether Frankenstein or his monster was the big baddie of the original book.")
+	mail_goodies = list(/obj/item/organ/external/tail)

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -28,7 +28,7 @@
 
 		if(IS_WEAKREF_OF(reciever, original_owner))
 			reciever.clear_mood_event("wrong_tail_regained")
-		else if(type in reciever.dna.species.external_organs)
+		else if(type in reciever.dna.species.external_organs && !HAS_TRAIT(organ_owner, TRAIT_FRANKENSTEIN))
 			reciever.add_mood_event("wrong_tail_regained", /datum/mood_event/tail_regained_wrong)
 
 /obj/item/organ/external/tail/Remove(mob/living/carbon/organ_owner, special, moving)
@@ -38,7 +38,8 @@
 	UnregisterSignal(organ_owner, COMSIG_ORGAN_WAG_TAIL)
 
 	if(type in organ_owner.dna.species.external_organs)
-		organ_owner.add_mood_event("tail_lost", /datum/mood_event/tail_lost)
+		if(!HAS_TRAIT(organ_owner, TRAIT_FRANKENSTEIN))
+			organ_owner.add_mood_event("tail_lost", /datum/mood_event/tail_lost)
 		organ_owner.add_mood_event("tail_balance_lost", /datum/mood_event/tail_balance_lost)
 
 /obj/item/organ/external/tail/proc/wag(mob/user, start = TRUE, stop_after = 0)

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -28,7 +28,7 @@
 
 		if(IS_WEAKREF_OF(reciever, original_owner))
 			reciever.clear_mood_event("wrong_tail_regained")
-		else if(type in reciever.dna.species.external_organs && !HAS_TRAIT(organ_owner, TRAIT_FRANKENSTEIN))
+		else if(type in reciever.dna.species.external_organs && !HAS_TRAIT(reciever, TRAIT_FRANKENSTEIN))
 			reciever.add_mood_event("wrong_tail_regained", /datum/mood_event/tail_regained_wrong)
 
 /obj/item/organ/external/tail/Remove(mob/living/carbon/organ_owner, special, moving)


### PR DESCRIPTION

## About The Pull Request

Adds the Frankenstein's Monster quirk. It's quite simple: You don't get bad moodlets from losing the tail, expandable in the future to bad moodlets. Still get off balance moodlet if your species inherently wants a tail, because that's less of an opinion on medical malpractice and more of a painful existence.

## Why It's Good For The Game

Some maints want to full send the ability to make people into frankenstein monsters with all sorts of internal, external, and bodyparts scrambled and randomly picked, some maints want to incur moodlet penalties on purposefully or circumstantially having to use the wrong kind of organs. This calls for a compromise and what better way to make everyone ~~un~~happy with a quirk!

## Changelog
:cl:
add: Frankenstein's Monster quirk
/:cl:
