### PR TITLE
APC assigns itself the correct name based on its area

### DIFF
--- a/code/game/objects/items/apc_frame.dm
+++ b/code/game/objects/items/apc_frame.dm
@@ -3,7 +3,7 @@
 	name = "\improper APC frame"
 	desc = "Used for repairing or building APCs."
 	icon_state = "apc"
-	result_path = /obj/machinery/power/apc
+	result_path = /obj/machinery/power/apc/auto_name
 
 /obj/item/wallframe/apc/try_build(turf/on_wall, user)
 	if(!..())

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -122,12 +122,6 @@
 
 /obj/machinery/power/apc/Initialize(mapload, ndir)
 	. = ..()
-	//Initialize name & access of the apc
-	if(!req_access)
-		req_access = list(ACCESS_ENGINE_EQUIP)
-	if(auto_name)
-		name = "\improper [get_area_name(area, TRUE)] APC"
-
 	//Pixel offset its appearance based on its direction
 	dir = ndir
 	switch(dir)
@@ -157,6 +151,12 @@
 		if(area.apc)
 			log_mapping("Duplicate APC created at [AREACOORD(src)] [area.type]. Original at [AREACOORD(area.apc)] [area.type].")
 		area.apc = src
+
+	//Initialize name & access of the apc. Name requires area to be assigned first
+	if(!req_access)
+		req_access = list(ACCESS_ENGINE_EQUIP)
+	if(auto_name)
+		name = "\improper [get_area_name(area, TRUE)] APC"
 
 	//Initialize its electronics
 	wires = new /datum/wires/apc(src)


### PR DESCRIPTION
## About The Pull Request
APC was assigned a name before it was assigned an area causing null names.

Another bug i noticed was that newly built apcs were also not assigned names. Thats fixed now too

Fixes #73052

## Changelog
:cl:
fix: apc not assigning itself a name based on its area
fix: newly built apc's not getting assigned area names
/:cl: