### PR TITLE
Fixes the dme validator erroring on an error for duplicate lines

### DIFF
--- a/tools/validate_dme.py
+++ b/tools/validate_dme.py
@@ -84,7 +84,8 @@ def compare_lines(a, b):
         if a_segment != b_segment:
             return (a_segment > b_segment) - (a_segment < b_segment)
 
-    raise ValueError(f"Two lines were exactly the same ({a} vs. {b})")
+    print(f"Two lines were exactly the same ({a} vs. {b})")
+    sys.exit(1)
 
 sorted_lines = sorted(lines, key = functools.cmp_to_key(compare_lines))
 for (index, line) in enumerate(lines):

--- a/tools/validate_dme.py
+++ b/tools/validate_dme.py
@@ -84,7 +84,7 @@ def compare_lines(a, b):
         if a_segment != b_segment:
             return (a_segment > b_segment) - (a_segment < b_segment)
 
-    raise f"Two lines were exactly the same ({a} vs. {b})"
+    raise ValueError(f"Two lines were exactly the same ({a} vs. {b})")
 
 sorted_lines = sorted(lines, key = functools.cmp_to_key(compare_lines))
 for (index, line) in enumerate(lines):


### PR DESCRIPTION
## About The Pull Request

Wouldn't show the actual error due to an error in the throw:
```
Traceback (most recent call last):
  File "P:\goonstation\tools\ci\validate_dme.py", line 92, in <module>
    sorted_lines = sorted(lines, key = functools.cmp_to_key(compare_lines))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "P:\goonstation\tools\ci\validate_dme.py", line 90, in compare_lines
    raise f"Two lines were exactly the same ({a} vs. {b})"
TypeError: exceptions must derive from BaseException
```

With my change:
```
Traceback (most recent call last):
  File "P:\goonstation\tools\ci\validate_dme.py", line 92, in <module>
    sorted_lines = sorted(lines, key = functools.cmp_to_key(compare_lines))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "P:\goonstation\tools\ci\validate_dme.py", line 90, in compare_lines
    raise ValueError(f"Two lines were exactly the same ({a} vs. {b})")
ValueError: Two lines were exactly the same (code\serialization.dm vs. code\serialization.dm)
```

I thought about `ImportWarning` but too much work to decide

## Why It's Good For The Game

not broeken

from ur favorite Big Daddy upstream ❤️ 

## Changelog

no
