### PR TITLE
Adds an ghost orbit popup for the wise cow

### DIFF
--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -13,4 +13,5 @@
 	var/turf/targetloc = get_safe_random_station_turf()
 	var/mob/living/basic/cow/wisdom/wise = new (targetloc)
 	do_smoke(1, holder = wise, location = targetloc)
+	announce_to_ghosts(wise)
 


### PR DESCRIPTION

## About The Pull Request

Ghosts now get a "hey look orbit here there's something cool going on" alert when a wisdom cow spawns. This only applies to event spawns, not any instance of a wisdom cow spawning.

This not being a thing has annoyed me for a LONG TIME and I've kept on forgetting to do it. 
## Why It's Good For The Game

There might not be a huge reason to orbit a wisdom cow, since it's not a particularly juicy event or anything. Regardless, it gives deadchat somewhere to congregate and appreciate the cow's extensive dialogue choices before a player disintegrates it. 
## Changelog
:cl:
qol: ghosts now get an orbit notification for wise cows!
/:cl:
