### PR TITLE
Adds plasmaman support to mob spawners

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -245,7 +245,7 @@
 	if(!visualsOnly)
 		apply_fingerprints(H)
 		if(internals_slot)
-			if(internals_slot == ITEM_SLOT_HANDS)
+			if(internals_slot & ITEM_SLOT_HANDS)
 				var/obj/item/tank/internals/internals = H.is_holding_item_of_type(/obj/item/tank/internals)
 				if(internals)
 					H.open_internals(internals)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -245,7 +245,12 @@
 	if(!visualsOnly)
 		apply_fingerprints(H)
 		if(internals_slot)
-			H.open_internals(H.get_item_by_slot(internals_slot))
+			if(internals_slot == ITEM_SLOT_HANDS)
+				var/obj/item/tank/internals/internals = H.is_holding_item_of_type(/obj/item/tank/internals)
+				if(internals)
+					H.open_internals(internals)
+			else 
+				H.open_internals(H.get_item_by_slot(internals_slot))
 		if(implants)
 			for(var/implant_type in implants)
 				var/obj/item/implant/I = SSwardrobe.provide_type(implant_type, H)

--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -5,8 +5,8 @@
 	gloves = /obj/item/clothing/gloves/color/plasmaman
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	mask = /obj/item/clothing/mask/breath
-	r_pocket= /obj/item/tank/internals/plasmaman/belt/full
-	internals_slot = ITEM_SLOT_RPOCKET
+	r_hand= /obj/item/tank/internals/plasmaman/belt/full
+	internals_slot = ITEM_SLOT_HANDS
 
 /datum/outfit/plasmaman/security
 	name = "Security Plasmaman"

--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -5,7 +5,8 @@
 	gloves = /obj/item/clothing/gloves/color/plasmaman
 	head = /obj/item/clothing/head/helmet/space/plasmaman
 	mask = /obj/item/clothing/mask/breath
-	r_hand= /obj/item/tank/internals/plasmaman/belt/full
+	r_pocket= /obj/item/tank/internals/plasmaman/belt/full
+	internals_slot = ITEM_SLOT_RPOCKET
 
 /datum/outfit/plasmaman/security
 	name = "Security Plasmaman"

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -122,7 +122,6 @@
 		equipping.equipOutfit(job.plasmaman_outfit, visuals_only)
 	else 
 		give_important_for_life(equipping)
-	equipping.open_internals(equipping.get_item_for_held_index(2))
 
 /datum/species/plasmaman/random_name(gender,unique,lastname)
 	if(unique)

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -51,6 +51,7 @@
 		var/mob/living/carbon/human/spawned_human = spawned_mob
 		if(mob_species)
 			spawned_human.set_species(mob_species)
+		spawned_human.dna.species.give_important_for_life(spawned_mob) // for preventing plasmamen from combusting immediately upon spawning
 		spawned_human.underwear = "Nude"
 		spawned_human.undershirt = "Nude"
 		spawned_human.socks = "Nude"

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -51,7 +51,7 @@
 		var/mob/living/carbon/human/spawned_human = spawned_mob
 		if(mob_species)
 			spawned_human.set_species(mob_species)
-		spawned_human.dna.species.give_important_for_life(spawned_mob) // for preventing plasmamen from combusting immediately upon spawning
+		spawned_human.dna.species.give_important_for_life(spawned_human) // for preventing plasmamen from combusting immediately upon spawning
 		spawned_human.underwear = "Nude"
 		spawned_human.undershirt = "Nude"
 		spawned_human.socks = "Nude"


### PR DESCRIPTION
## About The Pull Request

A very minor change but one that will save headache down the line. Adds plasmaman support to mob spawners, meaning they will be guaranteed to get their internals and suit upon spawning from those.

Modified the equip proc to be able to automatically turn hand slot internals on without the need for snowflakey open_internals checks everywhere, as that should already handled by the equip proc (shown below). Just modified it to work on hand slots.

https://github.com/tgstation/tgstation/blob/4b832e7d01c079e2548940d352fb089bb336ec54/code/datums/outfit.dm#L245-L248

## Why It's Good For The Game

Adds support for present and future mob spawners involving plasmapeople.

## Changelog

:cl:
qol: prevents mob spawner plasmamen from spawning without their suit and internals. 
code: the equip proc can now find internals in the hand slot and automatically open them, allowing for less snowflakey code down the line.
/:cl:

