### PR TITLE
Clarifies the comment about images in the MOTD config.

### DIFF
--- a/config/motd.txt
+++ b/config/motd.txt
@@ -1,4 +1,4 @@
-<!-- Most valid html will work in here, excluding images. -->
+<!-- Most valid html will work in here, but you have to use URL links for images. -->
 
 <h1>Welcome to Space Station 13!</h1>
 


### PR DESCRIPTION

## About The Pull Request

Currently, the comment in the MOTD config states that images won't work, and that is the case, if you try to use local paths.

However, i discovered that, if you use a URL for the image instead of a local path, it seems to work perfectly fine.

Case in point, here's an MOTD with an image:

![Screenshot_50](https://user-images.githubusercontent.com/31294280/215476678-418936d2-3366-42ef-90d3-4991ae41eae4.png)

After discovering this, i felt the need to update the MOTD comment to be more accurate, so i made this pull request.

## Why It's Good For The Game

The current comment creates a false impression that no images will work in the MOTD whatsoever when. in fact, it's totally doable.

The new comment may make it aware to more people that, as long as they host the image on a external link, images can be embedded into the MOTD.

## Changelog
I don't believe this change is player facing.
