### PR TITLE
Revert "Underwear Update (Sanity edition)"

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -791,7 +791,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 ///Proc that will randomise the underwear (i.e. top, pants and socks) of a species' associated mob,
 /// but will not update the body right away.
 /datum/species/proc/randomize_active_underwear_only(mob/living/carbon/human/human_mob)
-	return
+	human_mob.undershirt = random_undershirt(human_mob.gender)
+	human_mob.underwear = random_underwear(human_mob.gender)
+	human_mob.socks = random_socks(human_mob.gender)
 
 ///Proc that will randomise the underwear (i.e. top, pants and socks) of a species' associated mob
 /datum/species/proc/randomize_active_underwear(mob/living/carbon/human/human_mob)

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -162,11 +162,6 @@
 
 	return to_add
 
-/datum/species/dullahan/randomize_active_underwear_only(mob/living/carbon/human/human_mob)
-	human_mob.undershirt = random_undershirt(human_mob.gender)
-	human_mob.underwear = random_underwear(human_mob.gender)
-	human_mob.socks = random_socks(human_mob.gender)
-
 /obj/item/organ/internal/brain/dullahan
 	decoy_override = TRUE
 	organ_flags = NONE
@@ -278,4 +273,3 @@
 			owner.gib()
 	owner = null
 	return ..()
-

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -92,8 +92,3 @@
 		))
 
 	return to_add
-
-/datum/species/human/randomize_active_underwear_only(mob/living/carbon/human/human_mob)
-	human_mob.undershirt = random_undershirt(human_mob.gender)
-	human_mob.underwear = random_underwear(human_mob.gender)
-	human_mob.socks = random_socks(human_mob.gender)

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -108,11 +108,6 @@
 
 	return to_add
 
-/datum/species/vampire/randomize_active_underwear_only(mob/living/carbon/human/human_mob)
-	human_mob.undershirt = random_undershirt(human_mob.gender)
-	human_mob.underwear = random_underwear(human_mob.gender)
-	human_mob.socks = random_socks(human_mob.gender)
-
 // Vampire blood is special, so it needs to be handled with its own entry.
 /datum/species/vampire/create_pref_blood_perks()
 	var/list/to_add = list()

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -23,14 +23,6 @@
 		return FALSE
 	return ..()
 
-/obj/item/bodypart/chest/on_removal()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/undie_haver = owner
-		undie_haver.underwear = "Nude"
-		undie_haver.undershirt = "Nude"
-
-	..()
-
 /obj/item/bodypart/chest/Destroy()
 	QDEL_NULL(cavity_item)
 	return ..()
@@ -311,12 +303,6 @@
 	unarmed_damage_low = 2
 	unarmed_damage_high = 15
 	unarmed_stun_threshold = 10
-
-/obj/item/bodypart/leg/on_removal()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/sock_haver = owner
-		sock_haver.socks = "Nude"
-	..()
 
 /obj/item/bodypart/leg/left
 	name = "left leg"


### PR DESCRIPTION
Reverts tgstation/tgstation#73010

This PR caused problems for underwear code that somehow didn't get caught in testing. Discovered so far are:

- Spawning at roundstart, latejoin, or by admin tools as a non-human character removes your underwear #73063
- Taking a head roll with a non-human character results in the human alternative character also having new underwear https://github.com/tgstation/tgstation/pull/73010#issuecomment-1408080782

According to @NamelessFairy the root problem here is that on_removal() gets called during the process of setting up non-human species, leading to their underwear being removed. The human alternative is presumably a further extension of this same behaviour.

Given this is likely to require some level of refactoring to avoid, I think it would be better for everyone to revert until that can be done and save all non-human players the burden of having to find a dresser and fix their underwear every time they want to wear it.