### PR TITLE
[no gbp] Dehydrated Carp will follow orders correctly

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -98,8 +98,8 @@
 
 	AddComponent(/datum/component/regenerator, outline_colour = regenerate_colour)
 	if (tamer)
-		befriend(tamer)
 		on_tamed(tamer, FALSE)
+		befriend(tamer)
 	else
 		AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/meat), tame_chance = 10, bonus_tame_chance = 5, after_tame = CALLBACK(src, PROC_REF(on_tamed)))
 

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -98,7 +98,7 @@
 
 	AddComponent(/datum/component/regenerator, outline_colour = regenerate_colour)
 	if (tamer)
-		on_tamed(tamer, FALSE)
+		on_tamed(tamer, feedback = FALSE)
 		befriend(tamer)
 	else
 		AddComponent(/datum/component/tameable, food_types = list(/obj/item/food/meat), tame_chance = 10, bonus_tame_chance = 5, after_tame = CALLBACK(src, PROC_REF(on_tamed)))


### PR DESCRIPTION
## About The Pull Request

Fixes #72914
The order of operations here were wrong, such that it was calling a proc which sent signals to inform a component about a new "master" before actually adding the component.
I switched the proc calls around so that now it adds the component before telling the component that there is someone to listen to.

## Why It's Good For The Game

Item you spent a valuable single telecrystal on did not work as advertised, now does.

## Changelog

:cl:
fix: Rehydrated Carp should now properly recognise who is the boss and follow their instructions.
/:cl: