### PR TITLE
EMPs require aluminum, but it doesn't contribute to the total size of the EMP

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -164,16 +164,17 @@
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
 
 /datum/chemical_reaction/emp_pulse
-	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/iron = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
+	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/iron = 1, /datum/reagent/aluminium = 1)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_EXPLOSIVE | REACTION_TAG_DANGEROUS
 
 /datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
+	//pretending this reaction took two ingredients and not three for its effects
+	var/two_thirds = created_volume / 1.5
 	var/location = get_turf(holder.my_atom)
 	// 100 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
 	// 200 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
-	empulse(location, round(created_volume / 12), round(created_volume / 7), 1)
+	empulse(location, round(two_thirds / 12), round(two_thirds / 7), 1)
 	holder.clear_reagents()
-
 
 /datum/chemical_reaction/beesplosion
 	required_reagents = list(/datum/reagent/consumable/honey = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/uranium/radium = 1)


### PR DESCRIPTION

## About The Pull Request

EMPs now require aluminum. For example, making a 4 heavy range & 7 light range EMP used to take 100 iron and 100 uranium, now it takes 100 iron, 100 uranium, and 100 aluminum. The aluminum doesn't contribute to a higher EMP explosion despite making more of the final product in the reaction.

## Why It's Good For The Game

AI is on the weak side right now, with every department being able to quickly produce EMPs by depositing iron and uranium from protolathes and grinding them. I chose aluminum as it still makes the recipe very possible ghetto (grind cans for 10 aluminum each), but it isn't instantly achievable from protolathes either. Historically, this was far less of a problem, as each department didn't have its own big supply of mats.

## Changelog
:cl:
balance: EMP requires aluminum, but the aluminum doesn't contribute to a bigger EMP size.
/:cl:
