### PR TITLE
[NO GBP] makes pizza crates' pizza list weighted again

### DIFF
--- a/code/modules/cargo/packs/organic.dm
+++ b/code/modules/cargo/packs/organic.dm
@@ -224,7 +224,7 @@
 
 /// adds a randomized pizza from the pizza list
 /datum/supply_pack/organic/pizza/proc/add_normal_pizza(obj/structure/closet/crate/new_crate, list/rng_pizza_list)
-	var/randomize_pizza = pick_n_take(rng_pizza_list)
+	var/randomize_pizza = pick_weight(rng_pizza_list)
 	rng_pizza_list -= randomize_pizza
 	var/obj/item/pizzabox/new_pizza_box = new(new_crate)
 	new_pizza_box.pizza = new randomize_pizza


### PR DESCRIPTION
## About The Pull Request

didnt realize in #71202 pick-n-take didnt have the weight function like pick weight obviously does oops! 

## Why It's Good For The Game

pizza crates did not care about assigned weight, if you think that the arnold pizza was showing up too often, it was!

## Changelog

:cl:
fix: pizza crates' pizza list applies the assigned weight on its pizza list
/:cl:

