### PR TITLE
Medical/Security records now use the max/min age.

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -76,6 +76,12 @@
 
 	return data
 
+/obj/machinery/computer/med_data/ui_static_data(mob/user)
+	var/list/data = list()
+	data["min_age"] = AGE_MIN
+	data["max_age"] = AGE_MAX
+	return data
+
 /obj/machinery/computer/med_data/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()
 	if(.)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -135,6 +135,12 @@
 
 	return data
 
+/obj/machinery/computer/secure_data/ui_static_data(mob/user)
+	var/list/data = list()
+	data["min_age"] = AGE_MIN
+	data["max_age"] = AGE_MAX
+	return data
+
 /obj/machinery/computer/secure_data/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()
 	if(.)

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -14,6 +14,8 @@ export const MedicalRecordView = (props, context) => {
   const { act, data } = useBackend<MedicalRecordData>(context);
   const { assigned_view } = data;
 
+  const { min_age, max_age } = data;
+
   const {
     age,
     blood_type,
@@ -67,8 +69,8 @@ export const MedicalRecordView = (props, context) => {
             </LabeledList.Item>
             <LabeledList.Item label="Age">
               <RestrictedInput
-                minValue={18}
-                maxValue={100}
+                minValue={min_age}
+                maxValue={max_age}
                 onEnter={(event, value) =>
                   act('edit_field', {
                     field: 'age',

--- a/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
@@ -4,6 +4,8 @@ export type MedicalRecordData = {
   assigned_view: string;
   authenticated: BooleanLike;
   records: MedicalRecord[];
+  min_age: number;
+  max_age: number;
 };
 
 export type MedicalRecord = {

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordView.tsx
@@ -43,6 +43,8 @@ const RecordInfo = (props, context) => {
   const { available_statuses } = data;
   const [open, setOpen] = useLocalState<boolean>(context, 'printOpen', false);
 
+  const { min_age, max_age } = data;
+
   const {
     age,
     crew_ref,
@@ -128,8 +130,8 @@ const RecordInfo = (props, context) => {
             </LabeledList.Item>
             <LabeledList.Item label="Age">
               <RestrictedInput
-                minValue={18}
-                maxValue={100}
+                minValue={min_age}
+                maxValue={max_age}
                 onEnter={(event, value) =>
                   act('edit_field', {
                     crew_ref: crew_ref,

--- a/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
@@ -5,6 +5,8 @@ export type SecurityRecordsData = {
   authenticated: BooleanLike;
   available_statuses: string[];
   records: SecurityRecord[];
+  min_age: number;
+  max_age: number;
 };
 
 export type SecurityRecord = {


### PR DESCRIPTION

## About The Pull Request

Both record types were using different minimum and maximum ages to the normal ones, resulting in 17 year old crewmembers having their records state 18 and records could be increased beyond normal crew ages (technically this isn't an issue I guess if any maintainers want this reverted)
## Why It's Good For The Game

Fixes a bug with 17 year old crewmember and consistency.
## Changelog
:cl:
fix: 17 year old crew member medical/security records will no longer show them as 18
code: Medical and security records now use the minimum and maximum age defines rather than hardcoded minimums and maximums
/:cl:
