### PR TITLE
revenant speech is now deadchat-colored

### DIFF
--- a/code/modules/mob/living/simple_animal/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant.dm
@@ -179,7 +179,7 @@
 	if(sanitize)
 		message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 	src.log_talk(message, LOG_SAY)
-	var/rendered = span_deadsay(span_command_headset("<b>UNDEAD: [src]</b> says, \"[message]\""))
+	var/rendered = span_deadsay("<b>UNDEAD: [src]</b> says, \"[message]\"")
 	for(var/mob/M in GLOB.mob_list)
 		if(isrevenant(M))
 			to_chat(M, rendered)

--- a/code/modules/mob/living/simple_animal/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant.dm
@@ -179,7 +179,7 @@
 	if(sanitize)
 		message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 	src.log_talk(message, LOG_SAY)
-	var/rendered = span_deadsay("<b>UNDEAD: [src]</b> says, \"[message]\"")
+	var/rendered = span_deadsay(span_command_headset("<b>UNDEAD: [src]</b> says, \"[message]\""))
 	for(var/mob/M in GLOB.mob_list)
 		if(isrevenant(M))
 			to_chat(M, rendered)

--- a/code/modules/mob/living/simple_animal/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant.dm
@@ -179,7 +179,7 @@
 	if(sanitize)
 		message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 	src.log_talk(message, LOG_SAY)
-	var/rendered = span_revennotice("<b>[src]</b> says, \"[message]\"")
+	var/rendered = span_deadsay("<b>[src]</b> says, \"[message]\"")
 	for(var/mob/M in GLOB.mob_list)
 		if(isrevenant(M))
 			to_chat(M, rendered)

--- a/code/modules/mob/living/simple_animal/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant.dm
@@ -179,7 +179,7 @@
 	if(sanitize)
 		message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 	src.log_talk(message, LOG_SAY)
-	var/rendered = span_deadsay("<b>[src]</b> says, \"[message]\"")
+	var/rendered = span_deadsay("<b>UNDEAD: [src]</b> says, \"[message]\"")
 	for(var/mob/M in GLOB.mob_list)
 		if(isrevenant(M))
 			to_chat(M, rendered)


### PR DESCRIPTION
## About The Pull Request

he's one of the booooooooooooooooooooooooooooys

((Revenant monologuing is now the same color as deadchat.))

## Why It's Good For The Game

Ghosts and revenants can (already) hear each other, but ghosts have a really hard time picking out revenant speech from the general chatter of the round. This leads to ghost-revenant conversations being pretty one-sided, which is annoying for both parties.

Revenants are ghosts, so it makes sense that their speech would be deadchat-colored. This shouldn't affect their telepathy, which is what most mortals will be hearing anyway.

pic:
![image](https://user-images.githubusercontent.com/42606352/215659138-9abc1882-97e5-4e16-bb3c-f0ff22076613.png)
![image](https://user-images.githubusercontent.com/42606352/215659152-09131a54-1aa3-461f-9ad3-5d3fa82de880.png)
(ghosts other than the revenant should see an (F) next to this text, it's just not in this image because it was taken from the perspective of the revenant)
![image](https://user-images.githubusercontent.com/42606352/215659194-fb1f8861-bcec-4322-b941-a0a4798f20ca.png)


## Changelog

:cl: ATHATH
qol: Revenant monologuing is now the same color as deadchat.
/:cl: