### PR TITLE
Fixes Wacky Wizard Spellbook Visual Bug

### DIFF
--- a/tgui/packages/tgui/interfaces/Spellbook.js
+++ b/tgui/packages/tgui/interfaces/Spellbook.js
@@ -324,7 +324,7 @@ const Randomize = (props, context) => {
   return (
     <Stack fill vertical>
       {points < 10 && <PointLocked />}
-      <Stack.Item grow mt={10}>
+      <Stack.Item>
         Semi-Randomize will ensure you at least get some mobility and lethality.
         Guaranteed to have {semi_random_bonus} points worth of spells.
       </Stack.Item>


### PR DESCRIPTION

## About The Pull Request

Hey there,

![image](https://user-images.githubusercontent.com/34697715/215665721-33d6ec03-c747-4e09-b7de-089156e711b9.png)

There was a weird variable set here, meaning that the text that described what Semi-Randomize actually was was obscured. Let's remove that oddness and fix that UI right up.
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/215665743-03b0da52-dde7-48e7-8595-e11e4a67a239.png)

It's actually readable now! Great.
## Changelog
:cl:
fix: The wizard's magickal printing press has been corrected such that ye magickal text describing what the semi-randomize option do is no longer printed _underneath_ the semi-randomize button.
/:cl:
