### PR TITLE
Fixes mime's vow of silence requiring wizard robes to be casted.

### DIFF
--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -9,6 +9,7 @@
 
 	school = SCHOOL_MIME
 	cooldown_time = 5 MINUTES
+	spell_requirements = NONE
 
 	spell_max_level = 1
 


### PR DESCRIPTION
## About The Pull Request
As it says in title. Also somewhat fixes this #73060 
## Why It's Good For The Game
Cringe mimes can speak again/Changeling mimes can pretend other people again.
## Changelog
:cl:
fix: Mime's Vow of silence will no longer requiere wizard robes to be casted.
/:cl:
