### PR TITLE
Fixes runtime error in bot path drawing code

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1063,6 +1063,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 				var/image/prevI = path[prevT]
 				direction = get_dir(prevT, T)
 				if(i > 2)
+					if(!prevI) // no image to put
+						continue
 					var/turf/prevprevT = path[i - 2]
 					var/prevDir = get_dir(prevprevT, prevT)
 					var/mixDir = direction|prevDir

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1063,21 +1063,20 @@ Pass a positive integer as an argument to override a bot's default speed.
 				var/image/prevI = path[prevT]
 				direction = get_dir(prevT, T)
 				if(i > 2)
-					if(!prevI) // no image to put
-						continue
-					var/turf/prevprevT = path[i - 2]
-					var/prevDir = get_dir(prevprevT, prevT)
-					var/mixDir = direction|prevDir
-					if(ISDIAGONALDIR(mixDir))
-						prevI.dir = mixDir
-						if(prevDir & (NORTH|SOUTH))
-							var/matrix/ntransform = matrix()
-							ntransform.Turn(90)
-							if((mixDir == NORTHWEST) || (mixDir == SOUTHEAST))
-								ntransform.Scale(-1, 1)
-							else
-								ntransform.Scale(1, -1)
-							prevI.transform = ntransform
+					if(prevI) // make sure we actually have an image to manipulate
+						var/turf/prevprevT = path[i - 2]
+						var/prevDir = get_dir(prevprevT, prevT)
+						var/mixDir = direction|prevDir
+						if(ISDIAGONALDIR(mixDir))
+							prevI.dir = mixDir
+							if(prevDir & (NORTH|SOUTH))
+								var/matrix/ntransform = matrix()
+								ntransform.Turn(90)
+								if((mixDir == NORTHWEST) || (mixDir == SOUTHEAST))
+									ntransform.Scale(-1, 1)
+								else
+									ntransform.Scale(1, -1)
+								prevI.transform = ntransform
 
 			SET_PLANE(path_image, GAME_PLANE, T)
 			path_image.dir = direction

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -1062,21 +1062,20 @@ Pass a positive integer as an argument to override a bot's default speed.
 				var/turf/prevT = path[i - 1]
 				var/image/prevI = path[prevT]
 				direction = get_dir(prevT, T)
-				if(i > 2)
-					if(prevI) // make sure we actually have an image to manipulate
-						var/turf/prevprevT = path[i - 2]
-						var/prevDir = get_dir(prevprevT, prevT)
-						var/mixDir = direction|prevDir
-						if(ISDIAGONALDIR(mixDir))
-							prevI.dir = mixDir
-							if(prevDir & (NORTH|SOUTH))
-								var/matrix/ntransform = matrix()
-								ntransform.Turn(90)
-								if((mixDir == NORTHWEST) || (mixDir == SOUTHEAST))
-									ntransform.Scale(-1, 1)
-								else
-									ntransform.Scale(1, -1)
-								prevI.transform = ntransform
+				if(i > 2 && prevI) // make sure we actually have an image to manipulate at index > 2
+					var/turf/prevprevT = path[i - 2]
+					var/prevDir = get_dir(prevprevT, prevT)
+					var/mixDir = direction|prevDir
+					if(ISDIAGONALDIR(mixDir))
+						prevI.dir = mixDir
+						if(prevDir & (NORTH|SOUTH))
+							var/matrix/ntransform = matrix()
+							ntransform.Turn(90)
+							if((mixDir == NORTHWEST) || (mixDir == SOUTHEAST))
+								ntransform.Scale(-1, 1)
+							else
+								ntransform.Scale(1, -1)
+							prevI.transform = ntransform
 
 			SET_PLANE(path_image, GAME_PLANE, T)
 			path_image.dir = direction


### PR DESCRIPTION
## About The Pull Request

Fixes #72951. 

#69395 and #72302 both seem unrelated and still persist after this.

The first seems likely caused by there not being any navigation beacons on the map or z-level they're on. Bots actually need those to be able to patrol it seems. The second is a bug unrelated to this one.

This just fixes a nullref caused by all kinds of bots that has been cropping up a lot lately. I ran a small army of bots for a while and the nullref was never triggered after this fix. Details below on the precise cause of it so it can be documented because I suspect this may be helpful whenever someone decides to properly fix the broken bot code.


---

https://github.com/tgstation/tgstation/blob/9de81146ec873abe6329fe14e75023c189e1c931/code/modules/mob/living/simple_animal/bot/bot.dm#L1056-L1085

The first index of the path list is the starting turf. This is always skipped via the continue statement, and so path[1] does not get an image stored at its index. After that, we are at path[2] and can go into the first conditional block:

https://github.com/tgstation/tgstation/blob/9de81146ec873abe6329fe14e75023c189e1c931/code/modules/mob/living/simple_animal/bot/bot.dm#L1061-L1064

This is where `prevI` gets set. For path[2], `prevI` will be null because path[1] did not have an image stored in it as mentioned above. This is fine, because we don't do anything with the image until we get to path[3].

Once we are at path[3] and beyond, we can go into the second conditional block, and this is where the issue arises because it assumes path[3] is going to have `prevI` set to an image and not null:

https://github.com/tgstation/tgstation/blob/9de81146ec873abe6329fe14e75023c189e1c931/code/modules/mob/living/simple_animal/bot/bot.dm#L1065-L1078

---

tl;dr 

The code expects the list to look like this
path[1] = null
path[2] = image
path[3 ... and so on] = image

From my testing, I found that very occasionally you can have a turf = loc at both index 1 and 2. Possibly even beyond, but I didn't see more than 2 in my testing. This is bad because the second conditional block assumes path[2] is not null.

so in those cases, the list looks like this
path[1] = null
path[2] = null
path[3 ... and so on] = image

In these cases, once we are at path[3], and enter the second conditional, `prevI` is null, and so trying to access `prevI.dir` will cause a runtime

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/18968

## Why It's Good For The Game

Fixes a bug that keeps coming up in the unit tests.

## Changelog

:cl:
fix: fixes a runtime error caused by patrolling bots
/:cl: