### PR TITLE
you can no longer change non null rod null rods

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -32,7 +32,7 @@
 
 	AddElement(/datum/element/bane, target_type = /mob/living/simple_animal/revenant, damage_multiplier = 0, added_damage = 25, requires_combat_mode = FALSE)
 
-	if(!GLOB.holy_weapon_type && istype(src, /obj/item/nullrod))
+	if(!GLOB.holy_weapon_type && type == /obj/item/nullrod)
 		var/list/rods = list()
 		for(var/obj/item/nullrod/nullrod_type as anything in typesof(/obj/item/nullrod))
 			if(!initial(nullrod_type.chaplain_spawnable))


### PR DESCRIPTION

## About The Pull Request
the initialize used an istype checkf or null rods. on a null rod. obviousl this never worked
,makes it use a direct type check

## Why It's Good For The Game
stupid

## Changelog
:cl:
fix: you can no longer change null rods that arent the normal null rod into different types
/:cl:
