### PR TITLE
fixes fov removal f12 exploit

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -45,7 +45,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	var/list/toggleable_inventory = list() //the screen objects which can be hidden
 	var/list/atom/movable/screen/hotkeybuttons = list() //the buttons that can be used via hotkeys
 	var/list/infodisplay = list() //the screen objects that display mob info (health, alien plasma, etc...)
-	var/list/screenoverlays = list() //the screen objects used as whole screen overlays (flash, damageoverlay, etc...)
+	/// Screen objects that never exit view.
+	var/list/always_visible_inventory = list()
 	var/list/inv_slots[SLOTS_AMT] // /atom/movable/screen/inventory objects, ordered by their slot ID.
 	var/list/hand_slots // /atom/movable/screen/inventory/hand objects, assoc list of "[held_index]" = object
 
@@ -222,7 +223,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 
 	QDEL_LIST_ASSOC_VAL(master_groups)
 	QDEL_LIST_ASSOC_VAL(plane_master_controllers)
-	QDEL_LIST(screenoverlays)
+	QDEL_LIST(always_visible_inventory)
 	mymob = null
 
 	QDEL_NULL(screentip_text)
@@ -308,6 +309,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 				screenmob.client.screen += hotkeybuttons
 			if(infodisplay.len)
 				screenmob.client.screen += infodisplay
+			if(always_visible_inventory.len)
+				screenmob.client.screen += always_visible_inventory
 
 			screenmob.client.screen += toggle_palette
 
@@ -324,6 +327,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 				screenmob.client.screen -= hotkeybuttons
 			if(infodisplay.len)
 				screenmob.client.screen += infodisplay
+			if(always_visible_inventory.len)
+				screenmob.client.screen += always_visible_inventory
 
 			//These ones are a part of 'static_inventory', 'toggleable_inventory' or 'hotkeybuttons' but we want them to stay
 			for(var/h in hand_slots)
@@ -344,6 +349,8 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 				screenmob.client.screen -= hotkeybuttons
 			if(infodisplay.len)
 				screenmob.client.screen -= infodisplay
+			if(always_visible_inventory.len)
+				screenmob.client.screen += always_visible_inventory
 
 	hud_version = display_hud_version
 	persistent_inventory_update(screenmob)
@@ -397,7 +404,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	if (initial(ui_style) || ui_style == new_ui_style)
 		return
 
-	for(var/atom/item in static_inventory + toggleable_inventory + hotkeybuttons + infodisplay + screenoverlays + inv_slots)
+	for(var/atom/item in static_inventory + toggleable_inventory + hotkeybuttons + infodisplay + always_visible_inventory + inv_slots)
 		if (item.icon == ui_style)
 			item.icon = new_ui_style
 

--- a/code/datums/components/fov_handler.dm
+++ b/code/datums/components/fov_handler.dm
@@ -101,6 +101,8 @@
 	applied_mask = FALSE
 	parent_client.screen -= blocker_mask
 	parent_client.screen -= visual_shadow
+	parent_mob.hud_used.always_visible_inventory -= blocker_mask
+	parent_mob.hud_used.always_visible_inventory -= visual_shadow
 
 /datum/component/fov_handler/proc/add_mask()
 	var/mob/parent_mob = parent
@@ -110,6 +112,8 @@
 	applied_mask = TRUE
 	parent_client.screen += blocker_mask
 	parent_client.screen += visual_shadow
+	parent_mob.hud_used.always_visible_inventory += blocker_mask
+	parent_mob.hud_used.always_visible_inventory += visual_shadow
 
 /// When a direction of the user changes, so do the masks
 /datum/component/fov_handler/proc/on_dir_change(mob/source, old_dir, new_dir)


### PR DESCRIPTION

## About The Pull Request
adds a variable to huds containing all screen objects that should be permanently there
fov stuff goes there now rather than not being kept on the screen at all
therefore fov no longer disappears

## Why It's Good For The Game
i must torture lemon.

## Changelog
:cl:
fix: fixes fov removal f12 exploit
/:cl:
