### PR TITLE
Admins can now choose where fish go

### DIFF
--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -88,6 +88,7 @@
 	while (tgui_alert(usr, "Add additional locations? Only applies to your current Z level..", "Carp Direction", list("Yes", "No")) == "Yes")
 		record_admin_location()
 
+/// Stores the admin's current location corresponding to the z level of that location
 /datum/event_admin_setup/carp_migration/proc/record_admin_location()
 	var/turf/aimed_turf = get_turf(usr)
 	var/z_level_key = "[aimed_turf.z]"

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -82,10 +82,10 @@
 
 /datum/event_admin_setup/carp_migration/prompt_admins()
 	targets_per_z = list()
-	if (tgui_alert(usr, "Direct carp to your current location? Only applies to your current Z level.", "Carp Direction", list("Yes", "No")) == "No")
+	if (tgui_alert(usr, "Direct carp to your current location? Only applies to your current Z level.", "Carp Direction", list("Yes", "No")) != "Yes")
 		return
 	record_admin_location()
-	while (tgui_alert(usr, "Add additional locations? Only applies to your current Z level..", "Carp Direction", list("Yes", "No")) == "Yes")
+	while (tgui_alert(usr, "Add additional locations? Only applies to your current Z level.", "More Carp Direction", list("Yes", "No")) == "Yes")
 		record_admin_location()
 
 /// Stores the admin's current location corresponding to the z level of that location

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -7,6 +7,7 @@
 	max_occurrences = 6
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Summons a school of space carp."
+	admin_setup = /datum/event_admin_setup/carp_migration
 
 /datum/round_event_control/carp_migration/New()
 	. = ..()
@@ -27,6 +28,8 @@
 	var/boss_type = /mob/living/basic/carp/mega
 	/// What to describe detecting near the station
 	var/fluff_signal = "Unknown biological entities"
+	/// Associated lists of z level to a list of points to travel to, so that grouped fish move to the same places
+	var/list/z_migration_paths = list()
 
 /datum/round_event/carp_migration/setup()
 	start_when = rand(40, 60)
@@ -37,8 +40,6 @@
 /datum/round_event/carp_migration/start()
 	// Stores the most recent fish we spawn
 	var/mob/living/basic/carp/fish
-	// Associated lists of z level to a list of points to travel to, so that grouped fish move to the same places
-	var/list/z_migration_paths = list()
 
 	for(var/obj/effect/landmark/carpspawn/spawn_point in GLOB.landmarks_list)
 		if(prob(95))
@@ -74,3 +75,25 @@
 	if (!hasAnnounced)
 		announce_to_ghosts(fish) //Only anounce the first fish
 		hasAnnounced = TRUE
+
+/datum/event_admin_setup/carp_migration
+	/// Admin set list of turfs for carp to travel to for each z level
+	var/list/targets_per_z = list()
+
+/datum/event_admin_setup/carp_migration/prompt_admins()
+	targets_per_z = list()
+	if (tgui_alert(usr, "Direct carp to your current location? Only applies to your current Z level.", "Carp Direction", list("Yes", "No")) == "No")
+		return
+	record_admin_location()
+	while (tgui_alert(usr, "Add additional locations? Only applies to your current Z level..", "Carp Direction", list("Yes", "No")) == "Yes")
+		record_admin_location()
+
+/datum/event_admin_setup/carp_migration/proc/record_admin_location()
+	var/turf/aimed_turf = get_turf(usr)
+	var/z_level_key = "[aimed_turf.z]"
+	if (!targets_per_z[z_level_key])
+		targets_per_z[z_level_key] = list()
+	targets_per_z[z_level_key] += WEAKREF(aimed_turf)
+
+/datum/event_admin_setup/carp_migration/apply_to_event(datum/round_event/carp_migration/event)
+	event.z_migration_paths = targets_per_z

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -5,6 +5,7 @@
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
 	description = "Summons a school of carps with magic projectiles."
+	admin_setup = /datum/event_admin_setup/carp_migration
 
 /datum/round_event/carp_migration/wizard
 	carp_type = /mob/living/basic/carp/magic


### PR DESCRIPTION
## About The Pull Request

I've pigeonholed myself as the fish guy now. It seems like someone made events easier to add admin controls for so I thought I'd add some to the event I most recently touched.

Instead of letting the RNG choose admins can now direct a circle of carp to converge upon a specific location, or even a trail of specific locations if they want the carp to just sort of swim in a circle around the space station (although the ones on the far side of the station from the starting point will travel all the way through it to get there). This also works with magicarp.
They don't really move fast enough for you to use this to punish a specific person but you can use it to annoy a specific location full of people.

Plausibly there's no reason the code _wouldn't_ work for a specified atom instead of a turf (as long as it sticks to one z level) but I couldn't think of an elegant way of selecting that whereas "use my current ghost location" is very intuitive, so I didn't add one.

## Why It's Good For The Game

Plausibly this permits admins do more fun things.

## Changelog

:cl:
admin: Admins can direct where carp (or magicarp) are interested in going when manually triggering the event
/:cl: