### PR TITLE
Burn wounds bugfixing

### DIFF
--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -116,10 +116,9 @@
 
 		if(WOUND_INFECTION_SEPTIC to INFINITY)
 			if(DT_PROB(0.5 * infestation, delta_time))
+				strikes_to_lose_limb--
 				switch(strikes_to_lose_limb)
-					if(3 to INFINITY)
-						to_chat(victim, span_deadsay("The skin on your [limb.plaintext_zone] is literally dripping off, you feel awful!"))
-					if(2)
+					if(2 to INFINITY)
 						to_chat(victim, span_deadsay("<b>The infection in your [limb.plaintext_zone] is literally dripping off, you feel horrible!</b>"))
 					if(1)
 						to_chat(victim, span_deadsay("<b>Infection has just about completely claimed your [limb.plaintext_zone]!</b>"))
@@ -128,7 +127,6 @@
 						threshold_penalty = 120 // piss easy to destroy
 						var/datum/brain_trauma/severe/paralysis/sepsis = new (limb.body_zone)
 						victim.gain_trauma(sepsis)
-				strikes_to_lose_limb--
 
 /datum/wound/burn/get_examine_description(mob/user)
 	if(strikes_to_lose_limb <= 0)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -240,6 +240,10 @@
 // people complained about burns not healing on stasis beds, so in addition to checking if it's cured, they also get the special ability to very slowly heal on stasis beds if they have the healing effects stored
 /datum/wound/burn/on_stasis(delta_time, times_fired)
 	. = ..()
+	if(strikes_to_lose_limb == 0) // we've already hit sepsis, nothing more to do
+		if(DT_PROB(0.5, delta_time))
+			victim.visible_message(span_danger("The infection on the remnants of [victim]'s [limb.plaintext_zone] shift and bubble nauseatingly!"), span_warning("You can feel the infection on the remnants of your [limb.plaintext_zone] coursing through your veins!"), vision_distance = COMBAT_MESSAGE_RANGE)
+		return
 	if(flesh_healing > 0)
 		flesh_damage = max(flesh_damage - (0.1 * delta_time), 0)
 	if((flesh_damage <= 0) && (infestation <= 1))

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -158,7 +158,7 @@
 		to_chat(user, span_notice("There's no wounds that require bandaging on [user == M ? "your" : "[M]'s"] [limb.plaintext_zone]!")) // good problem to have imo
 		return
 
-	if(limb.current_gauze && (limb.current_gauze.absorption_capacity * 0.8 > absorption_capacity)) // ignore if our new wrap is < 20% better than the current one, so someone doesn't bandage it 5 times in a row
+	if(limb.current_gauze && (limb.current_gauze.absorption_capacity * 1.2 > absorption_capacity)) // ignore if our new wrap is < 20% better than the current one, so someone doesn't bandage it 5 times in a row
 		to_chat(user, span_warning("The bandage currently on [user == M ? "your" : "[M]'s"] [limb.plaintext_zone] is still in good condition!"))
 		return
 


### PR DESCRIPTION

## About The Pull Request
Fixes three bugs related to burn wounds and medical gauze:

- Septic limbs could still heal slowly in stasis, despite the intention being for the limb to be totally lost
- Limbs undergoing sepsis did not apply the intended cerebral paralysis trauma
- Medical gauze can be re-applied immediately to no effect
## Why It's Good For The Game
Restores the original intent of these mechanics. Burn wounds will be more predictable, as a septic wound can no longer be healed through any means except cryo. Medical gauze now makes more sense and stops you from blowing a whole stack for no effect.
## Changelog
:cl:
fix: burn wounds going septic now properly paralyze the limb
fix: septic burn wounds no longer heal on stasis
fix: gauze now properly stops you from re-wrapping limbs that already have fresh gauze
/:cl:
