### PR TITLE
Fixes bubbles not doing the stage 1 version of the hallucination charge

### DIFF
--- a/code/datums/actions/mobs/charge.dm
+++ b/code/datums/actions/mobs/charge.dm
@@ -227,7 +227,7 @@
 	var/spawn_blood = FALSE
 
 /datum/action/cooldown/mob_cooldown/charge/hallucination_charge/charge_sequence(atom/movable/charger, atom/target_atom, delay, past)
-	if(!enraged)
+	if(!enraged || prob(33))
 		hallucination_charge(target_atom, 6, 8, 0, 6, TRUE)
 		return
 	for(var/i in 0 to 2)


### PR DESCRIPTION

## About The Pull Request
title
![Screenshot (1277)](https://user-images.githubusercontent.com/59183821/215928592-939214b2-4752-424c-99cc-63170894a1a0.png)
## Why It's Good For The Game
restores intended behavior
## Changelog
:cl:
fix: Bubblegum is once again capable of performing his 5 hallucination, one real Bubblegum attack.
/:cl:
