### PR TITLE
Changes spear custom_materials values to be more appropriate

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -65,6 +65,7 @@
 		if(/obj/item/shard/plasma)
 			force = 11
 			throwforce = 21
+			custom_materials = list(/datum/material/iron=1000, /datum/material/glass=2000, /datum/material/plasma=750)
 			icon_prefix = "spearplasma"
 			force_unwielded = 11
 			force_wielded = 19
@@ -74,6 +75,7 @@
 			throwforce = 21
 			throw_range = 8
 			throw_speed = 5
+			custom_materials = list(/datum/material/iron=1000, /datum/material/glass=2000, /datum/material/titanium=750)
 			wound_bonus = -10
 			force_unwielded = 13
 			force_wielded = 18
@@ -84,6 +86,7 @@
 			throwforce = 22
 			throw_range = 9
 			throw_speed = 5
+			custom_materials = list(/datum/material/iron=1000, /datum/material/glass=2000, /datum/material/plasma=750, /datum/material/titanium=750)
 			wound_bonus = -10
 			bare_wound_bonus = 20
 			force_unwielded = 13

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -13,7 +13,7 @@
 	demolition_mod = 0.75
 	embedding = list("impact_pain_mult" = 2, "remove_pain_mult" = 4, "jostle_chance" = 2.5)
 	armour_penetration = 10
-	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
+	custom_materials = list(/datum/material/iron=1000, /datum/material/glass=2000)
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("attack", "poke", "jab", "tear", "lacerate", "gore")
@@ -206,6 +206,7 @@
 
 	throwforce = 22
 	armour_penetration = 15 //Enhanced armor piercing
+	custom_materials = list(/datum/material/bone=7000)
 	force_unwielded = 12
 	force_wielded = 20
 
@@ -220,5 +221,6 @@
 	desc = "A haphazardly-constructed bamboo stick with a sharpened tip, ready to poke holes into unsuspecting people."
 
 	throwforce = 22	//Better to throw
+	custom_materials = list(/datum/material/bamboo=40000)
 	force_unwielded = 10
 	force_wielded = 18

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -65,7 +65,7 @@
 		if(/obj/item/shard/plasma)
 			force = 11
 			throwforce = 21
-			custom_materials = list(/datum/material/iron=1000, /datum/material/glass=2000, /datum/material/plasma=750)
+			custom_materials = list(/datum/material/iron=1000, /datum/material/alloy/plasmaglass=2000)
 			icon_prefix = "spearplasma"
 			force_unwielded = 11
 			force_wielded = 19
@@ -75,7 +75,7 @@
 			throwforce = 21
 			throw_range = 8
 			throw_speed = 5
-			custom_materials = list(/datum/material/iron=1000, /datum/material/glass=2000, /datum/material/titanium=750)
+			custom_materials = list(/datum/material/iron=1000, /datum/material/alloy/titaniumglass=2000)
 			wound_bonus = -10
 			force_unwielded = 13
 			force_wielded = 18
@@ -86,7 +86,7 @@
 			throwforce = 22
 			throw_range = 9
 			throw_speed = 5
-			custom_materials = list(/datum/material/iron=1000, /datum/material/glass=2000, /datum/material/plasma=750, /datum/material/titanium=750)
+			custom_materials = list(/datum/material/iron=1000, /datum/material/alloy/plastitaniumglass=2000)
 			wound_bonus = -10
 			bare_wound_bonus = 20
 			force_unwielded = 13


### PR DESCRIPTION
## About The Pull Request

The iron and glass spear was, for some reason, given material values that perfectly encapsulated the cost of making it: accounting for rod, cable, and shard. No other items as far as I can tell do this, with most tools recycling at a material loss. The material total for the basic spear now only accounts for the rod and the glass, introducing a small loss factor into autolathe recycling.

Different glass spears, such as plasma glass and titanium glass spears, also have been given their appropriate material values.

Bamboo and bone spears are now made of bamboo and bone, and recycle at a much bigger loss factor than their rod/glass counterparts. [Recycling these into an autolathe gets those materials stuck uselessly in the lathe unless you deconstruct the lathe, but that's a completely separate problem that requires a smarter coder than I to fix. autolathes accept a LOT of materials they can't actually use/print rn. #73123]

## Why It's Good For The Game

Crafting and de-crafting a spear is no longer a materially perfect process. Examining a spear made of plant no longer tells you that it's made of iron and glass.

## Changelog
:cl:
fix: Different types of spear now display accurate materials on examine, and recycle appropriately.
/:cl:
