### PR TITLE
Fixes a spelling error in the Reload Configuration confirmation dialog.

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -861,7 +861,7 @@
 	set desc = "Force config reload to world default"
 	if(!check_rights(R_DEBUG))
 		return
-	if(tgui_alert(usr, "Are you absolutely sure you want to reload the configuration from the default path on the disk, wiping any in-round modificatoins?", "Really reset?", list("No", "Yes")) == "Yes")
+	if(tgui_alert(usr, "Are you absolutely sure you want to reload the configuration from the default path on the disk, wiping any in-round modifications?", "Really reset?", list("No", "Yes")) == "Yes")
 		config.admin_reload()
 
 /// A debug verb to check the sources of currently running timers


### PR DESCRIPTION

## About The Pull Request

This, as the title states, fixes a spelling error in the confirmation dialog for the Reload Configuration verb.

Specifically, it changes "modificat**oi**ns" to "modificat**io**ns".

## Why It's Good For The Game

It's nice to not have to look at spelling errors.

## Changelog
:cl:
spellcheck: The word "modifications" is now spelled correctly in the Reload Configuration confirmation dialog.
/:cl:
