### PR TITLE
The toy crossbow nolonger floats nearby your hand when you hold it.

### DIFF
--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -63,6 +63,8 @@
 	inhand_icon_state = "crossbow"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
+	inhand_x_dimension = 32
+	inhand_y_dimension = 32
 	worn_icon_state = "gun"
 	worn_icon = null
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/toy/crossbow


### PR DESCRIPTION

## About The Pull Request

The toy crossbow had its inhand dimensions set incorrectly to 64 causing the inhand sprites to be offset incorrectly, I've set them to 32.
## Why It's Good For The Game

Bugfix.
## Changelog
:cl:
fix: Toy crossbows have had their offset fixed and will now correctly display in your hand.
/:cl:
