### PR TITLE
Clarifies that TRAC bullets are not teleporter compatible

### DIFF
--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -25,7 +25,7 @@
 
 /obj/item/ammo_box/c38/trac
 	name = "speed loader (.38 TRAC)"
-	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant within the target's body."
+	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant within the target's body. The implant's signal is incompatible with teleporters."
 	ammo_type = /obj/item/ammo_casing/c38/trac
 
 /obj/item/ammo_box/c38/match

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -13,7 +13,7 @@
 
 /datum/design/c38_trac
 	name = "Speed Loader (.38 TRAC)"
-	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant within the target's body."
+	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant within the target's body. However, the implant's signal is incompatible with teleporters."
 	id = "c38_trac"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 20000, /datum/material/silver = 5000, /datum/material/gold = 1000)

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -13,7 +13,7 @@
 
 /datum/design/c38_trac
 	name = "Speed Loader (.38 TRAC)"
-	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant within the target's body. However, the implant's signal is incompatible with teleporters."
+	desc = "Designed to quickly reload revolvers. TRAC bullets embed a tracking implant within the target's body. The implant's signal is incompatible with teleporters."
 	id = "c38_trac"
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = 20000, /datum/material/silver = 5000, /datum/material/gold = 1000)


### PR DESCRIPTION

## About The Pull Request

The detective's TRAC bullets embeds tracking implants into people. This implants works similarly to the injectable tracking implant, such as with the Prisoner Console or the Bluespace Locator. However, it has `allow_teleport` set to false, preventing it from being used on the teleporter. This has not been communicated in game, unless if you take out the implant from whoever you shot, and stuck it inside the implanter pad to read its in detail description. 

This PR updates the ammo box and the design datum's description, to make this clearer.

## Why It's Good For The Game

Closes  #73121 , if a future detective examines the box, they will know not to walk into the teleporter room to set up an ambush.

## Changelog
 

:cl:
spellcheck: Clarifies that TRAC bullets are not teleporter compatible
/:cl:
