### PR TITLE
[WEBEDIT INCOMING] Corrects pluoxium and freon gasmix power ratios to their original values.

### DIFF
--- a/code/modules/power/supermatter/supermatter_gas.dm
+++ b/code/modules/power/supermatter/supermatter_gas.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(sm_gas_behavior, init_sm_gas())
 	gas_path = /datum/gas/pluoxium
 	heat_modifier = -1.5
 	power_transmission = -0.5
-	heat_power_generation = 1
+	heat_power_generation = -1
 
 /datum/sm_gas/miasma
 	gas_path = /datum/gas/miasma
@@ -180,7 +180,7 @@ GLOBAL_LIST_INIT(sm_gas_behavior, init_sm_gas())
 	gas_path = /datum/gas/freon
 	heat_modifier = -9
 	power_transmission = -3
-	heat_power_generation = 1
+	heat_power_generation = -1
 
 /datum/sm_gas/hydrogen
 	gas_path = /datum/gas/hydrogen


### PR DESCRIPTION
## About The Pull Request
Changes pluoxium and freon powermix ratio to -1.
## Why It's Good For The Game
They were -1 before #69158. The PR stated there were no changes except for the CO2 thing. It is extremely plausible it was an accidental change during the refactor, as they were undocumented changes, while also countering the point of the gases.
## Changelog
:cl:
fix: Reverts accidental change to pluoxium and freon gasmix power ratio values.
/:cl:
