### PR TITLE
Xenobiology regenerative sepia crossbreed usage's description is corrected

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -156,7 +156,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/sepia
 	colour = "sepia"
-	effect_desc = "Fully heals the target and stops time."
+	effect_desc = "Fully heals the target. After 10 seconds, relocate the target to the initial position the core was used with their previous health status."
 
 /obj/item/slimecross/regenerative/sepia/core_effect_before(mob/living/target, mob/user)
 	to_chat(target, span_notice("You try to forget how you feel."))


### PR DESCRIPTION
## About The Pull Request
Changes the description of the "regenerative sepia crossbreed" to tell what it actually does : Fully heal, then "déjà-vu" on the position it was used.
![image](https://user-images.githubusercontent.com/17699222/216128187-52ac8449-70a3-4d94-8198-c75366f30dd3.png)

"Corrects" #72600 
## Why It's Good For The Game
An OOC description shouldn't be wrong about an item's usage.
## Changelog
:cl:
spellcheck: The regenerative sepia crossbreed's usage description has been corrected
/:cl:
