### PR TITLE
Changes crate description for snake crate

### DIFF
--- a/code/modules/cargo/packs/livestock.dm
+++ b/code/modules/cargo/packs/livestock.dm
@@ -184,7 +184,7 @@
 /datum/supply_pack/critter/snake
 	name = "Snake Crate"
 	desc = "Tired of these MOTHER FUCKING snakes on this MOTHER FUCKING space station? \
-		Then this isn't the crate for you. Contains three poisonous snakes."
+		Then this isn't the crate for you. Contains three venomous snakes."
 	cost = CARGO_CRATE_VALUE * 6
 	access_view = ACCESS_SECURITY
 	contains = list(/mob/living/simple_animal/hostile/retaliate/snake = 3)


### PR DESCRIPTION

## About The Pull Request

Changes the snake cargo crate description from "three poisonous snakes" to "three venomous snakes". While snakes can (rarely) be poisonous, the snakes in-game are venomous. 

## Why It's Good For The Game

Correct word usage is good. Venomous animals inject toxins via bite or sting (which is what the in-game snakes do). Poisonous animals only transfer toxins when they are consumed. 

## Changelog
:cl:
spellcheck: changes the snake crate description from poisonous to venomous
/:cl:
