### PR TITLE
Fixes a bug where glide-size could become out of sync if you get unbuckled

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -152,7 +152,7 @@
 	buckled_mob.set_buckled(null)
 	buckled_mob.set_anchored(initial(buckled_mob.anchored))
 	buckled_mob.clear_alert(ALERT_BUCKLED)
-	buckled_mob.set_glide_size(DELAY_TO_GLIDE_SIZE(buckled_mob.total_multiplicative_slowdown()))
+	buckled_mob.set_glide_size(DELAY_TO_GLIDE_SIZE(buckled_mob.cached_multiplicative_slowdown))
 	buckled_mobs -= buckled_mob
 	if(anchored)
 		REMOVE_TRAIT(buckled_mob, TRAIT_NO_FLOATING_ANIM, BUCKLED_TRAIT)

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -194,13 +194,6 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 	for(var/id in movespeed_mod_immunities)
 		. -= id
 
-/// Calculate the total slowdown of all movespeed modifiers
-/mob/proc/total_multiplicative_slowdown()
-	. = 0
-	for(var/id in get_movespeed_modifiers())
-		var/datum/movespeed_modifier/M = movespeed_modification[id]
-		. += M.multiplicative_slowdown
-
 /// Checks if a move speed modifier is valid and not missing any data
 /proc/movespeed_data_null_check(datum/movespeed_modifier/M) //Determines if a data list is not meaningful and should be discarded.
 	. = TRUE


### PR DESCRIPTION


## About The Pull Request

This fixes a bug where you could theoretically un-sync your glide-size from your movespeed if you unbuckled. Currently, if you unbuckle, we use a proc that's only used there which gets all of the slowdowns from all of your movespeed modifiers. There's two problems with that:

1. We already have a variable with your movespeed (cached)
2. This proc does not check any of the conditionals that might make a movespeed modifier not apply, such as whether or not you are flying, or if you're immune to it for some other reason.

This means that in specific edge-cases you could mess up your glide-size.

I have not actually seen this happen, but this seems like a better way of doing it :)

## Changelog

:cl: Capybara Holly
fix: Fixes a theoretical bug where glide-size could get unsynced from your movespeed after unbuckling
/:cl:
