### PR TITLE
Admin Request: Trigger Event Panel Includes a Gear on Events That Have Admin Setups

### DIFF
--- a/code/modules/admin/force_event.dm
+++ b/code/modules/admin/force_event.dm
@@ -66,7 +66,7 @@
 			"description" = event_control.description,
 			"type" = event_control.type,
 			"category" = event_control.category,
-			"has_customization" = (event_control.admin_setup != null),
+			"has_customization" = !isnull(event_control.admin_setup),
 		))
 	data["categories"] = categories
 	data["events"] = events

--- a/code/modules/admin/force_event.dm
+++ b/code/modules/admin/force_event.dm
@@ -66,6 +66,7 @@
 			"description" = event_control.description,
 			"type" = event_control.type,
 			"category" = event_control.category,
+			"has_customization" = (event_control.admin_setup != null),
 		))
 	data["categories"] = categories
 	data["events"] = events

--- a/tgui/packages/tgui/interfaces/ForceEvent.tsx
+++ b/tgui/packages/tgui/interfaces/ForceEvent.tsx
@@ -1,4 +1,5 @@
 import { paginate } from 'common/collections';
+import { BooleanLike } from 'common/react';
 import { useBackend, useLocalState } from '../backend';
 import { Stack, Button, Icon, Input, Section, Tabs } from '../components';
 import { Window } from '../layouts';
@@ -48,6 +49,7 @@ type Event = {
   description: string;
   type: string;
   category: string;
+  has_customization: BooleanLike;
 };
 
 type Category = {
@@ -146,8 +148,16 @@ export const EventSection = (props, context) => {
               {eventPage.map((event) => (
                 <Stack.Item grow key={event.type}>
                   <Button
-                    tooltip={event.description}
+                    className="Button__rightIcon"
+                    tooltip={
+                      event.description +
+                      (event.has_customization
+                        ? ' Includes admin customization.'
+                        : '')
+                    }
                     fluid
+                    icon={event.has_customization ? 'gear' : undefined}
+                    iconPosition="right"
                     onClick={() =>
                       act('forceevent', {
                         type: event.type,


### PR DESCRIPTION

## About The Pull Request

![image](https://user-images.githubusercontent.com/40974010/216196611-64c943f1-7919-4be5-bd85-021d6c228f37.png)

Admin events with admin setups now have a gear icon on the right of the button.

## Why It's Good For The Game

Requested by @NamelessFairy for future admin compatibility development and a small indication in game of potentially more customizable events for... well, admin events!

## Changelog
:cl:
admin: There's a cog next to events you can trigger if it has an admin setup.
/:cl:
