### PR TITLE
Makes arms regrown by the Rod of Asclepius the correct color

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -254,6 +254,8 @@
 					if(((hand % 2) == 0))
 						var/obj/item/bodypart/L = itemUser.newBodyPart(BODY_ZONE_R_ARM, FALSE, FALSE)
 						if(L.try_attach_limb(itemUser))
+							L.update_limb(is_creating = TRUE)
+							itemUser.update_body_parts()
 							itemUser.put_in_hand(newRod, hand, forced = TRUE)
 						else
 							qdel(L)
@@ -262,6 +264,8 @@
 					else
 						var/obj/item/bodypart/L = itemUser.newBodyPart(BODY_ZONE_L_ARM, FALSE, FALSE)
 						if(L.try_attach_limb(itemUser))
+							L.update_limb(is_creating = TRUE)
+							itemUser.update_body_parts()
 							itemUser.put_in_hand(newRod, hand, forced = TRUE)
 						else
 							qdel(L)


### PR DESCRIPTION

## About The Pull Request

When an arm holding an activated Rod of Asclepius is cut off, the arm grows back with the rod held in it. However, due to an oversight, the arm that grows back is always the "default" color - the albino skintone for humans/felinids, and grey for everyone else. This PR makes the regenerated arm have the proper skintone instead.
## Why It's Good For The Game

There's no good reason that a magical doctoring rod should drain all color from your arm, probably.
## Changelog
:cl:
fix: Corrected the skintone on arms grown back by the Rod of Asclepius
/:cl:
