### PR TITLE
Fixes camera chunks being 1 tile short (kills AI GRID OF DOOM again)

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -156,7 +156,7 @@
 
 		var/image/mirror_from = GLOB.cameranet.obscured_images[GET_Z_PLANE_OFFSET(z_level) + 1]
 		var/turf/chunk_corner = locate(x, y, z_level)
-		for(var/turf/lad as anything in CORNER_BLOCK(chunk_corner, CHUNK_SIZE - 1, CHUNK_SIZE - 1))
+		for(var/turf/lad as anything in CORNER_BLOCK(chunk_corner, CHUNK_SIZE, CHUNK_SIZE)) //we use CHUNK_SIZE for width and height here as it handles subtracting 1 from those two parameters by itself
 			var/image/our_image = new /image(mirror_from)
 			our_image.loc = lad
 			turfs[lad] = our_image


### PR DESCRIPTION
## About The Pull Request
#72709 replaced `block` calculating a new chunk with `CORNER_BLOCK`. The new proc handles subtracting 1 from input `width` and `height` in its own `block` down the line, so doing it here is fucking up chunks.

## Why It's Good For The Game
Frees freelook consoles/AIs from fake freevision in a grid. Kind of a reverse problem that was handled back in #70685, somewhat amusing really
Fixes #73091

## Changelog
:cl:
fix: Nanotrasen Artificial Intelligence Department has repelled a Cybersun attack on AI personalities and advanced camera frameworks that was based on the last year's AI GRID OF DOOM ion law incident. Free-look camera consoles and AIs should no longer have a grid of free vision that also prevents interacting with stuff on the grid.
/:cl:
