### PR TITLE
Smugglers satchels will no longer spawn inside the holodeck.

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -39,12 +39,16 @@ SUBSYSTEM_DEF(minor_mapping)
 
 /datum/controller/subsystem/minor_mapping/proc/place_satchels(amount=10)
 	var/list/turfs = find_satchel_suitable_turfs()
+	///List of areas where satchels should not be placed.
+	var/list/blacklisted_area_types = list(/area/station/holodeck)
 
 	while(turfs.len && amount > 0)
-		var/turf/T = pick_n_take(turfs)
-		var/obj/item/storage/backpack/satchel/flat/F = new(T)
+		var/turf/turf = pick_n_take(turfs)
+		if(is_type_in_list(get_area(turf), blacklisted_area_types))
+			continue
+		var/obj/item/storage/backpack/satchel/flat/flat_satchel = new(turf)
 
-		SEND_SIGNAL(F, COMSIG_OBJ_HIDE, T.underfloor_accessibility)
+		SEND_SIGNAL(flat_satchel, COMSIG_OBJ_HIDE, turf.underfloor_accessibility)
 		amount--
 
 /proc/find_exposed_wires()


### PR DESCRIPTION

## About The Pull Request

Once the holodeck is activated the floors become un-removable thus rendering smugglers satchels in-accessible, I'm pretty sure its unintended to place smugglers satchels on the holodeck as the turfs it uses don't allow for any player interaction.
I also got rid of some single letter variables.
## Why It's Good For The Game

Placing things that are intended to be accessed in inaccessible locations seemed like an oversight to me.
## Changelog
:cl:
fix: Smugglers satchels will no longer spawn inside the holodeck.
/:cl:
