### PR TITLE
Rewrites monkey AI examine text to not mention eyes

### DIFF
--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -87,7 +87,7 @@ have ways of interacting with a specific mob and control it.
 	return ..()
 
 /datum/ai_controller/monkey/get_human_examine_text()
-	var/text = "[span_monkey("[pawn.p_they(TRUE)] have a primal look in [pawn.p_their()] eyes.")]"
+	var/text = "[span_monkey("[pawn.p_they(TRUE)] seem to have mentally regressed to a primal state...")]"
 	return text
 
 /datum/ai_controller/monkey/proc/set_trip_mode(mode = TRUE)

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -87,7 +87,7 @@ have ways of interacting with a specific mob and control it.
 	return ..()
 
 /datum/ai_controller/monkey/get_human_examine_text()
-	var/text = "[span_monkey("[pawn.p_they(TRUE)] seem to have mentally regressed to a primal state...")]"
+	var/text = "[span_monkey("[pawn.p_their(TRUE)] mental state is primal, with only lower-level animalistic thought.")]"
 	return text
 
 /datum/ai_controller/monkey/proc/set_trip_mode(mode = TRUE)


### PR DESCRIPTION

## About The Pull Request

This examine needs to be more generic because we can't ensure a monkey has eyes. Or a head.

## Why It's Good For The Game

Bugfix

## Changelog
:cl:
spellcheck: Changed the monkey ai examine to not mention eyes.
/:cl:
