### PR TITLE
Fixes CQC disarming items that shouldn't drop from a player's hands in the first place

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -221,7 +221,9 @@
 			to_chat(A, span_danger("You strike [D]'s jaw, leaving [D.p_them()] disoriented!"))
 			playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
 			if(I && D.temporarilyRemoveItemFromInventory(I))
-				A.put_in_hands(I)
+				D.dropItemToGround(I) //try dropping the item in active hand
+				if(I.loc == I.drop_location()) //if it didn't drop on the floor below the victim, it probably wasn't supposed to be handed to others (NODROP, backpack-mounted things)
+					A.put_in_hands(I)
 			D.set_jitter_if_lower(4 SECONDS)
 			D.apply_damage(5, A.get_attack_type())
 	else

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -324,27 +324,24 @@
 	to_chat(src, span_danger("You shove [target.name]!"))
 
 	//Take their lunch money
-	var/obj/item/target_held_item = target.get_active_held_item()
+	var/target_held_item = target.get_active_held_item()
 	var/append_message = ""
 	if(!is_type_in_typecache(target_held_item, GLOB.shove_disarming_types)) //It's too expensive we'll get caught
-		target_held_item = null
-
-	if(HAS_TRAIT(target_held_item, TRAIT_NODROP)) //we can't disarm a NODROP item, don't bother with messages
 		target_held_item = null
 
 	if(!target.has_movespeed_modifier(/datum/movespeed_modifier/shove))
 		target.add_movespeed_modifier(/datum/movespeed_modifier/shove)
 		if(target_held_item)
-			append_message = "loosening [target.p_their()] grip on [target_held_item.name]"
-			target.visible_message(span_danger("[target.name]'s grip on \the [target_held_item.name] loosens!"), //He's already out what are you doing
-				span_warning("Your grip on \the [target_held_item.name] loosens!"), null, COMBAT_MESSAGE_RANGE)
+			append_message = "loosening [target.p_their()] grip on [target_held_item]"
+			target.visible_message(span_danger("[target.name]'s grip on \the [target_held_item] loosens!"), //He's already out what are you doing
+				span_warning("Your grip on \the [target_held_item] loosens!"), null, COMBAT_MESSAGE_RANGE)
 		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon, clear_shove_slowdown)), SHOVE_SLOWDOWN_LENGTH)
 
 	else if(target_held_item)
 		target.dropItemToGround(target_held_item)
-		append_message = "causing [target.p_them()] to drop [target_held_item.name]"
-		target.visible_message(span_danger("[target.name] drops \the [target_held_item.name]!"),
-			span_warning("You drop \the [target_held_item.name]!"), null, COMBAT_MESSAGE_RANGE)
+		append_message = "causing [target.p_them()] to drop [target_held_item]"
+		target.visible_message(span_danger("[target.name] drops \the [target_held_item]!"),
+			span_warning("You drop \the [target_held_item]!"), null, COMBAT_MESSAGE_RANGE)
 
 	log_combat(src, target, "shoved", append_message)
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -324,24 +324,27 @@
 	to_chat(src, span_danger("You shove [target.name]!"))
 
 	//Take their lunch money
-	var/target_held_item = target.get_active_held_item()
+	var/obj/item/target_held_item = target.get_active_held_item()
 	var/append_message = ""
 	if(!is_type_in_typecache(target_held_item, GLOB.shove_disarming_types)) //It's too expensive we'll get caught
+		target_held_item = null
+
+	if(HAS_TRAIT(target_held_item, TRAIT_NODROP)) //we can't disarm a NODROP item, don't bother with messages
 		target_held_item = null
 
 	if(!target.has_movespeed_modifier(/datum/movespeed_modifier/shove))
 		target.add_movespeed_modifier(/datum/movespeed_modifier/shove)
 		if(target_held_item)
-			append_message = "loosening [target.p_their()] grip on [target_held_item]"
-			target.visible_message(span_danger("[target.name]'s grip on \the [target_held_item] loosens!"), //He's already out what are you doing
-				span_warning("Your grip on \the [target_held_item] loosens!"), null, COMBAT_MESSAGE_RANGE)
+			append_message = "loosening [target.p_their()] grip on [target_held_item.name]"
+			target.visible_message(span_danger("[target.name]'s grip on \the [target_held_item.name] loosens!"), //He's already out what are you doing
+				span_warning("Your grip on \the [target_held_item.name] loosens!"), null, COMBAT_MESSAGE_RANGE)
 		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon, clear_shove_slowdown)), SHOVE_SLOWDOWN_LENGTH)
 
 	else if(target_held_item)
 		target.dropItemToGround(target_held_item)
-		append_message = "causing [target.p_them()] to drop [target_held_item]"
-		target.visible_message(span_danger("[target.name] drops \the [target_held_item]!"),
-			span_warning("You drop \the [target_held_item]!"), null, COMBAT_MESSAGE_RANGE)
+		append_message = "causing [target.p_them()] to drop [target_held_item.name]"
+		target.visible_message(span_danger("[target.name] drops \the [target_held_item.name]!"),
+			span_warning("You drop \the [target_held_item.name]!"), null, COMBAT_MESSAGE_RANGE)
 
 	log_combat(src, target, "shoved", append_message)
 


### PR DESCRIPTION
## About The Pull Request
Makes CQC disarming try and drop the disarmed item before putting it into hands of Big Boss. This makes sure so items that shouldn't be held by other spessmen don't get disarmed (things like water backpack nozzles for instance, some other things that snap to a backpack or something)

the last two commits should be in another PR lol

## Why It's Good For The Game
Fixes #43100 so no nozzle leaves its home by unlawful means

## Changelog
:cl:
fix: fixed CQC disarming items like backpack tank nozzles or other snappable things that normally can't be passed onto other spessmen
/:cl:
