### PR TITLE
Moths can't eat indestructible items

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -95,7 +95,7 @@
 /obj/item/clothing/attack(mob/living/target, mob/living/user, params)
 	if(user.combat_mode || !ismoth(target) || ispickedupmob(src))
 		return ..()
-	if(clothing_flags & INEDIBLE_CLOTHING)
+	if((clothing_flags & INEDIBLE_CLOTHING) || (resistance_flags & INDESTRUCTIBLE))
 		return ..()
 	if(isnull(moth_snack))
 		moth_snack = new


### PR DESCRIPTION
## About The Pull Request

Prevents mothmen from eating indestructible clothings like the advanced magboots

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/66923 and makes indestructible items not be destructible through the power of your damn mouth.

## Changelog

:cl:
fix: Moths can no longer eat indestructible items (like the CE's magboots)
/:cl: