### PR TITLE
Abductor scientist self-retrieve failure/runtime fix

### DIFF
--- a/code/game/objects/items/implants/implant_abductor.dm
+++ b/code/game/objects/items/implants/implant_abductor.dm
@@ -13,22 +13,28 @@
 		to_chat(imp_in, span_warning("You must wait [timeleft(on_cooldown)*0.1] seconds to use [src] again!"))
 		return
 
-	home.Retrieve(imp_in,1)
+	if(!home)
+		link_pad(imp_in)
+
+	home.Retrieve(imp_in)
 	on_cooldown = addtimer(VARSET_CALLBACK(src, on_cooldown, null), cooldown , TIMER_STOPPABLE)
 
 /obj/item/implant/abductor/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	if(..())
-		var/obj/machinery/abductor/console/console
-		if(ishuman(target))
-			var/datum/antagonist/abductor/A = target.mind.has_antag_datum(/datum/antagonist/abductor)
-			if(A)
-				console = get_abductor_console(A.team.team_number)
-				home = console.pad
-
-		if(!home)
-			var/list/consoles = list()
-			for(var/obj/machinery/abductor/console/C in GLOB.machines)
-				consoles += C
-			console = pick(consoles)
-			home = console.pad
+		link_pad(target)
 		return TRUE
+
+/obj/item/implant/abductor/proc/link_pad(mob/living/mob_to_link)
+	var/obj/machinery/abductor/console/console
+	if(ishuman(mob_to_link))
+		var/datum/antagonist/abductor/A = mob_to_link.mind.has_antag_datum(/datum/antagonist/abductor)
+		if(A)
+			console = get_abductor_console(A.team.team_number)
+			home = console.pad
+
+	if(!home) //If we still cannot find a home associated with our team, we just pick a random pad and make it our own.
+		var/list/consoles = list()
+		for(var/obj/machinery/abductor/console/C in GLOB.machines)
+			consoles += C
+		console = pick(consoles)
+		home = console.pad

--- a/code/game/objects/items/implants/implant_abductor.dm
+++ b/code/game/objects/items/implants/implant_abductor.dm
@@ -14,17 +14,18 @@
 		return
 
 	if(isnull(home) && !link_pad())
-		if(!link_pad())
-			imp_in.balloon_alert(imp_in, "no teleport pads detected!")
-			return
+		imp_in.balloon_alert(imp_in, "no teleport pads detected!")
+		return
 
 	home.Retrieve(imp_in)
 	on_cooldown = addtimer(VARSET_CALLBACK(src, on_cooldown, null), cooldown , TIMER_STOPPABLE)
 
 /obj/item/implant/abductor/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
-	if(..())
-		link_pad()
-		return TRUE
+	if(!..())
+		return FALSE
+
+	link_pad()
+	return TRUE
 
 /**
  * Manages the process of linking a recall implant to an abductor pad
@@ -34,6 +35,9 @@
  */
 
 /obj/item/implant/abductor/proc/link_pad()
+	if(home)
+		return TRUE
+
 	var/obj/machinery/abductor/console/console
 	if(ishuman(imp_in))
 		var/datum/antagonist/abductor/new_abductor = imp_in.mind.has_antag_datum(/datum/antagonist/abductor)

--- a/code/game/objects/items/implants/implant_abductor.dm
+++ b/code/game/objects/items/implants/implant_abductor.dm
@@ -14,7 +14,8 @@
 		return
 
 	if(!home)
-		link_pad(imp_in)
+		if(!link_pad(imp_in))
+			imp_in.balloon_alert(imp_in, "no teleport pads detected!")
 
 	home.Retrieve(imp_in)
 	on_cooldown = addtimer(VARSET_CALLBACK(src, on_cooldown, null), cooldown , TIMER_STOPPABLE)
@@ -37,4 +38,7 @@
 		for(var/obj/machinery/abductor/console/C in GLOB.machines)
 			consoles += C
 		console = pick(consoles)
-		home = console.pad
+		if(console)
+			home = console.pad
+
+	return FALSE //We somehow couldn't find any pads (maybe they're not loaded in yet)

--- a/code/game/objects/items/implants/implant_abductor.dm
+++ b/code/game/objects/items/implants/implant_abductor.dm
@@ -16,6 +16,7 @@
 	if(!home)
 		if(!link_pad(imp_in))
 			imp_in.balloon_alert(imp_in, "no teleport pads detected!")
+			return
 
 	home.Retrieve(imp_in)
 	on_cooldown = addtimer(VARSET_CALLBACK(src, on_cooldown, null), cooldown , TIMER_STOPPABLE)
@@ -31,6 +32,9 @@
 		var/datum/antagonist/abductor/A = mob_to_link.mind.has_antag_datum(/datum/antagonist/abductor)
 		if(A)
 			console = get_abductor_console(A.team.team_number)
+			if(!console)
+				WARNING("Attempted to link [name] within [mob_to_link] to a pad using their abductor antagonist datum, however no associated machinery exists for their team.")
+				return FALSE
 			home = console.pad
 
 	if(!home) //If we still cannot find a home associated with our team, we just pick a random pad and make it our own.
@@ -40,5 +44,8 @@
 		console = pick(consoles)
 		if(console)
 			home = console.pad
+
+	if(home)
+		return TRUE
 
 	return FALSE //We somehow couldn't find any pads (maybe they're not loaded in yet)

--- a/code/game/objects/items/implants/implant_abductor.dm
+++ b/code/game/objects/items/implants/implant_abductor.dm
@@ -13,7 +13,7 @@
 		to_chat(imp_in, span_warning("You must wait [timeleft(on_cooldown)*0.1] seconds to use [src] again!"))
 		return
 
-	if(!home)
+	if(isnull(home) && !link_pad())
 		if(!link_pad())
 			imp_in.balloon_alert(imp_in, "no teleport pads detected!")
 			return
@@ -36,23 +36,28 @@
 /obj/item/implant/abductor/proc/link_pad()
 	var/obj/machinery/abductor/console/console
 	if(ishuman(imp_in))
-		var/datum/antagonist/abductor/A = imp_in.mind.has_antag_datum(/datum/antagonist/abductor)
-		if(A)
-			console = get_abductor_console(A.team.team_number)
+		var/datum/antagonist/abductor/new_abductor = imp_in.mind.has_antag_datum(/datum/antagonist/abductor)
+		if(new_abductor)
+			console = get_abductor_console(new_abductor.team.team_number)
 			if(!console)
 				WARNING("Attempted to link [name] within [imp_in] to a pad using their abductor antagonist datum, however no associated machinery exists for their team.")
 				return FALSE
 			home = console.pad
 
-	if(!home) //If we still cannot find a home associated with our team, we just pick a random pad and make it our own.
+	if(home)
+		return TRUE
+
+	else //If we still cannot find a home associated with our team, we just pick a random pad and make it our own.
 		var/list/consoles = list()
-		for(var/obj/machinery/abductor/console/C in GLOB.machines)
-			consoles += C
+		for(var/obj/machinery/abductor/console/found_console in GLOB.machines)
+			consoles += found_console
 		console = pick(consoles)
 		if(console)
 			home = console.pad
 
 	if(home)
 		return TRUE
+
+	stack_trace("[name] within [imp_in] failed to find any abductor machinery to connect to.")
 
 	return FALSE //We somehow couldn't find any pads (maybe they're not loaded in yet)

--- a/code/game/objects/items/implants/implant_abductor.dm
+++ b/code/game/objects/items/implants/implant_abductor.dm
@@ -14,7 +14,7 @@
 		return
 
 	if(!home)
-		if(!link_pad(imp_in))
+		if(!link_pad())
 			imp_in.balloon_alert(imp_in, "no teleport pads detected!")
 			return
 
@@ -23,7 +23,7 @@
 
 /obj/item/implant/abductor/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
 	if(..())
-		link_pad(target)
+		link_pad()
 		return TRUE
 
 /**

--- a/code/game/objects/items/implants/implant_abductor.dm
+++ b/code/game/objects/items/implants/implant_abductor.dm
@@ -26,14 +26,21 @@
 		link_pad(target)
 		return TRUE
 
-/obj/item/implant/abductor/proc/link_pad(mob/living/mob_to_link)
+/**
+ * Manages the process of linking a recall implant to an abductor pad
+ *
+ * Attempts to link the abductor implant to an abductor console. First, it tries to do so through the abductor's antag datum
+ * If not, a random teleport pad will be defaulted to. Returns TRUE if a home is found, and FALSE is one somehow is not.
+ */
+
+/obj/item/implant/abductor/proc/link_pad()
 	var/obj/machinery/abductor/console/console
-	if(ishuman(mob_to_link))
-		var/datum/antagonist/abductor/A = mob_to_link.mind.has_antag_datum(/datum/antagonist/abductor)
+	if(ishuman(imp_in))
+		var/datum/antagonist/abductor/A = imp_in.mind.has_antag_datum(/datum/antagonist/abductor)
 		if(A)
 			console = get_abductor_console(A.team.team_number)
 			if(!console)
-				WARNING("Attempted to link [name] within [mob_to_link] to a pad using their abductor antagonist datum, however no associated machinery exists for their team.")
+				WARNING("Attempted to link [name] within [imp_in] to a pad using their abductor antagonist datum, however no associated machinery exists for their team.")
 				return FALSE
 			home = console.pad
 


### PR DESCRIPTION
## About The Pull Request

Since the abductor outfit/implant would load before the abductor ship (and it's teleport pad) when first generating a team, a runtime would occur when trying to link the pad to the implant. Another would occur every time you attempted to retrieve yourself (as the linked pad would be null), preventing recall and completely neutering an abductor team's most important maneuver.

Now, using the implant will perform the linking process again if no linked pad is found, and provides the owner with a warning if (by some great calamity) they genuinely have no pad to teleport back to. This solves the issue of the implant sometimes not linking to a pad properly on initialize, and makes them way less prone to breaking.

Apparently this has been broken for a while, presumably since the abductor ship was made into a lazyloading template.
## Why It's Good For The Game

The funny silly grey men get to torture the poor hapless crew once again.
## Changelog
:cl:
fix: abductor scientist's retrieval implants will now properly recall the owner, and inform them upon recall failure.
/:cl:
