### PR TITLE
Disks don't delete eachother & Grammar fix

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -383,7 +383,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		. = CONTEXTUAL_SCREENTIP_SET
 
 	if(inserted_disk)
-		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Remove SSD"
+		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = "Remove Disk"
 		. = CONTEXTUAL_SCREENTIP_SET
 	return . || NONE
 
@@ -780,6 +780,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 
 	// Insert a data disk
 	if(istype(attacking_item, /obj/item/computer_disk))
+		if(inserted_disk)
+			return
 		if(!user.transferItemToLoc(attacking_item, src))
 			return
 		inserted_disk = attacking_item

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -781,7 +781,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	// Insert a data disk
 	if(istype(attacking_item, /obj/item/computer_disk))
 		if(inserted_disk)
-			return
+			user.put_in_hands(inserted_disk)
+			balloon_alert(user, "disks swapped")
 		if(!user.transferItemToLoc(attacking_item, src))
 			return
 		inserted_disk = attacking_item


### PR DESCRIPTION
## About The Pull Request

CtrlShift LMB screentip key now says you'll remove the disk instead of the drive, to be more accurate to what it does. Also checks for a disk when you try to add a new one in, preventing new disks from deleting the old by swapping disks instead.

## Why It's Good For The Game

Bug fixes for feature freeze, swag
Adds a better description and prevents the deletion of disks.

## Changelog

:cl:
fix: Computers no longer delete disks if you try to add a second one.
spellcheck: Computer screentips says you're now removing the disk instead of the SSD.
/:cl: