### PR TITLE
Station traits won't roll twice

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -75,7 +75,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 		return
 	for(var/iterator in 1 to amount)
 		var/datum/station_trait/trait_type = pick_weight(selectable_traits_by_types[trait_sign]) //Rolls from the table for the specific trait type
-		selectable_traits_by_types[initial(trait_type.trait_type)] -= trait_type
+		selectable_traits_by_types[trait_sign] -= trait_type
 		setup_trait(trait_type)
 
 ///Creates a given trait of a specific type, while also removing any blacklisted ones from the future pool.

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -68,12 +68,14 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_count)
 	pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_count)
 
-///Picks traits of a specific category (e.g. bad or good) and a specified amount, then initializes them and adds them to the list of traits.
+///Picks traits of a specific category (e.g. bad or good) and a specified amount, then initializes them, adds them to the list of traits,
+///then removes them from possible traits as to not roll twice.
 /datum/controller/subsystem/processing/station/proc/pick_traits(trait_sign, amount)
 	if(!amount)
 		return
 	for(var/iterator in 1 to amount)
 		var/datum/station_trait/trait_type = pick_weight(selectable_traits_by_types[trait_sign]) //Rolls from the table for the specific trait type
+		selectable_traits_by_types[initial(trait_type.trait_type)] -= trait_type
 		setup_trait(trait_type)
 
 ///Creates a given trait of a specific type, while also removing any blacklisted ones from the future pool.


### PR DESCRIPTION
## About The Pull Request

Station traits can't roll twice in the same round.
They currently have blacklist for traits that can't roll together, this makes them not roll with themselves too.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/61873
Station traits are not made with rolling twice in the same round in mind, and is just a waste of trait points, or will just be annoying (like in the issue report's case)

## Changelog

:cl:
fix: There will no longer have 2 of the same station trait roll twice in the same round.
/:cl:
