### PR TITLE
Fixes ghost roles announcing when they fail

### DIFF
--- a/code/modules/events/ghost_role/_ghost_role.dm
+++ b/code/modules/events/ghost_role/_ghost_role.dm
@@ -35,30 +35,35 @@
 		addtimer(CALLBACK(src, PROC_REF(try_spawning), 0, ++retry), waittime)
 		return
 
-	if(status == MAP_ERROR)
-		message_admins("[role_name] cannot be spawned due to a map error.")
-	else if(status == NOT_ENOUGH_PLAYERS)
-		message_admins("[role_name] cannot be spawned due to lack of players \
-			signing up.")
-		deadchat_broadcast(" did not get enough candidates ([minimum_required]) to spawn.", "<b>[role_name]</b>", message_type=DEADCHAT_ANNOUNCEMENT)
-	else if(status == SUCCESSFUL_SPAWN)
-		message_admins("[role_name] spawned successfully.")
-		if(spawned_mobs.len)
-			for (var/mob/M in spawned_mobs)
-				announce_to_ghosts(M)
-		else
-			message_admins("No mobs found in the `spawned_mobs` list, this is \
-				a bug.")
-	else
-		message_admins("An attempt to spawn [role_name] returned [status], \
-			this is a bug.")
+	if(!status)
+		message_admins("An attempt to spawn [role_name] returned [status], this is a bug.")
+		kill()
+		return
+
+	switch(status)
+		if(MAP_ERROR)
+			message_admins("[role_name] cannot be spawned due to a map error.")
+			kill()
+			return
+		if(NOT_ENOUGH_PLAYERS)
+			message_admins("[role_name] cannot be spawned due to lack of players signing up.")
+			deadchat_broadcast(" did not get enough candidates ([minimum_required]) to spawn.", "<b>[role_name]</b>", message_type=DEADCHAT_ANNOUNCEMENT)
+			kill()
+			return
+		if(SUCCESSFUL_SPAWN)
+			message_admins("[role_name] spawned successfully.")
+			if(spawned_mobs.len)
+				for (var/mob/mobs as anything in spawned_mobs)
+					announce_to_ghosts(mobs)
+			else
+				message_admins("No mobs found in the `spawned_mobs` list, this is a bug.")
 
 	processing = TRUE
 
 /datum/round_event/ghost_role/proc/spawn_role()
 	// Return true if role was successfully spawned, false if insufficent
 	// players could be found, and just runtime if anything else happens
-	return TRUE
+	return FALSE
 
 /datum/round_event/ghost_role/proc/get_candidates(jobban, be_special)
 	// Returns a list of candidates in priority order, with candidates from

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -54,9 +54,8 @@
 		spawned_mobs += S
 	if(!isnull(leader))
 		gear_fugitive_leader(leader, landing_turf, backstory)
-	return SUCCESSFUL_SPAWN
 
-//after spawning
+	//after spawning
 	playsound(src, 'sound/weapons/emitter.ogg', 50, TRUE)
 	new /obj/item/storage/toolbox/mechanical(landing_turf) //so they can actually escape maint
 	addtimer(CALLBACK(src, PROC_REF(spawn_hunters)), 10 MINUTES)

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -54,6 +54,7 @@
 		spawned_mobs += S
 	if(!isnull(leader))
 		gear_fugitive_leader(leader, landing_turf, backstory)
+	return SUCCESSFUL_SPAWN
 
 //after spawning
 	playsound(src, 'sound/weapons/emitter.ogg', 50, TRUE)


### PR DESCRIPTION
## About The Pull Request

Fixes ghost roles from being announced if they haven't managed to get a player to spawn as the mob. We do this by killing and returning when we fail to spawn a player, while the ruleset isn't processing.

Also makes these rulesets FAIL by default, so they aren't secretly passing events that don't exist.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/38241
Players no longer get announced about events that aren't occurring, and weren't intended to be played (like fake announcements), making actual fake announcements actually fake.

## Changelog

:cl:
fix: Announcements of ghost roles don't play if no one accepts the poll to play as the role.
/:cl: