### PR TITLE
Run Linters Provides Context On Code Annotations

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - master
     - 'project/**'
+env:
+  REPOSITORY_URL: ${{ GITHUB_SERVER_URL }}/tgstation/tgstation
+  PR_NUMBER: ${{ github.event.number }}
 jobs:
   run_linters:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
@@ -57,6 +60,9 @@ jobs:
           tools/build/build --ci lint tgui-test
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test
+          echo
+          echo If you do not readily see any errors here, please check your code for annotations: ${{ REPOSITORY_URL }}/${{ PR_NUMBER }}/files
+          echo
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
         uses: yogstation13/DreamAnnotate@v2

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -9,7 +9,7 @@ on:
     - master
     - 'project/**'
 env:
-  REPOSITORY_URL: ${{ GITHUB_SERVER_URL }}/tgstation/tgstation
+  REPOSITORY_URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
   PR_NUMBER: ${{ github.event.number }}
 jobs:
   run_linters:
@@ -61,7 +61,7 @@ jobs:
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test
           echo
-          echo If you do not readily see any errors here, please check your code for annotations: ${{ REPOSITORY_URL }}/${{ PR_NUMBER }}/files
+          echo "If you do not readily see any errors here, please check your code for annotations: ${{ env.REPOSITORY_URL }}/${{ env.PR_NUMBER }}/files"
           echo
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -9,8 +9,7 @@ on:
     - master
     - 'project/**'
 env:
-  REPOSITORY_URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY
-  PR_NUMBER: ${{ github.event.number }}
+  ASSOCIATED_FILES_URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/${{ github.event.number }}/files
 jobs:
   run_linters:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
@@ -51,6 +50,7 @@ jobs:
           tools/bootstrap/python -c ''
       - name: Run Linters
         run: |
+          echo "Check ${{ env.ASSOCIATED_FILES_URL }} for potential annotations."
           bash tools/ci/check_filedirs.sh tgstation.dme
           bash tools/ci/check_changelogs.sh
           bash tools/ci/check_grep.sh
@@ -60,7 +60,7 @@ jobs:
           tools/build/build --ci lint tgui-test
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test
-          echo "If you do not readily see any errors here, you may need to check your code for annotations: ${{ env.REPOSITORY_URL }}/pull/${{ env.PR_NUMBER }}/files"
+          echo "If you do not readily see any errors here, you may need to check your code for annotations: ${{ env.ASSOCIATED_FILES_URL }}"
           echo "You may also expand the Annotate Lints category below this one, but the link above will offer the greatest context when available."
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -60,9 +60,8 @@ jobs:
           tools/build/build --ci lint tgui-test
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test
-          echo
-          echo "If you do not readily see any errors here, please check your code for annotations: ${{ env.REPOSITORY_URL }}/${{ env.PR_NUMBER }}/files"
-          echo
+          echo "If you do not readily see any errors here, you may need to check your code for annotations: ${{ env.REPOSITORY_URL }}/pull/${{ env.PR_NUMBER }}/files"
+          echo "You may also expand the Annotate Lints category below this one, but the link above will offer the greatest context."
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
         uses: yogstation13/DreamAnnotate@v2

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -9,7 +9,7 @@ on:
     - master
     - 'project/**'
 env:
-  ASSOCIATED_FILES_URL: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/${{ github.event.number }}/files
+  ASSOCIATED_FILES_URL: ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number }}/files
 jobs:
   run_linters:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -61,7 +61,7 @@ jobs:
           tools/bootstrap/python -m dmi.test
           tools/bootstrap/python -m mapmerge2.dmm_test
           echo "If you do not readily see any errors here, you may need to check your code for annotations: ${{ env.REPOSITORY_URL }}/pull/${{ env.PR_NUMBER }}/files"
-          echo "You may also expand the Annotate Lints category below this one, but the link above will offer the greatest context."
+          echo "You may also expand the Annotate Lints category below this one, but the link above will offer the greatest context when available."
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
         uses: yogstation13/DreamAnnotate@v2


### PR DESCRIPTION
## About The Pull Request

In a nutshell, this adds a small message to the bottom of Run Linters workflow with a dynamically generated link to the files tab of the PR that we were ran on, as well as some information on the annotated file.
## Why It's Good For The Game

While I was reviewing some code [here](https://github.com/tgstation/tgstation/actions/runs/4070373970/jobs/7011149978), I was frustrated because I kept scrolling up and down the Run Linters dropdown trying to see what failed. Then, I remembered that it probably was a code annotation/dreamchecker-esque failure (which it was). I realized how fuckin' silly it was for me to forget given my experience with linters, and I realized that it is doubly more unintuitive for new contributors to realize where the feedback to their linters failing are.

So, let's just give them a usable message at the top and bottom of that specific run. Sounds neat to me.

See it in action here: https://github.com/tgstation/tgstation/actions/runs/4081509942/jobs/7034948882

![image](https://user-images.githubusercontent.com/34697715/216523538-3f49bac6-51d2-4583-8946-37449da48638.png)
## Changelog
This doesn't impact players.
