### PR TITLE
Do not alert admins when an inert BoH is made

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -45,8 +45,6 @@ other types of metals and chemistry for reagents).
 	var/maxstack = 1
 	/// How many times faster than normal is this to build on the protolathe
 	var/lathe_time_factor = 1
-	/// If this is [TRUE] the admins get notified whenever anyone prints this. Currently only used by the BoH.
-	var/dangerous_construction = FALSE
 	/// Bitflags indicating what departmental lathes should be allowed to process this design.
 	var/departmental_flags = ALL
 	/// What techwebs nodes unlock this design. Constructed by SSresearch

--- a/code/modules/research/designs/bluespace_designs.dm
+++ b/code/modules/research/designs/bluespace_designs.dm
@@ -25,7 +25,6 @@
 	category = list(
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SCIENCE
 	)
-	dangerous_construction = TRUE
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/bluespace_crystal

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -218,7 +218,7 @@
 
 	return ..()
 
-/obj/machinery/rnd/production/proc/do_print(path, amount, list/matlist, )
+/obj/machinery/rnd/production/proc/do_print(path, amount, list/matlist)
 	usr.investigate_log("built [amount] of [path] at [src]([type]).", INVESTIGATE_RESEARCH)
 
 	for(var/i in 1 to amount)

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -218,10 +218,8 @@
 
 	return ..()
 
-/obj/machinery/rnd/production/proc/do_print(path, amount, list/matlist, notify_admins)
-	if(notify_admins && ismob(usr))
-		usr.investigate_log("built [amount] of [path] at [src]([type]).", INVESTIGATE_RESEARCH)
-		message_admins("[ADMIN_LOOKUPFLW(usr)] has built [amount] of [path] at \a [src]([type]).")
+/obj/machinery/rnd/production/proc/do_print(path, amount, list/matlist, )
+	usr.investigate_log("built [amount] of [path] at [src]([type]).", INVESTIGATE_RESEARCH)
 
 	for(var/i in 1 to amount)
 		new path(get_turf(src))
@@ -335,7 +333,7 @@
 	var/time_coefficient = design.lathe_time_factor * efficiency_coeff
 
 	addtimer(CALLBACK(src, PROC_REF(reset_busy)), (30 * time_coefficient * print_quantity) ** 0.5)
-	addtimer(CALLBACK(src, PROC_REF(do_print), design.build_path, print_quantity, efficient_mats, design.dangerous_construction), (32 * time_coefficient * print_quantity) ** 0.8)
+	addtimer(CALLBACK(src, PROC_REF(do_print), design.build_path, print_quantity, efficient_mats), (32 * time_coefficient * print_quantity) ** 0.8)
 
 	return TRUE
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -219,8 +219,6 @@
 	return ..()
 
 /obj/machinery/rnd/production/proc/do_print(path, amount, list/matlist)
-	usr.investigate_log("built [amount] of [path] at [src]([type]).", INVESTIGATE_RESEARCH)
-
 	for(var/i in 1 to amount)
 		new path(get_turf(src))
 


### PR DESCRIPTION
## About The Pull Request
Removes the `dangerous_construction` variable that was only used by the BoH, as well as the admin message sent when an inert BoH was printed.

## Why It's Good For The Game
Since the bag of holding changes, admins don't need to know when an inert BoH is printed.

## Changelog

:cl: Tattle
admin: Admins are no longer alerted when an inert BoH is printed
/:cl: