### PR TITLE
Adds arrivals to the station

### DIFF
--- a/code/game/area/areas/station.dm
+++ b/code/game/area/areas/station.dm
@@ -340,7 +340,7 @@
 /area/station/hallway/secondary/entry
 	name = "\improper Arrival Shuttle Hallway"
 	icon_state = "entry"
-	area_flags = EVENT_PROTECTED
+	area_flags = UNIQUE_AREA | EVENT_PROTECTED
 
 /area/station/hallway/secondary/service
 	name = "\improper Service Hallway"


### PR DESCRIPTION
## About The Pull Request

Arrivals previously wasn't part of GLOB.the_station_areas because it wasn't a unique area, this fixes that

## Why It's Good For The Game

Arrivals is part of the station and is a unique area, their area flags should reflect that.

## Changelog

:cl:
fix: Arrivals is now part of the station's areas.
/:cl:
