### PR TITLE
Makes AI controlled aliens spit acid (almost), which deals burn damage instead of toxin.

### DIFF
--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -15,5 +15,7 @@
 	return ..()
 
 /obj/projectile/neurotoxin/damaging //for ai controlled aliums
+	name = "acid spit"
 	damage = 30
+	damage_type = BURN
 	paralyze = 0 SECONDS


### PR DESCRIPTION

## About The Pull Request
So, AI controlled xenos, which you can meet on CharlieStation or Lavaland, spit with neurotoxin, which straigh up deals toxin damage and i remember it dealing brute damage, so it the whole idea.
Changes subtypes projectile name and damage_type, so it will write that it spits acid instead of neurotoxin when it hits someone and deal burn damage.
## Why It's Good For The Game
I dont know.
## Changelog
:cl:
add: AI controlled xenomorphs now spit acid, which deals burn damage instead of toxin.
/:cl:
