### PR TITLE
Deletes Rapid_melee on wendigo

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -34,7 +34,6 @@ Difficulty: Hard
 	aggro_vision_range = 18 // man-eating for a reason
 	speed = 6
 	move_to_delay = 6
-	rapid_melee = 8 // every 1/4 second
 	melee_queue_distance = 18 // as far as possible really, need this because of charging and teleports
 	ranged = TRUE
 	pixel_x = -16

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/wendigo.dm
@@ -34,7 +34,6 @@ Difficulty: Hard
 	aggro_vision_range = 18 // man-eating for a reason
 	speed = 6
 	move_to_delay = 6
-	melee_queue_distance = 18 // as far as possible really, need this because of charging and teleports
 	ranged = TRUE
 	pixel_x = -16
 	base_pixel_x = -16


### PR DESCRIPTION

## About The Pull Request
Deletes Rapid_melee on wendigo.
Also closes https://github.com/tgstation/tgstation/issues/72555
## Why It's Good For The Game
Currently Wendigo has a rare chance (or maybe some weird trigger that I was only rarely able to activate) of activating rapid_melee, causing it to attack 8 times per second. I don't think Wendigo doing 224 damage to someone wearing Ash Drake armor is intended so I think it's safe to say this is an unintended bug.
## Changelog
:cl:
fix: Wendigo no longer has a chance to melee attack 8 times in a second.
/:cl:
