### PR TITLE
Fix incorrectly passed biotype args in take_overall_damage

### DIFF
--- a/code/datums/brain_damage/magic.dm
+++ b/code/datums/brain_damage/magic.dm
@@ -27,7 +27,7 @@
 	if(COOLDOWN_FINISHED(src, damage_warning_cooldown))
 		to_chat(owner, span_warning("<b>The light burns you!</b>"))
 		COOLDOWN_START(src, damage_warning_cooldown, 10 SECONDS)
-	owner.take_overall_damage(0, 1.5 * delta_time)
+	owner.take_overall_damage(burn = 1.5 * delta_time)
 
 /datum/brain_trauma/magic/poltergeist
 	name = "Poltergeist"

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -58,7 +58,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
 	if(amount > 0)
-		take_overall_damage(amount, 0, updating_health, required_bodytype)
+		take_overall_damage(brute = amount, updating_health = updating_health, required_bodytype = required_bodytype)
 	else
 		heal_overall_damage(abs(amount), 0, required_bodytype, updating_health)
 	return amount
@@ -74,7 +74,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
 	if(amount > 0)
-		take_overall_damage(0, amount, updating_health, required_bodytype)
+		take_overall_damage(burn = amount, updating_health = updating_health, required_bodytype = required_bodytype)
 	else
 		heal_overall_damage(0, abs(amount), required_bodytype, updating_health)
 	return amount
@@ -245,7 +245,7 @@
 		update_damage_overlays()
 
 /// damage MANY bodyparts, in random order
-/mob/living/carbon/take_overall_damage(brute = 0, burn = 0, updating_health = TRUE, required_bodytype)
+/mob/living/carbon/take_overall_damage(brute = 0, burn = 0, stamina = 0, updating_health = TRUE, required_bodytype)
 	if(status_flags & GODMODE)
 		return //godmode
 

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -357,7 +357,7 @@
 			H.adjustOxyLoss(-0.5 * delta_time)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
-		H.take_overall_damage(2,0)
+		H.take_overall_damage(brute = 2, required_bodytype = BODYTYPE_ORGANIC)
 
 /datum/species/golem/wood/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H, delta_time, times_fired)
 	if(chem.type == /datum/reagent/toxin/plantbgone)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -55,7 +55,7 @@
 		H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
-		H.take_overall_damage(1 * delta_time)
+		H.take_overall_damage(brute = 1 * delta_time, required_bodytype = BODYTYPE_ORGANIC)
 	..()
 
 /datum/species/pod/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H, delta_time, times_fired)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -55,7 +55,7 @@
 		H.set_nutrition(NUTRITION_LEVEL_ALMOST_FULL)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
-		H.take_overall_damage(1 * delta_time, 0)
+		H.take_overall_damage(1 * delta_time)
 	..()
 
 /datum/species/pod/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H, delta_time, times_fired)

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -101,7 +101,7 @@
 	var/light_amount = owner_turf.get_lumcount()
 
 	if(light_amount > SHADOW_SPECIES_LIGHT_THRESHOLD) //if there's enough light, start dying
-		owner.take_overall_damage(0.5 * delta_time, 0.5 * delta_time, 0, BODYTYPE_ORGANIC)
+		owner.take_overall_damage(brute = 0.5 * delta_time, burn = 0.5 * delta_time, required_bodytype = BODYTYPE_ORGANIC)
 	else if (light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD) //heal in the dark
 		owner.heal_overall_damage(0.5 * delta_time, 0.5 * delta_time, BODYTYPE_ORGANIC)
 

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -141,7 +141,7 @@
 	else if(issilicon(user))
 		if(prob(20))
 			user.Stun(40)
-		user.take_overall_damage(0, shock_damage)
+		user.take_overall_damage(burn = shock_damage)
 		user.visible_message(span_danger("[user.name] is shocked by the [src.name]!"), \
 		span_userdanger("Energy pulse detected, system damaged!"), \
 		span_hear("You hear an electrical crack."))


### PR DESCRIPTION

## About The Pull Request

The linters in #73202 revealed to me that `heal_overall_damage` was overridden wrong in `carbon` and left out an argument, meaning that plausibly some places that didn't provide an argument for `stamina` probably had an off-by-one error with args and wouldn't apply them properly.
I fixed that in that PR because it was using it. Then I noticed that the same problem exists in `take_overall_damage` so I am fixing that too.

I don't know if this was linked to any actual bugs, but it might cause some. They'd be hard to spot because it'd be for stuff like "a shadowperson with a prosthetic takes damage to their prosthetic if not in darkness" and probably nobody would even get into that situation let alone notice to report it.

## Why It's Good For The Game

We want arguments to do what they are supposed to do.

## Changelog

:cl:
fix: Biotypes will be more consistently applied when taking damage, pod and shadowperson prosthetic limbs won't be corroded due to light levels.
fix: Podperson and Wooden Golem prosthetic limbs won't be corroded by having a hungry tummy.
/:cl:
