### PR TITLE
Redoes the admin verb define to require passing in an Admin Visible Name, and restores the usage of '-' for the verb bar when you want to call verbs from the command bar. Also cleans up and organizes the backend for drawing verbs to make it easier in the future for me to make it look better

### DIFF
--- a/code/__HELPERS/admin_verb.dm
+++ b/code/__HELPERS/admin_verb.dm
@@ -1,10 +1,10 @@
 /**
  * Creates an admin verb with the specified module(category) name, desc, permissions, and parameters as needed.
  */
-#define ADMIN_VERB(module, verb_name, verb_desc, permissions, params...) \
-/mob/admin_module_holder/##module/##verb_name/verb/invoke(##params){ \
+#define ADMIN_VERB(module, verb_id, verb_name, verb_desc, permissions, params...) \
+/mob/admin_module_holder/##module/##verb_id/verb/invoke(##params){ \
 	set src in usr.group; \
-	set name = #verb_name; \
+	set name = verb_name; \
 	set desc = verb_desc; \
 	if(datum_flags & DF_VAR_EDITED) { \
 		message_admins("[key_name_admin(usr)] attempted to elevate permissions by executing from a var edited admin verb holder!"); \
@@ -16,16 +16,16 @@
 		return; \
 	} \
 	if(check_rights_for(usr.client, permissions)) { \
-		_##verb_name(arglist(args)); \
-		SSblackbox.record_feedback("tally", "admin_verb", 1, "[#module]/[#verb_name]"); \
+		_##verb_id(arglist(args)); \
+		SSblackbox.record_feedback("tally", "admin_verb", 1, "[#module]/[#verb_id]"); \
 	} else { \
 		to_chat(usr, span_warning("You lack the permissions ([rights2text(permissions, " ")]) for this verb!")); \
 	} \
 } \
-/mob/admin_module_holder/##module/##verb_name/dynamic_map_generate(){ \
-	return list(#module, #verb_name, verb_desc, permissions); \
+/mob/admin_module_holder/##module/##verb_id/dynamic_map_generate(){ \
+	return list(#module, verb_name, verb_desc, permissions); \
 } \
-/mob/admin_module_holder/##module/##verb_name/proc/_##verb_name(##params)
+/mob/admin_module_holder/##module/##verb_id/proc/_##verb_id(##params)
 
 /**
  * Creates a context menu entry for the client. The source of this proc will be the client!

--- a/code/controllers/subsystem/admin_verbs.dm
+++ b/code/controllers/subsystem/admin_verbs.dm
@@ -72,20 +72,11 @@ GENERAL_PROTECT_DATUM(/datum/controller/subsystem/admin_verbs)
 			cached_formats[verb_module] = verb_module_formatted
 
 		var/original_name = verb_information[VERB_MAP_NAME]
-		if(!cached_formats[original_name])
-			var/formatted_name = ""
-			for(var/name_part in splittext(original_name, "_"))
-				if(name_part in abbreviations)
-					formatted_name += "[uppertext(name_part)] "
-				else
-					formatted_name += "[capitalize(name_part)] "
-			formatted_name = copytext(formatted_name, 1, -1)
-			cached_formats[original_name] = formatted_name
 
 		var/verb_desc = verb_information[VERB_MAP_DESCRIPTION]
 		if(!stat_data[cached_formats[verb_module]])
 			stat_data[cached_formats[verb_module]] = list()
-		stat_data[cached_formats[verb_module]] += list(list(cached_formats[original_name], verb_desc, original_name))
+		stat_data[cached_formats[verb_module]] += list(list(original_name, verb_desc, original_name))
 	var/sorted_stat_data = list()
 	for(var/verb_category in stat_data)
 		sorted_stat_data[verb_category] = sort_list(stat_data[verb_category], GLOBAL_PROC_REF(cmp_admin_verb_name))

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -81,7 +81,7 @@ SUBSYSTEM_DEF(explosions)
 	flameturf -= T
 	throwturf -= T
 
-ADMIN_VERB(debug, check_bomb_impact, "", R_DEBUG)
+ADMIN_VERB(debug, check_bomb_impact, "Check Bomb Impact", "", R_DEBUG)
 	var/newmode = tgui_alert(usr, "Use reactionary explosions?","Check Bomb Impact", list("Yes", "No"))
 	var/turf/epicenter = get_turf(usr)
 	if(!epicenter)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -603,7 +603,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 		holodeck_templates[holo_template.template_id] = holo_template
 
-ADMIN_VERB(events, load_away_mission, "", R_FUN)
+ADMIN_VERB(events, load_away_mission, "Load Away Mission", "", R_FUN)
 	if(!GLOB.the_gateway)
 		if(tgui_alert(usr, "There's no home gateway on the station. You sure you want to continue ?", "Uh oh", list("Yes", "No")) != "Yes")
 			return

--- a/code/datums/components/puzzgrid.dm
+++ b/code/datums/components/puzzgrid.dm
@@ -276,7 +276,7 @@
 
 /// Debug verb for validating that all puzzgrids can be created successfully.
 /// Locked behind a verb because it's fairly slow and memory intensive.
-ADMIN_VERB(debug, validate_puzzgrids, "", R_DEBUG)
+ADMIN_VERB(debug, validate_puzzgrids, "Validate Puzzgrids", "", R_DEBUG)
 	var/line_number = 0
 
 	for (var/line in world.file2list(PUZZGRID_CONFIG))

--- a/code/datums/station_traits/admin_panel.dm
+++ b/code/datums/station_traits/admin_panel.dm
@@ -1,6 +1,6 @@
 /// Opens the station traits admin panel
 
-ADMIN_VERB(events, modify_station_traits, "", R_FUN)
+ADMIN_VERB(events, modify_station_traits, "Modify Station Traits", "", R_FUN)
 	var/static/datum/station_traits_panel/station_traits_panel
 	if(!station_traits_panel)
 		station_traits_panel = new

--- a/code/game/gamemodes/dynamic/dynamic_simulations.dm
+++ b/code/game/gamemodes/dynamic/dynamic_simulations.dm
@@ -69,7 +69,7 @@
 	var/forced_threat_level
 
 #ifdef TESTING
-ADMIN_VERB(debug, run_dynamic_simulations, "", R_DEBUG)
+ADMIN_VERB(debug, run_dynamic_simulations, "Run Dynamic Simulations", "", R_DEBUG)
 	var/simulations = input(usr, "Enter number of simulations") as num
 	var/roundstart_players = input(usr, "Enter number of round start players") as num
 	var/forced_threat_level = input(usr, "Enter forced threat level, if you want one") as num | null

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -46,14 +46,9 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////ADMIN HELPER PROCS
 
-/datum/admins/proc/spawn_atom(object as text)
-	set category = "Debug"
-	set desc = "(atom path) Spawn an atom"
-	set name = "Spawn"
-
-	if(!check_rights(R_SPAWN) || !object)
+ADMIN_VERB(debug, spawn_atom, "Spawn Atom", "", R_SPAWN, object as text)
+	if(!object)
 		return
-
 	var/list/preparsed = splittext(object,":")
 	var/path = preparsed[1]
 	var/amount = 1
@@ -73,9 +68,8 @@
 			A.flags_1 |= ADMIN_SPAWNED_1
 
 	log_admin("[key_name(usr)] spawned [amount] x [chosen] at [AREACOORD(usr)]")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Spawn Atom") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-ADMIN_VERB(debug, podspawn_atom, "Spawn an atom typepath via supply drop", R_SPAWN, object as text)
+ADMIN_VERB(debug, podspawn_atom, "Podspawn Atom", "Spawn an atom typepath via supply drop", R_SPAWN, object as text)
 	var/chosen = pick_closest_path(object)
 	if(!chosen)
 		return
@@ -93,7 +87,7 @@ ADMIN_VERB(debug, podspawn_atom, "Spawn an atom typepath via supply drop", R_SPA
 		A.flags_1 |= ADMIN_SPAWNED_1
 	log_admin("[key_name(usr)] pod-spawned [chosen] at [AREACOORD(usr)]")
 
-ADMIN_VERB(debug, spawn_cargo_crate, "Spawn a cargo crate", R_SPAWN, object as text)
+ADMIN_VERB(debug, spawn_cargo_crate, "Spawn Cargo Crate", "Spawn a cargo crate", R_SPAWN, object as text)
 	var/chosen = pick_closest_path(object, make_types_fancy(subtypesof(/datum/supply_pack)))
 	if(!chosen)
 		return
@@ -102,7 +96,7 @@ ADMIN_VERB(debug, spawn_cargo_crate, "Spawn a cargo crate", R_SPAWN, object as t
 	S.generate(get_turf(usr))
 	log_admin("[key_name(usr)] spawned cargo pack [chosen] at [AREACOORD(usr)]")
 
-ADMIN_VERB(debug, toggle_tinted_welding_helmets, "Reduces view range when wearing welding helmets", R_DEBUG)
+ADMIN_VERB(debug, toggle_tinted_welding_helmets, "Toggle Tinted Welding Helmets", "Reduces view range when wearing welding helmets", R_DEBUG)
 	GLOB.tinted_weldhelh = !GLOB.tinted_weldhelh
 	to_chat(world, span_bold("Welding Helmet tinting has been [(GLOB.tinted_weldhelh ? "enabled" : "disabled")]"))
 	log_admin("[key_name(usr)] toggled tinted_weldhelh.")
@@ -131,7 +125,7 @@ ADMIN_VERB(debug, toggle_tinted_welding_helmets, "Reduces view range when wearin
 
 	user << browse(dat, "window=dyn_mode_options;size=900x650")
 
-ADMIN_VERB(debug, create_or_modify_area, "", R_DEBUG)
+ADMIN_VERB(debug, create_or_modify_area, "Create or Modify Area", "", R_DEBUG)
 	create_area(usr)
 
 //Kicks all the clients currently in the lobby. The second parameter (kick_only_afk) determins if an is_afk() check is ran, or if all clients are kicked

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -7,7 +7,7 @@
 /client/proc/remove_admin_verbs()
 	SSadmin_verbs.deassosciate_admin(src)
 
-ADMIN_VERB(admin, hide_all_verbs, "Hide all of your Admin Verbs", NONE)
+ADMIN_VERB(admin, hide_all_verbs, "Hide All Verbs", "Hide all of your Admin Verbs", NONE)
 	usr.client.remove_admin_verbs()
 	add_verb(usr.client, /client/proc/show_verbs)
 	to_chat(usr, span_admin("Almost all of your adminverbs have been hidden."))
@@ -22,7 +22,7 @@ ADMIN_VERB(admin, hide_all_verbs, "Hide all of your Admin Verbs", NONE)
 	to_chat(src, span_interface("All of your adminverbs are now visible."), confidential = TRUE)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Show Adminverbs") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-ADMIN_VERB(game, aghost, "Observe without leaving the game", R_ADMIN)
+ADMIN_VERB(game, aghost, "AGhost", "Observe without leaving the game", R_ADMIN)
 	if(isnewplayer(usr))
 		to_chat(usr, span_red("Error: AGhost: Cannot admin-ghost wile in the lobby. Join or Observe first."))
 		return
@@ -45,7 +45,7 @@ ADMIN_VERB(game, aghost, "Observe without leaving the game", R_ADMIN)
 	if(usr && !usr.key)
 		usr.key = "@[key]" // If the key starts with '@' it designates an admin ghost
 
-ADMIN_VERB(game, invisimin, "Toggles ghost-like invisibility", R_ADMIN)
+ADMIN_VERB(game, invisimin, "Invisimin", "Toggles ghost-like invisibility", R_ADMIN)
 	if(initial(usr.invisibility) == INVISIBILITY_OBSERVER)
 		to_chat(usr, span_boldannounce("Invisimin toggle failed. You are already an invisible mob like a ghost."), confidential = TRUE)
 		return
@@ -56,40 +56,40 @@ ADMIN_VERB(game, invisimin, "Toggles ghost-like invisibility", R_ADMIN)
 		usr.invisibility = INVISIBILITY_OBSERVER
 		to_chat(usr, span_adminnotice("<b>Invisimin on. You are now as invisible as a ghost.</b>"), confidential = TRUE)
 
-ADMIN_VERB(game, check_antagonists, "", R_ADMIN)
+ADMIN_VERB(game, check_antagonists, "Check Antagonists", "", R_ADMIN)
 	usr.client.holder.check_antagonists()
 	log_admin("[key_name(usr)] checked antagonists.") //for tsar~ get a room you two
 	if(!isobserver(usr) && SSticker.HasRoundStarted())
 		message_admins("[key_name_admin(usr)] checked antagonists.")
 
-ADMIN_VERB(game, list_bombers, "", R_ADMIN)
+ADMIN_VERB(game, list_bombers, "List Bombers", "", R_ADMIN)
 	usr.client.holder.list_bombers()
 
-ADMIN_VERB(game, list_signalers, "", R_ADMIN)
+ADMIN_VERB(game, list_signalers, "List Signalers", "", R_ADMIN)
 	usr.client.holder.list_signalers()
 
-ADMIN_VERB(game, list_law_changes, "", R_ADMIN)
+ADMIN_VERB(game, list_law_changes, "List Law Changes", "", R_ADMIN)
 	usr.client.holder.list_law_changes()
 
-ADMIN_VERB(game, show_manifest, "", R_ADMIN)
+ADMIN_VERB(game, show_manifest, "Show Manifest", "", R_ADMIN)
 	usr.client.holder.show_manifest()
 
-ADMIN_VERB(game, list_dna, "", R_ADMIN)
+ADMIN_VERB(game, list_dna, "List DNA", "", R_ADMIN)
 	usr.client.holder.list_dna()
 
-ADMIN_VERB(game, list_fingerprints, "", R_ADMIN)
+ADMIN_VERB(game, list_fingerprints, "List Fingerprints", "", R_ADMIN)
 	usr.client.holder.list_fingerprints()
 
-ADMIN_VERB(admin, banning_panel, "", R_BAN)
+ADMIN_VERB(admin, banning_panel, "Banning Panel", "", R_BAN)
 	usr.client.holder.ban_panel()
 
-ADMIN_VERB(admin, unbanning_panel, "", R_BAN)
+ADMIN_VERB(admin, unbanning_panel, "Unbanning Panel", "", R_BAN)
 	usr.client.holder.unban_panel()
 
-ADMIN_VERB(game, game_panel, "", NONE)
+ADMIN_VERB(game, game_panel, "Game Panel", "", NONE)
 	usr.client.holder.Game()
 
-ADMIN_VERB(admin, server_poll_management, "", R_POLL)
+ADMIN_VERB(admin, server_poll_management, "Server Poll Management", "", R_POLL)
 	usr.client.holder.poll_list_panel()
 
 /// Returns this client's stealthed ckey
@@ -125,7 +125,7 @@ ADMIN_VERB(admin, server_poll_management, "", R_POLL)
 /client/proc/createStealthKey()
 	GLOB.stealthminID["[ckey]"] = generateStealthCkey()
 
-ADMIN_VERB(admin, stealth_mode, "Makes you unable to be seen through most means", R_STEALTH)
+ADMIN_VERB(admin, stealth_mode, "Stealth Mode", "Makes you unable to be seen through most means", R_STEALTH)
 	if(usr.client.holder.fakekey)
 		usr.client.disable_stealth_mode()
 	else
@@ -172,7 +172,7 @@ ADMIN_VERB(admin, stealth_mode, "Makes you unable to be seen through most means"
 
 #undef STEALTH_MODE_TRAIT
 
-ADMIN_VERB(fun, drop_bomb, "Cause an explosion of varying strength at your location", R_FUN)
+ADMIN_VERB(fun, drop_bomb, "Drop Bomb", "Cause an explosion of varying strength at your location", R_FUN)
 	var/list/choices = list("Small Bomb (1, 2, 3, 3)", "Medium Bomb (2, 3, 4, 4)", "Big Bomb (3, 5, 7, 5)", "Maxcap", "Custom Bomb")
 	var/choice = tgui_input_list(usr, "What size explosion would you like to produce? NOTE: You can do all this rapidly and in an IC manner (using cruise missiles!) with the Config/Launch Supplypod verb. WARNING: These ignore the maxcap", "Drop Bomb", choices)
 	if(isnull(choice))
@@ -209,7 +209,7 @@ ADMIN_VERB(fun, drop_bomb, "Cause an explosion of varying strength at your locat
 	message_admins("[ADMIN_LOOKUPFLW(usr)] creating an admin explosion at [epicenter.loc].")
 	log_admin("[key_name(usr)] created an admin explosion at [epicenter.loc].")
 
-ADMIN_VERB(fun, drop_dynex_bomb, "Cause an explosion of varting strength at your location", R_FUN)
+ADMIN_VERB(fun, drop_dynex_bomb, "Drop Dynex Bomb", "Cause an explosion of varting strength at your location", R_FUN)
 	var/ex_power = input(usr, "Explosive Power:") as null|num
 	var/turf/epicenter = get_turf(usr)
 	if(ex_power && epicenter)
@@ -217,21 +217,21 @@ ADMIN_VERB(fun, drop_dynex_bomb, "Cause an explosion of varting strength at your
 		message_admins("[ADMIN_LOOKUPFLW(usr)] creating an admin explosion at [epicenter.loc].")
 		log_admin("[key_name(usr)] created an admin explosion at [epicenter.loc].")
 
-ADMIN_VERB(debug, get_dynex_range, "Get the estimated range of a bomb, using explosive power", R_FUN)
+ADMIN_VERB(debug, get_dynex_range, "Get Dynex Range", "Get the estimated range of a bomb, using explosive power", R_FUN)
 	var/ex_power = input(usr, "Explosive Power:") as null|num
 	if (isnull(ex_power))
 		return
 	var/range = round((2 * ex_power)**GLOB.DYN_EX_SCALE)
 	to_chat(usr, "Estimated Explosive Range: (Devastation: [round(range*0.25)], Heavy: [round(range*0.5)], Light: [round(range)])")
 
-ADMIN_VERB(debug, get_dynex_power, "Get the estimated power of a bomb, to reach the specific range", R_FUN)
+ADMIN_VERB(debug, get_dynex_power, "Get Dynex Power", "Get the estimated power of a bomb, to reach the specific range", R_FUN)
 	var/ex_range = input(usr, "Light Explosion Range:") as null|num
 	if (isnull(ex_range))
 		return
 	var/power = (0.5 * ex_range)**(1/GLOB.DYN_EX_SCALE)
 	to_chat(usr, "Estimated Explosive Power: [power]")
 
-ADMIN_VERB(debug, set_dynex_scale, "Set the scale multiplier on dynex explosions. Default of 0.5", R_FUN)
+ADMIN_VERB(debug, set_dynex_scale, "Set Dynex Scale", "Set the scale multiplier on dynex explosions. Default of 0.5", R_FUN)
 	var/ex_scale = input("New DynEx Scale:") as null|num
 	if(isnull(ex_scale))
 		return
@@ -239,17 +239,17 @@ ADMIN_VERB(debug, set_dynex_scale, "Set the scale multiplier on dynex explosions
 	log_admin("[key_name(usr)] has modified Dynamic Explosion Scale: [ex_scale]")
 	message_admins("[key_name_admin(usr)] has  modified Dynamic Explosion Scale: [ex_scale]")
 
-ADMIN_VERB(debug, atmos_control_panel, "", R_DEBUG)
+ADMIN_VERB(debug, atmos_control_panel, "Atmos Control Panel", "", R_DEBUG)
 	SSair.ui_interact(usr)
 
-ADMIN_VERB(trading_card_game, reload_cards, "", R_DEBUG)
+ADMIN_VERB(trading_card_game, reload_cards, "Reload Cards", "", R_DEBUG)
 	if(!SStrading_card_game.loaded)
 		to_chat(usr, span_admin("The card subsystem is not currently loaded!"))
 		return
 	message_admins("[key_name_admin(usr)] manually reloaded SStrading_card_game.")
 	SStrading_card_game.reloadAllCardFiles()
 
-ADMIN_VERB(trading_card_game, validate_cards, "", R_DEBUG)
+ADMIN_VERB(trading_card_game, validate_cards, "Validate Cards", "", R_DEBUG)
 	if(!SStrading_card_game.loaded)
 		to_chat(usr, span_admin("The card subsystem is not currently loaded!"))
 		return
@@ -261,7 +261,7 @@ ADMIN_VERB(trading_card_game, validate_cards, "", R_DEBUG)
 	else
 		to_chat(usr, span_admin("No errors found in card rarities or overrides."))
 
-ADMIN_VERB(trading_card_game, test_cardpack_distribution, "", R_DEBUG)
+ADMIN_VERB(trading_card_game, test_cardpack_distribution, "Test Cardpack Distribution", "", R_DEBUG)
 	if(!SStrading_card_game.loaded)
 		to_chat(usr, span_admin("The card subsystem is not currently loaded!"))
 		return
@@ -275,14 +275,14 @@ ADMIN_VERB(trading_card_game, test_cardpack_distribution, "", R_DEBUG)
 	var/guar = tgui_input_number(usr, "Should we use the pack's guaranteed rarity? If so, how many?", "We've all been there. Man you should have seen the old system")
 	SStrading_card_game.check_card_distribution(pack, batch_size, batch_count, guar)
 
-ADMIN_VERB(trading_card_game, print_cards, "", R_DEBUG)
+ADMIN_VERB(trading_card_game, print_cards, "Print Cards", "", R_DEBUG)
 	if(!SStrading_card_game.loaded)
 		to_chat(usr, span_admin("The card subsystem is not currently loaded!"))
 		return
 
 	SStrading_card_game.printAllCards()
 
-ADMIN_VERB(fun, give_mob_spell, "", R_FUN, mob/spell_recipient in GLOB.mob_list)
+ADMIN_VERB(fun, give_mob_spell, "Give Mob Spell", "", R_FUN, mob/spell_recipient in GLOB.mob_list)
 	var/which = tgui_alert(usr, "Chose by name or by type path?", "Chose option", list("Name", "Typepath"))
 	if(!which)
 		return
@@ -325,7 +325,7 @@ ADMIN_VERB(fun, give_mob_spell, "", R_FUN, mob/spell_recipient in GLOB.mob_list)
 		to_chat(usr, span_userdanger("Spells given to mindless mobs will belong to the mob and not their mind, \
 			and as such will not be transferred if their mind changes body (Such as from Mindswap)."))
 
-ADMIN_VERB(fun, remove_spell, "", R_FUN, mob/removal_target in GLOB.mob_list)
+ADMIN_VERB(fun, remove_spell, "Remove Spell", "", R_FUN, mob/removal_target in GLOB.mob_list)
 	var/list/target_spell_list = list()
 	for(var/datum/action/cooldown/spell/spell in removal_target.actions)
 		target_spell_list[spell.name] = spell
@@ -344,7 +344,7 @@ ADMIN_VERB(fun, remove_spell, "", R_FUN, mob/removal_target in GLOB.mob_list)
 	log_admin("[key_name(usr)] removed the spell [chosen_spell] from [key_name(removal_target)].")
 	message_admins("[key_name_admin(usr)] removed the spell [chosen_spell] from [key_name_admin(removal_target)].")
 
-ADMIN_VERB(fun, give_disease, "Give Disease", R_FUN, mob/living/victim in GLOB.mob_living_list)
+ADMIN_VERB(fun, give_disease, "Give Disease", "", R_FUN, mob/living/victim in GLOB.mob_living_list)
 	var/datum/disease/disease_type = input(usr, "Choose the disease to give to that guy", "ACHOO") as null|anything in sort_list(SSdisease.diseases, GLOBAL_PROC_REF(cmp_typepaths_asc))
 	if(!disease_type)
 		return
@@ -361,10 +361,10 @@ ADMIN_CONTEXT_ENTRY(context_object_say, "Object Say", R_FUN, obj/target in world
 	log_admin("[key_name(usr)] made [target] at [AREACOORD(target)] say \"[message]\"")
 	message_admins(span_adminnotice("[key_name_admin(usr)] made [target] at [AREACOORD(target)]. say \"[message]\""))
 
-ADMIN_VERB(build_mode, toggle_build_mode_self, "", R_BUILD)
+ADMIN_VERB(build_mode, toggle_build_mode_self, "Toggle Build Mode Self", "", R_BUILD)
 	togglebuildmode(usr)
 
-ADMIN_VERB(game, check_ai_laws, "", R_ADMIN)
+ADMIN_VERB(game, check_ai_laws, "Check AI Laws", "", R_ADMIN)
 	var/law_bound_entities = 0
 	for(var/mob/living/silicon/subject as anything in GLOB.silicon_mobs)
 		law_bound_entities++
@@ -418,14 +418,14 @@ ADMIN_VERB(game, check_ai_laws, "", R_ADMIN)
 	log_admin("[src] re-adminned themselves.")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Readmin")
 
-ADMIN_VERB(debug, populate_world, "Populate the world with the given number of test mobs", R_DEBUG, amount = 50 as num)
+ADMIN_VERB(debug, populate_world, "Populate World", "Populate the world with the given number of test mobs", R_DEBUG, amount = 50 as num)
 	for (var/i in 1 to amount)
 		var/turf/tile = get_safe_random_station_turf()
 		var/mob/living/carbon/human/hooman = new(tile)
 		hooman.equipOutfit(pick(subtypesof(/datum/outfit)))
 		testing("Spawned test mob at [get_area_name(tile, TRUE)] ([tile.x],[tile.y],[tile.z])")
 
-ADMIN_VERB(game, toggle_admin_ai_interaction, "Allows you to interact with most machines as an AI would as a ghost", R_ADMIN)
+ADMIN_VERB(game, toggle_admin_ai_interaction, "Toggle Admin AI Interaction", "Allows you to interact with most machines as an AI would as a ghost", R_ADMIN)
 	usr.client.AI_Interact = !usr.client.AI_Interact
 	if(usr && isAdminGhostAI(usr))
 		usr.has_unlimited_silicon_privilege = usr.client.AI_Interact
@@ -440,7 +440,7 @@ ADMIN_VERB(game, toggle_admin_ai_interaction, "Allows you to interact with most 
 	var/datum/admins/admin = GLOB.admin_datums[ckey]
 	admin?.associate(src)
 
-ADMIN_VERB(debug, send_maps_profile, "", R_DEBUG)
+ADMIN_VERB(debug, send_maps_profile, "Send Maps Profile", "", R_DEBUG)
 	usr.client << link("?debug=profile&type=sendmaps&window=test")
 
 /**
@@ -452,7 +452,7 @@ ADMIN_VERB(debug, send_maps_profile, "", R_DEBUG)
  * They're all clientles mobs with minds / jobs.
  */
 
-ADMIN_VERB(debug, spawn_debug_full_crew, "Creates a full crew for the station, filling the datacore and assigning them all minds/jobs. Don't do this on live", R_DEBUG)
+ADMIN_VERB(debug, spawn_debug_full_crew, "Spawn Full Debug Crew", "Creates a full crew for the station, filling the datacore and assigning them all minds/jobs. Don't do this on live", R_DEBUG)
 	if(SSticker.current_state != GAME_STATE_PLAYING)
 		to_chat(usr, "You should only be using this after a round has setup and started.")
 		return
@@ -515,7 +515,7 @@ ADMIN_VERB(debug, spawn_debug_full_crew, "Creates a full crew for the station, f
 
 /// Debug verb for seeing at a glance what all spells have as set requirements
 
-ADMIN_VERB(debug, show_spell_requirements, "seeing at a glance what all spells have as set requirements", R_DEBUG)
+ADMIN_VERB(debug, show_spell_requirements, "Show Spell Requirements", "seeing at a glance what all spells have as set requirements", R_DEBUG)
 	var/header = "<tr><th>Name</th> <th>Requirements</th>"
 	var/all_requirements = list()
 	for(var/datum/action/cooldown/spell/spell as anything in typesof(/datum/action/cooldown/spell))
@@ -549,7 +549,7 @@ ADMIN_VERB(debug, show_spell_requirements, "seeing at a glance what all spells h
 	popup.set_content(page_contents)
 	popup.open()
 
-ADMIN_VERB(events, load_jump_lazy_template, "", R_ADMIN)
+ADMIN_VERB(events, load_jump_lazy_template, "Load or Jump Lazy Template", "", R_ADMIN)
 	var/list/choices = LAZY_TEMPLATE_KEY_LIST_ALL()
 	var/choice = tgui_input_list(usr, "Key?", "Lazy Loader", choices)
 	if(!choice)

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -92,7 +92,7 @@ GLOBAL_PROTECT(AdminProcCallHandler)
 	usr = lastusr
 	handler.remove_caller(user)
 
-ADMIN_VERB(debug, advanced_proccall, "", R_DEBUG)
+ADMIN_VERB(debug, advanced_proccall, "Advanced ProcCall", "", R_DEBUG)
 	usr.client.callproc_blocking()
 
 /client/proc/callproc_blocking(list/get_retval)

--- a/code/modules/admin/force_event.dm
+++ b/code/modules/admin/force_event.dm
@@ -1,5 +1,5 @@
 ///Allows an admin to force an event
-ADMIN_VERB(events, trigger_event, "", R_FUN)
+ADMIN_VERB(events, trigger_event, "Trigger Event", "", R_FUN)
 	usr.client.holder.forceEvent()
 
 ///Opens up the Force Event Panel

--- a/code/modules/admin/outfit_manager.dm
+++ b/code/modules/admin/outfit_manager.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(debug, outfit_manager, "", R_DEBUG)
+ADMIN_VERB(debug, outfit_manager, "Outfit Manager", "", R_DEBUG)
 	var/datum/outfit_manager/ui = new(usr)
 	ui.ui_interact(usr)
 

--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(admin, permissions_panel, "Edit/Set admin permissions", R_PERMISSIONS)
+ADMIN_VERB(admin, permissions_panel, "Permissions Panel", "Edit/Set admin permissions", R_PERMISSIONS)
 	usr.client.holder.edit_admin_permissions()
 
 /datum/admins/proc/edit_admin_permissions(action, target, operation, page)

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -481,5 +481,5 @@
 
 	. = list2params(.)
 
-ADMIN_VERB(admin, sticky_ban_panel, "", R_BAN)
+ADMIN_VERB(admin, sticky_ban_panel, "Sticky Ban Panel", "", R_BAN)
 	usr.client.holder.stickyban_show()

--- a/code/modules/admin/verbs/SDQL2/SDQL_2.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2.dm
@@ -198,7 +198,7 @@
 		state = SDQL2_STATE_ERROR;\
 		CRASH("SDQL2 fatal error");};
 
-ADMIN_VERB(debug, query_text, "", R_DEBUG, query_text as message)
+ADMIN_VERB(debug, query_text, "Query Text", "", R_DEBUG, query_text as message)
 	var/list/results = world.SDQL2_query(query_text, key_name_admin(usr), "[key_name(usr)]")
 	if(length(results) == 3)
 		for(var/I in 1 to 3)

--- a/code/modules/admin/verbs/admin.dm
+++ b/code/modules/admin/verbs/admin.dm
@@ -1,6 +1,6 @@
 // Admin Tab - Admin Verbs
 
-ADMIN_VERB(admin, show_tip, "Sends a tip, which you specify, to all players", R_ADMIN)
+ADMIN_VERB(admin, show_tip, "Show Tip", "Sends a tip, which you specify, to all players", R_ADMIN)
 	var/input = input(usr, "Please specify your tip that you want to send to the players.", "Tip", "") as message|null
 	if(!input)
 		return
@@ -18,7 +18,7 @@ ADMIN_VERB(admin, show_tip, "Sends a tip, which you specify, to all players", R_
 	message_admins("[key_name_admin(usr)] sent a tip of the round.")
 	log_admin("[key_name(usr)] sent \"[input]\" as the Tip of the Round.")
 
-ADMIN_VERB(admin, release_from_prison, "", R_ADMIN, mob/freeing in world)
+ADMIN_VERB(admin, release_from_prison, "Release from Prison", "", R_ADMIN, mob/freeing in world)
 	if(is_centcom_level(freeing.z))
 		SSjob.SendToLateJoin(freeing)
 		message_admins("[key_name_admin(usr)] has unprisoned [key_name_admin(freeing)]")
@@ -26,7 +26,7 @@ ADMIN_VERB(admin, release_from_prison, "", R_ADMIN, mob/freeing in world)
 	else
 		tgui_alert(usr,"[freeing.name] is not prisoned.")
 
-ADMIN_VERB(admin, player_playtime, "Check the playtime for connected players", R_ADMIN)
+ADMIN_VERB(admin, player_playtime, "Player Playtime", "Check the playtime for connected players", R_ADMIN)
 	if(!CONFIG_GET(flag/use_exp_tracking))
 		to_chat(usr, span_warning("Tracking is disabled in the server configuration file."), confidential = TRUE)
 		return
@@ -38,7 +38,7 @@ ADMIN_VERB(admin, player_playtime, "Check the playtime for connected players", R
 	msg += "</UL></BODY></HTML>"
 	usr << browse(msg.Join(), "window=Player_playtime_check")
 
-ADMIN_VERB(admin, trigger_centcom_recall, "", R_ADMIN)
+ADMIN_VERB(admin, trigger_centcom_recall, "Trigger Centcom Recall", "", R_ADMIN)
 	var/message = pick(GLOB.admiral_messages)
 	message = input("Enter message from the on-call admiral to be put in the recall report.", "Admiral Message", message) as message|null
 
@@ -49,7 +49,7 @@ ADMIN_VERB(admin, trigger_centcom_recall, "", R_ADMIN)
 	usr.log_message("triggered a CentCom recall, with the message of: [message]", LOG_GAME)
 	SSshuttle.centcom_recall(SSshuttle.emergency.timer, message)
 
-ADMIN_VERB(admin, player_panel, "", R_ADMIN)
+ADMIN_VERB(admin, player_panel, "Player Panel", "", R_ADMIN)
 	usr.client.holder?.player_panel_new()
 
 /datum/admins/proc/cmd_show_exp_panel(client/client_to_check)
@@ -134,7 +134,7 @@ ADMIN_VERB(admin, player_panel, "", R_ADMIN)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 
-ADMIN_VERB(admin, drop_everything, "", R_ADMIN, mob/target in world)
+ADMIN_VERB(admin, drop_everything, "Drop Everything", "", R_ADMIN, mob/target in world)
 	var/confirm = tgui_alert(usr, "Make [target] drop everything?", "Message", list("Yes", "No"))
 	if(confirm != "Yes")
 		return

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -33,7 +33,7 @@ ADMIN_CONTEXT_ENTRY(contexxt_headset_message, "Headset Message", R_ADMIN, mob/li
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Headset Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-ADMIN_VERB(events, global_narrate, "Send raw html to all conneted clients", R_ADMIN, raw_html as message)
+ADMIN_VERB(events, global_narrate, "Global Narrate", "Send raw html to all conneted clients", R_ADMIN, raw_html as message)
 	to_chat(world, "[raw_html]")
 	log_admin("GlobalNarrate: [key_name(usr)] : [raw_html]")
 	message_admins(span_adminnotice("[key_name_admin(usr)] Sent a global narrate"))
@@ -64,7 +64,7 @@ ADMIN_CONTEXT_ENTRY(context_direct_narrate, "Direct Narrate", R_ADMIN, mob/heare
 	message_admins(msg)
 	admin_ticket_log(hearer, msg)
 
-ADMIN_VERB(fun, add_ion_law, "Add an ion law to all silicons", R_FUN)
+ADMIN_VERB(fun, add_ion_law, "Add Ion Law", "Add an ion law to all silicons", R_FUN)
 	var/input = input(usr, "Please enter anything you want the AI to do. Anything. Serious.", "What?", "") as text|null
 	if(!input)
 		return
@@ -81,7 +81,7 @@ ADMIN_VERB(fun, add_ion_law, "Add an ion law to all silicons", R_FUN)
 	ion.start()
 	qdel(ion)
 
-ADMIN_VERB(events, call_shuttle, "", R_ADMIN)
+ADMIN_VERB(events, call_shuttle, "Call Shuttle", "", R_ADMIN)
 	if(EMERGENCY_AT_LEAST_DOCKED)
 		return
 
@@ -97,7 +97,7 @@ ADMIN_VERB(events, call_shuttle, "", R_ADMIN)
 	log_admin("[key_name(usr)] admin-called the emergency shuttle.")
 	message_admins(span_adminnotice("[key_name_admin(usr)] admin-called the emergency shuttle[confirm == "Yes (No Recall)" ? " (non-recallable)" : ""]."))
 
-ADMIN_VERB(events, recall_shuttle, "", R_ADMIN)
+ADMIN_VERB(events, recall_shuttle, "Recall Shuttle", "", R_ADMIN)
 	if(tgui_alert(usr, "You sure?", "Confirm", list("Yes", "No")) != "Yes")
 		return
 
@@ -109,7 +109,7 @@ ADMIN_VERB(events, recall_shuttle, "", R_ADMIN)
 	log_admin("[key_name(usr)] admin-recalled the emergency shuttle.")
 	message_admins(span_adminnotice("[key_name_admin(usr)] admin-recalled the emergency shuttle."))
 
-ADMIN_VERB(events, disable_shuttle, "", R_ADMIN)
+ADMIN_VERB(events, disable_shuttle, "Disable Shuttle", "", R_ADMIN)
 	if(SSshuttle.emergency.mode == SHUTTLE_DISABLED)
 		to_chat(usr, span_warning("Error, shuttle is already disabled."))
 		return
@@ -126,7 +126,7 @@ ADMIN_VERB(events, disable_shuttle, "", R_ADMIN)
 	SSshuttle.emergency.mode = SHUTTLE_DISABLED
 	priority_announce("Warning: Emergency Shuttle uplink failure, shuttle disabled until further notice.", "Emergency Shuttle Uplink Alert", 'sound/misc/announce_dig.ogg')
 
-ADMIN_VERB(events, enable_shuttle, "", R_ADMIN)
+ADMIN_VERB(events, enable_shuttle, "Enable Shuttle", "", R_ADMIN)
 	if(SSshuttle.emergency.mode != SHUTTLE_DISABLED)
 		to_chat(usr, span_warning("Error, shuttle not disabled."))
 		return
@@ -151,7 +151,7 @@ ADMIN_VERB(events, enable_shuttle, "", R_ADMIN)
 #define HOSTILE_ENVIRONMENT_CLEAR "Clear All"
 #define HOSTILE_ENVIRONMENT_OPTIONS list(HOSTILE_ENVIRONMENT_ENABLE, HOSTILE_ENVIRONMENT_DISABLE, HOSTILE_ENVIRONMENT_CLEAR)
 
-ADMIN_VERB(events, hostile_environments, "", R_ADMIN)
+ADMIN_VERB(events, hostile_environments, "Hostile Environments", "", R_ADMIN)
 	switch(tgui_alert(usr, "Select an Option", "Hostile Environment Manager", HOSTILE_ENVIRONMENT_OPTIONS))
 		if(HOSTILE_ENVIRONMENT_ENABLE)
 			if(SSshuttle.hostile_environments["Admin"])
@@ -174,7 +174,7 @@ ADMIN_VERB(events, hostile_environments, "", R_ADMIN)
 			SSshuttle.hostile_environments.Cut()
 			SSshuttle.checkHostileEnvironment()
 
-ADMIN_VERB(events, toggle_nuke, "", (R_ADMIN|R_DEBUG), obj/machinery/nuclearbomb/nuke in GLOB.nuke_list)
+ADMIN_VERB(events, toggle_nuke, "Toggle Nuke", "", (R_ADMIN|R_DEBUG), obj/machinery/nuclearbomb/nuke in GLOB.nuke_list)
 	if(!nuke.timing)
 		var/newtime = input(usr, "Set activation timer.", "Activate Nuke", "[nuke.timer_set]") as num|null
 		if(!newtime)
@@ -186,7 +186,7 @@ ADMIN_VERB(events, toggle_nuke, "", (R_ADMIN|R_DEBUG), obj/machinery/nuclearbomb
 	log_admin("[key_name(usr)] [nuke.timing ? "activated" : "deactivated"] a nuke at [AREACOORD(nuke)].")
 	message_admins("[ADMIN_LOOKUPFLW(usr)] [nuke.timing ? "activated" : "deactivated"] a nuke at [ADMIN_VERBOSEJMP(nuke)].")
 
-ADMIN_VERB(events, set_security_level, "Changes the security level. Announcement only, i.e. setting to Delta won't activate nuke", R_ADMIN)
+ADMIN_VERB(events, set_security_level, "Set Security Level", "Changes the security level. Announcement only, i.e. setting to Delta won't activate nuke", R_ADMIN)
 	var/level = tgui_input_list(usr, "Select Security Level:", "Set Security Level", SSsecurity_level.available_levels)
 	if(!level)
 		return
@@ -195,7 +195,7 @@ ADMIN_VERB(events, set_security_level, "Changes the security level. Announcement
 	log_admin("[key_name(usr)] changed the security level to [level]")
 	message_admins("[key_name_admin(usr)] changed the security level to [level]")
 
-ADMIN_VERB(events, run_weather, "Triggers a weather on the specified z-level", R_FUN)
+ADMIN_VERB(events, run_weather, "Run Weather", "Triggers a weather on the specified z-level", R_FUN)
 	var/weather_type = input(usr, "Choose a weather", "Weather")  as null|anything in sort_list(subtypesof(/datum/weather), GLOBAL_PROC_REF(cmp_typepaths_asc))
 	if(!weather_type)
 		return
@@ -209,7 +209,7 @@ ADMIN_VERB(events, run_weather, "Triggers a weather on the specified z-level", R
 	message_admins("[key_name_admin(usr)] started weather of type [weather_type] on the z-level [z_level].")
 	log_admin("[key_name(usr)] started weather of type [weather_type] on the z-level [z_level].")
 
-ADMIN_VERB(events, add_mob_ability, "Adds an ability to a marked mob", R_FUN)
+ADMIN_VERB(events, add_mob_ability, "Add Mob Ability", "Adds an ability to a marked mob", R_FUN)
 	var/datum/admins/holder = usr.client.holder
 	if(!isliving(holder.marked_datum))
 		to_chat(usr, span_warning("Error: Please mark a mob to add actions to it."))
@@ -256,7 +256,7 @@ ADMIN_VERB(events, add_mob_ability, "Adds an ability to a marked mob", R_FUN)
 	message_admins("[key_name_admin(usr)] added mob ability [ability_type] to mob [marked_mob].")
 	log_admin("[key_name(usr)] added mob ability [ability_type] to mob [marked_mob].")
 
-ADMIN_VERB(events, remove_mob_ability, "Removes an ability from the marked mob", R_FUN)
+ADMIN_VERB(events, remove_mob_ability, "Remove Mob Ability", "Removes an ability from the marked mob", R_FUN)
 	var/datum/admins/holder = usr.client.holder
 	if(!isliving(holder.marked_datum))
 		to_chat(usr, span_warning("Error: Please mark a mob to remove actions from it."))
@@ -279,7 +279,7 @@ ADMIN_VERB(events, remove_mob_ability, "Removes an ability from the marked mob",
 	message_admins("[key_name_admin(usr)] removed ability [ability_name] from mob [marked_mob].")
 	log_admin("[key_name(usr)] removed mob ability [ability_name] from mob [marked_mob].")
 
-ADMIN_VERB(events, command_report_footnote, "Adds a footnote to the roundstart command report", R_ADMIN)
+ADMIN_VERB(events, command_report_footnote, "Command Report Footnote", "Adds a footnote to the roundstart command report", R_ADMIN)
 	var/datum/command_footnote/command_report_footnote = new /datum/command_footnote()
 	SScommunications.block_command_report++ //Add a blocking condition to the counter until the inputs are done.
 
@@ -300,7 +300,7 @@ ADMIN_VERB(events, command_report_footnote, "Adds a footnote to the roundstart c
 	var/message
 	var/signature
 
-ADMIN_VERB(events, delay_command_report, "Prevents the roundstart command report from being sent until toggled", R_ADMIN)
+ADMIN_VERB(events, delay_command_report, "Delay Command Report", "Prevents the roundstart command report from being sent until toggled", R_ADMIN)
 	if(SScommunications.block_command_report) //If it's anything other than 0, decrease. If 0, increase.
 		SScommunications.block_command_report--
 		message_admins("[key_name_admin(usr)] has enabled the roundstart command report.")

--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -1,6 +1,6 @@
 // Admin Tab - Fun Verbs
 
-ADMIN_VERB(game, explosion, "Explosion", R_ADMIN, atom/target as obj|mob|turf in view())
+ADMIN_VERB(game, explosion, "Explosion", "", R_ADMIN, atom/target as obj|mob|turf in view())
 	var/devastation = input("Range of total devastation. -1 to none", text("Input"))  as num|null
 	if(devastation == null)
 		return
@@ -26,7 +26,7 @@ ADMIN_VERB(game, explosion, "Explosion", R_ADMIN, atom/target as obj|mob|turf in
 		log_admin("[key_name(usr)] created an explosion ([devastation],[heavy],[light],[flames]) at [AREACOORD(target)]")
 		message_admins("[key_name_admin(usr)] created an explosion ([devastation],[heavy],[light],[flames]) at [AREACOORD(target)]")
 
-ADMIN_VERB(game, emp, "", R_ADMIN, atom/target as obj|mob|turf in view())
+ADMIN_VERB(game, emp, "EMPulse", "", R_ADMIN, atom/target as obj|mob|turf in view())
 	var/heavy = input("Range of heavy pulse.", text("Input"))  as num|null
 	if(heavy == null)
 		return
@@ -63,7 +63,7 @@ ADMIN_CONTEXT_ENTRY(context_mob_gib, "Gib", R_ADMIN, mob/victim in GLOB.mob_list
 		else
 			living_victim.gib(TRUE)
 
-ADMIN_VERB(fun, gibself, "", R_ADMIN)
+ADMIN_VERB(fun, gibself, "Gibself", "", R_ADMIN)
 	if(!isliving(usr))
 		to_chat(usr, span_warning("You must be alive to use this!"))
 		return
@@ -77,7 +77,7 @@ ADMIN_VERB(fun, gibself, "", R_ADMIN)
 	var/mob/living/ourself = usr
 	ourself.gib(TRUE, TRUE, TRUE)
 
-ADMIN_VERB(fun, make_everyone_random, "Make everyone have a random appearance. You can only use this before rounds!", R_FUN)
+ADMIN_VERB(fun, make_everyone_random, "Make Everyone Random", "Make everyone have a random appearance. You can only use this before rounds!", R_FUN)
 	if(SSticker.HasRoundStarted())
 		to_chat(usr, "Nope you can't do this, the game's already started. This only works before rounds!")
 		return
@@ -102,7 +102,7 @@ ADMIN_VERB(fun, make_everyone_random, "Make everyone have a random appearance. Y
 	to_chat(usr, "<i>Remember: you can always disable the randomness by using the verb again, assuming the round hasn't started yet</i>.", confidential = TRUE)
 	CONFIG_SET(flag/force_random_names, TRUE)
 
-ADMIN_VERB(fun, mass_zombie_infection, "Infects all humans with a latent organ that will zombify them upon death", R_FUN)
+ADMIN_VERB(fun, mass_zombie_infection, "Mass Zombie Infection", "Infects all humans with a latent organ that will zombify them upon death", R_FUN)
 	var/confirm = tgui_alert(usr, "Please confirm you want to add latent zombie organs in all humans?", "Confirm Zombies", list("Yes", "No"))
 	if(confirm != "Yes")
 		return
@@ -114,7 +114,7 @@ ADMIN_VERB(fun, mass_zombie_infection, "Infects all humans with a latent organ t
 	log_admin("[key_name(usr)] added a latent zombie infection to all humans.")
 
 // Infecting everyone needs R_FUN, but curing only needs R_ADMIN
-ADMIN_VERB(fun, mass_zombie_cure, "Removes the admin zombie infection from all humans, returning them to normal", R_ADMIN)
+ADMIN_VERB(fun, mass_zombie_cure, "Mass Zombie Cure", "Removes the admin zombie infection from all humans, returning them to normal", R_ADMIN)
 	var/confirm = tgui_alert(usr, "Please confirm you want to cure all zombies?", "Confirm Zombie Cure", list("Yes", "No"))
 	if(confirm != "Yes")
 		return
@@ -125,7 +125,7 @@ ADMIN_VERB(fun, mass_zombie_cure, "Removes the admin zombie infection from all h
 	message_admins("[key_name_admin(usr)] cured all zombies.")
 	log_admin("[key_name(usr)] cured all zombies.")
 
-ADMIN_VERB(fun, polymorph_all_mobs, "This will prove to be a terrible idea", R_FUN)
+ADMIN_VERB(fun, polymorph_all_mobs, "Polymorph All Mobs", "This will prove to be a terrible idea", R_FUN)
 	var/confirm = tgui_alert(usr, "Please confirm you want polymorph all mobs?", "Confirm Polymorph", list("Yes", "No"))
 	if(confirm != "Yes")
 		return

--- a/code/modules/admin/verbs/admingame.dm
+++ b/code/modules/admin/verbs/admingame.dm
@@ -134,7 +134,7 @@ ADMIN_CONTEXT_ENTRY(context_player_panel, "Show Player Panel", R_ADMIN, mob/play
 	usr << browse(body, "window=adminplayeropts-[REF(player)];size=550x515")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Player Panel") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-ADMIN_VERB(game, toggle_godmode, "", R_ADMIN, mob/demigod in view())
+ADMIN_VERB(game, toggle_godmode, "Toggle Godmode", "", R_ADMIN, mob/demigod in view())
 	demigod.status_flags ^= GODMODE
 	to_chat(usr, span_adminnotice("Toggled [(demigod.status_flags & GODMODE) ? "ON" : "OFF"]"), confidential = TRUE)
 
@@ -148,7 +148,7 @@ If a guy was gibbed and you want to revive him, this is a good way to do so.
 Works kind of like entering the game with a new character. Character receives a new mind if they didn't have one.
 Traitors and the like can also be revived with the previous role mostly intact.
 */
-ADMIN_VERB(game, respawn_character, "Respawn a player that has been gibbed/dusted/killed. They must be a ghost", R_SPAWN, input as text)
+ADMIN_VERB(game, respawn_character, "Respawn Character", "Respawn a player that has been gibbed/dusted/killed. They must be a ghost", R_SPAWN, input as text)
 	var/mob/dead/observer/G_found
 	for(var/mob/dead/observer/G in GLOB.player_list)
 		if(G.ckey == input)
@@ -264,7 +264,7 @@ ADMIN_VERB(game, respawn_character, "Respawn a player that has been gibbed/duste
 
 	return new_character
 
-ADMIN_VERB(game, manage_job_slots, "", R_ADMIN)
+ADMIN_VERB(game, manage_job_slots, "Manage Job Slots", "", R_ADMIN)
 	usr.client.holder.manage_free_slots()
 
 /datum/admins/proc/manage_free_slots()
@@ -307,7 +307,7 @@ ADMIN_VERB(game, manage_job_slots, "", R_ADMIN)
 	browser.set_content(dat.Join())
 	browser.open()
 
-ADMIN_VERB(game, change_view_range, "Switch between default and larger views", R_ADMIN)
+ADMIN_VERB(game, change_view_range, "Change View Range", "Switch between default and larger views", R_ADMIN)
 	var/datum/view_data/view_size = usr.client.view_size
 	if(view_size.getView() == view_size.default)
 		view_size.setTo(input("Select view range:", "FUCK YE", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,37) - 7)
@@ -315,7 +315,7 @@ ADMIN_VERB(game, change_view_range, "Switch between default and larger views", R
 		view_size.resetToDefault(getScreenSize(usr.client.prefs.read_preference(/datum/preference/toggle/widescreen)))
 	log_admin("[key_name(usr)] changed their view range to [usr.client.view].")
 
-ADMIN_VERB(game, toggle_combo_hud, "Toggles the Admin Combo HUD (all huds)", R_ADMIN)
+ADMIN_VERB(game, toggle_combo_hud, "Toggle Combo HUD", "Toggles the Admin Combo HUD (all huds)", R_ADMIN)
 	if(usr.client.combo_hud_enabled)
 		usr.client.disable_combo_hud()
 	else
@@ -357,14 +357,14 @@ ADMIN_VERB(game, toggle_combo_hud, "Toggles the Admin Combo HUD (all huds)", R_A
 	mob.lighting_alpha = mob.default_lighting_alpha()
 	mob.update_sight()
 
-ADMIN_VERB(game, traitor_panel, "", R_ADMIN, mob/traitor in view())
+ADMIN_VERB(game, traitor_panel, "Traitor Panel", "", R_ADMIN, mob/traitor in view())
 	var/datum/mind/target_mind = traitor.mind
 	if(!target_mind)
 		to_chat(usr, "This mob has no mind!", confidential = TRUE)
 		return
 	target_mind.traitor_panel()
 
-ADMIN_VERB(game, skill_panel, "", R_ADMIN, mob/skilled in view())
+ADMIN_VERB(game, skill_panel, "Skill Panel", "", R_ADMIN, mob/skilled in view())
 	if(!SSticker.HasRoundStarted())
 		tgui_alert(usr,"The game hasn't started yet!")
 		return
@@ -376,7 +376,7 @@ ADMIN_VERB(game, skill_panel, "", R_ADMIN, mob/skilled in view())
 	var/datum/skill_panel/SP = new(usr, target_mind)
 	SP.ui_interact(usr)
 
-ADMIN_VERB(game, show_lag_switches, "Display the controls for drastic lag mitigation measures", R_ADMIN)
+ADMIN_VERB(game, show_lag_switches, "Show Lag Switches", "Display the controls for drastic lag mitigation measures", R_ADMIN)
 	if(!SSlag_switch.initialized)
 		to_chat(usr, span_notice("The Lag Switch subsystem has not yet been initialized."))
 		return

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(game, jump_to_area, "Jump to the specified area", NONE, area/destination in world)
+ADMIN_VERB(game, jump_to_area, "Jump to Area", "Jump to the specified area", NONE, area/destination in world)
 	var/turf/point
 
 	for(var/turf/turf as anything in destination.get_contained_turfs())
@@ -14,12 +14,12 @@ ADMIN_VERB(game, jump_to_area, "Jump to the specified area", NONE, area/destinat
 	log_admin("[key_name(usr)] jumped to [AREACOORD(point)]")
 	key_name_admin("[key_name(usr)] jumped to [AREACOORD(point)]")
 
-ADMIN_VERB(game, jump_to_turf, "", NONE, turf/destination in world)
+ADMIN_VERB(game, jump_to_turf, "Jump to Turf", "", NONE, turf/destination in world)
 	usr.forceMove(destination)
 	log_admin("[key_name(usr)] jumped to [AREACOORD(destination)]")
 	key_name_admin("[key_name(usr)] jumped to [AREACOORD(destination)]")
 
-ADMIN_VERB(game, jump_to_mob, "", NONE, mob/destination)
+ADMIN_VERB(game, jump_to_mob, "Jump to Mob", "", NONE, mob/destination)
 	destination ||= tgui_input_list(usr, "Select a mob to teleport to you", "Admin Jump", GLOB.mob_list - usr)
 	if(!destination)
 		return
@@ -28,7 +28,7 @@ ADMIN_VERB(game, jump_to_mob, "", NONE, mob/destination)
 	log_admin("[key_name(usr)] jumped to [key_name(destination)]")
 	message_admins("[key_name_admin(usr)] jumped to [ADMIN_LOOKUPFLW(destination)] at [AREACOORD(destination)]")
 
-ADMIN_VERB(game, jump_to_coordinate, "", NONE, x as num, y as num, z as num)
+ADMIN_VERB(game, jump_to_coordinate, "Jump to Coordinate", "", NONE, x as num, y as num, z as num)
 	if(x < 1 || y < 1 || z < 1 || x > world.maxx || y > world.maxy || z > world.maxz)
 		to_chat(usr, span_warning("Invaild coordinates"))
 		return
@@ -38,7 +38,7 @@ ADMIN_VERB(game, jump_to_coordinate, "", NONE, x as num, y as num, z as num)
 	log_admin("[key_name(usr)] jumped to [AREACOORD(destination)]")
 	message_admins("[key_name_admin(usr)] jumped to [AREACOORD(destination)]")
 
-ADMIN_VERB(game, jump_to_player, "", NONE)
+ADMIN_VERB(game, jump_to_player, "Jump to Player", "", NONE)
 	var/list/players = list()
 	for(var/client/player as anything in GLOB.clients)
 		players[key_name(player)] = WEAKREF(player.mob)
@@ -54,7 +54,7 @@ ADMIN_VERB(game, jump_to_player, "", NONE)
 	log_admin("[key_name(usr)] jumped to player [key_name(usr)]")
 	message_admins("[key_name_admin(usr)] jumped to player [key_name_admin(usr)]")
 
-ADMIN_VERB(game, get_mob, "", NONE, mob/teleportee)
+ADMIN_VERB(game, get_mob, "Get Mob", "", NONE, mob/teleportee)
 	teleportee ||= tgui_input_list(usr, "Select a mob to teleport to you", "Admin Jump", GLOB.mob_list - usr)
 	if(!teleportee)
 		return
@@ -79,7 +79,7 @@ ADMIN_VERB(game, get_mob, "", NONE, mob/teleportee)
 	admin_ticket_log(src, msg)
 	return ..()
 
-ADMIN_VERB(game, get_player, "", NONE)
+ADMIN_VERB(game, get_player, "Get Player", "", NONE)
 	var/list/players = list()
 	for(var/client/player as anything in GLOB.clients)
 		players[key_name(player)] = WEAKREF(player.mob)

--- a/code/modules/admin/verbs/ai_triumvirate.dm
+++ b/code/modules/admin/verbs/ai_triumvirate.dm
@@ -27,7 +27,7 @@ GLOBAL_DATUM(triple_ai_controller, /datum/triple_ai_controller)
 	GLOB.triple_ai_controller = null
 	. = ..()
 
-ADMIN_VERB(events, toggle_ai_triumvirate, "", R_FUN)
+ADMIN_VERB(events, toggle_ai_triumvirate, "Toggle AI Triumvirate", "", R_FUN)
 	if(SSticker.current_state > GAME_STATE_PREGAME)
 		to_chat(usr, "This option is currently only usable during pregame. This may change at a later date.", confidential = TRUE)
 		return

--- a/code/modules/admin/verbs/anonymousnames.dm
+++ b/code/modules/admin/verbs/anonymousnames.dm
@@ -7,7 +7,7 @@ GLOBAL_DATUM(current_anonymous_theme, /datum/anonymous_theme)
 
 	this is the setup, it handles announcing crew and other settings for the mode and then creating the datum singleton
 */
-ADMIN_VERB(events, setup_anonymous_names, "", R_FUN)
+ADMIN_VERB(events, setup_anonymous_names, "Setup Anonymous Names", "", R_FUN)
 	if(GLOB.current_anonymous_theme)
 		var/response = tgui_alert(usr, "Anon mode is currently enabled. Disable?", "cold feet", list("Disable Anon Names", "Keep it Enabled"))
 		if(response != "Disable Anon Names")

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(mapping, check_plumbing, "", R_DEBUG)
+ADMIN_VERB(mapping, check_plumbing, "Check Plumbing", "", R_DEBUG)
 	//all plumbing - yes, some things might get stated twice, doesn't matter.
 	for(var/obj/machinery/atmospherics/components/pipe in GLOB.machines)
 		if(pipe.z && (!pipe.nodes || !pipe.nodes.len || (null in pipe.nodes)))
@@ -17,7 +17,7 @@ ADMIN_VERB(mapping, check_plumbing, "", R_DEBUG)
 			if(!(node1 in node2.nodes))
 				to_chat(usr, "One-way connection in [node1.name] located at [ADMIN_VERBOSEJMP(node1)]", confidential = TRUE)
 
-ADMIN_VERB(mapping, check_power, "", R_DEBUG)
+ADMIN_VERB(mapping, check_power, "Check Power", "", R_DEBUG)
 	var/list/results = list()
 
 	for (var/datum/powernet/PN in SSmachines.powernets)

--- a/code/modules/admin/verbs/beakerpanel.dm
+++ b/code/modules/admin/verbs/beakerpanel.dm
@@ -60,7 +60,7 @@
 		reagents.add_reagent(reagenttype, amount)
 	return container
 
-ADMIN_VERB(events, spawn_reagent_container, "", R_SPAWN)
+ADMIN_VERB(events, spawn_reagent_container, "Spawn Reagent Container", "", R_SPAWN)
 	var/datum/asset/asset_datum = get_asset_datum(/datum/asset/simple/namespaced/common)
 	asset_datum.send(usr)
 	//Could somebody tell me why this isn't using the browser datum, given that it copypastes all of browser datum's html

--- a/code/modules/admin/verbs/cinematic.dm
+++ b/code/modules/admin/verbs/cinematic.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(fun, show_cinematic, "Shows a cinematic", R_FUN)
+ADMIN_VERB(fun, show_cinematic, "Show Cinematic", "Shows a cinematic", R_FUN)
 	if(!SSticker.initialized)
 		to_chat(usr, span_warning("Wait for the game to finish loading!"))
 		return

--- a/code/modules/admin/verbs/commandreport.dm
+++ b/code/modules/admin/verbs/commandreport.dm
@@ -7,7 +7,7 @@
 #define WIZARD_PRESET "The Wizard Federation"
 #define CUSTOM_PRESET "Custom Command Name"
 
-ADMIN_VERB(events, change_command_name, "", R_ADMIN)
+ADMIN_VERB(events, change_command_name, "Change Command NAme", "", R_ADMIN)
 	var/input = input(usr, "Please input a new name for Central Command.", "What?", "") as text|null
 	if(!input)
 		return
@@ -15,7 +15,7 @@ ADMIN_VERB(events, change_command_name, "", R_ADMIN)
 	message_admins("[key_name_admin(usr)] has changed Central Command's name to [input]")
 	log_admin("[key_name(usr)] has changed the Central Command name to: [input]")
 
-ADMIN_VERB(events, create_command_report, "", R_ADMIN)
+ADMIN_VERB(events, create_command_report, "Create Command Report", "", R_ADMIN)
 	var/datum/command_report_menu/tgui = new(usr)
 	tgui.ui_interact(usr)
 

--- a/code/modules/admin/verbs/config_helpers.dm
+++ b/code/modules/admin/verbs/config_helpers.dm
@@ -1,6 +1,6 @@
 /// Verbs created to help server operators with generating certain config files.
 
-ADMIN_VERB(server, generate_job_configuration, "", R_SERVER)
+ADMIN_VERB(server, generate_job_configuration, "Generate Job Configuration", "", R_SERVER)
 	if(tgui_alert(usr, "This verb is not at all useful if you are not a server operator with access to the configuration folder. Do you wish to proceed?", "Generate jobconfig.toml for download", list("Yes", "No")) != "Yes")
 		return
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1,13 +1,13 @@
-ADMIN_VERB(debug, toggle_global_debugging, "", R_DEBUG)
+ADMIN_VERB(debug, toggle_global_debugging, "Toggle Global Debugging", "", R_DEBUG)
 	GLOB.Debug2 = !GLOB.Debug2
 	var/message = "has toggled global debugging [(GLOB.Debug2 ? "on" : "off")]"
 	log_admin("[key_name(usr)] [message]")
 	message_admins("[key_name_admin(usr)] [message]")
 
-ADMIN_VERB(debug, get_air_status, "", R_DEBUG)
+ADMIN_VERB(debug, get_air_status, "Get Air Status", "", R_DEBUG)
 	atmos_scan(user=usr, target=get_turf(usr), silent=TRUE)
 
-ADMIN_VERB(debug, make_cyborg, "", R_DEBUG, mob/target in GLOB.mob_list)
+ADMIN_VERB(debug, make_cyborg, "Make Cyborg", "", R_DEBUG, mob/target in GLOB.mob_list)
 	if(!SSticker.HasRoundStarted())
 		tgui_alert(usr, "Wait until the game starts")
 		return
@@ -29,7 +29,7 @@ ADMIN_VERB(debug, make_cyborg, "", R_DEBUG, mob/target in GLOB.mob_list)
 		return
 	return types[key]
 
-ADMIN_VERB(debug, delete_all_of_type, "", R_DEBUG, object as text)
+ADMIN_VERB(debug, delete_all_of_type, "Delete All of Type", "", R_DEBUG, object as text)
 	var/type_to_del = usr.client.poll_type_to_del(object)
 	if(!type_to_del)
 		return
@@ -50,7 +50,7 @@ ADMIN_VERB(debug, delete_all_of_type, "", R_DEBUG, object as text)
 	log_admin("[key_name(usr)] [message]")
 	message_admins("[key_name_admin(usr)] [message]")
 
-ADMIN_VERB(debug, hard_delete_all_of_type, "", R_DEBUG, object as text)
+ADMIN_VERB(debug, hard_delete_all_of_type, "Hard Delete All of Type", "", R_DEBUG, object as text)
 	var/type_to_del = usr.client.poll_type_to_del(object)
 	if(!type_to_del)
 		return
@@ -99,12 +99,12 @@ ADMIN_VERB(debug, hard_delete_all_of_type, "", R_DEBUG, object as text)
 	log_admin("[key_name(usr)] [message]")
 	message_admins("[key_name_admin(usr)] [message]")
 
-ADMIN_VERB(debug, make_powernets, "", R_DEBUG)
+ADMIN_VERB(debug, make_powernets, "Make Powernets", "", R_DEBUG)
 	SSmachines.makepowernets()
 	log_admin("[key_name(usr)] has remade the powernet.")
 	message_admins("[key_name_admin(usr)] has remade the powernets.")
 
-ADMIN_VERB(game, grant_full_access, "", R_ADMIN, mob/living/carbon/human/target in view())
+ADMIN_VERB(game, grant_full_access, "Grant Full Access", "", R_ADMIN, mob/living/carbon/human/target in view())
 	if(!SSticker.HasRoundStarted())
 		tgui_alert(usr, "Wait until the game starts")
 		return
@@ -141,7 +141,7 @@ ADMIN_VERB(game, grant_full_access, "", R_ADMIN, mob/living/carbon/human/target 
 	log_admin("[key_name(usr)] has granted [key_name(target)] full access.")
 	message_admins("[key_name_admin(usr)] has granted [key_name_admin(target)] full access.")
 
-ADMIN_VERB(game, assume_direct_control, "", R_ADMIN, mob/target in view())
+ADMIN_VERB(game, assume_direct_control, "Assume Direct Control", "", R_ADMIN, mob/target in view())
 	if(target.ckey)
 		var/force = tgui_alert(
 			usr,
@@ -168,7 +168,7 @@ ADMIN_VERB(game, assume_direct_control, "", R_ADMIN, mob/target in view())
 	message_admins(span_adminnotice("[key_name_admin(usr)] assumed direct control of [target_name]."))
 	log_admin("[key_name(usr)] assumed direct control of [target_name].")
 
-ADMIN_VERB(game, give_direct_control, "", R_DEBUG, mob/pawn in view())
+ADMIN_VERB(game, give_direct_control, "Give Direct Control", "", R_DEBUG, mob/pawn in view())
 	if(pawn.ckey)
 		if(tgui_alert(usr,"This mob is being controlled by [pawn.key]. Are you sure you wish to give someone else control of it? [pawn.key] will be made a ghost.",,list("Yes","No")) != "Yes")
 			return
@@ -380,13 +380,13 @@ ADMIN_VERB(game, give_direct_control, "", R_DEBUG, mob/pawn in view())
 	popup.set_content(dat.Join())
 	popup.open()
 
-ADMIN_VERB(mapping, test_station_areas, "", R_DEBUG)
+ADMIN_VERB(mapping, test_station_areas, "Test Station Areas", "", R_DEBUG)
 	usr.client.holder.cmd_admin_areatest(on_station = TRUE)
 
-ADMIN_VERB(mapping, test_station_areas_without_maint, "", R_DEBUG)
+ADMIN_VERB(mapping, test_station_areas_without_maint, "Test Station Areas (Without Maint)", "", R_DEBUG)
 	usr.client.holder.cmd_admin_areatest(on_station = TRUE, filter_maint = TRUE)
 
-ADMIN_VERB(mapping, test_all_areas, "", R_DEBUG)
+ADMIN_VERB(mapping, test_all_areas, "Test All Areas", "", R_DEBUG)
 	usr.client.holder.cmd_admin_areatest()
 
 /client/proc/robust_dress_shop()
@@ -455,7 +455,7 @@ ADMIN_CONTEXT_ENTRY(context_check_contents, "Check Contents", R_ADMIN, mob/livin
 	for(var/content in all_contents)
 		to_chat(usr, "[content] [ADMIN_VV(content)] [ADMIN_TAG(content)]", confidential = TRUE)
 
-ADMIN_VERB(debug, modify_goals, "", R_ADMIN)
+ADMIN_VERB(debug, modify_goals, "Modify Goals", "", R_ADMIN)
 	var/dat = ""
 	for(var/datum/station_goal/S in GLOB.station_goals)
 		dat += "[S.name] - <a href='?src=[REF(S)];[HrefToken()];announce=1'>Announce</a> | <a href='?src=[REF(S)];[HrefToken()];remove=1'>Remove</a><br>"
@@ -479,7 +479,7 @@ ADMIN_VERB(debug, modify_goals, "", R_ADMIN)
 	MOB_LIST_CLIENTS, \
 	MOB_LIST_CLIENTS_JOINED)
 
-ADMIN_VERB(debug, debug_mob_lists, "For when you just gotta know", R_DEBUG)
+ADMIN_VERB(debug, debug_mob_lists, "Debug Mob Lists", "For when you just gotta know", R_DEBUG)
 	var/chosen_list = tgui_input_list(usr, "Which list?", "Select List", MOB_LIST_LIST)
 	if(isnull(chosen_list))
 		return
@@ -499,7 +499,7 @@ ADMIN_VERB(debug, debug_mob_lists, "For when you just gotta know", R_DEBUG)
 		if(MOB_LIST_CLIENTS_JOINED)
 			to_chat(usr, jointext(GLOB.joined_player_list,","), confidential = TRUE)
 
-ADMIN_VERB(debug, display_del_log, "Display del's log of everything that's passed through it", R_DEBUG)
+ADMIN_VERB(debug, display_del_log, "Display Del Log", "Display del's log of everything that's passed through it", R_DEBUG)
 	var/list/dellog = list("<B>List of things that have gone through qdel this round</B><BR><BR><ol>")
 	sortTim(SSgarbage.items, cmp=/proc/cmp_qdel_item_time, associative = TRUE)
 	for(var/path in SSgarbage.items)
@@ -529,16 +529,16 @@ ADMIN_VERB(debug, display_del_log, "Display del's log of everything that's passe
 
 	usr << browse(dellog.Join(), "window=dellog")
 
-ADMIN_VERB(debug, display_overlay_log, "Display SSoverlays log of everything that's passed through it", R_DEBUG)
+ADMIN_VERB(debug, display_overlay_log, "Display Overlay Log", "Display SSoverlays log of everything that's passed through it", R_DEBUG)
 	render_stats(SSoverlays.stats, usr)
 
-ADMIN_VERB(debug, display_initailize_log, "Displays a list of things that didn't handle Initialize() properly", R_DEBUG)
+ADMIN_VERB(debug, display_initailize_log, "Display Initialize Log", "Displays a list of things that didn't handle Initialize() properly", R_DEBUG)
 	usr << browse(replacetext(SSatoms.InitLog(), "\n", "<br>"), "window=initlog")
 
-ADMIN_VERB(debug, colorblind_testing, "Change your view to a budger version of colorblindness to test for usability", R_DEBUG)
+ADMIN_VERB(debug, colorblind_testing, "Colorblind Testing", "Change your view to a budger version of colorblindness to test for usability", R_DEBUG)
 	usr.client.holder.color_test.ui_interact(usr)
 
-ADMIN_VERB(debug, edit_debug_planes, "Edit and visuaize plane masters and their connections (relays)", R_DEBUG)
+ADMIN_VERB(debug, edit_debug_planes, "Edit Debug Planes", "Edit and visuaize plane masters and their connections (relays)", R_DEBUG)
 	usr.client.holder.edit_plane_masters()
 
 /datum/admins/proc/edit_plane_masters(mob/debug_on)
@@ -549,7 +549,7 @@ ADMIN_VERB(debug, edit_debug_planes, "Edit and visuaize plane masters and their 
 		owner.holder.plane_debug.set_mirroring(FALSE)
 	owner.holder.plane_debug.ui_interact(usr)
 
-ADMIN_VERB(debug, debug_huds, "Debug one of the HUDs", R_DEBUG)
+ADMIN_VERB(debug, debug_huds, "Debug HUDs", "Debug one of the HUDs", R_DEBUG)
 	var/list/choices = list()
 	for(var/idx in 1 to length(GLOB.huds))
 		var/datum/hud = GLOB.huds[idx]
@@ -560,7 +560,7 @@ ADMIN_VERB(debug, debug_huds, "Debug one of the HUDs", R_DEBUG)
 		return
 	SSadmin_verbs.dynamic_invoke_admin_verb(usr, /mob/admin_module_holder/debug/view_variables, choices[choice])
 
-ADMIN_VERB(debug, jump_to_ruin, "Displays a list of all placed ruins for teleporting", R_DEBUG)
+ADMIN_VERB(debug, jump_to_ruin, "Jump To Ruin", "Displays a list of all placed ruins for teleporting", R_DEBUG)
 	var/list/names = list()
 	for(var/obj/effect/landmark/ruin/ruin_landmark as anything in GLOB.ruin_landmarks)
 		var/datum/map_template/ruin/template = ruin_landmark.ruin_template
@@ -590,7 +590,7 @@ ADMIN_VERB(debug, jump_to_ruin, "Displays a list of all placed ruins for telepor
 		to_chat(usr, span_name("[template.name]"), confidential = TRUE)
 		to_chat(usr, "<span class='italics'>[template.description]</span>", confidential = TRUE)
 
-ADMIN_VERB(debug, spawn_ruin, "Attempt to randomly place a specific ruin", R_DEBUG)
+ADMIN_VERB(debug, spawn_ruin, "Spawn Ruin", "Attempt to randomly place a specific ruin", R_DEBUG)
 	var/list/exists = list()
 	for(var/landmark in GLOB.ruin_landmarks)
 		var/obj/effect/landmark/ruin/L = landmark
@@ -635,10 +635,10 @@ ADMIN_VERB(debug, spawn_ruin, "Attempt to randomly place a specific ruin", R_DEB
 	else
 		to_chat(usr, span_warning("Failed to place [template.name]."), confidential = TRUE)
 
-ADMIN_VERB(debug, unload_ctf, "Despawns CTF", R_DEBUG)
+ADMIN_VERB(debug, unload_ctf, "Unload CTF", "Despawns CTF", R_DEBUG)
 	toggle_id_ctf(usr, unload=TRUE)
 
-ADMIN_VERB(debug, run_empty_query, "Runs a query that does nothing", R_DEBUG, val as num)
+ADMIN_VERB(debug, run_empty_query, "Run Empty Query", "Runs a query that does nothing", R_DEBUG, val as num)
 	var/list/queries = list()
 	for(var/i in 1 to val)
 		var/datum/db_query/query = SSdbcore.NewQuery("NULL")
@@ -653,7 +653,7 @@ ADMIN_VERB(debug, run_empty_query, "Runs a query that does nothing", R_DEBUG, va
 	message_admins("[key_name_admin(usr)] ran [val] empty queries.")
 
 //Debug procs
-ADMIN_VERB(debug, test_movable_UI, "", R_DEBUG)
+ADMIN_VERB(debug, test_movable_UI, "Test Movable UI", "", R_DEBUG)
 	var/atom/movable/screen/movable/M = new()
 	M.name = "Movable UI Object"
 	M.icon_state = "block"
@@ -669,7 +669,7 @@ ADMIN_VERB(debug, test_movable_UI, "", R_DEBUG)
 	usr.client.screen += M
 
 // Debug verbs.
-ADMIN_VERB(debug, restart_controller, "Restart one of the two main controllers for the game (be careful!)", R_DEBUG, controller in list("Master", "Failsafe"))
+ADMIN_VERB(debug, restart_controller, "Restart Controller", "Restart one of the two main controllers for the game (be careful!)", R_DEBUG, controller in list("Master", "Failsafe"))
 	switch(controller)
 		if("Master")
 			Recreate_MC()
@@ -679,7 +679,7 @@ ADMIN_VERB(debug, restart_controller, "Restart one of the two main controllers f
 			stack_trace("Invalid controller type [controller] passed to restart_controller()")
 	message_admins("Admin [key_name_admin(usr)] has restarted the [controller] controller.")
 
-ADMIN_VERB(debug, debug_controller, "Debug one of the subsystem controllers", R_DEBUG)
+ADMIN_VERB(debug, debug_controller, "Debug Controller", "Debug one of the subsystem controllers", R_DEBUG)
 	var/list/controllers = list()
 	var/list/controller_choices = list()
 
@@ -697,7 +697,7 @@ ADMIN_VERB(debug, debug_controller, "Debug one of the subsystem controllers", R_
 	SSadmin_verbs.dynamic_invoke_admin_verb(usr, /mob/admin_module_holder/debug/view_variables, controller)
 	message_admins("Admin [key_name_admin(usr)] is debugging the [controller] controller.")
 
-ADMIN_VERB(debug, spawn_snap_ui_object, "", R_DEBUG)
+ADMIN_VERB(debug, spawn_snap_ui_object, "Spawn Snap UI Object", "", R_DEBUG)
 	var/atom/movable/screen/movable/snap/S = new()
 	S.name = "Snap UI Object"
 	S.icon_state = "block"
@@ -713,7 +713,7 @@ ADMIN_VERB(debug, spawn_snap_ui_object, "", R_DEBUG)
 	usr.client.screen += S
 
 /// Debug verb for getting the weight of each distinct type within the random_hallucination_weighted_list
-ADMIN_VERB(debug, show_hallucination_weights, "", R_DEBUG)
+ADMIN_VERB(debug, show_hallucination_weights, "Show Hallucination Weights", "", R_DEBUG)
 	var/header = "<tr><th>Type</th> <th>Weight</th> <th>Percent</th>"
 
 	var/total_weight = debug_hallucination_weighted_list()
@@ -753,7 +753,7 @@ ADMIN_VERB(debug, show_hallucination_weights, "", R_DEBUG)
 	popup.set_content(page_contents)
 	popup.open()
 
-ADMIN_VERB(debug, clear_dynamic_turf_reserverations, "Deallocates all reserved space, restoring it to round start conditions", R_DEBUG)
+ADMIN_VERB(debug, clear_dynamic_turf_reserverations, "Clear Dynamic Turf Reservations", "Deallocates all reserved space, restoring it to round start conditions", R_DEBUG)
 	if(length(SSmapping.loaded_lazy_templates))
 		to_chat(usr, span_boldbig("WARNING, THERE ARE LOADED LAZY TEMPLATES, THIS WILL CAUSE THEM TO BE UNLOADED AND POTENTIALLY RUIN THE ROUND"))
 
@@ -765,12 +765,12 @@ ADMIN_VERB(debug, clear_dynamic_turf_reserverations, "Deallocates all reserved s
 	log_admin("[key_name(src)] cleared dynamic transit space.")
 	SSmapping.wipe_reservations() //this goes after it's logged, incase something horrible happens.
 
-ADMIN_VERB(debug, toggle_medal_disable, "Toggles the safety lock on trying to contact the medal hub", R_DEBUG)
+ADMIN_VERB(debug, toggle_medal_disable, "Toggle Medal Disable", "Toggles the safety lock on trying to contact the medal hub", R_DEBUG)
 	SSachievements.achievements_enabled = !SSachievements.achievements_enabled
 	message_admins(span_adminnotice("[key_name_admin(usr)] [SSachievements.achievements_enabled ? "disabled" : "enabled"] the medal hub lockout."))
 	log_admin("[key_name(usr)] [SSachievements.achievements_enabled ? "disabled" : "enabled"] the medal hub lockout.")
 
-ADMIN_VERB(debug, view_runtimes, "Opem the Runtime Viewer", R_DEBUG)
+ADMIN_VERB(debug, view_runtimes, "View Runtimes", "Opem the Runtime Viewer", R_DEBUG)
 	GLOB.error_cache.show_to(usr)
 
 	// The runtime viewer has the potential to crash the server if there's a LOT of runtimes
@@ -782,22 +782,22 @@ ADMIN_VERB(debug, view_runtimes, "Opem the Runtime Viewer", R_DEBUG)
 		// Not using TGUI alert, because it's view runtimes, stuff is probably broken
 		alert(usr, "[warning]. Proceed with caution. If you really need to see the runtimes, download the runtime log and view it in a text editor.", "HEED THIS WARNING CAREFULLY MORTAL")
 
-ADMIN_VERB(debug, pump_random_event, "Schedules the event subsystem to fire a new random event immediately. Some events may fire without notification", R_FUN)
+ADMIN_VERB(debug, pump_random_event, "Pump Random Event", "Schedules the event subsystem to fire a new random event immediately. Some events may fire without notification", R_FUN)
 	SSevents.scheduled = world.time
 	message_admins(span_adminnotice("[key_name_admin(usr)] pumped a random event."))
 	log_admin("[key_name(usr)] pumped a random event.")
 
-ADMIN_VERB(debug, start_line_profiling, "Starts tracking line by line profiling for code lines that support it", R_DEBUG)
+ADMIN_VERB(debug, start_line_profiling, "Start Line Profiling", "Starts tracking line by line profiling for code lines that support it", R_DEBUG)
 	LINE_PROFILE_START
 	message_admins(span_adminnotice("[key_name_admin(src)] started line by line profiling."))
 	log_admin("[key_name(src)] started line by line profiling.")
 
-ADMIN_VERB(debug, stop_line_profiling, "Stops tracking line by line profiling for code lines that support it", R_DEBUG)
+ADMIN_VERB(debug, stop_line_profiling, "Stop Line Profiling", "Stops tracking line by line profiling for code lines that support it", R_DEBUG)
 	LINE_PROFILE_STOP
 	message_admins(span_adminnotice("[key_name_admin(src)] stopped line by line profiling."))
 	log_admin("[key_name(src)] stopped line by line profiling.")
 
-ADMIN_VERB(debug, show_line_profiling, "Shows tracked profiling info from code lines that support it", R_DEBUG)
+ADMIN_VERB(debug, show_line_profiling, "Show Line Profiling", "Shows tracked profiling info from code lines that support it", R_DEBUG)
 	var/sortlist = list(
 		"Avg time" = GLOBAL_PROC_REF(cmp_profile_avg_time_dsc),
 		"Total Time" = GLOBAL_PROC_REF(cmp_profile_time_dsc),
@@ -809,11 +809,11 @@ ADMIN_VERB(debug, show_line_profiling, "Shows tracked profiling info from code l
 	sort = sortlist[sort]
 	profile_show(usr, sort)
 
-ADMIN_VERB(debug, reload_configuration, "Force config reload to world default", R_DEBUG)
+ADMIN_VERB(debug, reload_configuration, "Reload Configuration", "Force config reload to world default", R_DEBUG)
 	if(tgui_alert(usr, "Are you absolutely sure you want to reload the configuration from the default path on the disk, wiping any in-round modificatoins?", "Really reset?", list("No", "Yes")) == "Yes")
 		config.admin_reload()
 
-ADMIN_VERB(debug, check_timer_sources, "Checks the sources of the running timers", R_DEBUG)
+ADMIN_VERB(debug, check_timer_sources, "Check Timer Sources", "Checks the sources of the running timers", R_DEBUG)
 	var/bucket_list_output = generate_timer_source_output(SStimer.bucket_list)
 	var/second_queue = generate_timer_source_output(SStimer.second_queue)
 
@@ -867,7 +867,7 @@ ADMIN_VERB(debug, check_timer_sources, "Checks the sources of the running timers
 	return b["count"] - a["count"]
 
 #ifdef TESTING
-ADMIN_VERB(debug, check_missing_sprites, "We're cancelling the Spritemageddon. (This will create a LOT of runtimes! Don't use on a live server!)", R_DEBUG)
+ADMIN_VERB(debug, check_missing_sprites, "Check Missing Sprites", "We're cancelling the Spritemageddon. (This will create a LOT of runtimes! Don't use on a live server!)", R_DEBUG)
 	var/actual_file_name
 	for(var/test_obj in subtypesof(/obj/item))
 		var/obj/item/sprite = new test_obj

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -1,7 +1,7 @@
-ADMIN_VERB(debug, display_air_status, "", R_DEBUG, turf/target in view())
+ADMIN_VERB(debug, display_air_status, "Display Air Status", "", R_DEBUG, turf/target in view())
 	atmos_scan(user=usr, target=target, silent=TRUE)
 
-ADMIN_VERB(debug, unfreeze_everyone, "When movement gets fucked", R_ADMIN)
+ADMIN_VERB(debug, unfreeze_everyone, "Unfreeze Everyone", "When movement gets fucked", R_ADMIN)
 	var/largest_move_time = 0
 	var/largest_click_time = 0
 	var/mob/largest_move_mob = null
@@ -26,7 +26,7 @@ ADMIN_VERB(debug, unfreeze_everyone, "When movement gets fucked", R_ADMIN)
 	message_admins("[ADMIN_LOOKUPFLW(largest_click_mob)] had the largest click delay with [largest_click_time] frames / [DisplayTimeText(largest_click_time)]!")
 	message_admins("world.time = [world.time]")
 
-ADMIN_VERB(debug, radio_report, "", R_DEBUG)
+ADMIN_VERB(debug, radio_report, "Radio Report", "", R_DEBUG)
 	var/output = "<b>Radio Report</b><hr>"
 	for (var/fq in SSradio.frequencies)
 		output += "<b>Freq: [fq]</b><br>"
@@ -52,7 +52,7 @@ ADMIN_VERB(debug, radio_report, "", R_DEBUG)
 					output += "&nbsp;&nbsp;&nbsp;&nbsp;[device]<br>"
 	usr << browse(output,"window=radioreport")
 
-ADMIN_VERB(server, toggle_cdn, "", R_SERVER|R_DEBUG)
+ADMIN_VERB(server, toggle_cdn, "Toggle CDN", "", R_SERVER|R_DEBUG)
 	var/static/admin_disabled_cdn_transport = null
 	if (alert(usr, "Are you sure you want to toggle the CDN asset transport?", "Confirm", "Yes", "No") != "Yes")
 		return

--- a/code/modules/admin/verbs/ert.dm
+++ b/code/modules/admin/verbs/ert.dm
@@ -261,7 +261,7 @@
 
 	return
 
-ADMIN_VERB(fun, summon_ert, "Summons an Emergency Response Team", R_FUN)
+ADMIN_VERB(fun, summon_ert, "Summon ERT", "Summons an Emergency Response Team", R_FUN)
 	message_admins("[key_name(usr)] is creating a CentCom response team...")
 	if(usr.client.holder?.makeEmergencyresponseteam())
 		message_admins("[key_name(usr)] created a CentCom response team.")

--- a/code/modules/admin/verbs/fov.dm
+++ b/code/modules/admin/verbs/fov.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(debug, toggle_field_of_view, "", (R_ADMIN|R_DEBUG))
+ADMIN_VERB(debug, toggle_field_of_view, "Toggle Field of View", "", (R_ADMIN|R_DEBUG))
 	var/on_off = CONFIG_GET(flag/native_fov)
 
 	message_admins("[key_name_admin(usr)] has [on_off ? "disabled" : "enabled"] the Native Field of View configuration..")

--- a/code/modules/admin/verbs/fps.dm
+++ b/code/modules/admin/verbs/fps.dm
@@ -1,5 +1,5 @@
 //replaces the old Ticklag verb, fps is easier to understand
-ADMIN_VERB(debug, set_server_fps, "Sets game speed in frames-per-second. Will break the game, but that's why it's fun!", R_DEBUG)
+ADMIN_VERB(debug, set_server_fps, "Set Server FPS", "Sets game speed in frames-per-second. Will break the game, but that's why it's fun!", R_DEBUG)
 	var/cfg_fps = CONFIG_GET(number/fps)
 	var/new_fps = round(input("Sets game frames-per-second. Can potentially break the game (default: [cfg_fps])","FPS", world.fps) as num|null)
 

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -1,7 +1,7 @@
-ADMIN_VERB(admin, get_server_logs, "View/Retrieve logfiles", R_ADMIN)
+ADMIN_VERB(admin, get_server_logs, "Get Server Logs", "View/Retrieve logfiles", R_ADMIN)
 	usr.client.holder.browseserverlogs()
 
-ADMIN_VERB(admin, get_current_logs, "View/Retrieve current logfiles", R_ADMIN)
+ADMIN_VERB(admin, get_current_logs, "Get Current Logs", "View/Retrieve current logfiles", R_ADMIN)
 	usr.client.holder.browseserverlogs(current = TRUE)
 
 /datum/admins/proc/browseserverlogs(current = FALSE)

--- a/code/modules/admin/verbs/ghost_pool_protection.dm
+++ b/code/modules/admin/verbs/ghost_pool_protection.dm
@@ -1,6 +1,6 @@
 //very similar to centcom_podlauncher in terms of how this is coded, so i kept a lot of comments from it
 
-ADMIN_VERB(events, ghost_pool_protection, "Choose which ways people can get into the round, or just clear it out completely for admin events", R_FUN)
+ADMIN_VERB(events, ghost_pool_protection, "Ghost Pool Protection", "Choose which ways people can get into the round, or just clear it out completely for admin events", R_FUN)
 	var/datum/ghost_pool_menu/tgui = new(usr)//create the datum
 	tgui.ui_interact(usr)//datum has a tgui component, here we open the window
 

--- a/code/modules/admin/verbs/lua/lua_editor.dm
+++ b/code/modules/admin/verbs/lua/lua_editor.dm
@@ -234,7 +234,7 @@
 	. = ..()
 	qdel(src)
 
-ADMIN_VERB(debug, open_lua_editor, "", R_DEBUG)
+ADMIN_VERB(debug, open_lua_editor, "Open Lua Editor", "", R_DEBUG)
 	if(SSlua.initialized != TRUE)
 		to_chat(usr, span_warning("SSlua is not initialized!"))
 		return

--- a/code/modules/admin/verbs/manipulate_organs.dm
+++ b/code/modules/admin/verbs/manipulate_organs.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(debug, manipulate_organs, "", R_DEBUG, mob/living/carbon/target in view())
+ADMIN_VERB(debug, manipulate_organs, "Manipulate Organs", "", R_DEBUG, mob/living/carbon/target in view())
 	var/operation = tgui_input_list(usr, "Select organ operation", "Organ Manipulation", list("add organ", "add implant", "drop organ/implant", "remove organ/implant"))
 	if (isnull(operation))
 		return

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(debug, map_template_load, "", R_DEBUG)
+ADMIN_VERB(debug, map_template_load, "Map Template Load", "", R_DEBUG)
 	var/datum/map_template/template
 
 	var/map = input(usr, "Choose a Map Template to place at your CURRENT LOCATION","Place Map Template") as null|anything in sort_list(SSmapping.map_templates)
@@ -39,7 +39,7 @@ ADMIN_VERB(debug, map_template_load, "", R_DEBUG)
 			to_chat(usr, "Failed to place map", confidential = TRUE)
 	usr.client.images -= preview
 
-ADMIN_VERB(debug, map_template_upload, "", R_DEBUG)
+ADMIN_VERB(debug, map_template_upload, "Map Template Upload", "", R_DEBUG)
 	var/map = input(usr, "Choose a Map Template to upload to template storage","Upload Map Template") as null|file
 	if(!map)
 		return

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -19,7 +19,7 @@
 //- Identify how hard it is to break into the area and where the weak points are
 //- Check if the area has too much empty space. If so, make it smaller and replace the rest with maintenance tunnels.
 
-ADMIN_VERB(mapping, camera_range_display, "Iterate over all cameras in world and generate a camera map", R_DEBUG)
+ADMIN_VERB(mapping, camera_range_display, "Camera Range Display", "Iterate over all cameras in world and generate a camera map", R_DEBUG)
 	if(tgui_alert(usr, "This can take a very long time and lock up the game!", "Don't do this on live", list("Okay", "Nevermind")) != "Okay")
 		return
 
@@ -39,7 +39,7 @@ ADMIN_VERB(mapping, camera_range_display, "Iterate over all cameras in world and
 
 #ifdef TESTING
 GLOBAL_LIST_EMPTY(dirty_vars)
-ADMIN_VERB(mapping, dirty_varedits, "", R_DEBUG)
+ADMIN_VERB(mapping, dirty_varedits, "Dirty VarEdits", "", R_DEBUG)
 	var/list/dat = list()
 	dat += "<h3>Abandon all hope ye who enter here</h3><br><br>"
 	for(var/thing in GLOB.dirty_vars)
@@ -50,7 +50,7 @@ ADMIN_VERB(mapping, dirty_varedits, "", R_DEBUG)
 	popup.open()
 #endif
 
-ADMIN_VERB(mapping, camera_report, "", R_DEBUG)
+ADMIN_VERB(mapping, camera_report, "Camera Report", "", R_DEBUG)
 	var/list/obj/machinery/camera/CL = list()
 
 	for(var/obj/machinery/camera/C as anything in GLOB.cameranet.cameras)
@@ -82,7 +82,7 @@ ADMIN_VERB(mapping, camera_report, "", R_DEBUG)
 	output += "</ul>"
 	usr << browse(output,"window=airreport;size=1000x500")
 
-ADMIN_VERB(mapping, intercom_range_display, "", R_DEBUG)
+ADMIN_VERB(mapping, intercom_range_display, "Intercomm Range Display", "", R_DEBUG)
 	var/static/intercom_range_display_status = FALSE
 	//blame cyberboss if this breaks something //blamed
 	intercom_range_display_status = !intercom_range_display_status
@@ -96,7 +96,7 @@ ADMIN_VERB(mapping, intercom_range_display, "", R_DEBUG)
 				for(var/turf/turf in view(7,intercom.loc))
 					new /obj/effect/abstract/marker/intercom(turf)
 
-ADMIN_VERB(mapping, show_map_report_list, "Display a list of map reports", R_DEBUG)
+ADMIN_VERB(mapping, show_map_report_list, "Show Map Report List", "Display a list of map reports", R_DEBUG)
 	var/dat = {"<b>List of all map reports:</b><br>"}
 
 	for(var/datum/map_report/report as anything in GLOB.map_reports)
@@ -104,7 +104,7 @@ ADMIN_VERB(mapping, show_map_report_list, "Display a list of map reports", R_DEB
 
 	usr << browse(dat, "window=map_reports")
 
-ADMIN_VERB(mapping, show_roundstart_at_list, "Displays a list of active turfs at roundstart", R_DEBUG)
+ADMIN_VERB(mapping, show_roundstart_at_list, "Show Roundstart AT List", "Displays a list of active turfs at roundstart", R_DEBUG)
 	var/dat = {"<b>Coordinate list of Active Turfs at Roundstart</b>
 		<br>Real-time Active Turfs list you can see in Air Subsystem at active_turfs var<br>"}
 
@@ -114,7 +114,7 @@ ADMIN_VERB(mapping, show_roundstart_at_list, "Displays a list of active turfs at
 		dat += "<br>"
 	usr << browse(dat, "window=at_list")
 
-ADMIN_VERB(mapping, show_roundstart_at_markers, "Places a marker on all active-at-roundstart turfs", R_DEBUG)
+ADMIN_VERB(mapping, show_roundstart_at_markers, "Show Roundstart AT Markers", "Places a marker on all active-at-roundstart turfs", R_DEBUG)
 	var/count = 0
 	for(var/obj/effect/abstract/marker/at/AT in GLOB.all_abstract_markers)
 		qdel(AT)
@@ -128,7 +128,7 @@ ADMIN_VERB(mapping, show_roundstart_at_markers, "Places a marker on all active-a
 			count++
 		to_chat(usr, "[count] AT markers placed.", confidential = TRUE)
 
-ADMIN_VERB(mapping, count_objects_on_zlevel, "", R_DEBUG)
+ADMIN_VERB(mapping, count_objects_on_zlevel, "Count Objects on ZLevel", "", R_DEBUG)
 	var/level = input("Which z-level?","Level?") as text|null
 	if(!level)
 		return
@@ -164,7 +164,7 @@ ADMIN_VERB(mapping, count_objects_on_zlevel, "", R_DEBUG)
 
 	to_chat(world, "There are [count] objects of type [type_path] on z-level [num_level]", confidential = TRUE)
 
-ADMIN_VERB(mapping, count_all_objects, "", R_DEBUG)
+ADMIN_VERB(mapping, count_all_objects, "Count All Objects", "", R_DEBUG)
 	var/type_text = input("Which type path?","") as text|null
 	if(!type_text)
 		return
@@ -183,13 +183,13 @@ ADMIN_VERB(mapping, count_all_objects, "", R_DEBUG)
 //This proc is intended to detect lag problems relating to communication procs
 GLOBAL_VAR_INIT(say_disabled, FALSE)
 // Why is this a mapping verb?
-ADMIN_VERB(mapping, disable_all_communication_verbs, "", R_DEBUG)
+ADMIN_VERB(mapping, disable_all_communication_verbs, "Disable All Communication Verbs", "", R_DEBUG)
 	GLOB.say_disabled = !GLOB.say_disabled
 	var/message = "has [(GLOB.say_disabled ? "disabled" : "enabled")] all forms of communication"
 	message_admins("[key_name_admin(usr)] [message]")
 	log_admin("[key_name(usr)] [message]")
 
-ADMIN_VERB(mapping,	generate_job_landmark_icons, "This generates the icon states for job starting location landmarks", R_DEBUG)
+ADMIN_VERB(mapping,	generate_job_landmark_icons, "Generate Job Landmark Icons", "This generates the icon states for job starting location landmarks", R_DEBUG)
 	var/icon/final = icon()
 	var/mob/living/carbon/human/dummy/D = new(locate(1,1,1)) //spawn on 1,1,1 so we don't have runtimes when items are deleted
 	D.setDir(SOUTH)
@@ -213,7 +213,7 @@ ADMIN_VERB(mapping,	generate_job_landmark_icons, "This generates the icon states
 		final.Insert(icon('icons/hud/screen_gen.dmi', "x[x_number == 1 ? "" : x_number]"), "x[x_number == 1 ? "" : x_number]")
 	fcopy(final, "icons/mob/landmarks.dmi")
 
-ADMIN_VERB(mapping, debug_zlevels, "", R_DEBUG)
+ADMIN_VERB(mapping, debug_zlevels, "Debug ZLevels", "", R_DEBUG)
 	var/list/z_list = SSmapping.z_list
 	var/list/messages = list()
 	messages += "<b>World</b>: [world.maxx] x [world.maxy] x [world.maxz]<br><br>"
@@ -269,7 +269,7 @@ ADMIN_VERB(mapping, debug_zlevels, "", R_DEBUG)
 	messages += "</table>"
 	to_chat(usr, examine_block(messages.Join("")), confidential = TRUE)
 
-ADMIN_VERB(mapping, count_station_food, "", R_DEBUG)
+ADMIN_VERB(mapping, count_station_food, "Count Station Food", "", R_DEBUG)
 	var/list/foodcount = list()
 	for(var/obj/item/food/fuck_me in world)
 		var/turf/location = get_turf(fuck_me)
@@ -290,7 +290,7 @@ ADMIN_VERB(mapping, count_station_food, "", R_DEBUG)
 	popup.set_content(page_contents)
 	popup.open()
 
-ADMIN_VERB(mapping, count_station_stacks, "", R_DEBUG)
+ADMIN_VERB(mapping, count_station_stacks, "Count Station Stacks", "", R_DEBUG)
 	var/list/stackcount = list()
 	for(var/obj/item/stack/fuck_me in world)
 		var/turf/location = get_turf(fuck_me)
@@ -311,7 +311,7 @@ ADMIN_VERB(mapping, count_station_stacks, "", R_DEBUG)
 	popup.set_content(page_contents)
 	popup.open()
 
-ADMIN_VERB(mapping, check_for_obstructed_atmopsherics, "Check all tiles with a vent or scrubber on it and ensure that nothing is covering it up", R_DEBUG)
+ADMIN_VERB(mapping, check_for_obstructed_atmopsherics, "Check For Obstructed Atmospherics", "Check all tiles with a vent or scrubber on it and ensure that nothing is covering it up", R_DEBUG)
 	message_admins(span_adminnotice("[key_name_admin(usr)] is checking for obstructed atmospherics through the debug command."))
 	var/list/results = list()
 	results += "<h2><b>Anything that is considered to aesthetically obstruct an atmospherics machine (vent, scrubber, port) is listed below.</b> Please re-arrange to accomodate for this.</h2><br>"

--- a/code/modules/admin/verbs/maprotation.dm
+++ b/code/modules/admin/verbs/maprotation.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(server, trigger_random_map_rotation, "", R_SERVER)
+ADMIN_VERB(server, trigger_random_map_rotation, "Trigger Random Map Rotation", "", R_SERVER)
 	var/rotate = tgui_alert(usr,"Force a random map rotation to trigger?", "Rotate map?", list("Yes", "Cancel"))
 	if (rotate != "Yes")
 		return
@@ -6,7 +6,7 @@ ADMIN_VERB(server, trigger_random_map_rotation, "", R_SERVER)
 	log_admin("[key_name(usr)] is forcing a random map rotation.")
 	SSmapping.maprotate()
 
-ADMIN_VERB(server, change_map, "", R_SERVER)
+ADMIN_VERB(server, change_map, "Change Map", "", R_SERVER)
 	var/list/maprotatechoices = list()
 	for (var/map in config.maplist)
 		var/datum/map_config/virtual_map = config.maplist[map]

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(server, toggle_panic_bunker, "", R_SERVER)
+ADMIN_VERB(server, toggle_panic_bunker, "Toggle Panic Bunker", "", R_SERVER)
 	if (!CONFIG_GET(flag/sql_enabled))
 		to_chat(usr, span_adminnotice("The Database is not enabled!"), confidential = TRUE)
 		return
@@ -24,7 +24,7 @@ ADMIN_VERB(server, toggle_panic_bunker, "", R_SERVER)
 		message_admins("The Database is not connected! Panic bunker will not work until the connection is reestablished.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Panic Bunker", "[new_pb ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-ADMIN_VERB(server, toggle_pb_interviews, "", R_SERVER)
+ADMIN_VERB(server, toggle_pb_interviews, "Toggle PB Interviews", "", R_SERVER)
 	if (!CONFIG_GET(flag/panic_bunker))
 		to_chat(usr, span_adminnotice("NOTE: The panic bunker is not enabled, so this change will not effect anything until it is enabled."), confidential = TRUE)
 	var/new_interview = !CONFIG_GET(flag/panic_bunker_interview)

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -3,7 +3,7 @@
 #define SHELLEO_STDOUT 2
 #define SHELLEO_STDERR 3
 
-ADMIN_VERB(fun, play_global_sound, "", R_SOUND, sound/to_play as sound)
+ADMIN_VERB(fun, play_global_sound, "Play Global Sound", "", R_SOUND, sound/to_play as sound)
 	var/freq = 1
 	var/vol = input(usr, "What volume would you like the sound to play at?",, 100) as null|num
 	if(!vol)
@@ -36,12 +36,12 @@ ADMIN_VERB(fun, play_global_sound, "", R_SOUND, sound/to_play as sound)
 			SEND_SOUND(listener, admin_sound)
 			admin_sound.volume = vol
 
-ADMIN_VERB(fun, play_local_sound, "", R_SOUND, sound/playing as sound)
+ADMIN_VERB(fun, play_local_sound, "Play Local Sound", "", R_SOUND, sound/playing as sound)
 	log_admin("[key_name(usr)] played a local sound [playing]")
 	message_admins("[key_name_admin(usr)] played a local sound [playing]")
 	playsound(get_turf(usr), playing, 50, FALSE, FALSE)
 
-ADMIN_VERB(fun, play_direct_mob_sound, "", R_SOUND, sound/playing as sound, mob/target as mob in view())
+ADMIN_VERB(fun, play_direct_mob_sound, "Play Direct Mob Sound", "", R_SOUND, sound/playing as sound, mob/target as mob in view())
 	if(!target)
 		target = input(usr, "Choose a mob to play the sound to. Only they will hear it.", "Play Mob Sound") as null|anything in sort_names(GLOB.player_list)
 	if(!target || QDELETED(target))
@@ -50,7 +50,7 @@ ADMIN_VERB(fun, play_direct_mob_sound, "", R_SOUND, sound/playing as sound, mob/
 	message_admins("[key_name_admin(usr)] played a direct mob sound [playing] to [ADMIN_LOOKUPFLW(target)].")
 	SEND_SOUND(target, playing)
 
-ADMIN_VERB(fun, play_internet_sound, "", R_SOUND)
+ADMIN_VERB(fun, play_internet_sound, "Play Internet Sound", "", R_SOUND)
 	var/ytdl = CONFIG_GET(string/invoke_youtubedl)
 	if(!ytdl)
 		to_chat(usr, span_boldwarning("Youtube-dl was not configured, action unavailable")) //Check config.txt for the INVOKE_YOUTUBEDL value
@@ -147,7 +147,7 @@ ADMIN_VERB(fun, play_internet_sound, "", R_SOUND)
 					else
 						listner_client.tgui_panel?.stop_music()
 
-ADMIN_VERB(fun, set_round_end_sound, "", R_SOUND, sound/to_play as sound)
+ADMIN_VERB(fun, set_round_end_sound, "Set Round End Sound", "", R_SOUND, sound/to_play as sound)
 	SSticker.SetRoundEndSound(to_play)
 
 	log_admin("[key_name(usr)] set the round end sound to [to_play]")

--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(object, possess_object, "", R_POSSESS, obj/target in world)
+ADMIN_VERB(object, possess_object, "Possess Object", "", R_POSSESS, obj/target in world)
 	if((target.obj_flags & DANGEROUS_POSSESSION) && CONFIG_GET(flag/forbid_singulo_possession))
 		to_chat(usr, "[target] is too powerful for you to possess.", confidential = TRUE)
 		return
@@ -22,7 +22,7 @@ ADMIN_VERB(object, possess_object, "", R_POSSESS, obj/target in world)
 	usr.control_object = target
 	target.AddElement(/datum/element/weather_listener, /datum/weather/ash_storm, ZTRAIT_ASHSTORM, GLOB.ash_storm_sounds)
 
-ADMIN_VERB(object, release_object, "", R_POSSESS)
+ADMIN_VERB(object, release_object, "Release Object", "", R_POSSESS)
 	if(!usr.control_object) //lest we are banished to the nullspace realm.
 		return
 

--- a/code/modules/admin/verbs/server.dm
+++ b/code/modules/admin/verbs/server.dm
@@ -1,12 +1,12 @@
 // Server Tab - Server Verbs
 
 
-ADMIN_VERB(server, toggle_random_events, "Toggles random events such as meteors, black holes, blob (but not space dust) on/off", R_SERVER)
+ADMIN_VERB(server, toggle_random_events, "Toggle Random Events", "Toggles random events such as meteors, black holes, blob (but not space dust) on/off", R_SERVER)
 	var/new_are = !CONFIG_GET(flag/allow_random_events)
 	CONFIG_SET(flag/allow_random_events, new_are)
 	message_admins("[key_name_admin(usr)] has [new_are ? "enabled" : "disabled"] random events.")
 
-ADMIN_VERB(server, toggle_hub, "", R_SERVER)
+ADMIN_VERB(server, toggle_hub, "Toggle Hub", "", R_SERVER)
 	world.update_hub_visibility(!GLOB.hub_visibility)
 
 	log_admin("[key_name(usr)] has toggled the server's hub status for the round, it is now [(GLOB.hub_visibility?"on":"off")] the hub.")
@@ -14,7 +14,7 @@ ADMIN_VERB(server, toggle_hub, "", R_SERVER)
 	if (GLOB.hub_visibility && !world.reachable)
 		message_admins("WARNING: The server will not show up on the hub because byond is detecting that a filewall is blocking incoming connections.")
 
-ADMIN_VERB(server, reboot_world, "Restarts the world immediately", R_SERVER)
+ADMIN_VERB(server, reboot_world, "Reboot World", "Restarts the world immediately", R_SERVER)
 	var/localhost_addresses = list("127.0.0.1", "::1")
 	var/list/options = list("Regular Restart", "Regular Restart (with delay)", "Hard Restart (No Delay/Feeback Reason)", "Hardest Restart (No actions, just reboot)")
 	if(world.TgsAvailable())
@@ -51,24 +51,24 @@ ADMIN_VERB(server, reboot_world, "Restarts the world immediately", R_SERVER)
 				to_chat(world, "Server restart - [init_by]")
 				world.TgsEndProcess()
 
-ADMIN_VERB(server, end_round, "Attempts to produce a round end report and then restart the server organically.", R_SERVER)
+ADMIN_VERB(server, end_round, "End Round", "Attempts to produce a round end report and then restart the server organically.", R_SERVER)
 	var/confirm = tgui_alert(usr, "End the round and  restart the game world?", "End Round", list("Yes", "Cancel"))
 	if(confirm == "Cancel")
 		return
 	if(confirm == "Yes")
 		SSticker.force_ending = TRUE
 
-ADMIN_VERB(server, toggle_ooc, "Toggle dis bitch", R_SERVER)
+ADMIN_VERB(server, toggle_ooc, "Toggle OOC", "Toggle dis bitch", R_SERVER)
 	toggle_ooc()
 	log_admin("[key_name(usr)] toggled OOC.")
 	message_admins("[key_name_admin(usr)] toggled OOC.")
 
-ADMIN_VERB(server, toggle_dead_ooc, "Toggle dis bitch", R_SERVER)
+ADMIN_VERB(server, toggle_dead_ooc, "Toggle Dead OOC", "Toggle dis bitch", R_SERVER)
 	toggle_dooc()
 	log_admin("[key_name(usr)] toggled OOC.")
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.")
 
-ADMIN_VERB(server, start_now, "Start the round RIGHT NOW", R_SERVER)
+ADMIN_VERB(server, start_now, "Start Now", "Start the round RIGHT NOW", R_SERVER)
 	if(SSticker.current_state == GAME_STATE_PREGAME || SSticker.current_state == GAME_STATE_STARTUP)
 		if(!SSticker.start_immediately)
 			var/localhost_addresses = list("127.0.0.1", "::1")
@@ -94,7 +94,7 @@ ADMIN_VERB(server, start_now, "Start the round RIGHT NOW", R_SERVER)
 		to_chat(usr, "<span class='warningplain'><font color='red'>Error: Start Now: Game has already started.</font></span>")
 	return FALSE
 
-ADMIN_VERB(server, delay_round_end, "Prevent the server from restarting", R_SERVER)
+ADMIN_VERB(server, delay_round_end, "Delay Round End", "Prevent the server from restarting", R_SERVER)
 	if(SSticker.delay_end)
 		tgui_alert(usr, "The round end is already delayed. The reason for the current delay is: \"[SSticker.admin_delay_notice]\"", "Alert", list("Ok"))
 		return
@@ -114,14 +114,14 @@ ADMIN_VERB(server, delay_round_end, "Prevent the server from restarting", R_SERV
 	log_admin("[key_name(usr)] delayed the round end for reason: [SSticker.admin_delay_notice]")
 	message_admins("[key_name_admin(usr)] delayed the round end for reason: [SSticker.admin_delay_notice]")
 
-ADMIN_VERB(server, toggle_entering, "People can't enter", R_SERVER)
+ADMIN_VERB(server, toggle_entering, "Toggle Entering", "People can't enter", R_SERVER)
 	if(!SSlag_switch.initialized)
 		return
 	SSlag_switch.set_measure(DISABLE_NON_OBSJOBS, !SSlag_switch.measures[DISABLE_NON_OBSJOBS])
 	log_admin("[key_name(usr)] toggled new player game entering. Lag Switch at index ([DISABLE_NON_OBSJOBS])")
 	message_admins("[key_name_admin(usr)] toggled new player game entering [SSlag_switch.measures[DISABLE_NON_OBSJOBS] ? "OFF" : "ON"].")
 
-ADMIN_VERB(server, toggle_ai, "People can't be AI", R_SERVER)
+ADMIN_VERB(server, toggle_ai, "Toggle AI", "People can't be AI", R_SERVER)
 	var/alai = CONFIG_GET(flag/allow_ai)
 	CONFIG_SET(flag/allow_ai, !alai)
 	if (alai)
@@ -131,7 +131,7 @@ ADMIN_VERB(server, toggle_ai, "People can't be AI", R_SERVER)
 	log_admin("[key_name(usr)] toggled AI allowed.")
 	world.update_status()
 
-ADMIN_VERB(server, toggle_respawn, "Respawn basically", R_SERVER)
+ADMIN_VERB(server, toggle_respawn, "Toggle Respawn", "Respawn basically", R_SERVER)
 	var/new_nores = !CONFIG_GET(flag/norespawn)
 	CONFIG_SET(flag/norespawn, new_nores)
 	if (!new_nores)
@@ -142,7 +142,7 @@ ADMIN_VERB(server, toggle_respawn, "Respawn basically", R_SERVER)
 	log_admin("[key_name(usr)] toggled respawn to [!new_nores ? "On" : "Off"].")
 	world.update_status()
 
-ADMIN_VERB(server, delay_pre_game, "Delay the game start", R_SERVER)
+ADMIN_VERB(server, delay_pre_game, "Delay Pre Game", "Delay the game start", R_SERVER)
 	var/newtime = input(usr, "Set a new time in seconds. Set -1 for indefinite delay.","Set Delay",round(SSticker.GetTimeLeft()/10)) as num|null
 	if(SSticker.current_state > GAME_STATE_PREGAME)
 		return tgui_alert(usr, "Too late... The game has already started!")
@@ -158,7 +158,7 @@ ADMIN_VERB(server, delay_pre_game, "Delay the game start", R_SERVER)
 			SEND_SOUND(world, sound('sound/ai/default/attention.ogg'))
 			log_admin("[key_name(usr)] set the pre-game delay to [DisplayTimeText(newtime)].")
 
-ADMIN_VERB(server, set_admin_notice, "Set an announcement that appears to everone who joins the server; only lasts this round", R_SERVER)
+ADMIN_VERB(server, set_admin_notice, "Set Admin Notice", "Set an announcement that appears to everone who joins the server; only lasts this round", R_SERVER)
 	var/new_admin_notice = input(src,"Set a public notice for this round. Everyone who joins the server will see it.\n(Leaving it blank will delete the current notice):","Set Notice",GLOB.admin_notice) as message|null
 	if(new_admin_notice == null)
 		return
@@ -173,7 +173,7 @@ ADMIN_VERB(server, set_admin_notice, "Set an announcement that appears to everon
 		to_chat(world, span_adminnotice("<b>Admin Notice:</b>\n \t [new_admin_notice]"), confidential = TRUE)
 	GLOB.admin_notice = new_admin_notice
 
-ADMIN_VERB(server, toggle_guests, "Guests can't enter", R_SERVER)
+ADMIN_VERB(server, toggle_guests, "Toggle Guests", "Guests can't enter", R_SERVER)
 	var/new_guest_ban = !CONFIG_GET(flag/guest_ban)
 	CONFIG_SET(flag/guest_ban, new_guest_ban)
 	if (new_guest_ban)

--- a/code/modules/admin/verbs/spawnobjasmob.dm
+++ b/code/modules/admin/verbs/spawnobjasmob.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(debug, spawn_object_as_mob, "Spawn an object-mob", R_SPAWN, object as text)
+ADMIN_VERB(debug, spawn_object_as_mob, "Spawn Object as Mob", "Spawn an object-mob", R_SPAWN, object as text)
 	var/chosen = pick_closest_path(object, make_types_fancy(subtypesof(/obj)))
 	if (!chosen)
 		return

--- a/code/modules/admin_verbs/admin_verbs.dm
+++ b/code/modules/admin_verbs/admin_verbs.dm
@@ -1,8 +1,3 @@
-//
-// Admin Verbs modify the game state in some manner, whether that is by modifying the local area, or the station as a whole
-//
-#define ADMIN_VERB_ADMIN(module, _name, _desc, params...) ADMIN_VERB(module, _name, _desc, R_ADMIN, ##params)
-
 ADMIN_CONTEXT_ENTRY(contextcmd_fix_air, "Fix Air", R_ADMIN, turf/target in world)
 	var/range = tgui_input_number(usr, "Specify the radius", "Fix Air", 2, min_value = 0)
 	message_admins("[key_name_admin(usr)] fixed air with range [range] in area [target.loc.name]")
@@ -15,16 +10,16 @@ ADMIN_CONTEXT_ENTRY(contextcmd_fix_air, "Fix Air", R_ADMIN, turf/target in world
 		open_turf.copy_air(initial_air)
 		open_turf.update_visuals()
 
-ADMIN_VERB_ADMIN(events, access_news_network, "Allows you to view, add and edit news feeds")
+ADMIN_VERB(events, access_news_network, "Access News Network", "Allows you to view, add and edit news feeds", R_ADMIN)
 	var/datum/newspanel/new_newspanel = new
 	new_newspanel.ui_interact(usr)
 
-ADMIN_VERB_ADMIN(admin, announce, "Announce your desires to the world", message as message|null)
+ADMIN_VERB(admin, announce, "Announce", "Announce your desires to the world", (R_ADMIN|R_SERVER), message as message|null)
 	if(!message)
 		return
 	message = check_rights_for(usr.client, R_SERVER) ? message : adminscrub(message, 500)
 	to_chat(world, "[span_adminnotice("<b>[usr.client.holder.fakekey ? "Administrator" : usr.key] Announces:</b>")]\n \t [message]")
 	log_admin("Announce: [key_name(usr)] : [message]")
 
-ADMIN_VERB(admin, known_alts_panel, "View all known alt accounts", NONE)
+ADMIN_VERB(admin, known_alts_panel, "Known Alts Panel", "View all known alt accounts", NONE)
 	GLOB.known_alts.show_panel(usr.client)

--- a/code/modules/admin_verbs/default_verbs.dm
+++ b/code/modules/admin_verbs/default_verbs.dm
@@ -1,9 +1,5 @@
-//
-// Default Verbs have no permissions and are available to any and all admins
-//
-#define ADMIN_VERB_DEFAULT(module, _name, _desc, params...) ADMIN_VERB(module, _name, _desc, NONE, ##params)
 
-ADMIN_VERB_DEFAULT(server, reestablish_db_connection, "Attempts to establish a connection to the DB")
+ADMIN_VERB(server, reestablish_db_connection, "Reestablish DB Connection", "Attempts to establish a connection to the DB", NONE)
 	if(!CONFIG_GET(flag/sql_enabled))
 		to_chat(usr, span_adminnotice("The Database is not enabled!"))
 		return
@@ -30,10 +26,10 @@ ADMIN_VERB_DEFAULT(server, reestablish_db_connection, "Attempts to establish a c
 	else
 		message_admins("Database connection re-established")
 
-ADMIN_VERB_DEFAULT(debug, debug_stat_panel, "Enable advanced stat panel debugging")
+ADMIN_VERB(debug, debug_stat_panel, "Debug Stat Panel", "Enable advanced stat panel debugging", NONE)
 	usr.client.stat_panel.send_message("create_debug")
 
-ADMIN_VERB_DEFAULT(game, dead_say, "Speak a message to observers", message as text)
+ADMIN_VERB(game, dead_say, "Dead Say", "Speak a message to observers", NONE, message as text)
 	if(usr.client.prefs.muted & MUTE_DEADCHAT)
 		to_chat(src, span_danger("You cannot send DSAY messages (muted)."))
 		return
@@ -59,11 +55,11 @@ ADMIN_VERB_DEFAULT(game, dead_say, "Speak a message to observers", message as te
 	var/name_and_rank = "[span_tooltip(rank_name, "STAFF")] ([admin_name])"
 	deadchat_broadcast("[span_prefix("DEAD:")] [name_and_rank] says, <span class='message'>\"[emoji_parse(message)]\"</span>")
 
-ADMIN_VERB_DEFAULT(admin, deadmin, "Become a normal player")
+ADMIN_VERB(admin, deadmin, "Deadmin", "Become a normal player", NONE)
 	usr.client.holder.deactivate()
 	log_admin("[key_name(usr)] deadmined")
 
-ADMIN_VERB_DEFAULT(debug, reload_admins, "Reloads all admins from the data store")
+ADMIN_VERB(debug, reload_admins, "Reload Admins", "Reloads all admins from the data store", NONE)
 	var/confirm = tgui_alert(usr, "Are you sure you want to reload all admins?", "Confirm", list("Yes", "No"))
 	if(confirm != "Yes")
 		return
@@ -71,7 +67,7 @@ ADMIN_VERB_DEFAULT(debug, reload_admins, "Reloads all admins from the data store
 	message_admins("[key_name_admin(usr)] manually reloaded admins.")
 	load_admins()
 
-ADMIN_VERB_DEFAULT(debug, stop_all_sounds, "Stop all sounds on all connected clients")
+ADMIN_VERB(debug, stop_all_sounds, "Stop All Sounds", "Stop all sounds on all connected clients", NONE)
 	log_admin("[key_name(usr)] stopped all currently playing sounds.")
 	message_admins("[key_name_admin(usr)] stopped all currently playing sounds.")
 	for(var/mob/player as anything in GLOB.player_list)
@@ -80,13 +76,13 @@ ADMIN_VERB_DEFAULT(debug, stop_all_sounds, "Stop all sounds on all connected cli
 		// but clients can just poof in and out of existence
 		player.client?.tgui_panel.stop_music()
 
-ADMIN_VERB_DEFAULT(game, secrets_panel, "Abuse harder than you ever knew was possible")
+ADMIN_VERB(game, secrets_panel, "Secrets Panel", "Abuse harder than you ever knew was possible", NONE)
 	usr.client?.secrets()
 
-ADMIN_VERB_DEFAULT(game, requests_manager, "Open the request manager panel to view all requests during this round")
+ADMIN_VERB(game, requests_manager, "Requests Manager", "Open the request manager panel to view all requests during this round", NONE)
 	GLOB.requests.ui_interact(usr)
 
-ADMIN_VERB_DEFAULT(admin, admin_say, "Speak to your fellow jannies", message as text)
+ADMIN_VERB(admin, admin_say, "Admin Say", "Speak to your fellow jannies", NONE, message as text)
 	message ||= tgui_input_text(usr, "Message", "Admin Say")
 	message = emoji_parse(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
 	if(!message)
@@ -114,7 +110,7 @@ ADMIN_VERB_DEFAULT(admin, admin_say, "Speak to your fellow jannies", message as 
 		html = message,
 		confidential = TRUE)
 
-ADMIN_VERB_DEFAULT(admin, admin_pm, "Send a message directly to a client")
+ADMIN_VERB(admin, admin_pm, "Admin PM", "Send a message directly to a client", NONE)
 	var/list/targets = list()
 	for(var/client/client in GLOB.clients)
 		var/nametag = ""
@@ -144,7 +140,7 @@ ADMIN_VERB_DEFAULT(admin, admin_pm, "Send a message directly to a client")
 ADMIN_CONTEXT_ENTRY(contextcmd_tag_atom, "Tag Atom", NONE, atom/target in view(view))
 	tag_datum(target)
 
-ADMIN_VERB(debug, tag_datum, "Tag an atom in view", NONE, atom/target)
+ADMIN_VERB(debug, tag_datum, "Tag Datum", "Tag an atom in view", NONE, atom/target)
 	usr.client.tag_datum(target)
 
 /client/proc/tag_datum(datum/target_datum)
@@ -164,7 +160,7 @@ ADMIN_VERB(debug, tag_datum, "Tag an atom in view", NONE, atom/target)
 ADMIN_CONTEXT_ENTRY(contextcmd_mark_atom, "Mark Atom", NONE, atom/target in view(view))
 	mark_datum(target)
 
-ADMIN_VERB(debug, mark_object, "Mark an atom in view", NONE, atom/target)
+ADMIN_VERB(debug, mark_object, "Mark Object", "Mark an atom in view", NONE, atom/target)
 	usr.client.mark_datum(target)
 
 /client/proc/mark_datum(datum/D)
@@ -194,7 +190,7 @@ ADMIN_VERB(debug, mark_object, "Mark an atom in view", NONE, atom/target)
 
 	WRITE_FILE(F, "[time_stamp(format = "YYYY-MM-DD hh:mm:ss")] [REF(src)] ([x],[y],[z]) || [source] [message]<br>")
 
-ADMIN_VERB(game, investigate, "Look at various detailed investigate sources", NONE)
+ADMIN_VERB(game, investigate, "Investigate", "Look at various detailed investigate sources", NONE)
 	var/list/investigates = list(
 		INVESTIGATE_ACCESSCHANGES,
 		INVESTIGATE_ATMOS,

--- a/code/modules/admin_verbs/fishing_calculator.dm
+++ b/code/modules/admin_verbs/fishing_calculator.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(debug, fishing_calculator, "Helper tool to see fishing probabilities with different setups", R_DEBUG)
+ADMIN_VERB(debug, fishing_calculator, "Fishing Calculator", "Helper tool to see fishing probabilities with different setups", R_DEBUG)
 	var/datum/fishing_calculator/ui = new(usr)
 	ui.ui_interact(usr)
 

--- a/code/modules/admin_verbs/vv_admin_verb.dm
+++ b/code/modules/admin_verbs/vv_admin_verb.dm
@@ -1,7 +1,7 @@
 ADMIN_CONTEXT_ENTRY(contextcmd_vv, "View Variables", NONE, datum/target in world)
 	SSadmin_verbs.dynamic_invoke_admin_verb(src, /mob/admin_module_holder/debug/view_variables, target)
 
-ADMIN_VERB(debug, view_variables, "View a list of all vars on most datums aswell as provide additional functions via a dropdown", NONE, selected as anything)
+ADMIN_VERB(debug, view_variables, "View Variables", "View a list of all vars on most datums aswell as provide additional functions via a dropdown", NONE, selected as anything)
 	var/static/cookieoffset = rand(1, 9999) //to force cookies to reset after the round.
 
 	var/datum/target = selected

--- a/code/modules/antagonists/traitor/balance_helper.dm
+++ b/code/modules/antagonists/traitor/balance_helper.dm
@@ -1,4 +1,4 @@
-ADMIN_VERB(debug, debug_traitor_objectives, "", R_DEBUG)
+ADMIN_VERB(debug, debug_traitor_objectives, "Debug Traitor Objectives", "", R_DEBUG)
 	SStraitor.traitor_debug_panel?.ui_interact(usr)
 
 /datum/traitor_objective_debug

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -127,7 +127,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	else
 		GLOB.dooc_allowed = !GLOB.dooc_allowed
 
-ADMIN_VERB(server, set_player_ooc_color, "Set the default OOC color", (R_FUN|R_ADMIN))
+ADMIN_VERB(server, set_player_ooc_color, "Set Player OOC Color", "Set the default OOC color", (R_FUN|R_ADMIN))
 	var/newColor = input(src, "Please select the new player OOC color.", "OOC color") as color|null
 	if(isnull(newColor))
 		return
@@ -136,7 +136,7 @@ ADMIN_VERB(server, set_player_ooc_color, "Set the default OOC color", (R_FUN|R_A
 	log_admin("[key_name_admin(usr)] has set the player ooc color to [new_color].")
 	GLOB.OOC_COLOR = new_color
 
-ADMIN_VERB(server, reset_player_ooc_color, "Returns all player colors to default", (R_FUN|R_ADMIN))
+ADMIN_VERB(server, reset_player_ooc_color, "Reset Player OOC Color", "Returns all player colors to default", (R_FUN|R_ADMIN))
 	if(tgui_alert(usr, "Are you sure you want to reset the OOC color of all players?", "Reset Player OOC Color", list("Yes", "No")) != "Yes")
 		return
 	message_admins("[key_name_admin(usr)] has reset the players' ooc color.")

--- a/code/modules/explorer_drone/manager.dm
+++ b/code/modules/explorer_drone/manager.dm
@@ -141,6 +141,6 @@
 	. = ..()
 	QDEL_NULL(temp_adventure)
 
-ADMIN_VERB(debug, adventure_manager, "", R_DEBUG)
+ADMIN_VERB(debug, adventure_manager, "Adventure Manager", "", R_DEBUG)
 	var/datum/adventure_browser/browser = new()
 	browser.ui_interact(usr)

--- a/code/modules/procedural_mapping/mapGenerator.dm
+++ b/code/modules/procedural_mapping/mapGenerator.dm
@@ -141,7 +141,7 @@
 // HERE BE DEBUG DRAGONS //
 ///////////////////////////
 
-ADMIN_VERB(debug, test_nature_map_generator, "", R_DEBUG)
+ADMIN_VERB(debug, test_nature_map_generator, "Test Nature Map Generator", "", R_DEBUG)
 	var/datum/map_generator/nature/N = new()
 	var/startInput = input(usr,"Start turf of Map, (X;Y;Z)", "Map Gen Settings", "1;1;1") as text|null
 

--- a/code/modules/reagents/chemistry/chem_wiki_render.dm
+++ b/code/modules/reagents/chemistry/chem_wiki_render.dm
@@ -1,5 +1,5 @@
 //Generates a wikitable txt file for use with the wiki - does not support productless reactions at the moment
-ADMIN_VERB(debug, generate_wikichem_list, "Generate a wikichem list for the wiki", R_DEBUG)
+ADMIN_VERB(debug, generate_wikichem_list, "Generate Wikichem List", "Generate a wikichem list for the wiki", R_DEBUG)
 	//If we're a reaction product
 	var/prefix_reaction = {"{| class=\"wikitable sortable\" style=\"width:100%; text-align:left; border: 3px solid #FFDD66; cellspacing=0; cellpadding=2; background-color:white;\"
 ! scope=\"col\" style='width:150px; background-color:#FFDD66;'|Name

--- a/code/modules/wiremod/core/duplicator.dm
+++ b/code/modules/wiremod/core/duplicator.dm
@@ -217,7 +217,7 @@ GLOBAL_LIST_INIT(circuit_dupe_whitelisted_types, list(
 	rel_x = component_data["rel_x"]
 	rel_y = component_data["rel_y"]
 
-ADMIN_VERB(fun, load_circuit, "", R_VAREDIT)
+ADMIN_VERB(fun, load_circuit, "Load Circuit", "", R_VAREDIT)
 	var/list/errors = list()
 
 	var/option = alert(usr, "Load by file or direct input?", "Load by file or string", "File", "Direct Input")

--- a/html/statbrowser.css
+++ b/html/statbrowser.css
@@ -225,3 +225,31 @@ img {
 .interview_panel_stats {
 	margin-bottom: 10px;
 }
+
+.admin-verb-menu ul {
+	margin: 0;
+	padding: 5px;
+	list-style-type: none;
+	text-align: center;
+	background-color: #000;
+}
+
+.admin-verb-menu ul li {
+	display: inline;
+}
+
+.admin-verb-menu ul li a {
+	text-decoration: none;
+	padding: .2em 1em;
+	color: #fff;
+	background-color: #000;
+}
+
+.admin-verb-menu .selected {
+	color: #00f;
+}
+
+.admin-verb-menu ul li a:hover {
+	color: #000;
+	background-color: #fff;
+}

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -19,6 +19,7 @@ var status_tab_parts = ["Loading..."];
 var current_tab = null;
 var mc_tab_parts = [["Loading...", ""]];
 var admin_verb_cats = [];
+var admin_verb_groups = [["Server"], ["Debug"]];
 var href_token = null;
 var spells = [];
 var spell_tabs = [];
@@ -396,42 +397,66 @@ function draw_mc() {
 function draw_admin_verbs() {
 	try {
 		statcontentdiv.textContent = "";
-		var categories = Object.keys(admin_verb_cats);
-		for(var i = 0; i < categories.length; i++) {
-			var category = categories[i];
-			var categoryHeader = document.createElement("h3");
-			categoryHeader.textContent = category;
-
-			var verbList = admin_verb_cats[category];
-			var categoryTable = document.createElement("div");
-			categoryTable.className = "grid-container";
-			var verbIdx = 0;
-
-			for(var l = 0; l < verbList.length; l++) {
-				var verbInfo = verbList[l];
-
-				var verbName = verbInfo[0];
-				var verbDesc = verbInfo[1];
-				var verbRef = verbInfo[2];
-
-				var verbEntry = document.createElement("a");
-				verbEntry.onclick = make_verb_onclick(verbRef)
-				verbEntry.className = "grid-item";
-				verbEntry.title = verbDesc;
-
-				var verbTitle = document.createElement("span");
-				verbTitle.textContent = verbName;
-				verbTitle.className = "grid-item-text";
-
-				verbEntry.appendChild(verbTitle);
-				categoryTable.appendChild(verbEntry);
-			}
-			statcontentdiv.appendChild(categoryHeader);
-			statcontentdiv.appendChild(categoryTable);
+		var verb_groups = admin_verb_convert_into_groups(admin_verb_cats);
+		var group_names = Object.keys(verb_groups).sort();
+		for (var i = 0; i < group_names.length; i++) {
+			var group_name = group_names[i];
+			var group_header = document.createElement("h3");
+			group_header.textContent = group_name;
+			statcontentdiv.appendChild(group_header);
+			statcontentdiv.appendChild(get_admin_verb_group_div(verb_groups[group_name]));
 		}
 	} catch(except) {
 		statcontentdiv.textContent = "NTOS Exception: " + except + "\nReport this to your nearest Technical Resolution Specialist"
 	}
+}
+
+// converts a verb payload into a button used to render that payload
+function admin_verb_convert_verb_info_into_button(verb_info) {
+	var verb_name = verb_info[0];
+	var verb_desc = verb_info[1];
+	var verb_ref = verb_info[2];
+
+	var verb_button = document.createElement("a");
+	var verb_button_text = document.createElement("span");
+
+	verb_button.onclick = make_verb_onclick(verb_ref.replace(" ", "-"));
+	verb_button.className = "grid-item";
+	verb_button.title = verb_desc;
+
+	verb_button_text.textContent = verb_name;
+	verb_button_text.className = "grid-item-text";
+
+	verb_button.appendChild(verb_button_text);
+	return verb_button;
+}
+
+// converts the preloaded verb list payload into a list sorted by category
+function admin_verb_convert_into_groups(raw_payload) {
+	var category_groups = {};
+	var categories = Object.keys(raw_payload).sort();
+	for(var cat_idx = 0; cat_idx < categories.length; cat_idx++) {
+		var category_name = categories[cat_idx];
+		var category_contents = raw_payload[category_name];
+		var category_list = [];
+
+		for (var i = 0; i < category_contents.length; i++) {
+			var verb_button = admin_verb_convert_verb_info_into_button(category_contents[i]);
+			category_list.push(verb_button);
+		}
+		category_list.sort(function (lh, rh) { return lh.innerText.localeCompare(rh.innerText) });
+		category_groups[category_name] = category_list;
+	}
+	return category_groups;
+}
+
+function get_admin_verb_group_div(group) {
+	var group_div = document.createElement("div");
+	group_div.className = "grid-container";
+	for (var i = 0; i < group.length; i++) {
+		group_div.appendChild(group[i]);
+	}
+	return group_div;
 }
 
 function remove_tickets() {


### PR DESCRIPTION

## About The Pull Request

Damn that's a long title.

Admin Verbs can be used in the verb bar with hyphens instead of spaces again.
## Why It's Good For The Game

Admin muscle memory
## Changelog
