### PR TITLE
Reverts Sprite changes done to smart pipes in #72957 & Fixes disappearing pipes.

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_piping.dm
+++ b/code/__DEFINES/atmospherics/atmos_piping.dm
@@ -15,8 +15,8 @@
 #define CARDINAL_TO_FULLPIPES(cardinals) (cardinals)
 #define CARDINAL_TO_SHORTPIPES(cardinals) ((cardinals) << 4)
 // A pipe is a stub if it only has zero or one permitted direction. For a regular pipe this is nonsensical, and there are no pipe sprites for this, so it is not allowed.
-#define ISSTUB(bits) !((bits) & (bits - 1))
-#define ISNOTSTUB(bits) ((bits) & (bits - 1))
+#define ISSTUB(bits) !((bits) & ((bits) - 1))
+#define ISNOTSTUB(bits) ((bits) & ((bits) - 1))
 //Atmos pipe limits
 /// (kPa) What pressure pumps and powered equipment max out at.
 #define MAX_OUTPUT_PRESSURE 4500

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 			//lets see if this direction is eligable to be added
 			candidate = initialize_directions & (1 << shift)
 			//we dont want to add connections again else it creates wrong values & its also redundant[bitfield was already initialized with connections so we shoudnt append it again]
-			if(candidate != connections)
+			if(!(candidate & connections))
 				bits_to_add |= candidate
 			shift += 1
 		bitfield |= CARDINAL_TO_SHORTPIPES(bits_to_add)

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -57,7 +57,7 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 			//lets see if this direction is eligable to be added
 			candidate= initialize_directions & (1 << shift)
 			//we dont want to add connections again else it creates wrong values & its also redundant[bitfield was already initialized with connections so we shoudnt append it again]
-			if(!(candidate & connections))
+			if(candidate != connections)
 				bits_to_add |= candidate
 			shift += 1
 			//temporary pipe to see if we have a full sprite

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -52,16 +52,13 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		var/shift = 0
 
 		// Note that candidates "should" never reach 0, as stub pipes are not allowed and break things
-		var/test_connection = connections | bits_to_add
-		while (ISSTUB(test_connection) && (initialize_directions >> shift)!=0)
+		while (ISSTUB(connections | bits_to_add) && (initialize_directions >> shift)!=0)
 			//lets see if this direction is eligable to be added
 			candidate = initialize_directions & (1 << shift)
 			//we dont want to add connections again else it creates wrong values & its also redundant[bitfield was already initialized with connections so we shoudnt append it again]
 			if(candidate != connections)
 				bits_to_add |= candidate
 			shift += 1
-			//temporary pipe to see if we have a full sprite
-			test_connection = connections | bits_to_add
 		bitfield |= CARDINAL_TO_SHORTPIPES(bits_to_add)
 	icon_state = "[bitfield]_[piping_layer]"
 

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -47,12 +47,21 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		var/bits_to_add = NONE
 		if(connections != NONE)
 			bits_to_add |= REVERSE_DIR(connections) & initialize_directions
-		var/candidates = initialize_directions
+
+		var/candidate = 0
 		var/shift = 0
+
 		// Note that candidates "should" never reach 0, as stub pipes are not allowed and break things
-		while (ISSTUB(connections | bits_to_add) && (candidates >> shift) != 0)
-			bits_to_add |= candidates & (1 << shift)
+		var/test_connection = connections | bits_to_add
+		while (ISSTUB(test_connection) && (initialize_directions >> shift)!=0)
+			//lets see if this direction is eligable to be added
+			candidate= initialize_directions & (1 << shift)
+			//we dont want to add connections again else it creates wrong values & its also redundant[bitfield was already initialized with connections so we shoudnt append it again]
+			if(!(candidate & connections))
+				bits_to_add |= candidate
 			shift += 1
+			//temporary pipe to see if we have a full sprite
+			test_connection = connections | bits_to_add
 		bitfield |= CARDINAL_TO_SHORTPIPES(bits_to_add)
 	icon_state = "[bitfield]_[piping_layer]"
 

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -55,7 +55,7 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		var/test_connection = connections | bits_to_add
 		while (ISSTUB(test_connection) && (initialize_directions >> shift)!=0)
 			//lets see if this direction is eligable to be added
-			candidate= initialize_directions & (1 << shift)
+			candidate = initialize_directions & (1 << shift)
 			//we dont want to add connections again else it creates wrong values & its also redundant[bitfield was already initialized with connections so we shoudnt append it again]
 			if(candidate != connections)
 				bits_to_add |= candidate

--- a/code/modules/atmospherics/machinery/pipes/smart.dm
+++ b/code/modules/atmospherics/machinery/pipes/smart.dm
@@ -12,22 +12,9 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 	pipe_state = "manifold4w"
 	///Current active connections
 	var/connections = NONE
-	///Was this pipe created during map load
-	var/map_loaded_pipe = FALSE
 
 /obj/machinery/atmospherics/pipe/smart/Initialize(mapload)
-	map_loaded_pipe = mapload
 	return ..()
-
-///helper function to append all directions into an single bit flag
-/obj/machinery/atmospherics/pipe/smart/proc/append_directions(list/spanning_directions)
-	var/bit_flag = NONE
-	for(var/i in 1 to length(spanning_directions))
-		var/spanning_direction = spanning_directions[i]
-		if(!spanning_direction)
-			continue
-		bit_flag |= spanning_direction
-	return bit_flag
 
 /obj/machinery/atmospherics/pipe/smart/update_pipe_icon()
 	icon = 'icons/obj/atmospherics/pipes/pipes_bitmask.dmi'
@@ -40,6 +27,7 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		var/obj/machinery/atmospherics/node = nodes[i]
 		var/connected_dir = get_dir(src, node)
 		connections |= connected_dir
+
 	//set the correct direction for this node in case of binary directions
 	switch(connections)
 		if(EAST | WEST)
@@ -49,39 +37,24 @@ GLOBAL_LIST_INIT(atmos_components, typecacheof(list(/obj/machinery/atmospherics)
 		else
 			dir = connections
 
-	//same as connections but used for spriting
-	var/sprite_bits = NONE
-	//the directions this pipe stretches out in e.g. T pipe is EAST,WEST & SOUTH, L pipe is NORTH,EAST & so on
-	var/list/spanning_directions = get_node_connects()
-	/**
-	 *For pipes created during mapload we draw the pipes sprite only in directions where its connected to a machine
-	 *so for example if an T shaped pipe is connected only in its EAST & WEST directions then only those ends are drawn
-	 *but the SOUTH end is not drawn
-	 *this will allow mappers to use whatever pipes but the end result has no visual clutter.
-	 *This is actually just an bandage for lazy mappers using + pipes all over the place without carying about directions so hopefully when they map pipes correctly we can remove this
-	 */
-	if(map_loaded_pipe)
-		sprite_bits = connections
-		/**
-		 * if pipe is connected in only one direction[e.g. after disconnecting its neighbour] then to avoid a broken sprite append the reverse direction of its one connected end.
-		 * this wont work for L pipes because if one of its ends is broken then the opposite direction of any of its last connected end is invalid
-		 * e.g. for an L pipe if the top[NORTH] end is broken the opposite of its one remaining connected end[i.e EAST END] is WEST but thats not an valid direction for this pipe
-		 * so we have to again check one last time after this to make sure the pipe isnt broken
-		 */
-		if(ISSTUB(sprite_bits))
-			// & initialize_directions will yield 0 if the reversed direction is not valid
-			sprite_bits |= REVERSE_DIR(sprite_bits) & get_init_directions()
-			//if its still broken after the above patch then screw it we make the pipe an normal non mapload type and do the usual stuff with player created pipes
-			if(ISSTUB(sprite_bits))
-				sprite_bits = append_directions(spanning_directions)
-	/**
-	 *for pipes created by players during the round we draw the pipe in all directions so they
-	 *can visually see what ends are free.
-	*/
-	else
-		sprite_bits = append_directions(spanning_directions)
-
-	icon_state = "[sprite_bits]_[piping_layer]"
+	// Smart pipe icons differ from classic pipe icons in that we stop adding
+	// short pipe directions as soon as we find a valid sprite, rather than
+	// adding in all connectable directions.
+	// This prevents a lot of visual clutter, though it does make it harder to
+	// notice completely disconnected pipes.
+	var/bitfield = CARDINAL_TO_FULLPIPES(connections)
+	if(ISSTUB(connections))
+		var/bits_to_add = NONE
+		if(connections != NONE)
+			bits_to_add |= REVERSE_DIR(connections) & initialize_directions
+		var/candidates = initialize_directions
+		var/shift = 0
+		// Note that candidates "should" never reach 0, as stub pipes are not allowed and break things
+		while (ISSTUB(connections | bits_to_add) && (candidates >> shift) != 0)
+			bits_to_add |= candidates & (1 << shift)
+			shift += 1
+		bitfield |= CARDINAL_TO_SHORTPIPES(bits_to_add)
+	icon_state = "[bitfield]_[piping_layer]"
 
 /obj/machinery/atmospherics/pipe/smart/set_init_directions(init_dir)
 	if(init_dir)


### PR DESCRIPTION
## About The Pull Request
Closes #73195

Reverts the sprite changes done to smart pipes in #72957. And makes sure pipes don't disappear. when connected only on 1 end

Co-sponsored by Lemon. who probably went insane for the 50th time today 

## Why It's Good For The Game
Brings back the old pipe sprites and stops them from disappearing

## Changelog
:cl:
del: Removes sprite changes done to smart pipes
fix: pipes disappearing at weird angles
/:cl: