### PR TITLE
Custom Scrubber Overflows work again and now also support random single reagent floods.

### DIFF
--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -141,11 +141,12 @@
 	reagents_amount = 150
 
 /datum/round_event_control/scrubber_overflow/custom //Used for the beer nuke as well as admin abuse
-	name = "Scrubber Overflow: Custom"
+	name = "Scrubber Overflow: Single Reagent"
 	typepath = /datum/round_event/scrubber_overflow/custom
 	weight = 0
 	max_occurrences = 0
-	description = "The scrubbers release a tide of custom froth."
+	description = "The scrubbers release a tide of identical froth."
+	admin_setup = /datum/event_admin_setup/listed_options/scrubber_overflow/custom
 	///Reagent thats going to be flooded.
 	var/datum/reagent/custom_reagent
 
@@ -163,10 +164,19 @@
 	return ..()
 
 /datum/event_admin_setup/listed_options/scrubber_overflow
-	normal_run_option = "Random Reagent"
+	normal_run_option = "Random Reagents"
 
 /datum/event_admin_setup/listed_options/scrubber_overflow/get_list()
 	return sort_list(subtypesof(/datum/reagent), /proc/cmp_typepaths_asc)
 
 /datum/event_admin_setup/listed_options/scrubber_overflow/apply_to_event(datum/round_event/scrubber_overflow/event)
 	event.forced_reagent = chosen
+
+/datum/event_admin_setup/listed_options/scrubber_overflow/custom
+	normal_run_option = "Random Reagent"
+
+/datum/event_admin_setup/listed_options/scrubber_overflow/custom/apply_to_event(datum/round_event/scrubber_overflow/event)
+	var/datum/round_event_control/scrubber_overflow/custom/event_controller = event_control
+	if(!chosen)
+		chosen = pick(get_list())
+	event_controller.custom_reagent = chosen


### PR DESCRIPTION

## About The Pull Request

72998 broke the custom reagent event, this PR fixes it. Since 72998 also added support for customizing the reagents of the default floods I've also modified the code slightly on the custom reagent flood, so that when a custom reagent flood is randomized it will choose only 1 reagent giving it some uniqueness. Also changed the normal run option text for scrubber overflows to random reagent**s** since its a multi-reagent thing.
## Why It's Good For The Game

Bug fix and a slight improvement of everyone's least favorite admin grief tool
## Changelog
:cl:
fix: Custom Scrubber Overflow works again.
admin: Custom Scrubber overflow has been changed into single reagent scrubber overflow, the random option will now produce only one reagent.
/:cl:
