### PR TITLE
Properly hides syndie crate keys from operative uplinks

### DIFF
--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -173,4 +173,5 @@
 	cost = 20
 	item = /obj/item/syndicrate_key
 	progression_minimum = 30 MINUTES
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	stock_key = UPLINK_SHARED_STOCK_SURPLUS


### PR DESCRIPTION

## About The Pull Request

United Surplus Crate Key had no flags, unlike United Surplus Crates, so they appeared in Nuke Ops uplinks. This PR adds the proper flags to hide them.

Future Improvement: It looks like something messes up uplink flags if an admin removes your Traitor role and gives you Nuke Op or vica versa, which can result you getting an uplink where you can not see either role's unique gear, but I can not reliably replicate this, so for now that has to wait for a future PR.

## Why It's Good For The Game

Fixes #72978

## Changelog


:cl:
fix: United Surplus Crate Key is no longer visible in the nuke ops uplink
/:cl: