### PR TITLE
Refactors "Custom" level scrubber overflow into a generic "All Vents" overflow, gives its (currently broken) functionality to all levels of scrubber overflow events.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_event.dm
+++ b/code/__DEFINES/dcs/signals/signals_event.dm
@@ -5,3 +5,6 @@
 
 /// A different signal, used specifically for flickering the lights during the event
 #define COMSIG_GLOB_GREY_TIDE_LIGHT "grey_tide_light"
+
+/// Signal sent by round event controls when they create round event datums before calling setup() on them: (datum/round_event_control/source_event_control, datum/round_event/created_event)
+#define COMSIG_CREATED_ROUND_EVENT "creating_round_event"

--- a/code/__HELPERS/reagents.dm
+++ b/code/__HELPERS/reagents.dm
@@ -184,10 +184,9 @@
 /proc/get_random_reagent_id()
 	var/static/list/random_reagents = list()
 	if(!random_reagents.len)
-		for(var/thing in subtypesof(/datum/reagent))
-			var/datum/reagent/R = thing
-			if(initial(R.chemical_flags) & REAGENT_CAN_BE_SYNTHESIZED)
-				random_reagents += R
+		for(var/datum/reagent/reagent_path as anything in subtypesof(/datum/reagent))
+			if(initial(reagent_path.chemical_flags) & REAGENT_CAN_BE_SYNTHESIZED)
+				random_reagents += reagent_path
 	var/picked_reagent = pick(random_reagents)
 	return picked_reagent
 

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
@@ -7,11 +7,19 @@
 	var/obj/structure/reagent_dispensers/beerkeg/keg
 	/// Reagent that is produced once the nuke detonates.
 	var/flood_reagent = /datum/reagent/consumable/ethanol/beer
+	/// Round event control we might as well keep track of instead of locating every time
+	var/datum/round_event_control/scrubber_overflow/every_vent/overflow_control
 
 /obj/machinery/nuclearbomb/beer/Initialize(mapload)
 	. = ..()
 	keg = new(src)
 	QDEL_NULL(core)
+	overflow_control = locate(/datum/round_event_control/scrubber_overflow/every_vent) in SSevents.control
+	RegisterSignal(overflow_control, COMSIG_CREATED_ROUND_EVENT, PROC_REF(on_created_round_event))
+
+/obj/machinery/nuclearbomb/beer/Destroy()
+	UnregisterSignal(overflow_control, COMSIG_CREATED_ROUND_EVENT)
+	. = ..()
 
 /obj/machinery/nuclearbomb/beer/examine(mob/user)
 	. = ..()
@@ -61,6 +69,7 @@
 
 /obj/machinery/nuclearbomb/beer/really_actually_explode(detonation_status)
 	disarm_nuke()
-	var/datum/round_event_control/scrubber_overflow/custom/event = locate(/datum/round_event_control/scrubber_overflow/custom) in SSevents.control
-	event.custom_reagent = flood_reagent
-	event.runEvent()
+	overflow_control.runEvent()
+
+/obj/machinery/nuclearbomb/beer/proc/on_created_round_event(datum/round_event_control/source_event_control, datum/round_event/scrubber_overflow/every_vent/created_event)
+	created_event.forced_reagent_type = flood_reagent

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
@@ -15,7 +15,6 @@
 	keg = new(src)
 	QDEL_NULL(core)
 	overflow_control = locate(/datum/round_event_control/scrubber_overflow/every_vent) in SSevents.control
-	RegisterSignal(overflow_control, COMSIG_CREATED_ROUND_EVENT, PROC_REF(on_created_round_event))
 
 /obj/machinery/nuclearbomb/beer/Destroy()
 	UnregisterSignal(overflow_control, COMSIG_CREATED_ROUND_EVENT)
@@ -68,8 +67,13 @@
 	disarm_nuke()
 
 /obj/machinery/nuclearbomb/beer/really_actually_explode(detonation_status)
+	//if it's always hooked in it'll override admin choices
+	RegisterSignal(overflow_control, COMSIG_CREATED_ROUND_EVENT, PROC_REF(on_created_round_event))
 	disarm_nuke()
 	overflow_control.runEvent()
 
+/// signal sent from overflow control when it fires an event
 /obj/machinery/nuclearbomb/beer/proc/on_created_round_event(datum/round_event_control/source_event_control, datum/round_event/scrubber_overflow/every_vent/created_event)
+	SIGNAL_HANDLER
+	UnregisterSignal(overflow_control, COMSIG_CREATED_ROUND_EVENT)
 	created_event.forced_reagent_type = flood_reagent

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -120,7 +120,9 @@ Runs the event
 	UnregisterSignal(SSdcs, COMSIG_GLOB_RANDOM_EVENT)
 	var/datum/round_event/round_event = new typepath(TRUE, src)
 	if(admin_forced && admin_setup)
+		//not part of the signal because it's conditional and relies on usr heavily
 		admin_setup.apply_to_event(round_event)
+	SEND_SIGNAL(src, COMSIG_CREATED_ROUND_EVENT, round_event)
 	round_event.setup()
 	round_event.current_players = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)
 	occurrences++
@@ -141,14 +143,10 @@ Runs the event
 		log_game("Random Event triggering: [name] ([typepath]).")
 
 	if(alert_observers)
-		announce_deadchat(random)
+		round_event.announce_deadchat(random)
 
 	SSblackbox.record_feedback("tally", "event_ran", 1, "[round_event]")
 	return round_event
-
-///Annouces the event name to deadchat, override this if what an event should show to deadchat is different to its event name.
-/datum/round_event_control/proc/announce_deadchat(random)
-	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
 
 //Returns the component for the listener
 /datum/round_event_control/proc/stop_random_event()
@@ -190,6 +188,10 @@ Runs the event
 /datum/round_event/proc/setup()
 	SHOULD_CALL_PARENT(FALSE)
 	return
+
+///Annouces the event name to deadchat, override this if what an event should show to deadchat is different to its event name.
+/datum/round_event/proc/announce_deadchat(random)
+	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[control.name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
 
 //Called when the tick is equal to the start_when variable.
 //Allows you to start before announcing or vice versa.

--- a/code/modules/events/_event_admin_setup.dm
+++ b/code/modules/events/_event_admin_setup.dm
@@ -22,6 +22,9 @@
 	var/input_text = "Unset Text"
 	/// If set, picking this will be the same as running the event without admin setup.
 	var/normal_run_option
+	/// if you want a special button, this will add it. Remember to actually handle that case for chosen in `apply_to_event`
+	/// Example is in scrubber_overflow.dm
+	var/special_run_option
 	/// Picked list option to be applied.
 	var/chosen
 
@@ -31,6 +34,8 @@
 
 /datum/event_admin_setup/listed_options/prompt_admins()
 	var/list/options = get_list()
+	if(special_run_option)
+		options.Insert(1, special_run_option)
 	if(normal_run_option)
 		options.Insert(1, normal_run_option)
 	chosen = tgui_input_list(usr, input_text, event_control.name, options)

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -61,6 +61,9 @@
 	//needs to be chemid unit checked at some point
 
 /datum/round_event/scrubber_overflow/announce_deadchat(random)
+	if(!forced_reagent_type)
+		//nothing out of the ordinary, so default announcement
+		return ..()
 	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>Scrubber Overflow: [initial(forced_reagent_type.name)]</b>", message_type=DEADCHAT_ANNOUNCEMENT)
 
 /datum/round_event/scrubber_overflow/announce(fake)

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -18,7 +18,7 @@
 	/// Probability of an individual scrubber overflowing
 	var/overflow_probability = 50
 	/// Specific reagent to force all scrubbers to use, null for random reagent choice
-	var/forced_reagent
+	var/datum/reagent/forced_reagent_type
 	/// A list of scrubbers that will have reagents ejected from them
 	var/list/scrubbers = list()
 	/// The list of chems that scrubbers can produce
@@ -60,6 +60,9 @@
 	)
 	//needs to be chemid unit checked at some point
 
+/datum/round_event/scrubber_overflow/announce_deadchat(random)
+	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>Scrubber Overflow: [initial(forced_reagent_type.name)]</b>", message_type=DEADCHAT_ANNOUNCEMENT)
+
 /datum/round_event/scrubber_overflow/announce(fake)
 	priority_announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert")
 
@@ -94,6 +97,10 @@
 		return TRUE //there's at least one. we'll let the codergods handle the rest with prob() i guess.
 	return FALSE
 
+/// proc that will run the prob check of the event and return a safe or dangerous reagent based off of that.
+/datum/round_event/scrubber_overflow/proc/get_overflowing_reagent(dangerous)
+	return dangerous ? get_random_reagent_id() : pick(safer_chems)
+
 /datum/round_event/scrubber_overflow/start()
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/vent as anything in scrubbers)
 		if(!vent.loc)
@@ -101,14 +108,14 @@
 
 		var/datum/reagents/dispensed_reagent = new /datum/reagents(reagents_amount)
 		dispensed_reagent.my_atom = vent
-		if (forced_reagent)
-			dispensed_reagent.add_reagent(forced_reagent, reagents_amount)
+		if (forced_reagent_type)
+			dispensed_reagent.add_reagent(forced_reagent_type, reagents_amount)
 		else if (prob(danger_chance))
-			dispensed_reagent.add_reagent(get_random_reagent_id(), reagents_amount)
+			dispensed_reagent.add_reagent(get_overflowing_reagent(dangerous = TRUE), reagents_amount)
 			new /mob/living/basic/cockroach(get_turf(vent))
 			new /mob/living/basic/cockroach(get_turf(vent))
 		else
-			dispensed_reagent.add_reagent(pick(safer_chems), reagents_amount)
+			dispensed_reagent.add_reagent(get_overflowing_reagent(dangerous = FALSE), reagents_amount)
 
 		dispensed_reagent.create_foam(/datum/effect_system/fluid_spread/foam/short, reagents_amount)
 
@@ -140,33 +147,25 @@
 	danger_chance = 30
 	reagents_amount = 150
 
-/datum/round_event_control/scrubber_overflow/custom //Used for the beer nuke as well as admin abuse
-	name = "Scrubber Overflow: Custom"
-	typepath = /datum/round_event/scrubber_overflow/custom
+/datum/round_event_control/scrubber_overflow/every_vent
+	name = "Scrubber Overflow: Every Vent"
+	typepath = /datum/round_event/scrubber_overflow/every_vent
 	weight = 0
 	max_occurrences = 0
-	description = "The scrubbers release a tide of custom froth."
-	///Reagent thats going to be flooded.
-	var/datum/reagent/custom_reagent
+	description = "The scrubbers release a tide of mostly harmless froth, but every scrubber is affected."
 
-/datum/round_event_control/scrubber_overflow/custom/announce_deadchat(random)
-	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>Scrubber Overflow: [initial(custom_reagent.name)]</b>", message_type=DEADCHAT_ANNOUNCEMENT)
-
-/datum/round_event/scrubber_overflow/custom
+/datum/round_event/scrubber_overflow/every_vent
 	overflow_probability = 100
-	forced_reagent = /datum/reagent/consumable/ethanol/beer
 	reagents_amount = 100
 
-/datum/round_event/scrubber_overflow/custom/start()
-	var/datum/round_event_control/scrubber_overflow/custom/event_controller = control
-	forced_reagent = event_controller.custom_reagent
-	return ..()
-
 /datum/event_admin_setup/listed_options/scrubber_overflow
-	normal_run_option = "Random Reagent"
+	normal_run_option = "Random Reagents"
+	special_run_option = "Random Single Reagent"
 
 /datum/event_admin_setup/listed_options/scrubber_overflow/get_list()
 	return sort_list(subtypesof(/datum/reagent), /proc/cmp_typepaths_asc)
 
 /datum/event_admin_setup/listed_options/scrubber_overflow/apply_to_event(datum/round_event/scrubber_overflow/event)
-	event.forced_reagent = chosen
+	if(chosen == special_run_option)
+		chosen = event.get_overflowing_reagent(dangerous = prob(event.danger_chance))
+	event.forced_reagent_type = chosen


### PR DESCRIPTION
## About The Pull Request

closes #73216 as an alternate

Custom overflow is no longer broken, and is now generic and works like every other tier just with every scrubber overflowing. Now all tiers have access to "Single Random Reagent" mode, something only custom scrubber overflow could do.

## Why It's Good For The Game

There really was zero reason for this to be hardcoded and it was begetting more hardcoding

## Changelog
:cl:
admin: Every tier of "Scrubber Overflow" can now choose a random single reagent mode
admin: "Custom" overflow, which was kinda confusing and unintuitive, is now called "Every Vent", much more self-explanatory in what it does.
/:cl:
