### PR TITLE
Fixes ghost roles trying to spawn people when there /should/ be zero uses left

### DIFF
--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -161,6 +161,7 @@
 		if(ghost_role != "Yes" || !loc || QDELETED(user))
 			currently_deciding_ghosts -= user.key
 			return
+	currently_deciding_ghosts -= user.key
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
 		to_chat(user, span_warning("An admin has temporarily disabled non-admin ghost roles!"))
 		return
@@ -175,7 +176,6 @@
 	if(QDELETED(src) || QDELETED(user))
 		return
 	user.log_message("became a [prompt_name].", LOG_GAME)
-	currently_deciding_ghosts -= user.key
 	create(user)
 
 /obj/effect/mob_spawn/ghost_role/special(mob/living/spawned_mob, mob/mob_possessor)

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -155,7 +155,8 @@
 		to_chat(user, span_warning("Other ghosts have already claimed the uses of this spawner, you can try again later if they decide to not spawn."))
 		return
 	if(prompt_ghost)
-		currently_deciding_ghosts += user.key
+		if(!(user.key in currently_deciding_ghosts))
+			currently_deciding_ghosts += user.key
 		var/ghost_role = tgui_alert(usr, "Become [prompt_name]? (Warning, You can no longer be revived!)", buttons = list("Yes", "No"), timeout = 10 SECONDS)
 		if(ghost_role != "Yes" || !loc || QDELETED(user))
 			currently_deciding_ghosts -= user.key

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -148,17 +148,19 @@
 /obj/effect/mob_spawn/ghost_role/attack_ghost(mob/user)
 	if(!SSticker.HasRoundStarted() || !loc)
 		return
-	// This part prevents a strange bug related to a lot of players trying to use a single spawner at once
+
 	if(prompt_ghost)
 		var/ghost_role = tgui_alert(usr, "Become [prompt_name]? (Warning, You can no longer be revived!)", buttons = list("Yes", "No"), timeout = 10 SECONDS)
 		if(ghost_role != "Yes" || !loc || QDELETED(user))
 			return
+
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
 		to_chat(user, span_warning("An admin has temporarily disabled non-admin ghost roles!"))
 		return
 	if(!uses) //just in case
 		to_chat(user, span_warning("This spawner is out of charges!"))
 		return
+
 	if(is_banned_from(user.key, role_ban))
 		to_chat(user, span_warning("You are banned from this role!"))
 		return
@@ -166,12 +168,15 @@
 		return
 	if(QDELETED(src) || QDELETED(user))
 		return
+
 	user.log_message("became a [prompt_name].", LOG_GAME)
-	uses -= 1
+	uses -= 1 // Remove a use before trying to spawn to prevent strangeness like the spawner trying to spawn more mobs than it should be able to
+
 	if(!(create(user)))
 		message_admins("[src] didn't return anything when creating a mob, this might be broken! The use of the spawner it would have taken has been refunded.")
-		uses += 1
-	check_uses()
+		uses += 1 // Oops! We messed up and somehow the mob didn't spawn, but that's alright we can refund the use.
+
+	check_uses() // Now we check if the spawner should delete itself or not
 
 /obj/effect/mob_spawn/ghost_role/special(mob/living/spawned_mob, mob/mob_possessor)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

By means of making a particularly popular ghost role (do NOT put catgirls on icebox bro you don't know the consequences) I have discovered a strange bug where despite any of the checks that are in place, it will still attempt to spawn more people than the role should allow. I've found the likely caused to be that a lot of people are clicking the role then clicking spawn at once, and the spawner simply does not have time to tell everyone "wait no you can't do that" before it deletes itself from running out of uses.

The solution? Even easier than the reservation thing: Subtract uses **BEFORE** spawning the mob, as spawning the mob can take some time, then if it fails to spawn somehow we can refund the uses.

## Why It's Good For The Game

Ghost roles spawning in the nullspace spawn room every now and then is a bad thing I think.

## Changelog
:cl:
fix: Ghost role spawners will now no longer try and spawn people when they /should/ have been out of uses but due to a bug were not
/:cl:
