### PR TITLE
Fixes some redundant / incorrect messages w/ spontaneous combustion symptom

### DIFF
--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -44,33 +44,33 @@
 	. = ..()
 	if(!.)
 		return
-	var/mob/living/M = A.affected_mob
+	var/mob/living/living_mob = A.affected_mob
 	switch(A.stage)
 		if(1 to 2)
 			return
 		if(3)
 			if(prob(base_message_chance) && !suppress_warning)
-				if(prob(33.33))
-					M.audible_message(self_message = "You hear a crackling noise.")
-				else
-					to_chat(M, span_warning("[pick("You feel hot.", "You smell smoke.")]"))
+				warn_mob(living_mob)
 		else
 			var/advanced_stage = A.stage > 4
-			M.adjust_fire_stacks((advanced_stage ? 3 : 1) * power)
-			M.take_overall_damage(burn = ((advanced_stage ? 5 : 3) * power), required_bodytype = BODYTYPE_ORGANIC)
-			M.ignite_mob(silent = TRUE)
-			if(M.on_fire) //check to make sure they actually caught on fire, or if it was prevented cause they were wet.
-				M.visible_message(span_warning("[M] catches fire!"), ignored_mobs = M)
-				to_chat(M, span_userdanger(advanced_stage ? "Your skin erupts into an inferno!" : "Your skin bursts into flames!"))
-				M.emote("scream")
+			living_mob.adjust_fire_stacks((advanced_stage ? 3 : 1) * power)
+			living_mob.take_overall_damage(burn = ((advanced_stage ? 5 : 3) * power), required_bodytype = BODYTYPE_ORGANIC)
+			living_mob.ignite_mob(silent = TRUE)
+			if(living_mob.on_fire) //check to make sure they actually caught on fire, or if it was prevented cause they were wet.
+				living_mob.visible_message(span_warning("[living_mob] catches fire!"), ignored_mobs = living_mob)
+				to_chat(living_mob, span_userdanger(advanced_stage ? "Your skin erupts into an inferno!" : "Your skin bursts into flames!"))
+				living_mob.emote("scream")
 			else if(!suppress_warning)
-				if(prob(33.33))
-					M.audible_message(self_message = "You hear a crackling noise.")
-				else
-					to_chat(M, span_warning("[pick("You feel hot.", "You smell smoke.")]"))
+				warn_mob(living_mob)
 
 			if(infective)
 				A.spread(advanced_stage ? 4 : 2)
+
+/datum/symptom/fire/proc/warn_mob(mob/living/living_mob)
+	if(prob(33.33))
+		living_mob.audible_message(self_message = "You hear a crackling noise.")
+	else
+		to_chat(living_mob, span_warning("[pick("You feel hot.", "You smell smoke.")]"))
 
 /*
 Alkali perspiration

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -46,33 +46,31 @@
 		return
 	var/mob/living/M = A.affected_mob
 	switch(A.stage)
+		if(1 to 2)
+			return
 		if(3)
 			if(prob(base_message_chance) && !suppress_warning)
-				to_chat(M, span_warning("[pick("You feel hot.", "You hear a crackling noise.", "You smell smoke.")]"))
-		if(4)
-			Firestacks_stage_4(M, A)
-			M.ignite_mob()
-			to_chat(M, span_userdanger("Your skin bursts into flames!"))
-			M.emote("scream")
-		if(5)
-			Firestacks_stage_5(M, A)
-			M.ignite_mob()
-			to_chat(M, span_userdanger("Your skin erupts into an inferno!"))
-			M.emote("scream")
+				if(prob(33.33))
+					M.audible_message(self_message = "You hear a crackling noise.")
+				else
+					to_chat(M, span_warning("[pick("You feel hot.", "You smell smoke.")]"))
+		else
+			var/advanced_stage = A.stage > 4
+			M.adjust_fire_stacks((advanced_stage ? 3 : 1) * power)
+			M.take_overall_damage(burn = ((advanced_stage ? 5 : 3) * power), required_bodytype = BODYTYPE_ORGANIC)
+			M.ignite_mob(silent = TRUE)
+			if(M.on_fire) //check to make sure they actually caught on fire, or if it was prevented cause they were wet.
+				M.visible_message(span_warning("[M] catches fire!"), ignored_mobs = M)
+				to_chat(M, span_userdanger(advanced_stage ? "Your skin erupts into an inferno!" : "Your skin bursts into flames!"))
+				M.emote("scream")
+			else if(!suppress_warning)
+				if(prob(33.33))
+					M.audible_message(self_message = "You hear a crackling noise.")
+				else
+					to_chat(M, span_warning("[pick("You feel hot.", "You smell smoke.")]"))
 
-/datum/symptom/fire/proc/Firestacks_stage_4(mob/living/M, datum/disease/advance/A)
-	M.adjust_fire_stacks(1 * power)
-	M.take_overall_damage(burn = 3 * power, required_bodytype = BODYTYPE_ORGANIC)
-	if(infective)
-		A.spread(2)
-	return 1
-
-/datum/symptom/fire/proc/Firestacks_stage_5(mob/living/M, datum/disease/advance/A)
-	M.adjust_fire_stacks(3 * power)
-	M.take_overall_damage(burn = 5 * power, required_bodytype = BODYTYPE_ORGANIC)
-	if(infective)
-		A.spread(4)
-	return 1
+			if(infective)
+				A.spread(advanced_stage ? 4 : 2)
 
 /*
 Alkali perspiration

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1450,7 +1450,7 @@
 /// Global list that containes cached fire overlays for mobs
 GLOBAL_LIST_EMPTY(fire_appearances)
 
-/mob/living/proc/ignite_mob()
+/mob/living/proc/ignite_mob(silent)
 	if(fire_stacks <= 0)
 		return FALSE
 
@@ -1458,7 +1458,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	if(!fire_status || fire_status.on_fire)
 		return FALSE
 
-	return fire_status.ignite()
+	return fire_status.ignite(silent)
 
 /mob/living/proc/update_fire()
 	var/datum/status_effect/fire_handler/fire_handler = has_status_effect(/datum/status_effect/fire_handler)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -250,7 +250,7 @@
 			if(istype(A, initial(AM.power_type)))
 				qdel(A)
 
-/mob/living/silicon/ai/ignite_mob()
+/mob/living/silicon/ai/ignite_mob(silent)
 	return FALSE
 
 /mob/living/silicon/ai/proc/set_core_display_icon(input, client/C)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -496,7 +496,7 @@
 			return FALSE
 	return TRUE
 
-/mob/living/simple_animal/ignite_mob()
+/mob/living/simple_animal/ignite_mob(silent)
 	if(!flammable)
 		return FALSE
 	return ..()

--- a/code/modules/pai/defense.dm
+++ b/code/modules/pai/defense.dm
@@ -61,7 +61,7 @@
 		src.visible_message(span_warning("The electrically-charged projectile disrupts [src]'s holomatrix, forcing [src] to fold in!"))
 	. = ..(Proj)
 
-/mob/living/silicon/pai/ignite_mob()
+/mob/living/silicon/pai/ignite_mob(silent)
 	return FALSE
 
 /mob/living/silicon/pai/proc/take_holo_damage(amount)


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed some duplicated and incorrect messages being presented when infected with a virus that has the spontaneous combustion symptom.
/:cl:
