### PR TITLE
Fixes custom drink names / description being overridden

### DIFF
--- a/code/datums/components/takes_reagent_appearance.dm
+++ b/code/datums/components/takes_reagent_appearance.dm
@@ -90,6 +90,9 @@
  */
 /datum/component/takes_reagent_appearance/proc/update_name(datum/glass_style/style)
 	var/obj/item/item_parent = parent
+	if(item_parent.renamedByPlayer)
+		return NONE
+
 	if(isnull(style))
 		// no style (reset)
 		item_parent.name = initial(item_parent.name)
@@ -109,6 +112,9 @@
  */
 /datum/component/takes_reagent_appearance/proc/update_desc(datum/glass_style/style)
 	var/obj/item/item_parent = parent
+	if(item_parent.renamedByPlayer)
+		return NONE
+
 	if(isnull(style))
 		// no style (reset)
 		item_parent.desc = initial(item_parent.desc)


### PR DESCRIPTION
## About The Pull Request

If the glass was renamed by a player, don't override the name / description in `update_name` and `update_desc`. Simple enough

Unfortunate side effect is changing the name but not the desc leaves the desc as it is, but I don't think anyone would really care or notice. It used to be like this anyways.

## Why It's Good For The Game

Aesthetics. Fixes #72890

## Changelog

:cl: Melbert
fix: Custom named drinks (with a pen) no longer reset after their glass volume updates
/:cl: