### PR TITLE
Meteor events won't try and run on icebox

### DIFF
--- a/code/__DEFINES/events.dm
+++ b/code/__DEFINES/events.dm
@@ -35,3 +35,8 @@
 
 /// Return from admin setup to stop the event from triggering entirely.
 #define ADMIN_CANCEL_EVENT "cancel event"
+
+/// Event can only run on a map set in space
+#define EVENT_SPACE_ONLY (1 << 0)
+/// Event can only run on a map which is a planet
+#define EVENT_PLANETARY_ONLY (1 << 1)

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -15,10 +15,12 @@ SUBSYSTEM_DEF(events)
 
 /datum/controller/subsystem/events/Initialize()
 	for(var/type in typesof(/datum/round_event_control))
-		var/datum/round_event_control/E = new type()
-		if(!E.typepath)
+		var/datum/round_event_control/event = new type()
+		if(!event.typepath)
 			continue //don't want this one! leave it for the garbage collector
-		control += E //add it to the list of all events (controls)
+		if(!event.valid_for_map())
+			continue
+		control += event //add it to the list of all events (controls)
 	reschedule()
 	// Instantiate our holidays list if it hasn't been already
 	if(isnull(GLOB.holidays))

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -16,10 +16,8 @@ SUBSYSTEM_DEF(events)
 /datum/controller/subsystem/events/Initialize()
 	for(var/type in typesof(/datum/round_event_control))
 		var/datum/round_event_control/event = new type()
-		if(!event.typepath)
+		if(!event.typepath || !event.valid_for_map())
 			continue //don't want this one! leave it for the garbage collector
-		if(!event.valid_for_map())
-			continue
 		control += event //add it to the list of all events (controls)
 	reschedule()
 	// Instantiate our holidays list if it hasn't been already

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -880,3 +880,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	if(length(GLOB.default_lighting_underlays_by_z) < z_level)
 		GLOB.default_lighting_underlays_by_z.len = z_level
 	GLOB.default_lighting_underlays_by_z[z_level] = mutable_appearance(LIGHTING_ICON, "transparent", z_level * 0.01, null, LIGHTING_PLANE, 255, RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM, offset_const = GET_Z_PLANE_OFFSET(z_level))
+
+/// Returns true if the map we're playing on is on a planet
+/datum/controller/subsystem/mapping/proc/is_planetary()
+	return config.planetary

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -800,7 +800,7 @@
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/pirates/acceptable(population=0, threat=0)
-	if (!SSmapping.empty_space)
+	if (is_planetary())
 		return FALSE
 	return ..()
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -800,7 +800,7 @@
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/midround/pirates/acceptable(population=0, threat=0)
-	if (is_planetary())
+	if (SSmapping.is_planetary())
 		return FALSE
 	return ..()
 

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -8,12 +8,9 @@
 	INVOKE_ASYNC(src, PROC_REF(_unfavorable_situation))
 
 /datum/game_mode/dynamic/proc/_unfavorable_situation()
-	var/static/list/unfavorable_random_events = list(
-		/datum/round_event_control/immovable_rod,
-		/datum/round_event_control/meteor_wave,
-		/datum/round_event_control/portal_storm_syndicate,
-	)
-
+	var/static/list/unfavorable_random_events = list()
+	if (!length(unfavorable_random_events))
+		unfavorable_random_events = generate_unfavourable_events()
 	var/list/possible_heavies = list()
 
 	// Ignored factors: threat cost, minimum round time
@@ -56,3 +53,18 @@
 		var/datum/dynamic_ruleset/midround/heavy_ruleset = pick_weight(possible_heavies)
 		log_dynamic_and_announce("An unfavorable situation was requested, spawning [initial(heavy_ruleset.name)]")
 		picking_specific_rule(heavy_ruleset, forced = TRUE, ignore_cost = TRUE)
+
+/// Filter the below list by which events can actually run on this map
+/datum/game_mode/dynamic/proc/generate_unfavourable_events()
+	var/static/list/unfavorable_random_events = list(
+		/datum/round_event_control/immovable_rod,
+		/datum/round_event_control/meteor_wave,
+		/datum/round_event_control/portal_storm_syndicate,
+	)
+	var/list/picked_events = list()
+	for(var/type in unfavorable_random_events)
+		var/datum/round_event_control/event = new type()
+		if(!event.valid_for_map())
+			continue
+		picked_events += type
+	return picked_events

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -198,7 +198,7 @@
 /datum/game_mode/proc/generate_station_goals(greenshift)
 	var/goal_budget = greenshift ? INFINITY : CONFIG_GET(number/station_goal_budget)
 	var/list/possible = subtypesof(/datum/station_goal)
-	if(!(SSmapping.empty_space))
+	if(SSmapping.is_planetary())
 		for(var/datum/station_goal/goal in possible)
 			if(goal.requires_space)
 				///Removes all goals that require space if space is not present

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -845,10 +845,10 @@
 	var/num_ghosts = length(GLOB.current_observers_list) + length(GLOB.dead_player_list)
 
 	// Pirates require empty space for the ship, and ghosts for the pirates obviously
-	if(SSmapping.empty_space && (num_ghosts >= MIN_GHOSTS_FOR_PIRATES))
+	if(!SSmapping.is_planetary() && (num_ghosts >= MIN_GHOSTS_FOR_PIRATES))
 		hack_options += HACK_PIRATE
 	// Fugitives require empty space for the hunter's ship, and ghosts for both fugitives and hunters (Please no waldo)
-	if(SSmapping.empty_space && (num_ghosts >= MIN_GHOSTS_FOR_FUGITIVES))
+	if(!SSmapping.is_planetary() && (num_ghosts >= MIN_GHOSTS_FOR_FUGITIVES))
 		hack_options += HACK_FUGITIVES
 	// If less than a certain percent of the population is ghosts, consider sleeper agents
 	if(num_ghosts < (length(GLOB.clients) * MAX_PERCENT_GHOSTS_FOR_SLEEPER))

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -8,9 +8,10 @@
 	category = EVENT_CATEGORY_INVASION
 	description = "The crew will either pay up, or face a pirate assault."
 	admin_setup = /datum/event_admin_setup/pirates
+	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event_control/pirates/preRunEvent()
-	if (!SSmapping.empty_space)
+	if (!SSmapping.is_planetary())
 		return EVENT_CANT_RUN
 	return ..()
 

--- a/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/battlecruiser.dm
@@ -11,7 +11,7 @@
 
 /datum/traitor_objective/ultimate/battlecruiser/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	// There's no empty space to load a battlecruiser in...
-	if(!SSmapping.empty_space)
+	if(SSmapping.is_planetary())
 		return FALSE
 
 	return TRUE

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -33,6 +33,8 @@
 	/// Datum that will handle admin options for forcing the event.
 	/// If there are no options, just leave it null.
 	var/datum/event_admin_setup/admin_setup = null
+	/// Flags dictating whether this event should be run on certain kinds of map
+	var/map_flags = NONE
 
 /datum/round_event_control/New()
 	if(config && !wizardevent) // Magic is unaffected by configs
@@ -44,6 +46,18 @@
 /datum/round_event_control/wizard
 	category = EVENT_CATEGORY_WIZARD
 	wizardevent = TRUE
+
+/// Returns true if event can run in current map
+/datum/round_event_control/proc/valid_for_map()
+	if (!map_flags)
+		return TRUE
+	if (SSmapping.is_planetary())
+		if (map_flags & EVENT_SPACE_ONLY)
+			return FALSE
+	else
+		if (map_flags & EVENT_PLANETARY_ONLY)
+			return FALSE
+	return TRUE
 
 // Checks if the event can be spawned. Used by event controller and "false alarm" event.
 // Admin-created events override this.

--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -7,6 +7,7 @@
 	alert_observers = FALSE
 	category = EVENT_CATEGORY_SPACE
 	description = "A single space dust is hurled at the station."
+	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event/space_dust
 	start_when = 1

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -6,6 +6,7 @@
 	earliest_start = 30 MINUTES //deadchat sink, lets not even consider it early on.
 	category = EVENT_CATEGORY_INVASION
 	description = "Fugitives will hide on the station, followed by hunters."
+	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event/ghost_role/fugitives
 	minimum_required = 1

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -9,6 +9,7 @@
 	earliest_start = 25 MINUTES
 	category = EVENT_CATEGORY_SPACE
 	description = "A regular meteor wave."
+	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event/meteor_wave
 	start_when = 6

--- a/code/modules/events/sandstorm.dm
+++ b/code/modules/events/sandstorm.dm
@@ -16,6 +16,7 @@
 	category = EVENT_CATEGORY_SPACE
 	description = "A wave of space dust continually grinds down a side of the station."
 	admin_setup = /datum/event_admin_setup/listed_options/sandstorm
+	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event/sandstorm
 	start_when = 60
@@ -69,6 +70,7 @@
 	earliest_start = 0 MINUTES
 	category = EVENT_CATEGORY_SPACE
 	description = "The station is pelted by an extreme amount of dust, from all sides, for several minutes. Very destructive and likely to cause lag. Use at own risk."
+	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event/sandstorm_classic
 	start_when = 1

--- a/code/modules/events/stray_meteor.dm
+++ b/code/modules/events/stray_meteor.dm
@@ -8,6 +8,7 @@
 	category = EVENT_CATEGORY_SPACE
 	description = "Throw a random meteor somewhere near the station."
 	admin_setup = /datum/event_admin_setup/listed_options/stray_meteor
+	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event/stray_meteor
 	announce_when = 1

--- a/code/modules/meteors/meteors.dm
+++ b/code/modules/meteors/meteors.dm
@@ -37,6 +37,9 @@ GLOBAL_LIST_INIT(meteors_sandstorm, list(/obj/effect/meteor/sand=45, /obj/effect
 		spawn_meteor(meteor_types, direction)
 
 /proc/spawn_meteor(list/meteor_types, direction)
+	if (SSmapping.is_planetary())
+		stack_trace("Tried to spawn meteors in a map which isn't in space.")
+		return // We're not going to find any space turfs here
 	var/turf/picked_start
 	var/turf/picked_goal
 	var/max_i = 10//number of tries to spawn meteor.


### PR DESCRIPTION
## About The Pull Request

While I was trying to improve changeling meteor spawning on Icebox I noticed that several other meteor-like events don't seem to be blocked on Icebox either even though they don't do anything.
I added a new capability to events which can prevent them being loaded under certain map conditions (specifically: whether the map is in space or not). Currently there's no events which _only_ run on a planet but, now someone could add one I guess? 

Now all of the events which spawn meteors are filtered out on icebox and you can't absent-mindedly try to trigger them.
![image](https://user-images.githubusercontent.com/7483112/216799539-f843bdf6-c70f-4815-a355-0b297acad1a6.png)

Also a couple of dynamic options had this applied too, chiefly ones which expect you to be able to fly a space ship to the space station.

## Why It's Good For The Game

These events shouldn't run on Icebox (or soon, Chilled) because they don't do anything there.
AFAICT Meteors were getting as far as trying to spawn, then would retry trying to find space tiles which didn't exist until they failed 10 times, then give up. Once per every meteor it tried to spawn. Gross.

## Changelog

:cl:
fix: Meteors can't be triggered automatically or manually on Icebox, where they do nothing.
fix: Hacking a comms console as a traitor won't try to summon meteors or pirates to Icebox, where they do nothing.
/:cl:
