### PR TITLE
Fixes HUD elements not being set properly on Login()

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -285,6 +285,7 @@
 
 	rest_icon = new /atom/movable/screen/rest()
 	rest_icon.icon = ui_style
+	rest_icon.update_appearance()
 	rest_icon.screen_loc = ui_above_movement
 	rest_icon.hud = src
 	static_inventory += rest_icon

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -285,9 +285,9 @@
 
 	rest_icon = new /atom/movable/screen/rest()
 	rest_icon.icon = ui_style
-	rest_icon.update_appearance()
 	rest_icon.screen_loc = ui_above_movement
 	rest_icon.hud = src
+	rest_icon.update_appearance()
 	static_inventory += rest_icon
 
 	spacesuit = new /atom/movable/screen/spacesuit
@@ -308,9 +308,9 @@
 
 	pull_icon = new /atom/movable/screen/pull()
 	pull_icon.icon = ui_style
-	pull_icon.update_appearance()
 	pull_icon.screen_loc = ui_above_intent
 	pull_icon.hud = src
+	pull_icon.update_appearance()
 	static_inventory += pull_icon
 
 	zone_select = new /atom/movable/screen/zone_sel()


### PR DESCRIPTION

## About The Pull Request
If a mob is set to Rest before a client logs in, their HUD icon will not update to match the status on login. This fixes that.
(Same for pulling)

This notably affected the Hangover station trait, which set all players resting before they are able to Login() to their characters.

## Changelog
:cl:
fix: The "Rest" and "Pull" HUD icons correctly match the mob's current state on Login().
/:cl:
