### PR TITLE
Fixes belts not updating their overlays when transferring their contents to another storage item.

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -736,6 +736,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 			if(to_dump.loc != resolve_location)
 				continue
 			dest_object.atom_storage.attempt_insert(to_dump, user)
+		resolve_parent.update_appearance()
 
 		return
 


### PR DESCRIPTION

## About The Pull Request

When you drag and drop a belt to another storage item it transfers all its contents but retains its overlays. This PR calls update appearance at the end of storage to storage transfers so this shouldn't occur again.
## Why It's Good For The Game

Bug fix, belts appearing to have things on them which they don't is bad.
## Changelog
:cl:
fix: Transferring objects from a belt to another storage object now removes those objects from the belts visuals.
/:cl:
