### PR TITLE
Fixes an issue with the copy_dna proc when called on a DNA without a holder mob

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -121,7 +121,11 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	new_dna.unique_features = unique_features
 	new_dna.blood_type = blood_type
 	new_dna.features = features.Copy()
-	new_dna.holder.set_species(species.type, icon_update = 0)
+	//if the new DNA has a holder, transform them immediately, otherwise save it
+	if(new_dna.holder)
+		new_dna.holder.set_species(species.type, icon_update = 0)
+	else
+		new_dna.species = species
 	new_dna.real_name = real_name
 	// Mutations aren't gc managed, but they still aren't templates
 	// Let's do a proper copy


### PR DESCRIPTION

## About The Pull Request

Recently, the copy_dna proc was changed to immediately transform the species of the DNA's holder. However, DNA does not always have a holder, for example, the stored DNA's of changeling. Due to this, it had a null exception runtime, leaving the stored DNA as a default human, including your original. This PR fixes that. 

This also fixes stabilized green slime extracts, due to the same error, you turned human when you dropped them.

Curing Space Retrovirus probably also had this issue, I couldn't test that one.

## Why It's Good For The Game

Fixes #73242

## Changelog

:cl:
fix: swapping to a stored DNA no longer forces you to be human instead of the species stored in the DNA
/:cl: