### PR TITLE
Fixes freezers locking automatically when closed.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -24,6 +24,7 @@
 /obj/structure/closet/secure_closet/freezer/close(mob/living/user)
 	if(..()) //if we actually closed the locker
 		toggle_organ_decay(src)
+		return TRUE
 
 /obj/structure/closet/secure_closet/freezer/ex_act()
 	if(jones)


### PR DESCRIPTION

## About The Pull Request

Took a little while to figure out what was going on, Freezers override close() but never return true when they successfully close which results in the code for locking the freezer being called right after closing it.
## Why It's Good For The Game

Fixes an oversight.
## Changelog
:cl:
fix: Freezer no longer lock automatically when closed.
/:cl:
