### PR TITLE
[PROJECT] Admin Verbs - menu bar | dynamic verb invocation | button feedback

### DIFF
--- a/code/controllers/subsystem/admin_verbs.dm
+++ b/code/controllers/subsystem/admin_verbs.dm
@@ -72,11 +72,12 @@ GENERAL_PROTECT_DATUM(/datum/controller/subsystem/admin_verbs)
 			cached_formats[verb_module] = verb_module_formatted
 
 		var/original_name = verb_information[VERB_MAP_NAME]
-
+		var/verb_ref = replacetext(original_name, " ", "-")
 		var/verb_desc = verb_information[VERB_MAP_DESCRIPTION]
+
 		if(!stat_data[cached_formats[verb_module]])
 			stat_data[cached_formats[verb_module]] = list()
-		stat_data[cached_formats[verb_module]] += list(list(original_name, verb_desc, original_name))
+		stat_data[cached_formats[verb_module]] += list(list(original_name, verb_desc, verb_ref))
 	var/sorted_stat_data = list()
 	for(var/verb_category in stat_data)
 		sorted_stat_data[verb_category] = sort_list(stat_data[verb_category], GLOBAL_PROC_REF(cmp_admin_verb_name))
@@ -114,7 +115,10 @@ GENERAL_PROTECT_DATUM(/datum/controller/subsystem/admin_verbs)
 	usr = target
 	var/holder_proc = text2path("[verb_type]/verb/invoke")
 	var/list/arguments = args.Copy(3)
-	call(holder, holder_proc)(arglist(arguments))
+	if(!length(arguments))
+		usr.client.invoke_verb(holder_proc) // no arguments? let byond handle it
+	else
+		call(holder, holder_proc)(arglist(arguments))
 
 /datum/controller/subsystem/admin_verbs/proc/link_admin(mob/admin)
 	assosciations_by_ckey[admin.ckey] = list()

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1180,6 +1180,11 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	// Place Help back at the end.
 	winset(src, "help-menu", "index=1000")
 
+/// Instructs the client's statpanel to invoke the given verb, there is no sanity checking here
+/client/proc/invoke_verb(procpath/verbpath)
+	var/verb_name = istext(verbpath.name) ? verbpath : verbpath.name
+	stat_panel.send_message("invoke_verb", replacetext(verb_name, " ", "-"))
+
 /client/proc/open_filter_editor(atom/in_atom)
 	if(holder)
 		holder.filteriffic = new /datum/filter_editor(in_atom)

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -420,7 +420,8 @@ function admin_verb_convert_verb_info_into_button(verb_info) {
 	var verb_button = document.createElement("a");
 	var verb_button_text = document.createElement("span");
 
-	verb_button.onclick = make_verb_onclick(verb_ref.replace(" ", "-"));
+	verb_button.onclick = make_verb_onclick(verb_ref);
+	verb_button.href = "#";
 	verb_button.className = "grid-item";
 	verb_button.title = verb_desc;
 
@@ -1065,3 +1066,7 @@ Byond.subscribeTo('remove_sdql2', remove_sdql2);
 Byond.subscribeTo('remove_mc', remove_mc);
 
 Byond.subscribeTo('add_verb_list', add_verb_list);
+
+Byond.subscribeTo('invoke_verb', function (payload) {
+	Byond.command(payload);
+});

--- a/html/statbrowser.js
+++ b/html/statbrowser.js
@@ -19,6 +19,7 @@ var status_tab_parts = ["Loading..."];
 var current_tab = null;
 var mc_tab_parts = [["Loading...", ""]];
 var admin_verb_cats = [];
+var admin_verb_selected_cat = "";
 var admin_verb_groups = [["Server"], ["Debug"]];
 var href_token = null;
 var spells = [];
@@ -397,15 +398,23 @@ function draw_mc() {
 function draw_admin_verbs() {
 	try {
 		statcontentdiv.textContent = "";
+
 		var verb_groups = admin_verb_convert_into_groups(admin_verb_cats);
 		var group_names = Object.keys(verb_groups).sort();
-		for (var i = 0; i < group_names.length; i++) {
-			var group_name = group_names[i];
-			var group_header = document.createElement("h3");
-			group_header.textContent = group_name;
-			statcontentdiv.appendChild(group_header);
-			statcontentdiv.appendChild(get_admin_verb_group_div(verb_groups[group_name]));
+
+		if(!group_names.includes(admin_verb_selected_cat)) {
+			admin_verb_selected_cat = group_names[0];
 		}
+
+		var menu = get_admin_verb_header_menu_div(group_names, admin_verb_selected_cat, function (cat) {
+			admin_verb_selected_cat = cat;
+			draw_admin_verbs();
+		});
+		var selected_group = verb_groups[admin_verb_selected_cat];
+
+		statcontentdiv.appendChild(menu);
+		statcontentdiv.appendChild(document.createElement("br"));
+		statcontentdiv.appendChild(get_admin_verb_group_div(selected_group));
 	} catch(except) {
 		statcontentdiv.textContent = "NTOS Exception: " + except + "\nReport this to your nearest Technical Resolution Specialist"
 	}
@@ -458,6 +467,30 @@ function get_admin_verb_group_div(group) {
 		group_div.appendChild(group[i]);
 	}
 	return group_div;
+}
+
+// Creates the header menu for the admin verb tab
+function get_admin_verb_header_menu_div(groups, selected, set_selected) {
+	var header_div = document.createElement("div");
+	header_div.className = "admin-verb-menu";
+
+	var header_ul = document.createElement("ul");
+	var group_names = Object.keys(groups).sort();
+	for (var i = 0; i < group_names.length; i++) {
+		var group_name = group_names[i];
+		var group_li = document.createElement("li");
+		var group_a = document.createElement("a");
+		group_a.href = "#";
+		group_a.textContent = group_name;
+		group_a.onclick = set_selected(group_name);
+		group_li.appendChild(group_a);
+		if (group_name == selected) {
+			group_li.className = "selected";
+		}
+		header_ul.appendChild(group_li);
+	}
+	header_div.appendChild(header_ul);
+	return header_div;
 }
 
 function remove_tickets() {


### PR DESCRIPTION
Adds a menu bar to admin verbs so you can swap between active categories, which is a precursor to a custom tab / custom grouping system

Adds a proc to client to ask the statpanel to invoke a verb; and adds a subscriber to the stat_panel to listen to and attempt to do so

Buttons now have an href of '#' which allows them to be obvious when you hover over and click on them

the statbrowser js no longer formats the verb_ref for you, it must be formatted when sent, this prevents issues where verb buttons wouldn't actually make a valid topic call to invoke the verb
Stat data generation for admin verbs now formats the verb name into the callable verb ref string