### PR TITLE
Update tgui say keybindings when keybindings are updated

### DIFF
--- a/code/modules/client/preferences/middleware/keybindings.dm
+++ b/code/modules/client/preferences/middleware/keybindings.dm
@@ -27,6 +27,7 @@
 	preferences.key_bindings = deep_copy_list(GLOB.default_hotkeys)
 	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
 	preferences.update_static_data(user)
+	user.client.update_special_keybinds()
 
 	return TRUE
 
@@ -41,10 +42,11 @@
 	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
 
 	preferences.update_static_data(user)
+	user.client.update_special_keybinds()
 
 	return TRUE
 
-/datum/preference_middleware/keybindings/proc/set_keybindings(list/params)
+/datum/preference_middleware/keybindings/proc/set_keybindings(list/params, mob/user)
 	var/keybind_name = params["keybind_name"]
 
 	if (isnull(GLOB.keybindings_by_name[keybind_name]))
@@ -72,6 +74,8 @@
 
 	preferences.key_bindings[keybind_name] = hotkeys
 	preferences.key_bindings_by_key = preferences.get_key_bindings_by_key(preferences.key_bindings)
+
+	user.client.update_special_keybinds()
 
 	return TRUE
 


### PR DESCRIPTION
Fixes (partial) #73247
## About The Pull Request

Updating or resetting your preferences doesn't actually currently update the movement/tgui say keybindings. This fixes that, although there's still a weird heisenbug with NULL keybindings that we haven't been able to reproduce at all from #73247
## Why It's Good For The Game

fix
## Changelog
:cl:
fix: preferences now respects your preferences
/:cl:
