### PR TITLE
Optimizes INVOKE_ASYNC by making it a macro and avoiding a proc call

### DIFF
--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -1,6 +1,6 @@
 #define GLOBAL_PROC "some_magic_bullshit"
 /// A shorthand for the callback datum, [documented here](datum/callback.html)
 #define CALLBACK new /datum/callback
-#define INVOKE_ASYNC world.ImmediateInvokeAsync
+#define INVOKE_ASYNC(TRG, PR, ARG...) if ((TRG) == GLOBAL_PROC) { spawn (-1) call(PR)(##ARG); } else { spawn(-1) call(TRG, PR)(##ARG); }
 /// like CALLBACK but specifically for verb callbacks
 #define VERB_CALLBACK new /datum/callback/verb_callback

--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -8,7 +8,7 @@
 #define ASYNC spawn(MAKE_SPAWN_ACT_LIKE_WAITFOR)
 
 #define INVOKE_ASYNC(proc_owner, proc_path, proc_arguments...) \
-	if ((proc_owner) == GLOBAL_PROC){ \
+	if ((proc_owner) == GLOBAL_PROC) { \
 		ASYNC{ \
 			call(proc_path)(##proc_arguments); \
 		}; \

--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -17,7 +17,7 @@
 		ASYNC { \
 			call(proc_owner, proc_path)(##proc_arguments); \
 		}; \
-	} \
+	} 
 
 /// like CALLBACK but specifically for verb callbacks
 #define VERB_CALLBACK new /datum/callback/verb_callback

--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -1,14 +1,22 @@
 #define GLOBAL_PROC "some_magic_bullshit"
 /// A shorthand for the callback datum, [documented here](datum/callback.html)
 #define CALLBACK new /datum/callback
+
+///Per the DM reference, spawn(-1) will execute the spawned code immediately until a block is met.
+#define MAKE_SPAWN_ACT_LIKE_WAITFOR -1
+///Create a codeblock that will not block the callstack if a block is met.
+#define ASYNC spawn(MAKE_SPAWN_ACT_LIKE_WAITFOR)
+
 #define INVOKE_ASYNC(proc_owner, proc_path, proc_arguments...) \
 	if ((proc_owner) == GLOBAL_PROC){ \
-		spawn (-1); \
+		ASYNC{ \
 			call(proc_path)(##proc_arguments); \
+		}; \
 	} \
 	else { \
-		spawn(-1); \
+		ASYNC{ \
 			call(proc_owner, proc_path)(##proc_arguments); \
+		}; \
 	} \
 
 /// like CALLBACK but specifically for verb callbacks

--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -14,7 +14,7 @@
 		}; \
 	} \
 	else { \
-		ASYNC{ \
+		ASYNC { \
 			call(proc_owner, proc_path)(##proc_arguments); \
 		}; \
 	} \

--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -9,7 +9,7 @@
 
 #define INVOKE_ASYNC(proc_owner, proc_path, proc_arguments...) \
 	if ((proc_owner) == GLOBAL_PROC) { \
-		ASYNC{ \
+		ASYNC { \
 			call(proc_path)(##proc_arguments); \
 		}; \
 	} \

--- a/code/__DEFINES/callbacks.dm
+++ b/code/__DEFINES/callbacks.dm
@@ -1,6 +1,15 @@
 #define GLOBAL_PROC "some_magic_bullshit"
 /// A shorthand for the callback datum, [documented here](datum/callback.html)
 #define CALLBACK new /datum/callback
-#define INVOKE_ASYNC(TRG, PR, ARG...) if ((TRG) == GLOBAL_PROC) { spawn (-1) call(PR)(##ARG); } else { spawn(-1) call(TRG, PR)(##ARG); }
+#define INVOKE_ASYNC(proc_owner, proc_path, proc_arguments...) \
+	if ((proc_owner) == GLOBAL_PROC){ \
+		spawn (-1); \
+			call(proc_path)(##proc_arguments); \
+	} \
+	else { \
+		spawn(-1); \
+			call(proc_owner, proc_path)(##proc_arguments); \
+	} \
+
 /// like CALLBACK but specifically for verb callbacks
 #define VERB_CALLBACK new /datum/callback/verb_callback

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -67,26 +67,6 @@
 		arguments = args.Copy(3)
 	if(usr)
 		user = WEAKREF(usr)
-/**
- * Immediately Invoke proctocall on thingtocall, with waitfor set to false
- *
- * Arguments:
- * * thingtocall Object to call on
- * * proctocall Proc to call on that object
- * * ... optional list of arguments to pass as arguments to the proc being called
- */
-/world/proc/ImmediateInvokeAsync(thingtocall, proctocall, ...)
-	set waitfor = FALSE
-
-	if (!thingtocall)
-		return
-
-	var/list/calling_arguments = length(args) > 2 ? args.Copy(3) : null
-
-	if (thingtocall == GLOBAL_PROC)
-		call(proctocall)(arglist(calling_arguments))
-	else
-		call(thingtocall, proctocall)(arglist(calling_arguments))
 
 /**
  * Invoke this callback

--- a/code/datums/components/construction.dm
+++ b/code/datums/components/construction.dm
@@ -33,7 +33,7 @@
 
 /datum/component/construction/proc/action(datum/source, obj/item/I, mob/living/user)
 	SIGNAL_HANDLER
-	spawn(-1) //Please stop trying to get the return value from procs that can sleep
+	ASYNC //This proc will never actually sleep, it calls do_after with a time of 0.
 		. = check_step(I, user)
 	return .
 

--- a/code/datums/components/construction.dm
+++ b/code/datums/components/construction.dm
@@ -33,8 +33,9 @@
 
 /datum/component/construction/proc/action(datum/source, obj/item/I, mob/living/user)
 	SIGNAL_HANDLER
-
-	return INVOKE_ASYNC(src, PROC_REF(check_step), I, user)
+	spawn(-1) //Please stop trying to get the return value from procs that can sleep
+		. = check_step(I, user)
+	return .
 
 /datum/component/construction/proc/update_index(diff)
 	index += diff

--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -122,7 +122,7 @@
 		if(ishuman(user))
 			var/mob/living/carbon/human/paying_customer = user
 			var/successfully_put_in_hands
-			spawn(-1) //Put_in_hands can sleep, we don't want that.
+			ASYNC //Put_in_hands can sleep, we don't want that to block this proc.
 				successfully_put_in_hands = paying_customer.put_in_hands(holochange)
 			if(!successfully_put_in_hands)
 				user.pulling = holochange

--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -121,7 +121,9 @@
 		holochange.name = "[holochange.credits] credit holochip"
 		if(ishuman(user))
 			var/mob/living/carbon/human/paying_customer = user
-			var/successfully_put_in_hands = INVOKE_ASYNC(paying_customer, TYPE_PROC_REF(/mob, put_in_hands), holochange)
+			var/successfully_put_in_hands
+			spawn(-1) //Put_in_hands can sleep, we don't want that.
+				successfully_put_in_hands= paying_customer.put_in_hands(holochange)
 			if(!successfully_put_in_hands)
 				user.pulling = holochange
 		else

--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -121,7 +121,8 @@
 		holochange.name = "[holochange.credits] credit holochip"
 		if(ishuman(user))
 			var/mob/living/carbon/human/paying_customer = user
-			if(!INVOKE_ASYNC(paying_customer, TYPE_PROC_REF(/mob, put_in_hands), holochange))
+			var/successfully_put_in_hands = INVOKE_ASYNC(paying_customer, TYPE_PROC_REF(/mob, put_in_hands), holochange)
+			if(!successfully_put_in_hands)
 				user.pulling = holochange
 		else
 			user.pulling = holochange

--- a/code/datums/components/payment.dm
+++ b/code/datums/components/payment.dm
@@ -123,7 +123,7 @@
 			var/mob/living/carbon/human/paying_customer = user
 			var/successfully_put_in_hands
 			spawn(-1) //Put_in_hands can sleep, we don't want that.
-				successfully_put_in_hands= paying_customer.put_in_hands(holochange)
+				successfully_put_in_hands = paying_customer.put_in_hands(holochange)
 			if(!successfully_put_in_hands)
 				user.pulling = holochange
 		else

--- a/code/modules/vehicles/mecha/mecha_construction_paths.dm
+++ b/code/modules/vehicles/mecha/mecha_construction_paths.dm
@@ -384,7 +384,9 @@
 	outer_plating_amount=1
 
 /datum/component/construction/mecha/gygax/action(datum/source, atom/used_atom, mob/user)
-	return INVOKE_ASYNC(src, PROC_REF(check_step), used_atom,user)
+	spawn(-1) //Please stop trying to get the return value from procs that can sleep
+		. = check_step(used_atom, user)
+	return .
 
 //CLARKE
 /datum/component/construction/unordered/mecha_chassis/clarke

--- a/code/modules/vehicles/mecha/mecha_construction_paths.dm
+++ b/code/modules/vehicles/mecha/mecha_construction_paths.dm
@@ -384,7 +384,7 @@
 	outer_plating_amount=1
 
 /datum/component/construction/mecha/gygax/action(datum/source, atom/used_atom, mob/user)
-	spawn(-1) //Please stop trying to get the return value from procs that can sleep
+	ASYNC //This proc will never actually sleep, it calls do_after with a time of 0.
 		. = check_step(used_atom, user)
 	return .
 


### PR DESCRIPTION
## About The Pull Request
This is quite literally the same behavior but faster, and also catches improper arguments better than the old macro/proc approach.

Credit to Lohikar for writing the macro.
Port of https://github.com/DaedalusDock/daedalusdock/pull/196

Also, `world.ImmediateInvokeAsync()` never set a return value, so expecting one was never valid behavior.

At MSO's request, the documentation of `spawn(-1)`:

As per the reference, calling `spawn()` with a negative value will execute the spawned code until a blocking action (such as `sleep()`) is encountered. Then, it will step outside of the spawned code, and continue the proc. This is the same behavior as calling a `waitfor = FALSE` proc. Specifically, under the hood, `spawn(-1)` creates a copy of the callstack like `sleep()`, incase the spawned code is blocked and needs to be rescheduled.

As an added bonus, `spawn(-1)` silences SHOULD_NOT_SLEEP errors, whereas `waitfor = FALSE` does not.

## Why It's Good For The Game

ITS FREE FUCKING CPU TIME
