### PR TITLE
Fix barsign for kilo

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -11135,6 +11135,7 @@
 	icon_state = "plant-21"
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/central/fore)
 "dqg" = (
@@ -17922,7 +17923,6 @@
 /area/station/maintenance/department/chapel/monastery)
 "fnZ" = (
 /obj/structure/table,
-/obj/machinery/light/directional/north,
 /obj/item/reagent_containers/condiment/saltshaker{
 	desc = "Salt. From space oceans, presumably. A staple of modern medicine.";
 	pixel_x = -8;
@@ -17940,11 +17940,6 @@
 	pixel_y = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/directional/north{
-	c_tag = "Atrium Starboard";
-	name = "service camera"
-	},
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "fob" = (
@@ -20592,7 +20587,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -23213,6 +23207,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/camera/directional/north{
+	c_tag = "Atrium Starboard";
+	name = "service camera"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/bar/atrium)
 "gHA" = (
@@ -24690,7 +24688,6 @@
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -25015,7 +25012,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37933,13 +37929,11 @@
 /area/station/security/execution/transfer)
 "kNw" = (
 /obj/structure/table,
-/obj/machinery/light/directional/north,
 /obj/item/paper_bin{
 	pixel_x = -4;
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "kNz" = (
@@ -42854,6 +42848,8 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "mfU" = (
@@ -45916,6 +45912,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/atrium)
 "naK" = (
@@ -65339,7 +65336,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/barsign/directional/north,
+/obj/machinery/barsign/all_access/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
 "sHn" = (
@@ -71110,7 +71107,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/light/directional/south,
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
@@ -77123,7 +77119,6 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/obj/machinery/light/directional/north,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
@@ -79790,7 +79785,6 @@
 	dir = 1
 	},
 /obj/structure/chair/stool/bar/directional/east,
-/obj/machinery/light/directional/north,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/bar/atrium)
@@ -114417,7 +114411,7 @@ rOR
 tEE
 mfJ
 bqd
-qTC
+ijQ
 sHm
 ddp
 vRO
@@ -114674,7 +114668,7 @@ ukU
 dYy
 fzL
 yej
-qTC
+ijQ
 naG
 hJQ
 gpS
@@ -114931,7 +114925,7 @@ aOc
 laB
 npo
 uke
-ijQ
+qTC
 kNw
 tgZ
 bFw
@@ -116473,7 +116467,7 @@ twc
 qks
 nCv
 hdz
-ijQ
+qTC
 fnZ
 wgO
 iOb
@@ -116730,7 +116724,7 @@ imo
 tEE
 fzL
 nTG
-qTC
+ijQ
 mfT
 qOB
 vYI
@@ -116987,7 +116981,7 @@ xxP
 wqE
 wuh
 tzl
-qTC
+ijQ
 gHi
 jLq
 shP

--- a/tools/UpdatePaths/Scripts/73106_barsigns.txt
+++ b/tools/UpdatePaths/Scripts/73106_barsigns.txt
@@ -1,1 +1,3 @@
-/obj/machinery/barsign : /obj/structure/sign/barsign{@OLD}
+# This repaths barsigns to be a subtype of machinery
+
+/obj/structure/sign/barsign : /obj/machinery/barsign{@OLD}


### PR DESCRIPTION
## About The Pull Request
In #73106 I changed barsigns path to be `/obj/machinery/barsign` instead of `/obj/structure/sign/barsign` and this resulted in them being on a different render layer causing them to spawn underneath windows.  At some point barsigns will be wall mounted objects in the future, so having them appear on any windows is not ideal.  This fix changes kilo bar layout slightly to make room for the barsign to spawn on walls instead of windows.  I moved some lights and other wall mounted objects (newscaster, cameras) so it wouldn't look out of place.

Also:

[Fix barsign updatePath being backwards](https://github.com/tgstation/tgstation/pull/73268/commits/4d6a136a88bb222fe954d35117c8f7f8f5331aaa)

## Why It's Good For The Game
<details>
<summary>Before:</summary>

![StrongDMM_rrpmrrxzR9](https://user-images.githubusercontent.com/5195984/216935681-6b696dac-8c5e-41c9-8fbb-2e5dc7143c79.png)

</details>

<details>
<summary>After:</summary>

![StrongDMM_NkmfUydBGH](https://user-images.githubusercontent.com/5195984/216935372-be4da332-599a-4fb1-a7f1-3a334f466d81.png)

</details>

## Changelog
:cl:
fix: Fix kilo barsign spawning under windows
fix: Fix barsign updatePath being backwards
/:cl:
