### PR TITLE
[NO GBP] Changeling meteor catatonic body quick-fix

### DIFF
--- a/code/modules/events/ghost_role/changeling_event.dm
+++ b/code/modules/events/ghost_role/changeling_event.dm
@@ -42,8 +42,7 @@
  * * candidate - The mob (player) to be transformed into a changeling and meteored.
  */
 
-/proc/generate_changeling_meteor(mob/candidate)
-	var/mob/dead/selected = candidate
+/proc/generate_changeling_meteor(mob/dead/selected)
 	var/datum/mind/player_mind = new(selected.key)
 	player_mind.active = TRUE
 

--- a/code/modules/events/ghost_role/changeling_event.dm
+++ b/code/modules/events/ghost_role/changeling_event.dm
@@ -43,7 +43,7 @@
  */
 
 /proc/generate_changeling_meteor(mob/candidate)
-	var/mob/dead/selected = make_body(candidate) //Give the selected player a body, and grab their mind
+	var/mob/dead/selected = candidate
 	var/datum/mind/player_mind = new(selected.key)
 	player_mind.active = TRUE
 


### PR DESCRIPTION
## About The Pull Request

For some reason, I decided it would be a good idea to cast a dead mob with make_body(), and not use the resulting body as the meteor's contents. Since a second body is made and used later on down the line, the first body would end up on the emergency shuttle, naked and unused.
## Why It's Good For The Game

Considering they're an antagonist who excels at leaving the crew questioning if they've "got them all", maybe the "you have X midround changelings in the round" counter was a bad idea.

Closes #73258.
## Changelog
:cl: Rhials
fix: midround changelings no longer spawn a dummy body on the arrivals shuttle.
/:cl:
