### PR TITLE
De-hardcodes spawnDebris in windows, fixes a bunch of issues with windows.

### DIFF
--- a/code/datums/materials/_material.dm
+++ b/code/datums/materials/_material.dm
@@ -49,6 +49,8 @@ Simple datum which is instanced once per type and is used for every object of sa
 	var/cached_texture_filter_icon
 	///What type of shard the material will shatter to
 	var/obj/item/shard_type
+	///What type of debris the tile will leave behind when shattered.
+	var/obj/effect/decal/debris_type
 
 /** Handles initializing the material.
  *

--- a/code/datums/materials/alloys.dm
+++ b/code/datums/materials/alloys.dm
@@ -90,6 +90,7 @@
 	armor_modifiers = list(MELEE = 0.8, BULLET = 0.8, LASER = 1.2, ENERGY = 1.2, BOMB = 0.3, BIO = 1.2, FIRE = 2, ACID = 2)
 	sheet_type = /obj/item/stack/sheet/plasmaglass
 	shard_type = /obj/item/shard/plasma
+	debris_type = /obj/effect/decal/cleanable/glass/plasma
 	value_per_unit = 0.075
 	categories = list(MAT_CATEGORY_RIGID=TRUE, MAT_CATEGORY_BASE_RECIPES=TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	composition = list(/datum/material/glass=1, /datum/material/plasma=0.5)
@@ -109,6 +110,7 @@
 	armor_modifiers = list(MELEE = 1.2, BULLET = 1.2, LASER = 0.8, ENERGY = 0.8, BOMB = 0.5, BIO = 1.2, FIRE = 0.8, ACID = 2)
 	sheet_type = /obj/item/stack/sheet/titaniumglass
 	shard_type = /obj/item/shard/titanium
+	debris_type = /obj/effect/decal/cleanable/glass/titanium
 	value_per_unit = 0.04
 	categories = list(MAT_CATEGORY_RIGID=TRUE, MAT_CATEGORY_BASE_RECIPES=TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	composition = list(/datum/material/glass=1, /datum/material/titanium=0.5)
@@ -129,6 +131,7 @@
 	armor_modifiers = list(MELEE = 1.2, BULLET = 1.2, LASER = 1.2, ENERGY = 1.2, BOMB = 0.5, BIO = 1.2, FIRE = 2, ACID = 2)
 	sheet_type = /obj/item/stack/sheet/plastitaniumglass
 	shard_type = /obj/item/shard/plastitanium
+	debris_type = /obj/effect/decal/cleanable/glass/plastitanium
 	value_per_unit = 0.125
 	categories = list(MAT_CATEGORY_RIGID=TRUE, MAT_CATEGORY_BASE_RECIPES=TRUE, MAT_CATEGORY_ITEM_MATERIAL=TRUE)
 	composition = list(/datum/material/glass=1, /datum/material/alloy/plastitanium=0.5)

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -24,6 +24,7 @@
 	integrity_modifier = 0.1
 	sheet_type = /obj/item/stack/sheet/glass
 	shard_type = /obj/item/shard
+	debris_type = /obj/effect/decal/cleanable/glass
 	value_per_unit = 0.0025
 	beauty_modifier = 0.05
 	armor_modifiers = list(MELEE = 0.2, BULLET = 0.2, ENERGY = 1, BIO = 0.2, FIRE = 1, ACID = 0.2)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -332,24 +332,27 @@
 	if(!disassembled)
 		playsound(src, break_sound, 70, TRUE)
 		if(!(flags_1 & NODECONSTRUCT_1))
-			for(var/obj/item/shard/debris in spawnDebris(drop_location()))
+			for(var/obj/item/shard/debris in spawn_debris(drop_location()))
 				transfer_fingerprints_to(debris) // transfer fingerprints to shards only
 	qdel(src)
 	update_nearby_icons()
 
-/obj/structure/window/proc/spawnDebris(location)
+
+///Spawns shard and debris decal based on the glass_material_datum, spawns rods if window is reinforned and number of shards/rods is determined by the window being fulltile or not.
+/obj/structure/window/proc/spawn_debris(location)
 	var/datum/material/glass_material_ref = GET_MATERIAL_REF(glass_material_datum)
 	var/obj/item/shard_type = glass_material_ref.shard_type
 	var/obj/effect/decal/debris_type = glass_material_ref.debris_type
-	. = list()
+	var/list/dropped_debris = list()
 	if(!isnull(shard_type))
-		. += new shard_type(location)
+		dropped_debris += new shard_type(location)
 		if (fulltile)
-			. += new shard_type(location)
+			dropped_debris += new shard_type(location)
 	if(!isnull(debris_type))
-		. += new debris_type(location)
+		dropped_debris += new debris_type(location)
 	if (reinf)
-		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
+		dropped_debris += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
+	return dropped_debris
 
 /obj/structure/window/proc/AfterRotation(mob/user, degrees)
 	air_update_turf(TRUE, FALSE)
@@ -850,7 +853,7 @@
 	if(atom_integrity < max_integrity)
 		. += span_info("It looks a bit damaged, you may be able to fix it with some <b>paper</b>.")
 
-/obj/structure/window/paperframe/spawnDebris(location)
+/obj/structure/window/paperframe/spawn_debris(location)
 	. = list(new /obj/item/stack/sheet/mineral/wood(location))
 	for (var/i in 1 to rand(1,4))
 		. += new /obj/item/paper/natural(location)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -339,13 +339,17 @@
 
 /obj/structure/window/proc/spawnDebris(location)
 	var/datum/material/glass_material_ref = GET_MATERIAL_REF(glass_material_datum)
+	var/obj/item/shard_type = glass_material_ref.shard_type
+	var/obj/effect/decal/debris_type = glass_material_ref.debris_type
 	. = list()
-	. += new glass_material_ref.shard_type(location)
-	. += new glass_material_ref.debris_type(location)
+	if(!isnull(shard_type))
+		. += new shard_type(location)
+		if (fulltile)
+			. += new shard_type(location)
+	if(!isnull(debris_type))
+		. += new debris_type(location)
 	if (reinf)
 		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
-	if (fulltile)
-		new glass_material_ref.shard_type(location)
 
 /obj/structure/window/proc/AfterRotation(mob/user, degrees)
 	air_update_turf(TRUE, FALSE)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -33,6 +33,8 @@
 	var/hit_sound = 'sound/effects/glasshit.ogg'
 	/// If some inconsiderate jerk has had their blood spilled on this window, thus making it cleanable
 	var/bloodied = FALSE
+	///Datum that the shard and debris type is pulled from for when the glass is broken.
+	var/datum/material/glass_material_datum = /datum/material/glass
 
 /datum/armor/structure_window
 	melee = 50
@@ -336,13 +338,14 @@
 	update_nearby_icons()
 
 /obj/structure/window/proc/spawnDebris(location)
+	var/datum/material/glass_material_ref = GET_MATERIAL_REF(glass_material_datum)
 	. = list()
-	. += new /obj/item/shard(location)
-	. += new /obj/effect/decal/cleanable/glass(location)
+	. += new glass_material_ref.shard_type(location)
+	. += new glass_material_ref.debris_type(location)
 	if (reinf)
 		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
 	if (fulltile)
-		. += new /obj/item/shard(location)
+		new glass_material_ref.shard_type(location)
 
 /obj/structure/window/proc/AfterRotation(mob/user, degrees)
 	air_update_turf(TRUE, FALSE)
@@ -580,6 +583,7 @@
 	explosion_block = 1
 	glass_type = /obj/item/stack/sheet/plasmaglass
 	rad_insulation = RAD_MEDIUM_INSULATION
+	glass_material_datum = /datum/material/alloy/plasmaglass
 
 /datum/armor/window_plasma
 	melee = 80
@@ -591,15 +595,6 @@
 /obj/structure/window/plasma/Initialize(mapload, direct)
 	. = ..()
 	RemoveElement(/datum/element/atmos_sensitive)
-
-/obj/structure/window/plasma/spawnDebris(location)
-	. = list()
-	. += new /obj/item/shard/plasma(location)
-	. += new /obj/effect/decal/cleanable/glass/plasma(location)
-	if (reinf)
-		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
-	if (fulltile)
-		. += new /obj/item/shard/plasma(location)
 
 /obj/structure/window/plasma/spawner/east
 	dir = EAST
@@ -625,6 +620,7 @@
 	explosion_block = 2
 	glass_type = /obj/item/stack/sheet/plasmarglass
 	rad_insulation = RAD_HEAVY_INSULATION
+	glass_material_datum = /datum/material/alloy/plasmaglass
 
 /datum/armor/reinforced_plasma
 	melee = 80
@@ -764,21 +760,13 @@
 	glass_amount = 2
 	receive_ricochet_chance_mod = 1.2
 	rad_insulation = RAD_MEDIUM_INSULATION
+	glass_material_datum = /datum/material/alloy/titaniumglass
 
 /datum/armor/reinforced_shuttle
 	melee = 90
 	bomb = 50
 	fire = 80
 	acid = 100
-
-/obj/structure/window/reinforced/shuttle/spawnDebris(location)
-	. = list()
-	. += new /obj/item/shard/titanium(location)
-	. += new /obj/effect/decal/cleanable/glass/titanium(location)
-	if (reinf)
-		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
-	if (fulltile)
-		. += new /obj/item/shard/titanium(location)
 
 /obj/structure/window/reinforced/shuttle/narsie_act()
 	add_atom_colour("#3C3434", FIXED_COLOUR_PRIORITY)
@@ -810,21 +798,13 @@
 	glass_type = /obj/item/stack/sheet/plastitaniumglass
 	glass_amount = 2
 	rad_insulation = RAD_EXTREME_INSULATION
+	glass_material_datum = /datum/material/alloy/plastitaniumglass
 
 /datum/armor/plasma_plastitanium
 	melee = 95
 	bomb = 50
 	fire = 80
 	acid = 100
-
-/obj/structure/window/reinforced/plasma/plastitanium/spawnDebris(location)
-	. = list()
-	. += new /obj/item/shard/plastitanium(location)
-	. += new /obj/effect/decal/cleanable/glass/plastitanium(location)
-	if (reinf)
-		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
-	if (fulltile)
-		. += new /obj/item/shard/plastitanium(location)
 
 /obj/structure/window/reinforced/plasma/plastitanium/unanchored
 	anchored = FALSE

--- a/code/modules/industrial_lift/tram/tram_windows.dm
+++ b/code/modules/industrial_lift/tram/tram_windows.dm
@@ -1,24 +1,3 @@
-/obj/structure/window/reinforced/tram/front
-	name = "tram wall"
-	icon = 'icons/obj/smooth_structures/tram_window.dmi'
-	desc = "A lightweight titanium composite structure with a windscreen installed."
-	icon = 'icons/obj/smooth_structures/tram_window.dmi'
-	icon_state = "tram_window-0"
-	base_icon_state = "tram_window"
-	max_integrity = 100
-	wtype = "shuttle"
-	reinf = TRUE
-	fulltile = TRUE
-	flags_1 = PREVENT_CLICK_UNDER_1
-	reinf = TRUE
-	heat_resistance = 1600
-	armor_type = /datum/armor/window_tram
-	explosion_block = 3
-	glass_type = /obj/item/stack/sheet/titaniumglass
-	glass_amount = 2
-	receive_ricochet_chance_mod = 1.2
-	rad_insulation = RAD_MEDIUM_INSULATION
-
 /obj/structure/window/reinforced/tram
 	name = "tram window"
 	desc = "A window made out of a titanium-silicate alloy. It looks tough to break. Is that a challenge?"
@@ -31,6 +10,19 @@
 	explosion_block = 0
 	glass_type = /obj/item/stack/sheet/titaniumglass
 	rad_insulation = RAD_MEDIUM_INSULATION
+	glass_material_datum = /datum/material/alloy/titaniumglass
+
+/obj/structure/window/reinforced/tram/front
+	name = "tram wall"
+	desc = "A lightweight titanium composite structure with a windscreen installed."
+	icon_state = "tram_window-0"
+	base_icon_state = "tram_window"
+	wtype = "shuttle"
+	fulltile = TRUE
+	flags_1 = PREVENT_CLICK_UNDER_1
+	explosion_block = 3
+	glass_amount = 2
+	receive_ricochet_chance_mod = 1.2
 
 /obj/structure/window/reinforced/tram/left/directional/north
 	icon_state = "tram_left"
@@ -62,11 +54,6 @@
 	bomb = 45
 	fire = 99
 	acid = 100
-
-/obj/structure/window/reinforced/tram/spawnDebris(location)
-	. = list()
-	. += new /obj/item/stack/sheet/titaniumglass(location)
-	. += new /obj/item/stack/rods(location)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tram/left, 0)
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tram/mid, 0)


### PR DESCRIPTION

## About The Pull Request

spawnDebris was being overridden by almost every type of window, I've set up some new vars for it to pull shard and its debris decal from so spawnDebris only needed to be set up once (+ once more for paper windows which are unique).
Fixes an issue with reinforced plasma glass windows dropping regular glass when broken.
Fixes an oversight where tram windows were dropping only 1 rod instead of 2 and dropping glass sheets instead of shards.
Cleans up tram window code a bunch.
## Why It's Good For The Game

Fixes several issues, cleans up code and cuts down on a lot of repeat code.
## Changelog
:cl:
fix: Reinforced plasma windows will now drop plasma glass instead of regular glass when broken.
fix: Tram windows drop the correct number of rods and a shard when broken instead of a sheet.
code: Removed a ton of duplicate vars in tram window code and re-organize the file slightly.
refactor: spawnDebris has been un-hardcoded and all (but one) override of it has been removed.
/:cl:
