### PR TITLE
Documents `the_station_areas` global list, fixes some things which read from it incorrectly

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -439,8 +439,9 @@ Used by the AI doomsday and the self-destruct nuke.
 /**
  * Global list of AREA TYPES that are associated with the station.
  *
- * This tracks the types all areas in existence that are a UNIQUE_AREA and are on the station Z.
- * This does not track the areas themselves.
+ * This tracks the types of all areas in existence that are a UNIQUE_AREA and are on the station Z.
+ *
+ * This does not track the area instances themselves - See [GLOB.areas] for that.
  */
 GLOBAL_LIST_EMPTY(the_station_areas)
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -436,8 +436,15 @@ Used by the AI doomsday and the self-destruct nuke.
 		// And as the file is now removed set the next map to default.
 		next_map_config = load_default_map_config()
 
+/**
+ * Global list of AREA TYPES that are associated with the station.
+ *
+ * This tracks the types all areas in existence that are a UNIQUE_AREA and are on the station Z.
+ * This does not track the areas themselves.
+ */
 GLOBAL_LIST_EMPTY(the_station_areas)
 
+/// Generates the global station area list, filling it with typepaths of unique areas found on the station Z.
 /datum/controller/subsystem/mapping/proc/generate_station_area_list()
 	for(var/area/station/station_area in GLOB.areas)
 		if (!(station_area.area_flags & UNIQUE_AREA))

--- a/code/modules/antagonists/traitor/objectives/final_objective/romerol.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/romerol.dm
@@ -14,7 +14,7 @@
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)
 		//remove areas too close to the destination, too obvious for our poor shmuck, or just unfair
-		if(istype(possible_area, /area/station/hallway) || istype(possible_area, /area/station/security))
+		if(ispath(possible_area, /area/station/hallway) || ispath(possible_area, /area/station/security))
 			possible_areas -= possible_area
 	if(length(possible_areas) == 0)
 		return FALSE

--- a/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
@@ -18,7 +18,7 @@
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)
 		//remove areas too close to the destination, too obvious for our poor shmuck, or just unfair
-		if(istype(possible_area, /area/station/hallway) || istype(possible_area, /area/station/security))
+		if(ispath(possible_area, /area/station/hallway) || ispath(possible_area, /area/station/security))
 			possible_areas -= possible_area
 	if(length(possible_areas) == 0)
 		return FALSE

--- a/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/supermatter_cascade.dm
@@ -25,7 +25,7 @@
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)
 		//remove areas too close to the destination, too obvious for our poor shmuck, or just unfair
-		if(istype(possible_area, /area/station/hallway) || istype(possible_area, /area/station/security))
+		if(ispath(possible_area, /area/station/hallway) || ispath(possible_area, /area/station/security))
 			possible_areas -= possible_area
 	if(length(possible_areas) == 0)
 		return FALSE

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -181,7 +181,7 @@
 	AddComponent(/datum/component/traitor_objective_register, victim, fail_signals = list(COMSIG_PARENT_QDELETING))
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)
-		if(istype(possible_area, /area/station/hallway) || istype(possible_area, /area/station/security) || initial(possible_area.outdoors))
+		if(ispath(possible_area, /area/station/hallway) || ispath(possible_area, /area/station/security) || initial(possible_area.outdoors))
 			possible_areas -= possible_area
 
 	dropoff_area = pick(possible_areas)

--- a/code/modules/events/radiation_leak.dm
+++ b/code/modules/events/radiation_leak.dm
@@ -48,7 +48,7 @@
 	var/area/station/location_descriptor
 
 	if(fake)
-		location_descriptor = pick(GLOB.the_station_areas)
+		location_descriptor = GLOB.areas_by_type[pick(GLOB.the_station_areas)]
 
 	else if(the_source_of_our_problems)
 		location_descriptor = get_area(the_source_of_our_problems)


### PR DESCRIPTION
## About The Pull Request

At a glance this list may confuse people, so it should have documentation. 

It contains area typepaths, not area instances. 

Some things got this wrong, fixed those.

Perhaps this list can be changed to be associated `[type] to [area instance]` - though that brings in some redundancies when it comes to `areas_by_type`. 

Fixes #73298

## Changelog

:cl: Melbert
fix: False alarm radiation leaks should be less obvious
fix: Fixes some traitor objectives from dropping in blacklisted areas, like security. 
/:cl: