### PR TITLE
Removes ability to ride/carry when both your hands are risen hand; this fixes risen hands getting deleted after riding on/carrying someone

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
@@ -106,7 +106,7 @@
 	icon = 'icons/effects/blood.dmi'
 	base_icon_state = "bloodhand"
 	color = "#001aff"
-	item_flags = ABSTRACT | DROPDEL | HAND_ITEM
+	item_flags = ABSTRACT | DROPDEL
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	hitsound = SFX_SHATTER
 	force = 16


### PR DESCRIPTION

## About The Pull Request

Description of HAND_ITEM: // If an item is just your hand (circled hand, slapper) and shouldn't block things like riding

The risen hand item should block things like riding, so I removed HAND_ITEM


## Why It's Good For The Game

Fixes #73034

## Changelog
:cl:
fix: Removes ability for Shattered Risen to ride on/carry people as this caused a bug where their NO_DROP hands would get deleted
/:cl:
