### PR TITLE
Fixes soul-stealer component being broken

### DIFF
--- a/code/datums/components/soul_stealer.dm
+++ b/code/datums/components/soul_stealer.dm
@@ -6,14 +6,14 @@
  */
 /datum/component/soul_stealer
 	/// List of soulstones captured by this item.
-	var/list/obj/item/soulstones = list()
+	var/list/obj/item/soulstone/soulstones = list()
 
 /datum/component/soul_stealer/Initialize()
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
 /datum/component/soul_stealer/Destroy()
-	QDEL_LIST(soulstones)
+	QDEL_LIST(soulstones) // We own these, so we'll also just get rid of them. Any souls inside will die, this is fine.
 	return ..()
 
 /datum/component/soul_stealer/RegisterWithParent()

--- a/code/datums/components/soul_stealer.dm
+++ b/code/datums/components/soul_stealer.dm
@@ -5,12 +5,16 @@
  * Used in the cult bastard sword!
  */
 /datum/component/soul_stealer
-	/// weakref list of soulstones captured by this item.
-	var/list/weak_souls = list()
+	/// List of soulstones captured by this item.
+	var/list/obj/item/soulstones = list()
 
 /datum/component/soul_stealer/Initialize()
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
+
+/datum/component/soul_stealer/Destroy()
+	QDEL_LIST(soulstones)
+	return ..()
 
 /datum/component/soul_stealer/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
@@ -25,16 +29,14 @@
 
 	examine_list += span_notice("It will steal the soul of anyone it defeats in battle.")
 
-	//clears out any weakrefs that do not exist anymore
-	var/list/souls = recursive_list_resolve(weak_souls)
-
-	switch(souls.len)
+	var/num_souls = length(souls)
+	switch(num_souls)
 		if(0)
 			examine_list += span_notice("It has not consumed any souls yet.")
 		if(1 to 9)
-			examine_list += span_notice("There are <b>[souls.len]</b> souls trapped within it.")
+			examine_list += span_notice("There are <b>[num_souls]</b> souls trapped within it.")
 		if(10 to INFINITY)
-			examine_list += span_notice("A staggering <b>[souls.len]</b> souls have been claimed by it! And it hungers for more!")
+			examine_list += span_notice("A staggering <b>[num_souls]</b> souls have been claimed by it! And it hungers for more!")
 
 /datum/component/soul_stealer/proc/on_afterattack(obj/item/source, atom/target, mob/living/user, proximity_flag, click_parameters)
 	SIGNAL_HANDLER
@@ -45,19 +47,22 @@
 	if(ishuman(target))
 		INVOKE_ASYNC(src, PROC_REF(try_capture), target, user)
 
-	var/list/souls = recursive_list_resolve(weak_souls)
-
-	if(istype(target, /obj/structure/constructshell) && souls.len)
+	if(istype(target, /obj/structure/constructshell) && length(souls))
 		var/obj/item/soulstone/soulstone = souls[1]
 		INVOKE_ASYNC(soulstone, TYPE_PROC_REF(/obj/item/soulstone, transfer_to_construct), target, user)
-		///soulstone will be deleted from souls if successful
+		if(QDELETED(soulstone)) // successful transfer (transfer deletes us)
+			soulstones -= soulstone
+		else if(!length(soulstone.contents)) // something fucky happened
+			qdel(soulstone)
+			soulstones -= soulstone
+
 
 /datum/component/soul_stealer/proc/try_capture(mob/living/carbon/human/victim, mob/living/captor)
 	if(victim.stat == CONSCIOUS)
 		return
-	var/obj/item/soulstone/soulstone = new /obj/item/soulstone(parent)
+	var/obj/item/soulstone/soulstone = new(parent)
 	soulstone.attack(victim, captor)
-	if(!LAZYLEN(soulstone.contents))
+	if(!length(soulstone.contents)) // failed
 		qdel(soulstone)
 		return
-	weak_souls += WEAKREF(soulstone)
+	soulstones += soulstone

--- a/code/datums/components/soul_stealer.dm
+++ b/code/datums/components/soul_stealer.dm
@@ -29,7 +29,7 @@
 
 	examine_list += span_notice("It will steal the soul of anyone it defeats in battle.")
 
-	var/num_souls = length(souls)
+	var/num_souls = length(soulstones)
 	switch(num_souls)
 		if(0)
 			examine_list += span_notice("It has not consumed any souls yet.")
@@ -47,8 +47,8 @@
 	if(ishuman(target))
 		INVOKE_ASYNC(src, PROC_REF(try_capture), target, user)
 
-	if(istype(target, /obj/structure/constructshell) && length(souls))
-		var/obj/item/soulstone/soulstone = souls[1]
+	if(istype(target, /obj/structure/constructshell) && length(soulstones))
+		var/obj/item/soulstone/soulstone = soulstones[1]
 		INVOKE_ASYNC(soulstone, TYPE_PROC_REF(/obj/item/soulstone, transfer_to_construct), target, user)
 		if(QDELETED(soulstone)) // successful transfer (transfer deletes us)
 			soulstones -= soulstone


### PR DESCRIPTION
## About The Pull Request

It extracted the first index soulstone from the list and tried to proc-call it.

But it's a list of weakrefs, so that doesn't work. 

I just changed it to hard references. It didn't really need to be weakrefs, since it owned it. 

## Why It's Good For The Game

Useful items woo

## Changelog

:cl: Melbert
fix: The bastard sword can create constructs again. Just hit the shells with it
/:cl:
