### PR TITLE
Fixes solar tracker issues, and multiz emissives

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -57,7 +57,7 @@
 	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
 
 /obj/machinery/power/solar/proc/add_panel_overlay(icon_state, z_offset)
-	var/obj/effect/overlay/solar_panel/overlay = new()
+	var/obj/effect/overlay/solar_panel/overlay = new(src)
 	overlay.icon_state = icon_state
 	SET_PLANE_EXPLICIT(overlay, ABOVE_GAME_PLANE, src)
 	overlay.pixel_z = z_offset

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -50,7 +50,7 @@
 	layer = FLY_LAYER
 
 /obj/machinery/power/tracker/proc/add_panel_overlay(icon_state, z_offset)
-	var/obj/effect/overlay/overlay = new()
+	var/obj/effect/overlay/tracker/overlay = new(src)
 	overlay.icon_state = icon_state
 	SET_PLANE_EXPLICIT(overlay, ABOVE_GAME_PLANE, src)
 	overlay.pixel_z = z_offset


### PR DESCRIPTION

## About The Pull Request

Fixes solar trackers not showing up (they didn't have the right subtype so they weren't inheriting their parents icon)
Fixes solars not blocking emissives on multiz (They didn't pass a loc into their overlays, so the overlays were drawing their emissive blockers to the wrong plane)

## Why It's Good For The Game
## Changelog
:cl:
fix: Solar trackers actually uh, look right again
fix: Solar panels and trackers will now properly block space lighting on multiz maps
/:cl:
