### PR TITLE
WIREMOD Adds square root component

### DIFF
--- a/code/modules/wiremod/components/math/square_root.dm
+++ b/code/modules/wiremod/components/math/square_root.dm
@@ -1,0 +1,25 @@
+/**
+ * # Square root component
+ *
+ * Returns the square root of the input
+ */
+/obj/item/circuit_component/square_root
+	display_name = "Square root"
+	desc = "A component that returns the square root of its input."
+	category = "Math"
+
+	/// The input port
+	var/datum/port/input/input_port
+
+	/// The result from the output
+	var/datum/port/output/output
+	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
+
+/obj/item/circuit_component/length/populate_ports()
+	input_port = add_input_port("Input", PORT_TYPE_NUMBER)
+
+	output = add_output_port("Result", PORT_TYPE_NUMBER)
+
+/obj/item/circuit_component/length/input_received(datum/port/input/port)
+
+	output.set_output(sqrt(input_port.value))


### PR DESCRIPTION

## About The Pull Request

Adds a square root component to the wiremod circuits. The circuit takes a number as an input and returns its square root
## Why It's Good For The Game

I love math, who doesn't ? Trigonometry go brrrrrrrrr
## Changelog
:cl:
add: Square root component are now available for wiremod circuits.
/:cl:
