### PR TITLE
Basic Mobs can no longer melee attack you from an arbitrary range

### DIFF
--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/targetting.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/targetting.dm
@@ -16,7 +16,7 @@
 	var/datum/weakref/weak_target = controller.blackboard[target_key]
 	var/atom/current_target = weak_target?.resolve()
 	if (targetting_datum.can_attack(living_mob, current_target))
-		finish_action(controller, succeeded = TRUE)
+		finish_action(controller, succeeded = FALSE)
 		return
 
 	controller.blackboard[target_key] = null
@@ -50,6 +50,11 @@
 		controller.blackboard[hiding_location_key] = WEAKREF(potential_hiding_location)
 
 	finish_action(controller, succeeded = TRUE)
+
+/datum/ai_behavior/find_potential_targets/finish_action(datum/ai_controller/controller, succeeded, ...)
+	. = ..()
+	if (succeeded)
+		controller.CancelActions() // On retarget cancel any further queued actions so that they will setup again with new target
 
 /// Returns the desired final target from the filtered list of targets
 /datum/ai_behavior/find_potential_targets/proc/pick_final_target(datum/ai_controller/controller, list/filtered_targets)


### PR DESCRIPTION
## About The Pull Request

Fixes #73237 

So, this seems to be an interaction between targetting and the flag `AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION`.

When a mob starts the melee attack action it sets up its attack target as its movement target.
Once it is in range of its movement target then it starts running attacks on its attack target.
If a mob puts a target into crit then it ceases to be a valid target. 
If `AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION` is set on a behaviour then it will continue to plan and run other actions.
The targetting action will notice that our current attack target is invalid and retarget it _between_ executions of the attack action.
The attack action _doesn't_ call setup again at this point, so it does not set the new target as its movement target.
The attack action executes, is still next to the current movement target, so continue to attack the attack target even though that target has changed.

Result: Carp can attack you from the other side of a room if they have first empowered themselves by consuming the soul of your coworker.

There's a few fixes for this but none of them seem... precisely clean. I have gone with the one which I think is most "robust" in that it should fix this case in all future scenarios, but it has its own downsides.

That is: Whenever the targetting action acquires a new target it will manually cancel all further queued actions, which forces everything following to call setup again.

The obvious downside here is that this means that the AI will acquire a target and not immediately act on it within the same processing loop. It will now have to wait until its turn comes around again to do anything with a newly acquired target, making them slightly slower to react to things based on how often the subsystem is acting.
This might be beneficial to players in some ways in that it gives you a moment of grace to react to an AI acquiring you as a target which was present in simple mobs and not basic mobs but probably we do just want them to act as responsively as possible.

Alternate ideas were:

- Validate the target and range again in the `perform` action. I didn't go with this because it feels like it _should_ be redundant with the controller validating the distance to the movement target already, is much more fragile and easy to miss on an extended or new action, and would need to be done individually in all actions which require a movement target. 
- I could replace `CancelActions()` here with a new proc which cancels actions and then instantly reruns this mob's behaviour selection and runs the new list of actions. That sounds a little bit scary to me, and might risk a loop?
- Refactor movement target to be more tightly controlled by actions and not a property of the AI controller at all. This would be some work, reduce future possibilities (we have some flags to preserve movement target between actions which are just... not currently used) and might not actually solve the bug anyway.
- Investigate `AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION` and figure out if there is some way to ensure it calls setup at an appropriate time. I cannot figure out how this would be possible, because the trigger is essentially "an arbitrary blackboard key has changed value" and the result would probably have the same downside as the current implementation anyway. Being able to change blackboard keys while executing other actions is kind of the point of `AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION` really.
- Remove `AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION` from the attack behaviour. This would fix it for attacks but potentially remain for other future actions. It would mean that behaviour which relies on this (such as carp fleeing, I think? I don't remember precisely why it's on there only that we wanted to be able to change our minds and stop attacking without coding that specifically into `perform`) would have to be adjusted to add more checks to the attack action, and might result in an eventual proliferation of specific attack actions which exist only to track specific circumstances to interrupt the attack loop, which doesn't seem ideal.

If you have any better ideas than this or those listed let me know.

## Why It's Good For The Game

When you give a mob the "basic melee attack" behaviour you really expect that to mean that it will attack things that are next to it.

## Changelog

:cl:
fix: Hostile Basic Mobs such as carp, rats, and moonicorns will no longer gain the power to bite anyone they can see regardless of distance and intervening obstacles upon defeating their first target in combat.
/:cl:
