### PR TITLE
Fixes a logic error in disposal bin hitby (thrown objects don't always have a throwing mob)

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -57,7 +57,7 @@ SUBSYSTEM_DEF(throwing)
 	var/maxrange
 	///The speed of the projectile thrownthing being thrown.
 	var/speed
-	///If a mob is the one who has thrown the object, then it's moved here.
+	///If a mob is the one who has thrown the object, then it's moved here. This can be null and must be null checked before trying to use it.
 	var/mob/thrower
 	///A variable that helps in describing objects thrown at an angle, if it should be moved diagonally first or last.
 	var/diagonals_first

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -383,7 +383,7 @@
 
 /obj/machinery/disposal/bin/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	if(isitem(AM) && AM.CanEnterDisposals())
-		if(HAS_TRAIT(throwingdatum.thrower, TRAIT_THROWINGARM) || prob(75))
+		if((throwingdatum.thrower && HAS_TRAIT(throwingdatum.thrower, TRAIT_THROWINGARM)) || prob(75))
 			AM.forceMove(src)
 			visible_message(span_notice("[AM] lands in [src]."))
 			update_appearance()


### PR DESCRIPTION

## About The Pull Request

A throwing datum does not always have a throwing mob, and code should respect that
## Why It's Good For The Game

Closes #73138
Closes #73133
## Changelog
