### PR TITLE
Effects no longer runtime on being attacked

### DIFF
--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -19,6 +19,9 @@
 
 	return ..()
 
+/obj/effect/attack_generic(mob/user, damage_amount, damage_type, damage_flag, sound_effect, armor_penetration)
+	return
+
 /obj/effect/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
 	return
 


### PR DESCRIPTION

## About The Pull Request

Effects didn;t override generic attack, which caused runtimes when attacked
## Why It's Good For The Game
Closes #73295
## Changelog
