### PR TITLE
clear pai tracking when hacking cable retracts

### DIFF
--- a/code/modules/pai/door_jack.dm
+++ b/code/modules/pai/door_jack.dm
@@ -78,7 +78,7 @@
 /mob/living/silicon/pai/proc/handle_move(atom/movable/source, atom/movable/old_loc)
 	if(ismovable(old_loc))
 		untrack_thing(old_loc)
-	if(!IN_GIVEN_RANGE(src, hacking_cable, CABLE_LENGTH))
+	if(hacking_cable && (!IN_GIVEN_RANGE(src, hacking_cable, CABLE_LENGTH)))
 		retract_cable()
 		return
 	if(ismovable(source.loc))
@@ -89,6 +89,7 @@
  */
 /mob/living/silicon/pai/proc/retract_cable()
 	balloon_alert(src, "cable retracted")
+	untrack_pai()
 	QDEL_NULL(hacking_cable)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

We track the pai aswell as the cable to check for the pai moving away from the user
But we never clear that tracking

Also adds a check for the check proc to not run if there isn't even a hacking cable
## Why It's Good For The Game

resolves #73222
## Changelog
:cl:
fix: Using a hacking cable will no longer permanently spam you with balloon messages
/:cl:
