### PR TITLE
Possibly fixes basicmob speed for sentient basicmobs, slows down basicmob syndicates

### DIFF
--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -188,9 +188,8 @@
 	update_basic_mob_varspeed()
 
 /mob/living/basic/proc/update_basic_mob_varspeed()
-	if(speed == 0)
-		remove_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed)
-	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/simplemob_varspeed, multiplicative_slowdown = speed)
+	remove_movespeed_modifier(/datum/movespeed_modifier/basicmob_varspeed)
+	add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/basicmob_varspeed, multiplicative_slowdown = -(speed - 1))
 	SEND_SIGNAL(src, POST_BASIC_MOB_UPDATE_VARSPEED)
 
 /mob/living/basic/relaymove(mob/living/user, direction)

--- a/code/modules/mob/living/basic/syndicate/syndicate.dm
+++ b/code/modules/mob/living/basic/syndicate/syndicate.dm
@@ -8,8 +8,8 @@
 	sentience_type = SENTIENCE_HUMANOID
 	maxHealth = 100
 	health = 100
+	speed = 0.9
 	basic_mob_flags = DEL_ON_DEATH
-	speed = 1.1
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES
 	melee_damage_lower = 10
 	melee_damage_upper = 10
@@ -198,6 +198,7 @@
 	casingtype = /obj/item/ammo_casing/shotgun/buckshot //buckshot (up to 72.5 brute) fired in a two-round burst
 	ai_controller = /datum/ai_controller/basic_controller/syndicate/ranged/shotgunner
 	r_hand = /obj/item/gun/ballistic/shotgun/bulldog
+	speed = 0.8
 
 /mob/living/basic/syndicate/ranged/shotgun/space
 	name = "Syndicate Commando"
@@ -205,7 +206,6 @@
 	health = 170
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0
-	speed = 1
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/syndicatecommando
 
 /mob/living/basic/syndicate/ranged/shotgun/space/Initialize(mapload)

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -94,6 +94,9 @@
 	variable = TRUE
 	flags = IGNORE_NOSLOW
 
+/datum/movespeed_modifier/basicmob_varspeed
+	variable = TRUE
+
 /datum/movespeed_modifier/tarantula_web
 	multiplicative_slowdown = 5
 


### PR DESCRIPTION

## About The Pull Request

Speed variable now actually affects cached_multiplicative_slowdown (which sentient basicmobs used instead of the speed variable)
Basicmobs are also affected by the run speed config if they werent before

Changes default syndicate basicmob speed to 0.9, shotgunners changed to 0.8 because shotguns bulky or something

## Why It's Good For The Game

Syndifards less fast (they would be VERY fast)

Sentient basicmobs and nonsentient basicmobs now have a consistent speed

## Changelog
:cl:
fix: Sentient basicmobs and nonsentient basicmobs should now be the same speed
balance: Syndicate basicmobs are slightly slower
/:cl:
