### PR TITLE
Fixes all antag datum moodlets being removed when any single antag datum is removed

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -324,7 +324,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/give_antag_moodies()
 	if(!antag_moodlet)
 		return
-	owner.current.add_mood_event("antag_moodlet", antag_moodlet)
+	owner.current.add_mood_event("antag_moodlet_[type]", antag_moodlet)
 
 /**
  * Proc that removes this antagonist's ascribed moodlet from the player.
@@ -332,7 +332,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/clear_antag_moodies()
 	if(!antag_moodlet)
 		return
-	owner.current.clear_mood_event("antag_moodlet")
+	owner.current.clear_mood_event("antag_moodlet_[type]")
 
 /**
  * Proc that will return the team this antagonist belongs to, when called. Helpful with antagonists that may belong to multiple potential teams in a single round.
@@ -512,4 +512,3 @@ GLOBAL_LIST_EMPTY(antagonists)
 /// Used to create objectives for the antagonist.
 /datum/antagonist/proc/forge_objectives()
 	return
-

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -36,10 +36,13 @@
 	. = ..()
 	obtain_targets(user, silent = TRUE, heretic_datum = our_heretic)
 	heretic_mind = our_heretic.owner
+
+#ifndef UNIT_TESTS // This is a decently hefty thing to generate while unit testing, so we should skip it.
 	if(!heretic_level_generated)
 		heretic_level_generated = TRUE
 		log_game("Generating z-level for heretic sacrifices...")
 		INVOKE_ASYNC(src, PROC_REF(generate_heretic_z_level))
+#endif
 
 /// Generate the sacrifice z-level.
 /datum/heretic_knowledge/hunt_and_sacrifice/proc/generate_heretic_z_level()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -78,6 +78,7 @@
 #include "achievements.dm"
 #include "anchored_mobs.dm"
 #include "anonymous_themes.dm"
+#include "antag_moodlets.dm"
 #include "area_contents.dm"
 #include "autowiki.dm"
 #include "barsigns.dm"

--- a/code/modules/unit_tests/antag_moodlets.dm
+++ b/code/modules/unit_tests/antag_moodlets.dm
@@ -1,0 +1,64 @@
+#define HERETIC_MOODLET_PRESENT (1<<0)
+#define TRAITOR_MOODLET_PRESENT (1<<1)
+
+#define HAS_HERETIC_MOODLET(result) (result & HERETIC_MOODLET_PRESENT)
+#define HAS_TRAITOR_MOODLET(result) (result & TRAITOR_MOODLET_PRESENT)
+
+/datum/unit_test/antag_moodlets
+	// Saving the typepaths for each type of moodlet we give out here, for ease of access
+	var/heretic_moodlet
+	var/traitor_moodlet
+
+/datum/unit_test/antag_moodlets/Run()
+	var/mob/living/carbon/human/bad_man = allocate(/mob/living/carbon/human/consistent)
+	var/datum/antagonist/antag_heretic = /datum/antagonist/heretic
+	var/datum/antagonist/antag_traitor = /datum/antagonist/traitor
+	heretic_moodlet = initial(antag_heretic.antag_moodlet)
+	traitor_moodlet = initial(antag_traitor.antag_moodlet)
+	TEST_ASSERT_NOTEQUAL(heretic_moodlet, traitor_moodlet, "Antag moodlets test was ran with two identical moodlets, they should be different types.")
+
+	bad_man.mind_initialize()
+	bad_man.mind.add_antag_datum(antag_heretic)
+
+	var/list/mob_mood_list = bad_man.mob_mood.mood_events
+	var/result = NONE
+
+	// Check for heretic moodlet
+	result = check_moodlets(mob_mood_list)
+	TEST_ASSERT(HAS_HERETIC_MOODLET(result), "Upon becoming a heretic, the dummy had no heretic antag moodlet.")
+	TEST_ASSERT(!HAS_TRAITOR_MOODLET(result), "Upon becoming a heretic, the dummy had a tratior antag moodlet when it shouldn't have.")
+
+	// Check for heretic and traitor moodlet
+	bad_man.mind.add_antag_datum(antag_traitor)
+	result = check_moodlets(mob_mood_list)
+	TEST_ASSERT(HAS_HERETIC_MOODLET(result), "Upon becoming a traitor-heretic, the dummy had no heretic antag moodlet.")
+	TEST_ASSERT(HAS_TRAITOR_MOODLET(result), "Upon becoming a traitor-heretic, the dummy had no traitor antag moodlet.")
+
+	// Remove heretic, we should still have the traitor moodlet
+	bad_man.mind.remove_antag_datum(antag_heretic)
+	result = check_moodlets(mob_mood_list)
+	TEST_ASSERT(!HAS_HERETIC_MOODLET(result), "Upon losing heretic, the dummy had the heretic antag moodlet still.")
+	TEST_ASSERT(HAS_TRAITOR_MOODLET(result), "Upon losing heretic, the dummy also lost their traitor antag moodlet, when it should have remained.")
+
+	// Remove traitor, nothing left
+	bad_man.mind.remove_antag_datum(antag_traitor)
+	result = check_moodlets(mob_mood_list)
+	TEST_ASSERT(!HAS_HERETIC_MOODLET(result), "After removing all antag datums, the dummy still had their heretic moodlet.")
+	TEST_ASSERT(!HAS_TRAITOR_MOODLET(result), "After removing all antag datums, the dummy still had their traitor moodlet.")
+
+/datum/unit_test/antag_moodlets/proc/check_moodlets(list/in_mood_list)
+	var/results = NONE
+	for(var/category in in_mood_list)
+		var/datum/mood_event/moodie = in_mood_list[category]
+		if(istype(moodie, heretic_moodlet))
+			results |= HERETIC_MOODLET_PRESENT
+		if(istype(moodie, traitor_moodlet))
+			results |= TRAITOR_MOODLET_PRESENT
+
+	return results
+
+#undef HERETIC_MOODLET_PRESENT
+#undef TRAITOR_MOODLET_PRESENT
+
+#undef HAS_HERETIC_MOODLET
+#undef HAS_TRAITOR_MOODLET


### PR DESCRIPTION
## About The Pull Request

All antag datums operated under the `antag_moodlet` mood category, which is clearly an issue when you can (and commonly) have multiple antag datums of different types on your mob. 

New antag datums of different type will now no longer override older antag datum moodlets, now they will stack. This means traitor revolutionaries are the most zealous folk on the station.

This has a few potential oversights down the line: 
- Someone adds an antag datum players can have duplicates of, and also has a moodlet associated
- Re-used moodlets in antag datums that can easily be stacked will be noticed
   - Most solo antags used `focused` right now, but none can stack outside of admemes

But I don't think it's an issue for now.

## Why It's Good For The Game

Prevents a quick revolution from stripping you of your joy. 

Fixes #67313

## Changelog

:cl: Melbert
fix: Revolutionary Heretics and Cultists Traitors no longer lose all of their joy in life after being de-converted from their respective causes.
/:cl:

