### PR TITLE
Fixes double light fixture in metastation toxins.

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46723,7 +46723,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "qEF" = (
-/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 4
 	},


### PR DESCRIPTION

## About The Pull Request
There's a weird double light in toxins. 
![image](https://user-images.githubusercontent.com/66163761/217397841-e92c644e-18ac-422f-b872-fd7d5a0f950a.png)
## Why It's Good For The Game
Fixes a weird double light.
## Changelog
:cl:
fix: metastation toxins no longer has a weird double light fixture.
/:cl:
