### PR TITLE
Refactors photocopiers and fixes some bugs with them.

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -347,7 +347,7 @@
 	if(!check_ass() || !toner_cartridge)
 		return
 	if(ishuman(ass) && (ass.get_item_by_slot(ITEM_SLOT_ICLOTHING) || ass.get_item_by_slot(ITEM_SLOT_OCLOTHING)))
-		to_chat(user, span_notice("You feel kind of silly, copying [ass == usr ? "your" : ass][ass == usr ? "" : "\'s"] ass with [ass == usr ? "your" : "[ass.p_their()]"] clothes on.") )
+		to_chat(user, span_notice("You feel kind of silly, copying [ass == user ? "your" : ass][ass == user ? "" : "\'s"] ass with [ass == user ? "your" : "[ass.p_their()]"] clothes on.") )
 		return
 
 	var/icon/temp_img

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -12,10 +12,11 @@
 #define DOCUMENT_TONER_USE 0.75
 /// How much toner is used for making a copy of an ass.
 #define ASS_TONER_USE 0.625
-/// The maximum amount of copies you can make with one press of the copy button.
-#define MAX_COPIES_AT_ONCE 10
 /// How much toner is used for making a copy of paperwork
 #define PAPERWORK_TONER_USE 0.75
+
+/// The maximum amount of copies you can make with one press of the copy button.
+#define MAX_COPIES_AT_ONCE 10
 
 #define PAPER_COPY_TYPE "paper"
 #define PHOTO_COPY_TYPE "photo"

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -18,9 +18,13 @@
 /// The maximum amount of copies you can make with one press of the copy button.
 #define MAX_COPIES_AT_ONCE 10
 
+/// copy_type value that indicates the photocopier is copying a sheet of paper
 #define PAPER_COPY_TYPE "paper"
+/// copy_type value that indicates the photocopier is copying a photo
 #define PHOTO_COPY_TYPE "photo"
+/// copy_type value that indicates the photocopier is copying a document
 #define DOCUMENT_COPY_TYPE "document"
+/// copy_type value that indicates the photocopier is copying a stack of paperwork
 #define PAPERWORK_COPY_TYPE "paperwork"
 
 /obj/machinery/photocopier

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -222,16 +222,15 @@
 /obj/machinery/photocopier/proc/has_enough_toner()
 	if(ass)
 		return toner_cartridge.charges >= (ASS_TONER_USE * num_copies)
-	else
-		switch(copy_type)
-			if(PAPER_COPY_TYPE)
-				return toner_cartridge.charges >= (PAPER_TONER_USE * num_copies)
-			if(DOCUMENT_COPY_TYPE)
-				return toner_cartridge.charges >= (DOCUMENT_TONER_USE * num_copies)
-			if(PHOTO_COPY_TYPE)
-				return toner_cartridge.charges >= (PHOTO_TONER_USE * num_copies)
-			if(PAPERWORK_COPY_TYPE)
-				return toner_cartridge.charges >= (PAPERWORK_TONER_USE * num_copies)
+	switch(copy_type)
+		if(PAPER_COPY_TYPE)
+			return toner_cartridge.charges >= (PAPER_TONER_USE * num_copies)
+		if(DOCUMENT_COPY_TYPE)
+			return toner_cartridge.charges >= (DOCUMENT_TONER_USE * num_copies)
+		if(PHOTO_COPY_TYPE)
+			return toner_cartridge.charges >= (PHOTO_TONER_USE * num_copies)
+		if(PAPERWORK_COPY_TYPE)
+			return toner_cartridge.charges >= (PAPERWORK_TONER_USE * num_copies)
 	return FALSE
 
 /**

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -346,10 +346,10 @@
 /obj/machinery/photocopier/proc/make_blank_print(params)
 	if(!toner_cartridge)
 		return
-	var/obj/item/paper/printblank = new /obj/item/paper (loc)
+	var/obj/item/paper/printblank = new(loc)
 	var/printname = sanitize(params["name"])
 	var/list/printinfo
-	for(var/infoline as anything in params["info"])
+	for(var/infoline in params["info"])
 		printinfo += infoline
 	printblank.name = printname
 	printblank.add_raw_text(printinfo)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -17,6 +17,11 @@
 /// How much toner is used for making a copy of paperwork
 #define PAPERWORK_TONER_USE 0.75
 
+#define PAPER_COPY_TYPE "paper"
+#define PHOTO_COPY_TYPE "photo"
+#define DOCUMENT_COPY_TYPE "document"
+#define PAPERWORK_COPY_TYPE "paperwork"
+
 /obj/machinery/photocopier
 	name = "photocopier"
 	desc = "Used to copy important documents and anatomy studies."
@@ -38,8 +43,9 @@
 	var/busy = FALSE
 	/// Variable needed to determine the selected category of forms on Photocopier.js
 	var/category
-	///Variable that describes what object is trying to be copied.
+	///Variable that holds a reference to any object supported for photocopying inside the photocopier
 	var/obj/object_copy
+	///Variable that describes what object is trying to be copied.
 	var/copy_type
 
 /obj/machinery/photocopier/Initialize(mapload)
@@ -86,7 +92,7 @@
 	catch()
 		data["forms_exist"] = FALSE
 
-	if(copy_type == "photo")
+	if(copy_type == PHOTO_COPY_TYPE)
 		data["is_photo"] = TRUE
 		data["color_mode"] = color_mode
 
@@ -117,7 +123,7 @@
 		if("make_copy")
 			if(check_busy())
 				return FALSE
-			if(copy_type == "paper")
+			if(copy_type == PAPER_COPY_TYPE)
 				var/obj/item/paper/paper_copy = object_copy
 				if(!paper_copy.get_total_length())
 					to_chat(usr, span_warning("An error message flashes across [src]'s screen: \"The supplied paper is blank. Aborting.\""))
@@ -127,12 +133,12 @@
 					do_copy_loop(CALLBACK(src, PROC_REF(make_paper_copy), paper_copy), usr)
 					return TRUE
 			// Copying photo.
-			if(copy_type == "photo")
+			if(copy_type == PHOTO_COPY_TYPE)
 				var/obj/item/photo/photo_copy = object_copy
 				do_copy_loop(CALLBACK(src, PROC_REF(make_photo_copy), photo_copy), usr)
 				return TRUE
 			// Copying Documents.
-			if(copy_type == "document")
+			if(copy_type == DOCUMENT_COPY_TYPE)
 				var/obj/item/documents/document_copy = object_copy
 				do_copy_loop(CALLBACK(src, PROC_REF(make_document_copy), document_copy), usr)
 				return TRUE
@@ -141,7 +147,7 @@
 				do_copy_loop(CALLBACK(src, PROC_REF(make_ass_copy)), usr)
 				return TRUE
 			// Copying paperwork
-			if(copy_type == "paperwork")
+			if(copy_type == PAPERWORK_COPY_TYPE)
 				var/obj/item/paperwork/paperwork_copy = object_copy
 				do_copy_loop(CALLBACK(src, PROC_REF(make_paperwork_copy), paperwork_copy), usr)
 				return TRUE
@@ -211,13 +217,13 @@
 		return toner_cartridge.charges >= (ASS_TONER_USE * num_copies)
 	else
 		switch(copy_type)
-			if("paper")
+			if(PAPER_COPY_TYPE)
 				return toner_cartridge.charges >= (PAPER_TONER_USE * num_copies)
-			if("document")
+			if(DOCUMENT_COPY_TYPE)
 				return toner_cartridge.charges >= (DOCUMENT_TONER_USE * num_copies)
-			if("photo")
+			if(PHOTO_COPY_TYPE)
 				return toner_cartridge.charges >= (PHOTO_TONER_USE * num_copies)
-			if("paperwork")
+			if(PAPERWORK_COPY_TYPE)
 				return toner_cartridge.charges >= (PAPERWORK_TONER_USE * num_copies)
 	return FALSE
 
@@ -416,11 +422,11 @@
 
 /obj/machinery/photocopier/attackby(obj/item/object, mob/user, params)
 	if(istype(object, /obj/item/paper))
-		insert_copy_object(object, user, "paper")
+		insert_copy_object(object, user, PAPER_COPY_TYPE)
 	else if(istype(object, /obj/item/photo))
-		insert_copy_object(object, user, "photo")
+		insert_copy_object(object, user, PHOTO_COPY_TYPE)
 	else if(istype(object, /obj/item/documents))
-		insert_copy_object(object, user, "document")
+		insert_copy_object(object, user, DOCUMENT_COPY_TYPE)
 
 	else if(istype(object, /obj/item/toner))
 		if(toner_cartridge)
@@ -440,7 +446,7 @@
 				if(!user.temporarilyRemoveItemFromInventory(object))
 					return
 				object_copy = object
-				copy_type = "paperwork"
+				copy_type = PAPERWORK_COPY_TYPE
 				do_insertion(object, user)
 		else
 			to_chat(user, span_warning("There is already something in [src]!"))
@@ -570,3 +576,7 @@
 #undef ASS_TONER_USE
 #undef MAX_COPIES_AT_ONCE
 #undef PAPERWORK_TONER_USE
+#undef PAPER_COPY_TYPE
+#undef PHOTO_COPY_TYPE
+#undef DOCUMENT_COPY_TYPE
+#undef PAPERWORK_COPY_TYPE

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -449,7 +449,6 @@
 			to_chat(user, span_warning("The [object] is far too messy to produce a good copy!"))
 		else
 			insert_copy_object(object, user, PAPERWORK_COPY_TYPE)
-		return ..()
 
 /obj/machinery/photocopier/proc/insert_copy_object(obj/item/object, mob/user, object_copy_type)
 	if(copier_empty())

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -446,17 +446,10 @@
 	else if(istype(object, /obj/item/areaeditor/blueprints))
 		to_chat(user, span_warning("The Blueprint is too large to put into the copier. You need to find something else to record the document."))
 	else if(istype(object, /obj/item/paperwork))
-		if(copier_empty())
-			if(istype(object, /obj/item/paperwork/photocopy)) //No infinite paper chain. You need the original paperwork to make more copies.
-				to_chat(user, span_warning("The [object] is far too messy to produce a good copy!"))
-			else
-				if(!user.temporarilyRemoveItemFromInventory(object))
-					return
-				object_copy = object
-				copy_type = PAPERWORK_COPY_TYPE
-				do_insertion(object, user)
+		if(istype(object, /obj/item/paperwork/photocopy)) //No infinite paper chain. You need the original paperwork to make more copies.
+			to_chat(user, span_warning("The [object] is far too messy to produce a good copy!"))
 		else
-			to_chat(user, span_warning("There is already something in [src]!"))
+			insert_copy_object(object, user, PAPERWORK_COPY_TYPE)
 		return ..()
 
 /obj/machinery/photocopier/proc/insert_copy_object(obj/item/object, mob/user, object_copy_type)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -126,11 +126,11 @@
 	switch(action)
 		// Copying paper, photos, documents and asses.
 		if("make_copy")
-			if(check_busy())
+			if(check_busy(usr))
 				return FALSE
 			// ASS COPY. By Miauw
 			if(ass)
-				do_copy_loop(CALLBACK(src, PROC_REF(make_ass_copy)), usr)
+				do_copy_loop(CALLBACK(src, PROC_REF(make_ass_copy), usr), usr)
 				return TRUE
 			else
 				switch(copy_type)
@@ -171,7 +171,7 @@
 
 		// AI printing photos from their saved images.
 		if("ai_photo")
-			if(check_busy())
+			if(check_busy(usr))
 				return FALSE
 			var/mob/living/silicon/ai/tempAI = usr
 			if(!length(tempAI.aicamera.stored))
@@ -191,7 +191,7 @@
 
 		// Remove the toner cartridge from the copier.
 		if("remove_toner")
-			if(check_busy())
+			if(check_busy(usr))
 				return
 			if(issilicon(usr) || (ishuman(usr) && !usr.put_in_hands(toner_cartridge)))
 				toner_cartridge.forceMove(drop_location())
@@ -208,7 +208,7 @@
 			return TRUE
 		// Called when you press print blank
 		if("print_blank")
-			if(check_busy())
+			if(check_busy(usr))
 				return FALSE
 			if (toner_cartridge.charges - PAPER_TONER_USE < 0)
 				to_chat(usr, span_warning("There is not enough toner in [src] to print the form, please replace the cartridge."))
@@ -261,9 +261,9 @@
 	update_use_power(IDLE_POWER_USE)
 	busy = FALSE
 
-/obj/machinery/photocopier/proc/check_busy()
+/obj/machinery/photocopier/proc/check_busy(mob/user)
 	if(busy)
-		to_chat(usr, span_warning("[src] is currently busy copying something. Please wait until it is finished."))
+		to_chat(user, span_warning("[src] is currently busy copying something. Please wait until it is finished."))
 		return TRUE
 	return FALSE
 
@@ -362,11 +362,11 @@
  * Calls `check_ass()` first to make sure that `ass` exists, among other conditions. Since this proc is called from a timer, it's possible that it was removed.
  * Additionally checks that the mob has their clothes off.
  */
-/obj/machinery/photocopier/proc/make_ass_copy()
+/obj/machinery/photocopier/proc/make_ass_copy(mob/user)
 	if(!check_ass() || !toner_cartridge)
 		return
 	if(ishuman(ass) && (ass.get_item_by_slot(ITEM_SLOT_ICLOTHING) || ass.get_item_by_slot(ITEM_SLOT_OCLOTHING)))
-		to_chat(usr, span_notice("You feel kind of silly, copying [ass == usr ? "your" : ass][ass == usr ? "" : "\'s"] ass with [ass == usr ? "your" : "[ass.p_their()]"] clothes on.") )
+		to_chat(user, span_notice("You feel kind of silly, copying [ass == usr ? "your" : ass][ass == usr ? "" : "\'s"] ass with [ass == usr ? "your" : "[ass.p_their()]"] clothes on.") )
 		return
 
 	var/icon/temp_img

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -497,7 +497,7 @@
 		target.forceMove(drop_location())
 		ass = target
 
-		if(copy_type != "ass" || !isnull(copy_type))
+		if(!isnull(copy_type))
 			object_copy.forceMove(drop_location())
 			visible_message(span_warning("[object_copy] is shoved out of the way by [ass]!"))
 			object_copy = null

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -128,34 +128,36 @@
 		if("make_copy")
 			if(check_busy())
 				return FALSE
-			if(copy_type == PAPER_COPY_TYPE)
-				var/obj/item/paper/paper_copy = object_copy
-				if(!paper_copy.get_total_length())
-					to_chat(usr, span_warning("An error message flashes across [src]'s screen: \"The supplied paper is blank. Aborting.\""))
-					return FALSE
-				// Basic paper
-				if(istype(object_copy, /obj/item/paper))
-					do_copy_loop(CALLBACK(src, PROC_REF(make_paper_copy), paper_copy), usr)
-					return TRUE
-			// Copying photo.
-			if(copy_type == PHOTO_COPY_TYPE)
-				var/obj/item/photo/photo_copy = object_copy
-				do_copy_loop(CALLBACK(src, PROC_REF(make_photo_copy), photo_copy), usr)
-				return TRUE
-			// Copying Documents.
-			if(copy_type == DOCUMENT_COPY_TYPE)
-				var/obj/item/documents/document_copy = object_copy
-				do_copy_loop(CALLBACK(src, PROC_REF(make_document_copy), document_copy), usr)
-				return TRUE
 			// ASS COPY. By Miauw
 			if(ass)
 				do_copy_loop(CALLBACK(src, PROC_REF(make_ass_copy)), usr)
 				return TRUE
-			// Copying paperwork
-			if(copy_type == PAPERWORK_COPY_TYPE)
-				var/obj/item/paperwork/paperwork_copy = object_copy
-				do_copy_loop(CALLBACK(src, PROC_REF(make_paperwork_copy), paperwork_copy), usr)
-				return TRUE
+			else
+				switch(copy_type)
+					if(PAPER_COPY_TYPE)
+						var/obj/item/paper/paper_copy = object_copy
+						if(!paper_copy.get_total_length())
+							to_chat(usr, span_warning("An error message flashes across [src]'s screen: \"The supplied paper is blank. Aborting.\""))
+							return FALSE
+						// Basic paper
+						if(istype(object_copy, /obj/item/paper))
+							do_copy_loop(CALLBACK(src, PROC_REF(make_paper_copy), paper_copy), usr)
+							return TRUE
+					// Copying photo.
+					if(PHOTO_COPY_TYPE)
+						var/obj/item/photo/photo_copy = object_copy
+						do_copy_loop(CALLBACK(src, PROC_REF(make_photo_copy), photo_copy), usr)
+						return TRUE
+					// Copying Documents.
+					if(DOCUMENT_COPY_TYPE)
+						var/obj/item/documents/document_copy = object_copy
+						do_copy_loop(CALLBACK(src, PROC_REF(make_document_copy), document_copy), usr)
+						return TRUE
+					// Copying paperwork
+					if(PAPERWORK_COPY_TYPE)
+						var/obj/item/paperwork/paperwork_copy = object_copy
+						do_copy_loop(CALLBACK(src, PROC_REF(make_paperwork_copy), paperwork_copy), usr)
+						return TRUE
 
 		// Remove the paper/photo/document from the photocopier.
 		if("remove")


### PR DESCRIPTION
## About The Pull Request

I set out today to fix a bug with photocopiers, I couldn't replicate the bug but instead found two more and removed a bunch of duplicate code.
Fixes being able to print blanks despite having no money to print them.
Fixes paperwork not being removed from the photocopier when mounting it.
## Why It's Good For The Game

duplicate code bad, bug fixes good.
## Changelog
:cl:
fix: You cannot print blank documents from a photocopier if you cannot afford them anymore.
fix: Mounting the photocopier will now eject paperwork as it does with photos and paper.
refactor: Lots of duplicate code and some unnecessary vars removed from photocopier code.
/:cl:
