### PR TITLE
Fix underlying armor logic and fix bug with constructed ripleys having zero armor

### DIFF
--- a/code/datums/armor/_armor.dm
+++ b/code/datums/armor/_armor.dm
@@ -126,11 +126,11 @@ GLOBAL_LIST_INIT(armor_by_type, generate_armor_type_cache())
 			new_armor.vars[mod] = value_all
 		return new_armor
 
-	for(var/value in values)
-		if(value in all_keys)
-			new_armor.vars[value] = values[value]
+	for(var/armor_rating in all_keys)
+		if(armor_rating in values)
+			new_armor.vars[armor_rating] = values[armor_rating]
 		else
-			stack_trace("Attempt to call generate_new_with_specific with illegal value '[value]'! Ignoring it")
+			new_armor.vars[armor_rating] = vars[armor_rating]
 	return new_armor
 
 /datum/armor/immune/generate_new_with_specific(list/values)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -79,6 +79,7 @@
 #include "anchored_mobs.dm"
 #include "anonymous_themes.dm"
 #include "area_contents.dm"
+#include "armor_verification.dm"
 #include "autowiki.dm"
 #include "barsigns.dm"
 #include "baseturfs.dm"

--- a/code/modules/unit_tests/armor_verification.dm
+++ b/code/modules/unit_tests/armor_verification.dm
@@ -21,7 +21,7 @@
 	TEST_ASSERT_EQUAL(armor_totals(armor), totals, "modified an immune armor type")
 
 	var/wanted = 40
-	UNLINT(dummy.armor = null)
+	dummy.set_armor(/datum/armor/none)
 	dummy.set_armor_rating(ENERGY, wanted * 0.5)
 	dummy.set_armor_rating(FIRE, wanted * 0.5)
 	TEST_ASSERT_EQUAL(armor_totals(dummy.get_armor()), wanted, "modified armor type had incorrect values")

--- a/code/modules/unit_tests/armor_verification.dm
+++ b/code/modules/unit_tests/armor_verification.dm
@@ -1,0 +1,33 @@
+/// Verifies that armor procs are working as expected
+/datum/unit_test/armor_verification
+
+/datum/unit_test/armor_verification/Run()
+	var/obj/dummy = allocate(/obj)
+
+	dummy.armor_type = /datum/armor/none
+	var/datum/armor/armor = dummy.get_armor()
+	TEST_ASSERT_NOTNULL(armor, "armor didn't populate correctly when needed")
+	TEST_ASSERT_EQUAL(armor_totals(armor), 0, "none armor type had armor values")
+
+	armor = armor.generate_new_with_specific(list(FIRE = 20))
+	TEST_ASSERT_EQUAL(armor_totals(armor), 20, "modified armor type had incorrect values")
+
+	armor = armor.generate_new_with_specific(list(ACID = 20))
+	TEST_ASSERT_EQUAL(armor_totals(armor), 40, "modified armor type had incorrect values")
+
+	armor = get_armor_by_type(/datum/armor/immune)
+	var/totals = armor_totals(armor)
+	armor = armor.generate_new_with_multipliers(list(ARMOR_ALL = 0))
+	TEST_ASSERT_EQUAL(armor_totals(armor), totals, "modified an immune armor type")
+
+	var/wanted = 40
+	dummy.armor = null
+	dummy.set_armor_rating(ENERGY, wanted * 0.5)
+	dummy.set_armor_rating(FIRE, wanted * 0.5)
+	TEST_ASSERT_EQUAL(armor_totals(dummy.get_armor()), wanted, "modified armor type had incorrect values")
+
+/datum/unit_test/armor_verification/proc/armor_totals(datum/armor/armor)
+	var/total = 0
+	for(var/key in ARMOR_LIST_ALL())
+		total += armor.vars[key]
+	return total

--- a/code/modules/unit_tests/armor_verification.dm
+++ b/code/modules/unit_tests/armor_verification.dm
@@ -4,7 +4,7 @@
 /datum/unit_test/armor_verification/Run()
 	var/obj/dummy = allocate(/obj)
 
-	UNLINT(dummy.armor_type = /datum/armor/none)
+	dummy.set_armor(/datum/armor/none)
 	var/datum/armor/armor = dummy.get_armor()
 	TEST_ASSERT_NOTNULL(armor, "armor didn't populate correctly when needed")
 	TEST_ASSERT_EQUAL(armor_totals(armor), 0, "none armor type had armor values")

--- a/code/modules/unit_tests/armor_verification.dm
+++ b/code/modules/unit_tests/armor_verification.dm
@@ -4,7 +4,7 @@
 /datum/unit_test/armor_verification/Run()
 	var/obj/dummy = allocate(/obj)
 
-	dummy.armor_type = /datum/armor/none
+	UNLINT(dummy.armor_type = /datum/armor/none)
 	var/datum/armor/armor = dummy.get_armor()
 	TEST_ASSERT_NOTNULL(armor, "armor didn't populate correctly when needed")
 	TEST_ASSERT_EQUAL(armor_totals(armor), 0, "none armor type had armor values")
@@ -21,7 +21,7 @@
 	TEST_ASSERT_EQUAL(armor_totals(armor), totals, "modified an immune armor type")
 
 	var/wanted = 40
-	dummy.armor = null
+	UNLINT(dummy.armor = null)
 	dummy.set_armor_rating(ENERGY, wanted * 0.5)
 	dummy.set_armor_rating(FIRE, wanted * 0.5)
 	TEST_ASSERT_EQUAL(armor_totals(dummy.get_armor()), wanted, "modified armor type had incorrect values")

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -434,7 +434,7 @@
 	if(capacitor)
 		var/datum/armor/stock_armor = get_armor_by_type(armor_type)
 		var/initial_energy = stock_armor.get_rating(ENERGY)
-		set_armor_rating(initial_energy + (capacitor.rating * 5))
+		set_armor_rating(ENERGY, initial_energy + (capacitor.rating * 5))
 
 /obj/vehicle/sealed/mecha/examine(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

See title
## Why It's Good For The Game

Messed up one of the armor procs; it changed the given values but never carried over existing values.
So you would end up with an armor of that one specific value and nothing else.

This wasn't actually used anywhere other than mecha, lava burning, and sentient viruses, so the issue isn't that bad.
It's still an issue however.
## Changelog
:cl:
fix: Mechs no longer have zero armor when built.
/:cl:
