### PR TITLE
Updates space verification unit test to use new proc

### DIFF
--- a/code/modules/unit_tests/mapload_space_verification.dm
+++ b/code/modules/unit_tests/mapload_space_verification.dm
@@ -5,11 +5,8 @@
 	priority = TEST_LONGER
 
 /datum/unit_test/mapload_space_verification/Run()
-	// Get the datum associated with our currently running map.
-	var/datum/map_config/current_map = SSmapping.config
-
 	// Is our current map a planetary station (NO space turfs allowed)? If so, check for ANY space turfs.
-	if(current_map.planetary)
+	if(SSmapping.is_planetary())
 		validate_planetary_map()
 		return
 


### PR DESCRIPTION
## About The Pull Request

At San's request, updates the space verification unit test to use the new "are we a planetary map" proc instead of having its own implementation of the same thing.

## Why It's Good For The Game

If it gets broken in one place it will break in all of them, most importantly the unit test, which is what we want because that's what the test is for.

## Changelog

Not player facing.