### PR TITLE
Adjusts exclamation marks to forgotten 'loud' emotes.

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -89,7 +89,7 @@
 /datum/emote/living/carbon/human/scream/screech //If a human tries to screech it'll just scream.
 	key = "screech"
 	key_third_person = "screeches"
-	message = "screeches."
+	message = "screeches!"
 	message_mime = "screeches silently."
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
 	vary = FALSE
@@ -214,7 +214,7 @@
 /datum/emote/living/carbon/human/monkey/screech/roar
 	key = "roar"
 	key_third_person = "roars"
-	message = "roars."
+	message = "roars!"
 	message_mime = "acts out a roar."
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -312,7 +312,7 @@
 /datum/emote/living/scream
 	key = "scream"
 	key_third_person = "screams"
-	message = "screams."
+	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 	mob_type_blacklist_typecache = list(/mob/living/carbon/human) //Humans get specialized scream.


### PR DESCRIPTION

## About The Pull Request

A player expressed disappointment that as an artificer their yell ended with a period and not an exclamation mark. They said it did not express the hell of being a simple mob.

I think these are the only ones that needed to be corrected. 

## Why It's Good For The Game

Exclamation marks show a heightened level of expression, heightened expression allows for more in-depth roleplay, roleplay good.

## Changelog



:cl:
spellcheck: Adjusted punctuation marks for several emotes.
/:cl:
