### PR TITLE
blackbox data for order consoles

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/cook_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/cook_order.dm
@@ -7,6 +7,7 @@
 		CATEGORY_MILK_EGGS,
 		CATEGORY_SAUCES_REAGENTS,
 	)
+	blackbox_key = "chef"
 
 /obj/machinery/computer/order_console/cook/order_groceries(mob/living/purchaser, obj/item/card/id/card, list/groceries)
 	say("Thank you for your purchase! It will arrive on the next cargo shuttle!")

--- a/code/game/machinery/computer/orders/order_computer/golem_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/golem_order.dm
@@ -10,3 +10,4 @@
 		CATEGORY_TOYS_DRONE,
 		CATEGORY_PKA,
 	)
+	blackbox_key = null

--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -26,6 +26,7 @@
 		CATEGORY_TOYS_DRONE,
 		CATEGORY_PKA,
 	)
+	blackbox_key = "mining"
 
 /obj/machinery/computer/order_console/mining/purchase_items(obj/item/card/id/card, express = FALSE)
 	var/final_cost = get_total_cost()

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -34,6 +34,8 @@ GLOBAL_LIST_EMPTY(order_console_products)
 	var/list/order_categories = list()
 	///The current list of things we're trying to order, waiting for checkout.
 	var/list/datum/orderable_item/grocery_list = list()
+	///For blackbox logging, what kind of order is this? set nothing to not tally, like golem orders
+	var/blackbox_key
 
 /obj/machinery/computer/order_console/Initialize(mapload)
 	. = ..()
@@ -146,6 +148,8 @@ GLOBAL_LIST_EMPTY(order_console_products)
 			if(get_total_cost() < CARGO_CRATE_VALUE)
 				say("For the delivery order needs to cost more or equal to [CARGO_CRATE_VALUE] points!")
 				return
+			if(blackbox_key)
+				SSblackbox.record_feedback("tally", "non_express_[blackbox_key]_order", 1, name)
 			order_groceries(living_user, used_id_card, grocery_list)
 			grocery_list.Cut()
 			COOLDOWN_START(src, order_cooldown, cooldown_time)
@@ -163,6 +167,8 @@ GLOBAL_LIST_EMPTY(order_console_products)
 				say_message += "Please note: The charge of this purchase and machine cooldown has been multiplied by [express_cost_multiplier]!"
 			COOLDOWN_START(src, order_cooldown, cooldown_time * express_cost_multiplier)
 			say(say_message)
+			if(blackbox_key)
+				SSblackbox.record_feedback("tally", "express_[blackbox_key]_order", 1, name)
 			var/list/ordered_paths = list()
 			for(var/datum/orderable_item/item as anything in grocery_list)//every order
 				if(!(item.category_index in order_categories))


### PR DESCRIPTION

## About The Pull Request

Adds a tally for express orders and non-express orders to order consoles.

## Why It's Good For The Game

Help us collect data on how often cargo is being roped into the orders console.

## Changelog
Not player facing
