### PR TITLE
Grammar checks every closet that spawns on a station.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -33871,7 +33871,7 @@
 /area/station/maintenance/port/aft)
 "iju" = (
 /obj/structure/closet{
-	name = "Evidence Closet"
+	name = "evidence closet"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/firealarm/directional/west,
@@ -42342,11 +42342,11 @@
 /area/station/security/execution/transfer)
 "kiG" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/closet{
+	name = "evidence closet"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "kiQ" = (
@@ -47223,7 +47223,7 @@
 "luD" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "brig2";
-	name = "Cell 2 Locker"
+	name = "cell 2 locker"
 	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -47251,7 +47251,7 @@
 "lvk" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "brig1";
-	name = "Cell 1 Locker"
+	name = "cell 1 locker"
 	},
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -71633,11 +71633,11 @@
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
 "ryB" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/north,
+/obj/structure/closet{
+	name = "evidence closet"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "ryC" = (
@@ -90607,7 +90607,7 @@
 "weh" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "cargocell";
-	name = "Cargo Cell Locker"
+	name = "cargo cell locker"
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
@@ -95990,10 +95990,10 @@
 /turf/open/floor/iron,
 /area/station/command/corporate_showroom)
 "xsW" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet{
+	name = "evidence closet"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "xtg" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8853,7 +8853,7 @@
 /area/station/tcommsat/server)
 "cEP" = (
 /obj/structure/closet{
-	name = "Evidence Closet 3"
+	name = "evidence closet 3"
 	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Security - Lower Brig Evidence"
@@ -18351,7 +18351,7 @@
 /area/station/service/hydroponics/garden)
 "fzG" = (
 /obj/structure/closet{
-	name = "Evidence Closet 5"
+	name = "evidence closet 5"
 	},
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
@@ -33469,7 +33469,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
-	name = "Cell 2 Locker"
+	name = "cell 2 locker"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -54258,7 +54258,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
-	name = "Cell 1 Locker"
+	name = "cell 1 locker"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -57110,7 +57110,7 @@
 /area/station/command/heads_quarters/rd)
 "rEe" = (
 /obj/structure/closet{
-	name = "Evidence Closet 4"
+	name = "evidence closet 4"
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark/textured_edge{
@@ -61205,7 +61205,7 @@
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
-	name = "Cell 3 Locker"
+	name = "cell 3 locker"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
@@ -62899,7 +62899,7 @@
 /area/station/maintenance/department/medical/central)
 "tvK" = (
 /obj/structure/closet{
-	name = "Evidence Closet 2"
+	name = "evidence closet 2"
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/textured_edge,
@@ -69327,7 +69327,7 @@
 /area/station/science/lab)
 "vvG" = (
 /obj/structure/closet{
-	name = "Evidence Closet 6"
+	name = "evidence closet 6"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_edge{
@@ -70230,7 +70230,7 @@
 /area/station/hallway/secondary/entry)
 "vIH" = (
 /obj/structure/closet{
-	name = "Evidence Closet 1"
+	name = "evidence closet 1"
 	},
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/textured_edge,

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -43081,7 +43081,7 @@
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 5";
-	name = "Cell 5 Locker"
+	name = "cell 5 locker"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -43614,7 +43614,7 @@
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 6";
-	name = "Cell 6 Locker"
+	name = "cell 6 locker"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -48231,7 +48231,7 @@
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
-	name = "Cell 2 Locker"
+	name = "cell 2 locker"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -58477,7 +58477,7 @@
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
-	name = "Cell 3 Locker"
+	name = "cell 3 locker"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -59400,7 +59400,7 @@
 /area/station/maintenance/port/greater)
 "qXX" = (
 /obj/structure/closet{
-	name = "Evidence Closet"
+	name = "evidence closet"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -59685,7 +59685,7 @@
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
-	name = "Cell 1 Locker"
+	name = "cell 1 locker"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -65915,7 +65915,7 @@
 	},
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 4";
-	name = "Cell 4 Locker"
+	name = "cell 4 locker"
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
@@ -66510,7 +66510,7 @@
 	pixel_y = -3
 	},
 /obj/structure/closet/secure_closet{
-	name = "shotgun rubber rounds";
+	name = "shotgun rubber rounds locker";
 	req_access = list("armory")
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -71335,7 +71335,7 @@
 /area/station/engineering/atmos)
 "unv" = (
 /obj/structure/closet/secure_closet/injection{
-	name = "Justice Injections"
+	name = "justice injections locker"
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -78032,7 +78032,7 @@
 /area/station/hallway/primary/central/fore)
 "weR" = (
 /obj/structure/closet{
-	name = "Evidence Closet"
+	name = "evidence closet"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1204,7 +1204,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
-	name = "Cell 3 Locker"
+	name = "cell 3 locker"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -24491,7 +24491,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
-	name = "Cell 2 Locker"
+	name = "cell 2 locker"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -28186,7 +28186,7 @@
 /area/station/engineering/atmos)
 "kaU" = (
 /obj/structure/closet{
-	name = "Evidence Closet 3"
+	name = "evidence closet 3"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -37559,7 +37559,7 @@
 /area/station/medical/pharmacy)
 "nqD" = (
 /obj/structure/closet{
-	name = "Evidence Closet 2"
+	name = "evidence closet 2"
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -57625,7 +57625,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
-	name = "Cell 1 Locker"
+	name = "cell 1 locker"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -57736,7 +57736,7 @@
 /area/station/hallway/primary/aft)
 "urf" = (
 /obj/structure/closet/secure_closet/injection{
-	name = "educational injections";
+	name = "educational injections locker";
 	pixel_x = 2
 	},
 /obj/structure/cable,
@@ -58424,7 +58424,7 @@
 /area/station/security/prison)
 "uCW" = (
 /obj/structure/closet{
-	name = "Evidence Closet 1"
+	name = "evidence closet 1"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -59264,7 +59264,7 @@
 /area/station/maintenance/aft/lesser)
 "uQK" = (
 /obj/structure/closet{
-	name = "Evidence Closet 4"
+	name = "evidence closet 4"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -63515,7 +63515,7 @@
 /area/station/medical/virology)
 "wrb" = (
 /obj/structure/closet{
-	name = "Evidence Closet 5"
+	name = "evidence closet 5"
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -20042,7 +20042,7 @@
 /area/station/security/prison)
 "fsQ" = (
 /obj/structure/closet{
-	name = "Evidence Closet 1"
+	name = "evidence closet 7"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
@@ -29733,11 +29733,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/office)
 "jil" = (
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/structure/closet{
+	name = "evidence closet 5"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "jim" = (
@@ -31592,7 +31592,7 @@
 /area/station/engineering/supermatter/room)
 "jPw" = (
 /obj/structure/closet{
-	name = "Beekeeper Uniform"
+	name = "beekeeper uniform closet"
 	},
 /obj/item/clothing/head/utility/beekeeper_head,
 /obj/item/melee/flyswatter,
@@ -42830,11 +42830,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "nVx" = (
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet{
+	name = "evidence closet 2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "nVL" = (
@@ -46355,6 +46355,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"ppg" = (
+/obj/structure/closet{
+	name = "evidence closet 3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/evidence)
 "ppr" = (
 /obj/machinery/computer/security{
 	dir = 1
@@ -49146,10 +49152,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "qnr" = (
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet{
+	name = "evidence closet 6"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "qnu" = (
@@ -58063,11 +58069,11 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "tyx" = (
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/contraband/narcotics,
+/obj/structure/closet{
+	name = "evidence closet 4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "tyE" = (
@@ -59363,11 +59369,11 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "tYg" = (
-/obj/structure/closet{
-	name = "Evidence Closet 1"
-	},
 /obj/item/storage/secure/safe/directional/east,
 /obj/effect/spawner/random/contraband/cannabis,
+/obj/structure/closet{
+	name = "evidence closet 1"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "tYK" = (
@@ -158947,7 +158953,7 @@ abM
 abM
 tFJ
 tYg
-fsQ
+ppg
 jil
 fsQ
 jKq

--- a/code/game/objects/structures/crates_lockers/closets/fitness.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fitness.dm
@@ -15,7 +15,7 @@
 
 
 /obj/structure/closet/boxinggloves
-	name = "boxing gloves"
+	name = "boxing gloves closet"
 	desc = "It's a storage unit for gloves for use in the boxing ring."
 
 /obj/structure/closet/boxinggloves/PopulateContents()

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -25,7 +25,7 @@
 	generate_items_inside(items_inside,src)
 
 /obj/structure/closet/chefcloset
-	name = "\proper chef's closet"
+	name = "chef's closet"
 	desc = "It's a storage unit for foodservice garments and mouse traps."
 	icon_door = "black"
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -1,5 +1,5 @@
 /obj/structure/closet/secure_closet/quartermaster
-	name = "\proper quartermaster's locker"
+	name = "quartermaster's locker"
 	req_access = list(ACCESS_QM)
 	icon_state = "qm"
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -1,5 +1,5 @@
 /obj/structure/closet/secure_closet/engineering_chief
-	name = "\proper chief engineer's locker"
+	name = "chief engineer's locker"
 	req_access = list(ACCESS_CE)
 	icon_state = "ce"
 
@@ -72,7 +72,7 @@
 
 
 /obj/structure/closet/secure_closet/atmospherics
-	name = "\proper atmospheric technician's locker"
+	name = "atmospheric technician's locker"
 	req_access = list(ACCESS_ATMOSPHERICS)
 	icon_state = "atmos"
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -33,7 +33,7 @@
 	flags_1 &= ~PREVENT_CONTENTS_EXPLOSION_1
 
 /obj/structure/closet/secure_closet/freezer/empty
-	name = "empty freezer"
+	name = "freezer"
 
 /obj/structure/closet/secure_closet/freezer/empty/open
 	req_access = null

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -68,7 +68,7 @@
 	new /obj/item/clothing/glasses/blindfold(src)
 
 /obj/structure/closet/secure_closet/chief_medical
-	name = "\proper chief medical officer's locker"
+	name = "chief medical officer's locker"
 	req_access = list(ACCESS_CMO)
 	icon_state = "cmo"
 
@@ -100,7 +100,7 @@
 	new /obj/item/reagent_containers/hypospray/cmo(src)
 
 /obj/structure/closet/secure_closet/animal
-	name = "animal control"
+	name = "animal control locker"
 	req_access = list(ACCESS_SURGERY)
 
 /obj/structure/closet/secure_closet/animal/PopulateContents()

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -1,5 +1,5 @@
 /obj/structure/closet/secure_closet/research_director
-	name = "\proper research director's locker"
+	name = "research director's locker"
 	req_access = list(ACCESS_RD)
 	icon_state = "rd"
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -1,5 +1,5 @@
 /obj/structure/closet/secure_closet/captains
-	name = "\proper captain's locker"
+	name = "captain's locker"
 	req_access = list(ACCESS_CAPTAIN)
 	icon_state = "cap"
 
@@ -22,7 +22,7 @@
 	new /obj/item/storage/photo_album/captain(src)
 
 /obj/structure/closet/secure_closet/hop
-	name = "\proper head of personnel's locker"
+	name = "head of personnel's locker"
 	req_access = list(ACCESS_HOP)
 	icon_state = "hop"
 
@@ -46,7 +46,7 @@
 	new /obj/item/storage/lockbox/medal/hop(src)
 
 /obj/structure/closet/secure_closet/hos
-	name = "\proper head of security's locker"
+	name = "head of security's locker"
 	req_access = list(ACCESS_HOS)
 	icon_state = "hos"
 
@@ -173,7 +173,7 @@
 	new /obj/item/storage/box/rxglasses/spyglasskit(src)
 
 /obj/structure/closet/secure_closet/injection
-	name = "lethal injections"
+	name = "lethal injections locker"
 	req_access = list(ACCESS_HOS)
 
 /obj/structure/closet/secure_closet/injection/PopulateContents()
@@ -234,7 +234,7 @@
 
 /obj/structure/closet/secure_closet/evidence
 	anchored = TRUE
-	name = "Secure Evidence Closet"
+	name = "secure evidence closet"
 	req_one_access = list("armory","detective")
 
 /obj/structure/closet/secure_closet/brig/PopulateContents()
@@ -259,12 +259,12 @@
 
 /obj/structure/closet/secure_closet/contraband/armory
 	anchored = TRUE
-	name = "Contraband Locker"
+	name = "contraband locker"
 	req_access = list(ACCESS_ARMORY)
 
 /obj/structure/closet/secure_closet/contraband/heads
 	anchored = TRUE
-	name = "Contraband Locker"
+	name = "contraband locker"
 	req_access = list(ACCESS_COMMAND)
 
 /obj/structure/closet/secure_closet/armory1

--- a/code/modules/awaymissions/exile.dm
+++ b/code/modules/awaymissions/exile.dm
@@ -1,6 +1,6 @@
 
 /obj/structure/closet/secure_closet/exile
-	name = "exile implants"
+	name = "exile implants locker"
 	req_access = list(ACCESS_HOS)
 
 /obj/structure/closet/secure_closet/exile/PopulateContents()

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -43,7 +43,7 @@
 	new /obj/item/clothing/suit/hooded/wintercoat/miner(src)
 
 /obj/structure/closet/secure_closet/miner
-	name = "miner's equipment"
+	name = "miner's equipment locker"
 	icon_state = "mining"
 	req_access = list(ACCESS_MINING)
 


### PR DESCRIPTION
## About The Pull Request

All closets now are called either closets, lockers, wardrobes etc. (e.g. the lethal injections locker was previously called "lethal injections")
Head of staff and the cook's locker are no longer proper nouns, it didn't make much grammatical sense and it keeps consistency with other lockers (Example: detective's cabinet)
All locker names de-capitalized except the Thunderdome ones since those made sense.
The empty freezer is now just called a freezer since it being empty or not depends on what players and mappers do to it.
Tram now has evidence lockers labelled from 1 through 7 instead of 7 evidence lockers labelled as 1.

Changes have been made to all station maps and in code, I've not gone through all ruins, away missions, etc.
## Why It's Good For The Game

Cleans up a lot  of minor name issues.
## Changelog
:cl:
spellcheck: All station closet and lockers have had their naming conventions standardized.
fix: Tram now has evidence lockers labelled 1 through 7 instead of 7 evidence lockers labelled as locker 1.
/:cl:
