### PR TITLE
Fixes exosuit board sprites

### DIFF
--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -25,7 +25,8 @@
 /obj/item/circuitboard/Initialize(mapload)
 	if(name_extension)
 		name = "[initial(name)] [name_extension]"
-	set_greyscale(new_config = /datum/greyscale_config/circuit)
+	if(icon_state == "circuit_map") // some circuitboards have cool custom sprites
+		set_greyscale(new_config = /datum/greyscale_config/circuit)
 	return ..()
 
 /obj/item/circuitboard/proc/apply_default_parts(obj/machinery/machine)


### PR DESCRIPTION

## About The Pull Request

Any circuit board whose icon state is not "circuit_map" (others dont have gags) dont have gags applied to them

## Why It's Good For The Game

Fixes #71332

## Changelog
:cl:
fix: Any circuit boards with custom sprites now actually use that sprite
/:cl:
