### PR TITLE
Auxbase turrets now shoot stuff

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -820,6 +820,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	name = "perimeter defense turret"
 	desc = "A plasma beam turret calibrated to defend outposts against non-humanoid fauna. It is more effective when exposed to the environment."
 	installation = null
+	uses_stored = FALSE
 	lethal_projectile = /obj/projectile/plasma/turret
 	lethal_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	mode = TURRET_LETHAL //It would be useless in stun mode anyway


### PR DESCRIPTION

## About The Pull Request

Aux base turrets had uses_stored on TRUE by default so when process() fired it would return PROCESS_KILL
it is now FALSE and it shoots stuff now
projectile still sucks at damaging fauna

## Why It's Good For The Game

Fixes #67208

## Changelog
:cl:
fix: aux base turrets now shoot fauna
/:cl:
