### PR TITLE
Buckle sanity

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -121,6 +121,10 @@
 	M.Move(loc)
 	M.setDir(dir)
 
+	//Something has unbuckled us in reaction to the above movement
+	if(!M.buckled)
+		return FALSE
+
 	post_buckle_mob(M)
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_BUCKLE, M, force)


### PR DESCRIPTION

## About The Pull Request

When you slip on ice or lube, you get unbuckled from whatever you were buckled onto. The issue with this is that when you buckle yourself to something in the first place, you move onto the loc of the buckled item, which triggers this slip due to signals. Buckling code then continues, and post_buckle is called, which might have varied odd effects, such as setting the rollerbed into a dense and deployed state without anyone being in it; scooters, wheelchairs and secways adding you to the occupant lists, making you unable to buckle yourself into them again, stasis beds applying the stasis effect permanently, or this:
![image](https://user-images.githubusercontent.com/2676196/217907706-cb0e4012-8580-4bd3-8703-30fb12da3066.png)
Of course the last one requires you to build a guillotine before the tile stops being lubed, but it was still a real threat, and also, really funny.

Sadly, this is not the cleanest fix. Due to the slip calling post_unbuckle_mob before post_buckle_mob getting called, there might be some offset weirdness while the lubed person is flying through the air, thanks to buckling and unbuckling directly altering pixel_x and pixel_y, but they seem to realign themselves after the knockdown ran out.

## Why It's Good For The Game

Cleans up some rare slipping edge cases that result in odd behaviour. Actually fixes #67841 (which got closed because I foolishly thought this was not referring to lube)

## Changelog

:cl:
fix: slipping on lube while buckling will lead to less weird states
/:cl:
