### PR TITLE
Console Hack / Unfavourable Events won't run ghost roles which don't have time to do anything

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -25,6 +25,7 @@
 		log_dynamic_and_announce("An unfavorable situation was requested, spawning [initial(heavy_ruleset.name)]")
 		picking_specific_rule(heavy_ruleset, forced = TRUE, ignore_cost = TRUE)
 
+/// Return a valid heavy dynamic ruleset, or an empty list if there's no time to run any rulesets
 /datum/game_mode/dynamic/proc/generate_unfavourable_heavy_rulesets()
 	if (EMERGENCY_PAST_POINT_OF_NO_RETURN)
 		return list()

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -11,9 +11,25 @@
 	var/static/list/unfavorable_random_events = list()
 	if (!length(unfavorable_random_events))
 		unfavorable_random_events = generate_unfavourable_events()
-	var/list/possible_heavies = list()
+	var/list/possible_heavies = generate_unfavourable_heavy_rulesets()
+	if (possible_heavies.len == 0)
+		var/datum/round_event_control/round_event_control_type = pick(unfavorable_random_events)
+		var/delay = rand(20 SECONDS, 1 MINUTES)
 
-	// Ignored factors: threat cost, minimum round time
+		log_dynamic_and_announce("An unfavorable situation was requested, but no heavy rulesets could be drafted. Spawning [initial(round_event_control_type.name)] in [DisplayTimeText(delay)] instead.")
+
+		var/datum/round_event_control/round_event_control = new round_event_control_type
+		addtimer(CALLBACK(round_event_control, TYPE_PROC_REF(/datum/round_event_control, runEvent)), delay)
+	else
+		var/datum/dynamic_ruleset/midround/heavy_ruleset = pick_weight(possible_heavies)
+		log_dynamic_and_announce("An unfavorable situation was requested, spawning [initial(heavy_ruleset.name)]")
+		picking_specific_rule(heavy_ruleset, forced = TRUE, ignore_cost = TRUE)
+
+/datum/game_mode/dynamic/proc/generate_unfavourable_heavy_rulesets()
+	if (EMERGENCY_PAST_POINT_OF_NO_RETURN)
+		return list()
+
+	var/list/possible_heavies = list()
 	for (var/datum/dynamic_ruleset/midround/ruleset as anything in midround_rules)
 		if (ruleset.midround_ruleset_style != MIDROUND_RULESET_STYLE_HEAVY)
 			continue
@@ -40,19 +56,7 @@
 			continue
 
 		possible_heavies[ruleset] = ruleset.get_weight()
-
-	if (possible_heavies.len == 0)
-		var/datum/round_event_control/round_event_control_type = pick(unfavorable_random_events)
-		var/delay = rand(20 SECONDS, 1 MINUTES)
-
-		log_dynamic_and_announce("An unfavorable situation was requested, but no heavy rulesets could be drafted. Spawning [initial(round_event_control_type.name)] in [DisplayTimeText(delay)] instead.")
-
-		var/datum/round_event_control/round_event_control = new round_event_control_type
-		addtimer(CALLBACK(round_event_control, TYPE_PROC_REF(/datum/round_event_control, runEvent)), delay)
-	else
-		var/datum/dynamic_ruleset/midround/heavy_ruleset = pick_weight(possible_heavies)
-		log_dynamic_and_announce("An unfavorable situation was requested, spawning [initial(heavy_ruleset.name)]")
-		picking_specific_rule(heavy_ruleset, forced = TRUE, ignore_cost = TRUE)
+	return possible_heavies
 
 /// Filter the below list by which events can actually run on this map
 /datum/game_mode/dynamic/proc/generate_unfavourable_events()

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -12,7 +12,7 @@
 	if (!length(unfavorable_random_events))
 		unfavorable_random_events = generate_unfavourable_events()
 	var/list/possible_heavies = generate_unfavourable_heavy_rulesets()
-	if (possible_heavies.len == 0)
+	if (!length(possible_heavies))
 		var/datum/round_event_control/round_event_control_type = pick(unfavorable_random_events)
 		var/delay = rand(20 SECONDS, 1 MINUTES)
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -844,15 +844,20 @@
 	// If we have a certain amount of ghosts, we'll add some more !!fun!! options to the list
 	var/num_ghosts = length(GLOB.current_observers_list) + length(GLOB.dead_player_list)
 
-	// Pirates require empty space for the ship, and ghosts for the pirates obviously
-	if(!SSmapping.is_planetary() && (num_ghosts >= MIN_GHOSTS_FOR_PIRATES))
-		hack_options += HACK_PIRATE
-	// Fugitives require empty space for the hunter's ship, and ghosts for both fugitives and hunters (Please no waldo)
-	if(!SSmapping.is_planetary() && (num_ghosts >= MIN_GHOSTS_FOR_FUGITIVES))
-		hack_options += HACK_FUGITIVES
-	// If less than a certain percent of the population is ghosts, consider sleeper agents
-	if(num_ghosts < (length(GLOB.clients) * MAX_PERCENT_GHOSTS_FOR_SLEEPER))
-		hack_options += HACK_SLEEPER
+	// Pirates / Fugitives have enough lead in time that there's no point summoning them if the shuttle is called
+	// Both of these events also summon space ships and so cannot run on planetary maps
+	if (EMERGENCY_IDLE_OR_RECALLED && !SSmapping.is_planetary())
+		// Pirates require ghosts for the pirates obviously
+		if(num_ghosts >= MIN_GHOSTS_FOR_PIRATES)
+			hack_options += HACK_PIRATE
+		// Fugitives require ghosts for both fugitives and hunters (Please no waldo)
+		if(num_ghosts >= MIN_GHOSTS_FOR_FUGITIVES)
+			hack_options += HACK_FUGITIVES
+
+	if (!EMERGENCY_PAST_POINT_OF_NO_RETURN)
+		// If less than a certain percent of the population is ghosts, consider sleeper agents
+		if(num_ghosts < (length(GLOB.clients) * MAX_PERCENT_GHOSTS_FOR_SLEEPER))
+			hack_options += HACK_SLEEPER
 
 	var/picked_option = pick(hack_options)
 	message_admins("[ADMIN_LOOKUPFLW(hacker)] hacked a [name] located at [ADMIN_VERBOSEJMP(src)], resulting in: [picked_option]!")


### PR DESCRIPTION
## About The Pull Request

Fixes #69201
The dynamic subsystem will never roll a new antagonist once the shuttle is past the point of no return, but this check is bypassed by Console Hacks and Unfavourable Event rolls (which are chiefly triggered from console hacks, but also from when the Revolution wins).

I have made these procs more discerning.
Unfavourable Events will now never pick any heavy dynamic midround if the shuttle is past the point of no return.
Console Hacking will now never spawn sleeper agents if the shuttle is past the point of no return, and won't spawn Fugitives or Pirates if the shuttle is called at all even if it can still be recalled

It's my feeling that given the need to get organised and move a ship to the station there isn't really time for either of those events to actually start properly rolling, but if you feel like that information might be metagamed in some way by messing around with the shuttle (not sure why or to what end, but it's technically manipulatable if you know how the code works?) I can just give these the same restriction as Traitor even if it means the bounty hunters risk showing up after the shuttle has already left.

## Why It's Good For The Game

To some extent it's your own fault for clicking the popup while knowing full well how much round time is left until the game ends, but it's still disappointing to see a Blob or Pirates or Wizard alert appear at a time when they can't possibly do anything interesting.
This is more true for the Pirate and Fugitive events because they involve teamwork, placing a space ship, travel between the ship and the station, and in the case of Fugitives its own internal five minute timer before the other team actually arrives.

## Changelog

:cl:
fix: Hacking the Comms Console or winning a Revolution can no longer spawn antagonists if there's not enough time left in the round for them to antagonise anyone.
/:cl:
