### PR TITLE
[no gbp] The AI can't see you drawing heretic runes

### DIFF
--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -209,6 +209,9 @@
 	. = ..()
 	set_greyscale(colors = list(path_colour))
 	icon_state = animation_state
+	var/image/silicon_image = image(icon = 'icons/effects/eldritch.dmi', icon_state = null, loc = src)
+	silicon_image.override = TRUE
+	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/silicons, "heretic_rune", silicon_image)
 
 /obj/effect/temp_visual/drawing_heretic_rune/fast
 	duration = 12 SECONDS


### PR DESCRIPTION
## About The Pull Request

Fixes #72996 
Fixes an oversight where the alternate invisible sprite wasn't applied to the lengthy drawing animation as well as the finished product, so the AI could see you drawing lines on the ground which would then disappear on completion.

## Why It's Good For The Game

The AI is a big snitch but crucially doesn't believe that magic is real, so it shouldn't be able to tell on you.

## Changelog

:cl:
fix: Heretic runes are now invisible to the AI (and cyborgs) while being drawn as well as when finished.
/:cl:
