### PR TITLE
Fixes Admin Make AI not working on observers

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -140,6 +140,8 @@
 			to_chat(src, span_danger("You must obey your silicon laws above all else. Your objectives will consider you to be dead."))
 		if(!mind.has_ever_been_ai)
 			mind.has_ever_been_ai = TRUE
+	else if(target_ai.key)
+		key = target_ai.key
 
 	to_chat(src, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")
 	to_chat(src, "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>")


### PR DESCRIPTION
## About The Pull Request

Using player panel `make ai` on an observer no longer fails to insert the player into the created AI. 

`ai/Initialize()` does a mind transfer, but observers don't have minds. Fixes this by moving over any present keys if the player is mindless. 

## Why It's Good For The Game

Helps in testing

## Changelog

:cl: Melbert
fix: Fixes player panel "make ai" button not fully working on observers
/:cl:

