### PR TITLE
Recenters gravity gens

### DIFF
--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -170,7 +170,7 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 /obj/machinery/gravity_generator/main/proc/setup_parts()
 	var/turf/our_turf = get_turf(src)
 	// 9x9 block obtained from the bottom middle of the block
-	var/list/spawn_turfs = CORNER_BLOCK(our_turf, 3, 3)
+	var/list/spawn_turfs = CORNER_BLOCK_OFFSET(our_turf, 3, 3, -1, 0)
 	var/count = 10
 	for(var/turf/T in spawn_turfs)
 		count--


### PR DESCRIPTION

## About The Pull Request

Due to a change in how a gravity generator figured out the turfs it would be using to create itself, gravity generators were visually shifted to the right, but the interaction still remained where the main piece was placed. This just changes `CORNER_BLOCK` to `CORNER_BLOCK_OFFSET` and offsets the block one tile to the left.

## Why It's Good For The Game

No more wonky gravity generators
Fixes #73083

## Changelog
:cl:
fix: Gravity generators have been re-centered.
/:cl:
