### PR TITLE
Fixes encoding on syndicate declaration of war, Fixes a way to send unencoded text to newscasters

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -11,7 +11,7 @@
  *
  * Arguments
  * * text - required, the text to announce
- * * title - optinal, the title of the announcement.
+ * * title - optional, the title of the announcement.
  * * sound - optional, the sound played accompanying the announcement
  * * type - optional, the type of the announcement, for some "preset" announcement templates. "Priority", "Captain", "Syndicate Captain"
  * * sender_override - optional, modifies the sender of the announcement

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -1,6 +1,35 @@
-/proc/priority_announce(text, title = "", sound, type , sender_override, has_important_message, players)
+/**
+ * Make a big red text announcement to
+ *
+ * Formatted like:
+ *
+ * " Message from sender "
+ *
+ * " Title "
+ *
+ * " Text "
+ *
+ * Arguments
+ * * text - required, the text to announce
+ * * title - optinal, the title of the announcement.
+ * * sound - optional, the sound played accompanying the announcement
+ * * type - optional, the type of the announcement, for some "preset" announcement templates. "Priority", "Captain", "Syndicate Captain"
+ * * sender_override - optional, modifies the sender of the announcement
+ * * has_important_message - is this message critical to the game (and should not be overridden by station traits), or not
+ * * players - a list of all players to send the message to. defaults to all players (not including new players)
+ * * encode_title - if TRUE, the title will be HTML encoded
+ * * encode_text - if TRUE, the text will be HTML encoded
+ */
+/proc/priority_announce(text, title = "", sound, type, sender_override, has_important_message = FALSE, list/mob/players, encode_title = TRUE, encode_text = TRUE)
 	if(!text)
 		return
+
+	if(encode_title && title && length(title) > 0)
+		title = html_encode(title)
+	if(encode_text)
+		text = html_encode(text)
+		if(!length(text))
+			return
 
 	var/announcement
 	if(!sound)
@@ -11,10 +40,10 @@
 	if(type == "Priority")
 		announcement += "<h1 class='alert'>Priority Announcement</h1>"
 		if (title && length(title) > 0)
-			announcement += "<br><h2 class='alert'>[html_encode(title)]</h2>"
+			announcement += "<br><h2 class='alert'>[title]</h2>"
 	else if(type == "Captain")
 		announcement += "<h1 class='alert'>Captain Announces</h1>"
-		GLOB.news_network.submit_article(html_encode(text), "Captain's Announcement", "Station Announcements", null)
+		GLOB.news_network.submit_article(text, "Captain's Announcement", "Station Announcements", null)
 	else if(type == "Syndicate Captain")
 		announcement += "<h1 class='alert'>Syndicate Captain Announces</h1>"
 
@@ -24,7 +53,7 @@
 		else
 			announcement += "<h1 class='alert'>[sender_override]</h1>"
 		if (title && length(title) > 0)
-			announcement += "<br><h2 class='alert'>[html_encode(title)]</h2>"
+			announcement += "<br><h2 class='alert'>[title]</h2>"
 
 		if(!sender_override)
 			if(title == "")
@@ -36,7 +65,7 @@
 	if(SSstation.announcer.custom_alert_message && !has_important_message)
 		announcement += SSstation.announcer.custom_alert_message
 	else
-		announcement += "<br>[span_alert("[html_encode(text)]")]<br>"
+		announcement += "<br>[span_alert(text)]<br>"
 	announcement += "<br>"
 
 	if(!players)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -163,7 +163,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 #ifndef TESTING
 	// Reminder for our friends the admins
 	var/are_you_sure = tgui_alert(user, "Last second reminder that fake war declarations is a horrible idea and yes, \
-		the does the whole shebang, so be careful what you're doing.", "Don't do it", list("I'm sure", "You're right"))
+		this does the whole shebang, so be careful what you're doing.", "Don't do it", list("I'm sure", "You're right"))
 	if(are_you_sure != "I'm sure")
 		return
 #endif

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,7 +1,7 @@
 #define CHALLENGE_TELECRYSTALS 280
-#define CHALLENGE_TIME_LIMIT 3000
+#define CHALLENGE_TIME_LIMIT 5 MINUTES
 #define CHALLENGE_MIN_PLAYERS 50
-#define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
+#define CHALLENGE_SHUTTLE_DELAY 25 MINUTES // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
 
@@ -23,14 +23,14 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		return
 
 	declaring_war = TRUE
-	var/are_you_sure = tgui_alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You have [DisplayTimeText(world.time-SSticker.round_start_time - CHALLENGE_TIME_LIMIT)] to decide", "Declare war?", list("Yes", "No"))
+	var/are_you_sure = tgui_alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [DisplayTimeText(CHALLENGE_TIME_LIMIT - world.time - SSticker.round_start_time)] to decide.", "Declare war?", list("Yes", "No"))
 	declaring_war = FALSE
 
 	if(!check_allowed(user))
 		return
 
-	if(are_you_sure == "No")
-		to_chat(user, "On second thought, the element of surprise isn't so bad after all.")
+	if(are_you_sure != "Yes")
+		to_chat(user, span_notice("On second thought, the element of surprise isn't so bad after all."))
 		return
 
 	var/war_declaration = "A syndicate fringe group has declared their intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
@@ -44,29 +44,13 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 
 	if(custom_threat == "Yes")
 		declaring_war = TRUE
-		war_declaration = tgui_input_text(user, "Insert your custom declaration", "Declaration", multiline = TRUE)
+		war_declaration = tgui_input_text(user, "Insert your custom declaration", "Declaration", multiline = TRUE, encode = FALSE)
 		declaring_war = FALSE
 
 	if(!check_allowed(user) || !war_declaration)
 		return
 
-	priority_announce(war_declaration, title = "Declaration of War", sound = 'sound/machines/alarm.ogg',  has_important_message = TRUE)
-
-	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
-
-	for(var/V in GLOB.syndicate_shuttle_boards)
-		var/obj/item/circuitboard/computer/syndicate_shuttle/board = V
-		board.challenge = TRUE
-
-	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/D in GLOB.jam_on_wardec)
-		D.jammed = TRUE
-
-	distribute_tc()
-
-	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
-	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)
-
-	qdel(src)
+	war_was_declared(user, memo = war_declaration)
 
 ///Admin only proc to bypass checks and force a war declaration. Button on antag panel.
 /obj/item/nuclear_challenge/proc/force_war()
@@ -80,24 +64,29 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	var/custom_threat = tgui_alert(usr, "Do you want to customize the declaration?", "Customize?", list("Yes", "No"))
 
 	if(custom_threat == "Yes")
-		war_declaration = tgui_input_text(usr, "Insert your custom declaration", "Declaration", multiline = TRUE)
+		war_declaration = tgui_input_text(usr, "Insert your custom declaration", "Declaration", multiline = TRUE, encode = FALSE)
 
 	if(!war_declaration)
 		to_chat(usr, span_warning("Invalid war declaration."))
 		return
 
-	priority_announce(war_declaration, title = "Declaration of War", sound = 'sound/machines/alarm.ogg', has_important_message = TRUE)
+	war_was_declared(memo = war_declaration)
 
-	for(var/V in GLOB.syndicate_shuttle_boards)
-		var/obj/item/circuitboard/computer/syndicate_shuttle/board = V
-		board.challenge = TRUE
-
-	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/D in GLOB.jam_on_wardec)
-		D.jammed = TRUE
+/obj/item/nuclear_challenge/proc/war_was_declared(mob/living/user, memo)
+	priority_announce(memo, title = "Declaration of War", sound = 'sound/machines/alarm.ogg', has_important_message = TRUE)
+	if(user)
+		to_chat(user, "You've attracted the attention of powerful forces within the syndicate. \
+			A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 
 	distribute_tc()
-
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
+	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)
+
+	for(var/obj/item/circuitboard/computer/syndicate_shuttle/board as anything in GLOB.syndicate_shuttle_boards)
+		board.challenge = TRUE
+
+	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/dock as anything in GLOB.jam_on_wardec)
+		dock.jammed = TRUE
 
 	qdel(src)
 
@@ -145,11 +134,10 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	if(!user.onSyndieBase())
 		to_chat(user, span_boldwarning("You have to be at your base to use this."))
 		return FALSE
-	if(world.time-SSticker.round_start_time > CHALLENGE_TIME_LIMIT)
+	if(world.time - SSticker.round_start_time > CHALLENGE_TIME_LIMIT)
 		to_chat(user, span_boldwarning("It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."))
 		return FALSE
-	for(var/V in GLOB.syndicate_shuttle_boards)
-		var/obj/item/circuitboard/computer/syndicate_shuttle/board = V
+	for(var/obj/item/circuitboard/computer/syndicate_shuttle/board as anything in GLOB.syndicate_shuttle_boards)
 		if(board.moved)
 			to_chat(user, span_boldwarning("The shuttle has already been moved! You have forfeit the right to declare war."))
 			return FALSE
@@ -157,6 +145,25 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 
 /obj/item/nuclear_challenge/clownops
 	uplink_type = /obj/item/uplink/clownop
+
+/// Subtype that does nothing but plays the war op message. Intended for debugging
+/obj/item/nuclear_challenge/literally_just_does_the_message
+	name = "\"Declaration of War\""
+	desc = "It's a Syndicate Declaration of War thing-a-majig, but it only plays the loud sound and message. Nothing else."
+	var/admin_only = TRUE
+
+/obj/item/nuclear_challenge/literally_just_does_the_message/check_allowed(mob/living/user)
+	if(admin_only && !check_rights_for(user.client, R_SPAWN|R_FUN|R_DEBUG))
+		to_chat(user, span_hypnophrase("You shouldn't have this!"))
+		return FALSE
+
+	return TRUE
+
+/obj/item/nuclear_challenge/literally_just_does_the_message/war_was_declared(mob/living/user, memo)
+	priority_announce(memo, title = "Declaration of War", sound = 'sound/machines/alarm.ogg', has_important_message = TRUE)
+
+/obj/item/nuclear_challenge/literally_just_does_the_message/distribute_tc()
+	return
 
 #undef CHALLENGE_TELECRYSTALS
 #undef CHALLENGE_TIME_LIMIT

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,7 +1,7 @@
 #define CHALLENGE_TELECRYSTALS 280
-#define CHALLENGE_TIME_LIMIT 5 MINUTES
+#define CHALLENGE_TIME_LIMIT (5 MINUTES)
 #define CHALLENGE_MIN_PLAYERS 50
-#define CHALLENGE_SHUTTLE_DELAY 25 MINUTES // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
+#define CHALLENGE_SHUTTLE_DELAY (25 MINUTES) // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
 
@@ -160,6 +160,14 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	return TRUE
 
 /obj/item/nuclear_challenge/literally_just_does_the_message/war_was_declared(mob/living/user, memo)
+#ifndef TESTING
+	// Reminder for our friends the admins
+	var/are_you_sure = tgui_alert(user, "Last second reminder that fake war declarations is a horrible idea and yes, \
+		the does the whole shebang, so be careful what you're doing.", "Don't do it", list("I'm sure", "You're right"))
+	if(are_you_sure != "I'm sure")
+		return
+#endif
+
 	priority_announce(memo, title = "Declaration of War", sound = 'sound/machines/alarm.ogg', has_important_message = TRUE)
 
 /obj/item/nuclear_challenge/literally_just_does_the_message/distribute_tc()


### PR DESCRIPTION
## About The Pull Request

Ugly

![image](https://user-images.githubusercontent.com/51863163/218280311-f282bd75-2f6e-4290-b3f4-d9d856ff36d3.png)

Nice

![image](https://user-images.githubusercontent.com/51863163/218280315-233da635-f777-4006-8778-c673b83e887e.png)

War dec: 

- TGUI inputs for syndicate declaration of war no longer double-encode sending customized messages into the announcement
- The alert box for the war declaration no longer has multiple errors (an extra bracket, negative seconds)
- Reduces some copy and paste in the war declaration device
- Adds a debug item that's a war declaration device but it only does the sound and message. Please don't fake war decs admins it's a horrible idea

Additionally

- Documented `priority_announcement`
- Ensures all uses of text and title in the priority announcement message are encoded (Some were not!)

## Why It's Good For The Game

Encoding looks bad, unencoded text is also bad

## Changelog

:cl: Melbert
fix: Syndicate declarations of war no longer murder apostrophes and their friends
fix: The alert box for the declaration of war no longer looks funky, and counts forwards in time rather than backwards
fix: Fixed being able to send unencoded HTML to newscasters
/:cl:

