### PR TITLE
Make some unrefined foods no longer give mood boosts

### DIFF
--- a/code/__HELPERS/randoms.dm
+++ b/code/__HELPERS/randoms.dm
@@ -21,7 +21,6 @@
 		/obj/item/food/soup,
 		/obj/item/food/grown,
 		/obj/item/food/grown/mushroom,
-		/obj/item/food/clothing,
 		/obj/item/food/meat/slab/human/mutant,
 		/obj/item/food/grown/ash_flora,
 		/obj/item/food/grown/nettle,

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -30,6 +30,8 @@ Behavior that's still missing from this component that original food items had t
 	var/junkiness = 0
 	///Message to send when eating
 	var/list/eatverbs
+	///Callback to be ran for checking if a carbon can eat something
+	var/datum/callback/can_eat
 	///Callback to be ran for when you take a bite of something
 	var/datum/callback/after_eat
 	///Callback to be ran for when you take a bite of something
@@ -54,6 +56,7 @@ Behavior that's still missing from this component that original food items had t
 	list/eatverbs = list("bite", "chew", "nibble", "gnaw", "gobble", "chomp"),
 	bite_consumption = 2,
 	junkiness,
+	datum/callback/can_eat,
 	datum/callback/after_eat,
 	datum/callback/on_consume,
 	datum/callback/check_liked,
@@ -69,6 +72,7 @@ Behavior that's still missing from this component that original food items had t
 	src.eat_time = eat_time
 	src.eatverbs = string_list(eatverbs)
 	src.junkiness = junkiness
+	src.can_eat = can_eat
 	src.after_eat = after_eat
 	src.on_consume = on_consume
 	src.tastes = string_assoc_list(tastes)
@@ -130,6 +134,7 @@ Behavior that's still missing from this component that original food items had t
 	list/eatverbs,
 	bite_consumption,
 	junkiness,
+	datum/callback/can_eat,
 	datum/callback/after_eat,
 	datum/callback/on_consume,
 	datum/callback/check_liked,
@@ -183,6 +188,8 @@ Behavior that's still missing from this component that original food items had t
 		src.eat_time = eat_time
 	if(!isnull(junkiness))
 		src.junkiness = junkiness
+	if(!isnull(can_eat))
+		src.can_eat = can_eat
 	if(!isnull(after_eat))
 		src.after_eat = after_eat
 	if(!isnull(on_consume))
@@ -194,6 +201,7 @@ Behavior that's still missing from this component that original food items had t
 	setup_initial_reagents(initial_reagents)
 
 /datum/component/edible/Destroy(force, silent)
+	QDEL_NULL(can_eat)
 	QDEL_NULL(after_eat)
 	QDEL_NULL(on_consume)
 	QDEL_NULL(check_liked)
@@ -457,6 +465,8 @@ Behavior that's still missing from this component that original food items had t
 	if(!iscarbon(eater))
 		return FALSE
 	var/mob/living/carbon/C = eater
+	if(can_eat && !can_eat.Invoke(C))
+		return FALSE
 	var/covered = ""
 	if(C.is_mouth_covered(ITEM_SLOT_HEAD))
 		covered = "headgear"

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -22,6 +22,8 @@ Behavior that's still missing from this component that original food items had t
 	var/food_flags = NONE
 	///Bitfield of the types of this food
 	var/foodtypes = NONE
+	///Unrefined food is too boring to give mood boosts
+	var/refined = TRUE
 	///Amount of seconds it takes to eat this food
 	var/eat_time = 30
 	///Defines how much it lowers someones satiety (Need to eat, essentialy)
@@ -45,6 +47,7 @@ Behavior that's still missing from this component that original food items had t
 	list/initial_reagents,
 	food_flags = NONE,
 	foodtypes = NONE,
+	refined = TRUE,
 	volume = 50,
 	eat_time = 10,
 	list/tastes,
@@ -61,6 +64,7 @@ Behavior that's still missing from this component that original food items had t
 	src.bite_consumption = bite_consumption
 	src.food_flags = food_flags
 	src.foodtypes = foodtypes
+	src.refined = refined
 	src.volume = volume
 	src.eat_time = eat_time
 	src.eatverbs = string_list(eatverbs)
@@ -119,6 +123,7 @@ Behavior that's still missing from this component that original food items had t
 	list/initial_reagents,
 	food_flags = NONE,
 	foodtypes = NONE,
+	refined,
 	volume,
 	eat_time,
 	list/tastes,
@@ -170,6 +175,8 @@ Behavior that's still missing from this component that original food items had t
 	// just set these directly
 	if(!isnull(bite_consumption))
 		src.bite_consumption = bite_consumption
+	if(!isnull(refined))
+		src.refined = refined
 	if(!isnull(volume))
 		src.volume = volume
 	if(!isnull(eat_time))
@@ -508,9 +515,12 @@ Behavior that's still missing from this component that original food items had t
 			H.adjust_disgust(11 + 15 * fraction)
 			H.add_mood_event("gross_food", /datum/mood_event/gross_food)
 		if(FOOD_LIKED)
-			to_chat(H,span_notice("I love this taste!"))
 			H.adjust_disgust(-5 + -2.5 * fraction)
-			H.add_mood_event("fav_food", /datum/mood_event/favorite_food)
+			if(refined)
+				to_chat(H,span_notice("I love this taste!"))
+				H.add_mood_event("fav_food", /datum/mood_event/favorite_food)
+			else
+				to_chat(H,span_notice("I like this taste, but I'd prefer something more refined."))
 			if(istype(parent, /obj/item/food))
 				var/obj/item/food/memorable_food = parent
 				if(memorable_food.venue_value >= FOOD_PRICE_EXOTIC)

--- a/code/datums/elements/food/fried_item.dm
+++ b/code/datums/elements/food/fried_item.dm
@@ -46,6 +46,7 @@
 		bite_consumption = 2, \
 		food_flags = FOOD_FINGER_FOOD, \
 		junkiness = 10, \
+		refined = TRUE, \
 		foodtypes = FRIED, \
 	)
 

--- a/code/datums/materials/meat.dm
+++ b/code/datums/materials/meat.dm
@@ -33,6 +33,7 @@
 	source.AddComponent(/datum/component/edible, \
 		initial_reagents = list(/datum/reagent/consumable/nutriment = nutriment_count, /datum/reagent/consumable/cooking_oil = oil_count), \
 		foodtypes = RAW | MEAT | GROSS, \
+		refined = FALSE, \
 		eat_time = 3 SECONDS, \
 		tastes = list("Fleshy"))
 

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -16,6 +16,8 @@
 	var/food_flags
 	///Bitflag of the types of food this food is
 	var/foodtypes
+	///Whether the food can give mood boost
+	var/refined = TRUE
 	///Amount of volume the food can contain
 	var/max_volume
 	///How long it will take to eat this food without any other modifiers
@@ -72,6 +74,7 @@
 		initial_reagents = food_reagents,\
 		food_flags = food_flags,\
 		foodtypes = foodtypes,\
+		refined = refined,\
 		volume = max_volume,\
 		eat_time = eat_time,\
 		tastes = tastes,\

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -293,6 +293,7 @@
 	eatverbs = list("devour")
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
 	foodtypes = GORE | MEAT | RAW
+	refined = FALSE
 	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/consumable/liquidgibs = 5)
 	decomp_req_handle = TRUE
 	ant_attracting = FALSE

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -56,6 +56,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		AddComponent(/datum/component/edible,\
 			initial_reagents = food_reagents,\
 			foodtypes = RAW | MEAT | GORE,\
+			refined = FALSE,\
 			volume = reagent_vol,\
 			after_eat = CALLBACK(src, PROC_REF(OnEatFrom)))
 

--- a/code/modules/unit_tests/food_edibility_check.dm
+++ b/code/modules/unit_tests/food_edibility_check.dm
@@ -5,7 +5,6 @@
 	var/list/not_food = list(
 		/obj/item/food/grown,
 		/obj/item/food/grown/mushroom,
-		/obj/item/food/clothing,
 		/obj/item/food/meat/slab/human/mutant,
 		/obj/item/food/grown/shell)
 


### PR DESCRIPTION
## About The Pull Request
Makes several types of food such as clothing, organs, and dead mice no longer give mood boosts. This primarily applies to lizards and moths, who despite having entire categories of cuisine dedicated to them, currently have no reason whatsoever to engage with it instead of scooping food off the ground.

Some cute interactions result from this change. Dead mice are unrefined and do not give mood boosts to lizards on their own, but put it on a stick and now it's a proper meal! Frying foods always bestows the refined attribute, so the absolute minimum a moth needs to do to get their mood boost back is just go to the kitchen and ask the chef to fry their clothes.

While I was in there I tried making the whole moths eating clothes thing less awful. No more invisible fake food with infinite reagents.
## Why It's Good For The Game
Cloth can't taste _that_ good.

Also players might actually have a reason to engage with Moffic and Tiziran cuisines, which are some of the coolest flavor content I've seen. In particular I'm hoping to give moths a reason to interact with the cook.
## Changelog
:cl:
balance: certain "unrefined" foods like raw organs and clothes no longer give mood boosts
code: made moth clothes consumption code less weird
/:cl:
