### PR TITLE
Mice and Regal Rats won't spawn in the icebox solar panels

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -854,3 +854,8 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define HEALING_TOUCH_ANYONE "healing_touch_anyone"
 #define HEALING_TOUCH_NOT_SELF "healing_touch_not_self"
 #define HEALING_TOUCH_SELF_ONLY "healing_touch_self_only"
+
+/// Default minimum body temperature mobs can exist in before taking damage
+#define NPC_DEFAULT_MIN_TEMP 250
+/// Default maximum body temperature mobs can exist in before taking damage
+#define NPC_DEFAULT_MAX_TEMP 350

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -16,26 +16,20 @@ SUBSYSTEM_DEF(minor_mapping)
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
 	var/list/exposed_wires = find_exposed_wires()
 
-	var/mob/living/basic/mouse/mouse
 	var/turf/open/proposed_turf
-
-
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
-
-		if(!istype(proposed_turf))
+		if (!istype(proposed_turf)||
+			!proposed_turf.air.has_gas(/datum/gas/oxygen, 5) ||
+			proposed_turf.temperature > NPC_DEFAULT_MAX_TEMP ||
+			proposed_turf.temperature < NPC_DEFAULT_MIN_TEMP)
 			continue
 
-		if(prob(PROB_MOUSE_SPAWN))
-			if(!mouse)
-				mouse = new(proposed_turf)
-			else
-				mouse.forceMove(proposed_turf)
+		num_mice -= 1
+		if (prob(PROB_MOUSE_SPAWN))
+			new /mob/living/basic/mouse(proposed_turf)
 		else
-			mouse = new /mob/living/simple_animal/hostile/regalrat/controlled(proposed_turf)
-		if(proposed_turf.air.has_gas(/datum/gas/oxygen, 5))
-			num_mice -= 1
-			mouse = null
+			new /mob/living/simple_animal/hostile/regalrat/controlled(proposed_turf)
 
 /datum/controller/subsystem/minor_mapping/proc/place_satchels(amount=10)
 	var/list/turfs = find_satchel_suitable_turfs()

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(minor_mapping)
 	var/turf/open/proposed_turf
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
-		if (!istype(proposed_turf)||
+		if (!istype(proposed_turf) ||
 			!proposed_turf.air.has_gas(/datum/gas/oxygen, 5) ||
 			proposed_turf.temperature > NPC_DEFAULT_MAX_TEMP ||
 			proposed_turf.temperature < NPC_DEFAULT_MIN_TEMP)

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(minor_mapping)
 		return FALSE
 	var/datum/gas_mixture/turf/turf_gasmix = proposed_turf.air
 	var/turf_temperature = proposed_turf.temperature
-	return turf_gasmix.has_gas(/datum/gas/oxygen, 5) && proposed_turf.temperature < NPC_DEFAULT_MAX_TEMP && proposed_turf.temperature > NPC_DEFAULT_MIN_TEMP
+	return turf_gasmix.has_gas(/datum/gas/oxygen, 5) && turf_temperature < NPC_DEFAULT_MAX_TEMP && turf_temperature > NPC_DEFAULT_MIN_TEMP
 
 /datum/controller/subsystem/minor_mapping/proc/place_satchels(amount=10)
 	var/list/turfs = find_satchel_suitable_turfs()

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -19,9 +19,9 @@ SUBSYSTEM_DEF(minor_mapping)
 	var/turf/open/proposed_turf
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
-		if (!istype(proposed_turf) ||
-			!proposed_turf.air.has_gas(/datum/gas/oxygen, 5) ||
-			proposed_turf.temperature > NPC_DEFAULT_MAX_TEMP ||
+		if (!istype(proposed_turf) || \
+			!proposed_turf.air.has_gas(/datum/gas/oxygen, 5) || \
+			proposed_turf.temperature > NPC_DEFAULT_MAX_TEMP || \
 			proposed_turf.temperature < NPC_DEFAULT_MIN_TEMP)
 			continue
 

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -15,21 +15,25 @@ SUBSYSTEM_DEF(minor_mapping)
 
 /datum/controller/subsystem/minor_mapping/proc/trigger_migration(num_mice=10)
 	var/list/exposed_wires = find_exposed_wires()
-
 	var/turf/open/proposed_turf
 	while((num_mice > 0) && exposed_wires.len)
 		proposed_turf = pick_n_take(exposed_wires)
-		if (!istype(proposed_turf) || \
-			!proposed_turf.air.has_gas(/datum/gas/oxygen, 5) || \
-			proposed_turf.temperature > NPC_DEFAULT_MAX_TEMP || \
-			proposed_turf.temperature < NPC_DEFAULT_MIN_TEMP)
+		if (!valid_mouse_turf(proposed_turf))
 			continue
 
-		num_mice -= 1
+		num_mice--
 		if (prob(PROB_MOUSE_SPAWN))
 			new /mob/living/basic/mouse(proposed_turf)
 		else
 			new /mob/living/simple_animal/hostile/regalrat/controlled(proposed_turf)
+
+/// Returns true if a mouse won't die if spawned on this turf
+/datum/controller/subsystem/minor_mapping/proc/valid_mouse_turf(turf/open/proposed_turf)
+	if(!istype(proposed_turf))
+		return FALSE
+	var/datum/gas_mixture/turf/turf_gasmix = proposed_turf.air
+	var/turf_temperature = proposed_turf.temperature
+	return turf_gasmix.has_gas(/datum/gas/oxygen, 5) && proposed_turf.temperature < NPC_DEFAULT_MAX_TEMP && proposed_turf.temperature > NPC_DEFAULT_MIN_TEMP
 
 /datum/controller/subsystem/minor_mapping/proc/place_satchels(amount=10)
 	var/list/turfs = find_satchel_suitable_turfs()

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -89,9 +89,9 @@
 	var/unsuitable_atmos_damage = 1
 
 	///Minimal body temperature without receiving damage
-	var/minimum_survivable_temperature = 250
+	var/minimum_survivable_temperature = NPC_DEFAULT_MIN_TEMP
 	///Maximal body temperature without receiving damage
-	var/maximum_survivable_temperature = 350
+	var/maximum_survivable_temperature = NPC_DEFAULT_MAX_TEMP
 	///This damage is taken when the body temp is too cold. Set both this and unsuitable_heat_damage to 0 to avoid adding the basic_body_temp_sensitive element.
 	var/unsuitable_cold_damage = 1
 	///This damage is taken when the body temp is too hot. Set both this and unsuitable_cold_damage to 0 to avoid adding the basic_body_temp_sensitive element.

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -38,7 +38,6 @@
 	var/static/list/roach_drops = list(/obj/effect/decal/cleanable/insectguts)
 	AddElement(/datum/element/death_drops, roach_drops)
 	AddElement(/datum/element/swabable, cockroach_cell_line, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 7)
-	AddElement(/datum/element/basic_body_temp_sensitive, 270, INFINITY)
 	AddComponent(/datum/component/squashable, squash_chance = 50, squash_damage = 1)
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 

--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -1,4 +1,3 @@
-
 /mob/living/simple_animal/hostile/regalrat
 	name = "feral regal rat"
 	desc = "An evolved rat, created through some strange science. They lead nearby rats with deadly efficiency to protect their kingdom. Not technically a king."

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -59,9 +59,9 @@
 	var/stamina_recovery = 5
 
 	///Minimal body temperature without receiving damage
-	var/minbodytemp = 250
+	var/minbodytemp = NPC_DEFAULT_MIN_TEMP
 	///Maximal body temperature without receiving damage
-	var/maxbodytemp = 350
+	var/maxbodytemp = NPC_DEFAULT_MAX_TEMP
 	///This damage is taken when the body temp is too cold.
 	var/unsuitable_cold_damage
 	///This damage is taken when the body temp is too hot.


### PR DESCRIPTION
## About The Pull Request

Fixes #73238

This adds a temperature check to the turf locator in the mice migration event.
Also it refactors the check a bit because its loop seemed... odd? If there was some reason the old version was more efficient let me know but I can't see a purpose to do it that way around.
Also then the same numbers were being used in 3 separate files so I moved it into a define.
_Finally_ I removed a redundant element from the cockroach while I was looking at the files.

There was a moment when I started looking at this where I thought "I should add a generic helper proc which is given a turf and a mob and can tell you if it would die if it spawned on that turf".
Then I looked at lungs and immediately decided that was going to be a massive amount of work for this trivial bug fix... maybe one day.

## Why It's Good For The Game

This was sparing mappers from the punishment whoever added this feature surely intended for them to suffer.
Also it's just a bit sad to notify ghosts to join a ghost role which will die instantly 😢

## Changelog

:cl:
fix: Mice and Regal Rats will no longer spawn in icebox's solar panels and die of cold.
/:cl: