### PR TITLE
Modify photocopiers to no longer cause drones to delete toner

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -199,8 +199,10 @@
 			if(busy)
 				to_chat(usr, span_warning("[src] is currently busy copying something. Please wait until it is finished."))
 				return
-			if(issilicon(usr) || (ishuman(usr) && !usr.put_in_hands(toner_cartridge)))
+			var/success = usr.put_in_hands(toner_cartridge)
+			if(!success)
 				toner_cartridge.forceMove(drop_location())
+
 			toner_cartridge = null
 			return TRUE
 


### PR DESCRIPTION
A non-human user would skip the "put in hands" call, and just have the reference to the toner be set to null without actually moving it.

Silicons still just make the toner drop on the floor as before.

No doubt in the future, when Ian is given a mouth slot to do paperwork, he too will be able to use the photocopier.

:cl: coiax
fix: Drones no longer destroy toner cartridges when ejecting them from photocopiers.
/:cl:
## Why It's Good For The Game

It seems non-intuitive that interacting with photocopiers as a drone or other non-human with hands would cause the toner to get marooned inside the photocopier.