### PR TITLE
Fixes kitchen spike add context screentip runtime

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -85,6 +85,9 @@
 	. += "A <b>crowbar</b> could remove those spikes."
 
 /obj/structure/kitchenspike/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(isnull(held_item))
+		return NONE
+
 	if(held_item.tool_behaviour == TOOL_CROWBAR)
 		context[SCREENTIP_CONTEXT_LMB] = "Remove Spikes"
 		return CONTEXTUAL_SCREENTIP_SET

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -19,6 +19,9 @@
 	. += "You could attach <b>[MEATSPIKE_IRONROD_REQUIREMENT]</b> iron rods to it to create a <b>Meat Spike</b>."
 
 /obj/structure/kitchenspike_frame/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(isnull(held_item))
+		return NONE
+
 	var/message = ""
 	if(held_item.tool_behaviour == TOOL_WELDER)
 		message = "Deconstruct"


### PR DESCRIPTION
## About The Pull Request

`held_item` does not always exist, hovering over spikes with empty hands caused a runtime error

## Changelog

:cl: Melbert
fix: Fixed a runtime from hovering over a meat spike / kitchen spike with an empty hand
/:cl:
