### PR TITLE
Fixes an examine runtime with syndicate bombs

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -115,7 +115,8 @@
 /obj/machinery/syndicatebomb/examine(mob/user)
 	. = ..()
 	. += {"The patented external shell design is resistant to "probably all" forms of external explosive compression, protecting the electronically-trigged bomb core from accidental early detonation."}
-	. += "A small window reveals some information about the payload: [payload.desc]."
+	if(istype(payload))
+		. += "A small window reveals some information about the payload: [payload.desc]."
 	if(examinable_countdown)
 		. += {"A digital display on it reads "[seconds_remaining()]"."}
 	else

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -114,11 +114,11 @@
 
 /obj/machinery/syndicatebomb/examine(mob/user)
 	. = ..()
-	. += {"The patented external shell design is resistant to "probably all" forms of external explosive compression, protecting the electronically-trigged bomb core from accidental early detonation."}
+	. += "The patented external shell design is resistant to \"probably all\" forms of external explosive compression, protecting the electronically-trigged bomb core from accidental early detonation."
 	if(istype(payload))
 		. += "A small window reveals some information about the payload: [payload.desc]."
 	if(examinable_countdown)
-		. += {"A digital display on it reads "[seconds_remaining()]"."}
+		. += "A digital display on it reads \"[seconds_remaining()]\"."
 	else
 		. +={"The digital display on it is inactive."}
 


### PR DESCRIPTION
## About The Pull Request

`payload` is, not surprisingly, easily null-able if it's removed

## Why It's Good For The Game

@san7890 Why did we even add an examine message about the payload here? That's lame, now you can't trick people with empty bomb shells

## Changelog

:cl: Melbert
fix: Fixed a runtime with examining empty bomb frames
/:cl:
