### PR TITLE
Change always() to success() || failure() in CI

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -65,7 +65,7 @@ jobs:
           ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
         uses: yogstation13/DreamAnnotate@v2
-        if: always()
+        if: success() || failure()
         with:
           outputFile: output-annotations.txt
 
@@ -144,7 +144,7 @@ jobs:
       major: ${{ matrix.setup.major }}
       minor: ${{ matrix.setup.minor }}
   compare_screenshots:
-    if: "!contains(github.event.head_commit.message, '[ci skip]') && always()"
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && (success() || failure())"
     needs: [run_all_tests, run_alternate_tests]
     name: Compare Screenshot Tests
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Checking if this fixes merge queue. This ideally doesn't pass if CI is cancelled, which is a requirement right now for merge queue to work because reasons

Also:
![image](https://user-images.githubusercontent.com/35135081/218338953-96fa5b4e-fc07-4b3a-9ab5-f50a6772cd01.png)
