### PR TITLE
Fixes the benches' appearance and odd sitting offset

### DIFF
--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -100,7 +100,7 @@ COLORED_SOFA(/obj/structure/chair/sofa, maroon, SOFA_MAROON)
 	desc = "Perfectly designed to be comfortable to sit on, and hellish to sleep on."
 	icon_state = "bench_middle"
 	greyscale_config = /datum/greyscale_config/bench_middle
-	greyscale_colors = "#2E668A"
+	greyscale_colors = "#af7d28"
 
 /obj/structure/chair/sofa/bench/left
 	icon_state = "bench_left"
@@ -118,14 +118,6 @@ COLORED_SOFA(/obj/structure/chair/sofa, maroon, SOFA_MAROON)
 	icon_state = "bench_solo"
 	greyscale_config = /datum/greyscale_config/bench_solo
 
-/obj/structure/chair/sofa/bench/post_buckle_mob(mob/living/Mob)
-	if(src.dir == EAST || WEST)
-		Mob.pixel_y += 6
-	.=..()
-
-/obj/structure/chair/sofa/bench/post_unbuckle_mob(mob/living/Mob)
-	if(src.dir == EAST || WEST)
-		Mob.pixel_y -= 6
 
 // Bamboo benches
 /obj/structure/chair/sofa/bamboo


### PR DESCRIPTION
## About The Pull Request
Introduced in https://github.com/tgstation/tgstation/pull/73057, undocumented, was a change in the offset of players sitting in benches, which just made it look like if everyone was standing on benches, rather than sitting on them. I can understand the original goal behind that change (after discussing with LT3 about it), but I still think that, for one direction where it might _arguably_ look better, _every_ other direction looks absolutely awful, and goes against the norm when it comes to sitting on an chair/sofa/anything you can buckle onto that serves as a place to sit.

Introduced in https://github.com/tgstation/tgstation/pull/73243, undocumented, was a new color for benches that just made them look blue rather than the brown they were meant to be. I'm returning them to their prior color, as I think that it fits a lot better in its surroundings in light brown than it did with dirty blue.

This fixes both of these issues, bringing the benches back to consistency with the rest.

## Why It's Good For The Game
It just looks more consistent with everything else.
![image](https://user-images.githubusercontent.com/58045821/218340276-ee42d15b-fc54-4e56-b565-164b8a8b4db2.png)


## Changelog

:cl: GoldenAlpharex
fix: Sitting on benches no longer gives you a weird offset that makes you look like you're standing on them.
fix: Returns benches to their original light brown color, rather than the middle between brown and cyan that they were at for a bit.
/:cl: