### PR TITLE
Only cancel concurrent CI in the same PR

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -14,7 +14,7 @@ jobs:
     name: Run Linters
     runs-on: ubuntu-20.04
     concurrency:
-      group: run_linters-${{ github.ref }}
+      group: run_linters-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -68,7 +68,7 @@ jobs:
     name: Compile Maps
     runs-on: ubuntu-20.04
     concurrency:
-      group: compile_all_maps-${{ github.ref }}
+      group: compile_all_maps-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -91,7 +91,7 @@ jobs:
       maps: ${{ steps.map_finder.outputs.maps }}
       alternate_tests: ${{ steps.alternate_test_finder.outputs.alternate_tests }}
     concurrency:
-      group: find_all_maps-${{ github.ref }}
+      group: find_all_maps-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
@@ -116,7 +116,7 @@ jobs:
       matrix:
         map: ${{ fromJSON(needs.find_all_maps.outputs.maps).paths }}
     concurrency:
-      group: run_all_tests-${{ github.ref }}-${{ matrix.map }}
+      group: run_all_tests-${{ github.head_ref || github.run_id }}-${{ matrix.map }}
       cancel-in-progress: true
     uses: ./.github/workflows/run_integration_tests.yml
     with:
@@ -130,7 +130,7 @@ jobs:
       matrix:
         setup: ${{ fromJSON(needs.find_all_maps.outputs.alternate_tests) }}
     concurrency:
-      group: run_all_tests-${{ github.ref }}-${{ matrix.setup.major }}.${{ matrix.setup.minor }}-${{ matrix.setup.map }}
+      group: run_all_tests-${{ github.head_ref || github.run_id }}-${{ matrix.setup.major }}.${{ matrix.setup.minor }}-${{ matrix.setup.map }}
       cancel-in-progress: true
     uses: ./.github/workflows/run_integration_tests.yml
     with:
@@ -177,7 +177,7 @@ jobs:
     name: Windows Build
     runs-on: windows-latest
     concurrency:
-      group: test_windows-${{ github.ref }}
+      group: test_windows-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
More merge queue bullshit. Cancels are counted as failures, and even though on my test branch it worked completely fine, when trying on two real PRs, it did not.

This makes it so merges into master might mess with CI clogging again, but also merge queue is going to do that on its own, and the gain is worth it.

![image](https://user-images.githubusercontent.com/35135081/218340666-6f937611-c47e-4122-b4b8-b84e8edcc1e9.png)
