### PR TITLE
Don't error on dupe configs in other files.

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -239,7 +239,7 @@
 			log_config(log_message)
 			stack_trace(log_message)
 		else
-			if(E.modified && !E.dupes_allowed)
+			if(E.modified && !E.dupes_allowed && E.resident_file == filename)
 				log_config_error("Duplicate setting for [entry] ([value], [E.resident_file]) detected! Using latest.")
 
 		E.resident_file = filename


### PR DESCRIPTION
It ruins my whole every server defaults -> per server overrides model for config management

:cl:
config: Repeated configs in other files (from $include) will no longer trigger a config error. Repeated configs in the same file still will.
config: In all cases the new value will still be used
/:cl:
