### PR TITLE
Prevents nulls in the always_visible_inventory list (which caused runtimes blocking PM reapplication)

### DIFF
--- a/code/datums/components/fov_handler.dm
+++ b/code/datums/components/fov_handler.dm
@@ -96,13 +96,15 @@
 /datum/component/fov_handler/proc/remove_mask()
 	var/mob/parent_mob = parent
 	var/client/parent_client = parent_mob.client
+	// Prevents stupid ass hard deletes
+	parent_mob.hud_used.always_visible_inventory -= blocker_mask
+	parent_mob.hud_used.always_visible_inventory -= visual_shadow
 	if(!parent_client) //Love client volatility!!
 		return
 	applied_mask = FALSE
 	parent_client.screen -= blocker_mask
 	parent_client.screen -= visual_shadow
-	parent_mob.hud_used.always_visible_inventory -= blocker_mask
-	parent_mob.hud_used.always_visible_inventory -= visual_shadow
+
 
 /datum/component/fov_handler/proc/add_mask()
 	var/mob/parent_mob = parent


### PR DESCRIPTION

## About The Pull Request

Attempting to add a null to images (even in a list) is a runtime, which in this case blocks off the rest of show_hud, breaking planemasters and other shit

## Why It's Good For The Game

Closes #73387, closes #73364

## Changelog
:cl:
fix: Equipping an fov item, disconnecting, waiting 6 minutes and reconnecting will no longer break your game
/:cl:
