### PR TITLE
Fix Tiziran canned goods from being eaten by ants

### DIFF
--- a/code/game/objects/items/food/lizard.dm
+++ b/code/game/objects/items/food/lizard.dm
@@ -805,6 +805,7 @@
 	tastes = list("slime" = 1, "burning" = 1, "salt" = 1)
 	foodtypes = SEAFOOD | GORE
 	w_class = WEIGHT_CLASS_SMALL
+	preserved_food = TRUE
 
 /obj/item/food/desert_snails
 	name = "canned desert snails"
@@ -818,6 +819,7 @@
 	tastes = list("snails" = 1)
 	foodtypes = MEAT | GORE
 	w_class = WEIGHT_CLASS_SMALL
+	preserved_food = TRUE
 
 /obj/item/food/larvae
 	name = "canned bee larva"
@@ -831,3 +833,4 @@
 	tastes = list("sweet bugs" = 1)
 	foodtypes = MEAT | GORE | BUGS
 	w_class = WEIGHT_CLASS_SMALL
+	preserved_food = TRUE


### PR DESCRIPTION
Because these canned goods didn't inherit from /obj/item/food/canned, they didn't inherit the imperishable nature. Ideally in the future, they'll inherit properly from that, but they'll need trash and open sprites to make that happen.

Until then, let's just make the goods non-perishable.

:cl: coiax
fix: Tiziran canned goods no longer decompose into mush.
/:cl:


## Why It's Good For The Game
Inconsistent that canned goods would turn to mush if left on the ground. Doesn't happen to other (non-opened) canned goods.
