### PR TITLE
Removes tab cycling between TGUI say channels in asay

### DIFF
--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -1,5 +1,6 @@
 import { CHANNELS } from '../constants';
 import { Modal } from '../types';
+
 // Insert the names of channels you want to not cycle on tab here
 const BLACKLIST = ['Admin'];
 const BLACKLISTED_CHANNEL_INDICES = CHANNELS.map((channel, index) => {

--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -2,10 +2,9 @@ import { CHANNELS } from '../constants';
 import { Modal } from '../types';
 // Insert the names of channels you want to not cycle on tab here
 const BLACKLIST = ['Admin'];
-const BLACKLISTED_CHANNELS = [] as number[];
-CHANNELS.forEach((channel, index) => {
+const BLACKLISTED_CHANNEL_INDICES = CHANNELS.map((channel, index) => {
   if (BLACKLIST.includes(channel)) {
-    BLACKLISTED_CHANNELS.push(index);
+    return index;
   }
 });
 
@@ -21,10 +20,10 @@ export const handleIncrementChannel = function (this: Modal) {
     this.timers.channelDebounce({ mode: true });
   }
   this.fields.radioPrefix = '';
-  if (BLACKLISTED_CHANNELS.includes(channel)) {
+  if (BLACKLISTED_CHANNEL_INDICES.includes(channel)) {
     return;
   }
-  if (BLACKLISTED_CHANNELS.length === CHANNELS.length) {
+  if (BLACKLISTED_CHANNEL_INDICES.length === CHANNELS.length) {
     this.setState({
       buttonContent: CHANNELS[channel],
       channel: channel,
@@ -37,7 +36,7 @@ export const handleIncrementChannel = function (this: Modal) {
       this.timers.channelDebounce({ mode: true });
       channel = 0;
     }
-  } while (BLACKLISTED_CHANNELS.includes(channel));
+  } while (BLACKLISTED_CHANNEL_INDICES.includes(channel));
   if (channel === CHANNELS.indexOf('OOC')) {
     // Disables thinking indicator for OOC channel
     this.timers.channelDebounce({ mode: false });

--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -44,6 +44,6 @@ export const handleIncrementChannel = function (this: Modal) {
   }
   this.setState({
     buttonContent: CHANNELS[channel],
-    channel: channel,
+    channel,
   });
 };

--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -20,7 +20,7 @@ export const handleIncrementChannel = function (this: Modal) {
     return;
   }
   this.fields.radioPrefix = '';
-  if (channel === CHANNELS.length - 1) {
+  if (channel === CHANNELS.length - 2) {
     this.timers.channelDebounce({ mode: true });
     this.setState({
       buttonContent: CHANNELS[0],

--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -1,7 +1,7 @@
 import { CHANNELS } from '../constants';
 import { Modal } from '../types';
 const ADMIN_CHANNEL = CHANNELS.findIndex(
-  (channel) => channel == 'Admin'
+  (channel) => channel === 'Admin'
 ) as number;
 /**
  * Increments the channel or resets to the beginning of the list.

--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -6,7 +6,7 @@ const BLACKLISTED_CHANNEL_INDICES = CHANNELS.map((channel, index) => {
   if (BLACKLIST.includes(channel)) {
     return index;
   }
-});
+}).filter((x) => x !== undefined);
 
 /**
  * Increments the channel or resets to the beginning of the list.

--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -1,54 +1,49 @@
 import { CHANNELS } from '../constants';
 import { Modal } from '../types';
-const ADMIN_CHANNEL = CHANNELS.findIndex(
-  (channel) => channel === 'Admin'
-) as number;
+// Insert the names of channels you want to not cycle on tab here
+const BLACKLIST = ['Admin'];
+const BLACKLISTED_CHANNELS = [] as number[];
+CHANNELS.forEach((channel, index) => {
+  if (BLACKLIST.includes(channel)) {
+    BLACKLISTED_CHANNELS.push(index);
+  }
+});
+
 /**
  * Increments the channel or resets to the beginning of the list.
  * If the user switches between IC/OOC, messages Byond to toggle thinking
  * indicators.
  */
 export const handleIncrementChannel = function (this: Modal) {
-  const { channel } = this.state;
+  let { channel } = this.state;
   const { radioPrefix } = this.fields;
   if (radioPrefix === ':b ') {
     this.timers.channelDebounce({ mode: true });
   }
-  if (channel === ADMIN_CHANNEL) {
+  this.fields.radioPrefix = '';
+  if (BLACKLISTED_CHANNELS.includes(channel)) {
+    return;
+  }
+  if (BLACKLISTED_CHANNELS.length === CHANNELS.length) {
     this.setState({
       buttonContent: CHANNELS[channel],
       channel: channel,
     });
     return;
   }
-  this.fields.radioPrefix = '';
-  if (
-    channel === CHANNELS.length - 1 ||
-    (channel === ADMIN_CHANNEL - 1 && CHANNELS.length - 1 === ADMIN_CHANNEL)
-  ) {
-    this.timers.channelDebounce({ mode: true });
-    this.setState({
-      buttonContent: CHANNELS[0],
-      channel: 0,
-    });
-  } else {
-    if (channel === 2) {
-      // Disables thinking indicator for OOC channel
-      this.timers.channelDebounce({ mode: false });
+  do {
+    channel++;
+    if (channel === CHANNELS.length) {
+      this.timers.channelDebounce({ mode: true });
+      channel = 0;
     }
-    if (
-      channel === ADMIN_CHANNEL - 1 &&
-      CHANNELS.length - 1 !== ADMIN_CHANNEL
-    ) {
-      this.setState({
-        buttonContent: CHANNELS[channel + 2],
-        channel: channel + 2,
-      });
-    } else {
-      this.setState({
-        buttonContent: CHANNELS[channel + 1],
-        channel: channel + 1,
-      });
-    }
+  } while (BLACKLISTED_CHANNELS.includes(channel));
+  if (channel === CHANNELS.indexOf('OOC')) {
+    // Disables thinking indicator for OOC channel
+    this.timers.channelDebounce({ mode: false });
   }
+  this.setState({
+    buttonContent: CHANNELS[channel],
+    channel: channel,
+  });
 };

--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -27,7 +27,7 @@ export const handleIncrementChannel = function (this: Modal) {
   if (BLACKLISTED_CHANNEL_INDICES.length === CHANNELS.length) {
     this.setState({
       buttonContent: CHANNELS[channel],
-      channel: channel,
+      channel,
     });
     return;
   }

--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -12,6 +12,13 @@ export const handleIncrementChannel = function (this: Modal) {
   if (radioPrefix === ':b ') {
     this.timers.channelDebounce({ mode: true });
   }
+  if (channel === 4) {
+    this.setState({
+      buttonContent: CHANNELS[channel],
+      channel: channel,
+    });
+    return;
+  }
   this.fields.radioPrefix = '';
   if (channel === CHANNELS.length - 1) {
     this.timers.channelDebounce({ mode: true });

--- a/tgui/packages/tgui-say/handlers/incrementChannel.tsx
+++ b/tgui/packages/tgui-say/handlers/incrementChannel.tsx
@@ -1,6 +1,8 @@
 import { CHANNELS } from '../constants';
 import { Modal } from '../types';
-
+const ADMIN_CHANNEL = CHANNELS.findIndex(
+  (channel) => channel == 'Admin'
+) as number;
 /**
  * Increments the channel or resets to the beginning of the list.
  * If the user switches between IC/OOC, messages Byond to toggle thinking
@@ -12,7 +14,7 @@ export const handleIncrementChannel = function (this: Modal) {
   if (radioPrefix === ':b ') {
     this.timers.channelDebounce({ mode: true });
   }
-  if (channel === 4) {
+  if (channel === ADMIN_CHANNEL) {
     this.setState({
       buttonContent: CHANNELS[channel],
       channel: channel,
@@ -20,7 +22,10 @@ export const handleIncrementChannel = function (this: Modal) {
     return;
   }
   this.fields.radioPrefix = '';
-  if (channel === CHANNELS.length - 2) {
+  if (
+    channel === CHANNELS.length - 1 ||
+    (channel === ADMIN_CHANNEL - 1 && CHANNELS.length - 1 === ADMIN_CHANNEL)
+  ) {
     this.timers.channelDebounce({ mode: true });
     this.setState({
       buttonContent: CHANNELS[0],
@@ -31,9 +36,19 @@ export const handleIncrementChannel = function (this: Modal) {
       // Disables thinking indicator for OOC channel
       this.timers.channelDebounce({ mode: false });
     }
-    this.setState({
-      buttonContent: CHANNELS[channel + 1],
-      channel: channel + 1,
-    });
+    if (
+      channel === ADMIN_CHANNEL - 1 &&
+      CHANNELS.length - 1 !== ADMIN_CHANNEL
+    ) {
+      this.setState({
+        buttonContent: CHANNELS[channel + 2],
+        channel: channel + 2,
+      });
+    } else {
+      this.setState({
+        buttonContent: CHANNELS[channel + 1],
+        channel: channel + 1,
+      });
+    }
   }
 };


### PR DESCRIPTION


## About The Pull Request
Removes the capability to cycle input channels by pressing tab when the channel open is asay

## Why It's Good For The Game
Lowers chance to leak asay into ooc. I heard asay is supposed to be secret, so this sounds like an improvement.

## Changelog

:cl:
admin: Lowered the chance of accidentally leaking asay
/:cl:

