### PR TITLE
Fix extinguisher switch range, changing the delay on using it with a chair or something

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -255,9 +255,9 @@
 /obj/item/extinguisher/proc/manage_chair_speed(datum/move_loop/move/source)
 	SIGNAL_HANDLER
 	switch(source.lifetime)
-		if(5 to 4)
+		if(4 to 5)
 			source.delay = 2
-		if(3 to 1)
+		if(1 to 3)
 			source.delay = 3
 
 /obj/item/extinguisher/AltClick(mob/user)


### PR DESCRIPTION
Blocks compilation on newest BYOND

## Changelog
:cl:
fix: Using a fire extinguisher with a chair now properly does...something with how fast you move I think it makes you slower
/:cl:
