### PR TITLE
Properly fixes general benches color

### DIFF
--- a/code/game/objects/structures/beds_chairs/sofa.dm
+++ b/code/game/objects/structures/beds_chairs/sofa.dm
@@ -100,7 +100,7 @@ COLORED_SOFA(/obj/structure/chair/sofa, maroon, SOFA_MAROON)
 	desc = "Perfectly designed to be comfortable to sit on, and hellish to sleep on."
 	icon_state = "bench_middle"
 	greyscale_config = /datum/greyscale_config/bench_middle
-	greyscale_colors = "#2E668A"
+	greyscale_colors = "#af7d28"
 
 /obj/structure/chair/sofa/bench/left
 	icon_state = "bench_left"


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Proper fix for #73250

The general bench color changes were undocumented in the CL in #73057 and #73243, which made them blue.
This PR reverts them back to their brown color.

![image](https://user-images.githubusercontent.com/70232195/218350284-317def2b-4c11-4dca-9985-77d8486954a3.png)


## Changelog

:cl: Jolly
fix: The non-tram benches are brown again. Rejoice. Or are they yellow? Orange, perhaps?
/:cl:
