### PR TITLE
Fix durand shield overlay and light runtimes

### DIFF
--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -176,7 +176,7 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 /obj/durand_shield/Initialize(mapload, chassis, plane, layer, dir)
 	. = ..()
 	src.chassis = chassis
-	src.layer = layer
+	src.layer = ABOVE_MOB_LAYER
 	SET_PLANE_IMPLICIT(src, plane)
 	setDir(dir)
 	RegisterSignal(src, COMSIG_MECHA_ACTION_TRIGGER, PROC_REF(activate))
@@ -258,11 +258,6 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 
 /obj/durand_shield/proc/resetdir(datum/source, olddir, newdir)
 	SIGNAL_HANDLER
-
-	if(newdir & SOUTH) // so the shield appears on top of the mech
-		SET_PLANE_IMPLICIT(src, GAME_PLANE_UPPER)
-	else // other directions make the shield appear under the mech
-		SET_PLANE_IMPLICIT(src, initial(plane))
 
 	setDir(newdir)
 

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -20,7 +20,6 @@
 	)
 	var/obj/durand_shield/shield
 
-
 /datum/armor/mecha_durand
 	melee = 40
 	bullet = 35
@@ -178,11 +177,10 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 	. = ..()
 	src.chassis = chassis
 	src.layer = layer
-	SET_PLANE_EXPLICIT(src, plane, src)
+	SET_PLANE_IMPLICIT(src, plane)
 	setDir(dir)
 	RegisterSignal(src, COMSIG_MECHA_ACTION_TRIGGER, PROC_REF(activate))
 	RegisterSignal(chassis, COMSIG_MOVABLE_UPDATE_GLIDE_SIZE, PROC_REF(shield_glide_size_update))
-
 
 /obj/durand_shield/Destroy()
 	UnregisterSignal(src, COMSIG_MECHA_ACTION_TRIGGER)
@@ -236,13 +234,12 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 		invisibility = 0
 		flick("shield_raise", src)
 		playsound(src, 'sound/mecha/mech_shield_raise.ogg', 50, FALSE)
-		set_light(l_range = MINIMUM_USEFUL_LIGHT_RANGE , l_power = 5, l_color = "#00FFFF")
 		icon_state = "shield"
+		resetdir(chassis, dir, dir) // to set the plane for the shield properly when it's turned on
 		RegisterSignal(chassis, COMSIG_ATOM_DIR_CHANGE, PROC_REF(resetdir))
 	else
 		flick("shield_drop", src)
 		playsound(src, 'sound/mecha/mech_shield_drop.ogg', 50, FALSE)
-		set_light(0)
 		icon_state = "shield_null"
 		addtimer(CALLBACK(src, PROC_REF(make_invisible)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 		UnregisterSignal(chassis, COMSIG_ATOM_DIR_CHANGE)
@@ -261,6 +258,12 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 
 /obj/durand_shield/proc/resetdir(datum/source, olddir, newdir)
 	SIGNAL_HANDLER
+
+	if(newdir & SOUTH) // so the shield appears on top of the mech
+		SET_PLANE_IMPLICIT(src, GAME_PLANE_UPPER)
+	else // other directions make the shield appear under the mech
+		SET_PLANE_IMPLICIT(src, initial(plane))
+
 	setDir(newdir)
 
 /obj/durand_shield/take_damage()


### PR DESCRIPTION
## About The Pull Request
The Durand shield overlay would not be placed on top when facing south due to the planes not being set properly.  My changes update the planes whenever the dir gets updated.

There was also a lighting runtime due to using the wrong lighting proc call that would throw this error:

```
/atom/proc/update_light()
	SHOULD_NOT_SLEEP(TRUE)

	if(light_system != STATIC_LIGHT)
		CRASH("update_light() for [src] with following light_system value: [light_system]")
```

Someone mixed up the lighting code since `set_light()` is meant to be used by `STATIC_LIGHT` sources.  The durand shield lighting source is `MOVABLE_LIGHT`.  

All I needed to do was remove the extra procs since we already have `set_light_on(chassis.defense_mode)` that controls the `MOVABLE_LIGHT`.  Basically, someone added two different lighting systems to the same object, so big oof.

## Why It's Good For The Game
Better mech visuals and one less runtime.

<details>
<summary>Before:</summary>

![dreamseeker_yKywMgB7j3](https://user-images.githubusercontent.com/5195984/218541070-277af6c5-facb-48c1-bf73-ef51a1e6b0e2.gif)

</details>

<details>
<summary>After:</summary>

![dreamseeker_n94xpvzJyU](https://user-images.githubusercontent.com/5195984/218541159-b37dd33b-a3b3-411d-9704-f9be1efaf6aa.gif)

</details>


## Changelog
:cl:
fix: Fix durand shield overlay to appear above the mech when facing south.  Also fixed a lighting runtime when shield would turn on/off.  
/:cl:
