### PR TITLE
Vote System: Approval Voting

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -101,26 +101,6 @@ SUBSYSTEM_DEF(vote)
 	if(CONFIG_GET(flag/no_dead_vote) && voter.stat == DEAD && !voter.client?.holder)
 		return
 
-	// If user has already voted, remove their specific vote
-	if(voter.ckey in current_vote.choices_by_ckey)
-		var/their_old_vote = current_vote.choices_by_ckey[voter.ckey]
-		current_vote.choices[their_old_vote]--
-
-	else
-		voted += voter.ckey
-
-	current_vote.choices_by_ckey[voter.ckey] = their_vote
-	current_vote.choices[their_vote]++
-	return TRUE
-
-/datum/controller/subsystem/vote/proc/submit_vote_av(mob/voter, their_vote)
-	if(!current_vote)
-		return
-	if(!voter?.ckey)
-		return
-	if(CONFIG_GET(flag/no_dead_vote) && voter.stat == DEAD && !voter.client?.holder)
-		return
-
 	else
 		voted += voter.ckey
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -113,6 +113,27 @@ SUBSYSTEM_DEF(vote)
 	current_vote.choices[their_vote]++
 	return TRUE
 
+/datum/controller/subsystem/vote/proc/submit_vote_av(mob/voter, their_vote)
+	if(!current_vote)
+		return
+	if(!voter?.ckey)
+		return
+	if(CONFIG_GET(flag/no_dead_vote) && voter.stat == DEAD && !voter.client?.holder)
+		return
+
+	else
+		voted += voter.ckey
+
+	if(current_vote.choices_by_ckey[voter.ckey + their_vote] == 1)
+		current_vote.choices_by_ckey[voter.ckey + their_vote] = 0
+		current_vote.choices[their_vote]--
+
+	else
+		current_vote.choices_by_ckey[voter.ckey + their_vote] = 1
+		current_vote.choices[their_vote]++
+
+	return TRUE
+
 /**
  * Initiates a vote, allowing all players to vote on something.
  *

--- a/tgui/packages/tgui/interfaces/VotePanel.tsx
+++ b/tgui/packages/tgui/interfaces/VotePanel.tsx
@@ -156,7 +156,7 @@ const ChoicesPanel = (props, context) => {
 
   return (
     <Stack.Item grow>
-      <Section fill scrollable title="Choices">
+      <Section fill scrollable title="Toggle any number of options">
         {currentVote && currentVote.choices.length !== 0 ? (
           <LabeledList>
             {currentVote.choices.map((choice) => (


### PR DESCRIPTION
## About The Pull Request
Approval Voting is a system in which voters can select as many maps as they want, instead of selecting only one.

Final tallies show how many votes each map received, and the winner is the map with the most support.

https://user-images.githubusercontent.com/83487515/218571565-73bbe5d1-8f91-440a-acaf-27ed0cc88bfb.mp4

## Why It's Good For The Game
First-past-the-post (our current voting system) has flaws such as creating a bunch of wasted votes, in that a large number of selections ultimately have no impact and for example, a map can win a 3 way race 11/10/10, even though 2/3 of the votes were not for that map. This leads to people having to vote strategically, and perhaps not what their true choice is.

Approval Voting solves this by instead allowing the player to select all the maps they would like to play, so they can vote for their true preferred choice, as well as alternates.

For example, a player that wants Metastation, is okay with Icebox, and doesn't want Delta may feel pressured to vote Icebox if it's in a 2 way race with Delta.

AV lets them vote for Meta, and Icebox or as many others as they want as their alternates and creates a more fair outcome of a map vote.

## Changelog

:cl: LT3
balance: Map votes are now calculated using AV (approval voting) instead of FPTP (first-past-the-post)
/:cl:
