### PR TITLE
Stops AIs being disconnected from shells constantly from any form of healing

### DIFF
--- a/code/modules/mob/living/silicon/ai/life.dm
+++ b/code/modules/mob/living/silicon/ai/life.dm
@@ -54,10 +54,17 @@
 /mob/living/silicon/ai/updatehealth()
 	if(status_flags & GODMODE)
 		return
+
+	var/old_health = health
 	set_health(maxHealth - getOxyLoss() - getToxLoss() - getBruteLoss() - getFireLoss())
+
+	var/old_stat = stat
 	update_stat()
+
 	diag_hud_set_health()
-	disconnect_shell()
+
+	if(old_health > health || old_stat != stat) // only disconnect if we lose health or change stat
+		disconnect_shell()
 	SEND_SIGNAL(src, COMSIG_LIVING_HEALTH_UPDATE)
 
 /mob/living/silicon/ai/update_stat()


### PR DESCRIPTION

## About The Pull Request

AIs have disconnect_shell called in their health update logic, which makes sense but can be annoying
Let's just have it only disconnect shell if they are damaged or change stat
## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/73334
## Changelog
:cl:
fix: You can no longer keep an AI trapped in their core by healing them with a Rod of Asclepius
/:cl:
