### PR TITLE
Fixes health analyzers checking for missing stomachs and tongues

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -274,9 +274,9 @@
 				missing_organs += "lungs"
 			if(!(TRAIT_NOMETABOLISM in the_dudes_species.inherent_traits) && !humantarget.getorganslot(ORGAN_SLOT_LIVER))
 				missing_organs += "liver"
-			if(!the_dudes_species.mutantstomach && !humantarget.getorganslot(ORGAN_SLOT_STOMACH))
+			if(the_dudes_species.mutantstomach && !humantarget.getorganslot(ORGAN_SLOT_STOMACH))
 				missing_organs += "stomach"
-			if(!the_dudes_species.mutanttongue && !humantarget.getorganslot(ORGAN_SLOT_TONGUE))
+			if(the_dudes_species.mutanttongue && !humantarget.getorganslot(ORGAN_SLOT_TONGUE))
 				missing_organs += "tongue"
 			if(!humantarget.getorganslot(ORGAN_SLOT_EARS))
 				missing_organs += "ears"


### PR DESCRIPTION


## About The Pull Request

Healthanalyzer's check for missing tongues and stomachs were incorrect. They only printed the message for those organs if the target's species lacked them, and the organ was missing as intended (examples: abductors for stomachs, cardboard golems for tongues). This PR fixes this, and the healthanalyzer will only complain about the lack of those organs, if the targets are supposed to have them in the first place.

## Why It's Good For The Game

It is good to be told that your patient is missing a vital organ or two before booting them out of medbay.

## Changelog

:cl:
fix: Health analyzers will properly report missing stomachs and tongues 
/:cl:
