### PR TITLE
Medieval Sim holograms won't spawn with an unusable laser rifle

### DIFF
--- a/code/modules/capture_the_flag/medieval_sim/medisim_classes.dm
+++ b/code/modules/capture_the_flag/medieval_sim/medisim_classes.dm
@@ -7,7 +7,7 @@
 	suit = /obj/item/clothing/suit/armor/riot/knight/red
 	gloves = /obj/item/clothing/gloves/plate/red
 	head = /obj/item/clothing/head/helmet/knight/red
-	r_hand = /obj/item/claymore
+	l_hand = /obj/item/claymore
 
 	ears = null
 	id = null
@@ -28,7 +28,7 @@
 
 	belt = /obj/item/storage/bag/quiver
 	suit = /obj/item/clothing/suit/armor/vest/cuirass
-	r_hand = /obj/item/gun/ballistic/bow
+	l_hand = /obj/item/gun/ballistic/bow
 
 	class_description = "Ranged class. Armed with a bow and arrows."
 


### PR DESCRIPTION
## About The Pull Request

In #72960 the CTF outfits were updated to move all weapons to the left hand instead of the right.
The medieval sim outfits are children of the CTF outfits (because it's essentially a CTF map inside a shuttle) but were not also updated.
This meant that medieval sim spawns would be created with a bow/claymore in one hand and a laser rifle in the other, rendering them unable to use either as all of these items require a second free hand.

## Why It's Good For The Game

This is a fun shuttle and it's a shame when it stops working.

## Changelog

:cl:
fix: Medieval Sim holograms no longer spawn holding unusable laser rifles which also block using their old timey weaponry.
/:cl: