### PR TITLE
Guillotine can be unanchored again

### DIFF
--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -255,7 +255,7 @@
 			to_chat(user, span_warning("Can't unfasten, someone's strapped in!"))
 		return FAILED_UNFASTEN
 
-	if (current_action)
+	if (current_action && current_action != GUILLOTINE_ACTION_WRENCH)
 		return FAILED_UNFASTEN
 
 	current_action = GUILLOTINE_ACTION_WRENCH

--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -1,9 +1,16 @@
-#define GUILLOTINE_BLADE_IDLE 0
+/// The guillotine is not being interacted with at the moment
+#define GUILLOTINE_ACTION_IDLE 0
+/// The blade is ready to be dropped
 #define GUILLOTINE_BLADE_RAISED 1
+/// The blade is moving
 #define GUILLOTINE_BLADE_MOVING 2
+/// The blade has landed in the stocks
 #define GUILLOTINE_BLADE_DROPPED 3
+/// The blade is being sharpened
 #define GUILLOTINE_BLADE_SHARPENING 4
+/// The guillotine blade is being interacted with by the executor
 #define GUILLOTINE_ACTION_INUSE 5
+/// The guillotine is being unfastened
 #define GUILLOTINE_ACTION_WRENCH 6
 
 /// This is maxiumum sharpness and will decapitate without failure
@@ -18,6 +25,7 @@
 #define GUILLOTINE_LAYER_DIFF 1.2
 /// Delay for executing someone
 #define GUILLOTINE_ACTIVATE_DELAY (3 SECONDS)
+/// Delay for wrenching the guillotine
 #define GUILLOTINE_WRENCH_DELAY (1 SECONDS)
 
 /obj/structure/guillotine
@@ -35,11 +43,16 @@
 	buckle_prevents_pull = TRUE
 	layer = ABOVE_MOB_LAYER
 	plane = GAME_PLANE_UPPER
+	/// The sound the guillotine makes when it successfully cuts off a head
 	var/drop_sound = 'sound/weapons/guillotine.ogg'
+	/// The current state of the blade
 	var/blade_status = GUILLOTINE_BLADE_RAISED
-	var/blade_sharpness = GUILLOTINE_BLADE_MAX_SHARP // How sharp the blade is
+	/// How sharp the blade is
+	var/blade_sharpness = GUILLOTINE_BLADE_MAX_SHARP
+	/// The number of mobs the blade has killed
 	var/kill_count = 0
-	var/current_action = GUILLOTINE_BLADE_IDLE // What's currently happening to the guillotine
+	/// What's currently happening to the guillotine
+	var/current_action = GUILLOTINE_ACTION_IDLE
 
 /obj/structure/guillotine/Initialize(mapload)
 	LAZYINITLIST(buckled_mobs)
@@ -101,12 +114,12 @@
 					current_action = GUILLOTINE_ACTION_INUSE
 
 					if (do_after(user, GUILLOTINE_ACTIVATE_DELAY, target = src) && blade_status == GUILLOTINE_BLADE_RAISED)
-						current_action = GUILLOTINE_BLADE_IDLE
+						current_action = GUILLOTINE_ACTION_IDLE
 						blade_status = GUILLOTINE_BLADE_MOVING
 						icon_state = "guillotine_drop"
 						addtimer(CALLBACK(src, PROC_REF(drop_blade), user), GUILLOTINE_ANIMATION_LENGTH - 2) // Minus two so we play the sound and decap faster
 					else
-						current_action = GUILLOTINE_BLADE_IDLE
+						current_action = GUILLOTINE_ACTION_IDLE
 				else
 					var/mob/living/carbon/human/H = buckled_mobs[1]
 
@@ -119,10 +132,12 @@
 				icon_state = "guillotine_drop"
 				addtimer(CALLBACK(src, PROC_REF(drop_blade)), GUILLOTINE_ANIMATION_LENGTH)
 
+/// Sets the guillotine blade in a raised position
 /obj/structure/guillotine/proc/raise_blade()
 	blade_status = GUILLOTINE_BLADE_RAISED
 	icon_state = "guillotine_raised"
 
+/// Drops the guillotine blade, potentially beheading or harbing the buckled mob
 /obj/structure/guillotine/proc/drop_blade(mob/user)
 	if (has_buckled_mobs() && blade_sharpness)
 		var/mob/living/carbon/human/H = buckled_mobs[1]
@@ -265,9 +280,9 @@
 	. = ..()
 	if(default_unfasten_wrench(user, tool, time = GUILLOTINE_WRENCH_DELAY))
 		setDir(SOUTH)
-		current_action = GUILLOTINE_BLADE_IDLE
+		current_action = GUILLOTINE_ACTION_IDLE
 		return TOOL_ACT_TOOLTYPE_SUCCESS
-	current_action = GUILLOTINE_BLADE_IDLE
+	current_action = GUILLOTINE_ACTION_IDLE
 	return FALSE
 
 #undef GUILLOTINE_BLADE_MAX_SHARP
@@ -276,11 +291,12 @@
 #undef GUILLOTINE_HEAD_OFFSET
 #undef GUILLOTINE_LAYER_DIFF
 #undef GUILLOTINE_ACTIVATE_DELAY
+#undef GUILLOTINE_WRENCH_DELAY
 
-#undef GUILLOTINE_BLADE_IDLE
+#undef GUILLOTINE_ACTION_IDLE
 #undef GUILLOTINE_BLADE_RAISED
 #undef GUILLOTINE_BLADE_MOVING
 #undef GUILLOTINE_BLADE_DROPPED
 #undef GUILLOTINE_BLADE_SHARPENING
-#undef GUILLOTINE_WRENCH_DELAY
 #undef GUILLOTINE_ACTION_INUSE
+#undef GUILLOTINE_ACTION_WRENCH


### PR DESCRIPTION

## About The Pull Request

Guillotines could not be unanchored, because the unfasten check checked if any action is being applied to the guillotine, including being wrenched at the moment. This PR fixes that.

This PR also autodocs everything, adds a missing UNDEF, and renames GUILLOTINE_BLADE_IDLE to GUILLOTINE_ACTION_IDLE to make it clearer that this is intended for the current_action var, and not the blade_status var. 

## Why It's Good For The Game

Fixes a bug that prevents something from being moved around.

## Changelog

:cl:
fix: Guillotines can be unanchored again
/:cl: