### PR TITLE
Fixes reinforced plasma windows spawning normal glass shards when broken

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -633,6 +633,15 @@
 	fire = 99
 	acid = 100
 
+/obj/structure/window/reinforced/plasma/spawnDebris(location)
+	. = list()
+	. += new /obj/item/shard/plasma(location)
+	. += new /obj/effect/decal/cleanable/glass/plasma(location)
+	if (reinf)
+		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
+	if (fulltile)
+		. += new /obj/item/shard/plasma(location)
+
 /obj/structure/window/reinforced/plasma/block_superconductivity()
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/15551

This just makes reinforced plasma windows drop plasma glass shards when broken. The normal ones already did, but I guess someone forgot to make the reinforced ones do it too.

## Why It's Good For The Game

Very important for the immersive greytide experience.

## Changelog

:cl:
fix: reinforced plasma glass windows will now drop plasma glass shards instead of normal ones when smashed
/:cl:
