### PR TITLE
Bileworms won't evolve if they're dead

### DIFF
--- a/code/datums/components/evolutionary_leap.dm
+++ b/code/datums/components/evolutionary_leap.dm
@@ -51,6 +51,8 @@
 
 /datum/component/evolutionary_leap/proc/leap(silent)
 	var/mob/living/old_mob = parent
+	if (old_mob.stat == DEAD)
+		return
 	var/mob/living/new_mob = evolve_path
 	var/new_mob_name = initial(new_mob.name)
 	if(!silent)


### PR DESCRIPTION
## About The Pull Request

Fixes #70865 
I kind of agree with the comments that it would be funny to canonise _something else_ happening to dead ones once the alive ones evolve but that would qualify as "a feature".

## Why It's Good For The Game

Even if it's pretty funny it's not really ideal for unbutchered mobs to come back to life without warning at the 30 minute mark, and clearly not intended.

## Changelog

:cl:
fix: Bileworms which have been struck down but not butchered no longer return in a more powerful form.
/:cl:
