### PR TITLE
Fixes taking items from storage in hyperspace

### DIFF
--- a/code/datums/components/shuttle_cling.dm
+++ b/code/datums/components/shuttle_cling.dm
@@ -39,6 +39,10 @@
 
 	RegisterSignals(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_UNBUCKLE, COMSIG_ATOM_NO_LONGER_PULLED), PROC_REF(update_state))
 
+	//Items have this cool thing where they're first put on the floor if you grab them from storage, and then into your hand, which isn't caught by movement signals that well
+	if(isitem(parent))
+		RegisterSignal(parent, COMSIG_ITEM_PICKUP, PROC_REF(do_remove))
+
 	hyperloop = SSmove_manager.move(moving = parent, direction = direction, delay = not_clinging_move_delay, subsystem = SShyperspace_drift, priority = MOVEMENT_ABOVE_SPACE_PRIORITY, flags = MOVEMENT_LOOP_NO_DIR_UPDATE)
 
 	update_state(parent) //otherwise we'll get moved 1 tile before we can correct ourselves, which isnt super bad but just looks jank
@@ -145,6 +149,12 @@
 		if(blocker.density)
 			return TRUE
 	return FALSE
+
+///This is just for signals and doesn't run for most removals, so dont add behaviour here expecting it to do much
+/datum/component/shuttle_cling/proc/do_remove()
+	SIGNAL_HANDLER
+
+	qdel(src)
 
 /datum/component/shuttle_cling/Destroy(force, silent)
 	REMOVE_TRAIT(parent, TRAIT_HYPERSPACED, src)


### PR DESCRIPTION
Taking items from storages actually puts it on the floor and then in your hands, which isnt really caught by movement signals. So deletes the hyperspace component on item pickup

closes #72727

:cl:
fix: fixes taking items from inventories glitching out in hyperspace
/:cl: