### PR TITLE
Makes used up eyesnatchers actually be used up

### DIFF
--- a/code/modules/antagonists/traitor/objectives/eyesnatching.dm
+++ b/code/modules/antagonists/traitor/objectives/eyesnatching.dm
@@ -164,7 +164,7 @@
 	icon_state = "[base_icon_state][used ? "-used" : ""]"
 
 /obj/item/eyesnatcher/attack(mob/living/carbon/human/victim, mob/living/user, params)
-	if(!istype(victim) || !victim.Adjacent(user)) //No TK use
+	if(used || !istype(victim) || !victim.Adjacent(user)) //Works only once, no TK use
 		return ..()
 
 	var/obj/item/organ/internal/eyes/eyeballies = victim.getorganslot(ORGAN_SLOT_EYES)


### PR DESCRIPTION

## About The Pull Request

After you use an eyesnatcher, the `used` var is set to True, which changes the item state to a "used" sprite, and the description is updated with "it has been used up.", and yet, it can be used infinitely. This PR fixes that.

## Why It's Good For The Game

This honestly feels like an oversight in the original PR.

## Changelog

:cl:
fix: eyesnatchers that say that they haven been used up can't be used again
/:cl: