### PR TITLE
Tramstation Map Fixes 02/14

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -24743,7 +24743,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter Control Panel";
-	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
+	preset_destination_names = list("2"="Hydroponics","3"="Kitchen","4"="Hydroponics","5"="Kitchen")
 	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
@@ -47608,7 +47608,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter Control Panel";
-	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
+	preset_destination_names = list("2"="Hydroponics","3"="Kitchen","4"="Hydroponics","5"="Kitchen")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -13833,7 +13833,7 @@
 /obj/structure/industrial_lift/public,
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "tram_lower_center_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/secondary/construction/engineering)
@@ -22984,7 +22984,7 @@
 	},
 /obj/machinery/elevator_control_panel/directional/north{
 	linked_elevator_id = "tram_upper_center_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level")
 	},
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 1
@@ -26943,7 +26943,7 @@
 /obj/structure/industrial_lift/public,
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_cargo_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level")
 	},
 /obj/effect/landmark/lift_id{
 	specific_lift_id = "tram_cargo_lift"
@@ -42163,7 +42163,7 @@
 	},
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_perma_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/security/execution/transfer)
@@ -64086,7 +64086,7 @@
 /obj/effect/turf_decal/trimline/dark_red/warning,
 /obj/machinery/elevator_control_panel{
 	linked_elevator_id = "tram_sci_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck");
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level");
 	pixel_y = 3
 	},
 /turf/open/floor/plating/elevatorshaft,
@@ -67091,7 +67091,7 @@
 /obj/structure/industrial_lift/public,
 /obj/machinery/elevator_control_panel/directional/south{
 	linked_elevator_id = "tram_dorm_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level")
 	},
 /obj/structure/railing,
 /turf/open/floor/plating/elevatorshaft,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14088,10 +14088,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"dfz" = (
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/noslip,
-/area/station/hallway/primary/tram/right)
 "dfP" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -20365,7 +20361,6 @@
 "fBK" = (
 /obj/effect/landmark/tram/middle_part,
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/sign/plaques/tram,
 /turf/open/floor/noslip/tram_plate,
 /area/station/hallway/primary/tram/center)
 "fBX" = (
@@ -40083,6 +40078,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
+"naH" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
+	},
+/obj/machinery/computer/order_console/cook,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "naN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -46239,7 +46241,8 @@
 	name = "Head of Personnel's Requests Console";
 	assistance_requestable = 1;
 	anon_tips_receiver = 1;
-	supplies_requestable = 1
+	supplies_requestable = 1;
+	announcementConsole = 1
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -49758,6 +49761,7 @@
 /area/station/command/gateway)
 "qHk" = (
 /obj/structure/industrial_lift/tram,
+/obj/structure/sign/plaques/tram,
 /turf/open/floor/noslip/tram_plate,
 /area/station/hallway/primary/tram/center)
 "qHo" = (
@@ -101523,7 +101527,7 @@ dQt
 iRL
 snQ
 iRL
-pjC
+naH
 jra
 dWn
 cWZ
@@ -179933,7 +179937,7 @@ iOd
 ozQ
 vPi
 brm
-dfz
+xYV
 tfc
 aHr
 wpK

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -13833,7 +13833,7 @@
 /obj/structure/industrial_lift/public,
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "tram_lower_center_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level")
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/secondary/construction/engineering)
@@ -22984,7 +22984,7 @@
 	},
 /obj/machinery/elevator_control_panel/directional/north{
 	linked_elevator_id = "tram_upper_center_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level")
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
 	},
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 1
@@ -24743,7 +24743,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter Control Panel";
-	preset_destination_names = list("2"="Hydroponics","3"="Kitchen","4"="Hydroponics","5"="Kitchen")
+	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
 	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
@@ -26943,7 +26943,7 @@
 /obj/structure/industrial_lift/public,
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_cargo_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level")
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
 	},
 /obj/effect/landmark/lift_id{
 	specific_lift_id = "tram_cargo_lift"
@@ -42163,7 +42163,7 @@
 	},
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "tram_perma_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level")
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/security/execution/transfer)
@@ -47608,7 +47608,7 @@
 	desc = "A small control panel used to move the kitchen dumbwaiter up and down.";
 	linked_elevator_id = "dumbwaiter_lift";
 	name = "Dumbwaiter Control Panel";
-	preset_destination_names = list("2"="Hydroponics","3"="Kitchen","4"="Hydroponics","5"="Kitchen")
+	preset_destination_names = list("2"="Hydroponics","3"="Kitchen")
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
@@ -64086,7 +64086,7 @@
 /obj/effect/turf_decal/trimline/dark_red/warning,
 /obj/machinery/elevator_control_panel{
 	linked_elevator_id = "tram_sci_lift";
-	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck","4"="Lower Level","5"="Platform Level");
+	preset_destination_names = list("2"="Lower Deck","3"="Upper Deck");
 	pixel_y = 3
 	},
 /turf/open/floor/plating/elevatorshaft,


### PR DESCRIPTION
## About The Pull Request
- Added missing produce order console in service hall
- Removed duplicate vending machine in east wing
- Fix HoP Office announcement console
- Realigned information plate to end of tram
- Adds Z4/Z5 lift indicator text for downstream

## Changelog

:cl: LT3
fix: Tramstation: Added missing produce order console
fix: Tramstation: Removed duplicate vending machine in east wing
fix: Tramstation: HoP office can now broadcast announcements
code: Tramstation: Moved information plate for symmetry
/:cl: