### PR TITLE
A couple of minor Tramstation fixes

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2248,6 +2248,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/machinery/computer/order_console/mining,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "afS" = (
@@ -20532,16 +20533,10 @@
 "fFQ" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner,
-/obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/syringe,
+/obj/machinery/chem_master,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fFR" = (
@@ -25078,16 +25073,10 @@
 "hzT" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/window/reinforced/spawner/north,
-/obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 6;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/syringe,
+/obj/machinery/chem_master,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hzV" = (
@@ -54465,7 +54454,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "suG" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
 	},
@@ -54474,6 +54462,13 @@
 	name = "Pharmacy Privacy Shutters Toggle";
 	req_one_access = list("pharmacy")
 	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "suK" = (
@@ -64978,7 +64973,6 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/left)
 "wmy" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
@@ -64987,6 +64981,13 @@
 	name = "Pharmacy Privacy Shutters Toggle";
 	req_access = list("pharmacy")
 	},
+/obj/structure/table/glass,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wmz" = (


### PR DESCRIPTION

## About The Pull Request

This PR makes two minor fixes to the new version of Tramstation:

- Adds a mining equipment order console to the station, in the same place where it used to be on the old map.
- Swaps the tables and ChemMasters in the pharmacy, so that the smartfridges can be accessed from inside of the room.
## Why It's Good For The Game

Every other map has a mining equipment console on the station, and it's extremely inconvenient to have to ride the shuttle back and forth several times to get and spend your mining points. Presumably that was an oversight.

The smartfridge situation was previously fixed in #71895 - but the pharmacy redesign in the new version of Tramstation reintroduced this issue.
## Changelog
:cl:
fix: Placed a missing mining order console on Tramstation.
fix: Rearranged furniture in the Tramstation pharmacy to make the fridges accessible.
/:cl:
