### PR TITLE
Corrects a grammatical error in strip text

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -132,7 +132,7 @@
 		ignored_mobs = user,
 	)
 
-	to_chat(user, span_danger("You try to remove [source]'s [item]..."))
+	to_chat(user, span_danger("You try to remove [source]'s [item.name]..."))
 	user.log_message("is stripping [key_name(source)] of [item].", LOG_ATTACK, color="red")
 	source.log_message("is being stripped of [item] by [key_name(user)].", LOG_VICTIM, color="orange", log_globally=FALSE)
 	item.add_fingerprint(src)


### PR DESCRIPTION

## About The Pull Request

Changes this:
![image](https://user-images.githubusercontent.com/40036527/219127469-c725deeb-baba-4460-9f5e-e03fae486896.png)
into this:
![image](https://user-images.githubusercontent.com/40036527/219126813-db27e2eb-e65f-4799-86b2-a5dcafdf7bfc.png)



I might be missing something with how I've made this change, if theres a reason it just used item and not item.name do point it out to me.
## Why It's Good For The Game

Grammatically corrects something that was not.
## Changelog
:cl:
spellcheck: A grammatical error in strip text has been removed.
/:cl:
