### PR TITLE
Fixes revelation program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -27,12 +27,15 @@
 
 		computer.visible_message(span_notice("\The [computer]'s screen brightly flashes and loud electrical buzzing is heard."))
 		computer.enabled = FALSE
+		computer.update_appearance()
 
 		for(var/file_delete_index = computer.stored_files.len, file_delete_index >= 1, file_delete_index--)
 			var/datum/computer_file/selected_file = computer.stored_files[file_delete_index]
 			if(selected_file == src)
 				continue
 			computer.remove_file(selected_file)
+
+		computer.remove_file(src)
 
 		computer.take_damage(25, BRUTE, 0, 0)
 
@@ -41,9 +44,6 @@
 			computer.visible_message(span_notice("\The [computer]'s battery explodes in rain of sparks."))
 			var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread
 			spark_system.start()
-
-		computer.remove_file(src)
-		computer.update_appearance()
 
 /datum/computer_file/program/revelation/ui_act(action, params)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -27,14 +27,23 @@
 
 		computer.visible_message(span_notice("\The [computer]'s screen brightly flashes and loud electrical buzzing is heard."))
 		computer.enabled = FALSE
-		computer.update_appearance()
+
+		for(var/file_delete_index = computer.stored_files.len, file_delete_index >= 1, file_delete_index--)
+			var/datum/computer_file/selected_file = computer.stored_files[file_delete_index]
+			if(selected_file == src)
+				continue
+			computer.remove_file(selected_file)
+
 		computer.take_damage(25, BRUTE, 0, 0)
+
 		if(computer.internal_cell && prob(25))
 			QDEL_NULL(computer.internal_cell)
 			computer.visible_message(span_notice("\The [computer]'s battery explodes in rain of sparks."))
 			var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread
 			spark_system.start()
 
+		computer.remove_file(src)
+		computer.update_appearance()
 
 /datum/computer_file/program/revelation/ui_act(action, params)
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -29,13 +29,7 @@
 		computer.enabled = FALSE
 		computer.update_appearance()
 
-		for(var/file_delete_index = computer.stored_files.len, file_delete_index >= 1, file_delete_index--)
-			var/datum/computer_file/selected_file = computer.stored_files[file_delete_index]
-			if(selected_file == src)
-				continue
-			computer.remove_file(selected_file)
-
-		computer.remove_file(src)
+		QDEL_LIST(computer.stored_files)
 
 		computer.take_damage(25, BRUTE, 0, 0)
 

--- a/tgui/packages/tgui/interfaces/NtosRevelation.tsx
+++ b/tgui/packages/tgui/interfaces/NtosRevelation.tsx
@@ -44,6 +44,7 @@ export const NtosRevelation = (props, context) => {
             textAlign="center"
             color="bad"
             disabled={!armed}
+            onClick={() => act('PRG_activate')}
           />
         </Section>
       </NtosWindow.Content>


### PR DESCRIPTION


## About The Pull Request

#70678 removed hard drives from the game, and made the files be stored directly on the computer. However, revelation has not been updated in this regard. This PR once again makes it delete all files.

In addition, revelation also had a big red button yelling "activate" that did nothing, and an option in ui_act that said "PRG_activate", that wasn't used by anything, so I have linked up the two, allowing you to revelate immediately. This does not feel like a real change, since you could do this by arming, closing, and then reopening the program.

## Why It's Good For The Game

Fixes #72682

## Changelog

:cl:
fix: Revelation once again wipes the stored files on the computer
/:cl:
