### PR TITLE
[no gbp] Cramped Escape Pods won't smooth with station walls

### DIFF
--- a/_maps/shuttles/escape_pod_cramped.dmm
+++ b/_maps/shuttles/escape_pod_cramped.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "B" = (
-/turf/closed/wall/mineral/titanium/survival,
+/turf/closed/wall/mineral/titanium/survival/pod,
 /area/shuttle/pod_1)
 "N" = (
 /obj/docking_port/mobile/pod{
@@ -25,7 +25,7 @@
 /area/shuttle/pod_1)
 "Z" = (
 /obj/machinery/power/shuttle_engine/propulsion/burst,
-/turf/closed/wall/mineral/titanium/survival,
+/turf/closed/wall/mineral/titanium/survival/pod,
 /area/shuttle/pod_1)
 
 (1,1,1) = {"


### PR DESCRIPTION
## About The Pull Request

Fixes #72383
Replaces the walls of the cramped escape pod with a variant which does not smooth with iron walls.
![image](https://user-images.githubusercontent.com/7483112/219516166-f5af3d63-ba9f-4ecd-b6d5-3be23d17377c.png)
The iron walls still try to smooth with the pod, but they do that with regular escape pods too.

## Why It's Good For The Game

Looks nicer.

## Changelog

:cl:
fix: Cramped escape pod walls no longer appear to merge with those of the station, which will be a big relief to the single occupant.
/:cl:
