### PR TITLE
AI uploads can no longer be printed from a circuit imprinter.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -18,6 +18,7 @@
 	new /obj/item/circuitboard/machine/techfab/department/science(src)
 	new /obj/item/storage/photo_album/rd(src)
 	new /obj/item/storage/box/skillchips/science(src)
+	new /obj/item/circuitboard/computer/aiupload(src)
 
 /obj/structure/closet/secure_closet/research_director/populate_contents_immediate()
 	. = ..()

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -56,27 +56,27 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/aiupload
-	name = "AI Upload Board"
-	desc = "Allows for the construction of circuit boards used to build an AI Upload Console."
-	id = "aiupload"
-	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/diamond = 2000, /datum/material/bluespace = 2000)
-	build_path = /obj/item/circuitboard/computer/aiupload
-	category = list(
-		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+// /datum/design/board/aiupload
+//	name = "AI Upload Board"
+//	desc = "Allows for the construction of circuit boards used to build an AI Upload Console."
+//	id = "aiupload"
+//	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/diamond = 2000, /datum/material/bluespace = 2000)
+//	build_path = /obj/item/circuitboard/computer/aiupload
+//	category = list(
+//		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
+//	)
+//	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/borgupload
-	name = "Cyborg Upload Board"
-	desc = "Allows for the construction of circuit boards used to build a Cyborg Upload Console."
-	id = "borgupload"
-	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/diamond = 2000, /datum/material/bluespace = 2000)
-	build_path = /obj/item/circuitboard/computer/borgupload
-	category = list(
-		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+// /datum/design/board/borgupload
+//	name = "Cyborg Upload Board"
+//	desc = "Allows for the construction of circuit boards used to build a Cyborg Upload Console."
+//	id = "borgupload"
+//	materials = list(/datum/material/glass = 1000, /datum/material/gold = 2000, /datum/material/diamond = 2000, /datum/material/bluespace = 2000)
+//	build_path = /obj/item/circuitboard/computer/borgupload
+//	category = list(
+//		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
+//	)
+//	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
 /datum/design/board/med_data
 	name = "Medical Records Board"


### PR DESCRIPTION
## About The Pull Request

This PR simply prevents AI and cyborg uploads from being printed by circuit imprinters.
## Why It's Good For The Game

Tiding into science to build a maints upload isn't particularly fun for the person tampering with the AI, the AI, and the crew. This change makes the existing boards actually important along with making the upload itself more relevant while making it tougher to tamper with / fix one of the station's most important assets. If every board is hidden or destroyed (a feat in itself) you could always go hit the AI core with law change modules as a last resort.
## Changelog
:cl:
add: Adds an extra upload board to the RD's locker.
del: Removes the ability to print AI and cyborg uploads from circuit imprinters
/:cl:
