### PR TITLE
Nukes The 2.5-Minute Long Artifact Upload on Windows Build

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -199,12 +199,3 @@ jobs:
         run: pwsh tools/ci/build.ps1
         env:
           DM_EXE: "C:\\byond\\bin\\dm.exe"
-      - name: Create artifact
-        run: |
-          md deploy
-          bash tools/deploy.sh ./deploy
-      - name: Deploy artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: deploy
-          path: deploy


### PR DESCRIPTION
## About The Pull Request

This was added in #39040, and later replicated to Github Actions. The PR's intent was "Enables appveyor and artifacts, you can now download a .dmb deployment straight from a PR or master commit." However, this was not documented anywhere (e.g. https://github.com/tgstation/tgstation/blob/master/.github/guides/DOWNLOADING.md#downloading), so no one knew this was even a thing. This took up _2.5 minutes_ a run (e.g. https://github.com/tgstation/tgstation/actions/runs/4200213469/jobs/7285998135), for something we absolutely don't use. Let's save the time and free up that runner as fast as possible. Pretty sure "Windows Build" is just to be a way to ensure we compile on windows, and we should either do this or document it somewhere (and I'm more in favor of the former).

`deploy.sh` is ran with the Docker Build that we do nightly (which also happens to be only one of two supported ways to get a compilation of our code) (as well as other CI stuff we should be good in theory).
## Why It's Good For The Game

less ci clog wahoo
## Changelog
Nothing that concerns players.

CI Run on this PR that shows it only taking a solid two-three minutes (instead of five), yippie https://github.com/tgstation/tgstation/actions/runs/4200654031/jobs/7286891936