### PR TITLE
Frozen tanks now release the gasses inside them when shattered

### DIFF
--- a/code/datums/elements/frozen.dm
+++ b/code/datums/elements/frozen.dm
@@ -44,7 +44,8 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 	SIGNAL_HANDLER
 	var/obj/obj_target = target
 	obj_target.visible_message(span_danger("[obj_target] shatters into a million pieces!"))
-	qdel(obj_target)
+	obj_target.flags_1 |= NODECONSTRUCT_1	// disable item spawning
+	obj_target.deconstruct(FALSE)			// call pre-deletion specialized code -- internals release gas etc
 
 /// signal handler for COMSIG_MOVABLE_MOVED that unfreezes our target if it moves onto an open turf thats hotter than
 /// our melting temperature.

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -428,6 +428,7 @@ GLOBAL_LIST_INIT(gas_id_to_canister, init_gas_id_to_canister())
 
 /obj/machinery/portable_atmospherics/canister/deconstruct(disassembled = TRUE)
 	if((flags_1 & NODECONSTRUCT_1))
+		qdel(src)
 		return
 	if(!(machine_stat & BROKEN))
 		canister_break()


### PR DESCRIPTION
## About The Pull Request

Instead of simply being qdel'ed, shattered items have their deconstruct proc called (with flags set to prevent items from being dropped in the process). This means that if an object has code that should run before it's destroyed in order to maintain in-game consistency, that will be called instead of ignored.

As a result:
- Internals tanks release gasses inside of them (what I wanted to fix)
- Frozen containers only destroy themselves, not everything inside of them (unintended side effect -- I think it's good but others might disagree)
- Grenades detonate (unintended side effect -- can be disabled by changing the disassembled flag to true instead of false)
- Gas crystals release their contents (because theyre grenades)
- Hot Ice does NOT release anything, since it's a datum and not an object

Also, fixes a potential bug where holodeck canisters wouldn't be destroyed when their deconstruct was called, making them (possibly?) indestructible. I doubt this would ever have shown up, but... it's fixed now!

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/71121, adds potential support for similar future cases.
Fixes an issue where holodeck canisters (should those ever exist) would be indestructible.

## Changelog
:cl:
fix: frozen gas tanks now release their contents upon shattering
fix: holodeck gas tanks can now be deconstructed
/:cl:
