### PR TITLE
You can't eat a turf unless you are standing next to it

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -236,8 +236,6 @@ Behavior that's still missing from this component that original food items had t
 /datum/component/edible/proc/TryToEatIt(datum/source, mob/user)
 	SIGNAL_HANDLER
 
-	if(!in_range(source, user))
-		return
 	return TryToEat(user, user)
 
 ///Called when food is created through processing (Usually this means it was sliced). We use this to pass the OG items reagents.
@@ -302,7 +300,7 @@ Behavior that's still missing from this component that original food items had t
 
 	var/atom/owner = parent
 
-	if(feeder.combat_mode)
+	if(feeder.combat_mode || !in_range(owner, eater))
 		return
 
 	. = COMPONENT_CANCEL_ATTACK_CHAIN //Point of no return I suppose

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -236,6 +236,8 @@ Behavior that's still missing from this component that original food items had t
 /datum/component/edible/proc/TryToEatIt(datum/source, mob/user)
 	SIGNAL_HANDLER
 
+	if(!in_range(source, user))
+		return
 	return TryToEat(user, user)
 
 ///Called when food is created through processing (Usually this means it was sliced). We use this to pass the OG items reagents.


### PR DESCRIPTION
## About The Pull Request

Fixes #73115, don't you love telepathy?
Just adds a range check to the general "can I eat this now?" proc. I couldn't think of any situation where you should be able to eat something which isn't next to you.
I tested it and you can still feed people and eat food from your inventory.

## Why It's Good For The Game

It's funny to be able to eat pizza floor with your brain but not intended.

## Changelog

:cl:
fix: You can no longer eat pizza floor tiles with your brain.
/:cl: