### PR TITLE
Moth Wing Reconstruction surgery works

### DIFF
--- a/code/modules/surgery/advanced/wingreconstruction.dm
+++ b/code/modules/surgery/advanced/wingreconstruction.dm
@@ -50,7 +50,7 @@
 		display_pain(target, "You can feel your wings again!")
 		var/obj/item/organ/external/wings/moth/wings = target.getorganslot(ORGAN_SLOT_EXTERNAL_WINGS)
 		if(istype(wings, /obj/item/organ/external/wings/moth)) //make sure we only heal moth wings.
-			wings.heal_wings()
+			wings.heal_wings(user, ALL)
 
 		var/obj/item/organ/external/antennae/antennae = target.getorganslot(ORGAN_SLOT_EXTERNAL_ANTENNAE) //i mean we might aswell heal their antennae too
 		antennae?.heal_antennae()


### PR DESCRIPTION

## About The Pull Request

Moth wings only allow themselves to be healed if the proc is called with HEAL_ORGAN or HEAL_LIMB
So we just make the surgery force healing
## Why It's Good For The Game

Resolves https://github.com/tgstation/tgstation/issues/73485
## Changelog
:cl:
fix: Moth wings can now correctly be healed
/:cl:
