### PR TITLE
Adds some privacy shutters for qm.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -13314,7 +13314,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
 	},
 /turf/open/floor/iron,
@@ -23857,7 +23857,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
 	},
 /turf/open/floor/iron,
@@ -42901,6 +42901,10 @@
 /area/station/maintenance/department/crew_quarters/bar)
 "krp" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "krs" = (
@@ -49985,8 +49989,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/reinforced,
-/obj/item/folder/yellow,
-/obj/item/stamp/qm,
+/obj/item/folder/yellow{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/item/stamp/qm{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/obj/machinery/button/door{
+	id = "qmprivacy";
+	name = "Privacy Shutters Control";
+	req_access = list("qm");
+	pixel_x = 6;
+	pixel_y = 3
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
@@ -58154,6 +58171,10 @@
 "ofx" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "ofE" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3601,14 +3601,23 @@
 	pixel_x = 32
 	},
 /obj/item/radio/intercom/directional/east{
-	pixel_y = 3
+	pixel_y = 3;
+	pixel_x = 38
 	},
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
 	},
 /obj/machinery/keycard_auth/directional/east{
-	pixel_x = 25;
+	pixel_x = 40;
 	pixel_y = -8
+	},
+/obj/machinery/button/door/directional/east{
+	pixel_y = -8;
+	id = "qmspace"
+	},
+/obj/machinery/button/door/directional/east{
+	pixel_y = 6;
+	id = "qmprivacy"
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
@@ -46434,6 +46443,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"ljS" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmspace";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "ljT" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -49185,7 +49203,13 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/east,
+/obj/item/radio/intercom/directional/east{
+	pixel_y = 3
+	},
+/obj/machinery/button/door/directional/east{
+	id = "qmroom";
+	pixel_y = -6
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "lSh" = (
@@ -49995,13 +50019,6 @@
 	},
 /obj/item/stamp/qm{
 	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/machinery/button/door{
-	id = "qmprivacy";
-	name = "Privacy Shutters Control";
-	req_access = list("qm");
-	pixel_x = 6;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -58172,7 +58189,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
-	id = "qmprivacy";
+	id = "qmroom";
 	name = "Privacy Shutters"
 	},
 /turf/open/floor/plating,
@@ -78536,6 +78553,14 @@
 /obj/effect/mapping_helpers/mail_sorting/service/theater,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"tgX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmspace";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "thf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -145654,7 +145679,7 @@ aAU
 meV
 xhJ
 vMd
-krp
+tgX
 jfO
 jBM
 xVv
@@ -145905,13 +145930,13 @@ aaa
 aaa
 aaa
 aad
-ofx
+ljS
 gmo
 dfQ
 tYz
 dfQ
 cAZ
-krp
+tgX
 rWo
 rWo
 rWo
@@ -146162,13 +146187,13 @@ aaa
 aaa
 aaa
 aad
-ofx
+ljS
 aPo
 bdF
 wob
 sWD
 sNp
-krp
+tgX
 aad
 rWo
 juo

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -50016,14 +50016,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/reinforced,
-/obj/item/folder/yellow{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/stamp/qm{
-	pixel_x = -5;
-	pixel_y = 3
-	},
+/obj/item/folder/yellow,
+/obj/item/stamp/qm,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3613,11 +3613,13 @@
 	},
 /obj/machinery/button/door/directional/east{
 	pixel_y = -8;
-	id = "qmspace"
+	id = "qmspace";
+	name = "Space Shutters Control"
 	},
 /obj/machinery/button/door/directional/east{
 	pixel_y = 6;
-	id = "qmprivacy"
+	id = "qmprivacy";
+	name = "Privacy Control"
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
@@ -49208,7 +49210,8 @@
 	},
 /obj/machinery/button/door/directional/east{
 	id = "qmroom";
-	pixel_y = -6
+	pixel_y = -6;
+	name = "Privacy Control"
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -26934,6 +26934,10 @@
 /area/station/hallway/primary/starboard)
 "ikO" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "ikT" = (
@@ -44876,7 +44880,16 @@
 	pixel_y = 4
 	},
 /obj/item/folder/yellow,
-/obj/machinery/keycard_auth/directional/west,
+/obj/machinery/keycard_auth/directional/west{
+	pixel_y = -4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "qmprivacy";
+	name = "Privacy Shutters Control";
+	req_access = list("qm");
+	pixel_y = 5;
+	pixel_x = -25
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "nNv" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -26934,7 +26934,7 @@
 /area/station/hallway/primary/starboard)
 "ikO" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "qmprivacy";
 	name = "Privacy Shutters"
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -44881,14 +44881,14 @@
 	},
 /obj/item/folder/yellow,
 /obj/machinery/keycard_auth/directional/west{
-	pixel_y = -4
+	pixel_y = -5;
+	pixel_x = -25
 	},
 /obj/machinery/button/door/directional/west{
 	id = "qmprivacy";
 	name = "Privacy Shutters Control";
 	req_access = list("qm");
-	pixel_y = 5;
-	pixel_x = -25
+	pixel_y = 5
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1591,7 +1591,7 @@
 /area/station/command/teleporter)
 "atu" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "qmprivacy";
 	name = "Privacy Shutters"
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9334,12 +9334,11 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 1
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/east{
 	id = "qmprivacy";
 	name = "Privacy Shutters Control";
-	pixel_x = 24;
-	pixel_y = 38;
-	req_access = list("qm")
+	req_access = list("qm");
+	pixel_y = 38
 	},
 /obj/machinery/keycard_auth/directional/east{
 	pixel_y = 26

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -9337,8 +9337,8 @@
 /obj/machinery/button/door{
 	id = "qmprivacy";
 	name = "Privacy Shutters Control";
-	pixel_x = 25;
-	pixel_y = 36;
+	pixel_x = 24;
+	pixel_y = 38;
 	req_access = list("qm")
 	},
 /obj/machinery/keycard_auth/directional/east{

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1591,6 +1591,10 @@
 /area/station/command/teleporter)
 "atu" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "atB" = (
@@ -9329,6 +9333,13 @@
 	},
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "qmprivacy";
+	name = "Privacy Shutters Control";
+	pixel_x = 25;
+	pixel_y = 36;
+	req_access = list("qm")
 	},
 /obj/machinery/keycard_auth/directional/east{
 	pixel_y = 26
@@ -23266,7 +23277,7 @@
 "gHI" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
 	},
 /turf/open/floor/iron/dark,
@@ -74485,7 +74496,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -61597,11 +61597,11 @@
 /obj/machinery/keycard_auth/directional/south{
 	pixel_x = -6
 	},
-/obj/machinery/button/door{
+/obj/machinery/button/door/directional/south{
 	id = "qmprivacy";
 	name = "Privacy Shutters Control";
-	pixel_y = -26;
 	req_access = list("qm");
+	pixel_y = -26;
 	pixel_x = 8
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -61595,8 +61595,7 @@
 "vHG" = (
 /obj/structure/table/wood,
 /obj/machinery/keycard_auth/directional/south{
-	pixel_x = -5;
-	pixel_y = -25
+	pixel_x = -6
 	},
 /obj/machinery/button/door{
 	id = "qmprivacy";

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46960,6 +46960,10 @@
 /area/station/maintenance/starboard/fore)
 "qIK" = (
 /obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/qm)
 "qIP" = (
@@ -53796,7 +53800,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
 	},
 /turf/open/floor/iron,
@@ -61590,7 +61594,17 @@
 /area/station/commons/fitness/recreation)
 "vHG" = (
 /obj/structure/table/wood,
-/obj/machinery/keycard_auth/directional/south,
+/obj/machinery/keycard_auth/directional/south{
+	pixel_x = -5;
+	pixel_y = -25
+	},
+/obj/machinery/button/door{
+	id = "qmprivacy";
+	name = "Privacy Shutters Control";
+	pixel_y = -26;
+	req_access = list("qm");
+	pixel_x = 8
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "vHO" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -10895,13 +10895,12 @@
 	dir = 4
 	},
 /obj/machinery/keycard_auth/directional/east{
-	pixel_y = -5
+	pixel_y = -6
 	},
 /obj/machinery/button/door/directional/east{
 	id = "qmprivacy";
 	name = "Privacy Shutters Control";
-	pixel_x = 25;
-	pixel_y = 4;
+	pixel_y = 5;
 	req_access = list("qm")
 	},
 /obj/structure/cable,
@@ -22968,6 +22967,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"gEz" = (
+/turf/closed/mineral/random/stationside/asteroid/porus,
+/area)
 "gEC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door_buttons/airlock_controller{
@@ -45798,7 +45800,7 @@
 	name = "Privacy Shutters"
 	},
 /turf/open/floor/plating,
-/area/station/command/heads_quarters/qm)
+/area/station/cargo/office)
 "plk" = (
 /turf/closed/wall/r_wall,
 /area/station/solars/starboard/fore)
@@ -174788,7 +174790,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gEz
 aaa
 aaa
 aaa

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -10894,7 +10894,16 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/machinery/keycard_auth/directional/east,
+/obj/machinery/keycard_auth/directional/east{
+	pixel_y = -5
+	},
+/obj/machinery/button/door/directional/east{
+	id = "qmprivacy";
+	name = "Privacy Shutters Control";
+	pixel_x = 25;
+	pixel_y = 4;
+	req_access = list("qm")
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -21613,7 +21622,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
 	},
 /obj/structure/disposalpipe/segment,
@@ -45782,6 +45791,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"pli" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "qmprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/qm)
 "plk" = (
 /turf/closed/wall/r_wall,
 /area/station/solars/starboard/fore)
@@ -63961,7 +63978,7 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
-/obj/machinery/door/airlock/command/glass{
+/obj/machinery/door/airlock/command{
 	name = "Quartermaster's Office"
 	},
 /obj/structure/cable,
@@ -179920,9 +179937,9 @@ msn
 qza
 oAV
 oAV
-vYl
+pli
 vSX
-vYl
+pli
 oAV
 whL
 ged


### PR DESCRIPTION
## About The Pull [Request]
So, since qm is part of command and a head of cargo, it is logical that he will have some privacy. My choice of shutters was made from shutters in hop office on different maps.
I also changed door with windows on common doors because they dont give you privacy feeling, yeah...
![IceBox](https://user-images.githubusercontent.com/93882977/219941941-84c638e9-fcf6-4105-8c26-c13f921835e6.png)
![Meta](https://user-images.githubusercontent.com/93882977/219792453-c6705eef-a21d-4ce1-8652-0a492ecb58bf.png)
![image](https://user-images.githubusercontent.com/93882977/219951625-2226280a-d02e-4083-9948-6357d870a6ae.png)
![Delta](https://user-images.githubusercontent.com/93882977/219792459-2e70b6b8-e618-4058-8822-1188dd3e0051.png)
![Delta2](https://user-images.githubusercontent.com/93882977/219792460-7a4bc3c8-de32-4417-b0fd-42cd93f0219c.png)
![Kilo](https://user-images.githubusercontent.com/93882977/219941420-d60136ba-53d7-4361-9045-2f54a9236f49.png)

## Why It's Good For The Game
Dunno.
## Changelog
:cl:
add: Adds privacy shutters for quartermaster. Shutters on Kilo/IceBox and blastdoors on Meta/Delta/Tram. Also changed doors with glass to common ones.
/:cl:
