### PR TITLE
Fixes Seiver jank and bad code

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -294,20 +294,21 @@
 /datum/reagent/medicine/c2/seiver //a bit of a gray joke
 	name = "Seiver"
 	description = "A medicine that shifts functionality based on temperature. Hotter temperatures will heal more toxicity, while colder temperatures will heal larger amounts of toxicity but only while the patient is irradiated. Damages the heart." //CHEM HOLDER TEMPS, NOT AIR TEMPS
-	var/radbonustemp = 100 //being below this number gives you radiation healing.
 	inverse_chem_val = 0.3
 	ph = 3.7
 	inverse_chem = /datum/reagent/inverse/technetium
 	inverse_chem_val = 0.45
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	/// Temperatures below this number give radiation healing.
+	var/rads_heal_threshold = 100
 
 /datum/reagent/medicine/c2/seiver/on_mob_metabolize(mob/living/carbon/human/affected_mob)
 	. = ..()
-	radbonustemp = rand(radbonustemp - 50, radbonustemp + 50) // Basically this means 50K and below will always give the percent heal, and upto 150K could. Calculated once.
+	rads_heal_threshold = rand(rads_heal_threshold - 50, rads_heal_threshold + 50) // Basically this means 50K and below will always give the radiation heal, and upto 150K could. Calculated once.
 
 /datum/reagent/medicine/c2/seiver/on_mob_life(mob/living/carbon/human/affected_mob, delta_time, times_fired)
 	var/chemtemp = min(holder.chem_temp, 1000)
-	chemtemp = chemtemp ? chemtemp : 273 //why do you have null sweaty
+	chemtemp = chemtemp ? chemtemp : T0C //why do you have null sweaty
 	var/healypoints = 0 //5 healypoints = 1 heart damage; 5 rads = 1 tox damage healed for the purpose of healypoints
 
 	//you're hot
@@ -321,9 +322,9 @@
 	if(radcalc > 0 && HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
 		radcalc *= normalise_creation_purity()
 		// extra rad healing if you are SUPER cold
-		if(chemtemp < radbonustemp*0.1)
+		if(chemtemp < rads_heal_threshold*0.1)
 			affected_mob.adjustToxLoss(-radcalc * 0.9, required_biotype = affected_biotype)
-		else if(chemtemp < radbonustemp)
+		else if(chemtemp < rads_heal_threshold)
 			affected_mob.adjustToxLoss(-radcalc * 0.75, required_biotype = affected_biotype)
 		healypoints += (radcalc / 5)
 

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -293,8 +293,8 @@
 
 /datum/reagent/medicine/c2/seiver //a bit of a gray joke
 	name = "Seiver"
-	description = "A medicine that shifts functionality based on temperature. Hotter temperatures will remove amounts of toxins, while coder temperatures will heal larger amounts of toxins only while the patient is irradiated. Damages the heart." //CHEM HOLDER TEMPS, NOT AIR TEMPS
-	var/radbonustemp = (T0C - 100) //being below this number gives you 10% off rads.
+	description = "A medicine that shifts functionality based on temperature. Hotter temperatures will heal more toxicity, while colder temperatures will heal larger amounts of toxicity but only while the patient is irradiated. Damages the heart." //CHEM HOLDER TEMPS, NOT AIR TEMPS
+	var/radbonustemp = 100 //being below this number gives you radiation healing.
 	inverse_chem_val = 0.3
 	ph = 3.7
 	inverse_chem = /datum/reagent/inverse/technetium
@@ -313,18 +313,18 @@
 	//you're hot
 	var/toxcalc = min(round(5 + ((chemtemp-1000)/175), 0.1), 5) * REM * delta_time * normalise_creation_purity() //max 2.5 tox healing per second
 	if(toxcalc > 0)
-		affected_mob.adjustToxLoss(-toxcalc * delta_time * normalise_creation_purity(), required_biotype = affected_biotype)
+		affected_mob.adjustToxLoss(-toxcalc, required_biotype = affected_biotype)
 		healypoints += toxcalc
 
 	//and you're cold
 	var/radcalc = round((T0C-chemtemp) / 6, 0.1) * REM * delta_time //max ~45 rad loss unless you've hit below 0K. if so, wow.
 	if(radcalc > 0 && HAS_TRAIT(affected_mob, TRAIT_IRRADIATED))
 		radcalc *= normalise_creation_purity()
-		// no cost percent healing if you are SUPER cold (on top of cost healing)
+		// extra rad healing if you are SUPER cold
 		if(chemtemp < radbonustemp*0.1)
-			affected_mob.adjustToxLoss(-radcalc * (0.9**(REM * delta_time)), required_biotype = affected_biotype)
+			affected_mob.adjustToxLoss(-radcalc * 0.9, required_biotype = affected_biotype)
 		else if(chemtemp < radbonustemp)
-			affected_mob.adjustToxLoss(-radcalc * (0.75**(REM * delta_time)), required_biotype = affected_biotype)
+			affected_mob.adjustToxLoss(-radcalc * 0.75), required_biotype = affected_biotype)
 		healypoints += (radcalc / 5)
 
 	//you're yes and... oh no!

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -324,7 +324,7 @@
 		if(chemtemp < radbonustemp*0.1)
 			affected_mob.adjustToxLoss(-radcalc * 0.9, required_biotype = affected_biotype)
 		else if(chemtemp < radbonustemp)
-			affected_mob.adjustToxLoss(-radcalc * 0.75), required_biotype = affected_biotype)
+			affected_mob.adjustToxLoss(-radcalc * 0.75, required_biotype = affected_biotype)
 		healypoints += (radcalc / 5)
 
 	//you're yes and... oh no!


### PR DESCRIPTION

## About The Pull Request
Seiver is currently way stronger than it was intended due to bad code. Also the comments didn't make any sense whatsoever and were often just wrong.

This nerfs hot seiver significantly - it was often almost 3x stronger than intended, able to reach tox healing levels of 17.7 per tick. With the change, it maxes out at 6.7 tox healing per tick.
## Why It's Good For The Game
5u hot seiver can no longer heal 442 tox damage over less than a minute
## Changelog
:cl:
fix: seiver no longer applies purity and delta time twice
code: made seiver code much less confusing
/:cl:
