### PR TITLE
Fixes throw messages to always say you threw it very hard

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -198,7 +198,7 @@
 		power_throw++
 	visible_message(span_danger("[src] throws [thrown_thing][power_throw ? " really hard!" : "."]"), \
 					span_danger("You throw [thrown_thing][power_throw ? " really hard!" : "."]"))
-	log_message("has thrown [thrown_thing] [power_throw ? "really hard" : ""]", LOG_ATTACK)
+	log_message("has thrown [thrown_thing] [power_throw > 0 ? "really hard" : ""]", LOG_ATTACK)
 	var/extra_throw_range = HAS_TRAIT(src, TRAIT_THROWINGARM) ? 2 : 0
 	newtonian_move(get_dir(target, src))
 	thrown_thing.safe_throw_at(target, thrown_thing.throw_range + extra_throw_range, max(1,thrown_thing.throw_speed + power_throw), src, null, null, null, move_force)


### PR DESCRIPTION

## About The Pull Request
Fixes wrong check in throw messages to say "very hard throw" even if its a weak one. 
## Why It's Good For The Game
Actual correct description for throwing is good, at least thats what i think 
## Changelog
:cl:
fix: fixed throwing description to always say "it was thrown very hard" even when its not
/:cl:
