### PR TITLE
Fixes NtosNet Downloader & App themes

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -70,7 +70,7 @@
 		data["removable_media"] += "intelliCard"
 
 	data["programs"] = list()
-	for(var/datum/computer_file/program/program as anything in stored_files)
+	for(var/datum/computer_file/program/program in stored_files)
 		data["programs"] += list(list(
 			"name" = program.filename,
 			"desc" = program.filedesc,

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -50,7 +50,6 @@
 
 /obj/item/modular_computer/ui_data(mob/user)
 	var/list/data = get_header_data()
-	data["device_theme"] = device_theme
 
 	data["login"] = list(
 		IDName = saved_identification || "Unknown",

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -172,7 +172,7 @@
 /obj/item/modular_computer/pda/proc/get_detomatix_difficulty()
 	var/detomatix_difficulty
 
-	for(var/datum/computer_file/program/downloaded_apps as anything in stored_files)
+	for(var/datum/computer_file/program/downloaded_apps in stored_files)
 		detomatix_difficulty += downloaded_apps.detomatix_resistance
 
 	return detomatix_difficulty

--- a/code/modules/research/ordnance/tank_compressor.dm
+++ b/code/modules/research/ordnance/tank_compressor.dm
@@ -298,7 +298,7 @@
 			compressor_record -= record
 			return TRUE
 		if("save_record")
-			var/datum/data/compressor_record/record  = locate(params["ref"]) in compressor_record
+			var/datum/data/compressor_record/record = locate(params["ref"]) in compressor_record
 			if(!compressor_record || !(record in compressor_record))
 				return
 			print(usr, record)

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -5,7 +5,7 @@ import { NtosWindow } from '../layouts';
 export const NtosMain = (props, context) => {
   const { act, data } = useBackend(context);
   const {
-    device_theme,
+    PC_device_theme,
     show_imprint,
     programs = [],
     has_light,
@@ -22,9 +22,9 @@ export const NtosMain = (props, context) => {
   return (
     <NtosWindow
       title={
-        (device_theme === 'syndicate' && 'Syndix Main Menu') || 'NtOS Main Menu'
+        (PC_device_theme === 'syndicate' && 'Syndix Main Menu') ||
+        'NtOS Main Menu'
       }
-      theme={device_theme}
       width={400}
       height={500}>
       <NtosWindow.Content scrollable>

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -8,6 +8,7 @@ import { NtosWindow } from '../layouts';
 export const NtosNetDownloader = (props, context) => {
   const { act, data } = useBackend(context);
   const {
+    PC_device_theme,
     disk_size,
     disk_used,
     downloadcompletion,

--- a/tgui/packages/tgui/interfaces/NtosNetDownloader.js
+++ b/tgui/packages/tgui/interfaces/NtosNetDownloader.js
@@ -197,7 +197,7 @@ const Program = (props, context) => {
       <Box mt={1} italic color="label">
         {program.fileinfo}
       </Box>
-      {!program.verifiedsource && PC_device_theme === 'ntos' && (
+      {!program.verifiedsource && PC_device_theme !== 'syndicate' && (
         <NoticeBox mt={1} mb={0} danger fontSize="12px">
           Unverified source. Please note that Nanotrasen does not recommend
           download and usage of software from non-official servers.

--- a/tgui/packages/tgui/layouts/NtosWindow.js
+++ b/tgui/packages/tgui/layouts/NtosWindow.js
@@ -10,7 +10,7 @@ import { Box, Button } from '../components';
 import { Window } from './Window';
 
 export const NtosWindow = (props, context) => {
-  const { title, width = 575, height = 700, theme = 'ntos', children } = props;
+  const { title, width = 575, height = 700, children } = props;
   const { act, data } = useBackend(context);
   const {
     PC_device_theme,
@@ -24,7 +24,7 @@ export const NtosWindow = (props, context) => {
     PC_showexitprogram,
   } = data;
   return (
-    <Window title={title} width={width} height={height} theme={theme}>
+    <Window title={title} width={width} height={height} theme={PC_device_theme}>
       <div className="NtosWindow">
         <div className="NtosWindow__header NtosHeader">
           <div className="NtosHeader__left">


### PR DESCRIPTION
## About The Pull Request

NtOS' downloading app is the only application where PC device theme is actually used by the app directly, instead of handled by NtOS Window. I forgot about this, and removed it from the data, breaking the TGUI page.

Also two edits;
- NtosWindow now takes their theme directly from PC_device_theme, this means we're not relying anymore on apps to individually give the theme they want to have, and tablets will get alerts of downloading illegal programs if they are on any theme but the syndicate one (instead of not getting the message if theyre on any but the nt one).
- Removes bad uses of ``as anything`` on stored files, because it holds more than just programs (like ordnance data).

## Why It's Good For The Game

the NtOS app now works again, sorry for the issue.

Closes https://github.com/tgstation/tgstation/issues/73493
Closes https://github.com/tgstation/tgstation/issues/73507

## Changelog

:cl:
fix: NtOS program downloader now works again, and will now properly alert you of downloading illegal ROMs if you change your theme to anything that isn't Syndicate.
fix: NtOS themes are now recognized by all windows.
/:cl: