### PR TITLE
Messenger fixes

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -54,6 +54,7 @@
 	var/obj/item/photo/pic = attacking_item
 	saved_image = pic.picture
 	ProcessPhoto()
+	user.balloon_alert(user, "photo uploaded")
 	return TRUE
 
 /datum/computer_file/program/messenger/proc/ScrubMessengerList()
@@ -196,6 +197,19 @@
 			sending_virus = !sending_virus
 			return UI_UPDATE
 
+		if("PDA_selectPhoto")
+			if(!issilicon(usr))
+				return
+			var/mob/living/silicon/user = usr
+			if(!user.aicamera)
+				return
+			var/datum/picture/selected_photo = user.aicamera.selectpicture(user)
+			if(!selected_photo)
+				return
+			saved_image = selected_photo
+			ProcessPhoto()
+			return TRUE
+
 /datum/computer_file/program/messenger/ui_static_data(mob/user)
 	var/list/data = ..()
 
@@ -292,7 +306,8 @@
 		"ref" = REF(computer),
 		"targets" = targets,
 		"rigged" = rigged,
-		"photo" = photo_path,
+		"photo" = saved_image,
+		"photo_path" = photo_path,
 		"automated" = FALSE,
 	))
 	if(rigged) //Will skip the message server and go straight to the hub so it can't be cheesed by disabling the message server machine
@@ -319,7 +334,9 @@
 	message_data["contents"] = html_decode(signal.format_message())
 	message_data["outgoing"] = TRUE
 	message_data["ref"] = signal.data["ref"]
+	message_data["photo_path"] = signal.data["photo_path"]
 	message_data["photo"] = signal.data["photo"]
+	message_data["target_details"] = signal.format_target()
 
 	// Show it to ghosts
 	var/ghost_message = span_name("[message_data["name"]] </span><span class='game say'>[rigged ? "Rigged" : ""] PDA Message</span> --> [span_name("[signal.format_target()]")]: <span class='message'>[signal.format_message()]")
@@ -347,6 +364,8 @@
 		last_text_everyone = world.time
 
 	messages += list(message_data)
+	saved_image = null
+	photo_path = null
 	return TRUE
 
 /datum/computer_file/program/messenger/proc/receive_message(datum/signal/subspace/messaging/tablet_msg/signal)
@@ -357,6 +376,7 @@
 	message_data["outgoing"] = FALSE
 	message_data["ref"] = signal.data["ref"]
 	message_data["automated"] = signal.data["automated"]
+	message_data["photo_path"] = signal.data["photo_path"]
 	message_data["photo"] = signal.data["photo"]
 	messages += list(message_data)
 
@@ -382,8 +402,8 @@
 		inbound_message = emoji_parse(inbound_message)
 
 		if(L.is_literate())
-			to_chat(L, "<span class='infoplain'>[icon2html(src)] <b>PDA message from [hrefstart][signal.data["name"]] ([signal.data["job"]])[hrefend], </b>[inbound_message] [reply]</span>")
-
+			var/photo_message = message_data["photo"] ? " (<a href='byond://?src=[REF(signal.logged)];photo=1'>Photo</a>)" : ""
+			to_chat(L, span_infoplain("[icon2html(computer)] <b>PDA message from [hrefstart][signal.data["name"]] ([signal.data["job"]])[hrefend], </b>[inbound_message][photo_message] [reply]"))
 
 	if (ringer_status)
 		computer.ring(ringtone)

--- a/code/modules/photography/camera/silicon_camera.dm
+++ b/code/modules/photography/camera/silicon_camera.dm
@@ -15,15 +15,15 @@
 	to_chat(user, span_notice("Camera mode: [in_camera_mode ? "Activated" : "Deactivated"]."))
 
 /obj/item/camera/siliconcam/proc/selectpicture(mob/user)
-	var/list/nametemp = list()
+	RETURN_TYPE(/datum/picture)
 	if(!length(stored))
-		to_chat(usr, span_warning("No images saved"))
+		to_chat(user, span_notice("ERROR: No stored photos located."))
 		return
+	var/list/nametemp = list()
 	var/list/temp = list()
-	for(var/i in stored)
-		var/datum/picture/p = i
-		nametemp += p.picture_name
-		temp[p.picture_name] = p
+	for(var/datum/picture/stored_photo as anything in stored)
+		nametemp += stored_photo.picture_name
+		temp[stored_photo.picture_name] = stored_photo
 	var/find = tgui_input_list(user, "Select image", "Storage", nametemp)
 	if(isnull(find))
 		return

--- a/tgui/packages/tgui/interfaces/NtosMessenger.js
+++ b/tgui/packages/tgui/interfaces/NtosMessenger.js
@@ -104,6 +104,13 @@ const ContactsScreen = (props, context) => {
                 content={`Sort by: ${sortByJob ? 'Job' : 'Name'}`}
                 onClick={() => act('PDA_changeSortStyle')}
               />
+              {!!isSilicon && (
+                <Button
+                  icon="camera"
+                  content="Attach Photo"
+                  onClick={() => act('PDA_selectPhoto')}
+                />
+              )}
               {!!virus_attach && (
                 <Button
                   icon="bug"
@@ -203,7 +210,7 @@ const MessageListScreen = (props, context) => {
                   {message.outgoing ? '(OUTGOING)' : '(INCOMING)'}
                 </Box>
                 {message.outgoing ? (
-                  <Box bold>{message.name + ' (' + message.job + ')'}</Box>
+                  <Box bold>{message.target_details}</Box>
                 ) : (
                   <Button
                     transparent
@@ -220,7 +227,9 @@ const MessageListScreen = (props, context) => {
               </Section>
               <Section fill mt={-1}>
                 <Box italic>{message.contents}</Box>
-                {!!message.photo && <Box as="img" src={message.photo} mt={1} />}
+                {!!message.photo && (
+                  <Box as="img" src={message.photo_path} mt={1} />
+                )}
               </Section>
             </Stack>
           ))}


### PR DESCRIPTION
## About The Pull Request

- Photos now show up in the chat to the person recieving them as a (Photo) like how it used to be 
- Outgoing messages now properly say who it's outgoing to, instead of saying it's to themselves. 
- Messenger now clears photos after sending an image with them, so you don't accidentally send the same photo 50 times.
- AIs can now send an image from the messenger menu (code stolen from https://github.com/BeeStation/BeeStation-Hornet/pull/7550)
- Added a balloon alert when you uploaded a photo so it doesn't just silently pass and you have no idea if it worked or not.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/70140 - an issue report I've had open for months and kept procrastinating on working on.
Closes https://github.com/tgstation/tgstation/issues/70264

Messenger now properly works as it was originally supposed to.

## Changelog

:cl: JohnFulpWillard and itsmeow
fix: Messenger now clears photos after you send it, so you don't send a photo repeatedly until you manually clear it.
fix: Sending a photo now has a hyperlink in chat for the target to see (like with old PDAs)
fix: AIs can now select photos in their Messenger app.
fix: Messenger no longer says you're sending outgoing messages to yourself.
/:cl: