### PR TITLE
Flares and candles are now made of plastic

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -301,6 +301,7 @@
 	var/trash_type = /obj/item/trash/flare
 	/// If the light source can be extinguished
 	var/can_be_extinguished = FALSE
+	custom_materials = list(/datum/material/plastic=50)
 
 /obj/item/flashlight/flare/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Flares and candles are now made of plastic. 

![image](https://user-images.githubusercontent.com/12107211/219854793-378aba49-78e7-4b6d-95de-8cc1062de0ea.png)

That's close enough to wax, right? I'm sure those chemical-smelling fumes are nothing to worry about.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/73495 (arguably)

## Changelog

:cl:
fix: candles are made of a more appropriate material
/:cl:
