### PR TITLE
Station traits are chosen with more equalised randomness

### DIFF
--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -63,7 +63,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 
 	var/possible_types = list(STATION_TRAIT_POSITIVE, STATION_TRAIT_NEUTRAL, STATION_TRAIT_NEGATIVE)
 	while(length(possible_types))
-		var/picked = pick(possible_types) // this lets a type of station traits chosen more randomly.
+		var/picked = pick_n_take(possible_types) // this lets a type of station traits chosen more randomly.
 		switch(picked)
 			if(STATION_TRAIT_POSITIVE)
 				pick_traits(STATION_TRAIT_POSITIVE, positive_trait_count)
@@ -71,7 +71,6 @@ PROCESSING_SUBSYSTEM_DEF(station)
 				pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_count)
 			if(STATION_TRAIT_NEGATIVE)
 				pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_count)
-		possible_types -= picked
 
 ///Picks traits of a specific category (e.g. bad or good) and a specified amount, then initializes them and adds them to the list of traits.
 /datum/controller/subsystem/processing/station/proc/pick_traits(trait_sign, amount)

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -61,9 +61,17 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	var/neutral_trait_count = pick(10;0, 10;1, 3;2)
 	var/negative_trait_count = pick(20;0, 5;1, 1;2)
 
-	pick_traits(STATION_TRAIT_POSITIVE, positive_trait_count)
-	pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_count)
-	pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_count)
+	var/possible_types = list(STATION_TRAIT_POSITIVE, STATION_TRAIT_NEUTRAL, STATION_TRAIT_NEGATIVE, STATION_TRAIT_EXCLUSIVE)
+	while(length(possible_types))
+		var/picked = pick(possible_types) // this lets a type of station traits chosen more randomly.
+		switch(picked)
+			if(STATION_TRAIT_POSITIVE)
+				pick_traits(STATION_TRAIT_POSITIVE, positive_trait_count)
+			if(STATION_TRAIT_NEUTRAL)
+				pick_traits(STATION_TRAIT_NEUTRAL, neutral_trait_count)
+			if(STATION_TRAIT_NEGATIVE)
+				pick_traits(STATION_TRAIT_NEGATIVE, negative_trait_count)
+		possible_types -= picked
 
 ///Picks traits of a specific category (e.g. bad or good) and a specified amount, then initializes them and adds them to the list of traits.
 /datum/controller/subsystem/processing/station/proc/pick_traits(trait_sign, amount)

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -61,7 +61,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	var/neutral_trait_count = pick(10;0, 10;1, 3;2)
 	var/negative_trait_count = pick(20;0, 5;1, 1;2)
 
-	var/possible_types = list(STATION_TRAIT_POSITIVE, STATION_TRAIT_NEUTRAL, STATION_TRAIT_NEGATIVE, STATION_TRAIT_EXCLUSIVE)
+	var/possible_types = list(STATION_TRAIT_POSITIVE, STATION_TRAIT_NEUTRAL, STATION_TRAIT_NEGATIVE)
 	while(length(possible_types))
 		var/picked = pick(possible_types) // this lets a type of station traits chosen more randomly.
 		switch(picked)


### PR DESCRIPTION

## About The Pull Request
Station traits are chosen with more equalised randomness
Positive station traits are always chosen first, and it blacklists the traits that'll come up later.
This means the traits that come up later will not be chosen, and it's against the nature of randomness.

as a result of this PR, the chance of some neg station traits will appear slightly more than before,
while some neg traits that are not affected by blacklist will have lower chance to appear than before.

i.e.) `Distant supply lines` will appear slightly more than before, because it was blacklisted by positive trait `Strong supply lines` (and this means the strong supply lines trait will be chosen less than before)
## Why It's Good For The Game
more equalised randomness good.
## Changelog
:cl:
code: Station traits are now chosen with more equalised randomness.
/:cl:
