### PR TITLE
Paraplegics can be Frail, too.

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -27,7 +27,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Bad Touch", "Friendly"),
 		list("Extrovert", "Introvert"),
 		list("Prosthetic Limb", "Quadruple Amputee", "Body Purist"),
-		list("Quadruple Amputee", "Paraplegic", "Frail"),
+		list("Quadruple Amputee", "Paraplegic"),
+		list("Quadruple Amputee", "Frail"),
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()


### PR DESCRIPTION

## About The Pull Request

Current blacklist makes it so you cannot be both frail and paraplegic, but it's intended to exclude quad amputees from taking those. 

## Why It's Good For The Game

Who says a paraplegic can't also have weak bones?

## Changelog
:cl:
fix: frail and paraplegia quirks can once again be taken together.
/:cl:
