### PR TITLE
Fixes wrong icon state on goliath heart

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -156,15 +156,11 @@
 
 	organ_traits = list(TRAIT_ASHSTORM_IMMUNE)
 
-/// we dont have a beating and dead heart state so no need to update it
-/obj/item/organ/internal/heart/goliath/update_icon_state()
-	SHOULD_CALL_PARENT(FALSE)
-	return
-
 /obj/item/organ/internal/heart/goliath/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/noticable_organ, "skin has visible hard plates growing from within.", BODY_ZONE_CHEST)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/goliath)
+	AddElement(/datum/element/update_icon_blocker)
 
 #undef GOLIATH_ORGAN_COLOR
 #undef GOLIATH_SCLERA_COLOR

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -156,6 +156,10 @@
 
 	organ_traits = list(TRAIT_ASHSTORM_IMMUNE)
 
+/// we dont have a beating and dead heart state so no need to update it
+/obj/item/organ/internal/heart/goliath/update_icon_state()
+	return
+
 /obj/item/organ/internal/heart/goliath/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/noticable_organ, "skin has visible hard plates growing from within.", BODY_ZONE_CHEST)

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -158,6 +158,7 @@
 
 /// we dont have a beating and dead heart state so no need to update it
 /obj/item/organ/internal/heart/goliath/update_icon_state()
+	SHOULD_CALL_PARENT(FALSE)
 	return
 
 /obj/item/organ/internal/heart/goliath/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Fixes #73435
Heart organs has a proc to update between beating and unbeating icons, goliath heart does not have this an thus result in missing icon state. This pr fixes it by overriding the parent proc 
## Why It's Good For The Game
No more annoying error icon clogging your screen
## Changelog
:cl:
fix: fixed goliath heart having missing icon
/:cl:
