### PR TITLE
Fake messages now check the item

### DIFF
--- a/code/modules/hallucination/fake_message.dm
+++ b/code/modules/hallucination/fake_message.dm
@@ -25,25 +25,25 @@
 			// in the future, this could / should be de-harcoded and
 			// just draw from a pool uplink, theft, and antag item typepaths
 			var/static/list/stash_item_paths = list(
-				/obj/item/gun/ballistic/revolver,
-				/obj/item/melee/energy,
-				/obj/item/card/emag,
-				/obj/item/powersink, //this is a bulky item what
-				/obj/item/grenade/c4,
-				/obj/item/gun/energy/recharge/ebow,
-				/obj/item/melee/baton/security,
-				/obj/item/assembly/flash,
-				/obj/item/gun/syringe/syndicate,
-				/obj/item/circular_saw,
-				/obj/item/melee/cultblade/dagger,
-				/obj/item/spellbook,
-				/obj/item/codex_cicatrix,
-				/obj/item/card/id/advanced/gold/captains_spare,
-				/obj/item/hand_tele,
-				/obj/item/reagent_containers/hypospray/cmo,
-				/obj/item/gun/energy/laser/captain,
-				/obj/item/gun/energy/e_gun/hos,
 				/obj/item/areaeditor/blueprints,
+				/obj/item/assembly/flash,
+				/obj/item/card/id/advanced/gold/captains_spare,
+				/obj/item/card/emag,
+				/obj/item/circular_saw,
+				/obj/item/codex_cicatrix,
+				/obj/item/grenade/c4,
+				/obj/item/gun/ballistic/revolver,
+				/obj/item/gun/energy/e_gun/hos,
+				/obj/item/gun/energy/laser/captain,
+				/obj/item/gun/energy/recharge/ebow,
+				/obj/item/gun/syringe/syndicate,
+				/obj/item/hand_tele,
+				/obj/item/melee/baton/security,
+				/obj/item/melee/cultblade/dagger,
+				/obj/item/melee/energy,
+				/obj/item/powersink, //this is a bulky item what
+				/obj/item/reagent_containers/hypospray/cmo,
+				/obj/item/spellbook,
 			)
 			var/obj/item/stashed_item = pick(stash_item_paths)
 			message_pool[span_notice("[suspicious_personnel] puts the [initial(stashed_item.name)] into [equipped_backpack].")] = 5

--- a/code/modules/hallucination/fake_message.dm
+++ b/code/modules/hallucination/fake_message.dm
@@ -24,28 +24,29 @@
 		if(istype(equipped_backpack))
 			// in the future, this could / should be de-harcoded and
 			// just draw from a pool uplink, theft, and antag item typepaths
-			var/static/list/stash_items = list(
-				".357 revovler",
-				"energy sword",
-				"cryptographic sequencer",
-				"power sink",
-				"C-4 charge",
-				"energy bow",
-				"stun baton",
-				"flash",
-				"dart pistol",
-				"circular saw",
-				"ritual dagger",
-				"spellbook",
-				"Codex Cicatrix",
-				"captain's spare ID",
-				"hand teleporter",
-				"hypospray",
-				"antique laser gun",
-				"X-01 MultiPhase Energy Gun",
-				"station's blueprints",
+			var/static/list/stash_item_paths = list(
+				/obj/item/gun/ballistic/revolver,
+				/obj/item/melee/energy,
+				/obj/item/card/emag,
+				/obj/item/powersink, //this is a bulky item what
+				/obj/item/grenade/c4,
+				/obj/item/gun/energy/recharge/ebow,
+				/obj/item/melee/baton/security,
+				/obj/item/assembly/flash,
+				/obj/item/gun/syringe/syndicate,
+				/obj/item/circular_saw,
+				/obj/item/melee/cultblade/dagger,
+				/obj/item/spellbook,
+				/obj/item/codex_cicatrix,
+				/obj/item/card/id/advanced/gold/captains_spare,
+				/obj/item/hand_tele,
+				/obj/item/reagent_containers/hypospray/cmo,
+				/obj/item/gun/energy/laser/captain,
+				/obj/item/gun/energy/e_gun/hos,
+				/obj/item/areaeditor/blueprints,
 			)
-			message_pool[span_notice("[suspicious_personnel] puts the [pick(stash_items)] into [equipped_backpack].")] = 5
+			var/obj/item/stashed_item = pick(stash_item_paths)
+			message_pool[span_notice("[suspicious_personnel] puts the [initial(stashed_item.name)] into [equipped_backpack].")] = 5
 
 		message_pool["[span_bold("[suspicious_personnel]")] [pick("sneezes", "coughs")]."] = 1
 


### PR DESCRIPTION
## About The Pull Request

Fake messages about putting items away caused by hallucinations now checks the name of the item instead of being just a list of names. This fixes the names of the following items:
.357 Revolver
Energy Bow
Spell book
Hand tele
Station blueprints

![image](https://user-images.githubusercontent.com/53777086/219892805-8c660fad-da83-44dc-9e8c-3e491324a4bb.png)

## Why It's Good For The Game

Fixes grammar errors for hallucinations and futureproofs it a little.

## Changelog

:cl:
spellcheck: Hallucinations where you see people put things away now tell you they put the right thing away.
/:cl: