### PR TITLE
Fixes another case of broken huds on z level work (Also a runtime for ghosts)

### DIFF
--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -343,7 +343,7 @@ GLOBAL_LIST_INIT(huds, list(
 	var/list/exceptions = hud_exceptions
 	for(var/mob/requesting_mob as anything in requesting_mobs)
 		if(!requesting_mob.client)
-			return
+			continue
 		if(!exceptions[requesting_mob] || !(hud_atom in exceptions[requesting_mob]))
 			requesting_mob.client.images |= images_to_add
 
@@ -375,7 +375,7 @@ GLOBAL_LIST_INIT(huds, list(
 
 	for(var/mob/client_mob as anything in client_mobs)
 		if(!client_mob.client)
-			return
+			continue
 		client_mob.client.images -= images_to_remove
 
 /datum/atom_hud/proc/unregister_atom(datum/source, force)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1181,7 +1181,9 @@
 **/
 /mob/proc/has_nightvision()
 	// Somewhat conservative, basically is your lighting plane bright enough that you the user can see stuff
-	var/light_offset = (lighting_color_cutoffs[1] + lighting_color_cutoffs[2] + lighting_color_cutoffs[3]) / 3 + lighting_cutoff
+	var/light_offset = lighting_cutoff
+	if(length(lighting_color_cutoffs) == 3)
+		light_offset += (lighting_color_cutoffs[1] + lighting_color_cutoffs[2] + lighting_color_cutoffs[3]) / 3
 	return light_offset >= LIGHTING_NIGHTVISION_THRESHOLD
 
 /// This mob is abile to read books


### PR DESCRIPTION

## About The Pull Request

[Fixes another case of broken huds on z level work](https://github.com/tgstation/tgstation/commit/eed4336c715769f26c4fac844cc5b302014e5ab8)

This is I think new, but returning inside these loops is stupid and breaks shit bad.

[Fixes a runtime in nightvision checking](https://github.com/tgstation/tgstation/commit/c183fef185b66e65ae059a958a68881af7db1b25)

That list defaults to null, it can be null, be nice to it 📰

## Why It's Good For The Game

Huds are more stable, less runtimes

## Changelog
:cl:
fix: Moving up and down z levels will break hud stuff slightly less often
/:cl:
