### PR TITLE
Removes a stacked roller bed on lavaland.

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -363,7 +363,6 @@
 /area/mine/maintenance/production)
 "cy" = (
 /obj/structure/bed/roller,
-/obj/structure/bed/roller,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,


### PR DESCRIPTION

## About The Pull Request

Noticed this during a round earlier, there are 2 roller beds on the same tile on the lavaland base so I've removed one.
## Why It's Good For The Game

Very likely unintentional.
## Changelog
:cl:
fix: A accidently stacked roller bed on lavaland has been removed.
/:cl:
