### PR TITLE
Fix eating the bowl when eating poke

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -226,8 +226,9 @@
 		/datum/reagent/consumable/nutriment/vitamin = 5,
 		/datum/reagent/consumable/nutriment/protein = 2,
 	)
-	tastes = list("rice and meat" = 4, "lettuce" = 2, "soy sauce" = 2)
 	foodtypes = SEAFOOD | MEAT | VEGETABLES
+	tastes = list("rice and meat" = 4, "lettuce" = 2, "soy sauce" = 2)
+	trash_type = /obj/item/reagent_containers/cup/bowl
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/fish_poke
@@ -240,8 +241,9 @@
 		/datum/reagent/consumable/nutriment/vitamin = 4,
 		/datum/reagent/consumable/nutriment/protein = 2,
 	)
-	tastes = list("rice and fish" = 4, "lettuce" = 2, "soy sauce" = 2)
 	foodtypes = SEAFOOD | VEGETABLES
+	tastes = list("rice and fish" = 4, "lettuce" = 2, "soy sauce" = 2)
+	trash_type = /obj/item/reagent_containers/cup/bowl
 	w_class = WEIGHT_CLASS_SMALL
 
 ////////////////////////////////////////////MEATS AND ALIKE////////////////////////////////////////////


### PR DESCRIPTION
:cl: coiax
fix: Eating fish and meat poke bowls no longer consumes the bowl, just the food inside.
/:cl:

## Why It's Good For The Game

Those bowls are made out of glass in the protolathe, they can't be good for you to eat. Also, soups leave the bowl behind.