### PR TITLE
Don't reregister PDA signals we already registered

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -960,15 +960,6 @@
 	is_intern = FALSE
 	update_label()
 
-/obj/item/card/id/advanced/proc/on_holding_card_slot_moved(obj/item/modular_computer/pda/source, atom/old_loc, dir, forced)
-	SIGNAL_HANDLER
-	if(istype(old_loc, /obj/item/modular_computer/pda))
-		UnregisterSignal(old_loc, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
-
-	if(source)
-		RegisterSignal(source, COMSIG_ITEM_EQUIPPED, PROC_REF(update_intern_status))
-		RegisterSignal(source, COMSIG_ITEM_DROPPED, PROC_REF(remove_intern_status))
-
 /obj/item/card/id/advanced/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
 
@@ -977,7 +968,6 @@
 		UnregisterSignal(old_loc, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 
 	if(istype(old_loc, /obj/item/modular_computer/pda))
-		UnregisterSignal(old_loc, COMSIG_MOVABLE_MOVED)
 		UnregisterSignal(old_loc, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 
 	//New loc
@@ -986,7 +976,6 @@
 		RegisterSignal(loc, COMSIG_ITEM_DROPPED, PROC_REF(remove_intern_status))
 
 	if(istype(loc, /obj/item/modular_computer/pda))
-		RegisterSignal(loc, COMSIG_MOVABLE_MOVED, PROC_REF(on_holding_card_slot_moved))
 		RegisterSignal(loc, COMSIG_ITEM_EQUIPPED, PROC_REF(update_intern_status))
 		RegisterSignal(loc, COMSIG_ITEM_DROPPED, PROC_REF(remove_intern_status))
 


### PR DESCRIPTION
## About The Pull Request

Fixes #73102 by removing an apparently purposeless proc.
I'll be honest I have been staring and staring at this proc and have no idea what problem it is supposed to be solving and it looks kind of like nonsense, a victim of refactors maybe?

So here's what it was doing:
When you place an ID card into a PDA we register to the "moved" signal.
When the PDA is moved we first check if the PDA's old location was a PDA. First head-scratcher, when would that be true? Was there a point where PDAs could be nested, back when they were tablets? Doesn't seem to be possible now. 
We then unregister the other signals we registered when setting up this proc, but _only_ if it was previously inside a PDA.

Then we check if the source of the signal exists, which is also confusing but I _guess_ maybe something else listening to the move signal could have deleted it before we got here?
The source of the signal of course continues to be the PDA we registered signals to. We only unregister those signals if it was previously somehow inside of a different PDA. We then re-register the signals we already registered on it, causing a warning runtime because we're registering a signal we already registered.
Sure enough, the warning is telling us that we're just doing the same thing twice for as far as I can tell, absolutely no reason.

As far as I can tell this proc... doesn't do anything _except_ runtime? It's full range of possible behaviour is to register some signals we are already registered to. So I fixed the bug by deleting it.
If there's some edge case behaviour related to putting PDAs inside other PDAs which I am missing here, or I have misunderstood this code somehow, let me know.

## Why It's Good For The Game

We shouldn't runtime every time you move your PDA around.

## Changelog

:cl:
fix: Removes a runtime error caused by moving your PDA between slots.
/:cl:
