### PR TITLE
Add grep linter for can_perform_action arguments

### DIFF
--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -128,6 +128,13 @@ if $grep '^/[\w/]\S+\(.*(var/|, ?var/.*).*\)' $code_files; then
 	st=1
 fi;
 
+part "can_perform_action argument check"
+if $grep 'can_perform_action\(\s*\)' $code_files; then
+	echo
+	echo -e "${RED}ERROR: Found a can_perform_action() proc with improper arguments.${NC}"
+	st=1
+fi;
+
 part "balloon_alert sanity"
 if $grep 'balloon_alert\(".*"\)' $code_files; then
 	echo


### PR DESCRIPTION

## About The Pull Request
This adds a linter to check for missing arguments with the `can_perform_action` proc since several people had used it with no arguments provided and it caused persistent runtimes over several years.

## Why It's Good For The Game
Less runtimes in the future.

## Changelog
Not needed.
