### PR TITLE
Fix maplint help messages

### DIFF
--- a/tools/maplint/source/__main__.py
+++ b/tools/maplint/source/__main__.py
@@ -45,7 +45,7 @@ def print_error(message: str, filename: str, line_number: int, github_error_styl
 
 def print_maplint_error(error: MaplintError, github_error_style: bool):
     print_error(
-        f"{f'(in pop {error.pop_id}) ' if error.pop_id else ''}{f'(at {error.coordinates}) ' if error.coordinates else ''}{error}",
+        f"{f'(in pop {error.pop_id}) ' if error.pop_id else ''}{f'(at {error.coordinates}) ' if error.coordinates else ''}{error}" + (f"\n  {error.help}" if error.help is not None else ""),
         error.file_name,
         error.line_number,
         github_error_style,

--- a/tools/maplint/source/error.py
+++ b/tools/maplint/source/error.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 """Linting error with associated filename and line number."""
 class MaplintError(Exception):
     """The DMM file name the exception occurred in"""
@@ -7,10 +9,13 @@ class MaplintError(Exception):
     line_number = 1
 
     """The optional coordinates"""
-    coordinates: str = None
+    coordinates: Optional[str] = None
 
     """The optional pop ID"""
-    pop_id: str = None
+    pop_id: Optional[str] = None
+
+    """The optional help message"""
+    help: Optional[str] = None
 
     def __init__(self, message: str, file_name: str, line_number = 1):
         Exception.__init__(self, message)

--- a/tools/maplint/source/lint.py
+++ b/tools/maplint/source/lint.py
@@ -260,9 +260,8 @@ class Lint:
                         coordinate_texts.append(f"and {leftover_coordinates} more")
 
                     for failure in failures:
-                        if self.help is not None:
-                            failure.message += f"\n  {self.help}"
                         failure.coordinates = ', '.join(coordinate_texts)
+                        failure.help = self.help
                         failure.pop_id = pop
                         all_failures.append(failure)
 


### PR DESCRIPTION
Fixes this exception:

```
Error: An exception occurred, this is either a bug in maplint or a bug in a lint. 
Traceback (most recent call last):
  File "/home/runner/work/tgstation/tgstation/tools/maplint/source/__main__.py", line 29, in process_dmm
    problems.extend(lint.run(map_data))
  File "/home/runner/work/tgstation/tgstation/tools/maplint/source/lint.py", line 264, in run
    failure.message += f"\n  {self.help}"
AttributeError: 'MaplintError' object has no attribute 'message'
```