### PR TITLE
Fixes holopads using incorrect icon states

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -514,8 +514,8 @@ Possible to do for anyone motivated enough:
 			are_ringing = TRUE
 
 	if(ringing != are_ringing)
-		update_appearance(UPDATE_ICON_STATE)
 		ringing = are_ringing
+		update_appearance(UPDATE_ICON_STATE)
 
 /obj/machinery/holopad/proc/activate_holo(mob/living/user)
 	var/mob/living/silicon/ai/AI = user


### PR DESCRIPTION

## About The Pull Request

Fixes two bugs with holopads. Holopads were permanently entering a "ringing" state after being called once and they were using the on call icon when they were supposed to be ringing. Issues seemed to be caused by #71658 setting a var and updating the icon state in the wrong order.
## Why It's Good For The Game

Bug fix and you cant call every holopad on the station to make them blink forever anymore.
## Changelog
:cl:
fix: Holopads will blink when being called rather than just glowing.
fix: Holopads will not blink forever if you missed a call.
/:cl:
