### PR TITLE
[NO GBP] Fixes oculater not working... woops

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -776,7 +776,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/inverse/oculine/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	if(headache)
 		return ..()
-	if(DT_PROB(100*(1-creation_purity), delta_time))
+	if(DT_PROB(100 * creation_purity, delta_time))
 		affected_mob.become_blind(IMPURE_OCULINE)
 		to_chat(affected_mob, span_danger("You suddenly develop a pounding headache as your vision fluxuates."))
 		headache = TRUE


### PR DESCRIPTION

## About The Pull Request

I may or may not have neglected the fact that oculater can't be very low purity anymore due to my own revamp prior.
So uh, this makes it work like most inverse chemicals, getting better the higher the purity is.
## Why It's Good For The Game

Bug fix good.
## Changelog
:cl:
fix: Oculater works again.
/:cl:
