### PR TITLE
Fix Kilostation ordnance airlock

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -53006,7 +53006,7 @@
 /area/station/science/xenobiology)
 "pii" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,


### PR DESCRIPTION

## About The Pull Request

Fixes the vent pump in the burn chamber airlock in Ordnance on Kilostation. It was rotated and exhausting into distro and intaking from the waste loop.

## Why It's Good For The Game

It makes the airlock cycle at a normal speed.

## Changelog

:cl:
fix: a vent pump that was installed backwards in the Kilostation Ordnance airlock has been repaired.
/:cl:
