### PR TITLE
Refactor egg to chick logic into component

### DIFF
--- a/code/datums/components/fertile_egg.dm
+++ b/code/datums/components/fertile_egg.dm
@@ -1,5 +1,5 @@
 /**
- * # A fertile egg component!
+ * ### A fertile egg component!
  *
  * This component tracks over time if the atom is in ideal conditions,
  * and eventually hatches into the embryonic type.
@@ -7,8 +7,6 @@
  * The initial design of this component was to make more generic the code for
  * chickens laying eggs.
  */
-
-
 /datum/component/fertile_egg
 	/// What will come out of the egg when it's done.
 	var/embryo_type
@@ -23,7 +21,7 @@
 	var/total_growth_required
 
 	/// The current amount of growth.
-	var/current_growth = 0
+	var/current_growth
 
 	/// List of locations which, if set, the egg will only develop if in those locations.
 	var/list/location_allowlist

--- a/code/datums/components/fertile_egg.dm
+++ b/code/datums/components/fertile_egg.dm
@@ -1,0 +1,67 @@
+/**
+ * # A fertile egg component!
+ *
+ * This component tracks over time if the atom is in ideal conditions,
+ * and eventually hatches into the embryonic type.
+ *
+ * The initial design of this component was to make more generic the code for
+ * chickens laying eggs.
+ */
+
+
+/datum/component/fertile_egg
+	/// What will come out of the egg when it's done.
+	var/embryo_type
+
+	/// Minimum growth rate per tick
+	var/minimum_growth_rate
+
+	/// Maximum growth rate per tick
+	var/maximum_growth_rate
+
+	/// Total growth required before hatching.
+	var/total_growth_required
+
+	/// The current amount of growth.
+	var/current_growth = 0
+
+	/// List of locations which, if set, the egg will only develop if in those locations.
+	var/list/location_allowlist
+
+	/// If true, being in an unsuitable location spoils the egg (ie. kills the component). If false, it just pauses the egg's development.
+	var/spoilable
+
+/datum/component/fertile_egg/Initialize(embryo_type, minimum_growth_rate, maximum_growth_rate, total_growth_required, current_growth, location_allowlist, spoilable, examine_message)
+	// Quite how an _area_ can be a fertile egg is an open question, but it still has a location. Technically.
+	if(!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.embryo_type = embryo_type
+	src.minimum_growth_rate = minimum_growth_rate
+	src.maximum_growth_rate = maximum_growth_rate
+	src.total_growth_required = total_growth_required
+	src.current_growth = current_growth
+	src.location_allowlist = location_allowlist
+	src.spoilable = spoilable
+
+	START_PROCESSING(SSobj, src)
+
+/datum/component/fertile_egg/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	. = ..()
+
+/datum/component/fertile_egg/process(delta_time)
+	var/atom/parent_atom = parent
+
+	if(location_allowlist && !is_type_in_typecache(parent_atom.loc, location_allowlist))
+		// In a zone that is not allowed, do nothing, and possibly self destruct
+		if(spoilable)
+			qdel(src)
+		return
+
+	current_growth += rand(minimum_growth_rate, maximum_growth_rate) * delta_time
+	if(current_growth >= total_growth_required)
+		parent_atom.visible_message(span_notice("[parent] hatches with a quiet cracking sound."))
+		new embryo_type(get_turf(parent_atom))
+		// We destroy the parent on hatch, which will destroy the component as well, which will stop us processing.
+		qdel(parent_atom)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -179,6 +179,8 @@
 	..()
 	amount_grown = 0
 
+/// Counter for number of chicken mobs in the universe. Chickens will not lay fertile eggs if it exceeds the MAX_CHICKENS define.
+GLOBAL_VAR_INIT(chicken_count, 0)
 
 /mob/living/simple_animal/chicken
 	name = "\improper chicken"
@@ -210,14 +212,12 @@
 	mob_size = MOB_SIZE_SMALL
 	gold_core_spawnable = FRIENDLY_SPAWN
 	footstep_type = FOOTSTEP_MOB_CLAW
-	///counter for how many chickens are in existence to stop too many chickens from lagging shit up
-	var/static/chicken_count = 0
 	///boolean deciding whether eggs laid by this chicken can hatch into chicks
-	var/process_eggs = TRUE
+	var/fertile = TRUE
 
 /mob/living/simple_animal/chicken/Initialize(mapload)
 	. = ..()
-	chicken_count++
+	GLOB.chicken_count++
 	add_cell_sample()
 	AddElement(/datum/element/animal_variety, "chicken", pick("brown","black","white"), TRUE)
 	AddComponent(/datum/component/egg_layer,\
@@ -236,25 +236,20 @@
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_CHICKEN, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 
 /mob/living/simple_animal/chicken/Destroy()
-	chicken_count--
+	GLOB.chicken_count--
 	return ..()
 
 /mob/living/simple_animal/chicken/proc/egg_laid(obj/item/egg)
-	if(chicken_count <= MAX_CHICKENS && process_eggs && prob(25))
-		START_PROCESSING(SSobj, egg)
-
-/obj/item/food/egg/var/amount_grown = 0
-
-/obj/item/food/egg/process(delta_time)
-	if(isturf(loc))
-		amount_grown += rand(1,2) * delta_time
-		if(amount_grown >= 200)
-			visible_message(span_notice("[src] hatches with a quiet cracking sound."))
-			new /mob/living/simple_animal/chick(get_turf(src))
-			STOP_PROCESSING(SSobj, src)
-			qdel(src)
-	else
-		STOP_PROCESSING(SSobj, src)
+	if(GLOB.chicken_count <= MAX_CHICKENS && fertile && prob(25))
+		egg.AddComponent(/datum/component/fertile_egg,\
+			embryo_type = /mob/living/simple_animal/chick,\
+			minimum_growth_rate = 1,\
+			maximum_growth_rate = 2,\
+			total_growth_required = 200,\
+			current_growth = 0,\
+			location_allowlist = typecacheof(list(/turf)),\
+			spoilable = TRUE,\
+		)
 
 /mob/living/simple_animal/deer
 	name = "doe"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -879,6 +879,7 @@
 #include "code\datums\components\evolutionary_leap.dm"
 #include "code\datums\components\explodable.dm"
 #include "code\datums\components\faction_granter.dm"
+#include "code\datums\components\fertile_egg.dm"
 #include "code\datums\components\fishing_spot.dm"
 #include "code\datums\components\food_storage.dm"
 #include "code\datums\components\force_move.dm"


### PR DESCRIPTION
:cl: coiax
refactor: Refactored how eggs growing into chicks is implemented, and how the number of chickens and chicks are tracked. It's now possible for admins to make anything into an egg.
/:cl:

- Instead of the "fertility" of an egg being whether or not it's processing (along with the ugliness of adding a variable to a item defined in another file), fertile eggs are now implemented via components.
- The number of chickens in the world, and the number of chicks hatched from egg throwing are now global variables, rather than static variables on the class.

I've tried very hard to keep these changes completely feature freeze compatible, any variation in the old behaviour is non-intended (at this point).