### PR TITLE
Revert "Rat Trap"

### DIFF
--- a/.github/workflows/rerun_flaky_tests.yml
+++ b/.github/workflows/rerun_flaky_tests.yml
@@ -1,0 +1,31 @@
+name: Rerun/Report Flaky Tests
+on:
+  workflow_run:
+    workflows: [CI Suite]
+    types:
+    - completed
+jobs:
+  rerun_flaky_tests:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt == 1 }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Rerun flaky tests
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { rerunFlakyTests } = await import('${{ github.workspace }}/tools/pull_request_hooks/rerunFlakyTests.js')
+          await rerunFlakyTests({ github, context })
+  report_flaky_tests:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.run_attempt == 2 }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Report flaky tests
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const { reportFlakyTests } = await import('${{ github.workspace }}/tools/pull_request_hooks/rerunFlakyTests.js')
+          await reportFlakyTests({ github, context })

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -277,7 +277,7 @@ SUBSYSTEM_DEF(garbage)
 #endif
 	if (D.gc_destroyed <= 0)
 		D.gc_destroyed = queue_time
-
+	
 	var/list/queue = queues[level]
 
 	queue[++queue.len] = list(queue_time, refid, D.gc_destroyed) // not += for byond reasons
@@ -290,8 +290,6 @@ SUBSYSTEM_DEF(garbage)
 	var/refID = text_ref(D)
 
 	var/tick_usage = TICK_USAGE
-	if(ismouse(D))
-		log_world("Mouse [D:canon_tag] hard deleted")
 	del(D)
 	tick_usage = TICK_USAGE_TO_MS(tick_usage)
 

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -6,6 +6,9 @@ SUBSYSTEM_DEF(minor_mapping)
 	flags = SS_NO_FIRE
 
 /datum/controller/subsystem/minor_mapping/Initialize()
+	#ifdef UNIT_TESTS // This whole subsystem just introduces a lot of odd confounding variables into unit test situations, so let's just not bother with doing an initialize here.
+	return SS_INIT_NO_NEED
+	#endif // the mice are easily the bigger problem, but let's just avoid anything that could cause some bullshit.
 	trigger_migration(CONFIG_GET(number/mice_roundstart))
 	place_satchels()
 	return SS_INIT_SUCCESS

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -133,14 +133,10 @@ SUBSYSTEM_DEF(spatial_grid)
 /datum/controller/subsystem/spatial_grid/proc/enter_pre_init_queue(atom/movable/waiting_movable, type)
 	RegisterSignal(waiting_movable, COMSIG_PARENT_QDELETING, PROC_REF(queued_item_deleted), override = TRUE)
 	//override because something can enter the queue for two different types but that is done through unrelated procs that shouldnt know about eachother
-	if(ismouse(waiting_movable))
-		log_world("Mouse [waiting_movable:canon_tag] inserted into pre init queue at [waiting_movable.x], [waiting_movable.y], [waiting_movable.z]")
 	waiting_to_add_by_type[type] += waiting_movable
 
 ///removes an initialized and probably deleted movable from our pre init queue before we're initialized
 /datum/controller/subsystem/spatial_grid/proc/remove_from_pre_init_queue(atom/movable/movable_to_remove, exclusive_type)
-	if(ismouse(movable_to_remove))
-		log_world("Mouse [movable_to_remove:canon_tag] inserted removed from pre init queue at [movable_to_remove.x], [movable_to_remove.y], [movable_to_remove.z]")
 	if(exclusive_type)
 		waiting_to_add_by_type[exclusive_type] -= movable_to_remove
 
@@ -362,9 +358,6 @@ SUBSYSTEM_DEF(spatial_grid)
 	if(!target_turf || !new_target.spatial_grid_key)
 		CRASH("null turf loc or a new_target that doesn't support it trying to enter the spatial grid!")
 
-	if(ismouse(new_target))
-		log_world("Mouse [new_target:canon_tag] entered queue at [target_turf.x], [target_turf.y], [target_turf.z]")
-
 	var/x_index = GET_SPATIAL_INDEX(target_turf.x)
 	var/y_index = GET_SPATIAL_INDEX(target_turf.y)
 	var/z_index = target_turf.z
@@ -395,9 +388,6 @@ SUBSYSTEM_DEF(spatial_grid)
 
 	if(!target_turf || !(exclusive_type in spatial_grid_categories[new_target.spatial_grid_key]))
 		CRASH("null turf loc or a new_target that doesn't support it trying to enter the spatial grid as a [exclusive_type]!")
-
-	if(ismouse(new_target))
-		log_world("Mouse [new_target:canon_tag] entered queue for [exclusive_type] at [target_turf.x], [target_turf.y], [target_turf.z]")
 
 	var/x_index = GET_SPATIAL_INDEX(target_turf.x)
 	var/y_index = GET_SPATIAL_INDEX(target_turf.y)
@@ -430,12 +420,7 @@ SUBSYSTEM_DEF(spatial_grid)
  * * exclusive_type - either null or a valid contents channel. if you just want to remove a single type from the grid cell then use this
  */
 /datum/controller/subsystem/spatial_grid/proc/exit_cell(atom/movable/old_target, turf/target_turf, exclusive_type)
-	if(ismouse(old_target))
-		log_world("Mouse [old_target:canon_tag] tried to leave a at [target_turf.x], [target_turf.y], [target_turf.z]")
-
 	if(!initialized)
-		if(ismouse(old_target))
-			log_world("Mouse removal failed, no init")
 		return
 
 	if(!target_turf || !old_target.spatial_grid_key)
@@ -463,21 +448,15 @@ SUBSYSTEM_DEF(spatial_grid)
 				GRID_CELL_REMOVE(intersecting_cell.atmos_contents, old_target)
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(SPATIAL_GRID_CONTENTS_TYPE_ATMOS), old_target)
 
-	if(ismouse(old_target))
-		log_world("Mouse removal succeeded")
 	return TRUE
 
 ///acts like exit_cell() but only removes the target from the specified type of grid cell contents list
 /datum/controller/subsystem/spatial_grid/proc/remove_single_type(atom/movable/old_target, turf/target_turf, exclusive_type)
-	if(ismouse(old_target))
-		log_world("Mouse [old_target:canon_tag] tried to leave a at [target_turf.x], [target_turf.y], [target_turf.z]")
 	if(!target_turf || !exclusive_type || !old_target.spatial_grid_key)
 		stack_trace("/datum/controller/subsystem/spatial_grid/proc/remove_single_type() was given null arguments or an old_target that doesn't use the spatial grid!")
 		return FALSE
 
 	if(!(exclusive_type in spatial_grid_categories[old_target.spatial_grid_key]))
-		if(ismouse(old_target))
-			log_world("Mouse removal failed, bad key")
 		return FALSE
 
 	var/x_index = GET_SPATIAL_INDEX(target_turf.x)
@@ -501,15 +480,10 @@ SUBSYSTEM_DEF(spatial_grid)
 			GRID_CELL_REMOVE(intersecting_cell.atmos_contents, old_target)
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target)
 
-	if(ismouse(old_target))
-		log_world("Mouse removal succeeded")
-
 	return TRUE
 
 ///find the cell this movable is associated with and removes it from all lists
 /datum/controller/subsystem/spatial_grid/proc/force_remove_from_cell(atom/movable/to_remove, datum/spatial_grid_cell/input_cell)
-	if(ismouse(to_remove))
-		log_world("Mouse [to_remove:canon_tag] tried to leave by force at [to_remove.x], [to_remove.y], [to_remove.z]")
 	if(!initialized)
 		remove_from_pre_init_queue(to_remove)//the spatial grid doesnt exist yet, so just take it out of the queue
 		return

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -27,7 +27,6 @@
 	response_harm_simple = "splat"
 
 	ai_controller = /datum/ai_controller/basic_controller/mouse
-	var/canon_tag
 
 	/// Whether this rat is friendly to players
 	var/tame = FALSE
@@ -37,10 +36,6 @@
 	var/contributes_to_ratcap = TRUE
 	/// Probability that, if we successfully bite a shocked cable, that we will die to it.
 	var/cable_zap_prob = 85
-
-/mob/living/basic/mouse/New()
-	. = ..()
-	canon_tag = tag
 
 /mob/living/basic/mouse/Initialize(mapload, tame = FALSE)
 	. = ..()

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -89,6 +89,7 @@
 #include "blindness.dm"
 #include "bloody_footprints.dm"
 #include "breath.dm"
+#include "cable_powernets.dm"
 #include "card_mismatch.dm"
 #include "cardboard_cutouts.dm"
 #include "chain_pull_through_space.dm"


### PR DESCRIPTION
Reverts tgstation/tgstation#73159

Pretty sure this wasn't supposed to be merged, considering it disabled a test, a workflow run, and implements an atom New override