### PR TITLE
Map vote setup checks active players

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -152,7 +152,7 @@
 	flick_overlay(image_to_show, viewing, duration)
 
 ///Get active players who are playing in the round
-/proc/get_active_player_count(alive_check = 0, afk_check = 0, human_check = 0)
+/proc/get_active_player_count(alive_check = FALSE, afk_check = TRUE, human_check = FALSE)
 	var/active_players = 0
 	for(var/i = 1; i <= GLOB.player_list.len; i++)
 		var/mob/player_mob = GLOB.player_list[i]

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -158,7 +158,7 @@
 		var/mob/player_mob = GLOB.player_list[i]
 		if(!player_mob?.client)
 			continue
-		if(alive_check && player_mob.stat)
+		if(alive_check && player_mob.stat == DEAD)
 			continue
 		else if(afk_check && player_mob.client.is_afk())
 			continue

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -73,7 +73,7 @@
 		for(var/key in default_choices)
 			choices[key] = 0
 
-	var/eligible_players = get_active_player_count(alive_check = FALSE, afk_check = TRUE, human_check = TRUE)
+	var/eligible_players = get_active_player_count(alive_check = FALSE, afk_check = TRUE, human_check = FALSE)
 
 	for(var/map in choices)
 		var/datum/map_config/possible_config = config.maplist[map]

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -73,14 +73,14 @@
 		for(var/key in default_choices)
 			choices[key] = 0
 
-	var/eligible_players = get_active_player_count(alive_check = FALSE, afk_check = TRUE, human_check = FALSE)
+	var/active_players = get_active_player_count(alive_check = FALSE, afk_check = TRUE, human_check = FALSE)
 
 	for(var/map in choices)
 		var/datum/map_config/possible_config = config.maplist[map]
-		if(possible_config.config_min_users > 0 && eligible_players < possible_config.config_min_users)
+		if(possible_config.config_min_users > 0 && active_players < possible_config.config_min_users)
 			choices -= map
 
-		else if(possible_config.config_max_users > 0 && eligible_players > possible_config.config_max_users)
+		else if(possible_config.config_max_users > 0 && active_players > possible_config.config_max_users)
 			choices -= map
 
 	return choices

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -73,12 +73,14 @@
 		for(var/key in default_choices)
 			choices[key] = 0
 
+	var/eligible_players = get_active_player_count(alive_check = 0, afk_check = 1, human_check = 1)
+
 	for(var/map in choices)
 		var/datum/map_config/possible_config = config.maplist[map]
-		if(possible_config.config_min_users > 0 && GLOB.clients.len < possible_config.config_min_users)
+		if(possible_config.config_min_users > 0 && eligible_players < possible_config.config_min_users)
 			choices -= map
 
-		else if(possible_config.config_max_users > 0 && GLOB.clients.len > possible_config.config_max_users)
+		else if(possible_config.config_max_users > 0 && eligible_players > possible_config.config_max_users)
 			choices -= map
 
 	return choices

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -73,7 +73,7 @@
 		for(var/key in default_choices)
 			choices[key] = 0
 
-	var/eligible_players = get_active_player_count(alive_check = 0, afk_check = 1, human_check = 1)
+	var/eligible_players = get_active_player_count(alive_check = FALSE, afk_check = TRUE, human_check = TRUE)
 
 	for(var/map in choices)
 		var/datum/map_config/possible_config = config.maplist[map]


### PR DESCRIPTION
## About The Pull Request
Use the get_active_players proc when starting a map vote to get a more accurate number of active players for map filtering.

This changes the proc where the available maps to choose are determined, changing from counting all players connected (including AFKs) to only counting people who are playing or played in the round.

## Why It's Good For The Game
Lobby screen and nonparticipating ghosts don't count towards map population restrictions. Normal ghosts, alive, dead are included.

This is only applicable for map filtering, there is no change to the voting itself.
## Changelog

:cl: LT3
code: Map vote filtering now counts people playing/played in the round, not all connected clients
fix: Get active players proc now includes unconscious/crit players
/:cl:
