### PR TITLE
machinery/Topic() allows silicons to bypass distance checks

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -683,7 +683,7 @@
 	..()
 	if(!can_interact(usr))
 		return TRUE
-	if(!usr.can_perform_action(src))
+	if(!usr.can_perform_action(src, ALLOW_SILICON_REACH))
 		return TRUE
 	add_fingerprint(usr)
 	update_last_used(usr)


### PR DESCRIPTION

## About The Pull Request

Fixes #73542

Most machines use TGUI now, which uses `ui_act` instead of `Topic`. `Topic` by default didn't let silicons bypass a range check. I figured I'd add that and call it a day. I could also make this conditional and so computer subtypes do get the reach but normal machines don't, but again, this is just `Topic`.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Fixes some cases where AI couldn't interact with some old non-tgui machines
/:cl:
