### PR TITLE
[no gbp] Allows clothes to be eaten

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -236,6 +236,8 @@ Behavior that's still missing from this component that original food items had t
 /datum/component/edible/proc/TryToEatIt(datum/source, mob/user)
 	SIGNAL_HANDLER
 
+	if (!in_range(source, user))
+		return
 	return TryToEat(user, user)
 
 ///Called when food is created through processing (Usually this means it was sliced). We use this to pass the OG items reagents.
@@ -300,7 +302,7 @@ Behavior that's still missing from this component that original food items had t
 
 	var/atom/owner = parent
 
-	if(feeder.combat_mode || !in_range(owner, eater))
+	if(feeder.combat_mode)
 		return
 
 	. = COMPONENT_CANCEL_ATTACK_CHAIN //Point of no return I suppose


### PR DESCRIPTION
## About The Pull Request

Fixes #73546
In #73481 I made the foolish assertion that it's never correct for someone to eat something which isn't physically nearby.
I had of course forgotten that while Moths _think_ they can eat clothes, what they are actually eating is the abstract concept of clothes if they were edible, functionally nothing, which exists nowhere.
By moving the check to only run when you are trying to eat a turf (conveniently, no clothing is also a turf... yet) I allow them to return to their delusion.

Alternate fixes and why I didn't do them:
- Always allow people to eat food which is in nullspace. This feels pretty gross.
- Put the abstract clothes food physically inside the clothes. I assume this wasn't done because there's some scenarios where you would be able to remove abstract clothes food from the clothes, so that's not desirable.
- Move the food into the actual clothes object just before taking a bite and then put it back in nullspace again. This is silly.
- Try to make moth clothes food work in a way which doesn't involve creating an imaginary food item in the void. I don't want to do this.

## Why It's Good For The Game

It's funny to eat clothes I guess.

## Changelog

:cl:
fix: Moths can eat clothes again.
/:cl:
