### PR TITLE
Paradox Plasmamen won't immediately burn to death

### DIFF
--- a/code/modules/antagonists/paradox_clone/paradox_clone.dm
+++ b/code/modules/antagonists/paradox_clone/paradox_clone.dm
@@ -54,10 +54,11 @@
 	var/mob/living/carbon/human/original_human = original_mind.current
 
 	//equip them in the original's clothes
-	clone_human.equipOutfit(original_human.mind.assigned_role.outfit)
-	if(isplasmaman(original_human))
+	if(!isplasmaman(original_human))
+		clone_human.equipOutfit(original_human.mind.assigned_role.outfit)
+	else
 		clone_human.equipOutfit(original_human.mind.assigned_role.plasmaman_outfit)
-		clone_human.internal = clone_human.get_item_for_held_index(1)
+		clone_human.internal = clone_human.get_item_for_held_index(2)
 
 	//clone doesnt show up on message lists
 	var/obj/item/modular_computer/pda/messenger = locate() in clone_human


### PR DESCRIPTION
## About The Pull Request

Fixes #73376
The orignal code was _always_ equipping a human outfit and then sometimes trying to equip a plasmaman outfit over the top. 
The second outfit would ignore any slots occupied by the first, meaning you wouldn't actually end up with an envirosuit.

Also it was activating the internals in the wrong hand, so I fixed that for good measure.

## Why It's Good For The Game

Spawning a burning, dead skeleton in the maintenance tunnels isn't an efficient use of the round's threat budget.

## Changelog

:cl:
fix: The paradox clones of plasmamen now come properly dressed for the occasion.
/:cl:
