### PR TITLE
Fixes serving tray/microwave interaction

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -306,6 +306,7 @@
 				ingredients += S
 		if(loaded)
 			to_chat(user, span_notice("You insert [loaded] items into \the [src]."))
+			update_appearance()
 		return
 
 	if(O.w_class <= WEIGHT_CLASS_NORMAL && !istype(O, /obj/item/storage) && !user.combat_mode)


### PR DESCRIPTION
:cl: coiax
fix: When loading food into a microwave via serving tray, you can now see the food inside the microwave afterwards.
/:cl:

## Why It's Good For The Game

Because when I load rice via serving tray into the microwave, I want to be able to see it.