### PR TITLE
Fixes split personality ghosting its owner if cured in a wrong moment

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -58,12 +58,6 @@
 	QDEL_NULL(owner_backseat)
 	..()
 
-/datum/brain_trauma/severe/split_personality/Destroy()
-	if(stranger_backseat)
-		QDEL_NULL(stranger_backseat)
-	if(owner_backseat)
-		QDEL_NULL(owner_backseat)
-	return ..()
 
 /datum/brain_trauma/severe/split_personality/proc/switch_personalities(reset_to_owner = FALSE)
 	if(QDELETED(owner) || QDELETED(stranger_backseat) || QDELETED(owner_backseat))


### PR DESCRIPTION
## About The Pull Request

Fixes the bug that caused split personality to put the second personality in permament control if cured when it was in control. The problem was apparently that destroy() is called before on_lose(), which first deleted the mobs housing second personality, and then tried to swap the original owner back, which failed.

## Why It's Good For The Game

Works as it was originally intended again.

## Changelog

:cl:
fix: Fixes split personality kicking out the original owner of the body.
/:cl:

