### PR TITLE
Thermomachines no longer self-destruct when built on blocked ports

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -1154,7 +1154,7 @@
 		. += display_parts(user, TRUE)
 
 //called on machinery construction (i.e from frame to machinery) but not on initialization
-/obj/machinery/proc/on_construction()
+/obj/machinery/proc/on_construction(mob/user)
 	return
 
 //called on deconstruction before the final deletion

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -158,7 +158,7 @@
 						new_computer.component_parts += movable_part
 
 					new_computer.RefreshParts()
-					new_computer.on_construction()
+					new_computer.on_construction(user)
 
 				qdel(src)
 				return

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -283,7 +283,7 @@
 
 						//Inform machine that its finished & cleanup
 						new_machine.RefreshParts()
-						new_machine.on_construction()
+						new_machine.on_construction(user)
 						components = null
 					qdel(src)
 				return

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -229,7 +229,7 @@ Buildable meters
 
 	var/obj/machinery/atmospherics/built_machine = new pipe_type(loc, , , p_init_dir)
 	build_pipe(built_machine)
-	built_machine.on_construction(pipe_color, piping_layer)
+	built_machine.on_construction(user, pipe_color, piping_layer)
 	transfer_fingerprints_to(built_machine)
 
 	wrench.play_tool_sound(src)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -461,7 +461,7 @@
 		PIPING_FORWARD_SHIFT(pipe_overlay, piping_layer, 2)
 	return pipe_overlay
 
-/obj/machinery/atmospherics/on_construction(obj_color, set_layer = PIPING_LAYER_DEFAULT)
+/obj/machinery/atmospherics/on_construction(mob/user, obj_color, set_layer = PIPING_LAYER_DEFAULT)
 	if(can_unwrench)
 		add_atom_colour(obj_color, FIXED_COLOUR_PRIORITY)
 		set_pipe_color(obj_color)

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -97,7 +97,7 @@
 	airs[i] = null
 	return ..()
 
-/obj/machinery/atmospherics/components/on_construction()
+/obj/machinery/atmospherics/components/on_construction(mob/user)
 	. = ..()
 	update_parents()
 

--- a/code/modules/atmospherics/machinery/components/tank.dm
+++ b/code/modules/atmospherics/machinery/components/tank.dm
@@ -563,7 +563,7 @@
 	var/obj/machinery/atmospherics/components/tank/new_tank = new(build_location)
 	var/list/new_custom_materials = list((material_end_product) = TANK_PLATING_SHEETS * MINERAL_MATERIAL_AMOUNT)
 	new_tank.set_custom_materials(new_custom_materials)
-	new_tank.on_construction(new_tank.pipe_color, new_tank.piping_layer)
+	new_tank.on_construction(user, new_tank.pipe_color, new_tank.piping_layer)
 	to_chat(user, span_notice("[new_tank] has been sealed and is ready to accept gases."))
 	qdel(src)
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -147,8 +147,8 @@
 	. = ..()
 	update_appearance()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/on_construction()
-	..(dir, dir)
+/obj/machinery/atmospherics/components/unary/cryo_cell/on_construction(mob/user)
+	..(user, dir, dir)
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/RefreshParts()
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -62,7 +62,7 @@
 		set_panel_open(TRUE)
 		change_pipe_connection(TRUE)
 		icon_state = "thermo-open"
-		visible_message(span_warning("You fail to anchor the thermomachine as it's port is being hogged up by something else."))
+		visible_message(span_warning("The thermomachine is left unanchored as it's port is being hogged up by something else."))
 
 /obj/machinery/atmospherics/components/unary/thermomachine/RefreshParts()
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -49,7 +49,7 @@
 		return FALSE
 	. = ..()
 
-/obj/machinery/atmospherics/components/unary/thermomachine/on_construction(obj_color, set_layer)
+/obj/machinery/atmospherics/components/unary/thermomachine/on_construction(mob/user, obj_color, set_layer)
 	var/obj/item/circuitboard/machine/thermomachine/board = circuit
 	if(board)
 		piping_layer = board.pipe_layer
@@ -62,7 +62,7 @@
 		set_panel_open(TRUE)
 		change_pipe_connection(TRUE)
 		icon_state = "thermo-open"
-		visible_message(span_warning("The thermomachine is left unanchored as it's port is being hogged up by something else."))
+		balloon_alert(user, "the port is already in use!")
 
 /obj/machinery/atmospherics/components/unary/thermomachine/RefreshParts()
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -58,8 +58,9 @@
 	if(check_pipe_on_turf()) //If you're seeing weird behaviours from thermomachines, skipping the rest of on_construction() could be the cause.
 		set_anchored(FALSE)
 		set_panel_open(TRUE)
-		visible_message(span_warning("You fail to anchor the thermomachine as it's port is being hogged up by something else."))
 		icon_state = "thermo-open"
+		atmos_init() //Normally called in a parent on_construction() but we do it here since we're skipping that.
+		visible_message(span_warning("You fail to anchor the thermomachine as it's port is being hogged up by something else."))
 		return
 	return ..()
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -55,10 +55,13 @@
 		piping_layer = board.pipe_layer
 		set_layer = piping_layer
 
-	if(check_pipe_on_turf())
-		deconstruct(TRUE)
+	if(check_pipe_on_turf()) //If you're seeing weird behaviours from thermomachines, skipping the rest of on_construction() could be the cause.
+		set_anchored(FALSE)
+		set_panel_open(TRUE)
+		visible_message(span_warning("You fail to anchor the thermomachine as it's port is being hogged up by something else."))
+		icon_state = "thermo-open"
 		return
-	return..()
+	return ..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/RefreshParts()
 	. = ..()
@@ -213,13 +216,13 @@
 		if(device == src)
 			continue
 		if(device.piping_layer == piping_layer)
-			visible_message(span_warning("A pipe is hogging the port, remove the obstruction or change the machine piping layer."))
 			return TRUE
 	return FALSE
 
 /obj/machinery/atmospherics/components/unary/thermomachine/wrench_act_secondary(mob/living/user, obj/item/tool)
 	if(!panel_open || check_pipe_on_turf())
-		return
+		visible_message(span_warning("A pipe is hogging the port, remove the obstruction or change the machine piping layer."))
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 	if(default_unfasten_wrench(user, tool))
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 	return

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -55,14 +55,14 @@
 		piping_layer = board.pipe_layer
 		set_layer = piping_layer
 
-	if(check_pipe_on_turf()) //If you're seeing weird behaviours from thermomachines, skipping the rest of on_construction() could be the cause.
+	..() //Skipping the rest of on_construction() would be a bad idea so we clean up after it instead.
+
+	if(check_pipe_on_turf())
 		set_anchored(FALSE)
 		set_panel_open(TRUE)
+		change_pipe_connection(TRUE)
 		icon_state = "thermo-open"
-		atmos_init() //Normally called in a parent on_construction() but we do it here since we're skipping that.
 		visible_message(span_warning("You fail to anchor the thermomachine as it's port is being hogged up by something else."))
-		return
-	return ..()
 
 /obj/machinery/atmospherics/components/unary/thermomachine/RefreshParts()
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/unary_devices.dm
@@ -13,7 +13,7 @@
 /obj/machinery/atmospherics/components/unary/set_init_directions()
 	initialize_directions = dir
 
-/obj/machinery/atmospherics/components/unary/on_construction()
+/obj/machinery/atmospherics/components/unary/on_construction(mob/user)
 	..()
 	update_appearance()
 

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -32,7 +32,7 @@
 	. = ..()
 	packin_up()
 
-/obj/machinery/computer/cargo/express/on_construction()
+/obj/machinery/computer/cargo/express/on_construction(mob/user)
 	. = ..()
 	packin_up()
 

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -85,7 +85,7 @@
 	board.obj_flags |= EMAGGED
 	update_static_data(user)
 
-/obj/machinery/computer/cargo/on_construction()
+/obj/machinery/computer/cargo/on_construction(mob/user)
 	. = ..()
 	circuit.configure_machine(src)
 

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -102,7 +102,7 @@
 	DropFuel()
 	return ..()
 
-/obj/machinery/power/port_gen/pacman/on_construction()
+/obj/machinery/power/port_gen/pacman/on_construction(mob/user)
 	var/obj/item/circuitboard/machine/pacman/our_board = circuit
 	if(our_board.high_production_profile)
 		icon_state = "portgen1_0"


### PR DESCRIPTION
## About The Pull Request

Ever felt the utter pain when you make a new thermomachine, hook it up perfectly and then screwdriver it only for it to immediately become a pile of iron and components without warning? This PR fixes that.

Instead of doing what it did previously, it unanchors itself and opens its panel.

Right, almost forgot to mention, failing to wrench down a thermomachine no longer bonks it with the wrench.

Due to not being allowed to use visual messages for when the port is blocked, I've added a mob/user variable to all on_construction() procs. (This allowed me to use balloon messages instead.)
## Why It's Good For The Game

Saves a lot of unnecessary headaches when working with thermomachines.
## Changelog
:cl:
fix: Atmosians have finally convinced the thermomachines to not self-destruct when built on blocked ports.
fix: Failing to wrench down a thermomachine no longer hits it with the wrench.
/:cl:
