### PR TITLE
Maintenance crates that spawn open will have their contents loaded in.

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -123,6 +123,7 @@
 	if (prob(50))
 		crate.opened = TRUE
 		crate.update_appearance()
+		crate.dump_contents()
 
 	return INITIALIZE_HINT_QDEL
 


### PR DESCRIPTION
## About The Pull Request

Fixes: #69779

Crates and lockers in maintenance have a chance to spawn open, however when doing this their contents are not loaded in, this results in them generating their contents after closing and re-opening them. This PR makes it so if a maint closet spawns open its contents will already be loaded.
## Why It's Good For The Game

Seems like an oversight.
## Changelog
:cl:
fix: Open maintenance lockers/crates will spawn their contents immediately instead of needing to be closed and re-opened.
/:cl:
