### PR TITLE
Honorbound fixes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -655,7 +655,7 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/list/forbiddentraumas = list(/datum/brain_trauma/severe/split_personality,  // Split personality uses a ghost, I don't want to use a ghost for a temp thing
 		/datum/brain_trauma/special/obsessed, // Obsessed sets the owner as an antag - I presume this will lead to problems, so we'll remove it
 		/datum/brain_trauma/hypnosis, // Hypnosis, same reason as obsessed, plus a bug makes it remain even after the neurowhine purges and then turn into "nothing" on the med reading upon a second application
-		/datum/brain_trauma/special/honorbound, // Does not work when the sect does not exist, and is not meant to occur outside of the sect
+		/datum/brain_trauma/special/honorbound, // Designed to be chaplain exclusive
 		)
 	traumalist -= forbiddentraumas
 	var/obj/item/organ/internal/brain/brain = affected_mob.getorganslot(ORGAN_SLOT_BRAIN)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -654,7 +654,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	var/traumalist = subtypesof(/datum/brain_trauma)
 	var/list/forbiddentraumas = list(/datum/brain_trauma/severe/split_personality,  // Split personality uses a ghost, I don't want to use a ghost for a temp thing
 		/datum/brain_trauma/special/obsessed, // Obsessed sets the owner as an antag - I presume this will lead to problems, so we'll remove it
-		/datum/brain_trauma/hypnosis // Hypnosis, same reason as obsessed, plus a bug makes it remain even after the neurowhine purges and then turn into "nothing" on the med reading upon a second application
+		/datum/brain_trauma/hypnosis, // Hypnosis, same reason as obsessed, plus a bug makes it remain even after the neurowhine purges and then turn into "nothing" on the med reading upon a second application
+		/datum/brain_trauma/special/honorbound, // Does not work when the sect does not exist, and is not meant to occur outside of the sect
 		)
 	traumalist -= forbiddentraumas
 	var/obj/item/organ/internal/brain/brain = affected_mob.getorganslot(ORGAN_SLOT_BRAIN)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -652,11 +652,12 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	if(!(DT_PROB(creation_purity*10, delta_time)))
 		return
 	var/traumalist = subtypesof(/datum/brain_trauma)
-	var/list/forbiddentraumas = list(/datum/brain_trauma/severe/split_personality,  // Split personality uses a ghost, I don't want to use a ghost for a temp thing
+	var/list/forbiddentraumas = list(
+		/datum/brain_trauma/severe/split_personality,  // Split personality uses a ghost, I don't want to use a ghost for a temp thing
 		/datum/brain_trauma/special/obsessed, // Obsessed sets the owner as an antag - I presume this will lead to problems, so we'll remove it
 		/datum/brain_trauma/hypnosis, // Hypnosis, same reason as obsessed, plus a bug makes it remain even after the neurowhine purges and then turn into "nothing" on the med reading upon a second application
 		/datum/brain_trauma/special/honorbound, // Designed to be chaplain exclusive
-		)
+	)
 	traumalist -= forbiddentraumas
 	var/obj/item/organ/internal/brain/brain = affected_mob.getorganslot(ORGAN_SLOT_BRAIN)
 	traumalist = shuffle(traumalist)

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -5,6 +5,7 @@
 	scan_desc = "damaged frontal lobe"
 	gain_text = span_notice("You feel honorbound!")
 	lose_text = span_warning("You feel unshackled from your code of honor!")
+	random_gain = FALSE
 	/// list of guilty people
 	var/list/guilty = list()
 
@@ -24,7 +25,7 @@
 
 	//signal that checks for dishonorable attacks
 	RegisterSignal(owner, COMSIG_MOB_CLICKON, PROC_REF(attack_honor))
-	var/datum/action/cooldown/spell/pointed/declare_evil/declare = new(src)
+	var/datum/action/cooldown/spell/pointed/declare_evil/declare = new(owner)
 	declare.Grant(owner)
 	return ..()
 
@@ -224,13 +225,6 @@
 	. = ..()
 	declaration = "By the divine light of [GLOB.deity], you are an evil of this world that must be wrought low!"
 
-/datum/action/cooldown/spell/pointed/declare_evil/Destroy()
-	// If we had an owner, Destroy() called Remove(), and already handled this
-	if(honor_trauma)
-		UnregisterSignal(honor_trauma, COMSIG_PARENT_QDELETING)
-		honor_trauma = null
-	return ..()
-
 /datum/action/cooldown/spell/pointed/declare_evil/Grant(mob/grant_to)
 	if(!ishuman(grant_to))
 		return FALSE
@@ -258,6 +252,11 @@
 /datum/action/cooldown/spell/pointed/declare_evil/can_cast_spell(feedback = TRUE)
 	. = ..()
 	if(!.)
+		return FALSE
+
+	if(!GLOB.religious_sect)
+		if(feedback)
+			to_chat(owner, span_warning("There are no deities around to approve your declaration!"))
 		return FALSE
 
 	if(GLOB.religious_sect.favor < required_favor)


### PR DESCRIPTION
 
## About The Pull Request

Honorbound had a few issues.

You could randomly gain it as a special trauma from heavy brain damage, or from drinking Neruwhine. If the sect did not exist, both of these runtimed due to a null exception, several times on gain, and whenever you tried to use them. These have been solved by setting random_gain to false, and adding the trauma to the Neruwhine blacklist, respectively.
 
The declare evil spell has signed up to the same signal/object pair twice, as the honourbound mutation was passed as the Target (really, owner) of the ability, causing a runtime on gain. I have fixed this by properly passing the owner of the trauma on the spell's creation.

Finally, Destroy() had an identical segment to Remove(), which should be normally fine as it checked if honor_trauma was null or not, but due to how qdel and signals work, it became null between the if(honor_trauma) check, and the unregister. I have removed this proc definition, and let it be fully handled in Remove().

I have also made the spell not work if a sect does not exist, to avoid runtimes and have the action be properly disabled.

## Why It's Good For The Game

Fixes #72088, #72961
 
## Changelog

:cl:
fix: Honourbound can no longer be gained from neurowine or from heavy brain damage, no longer causing the player to be granted a spell that does nothing most of the time
/:cl:
