### PR TITLE
windows node bootstrapping now downloads node.exe to a separate file before renaming it

### DIFF
--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -20,7 +20,8 @@ function Download-Node {
 	Write-Output "Downloading Node v$NodeVersion (may take a while)"
 	New-Item $NodeTargetDir -ItemType Directory -ErrorAction silentlyContinue | Out-Null
 	$WebClient = New-Object Net.WebClient
-	$WebClient.DownloadFile($NodeSource, $NodeTarget)
+	$WebClient.DownloadFile($NodeSource, "$NodeTarget.downloading")
+	Rename-Item "$NodeTarget.downloading" $NodeTarget
 }
 
 ## Convenience variables


### PR DESCRIPTION
This should stop people from getting "corrupt" copies of node.exe in their `./tools/bootstrap/.cache` directory. I checked before making this commit that WebClient.DownloadFile can definitely result in a half-written file.