### PR TITLE
Elevator doors can be manually forced open

### DIFF
--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -722,6 +722,23 @@ GLOBAL_LIST_EMPTY(lifts)
 	desc = "Keeps idiots like you from walking into an open elevator shaft."
 	icon = 'icons/obj/doors/liftdoor.dmi'
 
+/**
+ * Let them pry open the elevator doors for that foul play.
+ */
+/obj/machinery/door/poddoor/lift/try_safety_unlock(mob/living/user)
+	if(density)
+		to_chat(user, span_notice("You begin pulling the elevator doors apart..."))
+		if(do_after(user, 7 SECONDS, target = src))
+			open(TRUE)
+			return TRUE
+
+/obj/machinery/door/poddoor/lift/crowbar_act(mob/living/user, obj/item/tool)
+	if(density)
+		to_chat(user, span_notice("You begin prying the elevator doors apart..."))
+		if(do_after(user, 2 SECONDS, target = src))
+			open(TRUE)
+			return TOOL_ACT_TOOLTYPE_SUCCESS
+
 // A subtype intended for "public use"
 /obj/structure/industrial_lift/public
 	icon = 'icons/turf/floors.dmi'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes elevator doors able to be opened both by hand and by crowbar. (They should be able to be opened even when powered, they are not airlocks or pod doors.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Enables mischief. No use having an elevator/shaft for you to emag/shove someone in if you have no way to open the doors.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: LT3
code: Elevator doors can now be forced open by hand or crowbar, try not to fall in if you value your bones
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
