### PR TITLE
check for client disconnect during hud updates

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -40,9 +40,14 @@
 	client.set_right_click_menu_mode(shift_to_open_context_menu)
 
 	if(!hud_used)
-		create_mob_hud()
+		create_mob_hud() // creating a hud will add it to the client's screen, which can process a disconnect
+		if(!client)
+			return FALSE
+
 	if(hud_used)
-		hud_used.show_hud(hud_used.hud_version)
+		hud_used.show_hud(hud_used.hud_version) // see above, this can process a disconnect
+		if(!client)
+			return FALSE
 		hud_used.update_ui_style(ui_style2icon(client.prefs?.read_preference(/datum/preference/choiced/ui_style)))
 
 	next_move = 1


### PR DESCRIPTION

## About The Pull Request

Noticed a few runtimes about trying to read a null.prefs and tracked it down to these lines.

When you go to create a hud for a mob, you add it to the client's screen, however adding to a client's screen is an internal byond operation and as such will allow a client disconnection to be processed.
## Why It's Good For The Game

Client DC catching is good, and some comments stating why it's needed
## Changelog
