### PR TITLE
[no gbp] dismantling an unplaced wallframe will now make a wrench sound

### DIFF
--- a/code/game/objects/items/wall_mounted.dm
+++ b/code/game/objects/items/wall_mounted.dm
@@ -72,6 +72,7 @@
 	if(!metal_amt && !glass_amt)
 		return FALSE
 	to_chat(user, span_notice("You dismantle [src]."))
+	tool.play_tool_sound(src)
 	if(metal_amt)
 		new /obj/item/stack/sheet/iron(get_turf(src), metal_amt)
 	if(glass_amt)


### PR DESCRIPTION

## About The Pull Request
Dismantling an unplaced wallframe will now make a wrench sound.
## Why It's Good For The Game
Using a wrench almost always makes the wrench noise. Having that noise not play when you wrench something feels very weird.
## Changelog
:cl:
soundadd: dismantling an unplaced wallframe will now make a wrench sound
/:cl:
