### PR TITLE
Fixes the labor claim console not properly linking in shuttle loads

### DIFF
--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -27,7 +27,8 @@ GLOBAL_LIST_EMPTY(default_lighting_underlays_by_z)
 		stack_trace("a lighting object was assigned to a turf that already had a lighting object!")
 
 	affected_turf.lighting_object = src
-	affected_turf.luminosity = 0
+	// Default to fullbright, so things can "see" if they use view() before we update
+	affected_turf.luminosity = 1
 
 	// This path is really hot. this is faster
 	// Really this should be a global var or something, but lets not think about that yes?

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -125,7 +125,7 @@ GLOBAL_LIST(labor_sheet_values)
 					return TRUE
 
 /obj/machinery/mineral/labor_claim_console/proc/locate_stacking_machine()
-	stacking_machine = locate(/obj/machinery/mineral/stacking_machine) in view(2, src)
+	stacking_machine = locate(/obj/machinery/mineral/stacking_machine) in dview(2, get_turf(src))
 	if(stacking_machine)
 		stacking_machine.labor_console = src
 


### PR DESCRIPTION

## About The Pull Request

Caused by f88edef0fb0c6988de0381d7c29e967ce04310dd

I prevented lighting objects transfering between space turfs and not space turfs.
This meant if you went from space turf -> non space turf, we had to spawn you a new lighting object.

This would set your luminosity to 0, then queue you for updates.

This meant that shuttles would go fulldark (To things without see_in_dark) on move. So when we'd try and do a view check to look for a stacking machine to feed from, we'd get blocked

Lets swap from a view to a dview() then, and default to lit instead of unlit turfs

Because mobs use infi see_in_dark this only impacts redundant view() calls. Lets just be nice to em yeah?

## Why It's Good For The Game

Closes #73324 

## Changelog
:cl:
fix: The gulag shuttle's point claim console will load in again. Whooops
/:cl:
