### PR TITLE
Disease Outbreak/Heart Attack candidate lists clear themselves before generating

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -49,6 +49,7 @@
  * This proc needs to be run at some point to ensure the event has candidates to infect.
  */
 /datum/round_event_control/disease_outbreak/proc/generate_candidates()
+	disease_candidates.Cut() //We clear the list and rebuild it again.
 	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list)) //Player list is much more up to date and requires less checks(?)
 		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER) || candidate.stat == DEAD)
 			continue

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -28,6 +28,7 @@
  * later, at the round_event level, so this proc mostly just checks users for whether or not a heart attack should be possible.
  */
 /datum/round_event_control/heart_attack/proc/generate_candidates()
+	heart_attack_candidates.Cut()
 	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list))
 		if(candidate.stat == DEAD || HAS_TRAIT(candidate, TRAIT_CRITICAL_CONDITION) || !candidate.can_heartattack() || (/datum/disease/heart_failure in candidate.diseases) || candidate.undergoing_cardiac_arrest())
 			continue


### PR DESCRIPTION
## About The Pull Request

When canSpawnEvent is run for the disease outbreak event, it would generate_candidates() and add whoever was a valid infectee to a list. Unfortunately, this list would not be cleared until the event was actually run, meaning the candidate list could become malformed if the event was cancelled, interrupted, or otherwise stopped before it could properly start.

Additionally, this issue would arise if the admin setup process was begun without actually running the event, or if two admins were attempting to press buttons at the same time.

The list could contain duplicates, or players who were valid candidates on the first candidacy check, but not at the present moment. The list now clears itself every time it is generated, meaning that a fresh candidate list is made every time one is needed.

Since the heart attack event uses the same candidate generating system as the disease event, the change has been made there as well.

## Why It's Good For The Game

Closes #73552, hopefully? I can't imagine it's an issue with how the candidates are selected, and am like 99% sure it's just the list getting fudged somehow.

## Changelog
:cl:
fix: The disease outbreak/heart attack event candidate list will now clear itself before generating.
/:cl:
