### PR TITLE
Disease Outbreak retries on event setup failure [NO GBP]

### DIFF
--- a/code/__HELPERS/logging/virus.dm
+++ b/code/__HELPERS/logging/virus.dm
@@ -12,4 +12,4 @@
 	var/list/name_symptoms = list()
 	for(var/datum/symptom/S in symptoms)
 		name_symptoms += S.name
-	return "[name] sym:[english_list(name_symptoms)] r:[totalResistance()] s:[totalStealth()] ss:[totalStageSpeed()] t:[totalTransmittable()]"
+	return "[name] - sym:[english_list(name_symptoms)] re:[totalResistance()] st:[totalStealth()] ss:[totalStageSpeed()] tr:[totalTransmittable()]"

--- a/code/__HELPERS/logging/virus.dm
+++ b/code/__HELPERS/logging/virus.dm
@@ -12,4 +12,4 @@
 	var/list/name_symptoms = list()
 	for(var/datum/symptom/S in symptoms)
 		name_symptoms += S.name
-	return "[name] - sym:[english_list(name_symptoms)] re:[totalResistance()] st:[totalStealth()] ss:[totalStageSpeed()] tr:[totalTransmittable()]"
+	return "[name] - sym: [english_list(name_symptoms)] re:[totalResistance()] st:[totalStealth()] ss:[totalStageSpeed()] tr:[totalTransmittable()]"

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -266,10 +266,10 @@
 			spread_text = "Fluids"
 		if(DISEASE_SPREAD_CONTACT_SKIN)
 			spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN
-			spread_text = "On contact"
+			spread_text = "Skin contact"
 		if(DISEASE_SPREAD_AIRBORNE)
 			spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_AIRBORNE
-			spread_text = "Airborne"
+			spread_text = "Respiration"
 
 /datum/disease/advance/proc/set_severity(level_sev)
 

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -49,6 +49,7 @@
  * This proc needs to be run at some point to ensure the event has candidates to infect.
  */
 /datum/round_event_control/disease_outbreak/proc/generate_candidates()
+	disease_candidates.Cut() //We clear the list and rebuild it again.
 	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list)) //Player list is much more up to date and requires less checks(?)
 		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER) || candidate.stat == DEAD)
 			continue

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -128,7 +128,7 @@
 			message_admins("Event triggered: Disease Outbreak - [new_disease.name] starting with patient zero [ADMIN_LOOKUPFLW(victim)]!")
 			log_game("Event triggered: Disease Outbreak - [new_disease.name] starting with patient zero [key_name(victim)].")
 			announce_to_ghosts(victim)
-			break
+			return
 		CHECK_TICK //don't lag the server to death
 	if(isnull(victim))
 		log_game("Event Disease Outbreak: Classic attempted to start, but failed.")
@@ -234,7 +234,7 @@
 			message_admins("Event triggered: Disease Outbreak - [advanced_disease.name] starting with patient zero [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]. It is transmissable via [advanced_disease.spread_text].")
 			log_game("Event triggered: Disease Outbreak - [advanced_disease.name] starting with patient zero [key_name(victim)]. It has these symptoms: [english_list(name_symptoms)]. It is transmissable via [advanced_disease.spread_text].")
 			announce_to_ghosts(victim)
-			break
+			return
 		CHECK_TICK //don't lag the server to death
 	if(isnull(victim))
 		log_game("Event Disease Outbreak: Advanced attempted to start, but failed.")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -120,13 +120,17 @@
 	new_disease.carrier = TRUE
 	illness_type = new_disease.name
 
-	var/mob/living/carbon/human/victim = pick_n_take(afflicted)
-	if(victim.ForceContractDisease(new_disease, FALSE))
-		log_game("An event has given [key_name(victim)] the [new_disease]")
-		message_admins("An event has triggered a [new_disease.name] virus outbreak on [ADMIN_LOOKUPFLW(victim)]!")
-		announce_to_ghosts(victim)
-	else
-		log_game("An event attempted to trigger a [new_disease.name] virus outbreak on [key_name(victim)], but failed.")
+	var/mob/living/carbon/human/victim
+	while(length(afflicted))
+		victim = pick_n_take(afflicted)
+		if(victim.ForceContractDisease(new_disease, FALSE))
+			message_admins("Event triggered: Disease Outbreak - [new_disease.name] starting with patient zero [ADMIN_LOOKUPFLW(victim)]!")
+			log_game("Event triggered: Disease Outbreak - [new_disease.name] starting with patient zero [key_name(victim)].")
+			announce_to_ghosts(victim)
+			break
+		CHECK_TICK //don't lag the server to death
+	if(isnull(victim))
+		log_game("Event Disease Outbreak: Classic attempted to start, but failed.")
 
 /datum/round_event_control/disease_outbreak/advanced
 	name = "Disease Outbreak: Advanced"
@@ -222,13 +226,17 @@
 
 	illness_type = advanced_disease.name
 
-	var/mob/living/carbon/human/victim = pick_n_take(afflicted)
-	if(victim.ForceContractDisease(advanced_disease, FALSE))
-		message_admins("An event has triggered a random advanced virus outbreak on [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]. It is transmissable via [advanced_disease.spread_text].")
-		log_game("An event has triggered a random advanced virus outbreak on [key_name(victim)]! It has these symptoms: [english_list(name_symptoms)]. It is transmissable via [advanced_disease.spread_text].")
-		announce_to_ghosts(victim)
-	else
-		log_game("An event attempted to trigger a random advanced virus outbreak on [key_name(victim)], but failed.")
+	var/mob/living/carbon/human/victim
+	while(length(afflicted))
+		victim = pick_n_take(afflicted)
+		if(victim.ForceContractDisease(advanced_disease, FALSE))
+			message_admins("Event triggered: Disease Outbreak - [advanced_disease.name] starting with patient zero [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]. It is transmissable via [advanced_disease.spread_text].")
+			log_game("Event triggered: Disease Outbreak - [advanced_disease.name] starting with patient zero [key_name(victim)]. It has these symptoms: [english_list(name_symptoms)]. It is transmissable via [advanced_disease.spread_text].")
+			announce_to_ghosts(victim)
+			break
+		CHECK_TICK //don't lag the server to death
+	if(isnull(victim))
+		log_game("Event Disease Outbreak: Advanced attempted to start, but failed.")
 
 /datum/disease/advance/random/event
 	name = "Event Disease"
@@ -336,6 +344,7 @@
 
 	addtimer(CALLBACK(src, PROC_REF(make_visible)), ((ADV_ANNOUNCE_DELAY * 2) - 10) SECONDS)
 
+	properties["transmittable"] = rand(4,7)
 	spreading_modifier = max(CEILING(0.4 * properties["transmittable"], 1), 1)
 	cure_chance = clamp(7.5 - (0.5 * properties["resistance"]), 5, 10) // Can be between 5 and 10
 	stage_prob = max(0.4 * properties["stage_rate"], 1)
@@ -346,6 +355,7 @@
 	if(properties["stage_rate"] >= 7)
 		name = "Advanced [name]"
 
+	//If severe enough, alert immediately on scanners
 	if(severity == "Dangerous" || severity == "BIOHAZARD")
 		visibility_flags &= ~HIDDEN_SCANNER
 		set_spread(DISEASE_SPREAD_CONTACT_SKIN)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -231,8 +231,9 @@
 	while(length(afflicted))
 		victim = pick_n_take(afflicted)
 		if(victim.ForceContractDisease(advanced_disease, FALSE))
-			message_admins("Event triggered: Disease Outbreak - [advanced_disease.name] starting with patient zero [ADMIN_LOOKUPFLW(victim)]! It has these symptoms: [english_list(name_symptoms)]. It is transmissable via [advanced_disease.spread_text].")
-			log_game("Event triggered: Disease Outbreak - [advanced_disease.name] starting with patient zero [key_name(victim)]. It has these symptoms: [english_list(name_symptoms)]. It is transmissable via [advanced_disease.spread_text].")
+			message_admins("Event triggered: Disease Outbreak: Advanced - starting with patient zero [key_name(victim)]! Details: [advanced_disease.admin_details()] spread [advanced_disease.spread_flags] ([advanced_disease.spread_text])")
+			log_game("Event triggered: Disease Outbreak: Advanced - starting with patient zero [key_name(victim)]. Details: [advanced_disease.admin_details()] sp:[advanced_disease.spread_flags] ([advanced_disease.spread_text])")
+			log_virus("Disease Outbreak: Advanced has triggered a custom virus outbreak of [advanced_disease.admin_details()] in [victim]!")
 			announce_to_ghosts(victim)
 			return
 		CHECK_TICK //don't lag the server to death

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -231,7 +231,7 @@
 	while(length(afflicted))
 		victim = pick_n_take(afflicted)
 		if(victim.ForceContractDisease(advanced_disease, FALSE))
-			message_admins("Event triggered: Disease Outbreak: Advanced - starting with patient zero [key_name(victim)]! Details: [advanced_disease.admin_details()] spread [advanced_disease.spread_flags] ([advanced_disease.spread_text])")
+			message_admins("Event triggered: Disease Outbreak: Advanced - starting with patient zero [key_name(victim)]! Details: [advanced_disease.admin_details()] sp:[advanced_disease.spread_flags] ([advanced_disease.spread_text])")
 			log_game("Event triggered: Disease Outbreak: Advanced - starting with patient zero [key_name(victim)]. Details: [advanced_disease.admin_details()] sp:[advanced_disease.spread_flags] ([advanced_disease.spread_text])")
 			log_virus("Disease Outbreak: Advanced has triggered a custom virus outbreak of [advanced_disease.admin_details()] in [victim]!")
 			announce_to_ghosts(victim)


### PR DESCRIPTION
## About The Pull Request
- When Disease Outbreak starts, instead of failing on the first attempt picks a new target if the chosen target is no longer valid for infection.
- Corrects transmission of disease, assigning a stat. Positive viruses with a resistance higher than transmissibility provide immunity from the disease outbreak.
- Improved logging and admin information

## Why It's Good For The Game
- Along with https://github.com/tgstation/tgstation/pull/73596 this makes the event reliably fire instead of giving up if the first selection has changed during setup. (Death, new immunity, infected with different virus, whatever.)
- Disease transmits as expected to unprotected. Positive viruses provide immunity from infection based on their resistance stat.

## Changelog

:cl: LT3
fix: Disease Outbreak doesn't give up so easily when trying to start the event
balance: Disease Outbreak will not spawn on positive virus mobs, but can be transmitted if resistance is low
fix: Disease Outbreak creates an entry in the virus log like it should
admin: Admins can see Disease Outbreak virus stats when the event starts
/:cl:
