### PR TITLE
Fix chef food ownership to follow mind

### DIFF
--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -11,7 +11,7 @@
 	///Time spent baking so far
 	var/current_bake_time = 0
 
-	/// REF() to the mob which placed us in an oven
+	/// REF() to the mind which placed us in an oven
 	var/who_baked_us
 
 /datum/component/bakeable/Initialize(bake_result, required_bake_time, positive_result, use_large_steam_sprite)
@@ -46,8 +46,8 @@
 /datum/component/bakeable/proc/on_baking_start(datum/source, atom/used_oven, mob/baker)
 	SIGNAL_HANDLER
 
-	if(baker)
-		who_baked_us = REF(baker)
+	if(baker && baker.mind)
+		who_baked_us = REF(baker.mind)
 
 ///Ran every time an item is baked by something
 /datum/component/bakeable/proc/on_bake(datum/source, atom/used_oven, delta_time = 1)

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -214,7 +214,8 @@ Behavior that's still missing from this component that original food items had t
 		var/list/types = bitfield_to_list(foodtypes, FOOD_FLAGS)
 		examine_list += span_notice("It is [lowertext(english_list(types))].")
 
-	if(HAS_TRAIT_FROM(parent, TRAIT_FOOD_CHEF_MADE, REF(user)))
+	var/datum/mind/mind = user.mind
+	if(mind && HAS_TRAIT_FROM(parent, TRAIT_FOOD_CHEF_MADE, REF(mind)))
 		examine_list += span_green("[parent] was made by you!")
 
 	if(!(food_flags & FOOD_IN_CONTAINER))

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -10,7 +10,7 @@
 	var/current_cook_time = 0
 	///Do we use the large steam sprite?
 	var/use_large_steam_sprite = FALSE
-	/// REF() to the mob which placed us on the griddle
+	/// REF() to the mind which placed us on the griddle
 	var/who_placed_us
 
 /datum/component/grillable/Initialize(cook_result, required_cook_time, positive_result, use_large_steam_sprite)
@@ -48,8 +48,8 @@
 /datum/component/grillable/proc/on_grill_start(datum/source, mob/griller)
 	SIGNAL_HANDLER
 
-	if(griller)
-		who_placed_us = REF(griller)
+	if(griller && griller.mind)
+		who_placed_us = REF(griller.mind)
 
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(add_grilled_item_overlay))

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -43,8 +43,8 @@
 	SEND_SIGNAL(result, COMSIG_ITEM_MICROWAVE_COOKED, source, efficiency)
 
 	if(IS_EDIBLE(result))
-		if(microwaver)
-			ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(microwaver))
+		if(microwaver && microwaver.mind)
+			ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(microwaver.mind))
 
 		result.reagents?.multiply_reagents(efficiency * CRAFTED_FOOD_BASE_REAGENT_MODIFIER)
 		source.reagents?.trans_to(result, source.reagents.total_volume)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1518,7 +1518,8 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	SEND_SIGNAL(src, COMSIG_ATOM_CREATEDBY_PROCESSING, original_atom, chosen_option)
-	ADD_TRAIT(src, TRAIT_FOOD_CHEF_MADE, REF(user))
+	if(user.mind)
+		ADD_TRAIT(src, TRAIT_FOOD_CHEF_MADE, REF(user.mind))
 
 //! Tool-specific behavior procs.
 ///

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -645,13 +645,14 @@
 	. = ..()
 	if(!IS_EDIBLE(target) || !target.reagents)
 		return
-	if(!firer || !target.Adjacent(firer))
+	if(!firer || !target.Adjacent(firer) || !ismob(firer))
 		return
+
+	var/mob/kisser = firer
 
 	// From here on, no message
 	suppressed = SUPPRESSED_VERY
-
-	if(!HAS_TRAIT_FROM(target, TRAIT_FOOD_CHEF_MADE, REF(firer)))
+	if(!(kisser.mind && HAS_TRAIT_FROM(target, TRAIT_FOOD_CHEF_MADE, REF(kisser.mind))))
 		to_chat(firer, span_warning("Wait a second, you didn't make this [target.name]. How can you claim it as your own?"))
 		return
 	if(target.reagents.has_reagent(/datum/reagent/love))

--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -184,7 +184,8 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	// Give them reagents to put frying oil in
 	if(isnull(frying.reagents))
 		frying.create_reagents(50, INJECTABLE)
-	ADD_TRAIT(frying, TRAIT_FOOD_CHEF_MADE, REF(user))
+	if(user.mind)
+		ADD_TRAIT(frying, TRAIT_FOOD_CHEF_MADE, REF(user.mind))
 	SEND_SIGNAL(frying, COMSIG_ITEM_ENTERED_FRYER)
 
 	icon_state = "fryer_on"

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -3,7 +3,8 @@
 	var/total_nutriment_factor
 
 /datum/crafting_recipe/food/on_craft_completion(mob/user, atom/result)
-	ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(user))
+	if(user.mind)
+		ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(user.mind))
 
 /datum/crafting_recipe/food/New()
 	if(ispath(result, /obj/item/food))


### PR DESCRIPTION
:cl: coiax
fix: A chef who is beheaded, and the head stitched on another body will still see their food as their own.
/:cl:

## Why It's Good For The Game

Having food ownership be based on the mind, rather than the mob, makes it resilient to body-swap, mind-swap, podcloning (cloning!?), situations. Because even though you may have been reduced to just a head, that stew is still yours, you still made it.