### PR TITLE
remove no longer existing config option

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -197,9 +197,6 @@ ID_CONSOLE_JOBSLOT_DELAY 30
 ## allow players to initiate a restart vote
 #ALLOW_VOTE_RESTART
 
-## allow players to initiate a mode-change vote
-#ALLOW_VOTE_MODE
-
 ## allow players to initiate a map-change vote
 #ALLOW_VOTE_MAP
 


### PR DESCRIPTION

## About the Pull Request
This was originally removed in https://github.com/tgstation/tgstation/pull/58470 
We should probably set up CI for things like this, though I can't think of a way to easily do this for commented out config options.
