### PR TITLE
Anchors incorrectly unanchored reinforced plasmaglass windows on snowdin.

### DIFF
--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -6451,7 +6451,7 @@
 /area/awaymission/snowdin/cave/cavern)
 "rW" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/window/reinforced/plasma/unanchored,
+/obj/structure/window/reinforced/plasma/spawner,
 /turf/open/lava/plasma,
 /area/awaymission/snowdin/cave/cavern)
 "rY" = (
@@ -7994,7 +7994,7 @@
 "zl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced/plasma/spawner/north,
-/obj/structure/window/reinforced/plasma/unanchored,
+/obj/structure/window/reinforced/plasma/spawner,
 /turf/open/lava/plasma,
 /area/awaymission/snowdin/cave/cavern)
 "zm" = (


### PR DESCRIPTION

## About The Pull Request

Every single south facing reinforced plasma-glass window on snowdin was unanchored, I've changed them to the anchored version.
## Why It's Good For The Game

Bug fix!
## Changelog
:cl:
fix: The unanchored reinforced plasma-glass windows on snowdin have been anchored.
/:cl:
