### PR TITLE
filled trashcarts spawn nearby grime when initialized instead of when opened for the first time

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -140,7 +140,8 @@
 
 /obj/structure/closet/crate/trashcart/filled/Initialize(mapload)
 	. = ..()
-	new /obj/effect/spawner/random/trash/grime(loc) //needs to be done before the trashcart is opened because it spawns things in a range outside of the trashcart
+	if(mapload)
+		new /obj/effect/spawner/random/trash/grime(loc) //needs to be done before the trashcart is opened because it spawns things in a range outside of the trashcart
 
 /obj/structure/closet/crate/trashcart/filled/PopulateContents()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -138,13 +138,16 @@
 
 /obj/structure/closet/crate/trashcart/filled
 
+/obj/structure/closet/crate/trashcart/filled/Initialize(mapload)
+	. = ..()
+	new /obj/effect/spawner/random/trash/grime(loc) //needs to be done before the trashcart is opened because it spawns things in a range outside of the trashcart
+
 /obj/structure/closet/crate/trashcart/filled/PopulateContents()
 	. = ..()
 	for(var/i in 1 to rand(7,15))
 		new /obj/effect/spawner/random/trash/garbage(src)
 		if(prob(12))
 			new /obj/item/storage/bag/trash/filled(src)
-	new /obj/effect/spawner/random/trash/grime(loc)
 
 /obj/structure/closet/crate/internals
 	desc = "An internals crate."


### PR DESCRIPTION

## About The Pull Request
Filled trashcarts spawn some trash in them once they are opened for the first time. But they also spawn grime, and the problem with that is that grime spawns in a range around the trashcart. So opening the trashcart for the first time would cause the grime to suddenly pop in around the cart.

This PR changes it so that the grime is spawned when the filled trashcart is initialized.
## Why It's Good For The Game
Having trash spawn around the trashcart the moment that you open it is probably not intended. The grime is probably meant to be there before the trashcart is opened for the first time.
## Changelog
:cl:
fix: filled trashcarts spawn nearby grime when initialized instead of when opened for the first time
/:cl:
