### PR TITLE
Fixes being able to "Drive" ridden vehicles without the key/in space.

### DIFF
--- a/code/datums/components/riding/riding.dm
+++ b/code/datums/components/riding/riding.dm
@@ -83,6 +83,7 @@
 	restore_position(rider)
 	unequip_buckle_inhands(rider)
 	rider.updating_glide_size = TRUE
+	UnregisterSignal(rider, COMSIG_LIVING_TRY_PULL)
 	if(!movable_parent.has_buckled_mobs())
 		qdel(src)
 
@@ -93,6 +94,18 @@
 	var/atom/movable/movable_parent = parent
 	handle_vehicle_layer(movable_parent.dir)
 	handle_vehicle_offsets(movable_parent.dir)
+
+	if(rider.pulling == source)
+		rider.stop_pulling()
+	RegisterSignal(rider, COMSIG_LIVING_TRY_PULL, PROC_REF(on_rider_try_pull))
+
+/// This proc is called when the rider attempts to grab the thing they're riding, preventing them from doing so.
+/datum/component/riding/proc/on_rider_try_pull(mob/living/rider_pulling, atom/movable/target, force)
+	SIGNAL_HANDLER
+	if(target == parent)
+		var/mob/living/ridden = parent
+		ridden.balloon_alert(rider_pulling, "not while riding it!")
+		return COMSIG_LIVING_CANCEL_PULL
 
 /// Some ridable atoms may want to only show on top of the rider in certain directions, like wheelchairs
 /datum/component/riding/proc/handle_vehicle_layer(dir)

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -77,17 +77,7 @@
 	if(can_be_driven)
 		//let the player take over if they should be controlling movement
 		ADD_TRAIT(ridden, TRAIT_AI_PAUSED, REF(src))
-	if(rider.pulling == ridden)
-		rider.stop_pulling()
-	RegisterSignal(rider, COMSIG_LIVING_TRY_PULL, PROC_REF(on_rider_try_pull))
 	return ..()
-
-/datum/component/riding/creature/proc/on_rider_try_pull(mob/living/rider_pulling, atom/movable/target, force)
-	SIGNAL_HANDLER
-	if(target == parent)
-		var/mob/living/ridden = parent
-		ridden.balloon_alert(rider_pulling, "not while riding it!")
-		return COMSIG_LIVING_CANCEL_PULL
 
 /datum/component/riding/creature/vehicle_mob_unbuckle(mob/living/formerly_ridden, mob/living/former_rider, force = FALSE)
 	if(istype(formerly_ridden) && istype(former_rider))
@@ -96,7 +86,6 @@
 	remove_abilities(former_rider)
 	if(!formerly_ridden.buckled_mobs.len)
 		REMOVE_TRAIT(formerly_ridden, TRAIT_AI_PAUSED, REF(src))
-	UnregisterSignal(former_rider, COMSIG_LIVING_TRY_PULL)
 	// We gotta reset those layers at some point, don't we?
 	former_rider.layer = MOB_LAYER
 	formerly_ridden.layer = MOB_LAYER


### PR DESCRIPTION

## About The Pull Request

Fixes: #73610

I've elevated the code that prevents you from grabbing the thing your riding from the creature subtype to the main riding component. I cannot think of any ridden vehicles that you should be able to grab while riding so I don't think there is any issue in making this change, although please advise me if this is not true.
## Why It's Good For The Game

Using a wheelchair for space traversal seems like a bug.
## Changelog
:cl:
fix: You can no longer drive ridable vehicles without keys or in space.
/:cl:
