### PR TITLE
Fixes non-advanced viruses from being seen in the PANDEMIC

### DIFF
--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -308,22 +308,21 @@
 		traits["index"] = index++
 		traits["name"] = disease.name
 		traits["spread"] = disease.spread_text || "none"
-		if(!istype(disease, /datum/disease/advance)) // Advanced diseases get more info
-			continue
-		var/datum/disease/advance/adv_disease = disease
-		var/disease_name = SSdisease.get_disease_name(adv_disease.GetDiseaseID())
-		traits["can_rename"] = ((disease_name == "Unknown") && adv_disease.mutable)
-		traits["is_adv"] = TRUE
-		traits["name"] = disease_name
-		traits["resistance"] = adv_disease.totalResistance()
-		traits["stage_speed"] = adv_disease.totalStageSpeed()
-		traits["stealth"] = adv_disease.totalStealth()
-		traits["symptoms"] = list()
-		for(var/datum/symptom/symptom as anything in adv_disease.symptoms)
-			var/list/this_symptom = list()
-			this_symptom = symptom.get_symptom_data()
-			traits["symptoms"] += list(this_symptom)
-		traits["transmission"] = adv_disease.totalTransmittable()
+		if(istype(disease, /datum/disease/advance)) // Advanced diseases get more info
+			var/datum/disease/advance/adv_disease = disease
+			var/disease_name = SSdisease.get_disease_name(adv_disease.GetDiseaseID())
+			traits["can_rename"] = ((disease_name == "Unknown") && adv_disease.mutable)
+			traits["is_adv"] = TRUE
+			traits["name"] = disease_name
+			traits["resistance"] = adv_disease.totalResistance()
+			traits["stage_speed"] = adv_disease.totalStageSpeed()
+			traits["stealth"] = adv_disease.totalStealth()
+			traits["symptoms"] = list()
+			for(var/datum/symptom/symptom as anything in adv_disease.symptoms)
+				var/list/this_symptom = list()
+				this_symptom = symptom.get_symptom_data()
+				traits["symptoms"] += list(this_symptom)
+			traits["transmission"] = adv_disease.totalTransmittable()
 		data += list(traits)
 	return data
 

--- a/tgui/packages/tgui/interfaces/Pandemic/Specimen.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic/Specimen.tsx
@@ -56,7 +56,8 @@ const Buttons = (props, context) => {
         <Button
           icon="flask"
           content="Create culture bottle"
-          disabled={!is_ready}
+          disabled={!is_ready || !virus}
+          tooltip={!virus ? 'No virus culture found.' : ''}
           onClick={() =>
             act('create_culture_bottle', {
               index: virus.index,

--- a/tgui/packages/tgui/interfaces/Pandemic/Specimen.tsx
+++ b/tgui/packages/tgui/interfaces/Pandemic/Specimen.tsx
@@ -57,7 +57,7 @@ const Buttons = (props, context) => {
           icon="flask"
           content="Create culture bottle"
           disabled={!is_ready || !virus}
-          tooltip={!virus ? 'No virus culture found.' : ''}
+          tooltip={virus ? '' : 'No virus culture found.'}
           onClick={() =>
             act('create_culture_bottle', {
               index: virus.index,


### PR DESCRIPTION
## About The Pull Request

Early continue was blocking traits being added to ui data. 

Added some sanity to stop some bluescreens.

## Changelog

:cl: Melbert
fix: Premade viruses (GBS, beesease, etc) now show up in the PANDEMIC again
fix: PANDEMICs should bluescreen less often. Maybe.
/:cl:
