### PR TITLE
Fixes `TRAIT_NOBREATH` leaving Nitrous Oxide alerts

### DIFF
--- a/code/modules/mob/living/carbon/init_signals.dm
+++ b/code/modules/mob/living/carbon/init_signals.dm
@@ -27,6 +27,9 @@
 	clear_alert(ALERT_TOO_MUCH_CO2)
 	clear_alert(ALERT_NOT_ENOUGH_CO2)
 
+	clear_alert(ALERT_TOO_MUCH_N2O)
+	clear_alert(ALERT_NOT_ENOUGH_N2O)
+
 	clear_mood_event("chemical_euphoria")
 	clear_mood_event("smell")
 	clear_mood_event("suffocation")


### PR DESCRIPTION
## About The Pull Request

Missed some copypasta here. 

N2O needed to be cleared when nobreath is gained.

## Changelog

:cl: Melbert
fix: Gaining nobreath in an N2O heavy environment doesn't make you forever aware of it
/:cl:
