### PR TITLE
Fixes mecha speech indicators never going away

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -114,7 +114,7 @@
 /// Like add_image_to_client, but will add the image from a list of clients
 /proc/add_image_to_clients(image/image_to_remove, list/show_to)
 	for(var/client/add_to as anything in show_to)
-		add_to.images += image_to_remove
+		add_to?.images += image_to_remove
 
 /// Removes an image from a client's `.images`. Useful as a callback.
 /proc/remove_image_from_client(image/image_to_remove, client/remove_from)
@@ -123,15 +123,15 @@
 /// Like remove_image_from_client, but will remove the image from a list of clients
 /proc/remove_image_from_clients(image/image_to_remove, list/hide_from)
 	for(var/client/remove_from as anything in hide_from)
-		remove_from.images -= image_to_remove
+		remove_from?.images -= image_to_remove
 
 
 ///Add an image to a list of clients and calls a proc to remove it after a duration
 /proc/flick_overlay_global(image/image_to_show, list/show_to, duration)
 	if(!show_to || !length(show_to) || !image_to_show)
 		return
-	for(var/client/add_to in show_to)
-		add_to.images += image_to_show
+	for(var/client/add_to as anything in show_to)
+		add_to?.images += image_to_show
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_image_from_clients), image_to_show, show_to), duration, TIMER_CLIENT_TIME)
 
 /// Flicks a certain overlay onto an atom, handling icon_state strings

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -113,8 +113,8 @@
 
 /// Like add_image_to_client, but will add the image from a list of clients
 /proc/add_image_to_clients(image/image_to_remove, list/show_to)
-	for(var/client/add_to as anything in show_to)
-		add_to?.images += image_to_remove
+	for(var/client/add_to in show_to)
+		add_to.images += image_to_remove
 
 /// Removes an image from a client's `.images`. Useful as a callback.
 /proc/remove_image_from_client(image/image_to_remove, client/remove_from)
@@ -122,16 +122,16 @@
 
 /// Like remove_image_from_client, but will remove the image from a list of clients
 /proc/remove_image_from_clients(image/image_to_remove, list/hide_from)
-	for(var/client/remove_from as anything in hide_from)
-		remove_from?.images -= image_to_remove
+	for(var/client/remove_from in hide_from)
+		remove_from.images -= image_to_remove
 
 
 ///Add an image to a list of clients and calls a proc to remove it after a duration
 /proc/flick_overlay_global(image/image_to_show, list/show_to, duration)
 	if(!show_to || !length(show_to) || !image_to_show)
 		return
-	for(var/client/add_to as anything in show_to)
-		add_to?.images += image_to_show
+	for(var/client/add_to in show_to)
+		add_to.images += image_to_show
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_image_from_clients), image_to_show, show_to), duration, TIMER_CLIENT_TIME)
 
 /// Flicks a certain overlay onto an atom, handling icon_state strings

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -675,11 +675,13 @@
 ///Displays a special speech bubble when someone inside the mecha speaks
 /obj/vehicle/sealed/mecha/proc/display_speech_bubble(datum/source, list/speech_args)
 	SIGNAL_HANDLER
-	var/list/speech_bubble_recipients = get_hearers_in_view(7,src)
-	for(var/mob/M in speech_bubble_recipients)
-		if(M.client)
-			speech_bubble_recipients.Add(M.client)
-	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(flick_overlay_global), image('icons/mob/effects/talk.dmi', src, "machine[say_test(speech_args[SPEECH_MESSAGE])]",MOB_LAYER+1), speech_bubble_recipients, 30)
+	var/list/speech_bubble_recipients = list()
+	for(var/mob/listener in get_hearers_in_view(7, src))
+		if(listener.client)
+			speech_bubble_recipients += listener.client
+
+	var/image/mech_speech = image('icons/mob/effects/talk.dmi', src, "machine[say_test(speech_args[SPEECH_MESSAGE])]",MOB_LAYER+1)
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(flick_overlay_global), mech_speech, speech_bubble_recipients, 3 SECONDS)
 
 
 /////////////////////////


### PR DESCRIPTION
## About The Pull Request

Mecha speech indicators mistakenly passed ALL hearers in view to `flick_overlay_global`, rather than just mobs with clients, so it runtimed when it meant to disappear. 

I also added some client sanity to the associated procs... I'm not sure if they're needed but it seems like they'd be valuable there?

## Changelog

:cl: Melbert
fix: Mecha speech indicators actually go away
/:cl:

