### PR TITLE
Adds required template keys to some midround rulesets, fixes midround nuclear operative leaders from spawning on arrivals

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -679,7 +679,7 @@
 	cost = 8
 	minimum_players = 30
 	repeatable = TRUE
-	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_NINJA_HOLDING_FACILITY) /// I mean, no one uses the nets anymore but whateva
+	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_NINJA_HOLDING_FACILITY) // I mean, no one uses the nets anymore but whateva
 
 	var/list/spawn_locs = list()
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -377,10 +377,12 @@
 	cost = 7
 	minimum_round_time = 70 MINUTES
 	requirements = REQUIREMENTS_VERY_HIGH_THREAT_NEEDED
+	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_NUKIEBASE)
+	flags = HIGH_IMPACT_RULESET
+
 	var/list/operative_cap = list(2,2,3,3,4,5,5,5,5,5)
 	/// The nuke ops team datum.
 	var/datum/team/nuclear/nuke_team
-	flags = HIGH_IMPACT_RULESET
 
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear/acceptable(population=0, threat=0)
 	if (locate(/datum/dynamic_ruleset/roundstart/nuclear) in mode.executed_rules)
@@ -638,6 +640,8 @@
 	cost = 7
 	minimum_players = 25
 	repeatable = TRUE
+	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_ABDUCTOR_SHIPS)
+
 	var/datum/team/abductor_team/new_team
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors/ready(forced = FALSE)
@@ -675,6 +679,8 @@
 	cost = 8
 	minimum_players = 30
 	repeatable = TRUE
+	ruleset_lazy_templates = list(LAZY_TEMPLATE_KEY_NINJA_HOLDING_FACILITY) /// I mean, no one uses the nets anymore but whateva
+
 	var/list/spawn_locs = list()
 
 /datum/dynamic_ruleset/midround/from_ghosts/space_ninja/execute()

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -117,6 +117,16 @@
 	if(nuke_team)
 		objectives |= nuke_team.objectives
 
+/// Actually moves our nukie to where they should be
+/datum/antagonist/nukeop/proc/move_to_spawnpoint()
+	// Ensure that the nukiebase is loaded, and wait for it if required
+	SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
+	var/turf/destination = get_spawnpoint()
+	owner.current.forceMove(destination)
+	if(!owner.current.onSyndieBase())
+		message_admins("[ADMIN_LOOKUPFLW(owner.current)] is a NUKE OP and move_to_spawnpoint put them somewhere that isn't the syndie base, help please.")
+		stack_trace("Nuke op move_to_spawnpoint resulted in a location not on the syndicate base. (Was moved to: [destination])")
+
 /// Gets the position we spawn at
 /datum/antagonist/nukeop/proc/get_spawnpoint()
 	var/team_number = 1
@@ -125,14 +135,8 @@
 
 	return GLOB.nukeop_start[((team_number - 1) % GLOB.nukeop_start.len) + 1]
 
-/// Actually moves our nukie to where they should be
-/datum/antagonist/nukeop/proc/move_to_spawnpoint()
-	// Ensure that the nukiebase is loaded, and wait for it if required
-	SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
-	owner.current.forceMove(get_spawnpoint())
-
 /datum/antagonist/nukeop/leader/get_spawnpoint()
-	return GLOB.nukeop_leader_start
+	return pick(GLOB.nukeop_leader_start)
 
 /datum/antagonist/nukeop/create_team(datum/team/nuclear/new_team)
 	if(!new_team)

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -117,17 +117,22 @@
 	if(nuke_team)
 		objectives |= nuke_team.objectives
 
-/datum/antagonist/nukeop/proc/move_to_spawnpoint()
-	// Ensure that the nukiebase is loaded, and wait for it if required
-	SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
-
+/// Gets the position we spawn at
+/datum/antagonist/nukeop/proc/get_spawnpoint()
 	var/team_number = 1
 	if(nuke_team)
 		team_number = nuke_team.members.Find(owner)
-	owner.current.forceMove(GLOB.nukeop_start[((team_number - 1) % GLOB.nukeop_start.len) + 1])
 
-/datum/antagonist/nukeop/leader/move_to_spawnpoint()
-	owner.current.forceMove(pick(GLOB.nukeop_leader_start))
+	return GLOB.nukeop_start[((team_number - 1) % GLOB.nukeop_start.len) + 1]
+
+/// Actually moves our nukie to where they should be
+/datum/antagonist/nukeop/proc/move_to_spawnpoint()
+	// Ensure that the nukiebase is loaded, and wait for it if required
+	SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
+	owner.current.forceMove(get_spawnpoint())
+
+/datum/antagonist/nukeop/leader/get_spawnpoint()
+	return GLOB.nukeop_leader_start
 
 /datum/antagonist/nukeop/create_team(datum/team/nuclear/new_team)
 	if(!new_team)

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -194,6 +194,15 @@
 	victim = null
 	dropoff_area = null
 
+/datum/traitor_objective/kidnapping/on_objective_taken(mob/user)
+	. = ..()
+	INVOKE_ASYNC(src, PROC_REF(generate_holding_area))
+
+/datum/traitor_objective/kidnapping/proc/generate_holding_area()
+	// Let's load in the holding facility ahead of time
+	// even if they fail the objective  it's better to get done now rather than later
+	SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NINJA_HOLDING_FACILITY)
+
 /datum/traitor_objective/kidnapping/generate_ui_buttons(mob/user)
 	var/list/buttons = list()
 	if(!pod_called)

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -424,6 +424,7 @@
 	addtimer(CALLBACK(src, PROC_REF(handleReturnAfterDeparting), holder), 15) //Finish up the pod's duties after a certain amount of time
 
 /obj/structure/closet/supplypod/extractionpod/preReturn(atom/movable/holder)
+	// Double ensure we're loaded, this SHOULD be here by now but you never know
 	SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NINJA_HOLDING_FACILITY)
 	var/turf/picked_turf = pick(GLOB.holdingfacility)
 	reverse_dropoff_coords = list(picked_turf.x, picked_turf.y, picked_turf.z)


### PR DESCRIPTION
## About The Pull Request

`/datum/antagonist/nukeop/leader/move_to_spawnpoint()` overrides `/datum/antagonist/nukeop/move_to_spawnpoint()`, which is responsible for calling `SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)`

Nuke op leaders also get created first thing, so they always got sent to arrivals

`move_to_spawnpoint` now is not overridden by anything, location is now obtained though `get_spawnpoint`

But this doesn't solve the entire issue! Seemed like there was a race condition in that, on nukie team creation, it looked for the nuke to generate the nuke code. But it created the team before creating the nuke (and template). So it runtimed and broke, no nukies. 

So I had to go deeper. 

Rulesets have this list, `ruleset_lazy_templates`, that none of the midround rulesets used. CC @ZephyrTFA on this, but it seemed like it caused a few issues related to lazyloading by missing them?

I added the keys to abductor and nukies. and also ninja even though it'll probably never be used

I also also made the kidnapping objective for traitors pre-emptively load the holding facility on objective *taken*, rather than waiting for the exact moment which the victim is kidnapped. 

(Should) Fix #72248

## Why It's Good For The Game

LATE FOR WORK

## Changelog

:cl: Melbert
fix: Nuke Ops Leaders midround don't spawn on Arrivals Shuttle late for work
fix: (Maybe) fixes some additional issues related to midround nukie / abductor spawns
/:cl:

