### PR TITLE
A worn item which has its color changed (such as by a slime potion) with now have its color change reflected on mobs.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1545,3 +1545,8 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 	user.log_message("is putting [equipping] on [key_name(target)]", LOG_ATTACK, color="red")
 	target.log_message("is having [equipping] put on them by [key_name(user)]", LOG_VICTIM, color="orange", log_globally=FALSE)
+
+/obj/item/update_atom_colour()
+	. = ..()
+	update_slot_icon()
+	

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1549,4 +1549,3 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 /obj/item/update_atom_colour()
 	. = ..()
 	update_slot_icon()
-	

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -907,7 +907,7 @@
 	resistance_flags = FIRE_PROOF
 	var/uses = 3
 
-/obj/item/slimepotion/fireproof/afterattack(obj/item/clothing/C, mob/user, proximity)
+/obj/item/slimepotion/fireproof/afterattack(obj/item/clothing/clothing, mob/user, proximity)
 	. = ..()
 	if(!proximity)
 		return
@@ -915,19 +915,19 @@
 		qdel(src)
 		return
 	. |= AFTERATTACK_PROCESSED_ITEM
-	if(!istype(C))
+	if(!istype(clothing))
 		to_chat(user, span_warning("The potion can only be used on clothing!"))
 		return
-	if(C.max_heat_protection_temperature >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
-		to_chat(user, span_warning("The [C] is already fireproof!"))
+	if(clothing.max_heat_protection_temperature >= FIRE_IMMUNITY_MAX_TEMP_PROTECT)
+		to_chat(user, span_warning("The [clothing] is already fireproof!"))
 		return
-	to_chat(user, span_notice("You slather the blue gunk over the [C], fireproofing it."))
-	C.name = "fireproofed [C.name]"
-	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
-	C.add_atom_colour("#000080", FIXED_COLOUR_PRIORITY)
-	C.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	C.heat_protection = C.body_parts_covered
-	C.resistance_flags |= FIRE_PROOF
+	to_chat(user, span_notice("You slather the blue gunk over the [clothing], fireproofing it."))
+	clothing.name = "fireproofed [clothing.name]"
+	clothing.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)
+	clothing.add_atom_colour("#000080", FIXED_COLOUR_PRIORITY)
+	clothing.max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
+	clothing.heat_protection = clothing.body_parts_covered
+	clothing.resistance_flags |= FIRE_PROOF
 	uses --
 	if(!uses)
 		qdel(src)


### PR DESCRIPTION

## About The Pull Request

If I'm wearing an outfit and use a slime fireproof potion on it at present it wont become blue until taking it off and putting it back on again, this PR makes it so it changes immediately. Also means if an admin VVs the color value of a worn item its icon worn color will update to reflect this change immediately.
## Why It's Good For The Game

Bugfix!
## Changelog
:cl:
fix: Any worn item that has its color changed will now have its color change reflected on the item's worn icon immediately.
/:cl:
