### PR TITLE
Fixes a major source of papercode lag and optimises paper for less (but still some) lag.

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -546,7 +546,7 @@
 			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
 
 			update_appearance()
-			update_static_data(user, ui)
+			update_static_data_for_all_viewers()
 			return TRUE
 		if("add_text")
 			var/paper_input = params["text"]
@@ -592,7 +592,7 @@
 			log_paper("[key_name(user)] wrote to [name]: \"[paper_input]\"")
 			to_chat(user, "You have added to your paper masterpiece!");
 
-			update_static_data(user, ui)
+			update_static_data_for_all_viewers()
 			update_appearance()
 			return TRUE
 		if("fill_input_field")
@@ -633,7 +633,7 @@
 				if(!add_field_input(field_key, field_text, writing_implement_data["font"], writing_implement_data["color"], writing_implement_data["use_bold"], user.real_name))
 					log_paper("[key_name(user)] tried to write to field [field_key] when it already has data, with the following text: [field_text]")
 
-			update_static_data(user, ui)
+			update_static_data_for_all_viewers()
 			return TRUE
 
 /obj/item/paper/proc/get_input_field_count(raw_text)

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -596,11 +596,44 @@ export class PreviewView extends Component<PreviewViewProps> {
       }
     };
 
+    // This is an extension for marked defining a complete custom tokenizer.
+    // This tokenizer should run before the the non-custom ones, and gives us
+    // the ability to handle [_____] fields before the em/strong tokenizers
+    // mangle them, since underscores are used for italic/bold.
+    // This massively improves the order of operations, allowing us to run
+    // marked, THEN sanitise the output (much safer) and finally insert fields
+    // manually afterwards.
+    const inputField = {
+      name: 'inputField',
+      level: 'inline',
+
+      start(src) {
+        return src.match(/\[/)?.index;
+      },
+
+      tokenizer(src: string) {
+        const rule = /^\[_+\]/;
+        const match = src.match(rule);
+        if (match) {
+          const token = {
+            type: 'inputField',
+            raw: match[0],
+          };
+          return token;
+        }
+      },
+
+      renderer(token) {
+        return `${token.raw}`;
+      },
+    };
+
     return marked.parse(rawText, {
       breaks: true,
       gfm: true,
       smartypants: true,
       walkTokens,
+      extensions: [inputField],
       // Once assets are fixed might need to change this for them
       baseUrl: 'thisshouldbreakhttp',
     });

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -10,7 +10,6 @@ import { sanitizeText } from '../sanitize';
 import { marked } from 'marked';
 import { Component, createRef, RefObject } from 'inferno';
 import { clamp } from 'common/math';
-import { logger } from '../logging';
 
 const Z_INDEX_STAMP = 1;
 const Z_INDEX_STAMP_PREVIEW = 2;
@@ -629,9 +628,7 @@ export class PreviewView extends Component<PreviewViewProps> {
       },
     };
 
-    const start = performance.now();
-
-    const mkd = marked.parse(rawText, {
+    return marked.parse(rawText, {
       breaks: true,
       gfm: true,
       smartypants: true,
@@ -640,12 +637,6 @@ export class PreviewView extends Component<PreviewViewProps> {
       // Once assets are fixed might need to change this for them
       baseUrl: 'thisshouldbreakhttp',
     });
-
-    const end = performance.now();
-
-    logger.log(`ParseTime: ${end - start}`);
-
-    return mkd;
   };
 
   // Fully formats, sanitises and parses the provided raw text and wraps it

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -10,7 +10,6 @@ import { sanitizeText } from '../sanitize';
 import { marked } from 'marked';
 import { Component, createRef, RefObject } from 'inferno';
 import { clamp } from 'common/math';
-import { logger } from '../logging';
 
 const Z_INDEX_STAMP = 1;
 const Z_INDEX_STAMP_PREVIEW = 2;
@@ -442,7 +441,6 @@ export class PreviewView extends Component<PreviewViewProps> {
 
   constructor(props, context) {
     super(props, context);
-    logger.log(`Configuring marked.`);
     this.configureMarked();
   }
 
@@ -590,10 +588,8 @@ export class PreviewView extends Component<PreviewViewProps> {
       this.lastDMInputCount === raw_text_input?.length &&
       this.lastFieldInputCount === raw_field_input?.length
     ) {
-      logger.log(`Using parsed DM cache`);
       return { text: this.parsedDMCache, newFieldCount: this.lastFieldCount };
     }
-    logger.log(`Parsing DM input`);
 
     this.lastReadOnly = readOnly;
 
@@ -646,11 +642,8 @@ export class PreviewView extends Component<PreviewViewProps> {
 
     // Use the cache if one exists.
     if (this.parsedTextBoxCache) {
-      logger.log(`Using parsed text box cache`);
       return this.parsedTextBoxCache;
     }
-
-    logger.log(`Parsing text box input`);
 
     const readOnly = true;
 
@@ -736,13 +729,7 @@ export class PreviewView extends Component<PreviewViewProps> {
       },
     };
 
-    const start = performance.now();
-    const parsedText = marked.parse(rawText);
-    const end = performance.now();
-
-    logger.log(`ParseTime: ${end - start}ms`);
-
-    return parsedText;
+    return marked.parse(rawText);
   };
 
   // Fully formats, sanitises and parses the provided raw text and wraps it

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -596,44 +596,11 @@ export class PreviewView extends Component<PreviewViewProps> {
       }
     };
 
-    // This is an extension for marked defining a complete custom tokenizer.
-    // This tokenizer should run before the the non-custom ones, and gives us
-    // the ability to handle [_____] fields before the em/strong tokenizers
-    // mangle them, since underscores are used for italic/bold.
-    // This massively improves the order of operations, allowing us to run
-    // marked, THEN sanitise the output (much safer) and finally insert fields
-    // manually afterwards.
-    const inputField = {
-      name: 'inputField',
-      level: 'inline',
-
-      start(src) {
-        return src.match(/\[/)?.index;
-      },
-
-      tokenizer(src: string) {
-        const rule = /^\[_+\]/;
-        const match = src.match(rule);
-        if (match) {
-          const token = {
-            type: 'inputField',
-            raw: match[0],
-          };
-          return token;
-        }
-      },
-
-      renderer(token) {
-        return `${token.raw}`;
-      },
-    };
-
     return marked.parse(rawText, {
       breaks: true,
       gfm: true,
       smartypants: true,
       walkTokens,
-      extensions: [inputField],
       // Once assets are fixed might need to change this for them
       baseUrl: 'thisshouldbreakhttp',
     });

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -10,6 +10,7 @@ import { sanitizeText } from '../sanitize';
 import { marked } from 'marked';
 import { Component, createRef, RefObject } from 'inferno';
 import { clamp } from 'common/math';
+import { logger } from '../logging';
 
 const Z_INDEX_STAMP = 1;
 const Z_INDEX_STAMP_PREVIEW = 2;
@@ -628,17 +629,23 @@ export class PreviewView extends Component<PreviewViewProps> {
       },
     };
 
-    // marked.use({ tokenizer });
-    marked.use({ extensions: [inputField] });
+    const start = performance.now();
 
-    return marked.parse(rawText, {
+    const mkd = marked.parse(rawText, {
       breaks: true,
+      gfm: true,
       smartypants: true,
-      smartLists: true,
       walkTokens,
+      extensions: [inputField],
       // Once assets are fixed might need to change this for them
       baseUrl: 'thisshouldbreakhttp',
     });
+
+    const end = performance.now();
+
+    logger.log(`ParseTime: ${end - start}`);
+
+    return mkd;
   };
 
   // Fully formats, sanitises and parses the provided raw text and wraps it

--- a/tgui/packages/tgui/interfaces/PaperSheet.tsx
+++ b/tgui/packages/tgui/interfaces/PaperSheet.tsx
@@ -690,15 +690,7 @@ export class PreviewView extends Component<PreviewViewProps> {
       },
     };
 
-    return marked.parse(rawText, {
-      breaks: true,
-      gfm: true,
-      smartypants: true,
-      walkTokens,
-      extensions: [inputField],
-      // Once assets are fixed might need to change this for them
-      baseUrl: 'thisshouldbreakhttp',
-    });
+    return marked.parse(rawText);
   };
 
   // Fully formats, sanitises and parses the provided raw text and wraps it

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -4,7 +4,7 @@
   "version": "4.3.1",
   "dependencies": {
     "@popperjs/core": "^2.9.3",
-    "@types/marked": "^4.0.3",
+    "@types/marked": "^4.0.8",
     "common": "workspace:*",
     "dateformat": "^4.5.1",
     "dompurify": "^2.3.1",
@@ -12,7 +12,7 @@
     "inferno": "^7.4.8",
     "inferno-vnode-flags": "^7.4.8",
     "js-yaml": "^4.1.0",
-    "marked": "^4.0.10",
+    "marked": "^4.2.12",
     "tgui-dev-server": "workspace:*",
     "tgui-polyfill": "workspace:*"
   }

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -2003,10 +2003,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/marked@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "@types/marked@npm:4.0.3"
-  checksum: 2fc409a6291cb770688731a444f54e7eab6257c9b565dea4e9d2f3b6654b606e9dd8ea4a924e306b2d2f581dedcb7a27f10f2ca7aed828b11642ab85955341f1
+"@types/marked@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "@types/marked@npm:4.0.8"
+  checksum: 68278fa7acaa5d920cdc239d675b5daf842e0ad4779e4848cd617d9baf2ac1afccb5a264c331e37d80031d647e1640cb983cd31e73d45b28552670b4853fad8e
   languageName: node
   linkType: hard
 
@@ -6741,12 +6741,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"marked@npm:^4.0.10":
-  version: 4.0.10
-  resolution: "marked@npm:4.0.10"
+"marked@npm:^4.2.12":
+  version: 4.2.12
+  resolution: "marked@npm:4.2.12"
   bin:
     marked: bin/marked.js
-  checksum: 46cd8ef1a7cfcf5e461727c7f3e16dd4244369ef58f60485e75d3f5df9d53a8249b9609e96a336521eaa5c88d9531cbd296509a148718056e9375e69609f4442
+  checksum: bd551cd61028ee639d4ca2ccdfcc5a6ba4227c1b143c4538f3cde27f569dcb57df8e6313560394645b418b84a7336c07ab1e438b89b6324c29d7d8cdd3102d63
   languageName: node
   linkType: hard
 
@@ -9316,7 +9316,7 @@ resolve@^2.0.0-next.3:
   resolution: "tgui@workspace:packages/tgui"
   dependencies:
     "@popperjs/core": ^2.9.3
-    "@types/marked": ^4.0.3
+    "@types/marked": ^4.0.8
     common: "workspace:*"
     dateformat: ^4.5.1
     dompurify: ^2.3.1
@@ -9324,7 +9324,7 @@ resolve@^2.0.0-next.3:
     inferno: ^7.4.8
     inferno-vnode-flags: ^7.4.8
     js-yaml: ^4.1.0
-    marked: ^4.0.10
+    marked: ^4.2.12
     tgui-dev-server: "workspace:*"
     tgui-polyfill: "workspace:*"
   languageName: unknown


### PR DESCRIPTION
## About The Pull Request

Doesn't quite fix but helps mitigate #71697 - The issue report is still valid, just less so.

Marked.js is just... Slow when used in BYOND's web browsing environment. New markdown elements **and HTML tags** add significant fractions of a millisecond to parsing time on my local.

However, I suspect I messed up with using the custom extensions and every parsing pass it may have be appending a new extension to the extension list.

I'm not sure why this never manifested in my 6 minutes of testing gif from the original PR, mind you. I checked out that commit and local and everything worked the same as I remember. Perhaps a change or version bump in the interim modified the behaviour.

That aside, on current master it's MASSIVELY obvious something is fucked.

Spamming 1000 characters of
```
# Slow
## Slower
### Slowest
```
then saving it, then puting **another** 1000 characters of the same thing for 2000 previewed characters total gave the following performance metrics:
![image](https://user-images.githubusercontent.com/24975989/221262868-c98d9b1a-e9d2-4a41-89e1-5ca6fb244cc6.png)

The marked.js parse time was about 150-180ms for the saved text and 220+ms for the input box text.

Moreso, if you leave the paper open for for a few minutes...
![image](https://user-images.githubusercontent.com/24975989/221263091-ae021caf-912d-4424-a33f-a91591ddf47e.png)

Yeah. That's 500+ms per parse (with 2 per render - one from the paper's saved text and one from the input box) and the game will basically crash.

Similar results using this template provided to me for testing purposes:
```
<center><b>Department Psychological Evaluation Survey</b></center>
<center><i>Test Log 230126-01</i></center>

<b>Question 1</b>
What department do you work in?
[_____________________________________]

<b>Question 2</b>
Which department are you least likely to recommend to a friend that they should work in?
<i>Please only choose one</i>
* Command [__]
* Security [__]
* Service [__]
* Cargo [__]
* Medical [__]
* Science [__]
* Engineering [__]

<b>Question 3</b>
Which department are you most likely to recommend to a friend that they should work in?
<i>Please only choose one</i>
* Command [__]
* Security [__]
* Service [__]
* Cargo [__]
* Medical [__]
* Science [__]
* Engineering [__]

<b>Question 4</b>
What is your favorite animal?
[_____________________________________]

---
Please sign here to confirm you are completing this survey voluntarily:
[_____________________________________]
<i>All Nanotrasen brand pens have an automatic signature system. Please write % s to automatically sign it.</i>
```

On first input + save, render time is normal but you can see it clearly rising each second...
![image](https://user-images.githubusercontent.com/24975989/221263763-a0974f94-a95d-472a-881a-99ebf435239c.png)
![image](https://user-images.githubusercontent.com/24975989/221263878-5ed49878-aac2-49d1-9658-a7ff019e0947.png)

You get the idea.

Fixing the problem by using the proper markdown method for accomplishing the same thing:

Markdown # Slow # Slower # Slowest test:
![image](https://user-images.githubusercontent.com/24975989/221264079-c58ec945-c130-4d3a-9dd7-b271b79321a3.png)

HoPaperwork Form
![image](https://user-images.githubusercontent.com/24975989/221264012-da121a5f-e4a8-4514-ab07-fb314ba50454.png)

And these numbers don't increase over time. So I think I nailed an interim fix.

Ultimately, marked.js in tgui/BYOND just seems slow as molasses. But it can at least be **usable** for now and this should majorly mitigate or even eliminate problems players have been having with paper (depending on how loaded it is with HTML and markdown tags).

All the features we had before seem to still work after I feex. So hopefully good for now?
![image](https://user-images.githubusercontent.com/24975989/221267657-03fb0536-63a5-43a2-8f2b-b09bf7686d75.png)

## Beeg edit
I decided I'd go a step further and implement some basic caching logic.
![image](https://user-images.githubusercontent.com/24975989/221320748-54d60715-f8b8-48f7-9690-34467b526df2.png)

This means that you don't pay a parsing cost from already saved text while writing new text, allowing complex forms to be created in multiple saved or one big copy-paste.

This means that reading paper and filling in input boxes in paper is free after the first parse, using the cache afterwards.

This is a workaround for the fact a parse can take longer than we'd like for complicated paper forms.

## Why It's Good For The Game

Paper good.
## Changelog
:cl:
fix: Papercode has been significantly improved and trivially filled paper forms should no longer lag or crash players' game clients.
/:cl:
