### PR TITLE
Corrects blocked limb balloon alert for borg hyposprays

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -178,7 +178,7 @@
 			balloon_alert(user, "[amount_per_transfer_from_this] unit\s injected")
 			log_combat(user, injectee, "injected", src, "(CHEMICALS: [selected_reagent])")
 	else
-		balloon_alert(user, "[user.zone_selected] is blocked!")
+		balloon_alert(user, "[parse_zone(user.zone_selected)] is blocked!")
 
 /obj/item/reagent_containers/borghypo/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION

## About The Pull Request

Fixes #73631
## Why It's Good For The Game

Reads better
## Changelog
:cl:
fix: Borg hypospray will correctly tell you the name of the limb that is blocked when trying to inject into a blocked limb.
/:cl:
