### PR TITLE
Fixes text input fields not working on copied paper.

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -143,7 +143,7 @@
 		for(var/datum/paper_field/text as anything in new_paper.raw_field_input_data)
 			text.field_data.colour = new_color
 
-
+	new_paper.input_field_count = input_field_count
 	new_paper.raw_stamp_data = copy_raw_stamps()
 	new_paper.stamp_cache = stamp_cache?.Copy()
 	new_paper.update_icon_state()


### PR DESCRIPTION

## About The Pull Request
Fixes #71698

The paper copying proc was incomplete and didn't copy over the total field count, which is used for sanity checking/user input verifying.

Because this wasn't copied over, none of the copied fields passed validation checks for text input and the ui_act would have rejected the inputs as invalid.
## Why It's Good For The Game
I feex.
## Changelog
:cl:
fix: Fixes broken input fields on photocopied paper.
/:cl:
