### PR TITLE
Remove double monitor from delta cargo

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -225,9 +225,9 @@
 	dir = 4
 	},
 /obj/machinery/requests_console/directional/east{
+	assistance_requestable = 1;
 	department = "Chemistry";
-	name = "Chemistry Requests Console";
-	assistance_requestable = 1
+	name = "Chemistry Requests Console"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/kirbyplants/random,
@@ -9545,9 +9545,9 @@
 /area/station/science/ordnance/freezerchamber)
 "ciK" = (
 /obj/machinery/requests_console/directional/north{
+	assistance_requestable = 1;
 	department = "Chapel";
-	name = "Chapel Requests Console";
-	assistance_requestable = 1
+	name = "Chapel Requests Console"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/chapel/office)
@@ -21333,11 +21333,11 @@
 	},
 /obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Research Director's Desk";
 	name = "Research Director's Requests Console";
-	receive_ore_updates = 1;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	receive_ore_updates = 1
 	},
 /obj/item/kirbyplants/dead,
 /obj/machinery/light/directional/west,
@@ -25035,10 +25035,10 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	name = "Head of Security's Requests Console";
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Head of Security's Desk";
+	name = "Head of Security's Requests Console"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/sign/nanotrasen{
@@ -29694,11 +29694,11 @@
 	},
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
+	anon_tips_receiver = 1;
+	assistance_requestable = 1;
 	department = "Research Lab";
 	name = "Research Requests Console";
-	receive_ore_updates = 1;
-	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	receive_ore_updates = 1
 	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Science - Research and Development";
@@ -30540,9 +30540,9 @@
 /obj/structure/cable,
 /obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
+	assistance_requestable = 1;
 	department = "Chief Engineer's Desk";
 	name = "Chief Engineer's Requests Console";
-	assistance_requestable = 1;
 	supplies_requestable = 1
 	},
 /obj/machinery/camera/directional/west{
@@ -41195,10 +41195,10 @@
 	},
 /obj/machinery/requests_console/directional/south{
 	announcementConsole = 1;
-	department = "Chief Medical Officer's Desk";
-	name = "Chief Medical Officer's Requests Console";
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Chief Medical Officer's Desk";
+	name = "Chief Medical Officer's Requests Console"
 	},
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
@@ -53806,10 +53806,10 @@
 	},
 /obj/machinery/requests_console/directional/south{
 	announcementConsole = 1;
-	department = "Bridge";
-	name = "Bridge Requests Console";
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Bridge";
+	name = "Bridge Requests Console"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/command/bridge)
@@ -63601,7 +63601,6 @@
 	c_tag = "Cargo - Waiting Room";
 	name = "cargo camera"
 	},
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "pBB" = (
@@ -70873,9 +70872,9 @@
 /obj/item/paper,
 /obj/item/pen,
 /obj/machinery/requests_console/directional/east{
+	assistance_requestable = 1;
 	department = "Atmospherics";
 	name = "Atmospherics Requests Console";
-	assistance_requestable = 1;
 	supplies_requestable = 1
 	},
 /obj/machinery/light/directional/east,
@@ -73609,9 +73608,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/machinery/requests_console/directional/south{
+	assistance_requestable = 1;
 	department = "Janitorial";
-	name = "Janitor's Request Console";
-	assistance_requestable = 1
+	name = "Janitor's Request Console"
 	},
 /obj/item/storage/box/mousetraps{
 	pixel_x = -3;
@@ -74089,10 +74088,10 @@
 	},
 /obj/machinery/requests_console/directional/west{
 	announcementConsole = 1;
-	department = "Captain's Desk";
-	name = "Captain's Requests Console";
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Captain's Desk";
+	name = "Captain's Requests Console"
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
@@ -77959,9 +77958,9 @@
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/bot,
 /obj/machinery/requests_console/directional/east{
+	assistance_requestable = 1;
 	department = "Atmospherics";
 	name = "Atmospherics Requests Console";
-	assistance_requestable = 1;
 	supplies_requestable = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
@@ -82033,9 +82032,9 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/requests_console/directional/south{
+	assistance_requestable = 1;
 	department = "Engineering";
 	name = "Engineering Requests Console";
-	assistance_requestable = 1;
 	supplies_requestable = 1
 	},
 /obj/structure/sign/poster/official/do_not_question{
@@ -82415,10 +82414,10 @@
 /obj/item/stamp/hop,
 /obj/machinery/requests_console/directional/north{
 	announcementConsole = 1;
-	department = "Head of Personnel's Desk";
-	name = "Head of Personnel's Requests Console";
+	anon_tips_receiver = 1;
 	assistance_requestable = 1;
-	anon_tips_receiver = 1
+	department = "Head of Personnel's Desk";
+	name = "Head of Personnel's Requests Console"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -91095,9 +91094,9 @@
 	dir = 6
 	},
 /obj/machinery/requests_console/directional/north{
+	assistance_requestable = 1;
 	department = "Medbay";
-	name = "Medbay Requests Console";
-	assistance_requestable = 1
+	name = "Medbay Requests Console"
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
@@ -95466,9 +95465,9 @@
 	dir = 8
 	},
 /obj/machinery/requests_console/directional/west{
+	assistance_requestable = 1;
 	department = "Security";
 	name = "Security Requests Console";
-	assistance_requestable = 1;
 	supplies_requestable = 1
 	},
 /obj/item/book/manual/wiki/security_space_law,


### PR DESCRIPTION

## About Why It's Good For The Game The Pull Request
![image](https://user-images.githubusercontent.com/66640614/221292003-bea6cbf0-fb54-46c9-9744-b9e866e0d088.png)

Fixes this

## Changelog
:cl: Tattle
fix: removed a double monitor from Delta cargo
/:cl:
