### PR TITLE
Tablets don't close their UI when changing program (and some fixes)

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -420,13 +420,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		update_appearance(UPDATE_ICON)
 	return ..()
 
-// On-click handling. Turns on the computer if it's off and opens the GUI.
-/obj/item/modular_computer/interact(mob/user)
-	if(enabled)
-		ui_interact(user)
-	else
-		turn_on(user)
-
 /obj/item/modular_computer/CtrlShiftClick(mob/user)
 	. = ..()
 	if(.)
@@ -605,7 +598,6 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		program.alert_pending = FALSE
 		idle_threads.Remove(program)
 		update_appearance()
-		updateUsrDialog()
 		return TRUE
 
 	if(!program.is_supported_by_hardware(hardware_flag, 1, user))
@@ -625,7 +617,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	active_program = program
 	program.alert_pending = FALSE
 	update_appearance()
-	updateUsrDialog()
+	ui_interact(user)
 	return TRUE
 
 // Returns 0 for No Signal, 1 for Low Signal and 2 for Good Signal. 3 is for wired connection (always-on)

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -182,4 +182,4 @@
 	. = ..()
 	if(.)
 		return
-	return TRUE
+	return .

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -144,17 +144,6 @@
 	return FALSE
 
 /**
- * This attempts to retrieve header data for UIs.
- *
- * If implementing completely new device of different type than existing ones
- * always include the device here in this proc. This proc basically relays the request to whatever is running the program.
- **/
-/datum/computer_file/program/proc/get_header_data()
-	if(computer)
-		return computer.get_header_data()
-	return list()
-
-/**
  * Called on program startup.
  *
  * May be overridden to add extra logic. Remember to include ..() call. Return 1 on success, 0 on failure.
@@ -189,61 +178,8 @@
 		generate_network_log("Connection closed -- Program ID: [filename] User:[ID ? "[ID.registered_name]" : "None"]")
 	return TRUE
 
-/datum/computer_file/program/ui_interact(mob/user, datum/tgui/ui)
-	ui = SStgui.try_update_ui(user, src, ui)
-	if(!ui && tgui_id)
-		ui = new(user, src, tgui_id, filedesc)
-		if(ui.open())
-			ui.send_asset(get_asset_datum(/datum/asset/simple/headers))
-
-// CONVENTIONS, READ THIS WHEN CREATING NEW PROGRAM AND OVERRIDING THIS PROC:
-// Topic calls are automagically forwarded from NanoModule this program contains.
-// Calls beginning with "PRG_" are reserved for programs handling.
-// Calls beginning with "PC_" are reserved for computer handling (by whatever runs the program)
-// ALWAYS INCLUDE PARENT CALL ..() OR DIE IN FIRE.
 /datum/computer_file/program/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
-
-	if(ishuman(usr) && !computer.allow_chunky) //in /obj/item/modular_computer/ui_act() too
-		var/mob/living/carbon/human/human_user = usr
-		if(human_user.check_chunky_fingers())
-			computer.balloon_alert(human_user, "fingers are too big!")
-			return TRUE
-
-	if(computer)
-		switch(action)
-			if("PC_exit")
-				computer.kill_program()
-				ui.close()
-				return TRUE
-			if("PC_shutdown")
-				computer.shutdown_computer()
-				ui.close()
-				return TRUE
-			if("PC_minimize")
-				var/mob/user = usr
-				if(!computer.active_program)
-					return
-
-				computer.idle_threads.Add(computer.active_program)
-				program_state = PROGRAM_STATE_BACKGROUND // Should close any existing UIs
-
-				computer.active_program = null
-				computer.update_appearance()
-				ui.close()
-
-				if(user && istype(user))
-					computer.ui_interact(user) // Re-open the UI on this computer. It should show the main screen now.
-
-/datum/computer_file/program/ui_host()
-	if(computer.physical)
-		return computer.physical
-	else
-		return computer
-
-/datum/computer_file/program/ui_status(mob/user)
-	if(program_state != PROGRAM_STATE_ACTIVE) // Our program was closed. Close the ui if it exists.
-		return UI_CLOSE
-	return ..()
+	return TRUE

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -177,9 +177,3 @@
 		var/obj/item/card/id/ID = computer.computer_id_slot?.GetID()
 		generate_network_log("Connection closed -- Program ID: [filename] User:[ID ? "[ID.registered_name]" : "None"]")
 	return TRUE
-
-/datum/computer_file/program/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
-	if(.)
-		return
-	return .

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -118,7 +118,7 @@
 				return TRUE
 
 /datum/computer_file/program/ai_restorer/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["ejectable"] = TRUE
 	data["AI_present"] = !!stored_card?.AI

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -41,7 +41,7 @@
 	return 1
 
 /datum/computer_file/program/alarm_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data += alert_control.ui_data(user)
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -68,7 +68,7 @@
 			return TRUE
 
 /datum/computer_file/program/ntnet_dos/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["error"] = error
 	if(target && executed)

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -64,7 +64,7 @@
 	return temp
 
 /datum/computer_file/program/revelation/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["armed"] = armed
 

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -82,7 +82,7 @@
 	)
 
 /datum/computer_file/program/arcade/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["Hitpoints"] = boss_hp
 	data["PlayerHitpoints"] = player_hp
 	data["PlayerMP"] = player_mp
@@ -97,7 +97,6 @@
 	. = ..()
 	if(.)
 		return
-
 	usr.played_game()
 
 	var/gamerSkillLevel = 0

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -54,7 +54,7 @@
 	return return_atmos_handbooks()
 
 /datum/computer_file/program/atmosscan/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/turf/turf = get_turf(computer)
 	data["atmozphereMode"] = atmozphere_mode
 	data["clickAtmozphereCompatible"] = (computer.hardware_flag & PROGRAM_TABLET)

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -69,7 +69,7 @@
 	DL_progress += 25
 
 /datum/computer_file/program/borg_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["card"] = FALSE
 	if(checkID())
@@ -112,20 +112,19 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("messagebot")
 			var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs
 			if(!istype(R))
-				return
+				return TRUE
 			var/ID = checkID()
 			if(!ID)
-				return
+				return TRUE
 			if(R.stat == DEAD) //Dead borgs will listen to you no longer
 				to_chat(usr, span_warning("Error -- Could not open a connection to unit:[R]"))
 			var/message = tgui_input_text(usr, "Message to be sent to remote cyborg", "Send Message")
 			if(!message)
-				return
+				return TRUE
 			to_chat(R, "<br><br>[span_notice("Message from [ID] -- \"[message]\"")]<br>")
 			to_chat(usr, "Message sent to [R]: [message]")
 			R.logevent("Message from [ID] -- \"[message]\"")
@@ -134,6 +133,7 @@
 				to_chat(R.connected_ai, "<br><br>[span_notice("Message from [ID] to [R] -- \"[message]\"")]<br>")
 				SEND_SOUND(R.connected_ai, 'sound/machines/twobeep_high.ogg')
 			usr.log_talk(message, LOG_PDA, tag="Cyborg Monitor Program: ID name \"[ID]\" to [R]")
+			return TRUE
 
 ///This proc is used to determin if a borg should be shown in the list (based on the borg's scrambledcodes var). Syndicate version overrides this to show only syndicate borgs.
 /datum/computer_file/program/borg_monitor/proc/evaluate_borg(mob/living/silicon/robot/R)

--- a/code/modules/modular_computers/file_system/programs/bounty_board.dm
+++ b/code/modules/modular_computers/file_system/programs/bounty_board.dm
@@ -19,7 +19,7 @@
 	var/networked = FALSE
 
 /datum/computer_file/program/bounty_board/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/list/formatted_requests = list()
 	var/list/formatted_applicants = list()
 	if(current_user)
@@ -82,7 +82,7 @@
 			for(var/datum/station_request/i in GLOB.request_list)
 				if("[i.req_number]" == "[current_user.account_id]")
 					computer.say("Account already has active bounty.")
-					return
+					return TRUE
 			var/datum/station_request/curr_request = new /datum/station_request(current_user.account_holder, bounty_value,bounty_text,current_user.account_id, current_user)
 			GLOB.request_list += list(curr_request)
 			for(var/obj/i in GLOB.allbountyboards)
@@ -126,9 +126,10 @@
 			bounty_value = text2num(params["bountyval"])
 			if(!bounty_value)
 				bounty_value = 1
+			return TRUE
 		if("bountyText")
 			bounty_text = (params["bountytext"])
-	. = TRUE
+			return TRUE
 
 /datum/computer_file/program/bounty_board/Destroy()
 	GLOB.allbountyboards -= computer

--- a/code/modules/modular_computers/file_system/programs/bounty_board.dm
+++ b/code/modules/modular_computers/file_system/programs/bounty_board.dm
@@ -129,7 +129,7 @@
 			return TRUE
 		if("bountyText")
 			bounty_text = (params["bountytext"])
-			return TRUE
+	return TRUE
 
 /datum/computer_file/program/bounty_board/Destroy()
 	GLOB.allbountyboards -= computer

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -61,8 +61,7 @@
 	return FALSE
 
 /datum/computer_file/program/budgetorders/ui_data()
-	. = ..()
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["location"] = SSshuttle.supply.getStatusText()
 	data["department"] = "Cargo"
 	var/datum/bank_account/buyer = SSeconomy.get_dep_account(cargo_account)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -77,7 +77,6 @@
 	. = ..()
 	if(.)
 		return
-
 	var/mob/user = usr
 	var/obj/item/card/id/inserted_auth_card = computer.computer_id_slot
 
@@ -287,7 +286,7 @@
 	return data
 
 /datum/computer_file/program/card_mod/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/obj/item/card/id/inserted_id = computer.computer_id_slot
 	data["authIDName"] = inserted_id ? inserted_id.name : "-----"

--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -17,7 +17,7 @@
 	var/cut_min = 0.01
 
 /datum/computer_file/program/shipping/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["has_id_slot"] = !!computer.computer_id_slot
 	data["paperamt"] = "[computer.stored_paper] / [computer.max_paper]"
@@ -30,21 +30,18 @@
 	. = ..()
 	if(.)
 		return
-	if(!computer)
-		return
-
 	if(!computer.computer_id_slot) //We need an ID to successfully run
-		return
+		return FALSE
 
 	switch(action)
 		if("ejectid")
 			computer.RemoveID(usr)
 		if("selectid")
 			if(!computer.computer_id_slot.registered_account)
-				playsound(get_turf(ui_host()), 'sound/machines/buzz-sigh.ogg', 50, TRUE, -1)
-				return
+				playsound(get_turf(computer.ui_host()), 'sound/machines/buzz-sigh.ogg', 50, TRUE, -1)
+				return TRUE
 			payments_acc = computer.computer_id_slot.registered_account
-			playsound(get_turf(ui_host()), 'sound/machines/ping.ogg', 50, TRUE, -1)
+			playsound(get_turf(computer.ui_host()), 'sound/machines/ping.ogg', 50, TRUE, -1)
 		if("resetid")
 			payments_acc = null
 		if("setsplit")
@@ -53,11 +50,11 @@
 		if("print")
 			if(computer.stored_paper <= 0)
 				to_chat(usr, span_notice("Printer is out of paper."))
-				return
+				return TRUE
 			if(!payments_acc)
 				to_chat(usr, span_notice("Software error: Please set a current user first."))
-				return
-			var/obj/item/barcode/barcode = new /obj/item/barcode(get_turf(ui_host()))
+				return TRUE
+			var/obj/item/barcode/barcode = new /obj/item/barcode(get_turf(computer.ui_host()))
 			barcode.payments_acc = payments_acc
 			barcode.cut_multiplier = cut_multiplier
 			computer.stored_paper--

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -12,7 +12,7 @@
 	detomatix_resistance = DETOMATIX_RESIST_MAJOR
 
 /datum/computer_file/program/crew_manifest/ui_static_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["manifest"] = GLOB.manifest.get_manifest()
 	return data
 
@@ -20,7 +20,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_print")
 			if(computer) //This option should never be called if there is no printer

--- a/code/modules/modular_computers/file_system/programs/emojipedia.dm
+++ b/code/modules/modular_computers/file_system/programs/emojipedia.dm
@@ -17,7 +17,7 @@
 	emoji_list = sortTim(emoji_list, /proc/cmp_text_asc)
 
 /datum/computer_file/program/emojipedia/ui_static_data(mob_user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	for(var/emoji in emoji_list)
 		data["emoji_list"] += list(list(
 			"name" = emoji,

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -17,7 +17,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_deletefile")
 			var/datum/computer_file/file = computer.find_file_by_name(params["name"])
@@ -82,7 +81,7 @@
 			binary.alert_silenced = !binary.alert_silenced
 
 /datum/computer_file/program/filemanager/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	if(error)
 		data["error"] = error
 	if(!computer)

--- a/code/modules/modular_computers/file_system/programs/frontier.dm
+++ b/code/modules/modular_computers/file_system/programs/frontier.dm
@@ -83,7 +83,7 @@
 
 /datum/computer_file/program/scipaper_program/ui_data()
 	// Program Headers:
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["currentTab"] = current_tab
 	data["has_techweb"] = !!linked_techweb
 
@@ -168,7 +168,6 @@
 	. = ..()
 	if (.)
 		return
-
 	switch(action)
 		if("et_alia")
 			paper_to_be.et_alia = !paper_to_be.et_alia
@@ -226,7 +225,7 @@
 					playsound(computer, 'sound/machines/ping.ogg', 25)
 					return TRUE
 			playsound(computer, 'sound/machines/terminal_error.ogg', 25)
-			return FALSE
+			return TRUE
 
 /// Publication and adding points.
 /datum/computer_file/program/scipaper_program/proc/publish()

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -70,17 +70,16 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	. = ..()
 	if(.)
 		return
-
 	var/obj/item/card/id/user_id = computer.computer_id_slot
 	if(!user_id || !(ACCESS_CHANGE_IDS in user_id.access))
-		return
+		return TRUE
 
 	switch(action)
 		if("PRG_open_job")
 			var/edit_job_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(edit_job_target)
 			if(!j || !can_open_job(j))
-				return
+				return TRUE
 			if(opened_positions[edit_job_target] >= 0)
 				GLOB.time_last_changed_position = world.time / 10
 			j.total_positions++
@@ -92,7 +91,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			var/edit_job_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(edit_job_target)
 			if(!j || !can_close_job(j))
-				return
+				return TRUE
 			//Allow instant closing without cooldown if a position has been opened before
 			if(opened_positions[edit_job_target] <= 0)
 				GLOB.time_last_changed_position = world.time / 10
@@ -105,9 +104,9 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 			var/priority_target = params["target"]
 			var/datum/job/j = SSjob.GetJob(priority_target)
 			if(!j || !can_edit_job(j))
-				return
+				return TRUE
 			if(j.total_positions <= j.current_positions)
-				return
+				return TRUE
 			if(j in SSjob.prioritized_jobs)
 				SSjob.prioritized_jobs -= j
 			else
@@ -120,7 +119,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 
 /datum/computer_file/program/job_management/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/authed = FALSE
 	var/obj/item/card/id/user_id = computer.computer_id_slot

--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -38,7 +38,7 @@
 	computer.save_photo(internal_picture.picture_image)
 
 /datum/computer_file/program/maintenance/camera/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	if(!isnull(internal_picture))
 		user << browse_rsc(internal_picture.picture_image, "tmp_photo[picture_number].png")
@@ -52,7 +52,6 @@
 	. = ..()
 	if(.)
 		return
-
 	var/mob/living/user = usr
 	switch(action)
 		if("print_photo")

--- a/code/modules/modular_computers/file_system/programs/maintenance/modsuit.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/modsuit.dm
@@ -32,18 +32,17 @@
 	controlled_suit = null
 
 /datum/computer_file/program/maintenance/modsuit_control/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["has_suit"] = !!controlled_suit
 	if(controlled_suit)
 		data += controlled_suit.ui_data()
 	return data
 
 /datum/computer_file/program/maintenance/modsuit_control/ui_static_data(mob/user)
-	return controlled_suit.ui_static_data()
+	return controlled_suit?.ui_static_data()
 
 /datum/computer_file/program/maintenance/modsuit_control/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
-
-	controlled_suit.ui_act(action, params, ui)
+	controlled_suit.ui_act(action, params, ui, state)

--- a/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
@@ -20,7 +20,7 @@
 	last_record = healthscan(user, carbon, 1, tochat = FALSE)
 
 /datum/computer_file/program/maintenance/phys_scanner/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["last_record"] = last_record
 	return data

--- a/code/modules/modular_computers/file_system/programs/newscasterapp.dm
+++ b/code/modules/modular_computers/file_system/programs/newscasterapp.dm
@@ -22,7 +22,7 @@
 	return ..()
 
 /datum/computer_file/program/newscaster/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data += newscaster_ui.ui_data(user)
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/notepad.dm
+++ b/code/modules/modular_computers/file_system/programs/notepad.dm
@@ -16,14 +16,13 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("UpdateNote")
 			written_note = params["newnote"]
 			return UI_UPDATE
 
 /datum/computer_file/program/notepad/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["note"] = written_note
 

--- a/code/modules/modular_computers/file_system/programs/nt_pay.dm
+++ b/code/modules/modular_computers/file_system/programs/nt_pay.dm
@@ -21,7 +21,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("Transaction")
 			token = params["token"]
@@ -62,7 +61,7 @@
 
 
 /datum/computer_file/program/nt_pay/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	current_user = computer.computer_id_slot?.registered_account || null
 	if(!current_user)

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -118,7 +118,7 @@
 	return FALSE
 
 /datum/computer_file/program/ntnetdownload/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	var/list/access = computer.GetAccess()
 
 	data["downloading"] = !!downloaded_file

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -108,7 +108,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PDA_ringSet")
 			var/new_ringtone = tgui_input_text(usr, "Enter a new ringtone", "Ringtone", ringtone, MESSENGER_RINGTONE_MAX_LENGTH)
@@ -220,7 +219,7 @@
 	return data
 
 /datum/computer_file/program/messenger/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["messages"] = messages
 	data["messengers"] = ScrubMessengerList()

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -52,7 +52,6 @@
 	. = ..()
 	if(.)
 		return
-
 	var/datum/ntnet_conversation/channel = SSmodular_computers.get_chat_channel_by_id(active_channel)
 	var/authed = FALSE
 	if(channel && ((channel.channel_operator == src) || netadmin_mode))
@@ -218,7 +217,7 @@
 	return data
 
 /datum/computer_file/program/chatclient/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	if(!SSmodular_computers.chat_channels)
 		return data
 

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -78,8 +78,8 @@
 			demand.Cut(1, 2)
 
 /datum/computer_file/program/power_monitor/ui_data()
+	var/list/data = list()
 	var/datum/powernet/connected_powernet = get_powernet()
-	var/list/data = get_header_data()
 	data["stored"] = record_size
 	data["interval"] = record_interval / 10
 	data["attached"] = connected_powernet ? TRUE : FALSE

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -45,7 +45,7 @@
 	)
 
 /datum/computer_file/program/radar/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["selected"] = selected
 	data["objects"] = list()
 	data["scanning"] = (world.time < next_scan)
@@ -66,7 +66,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("selecttarget")
 			selected = params["ref"]

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -64,7 +64,7 @@
 
 
 /datum/computer_file/program/records/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["records"] = GetRecordsReadable()
 	data["mode"] = mode
 	return data

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -22,8 +22,8 @@
 	)
 
 /datum/computer_file/program/robocontrol/ui_data(mob/user)
-	var/list/data = get_header_data()
-	var/turf/current_turf = get_turf(ui_host())
+	var/list/data = list()
+	var/turf/current_turf = get_turf(computer.ui_host())
 	var/list/botlist = list()
 	var/list/mulelist = list()
 
@@ -85,7 +85,7 @@
 
 /datum/computer_file/program/robocontrol/ui_act(action, list/params, datum/tgui/ui)
 	. = ..()
-	if(.)
+	if (.)
 		return
 	var/mob/current_user = ui.user
 	var/obj/item/card/id/id_card = computer?.computer_id_slot
@@ -124,7 +124,7 @@
 				GLOB.manifest.modify(id_card.registered_name, id_card.assignment, id_card.get_trim_assignment())
 				computer.RemoveID(usr)
 			else
-				playsound(get_turf(ui_host()) , 'sound/machines/buzz-sigh.ogg', 25, FALSE)
+				playsound(get_turf(computer.ui_host()) , 'sound/machines/buzz-sigh.ogg', 25, FALSE)
 		if("changedroneaccess")
 			if(!computer || !computer.computer_id_slot || !id_card)
 				to_chat(current_user, span_notice("No ID found, authorization failed."))

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -26,7 +26,7 @@
 	return FALSE
 
 /datum/computer_file/program/robotact/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	if(!iscyborg(user))
 		return data
 

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -72,7 +72,7 @@
 	return .
 
 /datum/computer_file/program/secureye/ui_data()
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["network"] = network
 	data["activeCamera"] = null
 	var/obj/machinery/camera/active_camera = camera_ref?.resolve()
@@ -100,7 +100,6 @@
 	. = ..()
 	if(.)
 		return
-
 	if(action == "switch_camera")
 		var/c_tag = format_text(params["name"])
 		var/list/cameras = get_available_cameras()

--- a/code/modules/modular_computers/file_system/programs/signalcommander.dm
+++ b/code/modules/modular_computers/file_system/programs/signalcommander.dm
@@ -24,7 +24,7 @@
 	SSradio.remove_object(computer, signal_frequency)
 
 /datum/computer_file/program/signal_commander/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["frequency"] = signal_frequency
 	data["code"] = signal_code
 	data["minFrequency"] = MIN_FREE_FREQ

--- a/code/modules/modular_computers/file_system/programs/skill_tracker.dm
+++ b/code/modules/modular_computers/file_system/programs/skill_tracker.dm
@@ -10,7 +10,7 @@
 	usage_flags = PROGRAM_TABLET // Must be a handheld device to read read your chakras or whatever
 
 /datum/computer_file/program/skill_tracker/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	var/list/skills = list()
 	data["skills"] = skills
@@ -54,7 +54,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_reward")
 			var/skill_type = find_skilltype(params["skill"])

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -31,7 +31,7 @@
 /datum/computer_file/program/supermatter_monitor/proc/refresh()
 	for(var/supermatter in supermatters)
 		clear_supermatter(supermatter)
-	var/turf/user_turf = get_turf(ui_host())
+	var/turf/user_turf = get_turf(computer.ui_host())
 	if(!user_turf)
 		return
 	for(var/obj/machinery/power/supermatter_crystal/sm in GLOB.machines)
@@ -47,7 +47,7 @@
 	return data
 
 /datum/computer_file/program/supermatter_monitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["sm_data"] = list()
 	for (var/obj/machinery/power/supermatter_crystal/sm as anything in supermatters)
 		data["sm_data"] += list(sm.sm_ui_data())
@@ -58,7 +58,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_refresh")
 			refresh()

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -66,7 +66,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("setStatusMessage")
 			upper_text = reject_bad_text(params["upperText"] || "", MAX_STATUS_LINE_LENGTH)
@@ -83,7 +82,7 @@
 	return data
 
 /datum/computer_file/program/status/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["upperText"] = upper_text
 	data["lowerText"] = lower_text

--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -41,7 +41,7 @@
 
 // heavy data from this proc should be moved to static data when possible
 /datum/computer_file/program/science/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 	data["stored_research"] = !!stored_research
 	if(!stored_research) //lack of a research node is all we care about.
 		return data
@@ -92,7 +92,6 @@
 	. = ..()
 	if (.)
 		return
-
 	// Check if the console is locked to block any actions occuring
 	if (locked && action != "toggleLock")
 		computer.say("Console is locked, cannot perform further actions.")

--- a/code/modules/modular_computers/file_system/programs/theme_selector.dm
+++ b/code/modules/modular_computers/file_system/programs/theme_selector.dm
@@ -15,7 +15,7 @@
 	var/list/imported_themes = list()
 
 /datum/computer_file/program/themeify/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	if(computer.obj_flags & EMAGGED)
 		data["themes"] += list(list("theme_name" = SYNDICATE_THEME_NAME, "theme_ref" = GLOB.pda_name_to_theme[SYNDICATE_THEME_NAME]))
@@ -28,7 +28,6 @@
 	. = ..()
 	if(.)
 		return
-
 	switch(action)
 		if("PRG_change_theme")
 			var/selected_theme = params["selected_theme"]

--- a/code/modules/modular_computers/file_system/programs/wirecarp.dm
+++ b/code/modules/modular_computers/file_system/programs/wirecarp.dm
@@ -40,7 +40,7 @@
 				messenger_app.spam_mode = !messenger_app.spam_mode
 
 /datum/computer_file/program/ntnetmonitor/ui_data(mob/user)
-	var/list/data = get_header_data()
+	var/list/data = list()
 
 	data["ntnetstatus"] = SSmodular_computers.check_function()
 	data["ntnetrelays"] = SSmodular_computers.ntnet_relays.len

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -103,14 +103,7 @@
 			))
 	else
 		window.send_message("ping")
-	var/flush_queue = window.send_asset(get_asset_datum(
-		/datum/asset/simple/namespaced/fontawesome))
-	flush_queue |= window.send_asset(get_asset_datum(
-		/datum/asset/simple/namespaced/tgfont))
-	for(var/datum/asset/asset in src_object.ui_assets(user))
-		flush_queue |= window.send_asset(asset)
-	if (flush_queue)
-		user.client.browse_queue_flush()
+	send_assets()
 	window.send_message("update", get_payload(
 		with_data = TRUE,
 		with_static_data = TRUE))
@@ -119,6 +112,16 @@
 	SStgui.on_open(src)
 
 	return TRUE
+
+/datum/tgui/proc/send_assets()
+	var/flush_queue = window.send_asset(get_asset_datum(
+		/datum/asset/simple/namespaced/fontawesome))
+	flush_queue |= window.send_asset(get_asset_datum(
+		/datum/asset/simple/namespaced/tgfont))
+	for(var/datum/asset/asset in src_object.ui_assets(user))
+		flush_queue |= window.send_asset(asset)
+	if (flush_queue)
+		user.client.browse_queue_flush()
 
 /**
  * public

--- a/tgui/packages/tgui/interfaces/NtosMain.js
+++ b/tgui/packages/tgui/interfaces/NtosMain.js
@@ -78,14 +78,14 @@ export const NtosMain = (props, context) => {
                     selected={light_on}
                     onClick={() => act('PC_toggle_light')}
                   />
-                  <Button
-                    icon="eject"
-                    content="Eject ID"
-                    disabled={!proposed_login.IDName}
-                    onClick={() => act('PC_Eject_Disk', { name: 'ID' })}
-                  />
                 </>
               )}
+              <Button
+                icon="eject"
+                content="Eject ID"
+                disabled={!proposed_login.IDName}
+                onClick={() => act('PC_Eject_Disk', { name: 'ID' })}
+              />
               {!!show_imprint && (
                 <Button
                   icon="dna"


### PR DESCRIPTION
## About The Pull Request

- Tablets now refresh their page when changing programs, this means the UI will no longer close and reopen itself several times (or even have several UIs open if shit broke hard enough).
- Removed tablet's attack self because interact already does everything it had to do.
- Header programs now close when minimized (as there's no button to close them in the main menu.
- Removed a lot of program UI stuff, it's now handled by the PC itself, such as header data and ui host.
- Cut off asset sending from TGUI into it's own proc so I can re-send assets when changing programs
- Added an ejection button for machine computers
- Fixed ID not ejecting into the user's hand when using 'Eject ID'
- Fixes a minor runtime when opening the MODsuit application without a MODsuit already connected.

## Why It's Good For The Game

Fixes some bugs that I found with tablets

UIS now won't be flickering as bad in front of them, or have inconsistent placement (like when you move your main menu UI, go to Messenger, then it's back to the center of the screen).

Video of it in action
https://user-images.githubusercontent.com/53777086/221301417-78321149-0c10-475e-bd29-79f5a4ba0597.mp4

## Changelog

:cl:
fix: Being in an application now properly uses the tablet's battery.
fix: Messenger and Themify apps now close when minimized, so don't count towards the running app limit.
fix: Tablet UIs will now no longer spam open/close the UI when changing applications
fix: Using the Eject ID button on tablets now ejects into your hand.
fix: Computers now have an Eject ID button
refactor: Cut down a lot of copy paste in tablet & program code, now it's mostly done by the tablet.
/:cl: