### PR TITLE
[NO GBP] Corrects the description of the transmission 4 threshold effect of the Narcolepsy symptom

### DIFF
--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -20,7 +20,7 @@
 	severity = 4
 	var/yawning = FALSE
 	threshold_descs = list(
-		"Transmission 4" = "Causes the host to periodically emit a yawn that spreads the virus in a manner similar to that of a sneeze.",
+		"Transmission 4" = "Causes the host to periodically emit a yawn that tries to infect bystanders within 6 meters of the host.",
 		"Stage Speed 10" = "Causes narcolepsy more often, increasing the chance of the host falling asleep.",
 	)
 


### PR DESCRIPTION
## About The Pull Request

The current description implies that it spreads the virus in a cone like a sneeze, when it in fact spreads the virus in a radius like a cough. This PR corrects that.

## Why It's Good For The Game

whoopsie doodle

## Changelog

:cl: ATHATH
spellcheck: Corrects the description of the transmission 4 threshold effect of the Narcolepsy symptom to more accurately reflect what the effect does.
/:cl:
