### PR TITLE
Fixes paper formatting on vote box tallies, for democracy.

### DIFF
--- a/code/game/objects/structures/votingbox.dm
+++ b/code/game/objects/structures/votingbox.dm
@@ -175,7 +175,7 @@
 
 		var/full_vote_text = ""
 		for(var/datum/paper_input/text as anything in paper_content.raw_text_inputs)
-			full_vote_text += "[text.raw_text]<br>"
+			full_vote_text += "[text.raw_text]"
 
 		if(!results[full_vote_text])
 			results[full_vote_text] = 1
@@ -204,12 +204,11 @@
 			.vote_box_content hr {
 				display: none;
 			}
-		</style>
-		"}
+		</style>"}
 
-	tally += "<h1>Voting Results:</h1><hr><ol>"
+	tally += "<h1>Voting Results:</h1><br/><h2>[vote_description]</h2><hr><ol>"
 	for(var/option in results)
-		tally += "<li>\"<div class='vote_box_content'>[option]</div>\" - [results[option]] Vote[results[option] > 1 ? "s" : ""].</li>"
+		tally += "<li>\"<span class='vote_box_content'>[option]</span>\" - [results[option]] Vote[results[option] > 1 ? "s" : ""].</li>"
 	tally += "</ol>"
 
 	vote_tally_paper.add_raw_text(tally.Join())


### PR DESCRIPTION
## About The Pull Request
Fixes #73139

In the spirit of AnturK's original PR the voting season, I present to you: Fixing a piece of paper.

Due to using DM's multiline template formatting, the `<div>` for the header started with double tab.

Markdown interpreted that as a code block, quote:
> [Code blocks](https://www.markdownguide.org/basic-syntax/#code-blocks) are normally indented four spaces or one tab. When they’re in a list, indent them eight spaces or two tabs.

So I just changed a line of code, then messed around with some other formatting to get this:
![image](https://user-images.githubusercontent.com/24975989/221327971-ce469b6b-8f0a-41ed-bad8-e8a1228e3130.png)
## Why It's Good For The Game
![i-love-it](https://user-images.githubusercontent.com/24975989/221327597-0251f55e-0103-4a95-95d2-e12312793364.gif)
## Changelog
:cl:
fix: Fixes formatting for the paper containing vote box final tallies. "I love democracy".
/:cl:
