### PR TITLE
Dont sleep brain mobs when their mech is destroyed (no forever-deaf-mute-whatever brains!)

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -317,7 +317,8 @@
 				mob_exit(ai,silent = TRUE, forced = TRUE) // so we dont ghost the AI
 			continue
 		mob_exit(occupant, forced = TRUE)
-		occupant.SetSleeping(destruction_sleep_duration)
+		if(!isbrain(occupant)) // who would win.. 1 brain vs 1 sleep proc..
+			occupant.SetSleeping(destruction_sleep_duration)
 
 	if(wreckage)
 		var/obj/structure/mecha_wreckage/WR = new wreckage(loc, unlucky_ai)


### PR DESCRIPTION

## About The Pull Request

brain mobs dont get slept on destruction

## Why It's Good For The Game

Fixes #72869
Fixes #73624
Fixes #57217

## Changelog
:cl:
fix: MMIs/Positrons dont get slept forever when the mech theyre in gets destroyed
/:cl:
