### PR TITLE
Fixes the Seek your Master cult construct ability not having an icon.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/constructs/harvester.dm
+++ b/code/modules/mob/living/simple_animal/hostile/constructs/harvester.dm
@@ -84,6 +84,7 @@
 	overlay_icon_state = "bg_demon_border"
 
 	buttontooltipstyle = "cult"
+	button_icon = "icons/mob/actions/actions_cult.dmi"
 	button_icon_state = "cult_mark"
 	/// Where is nar nar? Are we even looking?
 	var/tracking = FALSE


### PR DESCRIPTION

## About The Pull Request

This ability had the wrong icon file used for it.
## Why It's Good For The Game

Missing icon
## Changelog
:cl:
fix: Cult Seek your master now has an icon.
/:cl:
