### PR TITLE
Refactor how clown livers stop being squeaky

### DIFF
--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -27,7 +27,7 @@
 	)
 
 
-/datum/component/squeak/Initialize(custom_sounds, volume_override, chance_override, step_delay_override, use_delay_override, extrarange, falloff_exponent, fallof_distance)
+/datum/component/squeak/Initialize(custom_sounds, volume_override, chance_override, step_delay_override, use_delay_override, extrarange, falloff_exponent, fallof_distance, list/delete_signals)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 	RegisterSignals(parent, list(COMSIG_ATOM_ENTERED, COMSIG_ATOM_BLOB_ACT, COMSIG_ATOM_HULK_ATTACK, COMSIG_PARENT_ATTACKBY), PROC_REF(play_squeak))
@@ -46,9 +46,9 @@
 		else if(isstructure(parent))
 			RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND, PROC_REF(use_squeak))
 
-	if(istype(parent, /obj/item/organ/internal/liver))
-		// Liver squeaking is depending on them functioning like a clown's liver
-		RegisterSignal(parent, SIGNAL_REMOVETRAIT(TRAIT_COMEDY_METABOLISM), PROC_REF(on_comedy_metabolism_removal))
+	// List of signals, which if the parent recieves, to delete this component
+	if(islist(delete_signals) && length(delete_signals))
+		RegisterSignal(parent, delete_signals, PROC_REF(on_delete_signal))
 
 	override_squeak_sounds = custom_sounds
 	if(chance_override)
@@ -145,7 +145,7 @@
 	if(old_dir != new_dir)
 		play_squeak()
 
-/datum/component/squeak/proc/on_comedy_metabolism_removal(datum/source, trait)
+/datum/component/squeak/proc/on_delete_signal(datum/source)
 	SIGNAL_HANDLER
 
 	qdel(src)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -41,14 +41,20 @@
  * against things, or step on them.
  *
  * The removal of the component, if this liver loses that trait, is handled
- * by the component itself.
+ * by the component listening for removal of that trait.
  */
 /obj/item/organ/internal/liver/proc/on_add_comedy_metabolism()
 	SIGNAL_HANDLER
 
 	// Are clown "bike" horns made from the livers of ex-clowns?
 	// Would that make the clown more or less likely to honk it
-	AddComponent(/datum/component/squeak, list('sound/items/bikehorn.ogg'=1), 50, falloff_exponent = 20)
+	AddComponent(\
+		/datum/component/squeak,\
+		list('sound/items/bikehorn.ogg'= 1),\
+		volume_override = 50,\
+		falloff_exponent = 20,\
+		delete_signals=list(SIGNAL_REMOVETRAIT(TRAIT_COMEDY_METABOLISM)),\
+	)
 
 /obj/item/organ/internal/liver/examine(mob/user)
 	. = ..()
@@ -108,7 +114,7 @@
 	if(filterToxins && !HAS_TRAIT(liver_owner, TRAIT_TOXINLOVER))
 		for(var/datum/reagent/toxin/toxin in cached_reagents)
 			if(status != toxin.affected_organtype) //this particular toxin does not affect this type of organ
-				continue 
+				continue
 			var/amount = round(toxin.volume, CHEMICAL_QUANTISATION_LEVEL) // this is an optimization
 			if(belly)
 				amount += belly.reagents.get_reagent_amount(toxin.type)


### PR DESCRIPTION
Clown livers have a COMEDY_METABOLISM trait, which triggers a squeak component to be added. But if that trait disappears, so should the squeak component.

Currently as implemented, the squeak component sets up a specific listener for that trait being removed from the liver, if it's being added to a liver.

However, that means there's this inexplicable squeaking association with livers which only makes sense if you understand the other code's context.

In order to keep this behaviour, but make the code more understandable in smaller pieces, the squeak component is now instead passed a list of signals, which if the parent emits, it should clean up.

The component is still in charge of its own lifecycle, but has less special casing just for this code story.