### PR TITLE
Teleport scroll charges cannot be bypassed via clicking the action button

### DIFF
--- a/code/game/objects/items/scrolls.dm
+++ b/code/game/objects/items/scrolls.dm
@@ -17,10 +17,21 @@
 	. = ..()
 	// In the future, this can be generalized into just "magic scrolls that give you a specific spell".
 	var/datum/action/cooldown/spell/teleport/area_teleport/wizard/scroll/teleport = locate() in actions
-	if(teleport)
-		teleport.name = name
-		teleport.button_icon = icon
-		teleport.button_icon_state = icon_state
+	if(!teleport)
+		return
+	teleport.name = name
+	teleport.button_icon = icon
+	teleport.button_icon_state = icon_state
+	RegisterSignal(teleport, COMSIG_SPELL_AFTER_CAST, PROC_REF(on_spell_cast))
+
+/// Deplete charges if spell is cast successfully
+/obj/item/teleportation_scroll/proc/on_spell_cast(datum/action/cooldown/spell/cast_spell, mob/living/cast_on)
+	SIGNAL_HANDLER
+	uses--
+	if(uses > 0)
+		return
+	to_chat(cast_on, span_warning("[src] runs out of uses and crumbles to dust!"))
+	qdel(src)
 
 /obj/item/teleportation_scroll/item_action_slot_check(slot, mob/user)
 	return (slot & ITEM_SLOT_HANDS)
@@ -52,8 +63,4 @@
 		return
 	if(!teleport.Activate(user))
 		return
-	uses--
-	if(uses <= 0)
-		to_chat(user, span_warning("[src] runs out of uses and crumbles to dust!"))
-		qdel(src)
 	return TRUE

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -299,21 +299,20 @@
  */
 /datum/action/cooldown/spell/proc/after_cast(atom/cast_on)
 	SHOULD_CALL_PARENT(TRUE)
-
-	SEND_SIGNAL(src, COMSIG_SPELL_AFTER_CAST, cast_on)
-	if(!owner)
+	if(!owner) // Could have been destroyed by the effect of the spell
+		SEND_SIGNAL(src, COMSIG_SPELL_AFTER_CAST, cast_on)
 		return
 
-	SEND_SIGNAL(owner, COMSIG_MOB_AFTER_SPELL_CAST, src, cast_on)
-
-	// Sparks and smoke can only occur if there's an owner to source them from.
 	if(sparks_amt)
 		do_sparks(sparks_amt, FALSE, get_turf(owner))
-
 	if(ispath(smoke_type, /datum/effect_system/fluid_spread/smoke))
 		var/datum/effect_system/fluid_spread/smoke/smoke = new smoke_type()
 		smoke.set_up(smoke_amt, holder = owner, location = get_turf(owner))
 		smoke.start()
+
+	// Send signals last in case they delete the spell
+	SEND_SIGNAL(owner, COMSIG_MOB_AFTER_SPELL_CAST, src, cast_on)
+	SEND_SIGNAL(src, COMSIG_SPELL_AFTER_CAST, cast_on)
 
 /// Provides feedback after a spell cast occurs, in the form of a cast sound and/or invocation
 /datum/action/cooldown/spell/proc/spell_feedback()


### PR DESCRIPTION
## About The Pull Request

Teleport scrolls would only deplete a charge if used in hand, however their implementation actually granted you the spell as an item action which you could use by hitting the action button, This would not deplete a charge, and had no cooldown whatsoever.
The action button is convenient and should stay, but I modified the code so that instead of depleting a charge when clicked it depletes a charge when the spell contained by the item successfully casts.

I also changed the order of operations slightly in `spell/after_cast` because using the signal to delete the scroll would also delete the spell (sensibly, it should clean up after itself) before the last cast could make smoke, which was sad.

## Why It's Good For The Game

On live the teleport scroll gives all wizards _and_ apprentices the teleport spell with absolutely no cooldown and infinite usage, which is probably not intended.

## Changelog

:cl:
fix: Using a teleport scroll will deplete a charge regardless of whether used in-hand or by pressing the action button.
/:cl:
