### PR TITLE
[NO GBP] surplus crate and united surplus crate show up on round end screen

### DIFF
--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -126,7 +126,7 @@
 		new uplink_item.item(surplus_crate)
 
 /// overwrites purchase for surplus items to instead spawn this crate and run the previous procs
-/datum/uplink_item/bundles_tc/surplus/purchase(mob/user, datum/uplink_handler/handler, atom/movable/source)
+/datum/uplink_item/bundles_tc/surplus/spawn_item(spawn_path, mob/user, datum/uplink_handler/handler, atom/movable/source)
 	var/obj/structure/closet/crate/surplus_crate = new crate_type()
 	if(!istype(surplus_crate))
 		CRASH("crate_type is not a crate")
@@ -139,6 +139,7 @@
 		"style" = STYLE_SYNDICATE,
 		"spawn" = surplus_crate,
 	))
+	return source //For log icon
 
 /datum/uplink_item/bundles_tc/surplus/united
 	name = "United Surplus Crate"

--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -125,7 +125,7 @@
 		tc_budget -= uplink_item.cost
 		new uplink_item.item(surplus_crate)
 
-/// overwrites purchase for surplus items to instead spawn this crate and run the previous procs
+/// overwrites item spawning proc for surplus items to spawn an appropriate crate via a podspawn
 /datum/uplink_item/bundles_tc/surplus/spawn_item(spawn_path, mob/user, datum/uplink_handler/handler, atom/movable/source)
 	var/obj/structure/closet/crate/surplus_crate = new crate_type()
 	if(!istype(surplus_crate))


### PR DESCRIPTION
## About The Pull Request

I extended purchase() instead of spawn_item() when making the crates which meant that they didn't show up on the round end screen!

## Why It's Good For The Game

good for items to show up on the round end screen, potentially meant that the crates weren't being logged? unsure about that one

## Changelog
:cl:
fix: surplus crates and united surplus crates now properly show up as a purchase in the round end screen
/:cl:
