### PR TITLE
Don't create abandoned airlocks with walls underneath them.

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -139,10 +139,12 @@
 				var/turf/here = get_turf(src)
 				for(var/turf/closed/T in range(2, src))
 					here.PlaceOnTop(T.type)
+					qdel(airlock)
 					qdel(src)
 					return
 				here.PlaceOnTop(/turf/closed/wall)
 				qdel(airlock)
+				qdel(src)
 				return
 			if(9 to 11)
 				airlock.lights = FALSE


### PR DESCRIPTION
## About The Pull Request
Fixes #71504

#70237 attempted to remove this and did in some cases, however the case where the abandoned airlock is able to find an adjacent wall turf to copy the type of still fails to delete the airlock.
This fixes that.

Also in my testing, the times where it _failed_ to find a nearby wall turf to copy and spawned a default wall would leave the mapping helper visible in the round. Oops!

## Why It's Good For The Game

Mapping helpers should always delete themselves when finished.
The airlocks with walls under them are funny once and annoying the rest of the time. As of that older PR, this continuing to happen is regarded as a bug.
Also apparently it might be required anyway for Wallening.

## Changelog

:cl:
fix: Maintenance tunnels should no longer sometimes contain airlocks with walls underneath them.
/:cl:
