### PR TITLE
Improves Tramstation xenobio pens

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6338,6 +6338,11 @@
 	name = "Xenobio Bottom Right Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/north{
+	name = "Containment Pen #8";
+	base_state = "right";
+	icon_state = "right"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "aIi" = (
@@ -11111,6 +11116,9 @@
 	name = "Xenobio Topleft Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	name = "Containment Pen #1"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "cbn" = (
@@ -12723,6 +12731,11 @@
 	name = "Xenobio Top Right Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	name = "Containment Pen #4";
+	base_state = "right";
+	icon_state = "right"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "cFl" = (
@@ -21053,6 +21066,9 @@
 	name = "Xenobio Topleft Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	name = "Containment Pen #2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "fPy" = (
@@ -29715,6 +29731,9 @@
 	name = "Xenobio Bottom Left Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/north{
+	name = "Containment Pen #5"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "jmk" = (
@@ -36397,6 +36416,9 @@
 	name = "Xenobio Bottom Left Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/north{
+	name = "Containment Pen #6"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "lIe" = (
@@ -48805,6 +48827,11 @@
 	name = "Xenobio Bottom Right Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/north{
+	name = "Containment Pen #7";
+	base_state = "right";
+	icon_state = "right"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "qoD" = (
@@ -54613,6 +54640,11 @@
 	name = "Xenobio Top Right Pen Blast Door"
 	},
 /obj/structure/cable,
+/obj/machinery/door/window/left/directional/south{
+	name = "Containment Pen #3";
+	base_state = "right";
+	icon_state = "right"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "swC" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6327,8 +6327,6 @@
 /area/station/science/genetics)
 "aId" = (
 /obj/machinery/door/window/left/directional/south{
-	base_state = "right";
-	icon_state = "right";
 	name = "Containment Pen #8";
 	req_access = list("xenobiology")
 	},
@@ -6339,9 +6337,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/north{
-	name = "Containment Pen #8";
-	base_state = "right";
-	icon_state = "right"
+	name = "Containment Pen #8"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -11108,7 +11104,9 @@
 "cbj" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Containment Pen #1";
-	req_access = list("xenobiology")
+	req_access = list("xenobiology");
+	base_state = "right";
+	icon_state = "right"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -11117,7 +11115,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/south{
-	name = "Containment Pen #1"
+	name = "Containment Pen #1";
+	base_state = "right";
+	icon_state = "right"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -12720,8 +12720,6 @@
 /area/station/hallway/secondary/exit)
 "cFk" = (
 /obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	icon_state = "right";
 	name = "Containment Pen #4";
 	req_access = list("xenobiology")
 	},
@@ -12732,9 +12730,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/south{
-	name = "Containment Pen #4";
-	base_state = "right";
-	icon_state = "right"
+	name = "Containment Pen #4"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -29723,7 +29719,9 @@
 "jmb" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Containment Pen #5";
-	req_access = list("xenobiology")
+	req_access = list("xenobiology");
+	base_state = "right";
+	icon_state = "right"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -29732,7 +29730,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/north{
-	name = "Containment Pen #5"
+	name = "Containment Pen #5";
+	base_state = "right";
+	icon_state = "right"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6337,7 +6337,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/north{
-	name = "Containment Pen #8"
+	name = "Containment Pen #8";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -11104,9 +11105,9 @@
 "cbj" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Containment Pen #1";
-	req_access = list("xenobiology");
 	base_state = "right";
-	icon_state = "right"
+	icon_state = "right";
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -11117,7 +11118,8 @@
 /obj/machinery/door/window/left/directional/south{
 	name = "Containment Pen #1";
 	base_state = "right";
-	icon_state = "right"
+	icon_state = "right";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -12730,7 +12732,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/south{
-	name = "Containment Pen #4"
+	name = "Containment Pen #4";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -21063,7 +21066,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/south{
-	name = "Containment Pen #2"
+	name = "Containment Pen #2";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -29719,9 +29723,9 @@
 "jmb" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Containment Pen #5";
-	req_access = list("xenobiology");
 	base_state = "right";
-	icon_state = "right"
+	icon_state = "right";
+	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -29732,7 +29736,8 @@
 /obj/machinery/door/window/left/directional/north{
 	name = "Containment Pen #5";
 	base_state = "right";
-	icon_state = "right"
+	icon_state = "right";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -36417,7 +36422,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/north{
-	name = "Containment Pen #6"
+	name = "Containment Pen #6";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -48830,7 +48836,8 @@
 /obj/machinery/door/window/left/directional/north{
 	name = "Containment Pen #7";
 	base_state = "right";
-	icon_state = "right"
+	icon_state = "right";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -54643,7 +54650,8 @@
 /obj/machinery/door/window/left/directional/south{
 	name = "Containment Pen #3";
 	base_state = "right";
-	icon_state = "right"
+	icon_state = "right";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6326,7 +6326,9 @@
 /turf/open/floor/plating,
 /area/station/science/genetics)
 "aId" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
+	base_state = "right";
+	icon_state = "right";
 	name = "Containment Pen #8";
 	req_access = list("xenobiology")
 	},
@@ -11100,7 +11102,6 @@
 /area/station/cargo/lobby)
 "cbj" = (
 /obj/machinery/door/window/left/directional/north{
-	dir = 2;
 	name = "Containment Pen #1";
 	req_access = list("xenobiology")
 	},
@@ -12711,7 +12712,8 @@
 /area/station/hallway/secondary/exit)
 "cFk" = (
 /obj/machinery/door/window/left/directional/north{
-	dir = 2;
+	base_state = "right";
+	icon_state = "right";
 	name = "Containment Pen #4";
 	req_access = list("xenobiology")
 	},
@@ -21042,7 +21044,6 @@
 /area/station/security/processing)
 "fPi" = (
 /obj/machinery/door/window/left/directional/north{
-	dir = 2;
 	name = "Containment Pen #2";
 	req_access = list("xenobiology")
 	},
@@ -29704,9 +29705,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "jmb" = (
-/obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	icon_state = "right";
+/obj/machinery/door/window/left/directional/south{
 	name = "Containment Pen #5";
 	req_access = list("xenobiology")
 	},
@@ -36388,7 +36387,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "lIa" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	name = "Containment Pen #6";
 	req_access = list("xenobiology")
 	},
@@ -48794,7 +48793,7 @@
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
 "qoo" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
 	icon_state = "right";
 	name = "Containment Pen #7";
@@ -54604,7 +54603,6 @@
 "swy" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #3";
 	req_access = list("xenobiology")

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11104,9 +11104,9 @@
 /area/station/cargo/lobby)
 "cbj" = (
 /obj/machinery/door/window/left/directional/north{
-	name = "Containment Pen #1";
 	base_state = "right";
 	icon_state = "right";
+	name = "Containment Pen #1";
 	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/delivery,
@@ -11116,9 +11116,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/south{
-	name = "Containment Pen #1";
 	base_state = "right";
 	icon_state = "right";
+	name = "Containment Pen #1";
 	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
@@ -29722,9 +29722,9 @@
 /area/station/ai_monitored/security/armory)
 "jmb" = (
 /obj/machinery/door/window/left/directional/south{
-	name = "Containment Pen #5";
 	base_state = "right";
 	icon_state = "right";
+	name = "Containment Pen #5";
 	req_access = list("xenobiology")
 	},
 /obj/effect/turf_decal/delivery,
@@ -29734,9 +29734,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/north{
-	name = "Containment Pen #5";
 	base_state = "right";
 	icon_state = "right";
+	name = "Containment Pen #5";
 	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
@@ -48834,9 +48834,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/north{
-	name = "Containment Pen #7";
 	base_state = "right";
 	icon_state = "right";
+	name = "Containment Pen #7";
 	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,
@@ -54648,9 +54648,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/left/directional/south{
-	name = "Containment Pen #3";
 	base_state = "right";
 	icon_state = "right";
+	name = "Containment Pen #3";
 	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/dark,


### PR DESCRIPTION
## About The Pull Request
Adds another set of windoors to the Tramstation Xenobiology pens, opposite from the ones already present, and refactors those windoors to use `base_state = "right"; icon_state = "right";` instead of `dir`.
## Why It's Good For The Game
This removes one space from the pens, but ensures that everything inside a pen is visible from the floor above them, so there won't be any hidden monkeys or slimes sitting in the square that the windoors are in. If this square is meant to be used as part of the pen, then the lower floor should instead be made more accessible to the slime console, having fewer walls and more windows so all slimes can be seen at once. This also adds pens that are one space large for working on one slime at a time, though these tiny pens are not usable from the floor above. This change also makes the tramstation xenobio layout more like how it is on other maps. This also makes it more obvious how the windoors are setup, as the map file shows that they are explicitly set to close to the right, rather than changing their dir to an abitrary number.
## Changelog
:cl:
qol: Added another set of windoors to the Tramstation Xenobiology pens, fully enclosing the space before them. The creatures in the main pens can now always be accessed from above.
refactor: Tramstation Xenobiology pens explicitly close to the right rather than being rotated by using dir.
/:cl:
