### PR TITLE
Makes dead metabolization work properly

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -12,8 +12,8 @@
 		reagents.handle_stasis_chems(src, delta_time, times_fired)
 	else
 		//Reagent processing needs to come before breathing, to prevent edge cases.
+		handle_dead_metabolization(delta_time, times_fired) //Dead metabolization first since it can modify life metabolization.
 		handle_organs(delta_time, times_fired)
-		handle_dead_metabolization(delta_time, times_fired)
 
 		. = ..()
 		if(QDELETED(src))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -13,6 +13,7 @@
 	else
 		//Reagent processing needs to come before breathing, to prevent edge cases.
 		handle_organs(delta_time, times_fired)
+		handle_dead_metabolization(delta_time, times_fired)
 
 		. = ..()
 		if(QDELETED(src))
@@ -821,3 +822,12 @@
 		return
 
 	heart.beating = !status
+
+//////////////////////
+//SNOWFLAKE REAGENTS//
+//////////////////////
+
+/mob/living/carbon/proc/handle_dead_metabolization(delta_time, times_fired)
+	if (stat != DEAD)
+		return
+	reagents.metabolize(src, delta_time, times_fired, can_overdose = TRUE, liverless = TRUE, dead = TRUE)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -527,12 +527,7 @@
 
 /**
  * Handles calling metabolization for dead people.
- * It's done here instead of the liver so that it works independently of the liver, similarly
- * to normal metabolization.
- * It's called as liverless since it doesn't make sense for your liver
- * to work while you're dead, but self consuming chemicals will still be consumed by this.
- * Due to how reagent metabolization code works and is laid out, it's done here because it
- * couldn't be done literally anywhere else. (Trust me, I tried to fit it somewhere.)
+ * Due to how reagent metabolization code works this couldn't be done anywhere else.
  * 
  * Arguments:
  * - delta_time: The amount of time that has elapsed since the last tick.
@@ -541,7 +536,7 @@
 /mob/living/carbon/proc/handle_dead_metabolization(delta_time, times_fired)
 	if (stat != DEAD)
 		return
-	reagents.metabolize(src, delta_time, times_fired, can_overdose = TRUE, liverless = TRUE, dead = TRUE)
+	reagents.metabolize(src, delta_time, times_fired, can_overdose = TRUE, liverless = TRUE, dead = TRUE) // Your liver doesn't work while you're dead.
 
 /// Base carbon environment handler, adds natural stabilization
 /mob/living/carbon/handle_environment(datum/gas_mixture/environment, delta_time, times_fired)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -525,6 +525,24 @@
 		if(HM?.timeout)
 			dna.remove_mutation(HM.type)
 
+/**
+ * Handles calling metabolization for dead people.
+ * It's done here instead of the liver so that it works independently of the liver, similarly
+ * to normal metabolization.
+ * It's called as liverless since it doesn't make sense for your liver
+ * to work while you're dead, but self consuming chemicals will still be consumed by this.
+ * Due to how reagent metabolization code works and is laid out, it's done here because it
+ * couldn't be done literally anywhere else. (Trust me, I tried to fit it somewhere.)
+ * 
+ * Arguments:
+ * - delta_time: The amount of time that has elapsed since the last tick.
+ * - times_fired: The number of times SSmobs has ticked.
+ */
+/mob/living/carbon/proc/handle_dead_metabolization(delta_time, times_fired)
+	if (stat != DEAD)
+		return
+	reagents.metabolize(src, delta_time, times_fired, can_overdose = TRUE, liverless = TRUE, dead = TRUE)
+
 /// Base carbon environment handler, adds natural stabilization
 /mob/living/carbon/handle_environment(datum/gas_mixture/environment, delta_time, times_fired)
 	var/areatemp = get_temperature(environment)
@@ -822,12 +840,3 @@
 		return
 
 	heart.beating = !status
-
-//////////////////////
-//SNOWFLAKE REAGENTS//
-//////////////////////
-
-/mob/living/carbon/proc/handle_dead_metabolization(delta_time, times_fired)
-	if (stat != DEAD)
-		return
-	reagents.metabolize(src, delta_time, times_fired, can_overdose = TRUE, liverless = TRUE, dead = TRUE)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -757,7 +757,7 @@
 	if(!owner)
 		owner = reagent.holder.my_atom
 
-	if(owner && reagent && !(dead && !(reagent.chemical_flags & REAGENT_DEAD_PROCESS)))
+	if(owner && reagent && (!dead || (reagent.chemical_flags & REAGENT_DEAD_PROCESS)))
 		if(owner.reagent_check(reagent, delta_time, times_fired))
 			return
 		if(liverless && !reagent.self_consuming) //need to be metabolized

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -708,7 +708,7 @@
  * * can_overdose - Allows overdosing
  * * liverless - Stops reagents that aren't set as [/datum/reagent/var/self_consuming] from metabolizing
  */
-/datum/reagents/proc/metabolize(mob/living/carbon/owner, delta_time, times_fired, can_overdose = FALSE, liverless = FALSE)
+/datum/reagents/proc/metabolize(mob/living/carbon/owner, delta_time, times_fired, can_overdose = FALSE, liverless = FALSE, dead = FALSE)
 	var/list/cached_reagents = reagent_list
 	if(owner)
 		expose_temperature(owner.bodytemperature, 0.25)
@@ -723,7 +723,7 @@
 
 	for(var/datum/reagent/reagent as anything in cached_reagents)
 		// skip metabolizing effects for small units of toxins
-		if(istype(reagent, /datum/reagent/toxin) && liver)
+		if(istype(reagent, /datum/reagent/toxin) && liver && !dead)
 			var/datum/reagent/toxin/toxin = reagent
 			var/amount = round(toxin.volume, CHEMICAL_QUANTISATION_LEVEL)
 			if(belly)
@@ -733,7 +733,7 @@
 				owner.reagents.remove_reagent(toxin.type, toxin.metabolization_rate * owner.metabolism_efficiency * delta_time)
 				continue
 
-		need_mob_update += metabolize_reagent(owner, reagent, delta_time, times_fired, can_overdose, liverless)
+		need_mob_update += metabolize_reagent(owner, reagent, delta_time, times_fired, can_overdose, liverless, dead)
 
 	if(owner && need_mob_update) //some of the metabolized reagents had effects on the mob that requires some updates.
 		owner.updatehealth()
@@ -749,7 +749,7 @@
  * * can_overdose - Allows overdosing
  * * liverless - Stops reagents that aren't set as [/datum/reagent/var/self_consuming] from metabolizing
  */
-/datum/reagents/proc/metabolize_reagent(mob/living/carbon/owner, datum/reagent/reagent, delta_time, times_fired, can_overdose = FALSE, liverless = FALSE)
+/datum/reagents/proc/metabolize_reagent(mob/living/carbon/owner, datum/reagent/reagent, delta_time, times_fired, can_overdose = FALSE, liverless = FALSE, dead = FALSE)
 	var/need_mob_update = FALSE
 	if(QDELETED(reagent.holder))
 		return FALSE
@@ -757,7 +757,7 @@
 	if(!owner)
 		owner = reagent.holder.my_atom
 
-	if(owner && reagent)
+	if(owner && reagent && !(dead && !(reagent.chemical_flags & REAGENT_DEAD_PROCESS)))
 		if(owner.reagent_check(reagent, delta_time, times_fired))
 			return
 		if(liverless && !reagent.self_consuming) //need to be metabolized
@@ -776,8 +776,10 @@
 
 			if(reagent.overdosed)
 				need_mob_update += reagent.overdose_process(owner, delta_time, times_fired)
-
-		need_mob_update += reagent.on_mob_life(owner, delta_time, times_fired)
+		if(!dead)
+			need_mob_update += reagent.on_mob_life(owner, delta_time, times_fired)
+	if(dead)
+		need_mob_update += reagent.on_mob_dead(owner, delta_time)
 	return need_mob_update
 
 /// Signals that metabolization has stopped, triggering the end of trait-based effects

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -198,20 +198,6 @@
 		if(4 * LIVER_FAILURE_STAGE_SECONDS to INFINITY)
 			examine_list += span_danger("[owner]'s eyes are completely yellow and swelling with pus. [owner.p_they(TRUE)] [owner.p_do()]n't look like [owner.p_they()] will be alive for much longer.")
 
-/obj/item/organ/internal/liver/on_death(delta_time, times_fired)
-	. = ..()
-	var/mob/living/carbon/carbon_owner = owner
-	if(!owner)//If we're outside of a mob
-		return
-	if(!iscarbon(carbon_owner))
-		CRASH("on_death() called for [src] ([type]) with invalid owner ([isnull(owner) ? "null" : owner.type])")
-	if(carbon_owner.stat != DEAD)
-		CRASH("on_death() called for [src] ([type]) with not-dead owner ([owner])")
-	if((organ_flags & ORGAN_FAILING) && HAS_TRAIT(carbon_owner, TRAIT_NOMETABOLISM))//can't process reagents with a failing liver
-		return
-	for(var/datum/reagent/chem as anything in carbon_owner.reagents.reagent_list)
-		chem.on_mob_dead(carbon_owner, delta_time)
-
 /obj/item/organ/internal/liver/get_availability(datum/species/owner_species, mob/living/owner_mob)
 	return owner_species.mutantliver
 


### PR DESCRIPTION

## About The Pull Request

So, currently, on_mob_dead() metabolization is very barebones. It can't overdose and doesn't work when your liver is failing or you simply don't have one. It's been completely neglected and isn't up-to-date on all the fixes done to on_mob_life() and general metabolization.

This PR moves on_mob_dead() into the general metabolization chain and gives it it's own handling proc in the life cycle called handle_dead_metabolization() which simply calls metabolize() with dead and liverless. Sadly your liver doesn't work when you're dead, though self consuming reagents will still pass through due to my previous fixes to reagent processing.
## Why It's Good For The Game

Not having desynchronized updates on the metabolization procs is good for the sake of code quality, readability and futureproofing.

Making a proc do what it's supposed to is also a pretty good change.
## Changelog
:cl:
fix: Reagents metabolize properly when dead. (If they're supposed to.)
/:cl:
