### PR TITLE
Fixes player created security records being unprintable for wanted/missing posters.

### DIFF
--- a/code/datums/records/record.dm
+++ b/code/datums/records/record.dm
@@ -181,10 +181,14 @@
 	if(!character_appearance)
 		return new /icon()
 
-	var/mutable_appearance/appearance = character_appearance
-	appearance.setDir(orientation)
+	var/icon/picture_image
+	if(!isicon(character_appearance))
+		var/mutable_appearance/appearance = character_appearance
+		appearance.setDir(orientation)
 
-	var/icon/picture_image = getFlatIcon(appearance)
+		picture_image = getFlatIcon(appearance)
+	else
+		picture_image = character_appearance
 
 	var/datum/picture/picture = new
 	picture.picture_name = name

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -138,7 +138,7 @@
 		return FALSE
 
 	if(mugshot.picture.psize_x > world.icon_size || mugshot.picture.psize_y > world.icon_size)
-		balloon_alert(user, "photo too large")
+		balloon_alert(user, "photo too large!")
 		playsound(src, 'sound/machines/terminal_error.ogg', 70, TRUE)
 		return FALSE
 

--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -137,6 +137,11 @@
 		playsound(src, 'sound/machines/terminal_error.ogg', 70, TRUE)
 		return FALSE
 
+	if(mugshot.picture.psize_x > world.icon_size || mugshot.picture.psize_y > world.icon_size)
+		balloon_alert(user, "photo too large")
+		playsound(src, 'sound/machines/terminal_error.ogg', 70, TRUE)
+		return FALSE
+
 	var/trimmed = copytext(mugshot.name, 9, MAX_NAME_LEN) // Remove "photo - "
 	var/name = tgui_input_text(user, "Enter the name of the new record.", "New Record", trimmed, MAX_NAME_LEN)
 	if(!name || !is_operational || !user.can_perform_action(src, ALLOW_SILICON_REACH) || !mugshot || QDELETED(mugshot) || QDELETED(src))

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -73,6 +73,8 @@
 		var/txt = tgui_input_text(user, "What would you like to write on the back?", "Photo Writing", max_length = 128)
 		if(txt && user.can_perform_action(src))
 			scribble = txt
+	if(P.get_sharpness())
+		crop_photo(user)
 	else
 		return ..()
 
@@ -106,6 +108,14 @@
 	if(n_name && (loc == usr || loc.loc && loc.loc == usr) && usr.stat == CONSCIOUS && !usr.incapacitated())
 		name = "photo[(n_name ? text("- '[n_name]'") : null)]"
 	add_fingerprint(usr)
+
+/obj/item/photo/proc/crop_photo(mob/user)
+	if(isnull(picture.picture_image))
+		return
+	var/test_num = tgui_input_number(user, "Test", "Test", 1)
+	test_num = (test_num * world.icon_size) + 1
+	picture.picture_image.Crop(test_num , test_num, picture.psize_x, picture.psize_y)
+	picture.regenerate_small_icon()
 
 /obj/item/photo/old
 	icon_state = "photo_old"

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -73,8 +73,6 @@
 		var/txt = tgui_input_text(user, "What would you like to write on the back?", "Photo Writing", max_length = 128)
 		if(txt && user.can_perform_action(src))
 			scribble = txt
-	if(P.get_sharpness())
-		crop_photo(user)
 	else
 		return ..()
 
@@ -108,14 +106,6 @@
 	if(n_name && (loc == usr || loc.loc && loc.loc == usr) && usr.stat == CONSCIOUS && !usr.incapacitated())
 		name = "photo[(n_name ? text("- '[n_name]'") : null)]"
 	add_fingerprint(usr)
-
-/obj/item/photo/proc/crop_photo(mob/user)
-	if(isnull(picture.picture_image))
-		return
-	var/test_num = tgui_input_number(user, "Test", "Test", 1)
-	test_num = (test_num * world.icon_size) + 1
-	picture.picture_image.Crop(test_num , test_num, picture.psize_x, picture.psize_y)
-	picture.regenerate_small_icon()
 
 /obj/item/photo/old
 	icon_state = "photo_old"

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
@@ -50,7 +50,7 @@ export const MedicalRecordTabs = (props, context) => {
             <Button
               disabled
               icon="plus"
-              tooltip="Add new records by inserting a photo into the terminal. You do not need this screen open.">
+              tooltip="Add new records by inserting a 1 by 1 meter photo into the terminal. You do not need this screen open.">
               Create
             </Button>
           </Stack.Item>

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
@@ -51,7 +51,7 @@ export const SecurityRecordTabs = (props, context) => {
             <Button
               disabled
               icon="plus"
-              tooltip="Add new records by inserting a photo into the terminal. You do not need this screen open.">
+              tooltip="Add new records by inserting a 1 by 1 meter photo into the terminal. You do not need this screen open.">
               Create
             </Button>
           </Stack.Item>


### PR DESCRIPTION
## About The Pull Request

If a player created a security record during a round and attempted to print it the printing process would runtime and result in the printer being unusable.

As a side effect of fixing this I've discovered an annoying bug with posters with them defaulting to the bottom left corner of a record. So currently mugshot uploads has been restricted to 32x32 pixels with approval from @jlsnow301 . Ideally at some point a player exposed photo cropping system can be implemented to make it easier to create mugshots using larger photos.

## Why It's Good For The Game

Fixes a bug.

## Changelog
:cl:
fix: You can now create wanted/missing posters using player created security records. Due to a visual bug and usability issue photos above 1 by 1 meters in size will no longer work for mugshots in records.
/:cl:
