### PR TITLE
Improves admin rod logging and fixes un-aimed rods being aimed.

### DIFF
--- a/code/modules/events/immovable_rod/immovable_rod_event.dm
+++ b/code/modules/events/immovable_rod/immovable_rod_event.dm
@@ -44,8 +44,9 @@
 	var/looper = tgui_alert(usr,"Would you like this rod to force-loop across space z-levels?", "Loopy McLoopface", list("Yes", "No"))
 	if(looper == "Yes")
 		force_looping = TRUE
-	message_admins("[key_name_admin(usr)] has aimed an immovable rod [force_looping ? "(forced looping) " : ""]at [special_target ? AREACOORD(special_target) : "a random location"].")
-	log_admin("[key_name_admin(usr)] has aimed an immovable rod [force_looping ? "(forced looping)" : ""] at [special_target ? AREACOORD(special_target) : "a random location"].")
+	var/log_message = "[key_name_admin(usr)] has aimed an immovable rod [force_looping ? "(forced looping) " : ""]at [special_target ? AREACOORD(special_target) : "a random location"]."
+	message_admins(log_message)
+	log_admin(log_message)
 
 /datum/event_admin_setup/immovable_rod/apply_to_event(datum/round_event/immovable_rod/event)
 	event.special_target = special_target

--- a/code/modules/events/immovable_rod/immovable_rod_event.dm
+++ b/code/modules/events/immovable_rod/immovable_rod_event.dm
@@ -35,14 +35,17 @@
 	var/force_looping = FALSE
 
 /datum/event_admin_setup/immovable_rod/prompt_admins()
+	special_target = null
+	force_looping = FALSE
+
 	var/aimed = tgui_alert(usr,"Aimed at current location?", "Sniperod", list("Yes", "No"))
 	if(aimed == "Yes")
 		special_target = get_turf(usr)
 	var/looper = tgui_alert(usr,"Would you like this rod to force-loop across space z-levels?", "Loopy McLoopface", list("Yes", "No"))
 	if(looper == "Yes")
 		force_looping = TRUE
-	message_admins("[key_name_admin(usr)] has aimed an immovable rod [force_looping ? "(forced looping)" : ""] at [AREACOORD(special_target)].")
-	log_admin("[key_name_admin(usr)] has aimed an immovable rod [force_looping ? "(forced looping)" : ""] at [AREACOORD(special_target)].")
+	message_admins("[key_name_admin(usr)] has aimed an immovable rod [force_looping ? "(forced looping) " : ""]at [special_target ? AREACOORD(special_target) : "a random location"].")
+	log_admin("[key_name_admin(usr)] has aimed an immovable rod [force_looping ? "(forced looping)" : ""] at [special_target ? AREACOORD(special_target) : "a random location"].")
 
 /datum/event_admin_setup/immovable_rod/apply_to_event(datum/round_event/immovable_rod/event)
 	event.special_target = special_target


### PR DESCRIPTION

## About The Pull Request

Logs wont say a rod has been aimed at null location anymore and instead will say "a random location"
Also admin rods that were not aimed were retaining the location set by previous rods which is bad since it meant un-aimed rods were actually aimed.
## Why It's Good For The Game

Bug fix + better logging.
## Changelog
:cl:
fix: Un-aimed admin rods will now actually be un-aimed instead of aimed at the previous aimed rods target.
admin: Admin aimed rods will now log that they're aimed randomly when not aimed.
/:cl:
