### PR TITLE
Tram cargo diposals fixes

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5205,6 +5205,9 @@
 	supplies_requestable = 1;
 	name = "Cargo Bay Requests Console"
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "aAN" = (
@@ -37026,10 +37029,9 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "lSQ" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
+/obj/structure/disposalpipe/sorting/wrap/flip{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/mail_sorting/supply/cargo_bay,
 /turf/closed/wall,
 /area/station/cargo/sorting)
 "lSU" = (
@@ -43776,9 +43778,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "ouF" = (
@@ -54699,9 +54701,10 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/mail_sorting/supply/cargo_bay,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "sxT" = (


### PR DESCRIPTION


## About The Pull Request

Tramstation's incoming mail nook in the mail room has been hooked up incorrectly. Instead of using the wrapped parcel sorter, it was looking for mail tagged with Cargo Bay, so wrapped packages went to the disposals conveyor belt.

In addition, the actual Cargo Bay was also not hooked up, making mail intended for that location pass by.

Another minor issue that has been solved, the cargo office bin was not hooked up to disposals.

## Why It's Good For The Game

Disposals working properly is good.

## Changelog

:cl:
fix: Mail addressed to tram's cargo bay disposal bin will arrive successfully, and the Incoming Mail Chute will properly accept wrapped parcels.
/:cl:

