### PR TITLE
Write roundstart logout report to admin log

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -93,8 +93,11 @@
 #define AHELP_CLOSED 2
 #define AHELP_RESOLVED 3
 
-/// Amount of time (in deciseconds) after the rounds starts, that the player disconnect report is issued.
-#define ROUNDSTART_LOGOUT_REPORT_TIME 12600
+/// Amount of time after the round starts that the player disconnect report is issued.
+#define ROUNDSTART_LOGOUT_REPORT_TIME (10 MINUTES)
+
+/// Threshold in minutes for counting a player as AFK on the roundstart report.
+#define ROUNDSTART_LOGOUT_AFK_THRESHOLD (ROUNDSTART_LOGOUT_REPORT_TIME * 0.7)
 
 /// Number of identical messages required before the spam-prevention will warn you to stfu
 #define SPAM_TRIGGER_WARNING 5

--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -94,7 +94,7 @@
 #define AHELP_RESOLVED 3
 
 /// Amount of time (in deciseconds) after the rounds starts, that the player disconnect report is issued.
-#define ROUNDSTART_LOGOUT_REPORT_TIME 6000
+#define ROUNDSTART_LOGOUT_REPORT_TIME 12600
 
 /// Number of identical messages required before the spam-prevention will warn you to stfu
 #define SPAM_TRIGGER_WARNING 5

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -191,9 +191,9 @@
 						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] ([span_boldannounce("Ghosted")])\n"
 						continue //Ghosted while alive
 
-	log_admin(msg.Join())
-	for (var/C in GLOB.admins)
-		to_chat(C, msg.Join())
+	var/concatenated_message = msg.Join()
+	log_admin(concatenated_message)
+	to_chat(GLOB.admins, concatenated_message)
 
 /datum/game_mode/proc/generate_station_goals(greenshift)
 	var/goal_budget = greenshift ? INFINITY : CONFIG_GET(number/station_goal_budget)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -191,7 +191,7 @@
 						msg += "<b>[L.name]</b> ([ckey(D.mind.key)]), the [L.job] ([span_boldannounce("Ghosted")])\n"
 						continue //Ghosted while alive
 
-
+	log_admin(msg.Join())
 	for (var/C in GLOB.admins)
 		to_chat(C, msg.Join())
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -160,7 +160,7 @@
 
 		if(L.ckey && L.client)
 			var/failed = FALSE
-			if(L.client.inactivity >= (ROUNDSTART_LOGOUT_REPORT_TIME / 2)) //Connected, but inactive (alt+tabbed or something)
+			if(L.client.inactivity >= ROUNDSTART_LOGOUT_AFK_THRESHOLD) //Connected, but inactive (alt+tabbed or something)
 				msg += "<b>[L.name]</b> ([L.key]), the [L.job] (<font color='#ffcc00'><b>Connected, Inactive</b></font>)\n"
 				failed = TRUE //AFK client
 			if(!failed && L.stat)


### PR DESCRIPTION
## About The Pull Request
- Writes the roundstart logout report to the admin log
- Increases the threshold for the report, clients > 10 minutes are deemed AFK

## Why It's Good For The Game

While the report is broadcasted in chat, it's not actually saved in the log. Sometimes we want to go back and read this later.

## Changelog

:cl: LT3
admin: Roundstart logout report is written to the admin log
admin: Roundstart report threshold is now 10 minutes
/:cl: