### PR TITLE
Updates Coderbus and Adminbus Ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -18,13 +18,22 @@
 /area/ruin/space)
 "an" = (
 /obj/structure/fluff/bus/passable/seat,
-/obj/item/food/meatball,
+/obj/item/toy/plush/pkplush{
+	pixel_y = 17
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
 /area/ruin/space)
 "ao" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/telecomms/server{
+	pixel_y = 12;
+	layer = 2.91;
+	density = 0;
+	name = "tgsv3";
+	desc = "It's, uh... pending an upgrade."
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
@@ -33,21 +42,28 @@
 /obj/structure/fluff/bus/passable/seat{
 	pixel_y = 15
 	},
+/obj/item/toy/plush/lizard_plushie/green{
+	pixel_y = 17
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
 /area/ruin/space)
 "aq" = (
 /obj/structure/fluff/bus/passable/seat,
-/obj/item/food/meatball,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/helmet/knight{
+	pixel_y = 16
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
 /area/ruin/space)
 "ar" = (
 /obj/structure/fluff/bus/passable/seat,
-/obj/item/food/grown/cherry_bomb,
+/obj/item/food/grown/watermelon{
+	pixel_y = 17
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
@@ -55,7 +71,15 @@
 "as" = (
 /obj/structure/fluff/bus/passable/seat/driver,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/food/grown/citrus/orange,
+/obj/item/toy/plush/moth{
+	pixel_y = 28
+	},
+/obj/item/food/grown/citrus/orange{
+	pixel_y = 19
+	},
+/obj/item/toy/talking/ai{
+	pixel_y = 16
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
@@ -117,7 +141,9 @@
 "aU" = (
 /obj/structure/fluff/bus/passable/seat,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/food/meatball,
+/obj/item/bodypart/arm/right{
+	pixel_y = 14
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
@@ -132,27 +158,33 @@
 "aW" = (
 /obj/structure/fluff/bus/passable/seat/driver,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/banhammer{
+	pixel_y = 22
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
 /area/ruin/space)
 "aZ" = (
 /obj/structure/fluff/bus/passable,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/food/meatball,
+/obj/structure/sacrificealtar,
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
 /area/ruin/space)
 "ba" = (
-/obj/structure/fluff/bus/passable,
-/obj/item/banhammer,
+/obj/structure/fluff/bus/passable/seat,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/ants{
+	pixel_y = 8;
+	pixel_x = 9
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
 /area/ruin/space)
 "dI" = (
-/obj/item/food/meatball,
+/obj/item/toy/plush/awakenedplushie,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)
 "iE" = (
@@ -317,7 +349,13 @@
 "XA" = (
 /obj/structure/fluff/bus/passable/seat,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/toy/plush/awakenedplushie,
+/obj/item/toy/singlecard{
+	pixel_y = 25;
+	pixel_x = 0
+	},
+/obj/item/food/grown/potato{
+	pixel_y = 15
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
@@ -379,10 +417,10 @@ ab
 yY
 Bw
 yY
-dI
+yY
 Ne
-aU
-az
+am
+aZ
 ER
 yY
 yY
@@ -402,7 +440,7 @@ yY
 yY
 Ne
 am
-aZ
+ax
 Xj
 yY
 yY
@@ -422,7 +460,7 @@ Bw
 yY
 Ne
 aV
-ba
+az
 IQ
 yY
 yY
@@ -436,12 +474,12 @@ ab
 Gt
 yY
 Ne
-am
+ba
 ax
 ER
 yY
 Ne
-aU
+am
 az
 KK
 yY
@@ -576,10 +614,10 @@ ab
 Ds
 yY
 Ne
-am
+aU
 aD
 KK
-yY
+dI
 Wn
 yY
 yY
@@ -601,7 +639,7 @@ aE
 ud
 yY
 yY
-dI
+yY
 yY
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -26,17 +26,13 @@
 	},
 /area/ruin/space)
 "ao" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/telecomms/server{
 	pixel_y = 12;
 	layer = 2.91;
-	density = 0;
 	name = "tgsv3";
 	desc = "It's, uh... pending an upgrade."
 	},
-/turf/open/floor/iron/dark/airless{
-	icon_state = "bus"
-	},
+/turf/closed/mineral/ash_rock,
 /area/ruin/space)
 "ap" = (
 /obj/structure/fluff/bus/passable/seat{
@@ -271,6 +267,18 @@
 	},
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)
+"FZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/telecomms/server{
+	pixel_y = 12;
+	layer = 2.91;
+	name = "tgsv3";
+	desc = "It's, uh... pending an upgrade."
+	},
+/turf/open/floor/iron/dark/airless{
+	icon_state = "bus"
+	},
+/area/ruin/space)
 "Gf" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/suit/space,
@@ -474,7 +482,7 @@ ab
 Gt
 yY
 Ne
-ba
+FZ
 ax
 ER
 yY
@@ -534,7 +542,7 @@ ab
 ab
 yY
 Ne
-ao
+ba
 aA
 KK
 uO
@@ -735,7 +743,7 @@ ab
 ab
 ab
 ab
-ab
+ao
 yY
 yY
 yY

--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -57,6 +57,9 @@
 /area/ruin/space)
 "ar" = (
 /obj/structure/fluff/bus/passable/seat,
+/obj/item/grown/novaflower{
+	pixel_y = 25
+	},
 /obj/item/food/grown/watermelon{
 	pixel_y = 17
 	},
@@ -138,7 +141,11 @@
 /obj/structure/fluff/bus/passable/seat,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bodypart/arm/right{
-	pixel_y = 14
+	pixel_y = 26;
+	pixel_x = -4
+	},
+/obj/item/food/meat/slab/penguin{
+	pixel_y = 13
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -175,13 +182,16 @@
 	pixel_y = 8;
 	pixel_x = 9
 	},
+/obj/item/food/grown/tomato{
+	pixel_y = 25
+	},
+/obj/item/food/donut/plain{
+	pixel_y = 16;
+	pixel_x = 1
+	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
 	},
-/area/ruin/space)
-"dI" = (
-/obj/item/toy/plush/awakenedplushie,
-/turf/open/misc/asteroid/airless,
 /area/ruin/space)
 "iE" = (
 /obj/structure/table,
@@ -274,6 +284,9 @@
 	layer = 2.91;
 	name = "tgsv3";
 	desc = "It's, uh... pending an upgrade."
+	},
+/obj/item/toy/plush/awakenedplushie{
+	pixel_y = 27
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -625,7 +638,7 @@ Ne
 aU
 aD
 KK
-dI
+yY
 Wn
 yY
 yY

--- a/code/__DEFINES/toys.dm
+++ b/code/__DEFINES/toys.dm
@@ -5,3 +5,8 @@
 #define DICE_BASICALLY_RIGGED 2
 /// Dice has a 100% chance to land on a rigged value
 #define DICE_TOTALLY_RIGGED 3
+
+/// card is considered face down
+#define CARD_FACEDOWN 0
+/// card is considered face up
+#define CARD_FACEUP 1

--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -48,6 +48,9 @@
 		if(parent_deck.holodeck)
 			flags_1 |= HOLOGRAM_1
 			parent_deck.holodeck.spawned += src
+	if(mapload)
+		//maploaded card needs to be faceup anyways, and doing this will give it its name and appearance properly
+		Flip(TRUE)
 
 	register_context()
 

--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -24,7 +24,7 @@
 	/// The name of the card
 	var/cardname = "Ace of Spades"
 	/// Is the card flipped facedown (FALSE) or flipped faceup (TRUE)
-	var/flipped = FALSE
+	var/flipped = CARD_FACEDOWN
 	/// The card is blank and can be written on with a pen.
 	var/blank = FALSE
 	/// The color used to mark a card for cheating (by pens or crayons)
@@ -50,7 +50,7 @@
 			parent_deck.holodeck.spawned += src
 	if(mapload)
 		//maploaded card needs to be faceup anyways, and doing this will give it its name and appearance properly
-		Flip(TRUE)
+		Flip(CARD_FACEUP)
 
 	register_context()
 
@@ -112,11 +112,11 @@
  * Flips the card over
  *
  * * Arguments:
- * * orientation (optional) - Sets flipped state to CARD_FACEDOWN or CARD_FACEUP if given orientation (otherwise just invert the flipped state)
+ * * is_face_up (optional) - Sets flipped state to CARD_FACEDOWN or CARD_FACEUP if given (otherwise just invert the flipped state)
  */
-/obj/item/toy/singlecard/proc/Flip(orientation)
-	if(!isnull(orientation))
-		flipped = orientation
+/obj/item/toy/singlecard/proc/Flip(is_face_up)
+	if(!isnull(is_face_up))
+		flipped = is_face_up
 	else
 		flipped = !flipped
 

--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -1,6 +1,3 @@
-#define CARD_FACEDOWN 0
-#define CARD_FACEUP 1
-
 /obj/item/toy/singlecard
 	name = "card"
 	desc = "A playing card used to play card games like poker."


### PR DESCRIPTION

## About The Pull Request

Updates the people inside the coderbus and adminbus. Removes the meatballs, because... well, they used to be called something that actually accurately describes the admin team but now they're just meatballs. The banhammer now takes the driver seat of adminbus, with a sacrificial altar in the back. RIP to all the good players lost when they became admin

## Why It's Good For The Game

It was really out of date lol

## Changelog
:cl:
add: Updated the bus ruin
/:cl:
