### PR TITLE
Make glass and bone knives not conduct electricity and shocks from grille

### DIFF
--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -150,7 +150,7 @@
 
 /obj/item/knife/combat/bone/Initialize(mapload)
 	flags_1 &= ~CONDUCT_1
-	. = ..()
+	return ..()
 
 /obj/item/knife/combat/cyborg
 	name = "cyborg knife"

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -177,7 +177,6 @@
 	flags_1 &= ~CONDUCT_1
 	return ..()
 
-
 /obj/item/knife/shiv/plasma
 	name = "plasma shiv"
 	icon_state = "plasmashiv"

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -175,7 +175,7 @@
 
 /obj/item/knife/shiv/Initialize(mapload)
 	flags_1 &= ~CONDUCT_1
-	. = ..()
+	return ..()
 
 
 /obj/item/knife/shiv/plasma

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -148,6 +148,10 @@
 	throwforce = 15
 	custom_materials = null
 
+/obj/item/knife/combat/bone/Initialize(mapload)
+	flags_1 &= ~CONDUCT_1
+	. = ..()
+
 /obj/item/knife/combat/cyborg
 	name = "cyborg knife"
 	icon = 'icons/obj/items_cyborg.dmi'
@@ -168,6 +172,11 @@
 	attack_verb_simple = list("shank", "shiv")
 	armor_type = /datum/armor/none
 	custom_materials = list(/datum/material/glass=400)
+
+/obj/item/knife/shiv/Initialize(mapload)
+	flags_1 &= ~CONDUCT_1
+	. = ..()
+
 
 /obj/item/knife/shiv/plasma
 	name = "plasma shiv"


### PR DESCRIPTION
## About The Pull Request
Just making shivs more consistent with what is expected. It's weird when glass shard allows you to smash grille connected to power while shivs made out of glass dont. Extended to bone knives for the same reason.
## Why It's Good For The Game
Immersium
## Changelog
:cl: Remuluson2
fix: After pressure from Nanotrasen, Space Wizard Federation made glass and bone knives non-conductive again.
/:cl:
