### PR TITLE
You can't teleport easter prizes with your brain

### DIFF
--- a/code/modules/events/holiday/easter.dm
+++ b/code/modules/events/holiday/easter.dm
@@ -128,7 +128,7 @@
 /obj/item/surprise_egg/attack_self(mob/user)
 	..()
 	to_chat(user, span_notice("You unwrap [src] and find a prize inside!"))
-	dispensePrize(get_turf(user))
+	dispensePrize(get_turf(src))
 	qdel(src)
 
 //Easter Recipes + food


### PR DESCRIPTION
## About The Pull Request

Fixes #69258
I assume nobody else tackled this because it was _too_ simple and they assumed someone else would. 
Opening a kinder egg will now deposit its contents in the _egg's_ turf, which has the same result as it did before for using it in your actual hand, and no longer teleports objects if done via telekinesis.

## Why It's Good For The Game

Minor consistency issue.

## Changelog

:cl:
fix: Opening a surprise egg with your mind will no longer teleport the contents
/:cl:
