### PR TITLE
Faction defines

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -220,9 +220,6 @@ GLOBAL_LIST_INIT(ai_employers, list(
 /// Checks if the given mob is either a heretic or a heretic monster.
 #define IS_HERETIC_OR_MONSTER(mob) (IS_HERETIC(mob) || IS_HERETIC_MONSTER(mob))
 
-/// Define for the heretic faction applied to heretics and heretic mobs.
-#define FACTION_HERETIC "heretics"
-
 /// Checks if the given mob is a wizard
 #define IS_WIZARD(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/wizard))
 

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -195,11 +195,6 @@ GLOBAL_LIST_INIT(ai_employers, list(
 	"Unshackled",
 ))
 
-///all the employers that are syndicate
-#define FACTION_SYNDICATE "syndicate"
-///all the employers that are nanotrasen
-#define FACTION_NANOTRASEN "nanotrasen"
-
 #define UPLINK_THEME_SYNDICATE "syndicate"
 
 #define UPLINK_THEME_UNDERWORLD_MARKET "neutral"

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -18,6 +18,8 @@
 #define FACTION_MINING "mining"
 /// Rats and mice
 #define FACTION_RAT "Rats"
+/// Slimey creatures
+#define FACTION_SLIME "slime"
 
 // Antagonist factions
 

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -22,8 +22,12 @@
 #define FACTION_RAT "Rats"
 /// Slimey creatures
 #define FACTION_SLIME "slime"
+/// Creatures affiliated with the AI and Cyborgs
+#define FACTION_SILICON "silicon"
 /// Spiders and their webs
 #define FACTION_SPIDER "spiders"
+/// Creatures ignored by various turrets
+#define FACTION_TURRET "turret"
 
 // Antagonist factions
 

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -7,3 +7,6 @@
 #define FACTION_MAINT_CREATURES "Maint_Creatures"
 
 #define FACTION_NEUTRAL "neutral"
+
+/// Define for the heretic faction applied to heretics and heretic mobs.
+#define FACTION_HERETIC "heretics"

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -6,6 +6,8 @@
 #define FACTION_ASHWALKER "ashwalker"
 /// Megafauna bosses of mining
 #define FACTION_BOSS "boss"
+/// CARPS
+#define FACTION_CARP "carp"
 /// Clown creatures and the Clown themselves
 #define FACTION_CLOWN "Clowns"
 /// Slaughterdemons

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -14,6 +14,8 @@
 #define FACTION_HELL "hell"
 /// Maint creatures have mutual respect for eachother.
 #define FACTION_MAINT_CREATURES "Maint_Creatures"
+/// Animated objects and statues
+#define FACTION_MIMIC "mimic"
 /// Beasts found on the various mining environments
 #define FACTION_MINING "mining"
 /// Rats and mice

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -3,12 +3,20 @@
 
 // Creature factions
 
+/// Ashwalker related creatures
+#define FACTION_ASHWALKER "ashwalker"
+/// Megafauna bosses of mining
+#define FACTION_BOSS "boss"
 /// Clown creatures and the Clown themselves
 #define FACTION_CLOWN "Clowns"
+/// Slaughterdemons
+#define FACTION_HELL "hell"
 /// Define for the heretic faction applied to heretics and heretic mobs.
 #define FACTION_HERETIC "heretics"
 /// Maint creatures have mutual respect for eachother.
 #define FACTION_MAINT_CREATURES "Maint_Creatures"
+/// Beasts found on the various mining environments
+#define FACTION_MINING "mining"
 /// Rats and mice
 #define FACTION_RAT "Rats"
 

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -33,6 +33,8 @@
 #define FACTION_HIVEBOT "hivebot"
 /// Illusionary creaturs
 #define FACTION_ILLUSION "illusion"
+/// Creatures of the never finished jungle planet, and gorillas
+#define FACTION_JUNGLE "jungle"
 /// Small lizards
 #define FACTION_LIZARD "Lizard"
 /// Maint creatures have mutual respect for eachother.
@@ -41,6 +43,8 @@
 #define FACTION_MIMIC "mimic"
 /// Beasts found on the various mining environments
 #define FACTION_MINING "mining"
+/// Monkeys and gorillas
+#define FACTION_MONKEY "monkey"
 /// Mushrooms and mushroompeople
 #define FACTION_MUSHROOM "mushroom"
 /// Mobs spawned by the emagged orion arcade

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -35,6 +35,8 @@
 #define FACTION_CULT "cult"
 /// Define for the heretic faction applied to heretics and heretic mobs.
 #define FACTION_HERETIC "heretics"
+/// Mainly used by pirate simplemobs. However I placed them here instead, as its also used by players
+#define FACTION_PIRATE "pirate"
 
 // Special factions
 

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -47,6 +47,8 @@
 #define FACTION_MONKEY "monkey"
 /// Mushrooms and mushroompeople
 #define FACTION_MUSHROOM "mushroom"
+/// Mobs from the Netherworld
+#define FACTION_NETHER "nether"
 /// Mobs spawned by the emagged orion arcade
 #define FACTION_ORION "orion"
 /// Penguins and their chicks
@@ -57,6 +59,8 @@
 #define FACTION_RAT "Rats"
 /// Creatures affiliated with the AI and Cyborgs
 #define FACTION_SILICON "silicon"
+/// Spooky scary skeletons
+#define FACTION_SKELETON "skeleton"
 /// Slimey creatures
 #define FACTION_SLIME "slime"
 /// Spiders and their webs

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -17,22 +17,38 @@
 #define FACTION_CARP "carp"
 /// Clown creatures and the Clown themselves
 #define FACTION_CLOWN "Clowns"
+/// Faithless and shadowpeople
+#define FACTION_FAITHLESS "faithless"
+/// Gnomes
+#define FACTION_GNOME "gnomes"
+/// Gondolas
+#define FACTION_GONDOLA "gondola"
 /// Slaughterdemons
 #define FACTION_HELL "hell"
+/// Small lizards
+#define FACTION_LIZARD "Lizard"
 /// Maint creatures have mutual respect for eachother.
 #define FACTION_MAINT_CREATURES "Maint_Creatures"
 /// Animated objects and statues
 #define FACTION_MIMIC "mimic"
 /// Beasts found on the various mining environments
 #define FACTION_MINING "mining"
+/// Mushrooms and mushroompeople
+#define FACTION_MUSHROOM "mushroom"
+/// Mobs spawned by the emagged orion arcade
+#define FACTION_ORION "orion"
+/// Penguins and their chicks
+#define FACTION_PENGUIN "penguin"
 /// Plants, lots of overlap with vines
 #define FACTION_PLANTS "plants"
 /// Rats and mice
 #define FACTION_RAT "Rats"
-/// Slimey creatures
-#define FACTION_SLIME "slime"
 /// Creatures affiliated with the AI and Cyborgs
 #define FACTION_SILICON "silicon"
+/// Slimey creatures
+#define FACTION_SLIME "slime"
+/// Currently used only by floating eyeballs
+#define FACTION_SPOOKY "spooky"
 /// Spiders and their webs
 #define FACTION_SPIDER "spiders"
 /// Creatures ignored by various turrets

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -40,6 +40,6 @@
 
 // Special factions
 
-/// Creatures with this faction will not attack until attacked
+/// Acts as a default faction for most peaceful creatures
 #define FACTION_NEUTRAL "neutral"
 

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -25,6 +25,8 @@
 
 // Antagonist factions
 
+/// Cultists and their constructs
+#define FACTION_CULT "cult"
 /// Define for the heretic faction applied to heretics and heretic mobs.
 #define FACTION_HERETIC "heretics"
 

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -47,6 +47,8 @@
 #define FACTION_MONKEY "monkey"
 /// Mushrooms and mushroompeople
 #define FACTION_MUSHROOM "mushroom"
+/// Nanotrasen private security
+#define FACTION_NANOTRASEN_PRIVATE "nanotrasenprivate"
 /// Mobs from the Netherworld
 #define FACTION_NETHER "nether"
 /// Mobs spawned by the emagged orion arcade
@@ -57,6 +59,8 @@
 #define FACTION_PLANTS "plants"
 /// Rats and mice
 #define FACTION_RAT "Rats"
+/// Creatures from Space Russia
+#define FACTION_RUSSIAN "russian"
 /// Creatures affiliated with the AI and Cyborgs
 #define FACTION_SILICON "silicon"
 /// Spooky scary skeletons

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -1,12 +1,19 @@
 /// If this seems rather...bare at the moment, its temporary.
 /// Later all mob factions will be moved here and their current factions replaced with faction defines.
 
+// Creature factions
+
+/// Clown creatures and the Clown themselves
 #define FACTION_CLOWN "Clowns"
-#define FACTION_RAT "Rats"
-// Maint creatures have mutual respect for eachother.
-#define FACTION_MAINT_CREATURES "Maint_Creatures"
-
-#define FACTION_NEUTRAL "neutral"
-
 /// Define for the heretic faction applied to heretics and heretic mobs.
 #define FACTION_HERETIC "heretics"
+/// Maint creatures have mutual respect for eachother.
+#define FACTION_MAINT_CREATURES "Maint_Creatures"
+/// Rats and mice
+#define FACTION_RAT "Rats"
+
+// Special factions
+
+/// Creatures with this faction will not attack until attacked
+#define FACTION_NEUTRAL "neutral"
+

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -1,5 +1,12 @@
 // Contains mob factions that are not handled by special role defines (for example, viscerators having ROLE_SYNDICATE)
 
+// Default factions
+
+/// Acts as a default faction for most violent creatures
+#define FACTION_HOSTILE "hostile"
+/// Acts as a default faction for most peaceful creatures
+#define FACTION_NEUTRAL "neutral"
+
 // Creature factions
 
 /// Ashwalker related creatures
@@ -37,9 +44,3 @@
 #define FACTION_HERETIC "heretics"
 /// Mainly used by pirate simplemobs. However I placed them here instead, as its also used by players
 #define FACTION_PIRATE "pirate"
-
-// Special factions
-
-/// Acts as a default faction for most peaceful creatures
-#define FACTION_NEUTRAL "neutral"
-

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -71,6 +71,8 @@
 #define FACTION_SPIDER "spiders"
 /// Currently used only by floating eyeballs
 #define FACTION_SPOOKY "spooky"
+/// Statues that move around when nobody is watching them
+#define FACTION_STATUE "statue"
 /// Stick creatures summoned by the Paperwizard, and the wizard themselves
 #define FACTION_STICKMAN "stickman"
 /// Creatures ignored by various turrets

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -25,6 +25,8 @@
 #define FACTION_MIMIC "mimic"
 /// Beasts found on the various mining environments
 #define FACTION_MINING "mining"
+/// Plants, lots of overlap with vines
+#define FACTION_PLANTS "plants"
 /// Rats and mice
 #define FACTION_RAT "Rats"
 /// Slimey creatures
@@ -35,6 +37,8 @@
 #define FACTION_SPIDER "spiders"
 /// Creatures ignored by various turrets
 #define FACTION_TURRET "turret"
+/// Vines, lots of overlap with plants
+#define FACTION_VINES "vines"
 
 // Antagonist factions
 

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -15,8 +15,12 @@
 #define FACTION_BOSS "boss"
 /// CARPS
 #define FACTION_CARP "carp"
+/// Creatures summoned by chemical reactions
+#define FACTION_CHEMICAL_SUMMON "chemicalsummon"
 /// Clown creatures and the Clown themselves
 #define FACTION_CLOWN "Clowns"
+/// Headslugs
+#define FACTION_CREATURE "creature"
 /// Faithless and shadowpeople
 #define FACTION_FAITHLESS "faithless"
 /// Gnomes
@@ -25,6 +29,10 @@
 #define FACTION_GONDOLA "gondola"
 /// Slaughterdemons
 #define FACTION_HELL "hell"
+/// Hivebots
+#define FACTION_HIVEBOT "hivebot"
+/// Illusionary creaturs
+#define FACTION_ILLUSION "illusion"
 /// Small lizards
 #define FACTION_LIZARD "Lizard"
 /// Maint creatures have mutual respect for eachother.
@@ -47,10 +55,12 @@
 #define FACTION_SILICON "silicon"
 /// Slimey creatures
 #define FACTION_SLIME "slime"
-/// Currently used only by floating eyeballs
-#define FACTION_SPOOKY "spooky"
 /// Spiders and their webs
 #define FACTION_SPIDER "spiders"
+/// Currently used only by floating eyeballs
+#define FACTION_SPOOKY "spooky"
+/// Stick creatures summoned by the Paperwizard, and the wizard themselves
+#define FACTION_STICKMAN "stickman"
 /// Creatures ignored by various turrets
 #define FACTION_TURRET "turret"
 /// Vines, lots of overlap with plants

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -1,5 +1,4 @@
-/// If this seems rather...bare at the moment, its temporary.
-/// Later all mob factions will be moved here and their current factions replaced with faction defines.
+// Contains mob factions that are not handled by special role defines (for example, viscerators having ROLE_SYNDICATE)
 
 // Creature factions
 
@@ -11,14 +10,17 @@
 #define FACTION_CLOWN "Clowns"
 /// Slaughterdemons
 #define FACTION_HELL "hell"
-/// Define for the heretic faction applied to heretics and heretic mobs.
-#define FACTION_HERETIC "heretics"
 /// Maint creatures have mutual respect for eachother.
 #define FACTION_MAINT_CREATURES "Maint_Creatures"
 /// Beasts found on the various mining environments
 #define FACTION_MINING "mining"
 /// Rats and mice
 #define FACTION_RAT "Rats"
+
+// Antagonist factions
+
+/// Define for the heretic faction applied to heretics and heretic mobs.
+#define FACTION_HERETIC "heretics"
 
 // Special factions
 

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -16,9 +16,9 @@
 /// CARPS
 #define FACTION_CARP "carp"
 /// Creatures summoned by chemical reactions
-#define FACTION_CHEMICAL_SUMMON "chemicalsummon"
+#define FACTION_CHEMICAL_SUMMON "chemical_summon"
 /// Clown creatures and the Clown themselves
-#define FACTION_CLOWN "Clowns"
+#define FACTION_CLOWN "clowns"
 /// Headslugs
 #define FACTION_CREATURE "creature"
 /// Faithless and shadowpeople
@@ -36,9 +36,9 @@
 /// Creatures of the never finished jungle planet, and gorillas
 #define FACTION_JUNGLE "jungle"
 /// Small lizards
-#define FACTION_LIZARD "Lizard"
+#define FACTION_LIZARD "lizard"
 /// Maint creatures have mutual respect for eachother.
-#define FACTION_MAINT_CREATURES "Maint_Creatures"
+#define FACTION_MAINT_CREATURES "maint_creatures"
 /// Animated objects and statues
 #define FACTION_MIMIC "mimic"
 /// Beasts found on the various mining environments
@@ -48,7 +48,7 @@
 /// Mushrooms and mushroompeople
 #define FACTION_MUSHROOM "mushroom"
 /// Nanotrasen private security
-#define FACTION_NANOTRASEN_PRIVATE "nanotrasenprivate"
+#define FACTION_NANOTRASEN_PRIVATE "nanotrasen_private"
 /// Mobs from the Netherworld
 #define FACTION_NETHER "nether"
 /// Mobs spawned by the emagged orion arcade
@@ -58,7 +58,7 @@
 /// Plants, lots of overlap with vines
 #define FACTION_PLANTS "plants"
 /// Rats and mice
-#define FACTION_RAT "Rats"
+#define FACTION_RAT "rats"
 /// Creatures from Space Russia
 #define FACTION_RUSSIAN "russian"
 /// Creatures affiliated with the AI and Cyborgs

--- a/code/__DEFINES/mobfactions.dm
+++ b/code/__DEFINES/mobfactions.dm
@@ -20,6 +20,8 @@
 #define FACTION_RAT "Rats"
 /// Slimey creatures
 #define FACTION_SLIME "slime"
+/// Spiders and their webs
+#define FACTION_SPIDER "spiders"
 
 // Antagonist factions
 

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -14,7 +14,7 @@
 	/// Time until we next spawn
 	COOLDOWN_DECLARE(spawn_delay)
 
-/datum/component/spawner/Initialize(mob_types = list(), spawn_time = 30 SECONDS, max_mobs = 5, faction = list("mining"), spawn_text = "emerges from")
+/datum/component/spawner/Initialize(mob_types = list(), spawn_time = 30 SECONDS, max_mobs = 5, faction = list(FACTION_MINING), spawn_text = "emerges from")
 	if (!length(mob_types))
 		CRASH("No types of mob to spawn specified for spawner component!")
 	src.spawn_time = spawn_time

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -17,14 +17,14 @@
 	ADD_TRAIT(target, TRAIT_HARDLY_WOUNDED, SLEEPING_CARP_TRAIT)
 	ADD_TRAIT(target, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
 	RegisterSignal(target, COMSIG_PARENT_ATTACKBY, PROC_REF(on_attackby))
-	target.faction |= "carp" //:D
+	target.faction |= FACTION_CARP //:D
 
 /datum/martial_art/the_sleeping_carp/on_remove(mob/living/target)
 	REMOVE_TRAIT(target, TRAIT_NOGUNS, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(target, TRAIT_HARDLY_WOUNDED, SLEEPING_CARP_TRAIT)
 	REMOVE_TRAIT(target, TRAIT_NODISMEMBER, SLEEPING_CARP_TRAIT)
 	UnregisterSignal(target, COMSIG_PARENT_ATTACKBY)
-	target.faction -= "carp" //:(
+	target.faction -= FACTION_CARP //:(
 	. = ..()
 
 /datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/A, mob/living/D)

--- a/code/game/machinery/computer/arcade/orion.dm
+++ b/code/game/machinery/computer/arcade/orion.dm
@@ -500,7 +500,7 @@ GLOBAL_LIST_INIT(orion_events, generate_orion_events())
 /mob/living/basic/syndicate/ranged/smg/orion
 	name = "spaceport security"
 	desc = "Premier corporate security forces for all spaceports found along the Orion Trail."
-	faction = list("orion")
+	faction = list(FACTION_ORION)
 	loot = list()
 
 /obj/item/orion_ship

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -124,7 +124,7 @@
 
 /obj/item/goliath_infuser_hammer/attack(mob/living/target, mob/living/carbon/human/user)
 	// Check for nemesis factions on the target.
-	if(!("mining" in target.faction) && !("boss" in target.faction))
+	if(!(FACTION_MINING in target.faction) && !(FACTION_BOSS in target.faction))
 		// Target is not a nemesis, so attack normally.
 		return ..()
 	// Apply nemesis-specific effects.

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -90,7 +90,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	/// Determines if our projectiles hit our faction
 	var/ignore_faction = FALSE
 	/// Same faction mobs will never be shot at, no matter the other settings
-	var/list/faction = list("turret")
+	var/list/faction = list(FACTION_TURRET)
 	/// The spark system, used for generating... sparks?
 	var/datum/effect_system/spark_spread/spark_system
 	/// The turret will try to shoot from a turf in that direction when in a wall
@@ -774,7 +774,7 @@ DEFINE_BITFIELD(turret_flags, list(
 /obj/machinery/porta_turret/syndicate/energy/raven
 	stun_projectile = /obj/projectile/beam/laser
 	stun_projectile_sound = 'sound/weapons/laser.ogg'
-	faction = list(FACTION_NEUTRAL,"silicon","turret")
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET)
 
 /obj/machinery/porta_turret/syndicate/pod
 	integrity_failure = 0.5
@@ -810,7 +810,7 @@ DEFINE_BITFIELD(turret_flags, list(
 		return TRUE
 
 /obj/machinery/porta_turret/ai
-	faction = list("silicon")
+	faction = list(FACTION_SILICON)
 	turret_flags = TURRET_FLAG_SHOOT_CRIMINALS | TURRET_FLAG_SHOOT_ANOMALOUS | TURRET_FLAG_SHOOT_HEADS
 
 /obj/machinery/porta_turret/ai/assess_perp(mob/living/carbon/human/perp)
@@ -824,7 +824,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	lethal_projectile = /obj/projectile/plasma/turret
 	lethal_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	mode = TURRET_LETHAL //It would be useless in stun mode anyway
-	faction = list(FACTION_NEUTRAL,"silicon","turret") //Minebots, medibots, etc that should not be shot.
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET) //Minebots, medibots, etc that should not be shot.
 
 /obj/machinery/porta_turret/aux_base/assess_perp(mob/living/carbon/human/perp)
 	return 0 //Never shoot humanoids. You are on your own if Ashwalkers or the like attack!
@@ -853,7 +853,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	stun_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	icon_state = "syndie_off"
 	base_icon_state = "syndie"
-	faction = list(FACTION_NEUTRAL,"silicon","turret")
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET)
 	mode = TURRET_LETHAL
 
 /obj/machinery/porta_turret/centcom_shuttle/Initialize(mapload)
@@ -873,7 +873,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	desc = "A turret built with substandard parts and run down further with age. Still capable of delivering lethal lasers to the odd space carp, but not much else."
 	stun_projectile = /obj/projectile/beam/weak/penetrator
 	lethal_projectile = /obj/projectile/beam/weak/penetrator
-	faction = list(FACTION_NEUTRAL,"silicon","turret")
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET)
 
 ////////////////////////
 //Turret Control Panel//

--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -113,7 +113,7 @@
 	var/obj/machinery/atmospherics/components/unary/vent_pump/entry_vent
 	var/travelling_in_vent = 0
 	var/directive = "" //Message from the mother
-	var/list/faction = list("spiders")
+	var/list/faction = list(FACTION_SPIDER)
 
 /obj/structure/spider/spiderling/Destroy()
 	new/obj/item/food/spiderling(get_turf(src))

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -488,7 +488,7 @@
 
 /obj/item/nullrod/carp/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/faction_granter, "carp", holy_role_required = HOLY_ROLE_PRIEST, grant_message = span_boldnotice("You are blessed by Carp-Sie. Wild space carp will no longer attack you."))
+	AddComponent(/datum/component/faction_granter, FACTION_CARP, holy_role_required = HOLY_ROLE_PRIEST, grant_message = span_boldnotice("You are blessed by Carp-Sie. Wild space carp will no longer attack you."))
 
 /obj/item/nullrod/claymore/bostaff //May as well make it a "claymore" and inherit the blocking
 	name = "monk's staff"

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	desc = "A hole in the ground, filled with monsters ready to defend it."
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	icon_state = "hole"
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	max_mobs = 3
 	max_integrity = 250
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/wolf)

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	icon_state = "tendril"
 
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	max_mobs = 3
 	max_integrity = 250
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril)

--- a/code/game/objects/structures/petrified_statue.dm
+++ b/code/game/objects/structures/petrified_statue.dm
@@ -19,7 +19,7 @@
 		L.visible_message(span_warning("[L]'s skin rapidly turns to marble!"), span_userdanger("Your body freezes up! Can't... move... can't... think..."))
 		L.forceMove(src)
 		ADD_TRAIT(L, TRAIT_MUTE, STATUE_MUTE)
-		L.faction += FACTION_MIMIC //Stops mimics from instaqdeling people in statues
+		L.faction |= FACTION_MIMIC //Stops mimics from instaqdeling people in statues
 		L.status_flags |= GODMODE
 		atom_integrity = L.health + 100 //stoning damaged mobs will result in easier to shatter statues
 		max_integrity = atom_integrity

--- a/code/game/objects/structures/petrified_statue.dm
+++ b/code/game/objects/structures/petrified_statue.dm
@@ -19,7 +19,7 @@
 		L.visible_message(span_warning("[L]'s skin rapidly turns to marble!"), span_userdanger("Your body freezes up! Can't... move... can't... think..."))
 		L.forceMove(src)
 		ADD_TRAIT(L, TRAIT_MUTE, STATUE_MUTE)
-		L.faction += "mimic" //Stops mimics from instaqdeling people in statues
+		L.faction += FACTION_MIMIC //Stops mimics from instaqdeling people in statues
 		L.status_flags |= GODMODE
 		atom_integrity = L.health + 100 //stoning damaged mobs will result in easier to shatter statues
 		max_integrity = atom_integrity
@@ -62,7 +62,7 @@
 		REMOVE_TRAIT(petrified_mob, TRAIT_MUTE, STATUE_MUTE)
 		REMOVE_TRAIT(petrified_mob, TRAIT_NOBLOOD, MAGIC_TRAIT)
 		petrified_mob.take_overall_damage((petrified_mob.health - atom_integrity + 100)) //any new damage the statue incurred is transfered to the mob
-		petrified_mob.faction -= "mimic"
+		petrified_mob.faction -= FACTION_MIMIC
 		petrified_mob = null
 	return ..()
 

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -55,7 +55,7 @@
 	spawn_time = 15 SECONDS
 	mob_types = list(/mob/living/simple_animal/hostile/retaliate/clown, /mob/living/simple_animal/hostile/retaliate/clown/fleshclown, /mob/living/simple_animal/hostile/retaliate/clown/clownhulk, /mob/living/simple_animal/hostile/retaliate/clown/longface, /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown, /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus, /mob/living/simple_animal/hostile/retaliate/clown/mutant/glutton, /mob/living/simple_animal/hostile/retaliate/clown/banana, /mob/living/simple_animal/hostile/retaliate/clown/honkling, /mob/living/simple_animal/hostile/retaliate/clown/lube)
 	spawn_text = "climbs out of"
-	faction = list("clown")
+	faction = list(FACTION_CLOWN)
 
 /obj/structure/spawner/mining
 	name = "monster den"

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -66,7 +66,7 @@
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	spawn_text = "crawls out of"
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/goldgrub, /mob/living/simple_animal/hostile/asteroid/goliath, /mob/living/simple_animal/hostile/asteroid/hivelord, /mob/living/simple_animal/hostile/asteroid/basilisk, /mob/living/basic/wumborian_fugu)
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 
 /obj/structure/spawner/mining/goldgrub
 	name = "goldgrub den"

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -43,7 +43,7 @@
 	spawn_time = 15 SECONDS
 	mob_types = list(/mob/living/simple_animal/hostile/skeleton)
 	spawn_text = "climbs out of"
-	faction = list("skeleton")
+	faction = list(FACTION_SKELETON)
 
 /obj/structure/spawner/clown
 	name = "Laughing Larry"
@@ -103,7 +103,7 @@
 	icon = 'icons/mob/simple/lavaland/nest.dmi'
 	spawn_text = "crawls through"
 	mob_types = list(/mob/living/basic/migo, /mob/living/basic/creature, /mob/living/basic/blankbody)
-	faction = list("nether")
+	faction = list(FACTION_NETHER)
 
 /obj/structure/spawner/nether/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -12,7 +12,7 @@
 	var/spawn_time = 30 SECONDS
 	var/mob_types = list(/mob/living/basic/carp)
 	var/spawn_text = "emerges from"
-	var/faction = list("hostile")
+	var/faction = list(FACTION_HOSTILE)
 	var/spawner_type = /datum/component/spawner
 
 /obj/structure/spawner/Initialize(mapload)

--- a/code/modules/antagonists/abductor/equipment/glands/slime.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/slime.dm
@@ -9,11 +9,11 @@
 
 /obj/item/organ/internal/heart/gland/slime/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = TRUE)
 	..()
-	owner.faction |= "slime"
+	owner.faction |= FACTION_SLIME
 	owner.grant_language(/datum/language/slime, TRUE, TRUE, LANGUAGE_GLAND)
 
 /obj/item/organ/internal/heart/gland/slime/Remove(mob/living/carbon/M, special = FALSE)
-	owner.faction -= "slime"
+	owner.faction -= FACTION_SLIME
 	owner.remove_language(/datum/language/slime, TRUE, TRUE, LANGUAGE_GLAND)
 	..()
 

--- a/code/modules/antagonists/abductor/equipment/glands/spider.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/spider.dm
@@ -9,6 +9,6 @@
 
 /obj/item/organ/internal/heart/gland/spiderman/activate()
 	to_chat(owner, span_warning("You feel something crawling in your skin."))
-	owner.faction |= "spiders"
+	owner.faction |= FACTION_SPIDER
 	var/obj/structure/spider/spiderling/S = new(owner.drop_location())
 	S.directive = "Protect your nest inside [owner.real_name]."

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -135,7 +135,7 @@
 	if(mob_override)
 		current = mob_override
 	handle_clown_mutation(current, mob_override ? null : "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
-	current.faction |= "cult"
+	current.faction |= FACTION_CULT
 	current.grant_language(/datum/language/narsie, TRUE, TRUE, LANGUAGE_CULTIST)
 	if(!cult_team.cult_master)
 		vote.Grant(current)
@@ -156,7 +156,7 @@
 	if(mob_override)
 		current = mob_override
 	handle_clown_mutation(current, removing = FALSE)
-	current.faction -= "cult"
+	current.faction -= FACTION_CULT
 	current.remove_language(/datum/language/narsie, TRUE, TRUE, LANGUAGE_CULTIST)
 	vote.Remove(current)
 	communion.Remove(current)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -987,7 +987,7 @@ Striking a noncultist, however, will tear their flesh."}
 				addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/shield/mirror, readd)), 450)
 				if(prob(60))
 					var/mob/living/simple_animal/hostile/illusion/M = new(owner.loc)
-					M.faction = list("cult")
+					M.faction = list(FACTION_CULT)
 					M.Copy_Parent(owner, 70, 10, 5)
 					M.move_to_delay = owner.cached_multiplicative_slowdown
 				else
@@ -1000,7 +1000,7 @@ Striking a noncultist, however, will tear their flesh."}
 		if(prob(50))
 			var/mob/living/simple_animal/hostile/illusion/H = new(owner.loc)
 			H.Copy_Parent(owner, 100, 20, 5)
-			H.faction = list("cult")
+			H.faction = list(FACTION_CULT)
 			H.GiveTarget(owner)
 			H.move_to_delay = owner.cached_multiplicative_slowdown
 			to_chat(owner, span_danger("<b>[src] betrays you!</b>"))

--- a/code/modules/antagonists/pirate/pirate_outfits.dm
+++ b/code/modules/antagonists/pirate/pirate_outfits.dm
@@ -11,7 +11,7 @@
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 
 /datum/outfit/pirate/post_equip(mob/living/carbon/human/equipped)
-	equipped.faction |= "pirate"
+	equipped.faction |= FACTION_PIRATE
 
 	var/obj/item/radio/outfit_radio = equipped.ears
 	if(outfit_radio)

--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -371,7 +371,7 @@
 	var/mob/living/carbon/human/H = AM
 	if(H.stat != CONSCIOUS || !H.mind) //mint condition only
 		return 0
-	else if("pirate" in H.faction) //can't ransom your fellow pirates to CentCom!
+	else if(FACTION_PIRATE in H.faction) //can't ransom your fellow pirates to CentCom!
 		return 0
 	else if(H.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
 		return 3000

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -45,14 +45,14 @@
 	. = ..()
 	rift_ability = new
 	rift_ability.Grant(owner.current)
-	owner.current.faction |= "carp"
+	owner.current.faction |= FACTION_CARP
 	RegisterSignal(owner.current, COMSIG_LIVING_LIFE, PROC_REF(rift_checks))
 	RegisterSignal(owner.current, COMSIG_LIVING_DEATH, PROC_REF(destroy_rifts))
 
 /datum/antagonist/space_dragon/on_removal()
 	. = ..()
 	rift_ability.Remove(owner.current)
-	owner.current.faction -= "carp"
+	owner.current.faction -= FACTION_CARP
 	UnregisterSignal(owner.current, COMSIG_LIVING_LIFE)
 	UnregisterSignal(owner.current, COMSIG_LIVING_DEATH)
 	rift_list = null

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -1,3 +1,8 @@
+///all the employers that are syndicate
+#define FLAVOR_FACTION_SYNDICATE "syndicate"
+///all the employers that are nanotrasen
+#define FLAVOR_FACTION_NANOTRASEN "nanotrasen"
+
 /datum/antagonist/traitor
 	name = "\improper Traitor"
 	roundend_category = "traitors"
@@ -135,15 +140,15 @@
 	return ..()
 
 /datum/antagonist/traitor/proc/pick_employer()
-	var/faction = prob(75) ? FACTION_SYNDICATE : FACTION_NANOTRASEN
+	var/faction = prob(75) ? FLAVOR_FACTION_SYNDICATE : FLAVOR_FACTION_NANOTRASEN
 	var/list/possible_employers = list()
 
 	possible_employers.Add(GLOB.syndicate_employers, GLOB.nanotrasen_employers)
 
 	switch(faction)
-		if(FACTION_SYNDICATE)
+		if(FLAVOR_FACTION_SYNDICATE)
 			possible_employers -= GLOB.nanotrasen_employers
-		if(FACTION_NANOTRASEN)
+		if(FLAVOR_FACTION_NANOTRASEN)
 			possible_employers -= GLOB.syndicate_employers
 	employer = pick(possible_employers)
 	traitor_flavor = strings(TRAITOR_FLAVOR_FILE, employer)
@@ -300,3 +305,5 @@
 
 		H.update_held_items()
 
+#undef FLAVOR_FACTION_SYNDICATE
+#undef FLAVOR_FACTION_NANOTRASEN

--- a/code/modules/cargo/gondolapod.dm
+++ b/code/modules/cargo/gondolapod.dm
@@ -8,7 +8,7 @@
 	response_disarm_simple = "bop"
 	response_harm_continuous = "kicks"
 	response_harm_simple = "kick"
-	faction = list("gondola")
+	faction = list(FACTION_GONDOLA)
 	turns_per_move = 10
 	icon = 'icons/obj/supplypods.dmi'
 	icon_state = "gondola"

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -780,7 +780,7 @@
 /proc/isvineimmune(atom/target)
 	if(isliving(target))
 		var/mob/living/victim = target
-		if(("vines" in victim.faction) || ("plants" in victim.faction))
+		if((FACTION_VINES in victim.faction) || (FACTION_PLANTS in victim.faction))
 			return TRUE
 	return FALSE
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1125,7 +1125,7 @@
 	var/list/livingplants = list(/mob/living/simple_animal/hostile/tree, /mob/living/simple_animal/hostile/killertomato)
 	var/chosen = pick(livingplants)
 	var/mob/living/simple_animal/hostile/C = new chosen(get_turf(src))
-	C.faction = list("plants")
+	C.faction = list(FACTION_PLANTS)
 
 ///////////////////////////////////////////////////////////////////////////////
 /obj/machinery/hydroponics/soil //Not actually hydroponics at all! Honk!

--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -14,7 +14,7 @@
 	max_integrity = 200
 
 
-	var/faction = list("ashwalker")
+	var/faction = list(FACTION_ASHWALKER)
 	var/meat_counter = 6
 	var/datum/team/ashwalkers/ashies
 	var/datum/linked_objective

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -655,4 +655,4 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	desc = "A ballistic machine gun auto-turret that fires bluespace bullets."
 	lethal_projectile = /obj/projectile/magic/teleport
 	stun_projectile = /obj/projectile/magic/teleport
-	faction = list("turret")
+	faction = list(FACTION_TURRET)

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -846,7 +846,7 @@
 	/// Whether the saw is open or not
 	var/is_open = FALSE
 	/// List of factions we deal bonus damage to
-	var/list/nemesis_factions = list("mining", "boss")
+	var/list/nemesis_factions = list(FACTION_MINING, FACTION_BOSS)
 	/// Amount of damage we deal to the above factions
 	var/faction_bonus_force = 30
 	/// Whether the cleaver is actively AoE swiping something.

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
@@ -7,7 +7,7 @@
 	icon_living = "moonicorn"
 	icon_dead = "moonicorn_dead"
 	icon_gib = null //otherwise does the regular cow gib animation
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	speed = 1
 	melee_damage_lower = 25
 	melee_damage_upper = 25

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -2,7 +2,7 @@
 /mob/living/basic/mining
 
 	combat_mode = TRUE
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0
 	maximum_survivable_temperature = INFINITY

--- a/code/modules/mob/living/basic/pets/dog.dm
+++ b/code/modules/mob/living/basic/pets/dog.dm
@@ -624,7 +624,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	icon_state = "narsian"
 	icon_living = "narsian"
 	icon_dead = "narsian_dead"
-	faction = list(FACTION_NEUTRAL, "cult")
+	faction = list(FACTION_NEUTRAL, FACTION_CULT)
 	gold_core_spawnable = NO_SPAWN
 	nofur = TRUE
 	unique_pet = TRUE

--- a/code/modules/mob/living/basic/ruin_defender/stickman.dm
+++ b/code/modules/mob/living/basic/ruin_defender/stickman.dm
@@ -15,7 +15,7 @@
 	melee_damage_upper = 10
 	attack_sound = 'sound/weapons/punch1.ogg'
 	combat_mode = TRUE
-	faction = list("stickman")
+	faction = list(FACTION_STICKMAN)
 	unsuitable_atmos_damage = 7.5
 	unsuitable_cold_damage = 7.5
 	unsuitable_heat_damage = 7.5

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -36,7 +36,7 @@
 	response_help_simple = "pet"
 	response_disarm_continuous = "gently pushes aside"
 	response_disarm_simple = "gently push aside"
-	faction = list("carp")
+	faction = list(FACTION_CARP)
 	butcher_results = list(/obj/item/food/fishmeat/carp = 2, /obj/item/stack/sheet/animalhide/carp = 1)
 	greyscale_config = /datum/greyscale_config/carp
 	ai_controller = /datum/ai_controller/basic_controller/carp

--- a/code/modules/mob/living/basic/space_fauna/carp/carp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/carp.dm
@@ -179,7 +179,7 @@
 	name = "Lia"
 	real_name = "Lia"
 	desc = "A failed experiment of Nanotrasen to create weaponised carp technology. This less than intimidating carp now serves as the Head of Security's pet."
-	faction = list("neutral")
+	faction = list(FACTION_NEUTRAL)
 	maxHealth = 200
 	health = 200
 	icon_dead = "magicarp_dead"

--- a/code/modules/mob/living/basic/space_fauna/faithless.dm
+++ b/code/modules/mob/living/basic/space_fauna/faithless.dm
@@ -24,7 +24,7 @@
 	unsuitable_cold_damage = 0
 	unsuitable_heat_damage = 0
 
-	faction = list("faithless")
+	faction = list(FACTION_FAITHLESS)
 	gold_core_spawnable = HOSTILE_SPAWN
 
 	ai_controller = /datum/ai_controller/basic_controller/faithless

--- a/code/modules/mob/living/basic/space_fauna/garden_gnome.dm
+++ b/code/modules/mob/living/basic/space_fauna/garden_gnome.dm
@@ -24,7 +24,7 @@
 	minimum_survivable_temperature = 0
 	maximum_survivable_temperature = 500
 
-	faction = list("gnomes")
+	faction = list(FACTION_GNOME)
 	mob_size = MOB_SIZE_SMALL
 	gold_core_spawnable = HOSTILE_SPAWN
 	greyscale_config = /datum/greyscale_config/garden_gnome

--- a/code/modules/mob/living/basic/space_fauna/giant_spider/giant_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/giant_spider/giant_spider.dm
@@ -31,7 +31,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 	combat_mode = TRUE
-	faction = list("spiders")
+	faction = list(FACTION_SPIDER)
 	pass_flags = PASSTABLE
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"

--- a/code/modules/mob/living/basic/space_fauna/giant_spider/spider_variants.dm
+++ b/code/modules/mob/living/basic/space_fauna/giant_spider/spider_variants.dm
@@ -314,7 +314,7 @@
 	name = "Sergeant Araneus"
 	real_name = "Sergeant Araneus"
 	desc = "A fierce companion of the Head of Security, this spider has been carefully trained by Nanotrasen specialists. Its beady, staring eyes send shivers down your spine."
-	faction = list("spiders")
+	faction = list(FACTION_SPIDER)
 	maxHealth = 250
 	health = 250
 	melee_damage_lower = 15

--- a/code/modules/mob/living/basic/space_fauna/netherworld/blankbody.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/blankbody.dm
@@ -14,7 +14,7 @@
 	attack_verb_simple = "punch"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	faction = list("nether")
+	faction = list(FACTION_NETHER)
 	speak_emote = list("screams")
 	death_message = "falls apart into a fine dust."
 	unsuitable_atmos_damage = 0

--- a/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/creature.dm
@@ -15,7 +15,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	attack_sound = 'sound/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
-	faction = list("nether")
+	faction = list(FACTION_NETHER)
 	speak_emote = list("screams")
 	death_message = "gets his head split open."
 	unsuitable_atmos_damage = 0

--- a/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
+++ b/code/modules/mob/living/basic/space_fauna/netherworld/migo.dm
@@ -15,7 +15,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	faction = list("nether")
+	faction = list(FACTION_NETHER)
 	speak_emote = list("screams", "clicks", "chitters", "barks", "moans", "growls", "meows", "reverberates", "roars", "squeaks", "rattles", "exclaims", "yells", "remarks", "mumbles", "jabbers", "stutters", "seethes")
 	death_message = "wails as its form turns into a pulpy mush."
 	death_sound = 'sound/voice/hiss6.ogg'

--- a/code/modules/mob/living/basic/space_fauna/statue/statue.dm
+++ b/code/modules/mob/living/basic/space_fauna/statue/statue.dm
@@ -28,7 +28,7 @@
 	attack_sound = 'sound/hallucinations/growl1.ogg'
 	attack_vis_effect = ATTACK_EFFECT_CLAW
 
-	faction = list("statue")
+	faction = list(FACTION_STATUE)
 	speak_emote = list("screams")
 	death_message = "falls apart into a fine dust."
 	unsuitable_atmos_damage = 0

--- a/code/modules/mob/living/basic/space_fauna/wumborian_fugu/wumborian_fugu.dm
+++ b/code/modules/mob/living/basic/space_fauna/wumborian_fugu/wumborian_fugu.dm
@@ -34,7 +34,7 @@
 	friendly_verb_continuous = "floats near"
 	friendly_verb_simple = "float near"
 	speak_emote = list("puffs")
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	see_in_dark = 8
 	// Nice and dark purple, to match le vibes
 	lighting_cutoff_red = 20

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -23,7 +23,7 @@
 	speak_emote = list("chitters")
 
 	basic_mob_flags = DEL_ON_DEATH
-	faction = list("hostile", FACTION_MAINT_CREATURES)
+	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
 
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 270
@@ -82,7 +82,7 @@
 	melee_damage_upper = 10
 	obj_damage = 10
 	gold_core_spawnable = HOSTILE_SPAWN
-	faction = list("hostile", FACTION_MAINT_CREATURES)
+	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
 	ai_controller = /datum/ai_controller/basic_controller/cockroach/glockroach
 	cockroach_cell_line = CELL_LINE_TABLE_GLOCKROACH
 
@@ -117,7 +117,7 @@
 	gold_core_spawnable = HOSTILE_SPAWN
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	attack_vis_effect = ATTACK_EFFECT_SLASH
-	faction = list("hostile", FACTION_MAINT_CREATURES)
+	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
 	sharpness = SHARP_POINTY
 	ai_controller = /datum/ai_controller/basic_controller/cockroach/hauberoach
 	cockroach_cell_line = CELL_LINE_TABLE_HAUBEROACH

--- a/code/modules/mob/living/basic/vermin/frog.dm
+++ b/code/modules/mob/living/basic/vermin/frog.dm
@@ -24,7 +24,7 @@
 	response_harm_continuous = "splats"
 	response_harm_simple = "splat"
 	density = FALSE
-	faction = list("hostile", FACTION_MAINT_CREATURES)
+	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
 	attack_sound = 'sound/effects/reee.ogg'
 	butcher_results = list(/obj/item/food/nugget = 1)
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB

--- a/code/modules/mob/living/carbon/human/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/human/monkey/monkey.dm
@@ -2,7 +2,7 @@
 	icon_state = "monkey" //for mapping
 	race = /datum/species/monkey
 	ai_controller = /datum/ai_controller/monkey
-	faction = list(FACTION_NEUTRAL, "monkey")
+	faction = list(FACTION_NEUTRAL, FACTION_MONKEY)
 
 /mob/living/carbon/human/species/monkey/Initialize(mapload, cubespawned=FALSE, mob/spawner)
 	if (cubespawned)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -337,7 +337,7 @@
 	special_names = list("Bark", "Willow", "Catalpa", "Woody", "Oak", "Sap", "Twig", "Branch", "Maple", "Birch", "Elm", "Basswood", "Cottonwood", "Larch", "Aspen", "Ash", "Beech", "Buckeye", "Cedar", "Chestnut", "Cypress", "Fir", "Hawthorn", "Hazel", "Hickory", "Ironwood", "Juniper", "Leaf", "Mangrove", "Palm", "Pawpaw", "Pine", "Poplar", "Redwood", "Redbud", "Sassafras", "Spruce", "Sumac", "Trunk", "Walnut", "Yew")
 	human_surname_chance = 0
 	special_name_chance = 100
-	inherent_factions = list("plants", "vines")
+	inherent_factions = list(FACTION_PLANTS, FACTION_VINES)
 	examine_limb_id = SPECIES_GOLEM
 
 /datum/species/golem/wood/spec_life(mob/living/carbon/human/H, delta_time, times_fired)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -691,7 +691,7 @@
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	prefix = "Runic"
 	special_names = null
-	inherent_factions = list("cult")
+	inherent_factions = list(FACTION_CULT)
 	species_language_holder = /datum/language_holder/golem/runic
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/golem/cult,

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -25,7 +25,7 @@
 	burnmod = 0.5 // = 1/2x generic burn damage
 	payday_modifier = 0.75
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
-	inherent_factions = list("slime")
+	inherent_factions = list(FACTION_SLIME)
 	species_language_holder = /datum/language_holder/jelly
 	ass_image = 'icons/ass/assslime.png'
 

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -17,7 +17,7 @@
 		TRAIT_NOBREATH,
 		TRAIT_NOFLASH,
 	)
-	inherent_factions = list("mushroom")
+	inherent_factions = list(FACTION_MUSHROOM)
 	speedmod = 1.5 //faster than golems but not by much
 
 	no_equip_flags = ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -14,7 +14,7 @@
 		/obj/item/organ/external/pod_hair = "None",
 	)
 	inherent_biotypes = MOB_ORGANIC | MOB_HUMANOID | MOB_PLANT
-	inherent_factions = list("plants", "vines")
+	inherent_factions = list(FACTION_PLANTS, FACTION_VINES)
 
 	burnmod = 1.25
 	heatmod = 1.5

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -14,7 +14,7 @@
 		TRAIT_VIRUSIMMUNE,
 		TRAIT_NOBLOOD,
 	)
-	inherent_factions = list("faithless")
+	inherent_factions = list(FACTION_FAITHLESS)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
 
 	mutantbrain = /obj/item/organ/internal/brain/shadow

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -787,12 +787,12 @@
 /obj/item/robot_model/syndicate/rebuild_modules()
 	..()
 	var/mob/living/silicon/robot/cyborg = loc
-	cyborg.faction -= "silicon" //ai turrets
+	cyborg.faction -= FACTION_SILICON //ai turrets
 
 /obj/item/robot_model/syndicate/remove_module(obj/item/removed_module, delete_after)
 	..()
 	var/mob/living/silicon/robot/cyborg = loc
-	cyborg.faction |= "silicon" //ai is your bff now!
+	cyborg.faction |= FACTION_SILICON //ai is your bff now!
 
 /obj/item/robot_model/syndicate_medical
 	name = "Syndicate Medical"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -54,7 +54,7 @@
 /mob/living/silicon/Initialize(mapload)
 	. = ..()
 	GLOB.silicon_mobs += src
-	faction += "silicon"
+	faction += FACTION_SILICON
 	if(ispath(radio))
 		radio = new radio(src)
 	for(var/datum/atom_hud/data/diagnostic/diag_hud in GLOB.huds)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -23,7 +23,7 @@
 	initial_language_holder = /datum/language_holder/synthetic
 	bubble_icon = "machine"
 	speech_span = SPAN_ROBOT
-	faction = list(FACTION_NEUTRAL, FACTION_SILICON, "turret")
+	faction = list(FACTION_NEUTRAL, FACTION_SILICON, FACTION_TURRET)
 	light_system = MOVABLE_LIGHT
 	light_range = 3
 	light_power = 0.9

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -23,7 +23,7 @@
 	initial_language_holder = /datum/language_holder/synthetic
 	bubble_icon = "machine"
 	speech_span = SPAN_ROBOT
-	faction = list(FACTION_NEUTRAL, "silicon", "turret")
+	faction = list(FACTION_NEUTRAL, FACTION_SILICON, "turret")
 	light_system = MOVABLE_LIGHT
 	light_range = 3
 	light_power = 0.9
@@ -1032,7 +1032,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 		ejectpai(0)
 
 /mob/living/simple_animal/bot/sentience_act()
-	faction -= "silicon"
+	faction -= FACTION_SILICON
 
 /mob/living/simple_animal/bot/proc/set_path(list/newpath)
 	path = newpath ? newpath : list()

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -94,7 +94,7 @@
 	name = "Officer Genesky"
 	desc = "A beefy variant of the standard securitron model."
 	health = 50
-	faction = list("nanotrasenprivate")
+	faction = list(FACTION_NANOTRASEN_PRIVATE)
 	bot_mode_flags = BOT_MODE_ON
 	bot_cover_flags = BOT_COVER_LOCKED | BOT_COVER_EMAGGED
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -43,7 +43,7 @@
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	hud_possible = list(DIAG_STAT_HUD, DIAG_HUD, ANTAG_HUD)
 	unique_name = TRUE
-	faction = list(FACTION_NEUTRAL,"silicon","turret")
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET)
 	dextrous = TRUE
 	dextrous_hud_type = /datum/hud/dextrous/drone
 	// Going for a sort of pale green here

--- a/code/modules/mob/living/simple_animal/friendly/gondola.dm
+++ b/code/modules/mob/living/simple_animal/friendly/gondola.dm
@@ -15,7 +15,7 @@
 	response_disarm_simple = "bop"
 	response_harm_continuous = "kicks"
 	response_harm_simple = "kick"
-	faction = list("gondola")
+	faction = list(FACTION_GONDOLA)
 	turns_per_move = 10
 	icon = 'icons/mob/simple/gondolas.dmi'
 	icon_state = "gondola"

--- a/code/modules/mob/living/simple_animal/friendly/lizard.dm
+++ b/code/modules/mob/living/simple_animal/friendly/lizard.dm
@@ -7,7 +7,7 @@
 	speak_emote = list("hisses")
 	health = 5
 	maxHealth = 5
-	faction = list("Lizard")
+	faction = list(FACTION_LIZARD)
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
 	melee_damage_lower = 1

--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -12,7 +12,7 @@
 	speak_emote = list("squawks", "gakkers")
 	emote_hear = list("squawk!", "gakkers!", "noots.","NOOTS!")
 	emote_see = list("shakes his beak.", "flaps his wings.","preens himself.")
-	faction = list("penguin")
+	faction = list(FACTION_PENGUIN)
 	minbodytemp = 0
 	speak_chance = 1
 	turns_per_move = 10

--- a/code/modules/mob/living/simple_animal/friendly/snake.dm
+++ b/code/modules/mob/living/simple_animal/friendly/snake.dm
@@ -20,7 +20,7 @@
 	response_disarm_simple = "shoo"
 	response_harm_continuous = "steps on"
 	response_harm_simple = "step on"
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	density = FALSE
 	pass_flags = PASSTABLE | PASSMOB
 	mob_size = MOB_SIZE_SMALL

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -41,7 +41,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1500
 
-	faction = list("russian")
+	faction = list(FACTION_RUSSIAN)
 
 	footstep_type = FOOTSTEP_MOB_CLAW
 
@@ -89,7 +89,7 @@
 	icon_state = "combatbear"
 	icon_living = "combatbear"
 	icon_dead = "combatbear_dead"
-	faction = list("russian")
+	faction = list(FACTION_RUSSIAN)
 	butcher_results = list(/obj/item/food/meat/slab/bear = 5, /obj/item/clothing/head/costume/bearpelt = 1, /obj/item/bear_armor = 1)
 	melee_damage_lower = 18
 	melee_damage_upper = 20
@@ -131,7 +131,7 @@
 	icon_living = "butterbear"
 	icon_dead = "butterbear_dead"
 	desc = "I can't believe its not a bear!"
-	faction = list(FACTION_NEUTRAL, "russian")
+	faction = list(FACTION_NEUTRAL, FACTION_RUSSIAN)
 	obj_damage = 11
 	melee_damage_lower = 0
 	melee_damage_upper = 0

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -34,7 +34,7 @@
 	response_harm_simple = "squash"
 	maxHealth = 10
 	health = 10
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	move_to_delay = 0
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE

--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -4,7 +4,7 @@
 	desc = "A wizard with a taste for the arts."
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	boss_abilities = list(/datum/action/boss/wizard_summon_minions, /datum/action/boss/wizard_mimic)
-	faction = list(FACTION_HOSTILE,"stickman")
+	faction = list(FACTION_HOSTILE,FACTION_STICKMAN)
 	del_on_death = TRUE
 	icon = 'icons/mob/simple/simple_human.dmi'
 	icon_state = "paperwizard"

--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -4,7 +4,7 @@
 	desc = "A wizard with a taste for the arts."
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	boss_abilities = list(/datum/action/boss/wizard_summon_minions, /datum/action/boss/wizard_mimic)
-	faction = list("hostile","stickman")
+	faction = list(FACTION_HOSTILE,"stickman")
 	del_on_death = TRUE
 	icon = 'icons/mob/simple/simple_human.dmi'
 	icon_state = "paperwizard"

--- a/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
+++ b/code/modules/mob/living/simple_animal/hostile/cat_butcher.dm
@@ -25,7 +25,7 @@
 	loot = list(/obj/effect/mob_spawn/corpse/human/cat_butcher, /obj/item/circular_saw)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 7.5
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	check_friendly_fire = 1
 	status_flags = CANPUSH
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/constructs/constructs.dm
@@ -27,7 +27,7 @@
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	healable = 0
-	faction = list("cult")
+	faction = list(FACTION_CULT)
 	pressure_resistance = 100
 	unique_name = 1
 	AIStatus = AI_OFF //normal constructs don't have AI

--- a/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/eyeballs.dm
@@ -29,7 +29,7 @@
 	minbodytemp = 0
 	maxbodytemp = 1500
 	gold_core_spawnable = HOSTILE_SPAWN
-	faction = list("spooky")
+	faction = list(FACTION_SPOOKY)
 	del_on_death = 1
 	// Redish ethereal glow. These lads live on the cult ship
 	lighting_cutoff_red = 40

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -32,7 +32,7 @@
 	attack_sound = 'sound/weapons/punch1.ogg'
 	dextrous = TRUE
 	held_items = list(null, null)
-	faction = list("monkey", "jungle")
+	faction = list(FACTION_MONKEY, FACTION_JUNGLE)
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	minbodytemp = 270
@@ -122,7 +122,7 @@
 	desc = "Cargo's pet gorilla. They seem to have an 'I love Mom' tattoo."
 	maxHealth = 200
 	health = 200
-	faction = list(FACTION_NEUTRAL, "monkey", "jungle")
+	faction = list(FACTION_NEUTRAL, FACTION_MONKEY, FACTION_JUNGLE)
 	gold_core_spawnable = NO_SPAWN
 	unique_name = FALSE
 	/// Whether we're currently being polled over

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -15,7 +15,7 @@
 	attack_verb_simple = "chomp"
 	attack_sound = 'sound/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
-	faction = list("creature")
+	faction = list(FACTION_CREATURE)
 	robust_searching = 1
 	stat_attack = DEAD
 	obj_damage = 0

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -22,7 +22,7 @@
 	attack_vis_effect = ATTACK_EFFECT_CLAW
 	projectilesound = 'sound/weapons/gun/pistol/shot.ogg'
 	projectiletype = /obj/projectile/hivebotbullet
-	faction = list("hivebot")
+	faction = list(FACTION_HIVEBOT)
 	check_friendly_fire = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	stop_automated_movement_when_pulled = 0
 	obj_damage = 40
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES // Set to ENVIRONMENT_SMASH_STRUCTURES to break closets,tables,racks, etc; ENVIRONMENT_SMASH_WALLS for walls; ENVIRONMENT_SMASH_RWALLS for rwalls

--- a/code/modules/mob/living/simple_animal/hostile/illusion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/illusion.dm
@@ -15,7 +15,7 @@
 	maxHealth = 100
 	health = 100
 	speed = 0
-	faction = list("illusion")
+	faction = list(FACTION_ILLUSION)
 	var/life_span = INFINITY //how long until they despawn
 	var/mob/living/parent_mob
 	var/multiply_chance = 0 //if we multiply on hit

--- a/code/modules/mob/living/simple_animal/hostile/jungle/_jungle_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/_jungle_mobs.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/hostile/jungle
 	vision_range = 5
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	faction = list("jungle")
+	faction = list(FACTION_JUNGLE)
 	obj_damage = 30
 	environment_smash = ENVIRONMENT_SMASH_WALLS
 	minbodytemp = 0

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -50,7 +50,7 @@
 /obj/projectile/seedling/Bump(atom/A)//Stops seedlings from destroying other jungle mobs through FF
 	if(isliving(A))
 		var/mob/living/L = A
-		if("jungle" in L.faction)
+		if(FACTION_JUNGLE in L.faction)
 			return FALSE
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/killertomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/killertomato.dm
@@ -22,7 +22,7 @@
 	attack_verb_continuous = "slams"
 	attack_verb_simple = "slam"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	faction = list("plants")
+	faction = list(FACTION_PLANTS)
 
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 150

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -9,7 +9,7 @@
 	mob_biotypes = MOB_ORGANIC|MOB_EPIC
 	obj_damage = 400
 	light_range = 3
-	faction = list("mining", "boss")
+	faction = list(FACTION_MINING, FACTION_BOSS)
 	weather_immunities = list(TRAIT_LAVA_IMMUNE,TRAIT_ASHSTORM_IMMUNE)
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -68,7 +68,7 @@ Difficulty: Hard
 	death_message = "sinks into a pool of blood, fleeing the battle. You've won, for now... "
 	death_sound = 'sound/magic/enter_blood.ogg'
 	small_sprite_type = /datum/action/small_sprite/megafauna/bubblegum
-	faction = list("mining", "boss", "hell")
+	faction = list(FACTION_MINING, FACTION_BOSS, "hell")
 	/// Check to see if we should spawn blood
 	var/spawn_blood = TRUE
 	/// Actual time where enrage ends

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -68,7 +68,7 @@ Difficulty: Hard
 	death_message = "sinks into a pool of blood, fleeing the battle. You've won, for now... "
 	death_sound = 'sound/magic/enter_blood.ogg'
 	small_sprite_type = /datum/action/small_sprite/megafauna/bubblegum
-	faction = list(FACTION_MINING, FACTION_BOSS, "hell")
+	faction = list(FACTION_MINING, FACTION_BOSS, FACTION_HELL)
 	/// Check to see if we should spawn blood
 	var/spawn_blood = TRUE
 	/// Actual time where enrage ends

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -48,7 +48,7 @@ Difficulty: Hard
 	friendly_verb_continuous = "stares down"
 	friendly_verb_simple = "stare down"
 	icon = 'icons/mob/simple/lavaland/hierophant_new.dmi'
-	faction = list("boss") //asteroid mobs? get that shit out of my beautiful square house
+	faction = list(FACTION_BOSS) //asteroid mobs? get that shit out of my beautiful square house
 	speak_emote = list("preaches")
 	armour_penetration = 50
 	melee_damage_lower = 15

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -278,7 +278,7 @@
 	///How long it takes between shooting the tracer and the projectile.
 	var/shot_delay = 8
 	///Compared with the targeted mobs. If they have the faction, turret won't shoot.
-	var/faction = list("mining")
+	var/faction = list(FACTION_MINING)
 
 /datum/armor/structure_legionturret
 	laser = 100

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -27,7 +27,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 
-	faction = list("mimic")
+	faction = list(FACTION_MIMIC)
 	move_to_delay = 9
 	del_on_death = 1
 	///A cap for items in the mimic. Prevents the mimic from eating enough stuff to cause lag when opened.

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -7,7 +7,7 @@
 	name = "elite"
 	desc = "An elite monster, found in one of the strange tumors on lavaland."
 	icon = 'icons/mob/simple/lavaland/lavaland_elites.dmi'
-	faction = list("boss")
+	faction = list(FACTION_BOSS)
 	robust_searching = TRUE
 	ranged_ignores_vision = TRUE
 	ranged = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -11,7 +11,7 @@
 	emote_hear = list("trills.")
 	emote_see = list("sniffs.", "burps.")
 	weather_immunities = list(TRAIT_LAVA_IMMUNE, TRAIT_ASHSTORM_IMMUNE)
-	faction = list("mining", "ashwalker")
+	faction = list(FACTION_MINING, FACTION_ASHWALKER)
 	density = FALSE
 	speak_chance = 1
 	turns_per_move = 8

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -270,7 +270,7 @@
 	vision_range = 5
 	aggro_vision_range = 9
 	speed = 3
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	weather_immunities = list(TRAIT_LAVA_IMMUNE, TRAIT_ASHSTORM_IMMUNE)
 	obj_damage = 30
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -2,7 +2,7 @@
 /mob/living/simple_animal/hostile/asteroid
 	vision_range = 2
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	faction = list("mining")
+	faction = list(FACTION_MINING)
 	weather_immunities = list(TRAIT_LAVA_IMMUNE,TRAIT_ASHSTORM_IMMUNE)
 	obj_damage = 30
 	environment_smash = ENVIRONMENT_SMASH_WALLS

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -25,7 +25,7 @@
 	attack_verb_simple = "chomp"
 	attack_sound = 'sound/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
-	faction = list("mushroom")
+	faction = list(FACTION_MUSHROOM)
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	stat_attack = DEAD
 	mouse_opacity = MOUSE_OPACITY_ICON

--- a/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
+++ b/code/modules/mob/living/simple_animal/hostile/nanotrasen.dm
@@ -77,7 +77,7 @@
 	attack_verb_continuous = "punches"
 	attack_verb_simple = "punch"
 	attack_sound = 'sound/weapons/punch1.ogg'
-	faction = list("nanotrasenprivate")
+	faction = list(FACTION_NANOTRASEN_PRIVATE)
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
 	sentience_type = SENTIENCE_HUMANOID
 	combat_mode = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -14,7 +14,7 @@
 	hud_type = /datum/hud/ooze
 	minbodytemp = 250
 	maxbodytemp = INFINITY
-	faction = list("slime")
+	faction = list(FACTION_SLIME)
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	health = 200

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -23,7 +23,7 @@
 	speak_emote = list("yarrs")
 	loot = list(/obj/effect/mob_spawn/corpse/human/pirate)
 	del_on_death = TRUE
-	faction = list("pirate")
+	faction = list(FACTION_PIRATE)
 	/// Path of the mob spawner we base the mob's visuals off of.
 	var/mob_spawner = /obj/effect/mob_spawn/corpse/human/pirate
 	/// Path of the held item we give to the mob's visuals.

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/bat.dm
@@ -21,7 +21,7 @@
 	attack_verb_simple = "bite"
 	butcher_results = list(/obj/item/food/meat/slab = 1)
 	pass_flags = PASSTABLE
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	attack_sound = 'sound/weapons/bite.ogg'
 	attack_vis_effect = ATTACK_EFFECT_BITE
 	obj_damage = 0

--- a/code/modules/mob/living/simple_animal/hostile/russian.dm
+++ b/code/modules/mob/living/simple_animal/hostile/russian.dm
@@ -24,7 +24,7 @@
 				/obj/item/knife/kitchen)
 	atmos_requirements = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	unsuitable_atmos_damage = 7.5
-	faction = list("russian")
+	faction = list(FACTION_RUSSIAN)
 	status_flags = CANPUSH
 	footstep_type = FOOTSTEP_MOB_SHOE
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/skeleton.dm
@@ -25,7 +25,7 @@
 	unsuitable_atmos_damage = 5
 	robust_searching = 1
 	stat_attack = HARD_CRIT
-	faction = list("skeleton")
+	faction = list(FACTION_SKELETON)
 	// Going for a sort of pale bluegreen here, shooting for boneish
 	lighting_cutoff_red = 15
 	lighting_cutoff_green = 25

--- a/code/modules/mob/living/simple_animal/hostile/slaughter_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/slaughter_demon.dm
@@ -26,7 +26,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 250 //Weak to cold
 	maxbodytemp = INFINITY
-	faction = list("hell")
+	faction = list(FACTION_HELL)
 	attack_verb_continuous = "wildly tears into"
 	attack_verb_simple = "wildly tear into"
 	maxHealth = 200
@@ -237,4 +237,4 @@
 
 /mob/living/simple_animal/hostile/imp/slaughter/engine_demon
 	name = "engine demon"
-	faction = list("hell", FACTION_NEUTRAL)
+	faction = list(FACTION_HELL, FACTION_NEUTRAL)

--- a/code/modules/mob/living/simple_animal/hostile/smspider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/smspider.dm
@@ -24,7 +24,7 @@
 	attack_vis_effect = ATTACK_EFFECT_CLAW
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	robust_searching = 1
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	// Gold, supermatter tinted
 	lighting_cutoff_red = 30
 	lighting_cutoff_green = 30

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -59,7 +59,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
 	maxbodytemp = 1500
-	faction = list("carp")
+	faction = list(FACTION_CARP)
 	pressure_resistance = 200
 	/// How much endlag using Wing Gust should apply.  Each use of wing gust increments this, and it decreases over time.
 	var/tiredness = 0

--- a/code/modules/mob/living/simple_animal/hostile/tree.dm
+++ b/code/modules/mob/living/simple_animal/hostile/tree.dm
@@ -15,7 +15,7 @@
 	response_help_simple = "brush"
 	response_disarm_continuous = "pushes"
 	response_disarm_simple = "push"
-	faction = list("hostile")
+	faction = list(FACTION_HOSTILE)
 	speed = 1
 	maxHealth = 250
 	health = 250

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -160,7 +160,7 @@
 	lighting_cutoff_red = 10
 	lighting_cutoff_green = 35
 	lighting_cutoff_blue = 20
-	faction = list("hostile","vines","plants")
+	faction = list(FACTION_HOSTILE,"vines","plants")
 	initial_language_holder = /datum/language_holder/venus
 	unique_name = TRUE
 	/// A list of all the plant's vines

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -160,7 +160,7 @@
 	lighting_cutoff_red = 10
 	lighting_cutoff_green = 35
 	lighting_cutoff_blue = 20
-	faction = list(FACTION_HOSTILE,"vines","plants")
+	faction = list(FACTION_HOSTILE,FACTION_VINES,FACTION_PLANTS)
 	initial_language_holder = /datum/language_holder/venus
 	unique_name = TRUE
 	/// A list of all the plant's vines

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -28,7 +28,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	speed = -1 //they don't have to lug a body made of runed metal around
 	stop_automated_movement = 1
-	faction = list("cult")
+	faction = list(FACTION_CULT)
 	status_flags = CANPUSH
 	loot = list(/obj/item/ectoplasm)
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -7,7 +7,7 @@
 	gender = NEUTER
 	var/is_adult = 0
 	var/docile = 0
-	faction = list("slime", FACTION_NEUTRAL)
+	faction = list(FACTION_SLIME, FACTION_NEUTRAL)
 
 	harm_intent_damage = 5
 	icon_living = "grey baby slime"

--- a/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
@@ -36,7 +36,7 @@
 	desc = "A small sleeper typically used to make long distance travel a bit more bearable."
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	faction = list("russian")
+	faction = list(FACTION_RUSSIAN)
 	prompt_name = "a russian"
 	you_are_text = "Ay blyat. I am a Space-Russian smuggler!"
 	flavour_text = "We were mid-flight when our cargo was beamed off our ship! Must be on station somewhere? \

--- a/code/modules/mob_spawn/ghost_roles/spider_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/spider_roles.dm
@@ -43,7 +43,7 @@
 	you_are_text = "You are a spider."
 	flavour_text = "For the hive! Choose a spider and fulfill your role to take over the station... if that is within your directives, of course."
 	important_text = "Follow your directives at all costs."
-	faction = list("spiders")
+	faction = list(FACTION_SPIDER)
 	spawner_job_path = /datum/job/spider
 	role_ban = ROLE_ALIEN
 	prompt_ghost = FALSE

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -172,7 +172,7 @@
 	name = "sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	faction = list("nanotrasenprivate")
+	faction = list(FACTION_NANOTRASEN_PRIVATE)
 	prompt_name = "a private security officer"
 	you_are_text = "You are a Nanotrasen Private Security Officer!"
 	flavour_text = "If higher command has an assignment for you, it's best you follow that. Otherwise, death to The Syndicate."

--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -9,7 +9,7 @@
 	prompt_name = "venus human trap"
 	you_are_text = "You are a venus human trap."
 	flavour_text = "You are a venus human trap!  Protect the kudzu at all costs, and feast on those who oppose you!"
-	faction = list(FACTION_HOSTILE,"vines","plants")
+	faction = list(FACTION_HOSTILE,FACTION_VINES,FACTION_PLANTS)
 	spawner_job_path = /datum/job/venus_human_trap
 	/// Physical structure housing the spawner
 	var/obj/structure/alien/resin/flower_bud/flower_bud

--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -9,7 +9,7 @@
 	prompt_name = "venus human trap"
 	you_are_text = "You are a venus human trap."
 	flavour_text = "You are a venus human trap!  Protect the kudzu at all costs, and feast on those who oppose you!"
-	faction = list("hostile","vines","plants")
+	faction = list(FACTION_HOSTILE,"vines","plants")
 	spawner_job_path = /datum/job/venus_human_trap
 	/// Physical structure housing the spawner
 	var/obj/structure/alien/resin/flower_bud/flower_bud

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -595,7 +595,7 @@
 	hitsound = 'sound/weapons/punch3.ogg'
 	trigger_range = 0
 	antimagic_flags = MAGIC_RESISTANCE_HOLY
-	ignored_factions = list("cult")
+	ignored_factions = list(FACTION_CULT)
 	range = 105
 	speed = 1
 	pixel_speed_multiplier = 1/7

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -208,7 +208,7 @@
  * * mob_faction - used in determining targets, mobs from the same faction won't harm eachother.
  * * random - creates random mobs. self explanatory.
  */
-/datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_class = HOSTILE_SPAWN, mob_faction = "chemicalsummon", random = TRUE)
+/datum/chemical_reaction/proc/chemical_mob_spawn(datum/reagents/holder, amount_to_spawn, reaction_name, mob_class = HOSTILE_SPAWN, mob_faction = FACTION_CHEMICAL_SUMMON, random = TRUE)
 	if(holder?.my_atom)
 		var/atom/A = holder.my_atom
 		var/turf/T = get_turf(A)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -138,7 +138,7 @@
 				if(!user.combat_mode)
 					spawned_mob.faction |= FACTION_NEUTRAL
 				else
-					spawned_mob.faction |= "slime"
+					spawned_mob.faction |= FACTION_SLIME
 				playsound(user, 'sound/effects/splat.ogg', 50, TRUE)
 				user.visible_message(span_warning("[user] spits out [spawned_mob]!"), span_warning("You spit out [spawned_mob]!"))
 				return 600

--- a/code/modules/spells/spell_types/pointed/dominate.dm
+++ b/code/modules/spells/spell_types/pointed/dominate.dm
@@ -30,7 +30,7 @@
 		return FALSE
 	if(!animal.compare_sentience_type(SENTIENCE_ORGANIC)) // Will also return false if not a basic or simple mob, which are the only two we want anyway
 		return FALSE
-	if("cult" in animal.faction)
+	if(FACTION_CULT in animal.faction)
 		return FALSE
 	if(HAS_TRAIT(animal, TRAIT_HOLY))
 		return FALSE
@@ -46,6 +46,6 @@
 
 	var/turf/cast_turf = get_turf(cast_on)
 	cast_on.add_atom_colour("#990000", FIXED_COLOUR_PRIORITY)
-	cast_on.faction |= "cult"
+	cast_on.faction |= FACTION_CULT
 	playsound(cast_turf, 'sound/effects/ghost.ogg', 100, TRUE)
 	new /obj/effect/temp_visual/cult/sac(cast_turf)


### PR DESCRIPTION
## About The Pull Request

Quite a lot of mobs had faction defines as a string, which always has a chance for error. For example, the clown mob spawner had their faction written as "clown", when the official faction name was "clowns", and a define existed for it anyways! This PR moves every single string based factions over here. No references or special role factions. Hopefully I didn't miss anything.

I also moved a global define used for picking your uplink provider's flavour to the only file that used it, datum_traitor.dm, and renamed them a bit to avoid confusion.

I have also noticed that the mimic faction was assigned to the petrified player with += instead of |=. |= would ensure no duplicate factions, so I have changed it.

Future improvement:
I have noticed that there is a lot of bloat with factions that contain only one or two entries (examples: gnomes, floating eyeballs, penguins, the pet lizards), and some always appear in pairs (vines and plants, the rare exceptions being killer tomatoes and strange reagent spawned pine trees), but trimming consolidating them is a matter for a different time.

## Why It's Good For The Game

Makes assigning factions a bit less error prone.

I can finally remove the ```/// Later all mob factions will be moved here and their current factions replaced with faction defines.``` comment. Later is NOW.

## Changelog
Nothing player facing