### PR TITLE
Fixes a potential way of trapping yourself without access on the public lavaland base.

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2174,6 +2174,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/departmental,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/mine/maintenance/living/north)
 "mA" = (


### PR DESCRIPTION

## About The Pull Request

Public mining had a maint access route that you could get into without access but couldn't get out. An unrestricted airlock access helper has been added so it can now be exited.
## Why It's Good For The Game

Mapbug
## Changelog
:cl:
fix: You can no longer trap yourself in north public mining maintenance if you enter it without maint access.
/:cl:
