### PR TITLE
Fix lung stirfry to use a bowl and non-cybernetic lungs

### DIFF
--- a/code/game/objects/items/food/lizard.dm
+++ b/code/game/objects/items/food/lizard.dm
@@ -91,6 +91,7 @@
 	)
 	tastes = list("meat" = 1, "heat" = 1, "veggies" = 1)
 	foodtypes = MEAT | VEGETABLES | GORE
+	trash_type = /obj/item/reagent_containers/cup/bowl
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/tsatsikh

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -23,7 +23,7 @@
 	name = "Crispy shredded lung stirfry"
 	reqs = list(
 		/obj/item/food/grown/carrot = 1,
-		/obj/item/food/grown/chili = 1
+		/obj/item/food/grown/chili = 1,
 		/obj/item/food/grown/onion = 1,
 		/obj/item/organ/internal/lungs = 1,
 		/obj/item/reagent_containers/cup/bowl = 1,

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -22,11 +22,16 @@
 /datum/crafting_recipe/food/shredded_lungs
 	name = "Crispy shredded lung stirfry"
 	reqs = list(
+		/obj/item/reagent_containers/cup/bowl = 1,
 		/obj/item/organ/internal/lungs = 1,
 		/obj/item/food/grown/onion = 1,
 		/obj/item/food/grown/carrot = 1,
 		/obj/item/food/grown/chili = 1
 	)
+	blacklist = list(
+		/obj/item/organ/internal/lungs/cybernetic,
+	)
+
 	result = /obj/item/food/shredded_lungs
 	category = CAT_LIZARD
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -22,11 +22,11 @@
 /datum/crafting_recipe/food/shredded_lungs
 	name = "Crispy shredded lung stirfry"
 	reqs = list(
-		/obj/item/reagent_containers/cup/bowl = 1,
-		/obj/item/organ/internal/lungs = 1,
-		/obj/item/food/grown/onion = 1,
 		/obj/item/food/grown/carrot = 1,
 		/obj/item/food/grown/chili = 1
+		/obj/item/food/grown/onion = 1,
+		/obj/item/organ/internal/lungs = 1,
+		/obj/item/reagent_containers/cup/bowl = 1,
 	)
 	blacklist = list(
 		/obj/item/organ/internal/lungs/cybernetic,


### PR DESCRIPTION
:cl: coiax
fix: Tiziran lung stirfry now correctly uses a bowl in its construction, and is left over after eating. It also can only be constructed with organic lungs, because cybernetic lungs don't fry as well.
/:cl:

Sprite has a bowl, but no bowl involved in the crafting or left behind. Using cybernetic organs also seems like an oversight, given the whole "lizards love the raw meat" vibe they have with Tiziran food.