### PR TITLE
Fixes offstation roles being able to purge crew records

### DIFF
--- a/code/game/machinery/computer/records/records.dm
+++ b/code/game/machinery/computer/records/records.dm
@@ -14,6 +14,7 @@
 		return data
 
 	data["assigned_view"] = "preview_[user.ckey]_[REF(src)]_records"
+	data["station_z"] = !!(z && is_station_level(z))
 
 	return data
 
@@ -41,10 +42,15 @@
 		if("expunge_record")
 			if(!target)
 				return FALSE
+			// Don't let people off station futz with the station network.
+			if(!is_station_level(z))
+				balloon_alert(usr, "out of range!")
+				return TRUE
 
 			expunge_record_info(target)
 			balloon_alert(usr, "record expunged")
 			playsound(src, 'sound/machines/terminal_eject.ogg', 70, TRUE)
+			investigate_log("[key_name(usr)] expunged the record of [target.name].", INVESTIGATE_RECORDS)
 
 			return TRUE
 
@@ -60,8 +66,13 @@
 			return TRUE
 
 		if("purge_records")
+			// Don't let people off station futz with the station network.
+			if(!is_station_level(z))
+				balloon_alert(usr, "out of range!")
+				return TRUE
+
 			ui.close()
-			balloon_alert(usr, "purging records")
+			balloon_alert(usr, "purging records...")
 			playsound(src, 'sound/machines/terminal_alert.ogg', 70, TRUE)
 
 			if(do_after(usr, 5 SECONDS))
@@ -70,6 +81,9 @@
 
 				balloon_alert(usr, "records purged")
 				playsound(src, 'sound/machines/terminal_off.ogg', 70, TRUE)
+				investigate_log("[key_name(usr)] purged all records.", INVESTIGATE_RECORDS)
+			else
+				balloon_alert(usr, "interrupted!")
 
 			return TRUE
 

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordTabs.tsx
@@ -9,7 +9,7 @@ import { MedicalRecord, MedicalRecordData } from './types';
 /** Displays all found records. */
 export const MedicalRecordTabs = (props, context) => {
   const { act, data } = useBackend<MedicalRecordData>(context);
-  const { records = [] } = data;
+  const { records = [], station_z } = data;
 
   const errorMessage = !records.length
     ? 'No records found.'
@@ -58,6 +58,7 @@ export const MedicalRecordTabs = (props, context) => {
             <Button.Confirm
               content="Purge"
               icon="trash"
+              disabled={!station_z}
               onClick={() => act('purge_records')}
               tooltip="Wipe all record data."
             />

--- a/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/RecordView.tsx
@@ -12,7 +12,7 @@ export const MedicalRecordView = (props, context) => {
   if (!foundRecord) return <NoticeBox>No record selected.</NoticeBox>;
 
   const { act, data } = useBackend<MedicalRecordData>(context);
-  const { assigned_view } = data;
+  const { assigned_view, station_z } = data;
 
   const { min_age, max_age } = data;
 
@@ -52,6 +52,7 @@ export const MedicalRecordView = (props, context) => {
             <Button.Confirm
               content="Delete"
               icon="trash"
+              disabled={!station_z}
               onClick={() => act('expunge_record', { crew_ref: crew_ref })}
               tooltip="Expunge record data."
             />

--- a/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/MedicalRecords/types.ts
@@ -3,6 +3,7 @@ import { BooleanLike } from 'common/react';
 export type MedicalRecordData = {
   assigned_view: string;
   authenticated: BooleanLike;
+  station_z: BooleanLike;
   records: MedicalRecord[];
   min_age: number;
   max_age: number;

--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordTabs.tsx
@@ -10,7 +10,7 @@ import { SecurityRecordsData, SecurityRecord } from './types';
 /** Tabs on left, with search bar */
 export const SecurityRecordTabs = (props, context) => {
   const { act, data } = useBackend<SecurityRecordsData>(context);
-  const { higher_access, records = [] } = data;
+  const { higher_access, records = [], station_z } = data;
 
   const errorMessage = !records.length
     ? 'No records found.'
@@ -58,7 +58,7 @@ export const SecurityRecordTabs = (props, context) => {
           <Stack.Item>
             <Button.Confirm
               content="Purge"
-              disabled={!higher_access}
+              disabled={!higher_access || !station_z}
               icon="trash"
               onClick={() => act('purge_records')}
               tooltip="Wipe criminal record data."

--- a/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/types.ts
@@ -3,6 +3,7 @@ import { BooleanLike } from 'common/react';
 export type SecurityRecordsData = {
   assigned_view: string;
   authenticated: BooleanLike;
+  station_z: BooleanLike;
   available_statuses: string[];
   current_user: string;
   higher_access: BooleanLike;


### PR DESCRIPTION
## About The Pull Request

(Partially) Fixes #73689

**(It may also be sensible to just disable Syndicate records consoles from purging outright. I went for the more generic approach but if another maintainer prefers this solution, I can do that as well.)**

Off station roles with access to sec / med record consoles can't purge or expunge records.

Also re-adds some missing logs for the purging of records.

## Why It's Good For The Game

I can't recall for the life of me if Comms agents could purge records prior to the refactor, and if not, where that code was housed because I couldn't find any. 

In any case, it's a little too easy and a little too griefy to let ghost roles mess with records.
Balance pr? Fix pr? *shrug

## Changelog

:cl: Melbert
fix: Off station roles can't purge the station's records
fix: Purging records is logged again
/:cl:
