### PR TITLE
Adds a space ruin, inspired by all the fluke ops out there

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
@@ -3,11 +3,11 @@
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/five,
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "ao" = (
 /obj/effect/mob_spawn/corpse/human/syndicatepilot,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "bU" = (
 /obj/machinery/door/window/brigdoor/left/directional/east{
 	name = "EVA";
@@ -20,11 +20,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "cd" = (
 /obj/structure/mirror/directional/east,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "cj" = (
 /obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Bomb Storage";
@@ -36,7 +36,7 @@
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "cJ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -53,26 +53,26 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "df" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "do" = (
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "dJ" = (
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "ej" = (
 /obj/item/chair{
 	dir = 4
 	},
 /mob/living/basic/carp,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "en" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Cockpit"
@@ -85,11 +85,11 @@
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "fb" = (
 /obj/effect/turf_decal/syndicateemblem/top/middle,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "gr" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -104,7 +104,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "gT" = (
 /mob/living/basic/carp,
 /turf/template_noop,
@@ -115,14 +115,14 @@
 	pixel_y = 3
 	},
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "ie" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "iI" = (
 /obj/effect/turf_decal/syndicateemblem/top/left,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "jj" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -138,23 +138,23 @@
 	pixel_x = -3
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "js" = (
 /obj/structure/frame/computer{
 	dir = 1
 	},
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "jt" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "ju" = (
 /obj/machinery/power/shuttle_engine/propulsion/right,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "kC" = (
 /obj/machinery/light/directional/east,
 /obj/structure/window/reinforced/spawner/north,
@@ -163,7 +163,7 @@
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "la" = (
 /turf/template_noop,
 /area/template_noop)
@@ -178,21 +178,21 @@
 	pixel_x = 6
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "mg" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "mq" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "mr" = (
 /obj/item/grenade/smokebomb{
 	pixel_x = 5
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "ms" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/table,
@@ -202,11 +202,11 @@
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "mO" = (
 /obj/effect/turf_decal/syndicateemblem/top/right,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "nv" = (
 /obj/item/stack/sheet/mineral/plastitanium,
 /turf/template_noop,
@@ -219,20 +219,20 @@
 	pixel_y = 9
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "nR" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "pl" = (
 /obj/structure/table,
 /obj/item/relic{
 	pixel_y = 5
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "qL" = (
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	req_access = list("syndicate");
@@ -245,27 +245,27 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "ro" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "sz" = (
 /obj/structure/frame/machine,
 /obj/item/circuitboard/machine/recharger,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "sL" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
 /obj/machinery/light/directional/north,
 /obj/item/stack/cable_coil,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "tE" = (
 /obj/effect/turf_decal/syndicateemblem/middle/middle,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "us" = (
 /obj/effect/spawner/random/engineering/tool,
 /obj/machinery/light/directional/west,
@@ -275,24 +275,24 @@
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "uE" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "uP" = (
 /obj/machinery/power/shuttle_engine/propulsion/left,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "uS" = (
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "vi" = (
 /obj/structure/frame/computer,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "vw" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -306,11 +306,11 @@
 	pixel_x = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "vK" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "wJ" = (
 /obj/machinery/door/poddoor{
 	id = "ruined_infiltrator";
@@ -324,7 +324,7 @@
 	id = "ruined_infiltrator"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "wU" = (
 /obj/structure/table,
 /obj/item/food/ready_donk{
@@ -336,37 +336,37 @@
 	pixel_x = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "wZ" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "xk" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "yL" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "zg" = (
 /obj/item/crowbar/red,
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/structure/rack,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Aa" = (
 /obj/structure/closet/syndicate/resources,
 /obj/item/coin/antagtoken,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Bb" = (
 /obj/effect/turf_decal/syndicateemblem/middle/right,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "BA" = (
 /obj/structure/table,
 /obj/item/storage/belt/bandolier{
@@ -382,11 +382,11 @@
 	pixel_x = -8
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "CC" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "CX" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency/old{
@@ -394,12 +394,12 @@
 	pixel_x = 8
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Da" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Dx" = (
 /obj/structure/table,
 /obj/item/radio{
@@ -410,22 +410,22 @@
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "DM" = (
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "EK" = (
 /mob/living/basic/carp,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "EM" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "ET" = (
 /obj/structure/closet/cardboard/metal,
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Fn" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/shield/riot{
@@ -433,11 +433,11 @@
 	pixel_x = 7
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "FW" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "GN" = (
 /obj/structure/frame/computer,
 /obj/item/stack/cable_coil/five,
@@ -445,7 +445,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "GY" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -458,18 +458,18 @@
 	req_access = list("syndicate")
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Ig" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/right,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Ix" = (
 /obj/item/tank/internals/plasma/empty{
 	pixel_y = -13;
 	pixel_x = -12
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Jd" = (
 /obj/item/stack/rods,
 /turf/template_noop,
@@ -477,20 +477,20 @@
 "JH" = (
 /obj/structure/frame/machine,
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "JL" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/left,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Kr" = (
 /obj/structure/frame/computer,
 /obj/item/circuitboard/computer/security,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "KJ" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "KM" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -500,17 +500,17 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "LF" = (
 /obj/item/rack_parts,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "LP" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/suit_storage_unit/open,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Mw" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -518,17 +518,17 @@
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "MB" = (
 /mob/living/basic/carp/mega,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Nv" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "NY" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/shutters{
@@ -536,7 +536,7 @@
 	name = "Cockpit Shutters"
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "OT" = (
 /obj/machinery/door/window/brigdoor/right/directional/east{
 	name = "EVA";
@@ -549,34 +549,34 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Pe" = (
 /obj/item/flamethrower{
 	pixel_x = 9;
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Pq" = (
 /turf/closed/wall/r_wall/syndicate,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "PC" = (
 /obj/item/stock_parts/capacitor/adv{
 	pixel_x = 8;
 	pixel_y = 5
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "RM" = (
 /obj/item/restraints/handcuffs/cable/zipties/used{
 	pixel_y = 13
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "RP" = (
 /obj/structure/closet/crate/secure/loot,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "SS" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -584,11 +584,11 @@
 	},
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "SY" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/middle,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Tc" = (
 /obj/item/stack/rods/two,
 /turf/template_noop,
@@ -605,7 +605,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "TY" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -618,7 +618,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Ux" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table,
@@ -628,7 +628,7 @@
 	},
 /obj/item/stock_parts/cell/emproof/empty,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "UN" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -640,26 +640,26 @@
 	pixel_x = 5
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Xp" = (
 /obj/effect/turf_decal/syndicateemblem/middle/left,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Yb" = (
 /obj/structure/chair,
 /obj/item/toy/plush/nukeplushie,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "Yj" = (
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "YL" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/syndicate/black/red,
 /obj/item/clothing/head/helmet/space/syndicate/black/red,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "YN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/pill/morphine{
@@ -670,7 +670,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "YT" = (
 /obj/item/shard,
 /turf/template_noop,
@@ -689,11 +689,11 @@
 	pixel_x = -2
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 "ZO" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space/has_grav)
+/area/ruin/space)
 
 (1,1,1) = {"
 la

--- a/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
@@ -210,6 +210,11 @@
 "nF" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/blood/old,
+/obj/item/ammo_casing/a357/match,
+/obj/item/ammo_casing/a357/match{
+	pixel_y = -4;
+	pixel_x = -7
+	},
 /obj/item/camera_bug{
 	pixel_x = -5;
 	pixel_y = 9
@@ -293,6 +298,7 @@
 /area/ruin/space/unpowered)
 "uS" = (
 /obj/machinery/newscaster/directional/south,
+/obj/item/ammo_casing/a357/match,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/unpowered)
 "vi" = (
@@ -363,11 +369,16 @@
 /obj/item/crowbar/red,
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/structure/rack,
+/obj/item/book/manual/nuclear,
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/unpowered)
 "Aa" = (
-/obj/item/coin/antagtoken,
 /obj/structure/closet/syndicate,
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate,
+/obj/item/coin/antagtoken{
+	pixel_y = 4;
+	pixel_x = 3
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/unpowered)
 "Bb" = (
@@ -390,6 +401,10 @@
 	pixel_x = -8
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/unpowered)
+"Cv" = (
+/obj/item/ammo_casing/a357/match,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/unpowered)
 "CC" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
@@ -1010,7 +1025,7 @@ la
 la
 NY
 jj
-Yj
+Cv
 mq
 Yj
 Pq
@@ -1039,7 +1054,7 @@ NY
 GN
 mg
 Yj
-Yj
+Cv
 en
 DM
 EK
@@ -1065,8 +1080,8 @@ la
 NY
 gr
 Fn
-Yj
-Yj
+Cv
+Cv
 Pq
 EM
 yL

--- a/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
@@ -1,0 +1,1372 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"am" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/has_grav)
+"ao" = (
+/obj/effect/mob_spawn/corpse/human/syndicatepilot,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"bU" = (
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	name = "EVA";
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"cd" = (
+/obj/structure/mirror/directional/east,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"cj" = (
+/obj/machinery/door/window/brigdoor/left/directional/north{
+	name = "Bomb Storage";
+	req_access = list("syndicate")
+	},
+/obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"cJ" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/airlock/external/ruin{
+	name = "Exterior Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"df" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"do" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"dJ" = (
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/has_grav)
+"ej" = (
+/obj/item/chair{
+	dir = 4
+	},
+/mob/living/basic/carp,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"en" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Cockpit"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"fb" = (
+/obj/effect/turf_decal/syndicateemblem/top/middle,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"gr" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	name = "Cockpit View Control";
+	req_access = list("syndicate");
+	pixel_y = 6;
+	id = "ruined_infiltrator_shutters"
+	},
+/obj/item/knife/combat/survival,
+/obj/item/reagent_containers/pill/cyanide{
+	pixel_y = -2;
+	pixel_x = 6
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"gT" = (
+/mob/living/basic/carp,
+/turf/template_noop,
+/area/template_noop)
+"hx" = (
+/obj/structure/frame/machine,
+/obj/item/stock_parts/matter_bin/adv{
+	pixel_y = 3
+	},
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/has_grav)
+"ie" = (
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav)
+"iI" = (
+/obj/effect/turf_decal/syndicateemblem/top/left,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"jj" = (
+/obj/structure/table,
+/obj/item/folder/red{
+	pixel_y = 6;
+	pixel_x = 5
+	},
+/obj/item/paper/crumpled/ruins{
+	default_raw_text = "The nuclear authorization code is: <b>6</b>---...";
+	name = "nuclear bomb code"
+	},
+/obj/item/pen{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"js" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/has_grav)
+"jt" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"ju" = (
+/obj/machinery/power/shuttle_engine/propulsion/right,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav)
+"kC" = (
+/obj/machinery/light/directional/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"la" = (
+/turf/template_noop,
+/area/template_noop)
+"lR" = (
+/obj/structure/table,
+/obj/item/gps/spaceruin{
+	pixel_y = 3;
+	pixel_x = -6
+	},
+/obj/item/grenade/smokebomb{
+	pixel_y = 5;
+	pixel_x = 6
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"mg" = (
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"mq" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"mr" = (
+/obj/item/grenade/smokebomb{
+	pixel_x = 5
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"ms" = (
+/obj/machinery/status_display/ai/directional/north,
+/obj/structure/table,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"mO" = (
+/obj/effect/turf_decal/syndicateemblem/top/right,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"nv" = (
+/obj/item/stack/sheet/mineral/plastitanium,
+/turf/template_noop,
+/area/template_noop)
+"nF" = (
+/obj/item/radio/intercom/directional/south,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/camera_bug{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"nR" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav)
+"pl" = (
+/obj/structure/table,
+/obj/item/relic{
+	pixel_y = 5
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"qL" = (
+/obj/machinery/door/window/brigdoor/left/directional/west{
+	req_access = list("syndicate");
+	name = "Engineering"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"ro" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"sz" = (
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/recharger,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"sL" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/obj/machinery/light/directional/north,
+/obj/item/stack/cable_coil,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"tE" = (
+/obj/effect/turf_decal/syndicateemblem/middle/middle,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"us" = (
+/obj/effect/spawner/random/engineering/tool,
+/obj/machinery/light/directional/west,
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"uE" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"uP" = (
+/obj/machinery/power/shuttle_engine/propulsion/left,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav)
+"uS" = (
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"vi" = (
+/obj/structure/frame/computer,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"vw" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/left/directional/north{
+	name = "Teleporter";
+	req_access = list("syndicate")
+	},
+/obj/item/stock_parts/scanning_module/adv{
+	pixel_x = 8
+	},
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"vK" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"wJ" = (
+/obj/machinery/door/poddoor{
+	id = "ruined_infiltrator";
+	name = "Exterior Blast Door"
+	},
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/west{
+	id = "ruined_infiltrator"
+	},
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav)
+"wU" = (
+/obj/structure/table,
+/obj/item/food/ready_donk{
+	pixel_x = -2;
+	pixel_y = 18
+	},
+/obj/item/toy/talking/ai{
+	pixel_y = 6;
+	pixel_x = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"wZ" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav)
+"xk" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"yL" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"zg" = (
+/obj/item/crowbar/red,
+/obj/structure/sign/warning/vacuum/external/directional/north,
+/obj/structure/rack,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Aa" = (
+/obj/structure/closet/syndicate/resources,
+/obj/item/coin/antagtoken,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"Bb" = (
+/obj/effect/turf_decal/syndicateemblem/middle/right,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"BA" = (
+/obj/structure/table,
+/obj/item/storage/belt/bandolier{
+	pixel_y = 2;
+	pixel_x = 15
+	},
+/obj/item/assembly/igniter{
+	pixel_y = 4;
+	pixel_x = -1
+	},
+/obj/item/assembly/signaler{
+	pixel_y = 4;
+	pixel_x = -8
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"CC" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav)
+"CX" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency/old{
+	pixel_y = 4;
+	pixel_x = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Da" = (
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"Dx" = (
+/obj/structure/table,
+/obj/item/radio{
+	pixel_y = 6;
+	pixel_x = 6
+	},
+/obj/item/flashlight{
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"DM" = (
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"EK" = (
+/mob/living/basic/carp,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"EM" = (
+/obj/machinery/vending/assist,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"ET" = (
+/obj/structure/closet/cardboard/metal,
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/has_grav)
+"Fn" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/shield/riot{
+	pixel_y = 4;
+	pixel_x = 7
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"FW" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"GN" = (
+/obj/structure/frame/computer,
+/obj/item/stack/cable_coil/five,
+/obj/item/stack/sheet/glass{
+	pixel_y = 3
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"GY" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/right/directional/east{
+	name = "Medical";
+	req_access = list("syndicate")
+	},
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"Ig" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/right,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Ix" = (
+/obj/item/tank/internals/plasma/empty{
+	pixel_y = -13;
+	pixel_x = -12
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Jd" = (
+/obj/item/stack/rods,
+/turf/template_noop,
+/area/template_noop)
+"JH" = (
+/obj/structure/frame/machine,
+/turf/open/floor/circuit/red/airless,
+/area/ruin/space/has_grav)
+"JL" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/left,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Kr" = (
+/obj/structure/frame/computer,
+/obj/item/circuitboard/computer/security,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"KJ" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"KM" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"Lz" = (
+/obj/structure/table,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"LF" = (
+/obj/item/rack_parts,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"LP" = (
+/obj/effect/turf_decal/bot_red,
+/obj/machinery/suit_storage_unit/open,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"Mw" = (
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"MB" = (
+/mob/living/basic/carp/mega,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Nv" = (
+/obj/effect/turf_decal/bot_red,
+/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/machinery/suit_storage_unit/open,
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"NY" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/shutters{
+	id = "ruined_infiltrator_shutters";
+	name = "Cockpit Shutters"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav)
+"OT" = (
+/obj/machinery/door/window/brigdoor/right/directional/east{
+	name = "EVA";
+	req_access = list("syndicate")
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"Pe" = (
+/obj/item/flamethrower{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Pq" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/ruin/space/has_grav)
+"PC" = (
+/obj/item/stock_parts/capacitor/adv{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"RM" = (
+/obj/item/restraints/handcuffs/cable/zipties/used{
+	pixel_y = 13
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"RP" = (
+/obj/structure/closet/crate/secure/loot,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"SS" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/north,
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"SY" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/middle,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Tc" = (
+/obj/item/stack/rods/two,
+/turf/template_noop,
+/area/template_noop)
+"Tx" = (
+/obj/machinery/door/window/brigdoor/right/directional/west{
+	req_access = list("syndicate");
+	name = "Engineering"
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"TY" = (
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/obj/item/stack/cable_coil/five,
+/obj/item/electronics/airlock,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/airless,
+/area/ruin/space/has_grav)
+"Ux" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/table,
+/obj/item/stock_parts/cell/high/empty{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stock_parts/cell/emproof/empty,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"UN" = (
+/obj/machinery/status_display/evac{
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_y = 7;
+	pixel_x = 5
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"Xp" = (
+/obj/effect/turf_decal/syndicateemblem/middle/left,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Yb" = (
+/obj/structure/chair,
+/obj/item/toy/plush/nukeplushie,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"Yj" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav)
+"YL" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/space/syndicate/black/red,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"YN" = (
+/obj/structure/table,
+/obj/item/reagent_containers/pill/morphine{
+	pixel_y = 8;
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/pill/morphine{
+	pixel_x = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"YT" = (
+/obj/item/shard,
+/turf/template_noop,
+/area/template_noop)
+"Zh" = (
+/obj/structure/table,
+/obj/item/storage/medkit/ancient{
+	pixel_y = 3;
+	pixel_x = 19
+	},
+/obj/item/reagent_containers/pill/stimulant{
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/pill/epinephrine{
+	pixel_y = 4;
+	pixel_x = -2
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+"ZO" = (
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/has_grav)
+
+(1,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+"}
+(2,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+"}
+(3,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+"}
+(4,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+Tc
+la
+la
+la
+la
+"}
+(5,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+Jd
+la
+la
+la
+la
+la
+la
+Pq
+Pq
+Pq
+KM
+KM
+la
+la
+la
+la
+la
+"}
+(6,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+sz
+PC
+DM
+la
+KM
+la
+nv
+la
+la
+"}
+(7,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+KM
+la
+Da
+LP
+Nv
+Da
+Pq
+uE
+vK
+EK
+KM
+KM
+la
+la
+YT
+la
+"}
+(8,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+nv
+KM
+KM
+DM
+DM
+DM
+do
+Pq
+xk
+DM
+RM
+DM
+cd
+KM
+la
+la
+la
+"}
+(9,1,1) = {"
+la
+la
+Pq
+Pq
+Pq
+Pq
+Pq
+la
+la
+Pq
+DM
+Yb
+ej
+jt
+DM
+Pq
+ms
+vK
+DM
+Zh
+ie
+Pq
+Pq
+la
+la
+"}
+(10,1,1) = {"
+la
+la
+Pq
+df
+UN
+wU
+Pq
+Pq
+la
+Pq
+RP
+Lz
+pl
+DM
+DM
+Pq
+Dx
+DM
+DM
+YN
+Pq
+la
+la
+la
+la
+"}
+(11,1,1) = {"
+la
+la
+NY
+Yj
+Yj
+uS
+Pq
+Pq
+Pq
+Pq
+Pq
+CC
+Pq
+bU
+OT
+Pq
+Pq
+TY
+GY
+Pq
+ie
+Pq
+Pq
+la
+la
+"}
+(12,1,1) = {"
+la
+la
+NY
+jj
+Yj
+mq
+Yj
+Pq
+LF
+ro
+DM
+Pe
+DM
+DM
+iI
+Xp
+JL
+vK
+DM
+us
+JH
+nR
+uP
+la
+la
+"}
+(13,1,1) = {"
+la
+la
+NY
+GN
+mg
+Yj
+Yj
+en
+DM
+EK
+DM
+Ix
+vK
+MB
+fb
+tE
+SY
+DM
+DM
+cj
+dJ
+nR
+wZ
+la
+la
+"}
+(14,1,1) = {"
+la
+la
+NY
+gr
+Fn
+Yj
+Yj
+Pq
+EM
+yL
+vK
+FW
+DM
+DM
+mO
+Bb
+Ig
+mr
+vK
+kC
+ET
+nR
+ju
+la
+la
+"}
+(15,1,1) = {"
+la
+la
+NY
+Kr
+ao
+nF
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+Pq
+cJ
+CC
+Pq
+Pq
+Tx
+qL
+Pq
+ie
+Pq
+Pq
+la
+la
+"}
+(16,1,1) = {"
+la
+la
+Pq
+vi
+Mw
+Aa
+Pq
+Pq
+la
+la
+la
+Pq
+ZO
+DM
+DM
+Pq
+BA
+DM
+DM
+Ux
+Pq
+la
+la
+la
+la
+"}
+(17,1,1) = {"
+la
+la
+Pq
+Pq
+Pq
+Pq
+Pq
+la
+la
+la
+la
+wJ
+vK
+DM
+DM
+Pq
+CX
+vK
+DM
+lR
+ie
+Pq
+Pq
+Pq
+la
+"}
+(18,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+Pq
+zg
+yL
+YL
+Pq
+sL
+KM
+DM
+DM
+SS
+js
+nR
+uP
+la
+"}
+(19,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+YT
+la
+la
+Pq
+Pq
+Pq
+Pq
+Pq
+KM
+la
+DM
+vK
+vw
+am
+nR
+wZ
+la
+"}
+(20,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+gT
+Jd
+la
+la
+la
+la
+la
+Pq
+KM
+Jd
+KM
+KJ
+SS
+hx
+nR
+ju
+la
+"}
+(21,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+Pq
+KM
+KM
+KM
+Pq
+Pq
+Pq
+Pq
+Pq
+la
+"}
+(22,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+nv
+la
+la
+la
+la
+la
+la
+"}
+(23,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+"}
+(24,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+"}
+(25,1,1) = {"
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+la
+"}

--- a/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
@@ -290,7 +290,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space)
 "vi" = (
-/obj/structure/frame/computer,
+/obj/structure/frame/computer{
+	anchored = 1
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space)
 "vw" = (
@@ -358,8 +360,8 @@
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space)
 "Aa" = (
-/obj/structure/closet/syndicate/resources,
 /obj/item/coin/antagtoken,
+/obj/structure/closet/syndicate,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space)
 "Bb" = (
@@ -439,7 +441,9 @@
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space)
 "GN" = (
-/obj/structure/frame/computer,
+/obj/structure/frame/computer{
+	anchored = 1
+	},
 /obj/item/stack/cable_coil/five,
 /obj/item/stack/sheet/glass{
 	pixel_y = 3
@@ -483,8 +487,10 @@
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space)
 "Kr" = (
-/obj/structure/frame/computer,
 /obj/item/circuitboard/computer/security,
+/obj/structure/frame/computer{
+	anchored = 1
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space)
 "KJ" = (
@@ -972,7 +978,7 @@ NY
 Yj
 Yj
 uS
-Pq
+ie
 Pq
 Pq
 Pq
@@ -1080,7 +1086,7 @@ NY
 Kr
 ao
 nF
-Pq
+ie
 Pq
 Pq
 Pq

--- a/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
@@ -286,6 +286,14 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/airless,
 /area/ruin/space/unpowered)
+"uv" = (
+/obj/item/ammo_casing/spent,
+/obj/item/ammo_casing/spent{
+	pixel_y = -8;
+	pixel_x = 2
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/unpowered)
 "uE" = (
 /obj/machinery/recharge_station,
 /obj/machinery/status_display/ai/directional/north,
@@ -379,7 +387,21 @@
 	pixel_y = 4;
 	pixel_x = 3
 	},
+/obj/item/trench_tool,
 /turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/unpowered)
+"AX" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/ammo_casing/spent,
+/obj/item/ammo_casing/spent{
+	pixel_y = -8;
+	pixel_x = 2
+	},
+/obj/item/ammo_casing/spent{
+	pixel_y = -6;
+	pixel_x = -4
+	},
+/turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/unpowered)
 "Bb" = (
 /obj/effect/turf_decal/syndicateemblem/middle/right,
@@ -605,6 +627,10 @@
 /obj/structure/closet/crate/secure/loot,
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/unpowered)
+"SE" = (
+/obj/item/ammo_casing/spent,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/unpowered)
 "SS" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -669,9 +695,19 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/unpowered)
+"WS" = (
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/ammo_casing/spent{
+	pixel_y = -6;
+	pixel_x = -4
+	},
+/obj/item/ammo_casing/spent,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/unpowered)
 "Xp" = (
 /obj/effect/turf_decal/syndicateemblem/middle/left,
 /obj/item/radio/intercom/directional/west,
+/obj/item/ammo_casing/spent,
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/unpowered)
 "Yb" = (
@@ -925,7 +961,7 @@ nv
 KM
 KM
 DM
-DM
+SE
 DM
 DM
 Pq
@@ -957,7 +993,7 @@ jt
 pi
 Pq
 ms
-vK
+WS
 DM
 Zh
 ie
@@ -1031,7 +1067,7 @@ Yj
 Pq
 LF
 ro
-DM
+SE
 Pe
 DM
 DM
@@ -1087,7 +1123,7 @@ EM
 yL
 vK
 FW
-DM
+uv
 DM
 mO
 Bb
@@ -1173,7 +1209,7 @@ DM
 pi
 Pq
 CX
-vK
+AX
 DM
 lR
 ie

--- a/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
@@ -3,11 +3,11 @@
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/five,
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "ao" = (
 /obj/effect/mob_spawn/corpse/human/syndicatepilot,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "bU" = (
 /obj/machinery/door/window/brigdoor/left/directional/east{
 	name = "EVA";
@@ -20,11 +20,11 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "cd" = (
 /obj/structure/mirror/directional/east,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "cj" = (
 /obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Bomb Storage";
@@ -36,7 +36,7 @@
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "cJ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -53,26 +53,22 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "df" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
-"do" = (
-/obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "dJ" = (
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "ej" = (
 /obj/item/chair{
 	dir = 4
 	},
 /mob/living/basic/carp,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "en" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Cockpit"
@@ -85,11 +81,11 @@
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "fb" = (
 /obj/effect/turf_decal/syndicateemblem/top/middle,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "gr" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -104,7 +100,7 @@
 	pixel_x = 6
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "gT" = (
 /mob/living/basic/carp,
 /turf/template_noop,
@@ -115,14 +111,14 @@
 	pixel_y = 3
 	},
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "ie" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "iI" = (
 /obj/effect/turf_decal/syndicateemblem/top/left,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "jj" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -138,23 +134,23 @@
 	pixel_x = -3
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "js" = (
 /obj/structure/frame/computer{
 	dir = 1
 	},
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "jt" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "ju" = (
 /obj/machinery/power/shuttle_engine/propulsion/right,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "kC" = (
 /obj/machinery/light/directional/east,
 /obj/structure/window/reinforced/spawner/north,
@@ -163,7 +159,7 @@
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "la" = (
 /turf/template_noop,
 /area/template_noop)
@@ -178,35 +174,35 @@
 	pixel_x = 6
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "mg" = (
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "mq" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "mr" = (
 /obj/item/grenade/smokebomb{
 	pixel_x = 5
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "ms" = (
-/obj/machinery/status_display/ai/directional/north,
 /obj/structure/table,
 /obj/item/restraints/handcuffs/cable/zipties,
 /obj/item/storage/fancy/cigarettes/cigpack_syndicate{
 	pixel_x = -4;
 	pixel_y = 3
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "mO" = (
 /obj/effect/turf_decal/syndicateemblem/top/right,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "nv" = (
 /obj/item/stack/sheet/mineral/plastitanium,
 /turf/template_noop,
@@ -219,20 +215,24 @@
 	pixel_y = 9
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "nR" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plating/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
+"pi" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/mineral/plastitanium/red/airless,
+/area/ruin/space/unpowered)
 "pl" = (
 /obj/structure/table,
 /obj/item/relic{
 	pixel_y = 5
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "qL" = (
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	req_access = list("syndicate");
@@ -245,27 +245,32 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "ro" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "sz" = (
 /obj/structure/frame/machine,
-/obj/item/circuitboard/machine/recharger,
+/obj/item/circuitboard/machine/cyborgrecharger,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "sL" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
 /obj/machinery/light/directional/north,
 /obj/item/stack/cable_coil,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "tE" = (
 /obj/effect/turf_decal/syndicateemblem/middle/middle,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
+"ur" = (
+/obj/structure/lattice,
+/obj/machinery/status_display/ai/directional/north,
+/turf/template_noop,
+/area/template_noop)
 "us" = (
 /obj/effect/spawner/random/engineering/tool,
 /obj/machinery/light/directional/west,
@@ -275,26 +280,27 @@
 	},
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "uE" = (
 /obj/machinery/recharge_station,
+/obj/machinery/status_display/ai/directional/north,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "uP" = (
 /obj/machinery/power/shuttle_engine/propulsion/left,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "uS" = (
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "vi" = (
 /obj/structure/frame/computer{
 	anchored = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "vw" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -308,11 +314,11 @@
 	pixel_x = 8
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "vK" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "wJ" = (
 /obj/machinery/door/poddoor{
 	id = "ruined_infiltrator";
@@ -326,7 +332,7 @@
 	id = "ruined_infiltrator"
 	},
 /turf/open/floor/plating/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "wU" = (
 /obj/structure/table,
 /obj/item/food/ready_donk{
@@ -338,37 +344,37 @@
 	pixel_x = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "wZ" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "xk" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "yL" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "zg" = (
 /obj/item/crowbar/red,
 /obj/structure/sign/warning/vacuum/external/directional/north,
 /obj/structure/rack,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Aa" = (
 /obj/item/coin/antagtoken,
 /obj/structure/closet/syndicate,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Bb" = (
 /obj/effect/turf_decal/syndicateemblem/middle/right,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "BA" = (
 /obj/structure/table,
 /obj/item/storage/belt/bandolier{
@@ -384,24 +390,25 @@
 	pixel_x = -8
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "CC" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "CX" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency/old{
 	pixel_y = 4;
 	pixel_x = 8
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Da" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Dx" = (
 /obj/structure/table,
 /obj/item/radio{
@@ -412,22 +419,22 @@
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "DM" = (
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "EK" = (
 /mob/living/basic/carp,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "EM" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "ET" = (
 /obj/structure/closet/cardboard/metal,
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Fn" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/shield/riot{
@@ -435,11 +442,11 @@
 	pixel_x = 7
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "FW" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "GN" = (
 /obj/structure/frame/computer{
 	anchored = 1
@@ -449,7 +456,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "GY" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -462,18 +469,18 @@
 	req_access = list("syndicate")
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Ig" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/right,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Ix" = (
 /obj/item/tank/internals/plasma/empty{
 	pixel_y = -13;
 	pixel_x = -12
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Jd" = (
 /obj/item/stack/rods,
 /turf/template_noop,
@@ -481,22 +488,22 @@
 "JH" = (
 /obj/structure/frame/machine,
 /turf/open/floor/circuit/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "JL" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/left,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Kr" = (
 /obj/item/circuitboard/computer/security,
 /obj/structure/frame/computer{
 	anchored = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "KJ" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "KM" = (
 /obj/structure/lattice,
 /turf/template_noop,
@@ -506,17 +513,17 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "LF" = (
 /obj/item/rack_parts,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "LP" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/suit_storage_unit/open,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Mw" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -524,17 +531,17 @@
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "MB" = (
 /mob/living/basic/carp/mega,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Nv" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/sign/poster/contraband/random/directional/west,
 /obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "NY" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/shutters{
@@ -542,7 +549,7 @@
 	name = "Cockpit Shutters"
 	},
 /turf/open/floor/plating,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "OT" = (
 /obj/machinery/door/window/brigdoor/right/directional/east{
 	name = "EVA";
@@ -555,34 +562,34 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Pe" = (
 /obj/item/flamethrower{
 	pixel_x = 9;
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Pq" = (
 /turf/closed/wall/r_wall/syndicate,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "PC" = (
 /obj/item/stock_parts/capacitor/adv{
 	pixel_x = 8;
 	pixel_y = 5
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "RM" = (
 /obj/item/restraints/handcuffs/cable/zipties/used{
 	pixel_y = 13
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "RP" = (
 /obj/structure/closet/crate/secure/loot,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "SS" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/stripes/red/line{
@@ -590,11 +597,11 @@
 	},
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "SY" = (
 /obj/effect/turf_decal/syndicateemblem/bottom/middle,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Tc" = (
 /obj/item/stack/rods/two,
 /turf/template_noop,
@@ -611,7 +618,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "TY" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard,
@@ -624,7 +631,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Ux" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table,
@@ -634,7 +641,7 @@
 	},
 /obj/item/stock_parts/cell/emproof/empty,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "UN" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -646,26 +653,26 @@
 	pixel_x = 5
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Xp" = (
 /obj/effect/turf_decal/syndicateemblem/middle/left,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Yb" = (
 /obj/structure/chair,
 /obj/item/toy/plush/nukeplushie,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "Yj" = (
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "YL" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/syndicate/black/red,
 /obj/item/clothing/head/helmet/space/syndicate/black/red,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "YN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/pill/morphine{
@@ -676,7 +683,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "YT" = (
 /obj/item/shard,
 /turf/template_noop,
@@ -695,11 +702,11 @@
 	pixel_x = -2
 	},
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 "ZO" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/mineral/plastitanium/red/airless,
-/area/ruin/space)
+/area/ruin/space/unpowered)
 
 (1,1,1) = {"
 la
@@ -905,7 +912,7 @@ KM
 DM
 DM
 DM
-do
+DM
 Pq
 xk
 DM
@@ -932,7 +939,7 @@ DM
 Yb
 ej
 jt
-DM
+pi
 Pq
 ms
 vK
@@ -984,14 +991,14 @@ Pq
 Pq
 Pq
 CC
-Pq
+ie
 bU
 OT
-Pq
-Pq
+ie
+ie
 TY
 GY
-Pq
+ie
 ie
 Pq
 Pq
@@ -1092,14 +1099,14 @@ Pq
 Pq
 Pq
 Pq
-Pq
+ie
 cJ
 CC
-Pq
-Pq
+ie
+ie
 Tx
 qL
-Pq
+ie
 ie
 Pq
 Pq
@@ -1148,7 +1155,7 @@ la
 wJ
 vK
 DM
-DM
+pi
 Pq
 CX
 vK
@@ -1231,7 +1238,7 @@ la
 la
 la
 Pq
-KM
+ur
 Jd
 KM
 KJ

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -320,7 +320,6 @@
 	name = "Abandoned Infiltrator"
 	description = "Only one in five Gorlex Marauder strike forces return from their regular raids into Nanotrasen space. \
 		For the other four... well, their ship doesn't just disappear when their target evacuates."
-	always_place = TRUE
 
 /datum/map_template/ruin/space/hellfactory
 	id = "hellfactory"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -314,6 +314,14 @@
 	name = "Syndicate Forgotten Ship"
 	description = "Seemingly abandoned ship went of course right into NT controlled space. It seems that malfunction caused most systems to turn off, except for sleepers."
 
+/datum/map_template/ruin/space/old_syndie_infiltrator
+	id = "old_infiltrator"
+	suffix = "old_infiltrator.dmm"
+	name = "Abandoned Infiltrator"
+	description = "Only one in five Gorlex Marauder strike forces return from their regular raids into Nanotrasen space. \
+		For the other four... well, their ship doesn't just disappear when their target evacuates."
+	always_place = TRUE
+
 /datum/map_template/ruin/space/hellfactory
 	id = "hellfactory"
 	suffix = "hellfactory.dmm"

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -4,6 +4,12 @@
 	has_gravity = FALSE
 	area_flags = UNIQUE_AREA
 
+/area/ruin/space/unpowered
+	always_unpowered = TRUE
+	power_light = FALSE
+	power_equip = FALSE
+	power_environ = FALSE
+
 /area/ruin/space/has_grav
 	has_gravity = STANDARD_GRAVITY
 

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -36,6 +36,7 @@
 #_maps/RandomRuins/SpaceRuins/listeningstation.dmm
 #_maps/RandomRuins/SpaceRuins/mechtransport.dmm
 #_maps/RandomRuins/SpaceRuins/mrow_thats_right
+#_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
 #_maps/RandomRuins/SpaceRuins/oldAIsat.dmm
 #_maps/RandomRuins/SpaceRuins/oldstation.dmm
 #_maps/RandomRuins/SpaceRuins/oldteleporter.dmm


### PR DESCRIPTION
## About The Pull Request

Adds a space ruin, the Abandoned / Old Infiltrator.

Simply, it's a Syndicate Infiltrator that's seen better days. The design is pulled from the OLD Infiltrator design (VERY SLIGHTLY updated stylistically). Some carp have made it their home. 

There is very little in the way of loot, as scavengers have picked it clean. Some medical supplies, tools, and a locked crate. One suit remains locked in the airlock.
Within the cockpit lies more notable items (Illegal technology and an equipped corpse), but getting in there is much harder, as the last pilot bolted themselves in before the power died. 

<Details>

<Summary>Picture within</Summary>

![image](https://user-images.githubusercontent.com/51863163/221710445-24fbf773-1821-4ad6-9770-54cabd2e67ea.png)

![image](https://user-images.githubusercontent.com/51863163/221710925-7f801fca-6c78-4c58-8e95-52bf3d2e074a.png)

</Details>

## Why It's Good For The Game

More variety for deep space. 

## Changelog

:cl: Melbert
add: Somewhere, in deep space, a relic to every fluked nuclear operative mission drifts abandoned. 
/:cl:

