### PR TITLE
Fix .tgs.yml BYOND version being parsed as a float in JS

### DIFF
--- a/.tgs.yml
+++ b/.tgs.yml
@@ -1,5 +1,5 @@
 version: 1
-byond: 514.1588
+byond: "514.1588"
 static_files:
   - name: config
     populate: true


### PR DESCRIPTION
Title