### PR TITLE
Define anomaly event parameters, adjust timers

### DIFF
--- a/code/__DEFINES/anomaly.dm
+++ b/code/__DEFINES/anomaly.dm
@@ -15,7 +15,7 @@
 ///Time in seconds before anomaly is announced
 #define ANOMALY_ANNOUNCE_MEDIUM_TIME (2 EVENT_SECONDS)
 ///Let them know how far away the anomaly is
-#define ANOMALY_ANNOUNCE_MEDIUM_TEXT "long range scanners.  Expected location:"
+#define ANOMALY_ANNOUNCE_MEDIUM_TEXT "long range scanners. Expected location:"
 
 /**
  * Chaotic but not harmful anomalies. Give the station a chance to find it on their own.
@@ -26,7 +26,7 @@
 ///Time in seconds before anomaly is announced
 #define ANOMALY_ANNOUNCE_HARMFUL_TIME (30 EVENT_SECONDS)
 ///Let them know how far away the anomaly is
-#define ANOMALY_ANNOUNCE_HARMFUL_TEXT "localized scanners.  Detected location:"
+#define ANOMALY_ANNOUNCE_HARMFUL_TEXT "localized scanners. Detected location:"
 
 /**
  * Anomalies that can fuck you up. Give them a bit of warning.
@@ -37,4 +37,4 @@
 ///Time in seconds before anomaly is announced
 #define ANOMALY_ANNOUNCE_DANGEROUS_TIME (30 EVENT_SECONDS)
 ///Let them know how far away the anomaly is
-#define ANOMALY_ANNOUNCE_DANGEROUS_TEXT "localized scanners.  Detected location:"
+#define ANOMALY_ANNOUNCE_DANGEROUS_TEXT "localized scanners. Detected location:"

--- a/code/__DEFINES/anomaly.dm
+++ b/code/__DEFINES/anomaly.dm
@@ -1,0 +1,40 @@
+/**
+ *  # Anomaly Defines
+ *  This file contains defines for the random event anomaly subtypes.
+ */
+
+///Time in ticks before the anomaly goes poof/explodes depending on type.
+#define ANOMALY_COUNTDOWN_TIMER (75 SECONDS)
+
+/**
+ * Nuisance/funny anomalies
+ */
+
+///Time in ticks before anomaly spawns
+#define ANOMALY_START_MEDIUM_TIME 8
+///Time in ticks before anomaly is announced
+#define ANOMALY_ANNOUNCE_MEDIUM_TIME 1
+///Let them know how far away the anomaly is
+#define ANOMALY_ANNOUNCE_MEDIUM_TEXT "long range scanners.  Expected location:"
+
+/**
+ * Chaotic but not harmful anomalies. Give the station a chance to find it on their own.
+ */
+
+///Time in ticks before anomaly spawns
+#define ANOMALY_START_HARMFUL_TIME 1
+///Time in ticks before anomaly is announced
+#define ANOMALY_ANNOUNCE_HARMFUL_TIME 15
+///Let them know how far away the anomaly is
+#define ANOMALY_ANNOUNCE_HARMFUL_TEXT "localized scanners.  Detected location:"
+
+/**
+ * Anomalies that can fuck you up. Give them a bit of warning.
+ */
+
+///Time in ticks before anomaly spawns
+#define ANOMALY_START_DANGEROUS_TIME 1
+///Time in ticks before anomaly is announced
+#define ANOMALY_ANNOUNCE_DANGEROUS_TIME 15
+///Let them know how far away the anomaly is
+#define ANOMALY_ANNOUNCE_DANGEROUS_TEXT "localized scanners.  Detected location:"

--- a/code/__DEFINES/anomaly.dm
+++ b/code/__DEFINES/anomaly.dm
@@ -10,10 +10,10 @@
  * Nuisance/funny anomalies
  */
 
-///Time in ticks before anomaly spawns
-#define ANOMALY_START_MEDIUM_TIME 8
-///Time in ticks before anomaly is announced
-#define ANOMALY_ANNOUNCE_MEDIUM_TIME 1
+///Time in seconds before anomaly spawns
+#define ANOMALY_START_MEDIUM_TIME (6 EVENT_SECONDS)
+///Time in seconds before anomaly is announced
+#define ANOMALY_ANNOUNCE_MEDIUM_TIME (2 EVENT_SECONDS)
 ///Let them know how far away the anomaly is
 #define ANOMALY_ANNOUNCE_MEDIUM_TEXT "long range scanners.  Expected location:"
 
@@ -21,10 +21,10 @@
  * Chaotic but not harmful anomalies. Give the station a chance to find it on their own.
  */
 
-///Time in ticks before anomaly spawns
-#define ANOMALY_START_HARMFUL_TIME 1
-///Time in ticks before anomaly is announced
-#define ANOMALY_ANNOUNCE_HARMFUL_TIME 15
+///Time in seconds before anomaly spawns
+#define ANOMALY_START_HARMFUL_TIME (2 EVENT_SECONDS)
+///Time in seconds before anomaly is announced
+#define ANOMALY_ANNOUNCE_HARMFUL_TIME (30 EVENT_SECONDS)
 ///Let them know how far away the anomaly is
 #define ANOMALY_ANNOUNCE_HARMFUL_TEXT "localized scanners.  Detected location:"
 
@@ -32,9 +32,9 @@
  * Anomalies that can fuck you up. Give them a bit of warning.
  */
 
-///Time in ticks before anomaly spawns
-#define ANOMALY_START_DANGEROUS_TIME 1
-///Time in ticks before anomaly is announced
-#define ANOMALY_ANNOUNCE_DANGEROUS_TIME 15
+///Time in seconds before anomaly spawns
+#define ANOMALY_START_DANGEROUS_TIME (2 EVENT_SECONDS)
+///Time in seconds before anomaly is announced
+#define ANOMALY_ANNOUNCE_DANGEROUS_TIME (30 EVENT_SECONDS)
 ///Let them know how far away the anomaly is
 #define ANOMALY_ANNOUNCE_DANGEROUS_TEXT "localized scanners.  Detected location:"

--- a/code/__DEFINES/events.dm
+++ b/code/__DEFINES/events.dm
@@ -40,3 +40,5 @@
 #define EVENT_SPACE_ONLY (1 << 0)
 /// Event can only run on a map which is a planet
 #define EVENT_PLANETARY_ONLY (1 << 1)
+/// Event timer in seconds
+#define EVENT_SECONDS *0.5

--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -11,7 +11,7 @@
 	var/obj/item/assembly/signaler/anomaly/aSignal = /obj/item/assembly/signaler/anomaly
 	var/area/impact_area
 
-	var/lifespan = 99 SECONDS
+	var/lifespan = ANOMALY_COUNTDOWN_TIMER
 	var/death_time
 
 	var/countdown_colour

--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -3,7 +3,7 @@
 	desc = "It looks like the souls of the damned are trying to break into the realm of the living again. How upsetting."
 	icon_state = "ectoplasm"
 	aSignal = /obj/item/assembly/signaler/anomaly/ectoplasm
-	lifespan = 100 SECONDS //This one takes slightly longer, because it can run away.
+	lifespan = 77 SECONDS //This one takes slightly longer, because it can run away.
 
 	///Blocks the anomaly from updating ghost count. Used in case an admin wants to rig the anomaly to be a certain size or intensity.
 	var/override_ghosts = FALSE

--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -3,7 +3,7 @@
 	desc = "It looks like the souls of the damned are trying to break into the realm of the living again. How upsetting."
 	icon_state = "ectoplasm"
 	aSignal = /obj/item/assembly/signaler/anomaly/ectoplasm
-	lifespan = 77 SECONDS //This one takes slightly longer, because it can run away.
+	lifespan = ANOMALY_COUNTDOWN_TIMER + 2 SECONDS //This one takes slightly longer, because it can run away.
 
 	///Blocks the anomaly from updating ghost count. Used in case an admin wants to rig the anomaly to be a certain size or intensity.
 	var/override_ghosts = FALSE

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -178,15 +178,15 @@ Runs the event
 	var/datum/round_event_control/control
 
 	/// When in the lifetime to call start().
-	/// This is in seconds - so 1 = ~2 seconds in.
+	/// This is in ticks - so 1 = ~2 seconds in.
 	var/start_when = 0
 	/// When in the lifetime to call announce(). If you don't want it to announce use announce_chance, below.
-	/// This is in seconds - so 1 = ~2 seconds in.
+	/// This is in ticks - so 1 = ~2 seconds in.
 	var/announce_when = 0
 	/// Probability of announcing, used in prob(), 0 to 100, default 100. Called in process, and for a second time in the ion storm event.
 	var/announce_chance = 100
 	/// When in the lifetime the event should end.
-	/// This is in seconds - so 1 = ~2 seconds in.
+	/// This is in ticks - so 1 = ~2 seconds in.
 	var/end_when = 0
 
 	/// How long the event has existed. You don't need to change this.

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -178,15 +178,15 @@ Runs the event
 	var/datum/round_event_control/control
 
 	/// When in the lifetime to call start().
-	/// This is in ticks - so 1 = ~2 seconds in.
+	/// This is in seconds - so 1 = ~2 seconds in.
 	var/start_when = 0
 	/// When in the lifetime to call announce(). If you don't want it to announce use announce_chance, below.
-	/// This is in ticks - so 1 = ~2 seconds in.
+	/// This is in seconds - so 1 = ~2 seconds in.
 	var/announce_when = 0
 	/// Probability of announcing, used in prob(), 0 to 100, default 100. Called in process, and for a second time in the ion storm event.
 	var/announce_chance = 100
 	/// When in the lifetime the event should end.
-	/// This is in ticks - so 1 = ~2 seconds in.
+	/// This is in seconds - so 1 = ~2 seconds in.
 	var/end_when = 0
 
 	/// How long the event has existed. You don't need to change this.

--- a/code/modules/events/anomaly/_anomaly.dm
+++ b/code/modules/events/anomaly/_anomaly.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/anomaly
-	name = "Anomaly: Energetic Flux"
+	name = "Anomaly: Debug"
 	typepath = /datum/round_event/anomaly
 
 	min_players = 1
@@ -10,7 +10,8 @@
 	admin_setup = /datum/event_admin_setup/anomaly
 
 /datum/round_event/anomaly
-	announce_when = 1
+	start_when = ANOMALY_START_HARMFUL_TIME
+	announce_when = ANOMALY_ANNOUNCE_HARMFUL_TIME
 	var/area/impact_area
 	var/datum/anomaly_placer/placer = new()
 	var/obj/effect/anomaly/anomaly_path = /obj/effect/anomaly/flux
@@ -25,7 +26,7 @@
 		impact_area = placer.findValidArea()
 
 /datum/round_event/anomaly/announce(fake)
-	priority_announce("Localized energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Energetic flux wave detected on [ANOMALY_ANNOUNCE_DANGEROUS_TEXT] [impact_area.name].", "Anomaly Alert")
 
 /datum/round_event/anomaly/start()
 	var/turf/anomaly_turf

--- a/code/modules/events/anomaly/_anomaly.dm
+++ b/code/modules/events/anomaly/_anomaly.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/anomaly
-	name = "Anomaly: Debug"
+	name = "Anomaly: Energetic Flux"
 	typepath = /datum/round_event/anomaly
 
 	min_players = 1

--- a/code/modules/events/anomaly/anomaly_bioscrambler.dm
+++ b/code/modules/events/anomaly/anomaly_bioscrambler.dm
@@ -10,9 +10,9 @@
 	max_wizard_trigger_potency = 2
 
 /datum/round_event/anomaly/anomaly_bioscrambler
-	start_when = 10
-	announce_when = 3
+	start_when = ANOMALY_START_MEDIUM_TIME
+	announce_when = ANOMALY_ANNOUNCE_MEDIUM_TIME
 	anomaly_path = /obj/effect/anomaly/bioscrambler
 
 /datum/round_event/anomaly/anomaly_bioscrambler/announce(fake)
-	priority_announce("Localized limb swapping agent. Expected location: [impact_area.name]. Wear biosuits to counter the effects. Calculated half-life of %9£$T$%F3 years", "Anomaly Alert")
+	priority_announce("Biologic limb swapping agent detected on [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name]. Wear biosuits or other protective gear to counter the effects. Calculated half-life of %9£$T$%F3 years.", "Anomaly Alert")

--- a/code/modules/events/anomaly/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly/anomaly_bluespace.dm
@@ -9,9 +9,9 @@
 	max_wizard_trigger_potency = 2
 
 /datum/round_event/anomaly/anomaly_bluespace
-	start_when = 3
-	announce_when = 10
+	start_when = ANOMALY_START_MEDIUM_TIME
+	announce_when = ANOMALY_ANNOUNCE_MEDIUM_TIME
 	anomaly_path = /obj/effect/anomaly/bluespace
 
 /datum/round_event/anomaly/anomaly_bluespace/announce(fake)
-	priority_announce("Unstable bluespace anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Bluespace instability detected on [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name].", "Anomaly Alert")

--- a/code/modules/events/anomaly/anomaly_dimensional.dm
+++ b/code/modules/events/anomaly/anomaly_dimensional.dm
@@ -11,8 +11,8 @@
 	admin_setup = /datum/event_admin_setup/listed_options/anomaly_dimensional
 
 /datum/round_event/anomaly/anomaly_dimensional
-	start_when = 10
-	announce_when = 3
+	start_when = ANOMALY_START_MEDIUM_TIME
+	announce_when = ANOMALY_ANNOUNCE_MEDIUM_TIME
 	anomaly_path = /obj/effect/anomaly/dimensional
 	/// What theme should the anomaly initially apply to the area?
 	var/anomaly_theme
@@ -23,7 +23,7 @@
 	new_anomaly.prepare_area(new_theme_path = anomaly_theme)
 
 /datum/round_event/anomaly/anomaly_dimensional/announce(fake)
-	priority_announce("Localized dimensional instability detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Dimensional instability detected on [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name].", "Anomaly Alert")
 
 /datum/event_admin_setup/listed_options/anomaly_dimensional
 	input_text = "Select a dimensional anomaly theme?"

--- a/code/modules/events/anomaly/anomaly_ectoplasm.dm
+++ b/code/modules/events/anomaly/anomaly_ectoplasm.dm
@@ -16,8 +16,8 @@
 
 /datum/round_event/anomaly/anomaly_ectoplasm
 	anomaly_path = /obj/effect/anomaly/ectoplasm
-	start_when = 3
-	announce_when = 20
+	start_when = ANOMALY_START_HARMFUL_TIME
+	announce_when = ANOMALY_ANNOUNCE_HARMFUL_TIME
 	///The admin-set impact effect intensity override
 	var/effect_override
 	///The admin-set number of ghosts, for use in calculating impact size.
@@ -39,7 +39,7 @@
 		announce_to_ghosts(newAnomaly)
 
 /datum/round_event/anomaly/anomaly_ectoplasm/announce(fake)
-	priority_announce("Localized ectoplasmic outburst detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Paranormal ectoplasmic outburst detected on [ANOMALY_ANNOUNCE_HARMFUL_TEXT] [impact_area.name].", "Anomaly Alert")
 
 /datum/event_admin_setup/anomaly/anomaly_ectoplasm
 	///The admin-selected intensity

--- a/code/modules/events/anomaly/anomaly_flux.dm
+++ b/code/modules/events/anomaly/anomaly_flux.dm
@@ -10,9 +10,9 @@
 	max_wizard_trigger_potency = 4
 
 /datum/round_event/anomaly/anomaly_flux
-	start_when = 10
-	announce_when = 3
+	start_when = ANOMALY_START_DANGEROUS_TIME
+	announce_when = ANOMALY_ANNOUNCE_DANGEROUS_TIME
 	anomaly_path = /obj/effect/anomaly/flux
 
 /datum/round_event/anomaly/anomaly_flux/announce(fake)
-	priority_announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Hyper-energetic flux wave detected on [ANOMALY_ANNOUNCE_DANGEROUS_TEXT]. [impact_area.name].", "Anomaly Alert")

--- a/code/modules/events/anomaly/anomaly_grav.dm
+++ b/code/modules/events/anomaly/anomaly_grav.dm
@@ -9,8 +9,8 @@
 	max_wizard_trigger_potency = 3
 
 /datum/round_event/anomaly/anomaly_grav
-	start_when = 3
-	announce_when = 20
+	start_when = ANOMALY_START_HARMFUL_TIME
+	announce_when = ANOMALY_ANNOUNCE_HARMFUL_TIME
 	anomaly_path = /obj/effect/anomaly/grav
 
 /datum/round_event_control/anomaly/anomaly_grav/high
@@ -22,9 +22,9 @@
 	description = "This anomaly has an intense gravitational field, and can disable the gravity generator."
 
 /datum/round_event/anomaly/anomaly_grav/high
-	start_when = 3
-	announce_when = 20
+	start_when = 1
+	announce_when = 15
 	anomaly_path = /obj/effect/anomaly/grav/high
 
 /datum/round_event/anomaly/anomaly_grav/announce(fake)
-	priority_announce("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert" , ANNOUNCER_GRANOMALIES)
+	priority_announce("Gravitational anomaly detected on [ANOMALY_ANNOUNCE_HARMFUL_TEXT] [impact_area.name].", "Anomaly Alert" , ANNOUNCER_GRANOMALIES)

--- a/code/modules/events/anomaly/anomaly_grav.dm
+++ b/code/modules/events/anomaly/anomaly_grav.dm
@@ -22,8 +22,8 @@
 	description = "This anomaly has an intense gravitational field, and can disable the gravity generator."
 
 /datum/round_event/anomaly/anomaly_grav/high
-	start_when = 1
-	announce_when = 15
+	start_when = ANOMALY_START_HARMFUL_TIME
+	announce_when = ANOMALY_ANNOUNCE_HARMFUL_TIME
 	anomaly_path = /obj/effect/anomaly/grav/high
 
 /datum/round_event/anomaly/anomaly_grav/announce(fake)

--- a/code/modules/events/anomaly/anomaly_hallucination.dm
+++ b/code/modules/events/anomaly/anomaly_hallucination.dm
@@ -10,9 +10,9 @@
 	max_wizard_trigger_potency = 2
 
 /datum/round_event/anomaly/anomaly_hallucination
-	start_when = 10
-	announce_when = 3
+	start_when = ANOMALY_START_MEDIUM_TIME
+	announce_when = ANOMALY_ANNOUNCE_MEDIUM_TIME
 	anomaly_path = /obj/effect/anomaly/hallucination
 
 /datum/round_event/anomaly/anomaly_hallucination/announce(fake)
-	priority_announce("Hallucinatory event hitting the station. Expected location: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Hallucinatory event [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name].", "Anomaly Alert")

--- a/code/modules/events/anomaly/anomaly_pyro.dm
+++ b/code/modules/events/anomaly/anomaly_pyro.dm
@@ -9,9 +9,9 @@
 	max_wizard_trigger_potency = 4
 
 /datum/round_event/anomaly/anomaly_pyro
-	start_when = 3
-	announce_when = 10
+	start_when = ANOMALY_START_HARMFUL_TIME
+	announce_when = ANOMALY_ANNOUNCE_HARMFUL_TIME
 	anomaly_path = /obj/effect/anomaly/pyro
 
 /datum/round_event/anomaly/anomaly_pyro/announce(fake)
-	priority_announce("Pyroclastic anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
+	priority_announce("Pyroclastic anomaly detected on [ANOMALY_ANNOUNCE_HARMFUL_TEXT] [impact_area.name].", "Anomaly Alert")

--- a/code/modules/events/anomaly/anomaly_vortex.dm
+++ b/code/modules/events/anomaly/anomaly_vortex.dm
@@ -10,9 +10,9 @@
 	max_wizard_trigger_potency = 7
 
 /datum/round_event/anomaly/anomaly_vortex
-	start_when = 10
-	announce_when = 3
+	start_when = ANOMALY_START_DANGEROUS_TIME
+	announce_when = ANOMALY_ANNOUNCE_DANGEROUS_TIME
 	anomaly_path = /obj/effect/anomaly/bhole
 
 /datum/round_event/anomaly/anomaly_vortex/announce(fake)
-	priority_announce("Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name]", "Anomaly Alert")
+	priority_announce("Localized high-intensity vortex anomaly detected on [ANOMALY_ANNOUNCE_DANGEROUS_TEXT] [impact_area.name]", "Anomaly Alert")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -38,6 +38,7 @@
 #include "code\__DEFINES\ai_pet_commands.dm"
 #include "code\__DEFINES\alarm.dm"
 #include "code\__DEFINES\alerts.dm"
+#include "code\__DEFINES\anomaly.dm"
 #include "code\__DEFINES\antagonists.dm"
 #include "code\__DEFINES\apc_defines.dm"
 #include "code\__DEFINES\appearance.dm"


### PR DESCRIPTION
## About The Pull Request

- Moves parameters for all the anomaly random events to defines.
- Timers consolidated into three severities: medium, harmful, dangerous.
- Medium (harmless/nuisance) are announced immediately, higher severities keep delay allowing time for crew to notice it first.
- Removes 6 second wait for anomaly events to start.
- Countdown timer reduced to 75 seconds (+2 for ectoplasmic.) Previously 99/+1.

## Why It's Good For The Game

- Consolidates the timer/text configuration into a single defines file instead of spread among 12.
- Event gets started faster.
- Anomalies are frequently stopped at 40 seconds+ left, reduced timer adds a bit more urgency.

## Changelog

:cl: LT3
code: Anomaly event parameters consolidated to defines
balance: Anomaly countdown timer reduced to 75 seconds
/:cl: