### PR TITLE
Fixes the arguments of bodypart_overlay's color_image() and its lack of early returns in subtypes

### DIFF
--- a/code/datums/bodypart_overlays/bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/bodypart_overlay.dm
@@ -20,7 +20,7 @@
 	CRASH("Get image needs to be overridden")
 
 ///Color the image
-/datum/bodypart_overlay/proc/color_image(image/overlay, layer)
+/datum/bodypart_overlay/proc/color_image(image/overlay, layer, obj/item/bodypart/limb)
 	return
 
 ///Called on being added to a limb

--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -60,8 +60,6 @@
 	return appearance
 
 /datum/bodypart_overlay/mutant/color_image(image/overlay, layer, obj/item/bodypart/limb)
-	if(!overlay)
-		return
 
 	overlay.color = sprite_datum.color_src ? draw_color : null
 

--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -60,7 +60,7 @@
 	return appearance
 
 /datum/bodypart_overlay/mutant/color_image(image/overlay, layer, obj/item/bodypart/limb)
-	if(!sprite_datum || !overlay)
+	if(!overlay)
 		return
 
 	overlay.color = sprite_datum.color_src ? draw_color : null

--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -59,7 +59,10 @@
 
 	return appearance
 
-/datum/bodypart_overlay/mutant/color_image(image/overlay, obj/item/bodypart/limb)
+/datum/bodypart_overlay/mutant/color_image(image/overlay, layer, obj/item/bodypart/limb)
+	if(!sprite_datum || !overlay)
+		return
+
 	overlay.color = sprite_datum.color_src ? draw_color : null
 
 /datum/bodypart_overlay/mutant/added_to_limb(obj/item/bodypart/limb)

--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -42,7 +42,6 @@
 /datum/bodypart_overlay/mutant/get_image(image_layer, obj/item/bodypart/limb)
 	if(!sprite_datum)
 		CRASH("Trying to call get_image() on [type] while it didn't have a sprite_datum. This shouldn't happen, report it as soon as possible.")
-		return
 
 	var/gender = (limb?.limb_gender == FEMALE) ? "f" : "m"
 	var/list/icon_state_builder = list()

--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -41,6 +41,7 @@
 ///Get the image we need to draw on the person. Called from get_overlay() which is called from _bodyparts.dm. Limb can be null
 /datum/bodypart_overlay/mutant/get_image(image_layer, obj/item/bodypart/limb)
 	if(!sprite_datum)
+		CRASH("Trying to call get_image() on [type] while it didn't have a sprite_datum. This shouldn't happen, report it as soon as possible.")
 		return
 
 	var/gender = (limb?.limb_gender == FEMALE) ? "f" : "m"

--- a/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
@@ -12,8 +12,6 @@
 	return image(icon, icon_state, layer = layer)
 
 /datum/bodypart_overlay/simple/color_image(image/overlay, layer, obj/item/bodypart/limb)
-	if(!overlay)
-		return
 
 	overlay.color = draw_color
 

--- a/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
@@ -11,7 +11,10 @@
 /datum/bodypart_overlay/simple/get_image(layer, obj/item/bodypart/limb)
 	return image(icon, icon_state, layer = layer)
 
-/datum/bodypart_overlay/simple/color_image(image/overlay, layer)
+/datum/bodypart_overlay/simple/color_image(image/overlay, layer, obj/item/bodypart/limb)
+	if(!overlay)
+		return
+
 	overlay.color = draw_color
 
 /datum/bodypart_overlay/simple/generate_icon_cache()

--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -349,7 +349,7 @@
 /datum/bodypart_overlay/mutant/pod_hair/get_global_feature_list()
 	return GLOB.pod_hair_list
 
-/datum/bodypart_overlay/mutant/pod_hair/color_image(image/overlay, layer, obj/item/bodypart/limb)
+/datum/bodypart_overlay/mutant/pod_hair/color_image(image/overlay, draw_layer, obj/item/bodypart/limb)
 	if(draw_layer != bitflag_to_layer(color_swapped_layer))
 		return ..()
 

--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -349,7 +349,7 @@
 /datum/bodypart_overlay/mutant/pod_hair/get_global_feature_list()
 	return GLOB.pod_hair_list
 
-/datum/bodypart_overlay/mutant/pod_hair/color_image(image/overlay, draw_layer)
+/datum/bodypart_overlay/mutant/pod_hair/color_image(image/overlay, layer, obj/item/bodypart/limb)
 	if(draw_layer != bitflag_to_layer(color_swapped_layer))
 		return ..()
 


### PR DESCRIPTION
## About The Pull Request
That's about it, really. Just something inconsistent I noticed while fixing the bodypart_overlay refactor downstream. Might as well get everyone to benefit from it.

## Why It's Good For The Game
Less runtimes == more better

Also less confusing for future coders that might touch this proc and go "why are the arguments not what I was expecting???"

## Changelog

:cl: GoldenAlpharex
fix: Fixed some potential future runtimes relatively to the new bodypart overlay system's coloring procs.
/:cl: