### PR TITLE
Lowers nightvision threshold to work for mesons, fixes not being able to examine stuff lit by overlay lights

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -44,7 +44,7 @@
 #define LIGHTING_CUTOFF_FULLBRIGHT 100
 
 /// What counts as being able to see in the dark
-#define LIGHTING_NIGHTVISION_THRESHOLD 10
+#define LIGHTING_NIGHTVISION_THRESHOLD 7
 
 /// The amount of lumcount on a tile for it to be considered dark (used to determine reading and nyctophobia)
 #define LIGHTING_TILE_IS_DARK 0.2

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -541,7 +541,7 @@
 	if(is_blind()) //blind people see things differently (through touch)
 		if(!blind_examine_check(examinify))
 			return
-	else if(!examine_turf.luminosity && \
+	else if(!(examine_turf.luminosity || examine_turf.dynamic_lumcount) && \
 		get_dist(src, examine_turf) > 1 && \
 		!has_nightvision()) // If you aren't blind, it's in darkness (that you can't see) and farther then next to you
 		return


### PR DESCRIPTION

## About The Pull Request

Might be a bit low, but part of that is because it's kinda bad at figuring color, rgb isn't really balanced in that respect

Fixes not being able to see stuff under the light of a lamp

Overlay lights don't set lumen, which leads to stupid when you try and check with ONLY it
It worked before because the mob has THEIR luminosity set, which then "glowed" out

That doesn't work here cause yaknow I removed our uses of byond lighting (except for errant view() calls) so this is the best I've got

## Why It's Good For The Game

Closes #73548 

## Changelog
:cl:
fix: Examining in the dark is less wonk now, sorry bout that
/:cl:
