### PR TITLE
Adds logic to regal rat butchering, will now produce mouse meat.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -14,7 +14,7 @@
 	lighting_cutoff_green = 8
 	lighting_cutoff_blue = 5
 	obj_damage = 10
-	butcher_results = list(/obj/item/clothing/head/costume/crown = 1,)
+	butcher_results = list(/obj/item/food/meat/slab/mouse = 2, /obj/item/clothing/head/costume/crown = 1)
 	response_help_continuous = "glares at"
 	response_help_simple = "glare at"
 	response_disarm_continuous = "skoffs at"


### PR DESCRIPTION

## About The Pull Request

Okay, I had fun with the alert system. Simply, this just adds 2 meat to the butcher completion of regal rats. It's a pretty low amount of meat considering that they look like this.

![dumpyrat](https://user-images.githubusercontent.com/16896032/222053444-2218b35d-e3f1-45bd-800b-53f2c6d94a4f.gif)

I chose a low number for the meat considering that players will still be able to get a massive influx of meat from butchering the small rats.  

## Why It's Good For The Game

Regal Rats are often dragged to the kitchen immediately upon being killed, leaving confused chefs/assistants wondering why they only received a crown upon successful butchering. Hopefully, this change will leave people less baffled by the lack of meatiness from the huge creatures.

## Changelog

:cl:
qol: Regal Rats produce meat on butchering, reducing player confusion.
/:cl: