### PR TITLE
Fix admin lookup/follow on disease outbreak [NO GBP]

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -231,7 +231,7 @@
 	while(length(afflicted))
 		victim = pick_n_take(afflicted)
 		if(victim.ForceContractDisease(advanced_disease, FALSE))
-			message_admins("Event triggered: Disease Outbreak: Advanced - starting with patient zero [key_name(victim)]! Details: [advanced_disease.admin_details()] sp:[advanced_disease.spread_flags] ([advanced_disease.spread_text])")
+			message_admins("Event triggered: Disease Outbreak: Advanced - starting with patient zero [ADMIN_LOOKUPFLW(victim)]! Details: [advanced_disease.admin_details()] sp:[advanced_disease.spread_flags] ([advanced_disease.spread_text])")
 			log_game("Event triggered: Disease Outbreak: Advanced - starting with patient zero [key_name(victim)]. Details: [advanced_disease.admin_details()] sp:[advanced_disease.spread_flags] ([advanced_disease.spread_text])")
 			log_virus("Disease Outbreak: Advanced has triggered a custom virus outbreak of [advanced_disease.admin_details()] in [victim]!")
 			announce_to_ghosts(victim)


### PR DESCRIPTION
## About The Pull Request

In https://github.com/tgstation/tgstation/pull/73599 my copy/paste screwup removed the admin lookup in Disease Outbreak: Advanced. Puts it back.

## Why It's Good For The Game

Admins are supposed to have a link to jump/follow, not message the ckey.

## Changelog

:cl: LT3
fix: Admins can jump to/follow patient zero of a disease outbreak again
/:cl: