### PR TITLE
Makes toy reality pierces generate names randomly.

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1312,7 +1312,7 @@
 
 /obj/item/toy/reality_pierce/Initialize(mapload)
 	. = ..()
-	name = "\improper" + pick(strings(HERETIC_INFLUENCE_FILE, "drained")) +  " " + pick(strings(HERETIC_INFLUENCE_FILE, "prefix")) + " " + pick(strings(HERETIC_INFLUENCE_FILE, "postfix"))
+	name = "\improper" + pick(strings(HERETIC_INFLUENCE_FILE, "drained")) + " " + pick(strings(HERETIC_INFLUENCE_FILE, "prefix")) + " " + pick(strings(HERETIC_INFLUENCE_FILE, "postfix"))
 
 /obj/item/storage/box/heretic_box
 	name = "box of pierced realities"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1318,6 +1318,10 @@
 	for(var/i in 1 to rand(1,4))
 		new /obj/item/toy/reality_pierce(src)
 
+/obj/item/toy/reality_pierce/Initialize(mapload)
+	. = ..()
+	/obj/effect/heretic_influence/proc/generate_name()
+
 /obj/item/toy/foamfinger
 	name = "foam finger"
 	desc = "root for the home team! wait, does this station even have a sports team?"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1312,7 +1312,7 @@
 
 /obj/item/toy/reality_pierce/Initialize(mapload)
 	. = ..()
-	name = "\improper" + pick(strings(HERETIC_INFLUENCE_FILE, "prefix")) + " " + pick(strings(HERETIC_INFLUENCE_FILE, "postfix"))
+	name = "\improper" + pick(strings(HERETIC_INFLUENCE_FILE, "drained")) +  pick(strings(HERETIC_INFLUENCE_FILE, "prefix")) + " " + pick(strings(HERETIC_INFLUENCE_FILE, "postfix"))
 
 /obj/item/storage/box/heretic_box
 	name = "box of pierced realities"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1310,6 +1310,10 @@
 	icon_state = "pierced_illusion"
 	item_flags = NO_PIXEL_RANDOM_DROP
 
+/obj/item/toy/reality_pierce/Initialize(mapload)
+	. = ..()
+	name = "\improper" + pick(strings(HERETIC_INFLUENCE_FILE, "prefix")) + " " + pick(strings(HERETIC_INFLUENCE_FILE, "postfix"))
+
 /obj/item/storage/box/heretic_box
 	name = "box of pierced realities"
 	desc = "A box containing toys resembling pierced realities."
@@ -1317,10 +1321,6 @@
 /obj/item/storage/box/heretic_box/PopulateContents()
 	for(var/i in 1 to rand(1,4))
 		new /obj/item/toy/reality_pierce(src)
-
-/obj/item/toy/reality_pierce/Initialize(mapload)
-	. = ..()
-	/obj/effect/heretic_influence/proc/generate_name()
 
 /obj/item/toy/foamfinger
 	name = "foam finger"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1312,7 +1312,7 @@
 
 /obj/item/toy/reality_pierce/Initialize(mapload)
 	. = ..()
-	name = "\improper" + pick(strings(HERETIC_INFLUENCE_FILE, "drained")) +  pick(strings(HERETIC_INFLUENCE_FILE, "prefix")) + " " + pick(strings(HERETIC_INFLUENCE_FILE, "postfix"))
+	name = "\improper" + pick(strings(HERETIC_INFLUENCE_FILE, "drained")) +  " " + pick(strings(HERETIC_INFLUENCE_FILE, "prefix")) + " " + pick(strings(HERETIC_INFLUENCE_FILE, "postfix"))
 
 /obj/item/storage/box/heretic_box
 	name = "box of pierced realities"


### PR DESCRIPTION

## About The Pull Request
So if you have tooltips turned on you can just draw cursor on it and you already know that its fake. Now you wont know because it'll have random generated name based on reality pierces string.
Examples of how it was and how it will look like:
![image](https://user-images.githubusercontent.com/93882977/222175262-db561499-b43c-4b5b-84f4-ba78fb2f9b84.png)
![image](https://user-images.githubusercontent.com/93882977/222175002-f800a9bc-4e84-41ad-97c7-e45ff640cec1.png)
## Why It's Good For The Game
You can fool someone with this. Should be fun.
## Changelog
:cl:
add: Added random generated names of toy reality pierces, so you can fake heretics and fool somebody.
/:cl:
