### PR TITLE
new smite: deadchat control

### DIFF
--- a/code/modules/admin/smites/ghost_control.dm
+++ b/code/modules/admin/smites/ghost_control.dm
@@ -1,0 +1,51 @@
+/datum/smite/ghost_control
+	name = "Ghost Control"
+
+/datum/smite/ghost_control/effect(client/user, mob/living/target)
+	target.AddComponent(/datum/component/deadchat_control/cardinal_movement, ANARCHY_MODE, list(
+		"clap" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "clap"),
+		"cry" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "cry"),
+		"flip" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "flip"),
+		"laugh" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "laugh"),
+		"scream" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "scream"),
+		"spin" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "spin"),
+		"swear" = CALLBACK(target, TYPE_PROC_REF(/mob, emote), "swear"),
+		"drop" = CALLBACK(target, TYPE_PROC_REF(/mob, drop_all_held_items)),
+		"fall" = CALLBACK(target, TYPE_PROC_REF(/mob/living, Knockdown), 1 SECONDS),
+		"stand" = CALLBACK(target, TYPE_PROC_REF(/mob/living, resist_buckle)),
+		"throw" = CALLBACK(target, TYPE_PROC_REF(/mob, throw_item), get_edge_target_turf(target, pick(GLOB.alldirs))),
+		"shove" = CALLBACK(src, PROC_REF(ghost_shove), target),
+		"sit" = CALLBACK(src, PROC_REF(ghost_sit), target),
+		"run" = CALLBACK(src, PROC_REF(ghost_speed), target, MOVE_INTENT_RUN),
+		"walk" = CALLBACK(src, PROC_REF(ghost_speed), target, MOVE_INTENT_WALK),
+		), 7 SECONDS)
+
+	to_chat(target, span_revenwarning("You feel a ghastly presence!!!"))
+
+
+/datum/smite/ghost_control/proc/ghost_shove(mob/living/carbon/target)
+	if(!istype(target) || target.get_active_held_item())
+		return
+	var/list/shoveables = list()
+	for(var/mob/living/victim in orange(1, target))
+		shoveables += victim
+	if(!length(shoveables))
+		return
+	var/mob/living/shove_me = pick(shoveables)
+	target.attack_hand_secondary(shove_me)
+
+/datum/smite/ghost_control/proc/ghost_sit(mob/living/target)
+	if(HAS_TRAIT(target, TRAIT_IMMOBILIZED))
+		return
+	var/list/chairs = list()
+	for(var/obj/structure/chair/possible_chair in range(1, target))
+		chairs += possible_chair
+	if(!length(chairs))
+		return
+	var/obj/structure/chair/sitting_chair = pick(chairs)
+	sitting_chair.buckle_mob(target, check_loc = FALSE)
+
+/datum/smite/ghost_control/proc/ghost_speed(mob/living/target, new_speed)
+	if(target.m_intent == new_speed)
+		return
+	target.toggle_move_intent()

--- a/code/modules/admin/smites/ghost_control.dm
+++ b/code/modules/admin/smites/ghost_control.dm
@@ -32,7 +32,7 @@
 	if(!length(shoveables))
 		return
 	var/mob/living/shove_me = pick(shoveables)
-	target.attack_hand_secondary(shove_me)
+	target.UnarmedAttack(shove_me, proximity_flag = TRUE, modifiers = list("right" = TRUE))
 
 /datum/smite/ghost_control/proc/ghost_sit(mob/living/target)
 	if(HAS_TRAIT(target, TRAIT_IMMOBILIZED))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2261,6 +2261,7 @@
 #include "code\modules\admin\smites\fake_bwoink.dm"
 #include "code\modules\admin\smites\fat.dm"
 #include "code\modules\admin\smites\fireball.dm"
+#include "code\modules\admin\smites\ghost_control.dm"
 #include "code\modules\admin\smites\gib.dm"
 #include "code\modules\admin\smites\imaginary_friend_special.dm"
 #include "code\modules\admin\smites\immerse.dm"


### PR DESCRIPTION
## About The Pull Request
![dreamseeker_mvhLhGbMBg](https://user-images.githubusercontent.com/116288367/222195179-9202ffd8-9473-4cdd-b58d-3728cdcd3aaa.png)
![image](https://user-images.githubusercontent.com/116288367/222197560-f7015871-197c-4670-aefa-46ff5d33e44e.png)
![dreamseeker_7ds1Elskx4](https://user-images.githubusercontent.com/116288367/222195189-ce4228bc-8786-4afb-b1ec-782dcc2837ab.png)

I played around with the deadchat control component for some stuff downstream and then decided to turn it into a smite, something that is harsh but really funny especially with all of the inputs that ghosts have.

The emotes are ones that have the character do something, coordinated spins and flips have their usual consequences probably, drop causes them to drop their held items, fall causes them to fall over (and drop their held items), throw makes them throw whatever item they are holding in their active hand in a random direction, shove causes them to shove a random person or mob around them, sit and stand make them buckle and unbuckle themselves from a chair, and run and walk change their speed intent. Seven second cooldown and on anarchy ruleset because it _is_ a smite.

![dreamseeker_6hj6qqsREU](https://user-images.githubusercontent.com/116288367/222196421-5520e4bd-01aa-459b-8e61-aa0bd29e0bc1.gif)

## Why It's Good For The Game

There is a large range of smites from the small pay docking to the instant and absolute gib but it doesn't feel like there's a lot in for a nuisance. This would give an option that lets all of the ghosts annoy one person in particular as they struggle to play while ghosts interfere with them and constantly make them drop their items and interfere with their movements, which is obviously fun for the ghosts. 

Also I personally think that it is very funny.

## Changelog

:cl:
add: add new smite that adds deadchat control component to a victim
/:cl:

