### PR TITLE
fixes missing wire in tram cargo

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17875,6 +17875,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "eCz" = (


### PR DESCRIPTION
the drone bay not depowering every round is good

![image](https://user-images.githubusercontent.com/8881105/222212248-93b523e4-83bd-4449-b0da-640982a9a13d.png)

:cl:
fix: Fixed a missing wire in the Tramstation cargo warehouse.
/:cl: