### PR TITLE
Adds smartfridges (specifically, drying racks) to decomposition save surfaces (stops ants)

### DIFF
--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -21,6 +21,8 @@ GLOBAL_LIST_INIT(typecache_elevated_structures, typecacheof(list(
 	/obj/structure/closet,
 	/obj/structure/rack,
 	/obj/structure/table,
+	/obj/machinery/smartfridge,
+	/obj/machinery/smartfridge/drying_rack, // Redundant, given above, but this is for the sake of explicitness.
 )))
 
 /// A typecache of objects that player controlled, easily accessible, hostile mobs should not be able to attack


### PR DESCRIPTION
## About The Pull Request

I wanted to add Drying Racks to `typecache_elevated_structures`, because on successful drying they dump everything on the floor which immediately starts to decompose

Then I remembered they're smartfridges 

And I thought "well they could be in it to"

So I added Smartfridges to `typecache_elevated_structures`, then also put drying racks there to be explicit in case someone repaths them and separates them from fridges (as they should)

## Why It's Good For The Game

Man it's really annoying to have the drying rack dump all your stuff on the ground (as it should) then they start to attract ants. Kills the vibe.

## Changelog

:cl: Melbert
qol: Food over-top Drying Racks / Smartfridges will no longer decompose into ants
/:cl:
