### PR TITLE
Removes the pipegun's chance to misfire and make you shoot yourself

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -159,9 +159,7 @@
 	initial_fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
 	alternative_fire_sound = 'sound/weapons/gun/shotgun/shot.ogg'
 	can_modify_ammo = TRUE
-	can_misfire = TRUE
-	misfire_probability = 0
-	misfire_percentage_increment = 5 //Slowly increases every shot
+	can_misfire = FALSE
 	can_bayonet = TRUE
 	knife_y_offset = 11
 	can_be_sawn_off = FALSE
@@ -178,10 +176,7 @@
 	inhand_icon_state = "musket_prime"
 	worn_icon_state = "musket_prime"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime
-	can_misfire = FALSE
 	can_jam = FALSE
-	misfire_probability = 0
-	misfire_percentage_increment = 0
 	projectile_damage_multiplier = 1
 
 /// MAGICAL BOLT ACTIONS + ARCANE BARRAGE? ///


### PR DESCRIPTION

## About The Pull Request

As the title might imply, the increasing percentage chance that a pipegun misfires and fires at the user has been removed.
## Why It's Good For The Game

The pipegun already has a large number of other downsides, like a 1 round ammo capacity, it being bolt action, the fact it can get dirty and have the bolt jam, and the 3/4 damage modifier. While these all make sense and can make for a pretty fun improvised weapon, the chance to misfire brings it from 'interesting' to 'unusuable in 99% of situations'. 
## Changelog
:cl:
balance: The pipegun's chance to misfire and shoot at you rather than the person you're pointing it at has been removed
/:cl:
