### PR TITLE
Add mice infestation station trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -924,6 +924,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_UNNATURAL_ATMOSPHERE "station_trait_unnatural_atmosphere"
 #define STATION_TRAIT_UNIQUE_AI "station_trait_unique_ai"
 #define STATION_TRAIT_CARP_INFESTATION "station_trait_carp_infestation"
+#define STATION_TRAIT_MICE_INFESTATION "station_trait_mice_infestation"
 #define STATION_TRAIT_PREMIUM_INTERNALS "station_trait_premium_internals"
 #define STATION_TRAIT_LATE_ARRIVALS "station_trait_late_arrivals"
 #define STATION_TRAIT_RANDOM_ARRIVALS "station_trait_random_arrivals"

--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -9,7 +9,8 @@ SUBSYSTEM_DEF(minor_mapping)
 	#ifdef UNIT_TESTS // This whole subsystem just introduces a lot of odd confounding variables into unit test situations, so let's just not bother with doing an initialize here.
 	return SS_INIT_NO_NEED
 	#endif // the mice are easily the bigger problem, but let's just avoid anything that could cause some bullshit.
-	trigger_migration(CONFIG_GET(number/mice_roundstart))
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_MICE_INFESTATION))
+		trigger_migration(CONFIG_GET(number/mice_roundstart))
 	place_satchels()
 	return SS_INIT_SUCCESS
 

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -85,6 +85,16 @@
 		if(is_station_level(apc.z) && prob(60))
 			apc.overload_lighting()
 
+/datum/station_trait/mice_infestation
+	name = "Mice infestation"
+	trait_type = STATION_TRAIT_NEGATIVE
+	weight = 10
+	show_in_report = TRUE
+	report_message = "A nest of mice has infested the maintenace areas."
+	trait_to_give = STATION_TRAIT_MICE_INFESTATION
+	// Mice spawn on roundstart
+	can_revert = FALSE
+
 /datum/station_trait/empty_maint
 	name = "Cleaned out maintenance"
 	trait_type = STATION_TRAIT_NEGATIVE


### PR DESCRIPTION
## About The Pull Request

This changes mice spawns to be a negative station trait instead of **always** appearing every round.  In the event that the mice trait does not get selected, it is still possible for mice to spawn as a random event.

## Why It's Good For The Game

Having to fix wires **EVERY** shift is tedious, especially on lowpop.  Some maps are worse than others with this, and it can lead to repeated power failures.  I think moving mice to a negative station trait is the correct solution to this problem, since it will not always be guaranteed. 

## Changelog

:cl:
balance: Mice maintenance infestations are now a negative station trait that is not guaranteed to occur.
/:cl:

