### PR TITLE
Fixes an erroneous khinkali recipe in the cooking menu

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
@@ -630,11 +630,6 @@
 	result = /obj/item/food/spaghetti/boiledspaghetti
 	category = CAT_SPAGHETTI
 
-/datum/crafting_recipe/food/microwave/khinkali
-	reqs = list(/obj/item/food/rawkhinkali = 1)
-	result = /obj/item/food/khinkali
-	category = CAT_BREAD
-
 /datum/crafting_recipe/food/microwave/onionrings
 	reqs = list(/obj/item/food/onion_slice = 1)
 	result = /obj/item/food/onionrings


### PR DESCRIPTION
## About The Pull Request
Removes erroneous khinkali recipe that was using a microwave. The true way to make khinkali in spess is by grill.

## Why It's Good For The Game
Fixes #73677

## Changelog
:cl:
fix: fixed erroneous khinkali microwave recipe in the cooking menu. use a grill like a normal chef
/:cl:
