### PR TITLE
Fixes dog fashion items not clearing up when removed from the dog & fixes armor vest dog fashion

### DIFF
--- a/code/datums/dog_fashion.dm
+++ b/code/datums/dog_fashion.dm
@@ -47,6 +47,13 @@
 /datum/dog_fashion/back
 	icon_file = 'icons/mob/simple/corgi_back.dmi'
 
+/datum/dog_fashion/back/armorvest
+	obj_icon_state = "armor"
+
+/datum/dog_fashion/back/deathsquad
+	name = "Trooper REAL_NAME"
+	desc = "That's not red paint. That's real corgi blood."
+
 /datum/dog_fashion/head/helmet
 	name = "Sergeant REAL_NAME"
 	desc = "The ever-loyal, the ever-vigilant."
@@ -177,10 +184,6 @@
 	desc = "Honkman's best friend."
 	speak = list("HONK!", "Honk!")
 	emote_see = list("plays tricks.", "slips.")
-
-/datum/dog_fashion/back/deathsquad
-	name = "Trooper REAL_NAME"
-	desc = "That's not red paint. That's real corgi blood."
 
 /datum/dog_fashion/head/festive
 	name = "Festive REAL_NAME"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -100,6 +100,7 @@
 	desc = "A lighter plate armor used to still keep out those pesky arrows, while retaining the ability to move."
 	icon_state = "cuirass"
 	inhand_icon_state = "armor"
+	dog_fashion = null
 
 /obj/item/clothing/suit/armor/hos
 	name = "armored greatcoat"
@@ -453,6 +454,7 @@
 	max_integrity = 200
 	resistance_flags = FLAMMABLE
 	armor_type = /datum/armor/vest_durathread
+	dog_fashion = null
 
 /datum/armor/vest_durathread
 	melee = 20
@@ -469,6 +471,7 @@
 	icon_state = "rus_armor"
 	inhand_icon_state = null
 	armor_type = /datum/armor/vest_russian
+	dog_fashion = null
 
 /datum/armor/vest_russian
 	melee = 25
@@ -488,6 +491,7 @@
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
 	armor_type = /datum/armor/vest_russian_coat
+	dog_fashion = null
 
 /datum/armor/vest_russian_coat
 	melee = 25
@@ -556,3 +560,4 @@
 	icon_state = "hop_coat"
 	inhand_icon_state = "b_suit"
 	body_parts_covered = CHEST|GROIN|ARMS
+	dog_fashion = null

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -34,7 +34,7 @@
 	icon_state = "armoralt"
 	inhand_icon_state = "armor"
 	blood_overlay_type = "armor"
-	dog_fashion = /datum/dog_fashion/back
+	dog_fashion = /datum/dog_fashion/back/armorvest
 
 /obj/item/clothing/suit/armor/vest/alt
 	desc = "A Type I armored vest that provides decent protection against most types of damage."

--- a/code/modules/mob/living/basic/pets/dog.dm
+++ b/code/modules/mob/living/basic/pets/dog.dm
@@ -663,6 +663,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 
 /mob/living/basic/pet/dog/corgi/regenerate_icons()
 	..()
+	cut_overlays() //we are redrawing the mob after all
 	if(inventory_head)
 		var/image/head_icon
 		var/datum/dog_fashion/DF = new inventory_head.dog_fashion(src)


### PR DESCRIPTION
## About The Pull Request
Restores a `cut_overlays()` to dog's `regenerate_icons()` that was lost back in #70799.
Also makes an armorvest back fashion for armor vests. When a dog fashion datum doesn't have `obj_icon_state` declared, it defaults to the assigned item's icon. Dog fashion's sprite sheet has the armor vest sprite saved as _armor_. And the only vest that would actually show on a dog would be an _alt_ armor vest. Apparently, the standard-issue armor vest uses _armoralt_ icons. Go figure.
However, there are quite a few armor vest subtypes that don't look anything like the base vest; this needs addressing by either banning such vests from being used as dog fashion items, or making separate sprites for them (to be fair, the current dog fashion armor vest needs an update as well, it's quite old and doesn't correspond to the current armor vest).
- [x] go around and remove dog fashion from armor vests that don't look like the base vest

## Why It's Good For The Game
Closes #59224 (hats as items were not stuck, but their sprites were); dog's sprites will correctly update upon placing/removing a fashion item
Most armor vests placed on a dog will actually show on the sprite

## Changelog
:cl:
fix: undressing a hat/back item from a dog will correctly remove the item's overlay
fix: most armor vests will actually show on a dog when placed on its back
/:cl:
