### PR TITLE
[no gbp] Removes AB_CHECK_INCAPACITATED from spells

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -30,6 +30,7 @@
 	button_icon_state = "zap"
 	sound = 'sound/weapons/zapbang.ogg'
 	cooldown_time = 12 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 	antimagic_flags = NONE

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -30,7 +30,6 @@
 	button_icon_state = "zap"
 	sound = 'sound/weapons/zapbang.ogg'
 	cooldown_time = 12 SECONDS
-	check_flags = AB_CHECK_CONSCIOUS
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 	antimagic_flags = NONE

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -48,7 +48,7 @@
 	button_icon_state = "spell_default"
 	overlay_icon_state = "bg_spell_border"
 	active_overlay_icon_state = "bg_spell_border_active_red"
-	check_flags = AB_CHECK_CONSCIOUS | AB_CHECK_INCAPACITATED
+	check_flags = AB_CHECK_CONSCIOUS
 	panel = "Spells"
 	melee_cooldown_time = 0 SECONDS
 

--- a/code/modules/spells/spell_types/aoe_spell/repulse.dm
+++ b/code/modules/spells/spell_types/aoe_spell/repulse.dm
@@ -73,6 +73,7 @@
 	cooldown_time = 15 SECONDS
 	spell_requirements = NONE
 
+	check_flags = AB_CHECK_CONSCIOUS | AB_CHECK_INCAPACITATED
 	invocation_type = INVOCATION_NONE
 	antimagic_flags = NONE
 	aoe_radius = 2

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -19,7 +19,7 @@
  * (generally) inadvisable unless you know what you're doing
  */
 /datum/action/cooldown/spell/touch
-	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED
+	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
 	sound = 'sound/items/welder.ogg'
 	invocation = "High Five!"
 	invocation_type = INVOCATION_SHOUT


### PR DESCRIPTION
## About The Pull Request

In #73513 I was a little overzealous and now most spells can't be cast when you are batoned even though _silence_ is meant to be the counter to wizards (and heretics).
I took this back off the root of `spell` and then using the principle of "anything with an invocation should be able to be used while stunned" checked which spells didn't have invocations.

It seems like literally the only one of _those_ which was problematic was the one from the original bug, implying that just maybe perhaps I should have used a targeted solution instead of applying my fix to like 80% of actions in the game.

Side effect: Any non-invocation spell can once again be cast while time-stopped. So like, Blink, Smoke, Cult Wall Conversion, and Fire Breath.
Personally I think this is a niche enough interaction that it doesn't matter and I don't think it's worth adding a new trait and check just for this one spell.

## Why It's Good For The Game

Numerous abilities like jaunting and notably Hasty Realignment, the heretic spell which removes stuns from you, were being blocked by stuns. This makes their owners much more vulnerable than they are supposed to be.

## Changelog

:cl:
fix: Most spells can once again be cast even after someone stuns you with a baton.
/:cl:
