### PR TITLE
Makes the food trash element detach on trash making

### DIFF
--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -30,7 +30,15 @@
 
 /datum/element/food_trash/Detach(datum/target)
 	. = ..()
-	UnregisterSignal(target, COMSIG_FOOD_CONSUMED)
+	UnregisterSignal(target, list(
+		COMSIG_FOOD_CONSUMED,
+		COMSIG_ITEM_ATTACK_SELF,
+		COMSIG_FOOD_CROSSED,
+		COMSIG_ITEM_ON_GRIND,
+		COMSIG_ITEM_ON_JUICE,
+		COMSIG_ITEM_USED_AS_INGREDIENT,
+		COMSIG_ITEM_ON_COMPOSTED,
+		COMSIG_ITEM_SOLD_TO_CUSTOMER,))
 
 /datum/element/food_trash/proc/generate_trash(datum/source, mob/living/eater, mob/living/feeder)
 	SIGNAL_HANDLER
@@ -47,6 +55,8 @@
 		var/mob/living/food_holding_mob = edible_object.loc
 		food_holding_mob.dropItemToGround(edible_object)
 		food_holding_mob.put_in_hands(trash_item)
+
+	Detach(source)
 
 /datum/element/food_trash/proc/food_crossed(datum/source, mob/crosser, bitecount)
 	SIGNAL_HANDLER


### PR DESCRIPTION
 
## About The Pull Request

This PR makes the trash maker element detach on trash creation. Most of the times, the food is deleted soon after this element is activated. However, there has been one exception: when you place it in a custom, sliceable item, it will generate the trash, and then store the item in a list. When you slice the custom item, the saved item will be added to every slice, producing a trash for each. And this is how you get seven banana peels out of one banana, or seven revolvers out of one gatfruit using nothing but a humble knife and a plain pizza bread.

By detaching the trash creation element, we will prevent this behaviour, and further future proof this element, in case someone adds another behaviour that creates trash without destroying the food.

This PR also makes the element unregister all signals it has registered on.

## Why It's Good For The Game

Fixes #69285

## Changelog

:cl:
fix: You can no longer multiply banana peels, gatfruit and more by using sliceable custom food
/:cl:
