### PR TITLE
Restored power to Tram's drone bay.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17875,6 +17875,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "eCz" = (


### PR DESCRIPTION

## About The Pull Request

A single missing cable in Tramstation's warehouse means that the drone bay does not receive power. This has been corrected.

![image](https://user-images.githubusercontent.com/105025397/222645242-c53d7bf4-88dd-49a2-8da1-16c5a1fea091.png)
## Why It's Good For The Game

It's good for the whole station to be powered.
## Changelog
:cl:
fix: Fixed power to Tramstation's drone bay.
/:cl:
