### PR TITLE
Removes Cult perms from Survival pods

### DIFF
--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -5,7 +5,7 @@
 	static_lighting = TRUE
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
-	area_flags = BLOBS_ALLOWED | UNIQUE_AREA | CULT_PERMITTED
+	area_flags = BLOBS_ALLOWED | UNIQUE_AREA
 	flags_1 = CAN_BE_DIRTY_1
 
 //Survival Capsule


### PR DESCRIPTION
## About The Pull Request

Removes Cult permitted from survival pods, as it's very uninteresting to have cult bases in places no one will check.
This doesn't affect the mining base itself.

## Why It's Good For The Game

One of the drawbacks of Cult is that they get stronger at the cost of being more easy to spot, so being to completely bypass the negative part makes it unfair to fight cult if there's a single shaft miner, or literally anyone if it's icebox.

## Changelog

:cl:
balance: Cult can no longer draw runes in survival pods.
/:cl: