### PR TITLE
Varedited heat capacity of floortiles fix

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4185,7 +4185,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/ruin/syndicate_lava_base/dormitories)
 "RK" = (
@@ -4399,7 +4398,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/ruin/syndicate_lava_base/dormitories)
 "Vp" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -210,7 +210,6 @@
 	dir = 10
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "act" = (
@@ -2049,7 +2048,6 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "avX" = (
@@ -2559,7 +2557,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/hallway/primary/central/aft)
 "aCS" = (
@@ -2979,7 +2976,6 @@
 	dir = 1
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/command/heads_quarters/ce)
 "aHF" = (
@@ -3578,7 +3574,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/toilet/locker)
 "aPl" = (
@@ -3905,7 +3900,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "aUo" = (
@@ -5456,7 +5450,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/security/courtroom)
 "bmt" = (
@@ -5902,7 +5895,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "brZ" = (
@@ -6184,7 +6176,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/department/science)
 "bvj" = (
@@ -6974,7 +6965,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/toilet/locker)
 "bEN" = (
@@ -7009,7 +6999,6 @@
 	dir = 9
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "bFb" = (
@@ -7613,7 +7602,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "bLo" = (
@@ -9310,7 +9298,6 @@
 	dir = 1
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "cfu" = (
@@ -11118,7 +11105,6 @@
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/security/courtroom)
 "cBT" = (
@@ -12861,7 +12847,6 @@
 	},
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "cYD" = (
@@ -13963,7 +13948,6 @@
 	dir = 1
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "dnW" = (
@@ -17395,7 +17379,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/command/heads_quarters/ce)
 "egU" = (
@@ -18279,7 +18262,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/command/heads_quarters/ce)
 "erZ" = (
@@ -18737,7 +18719,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "exf" = (
@@ -19389,7 +19370,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "eHi" = (
@@ -20793,7 +20773,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "eXN" = (
@@ -25070,7 +25049,6 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/department/science)
 "fZO" = (
@@ -30927,7 +30905,6 @@
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "hwC" = (
@@ -31144,7 +31121,6 @@
 	dir = 1
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "hzJ" = (
@@ -37224,7 +37200,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "jbG" = (
@@ -37982,7 +37957,6 @@
 "jjU" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "jjX" = (
@@ -38293,7 +38267,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/security/courtroom)
 "jnd" = (
@@ -39889,7 +39862,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "jFz" = (
@@ -46141,7 +46113,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/hallway/primary/central/aft)
 "lgg" = (
@@ -48225,7 +48196,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "lGU" = (
@@ -50175,7 +50145,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "mgY" = (
@@ -53525,7 +53494,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/toilet/locker)
 "mWF" = (
@@ -56205,7 +56173,6 @@
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/department/science)
 "nGS" = (
@@ -56745,7 +56712,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/fore)
 "nMT" = (
@@ -57772,7 +57738,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "oaE" = (
@@ -59761,7 +59726,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "oBX" = (
@@ -64211,7 +64175,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "pIj" = (
@@ -69527,7 +69490,6 @@
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/toilet/locker)
 "qVJ" = (
@@ -70713,7 +70675,6 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "rlL" = (
@@ -71149,7 +71110,6 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/security/courtroom)
 "rrL" = (
@@ -75855,7 +75815,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/hallway/primary/central/aft)
 "sAh" = (
@@ -76098,7 +76057,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "sDk" = (
@@ -78187,7 +78145,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "tcc" = (
@@ -84341,7 +84298,6 @@
 	},
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "uBA" = (
@@ -85990,7 +85946,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/locker)
 "uXy" = (
@@ -86228,7 +86183,6 @@
 	dir = 1
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "uZV" = (
@@ -87056,7 +87010,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "vkG" = (
@@ -87107,7 +87060,6 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "vkN" = (
@@ -93693,7 +93645,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/commons/toilet/locker)
 "wMx" = (
@@ -94905,7 +94856,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/command/heads_quarters/ce)
 "xex" = (
@@ -95296,7 +95246,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/fore)
 "xjd" = (
@@ -95341,7 +95290,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "xjR" = (
@@ -96416,7 +96364,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/command/heads_quarters/ce)
 "xyb" = (
@@ -99198,7 +99145,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/station/maintenance/port/aft)
 "yho" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -206,7 +206,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/centcom/tdome/observation)
 "bi" = (
@@ -658,7 +657,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/centcom/tdome/observation)
 "el" = (
@@ -4142,7 +4140,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/centcom/central_command_areas/control)
 "tN" = (
@@ -4940,7 +4937,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/centcom/central_command_areas/control)
 "xo" = (
@@ -6148,7 +6144,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/centcom/tdome/observation)
 "DF" = (
@@ -7414,7 +7409,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/centcom/tdome/observation)
 "Nn" = (
@@ -8211,7 +8205,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/centcom/tdome/observation)
 "Rj" = (

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -158,7 +158,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/shuttle/arrival)
 "p" = (
@@ -186,7 +185,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/shuttle/arrival)
 "s" = (
@@ -260,7 +258,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/shuttle/arrival)
 "B" = (

--- a/_maps/shuttles/emergency_delta.dmm
+++ b/_maps/shuttles/emergency_delta.dmm
@@ -194,7 +194,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/shuttle/escape)
 "ap" = (
@@ -958,7 +957,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron{
-	heat_capacity = 1e+006
 	},
 /area/shuttle/escape)
 "cB" = (


### PR DESCRIPTION

## About The Pull Request
Removes varedited floortile's heat_capacity from deltastation, its shuttles, centcomm and lavaland syndie base

I didn't remove it from awaymissions because literally all floortiles there have increased heat capacity so it's probably intended to be that way
## Why It's Good For The Game
Completly random tiles shouldn't have heat capacity 100 times higher then normal tiles
## Changelog
:cl:
fix: Nanotrasen has conducted high precision in-depth analysis of Deltastation and its shuttles. As a result anomalous floortiles were replaced with standard issued ones.
/:cl:
