### PR TITLE
The chief engineer can now appear as a kidnap target, fixes kidnapping time period limit component

### DIFF
--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -47,7 +47,7 @@
 /datum/traitor_objective/kidnapping/New(datum/uplink_handler/handler)
 	. = ..()
 	AddComponent(/datum/component/traitor_objective_limit_per_time, \
-		/datum/traitor_objective/assassinate, \
+		/datum/traitor_objective/kidnapping, \
 		time_period = objective_period, \
 		maximum_objectives = maximum_objectives_in_period \
 	)

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -56,28 +56,28 @@
 	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
 	target_jobs = list(
+		// Cargo
+		/datum/job/cargo_technician,
+		// Engineering
+		/datum/job/atmospheric_technician,
+		/datum/job/station_engineer,
 		// Medical
+		/datum/job/chemist,
 		/datum/job/doctor,
 		/datum/job/paramedic,
 		/datum/job/psychologist,
-		/datum/job/chemist,
-		// Service
-		/datum/job/clown,
-		/datum/job/botanist,
-		/datum/job/janitor,
-		/datum/job/mime,
-		/datum/job/lawyer,
-		/datum/job/chaplain,
-		/datum/job/bartender,
-		/datum/job/curator,
-		// Cargo
-		/datum/job/cargo_technician,
 		// Science
 		/datum/job/geneticist,
 		/datum/job/roboticist,
-		// Engineering
-		/datum/job/station_engineer,
-		/datum/job/atmospheric_technician,
+		// Service
+		/datum/job/bartender,
+		/datum/job/botanist,
+		/datum/job/chaplain,
+		/datum/job/clown,
+		/datum/job/curator,
+		/datum/job/janitor,
+		/datum/job/lawyer,
+		/datum/job/mime,
 	)
 
 /datum/traitor_objective/kidnapping/less_common
@@ -91,14 +91,14 @@
 	progression_minimum = 0 MINUTES
 	progression_maximum = 45 MINUTES
 	target_jobs = list(
-		// Medical
-		/datum/job/virologist,
 		// Cargo
 		/datum/job/shaft_miner,
-		// Service
-		/datum/job/cook,
+		// Medical
+		/datum/job/virologist,
 		// Science
 		/datum/job/scientist,
+		// Service
+		/datum/job/cook,
 	)
 
 	progression_reward = list(4 MINUTES, 8 MINUTES)
@@ -109,15 +109,16 @@
 	progression_minimum = 15 MINUTES
 	progression_maximum = 60 MINUTES
 	target_jobs = list(
-		// Security
-		/datum/job/security_officer,
-		/datum/job/warden,
-		/datum/job/detective,
 		// Heads of staff
-		/datum/job/head_of_personnel,
+		/datum/job/chief_engineer,
 		/datum/job/chief_medical_officer,
+		/datum/job/head_of_personnel,
 		/datum/job/research_director,
 		/datum/job/quartermaster,
+		// Security
+		/datum/job/detective,
+		/datum/job/security_officer,
+		/datum/job/warden,
 	)
 
 	progression_reward = list(8 MINUTES, 12 MINUTES)
@@ -127,8 +128,8 @@
 /datum/traitor_objective/kidnapping/captain
 	progression_minimum = 30 MINUTES
 	target_jobs = list(
+		/datum/job/captain,
 		/datum/job/head_of_security,
-		/datum/job/captain
 	)
 
 	progression_reward = list(12 MINUTES, 16 MINUTES)


### PR DESCRIPTION
## About The Pull Request

CE was missing from the list of kidnappable people, so I have added them. 

I have looked over the original PR, but could not find any reasoning why they were not included, so it must have been an oversight, but I have marked this as balance because I could have also added prisoners, another missing job, but decided not to, because it would be rather difficult, and a prison break should be a separate objective.

I have also organized the kidnap lists' job department sections and the jobs inside them alphabetically.

I have also noticed, that the kidnap objectives signed up for the incorrect `/datum/component/traitor_objective_limit_per_time`. It was trying to make sure you have not taken 3 assassinate objectives in the last 15 minutes while generating, instead of three kidnaps.

## Why It's Good For The Game

No reason why the CE should be excluded from being kidnapped. After all they should know more secrets than an average engineer.

## Changelog

:cl:
balance: the syndicate realized Chief Engineer is important enough to kidnap
fix: kidnap objectives will now properly be unavailable for you for 15 minutes after you take three, instead of after you take three assassinations.
/:cl:
