### PR TITLE
Calomel Rework

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -273,7 +273,7 @@
 	SSwardrobe.provide_type(/obj/item/stack/medical/bone_gel, src)
 	SSwardrobe.provide_type(/obj/item/stack/sticky_tape/surgical, src)
 	SSwardrobe.provide_type(/obj/item/reagent_containers/syringe, src)
-	SSwardrobe.provide_type(/obj/item/reagent_containers/cup/bottle/calomel, src)
+	SSwardrobe.provide_type(/obj/item/reagent_containers/cup/bottle/ammoniated_mercury, src)
 	SSwardrobe.provide_type(/obj/item/reagent_containers/cup/bottle/formaldehyde, src)
 	update_appearance()
 
@@ -284,7 +284,7 @@
 	to_preload += /obj/item/stack/medical/bone_gel
 	to_preload += /obj/item/stack/sticky_tape/surgical
 	to_preload += /obj/item/reagent_containers/syringe
-	to_preload += /obj/item/reagent_containers/cup/bottle/calomel
+	to_preload += /obj/item/reagent_containers/cup/bottle/ammoniated_mercury
 	to_preload += /obj/item/reagent_containers/cup/bottle/formaldehyde
 	return to_preload
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -411,14 +411,14 @@
 	var/toxin_amount = round(affected_mob.health / 40, 0.1)
 	affected_mob.adjustToxLoss(toxin_amount * REM * delta_time, FALSE, required_biotype = affected_biotype)
 	..()
-	. = TRUE
+	return TRUE
 
 /datum/reagent/medicine/calomel/overdose_process(mob/living/affected_mob, delta_time, times_fired)
 	for(var/datum/reagent/medicine/calomel/target_reagent in affected_mob.reagents.reagent_list)
 		affected_mob.reagents.remove_reagent(target_reagent.type, 2 * REM * delta_time)
 	affected_mob.adjustToxLoss(2.5 * REM * delta_time, FALSE, required_biotype = affected_biotype)
 	..()
-	. = TRUE
+	return TRUE
 
 /datum/reagent/medicine/ammoniated_mercury
 	name = "Ammoniated Mercury"
@@ -430,7 +430,7 @@
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
 	taste_description = "metalic"
 	overdose_threshold = 10
-	ph = 1
+	ph = 7
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/medicine/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
@@ -444,12 +444,12 @@
 		for(var/datum/reagent/medicine/ammoniated_mercury/target_reagent in affected_mob.reagents.reagent_list)
 			affected_mob.reagents.remove_reagent(target_reagent.type, 1 * REM * delta_time)
 	..()
-	. = TRUE
+	return TRUE
 
 /datum/reagent/medicine/ammoniated_mercury/overdose_process(mob/living/affected_mob, delta_time, times_fired)
 	affected_mob.adjustToxLoss(3 * REM * delta_time, FALSE, required_biotype = affected_biotype)
 	..()
-	. = TRUE
+	return TRUE
 
 /datum/reagent/medicine/potass_iodide
 	name = "Potassium Iodide"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -406,8 +406,9 @@
 
 /datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	for(var/datum/reagent/target_reagent in affected_mob.reagents.reagent_list)
-		if(!istype(target_reagent, /datum/reagent/medicine/calomel))
-			affected_mob.reagents.remove_reagent(target_reagent.type, 3 * REM * delta_time)
+		if(istype(target_reagent, /datum/reagent/medicine/calomel))
+			continue
+		affected_mob.reagents.remove_reagent(target_reagent.type, 3 * REM * delta_time)
 	var/toxin_amount = round(affected_mob.health / 40, 0.1)
 	affected_mob.adjustToxLoss(toxin_amount * REM * delta_time, FALSE, required_biotype = affected_biotype)
 	..()
@@ -428,7 +429,7 @@
 	reagent_state = LIQUID
 	color = "#f3f1f0"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM
-	taste_description = "metalic"
+	taste_description = "metallic"
 	overdose_threshold = 10
 	ph = 7
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -394,7 +394,8 @@
 
 /datum/reagent/medicine/calomel
 	name = "Calomel"
-	description = "Quickly purges the body of all chemicals except itself. The more health a person has, the more toxin damage it will deal"
+	description = "Quickly purges the body of all chemicals except itself. The more health a person has, \
+		the more toxin damage it will deal. It can heal toxin damage when people have low enough health."
 	reagent_state = LIQUID
 	color = "#c85319"
 	metabolization_rate = 1 * REAGENTS_METABOLISM
@@ -421,7 +422,9 @@
 
 /datum/reagent/medicine/ammoniated_mercury
 	name = "Ammoniated Mercury"
-	description = "Quickly purges the body of toxic chemicals. Heals toxin damage when in a good condition. When hurt with brute or fire damage, it can deal a great amount of toxin damage."
+	description = "Quickly purges the body of toxic chemicals. Heals toxin damage when in a good condition someone has \
+		no brute and fire damage. When hurt with brute or fire damage, it can deal a great amount of toxin damage. \
+		When there are no toxins present, it starts slowly purging itself."
 	reagent_state = LIQUID
 	color = "#f3f1f0"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -394,21 +394,59 @@
 
 /datum/reagent/medicine/calomel
 	name = "Calomel"
-	description = "Quickly purges the body of toxic chemicals. Toxin damage is dealt if the patient is in good condition."
+	description = "Quickly purges the body of all chemicals except itself."
 	reagent_state = LIQUID
-	color = "#19C832"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	color = "#c85319"
+	metabolization_rate = 1 * REAGENTS_METABOLISM
 	taste_description = "acid"
+	overdose_threshold = 20
 	ph = 1.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/medicine/calomel/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
-	for(var/datum/reagent/toxin/R in affected_mob.reagents.reagent_list)
-		affected_mob.reagents.remove_reagent(R.type, 3 * REM * delta_time)
-	if(affected_mob.health > 20)
-		affected_mob.adjustToxLoss(1 * REM * delta_time, FALSE, required_biotype = affected_biotype)
-		. = TRUE
+	for(var/datum/reagent/target_reagent in affected_mob.reagents.reagent_list)
+		if(!istype(target_reagent, /datum/reagent/medicine/calomel))
+			affected_mob.reagents.remove_reagent(target_reagent.type, 3 * REM * delta_time)
+	var/toxin_amount = round(affected_mob.health / 40, 0.1)
+	affected_mob.adjustToxLoss(toxin_amount * REM * delta_time, FALSE, required_biotype = affected_biotype)
 	..()
+	. = TRUE
+
+/datum/reagent/medicine/calomel/overdose_process(mob/living/affected_mob, delta_time, times_fired)
+	for(var/datum/reagent/medicine/calomel/target_reagent in affected_mob.reagents.reagent_list)
+		affected_mob.reagents.remove_reagent(target_reagent.type, 2 * REM * delta_time)
+	affected_mob.adjustToxLoss(2.5 * REM * delta_time, FALSE, required_biotype = affected_biotype)
+	..()
+	. = TRUE
+
+/datum/reagent/medicine/ammoniated_mercury
+	name = "Ammoniated Mercury"
+	description = "Quickly purges the body of toxic chemicals. Heals toxin damage when in a good condition. When hurt with brute damage, deals a great amount of toxin damage."
+	reagent_state = LIQUID
+	color = "#f3f1f0"
+	metabolization_rate = 0.1 * REAGENTS_METABOLISM
+	taste_description = "metalic"
+	overdose_threshold = 10
+	ph = 1
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/medicine/ammoniated_mercury/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
+	var/toxin_chem_amount = 0
+	for(var/datum/reagent/toxin/target_reagent in affected_mob.reagents.reagent_list)
+		toxin_chem_amount += 1
+		affected_mob.reagents.remove_reagent(target_reagent.type, 5 * REM * delta_time)
+	var/toxin_amount = round(affected_mob.getBruteLoss() / 15, 0.1) + round(affected_mob.getFireLoss() / 30, 0.1) - 3
+	affected_mob.adjustToxLoss(toxin_amount * REM * delta_time, FALSE, required_biotype = affected_biotype)
+	if(toxin_chem_amount == 0)
+		for(var/datum/reagent/medicine/ammoniated_mercury/target_reagent in affected_mob.reagents.reagent_list)
+			affected_mob.reagents.remove_reagent(target_reagent.type, 1 * REM * delta_time)
+	..()
+	. = TRUE
+
+/datum/reagent/medicine/ammoniated_mercury/overdose_process(mob/living/affected_mob, delta_time, times_fired)
+	affected_mob.adjustToxLoss(3 * REM * delta_time, FALSE, required_biotype = affected_biotype)
+	..()
+	. = TRUE
 
 /datum/reagent/medicine/potass_iodide
 	name = "Potassium Iodide"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -394,7 +394,7 @@
 
 /datum/reagent/medicine/calomel
 	name = "Calomel"
-	description = "Quickly purges the body of all chemicals except itself."
+	description = "Quickly purges the body of all chemicals except itself. The more health a person has, the more toxin damage it will deal"
 	reagent_state = LIQUID
 	color = "#c85319"
 	metabolization_rate = 1 * REAGENTS_METABOLISM
@@ -421,7 +421,7 @@
 
 /datum/reagent/medicine/ammoniated_mercury
 	name = "Ammoniated Mercury"
-	description = "Quickly purges the body of toxic chemicals. Heals toxin damage when in a good condition. When hurt with brute damage, deals a great amount of toxin damage."
+	description = "Quickly purges the body of toxic chemicals. Heals toxin damage when in a good condition. When hurt with brute or fire damage, it can deal a great amount of toxin damage."
 	reagent_state = LIQUID
 	color = "#f3f1f0"
 	metabolization_rate = 0.1 * REAGENTS_METABOLISM

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -127,6 +127,11 @@
 	required_temp = 374
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER
 
+/datum/chemical_reaction/medicine/ammoniated_mercury
+	results = list(/datum/reagent/medicine/ammoniated_mercury = 3)
+	required_reagents = list(/datum/reagent/medicine/calomel = 1, /datum/reagent/ammonia = 2)
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING | REACTION_TAG_OTHER
+
 /datum/chemical_reaction/medicine/potass_iodide
 	results = list(/datum/reagent/medicine/potass_iodide = 2)
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/iodine = 1)

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -65,10 +65,12 @@
 	volume = 50
 	list_reagents = list(/datum/reagent/phlogiston = 30)
 
-/obj/item/reagent_containers/cup/bottle/calomel
-	name = "calomel bottle"
-	desc = "A small bottle of calomel, which quickly purges all chemicals from the patient. Causes toxin damage if the patient is not heavily injured."
-	list_reagents = list(/datum/reagent/medicine/calomel = 30)
+/obj/item/reagent_containers/cup/bottle/ammoniated_mercury
+	name = "ammoniated mercury bottle"
+	desc = "Quickly purges the body of toxic chemicals. Heals toxin damage when in a good condition someone has \
+		no brute and fire damage. When hurt with brute or fire damage, it can deal a great amount of toxin damage. \
+		When there are no toxins present, it starts slowly purging itself."
+	list_reagents = list(/datum/reagent/medicine/ammoniated_mercury = 30)
 
 /obj/item/reagent_containers/cup/bottle/syriniver
 	name = "syriniver bottle"


### PR DESCRIPTION
## About The Pull Request
This transforms the Calomel now into a better version called Ammoniated Mercury and brings the old Calomel back. Calomel purges all chemicals again and Ammoniated Mercury purges toxins. Calomel deals toxin damage until you have less than 100 health in which case it starts doing to opposite. Ammoniated Mercury heals toxin damage if you do not have enough brute or fire damage.

Paramedics now get a bottle of Ammoniated Mercury since it is the new Calomel.
## Why It's Good For The Game
I always used to use Calomel back in the day to get rid of all chemicals. Multiver does the same but has very weird conditions, so now I split the old and new Calomel into two chemicals for both uses to become available. I have never seen anyone use Calomel so now it can be used to fix overdoses again.
## Changelog
:cl:
add: Adds Ammoniated Mercury, a chemical to the game.
balance: Calomel now purges all chemicals again, and now Ammoniated Mercury only purges toxins.
/:cl:
