### PR TITLE
Fixes humanoid examine easter egg's pronoun game

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -174,7 +174,7 @@
 	if(l_limbs_missing >= 2 && r_limbs_missing == 0)
 		msg += "[t_He] look[p_s()] all right now.\n"
 	else if(l_limbs_missing == 0 && r_limbs_missing >= 2)
-		msg += "[t_He] really keeps to the left.\n"
+		msg += "[t_He] really keep[p_s()] to the left.\n"
 	else if(l_limbs_missing >= 2 && r_limbs_missing >= 2)
 		msg += "[t_He] [p_do()]n't seem all there.\n"
 


### PR DESCRIPTION
Fixes #41175 - it's in the issue, I can't come up with anything funny to put in the PR body.

## Changelog
:cl:
spellcheck: fixed humanoid examine easter egg's pronoun usage
/:cl:
