### PR TITLE
[no gbp] Latejoin Rulesets sync

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -68,7 +68,7 @@
 		JOB_CYBORG,
 	)
 	required_candidates = 1
-	weight = 7
+	weight = 11
 	cost = 5
 	requirements = list(5,5,5,5,5,5,5,5,5,5)
 	repeatable = TRUE
@@ -111,7 +111,7 @@
 	)
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
-	weight = 2
+	weight = 1
 	delay = 1 MINUTES // Prevents rule start while head is offstation.
 	cost = 10
 	requirements = list(101,101,70,40,30,20,20,20,20,20)
@@ -195,7 +195,7 @@
 		JOB_CYBORG,
 	)
 	required_candidates = 1
-	weight = 4
+	weight = 8
 	cost = 6
 	requirements = list(101,101,50,10,10,10,10,10,10,10)
 	repeatable = TRUE


### PR DESCRIPTION

## About The Pull Request
Syncs the codebase inherent values for dynamic rulesets with the current config-side values used on our LRP servers.

## Why It's Good For The Game

This is technically irrelevant for the game as these numbers are the ones currently used on the servers - it's more for the good of the codebase than the game.

## Changelog

:cl:
balance: Latejoin dynamic rulesets have been rebalanced to reduce the frequency of midround revolution spawns.
/:cl:

