### PR TITLE
Adds in the ability to craft normal chairs.

### DIFF
--- a/code/controllers/subsystem/materials.dm
+++ b/code/controllers/subsystem/materials.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(materials)
 	var/list/list/material_combos
 	///List of stackcrafting recipes for materials using base recipes
 	var/list/base_stack_recipes = list(
-		new /datum/stack_recipe("Chair", /obj/structure/chair/greyscale, one_per_turf = TRUE, on_solid_ground = TRUE, applies_mats = TRUE, category = CAT_FURNITURE),
+		new /datum/stack_recipe("Material chair", /obj/structure/chair/greyscale, one_per_turf = TRUE, on_solid_ground = TRUE, applies_mats = TRUE, category = CAT_FURNITURE),
 		new /datum/stack_recipe("Toilet", /obj/structure/toilet/greyscale, one_per_turf = TRUE, on_solid_ground = TRUE, applies_mats = TRUE, category = CAT_FURNITURE),
 		new /datum/stack_recipe("Sink Frame", /obj/structure/sinkframe, one_per_turf = TRUE, on_solid_ground = TRUE, applies_mats = TRUE, category = CAT_FURNITURE),
 		new /datum/stack_recipe("Material floor tile", /obj/item/stack/tile/material, 1, 4, 20, applies_mats = TRUE, category = CAT_TILES),

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -15,6 +15,7 @@
  * Iron
  */
 GLOBAL_LIST_INIT(metal_recipes, list ( \
+	new/datum/stack_recipe("chair", /obj/structure/chair, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_FURNITURE), \
 	new/datum/stack_recipe("stool", /obj/structure/chair/stool, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_FURNITURE), \
 	new/datum/stack_recipe("bar stool", /obj/structure/chair/stool/bar, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_FURNITURE), \
 	new/datum/stack_recipe("bed", /obj/structure/bed, 2, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_FURNITURE), \


### PR DESCRIPTION

## About The Pull Request

This, as the title suggests, adds in the ability to craft normal chairs.

Before, you could not craft normal chairs (obj/structure/chair), you could only craft material datum chairs (obj/structure/chair/greyscale).

As the picture below shows, crafting a material datum chair with iron makes something that is noticeably different in color from a regular chair, as well as it being named "iron chair" instead of just "chair".
![Screenshot_58](https://user-images.githubusercontent.com/31294280/222875720-c47b4de5-ea33-40da-a84a-3fd5b3a65e1b.png)
(The left one is a material datum iron chair, the right one is a normal one.)

This is something that has bothered me for years, so i finally decided to try and fix it.

This also renames the crafting entry for the material datum chair to "material chair", in the vein of the material floor tile, and the material airlock assembly.

## Why It's Good For The Game

I'm sure a lot of people will appreciate being able to craft regular, run of the mill chairs, instead of just having to put up with the material datum chairs, or stealing chairs from other parts of the station. Besides, every other chair variant, to my knowledge, is capable of being crafted through normal means, so it only makes sense that something this basic be craftable as well.

## Changelog
:cl:
add: You can now craft normal chairs.
/:cl:
