### PR TITLE
Brings back Bartenders fountain pen

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -295,6 +295,7 @@
 /obj/item/modular_computer/pda/bar
 	name = "bartender PDA"
 	greyscale_colors = "#333333#C7C7C7"
+	inserted_item = /obj/item/pen/fountain
 
 /obj/item/modular_computer/pda/clown
 	name = "clown PDA"


### PR DESCRIPTION

## About The Pull Request

When PDAs were switched over to tablets, it seems that the bartender's fountain pen was forgotten. This PR will add it back as the round start pen of choice for bartenders, replacing the old generic one.

Bardic bartenders rejoice.

## Why It's Good For The Game

A lot of bartenders are snobby and would use fountain pens. Non-snobby bartenders would still be able to write vulgar words with precise calligraphy abilities. Both sides win.

![image](https://user-images.githubusercontent.com/16896032/222891224-441bfcc0-c6b8-4c19-b994-35b4a7fa7658.png)


## Changelog


:cl:
fix: Bartender's fountain pen was omitted during the swap over to tablets, this has been amended.
/:cl:
