### PR TITLE
Refactors abstract traitor objectives to be more abstract and enforces this by using unit tests. Rebalances some traitor objectives

### DIFF
--- a/code/modules/antagonists/traitor/objectives/assassination.dm
+++ b/code/modules/antagonists/traitor/objectives/assassination.dm
@@ -21,9 +21,6 @@
 
 	progression_minimum = 30 MINUTES
 
-	progression_reward = 2 MINUTES
-	telecrystal_reward = list(1, 2)
-
 	// The code below is for limiting how often you can get this objective. You will get this objective at a maximum of maximum_objectives_in_period every objective_period
 	/// The objective period at which we consider if it is an 'objective'. Set to 0 to accept all objectives.
 	var/objective_period = 15 MINUTES
@@ -47,18 +44,22 @@
 /datum/traitor_objective/assassinate/calling_card
 	name = "Assassinate %TARGET% the %JOB TITLE%, and plant a calling card"
 	description = "Kill your target and plant a calling card in the pockets of your victim. If your calling card gets destroyed before you are able to plant it, this objective will fail."
+	progression_reward = 2 MINUTES
+	telecrystal_reward = list(1, 2)
 
 	var/obj/item/paper/calling_card/card
 
 /datum/traitor_objective/assassinate/calling_card/heads_of_staff
 	progression_reward = 4 MINUTES
-	telecrystal_reward = list(3, 4)
+	telecrystal_reward = list(2, 3)
 
 	heads_of_staff = TRUE
 
 /datum/traitor_objective/assassinate/behead
 	name = "Behead %TARGET%, the %JOB TITLE%"
 	description = "Behead and hold %TARGET%'s head to succeed this objective. If the head gets destroyed before you can do this, you will fail this objective."
+	progression_reward = 2 MINUTES
+	telecrystal_reward = list(1, 2)
 
 	///the body who needs to hold the head
 	var/mob/living/needs_to_hold_head
@@ -67,7 +68,7 @@
 
 /datum/traitor_objective/assassinate/behead/heads_of_staff
 	progression_reward = 4 MINUTES
-	telecrystal_reward = list(3, 4)
+	telecrystal_reward = list(2, 3)
 
 	heads_of_staff = TRUE
 

--- a/code/modules/antagonists/traitor/objectives/assassination.dm
+++ b/code/modules/antagonists/traitor/objectives/assassination.dm
@@ -19,8 +19,6 @@
 
 	abstract_type = /datum/traitor_objective/assassinate
 
-	progression_minimum = 30 MINUTES
-
 	// The code below is for limiting how often you can get this objective. You will get this objective at a maximum of maximum_objectives_in_period every objective_period
 	/// The objective period at which we consider if it is an 'objective'. Set to 0 to accept all objectives.
 	var/objective_period = 15 MINUTES
@@ -44,12 +42,14 @@
 /datum/traitor_objective/assassinate/calling_card
 	name = "Assassinate %TARGET% the %JOB TITLE%, and plant a calling card"
 	description = "Kill your target and plant a calling card in the pockets of your victim. If your calling card gets destroyed before you are able to plant it, this objective will fail."
+	progression_minimum = 30 MINUTES
 	progression_reward = 2 MINUTES
 	telecrystal_reward = list(1, 2)
 
 	var/obj/item/paper/calling_card/card
 
 /datum/traitor_objective/assassinate/calling_card/heads_of_staff
+	progression_minimum = 30 MINUTES
 	progression_reward = 4 MINUTES
 	telecrystal_reward = list(2, 3)
 
@@ -58,6 +58,7 @@
 /datum/traitor_objective/assassinate/behead
 	name = "Behead %TARGET%, the %JOB TITLE%"
 	description = "Behead and hold %TARGET%'s head to succeed this objective. If the head gets destroyed before you can do this, you will fail this objective."
+	progression_minimum = 30 MINUTES
 	progression_reward = 2 MINUTES
 	telecrystal_reward = list(1, 2)
 
@@ -67,6 +68,7 @@
 	var/obj/item/bodypart/head/behead_goal
 
 /datum/traitor_objective/assassinate/behead/heads_of_staff
+	progression_minimum = 30 MINUTES
 	progression_reward = 4 MINUTES
 	telecrystal_reward = list(2, 3)
 

--- a/code/modules/antagonists/traitor/objectives/assassination.dm
+++ b/code/modules/antagonists/traitor/objectives/assassination.dm
@@ -19,6 +19,8 @@
 
 	abstract_type = /datum/traitor_objective/assassinate
 
+	progression_minimum = 30 MINUTES
+
 	// The code below is for limiting how often you can get this objective. You will get this objective at a maximum of maximum_objectives_in_period every objective_period
 	/// The objective period at which we consider if it is an 'objective'. Set to 0 to accept all objectives.
 	var/objective_period = 15 MINUTES
@@ -42,14 +44,12 @@
 /datum/traitor_objective/assassinate/calling_card
 	name = "Assassinate %TARGET% the %JOB TITLE%, and plant a calling card"
 	description = "Kill your target and plant a calling card in the pockets of your victim. If your calling card gets destroyed before you are able to plant it, this objective will fail."
-	progression_minimum = 30 MINUTES
 	progression_reward = 2 MINUTES
 	telecrystal_reward = list(1, 2)
 
 	var/obj/item/paper/calling_card/card
 
 /datum/traitor_objective/assassinate/calling_card/heads_of_staff
-	progression_minimum = 30 MINUTES
 	progression_reward = 4 MINUTES
 	telecrystal_reward = list(2, 3)
 
@@ -58,7 +58,6 @@
 /datum/traitor_objective/assassinate/behead
 	name = "Behead %TARGET%, the %JOB TITLE%"
 	description = "Behead and hold %TARGET%'s head to succeed this objective. If the head gets destroyed before you can do this, you will fail this objective."
-	progression_minimum = 30 MINUTES
 	progression_reward = 2 MINUTES
 	telecrystal_reward = list(1, 2)
 
@@ -68,7 +67,6 @@
 	var/obj/item/bodypart/head/behead_goal
 
 /datum/traitor_objective/assassinate/behead/heads_of_staff
-	progression_minimum = 30 MINUTES
 	progression_reward = 4 MINUTES
 	telecrystal_reward = list(2, 3)
 

--- a/code/modules/antagonists/traitor/objectives/demoralise_crew.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_crew.dm
@@ -14,8 +14,6 @@
 	name = "Debug your code."
 	description = "If you actually get this objective someone fucked up."
 
-	progression_maximum = 30 MINUTES
-
 	abstract_type = /datum/traitor_objective/demoralise
 
 	/// How many 'mood events' are required?

--- a/code/modules/antagonists/traitor/objectives/demoralise_crew.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_crew.dm
@@ -14,9 +14,6 @@
 	name = "Debug your code."
 	description = "If you actually get this objective someone fucked up."
 
-	progression_reward = list(2 MINUTES, 8 MINUTES)
-	telecrystal_reward = list(0, 1)
-
 	progression_maximum = 30 MINUTES
 
 	abstract_type = /datum/traitor_objective/demoralise

--- a/code/modules/antagonists/traitor/objectives/demoralise_graffiti.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_graffiti.dm
@@ -7,6 +7,7 @@
 		People seeing or slipping on your graffiti grants progress towards success."
 
 	progression_minimum = 0 MINUTES
+	progression_maximum = 30 MINUTES
 	progression_reward = list(4 MINUTES, 8 MINUTES)
 	telecrystal_reward = list(0, 1)
 

--- a/code/modules/antagonists/traitor/objectives/demoralise_graffiti.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_graffiti.dm
@@ -7,6 +7,9 @@
 		People seeing or slipping on your graffiti grants progress towards success."
 
 	progression_minimum = 0 MINUTES
+	progression_reward = list(4 MINUTES, 8 MINUTES)
+	telecrystal_reward = list(0, 1)
+
 	duplicate_type = /datum/traitor_objective/demoralise/graffiti
 	/// Have we given out a spray can yet?
 	var/obtained_spray = FALSE

--- a/code/modules/antagonists/traitor/objectives/demoralise_poster.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_poster.dm
@@ -7,6 +7,9 @@
 		do-gooders who try to take it down a hard time!"
 
 	progression_minimum = 0 MINUTES
+	progression_reward = list(4 MINUTES, 8 MINUTES)
+	telecrystal_reward = list(0, 1)
+
 	duplicate_type = /datum/traitor_objective/demoralise/poster
 	/// Have we handed out a box of stuff yet?
 	var/granted_posters = FALSE

--- a/code/modules/antagonists/traitor/objectives/demoralise_poster.dm
+++ b/code/modules/antagonists/traitor/objectives/demoralise_poster.dm
@@ -7,6 +7,7 @@
 		do-gooders who try to take it down a hard time!"
 
 	progression_minimum = 0 MINUTES
+	progression_maximum = 30 MINUTES
 	progression_reward = list(4 MINUTES, 8 MINUTES)
 	telecrystal_reward = list(0, 1)
 

--- a/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
@@ -17,10 +17,6 @@
 
 	abstract_type = /datum/traitor_objective/destroy_heirloom
 
-	//this is a prototype so this progression is for all basic level kill objectives
-	progression_reward = list(8 MINUTES, 12 MINUTES)
-	telecrystal_reward = list(1, 2)
-
 	/// The jobs that this objective is targetting.
 	var/list/target_jobs
 	/// the item we need to destroy
@@ -36,6 +32,8 @@
 	/// 30 minutes in, syndicate won't care about common heirlooms anymore
 	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
+	progression_reward = list(8 MINUTES, 12 MINUTES)
+	telecrystal_reward = list(1, 2)
 	target_jobs = list(
 		// Medical
 		/datum/job/doctor,
@@ -65,6 +63,8 @@
 	/// 30 minutes in, syndicate won't care about common heirlooms anymore
 	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
+	progression_reward = list(8 MINUTES, 12 MINUTES)
+	telecrystal_reward = list(1, 2)
 	target_jobs = list(
 		/datum/job/assistant
 	)
@@ -73,6 +73,8 @@
 	/// 45 minutes in, syndicate won't care about uncommon heirlooms anymore
 	progression_minimum = 0 MINUTES
 	progression_maximum = 45 MINUTES
+	progression_reward = list(8 MINUTES, 12 MINUTES)
+	telecrystal_reward = list(1, 2)
 	target_jobs = list(
 		// Cargo
 		/datum/job/shaft_miner,
@@ -87,6 +89,8 @@
 	progression_minimum = 15 MINUTES
 	/// 60 minutes in, syndicate won't care about rare heirlooms anymore
 	progression_maximum = 60 MINUTES
+	progression_reward = list(10 MINUTES, 14 MINUTES)
+	telecrystal_reward = list(2, 3)
 	target_jobs = list(
 		// Security
 		/datum/job/security_officer,
@@ -101,6 +105,8 @@
 
 /datum/traitor_objective/destroy_heirloom/captain
 	progression_minimum = 30 MINUTES
+	progression_reward = list(10 MINUTES, 14 MINUTES)
+	telecrystal_reward = 4
 	target_jobs = list(
 		/datum/job/head_of_security,
 		/datum/job/captain

--- a/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
@@ -4,7 +4,7 @@
 		list(
 			// There's about 16 jobs in common, so assistant has a 1/21 chance of getting chosen.
 			/datum/traitor_objective/destroy_heirloom/common = 20,
-			/datum/traitor_objective/destroy_heirloom/less_common = 1,
+			/datum/traitor_objective/destroy_heirloom/common/assistant = 1,
 		) = 4,
 		/datum/traitor_objective/destroy_heirloom/uncommon = 3,
 		/datum/traitor_objective/destroy_heirloom/rare = 2,
@@ -59,12 +59,7 @@
 	)
 
 /// This is only for assistants, because the syndies are a lot less likely to give a shit about what an assistant does, so they're a lot less likely to appear
-/datum/traitor_objective/destroy_heirloom/less_common
-	/// 30 minutes in, syndicate won't care about common heirlooms anymore
-	progression_minimum = 0 MINUTES
-	progression_maximum = 30 MINUTES
-	progression_reward = list(8 MINUTES, 12 MINUTES)
-	telecrystal_reward = list(1, 2)
+/datum/traitor_objective/destroy_heirloom/common/assistant
 	target_jobs = list(
 		/datum/job/assistant
 	)

--- a/code/modules/antagonists/traitor/objectives/destroy_item.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_item.dm
@@ -2,10 +2,6 @@
 	name = "Steal %ITEM% and destroy it"
 	description = "Find %ITEM% and destroy it using any means necessary. We can't allow the crew to have %ITEM% as it conflicts with our interests."
 
-	progression_minimum = 20 MINUTES
-	progression_reward = 5 MINUTES
-	telecrystal_reward = 0
-
 	var/list/possible_items = list()
 	/// The current target item that we are stealing.
 	var/datum/objective_item/steal/target_item

--- a/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/final_objective.dm
@@ -12,6 +12,7 @@
 /datum/traitor_objective/ultimate
 	abstract_type = /datum/traitor_objective/ultimate
 	progression_minimum = 140 MINUTES
+	needs_reward = FALSE
 
 	var/progression_points_in_objectives = 20 MINUTES
 

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -3,7 +3,7 @@
 	objectives = list( //Similar weights to destroy heirloom objectives
 		list(
 			/datum/traitor_objective/kidnapping/common = 20,
-			/datum/traitor_objective/kidnapping/less_common = 1,
+			/datum/traitor_objective/kidnapping/common/assistant = 1,
 		) = 4,
 		/datum/traitor_objective/kidnapping/uncommon = 3,
 		/datum/traitor_objective/kidnapping/rare = 2,
@@ -78,11 +78,9 @@
 		/datum/job/atmospheric_technician,
 	)
 
-/datum/traitor_objective/kidnapping/less_common
+/datum/traitor_objective/kidnapping/common/assistant
 	progression_minimum = 0 MINUTES
 	progression_maximum = 15 MINUTES
-	progression_reward = list(2 MINUTES, 4 MINUTES)
-	telecrystal_reward = list(1, 2)
 	target_jobs = list(
 		/datum/job/assistant
 	)

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -17,10 +17,6 @@
 
 	abstract_type = /datum/traitor_objective/kidnapping
 
-	//this is a prototype so this progression is for all basic level kill objectives
-	progression_reward = list(2 MINUTES, 4 MINUTES)
-	telecrystal_reward = list(1, 2)
-
 	/// The period of time until you can take another objective after taking 3 objectives.
 	var/objective_period = 15 MINUTES
 	/// The maximum number of objectives we can get within this period.
@@ -55,6 +51,8 @@
 /datum/traitor_objective/kidnapping/common
 	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
+	progression_reward = list(2 MINUTES, 4 MINUTES)
+	telecrystal_reward = list(1, 2)
 	target_jobs = list(
 		// Medical
 		/datum/job/doctor,
@@ -83,6 +81,8 @@
 /datum/traitor_objective/kidnapping/less_common
 	progression_minimum = 0 MINUTES
 	progression_maximum = 15 MINUTES
+	progression_reward = list(2 MINUTES, 4 MINUTES)
+	telecrystal_reward = list(1, 2)
 	target_jobs = list(
 		/datum/job/assistant
 	)
@@ -90,6 +90,9 @@
 /datum/traitor_objective/kidnapping/uncommon //Hard to fish out victims
 	progression_minimum = 0 MINUTES
 	progression_maximum = 45 MINUTES
+	progression_reward = list(4 MINUTES, 8 MINUTES)
+	telecrystal_reward = list(1, 2)
+
 	target_jobs = list(
 		// Medical
 		/datum/job/virologist,
@@ -100,14 +103,13 @@
 		// Science
 		/datum/job/scientist,
 	)
-
-	progression_reward = list(4 MINUTES, 8 MINUTES)
-	telecrystal_reward = list(1, 2)
 	alive_bonus = 1
 
 /datum/traitor_objective/kidnapping/rare
 	progression_minimum = 15 MINUTES
 	progression_maximum = 60 MINUTES
+	progression_reward = list(8 MINUTES, 12 MINUTES)
+	telecrystal_reward = list(2, 3)
 	target_jobs = list(
 		// Security
 		/datum/job/security_officer,
@@ -119,20 +121,16 @@
 		/datum/job/research_director,
 		/datum/job/quartermaster,
 	)
-
-	progression_reward = list(8 MINUTES, 12 MINUTES)
-	telecrystal_reward = list(1, 2)
 	alive_bonus = 2
 
 /datum/traitor_objective/kidnapping/captain
 	progression_minimum = 30 MINUTES
+	progression_reward = list(12 MINUTES, 16 MINUTES)
+	telecrystal_reward = list(2, 3)
 	target_jobs = list(
 		/datum/job/head_of_security,
 		/datum/job/captain
 	)
-
-	progression_reward = list(12 MINUTES, 16 MINUTES)
-	telecrystal_reward = list(2, 3)
 	alive_bonus = 2
 
 /datum/traitor_objective/kidnapping/generate_objective(datum/mind/generating_for, list/possible_duplicates)

--- a/code/modules/antagonists/traitor/objectives/kill_pet.dm
+++ b/code/modules/antagonists/traitor/objectives/kill_pet.dm
@@ -11,9 +11,9 @@
 /datum/traitor_objective/kill_pet
 	name = "Kill the %DEPARTMENT HEAD%'s beloved %PET%"
 	description = "The %DEPARTMENT HEAD% has particularly annoyed us by sending us spam emails and we want their %PET% dead to show them what happens when they cross us. "
-	telecrystal_reward = list(1, 2)
 
 	progression_minimum = 0 MINUTES
+	telecrystal_reward = list(1, 2)
 	progression_reward = list(3 MINUTES, 6 MINUTES)
 
 	/// Possible heads mapped to their pet type. Can be a list of possible pets

--- a/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
+++ b/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
@@ -12,7 +12,7 @@
 	progression_minimum = 0 MINUTES
 
 	progression_reward = list(8 MINUTES, 15 MINUTES)
-	telecrystal_reward = 0
+	telecrystal_reward = 1
 
 	var/list/limited_to = list(
 		JOB_CHIEF_MEDICAL_OFFICER,
@@ -125,9 +125,8 @@
 	target.gain_trauma(new /datum/brain_trauma/mild/phobia/conspiracies(), TRAUMA_RESILIENCE_LOBOTOMY)
 
 /datum/traitor_objective/sleeper_protocol/everybody //Much harder for non-med and non-robo
-
 	progression_minimum = 30 MINUTES
-	progression_reward = list(15 MINUTES, 20 MINUTES)
-	telecrystal_reward = list(2, 3)
+	progression_reward = list(8 MINUTES, 15 MINUTES)
+	telecrystal_reward = 1
 
 	inverted_limitation = TRUE

--- a/code/modules/antagonists/traitor/objectives/steal.dm
+++ b/code/modules/antagonists/traitor/objectives/steal.dm
@@ -51,8 +51,6 @@ GLOBAL_DATUM_INIT(steal_item_handler, /datum/objective_item_handler, new())
 	description = "Use the button below to materialize the bug within your hand, where you'll then be able to place it on the item. Additionally, you can keep it near you for %TIME% minutes, and you will be rewarded with %PROGRESSION% reputation and %TC% telecrystals."
 
 	progression_minimum = 20 MINUTES
-	progression_reward = 5 MINUTES
-	telecrystal_reward = 0
 
 	var/list/possible_items = list()
 	/// The current target item that we are stealing.

--- a/code/modules/antagonists/traitor/traitor_objective.dm
+++ b/code/modules/antagonists/traitor/traitor_objective.dm
@@ -47,6 +47,9 @@
 	/// The duplicate type that will be used to check for duplicates.
 	/// If undefined, this will either take from the abstract type or the type of the objective itself
 	var/duplicate_type = null
+	/// Used only in unit testing. Can be used to explicitly skip the progression_reward and telecrystal_reward check for non-abstract objectives.
+	/// Useful for final objectives as they don't need a reward.
+	var/needs_reward = TRUE
 
 /// Returns a list of variables that can be changed by config, allows for balance through configuration.
 /// It is not recommended to finetweak any values of objectives on your server.

--- a/code/modules/unit_tests/objectives.dm
+++ b/code/modules/unit_tests/objectives.dm
@@ -9,15 +9,28 @@
 			else
 				objectives_that_exist += value
 
+	SStraitor.generate_objectives = TRUE
 	for(var/datum/traitor_objective/objective_typepath as anything in subtypesof(/datum/traitor_objective))
-		if(initial(objective_typepath.abstract_type) == objective_typepath)
+		var/datum/traitor_objective/objective = allocate(objective_typepath)
+		if(objective.abstract_type == objective_typepath)
+			// In this case, we don't want abstract types to define values that should be defined on non-abstract types
+			// Nor do we want abstract types to appear in the pool of traitor objectives.
+			if(objective_typepath in objectives_that_exist)
+				TEST_FAIL("[objective_typepath] is in a traitor category and is an abstract type! Please remove it from the [/datum/traitor_objective_category].")
+			if(objective.progression_minimum != null)
+				TEST_FAIL("[objective_typepath] has defined a minimum progression level as an abstract type! Please define minimum progression levels on non-abstract types rather than abstract types.")
+			if(objective.progression_reward != 0)
+				TEST_FAIL("[objective_typepath] has set a progression reward as an abstract type! Please define progression rewards on non-abstract types rather than abstract types.")
+			if(objective.telecrystal_reward != 0)
+				TEST_FAIL("[objective_typepath] has set a telecrystal reward as an abstract type! Please define telecrystal rewards on non-abstract types rather than abstract types.")
 			continue
 		if(!(objective_typepath in objectives_that_exist))
 			TEST_FAIL("[objective_typepath] is not in a traitor category and isn't an abstract type! Place it into a [/datum/traitor_objective_category] or remove it from code.")
-		if(initial(objective_typepath.progression_minimum) == null)
+		if(objective.progression_minimum == null)
 			TEST_FAIL("[objective_typepath] has not defined a minimum progression level and isn't an abstract type! Please define the progression minimum variable on the datum")
-		if(!ispath(objective_typepath, /datum/traitor_objective/ultimate) && initial(objective_typepath.progression_reward) == 0 && initial(objective_typepath.telecrystal_reward) == 0)
+		if(!ispath(objective_typepath, /datum/traitor_objective/ultimate) && objective.progression_reward == 0 && objective.telecrystal_reward == 0)
 			TEST_FAIL("[objective_typepath] has not set either a progression reward or a telecrystal reward! Please set either a telecrystal or progression reward for this objective.")
+	SStraitor.generate_objectives = FALSE
 
 /datum/unit_test/objectives_category/proc/recursive_check_list(base_type, list/to_check, list/to_add_to)
 	for(var/value in to_check)

--- a/code/modules/unit_tests/objectives.dm
+++ b/code/modules/unit_tests/objectives.dm
@@ -17,17 +17,23 @@
 			// Nor do we want abstract types to appear in the pool of traitor objectives.
 			if(objective_typepath in objectives_that_exist)
 				TEST_FAIL("[objective_typepath] is in a traitor category and is an abstract type! Please remove it from the [/datum/traitor_objective_category].")
-			if(objective.progression_reward != 0)
+			// Since we didn't generate the objective, the rewards are going to be in list form: (min, max)
+			if(!reward_is_zero(objective.progression_reward))
 				TEST_FAIL("[objective_typepath] has set a progression reward as an abstract type! Please define progression rewards on non-abstract types rather than abstract types.")
-			if(objective.telecrystal_reward != 0)
+			// Since we didn't generate the objective, the rewards are going to be in list form: (min, max)
+			if(!reward_is_zero(objective.telecrystal_reward))
 				TEST_FAIL("[objective_typepath] has set a telecrystal reward as an abstract type! Please define telecrystal rewards on non-abstract types rather than abstract types.")
 			continue
 		if(!(objective_typepath in objectives_that_exist))
 			TEST_FAIL("[objective_typepath] is not in a traitor category and isn't an abstract type! Place it into a [/datum/traitor_objective_category] or remove it from code.")
 		if(objective.progression_minimum == null)
 			TEST_FAIL("[objective_typepath] has not defined a minimum progression level and isn't an abstract type! Please define the progression minimum variable on the datum")
-		if(!ispath(objective_typepath, /datum/traitor_objective/ultimate) && objective.progression_reward == 0 && objective.telecrystal_reward == 0)
+		if(objective.needs_reward && reward_is_zero(objective.progression_reward) && reward_is_zero(objective.telecrystal_reward))
 			TEST_FAIL("[objective_typepath] has not set either a progression reward or a telecrystal reward! Please set either a telecrystal or progression reward for this objective.")
+
+/// Returns whether the reward specified (in format (min, max)) is zero or not.
+/datum/unit_test/objectives_category/proc/reward_is_zero(list/reward)
+	return (reward[1] == 0 && reward[2] == 0)
 
 /datum/unit_test/objectives_category/Destroy()
 	SStraitor.generate_objectives = TRUE

--- a/code/modules/unit_tests/objectives.dm
+++ b/code/modules/unit_tests/objectives.dm
@@ -9,7 +9,7 @@
 			else
 				objectives_that_exist += value
 
-	SStraitor.generate_objectives = TRUE
+	SStraitor.generate_objectives = FALSE
 	for(var/datum/traitor_objective/objective_typepath as anything in subtypesof(/datum/traitor_objective))
 		var/datum/traitor_objective/objective = allocate(objective_typepath)
 		if(objective.abstract_type == objective_typepath)
@@ -28,7 +28,11 @@
 			TEST_FAIL("[objective_typepath] has not defined a minimum progression level and isn't an abstract type! Please define the progression minimum variable on the datum")
 		if(!ispath(objective_typepath, /datum/traitor_objective/ultimate) && objective.progression_reward == 0 && objective.telecrystal_reward == 0)
 			TEST_FAIL("[objective_typepath] has not set either a progression reward or a telecrystal reward! Please set either a telecrystal or progression reward for this objective.")
-	SStraitor.generate_objectives = FALSE
+
+/datum/unit_test/objectives_category/Destroy()
+	SStraitor.generate_objectives = TRUE
+	return ..()
+
 
 /datum/unit_test/objectives_category/proc/recursive_check_list(base_type, list/to_check, list/to_add_to)
 	for(var/value in to_check)

--- a/code/modules/unit_tests/objectives.dm
+++ b/code/modules/unit_tests/objectives.dm
@@ -17,8 +17,6 @@
 			// Nor do we want abstract types to appear in the pool of traitor objectives.
 			if(objective_typepath in objectives_that_exist)
 				TEST_FAIL("[objective_typepath] is in a traitor category and is an abstract type! Please remove it from the [/datum/traitor_objective_category].")
-			if(objective.progression_minimum != null)
-				TEST_FAIL("[objective_typepath] has defined a minimum progression level as an abstract type! Please define minimum progression levels on non-abstract types rather than abstract types.")
 			if(objective.progression_reward != 0)
 				TEST_FAIL("[objective_typepath] has set a progression reward as an abstract type! Please define progression rewards on non-abstract types rather than abstract types.")
 			if(objective.telecrystal_reward != 0)


### PR DESCRIPTION
## About The Pull Request
In this PR, some of the traitor objectives are rebalanced to be more consistent with scaling risk.
Abstract traitor objectives have had their telecrystal reward and progression rewards moved to their non-abstract types and it's now enforced that abstract objectives should not have these values set.
Additionally, it's encouraged that people don't set progression_minimum on abstract types either, but I can see the usecase in doing so with final objectives and assassinate objectives. This is why it's fine to set progression_minimum on an abstract type as long as any of the derivatives of that abstract type do not redefine the progression minimum to avoid consistency errors when tweaking progression minimum values. Setting the progression minimum on an abstract type means that all derivatives of that abstract type should be unlocked at roughly the same time.

## Why It's Good For The Game
The rebalances are so that same risk objectives of different types are worth around the same amount. Repeatables should roughly award the same amount of TC when it comes to comparing the risk, but the progression rewards can vary.
The new standard enforcement on abstract traitor objectives is more so for robustness and ease of balance, as it's easier to lose consistency when rebalancing values between two objectives, because one of the objectives derive their rewards from an abstract type. Generally speaking, rewards from objectives of different risk level should not be the same and it's easier to enforce this if developers have to explicitly declare the rewards of the objectives they add.
This doesn't mean each objective has to declare explicitly what their reward is. Derivatives that subtype off of non-abstract types can still copy the rewards from their parent.

The progression minimum is fine to be set on abstract objectives as long as derivatives don't change the progression minimum. If they do, then it's better for consistency to declare the progression minimum on each type rather than the abstract type so that higher-tier objectives don't accidentally end up with a lower progression minimum when it comes to rebalancing. Of course, this isn't a set rule on, but it's something I'm going to try and enforce, when it makes sense, going forward, even if it may increase the number of lines of code each traitor objective file may have. Maintainability and robustness beat optimization.

## Changelog
:cl:
code: Abstract types don't hold telecrystal rewards or progression rewards anymore, this has been moved to the non-abstract types.
balance: Rebalances rewards from repeatable traitor objectives to be more consistent with each other.
/:cl:
