### PR TITLE
Fixes bread dog butchering producing error bread and adds some warnings to bread that shouldn't appear in-game.

### DIFF
--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -1,5 +1,6 @@
 
-/obj/item/food/bread //If you'll try to spawn it will occure in error sprite. Shouldn't do this.
+/// Abstract parent object for bread items. Should not be made obtainable in game.
+/obj/item/food/bread
 	name = "bread?"
 	desc = "You shouldn't see this, call the coders."
 	icon = 'icons/obj/food/burgerbread.dmi'

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -23,7 +23,8 @@
 		AddElement(/datum/element/processable, TOOL_KNIFE, slice_type, yield, 3 SECONDS, table_required = TRUE, screentip_verb = "Slice")
 		AddElement(/datum/element/processable, TOOL_SAW, slice_type, yield, 4 SECONDS, table_required = TRUE, screentip_verb = "Slice")
 
-/obj/item/food/breadslice //If you'll try to spawn it will occure in error sprite. Shouldn't do this.
+// Abstract parent object for sliced bread items. Should not be made obtainable in game.
+/obj/item/food/breadslice
 	name = "breadslice?"
 	desc = "You shouldn't see this, call the coders."
 	icon = 'icons/obj/food/burgerbread.dmi'

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -1,5 +1,7 @@
 
-/obj/item/food/bread
+/obj/item/food/bread //If you'll try to spawn it will occure in error sprite. Shouldn't do this.
+	name = "bread?"
+	desc = "You shouldn't see this, call the coders."
 	icon = 'icons/obj/food/burgerbread.dmi'
 	max_volume = 80
 	tastes = list("bread" = 10)
@@ -20,7 +22,9 @@
 		AddElement(/datum/element/processable, TOOL_KNIFE, slice_type, yield, 3 SECONDS, table_required = TRUE, screentip_verb = "Slice")
 		AddElement(/datum/element/processable, TOOL_SAW, slice_type, yield, 4 SECONDS, table_required = TRUE, screentip_verb = "Slice")
 
-/obj/item/food/breadslice
+/obj/item/food/breadslice //If you'll try to spawn it will occure in error sprite. Shouldn't do this.
+	name = "breadslice?"
+	desc = "You shouldn't see this, call the coders."
 	icon = 'icons/obj/food/burgerbread.dmi'
 	foodtypes = GRAIN
 	food_flags = FOOD_FINGER_FOOD

--- a/code/modules/mob/living/basic/pets/dog.dm
+++ b/code/modules/mob/living/basic/pets/dog.dm
@@ -793,7 +793,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 	maxHealth = 50
 	gender = NEUTER
 	damage_coeff = list(BRUTE = 3, BURN = 3, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
-	butcher_results = list(/obj/item/organ/internal/brain = 1, /obj/item/organ/internal/heart = 1, /obj/item/food/breadslice = 3,  \
+	butcher_results = list(/obj/item/organ/internal/brain = 1, /obj/item/organ/internal/heart = 1, /obj/item/food/breadslice/plain = 3,  \
 	/obj/item/food/meat/slab = 2)
 	response_harm_continuous = "takes a bite out of"
 	response_harm_simple = "take a bite out of"


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/73765
Also adds some warnings and description to bread/breadslice so you can more easily notice that something is wrong.
Not much to discuss i think.
## Why It's Good For The Game
You can get normal bread from butchering bread dog. And potentially less issues with bread in future.
## Changelog
:cl:
fix: fixed butchering bread dog spawning error bread.
/:cl:
