### PR TITLE
Updates the dynamic config's midround options to add in new additions

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -3,12 +3,7 @@
 /// The probability to replace an existing law with an ion law instead of adding a new ion law.
 #define REPLACE_LAW_WITH_ION_PROB 10
 
-//////////////////////////////////////////////
-//                                          //
-//            MIDROUND RULESETS             //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Rulesets
 /datum/dynamic_ruleset/midround // Can be drafted once in a while during a round
 	ruletype = "Midround"
 	var/midround_ruleset_style
@@ -204,12 +199,7 @@
 	return ..()
 
 
-//////////////////////////////////////////////
-//                                          //
-//           SYNDICATE TRAITORS             //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Traitor Ruleset (From Living)
 /datum/dynamic_ruleset/midround/from_living/autotraitor
 	name = "Syndicate Sleeper Agent"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
@@ -257,12 +247,7 @@
 	log_dynamic("[key_name(M)] was selected by the [name] ruleset and has been made into a midround traitor.")
 	return TRUE
 
-//////////////////////////////////////////////
-//                                          //
-//         Malfunctioning AI                //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Malf AI Ruleset (From Living)
 /datum/dynamic_ruleset/midround/malf
 	name = "Malfunctioning AI"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -318,12 +303,7 @@
 			new_malf_ai.add_ion_law(generate_ion_law())
 	return TRUE
 
-//////////////////////////////////////////////
-//                                          //
-//              WIZARD (GHOST)              //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Wizard Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/wizard
 	name = "Wizard"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -351,12 +331,7 @@
 	..()
 	new_character.forceMove(pick(GLOB.wizardstart))
 
-//////////////////////////////////////////////
-//                                          //
-//          NUCLEAR OPERATIVES (MIDROUND)   //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Nuclear Operatives Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/nuclear
 	name = "Nuclear Assault"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -413,12 +388,7 @@
 		return
 	return ..()
 
-//////////////////////////////////////////////
-//                                          //
-//              BLOB (GHOST)                //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Blob Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/blob
 	name = "Blob"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -436,7 +406,7 @@
 	var/body = applicant.become_overmind()
 	return body
 
-/// Infects a random player, making them explode into a blob.
+/// Midround Blob Infection Ruleset (From Living)
 /datum/dynamic_ruleset/midround/from_living/blob_infection
 	name = "Blob Infection"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -484,12 +454,7 @@
 	blob_antag.mind.special_role = antag_flag
 	return ..()
 
-//////////////////////////////////////////////
-//                                          //
-//           XENOMORPH (GHOST)              //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Xenomorph Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/xenomorph
 	name = "Alien Infestation"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -531,12 +496,7 @@
 	log_dynamic("[key_name(new_xeno)] was spawned as an alien by the midround ruleset.")
 	return new_xeno
 
-//////////////////////////////////////////////
-//                                          //
-//           NIGHTMARE (GHOST)              //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Nightmare Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/nightmare
 	name = "Nightmare"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
@@ -577,12 +537,7 @@
 	log_dynamic("[key_name(S)] was spawned as a Nightmare by the midround ruleset.")
 	return S
 
-//////////////////////////////////////////////
-//                                          //
-//           SPACE DRAGON (GHOST)           //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Space Dragon Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/space_dragon
 	name = "Space Dragon"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -621,11 +576,7 @@
 	priority_announce("A large organic energy flux has been recorded near of [station_name()], please stand-by.", "Lifesign Alert")
 	return S
 
-//////////////////////////////////////////////
-//                                          //
-//           ABDUCTORS    (GHOST)           //
-//                                          //
-//////////////////////////////////////////////
+/// Midround Abductors Ruleset (From Ghosts)
 #define ABDUCTOR_MAX_TEAMS 4
 
 /datum/dynamic_ruleset/midround/from_ghosts/abductors
@@ -662,12 +613,7 @@
 
 #undef ABDUCTOR_MAX_TEAMS
 
-//////////////////////////////////////////////
-//                                          //
-//            SPACE NINJA (GHOST)           //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Space Ninja Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/space_ninja
 	name = "Space Ninja"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -703,12 +649,7 @@
 	log_dynamic("[key_name(ninja)] was spawned as a Space Ninja by the midround ruleset.")
 	return ninja
 
-//////////////////////////////////////////////
-//                                          //
-//            SPIDERS     (GHOST)           //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Spiders Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/spiders
 	name = "Spiders"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -726,12 +667,7 @@
 	create_midwife_eggs(spawncount)
 	return ..()
 
-//////////////////////////////////////////////
-//                                          //
-//            REVENANT     (GHOST)          // //wow i didnt know
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Revenant Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/revenant
 	name = "Revenant"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
@@ -777,12 +713,7 @@
 	log_game("[key_name(revenant)] was spawned as a revenant by the midround ruleset.")
 	return revenant
 
-//////////////////////////////////////////////
-//                                          //
-//        SENTIENT DISEASE     (GHOST)      //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Sentient Disease Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/sentient_disease
 	name = "Sentient Disease"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -802,12 +733,7 @@
 	log_game("[key_name(virus)] was spawned as a sentient disease by the midround ruleset.")
 	return virus
 
-//////////////////////////////////////////////
-//                                          //
-//        SPACE PIRATES     (GHOST)         //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Space Pirates Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/pirates
 	name = "Space Pirates"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -829,12 +755,7 @@
 	send_pirate_threat()
 	return ..()
 
-//////////////////////////////////////////////
-//                                          //
-//          OBSESSED     (MIDROUND)         //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Obsessed Ruleset (From Living)
 /datum/dynamic_ruleset/midround/from_living/obsessed
 	name = "Obsessed"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
@@ -871,12 +792,7 @@
 	log_game("[key_name(obsessed)] was made Obsessed by the midround ruleset.")
 	return TRUE
 
-//////////////////////////////////////////////
-//                                          //
-//      SPACE CHANGELING     (GHOST)        //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Space Changeling Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/changeling_midround
 	name = "Space Changeling"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
@@ -897,12 +813,7 @@
 	log_dynamic("[key_name(body)] was spawned as a space changeling by the midround ruleset.")
 	return body
 
-//////////////////////////////////////////////
-//                                          //
-//        PARADOX CLONE      (GHOST)        //
-//                                          //
-//////////////////////////////////////////////
-
+/// Midround Paradox Clone Ruleset (From Ghosts)
 /datum/dynamic_ruleset/midround/from_ghosts/paradox_clone
 	name = "Paradox Clone"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -726,7 +726,12 @@
 	create_midwife_eggs(spawncount)
 	return ..()
 
-/// Revenant ruleset
+//////////////////////////////////////////////
+//                                          //
+//            REVENANT     (GHOST)          // //wow i didnt know
+//                                          //
+//////////////////////////////////////////////
+
 /datum/dynamic_ruleset/midround/from_ghosts/revenant
 	name = "Revenant"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
@@ -772,7 +777,12 @@
 	log_game("[key_name(revenant)] was spawned as a revenant by the midround ruleset.")
 	return revenant
 
-/// Sentient Disease ruleset
+//////////////////////////////////////////////
+//                                          //
+//        SENTIENT DISEASE     (GHOST)      //
+//                                          //
+//////////////////////////////////////////////
+
 /datum/dynamic_ruleset/midround/from_ghosts/sentient_disease
 	name = "Sentient Disease"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -792,7 +802,12 @@
 	log_game("[key_name(virus)] was spawned as a sentient disease by the midround ruleset.")
 	return virus
 
-/// Space Pirates ruleset
+//////////////////////////////////////////////
+//                                          //
+//        SPACE PIRATES     (GHOST)         //
+//                                          //
+//////////////////////////////////////////////
+
 /datum/dynamic_ruleset/midround/pirates
 	name = "Space Pirates"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
@@ -814,7 +829,12 @@
 	send_pirate_threat()
 	return ..()
 
-/// Obsessed ruleset
+//////////////////////////////////////////////
+//                                          //
+//          OBSESSED     (MIDROUND)         //
+//                                          //
+//////////////////////////////////////////////
+
 /datum/dynamic_ruleset/midround/from_living/obsessed
 	name = "Obsessed"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
@@ -851,7 +871,12 @@
 	log_game("[key_name(obsessed)] was made Obsessed by the midround ruleset.")
 	return TRUE
 
-/// Space Changeling ruleset
+//////////////////////////////////////////////
+//                                          //
+//      SPACE CHANGELING     (GHOST)        //
+//                                          //
+//////////////////////////////////////////////
+
 /datum/dynamic_ruleset/midround/from_ghosts/changeling_midround
 	name = "Space Changeling"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
@@ -872,7 +897,12 @@
 	log_dynamic("[key_name(body)] was spawned as a space changeling by the midround ruleset.")
 	return body
 
-/// Paradox Clone ruleset
+//////////////////////////////////////////////
+//                                          //
+//        PARADOX CLONE      (GHOST)        //
+//                                          //
+//////////////////////////////////////////////
+
 /datum/dynamic_ruleset/midround/from_ghosts/paradox_clone
 	name = "Paradox Clone"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -111,27 +111,27 @@
 
 		"Spiders": {
 			"weight": 0
-		}
+		},
 
 		"Revenant": {
 			"weight": 0
-		}
+		},
 
 		"Sentient Disease": {
 			"weight": 0
-		}
+		},
 
 		"Space Pirates": {
 			"weight": 0
-		}
+		},
 
 		"Obsessed": {
 			"weight": 0
-		}
+		},
 
 		"Space Changeling": {
 			"weight": 0
-		}
+		},
 
 		"Paradox Clone": {
 			"weight": 0

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -112,6 +112,30 @@
 		"Spiders": {
 			"weight": 0
 		}
+
+		"Revenant": {
+			"weight": 0
+		}
+
+		"Sentient Disease": {
+			"weight": 0
+		}
+
+		"Space Pirates": {
+			"weight": 0
+		}
+
+		"Obsessed": {
+			"weight": 0
+		}
+
+		"Space Changeling": {
+			"weight": 0
+		}
+
+		"Paradox Clone": {
+			"weight": 0
+		}
 	},
 
 	"Latejoin": {


### PR DESCRIPTION
## About The Pull Request

This PR updates the dynamic.json file to add in entries for midround rulesets which got added later in the code but never added to the config. Also, gives them the _proper_ ascii art in the code, which aids in navigation.

## Why It's Good For The Game

No need for server hosts to scratch their heads at why some dynamic rulesets just aren't present in the configuration for some reason.

## Changelog
:cl:
config: All dynamic midround rulesets are now properly accounted for in the dynamic.json config.
/:cl: