### PR TITLE
Fixes various space ruins causing warnings during initialization

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -443,9 +443,9 @@
 /area/ruin/space/ks13/medical/medbay)
 "fH" = (
 /obj/machinery/door/morgue{
-	name = "Chaplains Office"
+	name = "Chaplains Office";
+	req_access = list("chapel_office")
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/chapel_office,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ks13/service/chapel_office)
 "fJ" = (

--- a/_maps/RandomRuins/SpaceRuins/derelict4.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict4.dmm
@@ -87,9 +87,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav)
 "O" = (
-/obj/machinery/power/apc/auto_name/directional/north{
-	start_charge = 0
-	},
+/obj/item/wallframe/apc,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav)
 "Q" = (

--- a/_maps/RandomRuins/SpaceRuins/derelict8.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict8.dmm
@@ -323,7 +323,7 @@
 "SL" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/item/wallframe/apc,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav)
 "SQ" = (

--- a/_maps/shuttles/whiteship_pubby.dmm
+++ b/_maps/shuttles/whiteship_pubby.dmm
@@ -88,7 +88,6 @@
 	dir = 1;
 	piping_layer = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)
@@ -756,7 +755,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/shuttle/abandoned)


### PR DESCRIPTION
## About The Pull Request

- Pubby Whiteship had a two air pipes on one tile, creating a large amount warnings about pipes being added to the same atmospherics pipenet multiple times. I have finally hunted those down.
- The Derelict had an airlock access helper on the morgue curtains leading to the chapel office. Unfortunately, those curtains are not of the airlock subtype, so they did nothing, and deleted themselves after outputting a warning. I have removed the helper and have set the access by hand.
- Makes Derelict 4 and Derelict 8's APCs into wallframes. The first one powered nothing, the second powered some doors and a single grille that had a chance to not spawn anyways.

## Why It's Good For The Game

Less preventable warnings and errors during initialization will help us see actual bugs easier.

## Changelog

Nothing player facing.
