### PR TITLE
Fixes heirloom objective deduplication

### DIFF
--- a/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_heirloom.dm
@@ -25,6 +25,8 @@
 	var/list/target_jobs
 	/// the item we need to destroy
 	var/obj/item/target_item
+	/// the owner of the item we need to destroy
+	var/datum/mind/target_mind
 
 	// The code below is for limiting how often you can get this objective. You will get this objective at a maximum of maximum_objectives_in_period every objective_period
 	/// The objective period at which we consider if it is an 'objective'. Set to 0 to accept all objectives.
@@ -128,10 +130,10 @@
 			continue
 		possible_targets += possible_target
 	for(var/datum/traitor_objective/destroy_heirloom/objective as anything in possible_duplicates)
-		possible_targets -= objective.target_item
+		possible_targets -= objective.target_mind
 	if(!length(possible_targets))
 		return FALSE
-	var/datum/mind/target_mind = pick(possible_targets)
+	target_mind = pick(possible_targets)
 	AddComponent(/datum/component/traitor_objective_register, target_mind.current, fail_signals = list(COMSIG_PARENT_QDELETING))
 	var/datum/quirk/item_quirk/family_heirloom/quirk = locate() in target_mind.current.quirks
 	target_item = quirk.heirloom.resolve()
@@ -143,3 +145,4 @@
 
 /datum/traitor_objective/destroy_heirloom/ungenerate_objective()
 	target_item = null
+	target_mind = null


### PR DESCRIPTION


## About The Pull Request

When looking for duplicate objectives, removed the currently targeted heirloom items from the list of possible targets, resulting in an unchanged list. I chose to store the mind of the heirloom's owner, to solve this, and try to remove those from the possible targets.

## Why It's Good For The Game

Fixes #70925. Can't get the same objective active at the same time for free TC and Rep.

## Changelog

:cl:
fix: You can no longer have multiple copies of the same heirloom theft objective
/:cl:


