### PR TITLE
[NO GBP] Switches gondola infusion from the corpse (that gets deleted on death) to the slab of meat

### DIFF
--- a/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_two_entries.dm
+++ b/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_two_entries.dm
@@ -19,7 +19,7 @@
 		"stop caring about temperature... or pressure, or atmos... or much of anything...",
 	)
 	input_obj_or_mob = list(
-		/mob/living/simple_animal/pet/gondola,
+		/obj/item/food/meat/slab/gondola,
 	)
 	output_organs = list(
 		/obj/item/organ/internal/heart/gondola,


### PR DESCRIPTION

## About The Pull Request

I swear, gondolas used to not del on death. I should have tested

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: changed gondola mutants to require gondola meat instead
/:cl:
