### PR TITLE
Adds some extra loot to space

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/TheDerelict.dmm
@@ -1624,7 +1624,14 @@
 /obj/structure/table_frame/wood,
 /obj/item/clothing/head/helmet/chaplain{
 	armor = null;
-	desc = "The Chaplains crusader helment. It seems old and dented."
+	desc = "The Chaplain's crusader helmet. It seems old and dented.";
+	pixel_y = 7;
+	pixel_x = -7
+	},
+/obj/item/clothing/suit/chaplainsuit/armor/templar{
+	pixel_x = 6;
+	pixel_y = -5;
+	desc = "An old set of the Chaplain's holy armour. It's caked in dust."
 	},
 /turf/open/floor/wood,
 /area/ruin/space/ks13/service/chapel_office)
@@ -4198,7 +4205,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/grav_gen)
 "Fp" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate/black/engie,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/singulo)
@@ -6148,7 +6155,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/ks13/medical/morgue)
 "PG" = (
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/black/engie,
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/singulo)
@@ -6599,7 +6606,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/ks13/science/ordnance)
 "Sj" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space/syndicate,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/airless,
@@ -7194,7 +7201,7 @@
 /area/ruin/space/ks13/service/bar)
 "UK" = (
 /obj/structure/cable,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/aft_solars_control)
 "UL" = (
@@ -7267,7 +7274,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/hallway/aft)
 "Vd" = (
-/obj/item/clothing/head/helmet/space/eva,
+/obj/item/clothing/head/helmet/space,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/ai/vault)
 "Ve" = (
@@ -7608,7 +7615,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/ks13/command/bridge)
 "WX" = (
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/suit/space,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/ai/vault)

--- a/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedzoo.dmm
@@ -111,10 +111,7 @@
 /turf/template_noop,
 /area/template_noop)
 "aT" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/space/eva,
-/obj/item/tank/internals/emergency_oxygen/double,
-/obj/item/clothing/head/helmet/space/eva,
+/obj/machinery/suit_storage_unit/medical,
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/abandonedzoo)
 "aV" = (

--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -504,6 +504,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/closet/crate/secure/gear{
+	name = "contraband gear";
+	desc = "A secure contraband crate."
+	},
+/obj/item/mod/control/pre_equipped/empty/syndicate,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/item/toy/plush/nukeplushie,
 /turf/open/floor/iron/airless,
 /area/shuttle/ruin/caravan/freighter3)
 "qX" = (

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -858,7 +858,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/civilian,
 /turf/open/floor/engine,
 /area/awaymission/bmpship/midship)
 "EW" = (
@@ -1045,7 +1045,11 @@
 	pixel_x = 3;
 	pixel_y = 9
 	},
-/obj/item/screwdriver,
+/obj/item/screwdriver/caravan{
+	name = "Madsen's Wrath";
+	desc = "There are bits of an eyeball at the tip of this screwdriver..." ;
+	force = 10
+	},
 /obj/item/paper/fluff/ruins/crashedship/scribbled{
 	pixel_x = -7;
 	pixel_y = 2

--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -1047,8 +1047,8 @@
 	},
 /obj/item/screwdriver/caravan{
 	name = "Madsen's Wrath";
-	desc = "There are bits of an eyeball at the tip of this screwdriver..." ;
-	force = 10
+	desc = "There are what appears to be the crusty remains of an eyeball on the tip of this screwdriver...";
+	force = 13
 	},
 /obj/item/paper/fluff/ruins/crashedship/scribbled{
 	pixel_x = -7;

--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -703,6 +703,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/item/mod/module/anomaly_locked/teleporter/prebuilt,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/dangerous_research/lab)
 "js" = (
@@ -3901,6 +3902,7 @@
 "XX" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple,
+/obj/item/mod/module/anomaly_locked/antigrav,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/dangerous_research/lab)
 "Yb" = (

--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -703,7 +703,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/item/mod/module/anomaly_locked/teleporter/prebuilt,
+/obj/item/mod/module/anomaly_locked/kinesis/prebuilt,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/dangerous_research/lab)
 "js" = (

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -1634,6 +1634,8 @@
 "ex" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
+/obj/effect/spawner/random/engineering/tool_advanced,
+/obj/effect/spawner/random/engineering/tool_advanced,
 /obj/effect/spawner/random/exotic/tool,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/armory)

--- a/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
@@ -242,6 +242,11 @@
 	dir = 8
 	},
 /area/ruin/space/has_grav)
+"pm" = (
+/obj/structure/alien/weeds,
+/mob/living/simple_animal/hostile/alien,
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav)
 "pv" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Captain's Quarters"
@@ -307,6 +312,11 @@
 /obj/machinery/light/red/directional/west,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/iron/airless,
+/area/ruin/space/has_grav)
+"sl" = (
+/obj/structure/alien/weeds,
+/mob/living/simple_animal/hostile/alien,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav)
 "sr" = (
 /obj/structure/table/wood,
@@ -1139,7 +1149,7 @@ hi
 hi
 ZZ
 dk
-zw
+pm
 zw
 bU
 zw
@@ -1227,7 +1237,7 @@ UQ
 zw
 nd
 bI
-Oo
+sl
 Kq
 hi
 hi

--- a/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
@@ -204,6 +204,11 @@
 /obj/structure/frame/machine,
 /turf/open/floor/circuit/off,
 /area/ruin/space/has_grav)
+"nd" = (
+/obj/structure/alien/weeds,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav)
 "nn" = (
 /obj/structure/alien/weeds/node,
 /obj/effect/decal/cleanable/xenoblood,
@@ -218,6 +223,12 @@
 "nJ" = (
 /obj/machinery/pdapainter,
 /turf/open/floor/wood,
+/area/ruin/space/has_grav)
+"nR" = (
+/obj/structure/alien/weeds,
+/obj/structure/bed/nest,
+/obj/item/clothing/suit/armor/vest/marine,
+/turf/open/floor/iron/airless,
 /area/ruin/space/has_grav)
 "ob" = (
 /obj/structure/alien/weeds,
@@ -290,6 +301,12 @@
 	},
 /obj/effect/turf_decal/tile/red/half,
 /turf/open/floor/iron/smooth_edge,
+/area/ruin/space/has_grav)
+"si" = (
+/obj/structure/alien/weeds,
+/obj/machinery/light/red/directional/west,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/iron/airless,
 /area/ruin/space/has_grav)
 "sr" = (
 /obj/structure/table/wood,
@@ -416,6 +433,12 @@
 "BQ" = (
 /turf/open/floor/pod/light,
 /area/ruin/space/has_grav)
+"CG" = (
+/obj/structure/alien/weeds,
+/obj/structure/bed/nest,
+/obj/item/clothing/head/helmet/marine,
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav)
 "CU" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/east,
@@ -449,6 +472,11 @@
 	name = "Bridge Maintenance"
 	},
 /turf/open/floor/plating/airless,
+/area/ruin/space/has_grav)
+"EG" = (
+/obj/structure/alien/weeds,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/iron/airless,
 /area/ruin/space/has_grav)
 "EQ" = (
 /obj/effect/turf_decal/tile/red/anticorner{
@@ -661,6 +689,11 @@
 /obj/machinery/computer/terminal,
 /turf/open/floor/pod/light,
 /area/ruin/space/has_grav)
+"Wd" = (
+/obj/structure/alien/weeds,
+/obj/item/toy/plush/rouny,
+/turf/open/floor/iron/airless,
+/area/ruin/space/has_grav)
 "WC" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/xenoblood/xgibs/limb,
@@ -700,6 +733,11 @@
 /obj/item/soap/deluxe,
 /obj/machinery/shower/directional/north,
 /turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav)
+"Ya" = (
+/obj/structure/alien/weeds,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron/airless,
 /area/ruin/space/has_grav)
 "YA" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
@@ -1074,8 +1112,8 @@ hi
 Oo
 dk
 hT
-bO
-ib
+nR
+si
 UH
 Oo
 Oo
@@ -1130,8 +1168,8 @@ hi
 ZZ
 dk
 zw
-zw
-zw
+Wd
+EG
 bO
 WC
 hi
@@ -1159,8 +1197,8 @@ ZZ
 dk
 zw
 hT
-bO
-zw
+CG
+Ya
 WC
 ZZ
 hi
@@ -1187,7 +1225,7 @@ Oo
 dk
 UQ
 zw
-zw
+nd
 bI
 Oo
 Kq

--- a/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
@@ -227,7 +227,7 @@
 "nR" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
-/obj/item/clothing/suit/armor/vest/marine,
+/obj/item/clothing/suit/armor/vest/marine/old,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav)
 "ob" = (
@@ -446,7 +446,7 @@
 "CG" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
-/obj/item/clothing/head/helmet/marine,
+/obj/item/clothing/head/helmet/marine/old,
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav)
 "CU" = (

--- a/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
+++ b/_maps/RandomRuins/SpaceRuins/emptyshell.dmm
@@ -47,6 +47,10 @@
 /obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav)
+"Y" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav)
 
 (1,1,1) = {"
 a
@@ -208,7 +212,7 @@ c
 c
 d
 d
-d
+e
 g
 d
 d
@@ -244,7 +248,7 @@ d
 g
 d
 d
-d
+Y
 h
 d
 e

--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -662,13 +662,11 @@
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "qI" = (
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/mod/module/anomaly_locked/kinesis/prebuilt{
-	pixel_y = 10;
-	pixel_x = 5
+/obj/item/mod/module/anomaly_locked/teleporter/prebuilt{
+	pixel_y = -3
 	},
 /obj/item/mod/module/visor/night{
-	pixel_y = 0;
-	pixel_x = -1
+	pixel_y = 9
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)

--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -10,7 +10,12 @@
 "ao" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/stack/sheet/mineral/plasma/five{
-	pixel_y = 4
+	pixel_y = 7;
+	pixel_x = 1
+	},
+/obj/item/stack/sheet/bluespace_crystal{
+	amount = 7;
+	pixel_x = -5
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
@@ -482,7 +487,7 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "lL" = (
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/civilian,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
@@ -657,8 +662,13 @@
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "qI" = (
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/stack/sheet/bluespace_crystal{
-	amount = 7
+/obj/item/mod/module/anomaly_locked/kinesis/prebuilt{
+	pixel_y = 10;
+	pixel_x = 5
+	},
+/obj/item/mod/module/visor/night{
+	pixel_y = 0;
+	pixel_x = -1
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -624,6 +624,16 @@
 /area/ruin/space)
 "Fy" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/syndicate{
+	name = "security closet"
+	},
+/obj/item/clothing/shoes/chameleon,
+/obj/item/clothing/suit/chameleon,
+/obj/item/clothing/gloves/chameleon,
+/obj/item/clothing/head/chameleon,
+/obj/item/clothing/under/chameleon,
+/obj/item/clothing/neck/chameleon/broken,
+/obj/item/clothing/mask/chameleon/broken,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/listeningstation)
 "FV" = (

--- a/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mechtransport.dmm
@@ -58,6 +58,13 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/ruin/space/has_grav/powered/mechtransport)
+"o" = (
+/obj/structure/closet/crate/secure/science,
+/obj/item/mod/module/atrocinator,
+/obj/item/mod/module/stealth,
+/obj/item/mod/module/jetpack,
+/turf/open/floor/mineral/titanium/yellow/airless,
+/area/ruin/space/has_grav/powered/mechtransport)
 "p" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Cockpit"
@@ -157,6 +164,14 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/powered/mechtransport)
+"N" = (
+/obj/structure/lattice,
+/obj/structure/closet/crate/science,
+/obj/item/mod/module/storage/large_capacity,
+/obj/effect/spawner/random/exotic/technology,
+/obj/effect/spawner/random/exotic/technology,
+/turf/template_noop,
+/area/ruin/space/has_grav/powered/mechtransport)
 "O" = (
 /obj/structure/mecha_wreckage/odysseus,
 /turf/open/floor/mineral/titanium/yellow/airless,
@@ -182,6 +197,14 @@
 /area/ruin/space/has_grav/powered/mechtransport)
 "X" = (
 /obj/machinery/power/shuttle_engine/propulsion,
+/turf/template_noop,
+/area/ruin/space/has_grav/powered/mechtransport)
+"Y" = (
+/obj/structure/lattice,
+/obj/structure/closet/crate/science,
+/obj/item/mod/module/springlock,
+/obj/effect/spawner/random/exotic/technology,
+/obj/effect/spawner/random/exotic/technology,
 /turf/template_noop,
 /area/ruin/space/has_grav/powered/mechtransport)
 
@@ -232,7 +255,7 @@ w
 H
 M
 I
-I
+N
 T
 T
 "}
@@ -261,13 +284,13 @@ d
 s
 x
 w
-w
+o
 y
 K
 O
 s
 S
-I
+Y
 T
 "}
 (6,1,1) = {"

--- a/_maps/RandomRuins/SpaceRuins/onehalf.dmm
+++ b/_maps/RandomRuins/SpaceRuins/onehalf.dmm
@@ -798,8 +798,8 @@
 "cI" = (
 /obj/structure/safe/floor,
 /obj/item/tank/internals/oxygen/red,
-/obj/item/clothing/head/helmet/space/eva,
-/obj/item/clothing/suit/space/eva,
+/obj/item/clothing/head/helmet/space/syndicate/black/red,
+/obj/item/clothing/suit/space/syndicate/black/red,
 /obj/item/reagent_containers/cup/glass/bottle/rum,
 /obj/item/reagent_containers/cup/glass/bottle/rum,
 /obj/item/folder/syndicate/mining,

--- a/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
+++ b/_maps/RandomRuins/SpaceRuins/thelizardsgas.dmm
@@ -386,7 +386,7 @@
 /area/ruin/space/has_grav/thelizardsgas)
 "LT" = (
 /obj/structure/sign/warning/electric_shock/directional/north,
-/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/suit_storage_unit/security,
 /obj/machinery/power/terminal{
 	dir = 4
 	},

--- a/_maps/shuttles/ruin_cyborg_mothership.dmm
+++ b/_maps/shuttles/ruin_cyborg_mothership.dmm
@@ -162,6 +162,7 @@
 "ks" = (
 /obj/machinery/holopad/secure,
 /obj/structure/cable,
+/mob/living/simple_animal/hostile/hivebot/strong,
 /turf/open/floor/circuit/green/airless,
 /area/shuttle/ruin/cyborg_mothership)
 "ku" = (
@@ -411,6 +412,13 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/airless,
 /area/shuttle/ruin/cyborg_mothership)
+"uS" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/iron/showroomfloor,
+/area/shuttle/ruin/cyborg_mothership)
 "vy" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/cyborg_mothership{
 	dir = 1
@@ -576,6 +584,7 @@
 /obj/structure/table_frame,
 /obj/item/aicard,
 /obj/item/ai_module/core/full/overlord,
+/obj/item/surveillance_upgrade,
 /turf/open/floor/circuit/green/airless,
 /area/shuttle/ruin/cyborg_mothership)
 "Em" = (
@@ -704,7 +713,19 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/item/borg/upgrade/selfrepair{
+	pixel_x = 2;
+	pixel_y = -8
+	},
 /turf/open/floor/circuit/airless,
+/area/shuttle/ruin/cyborg_mothership)
+"LH" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mothership_left"
+	},
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plating/airless,
 /area/shuttle/ruin/cyborg_mothership)
 "MB" = (
 /obj/machinery/computer/shuttle/cyborg_mothership{
@@ -748,6 +769,10 @@
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/bot,
+/obj/item/borg/upgrade/hypospray/expanded{
+	pixel_x = -7;
+	pixel_y = 10
+	},
 /obj/structure/sink/directional/east,
 /obj/item/toy/figure/borg{
 	pixel_x = 7;
@@ -865,6 +890,10 @@
 "UL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/item/borg/upgrade/thrusters{
+	pixel_x = -2;
+	pixel_y = 2
+	},
 /turf/open/floor/circuit/airless,
 /area/shuttle/ruin/cyborg_mothership)
 "UU" = (
@@ -1105,7 +1134,7 @@ so
 hR
 hR
 az
-aB
+LH
 az
 hR
 BS
@@ -1273,7 +1302,7 @@ yF
 pY
 zZ
 Ey
-jH
+uS
 bE
 yF
 hB

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -64,6 +64,10 @@
 	mask_type = /obj/item/clothing/mask/breath
 	storage_type = /obj/item/tank/internals/oxygen
 
+/obj/machinery/suit_storage_unit/civilian
+	mask_type = /obj/item/clothing/mask/breath
+	mod_type = /obj/item/mod/control/pre_equipped/standard/civilian
+
 /obj/machinery/suit_storage_unit/captain
 	mask_type = /obj/item/clothing/mask/gas/atmos/captain
 	storage_type = /obj/item/tank/jetpack/oxygen/captain

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -105,6 +105,10 @@
 	acid = 50
 	wound = 20
 
+/obj/item/clothing/head/helmet/marine/old
+	desc = "A tactical black helmet, sealed from outside hazards with a plate of glass and not much else. The wear and tear on this helmet is evident, though it is still quite servicable."
+	armor_type = /datum/armor/head_helmet
+
 /obj/item/clothing/head/helmet/marine/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/seclite_attachable, starting_light = new /obj/item/flashlight/seclite(src), light_icon_state = "flight")

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -68,6 +68,10 @@
 	acid = 50
 	wound = 20
 
+/obj/item/clothing/suit/armor/vest/marine/old
+	desc = "A set of the finest mass produced, stamped plasteel armor plates, containing an environmental protection unit for all-condition door kicking. This one seems battered and scraped up, lessening its protective qualities."
+	armor_type = /datum/armor/suit_armor
+
 /obj/item/clothing/suit/armor/vest/marine/security
 	name = "large tactical armor vest"
 	icon_state = "marine_security"

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -45,6 +45,9 @@
 		/obj/item/mod/module/flashlight,
 	)
 
+/obj/item/mod/control/pre_equipped/standard/civilian
+	applied_skin = "civilian"
+
 /obj/item/mod/control/pre_equipped/engineering
 	theme = /datum/mod_theme/engineering
 	applied_modules = list(


### PR DESCRIPTION
## About The Pull Request

a few dozen space ruins have had some loot added, giving more reason to explore them.

- **abandoned zoo:** EVA suit was replaced with a medical MODsuit
- **ambushed caravan:** the syndicate-attacked caravan ship now contains a contraband gear crate, containing a syndicate MODsuit, along with a nuclear plushie and 3 random items (which may or may not be useful, exotic/antag_gear is not really that dangerous)
- **cyborg mothership:** added a few cyborg upgrades scattered around (ion thrusters, self repair and expanded hypospray), along with a AI surveillance upgrade. a few extra enemies have been added to compensate for the extra gear. a neat way to earn some favor with your murderous silicon buddies
- **crashed ship:** fear ye madsen's wrath, for it will poke yer bloody eyes out (one of the screwdrivers was replaced with an experimental one that does a decent chunk of damage). EVA suit replaced with a civilian MODsuit
- **dangerous research:** the central cult area contains a prebuilt kinesis module, along with an incomplete antigrav module
- **deep storage:** the tool storage area has a few extra experimental tools
- **derelict sulaco:** the nest area contains two xenomorphs which guard a rounie plushy along with a set of marine armour. the armour has most of the qualities of a normal marine set, barring the armour values (this set is protective as regular sec armour).
- **empty shell:** adds an extra abandoned crate and an O2 canister inside, giving you a nice little place to refuel your jetpack or internals
- **hilbert's research facility:** the cargo area has a prebuilt teleporter module along with a nightvision module. EVA suit was replaced with a civilian MODsuit
- **listening station:** has a locker filled with some working chameleon equipment, along with some that is broken
- **mech ship:** contains two unlocked crates, containing expanded storage and springlock respectively. a locked crate contains a prototype cloaking module, ion jetpack and the atrocinator. there is some tech stuff in the crates as well
- **one half:** the safe contains a classic black and red syndie softsuit instead of a regular EVA suit
- **the derelict:** the chapel now has a templar suit to compliment the helmet. brings back the engie syndie softsuit and also the classic red softsuit
- **the lizard's gas:** EVA suit replaced with a sec MODsuit

## Why It's Good For The Game

space right now has an okayish amount of loot, but not enough to really warrant exploring it. i understand the removal of most of the gamer gear but it has really hampered the drive for space exploration (why would i explore space to get 10 more pairs of EVA suits?)

hopefully by putting in some items that give neat little bonuses (the various experimental tools), various MODsuit modules that never get created or seen (teleporter, kinesis, springlock), and some minuscule gamer gear (the softsuits and whatnot), people will have a bit more fun exploring space.

## Changelog

:cl: Vile Beggar
add: A couple of space ruins are now updated with some extra loot and collectables!
/:cl: