### PR TITLE
Refactors admin event setup (again)

### DIFF
--- a/code/modules/admin/force_event.dm
+++ b/code/modules/admin/force_event.dm
@@ -66,7 +66,7 @@
 			"description" = event_control.description,
 			"type" = event_control.type,
 			"category" = event_control.category,
-			"has_customization" = length(event_control.admin_setup),
+			"has_customization" = !!length(event_control.admin_setup),
 		))
 	data["categories"] = categories
 	data["events"] = events

--- a/code/modules/admin/force_event.dm
+++ b/code/modules/admin/force_event.dm
@@ -66,7 +66,7 @@
 			"description" = event_control.description,
 			"type" = event_control.type,
 			"category" = event_control.category,
-			"has_customization" = !isnull(event_control.admin_setup),
+			"has_customization" = length(event_control.admin_setup),
 		))
 	data["categories"] = categories
 	data["events"] = events
@@ -89,8 +89,10 @@
 			var/datum/round_event_control/event = locate(event_to_run_type) in SSevents.control
 			if(!event)
 				return
-			if(event.admin_setup && event.admin_setup.prompt_admins() == ADMIN_CANCEL_EVENT)
-				return
+			if(length(event.admin_setup))
+				for(var/datum/event_admin_setup/admin_setup_datum in event.admin_setup)
+					if(admin_setup_datum.prompt_admins() == ADMIN_CANCEL_EVENT)
+						return
 			var/always_announce_chance = 100
 			var/no_announce_chance = 0
 			event.runEvent(announce_chance_override = announce_event ? always_announce_chance : no_announce_chance, admin_forced = TRUE)

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -86,10 +86,10 @@
 	normal_run_option = "Random Pirate Gang"
 
 /datum/event_admin_setup/listed_options/pirates/get_list()
-	var/list/gang_choices = list()
-	for(var/datum/pirate_gang/possible_gang as anything in GLOB.pirate_gangs)
-		gang_choices += possible_gang
-	return gang_choices
+	return subtypesof(/datum/pirate_gang)
 
 /datum/event_admin_setup/listed_options/pirates/apply_to_event(datum/round_event/pirates/event)
-	event.chosen_gang = chosen
+	if(isnull(chosen))
+		event.chosen_gang = null
+	else
+		event.chosen_gang = new chosen

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -7,7 +7,7 @@
 	dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_INVASION
 	description = "The crew will either pay up, or face a pirate assault."
-	admin_setup = /datum/event_admin_setup/pirates
+	admin_setup = list(/datum/event_admin_setup/pirates)
 	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event_control/pirates/preRunEvent()

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -7,7 +7,7 @@
 	dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_INVASION
 	description = "The crew will either pay up, or face a pirate assault."
-	admin_setup = list(/datum/event_admin_setup/pirates)
+	admin_setup = list(/datum/event_admin_setup/listed_options/pirates)
 	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event_control/pirates/preRunEvent()
@@ -81,22 +81,15 @@
 
 	priority_announce("Unidentified armed ship detected near the station.")
 
-/datum/event_admin_setup/pirates
-	///admin chosen pirate team
-	var/datum/pirate_gang/chosen_gang
+/datum/event_admin_setup/listed_options/pirates
+	input_text = "Select Pirate Gang"
+	normal_run_option = "Random Pirate Gang"
 
-/datum/event_admin_setup/pirates/prompt_admins()
-	var/list/gang_choices = list("Random")
-
+/datum/event_admin_setup/listed_options/pirates/get_list()
+	var/list/gang_choices = list()
 	for(var/datum/pirate_gang/possible_gang as anything in GLOB.pirate_gangs)
-		gang_choices[possible_gang.name] = possible_gang
+		gang_choices += possible_gang
+	return gang_choices
 
-	var/chosen = tgui_input_list(usr, "Select pirate gang", "TICKETS TO THE SPONGEBOB MOVIE!!", gang_choices)
-	if(!chosen)
-		return ADMIN_CANCEL_EVENT
-	if(chosen == "Random")
-		return //still do the event, but chosen_gang is still null, so it will pick from the choices
-	chosen_gang = gang_choices[chosen]
-
-/datum/event_admin_setup/pirates/apply_to_event(datum/round_event/pirates/event)
-	event.chosen_gang = chosen_gang
+/datum/event_admin_setup/listed_options/pirates/apply_to_event(datum/round_event/pirates/event)
+	event.chosen_gang = chosen

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -37,8 +37,8 @@
 	var/dynamic_should_hijack = FALSE
 
 	/// Datum that will handle admin options for forcing the event.
-	/// If there are no options, just leave it null.
-	var/datum/event_admin_setup/admin_setup = null
+	/// If there are no options, just leave it as an empty list.
+	var/list/datum/event_admin_setup/admin_setup = list()
 	/// Flags dictating whether this event should be run on certain kinds of map
 	var/map_flags = NONE
 
@@ -46,8 +46,11 @@
 	if(config && !wizardevent) // Magic is unaffected by configs
 		earliest_start = CEILING(earliest_start * CONFIG_GET(number/events_min_time_mul), 1)
 		min_players = CEILING(min_players * CONFIG_GET(number/events_min_players_mul), 1)
-	if(admin_setup)
-		admin_setup = new admin_setup(src)
+	if(length(admin_setup))
+		var/list/admin_setup_types = admin_setup.Copy()
+		admin_setup.Cut()
+		for(var/admin_setup_type in admin_setup_types)
+			admin_setup += new admin_setup_type(src)
 
 /datum/round_event_control/wizard
 	category = EVENT_CATEGORY_WIZARD
@@ -139,9 +142,10 @@ Runs the event
 	*/
 	UnregisterSignal(SSdcs, COMSIG_GLOB_RANDOM_EVENT)
 	var/datum/round_event/round_event = new typepath(TRUE, src)
-	if(admin_forced && admin_setup)
+	if(admin_forced && length(admin_setup))
 		//not part of the signal because it's conditional and relies on usr heavily
-		admin_setup.apply_to_event(round_event)
+		for(var/datum/event_admin_setup/admin_setup_datum in admin_setup)
+			admin_setup_datum.apply_to_event(round_event)
 	SEND_SIGNAL(src, COMSIG_CREATED_ROUND_EVENT, round_event)
 	round_event.setup()
 	round_event.current_players = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -46,11 +46,12 @@
 	if(config && !wizardevent) // Magic is unaffected by configs
 		earliest_start = CEILING(earliest_start * CONFIG_GET(number/events_min_time_mul), 1)
 		min_players = CEILING(min_players * CONFIG_GET(number/events_min_players_mul), 1)
-	if(length(admin_setup))
-		var/list/admin_setup_types = admin_setup.Copy()
-		admin_setup.Cut()
-		for(var/admin_setup_type in admin_setup_types)
-			admin_setup += new admin_setup_type(src)
+	if(!length(admin_setup))
+		return
+	var/list/admin_setup_types = admin_setup.Copy()
+	admin_setup.Cut()
+	for(var/admin_setup_type in admin_setup_types)
+		admin_setup += new admin_setup_type(src)
 
 /datum/round_event_control/wizard
 	category = EVENT_CATEGORY_WIZARD

--- a/code/modules/events/_event_admin_setup.dm
+++ b/code/modules/events/_event_admin_setup.dm
@@ -86,3 +86,20 @@
 
 /datum/event_admin_setup/warn_admin/apply_to_event(datum/round_event/event)
 	return
+
+/datum/event_admin_setup/set_location
+	///Text shown when admins are queried about setting the target location.
+	var/input_text = "Aimed at the turf we're on?"
+	///Turf that will be passed onto the event.
+	var/atom/chosen_turf
+
+/datum/event_admin_setup/set_location/prompt_admins()
+	var/set_location = tgui_alert(usr, input_text, event_control.name, list("Yes", "No", "Cancel"))
+	switch(set_location)
+		if("Yes")
+			chosen_turf = get_turf(usr)
+		if("No")
+			chosen_turf = null
+		else
+			return ADMIN_CANCEL_EVENT
+	

--- a/code/modules/events/_event_admin_setup.dm
+++ b/code/modules/events/_event_admin_setup.dm
@@ -141,3 +141,20 @@
 
 /datum/event_admin_setup/candidate_check/apply_to_event(datum/round_event/event)
 	return
+
+///For events that require a true/false question
+/datum/event_admin_setup/question
+	///Question shown to the admin.
+	var/input_text = "Are you sure you would like to do this?"
+	///Value passed to the event.
+	var/chosen
+
+/datum/event_admin_setup/question/prompt_admins()
+	var/response = tgui_alert(usr, input_text , event_control.name , list("Yes", "No", "Cancel"))
+	switch(response)
+		if("Yes")
+			chosen = TRUE
+		if("No")
+			chosen = FALSE
+		else
+			return ADMIN_CANCEL_EVENT

--- a/code/modules/events/_event_admin_setup.dm
+++ b/code/modules/events/_event_admin_setup.dm
@@ -103,3 +103,41 @@
 		else
 			return ADMIN_CANCEL_EVENT
 	
+/datum/event_admin_setup/input_number
+	///Text shown when admins are queried about what number to set.
+	var/input_text = ""
+	///The value the number will be set to by default
+	var/default_value
+	///The highest value setable by the admin.
+	var/max_value = 10000
+	///The lowest value setable by the admin
+	var/min_value = 0
+	///Value selected by the admin
+	var/chosen_value
+
+/datum/event_admin_setup/input_number/prompt_admins()
+	chosen_value = tgui_input_number(usr, input_text, event_control.name, default_value, max_value, min_value)
+	if(isnull(chosen_value))
+		return ADMIN_CANCEL_EVENT
+
+///For events that mandate a set number of candidates to function
+/datum/event_admin_setup/candidate_check
+	///Text shown when there are not enough candidates
+	var/output_text = "There are no candidates eligible to..."
+	///Minimum number of candidates for the event to function
+	var/min_candidates = 1
+
+/datum/event_admin_setup/candidate_check/prompt_admins()
+	var/candidate_count = candidate_check()
+	if(candidate_count < min_candidates)
+		tgui_alert(usr, output_text, "Error")
+		return ADMIN_CANCEL_EVENT
+	tgui_alert(usr, "[candidate_count] candidates found!", event_control.name)
+
+/// Checks for candidates. Should return the total number of candidates
+/datum/event_admin_setup/candidate_check/proc/candidate_check()
+	SHOULD_CALL_PARENT(FALSE)
+	CRASH("Unimplemented candidate_check() on [event_control]'s admin setup.")
+
+/datum/event_admin_setup/candidate_check/apply_to_event(datum/round_event/event)
+	return

--- a/code/modules/events/_event_admin_setup.dm
+++ b/code/modules/events/_event_admin_setup.dm
@@ -121,25 +121,25 @@
 		return ADMIN_CANCEL_EVENT
 
 ///For events that mandate a set number of candidates to function
-/datum/event_admin_setup/candidate_check
+/datum/event_admin_setup/minimum_candidate_requirement
 	///Text shown when there are not enough candidates
 	var/output_text = "There are no candidates eligible to..."
 	///Minimum number of candidates for the event to function
 	var/min_candidates = 1
 
-/datum/event_admin_setup/candidate_check/prompt_admins()
-	var/candidate_count = candidate_check()
+/datum/event_admin_setup/minimum_candidate_requirement/prompt_admins()
+	var/candidate_count = count_candidates()
 	if(candidate_count < min_candidates)
 		tgui_alert(usr, output_text, "Error")
 		return ADMIN_CANCEL_EVENT
 	tgui_alert(usr, "[candidate_count] candidates found!", event_control.name)
 
 /// Checks for candidates. Should return the total number of candidates
-/datum/event_admin_setup/candidate_check/proc/candidate_check()
+/datum/event_admin_setup/minimum_candidate_requirement/proc/count_candidates()
 	SHOULD_CALL_PARENT(FALSE)
-	CRASH("Unimplemented candidate_check() on [event_control]'s admin setup.")
+	CRASH("Unimplemented count_candidates() on [event_control]'s admin setup.")
 
-/datum/event_admin_setup/candidate_check/apply_to_event(datum/round_event/event)
+/datum/event_admin_setup/minimum_candidate_requirement/apply_to_event(datum/round_event/event)
 	return
 
 ///For events that require a true/false question

--- a/code/modules/events/anomaly/_anomaly.dm
+++ b/code/modules/events/anomaly/_anomaly.dm
@@ -7,7 +7,7 @@
 	weight = 15
 	category = EVENT_CATEGORY_ANOMALIES
 	description = "This anomaly shocks and explodes. This is the base type."
-	admin_setup = list(/datum/event_admin_setup/anomaly)
+	admin_setup = list(/datum/event_admin_setup/set_location/anomaly)
 
 /datum/round_event/anomaly
 	announce_when = 1
@@ -46,13 +46,9 @@
 /datum/round_event/anomaly/proc/apply_anomaly_properties(obj/effect/anomaly/new_anomaly)
 	return
 
-/datum/event_admin_setup/anomaly
-	///The admin-chosen spawn location.
-	var/turf/spawn_location
+/datum/event_admin_setup/set_location/anomaly
+	input_text = "Spawn anomaly at your current location?"
 
-/datum/event_admin_setup/anomaly/prompt_admins()
-	if(tgui_alert(usr, "Spawn anomaly at your current location?", "Anomaly Alert", list("Yes", "No")) == "Yes")
-		spawn_location = get_turf(usr)
-
-/datum/event_admin_setup/anomaly/apply_to_event(datum/round_event/anomaly/event)
-	event.spawn_location = spawn_location
+/datum/event_admin_setup/set_location/anomaly/apply_to_event(datum/round_event/anomaly/event)
+	event.spawn_location = chosen_turf
+	

--- a/code/modules/events/anomaly/_anomaly.dm
+++ b/code/modules/events/anomaly/_anomaly.dm
@@ -7,7 +7,7 @@
 	weight = 15
 	category = EVENT_CATEGORY_ANOMALIES
 	description = "This anomaly shocks and explodes. This is the base type."
-	admin_setup = /datum/event_admin_setup/anomaly
+	admin_setup = list(/datum/event_admin_setup/anomaly)
 
 /datum/round_event/anomaly
 	announce_when = 1

--- a/code/modules/events/anomaly/anomaly_dimensional.dm
+++ b/code/modules/events/anomaly/anomaly_dimensional.dm
@@ -8,7 +8,7 @@
 	description = "This anomaly replaces the materials of the surrounding area."
 	min_wizard_trigger_potency = 0
 	max_wizard_trigger_potency = 2
-	admin_setup = /datum/event_admin_setup/listed_options/anomaly_dimensional
+	admin_setup = list(/datum/event_admin_setup/listed_options/anomaly_dimensional)
 
 /datum/round_event/anomaly/anomaly_dimensional
 	start_when = 10

--- a/code/modules/events/anomaly/anomaly_dimensional.dm
+++ b/code/modules/events/anomaly/anomaly_dimensional.dm
@@ -8,7 +8,7 @@
 	description = "This anomaly replaces the materials of the surrounding area."
 	min_wizard_trigger_potency = 0
 	max_wizard_trigger_potency = 2
-	admin_setup = list(/datum/event_admin_setup/listed_options/anomaly_dimensional)
+	admin_setup = list(/datum/event_admin_setup/set_location/anomaly, /datum/event_admin_setup/listed_options/anomaly_dimensional)
 
 /datum/round_event/anomaly/anomaly_dimensional
 	start_when = 10
@@ -28,19 +28,9 @@
 /datum/event_admin_setup/listed_options/anomaly_dimensional
 	input_text = "Select a dimensional anomaly theme?"
 	normal_run_option = "Random Theme"
-	///The admin-chosen spawn location.
-	var/turf/spawn_location
 
 /datum/event_admin_setup/listed_options/anomaly_dimensional/get_list()
 	return subtypesof(/datum/dimension_theme)
 
-/datum/event_admin_setup/listed_options/anomaly_dimensional/prompt_admins()
-	. = ..()
-	if (. == ADMIN_CANCEL_EVENT)
-		return ADMIN_CANCEL_EVENT
-	if (tgui_alert(usr, "Spawn anomaly at your current location?", "Anomaly Alert", list("Yes", "No")) == "Yes")
-		spawn_location = get_turf(usr)
-
 /datum/event_admin_setup/listed_options/anomaly_dimensional/apply_to_event(datum/round_event/anomaly/anomaly_dimensional/event)
-	event.spawn_location = spawn_location
 	event.anomaly_theme = chosen

--- a/code/modules/events/anomaly/anomaly_ectoplasm.dm
+++ b/code/modules/events/anomaly/anomaly_ectoplasm.dm
@@ -12,7 +12,7 @@
 	category = EVENT_CATEGORY_ANOMALIES
 	min_wizard_trigger_potency = 0
 	max_wizard_trigger_potency = 3
-	admin_setup = list(/datum/event_admin_setup/anomaly/anomaly_ectoplasm)
+	admin_setup = list(/datum/event_admin_setup/set_location/anomaly, /datum/event_admin_setup/anomaly_ectoplasm)
 
 /datum/round_event/anomaly/anomaly_ectoplasm
 	anomaly_path = /obj/effect/anomaly/ectoplasm
@@ -41,15 +41,13 @@
 /datum/round_event/anomaly/anomaly_ectoplasm/announce(fake)
 	priority_announce("Localized ectoplasmic outburst detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert")
 
-/datum/event_admin_setup/anomaly/anomaly_ectoplasm
+/datum/event_admin_setup/anomaly_ectoplasm
 	///The admin-selected intensity
 	var/chosen_effect
 	///The number of ghosts the admin has selected to simulate orbiting the anomaly.
 	var/ghost_override
 
-/datum/event_admin_setup/anomaly/anomaly_ectoplasm/prompt_admins()
-	. = ..()
-
+/datum/event_admin_setup/anomaly_ectoplasm/prompt_admins()
 	if(tgui_alert(usr, "Override the anomaly effect and power?", "You'll be ruining the authenticity.", list("Yes", "No")) == "Yes")
 		var/list/power_values = list(ANOMALY_INTENSITY_MINOR, ANOMALY_INTENSITY_MODERATE, ANOMALY_INTENSITY_MAJOR)
 		chosen_effect = tgui_input_list(usr, "Provide effect override", "Criiiiinge.", power_values)
@@ -68,8 +66,7 @@
 		if(ANOMALY_INTENSITY_MAJOR)
 			chosen_effect = 50
 
-/datum/event_admin_setup/anomaly/anomaly_ectoplasm/apply_to_event(datum/round_event/anomaly/anomaly_ectoplasm/event)
-	. = ..()
+/datum/event_admin_setup/anomaly_ectoplasm/apply_to_event(datum/round_event/anomaly/anomaly_ectoplasm/event)
 	event.effect_override = chosen_effect
 	event.orbit_override = ghost_override
 

--- a/code/modules/events/anomaly/anomaly_ectoplasm.dm
+++ b/code/modules/events/anomaly/anomaly_ectoplasm.dm
@@ -12,7 +12,7 @@
 	category = EVENT_CATEGORY_ANOMALIES
 	min_wizard_trigger_potency = 0
 	max_wizard_trigger_potency = 3
-	admin_setup = /datum/event_admin_setup/anomaly/anomaly_ectoplasm
+	admin_setup = list(/datum/event_admin_setup/anomaly/anomaly_ectoplasm)
 
 /datum/round_event/anomaly/anomaly_ectoplasm
 	anomaly_path = /obj/effect/anomaly/ectoplasm

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -8,7 +8,7 @@
 	max_occurrences = 1
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = /datum/event_admin_setup/listed_options/brand_intelligence
+	admin_setup = list(/datum/event_admin_setup/listed_options/brand_intelligence)
 
 /datum/round_event/brand_intelligence
 	announce_when = 21

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -9,7 +9,7 @@
 	description = "Summons a school of space carp."
 	min_wizard_trigger_potency = 0
 	max_wizard_trigger_potency = 3
-	admin_setup = /datum/event_admin_setup/carp_migration
+	admin_setup = list(/datum/event_admin_setup/carp_migration)
 
 /datum/round_event_control/carp_migration/New()
 	. = ..()

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -79,9 +79,12 @@
 	return subtypesof(/datum/disease)
 
 /datum/event_admin_setup/listed_options/disease_outbreak/apply_to_event(datum/round_event/disease_outbreak/event)
+	var/datum/disease/virus
 	if(chosen == special_run_option)
-		chosen = pick(get_list())
-	event.virus_type = chosen
+		virus = pick(get_list())
+	else 
+		virus = chosen
+	event.virus_type = virus
 
 /datum/round_event/disease_outbreak
 	announce_when = ADV_ANNOUNCE_DELAY

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -142,7 +142,11 @@
 	description = "An 'advanced' disease will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = list(/datum/event_admin_setup/minimum_candidate_requirement/disease_outbreak, /datum/event_admin_setup/listed_options/disease_outbreak_advanced, /datum/event_admin_setup/input_number/disease_outbreak_advanced)
+	admin_setup = list(
+		/datum/event_admin_setup/minimum_candidate_requirement/disease_outbreak,
+		/datum/event_admin_setup/listed_options/disease_outbreak_advanced,
+		/datum/event_admin_setup/input_number/disease_outbreak_advanced
+	)
 
 /**
  * Admin virus customization

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -29,7 +29,7 @@
 	description = "A 'classic' virus will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = list(/datum/event_admin_setup/disease_outbreak)
+	admin_setup = list(/datum/event_admin_setup/disease_outbreak_candidate_check, /datum/event_admin_setup/listed_options/disease_outbreak)
 	///Disease recipient candidates
 	var/list/disease_candidates = list()
 
@@ -59,28 +59,38 @@
 			continue
 		disease_candidates += candidate
 
-/datum/event_admin_setup/disease_outbreak
-	///Admin selected disease, to be passed down to the round_event
-	var/virus_type
+///Handles checking and alerting admins about the number of valid candidates
+/datum/event_admin_setup/disease_outbreak_candidate_check
 
-/// Checks for candidates. Returns false if there isn't enough
-/datum/event_admin_setup/disease_outbreak/proc/candidate_check()
-	var/datum/round_event_control/disease_outbreak/disease_control = event_control
-	disease_control.generate_candidates() //can_spawn_event() is bypassed by admin_setup, so this makes sure that the candidates are still generated
-	return length(disease_control.disease_candidates)
-
-/datum/event_admin_setup/disease_outbreak/prompt_admins()
+/datum/event_admin_setup/disease_outbreak_candidate_check/prompt_admins()
 	var/candidate_count = candidate_check()
 	if(!candidate_count)
 		tgui_alert(usr, "There are no candidates eligible to recieve a disease!", "Error")
 		return ADMIN_CANCEL_EVENT
 	tgui_alert(usr, "[candidate_count] candidates found!", "Disease Outbreak")
 
-	if(tgui_alert(usr, "Select a specific disease?", "Sickening behavior", list("Yes", "No")) == "Yes")
-		virus_type = tgui_input_list(usr, "Warning: Some of these are EXTREMELY dangerous.","Bacteria Hysteria", subtypesof(/datum/disease))
+/// Checks for candidates. Returns false if there isn't enough
+/datum/event_admin_setup/disease_outbreak_candidate_check/proc/candidate_check()
+	var/datum/round_event_control/disease_outbreak/disease_control = event_control
+	disease_control.generate_candidates() //can_spawn_event() is bypassed by admin_setup, so this makes sure that the candidates are still generated
+	return length(disease_control.disease_candidates)
 
-/datum/event_admin_setup/disease_outbreak/apply_to_event(datum/round_event/disease_outbreak/event)
-	event.virus_type = virus_type
+/datum/event_admin_setup/disease_outbreak_candidate_check/apply_to_event(datum/round_event/event)
+	return
+
+///Handles actually selecting whicch disease will spawn.
+/datum/event_admin_setup/listed_options/disease_outbreak
+	input_text = "Select a specific disease? Warning: Some are EXTREMELY dangerous."
+	normal_run_option = "Random Classic Disease (Safe)"
+	special_run_option = "Entirely Random Disease (Dangerous)"
+
+/datum/event_admin_setup/listed_options/disease_outbreak/get_list()
+	return subtypesof(/datum/disease)
+
+/datum/event_admin_setup/listed_options/disease_outbreak/apply_to_event(datum/round_event/disease_outbreak/event)
+	if(chosen == special_run_option)
+		chosen = pick(get_list())
+	event.virus_type = chosen
 
 /datum/round_event/disease_outbreak
 	announce_when = ADV_ANNOUNCE_DELAY
@@ -141,7 +151,7 @@
 	description = "An 'advanced' disease will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = list(/datum/event_admin_setup/disease_outbreak/advanced)
+	admin_setup = list(/datum/event_admin_setup/disease_outbreak_candidate_check, /datum/event_admin_setup/disease_outbreak/advanced)
 
 /datum/event_admin_setup/disease_outbreak/advanced
 	///Admin selected custom severity rating for the event
@@ -154,14 +164,28 @@
  *
  * If the admin wishes, give them the opportunity to select the severity and number of symptoms.
  */
-/datum/event_admin_setup/disease_outbreak/advanced/prompt_admins()
-	var/candidate_count = candidate_check()
-	if(!candidate_count)
-		tgui_alert(usr, "There are no candidates eligible to recieve a disease!", "Error")
-		return ADMIN_CANCEL_EVENT
-	tgui_alert(usr, "[candidate_count] candidates found!", "Disease Outbreak")
 
-	if(tgui_alert(usr,"Customize your virus?", "Glorified Debug Tool", list("Yes", "No")) == "Yes")
+/datum/event_admin_setup/listed_options/disease_outbreak_advanced
+	input_text = "Pick a severity!"
+	normal_run_option = "Random Severity"
+
+/datum/event_admin_setup/listed_options/disease_outbreak_advanced/get_list()
+	return list("Medium", "Harmful", "Dangerous")
+
+/datum/event_admin_setup/listed_options/disease_outbreak_advanced/apply_to_event(datum/round_event/disease_outbreak/advanced/event)
+	switch(chosen)
+		if("Medium")
+			event.requested_severity = ADV_DISEASE_MEDIUM
+		if("Harmful")
+			event.requested_severity = ADV_DISEASE_HARMFUL
+		if("Dangerous")
+			event.requested_severity = ADV_DISEASE_DANGEROUS
+		else
+			event.requested_severity = null
+
+//TO DO FINISH THIS
+
+/datum/event_admin_setup/disease_outbreak/advanced/prompt_admins()
 		chosen_severity = tgui_alert(usr, "Pick a severity!", "In the event of an airborne virus, try not to breathe.", list("Medium", "Harmful", "Dangerous"))
 		switch(chosen_severity)
 			if("Medium")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -29,7 +29,7 @@
 	description = "A 'classic' virus will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = /datum/event_admin_setup/disease_outbreak
+	admin_setup = list(/datum/event_admin_setup/disease_outbreak)
 	///Disease recipient candidates
 	var/list/disease_candidates = list()
 
@@ -141,7 +141,7 @@
 	description = "An 'advanced' disease will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = /datum/event_admin_setup/disease_outbreak/advanced
+	admin_setup = list(/datum/event_admin_setup/disease_outbreak/advanced)
 
 /datum/event_admin_setup/disease_outbreak/advanced
 	///Admin selected custom severity rating for the event

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -29,7 +29,7 @@
 	description = "A 'classic' virus will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = list(/datum/event_admin_setup/candidate_check/disease_outbreak, /datum/event_admin_setup/listed_options/disease_outbreak)
+	admin_setup = list(/datum/event_admin_setup/minimum_candidate_requirement/disease_outbreak, /datum/event_admin_setup/listed_options/disease_outbreak)
 	///Disease recipient candidates
 	var/list/disease_candidates = list()
 
@@ -60,10 +60,10 @@
 		disease_candidates += candidate
 
 ///Handles checking and alerting admins about the number of valid candidates
-/datum/event_admin_setup/candidate_check/disease_outbreak
+/datum/event_admin_setup/minimum_candidate_requirement/disease_outbreak
 	output_text = "There are no candidates eligible to recieve a disease!"
 
-/datum/event_admin_setup/candidate_check/disease_outbreak/candidate_check()
+/datum/event_admin_setup/minimum_candidate_requirement/disease_outbreak/count_candidates()
 	var/datum/round_event_control/disease_outbreak/disease_control = event_control
 	disease_control.generate_candidates() //can_spawn_event() is bypassed by admin_setup, so this makes sure that the candidates are still generated
 	return length(disease_control.disease_candidates)
@@ -142,7 +142,7 @@
 	description = "An 'advanced' disease will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = list(/datum/event_admin_setup/candidate_check/disease_outbreak, /datum/event_admin_setup/listed_options/disease_outbreak_advanced, /datum/event_admin_setup/input_number/disease_outbreak_advanced)
+	admin_setup = list(/datum/event_admin_setup/minimum_candidate_requirement/disease_outbreak, /datum/event_admin_setup/listed_options/disease_outbreak_advanced, /datum/event_admin_setup/input_number/disease_outbreak_advanced)
 
 /**
  * Admin virus customization

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -29,7 +29,7 @@
 	description = "A 'classic' virus will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = list(/datum/event_admin_setup/disease_outbreak_candidate_check, /datum/event_admin_setup/listed_options/disease_outbreak)
+	admin_setup = list(/datum/event_admin_setup/candidate_check/disease_outbreak, /datum/event_admin_setup/listed_options/disease_outbreak)
 	///Disease recipient candidates
 	var/list/disease_candidates = list()
 
@@ -60,23 +60,14 @@
 		disease_candidates += candidate
 
 ///Handles checking and alerting admins about the number of valid candidates
-/datum/event_admin_setup/disease_outbreak_candidate_check
+/datum/event_admin_setup/candidate_check/disease_outbreak
+	output_text = "There are no candidates eligible to recieve a disease!"
 
-/datum/event_admin_setup/disease_outbreak_candidate_check/prompt_admins()
-	var/candidate_count = candidate_check()
-	if(!candidate_count)
-		tgui_alert(usr, "There are no candidates eligible to recieve a disease!", "Error")
-		return ADMIN_CANCEL_EVENT
-	tgui_alert(usr, "[candidate_count] candidates found!", "Disease Outbreak")
-
-/// Checks for candidates. Returns false if there isn't enough
-/datum/event_admin_setup/disease_outbreak_candidate_check/proc/candidate_check()
+/datum/event_admin_setup/candidate_check/disease_outbreak/candidate_check()
 	var/datum/round_event_control/disease_outbreak/disease_control = event_control
 	disease_control.generate_candidates() //can_spawn_event() is bypassed by admin_setup, so this makes sure that the candidates are still generated
 	return length(disease_control.disease_candidates)
 
-/datum/event_admin_setup/disease_outbreak_candidate_check/apply_to_event(datum/round_event/event)
-	return
 
 ///Handles actually selecting whicch disease will spawn.
 /datum/event_admin_setup/listed_options/disease_outbreak
@@ -151,13 +142,7 @@
 	description = "An 'advanced' disease will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
-	admin_setup = list(/datum/event_admin_setup/disease_outbreak_candidate_check, /datum/event_admin_setup/disease_outbreak/advanced)
-
-/datum/event_admin_setup/disease_outbreak/advanced
-	///Admin selected custom severity rating for the event
-	var/chosen_severity
-	///Admin selected custom value for the maximum symptoms this virus should have
-	var/chosen_max_symptoms
+	admin_setup = list(/datum/event_admin_setup/candidate_check/disease_outbreak, /datum/event_admin_setup/listed_options/disease_outbreak_advanced, /datum/event_admin_setup/input_number/disease_outbreak_advanced)
 
 /**
  * Admin virus customization
@@ -183,34 +168,25 @@
 		else
 			event.requested_severity = null
 
-//TO DO FINISH THIS
+/datum/event_admin_setup/input_number/disease_outbreak_advanced
+	input_text = "How many symptoms do you want your virus to have?"
+	default_value = 4
+	max_value = 7
+	min_value = 1
 
-/datum/event_admin_setup/disease_outbreak/advanced/prompt_admins()
-		chosen_severity = tgui_alert(usr, "Pick a severity!", "In the event of an airborne virus, try not to breathe.", list("Medium", "Harmful", "Dangerous"))
-		switch(chosen_severity)
-			if("Medium")
-				chosen_severity = ADV_DISEASE_MEDIUM
-			if("Harmful")
-				chosen_severity = ADV_DISEASE_HARMFUL
-			if("Dangerous")
-				chosen_severity = ADV_DISEASE_DANGEROUS
-			else
-				return ADMIN_CANCEL_EVENT
+/datum/event_admin_setup/input_number/disease_outbreak_advanced/prompt_admins()
+	var/customize_number_of_symptoms = tgui_alert(usr, "Select number of symptoms?", event_control.name, list("Custom", "Random", "Cancel"))
+	switch(customize_number_of_symptoms)
+		if("Custom")
+			return ..()
+		if("Random")
+			chosen_value = null
+		else
+			return ADMIN_CANCEL_EVENT
+	
 
-		//Ask the admin for max symptoms. Arguments: default, max, min
-		chosen_max_symptoms = tgui_input_number(usr, "How many symptoms do you want your virus to have?", "A pox upon ye!", 4, 7, 1)
-
-	else
-		chosen_severity = null
-		chosen_max_symptoms = null
-		return
-
-	if(tgui_alert(usr,"Are you happy with your selections?", "Epidemic warning, Standby!", list("Yes", "Cancel")) != "Yes")
-		return ADMIN_CANCEL_EVENT
-
-/datum/event_admin_setup/disease_outbreak/advanced/apply_to_event(datum/round_event/disease_outbreak/advanced/event)
-	event.requested_severity = chosen_severity
-	event.max_symptoms = chosen_max_symptoms
+/datum/event_admin_setup/input_number/disease_outbreak_advanced/apply_to_event(datum/round_event/disease_outbreak/advanced/event)
+	event.max_symptoms = chosen_value
 
 /datum/round_event/disease_outbreak/advanced
 	///Number of symptoms for our virus

--- a/code/modules/events/false_alarm.dm
+++ b/code/modules/events/false_alarm.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 5
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "Fakes an event announcement."
-	admin_setup = /datum/event_admin_setup/listed_options/false_alarm
+	admin_setup = list(/datum/event_admin_setup/listed_options/false_alarm)
 
 /datum/round_event_control/falsealarm/can_spawn_event(players_amt, allow_magic = FALSE)
 	. = ..()

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -8,7 +8,7 @@
 	description = "A random crewmember's heart gives out."
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
-	admin_setup = list(/datum/event_admin_setup/heart_attack)
+	admin_setup = list(/datum/event_admin_setup/candidate_check/heart_attack, /datum/event_admin_setup/input_number/heart_attack)
 	///Candidates for recieving a healthy dose of heart disease
 	var/list/heart_attack_candidates = list()
 
@@ -81,18 +81,24 @@
 		return TRUE
 	return FALSE
 
-/datum/event_admin_setup/heart_attack
-	///Number of candidates to be smote
-	var/quantity = 1
+/datum/event_admin_setup/candidate_check/heart_attack
+	output_text = "There are no candidates eligible to recieve a heart attack!"
 
-/datum/event_admin_setup/heart_attack/prompt_admins()
+/datum/event_admin_setup/candidate_check/heart_attack/candidate_check()
 	var/datum/round_event_control/heart_attack/heart_control = event_control
 	heart_control.generate_candidates() //can_spawn_event() is bypassed by admin_setup, so this makes sure that the candidates are still generated
+	return length(heart_control.heart_attack_candidates)
 
-	if(!length(heart_control.heart_attack_candidates))
-		tgui_alert(usr, "There are no candidates eligible to recieve a heart attack!", "Error")
-		return ADMIN_CANCEL_EVENT
-	quantity = tgui_input_number(usr, "There are [length(heart_control.heart_attack_candidates)] crewmembers eligible for a heart attack. Please select how many people's days you wish to ruin.", "Shia Hato Atakku!", 1, length(heart_control.heart_attack_candidates))
+/datum/event_admin_setup/input_number/heart_attack
+	input_text = "Please select how many people's days you wish to ruin."
+	default_value = 0
+	max_value = 90 //Will be overridden
+	min_value = 0
 
-/datum/event_admin_setup/heart_attack/apply_to_event(datum/round_event/heart_attack/event)
-	event.quantity = quantity
+/datum/event_admin_setup/input_number/heart_attack/prompt_admins()
+	var/datum/round_event_control/heart_attack/heart_control = event_control
+	max_value = length(heart_control.heart_attack_candidates)
+	. = ..()
+
+/datum/event_admin_setup/input_number/heart_attack/apply_to_event(datum/round_event/heart_attack/event)
+	event.quantity = chosen_value

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -8,7 +8,7 @@
 	description = "A random crewmember's heart gives out."
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
-	admin_setup = /datum/event_admin_setup/heart_attack
+	admin_setup = list(/datum/event_admin_setup/heart_attack)
 	///Candidates for recieving a healthy dose of heart disease
 	var/list/heart_attack_candidates = list()
 

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -8,7 +8,7 @@
 	description = "A random crewmember's heart gives out."
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
-	admin_setup = list(/datum/event_admin_setup/candidate_check/heart_attack, /datum/event_admin_setup/input_number/heart_attack)
+	admin_setup = list(/datum/event_admin_setup/minimum_candidate_requirement/heart_attack, /datum/event_admin_setup/input_number/heart_attack)
 	///Candidates for recieving a healthy dose of heart disease
 	var/list/heart_attack_candidates = list()
 
@@ -81,10 +81,10 @@
 		return TRUE
 	return FALSE
 
-/datum/event_admin_setup/candidate_check/heart_attack
+/datum/event_admin_setup/minimum_candidate_requirement/heart_attack
 	output_text = "There are no candidates eligible to recieve a heart attack!"
 
-/datum/event_admin_setup/candidate_check/heart_attack/candidate_check()
+/datum/event_admin_setup/minimum_candidate_requirement/heart_attack/count_candidates()
 	var/datum/round_event_control/heart_attack/heart_control = event_control
 	heart_control.generate_candidates() //can_spawn_event() is bypassed by admin_setup, so this makes sure that the candidates are still generated
 	return length(heart_control.heart_attack_candidates)

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -98,7 +98,7 @@
 /datum/event_admin_setup/input_number/heart_attack/prompt_admins()
 	var/datum/round_event_control/heart_attack/heart_control = event_control
 	max_value = length(heart_control.heart_attack_candidates)
-	. = ..()
+	return ..()
 
 /datum/event_admin_setup/input_number/heart_attack/apply_to_event(datum/round_event/heart_attack/event)
 	event.quantity = chosen_value

--- a/code/modules/events/immovable_rod/immovable_rod_event.dm
+++ b/code/modules/events/immovable_rod/immovable_rod_event.dm
@@ -9,7 +9,7 @@
 	description = "The station passes through an immovable rod."
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
-	admin_setup = list(/datum/event_admin_setup/immovable_rod)
+	admin_setup = list(/datum/event_admin_setup/set_location/immovable_rod, /datum/event_admin_setup/question/immovable_rod)
 
 /datum/round_event/immovable_rod
 	announce_when = 5
@@ -28,26 +28,20 @@
 	var/atom/rod = new /obj/effect/immovablerod(start_turf, end_turf, special_target, force_looping)
 	announce_to_ghosts(rod)
 
-/datum/event_admin_setup/immovable_rod
-	/// Admins can pick a spot the rod will aim for.
-	var/atom/special_target
-	/// Admins can also force it to loop around forever, or at least until the RD gets their hands on it.
-	var/force_looping = FALSE
+/// Admins can pick a spot the rod will aim for
+/datum/event_admin_setup/set_location/immovable_rod
+	input_text = "Aimed at current location?"
 
-/datum/event_admin_setup/immovable_rod/prompt_admins()
-	special_target = null
-	force_looping = FALSE
+/datum/event_admin_setup/set_location/immovable_rod/apply_to_event(datum/round_event/immovable_rod/event)
+	event.special_target = chosen_turf
 
-	var/aimed = tgui_alert(usr,"Aimed at current location?", "Sniperod", list("Yes", "No"))
-	if(aimed == "Yes")
-		special_target = get_turf(usr)
-	var/looper = tgui_alert(usr,"Would you like this rod to force-loop across space z-levels?", "Loopy McLoopface", list("Yes", "No"))
-	if(looper == "Yes")
-		force_looping = TRUE
-	var/log_message = "[key_name_admin(usr)] has aimed an immovable rod [force_looping ? "(forced looping) " : ""]at [special_target ? AREACOORD(special_target) : "a random location"]."
+/// Admins can also force it to loop around forever, or at least until the RD gets their hands on it.
+/datum/event_admin_setup/question/immovable_rod
+	input_text = "Would you like this rod to force-loop across space z-levels?"
+
+/datum/event_admin_setup/question/immovable_rod/apply_to_event(datum/round_event/immovable_rod/event)
+	event.force_looping = chosen
+	var/log_message = "[key_name_admin(usr)] has aimed an immovable rod [event.force_looping ? "(forced looping) " : ""]at [event.special_target ? AREACOORD(event.special_target) : "a random location"]."
 	message_admins(log_message)
 	log_admin(log_message)
-
-/datum/event_admin_setup/immovable_rod/apply_to_event(datum/round_event/immovable_rod/event)
-	event.special_target = special_target
-	event.force_looping = force_looping
+	

--- a/code/modules/events/immovable_rod/immovable_rod_event.dm
+++ b/code/modules/events/immovable_rod/immovable_rod_event.dm
@@ -9,7 +9,7 @@
 	description = "The station passes through an immovable rod."
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
-	admin_setup = /datum/event_admin_setup/immovable_rod
+	admin_setup = list(/datum/event_admin_setup/immovable_rod)
 
 /datum/round_event/immovable_rod
 	announce_when = 5

--- a/code/modules/events/immovable_rod/immovable_rod_event.dm
+++ b/code/modules/events/immovable_rod/immovable_rod_event.dm
@@ -44,4 +44,3 @@
 	var/log_message = "[key_name_admin(usr)] has aimed an immovable rod [event.force_looping ? "(forced looping) " : ""]at [event.special_target ? AREACOORD(event.special_target) : "a random location"]."
 	message_admins(log_message)
 	log_admin(log_message)
-	

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -8,7 +8,7 @@
 	category = EVENT_CATEGORY_HEALTH
 	min_wizard_trigger_potency = 0
 	max_wizard_trigger_potency = 2
-	admin_setup = /datum/event_admin_setup/mass_hallucination
+	admin_setup = list(/datum/event_admin_setup/mass_hallucination)
 
 /datum/round_event/mass_hallucination
 	fakeable = FALSE

--- a/code/modules/events/sandstorm.dm
+++ b/code/modules/events/sandstorm.dm
@@ -17,7 +17,7 @@
 	description = "A wave of space dust continually grinds down a side of the station."
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
-	admin_setup = /datum/event_admin_setup/listed_options/sandstorm
+	admin_setup = list(/datum/event_admin_setup/listed_options/sandstorm)
 	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event/sandstorm

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -6,7 +6,7 @@
 	min_players = 10
 	category = EVENT_CATEGORY_JANITORIAL
 	description = "The scrubbers release a tide of mostly harmless froth."
-	admin_setup = /datum/event_admin_setup/listed_options/scrubber_overflow
+	admin_setup = list(/datum/event_admin_setup/listed_options/scrubber_overflow)
 
 /datum/round_event/scrubber_overflow
 	announce_when = 1

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -38,15 +38,14 @@
 	priority_announce(message, "[command_name()] Spacecraft Engineering")
 
 /datum/round_event/shuttle_catastrophe/setup()
-	if(SSshuttle.shuttle_insurance)
+	if(SSshuttle.shuttle_insurance || !isnull(new_shuttle)) //If an admin has overridden it don't re-roll it
 		return
-	if(isnull(new_shuttle)) //If an admin has overridden it don't re-roll it
-		var/list/valid_shuttle_templates = list()
-		for(var/shuttle_id in SSmapping.shuttle_templates)
-			var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
-			if(!isnull(template.who_can_purchase) && template.credit_cost < INFINITY) //if we could get it from the communications console, it's cool for us to get it here
-				valid_shuttle_templates += template
-		new_shuttle = pick(valid_shuttle_templates)
+	var/list/valid_shuttle_templates = list()
+	for(var/shuttle_id in SSmapping.shuttle_templates)
+		var/datum/map_template/shuttle/template = SSmapping.shuttle_templates[shuttle_id]
+		if(!isnull(template.who_can_purchase) && template.credit_cost < INFINITY) //if we could get it from the communications console, it's cool for us to get it here
+			valid_shuttle_templates += template
+	new_shuttle = pick(valid_shuttle_templates)
 
 /datum/round_event/shuttle_catastrophe/start()
 	if(SSshuttle.shuttle_insurance)

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -80,4 +80,3 @@
 
 /datum/event_admin_setup/listed_options/shuttle_catastrophe/apply_to_event(datum/round_event/shuttle_catastrophe/event)
 	event.new_shuttle = chosen
-	

--- a/code/modules/events/shuttle_catastrophe.dm
+++ b/code/modules/events/shuttle_catastrophe.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 1
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "Replaces the emergency shuttle with a random one."
-	admin_setup = /datum/event_admin_setup/warn_admin/shuttle_catastrophe
+	admin_setup = list(/datum/event_admin_setup/warn_admin/shuttle_catastrophe)
 
 /datum/round_event_control/shuttle_catastrophe/can_spawn_event(players, allow_magic = FALSE)
 	. = ..()

--- a/code/modules/events/shuttle_loan/shuttle_loan_event.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_event.dm
@@ -7,7 +7,7 @@
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "If cargo accepts the offer, fills the shuttle with loot and/or enemies."
 	///The types of loan events already run (and to be excluded if the event triggers).
-	admin_setup = /datum/event_admin_setup/listed_options/shuttle_loan
+	admin_setup = list(/datum/event_admin_setup/listed_options/shuttle_loan)
 	var/list/run_situations = list()
 
 /datum/round_event_control/shuttle_loan/can_spawn_event(players_amt, allow_magic = FALSE)

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -151,6 +151,7 @@
 		else
 			return ADMIN_CANCEL_EVENT
 
+///This proc prompts admins to set a TC value and uplink type for the crate, those values are then passed to a new syndicate pack's setup_contents() to generate the contents before spawning it.
 /datum/event_admin_setup/syndicate_cargo_pod/proc/override_contents()
 	var/datum/supply_pack/misc/syndicate/custom_value/syndicate_pack = new
 	var/pack_telecrystals = tgui_input_number(usr, "Please input crate's value in telecrystals.", "Set Telecrystals.", 30)

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -24,7 +24,7 @@
 
 /datum/event_admin_setup/listed_options/stray_cargo/apply_to_event(datum/round_event/stray_cargo/event)
 	event.admin_override_contents = chosen
-	var/log_message = "[key_name_admin(usr)] has aimed a stray cargo pod at [event.admin_override_turf ? AREACOORD(event.admin_override_turf) : "a random location"]. The pod contents are [event.admin_override_contents ? event.admin_override_contents : "random"]."
+	var/log_message = "[key_name_admin(usr)] has aimed a stray cargo pod at [event.admin_override_turf ? AREACOORD(event.admin_override_turf) : "a random location"]. The pod contents are [chosen ? chosen : "random"]."
 	message_admins(log_message)
 	log_admin(log_message)
 
@@ -168,7 +168,7 @@
 
 /datum/event_admin_setup/syndicate_cargo_pod/apply_to_event(datum/round_event/stray_cargo/syndicate/event)
 	event.admin_override_contents = pack_type_override	
-	var/log_message = "[key_name_admin(usr)] has aimed a stray syndicate cargo pod at [event.admin_override_turf ? AREACOORD(event.admin_override_turf) : "a random location"]. The pod contents are [event.admin_override_contents ? event.admin_override_contents : "random"]."
+	var/log_message = "[key_name_admin(usr)] has aimed a stray syndicate cargo pod at [event.admin_override_turf ? AREACOORD(event.admin_override_turf) : "a random location"]. The pod contents are [pack_type_override ? pack_type_override : "random"]."
 	message_admins(log_message)
 	log_admin(log_message)
 

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -7,40 +7,26 @@
 	earliest_start = 10 MINUTES
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "A pod containing a random supply crate lands on the station."
-	admin_setup = list(/datum/event_admin_setup/stray_cargo)
+	admin_setup = list(/datum/event_admin_setup/set_location/stray_cargo, /datum/event_admin_setup/listed_options/stray_cargo)
 
-/datum/event_admin_setup/stray_cargo
-	///Admin setable override that is used instead of selecting a random location
-	var/atom/landing_turf_override
-	///Admin setable override to spawn a specific cargo pack type
-	var/pack_type_override
+/datum/event_admin_setup/set_location/stray_cargo
+	input_text = "Aim pod at turf we're on?"
 
-/datum/event_admin_setup/stray_cargo/prompt_admins()
-	var/admin_targeted = tgui_alert(usr,"Aimed at turf we're on?", "Pod Targetting", list("Yes", "No", "Cancel"))
-	switch(admin_targeted)
-		if("Yes")
-			landing_turf_override = get_turf(usr)
-		if("No")
-			landing_turf_override = null
-		else
-			return ADMIN_CANCEL_EVENT
-	var/admin_selected_pack = tgui_alert(usr,"Select pod contents?", "Pod Contents", list("Yes", "No", "Cancel"))
-	switch(admin_selected_pack)
-		if("Yes")
-			override_contents()
-		if("No")
-			pack_type_override = null
-		else
-			return ADMIN_CANCEL_EVENT
-	message_admins("[key_name_admin(usr)] has aimed a stray cargo pod at [landing_turf_override ? AREACOORD(landing_turf_override) : "a random location"]. The pod contents are [pack_type_override ? pack_type_override : "random"].")
-	log_admin("[key_name_admin(usr)] has aimed a stray cargo pod at [landing_turf_override ? AREACOORD(landing_turf_override) : "a random location"]. The pod contents are [pack_type_override ? pack_type_override : "random"].")
+/datum/event_admin_setup/set_location/stray_cargo/apply_to_event(datum/round_event/stray_cargo/event)
+	event.admin_override_turf = chosen_turf
 
-/datum/event_admin_setup/stray_cargo/proc/override_contents()
-	pack_type_override = tgui_input_list(usr, "Choose a cargo crate to drop.", "Choose pod contents.", sort_list(subtypesof(/datum/supply_pack), /proc/cmp_typepaths_asc))
+/datum/event_admin_setup/listed_options/stray_cargo
+	input_text = "Choose a cargo crate to drop."
+	normal_run_option = "Random Crate"
 
-/datum/event_admin_setup/stray_cargo/apply_to_event(datum/round_event/stray_cargo/event)
-	event.admin_override_turf = landing_turf_override
-	event.admin_override_contents = pack_type_override
+/datum/event_admin_setup/listed_options/stray_cargo/get_list()
+	return sort_list(subtypesof(/datum/supply_pack), /proc/cmp_typepaths_asc)
+
+/datum/event_admin_setup/listed_options/stray_cargo/apply_to_event(datum/round_event/stray_cargo/event)
+	event.admin_override_contents = chosen
+	var/log_message = "[key_name_admin(usr)] has aimed a stray cargo pod at [event.admin_override_turf ? AREACOORD(event.admin_override_turf) : "a random location"]. The pod contents are [event.admin_override_contents ? event.admin_override_contents : "random"]."
+	message_admins(log_message)
+	log_admin(log_message)
 
 ///Spawns a cargo pod containing a random cargo supply pack on a random area of the station
 /datum/round_event/stray_cargo
@@ -149,11 +135,23 @@
 	description = "A pod containing syndicate gear lands on the station."
 	min_wizard_trigger_potency = 3
 	max_wizard_trigger_potency = 6
-	admin_setup = list(/datum/event_admin_setup/stray_cargo/syndicate)
+	admin_setup = list(/datum/event_admin_setup/set_location/stray_cargo, /datum/event_admin_setup/syndicate_cargo_pod)
 
-/datum/event_admin_setup/stray_cargo/syndicate
+/datum/event_admin_setup/syndicate_cargo_pod
+	///Admin setable override to spawn a specific cargo pack type
+	var/pack_type_override
 
-/datum/event_admin_setup/stray_cargo/syndicate/override_contents()
+/datum/event_admin_setup/syndicate_cargo_pod/prompt_admins()
+	var/admin_selected_pack = tgui_alert(usr,"Customize Pod contents?", "Pod Contents", list("Yes", "No", "Cancel"))
+	switch(admin_selected_pack)
+		if("Yes")
+			override_contents()
+		if("No")
+			pack_type_override = null
+		else
+			return ADMIN_CANCEL_EVENT
+
+/datum/event_admin_setup/syndicate_cargo_pod/proc/override_contents()
 	var/datum/supply_pack/misc/syndicate/custom_value/syndicate_pack = new
 	var/pack_telecrystals = tgui_input_number(usr, "Please input crate's value in telecrystals.", "Set Telecrystals.", 30)
 	if(isnull(pack_telecrystals))
@@ -167,6 +165,12 @@
 		return ADMIN_CANCEL_EVENT
 	syndicate_pack.setup_contents(pack_telecrystals, selection)
 	pack_type_override = syndicate_pack
+
+/datum/event_admin_setup/syndicate_cargo_pod/apply_to_event(datum/round_event/stray_cargo/syndicate/event)
+	event.admin_override_contents = pack_type_override	
+	var/log_message = "[key_name_admin(usr)] has aimed a stray syndicate cargo pod at [event.admin_override_turf ? AREACOORD(event.admin_override_turf) : "a random location"]. The pod contents are [event.admin_override_contents ? event.admin_override_contents : "random"]."
+	message_admins(log_message)
+	log_admin(log_message)
 
 /datum/round_event/stray_cargo/syndicate
 	possible_pack_types = list(/datum/supply_pack/misc/syndicate)

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -7,7 +7,7 @@
 	earliest_start = 10 MINUTES
 	category = EVENT_CATEGORY_BUREAUCRATIC
 	description = "A pod containing a random supply crate lands on the station."
-	admin_setup = /datum/event_admin_setup/stray_cargo
+	admin_setup = list(/datum/event_admin_setup/stray_cargo)
 
 /datum/event_admin_setup/stray_cargo
 	///Admin setable override that is used instead of selecting a random location
@@ -149,7 +149,7 @@
 	description = "A pod containing syndicate gear lands on the station."
 	min_wizard_trigger_potency = 3
 	max_wizard_trigger_potency = 6
-	admin_setup = /datum/event_admin_setup/stray_cargo/syndicate
+	admin_setup = list(/datum/event_admin_setup/stray_cargo/syndicate)
 
 /datum/event_admin_setup/stray_cargo/syndicate
 

--- a/code/modules/events/stray_meteor.dm
+++ b/code/modules/events/stray_meteor.dm
@@ -20,7 +20,9 @@
 
 /datum/round_event/stray_meteor/start()
 	if(chosen_meteor)
-		spawn_meteor(list(chosen_meteor = 1))
+		var/list/chosen_meteor_list = list()
+		chosen_meteor_list[chosen_meteor] = 1
+		spawn_meteor(chosen_meteor_list)
 	else
 		spawn_meteor(GLOB.meteors_stray)
 

--- a/code/modules/events/stray_meteor.dm
+++ b/code/modules/events/stray_meteor.dm
@@ -9,7 +9,7 @@
 	description = "Throw a random meteor somewhere near the station."
 	min_wizard_trigger_potency = 3
 	max_wizard_trigger_potency = 7
-	admin_setup = /datum/event_admin_setup/listed_options/stray_meteor
+	admin_setup = list(/datum/event_admin_setup/listed_options/stray_meteor)
 	map_flags = EVENT_SPACE_ONLY
 
 /datum/round_event/stray_meteor

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -8,7 +8,7 @@
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
 	description = "A department is turned into an independent state."
-	admin_setup = list(/datum/event_admin_setup/department_revolt)
+	admin_setup = list(/datum/event_admin_setup/listed_options/departmental_revolt, /datum/event_admin_setup/question/departmental_revolt_annouce, /datum/event_admin_setup/question/departmental_revolt_dangerous)
 
 /datum/round_event/wizard/deprevolt
 	///which department is revolting?
@@ -22,37 +22,29 @@
 	// no setup needed, this proc handles empty values. God i'm good (i wrote all of this)
 	create_separatist_nation(picked_department, announce, dangerous_nation)
 
-/datum/event_admin_setup/department_revolt
-	///which department is revolting?
-	var/datum/job_department/picked_department
-	/// Announce the separatist nation to the round?
-	var/announce = FALSE
-	/// Is it going to try fighting other nations?
-	var/dangerous_nation = TRUE
+///which department is revolting?
+/datum/event_admin_setup/listed_options/departmental_revolt
+	input_text = "Which department should revolt?"
+	normal_run_option = "Random"
 
-/datum/event_admin_setup/department_revolt/prompt_admins()
-	var/list/options = list("Random" = RANDOM_DEPARTMENT)
-	var/list/pickable_departments = subtypesof(/datum/job_department)
-	for(var/datum/job_department/dep as anything in pickable_departments)
-		options[initial(dep.department_name)] = dep
-	picked_department = options[(tgui_input_list(usr,"Which department should revolt? Select none for a random department.","Select a department", options))]
-	if(!picked_department)
-		return ADMIN_CANCEL_EVENT
-	if(picked_department == RANDOM_DEPARTMENT)
-		picked_department = null
-		return
+/datum/event_admin_setup/listed_options/departmental_revolt/get_list()
+	return subtypesof(/datum/job_department)
+	
+/datum/event_admin_setup/listed_options/departmental_revolt/apply_to_event(datum/round_event/wizard/deprevolt/event)
+	event.picked_department = chosen
 
-	var/announce_question = tgui_alert(usr, "Announce This New Independent State?", "Secession", list("Announce", "No Announcement"))
-	if(announce_question == "Announce")
-		announce = TRUE
+/// Announce the separatist nation to the round?
+/datum/event_admin_setup/question/departmental_revolt_annouce
+	input_text = "Announce This New Independent State?"
 
-	var/dangerous_question = tgui_alert(usr, "Dangerous Nation? This means they will fight other nations.", "Conquest", list("Yes", "No"))
-	if(dangerous_question == "No")
-		dangerous_nation = FALSE
+/datum/event_admin_setup/question/departmental_revolt_annouce/apply_to_event(datum/round_event/wizard/deprevolt/event)
+	event.announce = chosen
 
-/datum/event_admin_setup/department_revolt/apply_to_event(datum/round_event/wizard/deprevolt/event)
-	event.picked_department = picked_department
-	event.announce = announce
-	event.dangerous_nation = dangerous_nation
+/// Is it going to try fighting other nations?
+/datum/event_admin_setup/question/departmental_revolt_dangerous
+	input_text = "Dangerous Nation? This means they will fight other nations."
+
+/datum/event_admin_setup/question/departmental_revolt_dangerous/apply_to_event(datum/round_event/wizard/deprevolt/event)
+	event.dangerous_nation = chosen
 
 #undef RANDOM_DEPARTMENT

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -8,7 +8,11 @@
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
 	description = "A department is turned into an independent state."
-	admin_setup = list(/datum/event_admin_setup/listed_options/departmental_revolt, /datum/event_admin_setup/question/departmental_revolt_annouce, /datum/event_admin_setup/question/departmental_revolt_dangerous)
+	admin_setup = list(
+		/datum/event_admin_setup/listed_options/departmental_revolt,
+		/datum/event_admin_setup/question/departmental_revolt_annouce,
+		/datum/event_admin_setup/question/departmental_revolt_dangerous
+	)
 
 /datum/round_event/wizard/deprevolt
 	///which department is revolting?

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -8,7 +8,7 @@
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
 	description = "A department is turned into an independent state."
-	admin_setup = /datum/event_admin_setup/department_revolt
+	admin_setup = list(/datum/event_admin_setup/department_revolt)
 
 /datum/round_event/wizard/deprevolt
 	///which department is revolting?

--- a/code/modules/events/wizard/madness.dm
+++ b/code/modules/events/wizard/madness.dm
@@ -4,7 +4,7 @@
 	typepath = /datum/round_event/wizard/madness
 	earliest_start = 0 MINUTES
 	description = "Reveals a horrifying truth to everyone, giving them a trauma."
-	admin_setup = /datum/event_admin_setup/text_input/madness
+	admin_setup = list(/datum/event_admin_setup/text_input/madness)
 
 /datum/round_event/wizard/madness
 	/// the horrifying truth sent to the crew, can be picked by admins.

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -7,7 +7,7 @@
 	description = "Summons a school of carps with magic projectiles."
 	min_wizard_trigger_potency = 4
 	max_wizard_trigger_potency = 6
-	admin_setup = /datum/event_admin_setup/carp_migration
+	admin_setup = list(/datum/event_admin_setup/carp_migration)
 
 /datum/round_event/carp_migration/wizard
 	carp_type = /mob/living/basic/carp/magic


### PR DESCRIPTION
## About The Pull Request

Requested by @tralezab 

Admin event setups now use a list rather than a single setup. This means common functionality list setting position and picking an option from a list can be applied to events that have multiple customizable factors rather than needing to making entirely overridden subtypes for every event.

Adds a few new subtypes of event_admin_setup:
- input_number for setting a number value. An example can be found in the heart attack event.
- set_location for causing an event to occur in a specific location. An example can be found in the stray cargo pod event.
- question, yes no question that returns true/false. An example of its usage can be found in immovable rod
- candidate_check, a more niche subtype used to block events that do not function unless theres a specific number of valid candidates. An example of its usage can be found in the disease events.

While doing the refactor I also implemented some simple extra options for some of the refactored events. Classic Disease now has an option for admins to roll **any** disease rather than just the "safe" ones. And shuttle catastrophe now allows admins to select which shuttle is used.
## Why It's Good For The Game

Cuts back on duplicate lines of code a lot, should make adding more customization to events slightly easier. Also more admin customization.
## Changelog
:cl:
refactor: Admin event setup's have been refactored to use lists.
fix: When admins customize the pirate event all options will be available rather than just options that have not been randomly rolled.
fix: The stray meteor event no longer runtimes when customized by admins.
admin: Admins can now select the shuttle brought in by the shuttle catastrophe event.
admin: Admins can now randomize the disease outbreak classic event to roll any disease type, including transformation diseases so have fun with that.
/:cl:
