### PR TITLE
Fixes Luminescence actions

### DIFF
--- a/code/datums/components/action_item_overlay.dm
+++ b/code/datums/components/action_item_overlay.dm
@@ -15,6 +15,8 @@
 	if(!istype(parent, /datum/action))
 		return COMPONENT_INCOMPATIBLE
 
+	ASSERT(isnull(item) || istype(item))
+
 	if(!item && !item_callback)
 		stack_trace("[type] created without a reference item or an item callback - one or the other is required.")
 		return COMPONENT_INCOMPATIBLE

--- a/code/datums/components/action_item_overlay.dm
+++ b/code/datums/components/action_item_overlay.dm
@@ -48,13 +48,17 @@
 	SIGNAL_HANDLER
 
 	// We're in the middle of being removed / deleted, remove our associated overlay
-	if(QDELING(src) && item_appearance)
-		current_button.cut_overlay(item_appearance)
-		item_appearance = null
+	if(QDELING(src))
+		if(item_appearance)
+			current_button.cut_overlay(item_appearance)
+			item_appearance = null
 		return
 
 	var/atom/movable/muse = item_callback?.Invoke() || item_ref?.resolve()
 	if(!istype(muse))
+		if(item_appearance) // New item does not exist but we have an old appearance
+			current_button.cut_overlay(item_appearance)
+			item_appearance = null
 		return
 
 	if(item_appearance)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -538,7 +538,7 @@
 
 /datum/action/innate/integrate_extract/New(Target)
 	. = ..()
-	AddComponent(/datum/component/action_item_overlay, CALLBACK(src, PROC_REF(locate_extract)))
+	AddComponent(/datum/component/action_item_overlay, item_callback = CALLBACK(src, PROC_REF(locate_extract)))
 
 /// Callback for /datum/component/action_item_overlay to find the slime extract from within the species
 /datum/action/innate/integrate_extract/proc/locate_extract()
@@ -608,7 +608,7 @@
 
 /datum/action/innate/use_extract/New(Target)
 	. = ..()
-	AddComponent(/datum/component/action_item_overlay, CALLBACK(src, PROC_REF(locate_extract)))
+	AddComponent(/datum/component/action_item_overlay, item_callback = CALLBACK(src, PROC_REF(locate_extract)))
 
 /// Callback for /datum/component/action_item_overlay to find the slime extract from within the species
 /datum/action/innate/use_extract/proc/locate_extract()


### PR DESCRIPTION
## About The Pull Request

- Add Component was supposed to use a named arg, quick fix
- While testing the fix I noticed it doesn't properly remove the appearance when the item is lost, cuts the overlay on failures

## Why It's Good For The Game

Mothblox said this broke things (it was making a weakref of a callback on accident)

## Changelog

:cl: Melbert
fix: Luminsecent slime actions correctly update their appearance when integrating or ejecting slime cores
/:cl:
