### PR TITLE
Removes bad `nodamage` var from projectiles, fixes Juggernaut / Rust Walker projectiles doing zero damage

### DIFF
--- a/code/datums/components/combustible_flooder.dm
+++ b/code/datums/components/combustible_flooder.dm
@@ -81,7 +81,7 @@
 /datum/component/combustible_flooder/proc/projectile_react(datum/source, obj/projectile/shot)
 	SIGNAL_HANDLER
 
-	if(shot.damage_type == BURN && !shot.nodamage)
+	if(shot.damage_type == BURN && shot.damage > 0)
 		flood(shot.firer, 2500)
 
 /// Welder check. Here because tool_act is higher priority than attackby.

--- a/code/datums/components/explodable.dm
+++ b/code/datums/components/explodable.dm
@@ -87,7 +87,7 @@
 /datum/component/explodable/proc/projectile_react(datum/source, obj/projectile/shot)
 	SIGNAL_HANDLER
 
-	if(shot.damage_type == BURN && !shot.nodamage)
+	if(shot.damage_type == BURN && shot.damage > 0)
 		detonate()
 
 ///Called when you attack a specific body part of the thing this is equipped on. Useful for exploding pants.

--- a/code/datums/elements/relay_attackers.dm
+++ b/code/datums/elements/relay_attackers.dm
@@ -48,7 +48,7 @@
 
 /datum/element/relay_attackers/proc/on_bullet_act(atom/target, obj/projectile/hit_projectile)
 	SIGNAL_HANDLER
-	if(hit_projectile.nodamage)
+	if(!hit_projectile.is_hostile_projectile())
 		return
 	if(!ismob(hit_projectile.firer))
 		return

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -536,8 +536,7 @@
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	speed = 1.6
 	damage_type = BRUTE
-	damage = 0
-	nodamage = TRUE // love can't actually hurt you
+	damage = 0 // love can't actually hurt you
 	armour_penetration = 100 // but if it could, it would cut through even the thickest plate
 
 /obj/projectile/kiss/fire(angle, atom/direct_target)
@@ -546,7 +545,7 @@
 	return ..()
 
 /obj/projectile/kiss/Impact(atom/A)
-	if(!nodamage || !isliving(A)) // if we do damage or we hit a nonliving thing, we don't have to worry about a harmless hit because we can't wrongly do damage anyway
+	if(damage > 0 || !isliving(A)) // if we do damage or we hit a nonliving thing, we don't have to worry about a harmless hit because we can't wrongly do damage anyway
 		return ..()
 
 	harmless_on_hit(A)
@@ -608,8 +607,7 @@
 
 /obj/projectile/kiss/death
 	name = "kiss of death"
-	nodamage = FALSE // okay i kinda lied about love not being able to hurt you
-	damage = 35
+	damage = 35 // okay i kinda lied about love not being able to hurt you
 	wound_bonus = 0
 	sharpness = SHARP_POINTY
 	color = COLOR_BLACK

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -57,7 +57,7 @@
 				qdel(src)
 
 /obj/item/latexballon/bullet_act(obj/projectile/P)
-	if(!P.nodamage)
+	if(P.damage > 0)
 		burst()
 	return ..()
 

--- a/code/game/objects/items/robot/items/food.dm
+++ b/code/game/objects/items/robot/items/food.dm
@@ -165,12 +165,10 @@
 	desc = "Oh noes! A fast-moving gumball!"
 	icon_state = "gumball"
 	ammo_type = /obj/item/food/gumball
-	nodamage = TRUE
 	damage = 0
 	speed = 0.5
 
 /obj/projectile/bullet/reusable/gumball/harmful
-	nodamage = FALSE
 	damage = 10
 
 /obj/projectile/bullet/reusable/gumball/handle_drop()
@@ -194,7 +192,6 @@
 	desc = "Oh noes! A fast-moving lollipop!"
 	icon_state = "lollipop_1"
 	ammo_type = /obj/item/food/lollipop/cyborg
-	nodamage = TRUE
 	damage = 0
 	speed = 0.5
 	var/color2 = rgb(0, 0, 0)
@@ -210,7 +207,6 @@
 		rip_time = 10,
 	)
 	damage = 10
-	nodamage = FALSE
 	embed_falloff_tile = 0
 
 /obj/projectile/bullet/reusable/lollipop/Initialize(mapload)

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -138,11 +138,11 @@
 
 /obj/item/borg/projectile_dampen/proc/process_usage(delta_time)
 	var/usage = 0
-	for(var/obj/projectile/projectil as anything in tracked)
-		if(!projectil.is_hostile_projectile())
+	for(var/obj/projectile/inner_projectile as anything in tracked)
+		if(!inner_projectile.is_hostile_projectile())
 			continue
 		usage += projectile_tick_speed_ecost * delta_time
-		usage += tracked[projectil] * projectile_damage_tick_ecost_coefficient * delta_time
+		usage += tracked[inner_projectile] * projectile_damage_tick_ecost_coefficient * delta_time
 	energy = clamp(energy - usage, 0, maxenergy)
 	if(energy <= 0)
 		deactivate_field()

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -138,9 +138,8 @@
 
 /obj/item/borg/projectile_dampen/proc/process_usage(delta_time)
 	var/usage = 0
-	for(var/to_track in tracked)
-		var/obj/projectile/projectil = to_track
-		if(!projectil.stun && projectil.nodamage) //No damage
+	for(var/obj/projectile/projectil as anything in tracked)
+		if(!projectil.is_hostile_projectile())
 			continue
 		usage += projectile_tick_speed_ecost * delta_time
 		usage += tracked[to_track] * projectile_damage_tick_ecost_coefficient * delta_time

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -142,7 +142,7 @@
 		if(!projectil.is_hostile_projectile())
 			continue
 		usage += projectile_tick_speed_ecost * delta_time
-		usage += tracked[to_track] * projectile_damage_tick_ecost_coefficient * delta_time
+		usage += tracked[projectil] * projectile_damage_tick_ecost_coefficient * delta_time
 	energy = clamp(energy - usage, 0, maxenergy)
 	if(energy <= 0)
 		deactivate_field()

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -448,7 +448,6 @@
 	icon = 'icons/obj/fishing.dmi'
 	icon_state = "hook_projectile"
 	damage = 0
-	nodamage = TRUE
 	range = 5
 	suppressed =  SUPPRESSED_VERY
 	can_hit_turfs = TRUE
@@ -530,4 +529,3 @@
 
 	var/lefthand_n_px = 13
 	var/lefthand_n_py = 15
-

--- a/code/modules/hallucination/stray_bullet.dm
+++ b/code/modules/hallucination/stray_bullet.dm
@@ -32,7 +32,6 @@
 	ricochets_max = 0
 	ricochet_chance = 0
 	damage = 0
-	nodamage = TRUE
 	projectile_type = /obj/projectile/hallucination
 	log_override = TRUE
 	/// Our parent hallucination that's created us

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -177,7 +177,6 @@
 /obj/projectile/destabilizer
 	name = "destabilizing force"
 	icon_state = "pulse1"
-	nodamage = TRUE
 	damage = 0 //We're just here to mark people. This is still a melee weapon.
 	damage_type = BRUTE
 	armor_flag = BOMB
@@ -304,7 +303,6 @@
 		marker.name = "heated [marker.name]"
 		marker.icon_state = "lava"
 		marker.damage = bonus_value
-		marker.nodamage = FALSE
 		deadly_shot = FALSE
 
 //icewing watcher
@@ -421,7 +419,6 @@
 		marker.name = "deadly [marker.name]"
 		marker.icon_state = "chronobolt"
 		marker.damage = bonus_value
-		marker.nodamage = FALSE
 		marker.speed = 2
 		deadly_shot = FALSE
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -91,7 +91,7 @@
 
 /mob/living/bullet_act(obj/projectile/P, def_zone, piercing_hit = FALSE)
 	. = ..()
-	if(!P.nodamage && (. != BULLET_ACT_BLOCK))
+	if(P.is_hostile_projectile() && (. != BULLET_ACT_BLOCK))
 		var/attack_direction = get_dir(P.starting, src)
 		// we need a second, silent armor check to actually know how much to reduce damage taken, as opposed to
 		// on [/atom/proc/bullet_act] where it's just to pass it to the projectile's on_hit().

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -254,7 +254,7 @@
 /mob/living/simple_animal/bot/secbot/bullet_act(obj/projectile/Proj)
 	if(istype(Proj, /obj/projectile/beam) || istype(Proj, /obj/projectile/bullet))
 		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
-			if(!Proj.nodamage && Proj.damage < src.health && ishuman(Proj.firer))
+			if(Proj.is_hostile_projectile() && Proj.damage < src.health && ishuman(Proj.firer))
 				retaliate(Proj.firer)
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
@@ -62,11 +62,8 @@
 
 /obj/projectile/mega_arachnid
 	name = "flesh snare"
-	nodamage = TRUE
-
-
-	damage = 0
 	icon_state = "tentacle_end"
+	damage = 0
 
 /obj/projectile/mega_arachnid/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target) && blocked < 100)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -42,7 +42,6 @@
 	icon_state = "ice_2"
 	damage = 10
 	damage_type = BURN
-	nodamage = FALSE
 	armor_flag = ENERGY
 	temperature = -50 // Cools you down! per hit!
 	var/slowdown = TRUE //Determines if the projectile applies a slowdown status effect on carbons or not
@@ -58,7 +57,6 @@
 	icon_state= "chronobolt"
 	damage = 40
 	damage_type = BRUTE
-	nodamage = FALSE
 	temperature = 0
 	slowdown = FALSE
 
@@ -194,7 +192,6 @@
 	icon_state = "lava"
 	damage = 5
 	damage_type = BURN
-	nodamage = FALSE
 	temperature = 200 // Heats you up! per hit!
 	slowdown = FALSE
 
@@ -209,7 +206,6 @@
 /obj/projectile/temp/basilisk/icewing
 	damage = 5
 	damage_type = BURN
-	nodamage = FALSE
 
 /obj/projectile/temp/basilisk/icewing/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -238,7 +238,7 @@
 		rock_target.gets_drilled()
 
 /obj/projectile/herald/teleshot
-	name ="golden bolt"
+	name = "golden bolt"
 	damage = 0
 	color = rgb(255,255,102)
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -226,20 +226,21 @@
 	damage_type = BRUTE
 	pass_flags = PASSTABLE
 
-/obj/projectile/herald/teleshot
-	name ="golden bolt"
-	damage = 0
-	color = rgb(255,255,102)
-
 /obj/projectile/herald/on_hit(atom/target, blocked = FALSE)
 	if(ismob(target) && ismob(firer))
 		var/mob/living/mob_target = target
 		if(mob_target.faction_check_mob(firer))
-			nodamage = TRUE
+			damage = 0
+
 	. = ..()
 	if(ismineralturf(target))
 		var/turf/closed/mineral/rock_target = target
 		rock_target.gets_drilled()
+
+/obj/projectile/herald/teleshot
+	name ="golden bolt"
+	damage = 0
+	color = rgb(255,255,102)
 
 /obj/projectile/herald/teleshot/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/ice_demon.dm
@@ -53,7 +53,6 @@
 	speed = 1
 	pixel_speed_multiplier = 0.25
 	range = 200
-	nodamage = FALSE
 	temperature = -75
 	slowdown = FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -189,7 +189,7 @@
 
 /mob/living/simple_animal/hostile/mushroom/bullet_act(obj/projectile/P)
 	. = ..()
-	if(P.nodamage)
+	if(P.damage > 0 && P.damage_type == BRUTE)
 		Bruise()
 
 /mob/living/simple_animal/hostile/mushroom/harvest()

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -373,7 +373,6 @@
 	icon_state = "glob_projectile"
 	shrapnel_type = /obj/item/mending_globule
 	embedding = list("embed_chance" = 100, ignore_throwspeed_threshold = TRUE, "pain_mult" = 0, "jostle_pain_mult" = 0, "fall_chance" = 0.5)
-	nodamage = TRUE
 	damage = 0
 
 ///This item is what is embedded into the mob, and actually handles healing of mending globules

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -115,7 +115,6 @@
 	icon_state = "tether_projectile"
 	icon = 'icons/obj/clothing/modsuit/mod_modules.dmi'
 	damage = 0
-	nodamage = TRUE
 	range = 10
 	hitsound = 'sound/weapons/batonextend.ogg'
 	hitsound_wall = 'sound/weapons/batonextend.ogg'

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -164,7 +164,6 @@
 /obj/projectile/organ
 	name = "organ"
 	damage = 0
-	nodamage = TRUE
 	hitsound = 'sound/effects/attackblob.ogg'
 	hitsound_wall = 'sound/effects/attackblob.ogg'
 	/// A reference to the organ we "are".

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -57,7 +57,7 @@
 /obj/item/mod/module/stealth/proc/on_bullet_act(datum/source, obj/projectile/projectile)
 	SIGNAL_HANDLER
 
-	if(projectile.nodamage)
+	if(!projectile.is_hostile_projectile())
 		return
 	unstealth(source)
 

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -560,7 +560,6 @@
 	icon_state = "mine_bomb"
 	icon = 'icons/obj/clothing/modsuit/mod_modules.dmi'
 	damage = 0
-	nodamage = TRUE
 	range = 6
 	suppressed = SUPPRESSED_VERY
 	armor_flag = BOMB

--- a/code/modules/mod/modules/modules_timeline.dm
+++ b/code/modules/mod/modules/modules_timeline.dm
@@ -294,7 +294,6 @@
 	name = "eradication beam"
 	icon_state = "chronobolt"
 	range = CHRONO_BEAM_RANGE
-	nodamage = TRUE
 	///Reference to the tem... given by the tem! weakref because back in the day we didn't know about harddels- or maybe we didn't care.
 	var/datum/weakref/tem_weakref
 

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -76,7 +76,7 @@
 
 /obj/machinery/power/rtg/abductor/bullet_act(obj/projectile/Proj)
 	. = ..()
-	if(!going_kaboom && istype(Proj) && !Proj.nodamage && ((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE)))
+	if(!going_kaboom && istype(Proj) && Proj.damage > 0 && ((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE)))
 		log_bomber(Proj.firer, "triggered a", src, "explosion via projectile")
 		overload()
 

--- a/code/modules/projectiles/ammunition/caseless/foam.dm
+++ b/code/modules/projectiles/ammunition/caseless/foam.dm
@@ -39,7 +39,6 @@
 					return
 				FD.pen = A
 				FD.damage = 5
-				FD.nodamage = FALSE
 				to_chat(user, span_notice("You insert [A] into [src]."))
 			else
 				to_chat(user, span_warning("There's already something in [src]."))
@@ -52,7 +51,6 @@
 	var/obj/projectile/bullet/reusable/foam_dart/FD = loaded_projectile
 	if(FD.pen)
 		FD.damage = initial(FD.damage)
-		FD.nodamage = initial(FD.nodamage)
 		user.put_in_hands(FD.pen)
 		to_chat(user, span_notice("You remove [FD.pen] from [src]."))
 		FD.pen = null

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -551,7 +551,7 @@
 
 /obj/item/gun/ballistic/suicide_act(mob/living/user)
 	var/obj/item/organ/internal/brain/B = user.getorganslot(ORGAN_SLOT_BRAIN)
-	if (B && chambered && chambered.loaded_projectile && can_trigger_gun(user) && !chambered.loaded_projectile.nodamage)
+	if (B && chambered && chambered.loaded_projectile && can_trigger_gun(user) && chambered.loaded_projectile.damage > 0)
 		user.visible_message(span_suicide("[user] is putting the barrel of [src] in [user.p_their()] mouth. It looks like [user.p_theyre()] trying to commit suicide!"))
 		sleep(2.5 SECONDS)
 		if(user.is_holding(src))

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -298,7 +298,7 @@
 		var/obj/projectile/energy/loaded_projectile = E.loaded_projectile
 		if(!loaded_projectile)
 			. = ""
-		else if(loaded_projectile.nodamage || !loaded_projectile.damage || loaded_projectile.damage_type == STAMINA)
+		else if(loaded_projectile.damage <= 0 || loaded_projectile.damage_type == STAMINA)
 			user.visible_message(span_danger("[user] tries to light [A.loc == user ? "[user.p_their()] [A.name]" : A] with [src], but it doesn't do anything. Dumbass."))
 			playsound(user, E.fire_sound, 50, TRUE)
 			playsound(user, loaded_projectile.hitsound, 50, TRUE)

--- a/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -488,7 +488,7 @@
 
 /obj/projectile/beam/beam_rifle/proc/handle_hit(atom/target, piercing_hit = FALSE)
 	set waitfor = FALSE
-	if(damage <= 0)
+	if(!is_hostile_projectile())
 		return FALSE
 	playsound(src, 'sound/effects/explosion3.ogg', 100, TRUE)
 	if(!do_pierce)
@@ -499,6 +499,9 @@
 /obj/projectile/beam/beam_rifle/on_hit(atom/target, blocked = FALSE, piercing_hit = FALSE)
 	handle_hit(target, piercing_hit)
 	return ..()
+
+/obj/projectile/beam/beam_rifle/is_hostile_projectile()
+	return TRUE // on hit = boom fire
 
 /obj/projectile/beam/beam_rifle/hitscan
 	icon_state = ""
@@ -533,6 +536,9 @@
 	hitscan_light_intensity = 0
 	hitscan_light_color_override = "#99ff99"
 	reflectable = REFLECT_FAKEPROJECTILE
+
+/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/is_hostile_projectile()
+	return FALSE // just an aiming reticle
 
 /obj/projectile/beam/beam_rifle/hitscan/aiming_beam/prehit_pierce(atom/target)
 	return PROJECTILE_DELETE_WITHOUT_HITTING

--- a/code/modules/projectiles/guns/energy/beam_rifle.dm
+++ b/code/modules/projectiles/guns/energy/beam_rifle.dm
@@ -488,7 +488,7 @@
 
 /obj/projectile/beam/beam_rifle/proc/handle_hit(atom/target, piercing_hit = FALSE)
 	set waitfor = FALSE
-	if(nodamage)
+	if(damage <= 0)
 		return FALSE
 	playsound(src, 'sound/effects/explosion3.ogg', 100, TRUE)
 	if(!do_pierce)
@@ -527,7 +527,6 @@
 	name = "aiming beam"
 	hitsound = null
 	hitsound_wall = null
-	nodamage = TRUE
 	damage = 0
 	constant_tracer = TRUE
 	hitscan_light_range = 0

--- a/code/modules/projectiles/guns/special/blastcannon.dm
+++ b/code/modules/projectiles/guns/special/blastcannon.dm
@@ -292,7 +292,6 @@
 	name = "blast wave"
 	icon_state = "blastwave"
 	damage = 0
-	nodamage = FALSE
 	armor_flag = BOMB // Doesn't actually have any functional purpose. But it makes sense.
 	movement_type = FLYING
 	projectile_phasing = ALL // just blows up the turfs lmao
@@ -313,6 +312,10 @@
 	src.light_ex_range = light_ex_range
 	src.reactionary = reactionary
 	return ..()
+
+// Though the projectile itself is not damaging its effects are
+/obj/projectile/blastwave/is_hostile_projectile()
+	return TRUE
 
 /obj/projectile/blastwave/Range()
 	. = ..()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -145,7 +145,7 @@
 
 	var/damage = 10
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
-	var/nodamage = FALSE //Determines if the projectile will skip any damage inflictions
+
 	///Defines what armor to use when it hits things.  Must be set to bullet, laser, energy, or bomb
 	var/armor_flag = BULLET
 	///How much armor this projectile pierces.
@@ -264,7 +264,7 @@
 		hitx = target.pixel_x + rand(-8, 8)
 		hity = target.pixel_y + rand(-8, 8)
 
-	if(!nodamage && (damage_type == BRUTE || damage_type == BURN) && iswallturf(target_loca) && prob(75))
+	if(damage > 0 && (damage_type == BRUTE || damage_type == BURN) && iswallturf(target_loca) && prob(75))
 		var/turf/closed/wall/W = target_loca
 		if(impact_effect_type && !hitscan)
 			new impact_effect_type(target_loca, hitx, hity)
@@ -1074,3 +1074,17 @@
 		pain_stam_pct = (!isnull(embedding["pain_stam_pct"]) ? embedding["pain_stam_pct"] : EMBEDDED_PAIN_STAM_PCT),\
 		projectile_payload = shrapnel_type)
 	return TRUE
+
+/**
+ * Is this projectile considered "hostile"?
+ *
+ * By default all projectiles which deal damage or impart crowd control effects (including stamina) are hostile
+ */
+/obj/projectile/proc/is_hostile_projectile()
+	if(damage > 0 || stamina > 0)
+		return TRUE
+
+	if(paralyze + stun + immobilize + knockdown > 0 SECONDS)
+		return TRUE
+
+	return FALSE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1079,6 +1079,9 @@
  * Is this projectile considered "hostile"?
  *
  * By default all projectiles which deal damage or impart crowd control effects (including stamina) are hostile
+ *
+ * This is NOT used for pacifist checks, that's handled by [/obj/item/ammo_casing/var/harmful]
+ * This is used in places such as AI responses to determine if they're being threatened or not (among other places)
  */
 /obj/projectile/proc/is_hostile_projectile()
 	if(damage > 0 || stamina > 0)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -219,3 +219,6 @@
 	if(isopenturf(target) || isindestructiblewall(target))//shrunk floors wouldnt do anything except look weird, i-walls shouldn't be bypassable
 		return
 	target.AddComponent(/datum/component/shrink, shrink_time)
+
+/obj/projectile/beam/shrink/is_hostile_projectile()
+	return TRUE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -63,7 +63,6 @@
 /obj/projectile/beam/practice
 	name = "practice laser"
 	damage = 0
-	nodamage = TRUE
 
 /obj/projectile/beam/scatter
 	name = "laser pellet"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -3,7 +3,6 @@
 	icon_state = "bullet"
 	damage = 60
 	damage_type = BRUTE
-	nodamage = FALSE
 	armor_flag = BULLET
 	hitsound_wall = SFX_RICOCHET
 	sharpness = SHARP_POINTY

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -5,7 +5,6 @@
 	damage = 0
 	movement_type = FLYING
 	projectile_piercing = ALL
-	nodamage = TRUE
 	hitsound = 'sound/items/bikehorn.ogg'
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "banana"

--- a/code/modules/projectiles/projectile/energy/chameleon.dm
+++ b/code/modules/projectiles/projectile/energy/chameleon.dm
@@ -1,2 +1,5 @@
 /obj/projectile/energy/chameleon
-	nodamage = TRUE
+
+// Doesn't deal any damage or has any side effects.
+/obj/projectile/energy/chameleon/is_hostile_projectile()
+	return FALSE

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -3,7 +3,6 @@
 	icon_state = "cbbolt"
 	damage = 15
 	damage_type = TOX
-	nodamage = FALSE
 	stamina = 60
 	eyeblur = 10
 	knockdown = 10

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -61,7 +61,6 @@
 /obj/projectile/energy/trap
 	name = "energy snare"
 	icon_state = "e_snare"
-	nodamage = TRUE
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 4
 
@@ -80,8 +79,6 @@
 /obj/projectile/energy/trap/cyborg
 	name = "Energy Bola"
 	icon_state = "e_snare"
-	nodamage = TRUE
-	paralyze = 0
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
 

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -2,8 +2,7 @@
 	name = "electrode"
 	icon_state = "spark"
 	color = "#FFFF00"
-	nodamage = FALSE
-	paralyze = 100
+	paralyze = 10 SECONDS
 	stutter = 10 SECONDS
 	jitter = 40 SECONDS
 	hitsound = 'sound/weapons/taserhit.ogg'

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -1,9 +1,8 @@
 /obj/projectile/magic
 	name = "bolt"
 	icon_state = "energy"
-	damage = 0
+	damage = 0 // MOST magic projectiles pass the "not a hostile projectile" test, despite many having negative effects
 	damage_type = OXY
-	nodamage = TRUE
 	armour_penetration = 100
 	armor_flag = NONE
 	/// determines what type of antimagic can block the spell projectile
@@ -57,9 +56,6 @@
 /obj/projectile/magic/resurrection
 	name = "bolt of resurrection"
 	icon_state = "ion"
-	damage = 0
-	damage_type = OXY
-	nodamage = TRUE
 
 /obj/projectile/magic/resurrection/on_hit(atom/target)
 	. = ..()
@@ -86,9 +82,6 @@
 /obj/projectile/magic/teleport
 	name = "bolt of teleportation"
 	icon_state = "bluespace"
-	damage = 0
-	damage_type = OXY
-	nodamage = TRUE
 	var/inner_tele_radius = 0
 	var/outer_tele_radius = 6
 
@@ -110,9 +103,6 @@
 /obj/projectile/magic/safety
 	name = "bolt of safety"
 	icon_state = "bluespace"
-	damage = 0
-	damage_type = OXY
-	nodamage = TRUE
 
 /obj/projectile/magic/safety/on_hit(atom/target)
 	. = ..()
@@ -131,9 +121,6 @@
 /obj/projectile/magic/door
 	name = "bolt of door creation"
 	icon_state = "energy"
-	damage = 0
-	damage_type = OXY
-	nodamage = TRUE
 	var/list/door_types = list(/obj/structure/mineral_door/wood, /obj/structure/mineral_door/iron, /obj/structure/mineral_door/silver, /obj/structure/mineral_door/gold, /obj/structure/mineral_door/uranium, /obj/structure/mineral_door/sandstone, /obj/structure/mineral_door/transparent/plasma, /obj/structure/mineral_door/transparent/diamond)
 
 /obj/projectile/magic/door/on_hit(atom/target)
@@ -160,9 +147,7 @@
 /obj/projectile/magic/change
 	name = "bolt of change"
 	icon_state = "ice_1"
-	damage = 0
 	damage_type = BURN
-	nodamage = TRUE
 	/// If set, this projectile will only do a certain wabbajack effect
 	var/set_wabbajack_effect
 	/// If set, this projectile will only pass certain changeflags to wabbajack
@@ -184,9 +169,7 @@
 /obj/projectile/magic/animate
 	name = "bolt of animation"
 	icon_state = "red_1"
-	damage = 0
 	damage_type = BURN
-	nodamage = TRUE
 
 /obj/projectile/magic/animate/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -232,20 +215,17 @@
 	damage = 15
 	damage_type = BURN
 	dismemberment = 50
-	nodamage = FALSE
 
 /obj/projectile/magic/arcane_barrage
 	name = "arcane bolt"
 	icon_state = "arcane_barrage"
 	damage = 20
 	damage_type = BURN
-	nodamage = FALSE
 	hitsound = 'sound/weapons/barragespellhit.ogg'
 
 /obj/projectile/magic/locker
 	name = "locker bolt"
 	icon_state = "locker"
-	nodamage = TRUE
 	var/weld = TRUE
 	var/created = FALSE //prevents creation of more then one locker if it has multiple hits
 	var/locker_suck = TRUE
@@ -498,7 +478,6 @@
 	icon_state = "tesla_projectile" //Better sprites are REALLY needed and appreciated!~
 	damage = 15
 	damage_type = BURN
-	nodamage = FALSE
 	speed = 0.3
 
 	/// The power of the zap itself when it electrocutes someone
@@ -533,7 +512,6 @@
 	icon_state = "fireball"
 	damage = 10
 	damage_type = BRUTE
-	nodamage = FALSE
 
 	/// Heavy explosion range of the fireball
 	var/exp_heavy = 0
@@ -573,7 +551,6 @@
 	pixel_speed_multiplier = 0.2
 	trigger_range = 0
 	can_only_hit_target = TRUE
-	nodamage = FALSE
 	paralyze = 6 SECONDS
 	hitsound = 'sound/magic/mm_hit.ogg'
 
@@ -600,7 +577,7 @@
 	speed = 1
 	pixel_speed_multiplier = 1/7
 
-/obj/projectile/magic/spell/juggernaut/on_hit(atom/target, blocked)
+/obj/projectile/magic/aoe/juggernaut/on_hit(atom/target, blocked)
 	. = ..()
 	var/turf/target_turf = get_turf(src)
 	playsound(target_turf, 'sound/weapons/resonator_blast.ogg', 100, FALSE)
@@ -619,9 +596,7 @@
 /obj/projectile/temp/chill
 	name = "bolt of chills"
 	icon_state = "ice_2"
-	damage = 0
 	damage_type = BURN
-	nodamage = FALSE
 	armour_penetration = 100
 	temperature = -200 // Cools you down greatly per hit
 
@@ -634,5 +609,4 @@
 	icon_state = "spellcard"
 	damage_type = BURN
 	damage = 2
-	nodamage = FALSE
 	antimagic_charge_cost = 0 // since the cards gets spammed like a shotgun

--- a/code/modules/projectiles/projectile/reusable/foam_dart.dm
+++ b/code/modules/projectiles/projectile/reusable/foam_dart.dm
@@ -3,7 +3,6 @@
 	desc = "I hope you're wearing eye protection."
 	damage = 0 // It's a damn toy.
 	damage_type = OXY
-	nodamage = TRUE
 	icon = 'icons/obj/weapons/guns/toy.dmi'
 	icon_state = "foamdart_proj"
 	base_icon_state = "foamdart_proj"
@@ -27,7 +26,6 @@
 		pen.forceMove(newdart)
 		pen = null
 		newdart.damage = 5
-		newdart.nodamage = FALSE
 	newdart.update_appearance()
 
 
@@ -40,5 +38,4 @@
 	icon_state = "foamdart_riot_proj"
 	base_icon_state = "foamdart_riot_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
-	nodamage = FALSE
 	stamina = 25

--- a/code/modules/projectiles/projectile/special/floral.dm
+++ b/code/modules/projectiles/projectile/special/floral.dm
@@ -3,7 +3,6 @@
 	icon_state = "energy"
 	damage = 0
 	damage_type = TOX
-	nodamage = TRUE
 	armor_flag = ENERGY
 
 /obj/projectile/energy/floramut/on_hit(atom/target, blocked = FALSE)
@@ -33,7 +32,6 @@
 	icon_state = "energy2"
 	damage = 0
 	damage_type = TOX
-	nodamage = TRUE
 	armor_flag = ENERGY
 
 /obj/projectile/energy/florayield/on_hit(atom/target, blocked = FALSE)
@@ -48,7 +46,6 @@
 	icon_state = "energy3"
 	damage = 0
 	damage_type = TOX
-	nodamage = TRUE
 	armor_flag = ENERGY
 
 /obj/projectile/energy/florarevolution/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/projectiles/projectile/special/gravity.dm
+++ b/code/modules/projectiles/projectile/special/gravity.dm
@@ -5,7 +5,6 @@
 	hitsound = 'sound/weapons/wave.ogg'
 	damage = 0
 	damage_type = BRUTE
-	nodamage = TRUE
 	color = "#33CCFF"
 	var/turf/T
 	var/power = 4
@@ -40,7 +39,6 @@
 	hitsound = 'sound/weapons/wave.ogg'
 	damage = 0
 	damage_type = BRUTE
-	nodamage = TRUE
 	color = "#FF6600"
 	var/turf/T
 	var/power = 4
@@ -74,7 +72,6 @@
 	hitsound = 'sound/weapons/wave.ogg'
 	damage = 0
 	damage_type = BRUTE
-	nodamage = TRUE
 	color = "#101010"
 	var/turf/T
 	var/power = 4

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -3,7 +3,6 @@
 	icon_state = "ion"
 	damage = 0
 	damage_type = BURN
-	nodamage = TRUE
 	armor_flag = ENERGY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
 	var/emp_radius = 1

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -3,15 +3,14 @@
 	icon_state = "neurotoxin"
 	damage = 5
 	damage_type = TOX
-	nodamage = FALSE
 	paralyze = 10 SECONDS
 	armor_flag = BIO
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/neurotoxin
 
 /obj/projectile/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))
-		paralyze = 0
-		nodamage = TRUE
+		paralyze = 0 SECONDS
+		damage = 0
 	return ..()
 
 /obj/projectile/neurotoxin/damaging //for ai controlled aliums

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -3,9 +3,11 @@
 	icon_state = "ice_2"
 	damage = 0
 	damage_type = BURN
-	nodamage = FALSE
 	armor_flag = ENERGY
 	var/temperature = -50 // reduce the body temperature by 50 points
+
+/obj/projectile/temp/is_hostile_projectile()
+	return temperature != 0 // our damage is done by cooling or heating (casting to boolean here)
 
 /obj/projectile/temp/on_hit(atom/target, blocked = 0)
 	. = ..()

--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -3,7 +3,6 @@
 	icon_state = "spark"
 	hitsound = SFX_SPARKS
 	damage = 0
-	nodamage = TRUE
 	pass_flags = PASSGLASS | PASSTABLE | PASSGRILLE | PASSMOB
 	//Weakref to the thing that shot us
 	var/datum/weakref/gun

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -32,7 +32,9 @@
 
 /obj/item/reagent_containers/cup/glass/bullet_act(obj/projectile/P)
 	. = ..()
-	if(!(P.nodamage) && P.damage_type == BRUTE && !QDELETED(src))
+	if(QDELETED(src))
+		return
+	if(P.damage > 0 && P.damage_type == BRUTE)
 		var/atom/T = get_turf(src)
 		smash(T)
 

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -73,7 +73,9 @@
 
 /obj/item/reagent_containers/cup/soda_cans/bullet_act(obj/projectile/P)
 	. = ..()
-	if(!(P.nodamage) && P.damage_type == BRUTE && !QDELETED(src))
+	if(QDELETED(src))
+		return
+	if(P.damage > 0 && P.damage_type == BRUTE)
 		var/obj/item/trash/can/crushed_can = new /obj/item/trash/can(src.loc)
 		crushed_can.icon_state = icon_state
 		var/atom/throw_target = get_edge_target_turf(crushed_can, pick(GLOB.alldirs))

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -265,10 +265,12 @@
 
 /obj/structure/reagent_dispensers/fueltank/bullet_act(obj/projectile/P)
 	. = ..()
-	if(!QDELETED(src)) //wasn't deleted by the projectile's effects.
-		if(!P.nodamage && ((P.damage_type == BURN) || (P.damage_type == BRUTE)))
-			log_bomber(P.firer, "detonated a", src, "via projectile")
-			boom()
+	if(QDELETED(src)) //wasn't deleted by the projectile's effects.
+		return
+
+	if(P.damage > 0 && ((P.damage_type == BURN) || (P.damage_type == BRUTE)))
+		log_bomber(P.firer, "detonated a", src, "via projectile")
+		boom()
 
 /obj/structure/reagent_dispensers/fueltank/attackby(obj/item/I, mob/living/user, params)
 	if(I.tool_behaviour == TOOL_WELDER)

--- a/code/modules/religion/honorbound/honorbound_trauma.dm
+++ b/code/modules/religion/honorbound/honorbound_trauma.dm
@@ -149,9 +149,9 @@
 	))
 	if(!is_type_in_typecache(proj, guilty_projectiles))
 		return
-	if((proj.damage_type == STAMINA))
+	if(proj.damage_type == STAMINA || !proj.is_hostile_projectile())
 		return
-	if(!proj.nodamage && proj.damage < shot_honorbound.health && isliving(proj.firer))
+	if(proj.damage > 0 && proj.damage < shot_honorbound.health && isliving(proj.firer))
 		guilty(proj.firer)
 
 /datum/brain_trauma/special/honorbound/proc/thrown_guilt(datum/source, atom/movable/thrown_movable, skipcatch = FALSE, hitpush = TRUE, blocked = FALSE, datum/thrownthing/throwingdatum)

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -125,9 +125,6 @@ Slimecrossing Weapons
 /obj/projectile/magic/bloodchill
 	name = "blood ball"
 	icon_state = "pulse0_bl"
-	damage = 0
-	damage_type = OXY
-	nodamage = TRUE
 	hitsound = 'sound/effects/splat.ogg'
 
 /obj/projectile/magic/bloodchill/on_hit(mob/living/target)

--- a/code/modules/wiremod/shell/gun.dm
+++ b/code/modules/wiremod/shell/gun.dm
@@ -26,7 +26,6 @@
 /obj/projectile/energy/wiremod_gun
 	name = "scanning beam"
 	icon_state = "energy"
-	nodamage = TRUE
 	damage = 0
 	range = 7
 


### PR DESCRIPTION
## About The Pull Request

- Juggernaut and Rust Walker projectiles were subtyped off of magic, which is `nodamage`.

- The juggernaut actually had a copy+paste error with their type `on_hit` which caused none of their special effects on hit ("relative patching catches this")

- Then I realized projectiles have this var `nodamage` which is, for all intents and purposes, just `damage > 0`. it's not checked for pacifism, it's just that. This is dumb. So very dumb, so I removed it. 
    - There are, however, a few situations which used it in a unique way, such as the blast wave cannon. This is why I replaced it with a proc, `is_hostile_projectile`, for certain situations to actually find out if the projectile is damaging. Projectiles can override this on a per type basis by default, damaging projectiles = hostile. 
    - This has a chance to break some things, but I ... kinda doubt it will. 

Fixes #73756

## Why It's Good For The Game

Projectiles that act as they should, less dumb vars

## Changelog

:cl: Melbert
fix: Fixes Juggernaut / Rust Walker projectiles doing zero damage
fix: Fixes Juggernaut projectiles not doing bonus damage to nearby structures
code: Removed projectile nodamage var, replaces it with just checking for damage 
/:cl:

