### PR TITLE
Fixes slime processor taking in slimes from behind glass panes/otherwise blocked locations

### DIFF
--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -207,12 +207,11 @@
 		return
 	var/mob/living/simple_animal/slime/picked_slime
 	for(var/mob/living/simple_animal/slime/slime in range(1,src))
-		if(slime.loc == src)
+		if(!CanReach(slime)) //don't take slimes behind glass panes or somesuch; also makes it ignore slimes inside the processor
 			continue
-		if(isslime(slime))
-			if(slime.stat)
-				picked_slime = slime
-				break
+		if(slime.stat)
+			picked_slime = slime
+			break
 	if(!picked_slime)
 		return
 	var/datum/food_processor_process/recipe = PROCESSOR_SELECT_RECIPE(picked_slime)


### PR DESCRIPTION
## About The Pull Request
Title; also removes an unnecessary `isslime` check

## Why It's Good For The Game
Fixes #42334

## Changelog
:cl:
fix: slime processor no longer sucks in slimes that it can't reach (glass panes, blocked by other machines etc)
/:cl:
