### PR TITLE
[NO GBP] Fixes some major (and minor) issues with the birthday station trait.

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -204,6 +204,7 @@
 	var/birthday_person_name = ""
 	///Variable that admins can override with a player's ckey in order to set them as the birthday person when the round starts.
 	var/birthday_override_ckey
+	force = TRUE
 
 /datum/station_trait/birthday/New()
 	. = ..()
@@ -273,11 +274,15 @@
 		/obj/item/storage/box/tail_pin = 1,
 	))
 	toy = new toy(spawned_mob)
-	spawned_mob.equip_to_slot_or_del(toy, ITEM_SLOT_BACKPACK)
+	if(istype(toy, /obj/item/toy/balloon))
+		spawned_mob.equip_to_slot_or_del(toy, ITEM_SLOT_HANDS) //Balloons do not fit inside of backpacks.
+	else
+		spawned_mob.equip_to_slot_or_del(toy, ITEM_SLOT_BACKPACK)
 	if(birthday_person_name) //Anyone who joins after the annoucement gets one of these.
 		var/obj/item/birthday_invite/birthday_invite = new(spawned_mob)
 		birthday_invite.setup_card(birthday_person_name)
-		spawned_mob.equip_to_slot_or_del(birthday_invite, ITEM_SLOT_HANDS)
+		if(!spawned_mob.equip_to_slot_if_possible(birthday_invite, ITEM_SLOT_HANDS, disable_warning))
+			spawned_mob.equip_to_slot_or_del(birthday_invite, ITEM_SLOT_BACKPACK) //Just incase someone spawns with both hands full.
 
 /obj/item/birthday_invite
 	name = "birthday invitation"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -204,7 +204,6 @@
 	var/birthday_person_name = ""
 	///Variable that admins can override with a player's ckey in order to set them as the birthday person when the round starts.
 	var/birthday_override_ckey
-	force = TRUE
 
 /datum/station_trait/birthday/New()
 	. = ..()

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -200,6 +200,8 @@
 	blacklist = list(/datum/station_trait/announcement_intern, /datum/station_trait/announcement_medbot) //Overiding the annoucer hides the birthday person in the annoucement message.
 	///Variable that stores a reference to the person selected to have their birthday celebrated.
 	var/mob/living/carbon/human/birthday_person
+	///Variable that holds the real name of the birthday person once selected, just incase the birthday person's real_name changes.
+	var/birthday_person_name
 	///Variable that admins can override with a player's ckey in order to set them as the birthday person when the round starts.
 	var/birthday_override_ckey
 
@@ -219,11 +221,12 @@
 			message_admins("Attempted to make [birthday_override_ckey] the birthday person but they are not a valid station role. A random birthday person has be selected instead.")		
 
 	if(!birthday_person)
-		var/list/birthday_options
+		var/list/birthday_options = list()
 		for(var/mob/living/carbon/human/human in GLOB.human_list)
 			if(human.mind?.assigned_role.job_flags & JOB_CREW_MEMBER)
-				birthday_options += human
+				birthday_options.Add(human)
 		birthday_person = pick(birthday_options)
+		birthday_person_name = birthday_person?.real_name
 	addtimer(CALLBACK(src, PROC_REF(announce_birthday)), 10 SECONDS)
 
 /datum/station_trait/birthday/proc/check_valid_override()
@@ -241,8 +244,8 @@
 
 
 /datum/station_trait/birthday/proc/announce_birthday()
-	report_message = "We here at Nanotrasen would all like to wish [birthday_person ? birthday_person.name : "Employee Name"] a very happy birthday"
-	priority_announce("Happy birthday to [birthday_person ? birthday_person.name : "Employee Name"]! Nanotrasen wishes you a very happy [birthday_person ? thtotext(birthday_person.age + 1) : "255th"] birthday.")
+	report_message = "We here at Nanotrasen would all like to wish [birthday_person ? birthday_person_name : "Employee Name"] a very happy birthday"
+	priority_announce("Happy birthday to [birthday_person ? birthday_person_name : "Employee Name"]! Nanotrasen wishes you a very happy [birthday_person ? thtotext(birthday_person.age + 1) : "255th"] birthday.")
 	if(birthday_person)
 		playsound(birthday_person, 'sound/items/party_horn.ogg', 50)
 		birthday_person.add_mood_event("birthday", /datum/mood_event/birthday)
@@ -270,7 +273,7 @@
 	spawned_mob.equip_to_slot_or_del(toy, ITEM_SLOT_BACKPACK)
 	if(birthday_person) //Anyone who joins after the annoucement gets one of these.
 		var/obj/item/birthday_invite/birthday_invite = new(spawned_mob)
-		birthday_invite.setup_card(birthday_person.name)
+		birthday_invite.setup_card(birthday_person_name)
 		spawned_mob.equip_to_slot_or_del(birthday_invite, ITEM_SLOT_HANDS)
 
 /obj/item/birthday_invite

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -201,7 +201,7 @@
 	///Variable that stores a reference to the person selected to have their birthday celebrated.
 	var/mob/living/carbon/human/birthday_person
 	///Variable that holds the real name of the birthday person once selected, just incase the birthday person's real_name changes.
-	var/birthday_person_name
+	var/birthday_person_name = ""
 	///Variable that admins can override with a player's ckey in order to set them as the birthday person when the round starts.
 	var/birthday_override_ckey
 
@@ -225,8 +225,9 @@
 		for(var/mob/living/carbon/human/human in GLOB.human_list)
 			if(human.mind?.assigned_role.job_flags & JOB_CREW_MEMBER)
 				birthday_options += human
-		birthday_person = pick(birthday_options)
-		birthday_person_name = birthday_person?.real_name
+		if(length(birthday_options))
+			birthday_person = pick(birthday_options)
+			birthday_person_name = birthday_person.real_name
 	addtimer(CALLBACK(src, PROC_REF(announce_birthday)), 10 SECONDS)
 
 /datum/station_trait/birthday/proc/check_valid_override()
@@ -238,6 +239,7 @@
 
 	if(birthday_override_mob.mind?.assigned_role.job_flags & JOB_CREW_MEMBER)
 		birthday_person = birthday_override_mob
+		birthday_person_name = birthday_person.real_name
 		return TRUE
 	else
 		return FALSE
@@ -249,6 +251,7 @@
 	if(birthday_person)
 		playsound(birthday_person, 'sound/items/party_horn.ogg', 50)
 		birthday_person.add_mood_event("birthday", /datum/mood_event/birthday)
+		birthday_person = null
 
 /datum/station_trait/birthday/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned_mob)
 	SIGNAL_HANDLER
@@ -271,7 +274,7 @@
 	))
 	toy = new toy(spawned_mob)
 	spawned_mob.equip_to_slot_or_del(toy, ITEM_SLOT_BACKPACK)
-	if(birthday_person) //Anyone who joins after the annoucement gets one of these.
+	if(birthday_person_name) //Anyone who joins after the annoucement gets one of these.
 		var/obj/item/birthday_invite/birthday_invite = new(spawned_mob)
 		birthday_invite.setup_card(birthday_person_name)
 		spawned_mob.equip_to_slot_or_del(birthday_invite, ITEM_SLOT_HANDS)

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -280,7 +280,7 @@
 	if(birthday_person_name) //Anyone who joins after the annoucement gets one of these.
 		var/obj/item/birthday_invite/birthday_invite = new(spawned_mob)
 		birthday_invite.setup_card(birthday_person_name)
-		if(!spawned_mob.equip_to_slot_if_possible(birthday_invite, ITEM_SLOT_HANDS, disable_warning))
+		if(!spawned_mob.equip_to_slot_if_possible(birthday_invite, ITEM_SLOT_HANDS, disable_warning = TRUE))
 			spawned_mob.equip_to_slot_or_del(birthday_invite, ITEM_SLOT_BACKPACK) //Just incase someone spawns with both hands full.
 
 /obj/item/birthday_invite

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -224,7 +224,7 @@
 		var/list/birthday_options = list()
 		for(var/mob/living/carbon/human/human in GLOB.human_list)
 			if(human.mind?.assigned_role.job_flags & JOB_CREW_MEMBER)
-				birthday_options.Add(human)
+				birthday_options += human
 		birthday_person = pick(birthday_options)
 		birthday_person_name = birthday_person?.real_name
 	addtimer(CALLBACK(src, PROC_REF(announce_birthday)), 10 SECONDS)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -378,6 +378,7 @@
 	current_range = 2
 	spray_range = 2
 	spray_sound = 'sound/effects/snap.ogg'
+	possible_transfer_amounts = list(5)
 
 /obj/item/reagent_containers/spray/chemsprayer/party/spray(atom/A, mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

I've identified several issues, this PR fixes the 2 major ones so the event actually functions, I'll have fixes up for the others up soon.
The birthday trait now works if a crew has more than 1 person on it.
Birthday invitations are no longer omnipotent and cannot be used to identify lings who've changed identities.

Minor Issues also fixed:
A reference to the birthday person is no longer held longer than needed.
The party popper cannot have its spray amount changed anymore.
Balloons spawn in hands instead of backpacks since they don't fit into backpacks.
Jobs that have both hands full still get an invite (Only really matters for MDs who either get a balloon or are dullahans) 

## Why It's Good For The Game

Peoples birthdays are being ruined.
## Changelog
:cl:
fix: The birthday station trait now actually works.
/:cl:
