### PR TITLE
Completing experiments after their associated nodes have been researched gives back a partial refund of the discount lost

### DIFF
--- a/code/modules/experisci/experiment/types/experiment.dm
+++ b/code/modules/experisci/experiment/types/experiment.dm
@@ -83,6 +83,6 @@
  */
 /datum/experiment/proc/finish_experiment(datum/component/experiment_handler/experiment_handler)
 	completed = TRUE
-	experiment_handler.announce_message_to_all("The [name] has been completed!")
 	experiment_handler.selected_experiment = null
-	experiment_handler.linked_web.complete_experiment(src)
+	var/announcetext = experiment_handler.linked_web.complete_experiment(src)
+	experiment_handler.announce_message_to_all(announcetext)

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -38,13 +38,13 @@
 	var/list/discovered_mutations = list()
 	/// Assoc list, id = number, 1 is available, 2 is all reqs are 1, so on
 	var/list/tiers = list()
-	/// This is a list of all incomplete experiment datums that are accessible for scienttists to complete
+	/// This is a list of all incomplete experiment datums that are accessible for scientists to complete
 	var/list/datum/experiment/available_experiments = list()
 	/// A list of all experiment datums that have been complete
 	var/list/datum/experiment/completed_experiments = list()
 	/// Assoc list of all experiment datums that have been skipped, to tech point reward for completing them -
 	/// That is, upon researching a node without completing its associated discounts, their experiments go here.
-	/// Completing these experiements will have a refund.
+	/// Completing these experiments will have a refund.
 	var/list/datum/experiment/skipped_experiment_types = list()
 
 	/// If science researches something without completing its discount experiments,
@@ -339,7 +339,7 @@
 	//Add to our researched list
 	researched_nodes[node.id] = TRUE
 
-	// Track any experiemnts we skipped relating to this
+	// Track any experiments we skipped relating to this
 	for(var/missed_experiment in node.discount_experiments)
 		if(completed_experiments[missed_experiment] || skipped_experiment_types[missed_experiment])
 			continue

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -305,11 +305,12 @@
 	completed_experiments[completed_experiment.type] = completed_experiment
 
 	var/result_text = "[completed_experiment] has been completed"
-	var/refund = skipped_experiment_types[completed_experiment.type]
-	if(refund)
+	var/refund = skipped_experiment_types[completed_experiment.type] || 0
+	if(refund > 0)
 		add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = refund))
 		result_text += ", refunding [refund] points."
-		skipped_experiment_types[completed_experiment.type] = -1 // Nothing more to gain here
+		// Nothing more to gain here, but we keep it in the list to prevent double dipping
+		skipped_experiment_types[completed_experiment.type] = -1
 	else
 		result_text += "!"
 

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -332,9 +332,9 @@
 			return FALSE
 	var/log_message = "[id]/[organization] researched node [node.id]"
 	if(auto_adjust_cost)
-		var/node_cost = node.get_price(src)
+		var/list/node_cost = node.get_price(src)
 		remove_point_list(node_cost)
-		log_message += " at the cost of [node_cost]"
+		log_message += " at the cost of [json_encode(node_cost)]"
 
 	//Add to our researched list
 	researched_nodes[node.id] = TRUE


### PR DESCRIPTION
## About The Pull Request

So we're like simultaneously moving two vague directions with research. One being "experisci grants discounts for prohibitively expensive nodes so you want to do the experiments to discount them" and the other being "Let's give Heads of Staff a way to research anything they want without any communication to the research department, including the very expensive nodes that scientists may be working on" 

You already see the issue, right? You can't have your cake and eat it too.

It sucks for scientists to be working on a complex experiment like weapons tech for that huge 90% discount only for the HoS to stumble onto the bridge and research it anyways. Your time is wasted and RND is slowed down massively. 

We can do something to assuage that.

This PR makes it so completing an experiment which discounts already completed nodes will refund a partial amount of the discount that would've applied.

For example, researching industrial engineering without scanning the iron toilets will refund ~5000 points. 

This can only apply once per experiment, so if an experiment discounts multiple technologies, they will only get a refund based on the first technology researched. 

## Why It's Good For The Game

This accomplishes the following: 

- Expensive research nodes with difficult experiments remain expensive without completing the experiments. If no one does the experiment, they act the same as before. 
- Expensive research nodes with very easy experiments (but time consuming) no longer put RND on a time crunch to beat the itchy trigger finger of the Heads of Staff. Stuff like scanning lathes allow the scientists to work more at their own pace: they can talk to people or maybe stop at the bar or kitchen between departments without feeling pressure to get it done urgently. 
- Scientists are able to complete experiments which previously were no longer deemed relevant if they need a point injection. Experiments left behind are no longer completely useless bricks. Maybe even gives latejoin scientists something to do.
- Scientists mid experiment can still complete it to not feel like their time is wasted. 

Overall I think this has many benefits to the current science system where many have complaints.

## Changelog

:cl: Melbert
qol: Completing an experiment which discounts a researched tech node will give a partial refund of the discount lost. For example, researching the industrial engineering research without scanning iron toilets will refund ~5000 points if you complete it afterwards. This only applies once per experiment, so experiments which discount multiple nodes only refund the first researched.
/:cl:
