### PR TITLE
Mimes can no longer remake a vow of silence after breaking it

### DIFF
--- a/code/modules/spells/spell_types/pointed/finger_guns.dm
+++ b/code/modules/spells/spell_types/pointed/finger_guns.dm
@@ -5,7 +5,7 @@
 	background_icon_state = "bg_mime"
 	overlay_icon_state = "bg_mime_border"
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
-	button_icon_state = "finger_guns0"
+	button_icon_state = "finger_guns"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED
 	panel = "Mime"
 	sound = null

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -13,6 +13,8 @@
 
 	spell_max_level = 1
 
+	var/popup = FALSE // is the confirmation window open?
+
 /datum/action/cooldown/spell/vow_of_silence/Grant(mob/living/grant_to)
 	. = ..()
 	ADD_TRAIT(grant_to, TRAIT_MIMING, "[type]")
@@ -24,6 +26,13 @@
 
 /datum/action/cooldown/spell/vow_of_silence/cast(mob/living/carbon/human/cast_on)
 	. = ..()
+	if(popup)
+		return FALSE
+	popup = TRUE
+	var/response = tgui_alert(cast_on, "Are you sure you want to break your vow of silence? This will remove your mime abilities!", "Break Vow of Silence Confirmation", list("Yes", "No"))
+	popup = FALSE
+	if(response != "Yes")
+		return FALSE
 	var/datum/action/cooldown/spell/vow_of_silence/vow = locate() in cast_on.actions
 	vow.Remove(cast_on)
 	to_chat(cast_on, span_notice("You break your vow of silence."))

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -1,6 +1,6 @@
 /datum/action/cooldown/spell/vow_of_silence
 	name = "Speech"
-	desc = "Make (or break) a vow of silence."
+	desc = "Break a vow of silence."
 	background_icon_state = "bg_mime"
 	overlay_icon_state = "bg_mime_border"
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
@@ -13,23 +13,20 @@
 
 	spell_max_level = 1
 
-/datum/action/cooldown/spell/vow_of_silence/Grant(mob/grant_to)
+/datum/action/cooldown/spell/vow_of_silence/Grant(mob/living/grant_to)
 	. = ..()
 	ADD_TRAIT(grant_to, TRAIT_MIMING, "[type]")
+	grant_to.clear_mood_event("vow")
 
-/datum/action/cooldown/spell/vow_of_silence/Remove(mob/living/remove_from)
+/datum/action/cooldown/spell/vow_of_silence/Remove(mob/remove_from)
 	. = ..()
 	REMOVE_TRAIT(remove_from, TRAIT_MIMING, "[type]")
-	remove_from.clear_mood_event("vow")
 
 /datum/action/cooldown/spell/vow_of_silence/cast(mob/living/carbon/human/cast_on)
 	. = ..()
-	if(HAS_TRAIT_FROM(cast_on, TRAIT_MIMING, "[type]"))
-		to_chat(cast_on, span_notice("You break your vow of silence."))
-		cast_on.add_mood_event("vow", /datum/mood_event/broken_vow)
-		REMOVE_TRAIT(cast_on, TRAIT_MIMING, "[type]")
-	else
-		to_chat(cast_on, span_notice("You make a vow of silence."))
-		cast_on.clear_mood_event("vow")
-		ADD_TRAIT(cast_on, TRAIT_MIMING, "[type]")
+	var/datum/action/cooldown/spell/vow_of_silence/vow = locate() in cast_on.actions
+	vow.Remove(cast_on)
+	to_chat(cast_on, span_notice("You break your vow of silence."))
+	cast_on.add_mood_event("vow", /datum/mood_event/broken_vow)
+	cast_on.log_message("broke their vow of silence.", LOG_GAME)
 	cast_on.update_mob_action_buttons()

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -29,7 +29,7 @@
 	if(popup)
 		return FALSE
 	popup = TRUE
-	var/response = tgui_alert(cast_on, "Are you sure you want to break your vow of silence? This will remove your mime abilities!", "Break Vow of Silence Confirmation", list("Yes", "No"))
+	var/response = tgui_alert(cast_on, "Are you sure you want to break your vow of silence? This will disable your mimery abilities!", "Break Vow of Silence Confirmation", list("Yes", "No"))
 	popup = FALSE
 	if(response != "Yes")
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
I think being able to have your mime powers after waiting just 5 minutes kind of defeats the point of not being able to talk as mime. It's supposed to be a tradeoff where you get cool powers in exchange for not being able to talk. I assumed it was permanent already, but [I just found out that it wasn't](https://tgstation13.org/phpBB/viewtopic.php?f=33&t=33526) so I decided to change it. 

Also adds logging to breaking the vow. It seemed strange that it wasn't logged, but maybe it's not important enough to be logged or it's already logged somehow? Let me know. 

Also fixes the finger gun icon being an error

## Why It's Good For The Game
Breaking vow of silence is now permanent and mimes have to live with their decisions. Breaking the vow has an actual consequence of permanently losing abilities instead of just 5 minutes without them. Makes things more challenging for traitor mimes as they can't get their advanced mime abilities back after talking. (Although if they didn't read both books they can read one of them to get the abilities back, since reading the books adds another vow of silence. Maybe that should be removed too?)
## Changelog
:cl:
balance: Mimes can no longer make a vow of silence after breaking it
admin: Mimes breaking vows is now logged
fix: Fixes icon for mime finger gun ability
/:cl:
