### PR TITLE
Buff Abductor Spawn Weight From 2 to 4

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -636,7 +636,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 2
 	required_applicants = 2
-	weight = 2
+	weight = 4
 	cost = 7
 	minimum_players = 25
 	repeatable = TRUE


### PR DESCRIPTION
## About The Pull Request

This PR buffs abductor spawn weight from 2 to 4. With this, abductors have the same weight as revenant and most other light midround antagonists, and matches their spawn weight prior to getting moved to being light weight antagonists as opposed to heavy.

## Why It's Good For The Game

Abductors in my opinion are currently needlessly too rare. This will resolve the issue.

## Changelog

:cl:
balance: Abductors' midround spawn weight has been increased. Expect to see them more often
/:cl: