### PR TITLE
Fixes some tramstation access issues/oversights

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11678,10 +11678,10 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Tech Storage"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "ckM" = (
@@ -35057,7 +35057,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Freezer Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/greater)
 "lgo" = (
@@ -35723,8 +35723,8 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "Secure Tech Storage"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/turf_decal/trimline/white/filled/line,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "luP" = (


### PR DESCRIPTION

## About The Pull Request

Engineers could access service lathe via maintenance, this changes the maint airlock for the service lathe to be service employees only.
Engineers and roboticists could access secure tech storage (the room with the spare comms console and upload board), this has been changed to command staff only as other maps do it.
## Why It's Good For The Game

Pretty sure these are oversights.
## Changelog
:cl:
fix: Some airlock access oversights on tramstation have been fixed. The service lathe cannot be accessed by jobs that shouldn't have access via maint and robo/engi's cant get into secure tech storage.
/:cl:
