### PR TITLE
Fixes mime finger gun icon and adds logging to vow of silence

### DIFF
--- a/code/modules/spells/spell_types/pointed/finger_guns.dm
+++ b/code/modules/spells/spell_types/pointed/finger_guns.dm
@@ -5,7 +5,7 @@
 	background_icon_state = "bg_mime"
 	overlay_icon_state = "bg_mime_border"
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
-	button_icon_state = "finger_guns0"
+	button_icon_state = "finger_guns"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED
 	panel = "Mime"
 	sound = null

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -31,6 +31,7 @@
 		REMOVE_TRAIT(cast_on, TRAIT_MIMING, "[type]")
 	else
 		to_chat(cast_on, span_notice("You make a vow of silence."))
+		cast_on.log_message("made a vow of silence.", LOG_GAME)
 		cast_on.clear_mood_event("vow")
 		ADD_TRAIT(cast_on, TRAIT_MIMING, "[type]")
 	cast_on.update_mob_action_buttons()

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -26,7 +26,7 @@
 	. = ..()
 	if(HAS_TRAIT_FROM(cast_on, TRAIT_MIMING, "[type]"))
 		to_chat(cast_on, span_notice("You break your vow of silence."))
-		cast_on.log_message("broke their vow of silence.", LOG_GAME)
+		cast_on.log_message("broke [cast_on.p_their()] vow of silence.", LOG_GAME)
 		cast_on.add_mood_event("vow", /datum/mood_event/broken_vow)
 		REMOVE_TRAIT(cast_on, TRAIT_MIMING, "[type]")
 	else

--- a/code/modules/spells/spell_types/self/mime_vow.dm
+++ b/code/modules/spells/spell_types/self/mime_vow.dm
@@ -26,6 +26,7 @@
 	. = ..()
 	if(HAS_TRAIT_FROM(cast_on, TRAIT_MIMING, "[type]"))
 		to_chat(cast_on, span_notice("You break your vow of silence."))
+		cast_on.log_message("broke their vow of silence.", LOG_GAME)
 		cast_on.add_mood_event("vow", /datum/mood_event/broken_vow)
 		REMOVE_TRAIT(cast_on, TRAIT_MIMING, "[type]")
 	else


### PR DESCRIPTION

## About The Pull Request

Decided against the balance changes in #73817
## Why It's Good For The Game

Although it is obvious when a mime talked, knowing the exact details can still be useful for administrators
## Changelog
:cl:
fix: Mime finger gun icon is no longer an error
admin: Logs when mimes break or make a vow of silence
/:cl:
