### PR TITLE
Added missing command access helpers to tram secure tech storage.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11682,6 +11682,7 @@
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "ckM" = (
@@ -35725,6 +35726,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/turf_decal/trimline/white/filled/line,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "luP" = (


### PR DESCRIPTION

## About The Pull Request

Tramstation's secure tech storage only had tech storage access helpers, rather than both that and command. This meant that anyone who could enter tech storage at all could make off with the AI upload board and more. This PR adds the missing command helpers to match all other maps.
## Why It's Good For The Game

The roboticist really isn't supposed to be in there.
## Changelog
:cl:
fix: Corrected access helpers for Tramstation's secure tech storage doors.
/:cl:
