### PR TITLE
Fixes pirates and starfury assailants transferring minds

### DIFF
--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -73,7 +73,7 @@
 		for(var/obj/effect/mob_spawn/ghost_role/human/pirate/spawner in A)
 			if(candidates.len > 0)
 				var/mob/our_candidate = candidates[1]
-				var/mob/spawned_mob = spawner.create(our_candidate)
+				var/mob/spawned_mob = spawner.create_from_ghost(our_candidate)
 				candidates -= our_candidate
 				notify_ghosts("The pirate ship has an object of interest: [spawned_mob]!", source = spawned_mob, action = NOTIFY_ORBIT, header="Pirates!")
 			else

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -175,6 +175,17 @@
 	if(QDELETED(src) || QDELETED(user))
 		return
 
+	create_from_ghost(user)
+
+/**
+ * Uses a use and creates a mob from a passed ghost
+ *
+ * Does NOT validate that the spawn is possible or valid - assumes this has been done already!
+ *
+ * If you are manually forcing a player into this mob spawn,
+ * you should be using this and not directly calling [proc/create].
+ */
+/obj/effect/mob_spawn/ghost_role/proc/create_from_ghost(mob/user)
 	user.log_message("became a [prompt_name].", LOG_GAME)
 	uses -= 1 // Remove a use before trying to spawn to prevent strangeness like the spawner trying to spawn more mobs than it should be able to
 	user.mind = null // dissassociate mind, don't let it follow us to the next life

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -185,7 +185,8 @@
  * If you are manually forcing a player into this mob spawn,
  * you should be using this and not directly calling [proc/create].
  */
-/obj/effect/mob_spawn/ghost_role/proc/create_from_ghost(mob/user)
+/obj/effect/mob_spawn/ghost_role/proc/create_from_ghost(mob/dead/user)
+	ASSERT(istype(user))
 	user.log_message("became a [prompt_name].", LOG_GAME)
 	uses -= 1 // Remove a use before trying to spawn to prevent strangeness like the spawner trying to spawn more mobs than it should be able to
 	user.mind = null // dissassociate mind, don't let it follow us to the next life

--- a/code/modules/shuttle/battlecruiser_starfury.dm
+++ b/code/modules/shuttle/battlecruiser_starfury.dm
@@ -165,7 +165,7 @@
 			spawner.antag_team = team
 			if(candidates.len > 0)
 				var/mob/our_candidate = candidates[1]
-				spawner.create(our_candidate)
+				spawner.create_from_ghost(our_candidate)
 				spawner.antag_team.players_spawned += (our_candidate.ckey)
 				candidates.Splice(1, 2)
 				notify_ghosts(


### PR DESCRIPTION
## About The Pull Request

Same issue as before, these skipped the spawn step and snowflaked their own creation process. 

So I split off the create part of attack ghost so these could share.

Fixes #73823 , may fix also #73822 but I don't *think* it will, whatever changed spawners a few months ago is a little sus

## Why It's Good For The Game

Changeling pirate bad

## Changelog

:cl: Melbert
fix: Fixes pirates and starfury assailants keeping minds of past lives
/:cl:
