### PR TITLE
New var on firing pins for admins to render them unremovable. Fixes firing pin swapping overlapping balloon alerts

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -117,7 +117,7 @@
 	if(!pinless)
 		if(pin)
 			. += "It has \a [pin] installed."
-			if(pin.pin_removeable)
+			if(pin.pin_removable)
 				. += span_info("[pin] looks like it could be removed with some <b>tools</b>.")
 			else
 				. += span_info("[pin] looks like its firmly locked in, it looks impossible to remove.")
@@ -454,7 +454,7 @@
 	if(bayonet && can_bayonet) //if it has a bayonet, and the bayonet can be removed
 		return remove_bayonet(user, I)
 
-	else if(pin?.pin_removeable && user.is_holding(src))
+	else if(pin?.pin_removable && user.is_holding(src))
 		user.visible_message(span_warning("[user] attempts to remove [pin] from [src] with [I]."),
 		span_notice("You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)"), null, 3)
 		if(I.use_tool(src, user, FIRING_PIN_REMOVAL_DELAY, volume = 50))
@@ -471,7 +471,7 @@
 		return
 	if(!user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return
-	if(pin?.pin_removeable && user.is_holding(src))
+	if(pin?.pin_removable && user.is_holding(src))
 		user.visible_message(span_warning("[user] attempts to remove [pin] from [src] with [I]."),
 		span_notice("You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)"), null, 3)
 		if(I.use_tool(src, user, FIRING_PIN_REMOVAL_DELAY, 5, volume = 50))
@@ -488,7 +488,7 @@
 		return
 	if(!user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return
-	if(pin?.pin_removeable && user.is_holding(src))
+	if(pin?.pin_removable && user.is_holding(src))
 		user.visible_message(span_warning("[user] attempts to remove [pin] from [src] with [I]."),
 		span_notice("You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)"), null, 3)
 		if(I.use_tool(src, user, FIRING_PIN_REMOVAL_DELAY, volume = 50))

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -118,9 +118,9 @@
 		if(pin)
 			. += "It has \a [pin] installed."
 			if(pin.pin_removable)
-				. += span_info("[pin] looks like it could be removed with some <b>tools</b>.")
+				. += span_info("[pin] looks like [pin.p_they()] could be removed with some <b>tools</b>.")
 			else
-				. += span_info("[pin] looks like its firmly locked in, it looks impossible to remove.")
+				. += span_info("[pin] looks like [pin.p_theyre()] firmly locked in, [pin.p_they()] looks impossible to remove.")
 		else
 			. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -117,7 +117,10 @@
 	if(!pinless)
 		if(pin)
 			. += "It has \a [pin] installed."
-			. += span_info("[pin] looks like it could be removed with some <b>tools</b>.")
+			if(pin.pin_removeable)
+				. += span_info("[pin] looks like it could be removed with some <b>tools</b>.")
+			else
+				. += span_info("[pin] looks like its firmly locked in, it looks impossible to remove.")
 		else
 			. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
 
@@ -451,7 +454,7 @@
 	if(bayonet && can_bayonet) //if it has a bayonet, and the bayonet can be removed
 		return remove_bayonet(user, I)
 
-	else if(pin && user.is_holding(src))
+	else if(pin?.pin_removeable && user.is_holding(src))
 		user.visible_message(span_warning("[user] attempts to remove [pin] from [src] with [I]."),
 		span_notice("You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)"), null, 3)
 		if(I.use_tool(src, user, FIRING_PIN_REMOVAL_DELAY, volume = 50))
@@ -468,7 +471,7 @@
 		return
 	if(!user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return
-	if(pin && user.is_holding(src))
+	if(pin?.pin_removeable && user.is_holding(src))
 		user.visible_message(span_warning("[user] attempts to remove [pin] from [src] with [I]."),
 		span_notice("You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)"), null, 3)
 		if(I.use_tool(src, user, FIRING_PIN_REMOVAL_DELAY, 5, volume = 50))
@@ -485,7 +488,7 @@
 		return
 	if(!user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
 		return
-	if(pin && user.is_holding(src))
+	if(pin?.pin_removeable && user.is_holding(src))
 		user.visible_message(span_warning("[user] attempts to remove [pin] from [src] with [I]."),
 		span_notice("You attempt to remove [pin] from [src]. (It will take [DisplayTimeText(FIRING_PIN_REMOVAL_DELAY)].)"), null, 3)
 		if(I.use_tool(src, user, FIRING_PIN_REMOVAL_DELAY, volume = 50))

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -44,9 +44,9 @@
 					return .
 				if(gun_insert(user, targetted_gun))
 					if(old_pin)
-						balloon_alert(user, "swapped firing pin.")
+						balloon_alert(user, "swapped firing pin")
 					else
-						balloon_alert(user, "inserted firing pin.")
+						balloon_alert(user, "inserted firing pin")
 			else
 				to_chat(user, span_notice("This firearm already has a firing pin installed."))
 

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -17,7 +17,7 @@
 	/// Can be replaced by any pin.
 	var/pin_hot_swappable = FALSE
 	///Can be removed from the gun using tools or replaced by a pin with force_replace
-	var/pin_removeable = TRUE
+	var/pin_removable = TRUE
 	var/obj/item/gun/gun
 
 /obj/item/firing_pin/New(newloc)
@@ -32,7 +32,7 @@
 			. |= AFTERATTACK_PROCESSED_ITEM
 			var/obj/item/gun/targetted_gun = target
 			var/obj/item/firing_pin/old_pin = targetted_gun.pin
-			if(old_pin?.pin_removeable && (force_replace || old_pin.pin_hot_swappable))
+			if(old_pin?.pin_removable && (force_replace || old_pin.pin_hot_swappable))
 				if(Adjacent(user))
 					user.put_in_hands(old_pin)
 				else

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -44,9 +44,9 @@
 					return .
 				if(gun_insert(user, targetted_gun))
 					if(old_pin)
-						balloon_alert(user, "firing pin swapped")
+						balloon_alert(user, "swapped firing pin.")
 					else
-						balloon_alert(user, "firing pin inserted.")
+						balloon_alert(user, "inserted firing pin.")
 			else
 				to_chat(user, span_notice("This firearm already has a firing pin installed."))
 

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -32,7 +32,7 @@
 			. |= AFTERATTACK_PROCESSED_ITEM
 			var/obj/item/gun/targetted_gun = target
 			var/obj/item/firing_pin/old_pin = targetted_gun.pin
-			if(old_pin && old_pin.pin_removeable && (force_replace || old_pin.pin_hot_swappable))
+			if(old_pin?.pin_removeable && (force_replace || old_pin.pin_hot_swappable))
 				if(Adjacent(user))
 					user.put_in_hands(old_pin)
 				else

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -10,9 +10,14 @@
 	attack_verb_continuous = list("pokes")
 	attack_verb_simple = list("poke")
 	var/fail_message = "invalid user!"
-	var/selfdestruct = FALSE // Explode when user check is failed.
-	var/force_replace = FALSE // Can forcefully replace other pins.
-	var/pin_removeable = FALSE // Can be replaced by any pin.
+	/// Explode when user check is failed.
+	var/selfdestruct = FALSE
+	/// Can forcefully replace other pins.
+	var/force_replace = FALSE
+	/// Can be replaced by any pin.
+	var/pin_hot_swappable = FALSE
+	///Can be removed from the gun using tools or replaced by a pin with force_replace
+	var/pin_removeable = TRUE
 	var/obj/item/gun/gun
 
 /obj/item/firing_pin/New(newloc)
@@ -27,8 +32,7 @@
 			. |= AFTERATTACK_PROCESSED_ITEM
 			var/obj/item/gun/targetted_gun = target
 			var/obj/item/firing_pin/old_pin = targetted_gun.pin
-			if(old_pin && (force_replace || old_pin.pin_removeable))
-				balloon_alert(user, "firing pin removed")
+			if(old_pin && old_pin.pin_removeable && (force_replace || old_pin.pin_hot_swappable))
 				if(Adjacent(user))
 					user.put_in_hands(old_pin)
 				else
@@ -39,7 +43,10 @@
 				if(!user.temporarilyRemoveItemFromInventory(src))
 					return .
 				if(gun_insert(user, targetted_gun))
-					balloon_alert(user, "firing pin inserted.")
+					if(old_pin)
+						balloon_alert(user, "firing pin swapped")
+					else
+						balloon_alert(user, "firing pin inserted.")
 			else
 				to_chat(user, span_notice("This firearm already has a firing pin installed."))
 
@@ -87,7 +94,7 @@
 	name = "test-range firing pin"
 	desc = "This safety firing pin allows weapons to be fired within proximity to a firing range."
 	fail_message = "test range check failed!"
-	pin_removeable = TRUE
+	pin_hot_swappable = TRUE
 
 /obj/item/firing_pin/test_range/pin_auth(mob/living/user)
 	if(!istype(user))


### PR DESCRIPTION
## About The Pull Request

A couple weeks ago I needed a gun that could not under any circumstances have its firing pin removed for an event, there was a var for "pin_removable" which didn't actually do this, I've reworked its purpose to allow admins to edit as firing pin to make it unremovable and renamed its old functionality to pin_hot_swappable to better clarify what the var actually did.

Also I've changed the balloon alert for pin swapping to be a single balloon alert stating the pins have been swapped rather than two, one for removal and one for replacement.

None of existing firing pins has had to functionality implemented on them so its admin only for the time being.
## Why It's Good For The Game

Better readability for pin swapping and admins/future coders can make firing pins unremovable for events/code additions.
## Changelog
:cl:
fix: Firing pin swapping's 2 balloon alerts have been replaced with a single more readable one.
admin: Admins can now edit a pin_removable var on firing pins to render them unremovable from the weapons they're installed in.
/:cl:
