### PR TITLE
Allows any bullet class that doesn't override wound_bonus to cause wounds.

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -10,6 +10,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect
 	shrapnel_type = /obj/item/shrapnel/bullet
 	embedding = list(embed_chance=20, fall_chance=2, jostle_chance=0, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.5, pain_mult=3, rip_time=10)
+	wound_bonus = 0
 	wound_falloff_tile = -5
 	embed_falloff_tile = -3
 


### PR DESCRIPTION
Overrides wound_bonus for the bullet class to be 0 instead of CANT_WOUND.
## About The Pull Request
The bullet class has wound_bonus 0 instead of CANT_WOUND. This allows things such as 9mm and 10mm to wound, and probably other things.
## Why It's Good For The Game
Makarovs that used 9mm and some other things just didn't cause any wounds, and that was sad. Bullets are physical things, so it doesn't make sense to make them not cause any wounds unless they were overidden.
## Changelog
:cl:
balance: 9mm, 10mm, and other stuff can cause wounds.
/:cl:
