### PR TITLE
Pirate ship arrival custom announcements

### DIFF
--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -33,7 +33,7 @@
 	var/datum/comm_message/threat = chosen_gang.generate_message(payoff)
 	//send message
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
-	threat.answer_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pirates_answered), threat, chosen_gang, payoff, world.time)
+	threat.answer_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pirates_answered), threat, chosen_gang, payoff, arrival_announcement, world.time)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(spawn_pirates), threat, chosen_gang, FALSE), RESPONSE_MAX_TIME)
 	SScommunications.send_message(threat, unique = TRUE)
 
@@ -50,7 +50,7 @@
 				priority_announce(chosen_gang.response_not_enough, sender_override = chosen_gang.ship_name)
 				spawn_pirates(threat, chosen_gang, TRUE)
 
-/proc/spawn_pirates(datum/comm_message/threat, datum/pirate_gang/chosen_gang, skip_answer_check)
+/proc/spawn_pirates(datum/comm_message/threat, datum/pirate_gang/chosen_gang, skip_answer_check, arrival_announcement)
 	if(!skip_answer_check && threat?.answered == 1)
 		return
 
@@ -79,7 +79,7 @@
 			else
 				notify_ghosts("The pirate ship has an object of interest: [spawner]!", source = spawner, action = NOTIFY_ORBIT, header="Pirate Spawn Here!")
 
-	priority_announce("Unidentified armed ship detected near the station.")
+	priority_announce(arrival_announcement)
 
 /datum/event_admin_setup/pirates
 	///admin chosen pirate team

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -33,7 +33,7 @@
 	var/datum/comm_message/threat = chosen_gang.generate_message(payoff)
 	//send message
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
-	threat.answer_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pirates_answered), threat, chosen_gang, payoff, arrival_announcement, world.time)
+	threat.answer_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pirates_answered), threat, chosen_gang, payoff, world.time)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(spawn_pirates), threat, chosen_gang, FALSE), RESPONSE_MAX_TIME)
 	SScommunications.send_message(threat, unique = TRUE)
 
@@ -50,7 +50,7 @@
 				priority_announce(chosen_gang.response_not_enough, sender_override = chosen_gang.ship_name)
 				spawn_pirates(threat, chosen_gang, TRUE)
 
-/proc/spawn_pirates(datum/comm_message/threat, datum/pirate_gang/chosen_gang, skip_answer_check, arrival_announcement)
+/proc/spawn_pirates(datum/comm_message/threat, datum/pirate_gang/chosen_gang, skip_answer_check)
 	if(!skip_answer_check && threat?.answered == 1)
 		return
 
@@ -79,7 +79,7 @@
 			else
 				notify_ghosts("The pirate ship has an object of interest: [spawner]!", source = spawner, action = NOTIFY_ORBIT, header="Pirate Spawn Here!")
 
-	priority_announce(arrival_announcement)
+	priority_announce(chosen_gang.arrival_announcement, sender_override = chosen_gang.ship_name)
 
 /datum/event_admin_setup/pirates
 	///admin chosen pirate team

--- a/code/modules/antagonists/pirate/pirate_gangs.dm
+++ b/code/modules/antagonists/pirate/pirate_gangs.dm
@@ -69,7 +69,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 		and crazy shuttle there with NO INSURANCE! Crazy. What if something happened to it, huh?! We've \
 		done a quick evaluation on your rates in this sector and we're offering %PAYOFF to cover for your \
 		shuttle in case of any disaster."
-	arrival_announcement = "Any second thoughts lads? Because we surely don't have any. Open up, we're coming soon."
+	arrival_announcement = "Do you want to reconsider our offer? Unfortunately, the time for negotiations has passed. Open up, we're coming aboard soon."
 	possible_answers = list("Purchase Insurance.","Reject Offer.")
 
 	response_received = "Sweet, free cash. Let's get outta here, boys."
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 	threat_title = "Tribute request"
 	threat_content = "This is the %SHIPNAME. The Silver Scales wish for some tribute \
 		from your plebeian lizards. %PAYOFF credits should do the trick."
-	arrival_announcement = "In a matter of moments, Your vessel's to be taken by surprise. We'd suggest yielding if We were you."
+	arrival_announcement = "Certainly, you don't deserve all of that aboard your vessel. It's going to fit us so much better."
 	possible_answers = list("We'll pay.","Tribute? Really? Go away.")
 
 	response_received = "A most generous donation. May the claws of Tizira reach into the furthest points of the cosmos."
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 
 	threat_title = "Transfer of goods"
 	threat_content = "Ahoy! This be the %SHIPNAME. Cough up %PAYOFF credits or you'll walk the plank."
-	arrival_announcement = "Jolly Roger won't wait forever, maties; we're by the starboard ready to send you some round gifts."
+	arrival_announcement = "The Jolly Roger won't wait forever, maties; we're laying alongside ready to send you some gifts."
 	possible_answers = list("We'll pay.","We will not be extorted.")
 
 	response_received = "Thanks for the credits, landlubbers."
@@ -118,7 +118,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 
 	threat_title = "Junkie tribute"
 	threat_content = "Hello, you psychically dormant pawn-pieces. It's the %SHIPNAME! Our funds are running a little low, and we're not going to be able to continue our gore-binge! %PAYOFF credits should do, wanna help us out?"
-	arrival_announcement = "We didn't drug this far just to send some pitty threats. Just you wait, We'll make you cry for a mental asylum."
+	arrival_announcement = "We didn't blaze this far just to send some idle threats. Just you wait, we'll make you wish you were in a mental asylum."
 	possible_answers = list("Send some funds so they go away.","We're not funding these junkies.")
 
 	response_received = "You guys aren't so bad for being dormants. Next gore-fest goes to you guys. Peace!"

--- a/code/modules/antagonists/pirate/pirate_gangs.dm
+++ b/code/modules/antagonists/pirate/pirate_gangs.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 	///%PAYOFF in the content will be replaced with the requested credits.
 	var/threat_content = "This is the %SHIPNAME. Give us %PAYOFF credits or we bug out the universe trying to spawn!"
 	///station receives this message upon the ship's spawn
-	var/arrival_announcement = "We have come for your Runtime!"
+	var/arrival_announcement = "We have come for your Bungopoints!"
 	///what the station can say in response, first item pays the pirates, second item rejects it.
 	var/list/possible_answers = list("Please, go away! We'll pay!", "I accept oblivion.")
 
@@ -86,7 +86,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 	threat_title = "Tribute request"
 	threat_content = "This is the %SHIPNAME. The Silver Scales wish for some tribute \
 		from your plebeian lizards. %PAYOFF credits should do the trick."
-	arrival_announcement = "In a matter of moments, Your uhuuuh uhm idfk ill think this shit through later."
+	arrival_announcement = "In a matter of moments, Your vessel's to be taken by surprise. We'd suggest yielding if We were you."
 	possible_answers = list("We'll pay.","Tribute? Really? Go away.")
 
 	response_received = "A most generous donation. May the claws of Tizira reach into the furthest points of the cosmos."
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 
 	threat_title = "Transfer of goods"
 	threat_content = "Ahoy! This be the %SHIPNAME. Cough up %PAYOFF credits or you'll walk the plank."
-	arrival_announcement = "Bone joek."
+	arrival_announcement = "Jolly Roger won't wait forever, maties; we're by the starboard ready to send you some round gifts."
 	possible_answers = list("We'll pay.","We will not be extorted.")
 
 	response_received = "Thanks for the credits, landlubbers."
@@ -118,7 +118,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 
 	threat_title = "Junkie tribute"
 	threat_content = "Hello, you psychically dormant pawn-pieces. It's the %SHIPNAME! Our funds are running a little low, and we're not going to be able to continue our gore-binge! %PAYOFF credits should do, wanna help us out?"
-	arrival_announcement = "We literally need a caretaker to fly the ship lmao."
+	arrival_announcement = "We didn't drug this far just to send some pitty threats. Just you wait, We'll make you cry for a mental asylum."
 	possible_answers = list("Send some funds so they go away.","We're not funding these junkies.")
 
 	response_received = "You guys aren't so bad for being dormants. Next gore-fest goes to you guys. Peace!"

--- a/code/modules/antagonists/pirate/pirate_gangs.dm
+++ b/code/modules/antagonists/pirate/pirate_gangs.dm
@@ -30,6 +30,8 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 	///%SHIPNAME in the content will be replaced with the pirate ship's name
 	///%PAYOFF in the content will be replaced with the requested credits.
 	var/threat_content = "This is the %SHIPNAME. Give us %PAYOFF credits or we bug out the universe trying to spawn!"
+	///station receives this message upon the ship's spawn
+	var/arrival_announcement = "We have come for your Runtime!"
 	///what the station can say in response, first item pays the pirates, second item rejects it.
 	var/list/possible_answers = list("Please, go away! We'll pay!", "I accept oblivion.")
 
@@ -67,6 +69,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 		and crazy shuttle there with NO INSURANCE! Crazy. What if something happened to it, huh?! We've \
 		done a quick evaluation on your rates in this sector and we're offering %PAYOFF to cover for your \
 		shuttle in case of any disaster."
+	arrival_announcement = "Any second thoughts lads? Because we surely don't have any. Open up, we're coming soon."
 	possible_answers = list("Purchase Insurance.","Reject Offer.")
 
 	response_received = "Sweet, free cash. Let's get outta here, boys."
@@ -83,6 +86,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 	threat_title = "Tribute request"
 	threat_content = "This is the %SHIPNAME. The Silver Scales wish for some tribute \
 		from your plebeian lizards. %PAYOFF credits should do the trick."
+	arrival_announcement = "In a matter of moments, Your uhuuuh uhm idfk ill think this shit through later."
 	possible_answers = list("We'll pay.","Tribute? Really? Go away.")
 
 	response_received = "A most generous donation. May the claws of Tizira reach into the furthest points of the cosmos."
@@ -98,6 +102,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 
 	threat_title = "Transfer of goods"
 	threat_content = "Ahoy! This be the %SHIPNAME. Cough up %PAYOFF credits or you'll walk the plank."
+	arrival_announcement = "Bone joek."
 	possible_answers = list("We'll pay.","We will not be extorted.")
 
 	response_received = "Thanks for the credits, landlubbers."
@@ -113,6 +118,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 
 	threat_title = "Junkie tribute"
 	threat_content = "Hello, you psychically dormant pawn-pieces. It's the %SHIPNAME! Our funds are running a little low, and we're not going to be able to continue our gore-binge! %PAYOFF credits should do, wanna help us out?"
+	arrival_announcement = "We literally need a caretaker to fly the ship lmao."
 	possible_answers = list("Send some funds so they go away.","We're not funding these junkies.")
 
 	response_received = "You guys aren't so bad for being dormants. Next gore-fest goes to you guys. Peace!"


### PR DESCRIPTION
## About The Pull Request
Makes the pirate ship's spawning/arrival announcement editable too, for additional flavor and cool factor.
![image](https://user-images.githubusercontent.com/42087567/223536935-566f04a7-f848-4b1e-8920-5779364854c3.png)


## Why It's Good For The Game
Adds a bit more variety and immersion to pirate groups' arrivals; makes pirate gang code more flexible and variable, thus allowing for more pirate type customization, if people are to add more.
## Changelog
:cl: Stalkeros, san7890 for the announcement texts
code: Made pirate groups' arrival messages editable and more importantly unique for each group.
/:cl:
