### PR TITLE
Fix not being able to read in full bright areas

### DIFF
--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -142,12 +142,6 @@ The areas used here are STRICTLY on the CC Z level.
 	static_lighting = FALSE
 	base_lighting_alpha = 255
 
-/area/centcom/tdome/arena_source
-	name = "Thunderdome Arena Template"
-	icon_state = "thunder"
-	static_lighting = FALSE
-	base_lighting_alpha = 255
-
 /area/centcom/tdome/tdome1
 	name = "Thunderdome (Team 1)"
 	icon_state = "thunder_team_one"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1232,7 +1232,15 @@
 **/
 /mob/proc/has_light_nearby(light_amount = LIGHTING_TILE_IS_DARK)
 	var/turf/mob_location = get_turf(src)
-	return mob_location.get_lumcount() > light_amount
+	var/area/mob_area = get_area(src)
+
+	if(mob_location.get_lumcount() > light_amount)
+		return TRUE
+	else if(!mob_area.static_lighting)
+		return TRUE
+
+	return FALSE
+
 
 
 /// Can this mob read


### PR DESCRIPTION
## About The Pull Request
Fixes #73830
Fixes #74107

There seems to be a problem when the map template reloads for full bright areas, but only for thunderdome specifically.  Very strange and my fix feels like a band-aid but it's a niche bug report.

Also deleted an area that was not used anywhere in the codebase.

## Why It's Good For The Game
Silly bug go bye bye.

## Changelog
:cl:
fix: Fix not being able to read in full bright areas
/:cl:
