### PR TITLE
Fixes several issues with the rapid lighting device, lights not actually emitting light and glowstick mode not working when its dark.

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -240,7 +240,7 @@ RLD
 /obj/item/construction/proc/range_check(atom/A, mob/user)
 	if(A.z != user.z)
 		return
-	if(!(A in view(7, get_turf(user))))
+	if(!(A in dview(7, get_turf(user))))
 		to_chat(user, span_warning("The \'Out of Range\' light on [src] blinks red."))
 		return FALSE
 	else
@@ -1011,7 +1011,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	)
 	///will contain the original icons modified with the color choice
 	var/list/display_options = list()
-	var/color_choice = null
+	var/color_choice = "#f3fffa"
 
 /obj/item/construction/rld/Initialize(mapload)
 	. = ..()
@@ -1126,7 +1126,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 						var/obj/machinery/light/L = new /obj/machinery/light(light)
 						L.setDir(align)
 						L.color = color_choice
-						L.set_light_color(L.color)
+						L.set_light_color(color_choice)
 						return TRUE
 				return FALSE
 
@@ -1146,7 +1146,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 						var/destination = get_turf(A)
 						var/obj/machinery/light/floor/FL = new /obj/machinery/light/floor(destination)
 						FL.color = color_choice
-						FL.set_light_color(FL.color)
+						FL.set_light_color(color_choice)
 						return TRUE
 				return FALSE
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -1011,7 +1011,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	)
 	///will contain the original icons modified with the color choice
 	var/list/display_options = list()
-	var/color_choice = "#f3fffa"
+	var/color_choice = "#ffffff"
 
 /obj/item/construction/rld/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Fixes: #73844

RLD's now have a default light color so they will work out of the box, and setting the light color to white doesn't result in the light color on produced lights being set to null anymore.

I'm not certain if the glowstick thing is a bug so give me a heads up if its not and I'll change it to balance but it seemed weird to me that the glowstick mode was unusable in the dark so it is now usable, this also impacts floor lights but wall lights worked in the dark already.
## Why It's Good For The Game

Bugfix good.
## Changelog
:cl:
fix: Rapid lighting devices can now have their color set to #ffffff and the resulting lights will now function.
fix: Rapid lighting devices will now default its set color to white when created instead of trying to produce colorless lights.
fix: The rapid lighting device can now be used in the dark when producing glow sticks or floor lights.
/:cl:
