### PR TITLE
[No GBP] Fixes double esword discounts

### DIFF
--- a/code/__DEFINES/uplink.dm
+++ b/code/__DEFINES/uplink.dm
@@ -12,3 +12,7 @@
 /// Progression gets turned into a user-friendly form. This is just an abstract equation that makes progression not too large.
 #define DISPLAY_PROGRESSION(time) round(time/60, 0.01)
 
+/// Traitor discount size categories
+#define TRAITOR_DISCOUNT_BIG "big_discount"
+#define TRAITOR_DISCOUNT_AVERAGE "average_discount"
+#define TRAITOR_DISCOUNT_SMALL "small_discount"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1,6 +1,3 @@
-#define TRAITOR_DISCOUNT_BIG "big_discount"
-#define TRAITOR_DISCOUNT_AVERAGE "average_discount"
-#define TRAITOR_DISCOUNT_SMALL "small_discount"
 
 // TODO: Work into reworked uplinks.
 /// Selects a set number of unique items from the uplink, and deducts a percentage discount from them
@@ -93,7 +90,11 @@
 		TRAITOR_DISCOUNT_BIG = 1,
 	)
 
-	switch(pick_weight(discount_types))
+	return get_discount_value(pick_weight(discount_types))
+
+/// Retruns the actual value
+/datum/uplink_item/proc/get_discount_value(var/discount_type)
+	switch(discount_type)
 		if(TRAITOR_DISCOUNT_BIG)
 			return 0.75
 		if(TRAITOR_DISCOUNT_AVERAGE)
@@ -156,7 +157,3 @@
 
 /// Code that enables the ability to have limited stock that is shared by different items
 /datum/shared_uplink_stock
-
-#undef TRAITOR_DISCOUNT_BIG
-#undef TRAITOR_DISCOUNT_AVERAGE
-#undef TRAITOR_DISCOUNT_SMALL

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -92,7 +92,7 @@
 
 	return get_discount_value(pick_weight(discount_types))
 
-/// Retruns the actual value
+/// Receives a traitor discount type value, returns the amount by which we will reduce the price
 /datum/uplink_item/proc/get_discount_value(var/discount_type)
 	switch(discount_type)
 		if(TRAITOR_DISCOUNT_BIG)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -93,7 +93,7 @@
 	return get_discount_value(pick_weight(discount_types))
 
 /// Receives a traitor discount type value, returns the amount by which we will reduce the price
-/datum/uplink_item/proc/get_discount_value(var/discount_type)
+/datum/uplink_item/proc/get_discount_value(discount_type)
 	switch(discount_type)
 		if(TRAITOR_DISCOUNT_BIG)
 			return 0.75

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -79,7 +79,7 @@
 	cost = 16
 	purchasable_from = ~UPLINK_CLOWN_OPS
 
-/datum/uplink_item/dangerous/doublesword/get_discount_value(var/discount_type)
+/datum/uplink_item/dangerous/doublesword/get_discount_value(discount_type)
 	switch(discount_type)
 		if(TRAITOR_DISCOUNT_BIG)
 			return 0.5

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -79,8 +79,14 @@
 	cost = 16
 	purchasable_from = ~UPLINK_CLOWN_OPS
 
-/datum/uplink_item/dangerous/doublesword/get_discount()
-	return pick(4;0.8,2;0.65,1;0.5)
+/datum/uplink_item/dangerous/doublesword/get_discount_value(var/discount_type)
+	switch(discount_type)
+		if(TRAITOR_DISCOUNT_BIG)
+			return 0.5
+		if(TRAITOR_DISCOUNT_AVERAGE)
+			return 0.35
+		else
+			return 0.2
 
 /datum/uplink_item/dangerous/guardian
 	name = "Holoparasites"


### PR DESCRIPTION
## About The Pull Request

In a recent PR, I have inverted the sales values to make it easier to calculate and modify the discounts. I did not notice that double eswords overrode this function, thus, deswords got terrifying discounts. This PR fixes that. Sorry about that.

I am not happy about the current solution (adding an assoc list directly to the uplink_item datum has not worked for some reason, it initialized as an odd value), but I will soon refactor discounts anyways.

## Why It's Good For The Game

There is a good reason double eswords have smaller discounts.

## Changelog

:cl:
fix: the double esword sales are now smaller than regular sales
/:cl:

