### PR TITLE
gives atmos techs the engie skillchip

### DIFF
--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -56,6 +56,8 @@
 	box = /obj/item/storage/box/survival/engineer
 	pda_slot = ITEM_SLOT_LPOCKET
 
+	skillchips = list(/obj/item/skillchip/job/engineer)
+	
 /datum/outfit/job/atmos/mod
 	name = "Atmospheric Technician (MODsuit)"
 


### PR DESCRIPTION
## About The Pull Request
Atmos techs suffer from a number of large issues, with a large one being unable to reach a breach to repair and re pressurize an area, often leading to atmos techs sitting in the gas cave making canisters full of gas that will never be used in the round, i say this because i do the exact same thing as an atmos tech
gives atmos techs the engie wire view skill chip
## Why It's Good For The Game
helps atmos techs get to the areas they are supposed to be working in. this will result in less shuttle calls due to firelock hell
## Changelog
:cl:
balance: Atmospheric technicians now have the engie wire skillchip.
/:cl:
