### PR TITLE
The CE blueprints can no longer be used to obfuscate cultist summon locations

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -555,7 +555,10 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 			var/datum/objective/eldergod/summon_objective = locate() in antag.cult_team.objectives
 			if(!summon_objective)
 				return
-			desc = "The sacrifice is complete, summon Nar'Sie! The summoning can only take place in [english_list(summon_objective.summon_spots)]!"
+			var/list/location_list = list()
+			for(var/area/area_to_check in summon_objective.summon_spots)
+				location_list += initial(area_to_check.name)
+			desc = "The sacrifice is complete, summon Nar'Sie! The summoning can only take place in [english_list(location_list)]!"
 			if(icon_state == "runed_sense1")
 				return
 			animate(src, transform = null, time = 1, loop = 0)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -557,7 +557,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 				return
 			var/list/location_list = list()
 			for(var/area/area_to_check in summon_objective.summon_spots)
-				location_list += initial(area_to_check.name)
+				location_list += area_to_check.get_original_area_name()
 			desc = "The sacrifice is complete, summon Nar'Sie! The summoning can only take place in [english_list(location_list)]!"
 			if(icon_state == "runed_sense1")
 				return

--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -357,7 +357,7 @@
 	if(!check_if_in_ritual_site(cultist, cult_team))
 		return FALSE
 	var/area/summon_location = get_area(cultist)
-	priority_announce("Figments from an eldritch god are being summoned by [cultist.real_name] into [initial(summon_location.name)] from an unknown dimension. Disrupt the ritual at all costs!", "Central Command Higher Dimensional Affairs", ANNOUNCER_SPANOMALIES, has_important_message = TRUE)
+	priority_announce("Figments from an eldritch god are being summoned by [cultist.real_name] into [summon_location.get_original_area_name()] from an unknown dimension. Disrupt the ritual at all costs!", "Central Command Higher Dimensional Affairs", ANNOUNCER_SPANOMALIES, has_important_message = TRUE)
 	for(var/shielded_turf in spiral_range_turfs(1, cultist, 1))
 		LAZYADD(shields, new /obj/structure/emergency_shield/cult/narsie(shielded_turf))
 

--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -356,7 +356,8 @@
 		return
 	if(!check_if_in_ritual_site(cultist, cult_team))
 		return FALSE
-	priority_announce("Figments from an eldritch god are being summoned by [cultist.real_name] into [get_area(cultist)] from an unknown dimension. Disrupt the ritual at all costs!", "Central Command Higher Dimensional Affairs", ANNOUNCER_SPANOMALIES, has_important_message = TRUE)
+	var/area/summon_location = get_area(cultist)
+	priority_announce("Figments from an eldritch god are being summoned by [cultist.real_name] into [initial(summon_location.name)] from an unknown dimension. Disrupt the ritual at all costs!", "Central Command Higher Dimensional Affairs", ANNOUNCER_SPANOMALIES, has_important_message = TRUE)
 	for(var/shielded_turf in spiral_range_turfs(1, cultist, 1))
 		LAZYADD(shields, new /obj/structure/emergency_shield/cult/narsie(shielded_turf))
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -541,7 +541,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	return
 
 /area/proc/get_original_area_name()
-    if(name == initial(name))
-        return name
-
-    return "[name] ([initial(name)])"
+	if(name == initial(name))
+		return name
+	return "[name] ([initial(name)])"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -539,3 +539,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /// Called when a living mob that spawned here, joining the round, receives the player client.
 /area/proc/on_joining_game(mob/living/boarder)
 	return
+
+/area/proc/get_original_area_name()
+    if(name == initial(name))
+        return name
+
+    return "[name] ([initial(name)])"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -540,6 +540,13 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 /area/proc/on_joining_game(mob/living/boarder)
 	return
 
+/**
+ * Returns the name of an area, with the original name if the area name has been changed.
+ *
+ * If an area has not been renamed, returns the area name. If it has been modified (by blueprints or other means)
+ * returns the current name, as well as the initial value, in the format of [Current Location Name (Original Name)]
+ */
+
 /area/proc/get_original_area_name()
 	if(name == initial(name))
 		return name


### PR DESCRIPTION

## About The Pull Request

The Nar'Sie summon message will now only use the original name of the ritual site area. You can no longer fake out the ritual announcement by renaming the area with the CE blueprints. 

The ritual site locator HUD popup now also uses the original area names, to prevent the same issue from occurring.
## Why It's Good For The Game

Closes #73036.
## Changelog
:cl:
fix: The cultist ritual site locator and Nar'Sie summon message will no longer use area names modified by the CE's blueprints.
/:cl:
