### PR TITLE
Fixes the `null` law check for the law panel not working adds an alert for non-observers using it

### DIFF
--- a/code/modules/admin/verbs/lawpanel.dm
+++ b/code/modules/admin/verbs/lawpanel.dm
@@ -4,6 +4,8 @@
 
 	if(!check_rights(R_ADMIN))
 		return
+	if(!isobserver(usr) && SSticker.HasRoundStarted())
+		message_admins("[key_name_admin(usr)] checked AI laws via the Law Panel.")
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Law Panel") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	var/datum/law_panel/tgui = new()
@@ -283,7 +285,11 @@
 		borg_information["ref"] = REF(borgo)
 
 		var/datum/ai_laws/lawset = borgo.laws
-		if(!isnull(lawset))
+		if(isnull(lawset))
+			// Whoopsie something wrong wrong this isn't supposed to happen
+			borg_information["laws"] = null
+
+		else
 			var/list/borg_laws = list()
 			// zeroth law on top
 			if(lawset.zeroth || lawset.zeroth_borg)

--- a/tgui/packages/tgui/interfaces/Lawpanel.tsx
+++ b/tgui/packages/tgui/interfaces/Lawpanel.tsx
@@ -46,11 +46,11 @@ type Silicon = {
   borg_name: string;
   borg_type: string;
   // List of our laws, this is almost never null. If it is null, that's an error.
-  laws: null | Law[];
+  laws: Law[] | null;
   // String, name of our master AI. Null means no master or we're not a borg
-  master_ai: null | string;
+  master_ai: string | null;
   // TRUE, we're law-synced to our master AI. FALSE, we're not, null, we're not a borg
-  borg_synced: null | BooleanLike;
+  borg_synced: BooleanLike | null;
   // REF() to our silicon
   ref: string;
 };
@@ -229,8 +229,12 @@ export const SiliconReadout = (props: { cyborg: Silicon }, context) => {
               <Stack.Item>
                 {cyborg.laws === null ? (
                   <Button
-                    content={`This silicon has a null law datum. That's a problem!
-                Click this this give them one.`}
+                    fluid
+                    textAlign="center"
+                    color="danger"
+                    content={`This silicon has a null law datum. This isn't
+                      supposed to ever happen! Issue report
+                      and then click this this give them one.`}
                     onClick={() => act('give_law_datum', { ref: cyborg.ref })}
                   />
                 ) : (

--- a/tgui/packages/tgui/interfaces/Lawpanel.tsx
+++ b/tgui/packages/tgui/interfaces/Lawpanel.tsx
@@ -46,11 +46,11 @@ type Silicon = {
   borg_name: string;
   borg_type: string;
   // List of our laws, this is almost never null. If it is null, that's an error.
-  laws: Law[] | null;
+  laws: null | Law[];
   // String, name of our master AI. Null means no master or we're not a borg
-  master_ai: string | null;
+  master_ai?: null | string;
   // TRUE, we're law-synced to our master AI. FALSE, we're not, null, we're not a borg
-  borg_synced: BooleanLike | null;
+  borg_synced?: null | BooleanLike;
   // REF() to our silicon
   ref: string;
 };
@@ -222,7 +222,7 @@ export const SiliconReadout = (props: { cyborg: Silicon }, context) => {
       <Flex.Item grow>
         <Collapsible title={`${cyborg.borg_type}: ${cyborg.borg_name}`}>
           <Section backgroundColor={'black'}>
-            {cyborg.master_ai && cyborg.borg_synced && (
+            {cyborg.master_ai && !!cyborg.borg_synced && (
               <SyncedBorgDimmer master={cyborg.master_ai} />
             )}
             <Stack vertical>


### PR DESCRIPTION
## About The Pull Request

- The `null` law check for the law panel existed in the UI side, but on the dm side it didn't pass it as null correctly. Fixes that

- Adds a message admins for non-observers using the panel, a la Check Antagonists. Just to be safe

## Changelog

Nothing player facing
