### PR TITLE
Fixes slimepeople not being affected by blood deficiency quirk

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -23,8 +23,8 @@
 
 /// How efficiently humans regenerate blood.
 #define BLOOD_REGEN_FACTOR 0.25
-/// Determines the rate at which humans lose blood when they have the blood deficiency quirk. The default is BLOOD_REGEN_FACTOR + BLOOD_DEFICIENCY_DRAIN_MODIFIER.
-#define BLOOD_DEFICIENCY_DRAIN_MODIFIER 0.025
+/// Determines the rate at which humans lose blood when they have the blood deficiency quirk. The default is BLOOD_REGEN_FACTOR + BLOOD_DEFICIENCY_MODIFIER.
+#define BLOOD_DEFICIENCY_MODIFIER 0.025
 
 /// Temperature at which blood loss and regen stops. [/mob/living/carbon/human/proc/handle_blood]
 #define BLOOD_STOP_TEMP 225

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -23,6 +23,8 @@
 
 /// How efficiently humans regenerate blood.
 #define BLOOD_REGEN_FACTOR 0.25
+/// Determines the rate at which humans lose blood when they have the blood deficiency quirk. The default is BLOOD_REGEN_FACTOR + BLOOD_DEFICIENCY_DRAIN_MODIFIER.
+#define BLOOD_DEFICIENCY_DRAIN_MODIFIER 0.025
 
 /// Temperature at which blood loss and regen stops. [/mob/living/carbon/human/proc/handle_blood]
 #define BLOOD_STOP_TEMP 225

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -63,20 +63,19 @@
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_PROCESSES
 	mail_goodies = list(/obj/item/reagent_containers/blood/o_minus) // universal blood type that is safe for all
 	var/min_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
-	var/drain_rate = 0.275
 
 /datum/quirk/blooddeficiency/process(delta_time)
 	if(quirk_holder.stat == DEAD)
 		return
 
 	var/mob/living/carbon/human/carbon_target = quirk_holder
-	if(HAS_TRAIT(carbon_target, TRAIT_NOBLOOD)) //can't lose blood if your species doesn't have any
+	if(HAS_TRAIT(carbon_target, TRAIT_NOBLOOD) && isnull(carbon_target.dna.species.exotic_blood)) //can't lose blood if your species doesn't have any
 		return
 
 	if (carbon_target.blood_volume <= min_blood)
 		return
 	// Ensures that we don't reduce total blood volume below min_blood.
-	carbon_target.blood_volume = max(min_blood, carbon_target.blood_volume - drain_rate * delta_time)
+	carbon_target.blood_volume = max(min_blood, carbon_target.blood_volume - carbon_target.dna.species.blood_deficiency_drain_rate * delta_time)
 
 /datum/quirk/item_quirk/blindness
 	name = "Blind"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///If your race uses a non standard bloodtype (A+, O-, AB-, etc). For example, lizards have L type blood.
 	var/exotic_bloodtype = ""
 	///The rate at which blood is passively drained by having the blood deficiency quirk. Some races such as slimepeople can regen their blood at different rates so this is to account for that
-	var/blood_deficiency_drain_rate = BLOOD_REGEN_FACTOR + BLOOD_DEFICIENCY_DRAIN_MODIFIER // slightly above the regen rate so it slowly drains instead of regenerates.
+	var/blood_deficiency_drain_rate = BLOOD_REGEN_FACTOR + BLOOD_DEFICIENCY_MODIFIER // slightly above the regen rate so it slowly drains instead of regenerates.
 	///What the species drops when gibbed by a gibber machine.
 	var/meat = /obj/item/food/meat/slab/human
 	///What skin the species drops when gibbed by a gibber machine.

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -62,6 +62,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/datum/reagent/exotic_blood
 	///If your race uses a non standard bloodtype (A+, O-, AB-, etc). For example, lizards have L type blood.
 	var/exotic_bloodtype = ""
+	///The rate at which blood is passively drained by having the blood deficiency quirk. Some races such as slimepeople can regen their blood at different rates so this is to account for that
+	var/blood_deficiency_drain_rate = BLOOD_REGEN_FACTOR + BLOOD_DEFICIENCY_DRAIN_MODIFIER // slightly above the regen rate so it slowly drains instead of regenerates.
 	///What the species drops when gibbed by a gibber machine.
 	var/meat = /obj/item/food/meat/slab/human
 	///What skin the species drops when gibbed by a gibber machine.

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -794,3 +794,6 @@
 		return FALSE
 
 	return TRUE
+	
+#undef JELLY_REGEN_RATE
+#undef JELLY_REGEN_RATE_EMPTY

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -22,7 +22,7 @@
 	mutantheart = null
 	meat = /obj/item/food/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimejelly
-	blood_deficiency_drain_rate = JELLY_REGEN_RATE + BLOOD_DEFICIENCY_DRAIN_MODIFIER
+	blood_deficiency_drain_rate = JELLY_REGEN_RATE + BLOOD_DEFICIENCY_MODIFIER
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
 	liked_food = MEAT | BUGS
 	toxic_food = NONE

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -1,3 +1,8 @@
+///The rate at which slimes regenerate their jelly normally
+#define JELLY_REGEN_RATE 1.5
+///The rate at which slimes regenerate their jelly when they completely run out of it and start taking damage, usually after having cannibalized all their limbs already
+#define JELLY_REGEN_RATE_EMPTY 2.5
+
 /datum/species/jelly
 	// Entirely alien beings that seem to be made entirely out of gel. They have three eyes and a skeleton visible within them.
 	name = "\improper Jellyperson"
@@ -17,6 +22,7 @@
 	mutantheart = null
 	meat = /obj/item/food/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimejelly
+	blood_deficiency_drain_rate = JELLY_REGEN_RATE + BLOOD_DEFICIENCY_DRAIN_MODIFIER
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
 	liked_food = MEAT | BUGS
 	toxic_food = NONE
@@ -56,13 +62,13 @@
 		return
 
 	if(!H.blood_volume)
-		H.blood_volume += 2.5 * delta_time
+		H.blood_volume += JELLY_REGEN_RATE_EMPTY * delta_time
 		H.adjustBruteLoss(2.5 * delta_time)
 		to_chat(H, span_danger("You feel empty!"))
 
 	if(H.blood_volume < BLOOD_VOLUME_NORMAL)
 		if(H.nutrition >= NUTRITION_LEVEL_STARVING)
-			H.blood_volume += 1.5 * delta_time
+			H.blood_volume += JELLY_REGEN_RATE * delta_time
 			H.adjust_nutrition(-1.25 * delta_time)
 
 	if(H.blood_volume < BLOOD_VOLUME_OKAY)

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -23,7 +23,7 @@
 	mutant_bodyparts = list("wings" = "None")
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 	exotic_bloodtype = "U"
-	blood_deficiency_drain_rate = BLOOD_DEFICIENCY_DRAIN_MODIFIER // vampires already passively lose blood, so this just makes them lose it slightly more quickly when they have blood deficiency.
+	blood_deficiency_drain_rate = BLOOD_DEFICIENCY_MODIFIER // vampires already passively lose blood, so this just makes them lose it slightly more quickly when they have blood deficiency.
 	use_skintones = TRUE
 	mutantheart = /obj/item/organ/internal/heart/vampire
 	mutanttongue = /obj/item/organ/internal/tongue/vampire

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -23,6 +23,7 @@
 	mutant_bodyparts = list("wings" = "None")
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
 	exotic_bloodtype = "U"
+	blood_deficiency_drain_rate = BLOOD_DEFICIENCY_DRAIN_MODIFIER // vampires already passively lose blood, so this just makes them lose it slightly more quickly when they have blood deficiency.
 	use_skintones = TRUE
 	mutantheart = /obj/item/organ/internal/heart/vampire
 	mutanttongue = /obj/item/organ/internal/tongue/vampire


### PR DESCRIPTION
## About The Pull Request

Slimepeople were not being affected by the blood deficiency quirk due to having `TRAIT_NOBLOOD`:

https://github.com/tgstation/tgstation/blob/0426f7ddbaa91439c7278189101f5db9c7f2ed95/code/datums/quirks/negative_quirks.dm#L73-L74

Additionally, the rate at which slimes regenerate blood is not the same as the rate for humans.
I added a new species var, `blood_deficiency_drain_rate`, to allow for variable drain rates that can be customized on a species basis.

Currently the only species with varying regen rates seem to be slimepeople and vampires. In the case of vampires, they already lost blood over time but it will now just happen slightly faster.

One thing to note for posterity: as a side effect of this, slimes with this trait will have a pretty impressive appetite due to this:

https://github.com/tgstation/tgstation/blob/afe6ecc353eef0db92a23dd1928768651071d11e/code/modules/mob/living/carbon/human/species_types/jellypeople.dm#L63-L66

If you find some way to keep your blood volume higher than `BLOOD_VOLUME_NORMAL` then you can prevent the nutrition loss entirely. Easier said than done though! Could lead to some interesting shenanigans.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/15447

## Why It's Good For The Game

Fixes a quirk being broken for some species. Code changes to allow for better handling of such cases as variable species blood regen rates in the future.

## Changelog

:cl:
fix: slimepeople and vampires are now affected by the blood deficiency quirk
/:cl: