### PR TITLE
Fixes robotic wings not having the correct sprite

### DIFF
--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -177,7 +177,7 @@
 /obj/item/organ/external/wings/functional/robotic
 	name = "robotic wings"
 	desc = "Using microscopic hover-engines, or \"microwings,\" as they're known in the trade, these tiny devices are able to lift a few grams at a time. Gathering enough of them, and you can lift impressively large things."
-	sprite_accessory_override = /datum/sprite_accessory/wings/megamoth
+	sprite_accessory_override = /datum/sprite_accessory/wings/robotic
 
 ///skeletal wings, which relate to skeletal races.
 /obj/item/organ/external/wings/functional/skeleton


### PR DESCRIPTION

## About The Pull Request

The robotic wings sprite override was instead using the megamoth one because of a repeated variable

## Why It's Good For The Game

v1 wings are now real again

![imagen](https://user-images.githubusercontent.com/68669754/224090005-74ad90ed-b0b1-4874-90e3-b668e0d6b1cc.png)


## Changelog

:cl:
fix: Androids now properly have robotic wings instead of moth wings.
/:cl:

