### PR TITLE
orbiting makes you click transparent

### DIFF
--- a/code/datums/components/orbiter.dm
+++ b/code/datums/components/orbiter.dm
@@ -101,6 +101,7 @@
 		orbiter.glide_size = movable_parent.glide_size
 
 	orbiter.abstract_move(get_turf(parent))
+	orbiter.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	to_chat(orbiter, span_notice("Now orbiting [parent]."))
 
 /datum/component/orbiter/proc/end_orbit(atom/movable/orbiter, refreshing=FALSE)
@@ -120,6 +121,7 @@
 		orbiter_mob.updating_glide_size = TRUE
 		orbiter_mob.glide_size = 8
 
+	orbiter.mouse_opacity = initial(orbiter.mouse_opacity)
 	REMOVE_TRAIT(orbiter, TRAIT_NO_FLOATING_ANIM, ORBITING_TRAIT)
 
 	if(!refreshing && !length(orbiter_list) && !QDELING(src))


### PR DESCRIPTION

## About The Pull Request

When you orbit something you can no longer be clicked on, and your clicks pass through
## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/27096
## Changelog
:cl:
qol: Ghosts who are orbiting something can no longer be clicked on, to prevent accidental click catching
/:cl:
