### PR TITLE
Roundend announcement is synced with adminchat

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -235,7 +235,7 @@
 	//Set news report and mode result
 	mode.set_round_result()
 
-	to_chat(world, "<span class='infoplain'><BR><BR><BR><span class='big bold'>The round has ended.</span></span>")
+	to_chat(world, span_infoplain(span_big(span_bold("<BR><BR><BR>The round has ended."))))
 	log_game("The round has ended.")
 	send2chat("[GLOB.round_id ? "Round [GLOB.round_id]" : "The round has"] just ended.", CONFIG_GET(string/channel_announce_end_game))
 	send2adminchat("Server", "Round just ended.")

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -204,9 +204,6 @@
 /datum/controller/subsystem/ticker/proc/declare_completion()
 	set waitfor = FALSE
 
-	to_chat(world, "<span class='infoplain'><BR><BR><BR><span class='big bold'>The round has ended.</span></span>")
-	log_game("The round has ended.")
-
 	for(var/datum/callback/roundend_callbacks as anything in round_end_events)
 		roundend_callbacks.InvokeAsync()
 	LAZYCLEARLIST(round_end_events)
@@ -238,6 +235,8 @@
 	//Set news report and mode result
 	mode.set_round_result()
 
+	to_chat(world, "<span class='infoplain'><BR><BR><BR><span class='big bold'>The round has ended.</span></span>")
+	log_game("The round has ended.")
 	send2chat("[GLOB.round_id ? "Round [GLOB.round_id]" : "The round has"] just ended.", CONFIG_GET(string/channel_announce_end_game))
 	send2adminchat("Server", "Round just ended.")
 


### PR DESCRIPTION
## About The Pull Request

The announcement that the round is over is now sent after the other roundend stuff such as the callbacks, antag hud reveals, and the roundend popup. Basically it will now play at the same time as it'll be said to admins/discord.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/34300 - only reason I made the PR

It's such an insignificant change that I don't even know if it's a problem anymore, but this is being on the safe side.

## Changelog

:cl:
code: The Server ending announcement is now sent to players once the game has properly ended.
/:cl: