### PR TITLE
Chef Diplomatic immunity has just been revoked

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -252,35 +252,6 @@
 	///List of all areas that CQC will work in, defaults to Kitchen.
 	var/list/kitchen_areas = list(/area/station/service/kitchen)
 
-/// Refreshes the valid areas from the cook's mapping config, adding areas in config to the list of possible areas.
-/datum/martial_art/cqc/under_siege/proc/refresh_valid_areas()
-	var/list/job_changes = SSmapping.config.job_changes
-
-	if(!length(job_changes))
-		return
-
-	var/list/cook_changes = job_changes[JOB_COOK]
-
-	if(!length(cook_changes))
-		return
-
-	var/list/additional_cqc_areas = cook_changes["additional_cqc_areas"]
-
-	if(!additional_cqc_areas)
-		return
-
-	if(!islist(additional_cqc_areas))
-		stack_trace("Incorrect CQC area format from mapping configs. Expected /list, got: \[[additional_cqc_areas.type]\]")
-		return
-
-	for(var/path_as_text in additional_cqc_areas)
-		var/path = text2path(path_as_text)
-		if(!ispath(path, /area))
-			stack_trace("Invalid path in mapping config for chef CQC: \[[path_as_text]\]")
-			continue
-
-		kitchen_areas |= path
-
 /// Limits where the chef's CQC can be used to only whitelisted areas.
 /datum/martial_art/cqc/under_siege/can_use(mob/living/owner)
 	if(!is_type_in_list(get_area(owner), kitchen_areas))

--- a/code/modules/library/skill_learning/job_skillchips/chef.dm
+++ b/code/modules/library/skill_learning/job_skillchips/chef.dm
@@ -12,7 +12,6 @@
 /obj/item/skillchip/job/chef/Initialize(mapload)
 	. = ..()
 	style = new
-	style.refresh_valid_areas()
 
 /obj/item/skillchip/job/chef/on_activate(mob/living/carbon/user, silent = FALSE)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

The chef CQC no longer works anywhere but the kitchen alone
## Why It's Good For The Game
This is a meme referencing the steven segal movie, and he was just a cook, not a bar tender.

## Changelog
:cl: oranges
balance: chef cqc no longer works outside the kitchen
/:cl:
https://www.youtube.com/watch?v=kwC_IaY3BmY