### PR TITLE
Ghosts cannot be clicked on by living mobs

### DIFF
--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -577,16 +577,28 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	plane = GHOST_PLANE
 	render_relay_planes = list(RENDER_PLANE_NON_GAME)
 
-/atom/movable/screen/plane_master/ghost/show_to(mob/living/mymob)
+/atom/movable/screen/plane_master/ghost/show_to(mob/mymob)
 	. = ..()
 	if(!.)
 		return
 
-	var/opacity = MOUSE_OPACITY_OPAQUE
-	// If the mob is not dead, don't let them click on ghosts
-	if(istype(mymob) && mymob.stat != DEAD)
-		opacity = MOUSE_OPACITY_TRANSPARENT
-	mouse_opacity = opacity
+	// if they are living listen to stat changes to determine mouse opacity
+	if(isliving(mymob))
+		RegisterSignal(mymob, COMSIG_MOB_STATCHANGE, PROC_REF(handle_stat_change))
+		handle_stat_change(mymob)
+
+/atom/movable/screen/plane_master/ghost/hide_from(mob/oldmob)
+	..()
+	UnregisterSignal(oldmob, COMSIG_MOB_STATCHANGE)
+
+/atom/movable/screen/plane_master/ghost/proc/handle_stat_change(mob/living/mymob)
+	SIGNAL_HANDLER
+
+	switch(mymob.stat)
+		if(DEAD)
+			mouse_opacity = MOUSE_OPACITY_OPAQUE
+		else
+			mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /atom/movable/screen/plane_master/fullscreen
 	name = "Fullscreen"

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -577,6 +577,17 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	plane = GHOST_PLANE
 	render_relay_planes = list(RENDER_PLANE_NON_GAME)
 
+/atom/movable/screen/plane_master/ghost/show_to(mob/living/mymob)
+	. = ..()
+	if(!.)
+		return
+
+	var/opacity = MOUSE_OPACITY_OPAQUE
+	// If the mob is not dead, don't let them click on ghosts
+	if(istype(mymob) && mymob.stat != DEAD)
+		opacity = MOUSE_OPACITY_TRANSPARENT
+	mouse_opacity = opacity
+
 /atom/movable/screen/plane_master/fullscreen
 	name = "Fullscreen"
 	documentation = "Holds anything that applies to or above the full screen. \

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -588,18 +588,13 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 
 	return .
 
-/atom/movable/screen/plane_master/ghost/Destroy(force, ...)
-	UnregisterSignal(home.our_hud.mymob, COMSIG_MOB_STATCHANGE) // this technically isn't needed, but it's a good idea to be explicit
-	return ..()
-
 /atom/movable/screen/plane_master/ghost/proc/handle_stat_change(mob/living/mymob)
 	SIGNAL_HANDLER
 
-	switch(mymob.stat)
-		if(DEAD)
-			mouse_opacity = MOUSE_OPACITY_OPAQUE
-		else
-			mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	if(mymob.stat == DEAD)
+		mouse_opacity = MOUSE_OPACITY_OPAQUE
+	else
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /atom/movable/screen/plane_master/fullscreen
 	name = "Fullscreen"

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -589,7 +589,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	return .
 
 /atom/movable/screen/plane_master/ghost/Destroy(force, ...)
-	UnregisterSignal(oldmob, COMSIG_MOB_STATCHANGE) // this technically isn't needed, but it's a good idea to be explicit
+	UnregisterSignal(home.our_hud.mymob, COMSIG_MOB_STATCHANGE) // this technically isn't needed, but it's a good idea to be explicit
 	return ..()
 
 /atom/movable/screen/plane_master/ghost/proc/handle_stat_change(mob/living/mymob)

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -577,19 +577,20 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	plane = GHOST_PLANE
 	render_relay_planes = list(RENDER_PLANE_NON_GAME)
 
-/atom/movable/screen/plane_master/ghost/show_to(mob/mymob)
+/atom/movable/screen/plane_master/ghost/Initialize(mapload, datum/plane_master_group/home, offset)
 	. = ..()
-	if(!.)
-		return
 
-	// if they are living listen to stat changes to determine mouse opacity
-	if(isliving(mymob))
-		RegisterSignal(mymob, COMSIG_MOB_STATCHANGE, PROC_REF(handle_stat_change))
-		handle_stat_change(mymob)
+	var/mob/hudmod = home.our_hud.mymob
+	if(isliving(hudmod))
+		// living? can't click on ghosts unless dead
+		RegisterSignal(hudmod, COMSIG_MOB_STATCHANGE, PROC_REF(handle_stat_change))
+		handle_stat_change(hudmod)
 
-/atom/movable/screen/plane_master/ghost/hide_from(mob/oldmob)
-	..()
-	UnregisterSignal(oldmob, COMSIG_MOB_STATCHANGE)
+	return .
+
+/atom/movable/screen/plane_master/ghost/Destroy(force, ...)
+	UnregisterSignal(oldmob, COMSIG_MOB_STATCHANGE) // this technically isn't needed, but it's a good idea to be explicit
+	return ..()
 
 /atom/movable/screen/plane_master/ghost/proc/handle_stat_change(mob/living/mymob)
 	SIGNAL_HANDLER

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -36,7 +36,7 @@
 	/// If FALSE, this will not be cleared when calling /client/clear_screen()
 	var/clear_with_screen = TRUE
 
-/atom/movable/screen/Destroy()
+/atom/movable/screen/Destroy(force, ...)
 	master = null
 	hud = null
 	return ..()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -300,7 +300,7 @@
  * * clears overlays and priority overlays
  * * clears the light object
  */
-/atom/Destroy(force)
+/atom/Destroy(force, ...)
 	if(alternate_appearances)
 		for(var/current_alternate_appearance in alternate_appearances)
 			var/datum/atom_hud/alternate_appearance/selected_alternate_appearance = alternate_appearances[current_alternate_appearance]

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -154,7 +154,7 @@
 		if(MOVABLE_LIGHT_DIRECTIONAL)
 			AddComponent(/datum/component/overlay_lighting, is_directional = TRUE)
 
-/atom/movable/Destroy(force)
+/atom/movable/Destroy(force, ...)
 	QDEL_NULL(language_holder)
 	QDEL_NULL(em_block)
 

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -33,6 +33,8 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 		//Both are abstract types meant to scream bloody murder if spawned in raw
 		/obj/item/organ/external,
 		/obj/item/organ/external/wings,
+		// runs logic on the mob owner, which cannot get passed
+		/atom/movable/screen/plane_master/ghost,
 	)
 	//Say it with me now, type template
 	ignore += typesof(/obj/effect/mapping_helpers)


### PR DESCRIPTION

## About The Pull Request

Makes it so that living players cannot hover over ghosts to see names, nor will ghosts eat clicks
## Why It's Good For The Game

Was an issue in the past
## Changelog
:cl:
qol: ghosts will no longer eat mouse clicks for living players, when visible
balance: you can no longer see the names of ghosts orbiting you as a living mob
/:cl:
