### PR TITLE
Splits Pirates into Two Subgroups, One For Light Midrounds And Another For Heavy

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -795,23 +795,45 @@
 /// Space Pirates ruleset
 /datum/dynamic_ruleset/midround/pirates
 	name = "Space Pirates"
+	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
+	antag_flag = "Space Pirates"
+	required_type = /mob/dead/observer
+	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
+	required_candidates = 0
+	weight = 3
+	cost = 8
+	minimum_players = 20
+	repeatable = TRUE
+
+/datum/dynamic_ruleset/midround/pirates/acceptable(population=0, threat=0)
+	if (SSmapping.is_planetary() || GLOB.light_pirate_gangs.len == 0)
+		return FALSE
+	return ..()
+
+/datum/dynamic_ruleset/midround/pirates/execute()
+	send_pirate_threat(null, FALSE)
+	return ..()
+
+/// Dangerous Space Pirates ruleset
+/datum/dynamic_ruleset/midround/dangerous_pirates
+	name = "Dangerous Space Pirates"
 	midround_ruleset_style = MIDROUND_RULESET_STYLE_HEAVY
 	antag_flag = "Space Pirates"
 	required_type = /mob/dead/observer
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 0
-	weight = 4
+	weight = 3
 	cost = 8
-	minimum_players = 27
+	minimum_players = 25
 	repeatable = TRUE
 
-/datum/dynamic_ruleset/midround/pirates/acceptable(population=0, threat=0)
-	if (SSmapping.is_planetary())
+/datum/dynamic_ruleset/midround/dangerous_pirates/acceptable(population=0, threat=0)
+	if (SSmapping.is_planetary() || GLOB.heavy_pirate_gangs.len == 0)
 		return FALSE
 	return ..()
 
-/datum/dynamic_ruleset/midround/pirates/execute()
-	send_pirate_threat()
+/datum/dynamic_ruleset/midround/dangerous_pirates/execute()
+	send_pirate_threat(null, TRUE)
 	return ..()
 
 /// Obsessed ruleset

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -811,7 +811,7 @@
 	return ..()
 
 /datum/dynamic_ruleset/midround/pirates/execute()
-	send_pirate_threat(null, FALSE)
+	send_pirate_threat(GLOB.light_pirate_gangs)
 	return ..()
 
 /// Dangerous Space Pirates ruleset
@@ -833,7 +833,7 @@
 	return ..()
 
 /datum/dynamic_ruleset/midround/dangerous_pirates/execute()
-	send_pirate_threat(null, TRUE)
+	send_pirate_threat(GLOB.heavy_pirate_gangs)
 	return ..()
 
 /// Obsessed ruleset

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -22,9 +22,15 @@
 /datum/round_event/pirates/start()
 	send_pirate_threat(chosen_gang)
 
-/proc/send_pirate_threat(datum/pirate_gang/chosen_gang)
+/proc/send_pirate_threat(datum/pirate_gang/chosen_gang, is_heavy)
 	if(!chosen_gang)
-		chosen_gang = pick_n_take(GLOB.pirate_gangs)
+		if(!is_heavy)
+			chosen_gang = pick_n_take(GLOB.light_pirate_gangs)
+		else
+			chosen_gang = pick_n_take(GLOB.heavy_pirate_gangs)
+	///If there was nothing to pull from our requested list, stop here.
+	if(!chosen_gang)
+		return
 	//set payoff
 	var/payoff = 0
 	var/datum/bank_account/account = SSeconomy.get_dep_account(ACCOUNT_CAR)

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -22,7 +22,7 @@
 /datum/round_event/pirates/start()
 	send_pirate_threat(gang_list)
 
-/proc/send_pirate_threat(var/list/pirate_selection)
+/proc/send_pirate_threat(list/pirate_selection)
 	var/datum/pirate_gang/chosen_gang = pick_n_take(pirate_selection)
 	///If there was nothing to pull from our requested list, stop here.
 	if(!chosen_gang)

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -17,19 +17,16 @@
 
 /datum/round_event/pirates
 	///admin chosen pirate team
-	var/datum/pirate_gang/chosen_gang
+	var/list/datum/pirate_gang/gang_list
 
 /datum/round_event/pirates/start()
-	send_pirate_threat(chosen_gang)
+	send_pirate_threat(gang_list)
 
-/proc/send_pirate_threat(datum/pirate_gang/chosen_gang, is_heavy)
-	if(!chosen_gang)
-		if(!is_heavy)
-			chosen_gang = pick_n_take(GLOB.light_pirate_gangs)
-		else
-			chosen_gang = pick_n_take(GLOB.heavy_pirate_gangs)
+/proc/send_pirate_threat(var/list/pirate_selection)
+	var/datum/pirate_gang/chosen_gang = pick_n_take(pirate_selection)
 	///If there was nothing to pull from our requested list, stop here.
 	if(!chosen_gang)
+		message_admins("Error attempting to run the space pirate event, as the given pirate gangs list was empty.")
 		return
 	//set payoff
 	var/payoff = 0
@@ -96,6 +93,6 @@
 
 /datum/event_admin_setup/listed_options/pirates/apply_to_event(datum/round_event/pirates/event)
 	if(isnull(chosen))
-		event.chosen_gang = null
+		event.gang_list = GLOB.light_pirate_gangs + GLOB.heavy_pirate_gangs
 	else
-		event.chosen_gang = new chosen
+		event.gang_list = list(new chosen)

--- a/code/modules/antagonists/pirate/pirate_gangs.dm
+++ b/code/modules/antagonists/pirate/pirate_gangs.dm
@@ -1,6 +1,6 @@
 ///global lists of all pirate gangs that can show up today. they will be taken out of the global lists as spawned so dupes cannot spawn.
-GLOBAL_LIST_INIT(light_pirate_gangs, init_pirate_gangs(FALSE))
-GLOBAL_LIST_INIT(heavy_pirate_gangs, init_pirate_gangs(TRUE))
+GLOBAL_LIST_INIT(light_pirate_gangs, init_pirate_gangs(is_heavy = FALSE))
+GLOBAL_LIST_INIT(heavy_pirate_gangs, init_pirate_gangs(is_heavy = TRUE))
 
 ///initializes the pirate gangs glob list, adding all subtypes that can roll today.
 /proc/init_pirate_gangs(is_heavy)

--- a/code/modules/antagonists/pirate/pirate_gangs.dm
+++ b/code/modules/antagonists/pirate/pirate_gangs.dm
@@ -1,15 +1,16 @@
-///global list of all pirate gangs that can show up today. these will be taken out of the global list as spawned so dupes cannot spawn.
-GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
+///global lists of all pirate gangs that can show up today. these will be taken out of the global list as spawned so dupes cannot spawn.
+GLOBAL_LIST_INIT(light_pirate_gangs, init_pirate_gangs(FALSE))
+GLOBAL_LIST_INIT(heavy_pirate_gangs, init_pirate_gangs(TRUE))
 
 ///initializes the pirate gangs glob list, adding all subtypes that can roll today.
-/proc/init_pirate_gangs()
+/proc/init_pirate_gangs(is_heavy)
 	var/list/pirate_gangs = list()
 
 	for(var/type in subtypesof(/datum/pirate_gang))
 		var/datum/pirate_gang/possible_gang = new type
 		if(!possible_gang.can_roll())
 			qdel(possible_gang)
-		else
+		else if(possible_gang.is_heavy_threat == is_heavy)
 			pirate_gangs += possible_gang
 	return pirate_gangs
 
@@ -18,6 +19,8 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 	///name of this gang, for spawning feedback
 	var/name = "Space Bugs"
 
+	///Whether or not this pirate crew is a heavy-level threat
+	var/is_heavy_threat = FALSE
 	///the random ship name chosen from pirates.json
 	var/ship_name
 	///the ship they load in on.
@@ -93,6 +96,7 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 /datum/pirate_gang/skeletons
 	name = "Skeleton Pirates"
 
+	is_heavy_threat = TRUE
 	ship_template_id = "dutchman"
 	ship_name_pool = "skeleton_names" //just points to THE ONE AND ONLY
 

--- a/code/modules/antagonists/pirate/pirate_gangs.dm
+++ b/code/modules/antagonists/pirate/pirate_gangs.dm
@@ -1,4 +1,4 @@
-///global lists of all pirate gangs that can show up today. these will be taken out of the global list as spawned so dupes cannot spawn.
+///global lists of all pirate gangs that can show up today. they will be taken out of the global lists as spawned so dupes cannot spawn.
 GLOBAL_LIST_INIT(light_pirate_gangs, init_pirate_gangs(FALSE))
 GLOBAL_LIST_INIT(heavy_pirate_gangs, init_pirate_gangs(TRUE))
 


### PR DESCRIPTION
## About The Pull Request

This PR splits the Pirate midround antagonists into two separate groups, normal and dangerous. Normal pirates are the human, silverscale, and psycker groups, and they are all light antagonists now, meaning they can show up early in the round, similar to when a revenant or nightmare can spawn. Dangerous Space Pirates only consist of the Skeleton Crew, and they will remain as heavy weight antagonists with the same spawning restrictions as it is currently. I also fudged with the crew required value some for both, not that it makes a huge difference.

Since pirates were split into two separate groups, both versions have a reduced dynamic weight of 3, from 4.

Also added a sanity check to the pirate's dynamic ruleset to make sure there are remaining pirates to be spawned for the ruleset to be allowed. Also added a check to the pirate event itself to prevent runtimes when no pirate team is available to be chosen, unless an admin specifies what pirate team they want to use.

## Why It's Good For The Game

As it is right now, there is a massive difference between the skeleton pirates and the rest of the pirate types. Skeleton Pirates have cannons, innate space immunity and other small benefits which make them much more threatening than the other pirate crews. In our current system, something like Psycker pirates can spawn in lieu of something like blob or xenomorphs when they aren't anywhere near the same level of threatening, so moving the less dangerous pirates off to be light weight midrounds seems like a good move, especially since we need more lightweight midrounds to keep the variety up anyway.

Keep in mind these designations are not permanent and may change at the request of maintainers or as the pirate teams get nerfed/buffed.

## Changelog

:cl:
balance: The pirate gangs have been split into two subcategories, one which can spawn earlier in a shift and one that spawns later as they currently do. While skeleton pirates will still be only seen later into the shift, expect to see the other pirate gangs earlier on.
fix: Prevented the pirate event from runtiming when no possible pirate gangs were available.
fix: Pirates can no longer be selected by Dynamic if there are no more pirates gangs that can be used.
/:cl: