### PR TITLE
Recolors and fixes holodeck chess board, fixes error on white king's description

### DIFF
--- a/_maps/templates/holodeck_spacechess.dmm
+++ b/_maps/templates/holodeck_spacechess.dmm
@@ -1,284 +1,315 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/open/floor/holofloor/carpet,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "b" = (
-/obj/structure/chess/blackbishop,
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/whitebishop,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "c" = (
-/obj/structure/chess/blackpawn,
 /obj/effect/turf_decal/board_number/two{
 	dir = 4
 	},
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/whitepawn,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "e" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/effect/turf_decal/board_number/one{
 	dir = 4
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "f" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/effect/turf_decal/board_number/four{
 	dir = 4
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "g" = (
-/obj/structure/chess/whitepawn,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/blackpawn,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "h" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/turf_decal/board_letter/b{
 	dir = 1
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "i" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/effect/turf_decal/board_number/six{
 	dir = 4
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "j" = (
 /obj/effect/turf_decal/board_number/five{
 	dir = 4
 	},
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "k" = (
-/obj/structure/chess/whitepawn,
 /obj/effect/turf_decal/board_number/seven{
 	dir = 4
 	},
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/blackpawn,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "l" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/turf_decal/board_letter/a{
 	dir = 1
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "m" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/effect/turf_decal/board_number/seven{
 	dir = 4
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "n" = (
 /obj/effect/turf_decal/board_number/three{
 	dir = 4
 	},
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "o" = (
-/obj/structure/chess/whitebishop,
 /obj/effect/turf_decal/board_letter/f{
 	dir = 1
 	},
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/blackbishop,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "p" = (
 /obj/effect/turf_decal/board_number/four{
 	dir = 4
 	},
-/turf/open/floor/holofloor/dark,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "q" = (
-/obj/structure/chess/blackrook,
 /obj/effect/turf_decal/board_number/one{
 	dir = 4
 	},
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/whiterook,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "r" = (
-/obj/structure/chess/blackpawn,
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/whitepawn,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "s" = (
-/obj/structure/chess/whiterook,
 /obj/effect/turf_decal/board_number/eight{
 	dir = 4
 	},
 /obj/effect/turf_decal/board_letter/h{
 	dir = 1
 	},
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/blackrook,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "t" = (
 /obj/effect/turf_decal/board_number/six{
 	dir = 4
 	},
-/turf/open/floor/holofloor/dark,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "u" = (
-/obj/structure/chess/whiteknight,
 /obj/effect/turf_decal/board_letter/g{
 	dir = 1
 	},
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/blackknight,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "v" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/turf_decal/board_letter/c{
 	dir = 1
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "w" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/effect/turf_decal/board_number/three{
 	dir = 4
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "y" = (
-/obj/structure/chess/blackbishop,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/whitebishop,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "z" = (
-/obj/structure/chess/whiterook,
 /obj/effect/turf_decal/board_letter/a{
 	dir = 1
 	},
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/blackrook,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "A" = (
-/obj/structure/chess/blackpawn,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/whitepawn,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "B" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/turf_decal/board_letter/g{
 	dir = 1
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "C" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/effect/turf_decal/board_number/five{
 	dir = 4
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
+/area/template_noop)
+"D" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "E" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/turf_decal/board_letter/d{
 	dir = 1
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "G" = (
-/obj/structure/chess/whiteknight,
 /obj/effect/turf_decal/board_letter/b{
 	dir = 1
 	},
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/blackknight,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "H" = (
-/obj/structure/chess/whiteking,
 /obj/effect/turf_decal/board_letter/d{
 	dir = 1
 	},
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/blackqueen,
+/turf/open/floor/holofloor/chess_black,
+/area/template_noop)
+"I" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "J" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/turf_decal/board_letter/h{
 	dir = 1
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "K" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/turf_decal/board_letter/e{
 	dir = 1
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "L" = (
-/obj/structure/chess/blackknight,
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/whiteknight,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "M" = (
-/obj/structure/chess/blackking,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/whitequeen,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "N" = (
-/obj/structure/chess/whitepawn,
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/blackpawn,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "O" = (
-/obj/structure/chess/blackknight,
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/whiteknight,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "P" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/effect/turf_decal/board_number/two{
 	dir = 4
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "Q" = (
-/turf/open/floor/holofloor/dark,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "S" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/effect/turf_decal/board_number/eight{
 	dir = 4
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "U" = (
-/obj/structure/chess/whitebishop,
 /obj/effect/turf_decal/board_letter/c{
 	dir = 1
 	},
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/blackbishop,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "V" = (
-/obj/structure/chess/blackrook,
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/whiterook,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "W" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/effect/turf_decal/board_letter/f{
 	dir = 1
 	},
-/turf/open/floor/holofloor/carpet,
+/turf/open/floor/holofloor/wood,
 /area/template_noop)
 "X" = (
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 "Y" = (
-/obj/structure/chess/blackqueen,
-/turf/open/floor/holofloor/dark,
+/obj/structure/chess/whiteking,
+/turf/open/floor/holofloor/chess_black,
 /area/template_noop)
 "Z" = (
-/obj/structure/chess/whitequeen,
 /obj/effect/turf_decal/board_letter/e{
 	dir = 1
 	},
-/turf/open/floor/holofloor{
-	icon_state = "white"
-	},
+/obj/structure/chess/blackking,
+/turf/open/floor/holofloor/chess_white,
 /area/template_noop)
 
 (1,1,1) = {"
@@ -291,10 +322,10 @@ f
 w
 P
 e
-a
+I
 "}
 (2,1,1) = {"
-a
+D
 z
 N
 X
@@ -306,7 +337,7 @@ V
 l
 "}
 (3,1,1) = {"
-a
+D
 G
 g
 Q
@@ -318,7 +349,7 @@ O
 h
 "}
 (4,1,1) = {"
-a
+D
 U
 N
 X
@@ -330,7 +361,7 @@ b
 v
 "}
 (5,1,1) = {"
-a
+D
 H
 g
 Q
@@ -342,7 +373,7 @@ M
 E
 "}
 (6,1,1) = {"
-a
+D
 Z
 N
 X
@@ -354,7 +385,7 @@ Y
 K
 "}
 (7,1,1) = {"
-a
+D
 o
 g
 Q
@@ -366,7 +397,7 @@ y
 W
 "}
 (8,1,1) = {"
-a
+D
 u
 N
 X
@@ -378,7 +409,7 @@ L
 B
 "}
 (9,1,1) = {"
-a
+D
 s
 k
 t

--- a/code/game/objects/structures/chess.dm
+++ b/code/game/objects/structures/chess.dm
@@ -22,62 +22,62 @@
 	return TRUE
 
 /obj/structure/chess/whitepawn
-	name = "\improper White Pawn"
+	name = "\improper white pawn"
 	desc = "A white pawn chess piece. Get accused of cheating when executing a sick En Passant."
 	icon_state = "white_pawn"
 
 /obj/structure/chess/whiterook
-	name = "\improper White Rook"
+	name = "\improper white rook"
 	desc = "A white rook chess piece. Also known as a castle. Can move any number of tiles in a straight line. It has a special move called castling."
 	icon_state = "white_rook"
 
 /obj/structure/chess/whiteknight
-	name = "\improper White Knight"
+	name = "\improper white knight"
 	desc = "A white knight chess piece. It can hop over other pieces, moving in L shapes. A white kni- oh. Hah!"
 	icon_state = "white_knight"
 
 /obj/structure/chess/whitebishop
-	name = "\improper White Bishop"
+	name = "\improper white bishop"
 	desc = "A white bishop chess piece. It can move any number of tiles in a diagonal line."
 	icon_state = "white_bishop"
 
 /obj/structure/chess/whitequeen
-	name = "\improper White Queen"
+	name = "\improper white queen"
 	desc = "A white queen chess piece. It can move any number of tiles in diagonal and straight lines."
 	icon_state = "white_queen"
 
 /obj/structure/chess/whiteking
-	name = "\improper White King"
-	desc = "A white king chess piece. It can move any tile in one direction."
+	name = "\improper white king"
+	desc = "A white king chess piece. It can move one tile in any direction."
 	icon_state = "white_king"
 
 /obj/structure/chess/blackpawn
-	name = "\improper Black Pawn"
+	name = "\improper black pawn"
 	desc = "A black pawn chess piece. Get accused of cheating when executing a sick En Passant."
 	icon_state = "black_pawn"
 
 /obj/structure/chess/blackrook
-	name = "\improper Black Rook"
+	name = "\improper black rook"
 	desc = "A black rook chess piece. Also known as a castle. Can move any number of tiles in a straight line. It has a special move called castling."
 	icon_state = "black_rook"
 
 /obj/structure/chess/blackknight
-	name = "\improper Black Knight"
+	name = "\improper black knight"
 	desc = "A black knight chess piece. It can hop over other pieces, moving in L shapes."
 	icon_state = "black_knight"
 
 /obj/structure/chess/blackbishop
-	name = "\improper Black Bishop"
+	name = "\improper black bishop"
 	desc = "A black bishop chess piece. It can move any number of tiles in a diagonal line."
 	icon_state = "black_bishop"
 
 /obj/structure/chess/blackqueen
-	name = "\improper Black Queen"
+	name = "\improper black queen"
 	desc = "A black queen chess piece. It can move any number of tiles in diagonal and straight lines."
 	icon_state = "black_queen"
 
 /obj/structure/chess/blackking
-	name = "\improper Black King"
+	name = "\improper black king"
 	desc = "A black king chess piece. It can move one tile in any direction."
 	icon_state = "black_king"
 

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -196,3 +196,11 @@
 
 /turf/open/floor/holofloor/stairs/right
 	icon_state = "stairs-r"
+
+/turf/open/floor/holofloor/chess_white
+	icon_state = "white_large"
+	color = "#eeeed2"
+
+/turf/open/floor/holofloor/chess_black
+	icon_state = "white_large"
+	color = "#93b570"


### PR DESCRIPTION
## About The Pull Request

In a chess board, the white pieces occupy the 1-2 squares, while the black pieces occupy the 7-8 squares. This was reversed in space chess, with the white pieces being on black's position and vice versa.
I changed the colors of the board as well, to make it nicer to the eye (and also occupying full tiles since the old version used the regular 4 square tiles). This accompanied by switching the carpet to wood for a more aesthetically pleasing view (esp since carpets look ugly in that shape).
I made the names of the chess pieces lowercase to make it consistent ("That's a Black Pawn." -> "That's a black pawn.") and fixed the white king's description.
All in all, the chess board looks like this now.

![imagen](https://user-images.githubusercontent.com/68669754/224214951-d10e9a8b-1a8e-492c-bd91-0fd5ecae4385.png)

## Why It's Good For The Game
![imagen](https://user-images.githubusercontent.com/68669754/224215899-2059f845-0071-4a21-84bb-13108ceec9b2.png)
![imagen](https://user-images.githubusercontent.com/68669754/224215206-1b5ef367-a5c5-436c-9bf5-665f243fe3e8.png)
![imagen](https://user-images.githubusercontent.com/68669754/224215215-0b5799b3-9f47-46f2-958a-6dd211eff59a.png)
![imagen](https://user-images.githubusercontent.com/68669754/224215235-4c5381de-93ce-4760-b881-50412a6e55b9.png)

## Changelog

:cl:
qol: Holodeck space chess board is more pleasing to look at.
fix: Fixes holodeck space chess pieces being reversed.
spellcheck: Fixed white king's description saying it moves any tile in one direction.
/:cl: