### PR TITLE
Stray Tramstation warehouse shutter button removal

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -40482,9 +40482,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "njx" = (
-/obj/machinery/button/door/directional/east{
-	id = "cargowarehouse"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{


### PR DESCRIPTION
## About The Pull Request

Takes out a shutter button hovering in the air in the tram warehouse.

Before:
![image](https://user-images.githubusercontent.com/127473522/224251343-c27ec403-7d9b-4142-bd16-27aa3ebe4f76.png)

After:
![image](https://user-images.githubusercontent.com/127473522/224250962-5e55508f-de68-4255-8c0b-63ce4e3c08f1.png)

## Why It's Good For The Game

It makes the map look nicer.
## Changelog
:cl:
fix: Fixes #73883
/:cl:
