### PR TITLE
Fake nuclear authentication disks now have a placebo keep_me_secure component (making them more convincing)

### DIFF
--- a/code/datums/components/keep_me_secure.dm
+++ b/code/datums/components/keep_me_secure.dm
@@ -24,7 +24,8 @@
 
 /datum/component/keep_me_secure/RegisterWithParent()
 	last_move = world.time
-	START_PROCESSING(SSobj, src)
+	if (secured_callback || unsecured_callback)
+		START_PROCESSING(SSobj, src)
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE_MORE, PROC_REF(on_examine_more))
 

--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -32,6 +32,8 @@
 	if(!fake)
 		AddComponent(/datum/component/keep_me_secure, CALLBACK(src, PROC_REF(secured_process)), CALLBACK(src, PROC_REF(unsecured_process)))
 		SSpoints_of_interest.make_point_of_interest(src)
+	else
+		AddComponent(/datum/component/keep_me_secure)
 
 /obj/item/disk/nuclear/proc/secured_process(last_move)
 	var/turf/new_turf = get_turf(src)


### PR DESCRIPTION

## About The Pull Request
In #73453, we were given the `keep_me_secure` component. Something I think was long overdue, really.

However, it came at a terrible price...
<details>
  <summary>The Lore</summary>

Tell me, John Assistant with absolutely no disk verifier skillchip, which nuclear authentication disk is real?
![image](https://user-images.githubusercontent.com/44104681/224259065-1176d783-355c-4d83-a7a2-d0a5fa1324fa.png)

The one on the plastitanium glass table?
![image](https://user-images.githubusercontent.com/44104681/224259331-3f7bc729-f451-4c52-9534-b4a86a433d91.png)

The one on the titanium glass table?
![image](https://user-images.githubusercontent.com/44104681/224259436-3aeecb65-57c8-4806-82e9-9e586d44d9e5.png)

Or the one on the reinforced plasma glass table?
![image](https://user-images.githubusercontent.com/44104681/224259583-2e2cb6ad-a6a7-4f7f-b012-9102fe51bc01.png)

The one on the plastitanium glass table you say?
![image](https://user-images.githubusercontent.com/44104681/224259817-1edfbe68-94a9-4f0d-be99-c52adf682774.png)
B-but how did you know?!
</details>

tldr: Anyone can tell the real disk apart from fakes because only the real one has the `keep_me_secure` component examine message! This PR fixes that by adding the `keep_me_secure` component to fake disks. It won't actually do anything - and I added a check to `keep_me_secure` so it won't process if there are no callbacks passed, avoiding Free Lag. This just gives the fake disks the same examine message as the disk, so it won't be so obvious.
## Why It's Good For The Game
Bugfix good. Futureproofing good. Fake disk noob trap bad. Disk verifier skillchip should actually do something.
## Changelog
:cl:
fix: Fake nuclear authentication disks have been updated to include the holographic security sticker found on the real disk, one again making them convincingly real to the average person.
code: The keep_me_secured component will now only process if it has at least one callback argument passed.
/:cl:
