### PR TITLE
Don't log scrubbing unless it changes (Saves 0.1s+ on init)

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -199,8 +199,10 @@
 	update_mode_power_usage(scrubbing == ATMOS_DIRECTION_SCRUBBING ? IDLE_POWER_USE : ACTIVE_POWER_USE, new_power_usage)
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/set_scrubbing(scrubbing, mob/user)
+	if (src.scrubbing != scrubbing)
+		investigate_log("was toggled to [scrubbing ? "scrubbing" : "siphon"] mode by [isnull(user) ? "the game" : key_name(user)]", INVESTIGATE_ATMOS)
+
 	src.scrubbing = scrubbing
-	investigate_log("was toggled to [scrubbing ? "scrubbing" : "siphon"] mode by [isnull(user) ? "the game" : key_name(user)]", INVESTIGATE_ATMOS)
 	update_appearance(UPDATE_ICON)
 	try_update_atmos_process()
 	update_power_usage()


### PR DESCRIPTION
We were getting 30KB worth of logs on "The air scrubber was toggled to scrubbing mode by the game". This isn't useful.

I opted to do this instead of checking mapload in case we want to do something funky like a station trait that randomly alters scrubbers or whatever.

I think we can't noop the entire function right now if scrubbing == new scrubbing?