### PR TITLE
Don't cache \ref on 515

### DIFF
--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -17,10 +17,17 @@
 /// Until a condition is true, sleep
 #define UNTIL(X) while(!(X)) stoplag()
 
+#if DM_VERSION <= 514
 /// Takes a datum as input, returns its ref string, or a cached version of it
 /// This allows us to cache \ref creation, which ensures it'll only ever happen once per datum, saving string tree time
 /// It is slightly less optimal then a []'d datum, but the cost is massively outweighed by the potential savings
 /// It will only work for datums mind, for datum reasons
 /// : because of the embedded typecheck
 #define text_ref(datum) (isdatum(datum) ? (datum:cached_ref ||= "\ref[datum]") : ("\ref[datum]"))
-
+#else 
+/// Wrapper around byond's ref()
+#define text_ref(datum) ref(datum)
+#endif
+if DM_VERSION >= 516
+#warn remove this old 514 compatiability code (and also the old `cached_ref` datum var).
+#endif

--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -28,6 +28,6 @@
 /// Wrapper around byond's ref()
 #define text_ref(datum) ref(datum)
 #endif
-if DM_VERSION >= 516
+#if DM_VERSION >= 516
 #warn remove this old 514 compatiability code (and also the old `cached_ref` datum var).
 #endif


### PR DESCRIPTION
Since strings are ref counted, and a `\ref` creates a string, then in cases where a `\ref` is only intended to go to an html window showed to a player or admin, storing it would extend how long the string for the `\ref` exists in the string tree, which is likely bloating the string tree and making it have to force a rebalance more often.

515's next version has a pretty decent speedup on `\ref`/`ref()`.