### PR TITLE
Experiment flag for not caching ref on 515

### DIFF
--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -17,10 +17,14 @@
 /// Until a condition is true, sleep
 #define UNTIL(X) while(!(X)) stoplag()
 
+#ifdef EXPERIMENT_515_DONT_CACHE_REF
+// REMOVE this and replace with `ref` when removing EXPERIMENT_515_DONT_CACHE_REF
+#define text_ref(datum) ref(datum)
+#else
 /// Takes a datum as input, returns its ref string, or a cached version of it
 /// This allows us to cache \ref creation, which ensures it'll only ever happen once per datum, saving string tree time
 /// It is slightly less optimal then a []'d datum, but the cost is massively outweighed by the potential savings
 /// It will only work for datums mind, for datum reasons
 /// : because of the embedded typecheck
 #define text_ref(datum) (isdatum(datum) ? (datum:cached_ref ||= "\ref[datum]") : ("\ref[datum]"))
-
+#endif

--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -18,7 +18,7 @@
 #define UNTIL(X) while(!(X)) stoplag()
 
 #ifdef EXPERIMENT_515_DONT_CACHE_REF
-// REMOVE this and replace with `ref` when removing EXPERIMENT_515_DONT_CACHE_REF
+/// Takes a datum as input, returns its ref string
 #define text_ref(datum) ref(datum)
 #else
 /// Takes a datum as input, returns its ref string, or a cached version of it

--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -4,7 +4,10 @@
 // For example, if you want to enable EXPERIMENT_MY_COOL_FEATURE, compile with -DEXPERIMENT_MY_COOL_FEATURE
 
 // EXPERIMENT_515_QDEL_HARD_REFERENCE
-// - On 515, will hold a hard reference for qdeleted items, and check ref_count, rather than using refs.
+// - Hold a hard reference for qdeleted items, and check ref_count, rather than using refs. Requires 515+.
+
+// EXPERIMENT_515_DONT_CACHE_REF
+// - Avoids `text_ref` caching, aided by improvements to ref() speed in 515.
 
 #if DM_VERSION < 515
 
@@ -14,8 +17,18 @@
 #undef EXPERIMENT_515_QDEL_HARD_REFERENCE
 #endif
 
+#ifdef EXPERIMENT_515_DONT_CACHE_REF
+#warn EXPERIMENT_515_DONT_CACHE_REF is only available on 515+
+#undef EXPERIMENT_515_DONT_CACHE_REF
+#endif
+
 #elif defined(UNIT_TESTS)
 
 #define EXPERIMENT_515_QDEL_HARD_REFERENCE
+#define EXPERIMENT_515_DONT_CACHE_REF
 
+#endif
+
+#if DM_VERSION >= 516
+#error "Remove all 515 experiments"
 #endif

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -40,10 +40,12 @@
 	/// Datum level flags
 	var/datum_flags = NONE
 
+#ifndef EXPERIMENT_515_DONT_CACHE_REF
 	/// A cached version of our \ref
 	/// The brunt of \ref costs are in creating entries in the string tree (a tree of immutable strings)
 	/// This avoids doing that more then once per datum by ensuring ref strings always have a reference to them after they're first pulled
 	var/cached_ref
+#endif
 
 	/// A weak reference to another datum
 	var/datum/weakref/weak_reference

--- a/code/modules/clothing/outfits/vv_outfit.dm
+++ b/code/modules/clothing/outfits/vv_outfit.dm
@@ -48,7 +48,9 @@
 	//Temporary/Internal stuff, do not copy these.
 	var/static/list/ignored_vars = list(
 		NAMEOF(item, animate_movement),
+#ifndef EXPERIMENT_515_DONT_CACHE_REF
 		NAMEOF(item, cached_ref),
+#endif
 		NAMEOF(item, datum_flags),
 		NAMEOF(item, fingerprintslast),
 		NAMEOF(item, layer),


### PR DESCRIPTION
Closes #73902

> Since strings are ref counted, and a `\ref` creates a string, then in cases where a `\ref` is only intended to go to an html window showed to a player or admin, storing it would extend how long the string for the `\ref` exists in the string tree, which is likely bloating the string tree and making it have to force a rebalance more often.
> 
> 515's next version has a pretty decent speedup on `\ref`/`ref()`.

Turned into an experiment flag for a few reasons:
1. I like the idea of when testing 515, only testing 515, and not our changes that benefit from 515
2. Lets me profile the differences a lot easier
3. Makes it clearer what needs to be removed, since I have locked `cached_ref` behind *not* having the flag.

Also adds a compile error if these flags live past 515.