### PR TITLE
Santizes racist robot code from the codebase.

### DIFF
--- a/code/modules/food_and_drinks/restaurant/customers/_customer.dm
+++ b/code/modules/food_and_drinks/restaurant/customers/_customer.dm
@@ -258,7 +258,6 @@
 			/datum/reagent/consumable/cafe_latte = 3,
 			/datum/reagent/consumable/coffee = 3,
 			/datum/reagent/consumable/soy_latte = 3,
-			/datum/reagent/consumable/ethanol/atomicbomb = 1,
 		),
 	)
 

--- a/strings/names/mexican_prefix.txt
+++ b/strings/names/mexican_prefix.txt
@@ -1,5 +1,6 @@
 Bandito
 Conquistador
+Enrique
 Embajador
 Gonzales
 Gulf

--- a/strings/names/mexican_prefix.txt
+++ b/strings/names/mexican_prefix.txt
@@ -1,6 +1,5 @@
 Bandito
 Conquistador
-Deportista
 Embajador
 Gonzales
 Gulf


### PR DESCRIPTION
## About The Pull Request

**Maintainer edit:**

 Floyd did not make the Mexican tourist bots, the name deportista is also the spanish word for sportsman.

The atomic bomb reference is not racist either, it casts no aspersions on the event that occurred and is simply a reference to a historical fact.

This PR is a character assassination based on faulty reasoning and is not good faith, because those from the past cannot offer a defence of their reasoning.


** Original PR body **
Floyd was cringe like usual, while most of the names are bad, deportista really takes the cake. 

## Why It's Good For The Game

Nobody wants another 'meatball' situation happening to the codebase down the line.

## Changelog


:cl:
qol: Mexican tourist bots are slightly less racist.
qol: Japanese tourist bots will no longer request atomic bombs, what the fuck is wrong with you qust?
/:cl:
