### PR TITLE
Fixes some areas on IceBoxStation

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -53277,7 +53277,7 @@
 "qtS" = (
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/mine/storage)
+/area/icemoon/underground/explored)
 "qtT" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock"
@@ -77326,7 +77326,7 @@
 "xPu" = (
 /obj/machinery/light/directional/east,
 /turf/open/misc/asteroid/snow/icemoon,
-/area/mine/storage)
+/area/icemoon/underground/explored)
 "xPv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -77401,7 +77401,7 @@
 "xQu" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/mine/storage)
+/area/icemoon/underground/explored)
 "xQB" = (
 /obj/effect/spawner/random/clothing/costume,
 /obj/structure/rack,


### PR DESCRIPTION

## About The Pull Request

Basically these still followed the old pattern (pre-#69975) where you would have the area also be outside of the room in order to power the lights. i just went through and patched those since I saw them today and it's too trivial to nag someone else to do it
### Mapping March
(does this count for that? i'm out of the loop and just noticed that something was outdated when someone asked me to double-check a map)
Ckey to recieve rewards: san7890

## Why It's Good For The Game

this is the mapping pattern now, and i sure as hell don't want to go back or otherwise insinuate that things should still be done this way
## Changelog
this doesn't matter as far as players are concerned
