### PR TITLE
Fixes cult spell buttons being stacked ontop of eachother.

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -21,7 +21,9 @@
 		var/our_view = hud.mymob?.client?.view || "15x15"
 		var/atom/movable/screen/movable/action_button/button = viewers[hud]
 		var/position = screen_loc_to_offset(button.screen_loc)
-		var/list/position_list = list(1,2,3,4) //List needs to be made longer if the max number of spells is raised
+		var/list/position_list = list()
+		for(var/possible_position in 1 to MAX_BLOODCHARGE)
+			position_list += possible_position
 		for(var/datum/action/innate/cult/blood_spell/blood_spell in spells)
 			if(blood_spell.positioned)
 				position_list.Remove(blood_spell.positioned)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -21,17 +21,17 @@
 		var/our_view = hud.mymob?.client?.view || "15x15"
 		var/atom/movable/screen/movable/action_button/button = viewers[hud]
 		var/position = screen_loc_to_offset(button.screen_loc)
-		var/spells_iterated = 0
+		var/list/position_list = list(1,2,3,4) //List needs to be made longer if the max number of spells is raised
 		for(var/datum/action/innate/cult/blood_spell/blood_spell in spells)
-			spells_iterated += 1
 			if(blood_spell.positioned)
+				position_list.Remove(blood_spell.positioned)
 				continue
 			var/atom/movable/screen/movable/action_button/moving_button = blood_spell.viewers[hud]
 			if(!moving_button)
 				continue
-			var/our_x = position[1] + spells_iterated * world.icon_size // Offset any new buttons into our list
+			var/our_x = position[1] + position_list[1] * world.icon_size // Offset any new buttons into our list
 			hud.position_action(moving_button, offset_to_screen_loc(our_x, position[2], our_view))
-			blood_spell.positioned = TRUE
+			blood_spell.positioned = position_list[1]
 
 /datum/action/innate/cult/blood_magic/Activate()
 	var/rune = FALSE

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -31,9 +31,10 @@
 			var/atom/movable/screen/movable/action_button/moving_button = blood_spell.viewers[hud]
 			if(!moving_button)
 				continue
-			var/our_x = position[1] + position_list[1] * world.icon_size // Offset any new buttons into our list
+			var/first_available_slot = position_list[1]
+			var/our_x = position[1] + first_available_slot * world.icon_size // Offset any new buttons into our list
 			hud.position_action(moving_button, offset_to_screen_loc(our_x, position[2], our_view))
-			blood_spell.positioned = position_list[1]
+			blood_spell.positioned = first_available_slot
 
 /datum/action/innate/cult/blood_magic/Activate()
 	var/rune = FALSE


### PR DESCRIPTION

## About The Pull Request

The system for making sure spells didn't get stacked on top of each other didn't account for spells being expended out of order  (e.g. you use all charges of your third spell but since you have 3 spells slot 4 must be open). I've changed the code to account for this.

Should fix: #66894
## Why It's Good For The Game

Really frustrating and annoying bug finally fixed.
## Changelog
:cl:
fix: When learning new cult spells their buttons will no longer stack on top of one another. 
/:cl:
