### PR TITLE
Glass Floors Can Break When Jumped On

### DIFF
--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -8,6 +8,9 @@
 	var/clawfootstep = null
 	var/heavyfootstep = null
 
+	///chance to break if somebody jumps on it
+	var/jump_fragility = 0
+
 //direction is direction of travel of A
 /turf/open/zPassIn(atom/movable/A, direction, turf/source)
 	if(direction == DOWN)

--- a/code/game/turfs/open/floor/glass.dm
+++ b/code/game/turfs/open/floor/glass.dm
@@ -14,6 +14,7 @@
 	barefootstep = FOOTSTEP_HARD_BAREFOOT
 	clawfootstep = FOOTSTEP_HARD_CLAW
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
+	jump_fragility = 80
 	floor_tile = /obj/item/stack/tile/glass
 	overfloor_placed = FALSE
 	/// List of /atom/movable/render_step that are being used to make this glass floor glow
@@ -68,6 +69,7 @@
 	icon = 'icons/turf/floors/reinf_glass.dmi'
 	icon_state = "reinf_glass-0"
 	base_icon_state = "reinf_glass"
+	jump_fragility = 5
 	floor_tile = /obj/item/stack/tile/rglass
 	alpha_to_leave = 206
 
@@ -83,6 +85,7 @@
 	icon = 'icons/turf/floors/plasma_glass.dmi'
 	icon_state = "plasma_glass-0"
 	base_icon_state = "plasma_glass"
+	jump_fragility = 50
 	floor_tile = /obj/item/stack/tile/glass/plasma
 	starlight_color = COLOR_STRONG_VIOLET
 	alpha_to_leave = 255
@@ -99,6 +102,7 @@
 	icon = 'icons/turf/floors/reinf_plasma_glass.dmi'
 	icon_state = "reinf_plasma_glass-0"
 	base_icon_state = "reinf_plasma_glass"
+	jump_fragility = 3
 	floor_tile = /obj/item/stack/tile/rglass/plasma
 	starlight_color = COLOR_STRONG_VIOLET
 	alpha_to_leave = 206

--- a/code/game/turfs/open/floor/glass.dm
+++ b/code/game/turfs/open/floor/glass.dm
@@ -69,7 +69,7 @@
 	icon = 'icons/turf/floors/reinf_glass.dmi'
 	icon_state = "reinf_glass-0"
 	base_icon_state = "reinf_glass"
-	jump_fragility = 5
+	jump_fragility = 0
 	floor_tile = /obj/item/stack/tile/rglass
 	alpha_to_leave = 206
 
@@ -85,7 +85,7 @@
 	icon = 'icons/turf/floors/plasma_glass.dmi'
 	icon_state = "plasma_glass-0"
 	base_icon_state = "plasma_glass"
-	jump_fragility = 50
+	jump_fragility = 0
 	floor_tile = /obj/item/stack/tile/glass/plasma
 	starlight_color = COLOR_STRONG_VIOLET
 	alpha_to_leave = 255
@@ -102,7 +102,6 @@
 	icon = 'icons/turf/floors/reinf_plasma_glass.dmi'
 	icon_state = "reinf_plasma_glass-0"
 	base_icon_state = "reinf_plasma_glass"
-	jump_fragility = 3
 	floor_tile = /obj/item/stack/tile/rglass/plasma
 	starlight_color = COLOR_STRONG_VIOLET
 	alpha_to_leave = 206

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -218,7 +218,7 @@
 	if(!isopenturf(current))
 		return
 	if(prob(current.jump_fragility))
-		playsound(current, SFX_SHATTER, 70, TRUE)
+		playsound(current, SFX_SHATTER, 70, vary = TRUE)
 		user.visible_message(
 				span_warning("[user] crashes through [current]!"),
 				span_userdanger("You crash through [current]!"),

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -220,9 +220,9 @@
 	if(prob(current.jump_fragility))
 		playsound(current, SFX_SHATTER, 70, vary = TRUE)
 		user.visible_message(
-				span_warning("[user] crashes through [current]!"),
-				span_userdanger("You crash through [current]!"),
-			)
+			span_warning("[user] crashes through [current]!"),
+			span_userdanger("You crash through [current]!"),
+		)
 		current.ScrapeAway(2, flags = CHANGETURF_INHERIT_AIR)
 
 /datum/emote/living/kiss

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -209,8 +209,21 @@
 /datum/emote/living/jump
 	key = "jump"
 	key_third_person = "jumps"
-	message = "jumps!"
+	message = "jumps up and down."
 	hands_use_check = TRUE
+
+/datum/emote/living/jump/run_emote(mob/living/user, params, type_override, intentional)
+	. = ..()
+	var/turf/open/current = get_turf(user)
+	if(!isopenturf(current))
+		return
+	if(prob(current.jump_fragility))
+		playsound(current, SFX_SHATTER, 70, TRUE)
+		user.visible_message(
+				span_warning("[user] crashes through [current]!"),
+				span_userdanger("You crash through [current]!"),
+			)
+		current.ScrapeAway(2, flags = CHANGETURF_INHERIT_AIR)
 
 /datum/emote/living/kiss
 	key = "kiss"


### PR DESCRIPTION
## About The Pull Request

Glass floors have a chance of breaking when someone *jump emotes on top of one.

## Why It's Good For The Game

It's a funny interaction for enhancing slapstick comedy.

## Changelog
:cl:
add: NanoTrasen no longer guarantees that glass floors are safe to jump on. Please exercise caution.
/:cl:
