### PR TITLE
viruses with the inorganic biology symptom can now infect androids

### DIFF
--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -43,8 +43,7 @@
 	severity = 0
 
 /datum/symptom/inorganic_adaptation/OnAdd(datum/disease/advance/A)
-	A.infectable_biotypes |= MOB_MINERAL //Mineral covers plasmamen and golems.
-	A.infectable_biotypes |= MOB_ROBOTIC //Robotic covers androids.
+	A.infectable_biotypes |= MOB_MINERAL | MOB_ROBOTIC // Plasmamen, Golems, and Androids.
 
 /datum/symptom/inorganic_adaptation/OnRemove(datum/disease/advance/A)
 	A.infectable_biotypes &= ~MOB_MINERAL

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -46,6 +46,5 @@
 	A.infectable_biotypes |= MOB_MINERAL | MOB_ROBOTIC // Plasmamen, Golems, and Androids.
 
 /datum/symptom/inorganic_adaptation/OnRemove(datum/disease/advance/A)
-	A.infectable_biotypes &= ~MOB_MINERAL
-	A.infectable_biotypes &= ~MOB_ROBOTIC
+	A.infectable_biotypes &= ~(MOB_MINERAL | MOB_ROBOTIC)
 

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -44,7 +44,9 @@
 
 /datum/symptom/inorganic_adaptation/OnAdd(datum/disease/advance/A)
 	A.infectable_biotypes |= MOB_MINERAL //Mineral covers plasmamen and golems.
+	A.infectable_biotypes |= MOB_ROBOTIC //Robotic covers androids.
 
 /datum/symptom/inorganic_adaptation/OnRemove(datum/disease/advance/A)
 	A.infectable_biotypes &= ~MOB_MINERAL
+	A.infectable_biotypes &= ~MOB_ROBOTIC
 

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -43,7 +43,7 @@
 	severity = 0
 
 /datum/symptom/inorganic_adaptation/OnAdd(datum/disease/advance/A)
-	A.infectable_biotypes |= MOB_MINERAL | MOB_ROBOTIC // Plasmamen, Golems, and Androids.
+	A.infectable_biotypes |= MOB_MINERAL | MOB_ROBOTIC // Plasmamen, golems, and androids.
 
 /datum/symptom/inorganic_adaptation/OnRemove(datum/disease/advance/A)
 	A.infectable_biotypes &= ~(MOB_MINERAL | MOB_ROBOTIC)


### PR DESCRIPTION
## About The Pull Request

The inorganic biology symptom now adds both MOB_MINERAL and MOB_ROBOTIC to a virus's list of infectable biotypes instead of only MOB_MINERAL. Currently, androids are the only species this change affects.

## Why It's Good For The Game

Robots are inorganic too!

EDIT: To be clear: No, inorganic biology viruses won't be able to infect borgs or AI cores, that's not how this works.

## Changelog

:cl: ATHATH
balance: The inorganic biology symptom now adds both MOB_MINERAL and MOB_ROBOTIC to a virus's list of infectable biotypes instead of only MOB_MINERAL. Currently, androids are the only species this change affects.
/:cl:
