### PR TITLE
Ethereal involuntary discharge fix

### DIFF
--- a/code/modules/surgery/organs/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/stomach/stomach_ethereal.dm
@@ -96,8 +96,7 @@
 		carbon.cut_overlay(overcharge)
 		tesla_zap(carbon, 2, crystal_charge*2.5, ZAP_OBJ_DAMAGE | ZAP_LOW_POWER_GEN | ZAP_ALLOW_DUPLICATES)
 		adjust_charge(ETHEREAL_CHARGE_FULL - crystal_charge)
-		to_chat(carbon, span_warning("You violently discharge energy!"))
-		carbon.visible_message(span_danger("[carbon] violently discharges energy!"))
+		carbon.visible_message(span_danger("[carbon] violently discharges energy!"), span_warning("You violently discharge energy!"))
 
 		if(prob(10)) //chance of developing heart disease to dissuade overcharging oneself
 			var/datum/disease/D = new /datum/disease/heart_failure


### PR DESCRIPTION

## About The Pull Request

fixes #73911 

### Mapping March

Ckey to recieve rewards: N/A

## Why It's Good For The Game

Double text = bad

## Changelog
:cl:
fix: Ethereal discharge no longer alerts you twice that you did it.
/:cl:
