### PR TITLE
Clicking on the >> WALL << of a fire alarm/light switch with your hand will activate it

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_attack.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_attack.dm
@@ -44,5 +44,9 @@
 #define COMSIG_ATOM_ATTACK_PAW "atom_attack_paw"
 ///from base of atom/mech_melee_attack(): (obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
 #define COMSIG_ATOM_ATTACK_MECH "atom_attack_mech"
+/// from base of atom/attack_robot(): (mob/user)
+#define COMSIG_ATOM_ATTACK_ROBOT "atom_attack_robot"
+/// from base of atom/attack_robot_secondary(): (mob/user)
+#define COMSIG_ATOM_ATTACK_ROBOT_SECONDARY "atom_attack_robot_secondary"
 ///from relay_attackers element: (atom/attacker)
 #define COMSIG_ATOM_WAS_ATTACKED "atom_was_attacked"

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -178,6 +178,9 @@
 	A.attack_robot(src)
 
 /atom/proc/attack_robot(mob/user)
+	if (SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ROBOT, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return
+
 	attack_ai(user)
 	return
 
@@ -189,4 +192,7 @@
  * * modifiers The list of the custom click modifiers
  */
 /atom/proc/attack_robot_secondary(mob/user, list/modifiers)
+	if (SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_ROBOT_SECONDARY, user) & COMPONENT_CANCEL_ATTACK_CHAIN)
+		return
+
 	return attack_ai_secondary(user, modifiers)

--- a/code/datums/components/redirect_attack_hand_from_turf.dm
+++ b/code/datums/components/redirect_attack_hand_from_turf.dm
@@ -88,7 +88,11 @@
 	SIGNAL_HANDLER
 	PRIVATE_PROC(TRUE)
 
-	user.UnarmedAttack(parent, proximity_flag = TRUE, modifiers = modifiers)
+	var/atom/movable/movable_parent = parent
+	if (!movable_parent.can_interact(user))
+		return NONE
+
+	INVOKE_ASYNC(user, TYPE_PROC_REF(/mob, UnarmedAttack), parent, proximity_flag = TRUE, modifiers = modifiers)
 
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
@@ -96,7 +100,7 @@
 	datum/source,
 	list/context,
 	obj/item/held_item,
-	mob/user
+	mob/user,
 )
 	PRIVATE_PROC(TRUE)
 	SIGNAL_HANDLER

--- a/code/datums/components/redirect_attack_hand_from_turf.dm
+++ b/code/datums/components/redirect_attack_hand_from_turf.dm
@@ -1,0 +1,116 @@
+/// Will redirect touching the turf it is on with your hand to the attack_hand of the parent object.
+/datum/component/redirect_attack_hand_from_turf
+	VAR_PRIVATE
+		/// If TRUE, will connect to the turf it *appears* to be on.
+		adjust_for_pixel_shift
+
+		/// If set, hovering over the turf you're on will show these screentips with an empty hand.
+		/// Takes lmb_text and rmb_text.
+		list/screentip_texts
+
+		turf/current_turf
+
+/datum/component/redirect_attack_hand_from_turf/Initialize(
+	adjust_for_pixel_shift = TRUE,
+	list/screentip_texts = null,
+)
+	. = ..()
+
+	if(!ismovable(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	src.adjust_for_pixel_shift = adjust_for_pixel_shift
+	src.screentip_texts = screentip_texts
+
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+	connect_to_new_turf()
+
+/datum/component/redirect_attack_hand_from_turf/Destroy(force, silent)
+	disconnect_from_old_turf()
+	return ..()
+
+/datum/component/redirect_attack_hand_from_turf/proc/find_turf()
+	PRIVATE_PROC(TRUE)
+
+	var/atom/movable/movable_parent = parent
+
+	if (!isturf(movable_parent.loc))
+		return null
+
+	return adjust_for_pixel_shift ? get_turf_pixel(movable_parent) : movable_parent.loc
+
+/datum/component/redirect_attack_hand_from_turf/proc/on_moved(atom/movable/source)
+	SIGNAL_HANDLER
+	PRIVATE_PROC(TRUE)
+
+	disconnect_from_old_turf()
+	connect_to_new_turf()
+
+/datum/component/redirect_attack_hand_from_turf/proc/check_blacklisted_turf(turf/next_turf)
+	PRIVATE_PROC(TRUE)
+	return locate(/obj/structure/falsewall) in next_turf
+
+/datum/component/redirect_attack_hand_from_turf/proc/connect_to_new_turf()
+	PRIVATE_PROC(TRUE)
+
+	var/turf/next_turf = find_turf()
+
+	if (isnull(next_turf))
+		return
+
+	if (check_blacklisted_turf(next_turf))
+		return
+
+	current_turf = next_turf
+
+	RegisterSignals(current_turf, list(
+		COMSIG_ATOM_ATTACK_HAND,
+		COMSIG_ATOM_ATTACK_HAND_SECONDARY,
+	), PROC_REF(on_attack_hand))
+
+	if (!isnull(screentip_texts))
+		current_turf.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
+		RegisterSignal(current_turf, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, PROC_REF(on_requesting_context_from_item))
+
+/datum/component/redirect_attack_hand_from_turf/proc/disconnect_from_old_turf()
+	PRIVATE_PROC(TRUE)
+
+	if (isnull(current_turf))
+		return
+
+	UnregisterSignal(current_turf, list(
+		COMSIG_ATOM_ATTACK_HAND,
+		COMSIG_ATOM_ATTACK_HAND_SECONDARY,
+		COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM,
+	))
+
+/datum/component/redirect_attack_hand_from_turf/proc/on_attack_hand(turf/source, mob/user, list/modifiers)
+	SIGNAL_HANDLER
+	PRIVATE_PROC(TRUE)
+
+	user.UnarmedAttack(parent, proximity_flag = TRUE, modifiers = modifiers)
+
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/datum/component/redirect_attack_hand_from_turf/proc/on_requesting_context_from_item(
+	datum/source,
+	list/context,
+	obj/item/held_item,
+	mob/user
+)
+	PRIVATE_PROC(TRUE)
+	SIGNAL_HANDLER
+
+	if (!isliving(user))
+		return NONE
+
+	if (!isnull(held_item))
+		return NONE
+
+	if (!isnull(screentip_texts["lmb_text"]))
+		context[SCREENTIP_CONTEXT_LMB] = screentip_texts["lmb_text"]
+
+	if (!isnull(screentip_texts["rmb_text"]))
+		context[SCREENTIP_CONTEXT_RMB] = screentip_texts["rmb_text"]
+
+	return CONTEXTUAL_SCREENTIP_SET

--- a/code/datums/components/redirect_attack_hand_from_turf.dm
+++ b/code/datums/components/redirect_attack_hand_from_turf.dm
@@ -66,6 +66,8 @@
 	RegisterSignals(current_turf, list(
 		COMSIG_ATOM_ATTACK_HAND,
 		COMSIG_ATOM_ATTACK_HAND_SECONDARY,
+		COMSIG_ATOM_ATTACK_ROBOT,
+		COMSIG_ATOM_ATTACK_ROBOT_SECONDARY,
 	), PROC_REF(on_attack_hand))
 
 	if (!isnull(screentip_texts))

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -98,7 +98,7 @@
 	hud_possible = list(DIAG_AIRLOCK_HUD)
 	smoothing_groups = SMOOTH_GROUP_AIRLOCK
 
-	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_REQUIRES_SILICON | INTERACT_MACHINE_OPEN
+	interaction_flags_machine = INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_OPEN
 	blocks_emissive = NONE // Custom emissive blocker. We don't want the normal behavior.
 
 	///The type of door frame to drop during deconstruction
@@ -174,10 +174,7 @@
 	RegisterSignal(src, COMSIG_MACHINERY_BROKEN, PROC_REF(on_break))
 
 	// Click on the floor to close airlocks
-	var/static/list/connections = list(
-		COMSIG_ATOM_ATTACK_HAND = PROC_REF(on_attack_hand)
-	)
-	AddElement(/datum/element/connect_loc, connections)
+	AddComponent(/datum/component/redirect_attack_hand_from_turf)
 
 	return INITIALIZE_HINT_LATELOAD
 
@@ -698,11 +695,6 @@
 
 /obj/machinery/door/airlock/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
-
-/obj/machinery/door/airlock/proc/on_attack_hand(atom/source, mob/user, list/modifiers)
-	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, attack_hand), user, modifiers)
-	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/door/airlock/attack_hand(mob/user, list/modifiers)
 	. = ..()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -67,6 +67,14 @@
 		rmb_text = "Turn off", \
 	)
 
+	AddComponent( \
+		/datum/component/redirect_attack_hand_from_turf, \
+		screentip_texts = list( \
+			lmb_text = "Turn on alarm", \
+			rmb_text = "Turn off alarm", \
+		), \
+	)
+
 /obj/machinery/firealarm/Destroy()
 	if(my_area)
 		LAZYREMOVE(my_area.firealarms, src)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -15,6 +15,9 @@
 
 /obj/machinery/light_switch/Initialize(mapload)
 	. = ..()
+
+	AddComponent(/datum/component/redirect_attack_hand_from_turf)
+
 	AddComponent(/datum/component/usb_port, list(
 		/obj/item/circuit_component/light_switch,
 	))

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -115,13 +115,6 @@
 /turf/open/floor/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
 
-/turf/open/floor/attack_hand(mob/user, list/modifiers)
-	. = ..()
-	if(.)
-		return
-
-	SEND_SIGNAL(src, COMSIG_ATOM_ATTACK_HAND, user, modifiers)
-
 /turf/open/floor/proc/break_tile_to_plating()
 	var/turf/open/floor/plating/T = make_plating()
 	if(!istype(T))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -939,6 +939,7 @@
 #include "code\datums\components\radiation_countdown.dm"
 #include "code\datums\components\radioactive_emitter.dm"
 #include "code\datums\components\reagent_refiller.dm"
+#include "code\datums\components\redirect_attack_hand_from_turf.dm"
 #include "code\datums\components\regenerator.dm"
 #include "code\datums\components\religious_tool.dm"
 #include "code\datums\components\remote_materials.dm"


### PR DESCRIPTION
## About The Pull Request

Clicking on the turf of a fire alarm/light switch with your hand will activate it, similar to how you can click the turf a door is on to close it and not pixel hunt. Refers to the turf it *looks* like it's on, not the one it actually is on, since fire alarms and light switches are actually on the turf near the wall, pixel shifted up.

False walls are ignored.

## Why It's Good For The Game

Lets our artists do whatever they want to these sprites, or those of future consumers, without worrying about niche balance stuff. I really like people using fire alarms for environmental combat and don't want that to get in the way of spriting.

## Changelog
:cl:
qol: Clicking on the turf of a fire alarm/light switch with your hand will activate it.
/:cl:
