### PR TITLE
Elevator doors open if called from same z-level

### DIFF
--- a/code/modules/industrial_lift/elevator_button.dm
+++ b/code/modules/industrial_lift/elevator_button.dm
@@ -92,11 +92,12 @@
 		loc.balloon_alert(activator, "elevator is moving!")
 		return FALSE
 
-	// We can't call an elevator if it's already at this destination
+	// If the elevator is already here, open the doors.
 	var/obj/structure/industrial_lift/prime_lift = lift.return_closest_platform_to_z(loc.z)
 	if(prime_lift.z == loc.z)
+		INVOKE_ASYNC(lift, TYPE_PROC_REF(/datum/lift_master, open_lift_doors_callback))
 		loc.balloon_alert(activator, "elevator is here!")
-		return FALSE
+		return TRUE
 
 	// At this point, we can start moving.
 


### PR DESCRIPTION
## About The Pull Request

Fixes oversight where button doesn't open doors if the elevator is on the same z-level.

## Why It's Good For The Game

The lower floor elevators will work properly on Tramstation and wherever else.

## Changelog
:cl: LT3
fix: Tramstation lower floor elevator buttons work properly at roundstart
/:cl:
