### PR TITLE
Adds tooltips for pneumatic cannon, changes powerfist's tooltip slightly and fixes some bugs about it.

### DIFF
--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -3,9 +3,9 @@
 #define PCANNON_FILO 2
 #define PCANNON_FIFO 3
 ///Defines for the pressure strength of the cannon
-#define LOW_PRESSURE 1
-#define MID_PRESSURE 2
-#define HIGH_PRESSURE 3
+#define LOW_PRESSURE "low"
+#define MID_PRESSURE "medium"
+#define HIGH_PRESSURE "high"
 
 /obj/item/pneumatic_cannon
 	name = "pneumatic cannon"
@@ -80,7 +80,7 @@
 	if(tank)
 		out += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it. It could be removed with a <b>screwdriver</b>.")
 	if(needs_air == TRUE)
-		. += span_notice("Use a wrench to change the pressure level. Current output at [pressureSetting].")
+		. += span_notice("Use a <b>wrench</b> to change the pressure level. Current output level is <b>[pressureSetting]</b>.")
 	. += out.Join("\n")
 
 /obj/item/pneumatic_cannon/screwdriver_act(mob/living/user, obj/item/tool)
@@ -93,7 +93,13 @@
 	if(needs_air == FALSE)
 		return
 	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
-	pressureSetting = pressureSetting >= HIGH_PRESSURE ? LOW_PRESSURE : pressureSetting + 1
+	switch(pressureSetting)
+		if("low")
+			pressureSetting = "medium"
+		if("medium")
+			pressureSetting = "high"
+		if("high")
+			pressureSetting = "low"
 	balloon_alert(user, "output level set to [pressureSetting]")
 	return TRUE
 

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -3,9 +3,9 @@
 #define PCANNON_FILO 2
 #define PCANNON_FIFO 3
 ///Defines for the pressure strength of the cannon
-#define LOW_PRESSURE "low"
-#define MID_PRESSURE "medium"
-#define HIGH_PRESSURE "high"
+#define LOW_PRESSURE 1
+#define MID_PRESSURE 2
+#define HIGH_PRESSURE 3
 
 /obj/item/pneumatic_cannon
 	name = "pneumatic cannon"
@@ -68,6 +68,15 @@
 /obj/item/pneumatic_cannon/CanItemAutoclick()
 	return automatic
 
+/obj/item/pneumatic_cannon/proc/pressureSetting_to_text(pressureSetting)
+	switch(pressureSetting)
+		if(LOW_PRESSURE)
+			. = "low"
+		if(MID_PRESSURE)
+			. = "medium"
+		if(HIGH_PRESSURE)
+			. = "high"
+
 /obj/item/pneumatic_cannon/examine(mob/user)
 	. = ..()
 	var/list/out = list()
@@ -80,7 +89,7 @@
 	if(tank)
 		out += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it. It could be removed with a <b>screwdriver</b>.")
 	if(needs_air == TRUE)
-		. += span_notice("Use a <b>wrench</b> to change the pressure level. Current output level is <b>[pressureSetting]</b>.")
+		. += span_notice("Use a <b>wrench</b> to change the pressure level. Current output level is <b>[pressureSetting_to_text(pressureSetting)]</b>.")
 	. += out.Join("\n")
 
 /obj/item/pneumatic_cannon/screwdriver_act(mob/living/user, obj/item/tool)
@@ -93,13 +102,7 @@
 	if(needs_air == FALSE)
 		return
 	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
-	switch(pressureSetting)
-		if(LOW_PRESSURE)
-			pressureSetting = MID_PRESSURE
-		if(MID_PRESSURE)
-			pressureSetting = HIGH_PRESSURE
-		if(HIGH_PRESSURE)
-			pressureSetting = LOW_PRESSURE
+	pressureSetting = pressureSetting >= HIGH_PRESSURE ? LOW_PRESSURE : pressureSetting + 1
 	balloon_alert(user, "output level set to [pressureSetting]")
 	return TRUE
 

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -2,6 +2,11 @@
 #define PCANNON_FIREALL 1
 #define PCANNON_FILO 2
 #define PCANNON_FIFO 3
+///Defines for the pressure strength of the cannon
+#define LOW_PRESSURE 1
+#define MID_PRESSURE 2
+#define HIGH_PRESSURE 3
+
 /obj/item/pneumatic_cannon
 	name = "pneumatic cannon"
 	desc = "A gas-powered cannon that can fire any object loaded into it."
@@ -20,7 +25,7 @@
 	var/obj/item/tank/internals/tank = null //The gas tank that is drawn from to fire things
 	var/gasPerThrow = 3 //How much gas is drawn from a tank's pressure to fire
 	var/list/loadedItems = list() //The items loaded into the cannon that will be fired out
-	var/pressureSetting = 1 //How powerful the cannon is - higher pressure = more gas but more powerful throws
+	var/pressureSetting = LOW_PRESSURE //How powerful the cannon is - higher pressure = more gas but more powerful throws
 	var/checktank = TRUE
 	var/range_multiplier = 1
 	var/throw_amount = 1 //How many items to throw per fire
@@ -73,6 +78,7 @@
 		CHECK_TICK
 	if(tank)
 		out += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it. It could be removed with a <b>screwdriver</b>.")
+	. += span_notice("Use a wrench to change the pressure level. Current output at [pressureSetting].")
 	. += out.Join("\n")
 
 /obj/item/pneumatic_cannon/screwdriver_act(mob/living/user, obj/item/tool)
@@ -83,14 +89,8 @@
 
 /obj/item/pneumatic_cannon/wrench_act(mob/living/user, obj/item/tool)
 	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
-	switch(pressureSetting)
-		if(1)
-			pressureSetting = 2
-		if(2)
-			pressureSetting = 3
-		if(3)
-			pressureSetting = 1
-	to_chat(user, span_notice("You tweak \the [src]'s pressure output to [pressureSetting]."))
+	pressureSetting = pressureSetting >= HIGH_PRESSURE ? LOW_PRESSURE : pressureSetting + 1
+	balloon_alert(user, "output level set to [pressureSetting]")
 	return TRUE
 
 /obj/item/pneumatic_cannon/attackby(obj/item/W, mob/living/user, params)
@@ -105,16 +105,6 @@
 			updateTank(W, 0, user)
 	else if(W.type == type)
 		to_chat(user, span_warning("You're fairly certain that putting a pneumatic cannon inside another pneumatic cannon would cause a spacetime disruption."))
-	else if(W.tool_behaviour == TOOL_WRENCH)
-		playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
-		switch(pressureSetting)
-			if(1)
-				pressureSetting = 2
-			if(2)
-				pressureSetting = 3
-			if(3)
-				pressureSetting = 1
-		to_chat(user, span_notice("You tweak \the [src]'s pressure output to [pressureSetting]."))
 	else if(loadedWeightClass >= maxWeightClass)
 		to_chat(user, span_warning("\The [src] can't hold any more items!"))
 	else if(isitem(W))
@@ -328,3 +318,10 @@
 	charge_type = /obj/item/food/pie/cream/nostun
 	maxWeightClass = 6 //2 pies
 	charge_ticks = 2 //4 second/pie
+
+#undef PCANNON_FIREALL
+#undef PCANNON_FILO
+#undef PCANNON_FIFO
+#undef LOW_PRESSURE
+#undef MID_PRESSURE
+#undef HIGH_PRESSURE

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -25,7 +25,7 @@
 	var/obj/item/tank/internals/tank = null //The gas tank that is drawn from to fire things
 	var/gasPerThrow = 3 //How much gas is drawn from a tank's pressure to fire
 	var/list/loadedItems = list() //The items loaded into the cannon that will be fired out
-	var/pressureSetting = LOW_PRESSURE //How powerful the cannon is - higher pressure = more gas but more powerful throws
+	var/pressure_setting = LOW_PRESSURE //How powerful the cannon is - higher pressure = more gas but more powerful throws
 	var/checktank = TRUE
 	var/range_multiplier = 1
 	var/throw_amount = 1 //How many items to throw per fire
@@ -68,14 +68,16 @@
 /obj/item/pneumatic_cannon/CanItemAutoclick()
 	return automatic
 
-/obj/item/pneumatic_cannon/proc/pressureSetting_to_text(pressureSetting)
-	switch(pressureSetting)
+/obj/item/pneumatic_cannon/proc/pressure_setting_to_text(pressure_setting)
+	switch(pressure_setting)
 		if(LOW_PRESSURE)
-			. = "low"
+			return "low"
 		if(MID_PRESSURE)
-			. = "medium"
+			return "medium"
 		if(HIGH_PRESSURE)
-			. = "high"
+			return "high"
+		else
+			CRASH("Invalid pressure setting: [pressure_setting]!")
 
 /obj/item/pneumatic_cannon/examine(mob/user)
 	. = ..()
@@ -89,7 +91,7 @@
 	if(tank)
 		out += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it. It could be removed with a <b>screwdriver</b>.")
 	if(needs_air == TRUE)
-		. += span_notice("Use a <b>wrench</b> to change the pressure level. Current output level is <b>[pressureSetting_to_text(pressureSetting)]</b>.")
+		. += span_notice("Use a <b>wrench</b> to change the pressure level. Current output level is <b>[pressure_setting_to_text(pressure_setting)]</b>.")
 	. += out.Join("\n")
 
 /obj/item/pneumatic_cannon/screwdriver_act(mob/living/user, obj/item/tool)
@@ -102,8 +104,8 @@
 	if(needs_air == FALSE)
 		return
 	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
-	pressureSetting = pressureSetting >= HIGH_PRESSURE ? LOW_PRESSURE : pressureSetting + 1
-	balloon_alert(user, "output level set to [pressureSetting]")
+	pressure_setting = pressure_setting >= HIGH_PRESSURE ? LOW_PRESSURE : pressure_setting + 1
+	balloon_alert(user, "output level set to [pressure_setting_to_text(pressure_setting)]")
 	return TRUE
 
 /obj/item/pneumatic_cannon/attackby(obj/item/W, mob/living/user, params)
@@ -183,7 +185,7 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("You can't bring yourself to fire \the [src]! You don't want to risk harming anyone...") )
 		return
-	if(tank && !tank.remove_air(gasPerThrow * pressureSetting))
+	if(tank && !tank.remove_air(gasPerThrow * pressure_setting))
 		to_chat(user, span_warning("\The [src] lets out a weak hiss and doesn't react!"))
 		return
 	if(HAS_TRAIT(user, TRAIT_CLUMSY) && prob(75) && clumsyCheck && iscarbon(user))
@@ -203,7 +205,7 @@
 	var/turf/T = get_target(target, get_turf(src))
 	playsound(src, fire_sound, 50, TRUE)
 	fire_items(T, user)
-	if(pressureSetting >= 3 && iscarbon(user))
+	if(pressure_setting >= 3 && iscarbon(user))
 		var/mob/living/carbon/C = user
 		C.visible_message(span_warning("[C] is thrown down by the force of the cannon!"), span_userdanger("[src] slams into your shoulder, knocking you down!"))
 		C.Paralyze(60)
@@ -235,7 +237,7 @@
 	else
 		loadedWeightClass--
 	AM.forceMove(get_turf(src))
-	AM.throw_at(target, pressureSetting * 10 * range_multiplier, pressureSetting * 2, user, spin_item)
+	AM.throw_at(target, pressure_setting * 10 * range_multiplier, pressure_setting * 2, user, spin_item)
 	return TRUE
 
 /obj/item/pneumatic_cannon/proc/get_target(turf/target, turf/starting)

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -94,12 +94,12 @@
 		return
 	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
 	switch(pressureSetting)
-		if("low")
-			pressureSetting = "medium"
-		if("medium")
-			pressureSetting = "high"
-		if("high")
-			pressureSetting = "low"
+		if(LOW_PRESSURE)
+			pressureSetting = MID_PRESSURE
+		if(MID_PRESSURE)
+			pressureSetting = HIGH_PRESSURE
+		if(HIGH_PRESSURE)
+			pressureSetting = LOW_PRESSURE
 	balloon_alert(user, "output level set to [pressureSetting]")
 	return TRUE
 

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -31,6 +31,7 @@
 	var/throw_amount = 1 //How many items to throw per fire
 	var/fire_mode = PCANNON_FIFO
 	var/automatic = FALSE
+	var/needs_air = TRUE
 	var/clumsyCheck = TRUE
 	var/list/allowed_typecache //Leave as null to allow all.
 	var/charge_amount = 1
@@ -78,7 +79,8 @@
 		CHECK_TICK
 	if(tank)
 		out += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it. It could be removed with a <b>screwdriver</b>.")
-	. += span_notice("Use a wrench to change the pressure level. Current output at [pressureSetting].")
+	if(needs_air == TRUE)
+		. += span_notice("Use a wrench to change the pressure level. Current output at [pressureSetting].")
 	. += out.Join("\n")
 
 /obj/item/pneumatic_cannon/screwdriver_act(mob/living/user, obj/item/tool)
@@ -88,6 +90,8 @@
 	return TRUE
 
 /obj/item/pneumatic_cannon/wrench_act(mob/living/user, obj/item/tool)
+	if(needs_air == FALSE)
+		return
 	playsound(src, 'sound/items/ratchet.ogg', 50, TRUE)
 	pressureSetting = pressureSetting >= HIGH_PRESSURE ? LOW_PRESSURE : pressureSetting + 1
 	balloon_alert(user, "output level set to [pressureSetting]")
@@ -97,6 +101,8 @@
 	if(user.combat_mode)
 		return ..()
 	if(istype(W, /obj/item/tank/internals))
+		if(needs_air == FALSE)
+			return
 		if(!tank)
 			var/obj/item/tank/internals/IT = W
 			if(IT.volume <= 3)
@@ -299,6 +305,7 @@
 	fire_mode = PCANNON_FIFO
 	throw_amount = 1
 	maxWeightClass = 150 //50 pies. :^)
+	needs_air = FALSE
 	clumsyCheck = FALSE
 	var/static/list/pie_typecache = typecacheof(/obj/item/food/pie)
 

--- a/code/game/objects/items/pneumaticCannon.dm
+++ b/code/game/objects/items/pneumaticCannon.dm
@@ -72,7 +72,7 @@
 		out += span_info("[icon2html(I, user)] It has \a [I] loaded.")
 		CHECK_TICK
 	if(tank)
-		out += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it.")
+		out += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it. It could be removed with a <b>screwdriver</b>.")
 	. += out.Join("\n")
 
 /obj/item/pneumatic_cannon/screwdriver_act(mob/living/user, obj/item/tool)

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -1,7 +1,7 @@
 ///Defines for the pressure strength of the fist
-#define LOW_PRESSURE "low"
-#define MID_PRESSURE "medium"
-#define HIGH_PRESSURE "high"
+#define LOW_PRESSURE 1
+#define MID_PRESSURE 2
+#define HIGH_PRESSURE 3
 ///Defines for the tank change action
 #define TANK_INSERTING 0
 #define TANK_REMOVING 1
@@ -47,13 +47,7 @@
 	. += span_notice("Use a <b>wrench</b> to change the valve strength. Current strength is at <b>[fist_pressure_setting]</b> level.")
 
 /obj/item/melee/powerfist/wrench_act(mob/living/user, obj/item/tool)
-	switch(fist_pressure_setting)
-		if(LOW_PRESSURE)
-			fist_pressure_setting = MID_PRESSURE
-		if(MID_PRESSURE)
-			fist_pressure_setting = HIGH_PRESSURE
-		if(HIGH_PRESSURE)
-			fist_pressure_setting = LOW_PRESSURE
+	fist_pressure_setting = fist_pressure_setting >= HIGH_PRESSURE ? LOW_PRESSURE : fist_pressure_setting + 1
 	tool.play_tool_sound(src)
 	balloon_alert(user, "piston strength set to [fist_pressure_setting]")
 	return TRUE

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -35,14 +35,16 @@
 	fire = 100
 	acid = 40
 
-/obj/item/melee/powerfist/proc/fist_pressure_setting_to_text(fist_pressure_setting)
+/obj/item/melee/powerfist/proc/pressure_setting_to_text(fist_pressure_setting)
 	switch(fist_pressure_setting)
 		if(LOW_PRESSURE)
-			. = "low"
+			return "low"
 		if(MID_PRESSURE)
-			. = "medium"
+			return "medium"
 		if(HIGH_PRESSURE)
-			. = "high"
+			return "high"
+		else
+			CRASH("Invalid pressure setting: [fist_pressure_setting]!")
 
 /obj/item/melee/powerfist/examine(mob/user)
 	. = ..()
@@ -53,12 +55,12 @@
 		. += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it.")
 		. += span_notice("Can be removed with a <b>screwdriver</b>.")
 
-	. += span_notice("Use a <b>wrench</b> to change the valve strength. Current strength is at <b>[fist_pressure_setting_to_text(fist_pressure_setting)]</b> level.")
+	. += span_notice("Use a <b>wrench</b> to change the valve strength. Current strength is at <b>[pressure_setting_to_text(fist_pressure_setting)]</b> level.")
 
 /obj/item/melee/powerfist/wrench_act(mob/living/user, obj/item/tool)
 	fist_pressure_setting = fist_pressure_setting >= HIGH_PRESSURE ? LOW_PRESSURE : fist_pressure_setting + 1
 	tool.play_tool_sound(src)
-	balloon_alert(user, "piston strength set to [fist_pressure_setting]")
+	balloon_alert(user, "piston strength set to [pressure_setting_to_text(fist_pressure_setting)]")
 	return TRUE
 
 /obj/item/melee/powerfist/screwdriver_act(mob/living/user, obj/item/tool)

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -35,6 +35,15 @@
 	fire = 100
 	acid = 40
 
+/obj/item/melee/powerfist/proc/fist_pressure_setting_to_text(fist_pressure_setting)
+	switch(fist_pressure_setting)
+		if(LOW_PRESSURE)
+			. = "low"
+		if(MID_PRESSURE)
+			. = "medium"
+		if(HIGH_PRESSURE)
+			. = "high"
+
 /obj/item/melee/powerfist/examine(mob/user)
 	. = ..()
 	if(!in_range(user, src))
@@ -44,7 +53,7 @@
 		. += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it.")
 		. += span_notice("Can be removed with a <b>screwdriver</b>.")
 
-	. += span_notice("Use a <b>wrench</b> to change the valve strength. Current strength is at <b>[fist_pressure_setting]</b> level.")
+	. += span_notice("Use a <b>wrench</b> to change the valve strength. Current strength is at <b>[fist_pressure_setting_to_text(fist_pressure_setting)]</b> level.")
 
 /obj/item/melee/powerfist/wrench_act(mob/living/user, obj/item/tool)
 	fist_pressure_setting = fist_pressure_setting >= HIGH_PRESSURE ? LOW_PRESSURE : fist_pressure_setting + 1

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -48,12 +48,12 @@
 
 /obj/item/melee/powerfist/wrench_act(mob/living/user, obj/item/tool)
 	switch(fist_pressure_setting)
-		if("low")
-			fist_pressure_setting = "medium"
-		if("medium")
-			fist_pressure_setting = "high"
-		if("high")
-			fist_pressure_setting = "low"
+		if(LOW_PRESSURE)
+			fist_pressure_setting = MID_PRESSURE
+		if(MID_PRESSURE)
+			fist_pressure_setting = HIGH_PRESSURE
+		if(HIGH_PRESSURE)
+			fist_pressure_setting = LOW_PRESSURE
 	tool.play_tool_sound(src)
 	balloon_alert(user, "piston strength set to [fist_pressure_setting]")
 	return TRUE

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -1,7 +1,7 @@
 ///Defines for the pressure strength of the fist
-#define LOW_PRESSURE 1
-#define MID_PRESSURE 2
-#define HIGH_PRESSURE 3
+#define LOW_PRESSURE "low"
+#define MID_PRESSURE "medium"
+#define HIGH_PRESSURE "high"
 ///Defines for the tank change action
 #define TANK_INSERTING 0
 #define TANK_REMOVING 1
@@ -42,12 +42,18 @@
 		return
 	if(tank)
 		. += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it.")
-		. += span_notice("Can be removed with a screwdriver.")
+		. += span_notice("Can be removed with a <b>screwdriver</b>.")
 
-	. += span_notice("Use a wrench to change the valve strength. Current strength at [fist_pressure_setting].")
+	. += span_notice("Use a <b>wrench</b> to change the valve strength. Current strength is at <b>[fist_pressure_setting]</b> level.")
 
 /obj/item/melee/powerfist/wrench_act(mob/living/user, obj/item/tool)
-	fist_pressure_setting = fist_pressure_setting >= HIGH_PRESSURE ? LOW_PRESSURE : fist_pressure_setting + 1
+	switch(fist_pressure_setting)
+		if("low")
+			fist_pressure_setting = "medium"
+		if("medium")
+			fist_pressure_setting = "high"
+		if("high")
+			fist_pressure_setting = "low"
 	tool.play_tool_sound(src)
 	balloon_alert(user, "piston strength set to [fist_pressure_setting]")
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
Adds tooltips for screwdriver and wrench with it's pressure level. It'll look like this:
![image](https://user-images.githubusercontent.com/93882977/224517382-b8bd8c32-2256-4516-8318-b9e52cd67f31.png)
And an image of how it look's at the moment just to compare:
![image](https://user-images.githubusercontent.com/93882977/224512677-5899722c-1e79-4975-afd2-2bf741adf829.png)

Also changed powerfist's tooltip slightly:
![image](https://user-images.githubusercontent.com/93882977/224842693-d0574328-2da3-467a-8fd5-f10d70e08da1.png)
And another image for comparison again:
![image](https://user-images.githubusercontent.com/93882977/224517677-4790add6-f433-49bd-93bf-6d4a498955f4.png)

You weren't able to put wrench in it, because it combined both LMB and RMB tool_acts, deleted the part with RMB as screwdriver uses LMB.

And for some reason you could put air tanks in pie guns and adjust its pressure level. Like is there even a purpose of it? It'll just hiss.
## Why It's Good For The Game
## Changelog
:cl:
qol: added tooltips for pneumatic cannon. Also changed powerfist's tooltips slightly.
fix: fixed that you can't put wrench in pneumatic cannon.
fix: fixed that you can manipulate with pie gun as if it's a normal pneumatic cannon (adjust air tank, wrench it's output level's and etc.)
/:cl:
