### PR TITLE
Optimizes atmos init by 20%

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -539,30 +539,30 @@ SUBSYSTEM_DEF(air)
 	var/time = -1
 
 	var/list/turf/open/difference_check = list()
-	for(var/turf/T as anything in ALL_TURFS())
-		if (!T.init_air)
+	for(var/turf/setup as anything in ALL_TURFS())
+		if (!setup.init_air)
 			continue
 		// We pass the tick as the current step so if we sleep the step changes
 		// This way we can make setting up adjacent turfs O(n) rather then O(n^2)
-		T.Initalize_Atmos(time)
+		setup.Initalize_Atmos(time)
 		// We assert that we'll only get open turfs here
-		difference_check += T
+		difference_check += setup
 		if(CHECK_TICK)
 			time--
 
 	// Now we're gonna compare for differences
 	// Taking advantage of current cycle being set to negative before this run to do A->B B->A prevention
-	for(var/turf/open/T as anything in difference_check)
-		T.current_cycle = 0
+	for(var/turf/open/potential_diff as anything in difference_check)
+		potential_diff.current_cycle = 0
 		for(var/turf/open/enemy_tile as anything in T.atmos_adjacent_turfs)
 			// If it's already been processed, then it's already talked to us
 			if(enemy_tile.current_cycle == 0)
 				continue
 			// .air instead of .return_air() because we can guarentee that the proc won't do anything
-			if(T.air.compare(enemy_tile.air))
+			if(potential_diff.air.compare(enemy_tile.air))
 				//testing("Active turf found. Return value of compare(): [T.air.compare(enemy_tile.air)]")
-				T.excited = TRUE
-				SSair.active_turfs += T
+				potential_diff.excited = TRUE
+				SSair.active_turfs += potential_diff
 				// No sense continuing to iterate
 				break
 		CHECK_TICK

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -554,7 +554,7 @@ SUBSYSTEM_DEF(air)
 	// Taking advantage of current cycle being set to negative before this run to do A->B B->A prevention
 	for(var/turf/open/potential_diff as anything in difference_check)
 		potential_diff.current_cycle = 0
-		for(var/turf/open/enemy_tile as anything in T.atmos_adjacent_turfs)
+		for(var/turf/open/enemy_tile as anything in potential_diff.atmos_adjacent_turfs)
 			// If it's already been processed, then it's already talked to us
 			if(enemy_tile.current_cycle == 0)
 				continue

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -182,15 +182,7 @@
 	update_visuals()
 
 	current_cycle = time
-
 	init_immediate_calculate_adjacent_turfs()
-	for(var/turf/open/enemy_tile as anything in atmos_adjacent_turfs)
-		if(air.compare(enemy_tile.return_air()))
-			//testing("Active turf found. Return value of compare(): [is_active]")
-			excited = TRUE
-			SSair.active_turfs += src
-			// No sense continuing to iterate
-			return
 
 /turf/open/GetHeatCapacity()
 	. = air.heat_capacity()


### PR DESCRIPTION

## About The Pull Request

Each time we intialized a turf's atmos, we checked all the turfs around it to see if they were different. This meant each pair of turfs talked to each other twice.

If we instead do the comparing in a second loop, we can use current_cycle to ensure we only compare a pair once. This saves 0.5 seconds of atmos init.

## Why It's Good For The Game

Speed