### PR TITLE
Makes the Bluespace Launchpad USB Circuit connection error out if the destination is out of range

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -505,6 +505,11 @@
 		y_pos.set_value(attached_launchpad.y_offset)
 		return
 
+	if(attached_launchpad.range > x_pos || attached_launchpad.range > y_pos)
+		why_fail.set_output("Out of range!")
+		on_fail.set_output(COMPONENT_SIGNAL)
+		return
+
 	var/checks = attached_launchpad.teleport_checks()
 	if(!isnull(checks))
 		why_fail.set_output(checks)


### PR DESCRIPTION

## About The Pull Request

Before, trying to teleport somewhere in which the launchpad could not reach would make the launchpad just teleport you to the closest as possible place, now it instead sends a failed signal and returns.
## Why It's Good For The Game

Due to the nerf to Launchpad range made in #61999, a new meta formed around launchpad circuits which involves using multiple launchpads instead of the sole one. Coding this in however was a pain, since the only way to check if you were actually out of range was by comparing the position with a hard-coded default. 
It also, by firing, activated the 4 second or so cooldown launchpads inherently have, which make no sense to still have if you weren't even trying to teleport there.
This PR fixes both of these issues.

This doesn't make launchpads "overpowered" or anything like that, it just makes it so that you can save a couple of comparison circuits when designing your circuitry.
## Changelog
:cl:
qol: Bluespace Launchpads will now use the fail trigger if your circuit destination is out of range.
/:cl:
