### PR TITLE
Remove dead /datum/asset/language cheat

### DIFF
--- a/code/modules/asset_cache/assets/language.dm
+++ b/code/modules/asset_cache/assets/language.dm
@@ -1,9 +1,0 @@
-//this exists purely to avoid meta by pre-loading all language icons.
-/datum/asset/language
-
-/datum/asset/language/register()
-	set waitfor = FALSE
-
-	for(var/path in typesof(/datum/language))
-		var/datum/language/language = new path()
-		language.get_icon()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2690,7 +2690,6 @@
 #include "code\modules\asset_cache\assets\inventory.dm"
 #include "code\modules\asset_cache\assets\irv.dm"
 #include "code\modules\asset_cache\assets\jquery.dm"
-#include "code\modules\asset_cache\assets\language.dm"
 #include "code\modules\asset_cache\assets\lobby.dm"
 #include "code\modules\asset_cache\assets\mafia.dm"
 #include "code\modules\asset_cache\assets\mecha.dm"


### PR DESCRIPTION
Used to be a thing to protect against meta-ing by reading cache files, but now is irrelevant.

![image](https://user-images.githubusercontent.com/35135081/224527046-8d7e5eab-1f32-45e7-bed4-4c7f1afa9a53.png)
