### PR TITLE
Polishes some side sources of light and color

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict_sulaco.dmm
@@ -48,7 +48,7 @@
 "eU" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/item/rack_parts,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "fd" = (
 /obj/structure/frame/machine,
@@ -145,7 +145,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/item/circuitboard/machine/telecomms/processor,
 /obj/item/rack_parts,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "jI" = (
 /obj/machinery/door/window/brigdoor/left/directional/south,
@@ -155,7 +155,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/item/stack/cable_coil/cut,
 /obj/structure/frame/machine,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "lq" = (
 /obj/machinery/door/airlock/maintenance/external{
@@ -202,7 +202,7 @@
 /obj/structure/window/reinforced/spawner/east,
 /obj/item/stack/cable_coil/cut,
 /obj/structure/frame/machine,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "nn" = (
 /obj/structure/alien/weeds/node,
@@ -360,7 +360,7 @@
 /area/ruin/space/has_grav)
 "yt" = (
 /obj/item/circuitboard/machine/telecomms/processor,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "yS" = (
 /obj/structure/window/reinforced/spawner,
@@ -542,16 +542,16 @@
 /obj/item/circuitboard/machine/telecomms/hub,
 /obj/item/stack/cable_coil/cut,
 /obj/structure/frame/machine,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "Lm" = (
 /obj/item/stack/cable_coil/cut,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "Lr" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/item/stack/cable_coil/cut,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "LS" = (
 /turf/open/floor/plating,
@@ -565,7 +565,7 @@
 /obj/structure/window/reinforced/spawner/east,
 /obj/item/circuitboard/machine/telecomms/relay,
 /obj/structure/frame/machine,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "MG" = (
 /obj/structure/frame/machine,
@@ -591,7 +591,7 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/item/circuitboard/machine/telecomms/bus,
 /obj/item/rack_parts,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "RH" = (
 /obj/structure/frame/computer,
@@ -704,7 +704,7 @@
 "YA" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
 /obj/item/stack/cable_coil/cut,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "YO" = (
 /obj/structure/toilet{
@@ -716,7 +716,7 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner,
 /obj/item/circuitboard/machine/teleporter_hub,
-/turf/open/floor/circuit/off,
+/turf/open/floor/circuit,
 /area/ruin/space/has_grav)
 "ZL" = (
 /obj/structure/window/reinforced/spawner/west,

--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -191,6 +191,8 @@
 #define LIGHT_COLOR_ELECTRIC_GREEN "#00FF00"
 /// Cold, diluted blue. rgb(100, 150, 250)
 #define LIGHT_COLOR_BLUE "#6496FA"
+/// Faint white blue. rgb(222, 239, 255)
+#define LIGHT_COLOR_FAINT_BLUE "#DEEFFF"
 /// Light blueish green. rgb(125, 225, 175)
 #define LIGHT_COLOR_BLUEGREEN "#7DE1AF"
 /// Diluted cyan. rgb(125, 225, 225)
@@ -206,7 +208,9 @@
 /// Diluted, mid-warmth pink. rgb(225, 125, 225)
 #define LIGHT_COLOR_PINK "#E17DE1"
 /// Dimmed yellow, leaning kaki. rgb(225, 225, 125)
-#define LIGHT_COLOR_YELLOW "#E1E17D"
+#define LIGHT_COLOR_DIM_YELLOW "#E1E17D"
+/// Bright yellow. rgb(255, 255, 150)
+#define LIGHT_COLOR_BRIGHT_YELLOW "#FFFF99"
 /// Clear brown, mostly dim. rgb(150, 100, 50)
 #define LIGHT_COLOR_BROWN "#966432"
 /// Mostly pure orange. rgb(250, 150, 50)
@@ -231,8 +235,8 @@
 #define LIGHT_COLOR_INTENSE_RED "#C81919"
 /// Weird color, between yellow and green, very slimy. rgb(175, 200, 75)
 #define LIGHT_COLOR_SLIME_LAMP "#AFC84B"
-/// Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)
-#define LIGHT_COLOR_TUNGSTEN "#FAE1AF"
+/// Extremely diluted yellow, close to skin color (for some reason). rgb(255, 214, 170)
+#define LIGHT_COLOR_TUNGSTEN "#FFD6AA"
 /// Barely visible cyan-ish hue, as the doctor prescribed. rgb(240, 250, 250)
 #define LIGHT_COLOR_HALOGEN "#F0FAFA"
 

--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -185,6 +185,8 @@
  */
 /// Bright but quickly dissipating neon green. rgb(100, 200, 100)
 #define LIGHT_COLOR_GREEN "#64C864"
+/// Vivid, slightly blue green. rgb(60, 240, 70)
+#define LIGHT_COLOR_VIVID_GREEN "#3CF046"
 /// Electric green. rgb(0, 255, 0)
 #define LIGHT_COLOR_ELECTRIC_GREEN "#00FF00"
 /// Cold, diluted blue. rgb(100, 150, 250)
@@ -193,6 +195,8 @@
 #define LIGHT_COLOR_BLUEGREEN "#7DE1AF"
 /// Diluted cyan. rgb(125, 225, 225)
 #define LIGHT_COLOR_CYAN "#7DE1E1"
+/// Baby Blue rgb(0, 170, 220)
+#define LIGHT_COLOR_BABY_BLUE "#00AADC"
 /// Electric cyan rgb(0, 255, 255)
 #define LIGHT_COLOR_ELECTRIC_CYAN "#00FFFF"
 /// More-saturated cyan. rgb(64, 206, 255)
@@ -223,6 +227,8 @@
 #define LIGHT_COLOR_LAVA "#C48A18"
 /// Bright, non-saturated red. Leaning slightly towards pink for visibility. rgb(250, 100, 75)
 #define LIGHT_COLOR_FLARE "#FA644B"
+/// Vivid red. Leans a bit darker to accentuate red colors and leave other channels a bit dry.  rgb(200, 25, 25)
+#define LIGHT_COLOR_INTENSE_RED "#C81919"
 /// Weird color, between yellow and green, very slimy. rgb(175, 200, 75)
 #define LIGHT_COLOR_SLIME_LAMP "#AFC84B"
 /// Extremely diluted yellow, close to skin color (for some reason). rgb(250, 225, 175)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -589,6 +589,8 @@
 #define AI_EMOTION_BLUE_GLOW "Blue Glow"
 #define AI_EMOTION_RED_GLOW "Red Glow"
 
+/// Icon state to use for ai displays that just turns them off
+#define AI_DISPLAY_DONT_GLOW "ai_off"
 /// Throw modes, defines whether or not to turn off throw mode after
 #define THROW_MODE_DISABLED 0
 #define THROW_MODE_TOGGLE 1

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -120,13 +120,8 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 	else
 		newA = area_choice
 
-	for(var/i in 1 to length(turfs))
-		var/turf/thing = turfs[i]
-		var/area/old_area = thing.loc
-		old_area.turfs_to_uncontain += thing
-		newA.contents += thing
-		newA.contained_turfs += thing
-		thing.transfer_area_lighting(old_area, newA)
+	for(var/turf/thing as anything in turfs)
+		thing.change_area(thing.loc, newA)
 
 	newA.reg_in_areas_in_z()
 

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -5,7 +5,7 @@
 	icon_keyboard = "power_key"
 	req_access = list(ACCESS_CE)
 	circuit = /obj/item/circuitboard/computer/apc_control
-	light_color = LIGHT_COLOR_YELLOW
+	light_color = LIGHT_COLOR_DIM_YELLOW
 	var/obj/machinery/power/apc/active_apc //The APC we're using right now
 	var/should_log = TRUE
 	var/restoring = FALSE

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -194,7 +194,7 @@
 			spotlights += new /obj/item/flashlight/spotlight(t, 1 + get_dist(src, t), 30 - (get_dist(src, t) * 8), LIGHT_COLOR_PURPLE)
 			continue
 		if(t.x > cen.x && t.y == cen.y)
-			spotlights += new /obj/item/flashlight/spotlight(t, 1 + get_dist(src, t), 30 - (get_dist(src, t) * 8), LIGHT_COLOR_YELLOW)
+			spotlights += new /obj/item/flashlight/spotlight(t, 1 + get_dist(src, t), 30 - (get_dist(src, t) * 8), LIGHT_COLOR_DIM_YELLOW)
 			continue
 		if(t.x < cen.x && t.y == cen.y)
 			spotlights += new /obj/item/flashlight/spotlight(t, 1 + get_dist(src, t), 30 - (get_dist(src, t) * 8), LIGHT_COLOR_GREEN)
@@ -289,12 +289,12 @@
 				if(LIGHT_COLOR_BLUEGREEN)
 					if(glow.even_cycle)
 						glow.set_light_range(glow.base_light_range * DISCO_INFENO_RANGE)
-						glow.set_light_color(LIGHT_COLOR_YELLOW)
+						glow.set_light_color(LIGHT_COLOR_DIM_YELLOW)
 						glow.set_light_on(TRUE)
 					else
 						glow.set_light_on(FALSE)
-						glow.set_light_color(LIGHT_COLOR_YELLOW)
-				if(LIGHT_COLOR_YELLOW)
+						glow.set_light_color(LIGHT_COLOR_DIM_YELLOW)
+				if(LIGHT_COLOR_DIM_YELLOW)
 					if(glow.even_cycle)
 						glow.set_light_on(FALSE)
 						glow.set_light_color(LIGHT_COLOR_CYAN)

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -85,7 +85,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	if(machine_stat & (NOPOWER|BROKEN))
 		set_light(0)
 		return
-	set_light(1.4,0.7,"#34D352") // green light
+	set_light(1.5, 0.7, "#34D352") // green light
 
 /obj/machinery/newscaster/update_overlays()
 	. = ..()

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 	if(machine_stat & NOPOWER)
 		set_light(0)
 		return
-	set_light(1.4,0.7,"#34D352")//green light
+	set_light(1.5, 0.7, "#34D352")//green light
 
 /obj/machinery/requests_console/update_icon_state()
 	if(open)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -153,7 +153,7 @@
 	)
 		set_light(0)
 		return
-	set_light(1.4, 0.7, LIGHT_COLOR_BLUE) // blue light
+	set_light(1.5, 0.7, LIGHT_COLOR_BLUE) // blue light
 
 /obj/machinery/status_display/update_overlays()
 	. = ..()
@@ -170,6 +170,8 @@
 		if(SD_PICTURE)
 			remove_messages()
 			. += mutable_appearance(icon, current_picture)
+			if(current_picture == AI_DISPLAY_DONT_GLOW) // If the thing's off, don't display the emissive yeah?
+				return .
 		else
 			var/overlay = update_message(message1_overlay, LINE1_Y, message1)
 			if(overlay)
@@ -285,7 +287,7 @@
 
 		maptext = generate_text(marquee_message, center = FALSE, text_color = text_color)
 		maptext_width = full_marquee_width
-		maptext_x = 0 
+		maptext_x = 0
 
 		// Mask off to fit in screen.
 		add_filter("mask", 1, alpha_mask_filter(icon = icon(icon, "outline")))
@@ -472,7 +474,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 
 	/// A mapping between AI_EMOTION_* string constants, which also double as user readable descriptions, and the name of the iconfile.
 	var/static/list/emotion_map = list(
-		AI_EMOTION_BLANK = "ai_off",
+		AI_EMOTION_BLANK = AI_DISPLAY_DONT_GLOW,
 		AI_EMOTION_VERY_HAPPY = "ai_veryhappy",
 		AI_EMOTION_HAPPY = "ai_happy",
 		AI_EMOTION_NEUTRAL = "ai_neutral",

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -256,8 +256,9 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	force = 10
-	light_range = 5
+	light_range = 3.5
 	light_system = STATIC_LIGHT
+	light_color = LIGHT_COLOR_FAINT_BLUE
 	w_class = WEIGHT_CLASS_BULKY
 	flags_1 = CONDUCT_1
 	custom_materials = null
@@ -268,6 +269,7 @@
 	desc = "A classic green-shaded desk lamp."
 	icon_state = "lampgreen"
 	inhand_icon_state = "lampgreen"
+	light_color = LIGHT_COLOR_TUNGSTEN
 
 //Bananalamp
 /obj/item/flashlight/lamp/bananalamp
@@ -275,6 +277,7 @@
 	desc = "Only a clown would think to make a ghetto banana-shaped lamp. Even has a goofy pullstring."
 	icon_state = "bananalamp"
 	inhand_icon_state = null
+	light_color = LIGHT_COLOR_BRIGHT_YELLOW
 
 // FLARES
 /obj/item/flashlight/flare
@@ -654,7 +657,7 @@
 
 /obj/item/flashlight/glowstick/yellow
 	name = "yellow glowstick"
-	color = LIGHT_COLOR_YELLOW
+	color = LIGHT_COLOR_DIM_YELLOW
 
 /obj/item/flashlight/glowstick/pink
 	name = "pink glowstick"

--- a/code/game/turfs/open/floor/light_floor.dm
+++ b/code/game/turfs/open/floor/light_floor.dm
@@ -14,7 +14,7 @@
 	///defines on top
 	var/state = LIGHTFLOOR_FINE
 	///list of colours to choose
-	var/static/list/coloredlights = list(LIGHT_COLOR_CYAN, COLOR_SOFT_RED, LIGHT_COLOR_ORANGE, LIGHT_COLOR_GREEN, LIGHT_COLOR_YELLOW, LIGHT_COLOR_DARK_BLUE, LIGHT_COLOR_LAVENDER, COLOR_WHITE,  LIGHT_COLOR_SLIME_LAMP, LIGHT_COLOR_FIRE)
+	var/static/list/coloredlights = list(LIGHT_COLOR_CYAN, COLOR_SOFT_RED, LIGHT_COLOR_ORANGE, LIGHT_COLOR_GREEN, LIGHT_COLOR_DIM_YELLOW, LIGHT_COLOR_DARK_BLUE, LIGHT_COLOR_LAVENDER, COLOR_WHITE,  LIGHT_COLOR_SLIME_LAMP, LIGHT_COLOR_FIRE)
 	///current light color
 	var/currentcolor = LIGHT_COLOR_CYAN
 	///var to prevent changing color on certain admin spawn only tiles
@@ -43,7 +43,7 @@
 		COLOR_SOFT_RED = image(icon = src.icon, icon_state = "light_on-2"),
 		LIGHT_COLOR_ORANGE = image(icon = src.icon, icon_state = "light_on-3"),
 		LIGHT_COLOR_GREEN = image(icon = src.icon, icon_state = "light_on-4"),
-		LIGHT_COLOR_YELLOW = image(icon = src.icon, icon_state = "light_on-5"),
+		LIGHT_COLOR_DIM_YELLOW = image(icon = src.icon, icon_state = "light_on-5"),
 		LIGHT_COLOR_DARK_BLUE = image(icon = src.icon, icon_state = "light_on-6"),
 		LIGHT_COLOR_LAVENDER = image(icon = src.icon, icon_state = "light_on-7"),
 		COLOR_WHITE = image(icon = src.icon, icon_state = "light_on-8"),

--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -37,7 +37,7 @@
 	icon_state = on ? (LAZYLEN(SSmapping.nuke_threats) ? "rcircuitanim" : icon_normal) : "[icon_normal]off"
 	return ..()
 
-/turf/open/floor/circuit/change_area(area/old_area, area/new_area)
+/turf/open/floor/circuit/on_change_area(area/old_area, area/new_area)
 	. = ..()
 	UnregisterSignal(old_area, COMSIG_AREA_POWER_CHANGE)
 	RegisterSignal(new_area, COMSIG_AREA_POWER_CHANGE, PROC_REF(handle_powerchange))

--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -62,6 +62,8 @@
 		source.removeStaticPower(CIRCUIT_FLOOR_POWERUSE, AREA_USAGE_STATIC_LIGHT)
 	update_appearance()
 
+#undef CIRCUIT_FLOOR_POWERUSE
+
 /turf/open/floor/circuit/off
 	icon_state = "bcircuitoff"
 	always_off = TRUE

--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -1,15 +1,23 @@
+// Usage for a bar light is 160, let's do a bit less then that since these tend to be used a lot in one place
+#define CIRCUIT_FLOOR_POWERUSE 120
 //Circuit flooring, glows a little
 /turf/open/floor/circuit
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "bcircuit"
 	var/icon_normal = "bcircuit"
-	light_color = LIGHT_COLOR_CYAN
+	light_color = LIGHT_COLOR_BABY_BLUE
 	floor_tile = /obj/item/stack/tile/circuit
-	var/on = TRUE
+	/// If we want to ignore our area's power status and just be always off
+	/// Mostly for mappers doing asthetic things, or cases where the floor should be broken
+	var/always_off = FALSE
+	/// If this floor is powered or not
+	/// We don't consume any power, but we do require it
+	var/on = -1
 
 /turf/open/floor/circuit/Initialize(mapload)
 	SSmapping.nuke_tiles += src
-	update_appearance()
+	RegisterSignal(loc, COMSIG_AREA_POWER_CHANGE, PROC_REF(handle_powerchange))
+	handle_powerchange(loc)
 	. = ..()
 
 /turf/open/floor/circuit/Destroy()
@@ -22,16 +30,41 @@
 		set_light(0)
 		return
 
-	set_light_color(LAZYLEN(SSmapping.nuke_threats) ? LIGHT_COLOR_FLARE : initial(light_color))
-	set_light(1.4, 0.5)
+	set_light_color(LAZYLEN(SSmapping.nuke_threats) ? LIGHT_COLOR_INTENSE_RED : initial(light_color))
+	set_light(2, 1.5)
 
 /turf/open/floor/circuit/update_icon_state()
 	icon_state = on ? (LAZYLEN(SSmapping.nuke_threats) ? "rcircuitanim" : icon_normal) : "[icon_normal]off"
 	return ..()
 
+/turf/open/floor/circuit/change_area(area/old_area, area/new_area)
+	. = ..()
+	UnregisterSignal(old_area, COMSIG_AREA_POWER_CHANGE)
+	RegisterSignal(new_area, COMSIG_AREA_POWER_CHANGE, PROC_REF(handle_powerchange))
+	if(on)
+		old_area.removeStaticPower(CIRCUIT_FLOOR_POWERUSE, AREA_USAGE_STATIC_LIGHT)
+	handle_powerchange(new_area)
+
+/// Enables/disables our lighting based off our source area
+/turf/open/floor/circuit/proc/handle_powerchange(area/source)
+	SIGNAL_HANDLER
+	var/old_on = on
+	if(always_off)
+		on = FALSE
+	else
+		on = source.powered(AREA_USAGE_LIGHT)
+	if(on == old_on)
+		return
+
+	if(on)
+		source.addStaticPower(CIRCUIT_FLOOR_POWERUSE, AREA_USAGE_STATIC_LIGHT)
+	else
+		source.removeStaticPower(CIRCUIT_FLOOR_POWERUSE, AREA_USAGE_STATIC_LIGHT)
+	update_appearance()
+
 /turf/open/floor/circuit/off
 	icon_state = "bcircuitoff"
-	on = FALSE
+	always_off = TRUE
 
 /turf/open/floor/circuit/airless
 	initial_gas_mix = AIRLESS_ATMOS
@@ -48,12 +81,12 @@
 /turf/open/floor/circuit/green
 	icon_state = "gcircuit"
 	icon_normal = "gcircuit"
-	light_color = LIGHT_COLOR_GREEN
+	light_color = LIGHT_COLOR_VIVID_GREEN
 	floor_tile = /obj/item/stack/tile/circuit/green
 
 /turf/open/floor/circuit/green/off
 	icon_state = "gcircuitoff"
-	on = FALSE
+	always_off = TRUE
 
 /turf/open/floor/circuit/green/anim
 	icon_state = "gcircuitanim"
@@ -72,12 +105,12 @@
 /turf/open/floor/circuit/red
 	icon_state = "rcircuit"
 	icon_normal = "rcircuit"
-	light_color = LIGHT_COLOR_FLARE
+	light_color = LIGHT_COLOR_INTENSE_RED
 	floor_tile = /obj/item/stack/tile/circuit/red
 
 /turf/open/floor/circuit/red/off
 	icon_state = "rcircuitoff"
-	on = FALSE
+	always_off = TRUE
 
 /turf/open/floor/circuit/red/anim
 	icon_state = "rcircuitanim"

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -219,8 +219,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /// Call to move a turf from its current area to a new one
 /turf/proc/change_area(area/old_area, area/new_area)
-	// Just in case the old area is the same as the new one, this seems to happen on occasion and I don't want to break anything
-	old_area.contents -= src
 	old_area.turfs_to_uncontain += src
 	new_area.contents += src
 	new_area.contained_turfs += src

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -217,6 +217,13 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		return
 	user.Move_Pulled(src)
 
+/// Call to move a turf from its current area to a new one
+/turf/proc/change_area(area/old_area, area/new_area)
+	old_area.turfs_to_uncontain += src
+	new_area.contents += src
+	new_area.contained_turfs += src
+	transfer_area_lighting(old_area, new_area)
+
 /turf/proc/multiz_turf_del(turf/T, dir)
 	SEND_SIGNAL(src, COMSIG_TURF_MULTIZ_DEL, T, dir)
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -222,6 +222,10 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	old_area.turfs_to_uncontain += src
 	new_area.contents += src
 	new_area.contained_turfs += src
+	on_change_area(old_area, new_area)
+
+/// Allows for reactions to an area change without inherently requiring change_area() be called (I hate maploading)
+/turf/proc/on_change_area(area/old_area, area/new_area)
 	transfer_area_lighting(old_area, new_area)
 
 /turf/proc/multiz_turf_del(turf/T, dir)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -219,6 +219,8 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /// Call to move a turf from its current area to a new one
 /turf/proc/change_area(area/old_area, area/new_area)
+	// Just in case the old area is the same as the new one, this seems to happen on occasion and I don't want to break anything
+	old_area.contents -= src
 	old_area.turfs_to_uncontain += src
 	new_area.contents += src
 	new_area.contained_turfs += src

--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -183,7 +183,7 @@
 		priority_announce("Spatial object has reached peak energy charge in [initial(A.name)], please stand-by.", "Central Command Wildlife Observations")
 		atom_integrity = INFINITY
 		icon_state = "carp_rift_charged"
-		set_light_color(LIGHT_COLOR_YELLOW)
+		set_light_color(LIGHT_COLOR_DIM_YELLOW)
 		update_light()
 		set_armor(/datum/armor/immune)
 		resistance_flags = INDESTRUCTIBLE

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -398,7 +398,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	else
 		color = "#03A728" // green
 
-	set_light(1.4, 1, color)
+	set_light(1.5, 1, color)
 
 /obj/machinery/airalarm/update_icon_state()
 	if(panel_open)

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -24,7 +24,7 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/microwave
 	pass_flags = PASSTABLE
-	light_color = LIGHT_COLOR_YELLOW
+	light_color = LIGHT_COLOR_DIM_YELLOW
 	light_power = 3
 	var/wire_disabled = FALSE // is its internal wire cut?
 	var/operating = FALSE

--- a/code/modules/mapfluff/ruins/spaceruin_code/TheDerelict.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/TheDerelict.dm
@@ -45,7 +45,7 @@
 	desc = "It seems to be powering and controlling the vault locks."
 	icon_screen = "power"
 	icon_keyboard = "power_key"
-	light_color = LIGHT_COLOR_YELLOW
+	light_color = LIGHT_COLOR_DIM_YELLOW
 	use_power = NO_POWER_USE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -847,7 +847,8 @@ GLOBAL_LIST_EMPTY(map_model_default)
 			world.preloader_load(instance)
 	// If this isn't template work, we didn't change our turf and we changed area, then we've gotta handle area lighting transfer
 	else if(!no_changeturf && old_area)
-		crds.change_area(old_area, crds.loc)
+		// Don't do contain/uncontain stuff, this happens a few lines up when the area actally changes
+		crds.transfer_area_lighting(old_area, crds.loc)
 	MAPLOADING_CHECK_TICK
 
 	//finally instance all remainings objects/mobs

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -848,7 +848,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 	// If this isn't template work, we didn't change our turf and we changed area, then we've gotta handle area lighting transfer
 	else if(!no_changeturf && old_area)
 		// Don't do contain/uncontain stuff, this happens a few lines up when the area actally changes
-		crds.transfer_area_lighting(old_area, crds.loc)
+		crds.on_change_area(old_area, crds.loc)
 	MAPLOADING_CHECK_TICK
 
 	//finally instance all remainings objects/mobs

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -847,7 +847,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 			world.preloader_load(instance)
 	// If this isn't template work, we didn't change our turf and we changed area, then we've gotta handle area lighting transfer
 	else if(!no_changeturf && old_area)
-		crds.transfer_area_lighting(old_area, crds.loc)
+		crds.change_area(old_area, crds.loc)
 	MAPLOADING_CHECK_TICK
 
 	//finally instance all remainings objects/mobs

--- a/code/modules/mining/equipment/marker_beacons.dm
+++ b/code/modules/mining/equipment/marker_beacons.dm
@@ -3,7 +3,7 @@ GLOBAL_LIST_INIT(marker_beacon_colors, sort_list(list(
 "Random" = FALSE, //not a true color, will pick a random color
 "Burgundy" = LIGHT_COLOR_FLARE,
 "Bronze" = LIGHT_COLOR_ORANGE,
-"Yellow" = LIGHT_COLOR_YELLOW,
+"Yellow" = LIGHT_COLOR_DIM_YELLOW,
 "Lime" = LIGHT_COLOR_SLIME_LAMP,
 "Olive" = LIGHT_COLOR_GREEN,
 "Jade" = LIGHT_COLOR_BLUEGREEN,

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -42,7 +42,7 @@
 	damage_type = BURN
 	light_range = 2
 	armor_flag = ENERGY
-	light_color = LIGHT_COLOR_YELLOW
+	light_color = LIGHT_COLOR_DIM_YELLOW
 	hitsound = 'sound/weapons/sear.ogg'
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
 	nondirectional_sprite = TRUE

--- a/code/modules/power/lighting/light_mapping_helpers.dm
+++ b/code/modules/power/lighting/light_mapping_helpers.dm
@@ -21,8 +21,8 @@
 	nightshift_allowed = FALSE
 
 /obj/machinery/light/cold
-	bulb_colour = "#deefff"
-	nightshift_light_color = "#deefff"
+	bulb_colour = LIGHT_COLOR_FAINT_BLUE
+	nightshift_light_color = LIGHT_COLOR_FAINT_BLUE
 
 /obj/machinery/light/cold/no_nightlight
 	nightshift_allowed = FALSE

--- a/code/modules/power/monitor.dm
+++ b/code/modules/power/monitor.dm
@@ -5,7 +5,7 @@
 	desc = "It monitors power levels across the station."
 	icon_screen = "power"
 	icon_keyboard = "power_key"
-	light_color = LIGHT_COLOR_YELLOW
+	light_color = LIGHT_COLOR_DIM_YELLOW
 	use_power = ACTIVE_POWER_USE
 	circuit = /obj/item/circuitboard/computer/powermonitor
 	tgui_id = "PowerMonitor"

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -59,13 +59,13 @@
 	impact_effect_type = null
 	hitscan_light_intensity = 3
 	hitscan_light_range = 0.75
-	hitscan_light_color_override = LIGHT_COLOR_YELLOW
+	hitscan_light_color_override = LIGHT_COLOR_DIM_YELLOW
 	muzzle_flash_intensity = 5
 	muzzle_flash_range = 1
-	muzzle_flash_color_override = LIGHT_COLOR_YELLOW
+	muzzle_flash_color_override = LIGHT_COLOR_DIM_YELLOW
 	impact_light_intensity = 5
 	impact_light_range = 1
-	impact_light_color_override = LIGHT_COLOR_YELLOW
+	impact_light_color_override = LIGHT_COLOR_DIM_YELLOW
 	ricochets_max = 1
 	ricochet_chance = 100
 	ricochet_auto_aim_angle = 45

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -88,7 +88,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 	. = ..()
 
 	if(event_source && !(machine_stat & (NOPOWER|BROKEN)))
-		set_light(1.4, 0.7, "#5668E1")
+		set_light(2, 1, "#5668E1")
 	else
 		set_light(0)
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -148,21 +148,12 @@ All ShuttleMove procs go here
 	if(newT == oldT) // In case of in place shuttle rotation shenanigans.
 		return TRUE
 
-	contents -= oldT
-	turfs_to_uncontain += oldT
-	underlying_old_area.contents += oldT
-	underlying_old_area.contained_turfs += oldT
-	oldT.transfer_area_lighting(src, underlying_old_area)
+	oldT.change_area(src, underlying_old_area)
 	//The old turf has now been given back to the area that turf originaly belonged to
 
 	var/area/old_dest_area = newT.loc
 	parallax_movedir = old_dest_area.parallax_movedir
-
-	old_dest_area.contents -= newT
-	old_dest_area.turfs_to_uncontain += newT
-	contents += newT
-	contained_turfs += newT
-	newT.transfer_area_lighting(old_dest_area, src)
+	newT.change_area(old_dest_area, src)
 	return TRUE
 
 // Called on areas after everything has been moved

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -746,11 +746,7 @@
 		var/turf/oldT = old_turfs[i]
 		if(!oldT || !istype(oldT.loc, area_type))
 			continue
-		var/area/old_area = oldT.loc
-		old_area.turfs_to_uncontain += oldT
-		underlying_area.contents += oldT
-		underlying_area.contained_turfs += oldT
-		oldT.transfer_area_lighting(old_area, underlying_area)
+		oldT.change_area(oldT.loc, underlying_area)
 		oldT.empty(FALSE)
 
 		// Here we locate the bottommost shuttle boundary and remove all turfs above it

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -62,7 +62,7 @@
 	armor_type = /datum/armor/machinery_vending
 	circuit = /obj/item/circuitboard/machine/vendor
 	payment_department = ACCOUNT_SRV
-	light_power = 0.5
+	light_power = 0.7
 	light_range = MINIMUM_USEFUL_LIGHT_RANGE
 
 	/// Is the machine active (No sales pitches if off)!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

[Circuit Floor Polish](https://github.com/tgstation/tgstation/commit/6b0ee9813271f693ceb44ad42277c36ef2e71268)

Circuit floors glow! but it looks like crap cause it's dim and the colors are washed out.
I'd like to make them look nicer. Let's make them more intense and longer range, and change the colors over to more vivid replacements.

While I'm here, these should really use power and turn on and off based off that. 
Simple enough to do, just need to hook into a signal (and add a setter for turf area, which cleans up other code too).

[Desklamp Upgrade](https://github.com/tgstation/tgstation/commit/8506b13b9c97bf740c3e97db04450555387dd126)

Desklamps look bad. They're fullwhite, have a way too large range.Crummy.
Let's lower their lightrange from 5 to 3.5, and make the ornate ones warmer, and the more utilitarian ones cooler. The clown one can be yellow because it's funny

I'm renaming a color define here so I'm touching more files then you'd expect

[Brightens Niknacks](https://github.com/tgstation/tgstation/pull/73936/commits/835bae28e9eb9946be53c9f5dac0a0a39f15ef21)

Increases the light range of request consoles, status displays, newscasters, and air alarms (keycard machines too, when they're awaiting input at least)
Increases the brightness of air alarms, I think they should be on par with apcs, should be able to tell when they're good/bad.
Increases the brightness of vending machines (I want them to light up the tiles around them very lightly, I think it's a vibe)

Fixes a bug with ai status displays where they'd display an emissive even if they didn't have anything on their screen, looking stupid. 
This was decently easy but required a define. Looked really bad tho

## Why It's Good For The Game

Pretty

<details>
<summary>
Circuit Floors
</summary>

Old
![image](https://user-images.githubusercontent.com/58055496/224534470-c6eac5f5-5de6-40e9-897d-3212b8796d81.png)
![image](https://user-images.githubusercontent.com/58055496/224534477-ad412ad9-f7c4-44ae-ad75-a1a2c9bd17be.png)

New
![image](https://user-images.githubusercontent.com/58055496/224534486-b7b408a3-546c-4f90-aa9f-0e58bf8128ad.png)
![image](https://user-images.githubusercontent.com/58055496/224534496-626458f7-ab63-429c-a5db-eae9c784d06a.png)
</details>

<details>
<summary>
Desk Lights
</summary>

Old
![image](https://user-images.githubusercontent.com/58055496/224534513-9868b0b8-bc73-4b45-b986-8445078a8653.png)
![image](https://user-images.githubusercontent.com/58055496/224534518-bbbc8c6d-b59e-4f28-a31c-6c6a7e2c2885.png)

New
![image](https://user-images.githubusercontent.com/58055496/224534529-7988f440-03be-42ef-894c-b9e77f577ae5.png)
![image](https://user-images.githubusercontent.com/58055496/224534532-c3f2c6bf-c925-4a59-a8f9-10bb955a9942.png)

</details>

The niknack changes are more minor so I'm not gonna grab photos for them. I can if you'd like but I don't think it's necessary. Mostly a vibes in dark spaces sorta thing
 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: I made circuit floors brighter and more vivid.
add: Made air alarms, vending machines, newscasters, request consoles, status displays and keycard machines slightly "brighter" (larger light range, tho I did make air alarms a bit brighter too)
add: Tweaked desklamps. Lower range, and each type gets its own coloring instead of just fullwhite.
fix: AI displays are no longer always emissive, they'll stop doing it if they aren't displaying anything. Hopefully this'll look nicer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
