### PR TITLE
More stuff to construct & destroy

### DIFF
--- a/code/datums/components/crafting/equipment.dm
+++ b/code/datums/components/crafting/equipment.dm
@@ -57,6 +57,16 @@
 	time = 20 SECONDS
 	category = CAT_EQUIPMENT
 
+/datum/crafting_recipe/freezer_cabinat
+	name = "Freezer Cabinat"
+	result = /obj/structure/closet/secure_closet/freezer/empty
+	reqs = list(
+		/obj/item/stack/sheet/iron = 2,
+		/obj/item/assembly/igniter/condenser = 1,
+	)
+	time = 5 SECONDS
+	category = CAT_EQUIPMENT
+
 /datum/crafting_recipe/trapdoor_kit
 	name = "Trapdoor Construction Kit"
 	result = /obj/item/trapdoor_kit

--- a/code/datums/components/crafting/equipment.dm
+++ b/code/datums/components/crafting/equipment.dm
@@ -58,7 +58,7 @@
 	category = CAT_EQUIPMENT
 
 /datum/crafting_recipe/freezer_cabinat
-	name = "Freezer Cabinat"
+	name = "Freezer Cabinet"
 	result = /obj/structure/closet/secure_closet/freezer/empty
 	reqs = list(
 		/obj/item/stack/sheet/iron = 2,

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -37,8 +37,8 @@
 	repairs = 0
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
 		recharge_speed += capacitor.tier * 100
-	for(var/datum/stock_part/manipulator/matter_bin in component_parts)
-		repairs += matter_bin.tier - 1
+	for(var/datum/stock_part/manipulator/manipulator in component_parts)
+		repairs += manipulator.tier - 1
 	for(var/obj/item/stock_parts/cell/cell in component_parts)
 		recharge_speed *= cell.maxcharge / 10000
 

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -51,8 +51,11 @@
 	var/message_cooldown
 	/// How long it takes to break out of the SSU.
 	var/breakout_time = 300
-	/// How fast it charges cells in a suit
-	var/charge_rate = 250
+	/// Power contributed by this machine to charge the mod suits cell without any capacitors
+	var/base_charge_rate = 200
+	// Final charge rate which is base_charge_rate + contribution by capacitors
+	var/final_charge_rate = 250
+
 
 /obj/machinery/suit_storage_unit/standard_unit
 	suit_type = /obj/item/clothing/suit/space/eva
@@ -210,6 +213,10 @@
 		else
 			. += "[base_icon_state]_ready"
 
+/obj/machinery/suit_storage_unit/RefreshParts()
+	. = ..()
+	for(var/datum/stock_part/capacitor/capacitor in component_parts)
+		final_charge_rate = base_charge_rate + (capacitor.tier * 50)
 
 /obj/machinery/suit_storage_unit/power_change()
 	. = ..()
@@ -455,9 +462,9 @@
 	if(!cell || cell.charge == cell.maxcharge)
 		return
 
-	var/cell_charged = cell.give(charge_rate * delta_time)
+	var/cell_charged = cell.give(final_charge_rate * delta_time)
 	if(cell_charged)
-		use_power((active_power_usage + charge_rate) * delta_time)
+		use_power((active_power_usage + final_charge_rate) * delta_time)
 
 /obj/machinery/suit_storage_unit/proc/shock(mob/user, prb)
 	if(!prob(prb))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -9,6 +9,7 @@
 	density = TRUE
 	obj_flags = NO_BUILD // Becomes undense when the unit is open
 	max_integrity = 250
+	circuit = /obj/item/circuitboard/machine/suit_storage_unit
 
 	var/obj/item/clothing/suit/space/suit = null
 	var/obj/item/clothing/head/helmet/space/helmet = null
@@ -230,8 +231,7 @@
 	if(!(flags_1 & NODECONSTRUCT_1))
 		open_machine()
 		dump_inventory_contents()
-		new /obj/item/stack/sheet/iron(loc, 2)
-	qdel(src)
+	return ..()
 
 /obj/machinery/suit_storage_unit/interact(mob/living/user)
 	var/static/list/items
@@ -551,9 +551,13 @@
 		update_appearance()
 		return
 
-	if(panel_open && is_wire_tool(I))
-		wires.interact(user)
-		return
+	if(panel_open)
+		if(is_wire_tool(I))
+			wires.interact(user)
+			return
+		else if(I.tool_behaviour == TOOL_CROWBAR)
+			default_deconstruction_crowbar(I)
+			return
 	if(!state_open)
 		if(default_deconstruction_screwdriver(user, "[base_icon_state]", "[base_icon_state]", I))	//Set to base_icon_state because the panels for this are overlays
 			update_appearance()

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -52,7 +52,8 @@
 	build_path = /obj/machinery/suit_storage_unit
 	req_components = list(
 		/obj/item/stack/sheet/glass = 2,
-		/obj/item/stack/cable_coil = 5)
+		/obj/item/stack/cable_coil = 5,
+	)
 
 /obj/item/circuitboard/machine/autolathe
 	name = "Autolathe"

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -53,7 +53,7 @@
 	req_components = list(
 		/obj/item/stack/sheet/glass = 2,
 		/obj/item/stack/cable_coil = 5,
-	)
+		/datum/stock_part/capacitor = 1)
 
 /obj/item/circuitboard/machine/autolathe
 	name = "Autolathe"

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -46,6 +46,14 @@
 		/obj/item/stack/cable_coil = 2,
 		/obj/item/stack/sheet/glass = 1)
 
+/obj/item/circuitboard/machine/suit_storage_unit
+	name = "Suit Storage Unit"
+	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
+	build_path = /obj/machinery/suit_storage_unit
+	req_components = list(
+		/obj/item/stack/sheet/glass = 2,
+		/obj/item/stack/cable_coil = 5)
+
 /obj/item/circuitboard/machine/autolathe
 	name = "Autolathe"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -47,12 +47,12 @@
 		return NONE
 
 	if(held_item.tool_behaviour == TOOL_WELDER)
-		context[SCREENTIP_CONTEXT_LMB] = "Deconstruct"
+		context[SCREENTIP_CONTEXT_LMB] = "Unweld"
 		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/structure/closet/secure_closet/freezer/examine(mob/user)
 	. = ..()
-	. += span_notice("It can be [EXAMINE_HINT("unwelded")] apart.")
+	. += span_notice("It can be [EXAMINE_HINT("welded")] apart.")
 
 /obj/structure/closet/secure_closet/freezer/atom_destruction(damage_flag)
 	new /obj/item/stack/sheet/iron(drop_location(), 1)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -41,7 +41,7 @@
 	. = ..()
 
 	if(!opened)
-		balloon_alert(user, span_warning("open it first!"))
+		balloon_alert(user, "open it first!")
 		return TRUE
 
 	if(!tool.use_tool(src, user, 40, volume=50))

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -7,6 +7,10 @@
 	/// If FALSE, we will protect the first person in the freezer from an explosion / nuclear blast.
 	var/jones = FALSE
 
+/obj/structure/closet/secure_closet/freezer/Initialize(mapload)
+	. = ..()
+	register_context()
+
 /obj/structure/closet/secure_closet/freezer/Destroy()
 	toggle_organ_decay(src)
 	return ..()
@@ -31,6 +35,24 @@
 		return ..()
 	jones = TRUE
 	flags_1 &= ~PREVENT_CONTENTS_EXPLOSION_1
+
+/obj/structure/closet/secure_closet/freezer/add_context(
+	atom/source,
+	list/context,
+	obj/item/held_item,
+	mob/living/user,
+)
+
+	if(isnull(held_item) || !opened)
+		return NONE
+
+	if(held_item.tool_behaviour == TOOL_WELDER)
+		context[SCREENTIP_CONTEXT_LMB] = "Deconstruct"
+		return CONTEXTUAL_SCREENTIP_SET
+
+/obj/structure/closet/secure_closet/freezer/examine(mob/user)
+	. = ..()
+	. += span_notice("It can be [EXAMINE_HINT("unwelded")] apart.")
 
 /obj/structure/closet/secure_closet/freezer/atom_destruction(damage_flag)
 	new /obj/item/stack/sheet/iron(drop_location(), 1)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -32,6 +32,27 @@
 	jones = TRUE
 	flags_1 &= ~PREVENT_CONTENTS_EXPLOSION_1
 
+/obj/structure/closet/secure_closet/freezer/atom_destruction(damage_flag)
+	new /obj/item/stack/sheet/iron(drop_location(), 1)
+	new /obj/item/assembly/igniter/condenser(drop_location())
+	return ..()
+
+/obj/structure/closet/secure_closet/freezer/welder_act(mob/living/user, obj/item/tool)
+	. = ..()
+
+	if(!opened)
+		balloon_alert(user, span_warning("open it first!"))
+		return TRUE
+
+	if(!tool.use_tool(src, user, 40, volume=50))
+		return TRUE
+
+	new /obj/item/stack/sheet/iron(drop_location(), 2)
+	new /obj/item/assembly/igniter/condenser(drop_location())
+	qdel(src)
+
+	return TRUE
+
 /obj/structure/closet/secure_closet/freezer/empty
 	name = "freezer"
 

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -42,7 +42,7 @@
 
 /obj/structure/floodlight_frame/wirecutter_act(mob/living/user, obj/item/tool)
 	if(state == FLOODLIGHT_NEEDS_SECURING)
-		to_chat(user, span_notice("You cut the wire from [src]."))
+		balloon_alert(user, "cut wire")
 		name = "floodlight frame"
 		desc = "A bare metal frame looking vaguely like a floodlight. Requires wiring."
 		icon_state = "floodlight_c1"

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -16,7 +16,7 @@
 /obj/structure/floodlight_frame/screwdriver_act(mob/living/user, obj/item/O)
 	. = ..()
 	if(state == FLOODLIGHT_NEEDS_SECURING)
-		to_chat(user, span_notice("You fasten the wiring and electronics in [src]."))
+		balloon_alert(user, "fastened electronics")
 		name = "secured [name]"
 		desc = "A bare metal frame that looks like a floodlight. Requires a light tube to complete."
 		icon_state = "floodlight_c3"

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -23,7 +23,7 @@
 		state = FLOODLIGHT_NEEDS_LIGHTS
 		return TRUE
 	else if(state == FLOODLIGHT_NEEDS_LIGHTS)
-		to_chat(user, span_notice("You unfasten the wiring and electronics in [src]."))
+		balloon_alert("unfastened electronics")
 		name = "wired [name]"
 		desc = "A bare metal frame looking vaguely like a floodlight. Requires securing with a screwdriver."
 		icon_state = "floodlight_c2"

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -156,7 +156,7 @@
 	. = ..()
 	change_setting(FLOODLIGHT_OFF)
 	panel_open = TRUE
-	to_chat(user, span_notice("You open the flood lights maintainence panel."))
+	balloon_alert(user, "opened panel")
 	return TRUE
 
 /obj/machinery/power/floodlight/attack_hand(mob/user, list/modifiers)

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -30,19 +30,19 @@
 	var/message = null
 	if(state == FLOODLIGHT_NEEDS_WIRES)
 		if(istype(held_item, /obj/item/stack/cable_coil))
-			message = "Add Cable"
+			message = "Add cable"
 		else if(held_item.tool_behaviour == TOOL_WRENCH)
-			message = "Dismantle Frame"
+			message = "Dismantle frame"
 
 	else if(state == FLOODLIGHT_NEEDS_SECURING)
 		if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
-			message = "Secure Cable"
+			message = "Secure cable"
 		else if(held_item.tool_behaviour == TOOL_WIRECUTTER)
-			message = "Cut Cable"
+			message = "Cut cable"
 
 	else if(state == FLOODLIGHT_NEEDS_LIGHTS)
 		if(istype(held_item, /obj/item/light/tube))
-			message = "Add Light"
+			message = "Add light"
 		else if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
 			message = "Unscrew cable"
 
@@ -166,7 +166,7 @@
 	if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
 		message = "Open Panel"
 	else if(held_item.tool_behaviour == TOOL_WRENCH)
-		message = anchored ? "Unsecure Light" : "Secure Light"
+		message = anchored ? "Unsecure light" : "Secure light"
 
 	if(isnull(message))
 		return NONE

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -104,7 +104,7 @@
 			state = FLOODLIGHT_NEEDS_SECURING
 			return
 		else
-			balloon_alert(user, "need 5 cable pieces")
+			balloon_alert(user, "need 5 cable pieces!")
 			return
 
 	if(istype(O, /obj/item/light/tube))

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -237,7 +237,7 @@
 	. = ..()
 	change_setting(FLOODLIGHT_OFF)
 	panel_open = TRUE
-	balloon_alert(user, "panel opened")
+	balloon_alert(user, "opened panel")
 	return TRUE
 
 /obj/machinery/power/floodlight/attack_hand(mob/user, list/modifiers)

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -248,7 +248,7 @@
 		var/obj/structure/floodlight_frame/floodlight_frame = new(loc)
 		floodlight_frame.state = FLOODLIGHT_NEEDS_LIGHTS
 
-		var/obj/item/light/tube/light_tube = new /obj/item/light/tube(loc)
+		var/obj/item/light/tube/light_tube = new(loc)
 		user.put_in_active_hand(light_tube)
 
 		qdel(src)

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -115,7 +115,7 @@
 			qdel(O)
 			return
 		else //A minute of silence for all the accidentally broken light tubes.
-			balloon_alert(user, "light tube is broken")
+			balloon_alert(user, "light tube is broken!")
 			return
 	if(istype(O, /obj/item/lightreplacer))
 		var/obj/item/lightreplacer/L = O

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -6,7 +6,7 @@
 
 /obj/structure/floodlight_frame
 	name = "floodlight frame"
-	desc = "A metal frame that requires wiring & a light tube to become a flood light"
+	desc = "A metal frame that requires wiring and a light tube to become a flood light."
 	max_integrity = 100
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "floodlight_c1"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -629,7 +629,7 @@
 	id = "suit_storage_unit"
 	build_path = /obj/item/circuitboard/machine/suit_storage_unit
 	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ROBOTICS
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -623,6 +623,16 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_CARGO
 
+/datum/design/board/suit_storage_unit
+	name = "Suit Storage Unit"
+	desc = "The circuit board for a suit storage unit."
+	id = "suit_storage_unit"
+	build_path = /obj/item/circuitboard/machine/suit_storage_unit
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_ENGINEERING
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+
 /datum/design/board/tesla_coil
 	name = "Tesla Coil Board"
 	desc = "The circuit board for a tesla coil."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -588,6 +588,7 @@
 		"solarcontrol",
 		"stack_console",
 		"stack_machine",
+		"suit_storage_unit",
 		"tank_compressor",
 		"tesla_coil",
 		"thermomachine",


### PR DESCRIPTION
## About The Pull Request
**1. Suit Storage Units**
- What about them?

   1. You can print "suit storage unit" circuit boards from engineering & science circuit printer's after research to make more suit storage units, now since they behave like regular constructable machines you can deconstruct them via screwdriver & crowbar.
   2.  You can upgrade its capacitor to get faster charging speeds

- Why its good for the game?
   1. You can rebuild these in the event they get destroyed
   2. Better tier capacitors = faster charging speeds
   3. More storage units = More places to decontaminate your equipment + Recharge more mod suits made in robotics
   4. If you decide to leave the game or your done using a mod suit e.g. a mining mod suit  rather than keeping it to yourself or throwing it away, just build a suit storage unit and hang it there so other players can use it i.e., sharing is caring.
  
**2. Freezer Cabinet**
- What about them?
 1. They are now craftable
       
![Screenshot (133)](https://user-images.githubusercontent.com/110812394/224561037-5461be22-e651-4d72-8afc-f797bb7d8a47.png)

  3. You can deconstruct them with a welding tool.
   
- Why its good for the game?
  1. You can now make more of them if they get stolen/destroyed
  2. More places to store food, dead bodies, whatever

**3. Flood Lights**
- What about them?
 They can now be fully deconstructed in the exact opposite sequence you constructed them.
  - First use screwdriver to open its panel
  - Then use empty hand to remove light
  - Then use screwdriver to unscrew the wiring from frame
  - Use wire cutter to remove wiring completely
  - Finally use wrench to completely deconstruct frame
 
- Why it's good for the game?
  Reclaim used material to build flood light else where . Also much more clean than what the wiki is suggesting.
  
![Screenshot (134)](https://user-images.githubusercontent.com/110812394/224561553-f44a97f3-ac70-49e7-892f-1a05e2323ecb.png)

  ## Changelog
:cl:
add: suit storage unit circuit boards to engineering & science department circuit printers.
add: freezer cabinet as a craftable & destructible item.
qol: flood light can now be deconstructed rather than destroyed/thrown away.
/:cl: