### PR TITLE
Restores the atomic bomb drink order to japanese bar bots

### DIFF
--- a/code/modules/food_and_drinks/restaurant/customers/_customer.dm
+++ b/code/modules/food_and_drinks/restaurant/customers/_customer.dm
@@ -218,6 +218,8 @@
 			/datum/reagent/consumable/tea = 4,
 			/datum/reagent/consumable/cherryshake = 1,
 			/datum/reagent/consumable/ethanol/bastion_bourbon = 1,
+			/datum/reagent/consumable/ethanol/atomicbomb = 1,
+
 		),
 	)
 


### PR DESCRIPTION
You might argue that this is a racist reference, but it's no more or less racist than the american bar bot having the exact same order. It references a horrible historical event without passing any specific judgement

More importantly, not a single replacement offering was provided and another person was unfairly slandered in the changelog for that change, without a chance for a defence.

I suggest if someone wants to actually remove this, they can find a decent replacement drink at the same time.

:cl: oranges
balance: restored the atomic bomb drink order to japanese bar bots.
/:cl:
