### PR TITLE
Add ketchup bottle, for mail and crafting purposes

### DIFF
--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -35,6 +35,7 @@
 		/obj/item/reagent_containers/cup/bottle/caramel = 20,
 		/obj/item/reagent_containers/condiment/flour = 20,
 		/obj/item/reagent_containers/condiment/rice = 20,
+		/obj/item/reagent_containers/condiment/ketchup = 20,
 		/obj/item/reagent_containers/condiment/enzyme = 15,
 		/obj/item/reagent_containers/condiment/soymilk = 15,
 		/obj/item/knife/kitchen = 4,

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -547,7 +547,7 @@
 			"soymilk" = list("icon_state" = "soymilk", "icon_empty" = "", "name" = "soy milk", "desc" = "It's soy milk. White and nutritious goodness!"),
 			"soysauce" = list("icon_state" = "soysauce", "inhand_icon_state" = "", "icon_empty" = "", "name" = "soy sauce bottle", "desc" = "A salty soy-based flavoring."),
 			"sugar" = list("icon_state" = "sugar", "icon_empty" = "", "name" = "sugar sack", "desc" = "Tasty spacey sugar!"),
-			"ketchup" = list("icon_state" = "ketchup", "icon_empty" = "", "name" = "ketchup bottle", "desc" = "You feel more American already."),
+			"ketchup" = list("icon_state" = "ketchup", "icon_empty" = "", "name" = "ketchup bottle", "desc" = "A tomato slurry in a tall plastic bottle. Somehow still vaguely American."),
 			"capsaicin" = list("icon_state" = "hotsauce", "icon_empty" = "", "name" = "hotsauce bottle", "desc" = "You can almost TASTE the stomach ulcers!"),
 			"frostoil" = list("icon_state" = "coldsauce", "icon_empty" = "", "name" = "coldsauce bottle", "desc" = "Leaves the tongue numb from its passage."),
 			"cornoil" = list("icon_state" = "oliveoil", "icon_empty" = "", "name" = "corn oil bottle", "desc" = "A delicious oil used in cooking. Made from corn."),

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -280,7 +280,7 @@
 	color = "#731008" // rgb: 115, 16, 8
 	taste_description = "ketchup"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	default_container = /obj/item/reagent_containers/condiment/pack/ketchup
+	default_container = /obj/item/reagent_containers/condiment/ketchup
 
 /datum/reagent/consumable/capsaicin
 	name = "Capsaicin Oil"
@@ -1097,7 +1097,7 @@
 	nutriment_factor = 1.5 * REAGENTS_METABOLISM
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/condiment/creamer
-	
+
 /datum/reagent/consumable/mintextract
 	name = "Mint Extract"
 	description = "Useful for dealing with undesirable customers."

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -308,6 +308,15 @@
 	list_reagents = list(/datum/reagent/consumable/honey = 50)
 	fill_icon_thresholds = null
 
+/obj/item/reagent_containers/condiment/ketchup
+	name = "ketchup"
+	// At time of writing, "ketchup" mechanically, is just ground tomatoes,
+	// rather than // tomatoes plus vinegar plus sugar.
+	desc = "A tomato slurry in a tall plastic bottle. Somehow still vaguely American."
+	icon_state = "ketchup"
+	list_reagents = list(/datum/reagent/consumable/ketchup = 50)
+	fill_icon_thresholds = null
+
 //technically condiment packs but they are non transparent
 
 /obj/item/reagent_containers/condiment/creamer


### PR DESCRIPTION
:cl: coiax
add: Chefs can sometimes get ketchup bottles in the mail.
fix: Ketchup in the crafting menu is now represented as the bottle, rather than an empty condiment pack.
/:cl:

A lot of recipes are harder to read than they need to be because the reagents don't have useful containers set. Although ketchup has the condiment pack set as its "default container", it doesn't display the red contents in the crafting menu.

Using the already existing ketchup bottle sprite that the condimaster uses, made a separate pre-defined ketchup bottle for the reagent to reference, which looks better.

And to provide something that cares about the existence of the dedicated ketchup bottle (apart from the copy-pasted condimaster code which I am not brave enough to refactor), lets chefs get ketchup in the mail.
![image](https://user-images.githubusercontent.com/609465/224579612-e439080f-3340-4ad6-816d-e6388fd86740.png)