### PR TITLE
Add new station trait: Expanded Access

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -936,6 +936,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_BIGGER_PODS "station_trait_bigger_pods"
 #define STATION_TRAIT_SMALLER_PODS "station_trait_smaller_pods"
 #define STATION_TRAIT_BIRTHDAY "station_trait_birthday"
+#define STATION_TRAIT_EXPANDED_ACCESS "station_trait_expanded_access"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -342,3 +342,12 @@
 	report_message = "Due to good performance, we've provided your station with luxury escape pods."
 	trait_to_give = STATION_TRAIT_BIGGER_PODS
 	blacklist = list(/datum/station_trait/cramped_escape_pods)
+
+/datum/station_trait/expanded_access
+	name = "Expanded Access"
+	trait_type = STATION_TRAIT_POSITIVE
+	weight = 5
+	show_in_report = TRUE
+	report_message = "We accidentally issued the crew with cards which may have more access than what their jobs strictly require."
+	trait_to_give = STATION_TRAIT_EXPANDED_ACCESS
+	can_revert = FALSE


### PR DESCRIPTION
:cl: coiax
add: Budget cuts in the Nanotrasen ID card issuing division may result in all crew members being given too much access, like they were part of a skeleton crew.
/:cl:

Adds a new trait, Expanded Access. Mechanically, this just triggers the additional access that operating under a skeleton crew may have granted (depending on config).

Keen eyed joiners may notice the slightly different message if there has been a clerical error somewhere, and if not, the station report will list it. Or you could just try to open a door.

This will give a little bit of variation to some rounds, maybe leading to a little more conflict as various departmental members barge into places uninvited, wherein previous they were kept out, like the riffraff they were.