### PR TITLE
[NO GBP]Bolter wrench's design is correctly at advanced engineering now.

### DIFF
--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -391,6 +391,7 @@
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_JANITORIAL
 	)
+
 /datum/design/bolter_wrench
 	name = "Bolter Wrench"
 	desc = "A wrench that can unbolt airlocks regardless of power status."
@@ -399,6 +400,6 @@
 	materials = list(/datum/material/iron = 2000)
 	build_path = /obj/item/wrench/bolter
 	category = list(
-		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_JANITORIAL
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING


### PR DESCRIPTION

## About The Pull Request
It was at janitorial because I'm pretty good at ctrl+C/V
## Why It's Good For The Game
The engineering tool is at the engineering tab now.
## Changelog
:cl: Guillaume Prata
fix: Bolter wrench's protolathe design is correctly at the advanced engineering tab now, instead of being under janitorial.
/:cl:
