### PR TITLE
Fixes ignoring space turfs in difference checks

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -553,16 +553,21 @@ SUBSYSTEM_DEF(air)
 	// Now we're gonna compare for differences
 	// Taking advantage of current cycle being set to negative before this run to do A->B B->A prevention
 	for(var/turf/open/potential_diff as anything in difference_check)
-		potential_diff.current_cycle = 0
+		// I can't use 0 here, so we're gonna do this instead. If it ever breaks I'll eat my shoe
+		potential_diff.current_cycle = -INFINITE
 		for(var/turf/open/enemy_tile as anything in potential_diff.atmos_adjacent_turfs)
 			// If it's already been processed, then it's already talked to us
-			if(enemy_tile.current_cycle == 0)
+			if(enemy_tile.current_cycle == -INFINITE)
 				continue
 			// .air instead of .return_air() because we can guarentee that the proc won't do anything
 			if(potential_diff.air.compare(enemy_tile.air))
 				//testing("Active turf found. Return value of compare(): [T.air.compare(enemy_tile.air)]")
-				potential_diff.excited = TRUE
-				SSair.active_turfs += potential_diff
+				if(!potential_diff.excited)
+					potential_diff.excited = TRUE
+					SSair.active_turfs += potential_diff
+				if(!enemy_tile.excited)
+					enemy_tile.excited = TRUE
+					SSair.active_turfs += enemy_tile
 				// No sense continuing to iterate
 				break
 		CHECK_TICK


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I done fucked it lads. Space turfs are never initialized, so asserting all shareable turfs have a cycle below 0 is not safe. instead we'll use -infinity. if that ever breaks I'll eat my shoe
Closes #73961