### PR TITLE
Optimize cutting part of update_icon (Saves 130+ms of init)

### DIFF
--- a/code/__DEFINES/overlays.dm
+++ b/code/__DEFINES/overlays.dm
@@ -1,0 +1,25 @@
+// A reasonable number of maximum overlays an object needs
+// If you think you need more, rethink it
+#define MAX_ATOM_OVERLAYS 100
+
+/// Checks if an atom has reached the overlay limit, and make a loud error if it does.
+#define VALIDATE_OVERLAY_LIMIT(changed_on) \
+	if(length(changed_on.overlays) >= MAX_ATOM_OVERLAYS) { \
+		var/text_lays = overlays2text(changed_on.overlays); \
+		stack_trace("Too many overlays on [changed_on.type] - [length(changed_on.overlays)], refusing to update and cutting.\
+			\n What follows is a printout of all existing overlays at the time of the overflow \n[text_lays]"); \
+		changed_on.overlays.Cut(); \
+		changed_on.add_overlay(mutable_appearance('icons/testing/greyscale_error.dmi')); \
+	} \
+
+
+/// Performs any operations that ought to run after an appearance change
+#define POST_OVERLAY_CHANGE(changed_on) \
+	if(alternate_appearances) { \
+		for(var/I in changed_on.alternate_appearances){\
+			var/datum/atom_hud/alternate_appearance/AA = changed_on.alternate_appearances[I];\
+			if(AA.transfer_overlays){\
+				AA.copy_overlays(changed_on, TRUE);\
+			}\
+		} \
+	}

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -255,25 +255,6 @@
 /// Game has round finished
 #define GAME_STATE_FINISHED 4
 
-//! ## Overlays subsystem
-
-#define POST_OVERLAY_CHANGE(changed_on) \
-	if(length(changed_on.overlays) >= MAX_ATOM_OVERLAYS) { \
-		var/text_lays = overlays2text(changed_on.overlays); \
-		stack_trace("Too many overlays on [changed_on.type] - [length(changed_on.overlays)], refusing to update and cutting.\
-			\n What follows is a printout of all existing overlays at the time of the overflow \n[text_lays]"); \
-		changed_on.overlays.Cut(); \
-		changed_on.add_overlay(mutable_appearance('icons/testing/greyscale_error.dmi')); \
-	} \
-	if(alternate_appearances) { \
-		for(var/I in changed_on.alternate_appearances){\
-			var/datum/atom_hud/alternate_appearance/AA = changed_on.alternate_appearances[I];\
-			if(AA.transfer_overlays){\
-				AA.copy_overlays(changed_on, TRUE);\
-			}\
-		} \
-	}
-
 /**
 	Create a new timer and add it to the queue.
 	* Arguments:

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -131,10 +131,6 @@
 #define CBT
 #endif
 
-// A reasonable number of maximum overlays an object needs
-// If you think you need more, rethink it
-#define MAX_ATOM_OVERLAYS 100
-
 #if !defined(CBT) && !defined(SPACEMAN_DMM)
 #warn Building with Dream Maker is no longer supported and will result in errors.
 #warn In order to build, run BUILD.bat in the root directory.

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -81,6 +81,7 @@ SUBSYSTEM_DEF(overlays)
 		return
 	STAT_START_STOPWATCH
 	overlays += build_appearance_list(add_overlays)
+	VALIDATE_OVERLAY_LIMIT(src)
 	POST_OVERLAY_CHANGE(src)
 	STAT_STOP_STOPWATCH
 	STAT_LOG_ENTRY(SSoverlays.stats, type)
@@ -98,11 +99,13 @@ SUBSYSTEM_DEF(overlays)
 			overlays = cached_other
 		else
 			overlays = null
+		VALIDATE_OVERLAY_LIMIT(src)
 		POST_OVERLAY_CHANGE(src)
 		STAT_STOP_STOPWATCH
 		STAT_LOG_ENTRY(SSoverlays.stats, type)
 	else if(cached_other)
 		overlays += cached_other
+		VALIDATE_OVERLAY_LIMIT(src)
 		POST_OVERLAY_CHANGE(src)
 		STAT_STOP_STOPWATCH
 		STAT_LOG_ENTRY(SSoverlays.stats, type)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -811,7 +811,7 @@
 
 		var/list/new_overlays = update_overlays(updates)
 		if (managed_overlays)
-			if (!islist(managed_overlays) || (managed_overlays.len == overlays.len))
+			if (overlays.len == (islist(managed_overlays) ? managed_overlays.len : 1))
 				overlays = null
 				POST_OVERLAY_CHANGE(src)
 			else

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -810,9 +810,13 @@
 			SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
 
 		var/list/new_overlays = update_overlays(updates)
-		if(managed_overlays)
-			cut_overlay(managed_overlays)
-			managed_overlays = null
+		if (managed_overlays)
+			if (!islist(managed_overlays) || (managed_overlays.len == overlays.len))
+				overlays = null
+				POST_OVERLAY_CHANGE(src)
+			else
+				cut_overlay(managed_overlays)
+				managed_overlays = null
 		if(length(new_overlays))
 			if (length(new_overlays) == 1)
 				managed_overlays = new_overlays[1]

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -811,7 +811,7 @@
 
 		var/list/new_overlays = update_overlays(updates)
 		if (managed_overlays)
-			if (overlays.len == (islist(managed_overlays) ? managed_overlays.len : 1))
+			if (length(overlays) == (islist(managed_overlays) ? length(managed_overlays) : 1))
 				overlays = null
 				POST_OVERLAY_CHANGE(src)
 			else

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -147,6 +147,7 @@
 #include "code\__DEFINES\nitrile.dm"
 #include "code\__DEFINES\nuclear_bomb.dm"
 #include "code\__DEFINES\obj_flags.dm"
+#include "code\__DEFINES\overlays.dm"
 #include "code\__DEFINES\pai.dm"
 #include "code\__DEFINES\paintings.dm"
 #include "code\__DEFINES\paper.dm"


### PR DESCRIPTION
Avoids calling `cut_overlay` if we know that we manage every overlay we're about to remove, and short-circuits to `overlays = null`. This saves the cost of building the appearance list and performing `-=` of the list.

More minor change, splits validation part of `POST_OVERLAY_CHANGE` into `VALIDATE_OVERLAY_LIMIT`. This is because there is no point checking if we hit the overlay limit after removing overlays, since we would've checked in `add_overlay` in reasonable cases.