### PR TITLE
[MetaStation] Replaces the two oxy canisters in the cold room storage to anesthetic canisters

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5612,7 +5612,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "caC" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
@@ -12626,7 +12626,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Most likely an oversight when anesthetic canisters got added for cryo.

## Changelog

:cl: Jolly
fix: In MetaStations cold room storage, the O2 canisters were replaced with anesthetic canisters. Now go put that clown into an eternal slumber, you traitorous CMO!
/:cl:

