### PR TITLE
Fixes malf camera upgrade appearing on security camera consoles

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -144,7 +144,7 @@
 	last_camera_turf = new_cam_turf
 
 	//Here we gather what's visible from the camera's POV based on its view_range and xray modifier if present
-	var/list/visible_things = active_camera.isXRay() ? range(active_camera.view_range, new_cam_turf) : view(active_camera.view_range, new_cam_turf)
+	var/list/visible_things = active_camera.isXRay(ignore_malf_upgrades = TRUE) ? range(active_camera.view_range, new_cam_turf) : view(active_camera.view_range, new_cam_turf)
 
 	for(var/turf/visible_turf in visible_things)
 		visible_turfs += visible_turf

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -149,7 +149,7 @@
 	last_camera_turf = new_cam_turf
 
 	//Here we gather what's visible from the camera's POV based on its view_range and xray modifier if present
-	var/list/visible_things = active_camera.isXRay() ? range(active_camera.view_range, new_cam_turf) : view(active_camera.view_range, new_cam_turf)
+	var/list/visible_things = active_camera.isXRay(ignore_malf_upgrades = TRUE) ? range(active_camera.view_range, new_cam_turf) : view(active_camera.view_range, new_cam_turf)
 
 	for(var/turf/visible_turf in visible_things)
 		visible_turfs += visible_turf


### PR DESCRIPTION
## About The Pull Request

Wow that was easier than I thought

Malf AI camera upgrade no longer shows up camera consoles. 
Advanced Camera consoles probably still show it but those are harder to get so someone else can fix those

## Why It's Good For The Game

It is admittedly very funny to instantly valid a malf ai but probably not fun

## Changelog

:cl: Melbert
fix: Malf AI's xray camera upgrade no longer shows on station security camera consoles
/:cl:
