### PR TITLE
Fixes the metallic hydrogen axe being silent when being used as a crowbar and crowbars can now hit windows.

### DIFF
--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -85,3 +85,4 @@
 	demolition_mod = 2
 	tool_behaviour = TOOL_CROWBAR
 	toolspeed = 1
+	usesound = 'sound/items/crowbar.ogg'

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -267,6 +267,8 @@
 			if(tool.use_tool(src, user, 5 SECONDS, volume = 75, extra_checks = CALLBACK(src, PROC_REF(check_state_and_anchored), state, anchored)))
 				state = WINDOW_SCREWED_TO_FRAME
 				to_chat(user, span_notice("You pry the window back into the frame."))
+		else
+			return FALSE
 
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 


### PR DESCRIPTION
## About The Pull Request

The metallic hydrogen axe had no usesound var set despite having a tool_behavior applied to it, this meant that when using it as a crowbar, for example to remove floor tiles no sound was played. I've given it the default crowbar sound for this.

Bonus fix: Crowbars were incapable of hitting fully constructed default windows, this included the H2 axe, They are now able to be used on standard windows (they already worked on reinforced windows)

## Why It's Good For The Game

Missing sound bad. Pretty sure the crowbar thing is a bug too.
## Changelog
:cl:
fix: The metallic hydrogen axe is no longer silent when using it as a crowbar.
fix: You are now capable of hitting standard windows with a crowbar when they're fully constructed.
/:cl:
