### PR TITLE
You can't instantly resist out of an unlocked labor camp teleporter if you are handcuffed

### DIFF
--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -95,15 +95,22 @@ The console is located at computer/gulag_teleporter.dm
 	open_machine()
 
 /obj/machinery/gulag_teleporter/container_resist_act(mob/living/user)
+	var/resist_time = breakout_time
 	if(!locked)
-		open_machine()
-		return
+		if(!HAS_TRAIT(user, TRAIT_RESTRAINED))
+			open_machine()
+			return
+		resist_time *= 0.5
+
 	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + CLICK_CD_BREAKOUT
-	user.visible_message(span_notice("You see [user] kicking against the door of [src]!"), \
-		span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)"), \
-		span_hear("You hear a metallic creaking from [src]."))
-	if(do_after(user,(breakout_time), target = src))
+	user.visible_message(
+		span_notice("You see [user] kicking against the door of [src]!"),
+		span_notice("You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(resist_time)].)"),
+		span_hear("You hear a metallic creaking from [src]."),
+	)
+
+	if(do_after(user, resist_time, target = src))
 		if(!user || user.stat != CONSCIOUS || user.loc != src || state_open || !locked)
 			return
 		locked = FALSE


### PR DESCRIPTION
## About The Pull Request

If you are restrained, and placed into an unlocked labor camp teleporter, you cannot instantly resist out of it. However the resist timer is cut in half while unlocked. 

## Why It's Good For The Game

Getting someone into the gulag teleporter is an incredibly un-necessary pain in the rear because simply *spamming resist* turns it into a game where you have to shove them in, then really quick go over to the computer and slam the lock button. This is... kinda lame. A lot of new player security officers get got by this, and I think it's sad. Inb4 "Skill issue"

## Changelog

:cl: Melbert
balance: If you are handcuffed, you can't instantly resist out of an unlocked labor camp teleporter (however, resist time is halved). 
/:cl:
