### PR TITLE
Fixes ghost role spawners not allowing you to spawn as more than one ghost role per round

### DIFF
--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -208,12 +208,13 @@
  */
 /obj/effect/mob_spawn/ghost_role/proc/create_from_ghost(mob/dead/user)
 	ASSERT(istype(user))
+	var/user_ckey = user.ckey // We need to do it before everything else, because after the create() the ckey will already have been transfered.
+
 	user.log_message("became a [prompt_name].", LOG_GAME)
 	uses -= 1 // Remove a use before trying to spawn to prevent strangeness like the spawner trying to spawn more mobs than it should be able to
 	user.mind = null // dissassociate mind, don't let it follow us to the next life
 
 	var/created = create(user)
-	var/user_ckey = user.ckey // Just in case shenanigans happen, we always want to remove it from the list.
 	LAZYREMOVE(ckeys_trying_to_spawn, user_ckey) // We do this AFTER the create() so that we're basically sure that the user won't be in their ghost body anymore, so they can't click on the spawner again.
 
 	if(!created)


### PR DESCRIPTION
## About The Pull Request
Turns out https://github.com/tgstation/tgstation/pull/73833 happened before my PR was merged, and somehow miraculously didn't conflict with it.

However, it still made it so the ckey was now null, and the way that Git handled the conflict, made it so the variable was now at the wrong spot, and now it was null.

Fun times.

## Why It's Good For The Game
People gotta be able to spawn in from other spawners, that's the whole point.

## Changelog


:cl: GoldenAlpharex
fix: Fixes ghost role spawners not allowing you to spawn from more than one ghost role per round.
/:cl: