### PR TITLE
Fixes the pubbystation monastery pod

### DIFF
--- a/_maps/shuttles/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod_large.dmm
@@ -58,9 +58,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Shuttle Airlock"
 	},
-/obj/docking_port/mobile/pod{
-	port_direction = 2
-	},
+/obj/docking_port/mobile/monastery,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/pod_1)
 "W" = (

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -567,6 +567,15 @@
 	setTimer(SSshuttle.emergency_escape_time)
 	priority_announce("The Emergency Shuttle is preparing for direct jump. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority")
 
+/obj/docking_port/mobile/monastery
+	name = "monastery pod"
+	shuttle_id = "mining_common" //set so mining can call it down
+	launch_status = UNLAUNCHED //required for it to launch as a pod.
+
+/obj/docking_port/mobile/monastery/on_emergency_dock()
+	if(launch_status == ENDGAME_LAUNCHED)
+		initiate_docking(SSshuttle.getDock("pod_away")) //docks our shuttle as any pod would
+		mode = SHUTTLE_ENDGAME
 
 /obj/docking_port/mobile/pod
 	name = "escape pod"

--- a/code/modules/shuttle/monastery.dm
+++ b/code/modules/shuttle/monastery.dm
@@ -2,6 +2,6 @@
 	name = "monastery shuttle console"
 	desc = "Used to control the monastery shuttle."
 	circuit = /obj/item/circuitboard/computer/monastery_shuttle
-	shuttleId = "pod"
+	shuttleId = "mining_common"
 	possible_destinations = "monastery_shuttle_asteroid;monastery_shuttle_station;lavaland_common_away;landing_zone_dock;mining_public"
 	no_destination_swap = TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes Pubby's monastery pod, as emergency pod changes have broken it overtime.
- Calling it from Lavaland now works
- Using it as a pod still works
- Sending it off using the console on the pod itself and from the station also now works again (which had broken ~4 months ago).

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/54370
This isn't player-facing unless an Admin runs it from Map Depot, where it's still maintained.

## Changelog

:cl:
fix: Pubbystation, if run, will now have a working monastery pod shuttle again.
/:cl: