### PR TITLE
Cyborg surgery processor shows downloaded surgeries & equip requirement on examine

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -257,6 +257,15 @@
 	item_flags = NOBLUDGEON
 	var/list/loaded_surgeries = list()
 
+/obj/item/surgical_processor/examine(mob/user)
+	. = ..()
+	. += span_notice("Equip the processor in one of your active modules to access downloaded surgeries.")
+	. += span_boldnotice("Surgeries available:")
+	var/list/surgeries_names = list()
+	for(var/datum/surgery/downloaded_surgery as anything in loaded_surgeries)
+		surgeries_names += "[initial(downloaded_surgery.name)]"
+	. += span_notice("[english_list(surgeries_names)]")
+
 /obj/item/surgical_processor/equipped(mob/user, slot, initial)
 	. = ..()
 	if(!(slot & ITEM_SLOT_HANDS))

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -259,10 +259,13 @@
 
 /obj/item/surgical_processor/examine(mob/user)
 	. = ..()
-	. += span_notice("Equip the processor in one of your active modules to access downloaded surgeries.")
-	. += span_boldnotice("Surgeries available:")
+	. += span_notice("Equip the processor in one of your active modules to access downloaded advanced surgeries.")
+	. += span_boldnotice("Advanced surgeries available:")
+	//list of downloaded surgeries' names
 	var/list/surgeries_names = list()
 	for(var/datum/surgery/downloaded_surgery as anything in loaded_surgeries)
+		if(initial(downloaded_surgery.replaced_by) in loaded_surgeries) //if a surgery has a better version replacing it, we don't include it in the list
+			continue
 		surgeries_names += "[initial(downloaded_surgery.name)]"
 	. += span_notice("[english_list(surgeries_names)]")
 


### PR DESCRIPTION
## About The Pull Request
Surgery processor can download surgeries to be accessed without a surgical computer. However, it does not tell the player that it needs to be actually in one of the three equipped modules to let the cyborg actually use those surgeries without relying on a surgical computer.

This PR addresses that + makes it show downloaded surgeries.

![image](https://user-images.githubusercontent.com/75863639/225000403-59cbf370-1c50-44a1-8758-2dab98876802.png)

## Why It's Good For The Game
Closes #71120
Players should be able to use the processor without any complications or misinterpretations of its intended function. Being able to check downloaded surgeries for something specific on the go can be handy.

## Changelog
:cl:
qol: medical cyborg's surgical processor now tells the user on examine that it needs to be equipped in an active module to access downloaded surgeries
qol: medical cyborg's surgical processor now lists downloaded surgeries on examine
/:cl:

