### PR TITLE
Log forced events in game log

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -164,8 +164,7 @@ Runs the event
 		return round_event
 
 	triggering = FALSE
-	if(random)
-		log_game("Random Event triggering: [name] ([typepath]).")
+	log_game("[random ? "Random" : "Forced"] Event triggering: [name] ([typepath]).")
 
 	if(alert_observers)
 		round_event.announce_deadchat(random)


### PR DESCRIPTION
## About The Pull Request

Forced events will be  logged to game log. Not sure why we don't already. 


## Why It's Good For The Game

Even outside of admins forcing events, new code that forces events to trigger is added often. They should be logged to, just so it's not completely up to guesswork that something happened

## Changelog

:cl: Melbert
admin: Logs when forced events trigger
/:cl:
