### PR TITLE
Adds requirement on adding maps to the config in MAPS_AND_AWAY_MISSIONS.md

### DIFF
--- a/.github/guides/MAPS_AND_AWAY_MISSIONS.md
+++ b/.github/guides/MAPS_AND_AWAY_MISSIONS.md
@@ -52,17 +52,20 @@ For a much more comprehensive guide on UpdatePaths, please see the documentation
 
 Map files for away missions are located in the `_maps/RandomZLevels` directory. Each away mission includes it's own code definitions located in `/code/modules/awaymissions/mission_code`. These files must be included and compiled with the server beforehand otherwise the server will crash upon trying to load away missions that lack their code.
 
-To enable an away mission open `config/awaymissionconfig.txt` and uncomment one of the .dmm lines by removing the #. If more than one away mission is uncommented then the away mission loader will randomly select one of the enabled ones to load. We also support functionality for config-only away missions, which can be set up using the `config/away_missions` folder.
+Away missions are _disabled_ by default. Go to the file denoted in the [Configuration](#configuration) section and "untick" (remove the #) in order to enable it for loading. If more than one away mission is uncommented, the away mission loader will randomly select one of the enabled ones to load. We also support functionality for config-only away missions, which can be set up using the `config/away_missions` folder.
 
-## RUINS
+## CONFIGURATION
 
-All ruins must be placed in their corresponding configuration folder to allow server operators to enable/disable the ruin for any reason they desire. Follow the chart below to see where you should add your new ruin.
+A majority of maps must be placed in their corresponding configuration file to allow server operators to enable/disable the ruin for any reason they desire. Follow the chart below to see where you should add your new ruin.
 
-| Type of Ruin | Associated File |
+| Type of Map | Associated File |
 | ----------- | ----------- |
-| Space Ruins | [config/spaceruinblacklist.txt](https://github.com/tgstation/tgstation/blob/master/config/spaceruinblacklist.txt) |
-| Lavaland Ruins | [config/lavaruinblacklist.txt](https://github.com/tgstation/tgstation/blob/master/config/lavaruinblacklist.txt) 
-| Icemoon Ruins | [config/iceruinblacklist.txt](https://github.com/tgstation/tgstation/blob/master/config/iceruinblacklist.txt) |
+| Station Maps | [`config/maps.txt`](https://github.com/tgstation/tgstation/blob/master/config/maps.txt) |
+| Space Ruins | [`config/spaceruinblacklist.txt`](https://github.com/tgstation/tgstation/blob/master/config/spaceruinblacklist.txt) |
+| Lavaland Ruins | [`config/lavaruinblacklist.txt`](https://github.com/tgstation/tgstation/blob/master/config/lavaruinblacklist.txt) 
+| Icemoon Ruins | [`config/iceruinblacklist.txt`](https://github.com/tgstation/tgstation/blob/master/config/iceruinblacklist.txt) |
+| Escape Shuttles |  [`config/unbuyableshuttles.txt`](https://github.com/tgstation/tgstation/blob/master/config/unbuyableshuttles.txt) |
+| Away Missions | [`config/awaymissionconfig.txt`](https://github.com/tgstation/tgstation/blob/master/config/awaymissionconfig.txt) |
 
 Each .txt file will have instructions on how to appropriately add your map to the file.
 

--- a/.github/guides/MAPS_AND_AWAY_MISSIONS.md
+++ b/.github/guides/MAPS_AND_AWAY_MISSIONS.md
@@ -56,7 +56,7 @@ Away missions are _disabled_ by default. Go to the file denoted in the [Configur
 
 ## CONFIGURATION
 
-A majority of maps must be placed in their corresponding configuration file to allow server operators to enable/disable the ruin for any reason they desire. Follow the chart below to see where you should add your new ruin.
+A majority of maps (outlined below) must be placed in their corresponding configuration file to allow server operators to enable/disable the map for any reason they desire. Follow the chart to see where you should add your new map.
 
 | Type of Map | Associated File with Link |
 | ----------- | ----------- |
@@ -67,7 +67,7 @@ A majority of maps must be placed in their corresponding configuration file to a
 | Escape Shuttles |  [`config/unbuyableshuttles.txt`](https://github.com/tgstation/tgstation/blob/master/config/unbuyableshuttles.txt) |
 | Away Missions | [`config/awaymissionconfig.txt`](https://github.com/tgstation/tgstation/blob/master/config/awaymissionconfig.txt) |
 
-Each .txt file will have instructions on how to appropriately add your map to the file.
+Each .txt file will have instructions on how to appropriately add your map to the file. If you're unsure about certain values, ask for help during the PR process (or beforehand).
 
 ## MAP DEPOT
 

--- a/.github/guides/MAPS_AND_AWAY_MISSIONS.md
+++ b/.github/guides/MAPS_AND_AWAY_MISSIONS.md
@@ -62,7 +62,7 @@ A majority of maps (outlined below) must be placed in their corresponding config
 | ----------- | ----------- |
 | Station Maps | [`config/maps.txt`](https://github.com/tgstation/tgstation/blob/master/config/maps.txt) |
 | Space Ruins | [`config/spaceruinblacklist.txt`](https://github.com/tgstation/tgstation/blob/master/config/spaceruinblacklist.txt) |
-| Lavaland Ruins | [`config/lavaruinblacklist.txt`](https://github.com/tgstation/tgstation/blob/master/config/lavaruinblacklist.txt) 
+| Lavaland Ruins | [`config/lavaruinblacklist.txt`](https://github.com/tgstation/tgstation/blob/master/config/lavaruinblacklist.txt) |
 | Icemoon Ruins | [`config/iceruinblacklist.txt`](https://github.com/tgstation/tgstation/blob/master/config/iceruinblacklist.txt) |
 | Escape Shuttles |  [`config/unbuyableshuttles.txt`](https://github.com/tgstation/tgstation/blob/master/config/unbuyableshuttles.txt) |
 | Away Missions | [`config/awaymissionconfig.txt`](https://github.com/tgstation/tgstation/blob/master/config/awaymissionconfig.txt) |

--- a/.github/guides/MAPS_AND_AWAY_MISSIONS.md
+++ b/.github/guides/MAPS_AND_AWAY_MISSIONS.md
@@ -52,7 +52,7 @@ For a much more comprehensive guide on UpdatePaths, please see the documentation
 
 Map files for away missions are located in the `_maps/RandomZLevels` directory. Each away mission includes it's own code definitions located in `/code/modules/awaymissions/mission_code`. These files must be included and compiled with the server beforehand otherwise the server will crash upon trying to load away missions that lack their code.
 
-Away missions are _disabled_ by default. Go to the file denoted in the [Configuration](#configuration) section and "untick" (remove the #) in order to enable it for loading. If more than one away mission is uncommented, the away mission loader will randomly select one of the enabled ones to load. We also support functionality for config-only away missions, which can be set up using the `config/away_missions` folder.
+<ins>Away missions are _disabled_ by default.</ins> Go to the file denoted in the [Configuration](#configuration) section and "untick" (remove the #) in order to enable it for loading. If more than one away mission is uncommented, the away mission loader will randomly select one of the enabled ones to load. We also support functionality for config-only away missions, which can be set up using the `config/away_missions` folder.
 
 ## CONFIGURATION
 

--- a/.github/guides/MAPS_AND_AWAY_MISSIONS.md
+++ b/.github/guides/MAPS_AND_AWAY_MISSIONS.md
@@ -58,7 +58,7 @@ Away missions are _disabled_ by default. Go to the file denoted in the [Configur
 
 A majority of maps must be placed in their corresponding configuration file to allow server operators to enable/disable the ruin for any reason they desire. Follow the chart below to see where you should add your new ruin.
 
-| Type of Map | Associated File |
+| Type of Map | Associated File with Link |
 | ----------- | ----------- |
 | Station Maps | [`config/maps.txt`](https://github.com/tgstation/tgstation/blob/master/config/maps.txt) |
 | Space Ruins | [`config/spaceruinblacklist.txt`](https://github.com/tgstation/tgstation/blob/master/config/spaceruinblacklist.txt) |

--- a/.github/guides/MAPS_AND_AWAY_MISSIONS.md
+++ b/.github/guides/MAPS_AND_AWAY_MISSIONS.md
@@ -54,6 +54,18 @@ Map files for away missions are located in the `_maps/RandomZLevels` directory. 
 
 To enable an away mission open `config/awaymissionconfig.txt` and uncomment one of the .dmm lines by removing the #. If more than one away mission is uncommented then the away mission loader will randomly select one of the enabled ones to load. We also support functionality for config-only away missions, which can be set up using the `config/away_missions` folder.
 
+## RUINS
+
+All ruins must be placed in their corresponding configuration folder to allow server operators to enable/disable the ruin for any reason they desire. Follow the chart below to see where you should add your new ruin.
+
+| Type of Ruin | Associated File |
+| ----------- | ----------- |
+| Space Ruins | [config/spaceruinblacklist.txt](https://github.com/tgstation/tgstation/blob/master/config/spaceruinblacklist.txt) |
+| Lavaland Ruins | [config/lavaruinblacklist.txt](https://github.com/tgstation/tgstation/blob/master/config/lavaruinblacklist.txt) 
+| Icemoon Ruins | [config/iceruinblacklist.txt](https://github.com/tgstation/tgstation/blob/master/config/iceruinblacklist.txt) |
+
+Each .txt file will have instructions on how to appropriately add your map to the file.
+
 ## MAP DEPOT
 
 For sentimental purposes, /tg/station hosts a [Map Depot](https://github.com/tgstation/map_depot) for any unused maps since retired from active use in the codebase. A lot of maps present in said depot do get severely outdated within weeks of their initial uploading, so do keep in mind that a bit of setup is required since active maintenance is not enforced there the same way as this repository.


### PR DESCRIPTION
## About The Pull Request

There's been a surplus of ruin mappers lately, but a lot of them are unaware that they must be adding their file path to the config so server operators may toggle them on/off. I had to go through at least four separate PRs reminding people that this has to be done.

Let's add it to a centralized place regarding maps/mapping such that it's easier for maintainers to be aware that this requirement exists, as well as players who are scrounging the github attempting to figure out what they should do.


see the changes for yourself around here https://github.com/tgstation/tgstation/blob/1aac72b3e1798364073fa5af312ef4a5e00843fe/.github/guides/MAPS_AND_AWAY_MISSIONS.md