### PR TITLE
[NO GBP] Fixs a typo in the box of party popper's name

### DIFF
--- a/code/game/objects/items/storage/boxes/service_boxes.dm
+++ b/code/game/objects/items/storage/boxes/service_boxes.dm
@@ -197,7 +197,7 @@
 		new /obj/item/tail_pin(src)
 
 /obj/item/storage/box/party_poppers
-	name = "box of party_poppers"
+	name = "box of party poppers"
 	desc = "Turn any event into a celebration and ensure the janitor stays busy."
 
 /obj/item/storage/box/party_poppers/PopulateContents()


### PR DESCRIPTION

## About The Pull Request

I left an underscore in here for some reason, its gone now.
## Why It's Good For The Game

underscore bad.
## Changelog
:cl:
spellcheck: The party popper box no longer has a typo in its name.
/:cl:
