### PR TITLE
Crew console shows if someone is DNR

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -248,9 +248,12 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		if (sensor_mode >= SENSOR_LIVING)
 			entry["life_status"] = (tracked_living_mob.stat != DEAD)
 
-		// Not revivable if blacklisted or committed suicide
+		// Not revivable if no key, no brain, or DNR
 		if (sensor_mode >= SENSOR_LIVING)
-			entry["is_revivable"] = !(tracked_living_mob.get_ghost.can_defib() == DEFIB_FAIL_BLACKLISTED || tracked_living_mob.get_ghost.can_defib() == DEFIB_FAIL_SUICIDE || tracked_living_mob.get_ghost.can_defib() == DEFIB_FAIL_NO_INTELLIGENCE)
+			if (tracked_living_mob.key || !tracked_living_mob.getorgan(/obj/item/organ/internal/brain) || ghost?.can_reenter_corpse)
+				entry["has_mind"] = TRUE
+			else
+				entry["has_mind"] = FALSE
 
 		// Damage
 		if (sensor_mode >= SENSOR_VITALS)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -45,7 +45,7 @@
 		"name",
 		"job",
 		"life_status",
-		"has_mind",
+		"is_revivable",
 		"suffocation",
 		"toxin",
 		"burn",
@@ -66,7 +66,7 @@
 		entry["name"] = player_record["name"]
 		entry["job"] = player_record["assignment"]
 		entry["life_status"] = player_record["life_status"]
-		entry["has_mind"] = player_record["has_mind"]
+		entry["is_revivable"] = player_record["is_revivable"]
 		entry["suffocation"] = player_record["oxydam"]
 		entry["toxin"] = player_record["toxdam"]
 		entry["burn"] = player_record["burndam"]
@@ -252,9 +252,9 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		if (sensor_mode >= SENSOR_LIVING)
 			var/mob/dead/observer/ghost = tracked_living_mob.get_ghost(TRUE, TRUE)
 			if (tracked_living_mob.key || !tracked_living_mob.getorgan(/obj/item/organ/internal/brain) || ghost?.can_reenter_corpse)
-				entry["has_mind"] = TRUE
+				entry["is_revivable"] = TRUE
 			else
-				entry["has_mind"] = FALSE
+				entry["is_revivable"] = FALSE
 
 		// Damage
 		if (sensor_mode >= SENSOR_VITALS)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -248,13 +248,9 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		if (sensor_mode >= SENSOR_LIVING)
 			entry["life_status"] = (tracked_living_mob.stat != DEAD)
 
-		// Whether the mob has mind or not
+		// Not revivable if blacklisted or committed suicide
 		if (sensor_mode >= SENSOR_LIVING)
-			var/mob/dead/observer/ghost = tracked_living_mob.get_ghost(TRUE, TRUE)
-			if (tracked_living_mob.key || !tracked_living_mob.getorgan(/obj/item/organ/internal/brain) || ghost?.can_reenter_corpse)
-				entry["is_revivable"] = TRUE
-			else
-				entry["is_revivable"] = FALSE
+			entry["is_revivable"] = !(tracked_living_mob.get_ghost.can_defib() == DEFIB_FAIL_BLACKLISTED || tracked_living_mob.get_ghost.can_defib() == DEFIB_FAIL_SUICIDE || tracked_living_mob.get_ghost.can_defib() == DEFIB_FAIL_NO_INTELLIGENCE)
 
 		// Damage
 		if (sensor_mode >= SENSOR_VITALS)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -45,6 +45,7 @@
 		"name",
 		"job",
 		"life_status",
+		"has_mind",
 		"suffocation",
 		"toxin",
 		"burn",
@@ -65,6 +66,7 @@
 		entry["name"] = player_record["name"]
 		entry["job"] = player_record["assignment"]
 		entry["life_status"] = player_record["life_status"]
+		entry["has_mind"] = player_record["has_mind"]
 		entry["suffocation"] = player_record["oxydam"]
 		entry["toxin"] = player_record["toxdam"]
 		entry["burn"] = player_record["burndam"]
@@ -245,6 +247,14 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		// Binary living/dead status
 		if (sensor_mode >= SENSOR_LIVING)
 			entry["life_status"] = (tracked_living_mob.stat != DEAD)
+
+		// Whether the mob has mind or not
+		if (sensor_mode >= SENSOR_LIVING)
+			var/mob/dead/observer/ghost = tracked_living_mob.get_ghost(TRUE, TRUE)
+			if (tracked_living_mob.key || !tracked_living_mob.getorgan(/obj/item/organ/internal/brain) || ghost?.can_reenter_corpse)
+				entry["has_mind"] = TRUE
+			else
+				entry["has_mind"] = FALSE
 
 		// Damage
 		if (sensor_mode >= SENSOR_VITALS)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -250,6 +250,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 		// Not revivable if no key, no brain, or DNR
 		if (sensor_mode >= SENSOR_LIVING)
+			var/mob/dead/observer/ghost = tracked_living_mob.get_ghost(TRUE, TRUE)
 			if (tracked_living_mob.key || !tracked_living_mob.getorgan(/obj/item/organ/internal/brain) || ghost?.can_reenter_corpse)
 				entry["has_mind"] = TRUE
 			else

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -112,6 +112,7 @@ const CrewTableEntry = (props, context) => {
     assignment,
     ijob,
     life_status,
+    has_mind,
     oxydam,
     toxdam,
     burndam,
@@ -127,7 +128,9 @@ const CrewTableEntry = (props, context) => {
         {assignment !== undefined ? ` (${assignment})` : ''}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
-        {oxydam !== undefined ? (
+        {!life_status && !has_mind ? (
+          <Icon name="ban" color="#801308" size={1} />
+        ) : oxydam !== undefined ? (
           <Icon
             name={healthToAttribute(
               oxydam,
@@ -164,6 +167,8 @@ const CrewTableEntry = (props, context) => {
           </Box>
         ) : life_status ? (
           'Alive'
+        ) : !has_mind ? (
+          'Dead (DNR)'
         ) : (
           'Dead'
         )}
@@ -175,7 +180,7 @@ const CrewTableEntry = (props, context) => {
           <Icon name="question" color="#ffffff" size={1} />
         )}
       </Table.Cell>
-      {!!link_allowed && (
+      {link_allowed && (
         <Table.Cell collapsing>
           <Button
             content="Track"

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -112,7 +112,7 @@ const CrewTableEntry = (props, context) => {
     assignment,
     ijob,
     life_status,
-    has_mind,
+    is_revivable,
     oxydam,
     toxdam,
     burndam,
@@ -128,7 +128,7 @@ const CrewTableEntry = (props, context) => {
         {assignment !== undefined ? ` (${assignment})` : ''}
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
-        {!life_status && !has_mind ? (
+        {!life_status && !is_revivable ? (
           <Icon name="ban" color="#801308" size={1} />
         ) : oxydam !== undefined ? (
           <Icon
@@ -167,7 +167,7 @@ const CrewTableEntry = (props, context) => {
           </Box>
         ) : life_status ? (
           'Alive'
-        ) : !has_mind ? (
+        ) : !is_revivable ? (
           'Dead (DNR)'
         ) : (
           'Dead'
@@ -180,7 +180,7 @@ const CrewTableEntry = (props, context) => {
           <Icon name="question" color="#ffffff" size={1} />
         )}
       </Table.Cell>
-      {link_allowed && (
+      {!!link_allowed && (
         <Table.Cell collapsing>
           <Button
             content="Track"


### PR DESCRIPTION

## About The Pull Request
Based on Skyrat-SS13/Skyrat-tg/pull/19629
This is the second Crew Monitor PR that I took from Skyrat

Adds a new entry to the table "is_revivable"  based on the generate_death_examine_text proc
Someone is considered not revivable if they are disconnected, brainless, or DNR

If someone is dead and DNR, their icon set to a no symbol
Dead people with binary sensors get "Dead" replaced with "Dead (DNR)"
Theoretically, the health value information for vital sensors could still be useful so I left that

Example:
![image](https://user-images.githubusercontent.com/47338680/225172881-fb9942be-1f5c-4c78-a907-48c53680ae0a.png)


Some things that I was unsure if they should be shown on the crew monitor or not:

Blacklisted from revival
No brain
Disconnected from the server

## Why It's Good For The Game

It's easier to filter out the bodies that don't matter
## Changelog
:cl:
qol: Crew Monitor now displays when someone is DNR
/:cl:
