### PR TITLE
[No GBP] Fixes harddels caused by copy DNA

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -125,7 +125,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	if(new_dna.holder)
 		new_dna.holder.set_species(species.type, icon_update = 0)
 	else
-		new_dna.species = species
+		new_dna.species = new species.type
 	new_dna.real_name = real_name
 	// Mutations aren't gc managed, but they still aren't templates
 	// Let's do a proper copy


### PR DESCRIPTION
## About The Pull Request

In #73252, I solved a null exception by storing a reference to the species of the copied target. Unfortunately, this meant multiple DNA datums referred to the same species datum instance, causing harddels. This PR solves this issue by instantiating a new instance of species, as I should have done so in the first place.

I tried this by just storing the species.type but alas, it did not work. Hopefully this solution is acceptable.

### Mapping March

Ckey to receive rewards: N/A

## Why It's Good For The Game

Fixes #74002

## Changelog

:cl:
fix: Your species will no longer get deleted if a changeling  who copied you is deleted from existence
/:cl:
