### PR TITLE
Syndicate bomb countdowns are now span_notice, also active bombs have a balloon alert when inspected

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -118,7 +118,7 @@
 	if(istype(payload))
 		. += "A small window reveals some information about the payload: [payload.desc]."
 	if(examinable_countdown)
-		. += "A digital display on it reads \"[seconds_remaining()]\"."
+		. += span_notice("A digital display on it reads \"[seconds_remaining()]\".")
 	else
 		. +={"The digital display on it is inactive."}
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -120,7 +120,7 @@
 	if(examinable_countdown)
 		. += span_notice("A digital display on it reads \"[seconds_remaining()]\".")
 	else
-		. +={"The digital display on it is inactive."}
+		. += span_notice({"The digital display on it is inactive."})
 
 /obj/machinery/syndicatebomb/update_icon_state()
 	icon_state = "[initial(icon_state)][active ? "-active" : "-inactive"][open_panel ? "-wires" : ""]"

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -119,6 +119,8 @@
 		. += "A small window reveals some information about the payload: [payload.desc]."
 	if(examinable_countdown)
 		. += span_notice("A digital display on it reads \"[seconds_remaining()]\".")
+		if(active)
+			balloon_alert(user, "[seconds_remaining()]")
 	else
 		. += span_notice({"The digital display on it is inactive."})
 


### PR DESCRIPTION
## About The Pull Request

Simply changes the line of text that shows how long a bomb has left on its timer to use span_notice making it stand out among the rest of its examine text.

Bonus change: Inspecting an active bomb will now make a balloon alert showing how many seconds are left.
## Why It's Good For The Game

I always had a bit of trouble reading the time remining on bomb countdowns due to them generally having a lot of info on examine and it all blending together, this makes the important information on bomb examine text stand out more which is good.
## Changelog
:cl:
qol: When inspecting syndicate bombs the text that tells you how long is on the timer stands out more.
qol: Inspecting an active syndicate bomb will give you a balloon alert on the bomb itself when inspected.
/:cl:
