### PR TITLE
Fix explosive holoparasite plant bomb runtime

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -45,7 +45,7 @@
 	to_chat(src, span_bolddanger("Success! Bomb armed!"))
 	COOLDOWN_START(src, bomb_cooldown, bomb_cooldown_time)
 	RegisterSignal(planting_on, COMSIG_PARENT_EXAMINE, PROC_REF(display_examine))
-	RegisterSignal(planting_on, boom_signals, PROC_REF(kaboom))
+	RegisterSignals(planting_on, boom_signals, PROC_REF(kaboom))
 	addtimer(CALLBACK(src, PROC_REF(disable), planting_on), decay_time, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 /mob/living/simple_animal/hostile/guardian/explosive/proc/kaboom(atom/source, mob/living/explodee)


### PR DESCRIPTION

## About The Pull Request

If you planted a bomb as an explosive holopara it would do a stack_trace cause it was using RegisterSignal instead of RegisterSignals
So, literally just changed RegisterSignal to RegisterSignals

## Why It's Good For The Game

Fixes #73854

## Changelog
:cl:
fix: Explosive holoparasites no longer runtime if they plant bombs
/:cl:
