### PR TITLE
Make turrets shoot basicmobs

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -435,11 +435,11 @@ DEFINE_BITFIELD(turret_flags, list(
 			continue
 
 		if(turret_flags & TURRET_FLAG_SHOOT_ANOMALOUS)//if it's set to check for simple animals
-			if(isanimal(A))
-				var/mob/living/simple_animal/SA = A
-				if(SA.stat || in_faction(SA)) //don't target if dead or in faction
+			if(isanimal_or_basicmob(A))
+				var/mob/living/animal = A
+				if(animal.stat || in_faction(animal)) //don't target if dead or in faction
 					continue
-				targets += SA
+				targets += animal
 				continue
 
 		if(issilicon(A))


### PR DESCRIPTION

## About The Pull Request

Turrets such as AI sat turrets will now be able to shoot basicmobs so AIs cant get owned by carp

## Why It's Good For The Game

Fixes #73809

## Changelog

:cl:
fix: Turrets will now shoot basicmobs such as carp
/:cl:
