### PR TITLE
Admins can now customize the outfit Necrostone victims wear and how many thralls the stone can produce.

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -118,7 +118,7 @@
 	if(istype(payload))
 		. += "A small window reveals some information about the payload: [payload.desc]."
 	if(examinable_countdown)
-		. += "A digital display on it reads \"[seconds_remaining()]\"."
+		. += span_notice("A digital display on it reads \"[seconds_remaining()]\".")
 	else
 		. +={"The digital display on it is inactive."}
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -118,7 +118,7 @@
 	if(istype(payload))
 		. += "A small window reveals some information about the payload: [payload.desc]."
 	if(examinable_countdown)
-		. += span_notice("A digital display on it reads \"[seconds_remaining()]\".")
+		. += "A digital display on it reads \"[seconds_remaining()]\"."
 	else
 		. +={"The digital display on it is inactive."}
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -252,8 +252,8 @@
 	if(spooky_scaries.len >= 3 && !unlimited)
 		to_chat(user, span_warning("This artifact can only affect three undead at a time!"))
 		return
-
-	M.set_species(applied_species, icon_update=0)
+	if(applied_species)
+		M.set_species(applied_species, icon_update=0)
 	M.revive(ADMIN_HEAL_ALL)
 	spooky_scaries |= M
 	to_chat(M, "[span_userdanger("You have been revived by ")]<B>[user.real_name]!</B>")
@@ -264,7 +264,8 @@
 			antag_datum.create_wiz_team()
 		M.mind.add_antag_datum(/datum/antagonist/wizard_minion, antag_datum.wiz_team)
 
-	equip_roman_skeleton(M)
+	if(applied_outfit)
+		equip_roman_skeleton(M)
 
 	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/3 active thralls."]"
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -300,7 +300,7 @@
 	r_hand = /obj/item/claymore
 	l_hand = /obj/item/shield/roman
 
-/datum/outfit/skeleton/pre_equip(mob/living/carbon/human/H, visualsOnly)
+/datum/outfit/roman/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
 	head = pick(/obj/item/clothing/head/helmet/roman, /obj/item/clothing/head/helmet/roman/legionnaire)
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -228,23 +228,23 @@
 /obj/item/necromantic_stone/unlimited
 	unlimited = 1
 
-/obj/item/necromantic_stone/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
-	if(!istype(M))
+/obj/item/necromantic_stone/attack(mob/living/carbon/human/target, mob/living/carbon/human/user)
+	if(!istype(target))
 		return ..()
 
-	if(!istype(user) || !user.can_perform_action(M))
+	if(!istype(user) || !user.can_perform_action(target))
 		return
 
-	if(M.stat != DEAD)
+	if(target.stat != DEAD)
 		to_chat(user, span_warning("This artifact can only affect the dead!"))
 		return
 
 	for(var/mob/dead/observer/ghost in GLOB.dead_mob_list) //excludes new players
-		if(ghost.mind && ghost.mind.current == M && ghost.client)  //the dead mobs list can contain clientless mobs
+		if(ghost.mind && ghost.mind.current == target && ghost.client)  //the dead mobs list can contain clientless mobs
 			ghost.reenter_corpse()
 			break
 
-	if(!M.mind || !M.client)
+	if(!target.mind || !target.client)
 		to_chat(user, span_warning("There is no soul connected to this body..."))
 		return
 
@@ -253,19 +253,19 @@
 		to_chat(user, span_warning("This artifact can only affect three undead at a time!"))
 		return
 	if(applied_species)
-		M.set_species(applied_species, icon_update=0)
-	M.revive(ADMIN_HEAL_ALL)
-	spooky_scaries |= M
-	to_chat(M, "[span_userdanger("You have been revived by ")]<B>[user.real_name]!</B>")
-	to_chat(M, span_userdanger("[user.p_theyre(TRUE)] your master now, assist [user.p_them()] even if it costs you your new life!"))
+		target.set_species(applied_species, icon_update=0)
+	target.revive(ADMIN_HEAL_ALL)
+	spooky_scaries |= target
+	to_chat(target, "[span_userdanger("You have been revived by ")]<B>[user.real_name]!</B>")
+	to_chat(target, span_userdanger("[user.p_theyre(TRUE)] your master now, assist [user.p_them()] even if it costs you your new life!"))
 	var/datum/antagonist/wizard/antag_datum = user.mind.has_antag_datum(/datum/antagonist/wizard)
 	if(antag_datum)
 		if(!antag_datum.wiz_team)
 			antag_datum.create_wiz_team()
-		M.mind.add_antag_datum(/datum/antagonist/wizard_minion, antag_datum.wiz_team)
+		target.mind.add_antag_datum(/datum/antagonist/wizard_minion, antag_datum.wiz_team)
 
 	if(applied_outfit)
-		equip_roman_skeleton(M)
+		equip_roman_skeleton(target)
 
 	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/3 active thralls."]"
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -286,8 +286,8 @@
 
 //Funny gimmick, skeletons always seem to wear roman/ancient armour
 /obj/item/necromantic_stone/proc/equip_roman_skeleton(mob/living/carbon/human/human)
-	for(var/obj/item/I in human)
-		human.dropItemToGround(I)
+	for(var/obj/item/worn_item in human)
+		human.dropItemToGround(worn_item)
 
 	human.equipOutfit(applied_outfit)
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -264,8 +264,7 @@
 			antag_datum.create_wiz_team()
 		target.mind.add_antag_datum(/datum/antagonist/wizard_minion, antag_datum.wiz_team)
 
-	if(applied_outfit)
-		equip_revived_servant(target)
+	equip_revived_servant(target)
 
 	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/3 active thralls."]"
 
@@ -285,6 +284,8 @@
 	list_clear_nulls(spooky_scaries)
 
 /obj/item/necromantic_stone/proc/equip_revived_servant(mob/living/carbon/human/human)
+	if(!istype(applied_outfit, /datum/outfit))
+		return
 	for(var/obj/item/worn_item in human)
 		human.dropItemToGround(worn_item)
 

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -256,7 +256,7 @@
 		target.set_species(applied_species, icon_update=0)
 	target.revive(ADMIN_HEAL_ALL)
 	spooky_scaries |= target
-	to_chat(target, "[span_userdanger("You have been revived by ")]<B>[user.real_name]!</B>")
+	to_chat(target, span_userdanger("You have been revived by <B>[user.real_name]</B>!"))
 	to_chat(target, span_userdanger("[user.p_theyre(TRUE)] your master now, assist [user.p_them()] even if it costs you your new life!"))
 	var/datum/antagonist/wizard/antag_datum = user.mind.has_antag_datum(/datum/antagonist/wizard)
 	if(antag_datum)
@@ -265,7 +265,7 @@
 		target.mind.add_antag_datum(/datum/antagonist/wizard_minion, antag_datum.wiz_team)
 
 	if(applied_outfit)
-		equip_roman_skeleton(target)
+		equip_revived_servant(target)
 
 	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/3 active thralls."]"
 
@@ -284,13 +284,13 @@
 			continue
 	list_clear_nulls(spooky_scaries)
 
-//Funny gimmick, skeletons always seem to wear roman/ancient armour
-/obj/item/necromantic_stone/proc/equip_roman_skeleton(mob/living/carbon/human/human)
+/obj/item/necromantic_stone/proc/equip_revived_servant(mob/living/carbon/human/human)
 	for(var/obj/item/worn_item in human)
 		human.dropItemToGround(worn_item)
 
 	human.equipOutfit(applied_outfit)
 
+//Funny gimmick, skeletons always seem to wear roman/ancient armour
 /datum/outfit/roman
 	name = "Roman"
 	head = /obj/item/clothing/head/helmet/roman

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -222,6 +222,8 @@
 	var/unlimited = 0
 	///Which species the resurected humanoid will be
 	var/applied_species = /datum/species/skeleton
+	///The outfit the resurected humanoid will wear
+	var/applied_outfit = /datum/outfit/roman
 
 /obj/item/necromantic_stone/unlimited
 	unlimited = 1
@@ -282,17 +284,24 @@
 	list_clear_nulls(spooky_scaries)
 
 //Funny gimmick, skeletons always seem to wear roman/ancient armour
-/obj/item/necromantic_stone/proc/equip_roman_skeleton(mob/living/carbon/human/H)
-	for(var/obj/item/I in H)
-		H.dropItemToGround(I)
+/obj/item/necromantic_stone/proc/equip_roman_skeleton(mob/living/carbon/human/human)
+	for(var/obj/item/I in human)
+		human.dropItemToGround(I)
 
-	var/hat = pick(/obj/item/clothing/head/helmet/roman, /obj/item/clothing/head/helmet/roman/legionnaire)
-	H.equip_to_slot_or_del(new hat(H), ITEM_SLOT_HEAD)
-	H.equip_to_slot_or_del(new /obj/item/clothing/under/costume/roman(H), ITEM_SLOT_ICLOTHING)
-	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/roman(H), ITEM_SLOT_FEET)
-	H.put_in_hands(new /obj/item/shield/roman(H), TRUE)
-	H.put_in_hands(new /obj/item/claymore(H), TRUE)
-	H.equip_to_slot_or_del(new /obj/item/spear(H), ITEM_SLOT_BACK)
+	human.equipOutfit(applied_outfit)
+
+/datum/outfit/roman
+	name = "Roman"
+	head = /obj/item/clothing/head/helmet/roman
+	uniform = /obj/item/clothing/under/costume/roman
+	shoes = /obj/item/clothing/shoes/roman
+	back = /obj/item/spear
+	r_hand = /obj/item/claymore
+	l_hand = /obj/item/shield/roman
+
+/datum/outfit/skeleton/pre_equip(mob/living/carbon/human/H, visualsOnly)
+	. = ..()
+	head = pick(/obj/item/clothing/head/helmet/roman, /obj/item/clothing/head/helmet/roman/legionnaire)
 
 //Provides a decent heal, need to pump every 6 seconds
 /obj/item/organ/internal/heart/cursed/wizard

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -219,11 +219,14 @@
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	var/list/spooky_scaries = list()
-	var/unlimited = 0
-	///Which species the resurected humanoid will be
+	///Allow for unlimited thralls to be produced.
+	var/unlimited = FALSE
+	///Which species the resurected humanoid will be.
 	var/applied_species = /datum/species/skeleton
-	///The outfit the resurected humanoid will wear
+	///The outfit the resurected humanoid will wear.
 	var/applied_outfit = /datum/outfit/roman
+	///Maximum number of thralls that can be created.
+	var/max_thralls = 3
 
 /obj/item/necromantic_stone/unlimited
 	unlimited = 1
@@ -239,18 +242,18 @@
 		to_chat(user, span_warning("This artifact can only affect the dead!"))
 		return
 
-	for(var/mob/dead/observer/ghost in GLOB.dead_mob_list) //excludes new players
-		if(ghost.mind && ghost.mind.current == target && ghost.client)  //the dead mobs list can contain clientless mobs
-			ghost.reenter_corpse()
-			break
+///	for(var/mob/dead/observer/ghost in GLOB.dead_mob_list) //excludes new players
+///		if(ghost.mind && ghost.mind.current == target && ghost.client)  //the dead mobs list can contain clientless mobs
+///			ghost.reenter_corpse()
+///			break
 
-	if(!target.mind || !target.client)
-		to_chat(user, span_warning("There is no soul connected to this body..."))
-		return
+///	if(!target.mind || !target.client)
+///		to_chat(user, span_warning("There is no soul connected to this body..."))
+///		return //REMEMBER TO UNCOMMENT
 
 	check_spooky()//clean out/refresh the list
-	if(spooky_scaries.len >= 3 && !unlimited)
-		to_chat(user, span_warning("This artifact can only affect three undead at a time!"))
+	if(spooky_scaries.len >= max_thralls && !unlimited)
+		to_chat(user, span_warning("This artifact can only affect [int_to_words(max_thralls)] thralls at a time!"))
 		return
 	if(applied_species)
 		target.set_species(applied_species, icon_update=0)
@@ -266,7 +269,12 @@
 
 	equip_revived_servant(target)
 
-	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/3 active thralls."]"
+//	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/[max_thralls] active thralls."]"
+
+/obj/item/necromantic_stone/examine(mob/user)
+	. = ..()
+	if(!unlimited)
+		. += span_notice("[spooky_scaries.len]/[max_thralls] active thralls.")
 
 /obj/item/necromantic_stone/proc/check_spooky()
 	if(unlimited) //no point, the list isn't used.
@@ -284,7 +292,7 @@
 	list_clear_nulls(spooky_scaries)
 
 /obj/item/necromantic_stone/proc/equip_revived_servant(mob/living/carbon/human/human)
-	if(!istype(applied_outfit, /datum/outfit))
+	if(isnull(applied_outfit))
 		return
 	for(var/obj/item/worn_item in human)
 		human.dropItemToGround(worn_item)

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -242,18 +242,18 @@
 		to_chat(user, span_warning("This artifact can only affect the dead!"))
 		return
 
-///	for(var/mob/dead/observer/ghost in GLOB.dead_mob_list) //excludes new players
-///		if(ghost.mind && ghost.mind.current == target && ghost.client)  //the dead mobs list can contain clientless mobs
-///			ghost.reenter_corpse()
-///			break
+	for(var/mob/dead/observer/ghost in GLOB.dead_mob_list) //excludes new players
+		if(ghost.mind && ghost.mind.current == target && ghost.client)  //the dead mobs list can contain clientless mobs
+			ghost.reenter_corpse()
+			break
 
-///	if(!target.mind || !target.client)
-///		to_chat(user, span_warning("There is no soul connected to this body..."))
-///		return //REMEMBER TO UNCOMMENT
+	if(!target.mind || !target.client)
+		to_chat(user, span_warning("There is no soul connected to this body..."))
+		return
 
 	check_spooky()//clean out/refresh the list
 	if(spooky_scaries.len >= max_thralls && !unlimited)
-		to_chat(user, span_warning("This artifact can only affect [int_to_words(max_thralls)] thralls at a time!"))
+		to_chat(user, span_warning("This artifact can only affect [convert_integer_to_words(max_thralls)] thralls at a time!"))
 		return
 	if(applied_species)
 		target.set_species(applied_species, icon_update=0)
@@ -268,8 +268,6 @@
 		target.mind.add_antag_datum(/datum/antagonist/wizard_minion, antag_datum.wiz_team)
 
 	equip_revived_servant(target)
-
-//	desc = "A shard capable of resurrecting humans as skeleton thralls[unlimited ? "." : ", [spooky_scaries.len]/[max_thralls] active thralls."]"
 
 /obj/item/necromantic_stone/examine(mob/user)
 	. = ..()

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -290,7 +290,7 @@
 	list_clear_nulls(spooky_scaries)
 
 /obj/item/necromantic_stone/proc/equip_revived_servant(mob/living/carbon/human/human)
-	if(isnull(applied_outfit))
+	if(!applied_outfit)
 		return
 	for(var/obj/item/worn_item in human)
 		human.dropItemToGround(worn_item)


### PR DESCRIPTION
## About The Pull Request

Adds a new var to the necrostone that can be set to an outfit by admins. The original roman skeleton clothing has been converted to an outfit.  I've also removed some single letter var names and added support for disabling the species change and outfit change code for admins in case they want to have a stone that only sets species/outfit.

Bonus changes: Admins can modify the max thralls per stone.
The stone no longer changes its description to show how many thralls are under control every time a thrall is created, instead it is added as a span_notice when the stone is examined.

## Why It's Good For The Game

This seemed like the logical next step when species customization was added, a stone that turns people into felinids is funny and all but isn't good gimmick material, however with this theres a bit more gimmick potential, such as giving all the heads of staff a necrostone that turns people into their employees or something. Also the necrostone not using outfits for the roman skeletons seemed dumb.
## Changelog
:cl:
admin: Admins can now customize the outfit necrostone victims are equiped with.
admin: Admins can now customize the maximum number of thralls that can be created by a necrostone
qol: The necrostone's thrall counter is now a shown as a separate colored line of text when examining the stone rather than part of its description.
/:cl:
