### PR TITLE
Fix borg synthesizers getting stuck on the status panel

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -896,6 +896,13 @@
 	if(model)
 		model.storages |= src
 		RegisterSignal(model.robot, COMSIG_MOB_GET_STATUS_TAB_ITEMS, PROC_REF(get_status_tab_item))
+		RegisterSignal(model, COMSIG_PARENT_QDELETING, PROC_REF(unregister_from_model))
+
+/datum/robot_energy_storage/proc/unregister_from_model(obj/item/robot_model/model)
+	SIGNAL_HANDLER
+	if(model)
+		model.storages -= src
+		UnregisterSignal(model.robot, COMSIG_MOB_GET_STATUS_TAB_ITEMS)
 
 /datum/robot_energy_storage/proc/get_status_tab_item(mob/living/silicon/robot/source, list/items)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

Unregisters status panel signal if the robot model item is deleting

## Why It's Good For The Game

Fixes #73594

## Changelog

:cl:
fix: Borg synthesizers will no longer remain on the status panel if a borg changes modules
/:cl:
