### PR TITLE
EMP no longer turns off defib safeties

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -193,14 +193,7 @@
 	if(combat) // Elite agents do not subscribe to your notion of "Safety"
 		visible_message(span_notice("[src] beeps: Safety protocols nonexistent!"))
 		playsound(src, 'sound/machines/defib_saftyOff.ogg', 50, FALSE)
-	else if(safety)
-		safety = FALSE
-		visible_message(span_notice("[src] beeps: Safety protocols disabled!"))
-		playsound(src, 'sound/machines/defib_saftyOff.ogg', 50, FALSE)
-	else
-		safety = TRUE
-		visible_message(span_notice("[src] beeps: Safety protocols enabled!"))
-		playsound(src, 'sound/machines/defib_saftyOn.ogg', 50, FALSE)
+
 	update_power()
 
 /obj/item/defibrillator/proc/toggle_paddles()

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -190,10 +190,6 @@
 	if (. & EMP_PROTECT_SELF)
 		return
 
-	if(combat) // Elite agents do not subscribe to your notion of "Safety"
-		visible_message(span_notice("[src] beeps: Safety protocols nonexistent!"))
-		playsound(src, 'sound/machines/defib_saftyOff.ogg', 50, FALSE)
-
 	update_power()
 
 /obj/item/defibrillator/proc/toggle_paddles()


### PR DESCRIPTION
## About The Pull Request

EMP can no longer disable safeties on defibs


## Why It's Good For The Game

Rewarding people with a slightly stronger baton that you don't drop when you get knocked down for literally just mixing a crushed can and like two common ingredients is a terrible idea.

edit: also ignores shielding and blocks
## Changelog
:cl:
balance: You can no longer EMP defibrillators to make them combat-usable
/:cl:
