### PR TITLE
Add mapping linter for cables underneath walls

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -131,7 +131,6 @@
 	anchored = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/circuit/red,
 /area/ruin/syndicate_lava_base/main)
 "bC" = (
@@ -886,6 +885,11 @@
 	dir = 1
 	},
 /area/ruin/syndicate_lava_base/main)
+"fW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "fY" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/table,
@@ -926,6 +930,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "gd" = (
@@ -935,16 +940,19 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/cargo)
 "gf" = (
 /obj/structure/sign/warning/vacuum/directional/south,
 /obj/machinery/light/small/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/cargo)
 "gg" = (
 /obj/structure/sign/warning/fire/directional/north,
 /obj/structure/sign/warning/xeno_mining/directional/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/cargo)
 "gh" = (
@@ -954,6 +962,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/syndicate_lava_base/cargo)
 "gi" = (
@@ -1414,6 +1423,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "ig" = (
@@ -1522,7 +1532,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "iM" = (
@@ -1561,7 +1570,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/circuit/red,
 /area/ruin/syndicate_lava_base/main)
 "iZ" = (
@@ -1573,7 +1581,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "jb" = (
@@ -2439,7 +2446,6 @@
 "ou" = (
 /obj/structure/sign/warning/explosives/alt/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/circuit/red,
 /area/ruin/syndicate_lava_base/main)
 "ov" = (
@@ -2848,7 +2854,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/main)
 "vA" = (
@@ -2919,7 +2924,9 @@
 	dir = 8;
 	volume_rate = 200
 	},
-/turf/open/floor/plating/lavaland_atmos,
+/obj/structure/cable,
+/obj/structure/lattice/catwalk,
+/turf/open/lava/smooth/lava_land_surface,
 /area/ruin/syndicate_lava_base/main)
 "wp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3522,10 +3529,10 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/syndicate_lava_base/dormitories)
 "FP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/ruin/syndicate_lava_base/main)
+/obj/structure/lattice/catwalk,
+/turf/open/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "FW" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -4139,6 +4146,7 @@
 /area/ruin/syndicate_lava_base/main)
 "QV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "Rd" = (
@@ -4336,7 +4344,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/main)
 "Uk" = (
@@ -6630,7 +6637,7 @@ gQ
 hV
 ha
 Dx
-FP
+Dx
 ha
 ha
 ju
@@ -6728,8 +6735,8 @@ dy
 eF
 eF
 dy
-si
-si
+FP
+FP
 ab
 ab
 ju
@@ -6775,10 +6782,10 @@ ab
 dy
 gg
 dy
-si
-si
-si
-si
+fW
+FP
+FP
+FP
 ab
 ab
 ab
@@ -6825,7 +6832,7 @@ ab
 fx
 gh
 fx
-si
+FP
 ab
 ab
 ab
@@ -6873,9 +6880,9 @@ ab
 ab
 ab
 ab
-si
-si
-si
+FP
+FP
+FP
 ab
 ab
 ab

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -2079,7 +2079,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
@@ -2281,7 +2280,6 @@
 "nd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "no" = (
@@ -2347,7 +2345,6 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/glass/incinerator/syndicatelava_interior,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/ruin/syndicate_lava_base/engineering)
 "nE" = (
@@ -2449,7 +2446,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump/off/general/visible,
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
@@ -2566,13 +2562,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "qa" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_syndicatelava{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/airlock_sensor/incinerator_syndicatelava{
 	pixel_x = 22
 	},
@@ -2714,9 +2710,11 @@
 	},
 /area/ruin/syndicate_lava_base/chemistry)
 "rO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "sc" = (
 /turf/open/floor/engine/o2,
@@ -3351,6 +3349,7 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "CR" = (
@@ -3390,6 +3389,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "Dx" = (
@@ -3464,6 +3464,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/orange/visible{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "EV" = (
@@ -3810,7 +3811,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/ruin/syndicate_lava_base/engineering)
 "KI" = (
@@ -3986,6 +3986,7 @@
 "OG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "OI" = (
@@ -4094,7 +4095,6 @@
 /area/ruin/syndicate_lava_base/engineering)
 "Qb" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
@@ -4520,6 +4520,7 @@
 /obj/machinery/atmospherics/pipe/color_adapter/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/engineering)
 "XR" = (
@@ -4632,7 +4633,6 @@
 "Za" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -6542,7 +6542,7 @@ kW
 lq
 lM
 Qb
-mG
+sl
 nd
 nD
 qa
@@ -6589,14 +6589,14 @@ Kf
 bM
 wX
 wv
-wv
+rO
 Rh
 Vp
 Xr
 yh
 nE
 PZ
-rO
+nE
 AB
 ju
 ju
@@ -6639,7 +6639,7 @@ ju
 ju
 JQ
 RK
-sl
+mG
 XP
 ET
 OG

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -2339,11 +2339,13 @@
 	dir = 10
 	},
 /obj/structure/cable,
-/turf/closed/wall/ice,
+/obj/effect/spawner/structure/window/ice,
+/turf/open/space/basic,
 /area/awaymission/snowdin/post/garage)
 "gP" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "gS" = (
@@ -2802,8 +2804,10 @@
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/hydro)
 "ic" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/ice,
+/turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "id" = (
 /turf/closed/wall/rust,
@@ -2814,6 +2818,7 @@
 "if" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "ih" = (
@@ -5500,7 +5505,8 @@
 "oX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
-/turf/closed/wall/ice,
+/obj/effect/spawner/structure/window/ice,
+/turf/open/floor/plating,
 /area/awaymission/snowdin/post/engineering)
 "pa" = (
 /turf/closed/wall/ice,
@@ -12146,6 +12152,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "Rm" = (
@@ -12756,6 +12763,7 @@
 "Ux" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/awaymission/snowdin/post/garage)
 "Uy" = (
@@ -31173,8 +31181,8 @@ Zy
 Zy
 fX
 gO
-ic
-ic
+fY
+fY
 iN
 jE
 kh
@@ -31944,7 +31952,7 @@ Zy
 Zy
 fY
 Rj
-Oe
+ic
 if
 iQ
 jG

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -28976,10 +28976,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/large,
 /area/station/medical/break_room)
-"gXx" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port)
 "gXM" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -61038,7 +61034,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "oVo" = (
-/obj/structure/cable,
 /obj/structure/sign/warning/no_smoking/circle{
 	pixel_x = 28;
 	pixel_y = -28
@@ -96714,7 +96709,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "xDm" = (
@@ -127296,7 +127290,7 @@ wGA
 pTC
 pTC
 pTC
-gXx
+pTC
 pTC
 vcB
 eru

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2219,7 +2219,6 @@
 "aLS" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "aLV" = (
@@ -6237,6 +6236,7 @@
 /area/station/hallway/primary/central)
 "bRb" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/cable,
 /turf/open/floor/grass,
 /area/station/security/prison/safe)
 "bRd" = (
@@ -10741,7 +10741,6 @@
 	network = list("ss13","prison");
 	view_range = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
 "dhU" = (
@@ -12016,13 +12015,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage/gas)
-"dBQ" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "MiniSat AI Chamber South";
-	network = list("aicore")
-	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
 "dBY" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -26650,6 +26642,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
 "ihG" = (
@@ -34129,6 +34122,7 @@
 	name = "Isolation Cell"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/prison/safe)
 "kvE" = (
@@ -37197,7 +37191,11 @@
 /area/station/maintenance/starboard/lesser)
 "lqz" = (
 /obj/structure/cable,
-/turf/closed/wall,
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat AI Chamber South";
+	network = list("aicore")
+	},
+/turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "lqA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -48937,7 +48935,6 @@
 "par" = (
 /obj/structure/toilet/greyscale,
 /obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
@@ -51449,9 +51446,12 @@
 	},
 /area/station/science/lab)
 "pOk" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/security/prison/safe)
+/obj/machinery/camera/directional/north{
+	c_tag = "MiniSat AI Chamber South";
+	network = list("aicore")
+	},
+/turf/open/genturf,
+/area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)
 "pOo" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -56384,7 +56384,6 @@
 	desc = "What is this? Is this a dog?";
 	name = "Therapy Dog"
 	},
-/obj/structure/cable,
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Isolation Cell";
 	network = list("ss13","prison","Isolation");
@@ -59482,9 +59481,10 @@
 /turf/open/floor/glass/reinforced,
 /area/station/medical/treatment_center)
 "sro" = (
+/obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/port/aft)
+/turf/open/floor/grass,
+/area/station/security/prison/safe)
 "srE" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -172329,7 +172329,7 @@ hBg
 ufF
 iSE
 bRb
-aaK
+sro
 xby
 gjq
 gjq
@@ -172584,7 +172584,7 @@ ddp
 hBg
 hBg
 dhT
-pOk
+xhK
 par
 rsM
 xby
@@ -238465,7 +238465,7 @@ qbO
 lAy
 pRj
 eAj
-sro
+mNY
 aLS
 qkT
 kzA
@@ -248034,7 +248034,7 @@ cZM
 uBi
 uBi
 lqz
-dBQ
+iJO
 eAx
 iHp
 iHp
@@ -248547,7 +248547,7 @@ ruZ
 pmC
 uBi
 uBi
-uBi
+iJO
 deg
 mYh
 iHp
@@ -257521,7 +257521,7 @@ wNO
 wNO
 wNO
 wNO
-wNO
+pOk
 wNO
 wNO
 wNO

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10535,7 +10535,7 @@
 /turf/open/floor/iron/large,
 /area/station/service/hydroponics/garden)
 "deg" = (
-/obj/structure/cable/layer3,
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "det" = (
@@ -31579,7 +31579,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "jJa" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -8849,7 +8849,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/office)
 "cIC" = (
-/obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -39597,7 +39596,6 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "ljA" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -423,7 +423,12 @@
 /area/station/ai_monitored/turret_protected/aisat/atmos)
 "adT" = (
 /obj/structure/cable,
-/turf/closed/wall,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "aed" = (
 /obj/effect/turf_decal/bot,
@@ -3869,15 +3874,10 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "bhm" = (
-/obj/machinery/computer/monitor{
-	dir = 1;
-	name = "backup power monitoring console"
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/noticeboard/directional/south,
 /obj/structure/spider/stickyweb,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "bhr" = (
@@ -5392,7 +5392,15 @@
 /area/station/maintenance/department/cargo)
 "bFu" = (
 /obj/structure/cable,
-/turf/closed/wall/rust,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "bFv" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -6619,6 +6627,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "ccz" = (
@@ -6941,17 +6950,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "cfs" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Supermatter Waste Line";
-	name = "engineering camera";
-	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/button/door/directional/east{
-	id = "engineaccess";
-	name = "Engine Access Lockdown";
-	req_access = list("engineering")
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -7150,7 +7148,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "chV" = (
-/obj/structure/cable/layer3,
 /turf/closed/wall/rust,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "cic" = (
@@ -8859,6 +8856,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/plastic,
 /area/station/hallway/secondary/service)
 "cIU" = (
@@ -11405,6 +11403,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/minisat,
 /obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "dsJ" = (
@@ -11944,14 +11943,12 @@
 "dBe" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/east,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high{
 	pixel_x = 4;
 	pixel_y = 4
 	},
 /obj/item/stock_parts/cell/high,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "dBg" = (
@@ -14071,10 +14068,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eki" = (
-/obj/effect/turf_decal/delivery,
+/obj/machinery/power/smes,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/east,
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/spider/stickyweb,
+/obj/structure/cable,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ekm" = (
@@ -14683,10 +14683,9 @@
 /area/station/security/warden)
 "esO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "esZ" = (
@@ -18818,8 +18817,11 @@
 /area/station/security/courtroom)
 "fyj" = (
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "fyp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19988,6 +19990,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/spider/stickyweb,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "fNe" = (
@@ -20519,6 +20522,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/storage/satellite)
 "fTr" = (
@@ -23483,6 +23487,10 @@
 /obj/machinery/status_display/ai/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/giant_spider/hunter/scrawny,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "gLn" = (
@@ -24220,12 +24228,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "gVc" = (
-/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/obj/item/storage/belt/utility,
+/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/east,
-/obj/structure/sign/poster/contraband/missing_gloves{
-	pixel_x = 32
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "gVg" = (
@@ -25159,14 +25165,14 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/bar/backroom)
 "hkd" = (
-/obj/machinery/power/smes,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/electric_shock/directional/north,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/spider/stickyweb,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
+/area/station/maintenance/starboard/aft)
 "hkp" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/medical/virology)
@@ -28790,8 +28796,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "ifB" = (
-/obj/structure/sign/warning/no_smoking{
-	pixel_x = 30
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -30024,6 +30030,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iwT" = (
@@ -30317,11 +30324,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "iAR" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "iAU" = (
@@ -33487,15 +33494,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"jtD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/port_gen/pacman,
-/obj/structure/sign/warning/no_smoking/directional/north,
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/spider/stickyweb,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "jtJ" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -39193,16 +39191,11 @@
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/hop)
 "lcZ" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Electrical Maintenance"
+/obj/machinery/computer/station_alert{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/electrical)
+/area/station/engineering/supermatter/room)
 "lda" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 8
@@ -39408,12 +39401,11 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "lgl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/spider/stickyweb,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/cable,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "lgu" = (
@@ -39615,6 +39607,13 @@
 	name = "Gravity Generator Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 4;
+	id = "engineaccess";
+	name = "Engine Access Shutters"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "ljJ" = (
@@ -41015,10 +41014,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "lDb" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/power/terminal{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lDc" = (
@@ -41904,6 +41906,10 @@
 "lRS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lRZ" = (
@@ -44321,7 +44327,6 @@
 	dir = 4
 	},
 /obj/structure/spider/stickyweb,
-/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
 "mCO" = (
@@ -46092,10 +46097,6 @@
 /area/station/cargo/storage)
 "ncS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ndz" = (
@@ -47059,6 +47060,8 @@
 	amount = 10
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ntR" = (
@@ -54423,8 +54426,8 @@
 /area/station/security/office)
 "pCj" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -55077,9 +55080,14 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
 "pKR" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall/rust,
-/area/station/maintenance/starboard/aft)
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/mask/gas,
+/obj/structure/sign/poster/contraband/missing_gloves{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "pLe" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -56064,9 +56072,7 @@
 "qai" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qaF" = (
@@ -57690,9 +57696,9 @@
 /area/station/medical/chemistry)
 "qyn" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/spider/stickyweb,
+/mob/living/basic/giant_spider/hunter/scrawny,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "qyo" = (
@@ -57764,10 +57770,10 @@
 "qzz" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qzA" = (
@@ -59533,16 +59539,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rau" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sink/kitchen/directional/south{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/landmark/xeno_spawn,
+/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "raM" = (
@@ -60337,10 +60338,15 @@
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_x = 32
 	},
-/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/circuit/red,
-/area/station/engineering/supermatter/room)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating,
+/area/station/maintenance/department/electrical)
 "rnG" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/service)
@@ -61916,12 +61922,19 @@
 	},
 /area/station/hallway/primary/fore)
 "rIm" = (
-/obj/machinery/airalarm/directional/east,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/east{
+	c_tag = "Supermatter Waste Line";
+	name = "engineering camera";
+	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rIq" = (
@@ -62068,10 +62081,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rKI" = (
@@ -62734,8 +62743,10 @@
 /area/station/medical/surgery/fore)
 "rSL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/mob/living/basic/giant_spider/hunter/scrawny,
+/obj/effect/decal/cleanable/oil,
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "rSN" = (
@@ -63092,8 +63103,11 @@
 /area/station/medical/medbay/central)
 "rZK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/machinery/computer/monitor{
+	dir = 4;
+	name = "backup power monitoring console"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "rZN" = (
@@ -63317,13 +63331,13 @@
 /area/station/hallway/primary/port)
 "scJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -66522,14 +66536,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "sWj" = (
-/obj/machinery/computer/station_alert{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/turf/open/floor/circuit/red,
 /area/station/engineering/supermatter/room)
 "sWl" = (
 /turf/closed/wall/rust,
@@ -66859,9 +66868,13 @@
 /area/station/medical/storage)
 "tbb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/belt/utility,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
+/obj/structure/sink/kitchen/directional/south{
+	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
+	name = "old sink"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/landmark/xeno_spawn,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "tbi" = (
@@ -67991,7 +68004,6 @@
 "tpM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/machinery/light/small/directional/west,
 /obj/machinery/light_switch/directional/west,
 /obj/item/assembly/prox_sensor{
 	desc = "Used for scanning and alerting when someone enters a certain proximity. This one is slightly shifted to the left.";
@@ -68942,16 +68954,18 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "tDJ" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	dir = 4;
-	id = "engineaccess";
-	name = "Engine Access Shutters"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/button/door/directional/south{
+	name = "Engine Access Lockdown";
+	id = "engineaccess";
+	req_access = list("engineering")
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tDT" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -71427,6 +71441,7 @@
 /area/station/hallway/primary/central)
 "uot" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -71434,7 +71449,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
@@ -73881,6 +73895,7 @@
 /obj/structure/table,
 /obj/item/radio/intercom/directional/west,
 /obj/item/wallframe/apc,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "vbi" = (
@@ -75875,7 +75890,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "vDk" = (
-/turf/closed/wall,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vDD" = (
 /obj/machinery/smartfridge/drinks,
@@ -80959,10 +80978,10 @@
 /area/station/cargo/warehouse)
 "wTS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/contraband/random/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -81626,6 +81645,7 @@
 /obj/structure/sign/warning/electric_shock/directional/south,
 /obj/structure/spider/stickyweb,
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "xfe" = (
@@ -82605,16 +82625,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/service/bar/atrium)
 "xtO" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/aft)
 "xtV" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -84353,6 +84370,8 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "xTG" = (
@@ -122670,7 +122689,7 @@ eJs
 uJN
 nHC
 iwS
-wXM
+shH
 uYM
 sJH
 shH
@@ -122926,10 +122945,10 @@ hjj
 jjs
 qZX
 rKn
-lyu
+vRo
 lDb
 lyu
-vRo
+lyu
 ifB
 cfs
 qai
@@ -123182,12 +123201,12 @@ cuV
 sOJ
 aov
 qZX
+pKR
+lcZ
 xNP
 wPU
-xtO
-rnp
 sWj
-tIr
+fyj
 vDk
 tDJ
 tIr
@@ -123439,10 +123458,10 @@ oQk
 xBz
 gDM
 qZX
-pKR
-fyj
+jjs
 qZX
-pKR
+jjs
+qZX
 qZX
 qZX
 qZX
@@ -123697,9 +123716,9 @@ lue
 xJc
 uot
 scJ
-qeX
+hkd
 wTS
-mFb
+xtO
 xvM
 aiB
 ejk
@@ -126189,7 +126208,7 @@ rZV
 vOX
 rZV
 rZV
-lcZ
+rZV
 fpz
 rZV
 vOX
@@ -126443,8 +126462,8 @@ smb
 rZV
 aeu
 aeu
+aeu
 asj
-jtD
 ntG
 rZK
 xeI
@@ -126700,8 +126719,8 @@ vOX
 vOX
 aeu
 aeu
+aeu
 rpl
-iAR
 qyn
 rSL
 iri
@@ -126957,9 +126976,9 @@ rZV
 aeu
 aeu
 aeu
+aeu
 rpl
 rpl
-rau
 tbb
 xTx
 gLm
@@ -127214,11 +127233,11 @@ aeu
 aeu
 aeu
 aeu
+aeu
 asj
 pSu
-esO
 pCj
-lgl
+rxX
 esO
 rou
 rZV
@@ -127471,10 +127490,10 @@ aeu
 aeu
 aeu
 aeu
+aeu
 rpl
-hkd
 eki
-rxX
+lgl
 dBe
 gVc
 xeT
@@ -127728,13 +127747,13 @@ aeu
 aeu
 aeu
 aeu
+aeu
 rpl
-adT
 bFu
+iAR
+rau
 adT
-bFu
-adT
-adT
+rnp
 vOX
 dJo
 mua
@@ -127986,12 +128005,12 @@ aeu
 aeu
 aeu
 aeu
-aeu
-aeu
-aeu
-aeu
-aeu
-aeu
+rpl
+rpl
+asj
+asj
+rpl
+rpl
 lDu
 lDu
 lWm

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7439,10 +7439,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"cML" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/starboard/fore)
 "cMQ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
@@ -29620,7 +29616,6 @@
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "kCC" = (
@@ -107557,10 +107552,10 @@ tCS
 tCS
 tCS
 tCS
-cML
 tCS
 tCS
-cML
+tCS
+tCS
 tCS
 tCS
 sqE

--- a/_maps/map_files/tramstation/maintenance_modules/dormenginelower_1.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/dormenginelower_1.dmm
@@ -237,6 +237,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "oa" = (
@@ -463,7 +464,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/food_packaging,
-/obj/machinery/duct,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "Ad" = (
@@ -718,11 +718,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Restroom Maintenance Access"
 	},
-/obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/dorms)
 "Qc" = (
@@ -1066,13 +1062,13 @@ Jw
 Jw
 Jw
 zQ
-Mr
-Mr
-Mr
-Mr
-Mr
-Mr
-Mr
+Jw
+Jw
+Jw
+Jw
+Jw
+Jw
+Jw
 NT
 gs
 gs
@@ -1108,7 +1104,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 gs
 gs
@@ -1144,7 +1140,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 gs
 gs
@@ -1180,7 +1176,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 gs
 gs
@@ -1216,7 +1212,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 gs
 gs
@@ -1252,7 +1248,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 gs
 gs
@@ -1288,7 +1284,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 gs
 gs
@@ -1324,7 +1320,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 gs
 gs
@@ -1360,7 +1356,7 @@ AN
 AN
 dj
 DP
-Mr
+Jw
 NT
 gs
 gs
@@ -1396,7 +1392,7 @@ AN
 AN
 Ej
 DP
-Mr
+Jw
 OF
 gs
 gs
@@ -1468,7 +1464,7 @@ AN
 AN
 iO
 DP
-Mr
+Jw
 NT
 NT
 NT
@@ -1504,9 +1500,9 @@ AN
 AN
 uc
 DP
-Mr
-Mr
-Mr
+Jw
+Jw
+Jw
 NT
 NT
 NT
@@ -1542,11 +1538,11 @@ AN
 AN
 AN
 AN
-Mr
-Mr
-Mr
-Mr
-Mr
+Jw
+Jw
+Jw
+Jw
+Jw
 NT
 "}
 (20,1,1) = {"
@@ -1582,7 +1578,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 "}
 (21,1,1) = {"
@@ -1618,7 +1614,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 "}
 (22,1,1) = {"
@@ -1654,7 +1650,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 "}
 (23,1,1) = {"
@@ -1690,7 +1686,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 "}
 (24,1,1) = {"
@@ -1726,7 +1722,7 @@ AN
 AN
 AN
 AN
-Mr
+Jw
 NT
 "}
 (25,1,1) = {"
@@ -1760,9 +1756,9 @@ AN
 AN
 AN
 ny
-Jw
-rg
 Mr
+rg
+Jw
 NT
 "}
 (26,1,1) = {"

--- a/_maps/map_files/tramstation/maintenance_modules/dormenginelower_2.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/dormenginelower_2.dmm
@@ -32,7 +32,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "ct" = (
@@ -208,7 +207,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "kt" = (
@@ -273,15 +271,11 @@
 	name = "Restroom Maintenance Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock_note_placer{
 	note_name = "breach notice";
 	note_info = "Due to recent hull damage suffered to this section of the station, the maintenance hall has been deemed unsafe for crew travel and has been blocked off until further notice for station repairs."
 	},
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/duct,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/dorms)
 "mV" = (
@@ -311,13 +305,6 @@
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/lesser)
-"ny" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/crew_quarters/dorms)
 "nT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -419,7 +406,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/item/stack/ore/gold,
-/obj/machinery/duct,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "sC" = (
@@ -465,7 +451,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/item/stack/ore/iron,
-/obj/machinery/duct,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "vf" = (
@@ -570,7 +555,6 @@
 /obj/structure/cable,
 /obj/item/stack/ore/iron,
 /obj/item/stack/ore/glass,
-/obj/machinery/duct,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "BN" = (
@@ -721,7 +705,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "JW" = (
@@ -852,7 +835,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
 "RF" = (
@@ -875,15 +857,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/lesser)
-"Sj" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/item/stack/ore/glass,
-/obj/machinery/duct,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/department/crew_quarters/dorms)
 "SP" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -931,15 +904,6 @@
 /obj/machinery/duct,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
-"Vt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/holosign/barrier/engineering,
-/obj/machinery/duct,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/crew_quarters/dorms)
 "Wp" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/closet/wardrobe/miner,
@@ -982,14 +946,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/department/crew_quarters/dorms)
-"XX" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/plating/airless,
-/area/station/maintenance/department/crew_quarters/dorms)
 "Yr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot{
@@ -1004,7 +960,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/duct,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "Zc" = (
@@ -1240,13 +1195,13 @@ na
 na
 hS
 ud
-Sj
+SP
 Rn
-XX
-XX
-XX
+na
+na
+na
 JJ
-XX
+na
 WC
 IK
 IK
@@ -1318,7 +1273,7 @@ AN
 AN
 AN
 AN
-XX
+na
 LQ
 IK
 IK
@@ -1354,7 +1309,7 @@ AN
 AN
 AN
 AN
-XX
+na
 NT
 IK
 IK
@@ -1498,7 +1453,7 @@ AN
 AN
 AN
 AN
-XX
+na
 NT
 KB
 NZ
@@ -1534,7 +1489,7 @@ AN
 AN
 kt
 Qo
-XX
+na
 Oj
 MA
 gx
@@ -1570,7 +1525,7 @@ AN
 AN
 XM
 OF
-XX
+na
 OF
 zR
 WC
@@ -1678,9 +1633,9 @@ AN
 AN
 BN
 Qo
-XX
-XX
-XX
+na
+na
+na
 OF
 ct
 NT
@@ -1716,9 +1671,9 @@ AN
 AN
 AN
 AN
-Sj
+SP
 sk
-Sj
+SP
 jX
 YW
 NT
@@ -1756,7 +1711,7 @@ AN
 AN
 AN
 AN
-MR
+Jw
 NT
 "}
 (21,1,1) = {"
@@ -1792,7 +1747,7 @@ AN
 AN
 AN
 AN
-Vt
+gO
 NT
 "}
 (22,1,1) = {"
@@ -1828,7 +1783,7 @@ AN
 AN
 AN
 AN
-MR
+Jw
 NT
 "}
 (23,1,1) = {"
@@ -1864,7 +1819,7 @@ AN
 AN
 AN
 AN
-MR
+Jw
 NT
 "}
 (24,1,1) = {"
@@ -1900,7 +1855,7 @@ AN
 AN
 AN
 AN
-MR
+Jw
 NT
 "}
 (25,1,1) = {"
@@ -1933,10 +1888,10 @@ AN
 AN
 AN
 AN
-ny
+ab
 MR
-MR
-MR
+Jw
+Jw
 NT
 "}
 (26,1,1) = {"

--- a/_maps/map_files/tramstation/maintenance_modules/dormenginelower_3.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/dormenginelower_3.dmm
@@ -169,13 +169,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
-"ny" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/department/crew_quarters/dorms)
 "oP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
@@ -306,13 +299,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/lesser)
-"wM" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/station/maintenance/department/crew_quarters/dorms)
 "wQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/wardrobe/mixed,
@@ -516,21 +502,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
-"Kx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/warning{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
 "Lh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -682,7 +653,6 @@
 	initialized_button = "trammaintlmaobro";
 	name = "Glass Walkway Emergency Seal Toggle"
 	},
-/obj/machinery/duct,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
 "UJ" = (
@@ -968,14 +938,14 @@ vM
 vM
 vM
 vM
-Kx
-Kx
-Kx
-Kx
-Kx
-Kx
+vM
+vM
+vM
+vM
+vM
+vM
 Ul
-IN
+Jw
 NT
 gs
 gs
@@ -1004,14 +974,14 @@ AN
 AN
 AN
 AN
-wM
+NT
 AN
 AN
 AN
 AN
 AN
 AN
-IN
+Jw
 NT
 gs
 gs
@@ -1047,7 +1017,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 gs
 gs
@@ -1083,7 +1053,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 gs
 gs
@@ -1119,7 +1089,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 gs
 gs
@@ -1155,7 +1125,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 gs
 gs
@@ -1191,7 +1161,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 gs
 gs
@@ -1227,7 +1197,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 gs
 gs
@@ -1263,7 +1233,7 @@ AN
 AN
 wQ
 DP
-IN
+Jw
 NT
 gs
 gs
@@ -1299,7 +1269,7 @@ AN
 AN
 YG
 DP
-IN
+Jw
 OF
 gs
 gs
@@ -1335,7 +1305,7 @@ AN
 AN
 kY
 DP
-IN
+Jw
 NT
 gs
 gs
@@ -1371,7 +1341,7 @@ AN
 AN
 zr
 DP
-IN
+Jw
 NT
 NT
 NT
@@ -1407,9 +1377,9 @@ AN
 AN
 Hw
 DP
-IN
-IN
-IN
+Jw
+Jw
+Jw
 NT
 NT
 NT
@@ -1445,11 +1415,11 @@ AN
 AN
 AN
 AN
-IN
-IN
-IN
-IN
-IN
+Jw
+Jw
+Jw
+Jw
+Jw
 NT
 "}
 (20,1,1) = {"
@@ -1485,7 +1455,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 "}
 (21,1,1) = {"
@@ -1521,7 +1491,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 "}
 (22,1,1) = {"
@@ -1557,7 +1527,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 "}
 (23,1,1) = {"
@@ -1593,7 +1563,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 "}
 (24,1,1) = {"
@@ -1629,7 +1599,7 @@ AN
 AN
 AN
 AN
-IN
+Jw
 NT
 "}
 (25,1,1) = {"
@@ -1662,10 +1632,10 @@ AN
 AN
 AN
 AN
-ny
+Qz
 IN
-IN
-IN
+Jw
+Jw
 NT
 "}
 (26,1,1) = {"

--- a/_maps/map_files/tramstation/maintenance_modules/secservicelower_1.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/secservicelower_1.dmm
@@ -128,10 +128,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/central/greater)
-"jf" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/central/greater)
 "kv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2462,7 +2458,7 @@ nk
 nk
 "}
 (34,1,1) = {"
-jf
+TQ
 vR
 vR
 vR

--- a/_maps/map_files/tramstation/maintenance_modules/secservicelower_2.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/secservicelower_2.dmm
@@ -670,10 +670,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/asteroid)
-"SR" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/central/greater)
 "SS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -2432,7 +2428,7 @@ zz
 zz
 "}
 (34,1,1) = {"
-SR
+ne
 cA
 cA
 cA

--- a/_maps/map_files/tramstation/maintenance_modules/secservicelower_3.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/secservicelower_3.dmm
@@ -195,10 +195,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/central)
-"pN" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/maintenance/central/greater)
 "pW" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -2241,7 +2237,7 @@ VY
 VY
 "}
 (34,1,1) = {"
-pN
+KU
 Ue
 Ue
 Ue

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -58847,7 +58847,7 @@
 /area/station/ai_monitored/command/nuke_storage)
 "tVf" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2452,13 +2452,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"ago" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/hallway/primary/tram/center)
 "agp" = (
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
@@ -4758,9 +4751,12 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "ayI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "ayJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -5465,13 +5461,6 @@
 /turf/open/openspace,
 /area/station/hallway/primary/tram/center)
 "aEv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/right)
-"aEx" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Ladder Access Hatch"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/right)
@@ -7314,10 +7303,14 @@
 /area/station/command/heads_quarters/ce)
 "aSK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/mail_sorting/science/genetics,
+/obj/effect/mapping_helpers/mail_sorting/science/rd_office,
+/obj/effect/mapping_helpers/mail_sorting/science/research,
+/obj/effect/mapping_helpers/mail_sorting/science/robotics,
+/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/right)
 "aSM" = (
@@ -7701,10 +7694,14 @@
 /turf/open/floor/catwalk_floor,
 /area/station/solars/starboard/fore)
 "bcl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "bcs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
@@ -7827,11 +7824,10 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/lesser)
 "beP" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/closed/wall,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/station/hallway/primary/tram/center)
 "beW" = (
 /obj/machinery/door/firedoor,
@@ -8174,6 +8170,10 @@
 	name = "Ladder Access Hatch"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/center)
 "blS" = (
@@ -8417,6 +8417,9 @@
 	dir = 4
 	},
 /obj/structure/industrial_lift/public,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/secondary/construction/engineering)
 "bsE" = (
@@ -8532,6 +8535,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "btV" = (
@@ -9636,6 +9640,7 @@
 	dir = 8
 	},
 /obj/machinery/bluespace_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "bME" = (
@@ -12723,12 +12728,15 @@
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/service/kitchen/coldroom)
 "cRc" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
 	},
-/turf/closed/wall,
-/area/station/hallway/primary/tram/center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "cRf" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -13092,10 +13100,6 @@
 	network = list("ss13","medbay")
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
@@ -13875,6 +13879,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/center)
 "dnp" = (
@@ -14188,9 +14193,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "dsZ" = (
@@ -15256,11 +15259,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "dPB" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Ladder Access Hatch"
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
+/obj/structure/mirror/directional/west,
+/obj/structure/sink/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "dPI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -15418,8 +15423,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/central/greater)
 "dQX" = (
@@ -16168,6 +16173,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/greater)
 "egJ" = (
@@ -17921,10 +17927,11 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "ePx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/right)
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	dir = 4
+	},
+/turf/open/space/openspace,
+/area/space)
 "ePG" = (
 /turf/closed/wall/r_wall,
 /area/station/science/auxlab/firing_range)
@@ -19955,7 +19962,8 @@
 "fEe" = (
 /obj/machinery/light/dim/directional/north,
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "fEi" = (
@@ -20852,6 +20860,9 @@
 	dir = 8
 	},
 /obj/structure/industrial_lift/public,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/secondary/construction/engineering)
 "fWn" = (
@@ -20999,6 +21010,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/command/minisat,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "fZL" = (
@@ -21994,11 +22006,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "gui" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
 	},
@@ -25001,7 +25013,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -25065,6 +25077,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "hFb" = (
@@ -26339,6 +26352,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/command/minisat,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "ief" = (
@@ -26426,6 +26440,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/catwalk_floor,
 /area/station/commons/dorms)
 "ifw" = (
@@ -28241,12 +28256,6 @@
 /obj/item/radio,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
-"iRT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/hallway/primary/tram/center)
 "iRZ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -29070,9 +29079,12 @@
 /turf/open/floor/carpet,
 /area/station/command/bridge)
 "jfu" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "jfH" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -29221,9 +29233,6 @@
 	c_tag = "Hallway - Starboard Tram Platform North-West"
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
@@ -30594,10 +30603,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
-"jHc" = (
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
 "jHd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -33284,6 +33289,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "kHt" = (
@@ -33582,7 +33588,8 @@
 /area/station/maintenance/tram/left)
 "kMD" = (
 /obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "kMI" = (
@@ -34212,7 +34219,9 @@
 /area/station/science/ordnance/storage)
 "kWp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "kWq" = (
@@ -35281,13 +35290,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/sorting/mail{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/mail_sorting/medbay/chemistry,
-/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
-/obj/effect/mapping_helpers/mail_sorting/medbay/general,
-/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
@@ -35717,7 +35722,6 @@
 "lwy" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/light/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "lwB" = (
@@ -36277,10 +36281,6 @@
 	c_tag = "Hallway - Central Tram Platform North-West"
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
@@ -36801,6 +36801,7 @@
 "lRs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/right)
 "lRC" = (
@@ -37432,6 +37433,7 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "mdx" = (
@@ -39605,10 +39607,14 @@
 /area/station/service/kitchen)
 "mUP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/chemistry,
+/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
+/obj/effect/mapping_helpers/mail_sorting/medbay/general,
+/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/center)
 "mUX" = (
@@ -40670,9 +40676,9 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "npR" = (
-/obj/machinery/recharge_station,
 /obj/machinery/light/small/directional/east,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable/multilayer/multiz,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "npX" = (
@@ -40989,6 +40995,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "nwg" = (
@@ -42864,6 +42871,7 @@
 /area/station/science/research)
 "odF" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "odH" = (
@@ -44119,10 +44127,11 @@
 /turf/closed/mineral/random/stationside/asteroid/porus,
 /area/station/medical/chemistry)
 "oGM" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 2
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/station/hallway/primary/tram/right)
 "oGN" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -44975,8 +44984,11 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
 	},
-/obj/structure/table,
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "pal" = (
@@ -45039,9 +45051,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "pby" = (
+/obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "pbH" = (
 /turf/closed/wall/r_wall,
@@ -45928,14 +45941,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/structure/disposalpipe/sorting/mail{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/mail_sorting/science/genetics,
-/obj/effect/mapping_helpers/mail_sorting/science/rd_office,
-/obj/effect/mapping_helpers/mail_sorting/science/research,
-/obj/effect/mapping_helpers/mail_sorting/science/robotics,
-/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
 "psB" = (
@@ -46345,12 +46353,6 @@
 /obj/item/folder/red,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom/holding)
-"pxO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/hallway/primary/tram/right)
 "pxW" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/safe)
@@ -46493,7 +46495,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/central/greater)
 "pAo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
@@ -46950,7 +46951,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
@@ -47496,11 +47497,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "pQY" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/station/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "pRm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -48317,10 +48317,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "qhP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/closed/wall,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/station/hallway/primary/tram/center)
 "qib" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48957,12 +48956,6 @@
 /obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
-"qug" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
 "qup" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50180,9 +50173,6 @@
 	c_tag = "Hallway - Central Tram Platform North-East"
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
@@ -51262,9 +51252,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "rko" = (
-/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/center)
 "rkp" = (
@@ -51464,6 +51456,10 @@
 /area/station/security/execution/transfer)
 "rnn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "rnA" = (
@@ -52056,7 +52052,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "rAf" = (
@@ -53509,6 +53507,7 @@
 "seG" = (
 /obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
 "seO" = (
@@ -53662,12 +53661,6 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
-"sig" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/closed/wall,
-/area/station/hallway/primary/tram/right)
 "sij" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -54012,6 +54005,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "snC" = (
@@ -54242,9 +54236,6 @@
 	dir = 10
 	},
 /obj/machinery/firealarm/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
@@ -54432,9 +54423,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "sul" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/central/greater)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/hallway/primary/tram/center)
 "sun" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -54820,7 +54814,6 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -55536,6 +55529,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "sNb" = (
@@ -57060,6 +57057,9 @@
 "tlO" = (
 /obj/structure/industrial_lift/public,
 /obj/effect/turf_decal/caution/stand_clear/red,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/secondary/construction/engineering)
 "tlP" = (
@@ -58497,7 +58497,6 @@
 	c_tag = "Secure - AI Upper External North";
 	network = list("aicore")
 	},
-/obj/structure/cable,
 /turf/open/floor/engine/hull/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "tNJ" = (
@@ -58730,6 +58729,9 @@
 /obj/machinery/teleport/station,
 /obj/machinery/light/small/directional/west,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "tSp" = (
@@ -58861,11 +58863,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "tVf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/station/hallway/primary/tram/center)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "tVp" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
@@ -61591,8 +61591,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/center)
 "uRv" = (
@@ -62213,11 +62215,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "vcJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/left)
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "vcS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65856,6 +65856,7 @@
 /area/station/science/research)
 "wtH" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "wtJ" = (
@@ -65887,12 +65888,15 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "wtS" = (
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
+/area/station/commons/dorms)
 "wuc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -65951,9 +65955,6 @@
 	dir = 6
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
@@ -67142,9 +67143,9 @@
 /turf/closed/wall,
 /area/station/service/kitchen/coldroom)
 "wSh" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/engineering/gravity_generator)
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "wSi" = (
 /turf/open/floor/iron/recharge_floor,
 /area/station/science/robotics/mechbay)
@@ -67660,9 +67661,6 @@
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "xft" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
@@ -70186,9 +70184,11 @@
 /turf/open/floor/iron/white/side,
 /area/station/science/explab)
 "yfa" = (
-/obj/machinery/light/dim/directional/south,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/left)
 "yfj" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -83034,7 +83034,7 @@ buv
 yeE
 oss
 oss
-qug
+kMD
 hAD
 veV
 thi
@@ -83545,7 +83545,7 @@ alR
 pAv
 veV
 hAD
-hAD
+alT
 veV
 mCQ
 kMD
@@ -83802,7 +83802,7 @@ rnL
 pAv
 veV
 cDZ
-hAD
+alT
 veV
 veV
 kMD
@@ -84059,7 +84059,7 @@ apC
 veV
 veV
 qcE
-hAD
+alT
 veV
 pdr
 kMD
@@ -84316,7 +84316,7 @@ apC
 rMa
 ffE
 hAD
-hAD
+alT
 veV
 veV
 kMD
@@ -84830,7 +84830,7 @@ apC
 oGY
 iCe
 hAD
-yfa
+anq
 veV
 veV
 fEe
@@ -85087,10 +85087,10 @@ apC
 veV
 veV
 hAD
-hAD
+alT
 ubY
-ubY
-kMD
+dPB
+jfu
 eEH
 veV
 veV
@@ -85344,10 +85344,10 @@ apC
 xkx
 lMw
 hAD
-hAD
-hAD
-hAD
-hAD
+alT
+alT
+ayI
+alT
 hAD
 rdk
 gAk
@@ -85603,7 +85603,7 @@ elr
 elr
 elr
 jeO
-hAD
+ayI
 elr
 elr
 elr
@@ -85860,7 +85860,7 @@ fOs
 gnC
 elr
 ujn
-ujn
+cRc
 elr
 ecu
 pKZ
@@ -86888,7 +86888,7 @@ rIC
 rIC
 rIC
 rIC
-rIC
+wtS
 kHp
 nwd
 hEY
@@ -92725,7 +92725,7 @@ aaa
 aaa
 aaa
 xwf
-sul
+xwf
 egD
 xwf
 xwf
@@ -103067,7 +103067,7 @@ laz
 kic
 swg
 uKK
-wtS
+ajF
 bzP
 fal
 aks
@@ -103323,7 +103323,7 @@ fal
 fal
 fal
 eSU
-wSh
+uKK
 vyD
 oZU
 fal
@@ -119065,7 +119065,7 @@ dBj
 wXI
 jqs
 dBj
-wOw
+tVf
 aur
 dnQ
 xvl
@@ -120112,7 +120112,7 @@ rDI
 aNk
 oqp
 oqp
-ayI
+oqp
 oqp
 oqp
 vXM
@@ -120369,7 +120369,7 @@ rDI
 aNq
 oqp
 oqp
-pQY
+vXM
 vXM
 vXM
 vXM
@@ -120606,7 +120606,7 @@ vXM
 vXM
 vXM
 xvl
-jHc
+tQq
 npR
 tQq
 xvl
@@ -157025,14 +157025,14 @@ vPD
 yiM
 ojT
 szW
-yiM
+iPy
 jcr
 uSL
 rwa
 mtQ
 jcr
-yiM
-vcJ
+iPy
+rnR
 ojT
 yiM
 sjN
@@ -157280,7 +157280,7 @@ hBf
 pkk
 sDe
 yiM
-tkv
+yfa
 qUg
 yiM
 afy
@@ -157290,7 +157290,7 @@ afX
 afy
 yiM
 rnR
-tkv
+yfa
 yiM
 qqi
 hMb
@@ -165247,7 +165247,7 @@ eSz
 eSz
 eSz
 izU
-seG
+pby
 vYA
 izU
 afy
@@ -165256,8 +165256,8 @@ omp
 afX
 afy
 izU
+ghg
 pby
-seG
 jyH
 pvp
 kSh
@@ -165512,7 +165512,7 @@ mvN
 nRH
 sUC
 rFW
-cRc
+beP
 rko
 wYw
 jyH
@@ -165763,13 +165763,13 @@ fnb
 htI
 izU
 dno
-ago
+izU
 eSz
 tCl
 omp
 wvE
 eSz
-ago
+izU
 blP
 izU
 jyH
@@ -170389,14 +170389,14 @@ izU
 izU
 izU
 lQe
-iRT
+izU
 eSz
 tCl
 omp
 wvE
 eSz
-iRT
-dPB
+izU
+lQe
 izU
 whz
 abM
@@ -170645,15 +170645,15 @@ aaa
 aaa
 abE
 wYw
-mUP
-tVf
+sul
+qhP
 wVC
 afQ
 sCG
 kwF
 wVC
 qhP
-bcl
+qtS
 wYw
 stE
 abM
@@ -179133,8 +179133,8 @@ xPf
 toF
 mRV
 vCl
-sig
-ePx
+oGM
+mzf
 rxO
 lVi
 abM
@@ -179384,14 +179384,14 @@ nfd
 vUE
 bMb
 car
-pxO
+bMb
 brm
 iOd
 ozQ
 vPi
 brm
-pxO
-aEx
+bMb
+car
 bMb
 lVi
 abM
@@ -180745,7 +180745,7 @@ jhd
 jhd
 jhd
 jhd
-jhd
+ePx
 jhd
 jhd
 jhd
@@ -183571,9 +183571,9 @@ jhd
 jhd
 jhd
 jhd
-vUu
-lwj
-vUu
+wSh
+pQY
+bcl
 gFf
 gFf
 oMI
@@ -184859,8 +184859,8 @@ lwj
 tqN
 tqN
 tNG
-jfu
-jfu
+gFf
+gFf
 lwy
 sVz
 bNr
@@ -186143,7 +186143,7 @@ jhd
 jhd
 vUu
 lwj
-vUu
+vcJ
 gFf
 gFf
 oMI

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2452,6 +2452,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"ago" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "agp" = (
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
@@ -4751,12 +4761,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
 "ayI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
+/turf/open/floor/iron/grimy,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "ayJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -7654,6 +7661,7 @@
 /area/station/hallway/secondary/entry)
 "baA" = (
 /obj/structure/window/reinforced/spawner/north,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "baK" = (
@@ -7697,11 +7705,8 @@
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
+/turf/open/space/openspace,
+/area/space)
 "bcs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
@@ -12727,16 +12732,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/service/kitchen/coldroom)
-"cRc" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
 "cRf" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -13301,6 +13296,7 @@
 "dbi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "dbr" = (
@@ -14231,6 +14227,7 @@
 	id = "AI";
 	pixel_y = 26
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "dtA" = (
@@ -15258,14 +15255,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"dPB" = (
-/obj/structure/mirror/directional/west,
-/obj/structure/sink/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
 "dPI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -15332,10 +15321,6 @@
 /area/station/engineering/supermatter)
 "dQq" = (
 /obj/structure/table/reinforced,
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = 5;
-	pixel_y = -1
-	},
 /obj/item/phone{
 	pixel_x = -3;
 	pixel_y = 3
@@ -17927,11 +17912,11 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "ePx" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	dir = 4
-	},
-/turf/open/space/openspace,
-/area/space)
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/left)
 "ePG" = (
 /turf/closed/wall/r_wall,
 /area/station/science/auxlab/firing_range)
@@ -28256,6 +28241,10 @@
 /obj/item/radio,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
+"iRT" = (
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "iRZ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -29078,13 +29067,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/bridge)
-"jfu" = (
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/station/commons/toilet)
 "jfH" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -29338,7 +29320,6 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "jkd" = (
@@ -30603,6 +30584,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
+"jHc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "jHd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -39607,14 +39595,9 @@
 /area/station/service/kitchen)
 "mUP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/mail_sorting/medbay/chemistry,
-/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
-/obj/effect/mapping_helpers/mail_sorting/medbay/general,
-/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/center)
 "mUX" = (
@@ -45051,11 +45034,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "pby" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/smooth,
-/area/station/hallway/primary/tram/center)
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "pbH" = (
 /turf/closed/wall/r_wall,
 /area/station/science/server)
@@ -45108,11 +45089,11 @@
 /area/station/engineering/gravity_generator)
 "pcY" = (
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/power/solar_control{
-	id = "aicore";
-	name = "AI Core Solar Control"
+/obj/structure/table/reinforced,
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 5;
+	pixel_y = -1
 	},
-/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "pdf" = (
@@ -47024,9 +47005,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pIQ" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/turret_protected/ai)
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "pIS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -47497,8 +47481,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "pQY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/multilayer/multiz,
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "pRm" = (
@@ -47627,6 +47610,7 @@
 /area/station/service/chapel)
 "pUz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "pUC" = (
@@ -48956,6 +48940,14 @@
 /obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
+"qug" = (
+/obj/structure/mirror/directional/west,
+/obj/structure/sink/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "qup" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52764,15 +52756,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/tram/right)
-"rOT" = (
-/obj/machinery/airalarm/directional/north,
-/obj/structure/cable,
-/obj/machinery/camera/motion/directional/north{
-	c_tag = "Secure - AI Core South";
-	network = list("aicore")
-	},
-/turf/open/floor/circuit,
-/area/station/ai_monitored/turret_protected/ai)
 "rPj" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -53661,6 +53644,15 @@
 /obj/effect/landmark/start/cook,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
+"sig" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/motion/directional/north{
+	c_tag = "Secure - AI Core South";
+	network = list("aicore")
+	},
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/ai_monitored/turret_protected/ai)
 "sij" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -54422,13 +54414,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"sul" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/hallway/primary/tram/center)
 "sun" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -54643,7 +54628,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
 "sxv" = (
@@ -56061,7 +56045,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/tram/right)
 "sVy" = (
-/obj/structure/cable,
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
@@ -58497,6 +58480,12 @@
 	c_tag = "Secure - AI Upper External North";
 	network = list("aicore")
 	},
+/obj/machinery/power/solar_control{
+	id = "aicore";
+	name = "AI Core Solar Control";
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/engine/hull/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "tNJ" = (
@@ -58863,9 +58852,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "tVf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/grimy,
-/area/station/ai_monitored/turret_protected/aisat/foyer)
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "tVp" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
@@ -59239,6 +59230,7 @@
 /area/station/science/robotics/mechbay)
 "uaM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "uba" = (
@@ -62215,9 +62207,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "vcJ" = (
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "vcS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65888,15 +65886,11 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "wtS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/structure/ladder,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/primary/tram/center)
 "wuc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -67143,9 +67137,17 @@
 /turf/closed/wall,
 /area/station/service/kitchen/coldroom)
 "wSh" = (
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/chemistry,
+/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
+/obj/effect/mapping_helpers/mail_sorting/medbay/general,
+/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
+/turf/open/floor/catwalk_floor,
+/area/station/hallway/primary/tram/center)
 "wSi" = (
 /turf/open/floor/iron/recharge_floor,
 /area/station/science/robotics/mechbay)
@@ -67465,11 +67467,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"wYX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/ai)
 "wZY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -70184,11 +70181,10 @@
 /turf/open/floor/iron/white/side,
 /area/station/science/explab)
 "yfa" = (
-/obj/structure/ladder,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/smooth,
-/area/station/hallway/primary/tram/left)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "yfj" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -85089,8 +85085,8 @@ veV
 hAD
 alT
 ubY
-dPB
-jfu
+qug
+pIQ
 eEH
 veV
 veV
@@ -85346,7 +85342,7 @@ lMw
 hAD
 alT
 alT
-ayI
+jHc
 alT
 hAD
 rdk
@@ -85603,7 +85599,7 @@ elr
 elr
 elr
 jeO
-ayI
+jHc
 elr
 elr
 elr
@@ -85860,7 +85856,7 @@ fOs
 gnC
 elr
 ujn
-cRc
+ago
 elr
 ecu
 pKZ
@@ -86888,7 +86884,7 @@ rIC
 rIC
 rIC
 rIC
-wtS
+vcJ
 kHp
 nwd
 hEY
@@ -119065,7 +119061,7 @@ dBj
 wXI
 jqs
 dBj
-tVf
+ayI
 aur
 dnQ
 xvl
@@ -157280,7 +157276,7 @@ hBf
 pkk
 sDe
 yiM
-yfa
+ePx
 qUg
 yiM
 afy
@@ -157290,7 +157286,7 @@ afX
 afy
 yiM
 rnR
-yfa
+ePx
 yiM
 qqi
 hMb
@@ -165247,7 +165243,7 @@ eSz
 eSz
 eSz
 izU
-pby
+wtS
 vYA
 izU
 afy
@@ -165257,7 +165253,7 @@ afX
 afy
 izU
 ghg
-pby
+wtS
 jyH
 pvp
 kSh
@@ -165505,7 +165501,7 @@ eSz
 eSz
 izU
 wYw
-mUP
+wSh
 beP
 rFW
 mvN
@@ -170645,7 +170641,7 @@ aaa
 aaa
 abE
 wYw
-sul
+mUP
 qhP
 wVC
 afQ
@@ -180745,7 +180741,7 @@ jhd
 jhd
 jhd
 jhd
-ePx
+bcl
 jhd
 jhd
 jhd
@@ -183571,9 +183567,9 @@ jhd
 jhd
 jhd
 jhd
-wSh
-pQY
-bcl
+iRT
+yfa
+tVf
 gFf
 gFf
 oMI
@@ -184356,7 +184352,7 @@ pUz
 dbi
 kgx
 vEj
-wYX
+rSB
 rSB
 dVM
 cHZ
@@ -184608,12 +184604,12 @@ tXU
 gVd
 dVM
 iqO
-njC
+aoh
 aCl
 dVM
 dVM
-dVM
-rOT
+sig
+jJv
 rSB
 dVM
 fho
@@ -184868,7 +184864,7 @@ aoh
 fyX
 ffe
 mgi
-pIQ
+dVM
 hhf
 xZx
 lDm
@@ -185126,8 +185122,8 @@ njC
 urd
 dVM
 dVM
-dVM
 qYJ
+pby
 rSB
 dVM
 jgq
@@ -185380,11 +185376,11 @@ bZA
 dVM
 mYB
 njC
-aoh
+njC
 sVy
 vTD
 baA
-njC
+aoh
 mEb
 dVM
 cHZ
@@ -185640,7 +185636,7 @@ lSG
 vyY
 jJv
 dtz
-jJv
+pby
 bcx
 jJv
 dVM
@@ -186143,7 +186139,7 @@ jhd
 jhd
 vUu
 lwj
-vcJ
+pQY
 gFf
 gFf
 oMI

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7701,12 +7701,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
 /area/station/solars/starboard/fore)
-"bcl" = (
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
-	dir = 4
-	},
-/turf/open/space/openspace,
-/area/space)
 "bcs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
@@ -180741,7 +180735,7 @@ jhd
 jhd
 jhd
 jhd
-bcl
+jhd
 jhd
 jhd
 jhd

--- a/_maps/shuttles/pirate_dutchman.dmm
+++ b/_maps/shuttles/pirate_dutchman.dmm
@@ -676,10 +676,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/airless,
 /area/shuttle/pirate/flying_dutchman)
-"Gt" = (
-/obj/structure/cable,
-/turf/closed/wall/mineral/wood/nonmetal,
-/area/shuttle/pirate/flying_dutchman)
 "Hh" = (
 /obj/machinery/computer/piratepad_control{
 	dir = 4
@@ -773,7 +769,7 @@
 /obj/docking_port/mobile/pirate{
 	dir = 8;
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "Pirate Ship";
 	port_direction = 4;
 	preferred_direction = 8
@@ -1138,7 +1134,7 @@ af
 af
 af
 ny
-Gt
+WR
 pG
 SV
 WR
@@ -1146,7 +1142,7 @@ Fz
 vw
 WR
 WR
-Gt
+WR
 WR
 WR
 af
@@ -1354,7 +1350,7 @@ af
 af
 af
 ny
-Gt
+WR
 pG
 uw
 WR
@@ -1362,7 +1358,7 @@ fH
 Pm
 WR
 WR
-Gt
+WR
 WR
 WR
 af

--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -105,6 +105,7 @@
 /area/centcom/syndicate_mothership/control)
 "bp" = (
 /obj/machinery/light/cold/directional/north,
+/obj/structure/cable,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
 "bs" = (
@@ -904,6 +905,7 @@
 /area/centcom/syndicate_mothership/control)
 "kF" = (
 /obj/machinery/light/cold/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/centcom/syndicate_mothership/control)
 "kG" = (
@@ -1340,6 +1342,7 @@
 /obj/machinery/camera/autoname/directional/south{
 	network = list("nukie")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 8
 	},
@@ -1389,6 +1392,7 @@
 	pixel_x = 32
 	},
 /obj/item/kirbyplants/random,
+/obj/structure/cable,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
 "pj" = (
@@ -1900,11 +1904,18 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "tL" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "War Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
-/turf/closed/indestructible/syndicate,
+/turf/open/floor/iron/textured_large,
 /area/centcom/syndicate_mothership/control)
 "tO" = (
 /turf/closed/indestructible/opsglass,
@@ -2169,6 +2180,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"xO" = (
+/obj/structure/cable,
+/turf/open/floor/mineral/titanium,
+/area/centcom/syndicate_mothership/control)
 "xU" = (
 /obj/structure/sign/poster/contraband/moffuchis_pizza{
 	pixel_x = -32
@@ -3123,6 +3138,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/structure/cable,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
 "IQ" = (
@@ -3143,6 +3159,20 @@
 	dir = 1
 	},
 /turf/open/misc/asteroid/snow/icemoon,
+/area/centcom/syndicate_mothership/control)
+"Jm" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Sky Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/turf/open/floor/iron/textured_large,
 /area/centcom/syndicate_mothership/control)
 "Jq" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
@@ -3384,6 +3414,7 @@
 /area/centcom/syndicate_mothership)
 "Ms" = (
 /obj/machinery/light/cold/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 8
 	},
@@ -3527,7 +3558,9 @@
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "Oi" = (
 /obj/structure/cable,
-/turf/closed/indestructible/syndicate,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 8
+	},
 /area/centcom/syndicate_mothership/control)
 "Om" = (
 /obj/structure/table/reinforced/plasmarglass,
@@ -4072,18 +4105,10 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "TR" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Sky Bridge"
-	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/syndicate_mothership/control)
 "TS" = (
 /obj/structure/chair/stool/directional/north,
@@ -4178,6 +4203,7 @@
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "VC" = (
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 8
 	},
@@ -4315,7 +4341,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/syndicate_mothership/control)
 "Xj" = (
@@ -7159,9 +7184,9 @@ No
 No
 KH
 rG
+Qr
 Wp
-Wp
-Wp
+Qr
 kF
 YF
 DZ
@@ -7260,12 +7285,12 @@ Gd
 MU
 YO
 DZ
-tL
+qp
 Ia
 Tn
 Tn
-Oi
-Oi
+DZ
+DZ
 DZ
 DZ
 MD
@@ -7568,7 +7593,7 @@ BH
 DZ
 kh
 Wp
-Wp
+Qr
 Mu
 DZ
 ad
@@ -7670,8 +7695,8 @@ VK
 DZ
 qp
 NY
-NY
-Oi
+Jm
+DZ
 DZ
 DZ
 DZ
@@ -7772,8 +7797,8 @@ gD
 VK
 qp
 wO
-wO
 Oi
+DZ
 VK
 DJ
 DZ
@@ -7874,7 +7899,7 @@ uT
 VK
 SR
 wO
-wO
+Oi
 Xb
 VK
 DJ
@@ -7976,7 +8001,7 @@ GA
 VK
 SR
 wO
-wO
+Oi
 Xb
 VK
 DJ
@@ -8079,7 +8104,7 @@ VK
 qp
 DN
 Ms
-Oi
+DZ
 VK
 DJ
 To
@@ -8181,7 +8206,7 @@ VK
 qp
 eo
 VC
-Oi
+DZ
 VK
 DJ
 YZ
@@ -8282,7 +8307,7 @@ uT
 VK
 SR
 wO
-wO
+Oi
 Xb
 VK
 DJ
@@ -8384,7 +8409,7 @@ uT
 VK
 SR
 wO
-wO
+Oi
 Xb
 VK
 DJ
@@ -8487,7 +8512,7 @@ VK
 qp
 jf
 oK
-Oi
+DZ
 VK
 DJ
 To
@@ -8589,7 +8614,7 @@ VK
 qp
 DN
 Ms
-Oi
+DZ
 VK
 DJ
 cV
@@ -8690,7 +8715,7 @@ uT
 VK
 SR
 wO
-wO
+Oi
 Xb
 VK
 DJ
@@ -8792,7 +8817,7 @@ td
 VK
 SR
 wO
-wO
+Oi
 Xb
 VK
 DJ
@@ -8894,8 +8919,8 @@ gD
 VK
 qp
 wO
-wO
 Oi
+DZ
 VK
 DJ
 DZ
@@ -8993,11 +9018,11 @@ qU
 PN
 DZ
 DZ
-tL
-tL
-TR
+qp
+qp
+NY
 OW
-Oi
+DZ
 DZ
 DZ
 DZ
@@ -9097,8 +9122,8 @@ DZ
 Cm
 GI
 IM
-wG
-wG
+TR
+TR
 Te
 rf
 rf
@@ -9709,7 +9734,7 @@ DZ
 Fp
 go
 pi
-wG
+TR
 AL
 DZ
 DZ
@@ -9811,7 +9836,7 @@ DZ
 DZ
 qp
 DZ
-gB
+tL
 gB
 DZ
 mz
@@ -9913,7 +9938,7 @@ DZ
 pK
 EJ
 VK
-ZZ
+xO
 ZZ
 dn
 qN
@@ -10015,7 +10040,7 @@ DZ
 NA
 FN
 VK
-ZZ
+xO
 ZZ
 IV
 tv
@@ -10116,7 +10141,7 @@ cT
 DZ
 DZ
 eg
-tL
+qp
 bp
 ZZ
 IV
@@ -10219,7 +10244,7 @@ VK
 ZZ
 ZZ
 Me
-ZZ
+xO
 ZZ
 IV
 rb

--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -383,6 +383,20 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/syndicate_mothership/control)
+"eA" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Sky Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/turf/open/floor/iron/textured_large,
+/area/centcom/syndicate_mothership/control)
 "eF" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -655,6 +669,20 @@
 	dir = 10
 	},
 /turf/open/lava/plasma/ice_moon,
+/area/centcom/syndicate_mothership/control)
+"hx" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "War Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/turf/open/floor/iron/textured_large,
 /area/centcom/syndicate_mothership/control)
 "hA" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -1904,18 +1932,10 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "tL" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "War Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/structure/cable,
-/turf/open/floor/iron/textured_large,
 /area/centcom/syndicate_mothership/control)
 "tO" = (
 /turf/closed/indestructible/opsglass,
@@ -2180,10 +2200,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"xO" = (
-/obj/structure/cable,
-/turf/open/floor/mineral/titanium,
-/area/centcom/syndicate_mothership/control)
 "xU" = (
 /obj/structure/sign/poster/contraband/moffuchis_pizza{
 	pixel_x = -32
@@ -2717,6 +2733,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/centcom/syndicate_mothership/control)
 "EH" = (
@@ -2791,6 +2808,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
+"FH" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 8
+	},
+/area/centcom/syndicate_mothership/control)
 "FM" = (
 /turf/closed/indestructible/opsglass,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
@@ -3160,20 +3183,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
-"Jm" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Sky Bridge"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/structure/cable,
-/turf/open/floor/iron/textured_large,
-/area/centcom/syndicate_mothership/control)
 "Jq" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -3215,6 +3224,20 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
+/area/centcom/syndicate_mothership/control)
+"Kl" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cafeteria"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/centcom/syndicate_mothership/control)
 "Kq" = (
 /turf/closed/indestructible/syndicate,
@@ -3558,9 +3581,7 @@
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "Oi" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 8
-	},
+/turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
 "Om" = (
 /obj/structure/table/reinforced/plasmarglass,
@@ -3985,7 +4006,6 @@
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "SM" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
@@ -6977,8 +6997,8 @@ uK
 ld
 ld
 ld
-ld
-KH
+tL
+Kl
 Ez
 Jz
 px
@@ -7695,7 +7715,7 @@ VK
 DZ
 qp
 NY
-Jm
+eA
 DZ
 DZ
 DZ
@@ -7797,7 +7817,7 @@ gD
 VK
 qp
 wO
-Oi
+FH
 DZ
 VK
 DJ
@@ -7899,7 +7919,7 @@ uT
 VK
 SR
 wO
-Oi
+FH
 Xb
 VK
 DJ
@@ -8001,7 +8021,7 @@ GA
 VK
 SR
 wO
-Oi
+FH
 Xb
 VK
 DJ
@@ -8307,7 +8327,7 @@ uT
 VK
 SR
 wO
-Oi
+FH
 Xb
 VK
 DJ
@@ -8409,7 +8429,7 @@ uT
 VK
 SR
 wO
-Oi
+FH
 Xb
 VK
 DJ
@@ -8715,7 +8735,7 @@ uT
 VK
 SR
 wO
-Oi
+FH
 Xb
 VK
 DJ
@@ -8817,7 +8837,7 @@ td
 VK
 SR
 wO
-Oi
+FH
 Xb
 VK
 DJ
@@ -8919,7 +8939,7 @@ gD
 VK
 qp
 wO
-Oi
+FH
 DZ
 VK
 DJ
@@ -9836,7 +9856,7 @@ DZ
 DZ
 qp
 DZ
-tL
+hx
 gB
 DZ
 mz
@@ -9938,7 +9958,7 @@ DZ
 pK
 EJ
 VK
-xO
+Oi
 ZZ
 dn
 qN
@@ -10040,7 +10060,7 @@ DZ
 NA
 FN
 VK
-xO
+Oi
 ZZ
 IV
 tv
@@ -10244,7 +10264,7 @@ VK
 ZZ
 ZZ
 Me
-xO
+Oi
 ZZ
 IV
 rb

--- a/tools/maplint/lints/cable_under_wall.yml
+++ b/tools/maplint/lints/cable_under_wall.yml
@@ -1,0 +1,3 @@
+/turf/closed:
+  banned_neighbors:
+  - /obj/structure/cable


### PR DESCRIPTION
## About The Pull Request

This adds a mapping linter that restricts cables being placed underneath any type of wall.  The aim is to prevent a repeat of #73884 from happening again.

This affects the following maps:

- Lavaland syndie base
- Snowdin away mission
- Delta
- IceBox
- Kilo
- Meta
- Tram (and modular mapping areas)
- Pirate Dutchman shuttle
- Nukie base

Most of the changes are cosmetic.  A slight few were done in places like the AI upload or SMES room where I had to tear down a r-wall or two to get the intended effect.  

Notable changes on Tram:

- Rerouted the atmos/water pipes on tram dorms so it goes from the east side instead of west due to the modular mapping not always having a guaranteed door spawning on the west.
- Changed the outlet injector on AI sat to be a passive vent and moved it to the west side of AI sat solars.  This was done so it was symmetrical with the wires multi-z cable on the east side.  The solars computer in AI sat was moved in to be located in center of solars.
- Adding r-windows spawners on ladder access hatches near tram paths.  I used these to reroute disposals, pipes, and cables properly instead of going through walls.

## Why It's Good For The Game

Less bugs in the future.

## Changelog

:cl:
fix: Fix and prevent mappers placing wires underneath walls with a mapping linter. (you can still place them under walls during game with no problem)
balance: Removed some walls near Kilo SMES engineering area.  Removed r-walls from AI sat SMES areas that had wires going through them.
balance: Lavaland syndie base, snowdin, delta, icebox, kilo, meta, tram (and modular mapping areas), pirate dutchman shuttle, and nukie base all had slight tweaks to areas that had wires running through walls.  Some of these spots had wires rerouted, others replaced walls with windows, and others simple just had a stray wire on a wall that was either cosmetic or a mistake.
balance: Changed the outlet injector on AI sat to be a passive vent and moved it to the west side of AI sat solars.  This was done so it was symmetrical with the wires multi-z cable on the east side.  The solars computer in AI sat was moved in to be located in center of solars.
fix:  Rerouted the atmos/water pipes on tram dorms so it goes from the east side instead of west due to the modular mapping not always having a guaranteed door spawning on the west.
/:cl:

