### PR TITLE
Stabilized gold extracts can now summon basicmobs

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -1025,7 +1025,12 @@
 	if(QDELETED(familiar))
 		familiar = new linked.mob_type(get_turf(owner.loc))
 		familiar.name = linked.mob_name
-		familiar.del_on_death = TRUE
+		if(isanimal(familiar))
+			familiar.del_on_death = TRUE
+		else //we are a basicmob otherwise
+			var/mob/living/basic/basic_familiar = familiar
+			basic_familiar.basic_mob_flags |= DEL_ON_DEATH
+		familiar.befriend(owner)
 		familiar.copy_languages(owner, LANGUAGE_MASTER)
 		if(linked.saved_mind)
 			linked.saved_mind.transfer_to(familiar)

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -130,11 +130,12 @@ Stabilized extracts:
 /obj/item/slimecross/stabilized/gold/proc/generate_mobtype()
 	var/static/list/mob_spawn_pets = list()
 	if(!length(mob_spawn_pets))
-		for(var/T in typesof(/mob/living/simple_animal))
-			var/mob/living/simple_animal/SA = T
-			switch(initial(SA.gold_core_spawnable))
-				if(FRIENDLY_SPAWN)
-					mob_spawn_pets += T
+		for(var/mob/living/simple_animal/animal as anything in subtypesof(/mob/living/simple_animal))
+			if(initial(animal.gold_core_spawnable) == FRIENDLY_SPAWN)
+				mob_spawn_pets += animal
+		for(var/mob/living/basic/basicanimal as anything in subtypesof(/mob/living/basic))
+			if(initial(basicanimal.gold_core_spawnable) == FRIENDLY_SPAWN)
+				mob_spawn_pets += basicanimal
 	mob_type = pick(mob_spawn_pets)
 
 /obj/item/slimecross/stabilized/gold/Initialize(mapload)

--- a/code/modules/unit_tests/spawn_mobs.dm
+++ b/code/modules/unit_tests/spawn_mobs.dm
@@ -2,7 +2,9 @@
 /datum/unit_test/spawn_mobs
 
 /datum/unit_test/spawn_mobs/Run()
-	for(var/_animal in typesof(/mob/living/simple_animal))
-		var/mob/living/simple_animal/animal = _animal
-		if (initial(animal.gold_core_spawnable) == HOSTILE_SPAWN || initial(animal.gold_core_spawnable) == FRIENDLY_SPAWN)
-			allocate(_animal)
+	for(var/mob/living/simple_animal/animal as anything in subtypesof(/mob/living/simple_animal))
+		if (initial(animal.gold_core_spawnable))
+			allocate(animal)
+	for(var/mob/living/basic/basic_animal as anything in subtypesof(/mob/living/basic))
+		if (initial(basic_animal.gold_core_spawnable))
+			allocate(basic_animal)


### PR DESCRIPTION

## About The Pull Request

Stabilized gold extracts can now summon basicmobs,
Also, summoned familiars become friendly to the owner, which stops stuff like mice running away.

## Why It's Good For The Game

They can now make cool basicmob carp and stuff
Fixes #74008

## Changelog



:cl:
fix: Stabilized gold extracts can now spawn basicmobs
/:cl:
