### PR TITLE
Makes all CTF windows actually indestructible

### DIFF
--- a/_maps/map_files/CTF/classic.dmm
+++ b/_maps/map_files/CTF/classic.dmm
@@ -51,11 +51,7 @@
 /turf/open/floor/circuit/green/off,
 /area/centcom/ctf)
 "ev" = (
-/obj/structure/window/reinforced/fulltile{
-	max_integrity = 5000;
-	name = "hardened window";
-	atom_integrity = 5000
-	},
+/obj/structure/window/reinforced/fulltile/indestructible,
 /turf/open/floor/plating,
 /area/centcom/ctf)
 "eW" = (

--- a/_maps/map_files/CTF/cruiser.dmm
+++ b/_maps/map_files/CTF/cruiser.dmm
@@ -56,11 +56,7 @@
 /turf/open/floor/pod/light,
 /area/centcom/ctf)
 "cK" = (
-/obj/structure/window/reinforced/shuttle{
-	max_integrity = 5000;
-	name = "hardened window";
-	atom_integrity = 5000
-	},
+/obj/effect/spawner/structure/window/reinforced/shuttle/indestructible,
 /turf/open/floor/plating,
 /area/centcom/ctf)
 "cO" = (
@@ -68,16 +64,8 @@
 /turf/open/floor/circuit/green/anim,
 /area/centcom/ctf)
 "dq" = (
-/obj/structure/window/reinforced/shuttle{
-	max_integrity = 5000;
-	name = "hardened window";
-	atom_integrity = 5000
-	},
-/obj/structure/window/reinforced/shuttle{
-	max_integrity = 5000;
-	name = "hardened window";
-	atom_integrity = 5000
-	},
+/obj/effect/spawner/structure/window/reinforced/shuttle/indestructible,
+/obj/effect/spawner/structure/window/reinforced/shuttle/indestructible,
 /turf/open/floor/plating,
 /area/centcom/ctf)
 "ds" = (

--- a/_maps/map_files/CTF/downtown.dmm
+++ b/_maps/map_files/CTF/downtown.dmm
@@ -1249,11 +1249,7 @@
 /turf/open/floor/iron,
 /area/centcom/ctf)
 "Am" = (
-/obj/structure/window/reinforced/fulltile{
-	atom_integrity = 5000;
-	max_integrity = 5000;
-	name = "hardened window"
-	},
+/obj/effect/spawner/structure/window/reinforced/indestructible,
 /turf/open/floor/plating,
 /area/centcom/ctf)
 "Ao" = (

--- a/_maps/map_files/CTF/fourSide.dmm
+++ b/_maps/map_files/CTF/fourSide.dmm
@@ -40,11 +40,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/ctf)
 "bI" = (
-/obj/structure/window/reinforced/fulltile{
-	max_integrity = 5000;
-	name = "hardened window";
-	atom_integrity = 5000
-	},
+/obj/effect/spawner/structure/window/reinforced/indestructible,
 /turf/open/floor/plating,
 /area/centcom/ctf)
 "cj" = (

--- a/_maps/map_files/CTF/limbo.dmm
+++ b/_maps/map_files/CTF/limbo.dmm
@@ -60,11 +60,8 @@
 /turf/open/floor/carpet/blue,
 /area/centcom/ctf)
 "ef" = (
-/obj/structure/window/reinforced/fulltile{
-	color = "#008000";
-	max_integrity = 5000;
-	name = "hardened window";
-	atom_integrity = 5000
+/obj/structure/window/reinforced/fulltile/indestructible{
+	color = "#008000"
 	},
 /turf/open/floor/plating,
 /area/centcom/ctf)

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -165,6 +165,10 @@ again.
 	icon_state = "swindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle)
 
+/obj/effect/spawner/structure/window/reinforced/shuttle/indestructible
+	name = "indestructible shuttle window spawner"
+	icon_state = "swindow_spawner"
+	spawn_list = list(/obj/structure/grille/indestructible, /obj/structure/window/reinforced/shuttle/indestructible)
 
 //plastitanium window
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -787,6 +787,14 @@
 	anchored = FALSE
 	state = WINDOW_OUT_OF_FRAME
 
+/obj/structure/window/reinforced/shuttle/indestructible
+	name = "hardened shuttle window"
+	flags_1 = PREVENT_CLICK_UNDER_1 | NODECONSTRUCT_1
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/structure/window/reinforced/shuttle/indestructible/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	return FALSE
+
 /obj/structure/window/reinforced/plasma/plastitanium
 	name = "plastitanium window"
 	desc = "A durable looking window made of an alloy of of plasma and titanium."


### PR DESCRIPTION

## About The Pull Request

Adds a spawner for indestructible shuttle windows
Replaces all "hardened windows" (which were actually not unbreakable) with proper unbreakable windows

## Why It's Good For The Game

Fixes #73297, people shouldn't be breaking into space in CTF

## Changelog
:cl:
fix: All CTF windows are now indestructible, fixes breaking into space during CTF.
/:cl:
