### PR TITLE
The Lance Crew Evacuation System (New Emergency Shuttle)

### DIFF
--- a/_maps/shuttles/emergency_lance.dmm
+++ b/_maps/shuttles/emergency_lance.dmm
@@ -1,0 +1,2509 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"af" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"ai" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"ao" = (
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/shuttle/escape)
+"aH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/rack,
+/obj/item/clothing/mask/breath{
+	pixel_x = -4
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = 4
+	},
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"aV" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"ba" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced/survival_pod/spawner/east,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"bj" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"bA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = -4
+	},
+/obj/item/tank/internals/emergency_oxygen/engi{
+	pixel_x = 4
+	},
+/obj/item/tank/internals/emergency_oxygen/engi,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"bV" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"ce" = (
+/obj/structure/sign/warning/vacuum/external/directional/east,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 4
+	},
+/obj/structure/marker_beacon/indigo,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"cw" = (
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/checker,
+/area/shuttle/escape)
+"cz" = (
+/obj/machinery/power/shuttle_engine/huge,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"cC" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"cU" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"df" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/shuttle/escape)
+"dn" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_blast";
+	name = "Cockpit Blast Door"
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"dW" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"eD" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"fo" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced/survival_pod/spawner/west,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"fz" = (
+/obj/machinery/computer/records/security{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/red/corners{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"gr" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/door/airlock/grunge{
+	name = "Shuttle Medical Center"
+	},
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"gF" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"gI" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"hu" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/shuttle/escape)
+"hv" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"ic" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "escape_public_windows";
+	name = "Secondary Chamber Window Blast Doors";
+	pixel_x = -7;
+	req_access = list("command")
+	},
+/obj/item/radio{
+	pixel_x = 5
+	},
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
+/area/shuttle/escape)
+"iy" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"iz" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"iZ" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"ji" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"jo" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 4
+	},
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	name = "Lance Emergency Shuttle"
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"jG" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/shuttle/escape)
+"jM" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Primary Chamber"
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"jN" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/rack,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment{
+	pixel_x = 5
+	},
+/obj/item/radio,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"jY" = (
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"kb" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/item/borg/upgrade/defib,
+/obj/item/defibrillator,
+/obj/structure/closet/crate/medical{
+	anchored = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/shuttle/escape)
+"kh" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/shuttle/escape)
+"ko" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/shuttle/escape)
+"kt" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"kz" = (
+/obj/effect/turf_decal/stripes/red/line,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig{
+	icon_state = "darkfull"
+	},
+/area/shuttle/escape/brig)
+"kN" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"le" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/door/airlock/grunge{
+	name = "Secondary Chamber"
+	},
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"lg" = (
+/obj/structure/sign/warning/vacuum/external/directional/south,
+/obj/machinery/light/small/directional/south,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"mb" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/east,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"mk" = (
+/obj/machinery/porta_turret/syndicate/energy/raven{
+	dir = 5
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"mp" = (
+/obj/machinery/door/airlock/medical{
+	id_tag = "lance_psych";
+	name = "Mental Health Crisis Room"
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/shuttle/escape)
+"mw" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/shuttle/escape)
+"mx" = (
+/obj/machinery/shieldgen{
+	anchored = 1
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"nb" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Holding Area"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/mineral/plastitanium/red/brig{
+	icon_state = "darkfull"
+	},
+/area/shuttle/escape/brig)
+"nd" = (
+/obj/machinery/shieldgen{
+	anchored = 1
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/shuttle/escape)
+"ne" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"nS" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/shuttle/escape)
+"od" = (
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/shuttle/escape)
+"oe" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"ol" = (
+/obj/structure/bed,
+/obj/item/bedsheet/nanotrasen,
+/obj/item/toy/plush/lizard_plushie{
+	color = "#52B4E9";
+	desc = "For when everything's going wrong and you just need a friend.";
+	name = "Calms-The-Panic"
+	},
+/turf/open/floor/iron/white/textured_large,
+/area/shuttle/escape)
+"pb" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"pu" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"pG" = (
+/obj/structure/rack,
+/obj/item/pickaxe/mini{
+	pixel_x = -5
+	},
+/obj/item/pickaxe/mini,
+/obj/item/pickaxe/mini{
+	pixel_x = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"pK" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"pX" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/emergency,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
+/area/shuttle/escape)
+"qe" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"qx" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"qH" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"re" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/shuttle/escape)
+"rr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/shuttle/escape)
+"rw" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"ry" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/sign/nanotrasen{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"rJ" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"sn" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/item/radio/intercom/directional/west,
+/obj/structure/sign/flag/nanotrasen/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"sp" = (
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"sE" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Emergency Shuttle Medical Storage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"tx" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/warning/electric_shock/directional/east,
+/obj/machinery/light/directional/east,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"tH" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"uF" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/departments/medbay/alt/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"uX" = (
+/turf/template_noop,
+/area/template_noop)
+"va" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/shuttle/escape)
+"vf" = (
+/obj/machinery/shieldgen{
+	anchored = 1
+	},
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"vm" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/reagent_dispensers/fueltank/large,
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/shuttle/escape)
+"vy" = (
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/shuttle/escape)
+"vI" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/shuttle/escape)
+"wp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"wB" = (
+/obj/machinery/recharger,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/shuttle/escape)
+"wD" = (
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 4
+	},
+/obj/effect/station_crash/devastating,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"xa" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/shuttle/escape)
+"xc" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/shuttle/escape)
+"xj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/machinery/light/directional/west,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"xR" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"yB" = (
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"zc" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"zh" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/shuttle/escape)
+"zP" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/shuttle/escape)
+"zU" = (
+/obj/machinery/porta_turret/syndicate/energy/raven{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"An" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_public_windows";
+	name = "Central Blast Door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ao" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"AE" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"AS" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"BC" = (
+/obj/machinery/porta_turret/syndicate/energy/raven{
+	dir = 10
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"BL" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"BS" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/shuttle/escape)
+"Cv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"CB" = (
+/obj/machinery/porta_turret/syndicate/energy/raven{
+	dir = 6
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"Dd" = (
+/obj/structure/window/reinforced/survival_pod/spawner,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"Dg" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Dx" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/lockbox/loyalty,
+/obj/machinery/recharger,
+/obj/effect/turf_decal/stripes/red/end{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig{
+	icon_state = "darkfull"
+	},
+/area/shuttle/escape/brig)
+"EL" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/turretid{
+	control_area = "/area/shuttle/escape";
+	desc = "Used to control the Lance's automated defenses.";
+	icon_state = "control_kill";
+	lethal = 1;
+	pixel_y = -26;
+	req_access = list("command")
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"ET" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/shuttle/escape)
+"EX" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/shuttle/escape)
+"FA" = (
+/obj/structure/window/reinforced/survival_pod/spawner,
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs{
+	pixel_y = 3
+	},
+/obj/item/restraints/handcuffs,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"FX" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/surgery{
+	pixel_x = -15
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 5
+	},
+/turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"Gr" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/item/stack/sheet/plastitaniumglass{
+	amount = 20;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/glass{
+	amount = 20;
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/obj/item/stack/sheet/mineral/plastitanium{
+	amount = 50;
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/structure/closet/crate/engineering,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/wrench/bolter,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/shuttle/escape)
+"Gt" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Gw" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"GA" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/shuttle/escape)
+"Hd" = (
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
+/area/shuttle/escape)
+"Hp" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Hq" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/door/airlock/grunge{
+	name = "Central Entrance"
+	},
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"Hu" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Hv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Window Blast Doors";
+	pixel_x = -7;
+	req_access = list("command")
+	},
+/obj/machinery/recharger{
+	pixel_x = 5
+	},
+/obj/item/assembly/flash,
+/obj/item/wrench,
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"HJ" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"HV" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Emergency Shutle Engineering"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"If" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"In" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/shuttle/escape)
+"Iq" = (
+/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/clothing/wardrobe_closet_colored,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"JN" = (
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/checker,
+/area/shuttle/escape)
+"JS" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 1;
+	pixel_y = 9
+	},
+/obj/item/toy/nuke,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"Ke" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 8
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_y = 4
+	},
+/obj/item/grenade/chem_grenade/smart_metal_foam{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Kz" = (
+/obj/machinery/power/shuttle_engine/large,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Ld" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/effect/spawner/random/medical/surgery_tool_advanced,
+/obj/item/storage/medkit/fire{
+	pixel_x = -2
+	},
+/obj/item/storage/medkit/toxin,
+/obj/item/storage/medkit/brute{
+	pixel_x = 3
+	},
+/obj/item/lazarus_injector,
+/obj/structure/closet/crate/medical{
+	anchored = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/shuttle/escape)
+"Lg" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/indigo,
+/turf/open/space/basic,
+/area/shuttle/escape)
+"Lj" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/machinery/computer/aifixer{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Lk" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/shuttle/escape)
+"LA" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/east{
+	id = "escape_cockpit_blast";
+	name = "Cockpit Airlock Blast Doors";
+	pixel_y = 6;
+	req_access = list("command")
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Mc" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"MA" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/shuttle/escape)
+"MC" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/shuttle/escape)
+"MQ" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/shuttle/escape)
+"MZ" = (
+/obj/structure/rack,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Nx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/checker,
+/area/shuttle/escape)
+"NS" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/structure/sign/departments/engineering/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"NW" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Of" = (
+/obj/effect/turf_decal/tile/dark_blue,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/emergency{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/emergency{
+	pixel_x = -2
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/shuttle/escape)
+"Ol" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/foamtank,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Oy" = (
+/obj/structure/table/reinforced,
+/obj/item/toy/redbutton,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"OE" = (
+/obj/structure/cable,
+/obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"OG" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/optable,
+/turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"OM" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 8
+	},
+/obj/machinery/computer/crew,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/shuttle/escape)
+"OY" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/shuttle/escape)
+"Pe" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/obj/machinery/button/door/directional/south{
+	id = "lance_psych";
+	name = "Panic Room Bolt Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/white/textured_large,
+/area/shuttle/escape)
+"Pv" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 1
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/shuttle/escape)
+"Px" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Qu" = (
+/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"Qv" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/shuttle/escape)
+"QH" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"QI" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/door/airlock/grunge{
+	name = "Secondary Chamber"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"QL" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/red/corners,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"QP" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/structure/fireaxecabinet/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Rj" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"RO" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/machinery/stasis,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/shuttle/escape)
+"Sg" = (
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 4
+	},
+/obj/structure/marker_beacon/indigo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"So" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Su" = (
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/checker,
+/area/shuttle/escape)
+"SD" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/shuttle/escape)
+"SM" = (
+/obj/structure/sign/warning/vacuum/external/directional/north,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Tc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"TE" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"TQ" = (
+/obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner,
+/area/shuttle/escape)
+"Um" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Uq" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"UG" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"UR" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/o2{
+	pixel_x = 3
+	},
+/obj/item/storage/medkit/regular,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/shuttle/escape)
+"Vf" = (
+/obj/machinery/shieldgen,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"VA" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/obj/machinery/stasis{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/shuttle/escape)
+"WI" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"WN" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 1;
+	name = "Holding Cell B";
+	req_access = list("security")
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"WO" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"WQ" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"Xc" = (
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Xh" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Xj" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/shuttle/escape)
+"XA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Yk" = (
+/obj/machinery/door/window/survival_pod{
+	name = "Holding Cell A";
+	req_access = list("security")
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"Yq" = (
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Yt" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"YM" = (
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/regular,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape/brig)
+"YN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"ZE" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/door/airlock/grunge{
+	name = "Bridge Hall"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/shuttle/escape)
+"ZZ" = (
+/obj/effect/turf_decal/tile/dark_blue{
+	dir = 1
+	},
+/mob/living/simple_animal/bot/medbot{
+	name = "\improper emergency medibot";
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/shuttle/escape)
+
+(1,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+zU
+WQ
+Rj
+Rj
+Rj
+Rj
+WQ
+BC
+uX
+uX
+uX
+WQ
+pu
+WQ
+WQ
+uX
+uX
+uX
+uX
+uX
+"}
+(2,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+WQ
+vf
+MZ
+Lj
+Gw
+YN
+mx
+WQ
+nS
+Lg
+nS
+qH
+Xc
+Px
+gI
+tH
+uX
+uX
+uX
+uX
+"}
+(3,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+ne
+Hp
+fz
+pb
+If
+Xh
+bj
+Gt
+Rj
+uX
+nS
+uX
+qH
+Xc
+Iq
+gI
+tH
+uX
+uX
+uX
+uX
+"}
+(4,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+ne
+Hp
+cC
+oe
+Yt
+Yt
+Yt
+EL
+WQ
+WQ
+WQ
+WQ
+WQ
+dW
+WQ
+WQ
+WQ
+BC
+uX
+uX
+uX
+"}
+(5,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+ne
+Hp
+QL
+kt
+LA
+af
+Mc
+QP
+WQ
+ol
+WQ
+Of
+Lk
+GA
+GA
+ET
+aV
+WQ
+uX
+uX
+uX
+"}
+(6,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+zU
+WQ
+WQ
+An
+WQ
+WQ
+WQ
+An
+aV
+aV
+uX
+uX
+WQ
+WQ
+dn
+WQ
+Hv
+ai
+UG
+WQ
+Pe
+WQ
+VA
+WI
+WI
+WI
+vy
+BS
+WQ
+uX
+uX
+uX
+"}
+(7,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+zU
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+pu
+WQ
+WQ
+NW
+Su
+Hu
+WQ
+sn
+JN
+Hu
+aV
+qH
+qH
+WQ
+ry
+WI
+WQ
+WQ
+Rj
+WQ
+WQ
+mp
+WQ
+re
+TQ
+WI
+WI
+WI
+AE
+WQ
+pK
+Kz
+uX
+"}
+(8,1,1) = {"
+uX
+uX
+uX
+Lg
+zU
+WQ
+WQ
+WQ
+qH
+WQ
+WQ
+WQ
+wp
+xj
+Tc
+aH
+WQ
+SM
+Px
+WQ
+ba
+Hd
+mb
+WQ
+ba
+Hd
+mb
+WQ
+qx
+So
+WQ
+BL
+WI
+So
+So
+So
+gF
+WQ
+XA
+WQ
+re
+eD
+EX
+WI
+WI
+AS
+gI
+pK
+pK
+uX
+"}
+(9,1,1) = {"
+uX
+zU
+qH
+bV
+WQ
+WQ
+jN
+kN
+So
+iy
+Px
+WQ
+GA
+zP
+GA
+In
+WQ
+dW
+WQ
+WQ
+MQ
+WI
+GA
+va
+GA
+WI
+jG
+WQ
+WI
+WI
+WQ
+SD
+WI
+GA
+GA
+GA
+GA
+MA
+ao
+gr
+WI
+TQ
+OY
+OY
+od
+HJ
+gI
+pK
+pK
+cz
+"}
+(10,1,1) = {"
+Lg
+jo
+Sg
+wD
+ce
+jM
+jY
+Yq
+wD
+Yq
+Yq
+Hq
+cw
+Hd
+Hd
+Hd
+JN
+JN
+Hd
+le
+WI
+Hd
+pX
+ic
+Nx
+Hd
+WI
+QI
+Hd
+Hd
+ZE
+WI
+Hd
+Hd
+Hd
+Hd
+Hd
+JN
+uF
+WQ
+Xj
+WI
+vy
+od
+WI
+FX
+gI
+pK
+pK
+pK
+"}
+(11,1,1) = {"
+uX
+mk
+qH
+bV
+WQ
+WQ
+mx
+xR
+zc
+rJ
+Px
+WQ
+WQ
+pu
+WQ
+kh
+OY
+OY
+OY
+WQ
+hu
+WI
+OY
+vI
+OY
+WI
+ko
+WQ
+Uq
+WI
+WQ
+OY
+WI
+wB
+mw
+xa
+ji
+df
+od
+gr
+WI
+vy
+GA
+GA
+ao
+HJ
+gI
+pK
+pK
+pK
+"}
+(12,1,1) = {"
+uX
+uX
+uX
+Lg
+mk
+WQ
+WQ
+WQ
+qH
+WQ
+WQ
+WQ
+Px
+lg
+WQ
+Ke
+bA
+pG
+Vf
+WQ
+fo
+Hd
+Um
+WQ
+fo
+Hd
+TE
+WQ
+iZ
+QH
+WQ
+BL
+WI
+WQ
+qH
+WQ
+nb
+WQ
+qH
+WQ
+xc
+WI
+WI
+jG
+Xj
+OG
+gI
+pK
+Kz
+uX
+"}
+(13,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+mk
+WQ
+WQ
+dW
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+BL
+JN
+Dg
+WQ
+BL
+Hd
+Hu
+aV
+qH
+qH
+WQ
+NS
+WI
+WQ
+iz
+Yk
+kz
+WN
+Ao
+WQ
+MC
+WI
+WI
+WI
+ao
+AE
+WQ
+pK
+pK
+uX
+"}
+(14,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+mk
+WQ
+WQ
+An
+WQ
+WQ
+WQ
+An
+aV
+aV
+uX
+uX
+WQ
+WQ
+HV
+WQ
+iz
+Dd
+kz
+yB
+Ao
+WQ
+RO
+WI
+WI
+WI
+TQ
+Pv
+WQ
+uX
+uX
+uX
+"}
+(15,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+ne
+Hp
+vm
+rr
+WQ
+Oy
+FA
+Dx
+YM
+JS
+WQ
+OM
+Qv
+OY
+OY
+UR
+aV
+WQ
+uX
+uX
+uX
+"}
+(16,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+ne
+Hp
+zh
+WO
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+qH
+sE
+WQ
+WQ
+CB
+uX
+uX
+uX
+"}
+(17,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+ne
+Hp
+Gr
+Qu
+sp
+Cv
+rw
+hv
+qe
+uX
+nS
+uX
+qH
+Ld
+jG
+gI
+tH
+uX
+uX
+uX
+uX
+"}
+(18,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+WQ
+nd
+OE
+Ol
+tx
+WQ
+cU
+WQ
+nS
+Lg
+nS
+qH
+kb
+ZZ
+gI
+tH
+uX
+uX
+uX
+uX
+"}
+(19,1,1) = {"
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+uX
+mk
+WQ
+qH
+qH
+WQ
+WQ
+WQ
+CB
+uX
+uX
+uX
+qH
+qH
+qH
+qH
+uX
+uX
+uX
+uX
+uX
+"}

--- a/_maps/shuttles/emergency_lance.dmm
+++ b/_maps/shuttles/emergency_lance.dmm
@@ -224,11 +224,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "ji" = (
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/shuttle/escape)
 "jo" = (
 /obj/machinery/door/airlock/external/ruin{
@@ -292,10 +296,11 @@
 	dir = 8
 	},
 /obj/item/borg/upgrade/defib,
-/obj/item/defibrillator,
 /obj/structure/closet/crate/medical{
 	anchored = 1
 	},
+/obj/item/defibrillator/loaded,
+/obj/item/defibrillator/loaded,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -358,6 +363,14 @@
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/east,
 /turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"mc" = (
+/obj/effect/turf_decal/tile/dark_blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/borg_restart_board,
+/turf/open/floor/iron/dark/side,
 /area/shuttle/escape)
 "mk" = (
 /obj/machinery/porta_turret/syndicate/energy/raven{
@@ -501,10 +514,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "qx" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "qH" = (
@@ -859,11 +870,9 @@
 /area/shuttle/escape)
 "FA" = (
 /obj/structure/window/reinforced/survival_pod/spawner,
-/obj/structure/table/reinforced,
-/obj/item/restraints/handcuffs{
-	pixel_y = 3
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/obj/item/restraints/handcuffs,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "FX" = (
@@ -912,6 +921,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Gw" = (
@@ -966,8 +976,6 @@
 /obj/machinery/recharger{
 	pixel_x = 5
 	},
-/obj/item/assembly/flash,
-/obj/item/wrench,
 /obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/textured,
@@ -1024,6 +1032,7 @@
 	},
 /obj/item/toy/nuke,
 /obj/machinery/light/small/directional/south,
+/obj/item/storage/medkit/regular,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "Ke" = (
@@ -1143,6 +1152,7 @@
 /area/shuttle/escape)
 "MZ" = (
 /obj/structure/rack,
+/obj/item/storage/medkit/advanced,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "Nx" = (
@@ -1193,6 +1203,10 @@
 /obj/structure/table/reinforced,
 /obj/item/toy/redbutton,
 /obj/machinery/light/small/directional/north,
+/obj/item/restraints/handcuffs{
+	pixel_y = 3
+	},
+/obj/item/restraints/handcuffs,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "OE" = (
@@ -1387,6 +1401,8 @@
 /area/shuttle/escape)
 "UG" = (
 /obj/structure/table/reinforced,
+/obj/item/wrench,
+/obj/item/assembly/flash,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "UR" = (
@@ -1460,6 +1476,10 @@
 	dir = 1
 	},
 /area/shuttle/escape)
+"Xr" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
 "XA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -1486,12 +1506,29 @@
 /area/shuttle/escape)
 "YM" = (
 /obj/structure/window/reinforced/survival_pod/spawner/north,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular,
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
 "YN" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/gun/energy/e_gun/mini{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun/mini,
+/obj/item/gun/energy/e_gun/mini{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/north,
+/obj/structure/window/reinforced/survival_pod/spawner,
+/obj/machinery/door/window/survival_pod{
+	dir = 4;
+	name = "emergency weapons";
+	req_access = list("command")
+	},
 /obj/structure/rack,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
@@ -1806,7 +1843,7 @@ WQ
 WQ
 WQ
 An
-aV
+WQ
 aV
 uX
 uX
@@ -1859,7 +1896,7 @@ WQ
 sn
 JN
 Hu
-aV
+WQ
 qH
 qH
 WQ
@@ -1887,7 +1924,7 @@ uX
 uX
 uX
 uX
-Lg
+uX
 zU
 WQ
 WQ
@@ -1913,7 +1950,7 @@ Hd
 mb
 WQ
 qx
-So
+Xr
 WQ
 BL
 WI
@@ -2085,7 +2122,7 @@ vy
 GA
 GA
 ao
-HJ
+mc
 gI
 pK
 pK
@@ -2095,7 +2132,7 @@ pK
 uX
 uX
 uX
-Lg
+uX
 mk
 WQ
 WQ
@@ -2171,7 +2208,7 @@ WQ
 BL
 Hd
 Hu
-aV
+WQ
 qH
 qH
 WQ
@@ -2222,7 +2259,7 @@ WQ
 WQ
 WQ
 An
-aV
+WQ
 aV
 uX
 uX

--- a/_maps/shuttles/emergency_lance.dmm
+++ b/_maps/shuttles/emergency_lance.dmm
@@ -100,11 +100,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
-"cU" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/iron/dark,
-/area/shuttle/escape)
 "df" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 8
@@ -135,7 +130,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "eD" = (
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -177,6 +176,24 @@
 /obj/structure/window/reinforced/survival_pod/spawner/north,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
+"hp" = (
+/obj/item/radio/intercom/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/blood/universal{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/blood/universal{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/hypospray/medipen/atropine,
+/obj/structure/closet/crate/medical{
+	name = "emergency survival supplies"
+	},
+/obj/item/reagent_containers/hypospray/medipen/blood_loss,
+/obj/item/reagent_containers/hypospray/medipen/blood_loss,
+/obj/item/reagent_containers/hypospray/medipen,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
 "hu" = (
 /obj/effect/turf_decal/tile/dark_blue{
 	dir = 8
@@ -188,7 +205,16 @@
 /area/shuttle/escape)
 "hv" = (
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"hz" = (
+/obj/structure/sign/warning/vacuum/external/directional/north,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw,
+/turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "ic" = (
 /obj/structure/table/reinforced,
@@ -216,13 +242,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape/brig)
-"iZ" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark/textured,
-/area/shuttle/escape)
 "ji" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
@@ -269,17 +288,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shuttle/escape)
-"jN" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/rack,
-/obj/item/stack/medical/gauze,
-/obj/item/stack/medical/bruise_pack,
-/obj/item/stack/medical/ointment{
-	pixel_x = 5
-	},
-/obj/item/radio,
-/turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "jY" = (
 /obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
@@ -351,12 +359,6 @@
 	},
 /turf/open/floor/iron,
 /area/shuttle/escape)
-"lg" = (
-/obj/structure/sign/warning/vacuum/external/directional/south,
-/obj/machinery/light/small/directional/south,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron/dark/textured,
-/area/shuttle/escape)
 "mb" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -370,6 +372,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/borg_restart_board,
+/obj/item/reagent_containers/cup/glass/mug/nanotrasen{
+	pixel_x = -11
+	},
 /turf/open/floor/iron/dark/side,
 /area/shuttle/escape)
 "mk" = (
@@ -474,7 +479,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "pG" = (
 /obj/structure/rack,
@@ -511,11 +520,11 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "qx" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/recharge_station,
+/obj/structure/rack,
+/obj/item/bodybag/environmental/nanotrasen,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "qH" = (
@@ -545,20 +554,13 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "ry" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
-/turf/open/floor/iron/dark/textured,
-/area/shuttle/escape)
-"rJ" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/item/radio/intercom/directional/east,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "sn" = (
@@ -600,6 +602,19 @@
 	},
 /obj/structure/sign/departments/medbay/alt/directional/south,
 /turf/open/floor/iron/dark/side,
+/area/shuttle/escape)
+"uK" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "uX" = (
 /turf/template_noop,
@@ -807,11 +822,37 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/shuttle/escape)
+"Cx" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
 "CB" = (
 /obj/machinery/porta_turret/syndicate/energy/raven{
 	dir = 6
 	},
 /turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"CR" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw,
+/turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "Dd" = (
 /obj/structure/window/reinforced/survival_pod/spawner,
@@ -985,6 +1026,12 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
+/obj/item/reagent_containers/blood/universal{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/blood/universal{
+	pixel_x = 3
+	},
 /turf/open/floor/iron/dark/side,
 /area/shuttle/escape)
 "HV" = (
@@ -1062,7 +1109,6 @@
 /area/shuttle/escape)
 "Ld" = (
 /obj/effect/turf_decal/tile/dark_blue,
-/obj/effect/spawner/random/medical/surgery_tool_advanced,
 /obj/item/storage/medkit/fire{
 	pixel_x = -2
 	},
@@ -1116,6 +1162,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
+"LD" = (
+/obj/machinery/door/airlock/external/ruin{
+	name = "Emegency Shuttle External Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
 "Mc" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -1154,6 +1213,11 @@
 /obj/structure/rack,
 /obj/item/storage/medkit/advanced,
 /turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
+"Nk" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron,
 /area/shuttle/escape)
 "Nx" = (
 /obj/structure/table/reinforced,
@@ -1352,6 +1416,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/checker,
 /area/shuttle/escape)
+"Sy" = (
+/obj/structure/sign/warning/vacuum/external/directional/south,
+/obj/machinery/light/small/directional/south,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
 "SD" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
@@ -1360,11 +1434,6 @@
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/shuttle/escape)
-"SM" = (
-/obj/structure/sign/warning/vacuum/external/directional/north,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "Tc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1435,6 +1504,17 @@
 	dir = 1
 	},
 /area/shuttle/escape)
+"Wg" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/rack,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/bruise_pack,
+/obj/item/stack/medical/ointment{
+	pixel_x = 5
+	},
+/obj/item/stack/medical/bone_gel/four,
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape)
 "WI" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron,
@@ -1458,7 +1538,11 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
 "Xc" = (
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw,
+/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
 "Xh" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -1483,6 +1567,11 @@
 "XA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"XY" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron,
 /area/shuttle/escape)
 "Yk" = (
 /obj/machinery/door/window/survival_pod{
@@ -1834,7 +1923,6 @@ uX
 uX
 uX
 uX
-uX
 zU
 WQ
 WQ
@@ -1845,6 +1933,7 @@ WQ
 An
 WQ
 aV
+uX
 uX
 uX
 WQ
@@ -1878,7 +1967,6 @@ uX
 uX
 uX
 uX
-uX
 zU
 WQ
 WQ
@@ -1886,7 +1974,7 @@ WQ
 WQ
 WQ
 WQ
-pu
+CR
 WQ
 WQ
 NW
@@ -1897,8 +1985,9 @@ sn
 JN
 Hu
 WQ
+WQ
 qH
-qH
+WQ
 WQ
 ry
 WI
@@ -1924,7 +2013,6 @@ uX
 uX
 uX
 uX
-uX
 zU
 WQ
 WQ
@@ -1938,7 +2026,7 @@ xj
 Tc
 aH
 WQ
-SM
+hz
 Px
 WQ
 ba
@@ -1949,6 +2037,7 @@ ba
 Hd
 mb
 WQ
+Xr
 qx
 Xr
 WQ
@@ -1973,13 +2062,12 @@ pK
 uX
 "}
 (9,1,1) = {"
-uX
 zU
 qH
 bV
 WQ
 WQ
-jN
+Wg
 kN
 So
 iy
@@ -1990,7 +2078,7 @@ zP
 GA
 In
 WQ
-dW
+LD
 WQ
 WQ
 MQ
@@ -2001,6 +2089,7 @@ GA
 WI
 jG
 WQ
+XY
 WI
 WI
 WQ
@@ -2025,7 +2114,6 @@ pK
 cz
 "}
 (10,1,1) = {"
-Lg
 jo
 Sg
 wD
@@ -2033,7 +2121,7 @@ ce
 jM
 jY
 Yq
-wD
+Yq
 Yq
 Yq
 Hq
@@ -2053,6 +2141,7 @@ Nx
 Hd
 WI
 QI
+Hd
 Hd
 Hd
 ZE
@@ -2077,7 +2166,6 @@ pK
 pK
 "}
 (11,1,1) = {"
-uX
 mk
 qH
 bV
@@ -2086,11 +2174,11 @@ WQ
 mx
 xR
 zc
-rJ
+hp
 Px
 WQ
 WQ
-pu
+uK
 WQ
 kh
 OY
@@ -2107,6 +2195,7 @@ ko
 WQ
 Uq
 WI
+Nk
 WQ
 OY
 WI
@@ -2132,7 +2221,6 @@ pK
 uX
 uX
 uX
-uX
 mk
 WQ
 WQ
@@ -2142,7 +2230,7 @@ WQ
 WQ
 WQ
 Px
-lg
+Sy
 WQ
 Ke
 bA
@@ -2157,7 +2245,8 @@ fo
 Hd
 TE
 WQ
-iZ
+QH
+QH
 QH
 WQ
 BL
@@ -2190,11 +2279,10 @@ uX
 uX
 uX
 uX
-uX
 mk
 WQ
 WQ
-dW
+Cx
 WQ
 WQ
 WQ
@@ -2209,8 +2297,9 @@ BL
 Hd
 Hu
 WQ
+WQ
 qH
-qH
+WQ
 WQ
 NS
 WI
@@ -2250,7 +2339,6 @@ uX
 uX
 uX
 uX
-uX
 mk
 WQ
 WQ
@@ -2261,6 +2349,7 @@ WQ
 An
 WQ
 aV
+uX
 uX
 uX
 WQ
@@ -2477,7 +2566,7 @@ OE
 Ol
 tx
 WQ
-cU
+Px
 WQ
 nS
 Lg

--- a/_maps/shuttles/emergency_lance.dmm
+++ b/_maps/shuttles/emergency_lance.dmm
@@ -1526,7 +1526,7 @@
 /obj/structure/window/reinforced/survival_pod/spawner,
 /obj/machinery/door/window/survival_pod{
 	dir = 4;
-	name = "emergency weapons";
+	name = "Emergency Weapons";
 	req_access = list("command")
 	},
 /obj/structure/rack,

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -1041,8 +1041,8 @@
 /area/shuttle/escape)
 "oI" = (
 /obj/machinery/airalarm/unlocked{
-	dir = 1;
-	pixel_y = 23
+	pixel_y = 23;
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -1041,8 +1041,8 @@
 /area/shuttle/escape)
 "oI" = (
 /obj/machinery/airalarm/unlocked{
-	pixel_y = 23;
-	dir = 1
+	dir = 1;
+	pixel_y = 23
 	},
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -466,6 +466,13 @@
 	admin_notes = "There's a chasm in it, it has railings but that won't stop determined players."
 	credit_cost = CARGO_CRATE_VALUE * 10
 
+/datum/map_template/shuttle/emergency/lance
+	suffix = "lance"
+	name = "The Lance Crew Evacuation System"
+	description = "A brand new shuttle by Nanotrasen's finest in shuttle-engineering, it's designed to tactically slam into a destroyed station, dispatching threats and saving crew at the same time! Be careful to stay out of it's path."
+	admin_notes = "WARNING: This shuttle is designed to crash into the station. It has turrets, similar to the raven."
+	credit_cost = CARGO_CRATE_VALUE * 70
+
 /datum/map_template/shuttle/ferry/base
 	suffix = "base"
 	name = "transport ferry"

--- a/config/unbuyableshuttles.txt
+++ b/config/unbuyableshuttles.txt
@@ -22,6 +22,7 @@
 #_maps/shuttles/emergency_discoinferno.dmm
 #_maps/shuttles/emergency_goon.dmm
 #_maps/shuttles/emergency_imfedupwiththisworld.dmm
+#_maps/shuttles/emergency_lance.dmm
 #_maps/shuttles/emergency_luxury.dmm
 #_maps/shuttles/emergency_meteor.dmm
 #_maps/shuttles/emergency_raven.dmm


### PR DESCRIPTION
## About The Pull Request
Yeah this shuttle deliberately hits the station.
While more hazardous to people in departures, the Lance is a great crew-friendly tool for a station that has a severely damaged departures! No longer will you need to struggle with firelocks and collapse just outside the shuttle in a depressurized departures, when The Lance comes RIGHT TO YOU.

<details>
<summary> The Lance being used </summary>

![image](https://cdn.discordapp.com/attachments/585862469508005888/1087777600535003266/image.png)

</details>

<details>

<summary> Map screenshot! </summary>

![image](https://user-images.githubusercontent.com/73589390/226687950-3844ade3-ee90-4056-b923-c1a9b460eb61.png)

</details>

### Mapping March
Ckey to receive rewards: Cheshify 
I don't need a token or anything, but the GBP or whatever would be nice so I can make more map stuff

## Why It's Good For The Game

New shuttles are good! This one has both immense pros (very safe when you're inside it, lots of supplies) and immense cons (smashes into the fucking station). It'll be an interesting purchase for the antagonist using it to kill a bunch of people in departures, and a useful tool for the crew making it easier for them to evacuate.

This shuttle is not restricted to emags or any other prerequisite, as that would defeat the purpose. It's supposed to be a mixture of pros and cons, and keeping it locked behind an emag removes it's use as a prohibitively expensive but ultimately useful tool for the crew.
## Changelog
:cl:
add: Nanotrasen has given the crew access to a brand new emergency shuttle! Watch out for it's destructive entrance!
/:cl:
