### PR TITLE
Prevents airlocks from shocking players who use the rust mansus grip on them

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -67,14 +67,13 @@
 /datum/heretic_knowledge/rust_fist/proc/on_secondary_mansus_grasp(mob/living/source, atom/target)
 	SIGNAL_HANDLER
 
-	target.rust_heretic_act()
-
 	// Rusting an airlock causes it to lose power, mostly to prevent the airlock from shocking you.
 	// This is a bit of a hack, but fixing this would require the enture wire cut/pulse system to be reworked.
 	if(istype(target, /obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/airlock = target
 		airlock.loseMainPower()
 
+	target.rust_heretic_act()
 	return COMPONENT_USE_HAND
 
 /datum/heretic_knowledge/rust_regen

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -68,6 +68,13 @@
 	SIGNAL_HANDLER
 
 	target.rust_heretic_act()
+
+	// Rusting an airlock causes it to lose power, mostly to prevent the airlock from shocking you.
+	// This is a bit of a hack, but fixing this would require the enture wire cut/pulse system to be reworked.
+	if(istype(target, /obj/machinery/door/airlock))
+		var/obj/machinery/door/airlock/airlock = target
+		airlock.loseMainPower()
+
 	return COMPONENT_USE_HAND
 
 /datum/heretic_knowledge/rust_regen


### PR DESCRIPTION

## About The Pull Request

Wire code is hell and needs a refactor bad; maybe I'll do that in the future.
### Mapping March
Ckey to receive rewards: N/A

## Why It's Good For The Game

Closes #73989 
## Changelog
:cl:
fix: airlocks will no longer shock you when using the rust mansus grip to destroy them
/:cl:
