### PR TITLE
Pocket Protectors drop items on detach

### DIFF
--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -362,6 +362,12 @@
 
 	create_storage(storage_type = /datum/storage/pockets/pocketprotector)
 
+/obj/item/clothing/accessory/pocketprotector/detach(obj/item/clothing/under/U, user)
+	var/drop_loc = drop_location()
+	for(var/atom/movable/held as anything in src)
+		held.forceMove(drop_loc)
+	return ..()
+
 /obj/item/clothing/accessory/pocketprotector/full/Initialize(mapload)
 	. = ..()
 


### PR DESCRIPTION

## About The Pull Request

Prevents having the ability to take items from nullspace anywhere
Closes https://github.com/tgstation/tgstation/issues/73637
### Mapping March
Ckey to receive rewards: N/A

## Why It's Good For The Game
## Changelog
:cl:
fix: You can no longer use Pocket Protectors to pull items out of nullspace
/:cl:
