### PR TITLE
Fixes some incorrect uses of `rand()`

### DIFF
--- a/code/game/objects/items/maintenance_loot.dm
+++ b/code/game/objects/items/maintenance_loot.dm
@@ -41,4 +41,5 @@
 /obj/item/stock_parts/cell/lead/Initialize(mapload)
 	AddElement(/datum/element/update_icon_blocker)
 	. = ..()
-	charge = rand(0.2,0.8) * maxcharge
+	var/initial_percent = rand(20, 80) / 100
+	charge = initial_percent * maxcharge

--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_actions.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_actions.dm
@@ -23,7 +23,7 @@
 	burrower.invisibility = INVISIBILITY_MAXIMUM
 	burrower.forceMove(unburrow_turf)
 	//not that it's gonna die with godmode but still
-	SLEEP_CHECK_DEATH(rand(0.75 SECONDS, 1.25 SECONDS), burrower)
+	SLEEP_CHECK_DEATH(rand(0.7 SECONDS, 1.2 SECONDS), burrower)
 	playsound(burrower, 'sound/effects/break_stone.ogg', 50, TRUE)
 	new /obj/effect/temp_visual/mook_dust(unburrow_turf)
 	burrower.status_flags &= ~GODMODE
@@ -108,7 +108,7 @@
 	devourer.invisibility = INVISIBILITY_MAXIMUM
 	devourer.forceMove(devour_turf)
 	//not that it's gonna die with godmode but still
-	SLEEP_CHECK_DEATH(rand(0.75 SECONDS, 1.25 SECONDS), devourer)
+	SLEEP_CHECK_DEATH(rand(0.7 SECONDS, 1.2 SECONDS), devourer)
 	playsound(devourer, 'sound/effects/break_stone.ogg', 50, TRUE)
 	new /obj/effect/temp_visual/mook_dust(devour_turf)
 	devourer.status_flags &= ~GODMODE

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -477,7 +477,7 @@
 		if(!recently_examined && !prob(YAWN_PROPAGATE_CHANCE_BASE - (YAWN_PROPAGATE_CHANCE_DECAY * dist_between)))
 			continue
 
-		var/yawn_delay = rand(0.25 SECONDS, 0.75 SECONDS) * dist_between
+		var/yawn_delay = rand(0.2 SECONDS, 0.7 SECONDS) * dist_between
 		addtimer(CALLBACK(src, PROC_REF(propagate_yawn), iter_living), yawn_delay)
 
 /// This yawn has been triggered by someone else yawning specifically, likely after a delay. Check again if they don't have the yawned recently trait


### PR DESCRIPTION
## About The Pull Request

`Rand` only takes integers 

![image](https://user-images.githubusercontent.com/51863163/225454770-bdb70aca-ed43-4c17-a943-2ec99720b53d.png)

![image](https://user-images.githubusercontent.com/51863163/225454784-8f9cc053-8e7d-46fd-b6b2-42efb0751d5e.png)

## Why It's Good For The Game

Less misleading code

## Changelog

:cl: Melbert
fix: Lead batteries now start partially drained as intended. 
/:cl:
