### PR TITLE
Fixes the 'shoot borgs' turret setting being nonfunctional for syndicate faction turrets

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -456,7 +456,9 @@ DEFINE_BITFIELD(turret_flags, list(
 				var/mob/living/silicon/robot/sillyconerobot = A
 				if(sillyconerobot.stat != CONSCIOUS)
 					continue
-				if(in_faction(sillyconerobot))
+				if(in_faction(sillyconerobot)) // borgs in faction are friendly
+					continue
+				if((ROLE_SYNDICATE in faction) && sillyconerobot.emagged) // special case: emagged station borgs are friendly to syndicate turrets
 					continue
 
 				targets += sillyconerobot

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -443,7 +443,6 @@ DEFINE_BITFIELD(turret_flags, list(
 				continue
 
 		if(issilicon(A))
-		
 			if(!(turret_flags & TURRET_FLAG_SHOOT_BORGS))
 				continue
 		

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -443,6 +443,10 @@ DEFINE_BITFIELD(turret_flags, list(
 				continue
 
 		if(issilicon(A))
+		
+			if(!(turret_flags & TURRET_FLAG_SHOOT_BORGS))
+				continue
+		
 			var/mob/living/silicon/sillycone = A
 
 			if(ispAI(A))
@@ -452,13 +456,10 @@ DEFINE_BITFIELD(turret_flags, list(
 				var/mob/living/silicon/robot/sillyconerobot = A
 				if(sillyconerobot.stat != CONSCIOUS)
 					continue
-				if((turret_flags & TURRET_FLAG_SHOOT_BORGS))
-					targets += sillyconerobot
-					continue
 				if(in_faction(sillyconerobot))
 					continue
-				if((ROLE_SYNDICATE in faction) && !sillyconerobot.emagged)
-					targets += sillyconerobot
+
+				targets += sillyconerobot
 
 		else if(iscarbon(A))
 			var/mob/living/carbon/C = A
@@ -731,6 +732,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	icon_state = "syndie_off"
 	base_icon_state = "syndie"
 	faction = list(ROLE_SYNDICATE)
+	turret_flags = TURRET_FLAG_SHOOT_CRIMINALS | TURRET_FLAG_SHOOT_ANOMALOUS | TURRET_FLAG_SHOOT_BORGS
 	desc = "A ballistic machine gun auto-turret."
 
 /obj/machinery/porta_turret/syndicate/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

#64650 made it so that syndicate turrets target station borgs but they did it in a weird, confusing, and hardcoded way that does not respect the turret settings for turrets belonging to the syndicate faction. 

Instead I slightly altered the logic to go like this:

1) Check for the Target Cyborgs setting, if it's off then that's that. Skip that mob. It should simply not target cyborgs at all, under any circumstances, as the setting implies.
2) If they can in fact Target Cyborgs, then check the faction of the cyborg to see if they can shoot it. If not, skip.
3) Finally, the special case, if the turret belongs to the syndicate faction and the cyborg is an emagged non-syndicate borg, consider it friendly and skip it.

Syndicate turrets and subtypes will now have cyborg targeting enabled by default.

This means that they will still (unless the setting is tampered with) defend the syndicate ships against station cyborgs.

---

Note: The only potential issue I can foresee is if there is a map that uses some weird var edited Syndicate faction turret instead of the syndicate subtypes. If that is the case anywhere, they should first off not be varedits but second all they have to do is varedit the turret flags to turn on that setting for said snowflake turret.


Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/18540

## Why It's Good For The Game

Better code logic, less unexpected outcomes. Now Syndicate turrets aren't hardlocked on one of their settings.

<details>
<summary>Syndicate turret and its subtypes spawn with the right setting</summary>
  
![image](https://user-images.githubusercontent.com/13398309/225512951-2979e8f9-566b-4bf6-892f-344bc43363cc.png)

</details>

<details>
<summary>Station borgs still get shot at by syndie turrets</summary>

 ![image](https://user-images.githubusercontent.com/13398309/225512923-e7ae696f-c646-43b1-9865-aae5c638186c.png)

</details>

<details>
<summary>Syndicate borgs do not get shot at by syndie turrets</summary>

![image](https://user-images.githubusercontent.com/13398309/225517582-29147e7f-19a9-4ce8-a70e-925d67928e49.png)

</details>

## Changelog

:cl:
fix: the 'target cyborgs' option for syndicate turrets is now functional again, and enabled by default. Station borgs will still be shot at on sight unless a syndicate crew member deliberately configures the turrets otherwise.
/:cl:
