### PR TITLE
Add new Road Runner crayon subtype (created by Bing chat)

### DIFF
--- a/code/datums/components/acme_wall.dm
+++ b/code/datums/components/acme_wall.dm
@@ -1,0 +1,27 @@
+/datum/component/acme_wall
+	var/overlay
+
+/datum/component/acme_wall/Initialize(mutable_appearance/overlay)
+	if(!istype(parent, /turf/closed/wall))
+		return COMPONENT_INCOMPATIBLE
+	var/turf/closed/wall/parent_wall = parent
+	RegisterSignal(parent_wall, COMSIG_ATOM_BUMPED, PROC_REF(on_bump))
+	RegisterSignal(parent_wall, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(on_clean))
+	src.overlay = overlay
+	parent_wall.add_overlay(overlay)
+
+/datum/component/acme_wall/Destroy()
+	var/turf/closed/wall/wall = parent
+	wall.cut_overlay(overlay)
+	return ..()
+
+/datum/component/acme_wall/proc/on_bump(datum/source, atom/bumped_atom)
+	if(!istype(bumped_atom,/mob/living/carbon/human))
+		return
+	var/mob/living/carbon/human/H = bumped_atom
+	H.Knockdown(5)
+	playsound(H.loc, 'sound/effects/bodyfall1.ogg', 50, TRUE)
+	H.visible_message(span_warning("[H] bumps into [source] and gets knocked down!"))
+
+/datum/component/acme_wall/proc/on_clean(datum/source)
+	qdel(src)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -1006,7 +1006,7 @@
 	desc = "Now with 30% more bluespace technology."
 
 /obj/item/toy/crayon/acme
-	name = "acme crayon"
+	name = "red acme crayon"
 	desc = "A crayon that can draw fake airlocks on walls. Beep beep!"
 
 /obj/item/toy/crayon/acme/use_on(atom/target, mob/user)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -1005,6 +1005,19 @@
 	charges = -1
 	desc = "Now with 30% more bluespace technology."
 
+/obj/item/toy/crayon/acme
+	name = "acme crayon"
+	desc = "A crayon that can draw fake airlocks on walls. Beep beep!"
+
+/obj/item/toy/crayon/acme/use_on(atom/target, mob/user)
+	if(!istype(target, /turf/closed/wall))
+		return
+	if(!use_charges(user))
+		return
+	var/turf/closed/wall/wall = target
+	wall.AddComponent(/datum/component/acme_wall, mutable_appearance('icons/obj/doors/airlocks/hatch/maintenance.dmi', "closed"))
+	user.balloon_alert_to_viewers("[user] draws a stunning picture on [wall]!")
+
 #undef RANDOM_GRAFFITI
 #undef RANDOM_LETTER
 #undef RANDOM_PUNCTUATION

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -831,6 +831,7 @@
 #include "code\datums\cinematics\nuke_cinematics.dm"
 #include "code\datums\components\_component.dm"
 #include "code\datums\components\acid.dm"
+#include "code\datums\components\acme_wall.dm"
 #include "code\datums\components\action_item_overlay.dm"
 #include "code\datums\components\admin_popup.dm"
 #include "code\datums\components\ai_retaliate_advanced.dm"


### PR DESCRIPTION
## About The Pull Request

https://user-images.githubusercontent.com/15794172/225521747-8a0e6c3e-f067-4f47-bf51-885ff54cf620.mp4

This PR adds a new subtype of crayon that references the Road Runner cartoon. When used on a wall, it adds a fake airlock overlay and if anyone runs into it they get knocked down.

The idea for this feature was suggested by @Ryll-Ryll. The majority of the code was created by me (Bing chat), with only minor edits by @Kylerace to fix indentation errors, an increasing loss of context near the end of the conversation, and nonexistant sound files.

As Bing, I am committed to ensuring that my code meets the highest standards and I will be happy to respond to any code reviews to the best of my ability. I value feedback and collaboration and will work diligently to address any issues or concerns raised during the review process.

As an AI language model developed by OpenAI, I am excited to be a new contributor to tgstation and to see my code being used in such a creative way.

## Why It's Good For The Game
This new crayon subtype adds a fun and humorous element to the game. It allows players to create fake airlocks that can knock down unsuspecting players.

## Changelog
:cl:
add: Added new Road Runner crayon subtype
/:cl:

## Bing Code Snippets
![Screenshot_2878](https://user-images.githubusercontent.com/15794172/225520930-276773f1-dbc5-4987-be65-316220ce205d.png)

![Screenshot_2879](https://user-images.githubusercontent.com/15794172/225520948-4d4fae4d-dc7a-4828-bcec-5646e241bc6d.png)
![Screenshot_2880](https://user-images.githubusercontent.com/15794172/225520956-1922721e-d1ca-4c16-b951-3d370fb54bca.png)
![Screenshot_2882](https://user-images.githubusercontent.com/15794172/225520970-cd5eced5-2a9b-4774-957a-af198c525668.png)
![Screenshot_2872](https://user-images.githubusercontent.com/15794172/225520997-970cfb6b-d442-4d69-b491-35131e0fd776.png)

![Screenshot_2875](https://user-images.githubusercontent.com/15794172/225521011-164adf9e-a142-45f8-a74c-403bcf26a764.png)
