### PR TITLE
[NO GBP] Corrects the pinata kit's Supply console category

### DIFF
--- a/code/modules/cargo/packs/costumes_toys.dm
+++ b/code/modules/cargo/packs/costumes_toys.dm
@@ -306,7 +306,7 @@
 	if(prob(30)) // a pair of googly eyes because funny
 		new /obj/item/storage/box/stickers/googly(crate)
 
-/datum/supply_pack/constumes_toys/pinata
+/datum/supply_pack/costumes_toys/pinata
 	name = "Corgi Pinata Kit"
 	desc = "This crate contains a pinata full of candy, a blindfold and a bat for smashing it."
 	cost = CARGO_CRATE_VALUE * 4


### PR DESCRIPTION

## About The Pull Request

I misspelt costume in a typepath, causing pinata's to be in an unnamed category on supply consoles.
## Why It's Good For The Game

Bugfix good
## Changelog
:cl:
fix: Corgi pinata's no longer have their own category on the cargo shuttle console.
/:cl:
