### PR TITLE
Prevent recyclers from recycling cyborg contents (causes null model), prevent recyclers from recycling indestructible contents, fixes a critical roundend null model runtime

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -57,7 +57,7 @@
 						mob_data["module"] = "pAI"
 					else if(iscyborg(L))
 						var/mob/living/silicon/robot/R = L
-						mob_data["module"] = R.model.name
+						mob_data["module"] = (R.model ? R.model.name : "Null Model")
 				else
 					category = "others"
 					mob_data["typepath"] = M.type


### PR DESCRIPTION
## About The Pull Request

Makes recyclers unable to recycle cyborg contents, which would cause its model to get deleted which would later cause a null model which would later break the roundend report

In addition, if a model is somehow null at roundend stops the runtime by just replacing it with "Null Model"

Also fixes an exploit where you could just recycle the blackbox by putting it into a locker

## Why It's Good For The Game

Fixes #69307 (was priority critical)
probably fixes #65316
Cyborg insides are very much not fit for qdeletion
Now you cant also shove the blackbox in a locker and push it into a recycler to destroy it

## Changelog
:cl:
fix: You can no longer bypass recyclers indestructibility check by just putting it into something
fix: Recyclers can no longer recycle the insides of cyborgs
/:cl:
