### PR TITLE
Admins can now customize the wisdom cow event.

### DIFF
--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -1,17 +1,23 @@
 /datum/round_event_control/wisdomcow
-	name = "Wisdom cow"
+	name = "Wisdom Cow"
 	typepath = /datum/round_event/wisdomcow
 	max_occurrences = 1
 	weight = 20
 	category = EVENT_CATEGORY_FRIENDLY
 	description = "A cow appears to tell you wise words."
-	admin_setup = list(/datum/event_admin_setup/set_location/wisdom_cow, /datum/event_admin_setup/listed_options/wisdom_cow)
+	admin_setup = list(
+		/datum/event_admin_setup/set_location/wisdom_cow,
+		/datum/event_admin_setup/listed_options/wisdom_cow,
+		/datum/event_admin_setup/input_number/wisdom_cow,
+	)
 
 /datum/round_event/wisdomcow
 	///Admin set overide location for the cow.
 	var/turf/admin_spawn_location
 	///Admin set override for the wisdom the cow will grant.
 	var/admin_selected_wisdom
+	///Admin set override for the amount of experience the wisdom cow will grant or remove
+	var/admin_selected_experience
 
 /datum/round_event/wisdomcow/announce(fake)
 	priority_announce("A wise cow has been spotted in the area. Be sure to ask for her advice.", "Nanotrasen Cow Ranching Agency")
@@ -22,7 +28,7 @@
 		targetloc = admin_spawn_location
 	else
 		targetloc = get_safe_random_station_turf()
-	var/mob/living/basic/cow/wisdom/wise = new(targetloc, admin_selected_wisdom)
+	var/mob/living/basic/cow/wisdom/wise = new(targetloc, admin_selected_wisdom, admin_selected_experience)
 	do_smoke(1, holder = wise, location = targetloc)
 	announce_to_ghosts(wise)
 
@@ -41,3 +47,14 @@
 
 /datum/event_admin_setup/listed_options/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
 	event.admin_selected_wisdom = chosen
+
+/datum/event_admin_setup/input_number/wisdom_cow
+	input_text = "How much experience should this cow grant."
+	default_value = 500
+	max_value = 2500
+	min_value = -2500
+
+/datum/event_admin_setup/input_number/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
+	event.admin_selected_experience = chosen_value
+	
+	

--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -5,13 +5,39 @@
 	weight = 20
 	category = EVENT_CATEGORY_FRIENDLY
 	description = "A cow appears to tell you wise words."
+	admin_setup = list(/datum/event_admin_setup/set_location/wisdom_cow, /datum/event_admin_setup/listed_options/wisdom_cow)
+
+/datum/round_event/wisdomcow
+	///Admin set overide location for the cow.
+	var/turf/admin_spawn_location
+	///Admin set override for the wisdom the cow will grant.
+	var/admin_selected_wisdom
 
 /datum/round_event/wisdomcow/announce(fake)
 	priority_announce("A wise cow has been spotted in the area. Be sure to ask for her advice.", "Nanotrasen Cow Ranching Agency")
 
 /datum/round_event/wisdomcow/start()
-	var/turf/targetloc = get_safe_random_station_turf()
-	var/mob/living/basic/cow/wisdom/wise = new (targetloc)
+	var/turf/targetloc
+	if(admin_spawn_location)
+		targetloc = admin_spawn_location
+	else
+		targetloc = get_safe_random_station_turf()
+	var/mob/living/basic/cow/wisdom/wise = new(targetloc, admin_selected_wisdom)
 	do_smoke(1, holder = wise, location = targetloc)
 	announce_to_ghosts(wise)
 
+/datum/event_admin_setup/set_location/wisdom_cow
+	input_text = "Spawn on current turf?"
+
+/datum/event_admin_setup/set_location/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
+	event.admin_spawn_location = chosen_turf
+
+/datum/event_admin_setup/listed_options/wisdom_cow
+	input_text = "Select a specific wisdom type?"
+	normal_run_option = "Random Wisdom"
+
+/datum/event_admin_setup/listed_options/wisdom_cow/get_list()
+	return subtypesof(/datum/skill)
+
+/datum/event_admin_setup/listed_options/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
+	event.admin_selected_wisdom = chosen

--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -12,23 +12,23 @@
 	)
 
 /datum/round_event/wisdomcow
-	///Admin set overide location for the cow.
-	var/turf/admin_spawn_location
-	///Admin set override for the wisdom the cow will grant.
-	var/admin_selected_wisdom
-	///Admin set override for the amount of experience the wisdom cow will grant or remove
-	var/admin_selected_experience
+	///Location override that, if set causes the cow to spawn in a pre-determined locaction instead of randomly.
+	var/turf/spawn_location
+	///An override that, if set rigs the cow to spawn with a specific wisdow rather than a random one.
+	var/selected_wisdom
+	///An override that, if set modifies the amount of wisdow the cow will add/remove, if not set will default to 500.
+	var/selected_experience
 
 /datum/round_event/wisdomcow/announce(fake)
 	priority_announce("A wise cow has been spotted in the area. Be sure to ask for her advice.", "Nanotrasen Cow Ranching Agency")
 
 /datum/round_event/wisdomcow/start()
 	var/turf/targetloc
-	if(admin_spawn_location)
-		targetloc = admin_spawn_location
+	if(spawn_location)
+		targetloc = spawn_location
 	else
 		targetloc = get_safe_random_station_turf()
-	var/mob/living/basic/cow/wisdom/wise = new(targetloc, admin_selected_wisdom, admin_selected_experience)
+	var/mob/living/basic/cow/wisdom/wise = new(targetloc, selected_wisdom, selected_experience)
 	do_smoke(1, holder = wise, location = targetloc)
 	announce_to_ghosts(wise)
 
@@ -36,7 +36,7 @@
 	input_text = "Spawn on current turf?"
 
 /datum/event_admin_setup/set_location/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
-	event.admin_spawn_location = chosen_turf
+	event.spawn_location = chosen_turf
 
 /datum/event_admin_setup/listed_options/wisdom_cow
 	input_text = "Select a specific wisdom type?"
@@ -46,7 +46,7 @@
 	return subtypesof(/datum/skill)
 
 /datum/event_admin_setup/listed_options/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
-	event.admin_selected_wisdom = chosen
+	event.selected_wisdom = chosen
 
 /datum/event_admin_setup/input_number/wisdom_cow
 	input_text = "How much experience should this cow grant."
@@ -55,6 +55,6 @@
 	min_value = -2500
 
 /datum/event_admin_setup/input_number/wisdom_cow/apply_to_event(datum/round_event/wisdomcow/event)
-	event.admin_selected_experience = chosen_value
+	event.selected_experience = chosen_value
 	
 	

--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -49,7 +49,7 @@
 	event.selected_wisdom = chosen
 
 /datum/event_admin_setup/input_number/wisdom_cow
-	input_text = "How much experience should this cow grant."
+	input_text = "How much experience should this cow grant?"
 	default_value = 500
 	max_value = 2500
 	min_value = -2500

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
@@ -6,12 +6,17 @@
 	ai_controller = /datum/ai_controller/basic_controller/cow/wisdom
 	///The type of wisdom this cow will grant
 	var/granted_wisdom
+	///How much experience this cow will grant.
+	var/granted_experience
 
-/mob/living/basic/cow/wisdom/Initialize(mapload, granted_wisdom)
+/mob/living/basic/cow/wisdom/Initialize(mapload, granted_wisdom, granted_experience = 500)
 	. = ..()
 	src.granted_wisdom = granted_wisdom
 	if(!granted_wisdom)
 		src.granted_wisdom = pick(GLOB.skill_types)
+	src.granted_experience = granted_experience
+	if(granted_experience < 0)
+		name = "unwise cow"
 
 /mob/living/basic/cow/wisdom/setup_eating()
 	return //cannot tame me! and I don't care about eatin' nothing, neither!
@@ -32,7 +37,7 @@
 /mob/living/basic/cow/wisdom/attack_hand(mob/living/carbon/user, list/modifiers)
 	if(!stat && !user.combat_mode)
 		to_chat(user, span_nicegreen("[src] whispers you some intense wisdoms and then disappears!"))
-		user.mind?.adjust_experience(granted_wisdom, 500)
+		user.mind?.adjust_experience(granted_wisdom, granted_experience)
 		do_smoke(1, holder = src, location = get_turf(src))
 		qdel(src)
 		return

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
@@ -7,12 +7,12 @@
 	///The type of wisdom this cow will grant
 	var/granted_wisdom
 
-/mob/living/basic/cow/wisdom/Initialize(mapload, wisdom_override)
+/mob/living/basic/cow/wisdom/Initialize(mapload, granted_wisdom)
 	. = ..()
-	if(wisdom_override)
-		granted_wisdom = wisdom_override
+	if(granted_wisdom)
+		src.granted_wisdom = granted_wisdom
 	else
-		granted_wisdom = pick(GLOB.skill_types)
+		src.granted_wisdom = pick(GLOB.skill_types)
 
 /mob/living/basic/cow/wisdom/setup_eating()
 	return //cannot tame me! and I don't care about eatin' nothing, neither!

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
@@ -4,6 +4,15 @@
 	desc = "Known for its wisdom, shares it with all."
 	gold_core_spawnable = FALSE
 	ai_controller = /datum/ai_controller/basic_controller/cow/wisdom
+	///The type of wisdom this cow will grant
+	var/granted_wisdom
+
+/mob/living/basic/cow/wisdom/Initialize(mapload, wisdom_override)
+	. = ..()
+	if(wisdom_override)
+		granted_wisdom = wisdom_override
+	else
+		granted_wisdom = pick(GLOB.skill_types)
 
 /mob/living/basic/cow/wisdom/setup_eating()
 	return //cannot tame me! and I don't care about eatin' nothing, neither!
@@ -24,7 +33,7 @@
 /mob/living/basic/cow/wisdom/attack_hand(mob/living/carbon/user, list/modifiers)
 	if(!stat && !user.combat_mode)
 		to_chat(user, span_nicegreen("[src] whispers you some intense wisdoms and then disappears!"))
-		user.mind?.adjust_experience(pick(GLOB.skill_types), 500)
+		user.mind?.adjust_experience(granted_wisdom, 500)
 		do_smoke(1, holder = src, location = get_turf(src))
 		qdel(src)
 		return

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_wisdom.dm
@@ -9,9 +9,8 @@
 
 /mob/living/basic/cow/wisdom/Initialize(mapload, granted_wisdom)
 	. = ..()
-	if(granted_wisdom)
-		src.granted_wisdom = granted_wisdom
-	else
+	src.granted_wisdom = granted_wisdom
+	if(!granted_wisdom)
 		src.granted_wisdom = pick(GLOB.skill_types)
 
 /mob/living/basic/cow/wisdom/setup_eating()


### PR DESCRIPTION

## About The Pull Request

Gives admins the ability to customize the spawn location of the cow and the wisdom that it grants.
## Why It's Good For The Game

Wisdom cows lack any sort of customization at present, this allows admins to set what type of wisdom which is granted which may be thematic for events and adding positional spawn support for them is a pretty easy addition.
## Changelog
:cl:
admin: Admins can now customize the wisdom cow event.
/:cl:
