### PR TITLE
[NO GBP] Fixes vents & scrubbers getting assigned twice to an area when it's merged with another area via station blueprints. Code clean up.

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -90,8 +90,8 @@
 	if (old_area == new_area)
 		return
 
-	disconnect_from_area()
-	assign_to_area()
+	disconnect_from_area(old_area)
+	assign_to_area(new_area)
 
 /obj/machinery/atmospherics/components/unary/vent_pump/on_enter_area(datum/source, area/area_to_register)
 	assign_to_area(area_to_register)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -28,10 +28,13 @@
 	// ATMOS_INTERNAL_BOUND: Do not pass internal_pressure_bound
 	// NO_BOUND: Do not pass either
 
-	///id of air sensor its connected to
+	/// id of air sensor its connected to
 	var/chamber_id
 
-/obj/machinery/atmospherics/components/unary/vent_pump/New()
+	///area this vent is assigned to
+	var/area/assigned_area
+
+/obj/machinery/atmospherics/components/unary/vent_pump/Initialize(mapload)
 	if(!id_tag)
 		id_tag = SSnetworks.assign_random_name()
 		var/static/list/tool_screentips = list(
@@ -40,9 +43,6 @@
 			)
 		)
 		AddElement(/datum/element/contextual_screentip_tools, tool_screentips)
-	. = ..()
-
-/obj/machinery/atmospherics/components/unary/vent_pump/Initialize(mapload)
 	. = ..()
 	assign_to_area()
 
@@ -98,12 +98,19 @@
 	. = ..()
 
 /obj/machinery/atmospherics/components/unary/vent_pump/proc/assign_to_area(area/target_area = get_area(src))
-	if(!isnull(target_area))
-		target_area.air_vents += src
-		update_appearance(UPDATE_NAME)
+	//this vent is already assigned to an area. Unassign it from here first before reassigning it to an new area
+	if(isnull(target_area) || !isnull(assigned_area))
+		return
+	assigned_area = target_area
+	assigned_area.air_vents += src
+	update_appearance(UPDATE_NAME)
 
 /obj/machinery/atmospherics/components/unary/vent_pump/proc/disconnect_from_area(area/target_area = get_area(src))
-	target_area?.air_vents -= src
+	//you cannot unassign from an area we never were assigned to
+	if(isnull(target_area) || assigned_area != target_area)
+		return
+	assigned_area.air_vents -= src
+	assigned_area = null
 
 /obj/machinery/atmospherics/components/unary/vent_pump/on_exit_area(datum/source, area/area_to_unregister)
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -60,8 +60,8 @@
 	if (old_area == new_area)
 		return
 
-	disconnect_from_area()
-	assign_to_area()
+	disconnect_from_area(old_area)
+	assign_to_area(new_area)
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on_enter_area(datum/source, area/area_to_register)
 	assign_to_area(area_to_register)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -26,22 +26,22 @@
 	///List of the turfs near the scrubber, used for widenet
 	var/list/turf/adjacent_turfs = list()
 
-	//Enables the use of plunger_act for ending the vent clog random event
+	///Enables the use of plunger_act for ending the vent clog random event
 	var/clogged = FALSE
+	///The area this scrubber is assigned to
+	var/area/assigned_area
 
 	COOLDOWN_DECLARE(check_turfs_cooldown)
 
-/obj/machinery/atmospherics/components/unary/vent_scrubber/New()
+/obj/machinery/atmospherics/components/unary/vent_scrubber/Initialize(mapload)
 	if(!id_tag)
 		id_tag = SSnetworks.assign_random_name()
 	. = ..()
+
 	for(var/to_filter in filter_types)
 		if(istext(to_filter))
 			filter_types -= to_filter
 			filter_types += gas_id2path(to_filter)
-
-/obj/machinery/atmospherics/components/unary/vent_scrubber/Initialize(mapload)
-	. = ..()
 
 	assign_to_area()
 	AddElement(/datum/element/atmos_sensitive, mapload)
@@ -68,12 +68,19 @@
 	. = ..()
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/assign_to_area(area/target_area = get_area(src))
-	if(!isnull(target_area))
-		target_area.air_scrubbers += src
-		update_appearance(UPDATE_NAME)
+	//this scrubber is already assigned to an area. Unassign it from here first before reassigning it to an new area
+	if(isnull(target_area) || !isnull(assigned_area))
+		return
+	assigned_area = target_area
+	assigned_area.air_scrubbers += src
+	update_appearance(UPDATE_NAME)
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/proc/disconnect_from_area(area/target_area = get_area(src))
-	target_area?.air_scrubbers -= src
+	//you cannot unassign from an area we never were assigned to
+	if(isnull(target_area) || assigned_area != target_area)
+		return
+	assigned_area.air_scrubbers -= src
+	assigned_area = null
 
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on_exit_area(datum/source, area/area_to_unregister)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

I should have caught this in #73850 my bad.

When areas get merged the vents & scrubbers of the target area don't get correctly unassigned from the old area and instead gets assigned twice to that new area causing them to appear twice in the air alarm interface.

Also merged `Initialize()` and `New()` into just `Initialize()` cause like why did they split it into two procs?
## Changelog
:cl:
fix: vents & scrubbers getting assigned twice to an area when it's merged with another area via station blueprints
refactor: merged` Initialize()` & `New()` of vents & scrubbers into just `Initialize()`
/:cl:
