### PR TITLE
Fixes gloves attackby proc not calling parent

### DIFF
--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -42,7 +42,7 @@
 		. += mutable_appearance('icons/effects/blood.dmi', "bloodyhands")
 
 /obj/item/clothing/gloves/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
-	..()
+	. = ..()
 	if(ismob(loc))
 		var/mob/M = loc
 		M.update_worn_gloves()

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -42,7 +42,7 @@
 		. += mutable_appearance('icons/effects/blood.dmi', "bloodyhands")
 
 /obj/item/clothing/gloves/update_clothes_damaged_state(damaged_state = CLOTHING_DAMAGED)
-	. = ..()
+	..()
 	if(ismob(loc))
 		var/mob/M = loc
 		M.update_worn_gloves()
@@ -55,7 +55,7 @@
 	return TRUE
 
 /obj/item/clothing/gloves/attackby(obj/item/tool, mob/user, params)
-	..()
+	. = ..()
 	if(tool.tool_behaviour != TOOL_WIRECUTTER && !tool.get_sharpness())
 		return
 	if (!can_cut_with(tool))

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -56,6 +56,8 @@
 
 /obj/item/clothing/gloves/attackby(obj/item/tool, mob/user, params)
 	. = ..()
+	if(.)
+		return
 	if(tool.tool_behaviour != TOOL_WIRECUTTER && !tool.get_sharpness())
 		return
 	if (!can_cut_with(tool))

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -69,3 +69,4 @@
 	balloon_alert(user, "cut fingertips off")
 	qdel(src)
 	user.put_in_hands(new cut_type)
+	return TRUE

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -55,6 +55,7 @@
 	return TRUE
 
 /obj/item/clothing/gloves/attackby(obj/item/tool, mob/user, params)
+	..()
 	if(tool.tool_behaviour != TOOL_WIRECUTTER && !tool.get_sharpness())
 		return
 	if (!can_cut_with(tool))


### PR DESCRIPTION
## About The Pull Request

Gloves' `attackby` proc is overridden in _gloves.dm. 

This overridden proc still needs to call its parent for  `COMSIG_PARENT_ATTACKBY` to be sent for things that need it.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/19831

## Why It's Good For The Game

Fixes a bug/oversight that will likely create issues down the line if it hasn't already.

## Changelog

:cl:
fix: fixes gloves not sending the COMSIG_PARENT_ATTACKBY signal
/:cl:
