### PR TITLE
create_midwife_eggs() now checks for safe atmos and spawns each cluster at a different location

### DIFF
--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -30,8 +30,8 @@
 		var/light_amount = spawn_turf.get_lumcount()
 		if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD && is_safe_turf(spawn_turf))
 			spawn_locs += spawn_turf
-	if(spawn_locs.len < amount)
-		message_admins("Not enough valid spawn locations found in GLOB.xeno_spawn, aborting spider spawning...")
+	if(!spawn_locs)
+		message_admins("No valid spawn locations found in GLOB.xeno_spawn, aborting spider spawning...")
 		return MAP_ERROR
 	while(amount > 0)
 		var/turf/spawn_loc = pick_n_take(spawn_locs)

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -28,13 +28,16 @@
 	for(var/x in GLOB.xeno_spawn)
 		var/turf/spawn_turf = x
 		var/light_amount = spawn_turf.get_lumcount()
-		if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD)
+		if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD && is_safe_turf(spawn_turf))
 			spawn_locs += spawn_turf
 	if(spawn_locs.len < amount)
 		message_admins("Not enough valid spawn locations found in GLOB.xeno_spawn, aborting spider spawning...")
 		return MAP_ERROR
 	while(amount > 0)
 		var/turf/spawn_loc = pick_n_take(spawn_locs)
+		if(!spawn_loc)
+			message_admins("Midwife egg creation ran out of locations to spawn at. Terminating egg spawn with [amount] spawns remaining.")
+			break
 		var/obj/effect/mob_spawn/ghost_role/spider/midwife/new_eggs = new /obj/effect/mob_spawn/ghost_role/spider/midwife(spawn_loc)
 		new_eggs.amount_grown = 98
 		amount--

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -30,7 +30,7 @@
 		var/light_amount = spawn_turf.get_lumcount()
 		if(light_amount < SHADOW_SPECIES_LIGHT_THRESHOLD && is_safe_turf(spawn_turf))
 			spawn_locs += spawn_turf
-	if(!spawn_locs)
+	if(!length(spawn_locs))
 		message_admins("No valid spawn locations found in GLOB.xeno_spawn, aborting spider spawning...")
 		return MAP_ERROR
 	while(amount > 0)

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -33,8 +33,8 @@
 	if(spawn_locs.len < amount)
 		message_admins("Not enough valid spawn locations found in GLOB.xeno_spawn, aborting spider spawning...")
 		return MAP_ERROR
-	var/turf/spawn_loc = pick_n_take(spawn_locs)
 	while(amount > 0)
+		var/turf/spawn_loc = pick_n_take(spawn_locs)
 		var/obj/effect/mob_spawn/ghost_role/spider/midwife/new_eggs = new /obj/effect/mob_spawn/ghost_role/spider/midwife(spawn_loc)
 		new_eggs.amount_grown = 98
 		amount--


### PR DESCRIPTION

## About The Pull Request

Bad things always come in pairs. Spiders are no exception. Midwife spiders, however, don't really benefit from spawning as a pair. Ultimately, the room they spawn in will fill up with eggs, and then there's nothing but uncomfortable waiting as they hatch. 

Placing the two broodmothers in separate location gives room for each broodmother to grow their own hive, and means that one wayward maintcrawler or cyborg won't _completely_ trash the threat. Single points of failure are BAD! I originally thought spider eggs spawning together was unintended behavior (bug!!) because of how little of a difference the second broodmother makes, but there's nothing pointing towards that being true, so it goes as a balance change.

As for the safe atmos check, I was watching a round and saw both sets of eggs spawn in a bombed-out room, leading to instant death upon hatching. I saw it, said to myself "huh, that's lame", then made this PR.

This also makes a minor code adjustment, which makes it so that spider eggs will spawn until there are no more valid turfs, rather than not spawning any unless there are enough spots (which wasn't really an issue until I made the proc pick distinct locations for each egg).
## Why It's Good For The Game

Atmos checks prevent people from spawning into certain death.

There's only so many tiles you can spit eggs out onto before it just becomes a game of waiting. Giving each broodmother their own space to work with means less waiting, and less risk of the entire threat being wiped out by a passing greytider, broken window, or other minor inconvenience. I guess this constitutes a spider buff, but hey, I'm of the opinion that they could use the boost anyways.
## Changelog
:cl:
balance: midwife spider eggs now spawn in separate locations. Divide and conquer!
fix: midwife spider eggs can no longer generate in atmos-hazardous areas.
/:cl:
