### PR TITLE
Tramstation Science Fixes

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2798,8 +2798,12 @@
 	},
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/camera/directional/east{
+	network = list("ss13","rd","xeno");
+	c_tag = "Science - Cytology East"
+	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "ahh" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/disposalpipe/junction/yjunction,
@@ -4880,6 +4884,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "aAE" = (
@@ -5301,7 +5308,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "aDu" = (
 /obj/effect/turf_decal/arrows/white{
 	dir = 8
@@ -6524,7 +6531,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "aMc" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1
@@ -7292,7 +7299,7 @@
 /area/station/cargo/storage)
 "aSt" = (
 /turf/open/openspace,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "aSB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
@@ -7953,7 +7960,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "bhr" = (
 /turf/closed/wall/rock/porous,
 /area/station/security/prison/workout)
@@ -8402,7 +8409,7 @@
 /obj/structure/table/glass,
 /obj/structure/microscope,
 /turf/open/floor/glass/reinforced,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "bso" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
@@ -9371,7 +9378,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "bIg" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -9727,7 +9734,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "bNz" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmospherics_engine)
@@ -11566,7 +11573,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "cwy" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -12227,7 +12234,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "cHZ" = (
 /obj/structure/railing,
 /turf/open/floor/glass/reinforced,
@@ -12359,6 +12366,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"cJR" = (
+/obj/machinery/rnd/server,
+/turf/open/floor/circuit/telecomms/server,
+/area/station/science/server)
 "cJS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -13207,7 +13218,7 @@
 "cZH" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "cZP" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -15971,7 +15982,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "ecn" = (
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
@@ -17631,7 +17642,7 @@
 /area/station/commons/vacant_room)
 "eJQ" = (
 /turf/open/floor/glass/reinforced,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "eJV" = (
 /obj/structure/sink/kitchen/directional/west,
 /turf/open/floor/wood,
@@ -18910,7 +18921,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "fjN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -20991,6 +21002,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "fZI" = (
@@ -21587,7 +21600,7 @@
 	name = "Secure Pen Lockdown"
 	},
 /turf/open/floor/plating,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "glA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -22022,7 +22035,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "guI" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -23567,7 +23580,7 @@
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "gYz" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 4"
@@ -26130,6 +26143,9 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "hZZ" = (
@@ -26640,7 +26656,7 @@
 "ijR" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "ijW" = (
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 8
@@ -26709,7 +26725,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "ilX" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron/white,
@@ -26873,7 +26889,6 @@
 /area/station/command/bridge)
 "ioW" = (
 /obj/structure/window/spawner,
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 6
 	},
@@ -26914,7 +26929,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "iqH" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/iron,
@@ -28306,7 +28321,9 @@
 /area/station/medical/medbay/lobby)
 "iTb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/window/left/directional/east,
+/obj/machinery/door/window/left/directional/east{
+	req_access = list("science")
+	},
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
@@ -29094,7 +29111,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "jge" = (
 /obj/structure/cable/layer1,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -29719,7 +29736,7 @@
 	},
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "jqS" = (
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
@@ -33207,7 +33224,7 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "kGA" = (
 /obj/structure/railing,
 /obj/machinery/door/firedoor/border_only,
@@ -35226,7 +35243,6 @@
 /area/station/hallway/secondary/construction/engineering)
 "lmk" = (
 /obj/structure/window/spawner/north,
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 9
 	},
@@ -35372,7 +35388,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "loF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/ai_slipper{
@@ -36436,10 +36452,6 @@
 	dir = 8
 	},
 /area/station/medical/medbay/central)
-"lLF" = (
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/engine,
-/area/station/science/cytology)
 "lLP" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -37130,7 +37142,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "lXd" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/dark_green/filled/end,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -38882,7 +38893,7 @@
 	id = "Xenobio"
 	},
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "mFo" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -38922,7 +38933,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "mGl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
@@ -39172,6 +39183,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "mKP" = (
@@ -39227,7 +39241,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "mMc" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
@@ -40855,7 +40869,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "nti" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41120,7 +41134,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "nyx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
 	dir = 6
@@ -41181,7 +41195,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "nzh" = (
 /obj/structure/fluff/tram_rail/end{
 	dir = 8
@@ -47282,7 +47296,7 @@
 	name = "Test Chamber Blast Door"
 	},
 /turf/open/floor/plating,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "pNc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -47610,7 +47624,7 @@
 	},
 /obj/effect/turf_decal/siding/thinplating/corner,
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "pUj" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -47754,7 +47768,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "pWC" = (
 /obj/structure/railing{
 	dir = 8
@@ -48135,7 +48149,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "qec" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -48916,7 +48930,7 @@
 	name = "Secure Pen Lockdown"
 	},
 /turf/open/floor/plating,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "qtD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -49045,9 +49059,18 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
 "qvU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/cytology)
+/obj/effect/turf_decal/box/red/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/red/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/box/red/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/red/corners,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "qvZ" = (
 /obj/structure/industrial_lift/tram/white,
 /obj/effect/landmark/start/hangover,
@@ -49190,7 +49213,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "qyZ" = (
 /turf/closed/wall/r_wall,
 /area/station/command/meeting_room)
@@ -49513,7 +49536,7 @@
 	pixel_y = -4
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "qEl" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -50273,7 +50296,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "qTp" = (
 /obj/machinery/door/airlock{
 	id_tag = "private_b";
@@ -50447,7 +50470,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "qVN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52031,7 +52054,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "rzL" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -52082,7 +52105,7 @@
 /obj/item/multitool,
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "rAS" = (
 /turf/closed/wall,
 /area/station/service/library/lounge)
@@ -52671,7 +52694,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "rNt" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -52884,7 +52907,7 @@
 	dir = 1
 	},
 /turf/open/floor/glass/reinforced,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "rQt" = (
 /obj/structure/ladder,
 /obj/structure/railing{
@@ -53078,7 +53101,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "rUQ" = (
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
@@ -54088,7 +54111,7 @@
 	supplies_requestable = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "spm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/heavy,
@@ -55022,7 +55045,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "sEV" = (
 /obj/machinery/computer/monitor{
 	dir = 8
@@ -57458,7 +57481,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "tsp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -57512,7 +57535,7 @@
 "ttj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "tto" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line{
@@ -57647,6 +57670,8 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "twO" = (
@@ -57902,7 +57927,7 @@
 	},
 /obj/item/electropack,
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "tBu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/external{
@@ -58046,7 +58071,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "tEF" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/item/radio/intercom/directional/south,
@@ -59212,14 +59237,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/button/door/directional/east{
 	id = "cytologysecure1";
 	name = "Secure Pen Lockdown"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "uax" = (
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -60664,7 +60687,7 @@
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/engine,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "uCh" = (
 /obj/structure/railing{
 	dir = 5
@@ -60927,7 +60950,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "uGL" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/bot,
@@ -61262,7 +61285,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/glass/reinforced,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "uLw" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -62090,9 +62113,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "vay" = (
 /turf/open/floor/plating,
 /area/station/commons/dorms)
@@ -62940,7 +62962,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /turf/open/floor/catwalk_floor,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "vqE" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light/directional/south,
@@ -63921,7 +63943,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "vGJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -66296,7 +66318,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "wAA" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Coffin Storage";
@@ -67365,7 +67387,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "wXx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -67684,7 +67706,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "xfN" = (
 /obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
@@ -68083,7 +68105,7 @@
 	},
 /obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/iron/dark,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "xmZ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/clock/directional/north,
@@ -68595,8 +68617,12 @@
 	},
 /obj/machinery/light/directional/west,
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Science - Cytology West";
+	network = list("ss13","rd","xeno")
+	},
 /turf/open/floor/iron/white,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "xzn" = (
 /obj/structure/closet/secure_closet/security/engine,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -69628,7 +69654,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/glass/reinforced,
-/area/station/science/cytology)
+/area/station/science/xenobiology)
 "xVH" = (
 /obj/structure/industrial_lift/tram,
 /obj/structure/window/reinforced/tram/mid/directional/north,
@@ -179683,10 +179709,10 @@ abM
 abM
 abM
 abM
-aSb
-aSb
-aSb
-aSb
+soq
+soq
+soq
+soq
 abM
 abM
 aaa
@@ -179943,7 +179969,7 @@ aaa
 aSb
 cOR
 eAU
-aSb
+soq
 abM
 abM
 abM
@@ -180200,7 +180226,7 @@ aaa
 aSb
 jbL
 jbL
-aSb
+soq
 abM
 abM
 abM
@@ -180453,13 +180479,13 @@ aaa
 aaa
 aaa
 aaa
-aSb
-aSb
+qVr
+qVr
 jfU
 glp
-aSb
-aSb
-aSb
+soq
+soq
+soq
 abM
 abM
 aaa
@@ -180705,20 +180731,20 @@ pbH
 pbH
 pbH
 pbH
-aSb
-aSb
-aSb
-aSb
-aSb
-aSb
+qVr
+qVr
+qVr
+qVr
+qVr
+qVr
 sph
 tsg
 rzt
 xyA
 wXi
-aSb
+soq
 vqe
-aSb
+soq
 aaa
 aaa
 aaa
@@ -180961,12 +180987,12 @@ fGS
 pbH
 uvU
 umu
-aSb
-aSb
+qVr
+qVr
 mFh
-jbL
-jbL
-aSb
+bfH
+bfH
+qVr
 gYw
 cHY
 aLR
@@ -180975,7 +181001,7 @@ xfL
 nsK
 sEx
 rNm
-aSb
+qVr
 aaa
 aaa
 aaa
@@ -181218,12 +181244,12 @@ jXF
 pbH
 mAL
 nKU
-aSb
+qVr
 tEx
-jbL
-jbL
-jbL
-aSb
+bfH
+bfH
+bfH
+qVr
 pNa
 uGJ
 pTP
@@ -181232,7 +181258,7 @@ qyQ
 gun
 qea
 mFY
-aSb
+qVr
 aaa
 aaa
 aaa
@@ -181475,12 +181501,12 @@ tdQ
 pbH
 lcc
 hMd
-aSb
+qVr
 ttj
-jbL
-jbL
-jbL
-jbL
+bfH
+bfH
+bfH
+bfH
 pNa
 qEj
 xmY
@@ -181489,7 +181515,7 @@ eJQ
 bNx
 aSt
 aSt
-aSb
+qVr
 aaa
 aaa
 aaa
@@ -181732,7 +181758,7 @@ cjz
 qKE
 chE
 ffk
-aSb
+qVr
 uBM
 ttj
 bhf
@@ -181746,7 +181772,7 @@ rQr
 loA
 aSt
 aSt
-aSb
+qVr
 aaa
 aaa
 aaa
@@ -181989,11 +182015,11 @@ cwX
 pbH
 kBo
 iwz
-aSb
-jbL
-jbL
-jbL
-jbL
+qVr
+bfH
+bfH
+bfH
+bfH
 kGv
 qSS
 ilM
@@ -182003,7 +182029,7 @@ eJQ
 bNx
 aSt
 aSt
-aSb
+qVr
 aaa
 aaa
 aaa
@@ -182246,12 +182272,12 @@ nwE
 pbH
 mAL
 nKU
-aSb
-jbL
-jbL
-jbL
-jbL
-aSb
+qVr
+bfH
+bfH
+bfH
+bfH
+qVr
 jqK
 ijR
 ecg
@@ -182260,7 +182286,7 @@ rUh
 wAs
 fjA
 aDn
-aSb
+qVr
 aaa
 aaa
 aaa
@@ -182502,22 +182528,22 @@ jst
 lSW
 pbH
 vSa
-umu
-aSb
-aSb
+cJR
+qVr
+qVr
 rAB
 qVL
 tBo
-aSb
+qVr
 gYw
 vav
 vGI
-qvU
-qvU
+dGs
+dGs
 bIf
 nyv
 ipU
-aSb
+qVr
 aaa
 aaa
 aaa
@@ -182761,20 +182787,20 @@ pbH
 pbH
 pbH
 pbH
-aSb
-aSb
-aSb
-aSb
-aSb
-aSb
+qVr
+qVr
+qVr
+qVr
+qVr
+qVr
 tZT
 cZH
 pWw
 ahg
 mLO
-aSb
-aSb
-aSb
+qVr
+qVr
+qVr
 aaa
 aaa
 aaa
@@ -183023,13 +183049,13 @@ aaa
 aaa
 aaa
 aaa
-aSb
-aSb
+qVr
+qVr
 jfU
 qtB
-aSb
-aSb
-aSb
+qVr
+qVr
+qVr
 aaa
 aaa
 aaa
@@ -183281,10 +183307,10 @@ aaa
 aaa
 aaa
 aaa
-aSb
-jbL
-jbL
-aSb
+qVr
+bfH
+bfH
+qVr
 aaa
 aaa
 aaa
@@ -183538,10 +183564,10 @@ aaa
 aaa
 aaa
 aaa
-aSb
-cOR
-lLF
-aSb
+qVr
+qvU
+dFC
+qVr
 aaa
 aaa
 aaa
@@ -183795,10 +183821,10 @@ aaa
 aaa
 aaa
 aaa
-aSb
-aSb
-aSb
-aSb
+qVr
+qVr
+qVr
+qVr
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

- The upper floor with the containment pen is now entirely considered to be Xenobiology
- Cameras now added to the upper containment pens (lol)
- The science delivery chute now requires science access to open
- The server room now has the proper amount of servers
- Filing cabinets removed from Genetics
- Command bridge is now reconnected to the powergrid and distro loop (it had 2 places to connect and i somehow managed to avoid connecting either)

Closes #74049
Closes #74052
Closes #74050

## Why It's Good For The Game
its not i hate this game i want it to explode

## Changelog
:cl: MMMiracles
fix: Xenobiology on Tramstation can now use their consoles to see the upper floor.
/:cl:
i ate like 20 pistachios while making this pr