### PR TITLE
Heretic sacrifice checks last mind as well

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -188,7 +188,7 @@
 	heretic_datum.remove_sacrifice_target(sacrifice)
 
 
-	var/feedback = "Your patrons accepts your offer"
+	var/feedback = "Your patrons accept your offer"
 	var/sac_department_flag = sacrifice.mind?.assigned_role?.departments_bitflags | sacrifice.last_mind?.assigned_role?.departments_bitflags
 	if(sac_department_flag & DEPARTMENT_BITFLAG_COMMAND)
 		heretic_datum.knowledge_points++

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -187,12 +187,15 @@
 		LAZYADD(target_blacklist, sacrifice.mind)
 	heretic_datum.remove_sacrifice_target(sacrifice)
 
-	to_chat(user, span_hypnophrase("Your patrons accepts your offer."))
 
-	if(sacrifice.mind?.assigned_role?.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
+	var/feedback = "Your patrons accepts your offer"
+	var/sac_department_flag = sacrifice.mind?.assigned_role?.departments_bitflags | sacrifice.last_mind?.assigned_role?.departments_bitflags
+	if(sac_department_flag & DEPARTMENT_BITFLAG_COMMAND)
 		heretic_datum.knowledge_points++
 		heretic_datum.high_value_sacrifices++
+		feedback += " <i>graciously</i>"
 
+	to_chat(user, span_hypnophrase("[feedback]."))
 	heretic_datum.total_sacrifices++
 	heretic_datum.knowledge_points += 2
 


### PR DESCRIPTION
## About The Pull Request

Makes heretic sacrifice a bit more generous when checking for high value sacrifice. Checks last mind to inhabit the body as well as current mind. Should fix cases where minds are swapped out (decapitation).

Modifies the message slightly if it is a high value sacrifice to let the player know. 

Fixes #74028

Fixes (the original source behind) #73236 (but not the issue itself) 

## Why It's Good For The Game

More clear objectives

## Changelog

:cl: Melbert
fix: Heretic sacrificing now checks both the last mind to inhabit the body as well as the current mind when checking for high value targets
/:cl:

