### PR TITLE
Allows populating new vv'd lists

### DIFF
--- a/code/modules/admin/view_variables/get_variables.dm
+++ b/code/modules/admin/view_variables/get_variables.dm
@@ -308,7 +308,7 @@
 				insert = vv_get_value(restricted_classes = list(VV_RESTORE_DEFAULT))
 				if(!insert["class"])
 					break
-				value += list(insert["value"])
+				value += LIST_VALUE_WRAP_LISTS(insert["value"])
 
 
 			.["value"] = value

--- a/code/modules/admin/view_variables/get_variables.dm
+++ b/code/modules/admin/view_variables/get_variables.dm
@@ -295,8 +295,23 @@
 			.["value"] = newguy
 
 		if(VV_NEW_LIST)
-			.["value"] = list()
 			.["type"] = /list
+			var/list/value = list()
+
+			var/expectation = alert("Would you like to populate the list", "Populate List?", "Yes", "No")
+			if(!expectation || expectation == "No")
+				.["value"] = value
+				return .
+
+			var/list/insert = null
+			while(TRUE)
+				insert = vv_get_value(restricted_classes = list(VV_RESTORE_DEFAULT))
+				if(!insert["class"])
+					break
+				value += list(insert["value"])
+
+
+			.["value"] = value
 
 		if(VV_TEXT_LOCATE)
 			var/datum/D


### PR DESCRIPTION

You get an alert, and can continue to enter variables until you hit cancel. Not sure if this is good ux or not, yell at me if not
## Why It's Good For The Game

Fikou asked me for it and that guy's pretty cool. Also it's annoying to not be able to feed lists into procs

## Changelog
:cl:
admin: You can now optionally populate new lists created via vv. hit cancel to stop filling them up
/:cl:
