### PR TITLE
Fixes "melty humans"

### DIFF
--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -545,7 +545,9 @@
 		if(!overlay.can_draw_on_bodypart(owner))
 			continue
 		. += "-[jointext(overlay.generate_icon_cache(), "-")]"
-
+	if(ishuman(owner))
+		var/mob/living/carbon/human/human_owner = owner
+		. += "-[human_owner.get_mob_height()]"
 	return .
 
 ///Generates a cache key specifically for husks
@@ -555,6 +557,9 @@
 	. += "[husk_type]"
 	. += "-husk"
 	. += "-[body_zone]"
+	if(ishuman(owner))
+		var/mob/living/carbon/human/human_owner = owner
+		. += "-[human_owner.get_mob_height()]"
 	return .
 
 /obj/item/bodypart/head/generate_icon_key()


### PR DESCRIPTION
## About The Pull Request

Fixes #73154 

Includes human height in icon render key.

The logic here is that if two mobs share the same icon render key they probably grab the same icon and thus a tall person would grab a "short person icon". 

## Why It's Good For The Game

Melty bad

## Changelog

:cl: Melbert
fix: Fixes rare human arm melting condition
/:cl:
