### PR TITLE
Disable rust url_encode and url_decode overrides

### DIFF
--- a/code/__DEFINES/rust_g_overrides.dm
+++ b/code/__DEFINES/rust_g_overrides.dm
@@ -1,3 +1,5 @@
 // RUSTG_OVERRIDE_BUILTINS is not used since the file APIs don't work well over Linux.
+/*
 #define url_encode(text) rustg_url_encode("[text]")
 #define url_decode(text) rustg_url_decode("[text]")
+*/


### PR DESCRIPTION
I'm suspicious of this causing the performance issue we're pinning down of strings leaking in 515 and it's very hard to test without a live server