### PR TITLE
Adds service radio to jani/curator/chaplain/lawyer vendor

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -268,6 +268,7 @@
 		/obj/item/clothing/glasses/regular = 2,
 		/obj/item/clothing/glasses/regular/jamjar = 1,
 		/obj/item/storage/bag/books = 1.
+		/obj/item/radio/headset/headset_srv = 2,
 		)
 	refill_canister = /obj/item/vending_refill/wardrobe/curator_wardrobe
 	payment_department = ACCOUNT_SRV
@@ -404,6 +405,7 @@
 		/obj/item/clothing/under/rank/civilian/lawyer/black/skirt = 1,
 		/obj/item/clothing/shoes/laceup = 2,
 		/obj/item/clothing/accessory/lawyers_badge = 2,
+		/obj/item/radio/headset/headset_srv = 2,
 		)
 	refill_canister = /obj/item/vending_refill/wardrobe/law_wardrobe
 	payment_department = ACCOUNT_SRV
@@ -435,6 +437,7 @@
 		/obj/item/clothing/suit/chaplainsuit/monkrobeeast = 1,
 		/obj/item/clothing/head/rasta = 1,
 		/obj/item/clothing/suit/chaplainsuit/shrinehand = 1,
+		/obj/item/radio/headset/headset_srv = 2,
 		)
 	contraband = list(
 		/obj/item/toy/plush/ratplush = 1,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -267,7 +267,7 @@
 		/obj/item/storage/backpack/satchel/explorer = 1,
 		/obj/item/clothing/glasses/regular = 2,
 		/obj/item/clothing/glasses/regular/jamjar = 1,
-		/obj/item/storage/bag/books = 1.
+		/obj/item/storage/bag/books = 1,
 		/obj/item/radio/headset/headset_srv = 2,
 		)
 	refill_canister = /obj/item/vending_refill/wardrobe/curator_wardrobe

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -364,6 +364,7 @@
 		/obj/item/watertank/janitor = 1,
 		/obj/item/storage/belt/janitor = 2,
 		/obj/item/plunger = 2,
+		/obj/item/radio/headset/headset_srv = 2,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe
 	default_price = PAYCHECK_CREW

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -366,7 +366,7 @@
 		/obj/item/storage/belt/janitor = 2,
 		/obj/item/plunger = 2,
 		/obj/item/radio/headset/headset_srv = 2,
-	)
+		)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe
 	default_price = PAYCHECK_CREW
 	extra_price = PAYCHECK_COMMAND * 0.8


### PR DESCRIPTION
## About The Pull Request
**Adds service radio to jani/curator/chaplain/lawyer vendor**
## Why It's Good For The Game
Janitor/curator/chaplain/lawyer belong to service department; yet janitor/curator/chaplain/lawyer have no source of getting service radio if transferred/lost. They don't have it in their vendor or closet.
## Changelog
:cl:
qol: adds service radio to jani/curator/chaplain/lawyer vendor
/:cl:
