### PR TITLE
[no GBP] non-organic human species can be implanted

### DIFF
--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -37,10 +37,10 @@
 	if(isslime(target))
 		return TRUE
 
-	if((target.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_SPIRIT)))
-		return FALSE
+	if(!isanimal_or_basicmob(target))
+		return TRUE
 
-	return TRUE
+	return !(target.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_SPIRIT))
 
 /**
  * What does the implant do upon injection?


### PR DESCRIPTION
## About The Pull Request

Fixes #74080 
In #74029 I intended to change the implant logic to use biotypes for animals and basic mobs, except what I actually did was make it use biotypes for _every_ mob.
Because plasmamen are "minerals" they then couldn't be implanted.

Now we only check biotypes for "animals".
You can implant Ian, you can implant your plasmaman coworker, and you can't implant Beepsky.

## Why It's Good For The Game

It fixes a bug.

## Changelog

:cl:
fix: Plasmamen and golems (and androids, if you ever find one) can be implanted again.
/:cl:
