### PR TITLE
Fixes infinite ghost role spawners not being infinite

### DIFF
--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -191,7 +191,7 @@
 		LAZYREMOVE(ckeys_trying_to_spawn, user_ckey)
 		return
 
-	if(uses <= 0) // Just in case something took longer than it should've and we got here after the uses went below zero.
+	if(uses <= 0 && !infinite_use) // Just in case something took longer than it should've and we got here after the uses went below zero.
 		to_chat(user, span_warning("This spawner is out of charges!"))
 		LAZYREMOVE(ckeys_trying_to_spawn, user_ckey)
 		return


### PR DESCRIPTION
## About The Pull Request
I love it when we add something and we have like three PRs around the same time touching the same code and none of it conflicts, it's awesome, believe me!

Adds the `!infinite_use` to the other check that checked the uses left, to ensure that it still allows infinite spawners to remain infinite.

## Why It's Good For The Game
Code that works is always good for the game.

## Changelog

:cl: GoldenAlpharex
fix: Ghost role spawners that are set to have infinite uses no longer run out of uses.
/:cl: