### PR TITLE
[no gbp] emote bodypart overlay generate_icon_cache() now accounts for offsets

### DIFF
--- a/code/datums/bodypart_overlays/emote_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/emote_bodypart_overlay.dm
@@ -27,6 +27,11 @@
 /datum/bodypart_overlay/simple/emote/removed_from_limb(obj/item/bodypart/limb)
 	attached_bodypart = null
 
+/datum/bodypart_overlay/simple/emote/generate_icon_cache()
+	. = ..()
+	. += "[offset_x]"
+	. += "[offset_y]"
+
 ///Removes the overlay from the attached bodypart and updates the necessary sprites
 /datum/bodypart_overlay/simple/emote/Destroy()
 	var/obj/item/bodypart/referenced_bodypart = attached_bodypart.resolve()


### PR DESCRIPTION

## About The Pull Request
/datum/bodypart_overlay/simple/emote now adds offset_x and offset_y to the list created by generate_icon_cache(). This doesn't seem to have caused any issues so far, probably because the offsets are almost always 0. But it's probably better to do this before any issues show up.
## Why It's Good For The Game
This should prevent issues with the icon cache if emote bodypart overlays with different offsets are used.
## Changelog
No player facing changes.
