### PR TITLE
Organ harvesters now open and abort harvesting when losing power

### DIFF
--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -104,11 +104,12 @@
 	warming_up = FALSE
 	update_appearance()
 	if(!harvesting || state_open || !powered() || !occupant || !iscarbon(occupant))
+		end_harvesting(success = FALSE)
 		return
 	playsound(src, 'sound/machines/juicer.ogg', 20, TRUE)
 	var/mob/living/carbon/C = occupant
 	if(!LAZYLEN(operation_order)) //The list is empty, so we're done here
-		end_harvesting()
+		end_harvesting(success = TRUE)
 		return
 	var/turf/target
 	for(var/adir in list(EAST,NORTH,SOUTH,WEST))
@@ -135,12 +136,16 @@
 	use_power(active_power_usage)
 	addtimer(CALLBACK(src, PROC_REF(harvest)), interval)
 
-/obj/machinery/harvester/proc/end_harvesting()
+/obj/machinery/harvester/proc/end_harvesting(var/success = TRUE)
 	warming_up = FALSE
 	harvesting = FALSE
 	open_machine()
-	say("Subject has been successfully harvested.")
-	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
+	if (!success)
+		say("Protocol interrupted. Aborting harvest.")
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
+	else
+		say("Subject has been successfully harvested.")
+		playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
 
 /obj/machinery/harvester/screwdriver_act(mob/living/user, obj/item/I)
 	. = TRUE

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -136,7 +136,7 @@
 	use_power(active_power_usage)
 	addtimer(CALLBACK(src, PROC_REF(harvest)), interval)
 
-/obj/machinery/harvester/proc/end_harvesting(var/success = TRUE)
+/obj/machinery/harvester/proc/end_harvesting(success = TRUE)
 	warming_up = FALSE
 	harvesting = FALSE
 	open_machine()


### PR DESCRIPTION

## About The Pull Request
The organ harvester will now open itself, say a short message (`"Protocol interrupted. Aborting harvest."`), and play `buzz-sigh.ogg` when its power is cutoff mid-harvest. This prevents players from being trapped inside, should they be mid-harvest during an outage. This Closes #46606.


## Why It's Good For The Game
Currently, if an organ harvester loses power it will pause the harvesting protocol, but be left in an awkward limbo state. If power resumes, harvesting will not restart, and until the machine is crowbarred open, it will remain this way forever. Any players inside are trapped, and visually the machine will still have a red lid, despite not actively harvesting anything.

These changes remove this limbo scenario, adding consistency to the machine's behavior. Additionally, this prevents players from potentially being stuck with little autonomy over their character (trapped inside a machine, unable to resist out, unable to succumb, forced to either suicide or wait).

Additionally, the flavor text and error noise for a failed harvest help indicate to players performing harvests that the machine has indeed failed, spurring them to investigate why.

## Changelog
:cl:
fix: Organ harvesters now open and abort harvesting when losing power
/:cl:
