### PR TITLE
Correct grammar, tags, procs involving food processing

### DIFF
--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -92,7 +92,10 @@
 
 	if(!current_bake_time) //Not baked yet
 		if(positive_result)
-			examine_list += span_notice("[parent] can be <b>baked</b> into \a [initial(bake_result.name)].")
+			if(initial(bake_result.gender) == PLURAL)
+				examine_list += span_notice("[parent] can be [span_bold("baked")] into some [initial(bake_result.name)].")
+			else
+				examine_list += span_notice("[parent] can be [span_bold("baked")] into \a [initial(bake_result.name)].")
 		return
 
 	if(positive_result)

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -99,7 +99,10 @@
 
 	if(!current_cook_time) //Not grilled yet
 		if(positive_result)
-			examine_list += span_notice("[parent] can be <b>grilled</b> into \a [initial(cook_result.name)].")
+			if(initial(cook_result.name) == PLURAL)
+				examine_list += span_notice("[parent] can be [span_bold("grilled")] into some [initial(cook_result.name)].")
+			else
+				examine_list += span_notice("[parent] can be [span_bold("grilled")] into \a [initial(cook_result.name)].")
 		return
 
 	if(positive_result)

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -72,4 +72,7 @@
 /datum/element/microwavable/proc/on_examine(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	examine_list += span_notice("[source] could be <b>microwaved</b> into \a [initial(result_typepath.name)].")
+	if(initial(result_typepath.gender) == PLURAL)
+		examine_list += span_notice("[source] can be [span_bold("microwaved")] into some [initial(result_typepath.name)].")
+	else
+		examine_list += span_notice("[source] can be [span_bold("microwaved")] into \a [initial(result_typepath.name)].")

--- a/code/datums/elements/food/processable.dm
+++ b/code/datums/elements/food/processable.dm
@@ -57,10 +57,23 @@
 /datum/element/processable/proc/OnExamine(atom/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
+	var/result_name = initial(result_atom_type.name)
+	var/result_gender = initial(result_atom_type.gender)
+	var/tool_desc = tool_behaviour_name(tool_behaviour)
+
+	// I admit, this is a lot of lines for very minor changes in the strings
+	// but at least it's readable?
 	if(amount_created > 1)
-		examine_list += span_notice("It can be turned into [amount_created] [initial(result_atom_type.name)]s with <b>[tool_behaviour_name(tool_behaviour)]</b>!")
+		if(result_gender == PLURAL)
+			examine_list += span_notice("It can be turned into [amount_created] [result_name] with [span_bold(tool_desc)]!")
+		else
+			examine_list += span_notice("It can be turned into [amount_created] [result_name][plural_s(result_name)] with [span_bold(tool_desc)]!")
+
 	else
-		examine_list += span_notice("It can be turned into \a [initial(result_atom_type.name)] with <b>[tool_behaviour_name(tool_behaviour)]</b>!")
+		if(result_gender == PLURAL)
+			examine_list += span_notice("It can be turned into some [result_name] with [span_bold(tool_desc)]</b>!")
+		else
+			examine_list += span_notice("It can be turned into \a [result_name] with <b>[span_bold(tool_desc)]</b>!")
 
 /**
  * Adds context sensitivy directly to the processable file for screentips

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1536,7 +1536,7 @@
 				created_atom.pixel_x += rand(-8,8)
 				created_atom.pixel_y += rand(-8,8)
 			created_atom.OnCreatedFromProcessing(user, process_item, chosen_option, src)
-			to_chat(user, span_notice("You manage to create [chosen_option[TOOL_PROCESSING_AMOUNT]] [initial(atom_to_create.gender) == PLURAL ? "[initial(atom_to_create.name)]" : "[initial(atom_to_create.name)]\s"] from [src]."))
+			to_chat(user, span_notice("You manage to create [chosen_option[TOOL_PROCESSING_AMOUNT]] [initial(atom_to_create.gender) == PLURAL ? "[initial(atom_to_create.name)]" : "[initial(atom_to_create.name)][plural_s(initial(atom_to_create.name))]"] from [src]."))
 			created_atoms.Add(created_atom)
 		SEND_SIGNAL(src, COMSIG_ATOM_PROCESSED, user, process_item, created_atoms)
 		UsedforProcessing(user, process_item, chosen_option)


### PR DESCRIPTION
The wording of microwable/grillable/processable outputs now takes into accounts plurals.

For example, the examine text for an onion slice is now: "The onion slices can be baked into _some_ onion rings", rather than "an onion rings".

- Examining microwavable things now uses "can be", rather than "could be"; the same verb as bakeable and griddlable.
- Processing atoms now uses `plural_s()` rather than just a flat `/s`, which is unreliable.
- The use of `<b>` tags has been changed to `span_bold()`.
