### PR TITLE
Makes the Rapid Pipe Dispenser available from the cargo lathe again

### DIFF
--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -72,7 +72,7 @@
 	category = list(
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/rcd_loaded
 	name = "Rapid Construction Device"


### PR DESCRIPTION
## About The Pull Request
The Rapid Pipe Dispenser was removed from the Cargo lathe due to https://github.com/tgstation/tgstation/pull/69990 PR. 

>Designs that are not sensible for a department to have are no longer accessible to that department (read: medbay printing turbine parts)

It is sensible for cargo to have access to the RPD because it is a genuinely useful tool for them when working on automating cargo.

![image](https://user-images.githubusercontent.com/68373373/226147246-65f7aa22-d745-4e73-9cdf-7763e7ba11a8.png)

### Mapping March
Ckey to receive rewards: N/A

## Why It's Good For The Game

This should help give cargo more options on how they make money and automate cargo. Additionally, I am not entirely sure that it's removal from the cargo lathe was an intentional choice or not.
## Changelog
:cl:
balance: cargo now has access to the Rapid Pipe Dispenser from their lathe again.
/:cl:
