### PR TITLE
Fix inconsistency in FREEZE_PROOF flag

### DIFF
--- a/code/datums/elements/frozen.dm
+++ b/code/datums/elements/frozen.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_INIT(freon_color_matrix, list("#2E5E69", "#60A2A8", "#A1AFB1", rgb(0
 		return ELEMENT_INCOMPATIBLE
 
 	var/obj/target_obj = target
-	if(target_obj.obj_flags & FREEZE_PROOF)
+	if(target_obj.resistance_flags & FREEZE_PROOF)
 		return ELEMENT_INCOMPATIBLE
 
 	if(HAS_TRAIT(target_obj, TRAIT_FROZEN))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -372,7 +372,7 @@ GLOBAL_LIST_EMPTY(objects_by_id_tag)
 /obj/proc/freeze()
 	if(HAS_TRAIT(src, TRAIT_FROZEN))
 		return FALSE
-	if(obj_flags & FREEZE_PROOF)
+	if(resistance_flags & FREEZE_PROOF)
 		return FALSE
 
 	AddElement(/datum/element/frozen)

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -196,7 +196,7 @@
 
 /turf/open/proc/freeze_turf()
 	for(var/obj/I in contents)
-		if(!HAS_TRAIT(I, TRAIT_FROZEN) && !(I.obj_flags & FREEZE_PROOF))
+		if(!HAS_TRAIT(I, TRAIT_FROZEN) && !(I.resistance_flags & FREEZE_PROOF))
 			I.AddElement(/datum/element/frozen)
 
 	for(var/mob/living/L in contents)


### PR DESCRIPTION
Although all objects that _have_ the flag attach it to `resistance_flags` (which is what the define location implies it's supposed to be set on), all the code that checked it for the purposes of applying the freezing element used `obj_flags`.

As far as I can tell, that meant the only things immune to freezing were things that "blocked z falling from above".

Also, freezing only happens with some obscure weapons and low temperature water vapour, but hey 🤷.

:cl: coiax
fix: Coffee cups are now correctly immune to becoming frozen by low temperature water vapour.
/:cl:

---

Shout out to @RaveRadbury who helped me with debugging this.