### PR TITLE
Fix holo signs being able to be frozen

### DIFF
--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -7,6 +7,8 @@
 	anchored = TRUE
 	max_integrity = 1
 	armor_type = /datum/armor/structure_holosign
+	// How can you freeze a trick of the light?
+	resistance_flags = FREEZE_PROOF
 	var/obj/item/holosign_creator/projector
 	var/use_vis_overlay = TRUE
 
@@ -105,7 +107,7 @@
 	can_atmos_pass = ATMOS_PASS_NO
 	alpha = 150
 	rad_insulation = RAD_LIGHT_INSULATION
-	resistance_flags = FIRE_PROOF
+	resistance_flags = FIRE_PROOF | FREEZE_PROOF
 
 /obj/structure/holosign/barrier/atmos/sturdy
 	name = "sturdy holofirelock"


### PR DESCRIPTION
:cl: coiax
fix: Holosigns, like the atmos holofan, can no longer be frozen by low temperature water vapour.
/:cl:

Seen this a couple of times where a holofan's been "frozen" which is quite silly.

This won't actually _do_ anything until #74102 is merged though, but let's keep our changes separate.