### PR TITLE
Modify sheet smashing to produce debris

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -39,6 +39,8 @@
 			var/obj/item/new_shard = new mat.shard_type(user.loc)
 			new_shard.add_fingerprint(user)
 			shards += "\a [new_shard.name]"
+			if(mat.debris_type)
+				new mat.debris_type(user.loc)
 	if(!shards.len)
 		return FALSE
 	user.do_attack_animation(src, ATTACK_EFFECT_BOOP)


### PR DESCRIPTION
:cl: coiax
add: Smashing a glass sheet against the ground to make a shard will also spray glass debris on the floor.
/:cl:

If you hit the floor with a sheet of glass in combat mode, you get a shard. But it always appeared without the accompanying fragments of glass you get from a window smashing. Well now it does. I apologise to janitors everywhere.