### PR TITLE
Changes Anti-Freeze's taste so it's actually useable in custom mixes.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1246,7 +1246,7 @@
 	color = "#30f0f8" // rgb: 48,240,248
 	boozepwr = 35
 	quality = DRINK_NICE
-	taste_description = "Jack Frost's piss"
+	taste_description = "icecream in winter"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/glass_style/drinking_glass/antifreeze


### PR DESCRIPTION


## About The Pull Request

Changes the taste description for the Anti-Freeze from "Jack Frost's piss" to "icecream in winter"

## Why It's Good For The Game

So the Anti-Freeze is the only actual drink sprite we have that's  blue. The only other one I know of at all is Curacao, which just has the standard glass sprite, but full of blue. That's fucking lame, and 'Jack Frost's piss' isn't really useful as a taste descriptor anyway. Noone goes "I'm going to like Anti-Freeze because it tastes like Jack Frost's piss." So I looked at the other ice + cream drinks being milkshakes or floats, and kept the Anti-Freeze's Cold/'Ultimate Refreshment' fluff.

I'd be down to change the taste to something else if someone else has a better idea, though.

## Changelog

:cl:
qol: Anti-Freeze now has a flavour you can actually use in drinks. Bartenders rejoice!
/:cl:
