### PR TITLE
Cryoxadone works while conscious and is affected by purity

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -136,7 +136,7 @@
 	if(affected_mob.bodytemperature >= T0C)
 		..()
 		return
-	var/power = (-0.00004 * (affected_mob.bodytemperature ** 2) + 3) * normalise_creation_purity() * HAS_TRAIT(affected_mob, TRAIT_KNOCKEDOUT) ? 1 : 0.75
+	var/power = (-0.00003 * (affected_mob.bodytemperature ** 2) + 3) * normalise_creation_purity() * HAS_TRAIT(affected_mob, TRAIT_KNOCKEDOUT) ? 1 : 0.75
 	affected_mob.adjustOxyLoss(-3 * power * REM * delta_time, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	affected_mob.adjustBruteLoss(-power * REM * delta_time, FALSE, required_bodytype = affected_bodytype)
 	affected_mob.adjustFireLoss(-power * REM * delta_time, FALSE, required_bodytype = affected_bodytype)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -125,6 +125,7 @@
 	description = "A chemical mixture with almost magical healing powers. Its main limitation is that the patient's body temperature must be under 270K for it to metabolise correctly."
 	color = "#0000C8"
 	taste_description = "blue"
+	creation_purity = REAGENT_STANDARD_PURITY
 	ph = 11
 	burning_temperature = 20 //cold burning
 	burning_volume = 0.1
@@ -132,10 +133,10 @@
 
 /datum/reagent/medicine/cryoxadone/on_mob_life(mob/living/carbon/affected_mob, delta_time, times_fired)
 	metabolization_rate = REAGENTS_METABOLISM * (0.00001 * (affected_mob.bodytemperature ** 2) + 0.5)
-	if(affected_mob.bodytemperature >= T0C || !HAS_TRAIT(affected_mob, TRAIT_KNOCKEDOUT))
+	if(affected_mob.bodytemperature >= T0C)
 		..()
 		return
-	var/power = -0.00003 * (affected_mob.bodytemperature ** 2) + 3
+	var/power = (-0.00004 * (affected_mob.bodytemperature ** 2) + 3) * normalise_creation_purity() * HAS_TRAIT(affected_mob, TRAIT_KNOCKEDOUT) ? 1 : 0.75
 	affected_mob.adjustOxyLoss(-3 * power * REM * delta_time, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 	affected_mob.adjustBruteLoss(-power * REM * delta_time, FALSE, required_bodytype = affected_bodytype)
 	affected_mob.adjustFireLoss(-power * REM * delta_time, FALSE, required_bodytype = affected_bodytype)


### PR DESCRIPTION
## About The Pull Request

It no longer straight up denies healing based on if you're knocked out or not, but rather, it just becomes less effective.

Cryoxadone is now also affected by purity and is only 75% pure by default. (standard purity)

Clearing up a previous misconception, my changes actually made cryoxadone slower, not faster. I've remedied that fact and cryoxadone in cryotubes should stay the same as it was before.

100% pure cryoxadone while conscious has the same exact speed as 75% pure cryoxadone while sleeping. 100% cryoxadone while sleeping is the fastest. In other words, grabbing roundstart cryoxadone and stabbing it into yourself won't be nearly as fast (partly due to the lack of extremely low temperatures) as just using it in a cryotube.

## Why It's Good For The Game

Cryoxadone never really had the same effect here as it did on goon due to how slowly it heals and how many disadvantages being cold gives. There was never any reason to limit cryoxadone to unconscious-only except for justifying the use of anesthetic mix in cryo tubes.

This will also finally stop medics from killing and potentially round-removing people by accidentally slamming them into a cryo tube without disabling their internals. It happens more often than you'd think.

The PR also adds consistency via making it affected by purity like most standard reagents.

Right, I was told to update some of the reasoning here. A main part of this PR is to enable cryoxadone to be used in combat once more. Making it require sleep completely denies it's use in combat. (it's still not OP due to the fact being cold slows you down significantly)
## Changelog
:cl:
balance: Cryoxadone can be used while conscious again and is affected by purity.
/:cl:
