### PR TITLE
[no gbp] Wizard Apprentices don't get the Grand Ritual

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -67,8 +67,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 /datum/antagonist/wizard/on_gain()
 	if(!owner)
 		CRASH("Wizard datum with no owner.")
-	ritual = new(owner.current)
-	RegisterSignal(ritual, COMSIG_GRAND_RITUAL_FINAL_COMPLETE, PROC_REF(on_ritual_complete))
+	assign_ritual()
 	equip_wizard()
 	if(give_objectives)
 		create_objectives()
@@ -96,6 +95,11 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	wiz_team = new(owner)
 	wiz_team.name = "[owner.current.real_name] team"
 	wiz_team.master_wizard = src
+
+/// Initialises the grand ritual action for this mob
+/datum/antagonist/wizard/proc/assign_ritual()
+	ritual = new(owner.current)
+	RegisterSignal(ritual, COMSIG_GRAND_RITUAL_FINAL_COMPLETE, PROC_REF(on_ritual_complete))
 
 /datum/antagonist/wizard/proc/send_to_lair()
 	// And now we ensure that its loaded
@@ -208,13 +212,14 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	var/mob/living/wizard_mob = mob_override || owner.current
 	wizard_mob.faction |= ROLE_WIZARD
 	add_team_hud(wizard_mob)
-	ritual.Grant(owner.current)
+	ritual?.Grant(owner.current)
 
 /datum/antagonist/wizard/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/wizard_mob = mob_override || owner.current
 	wizard_mob.faction -= ROLE_WIZARD
-	ritual.Remove(wizard_mob)
-	UnregisterSignal(ritual, COMSIG_GRAND_RITUAL_FINAL_COMPLETE)
+	if (ritual)
+		ritual.Remove(wizard_mob)
+		UnregisterSignal(ritual, COMSIG_GRAND_RITUAL_FINAL_COMPLETE)
 
 /// If we receive this signal, you're done with objectives
 /datum/antagonist/wizard/proc/on_ritual_complete()
@@ -244,6 +249,9 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 /datum/antagonist/wizard/apprentice/greet()
 	to_chat(owner, "<B>You are [master.current.real_name]'s apprentice! You are bound by magic contract to follow [master.p_their()] orders and help [master.p_them()] in accomplishing [master.p_their()] goals.")
 	owner.announce_objectives()
+
+/datum/antagonist/wizard/apprentice/assign_ritual()
+	return // Haven't learned how to do it yet
 
 /datum/antagonist/wizard/apprentice/equip_wizard()
 	. = ..()
@@ -351,6 +359,9 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	outfit_type = /datum/outfit/wizard/academy
 	move_to_lair = FALSE
 
+/datum/antagonist/wizard/academy/assign_ritual()
+	return // Has other duties to be getting on with
+
 /datum/antagonist/wizard/academy/equip_wizard()
 	. = ..()
 	if(!isliving(owner.current))
@@ -377,7 +388,8 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	var/list/parts = list()
 
 	parts += printplayer(owner)
-	parts += "<br><B>Grand Rituals completed:</B> [ritual.times_completed]<br>"
+	if (ritual)
+		parts += "<br><B>Grand Rituals completed:</B> [ritual.times_completed]<br>"
 
 	var/count = 1
 	var/wizardwin = 1

--- a/tgui/packages/tgui/interfaces/AntagInfoWizard.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoWizard.tsx
@@ -159,17 +159,28 @@ const ObjectivePrintout = (props, context) => {
             </Stack.Item>
           ))}
       </Stack.Item>
-      <Stack.Item>
-        Alternately, complete the{' '}
-        <span style={grandritualstyle}>Grand Ritual </span>
-        by invoking a ritual circle at several nexuses of power.
-        <br />
-        You must complete the ritual
-        <span style={grandritualstyle}> {ritual.remaining}</span> more times.
-        <br />
-        Your next ritual location is the
-        <span style={grandritualstyle}> {ritual.next_area}</span>.
-      </Stack.Item>
+      <RitualPrintout />
     </Stack>
+  );
+};
+
+const RitualPrintout = (props, context) => {
+  const { data } = useBackend<Info>(context);
+  const { objectives, ritual } = data;
+  if (!ritual.next_area) {
+    return <Stack.Item />;
+  }
+  return (
+    <Stack.Item>
+      Alternately, complete the{' '}
+      <span style={grandritualstyle}>Grand Ritual </span>
+      by invoking a ritual circle at several nexuses of power.
+      <br />
+      You must complete the ritual
+      <span style={grandritualstyle}> {ritual.remaining}</span> more times.
+      <br />
+      Your next ritual location is the
+      <span style={grandritualstyle}> {ritual.next_area}</span>.
+    </Stack.Item>
   );
 };


### PR DESCRIPTION
## About The Pull Request

So it turns out "wizard apprentice" is a subtype of wizard.
I moved the "grand ritual" initialising step into its own proc which the apprentice datum overrides to do nothing, so apprentices will no longer gain the Grand Ritual button or objectives.

## Why It's Good For The Game

This would allow a wizard with an apprentice to trigger twice as many events, and plausibly trigger two of the finale effects, which certainly wasn't intended.
Apprentices can still watch your back and can also actually perform the ritual invocation too (they just can't draw their own circles) so they're still handy to have around for this purpose.

## Changelog

:cl:
fix: Wizard Apprentices can no longer draw their own ritual circles.
/:cl:
