### PR TITLE
Dump ejected implant contents onto our turf, not inside our mob

### DIFF
--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -9,20 +9,17 @@
 	. = ..()
 	atom_storage?.open_storage(imp_in)
 
-/obj/item/implant/storage/removed(source, silent = FALSE, special = 0)
-	if(!special)
-		var/mob/living/implantee = source
+/obj/item/implant/storage/removed(source, silent = FALSE, special = FALSE)
+	if(special)
+		return ..()
 
-		var/atom/resolve_parent = atom_storage.parent?.resolve()
-		if(!resolve_parent)
-			return
-
-		for (var/obj/item/I in resolve_parent.contents)
-			I.add_mob_blood(implantee)
-		atom_storage.remove_all(implantee)
-		implantee.visible_message(span_warning("A bluespace pocket opens around [src] as it exits [implantee], spewing out its contents and rupturing the surrounding tissue!"))
-		implantee.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
-		qdel(atom_storage)
+	var/mob/living/implantee = source
+	for (var/obj/item/stored in contents)
+		stored.add_mob_blood(implantee)
+	atom_storage.remove_all()
+	implantee.visible_message(span_warning("A bluespace pocket opens around [src] as it exits [implantee], spewing out its contents and rupturing the surrounding tissue!"))
+	implantee.apply_damage(20, BRUTE, BODY_ZONE_CHEST)
+	qdel(atom_storage)
 	return ..()
 
 /obj/item/implant/storage/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)


### PR DESCRIPTION
## About The Pull Request

Fixes #74119
This was probably a victim of the storage refactor.
When removing items, it was dumping them _inside the mob_ rather than on the floor, additionally it was putting mob blood on every item already inside the mob rather than on the items being dumped for some reason? 
Now it doesn't do that.

## Why It's Good For The Game

Removing a storage implant from someone should dump the items, not trap them in your body.

## Changelog

:cl:
fix: Removing a storage implant from someone will dump the items on the ground rather than inside the mob.
/:cl: