### PR TITLE
Fixes stray cargo pod false alarms runtiming.

### DIFF
--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -40,6 +40,8 @@
 	var/admin_override_contents
 
 /datum/round_event/stray_cargo/announce(fake)
+	if(fake)
+		impact_area = find_event_area()
 	priority_announce("Stray cargo pod detected on long-range scanners. Expected location of impact: [impact_area.name].", "Collision Alert")
 
 /**


### PR DESCRIPTION

## About The Pull Request

False alarms for stray cargo pods were no generating a impact_area which is used for the announcements, I've added code that checks if the alarm is false and generates one in this case.
## Why It's Good For The Game

Bugfix
## Changelog
:cl:
fix: Stray Cargo Pod false alarms will once again play an announcement when they occur.
/:cl:
