### PR TITLE
Fixes misspelling of Paçoca.

### DIFF
--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -413,7 +413,7 @@
 	tastes = list()
 
 /obj/item/food/pacoca
-	name = "pacoca"
+	name = "paçoca"
 	desc = "A traditional Brazilian treat made of ground peanuts, sugar, and salt compressed into a cylinder."
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "pacoca"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -282,7 +282,7 @@
 	category = CAT_MISCFOOD
 
 /datum/crafting_recipe/food/pacoca
-	name = "Pacoca"
+	name = "Paçoca"
 	reqs = list(
 		/obj/item/food/grown/peanut = 2,
 		/datum/reagent/consumable/sugar = 5,


### PR DESCRIPTION

## About The Pull Request

I changed exactly 2 letters of code, The name of the food item in-game should now properly be "Paçoca"
## Why It's Good For The Game

I'm not really sure why it was wrong in the first place. This is the only Brazilian food item in the game, it better at least get the name right
I was initially worried that this might cause issues for those who do not have Ç on their keyboard to search it, but then again, mothic food exists
## Changelog
:cl:
spellcheck: Pacoca is now called "Paçoca", as it should
/:cl:
