### PR TITLE
Fix missing meat clown food types

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -720,6 +720,7 @@
 	)
 	tastes = list("meat" = 5, "clowns" = 3, "sixteen teslas" = 1)
 	w_class = WEIGHT_CLASS_SMALL
+	foodtypes = MEAT | FRUIT
 
 /obj/item/food/meatclown/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
:cl: coiax
fix: Fixed missing food types for the meat clown, it is now meat and fruit.
/:cl:

Liked by lizards, toxic to moths, and neutral to humans and felnids in terms of species biases.

The construction recipe is steak + banana, but the resulting product has no food types, making it blandly suitable for everyone. This is an oversight. Not everyone will like a mixture of banana and flesh.