### PR TITLE
Ups the internal damage threshold on particular mechs

### DIFF
--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -6,6 +6,7 @@
 	movedelay = 4
 	max_integrity = 400
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
+	internal_damage_threshold = 17
 	armor_type = /datum/armor/mecha_durand
 	max_temperature = 30000
 	force = 40

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -7,7 +7,7 @@
 	movedelay = 3
 	max_integrity = 250
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
-	internal_damage_threshold = 23
+	internal_damage_threshold = 22
 	armor_type = /datum/armor/mecha_gygax
 	max_temperature = 25000
 	leg_overload_coeff = 80

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -7,6 +7,7 @@
 	movedelay = 3
 	max_integrity = 250
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
+	internal_damage_threshold = 23
 	armor_type = /datum/armor/mecha_gygax
 	max_temperature = 25000
 	leg_overload_coeff = 80

--- a/code/modules/vehicles/mecha/combat/honker.dm
+++ b/code/modules/vehicles/mecha/combat/honker.dm
@@ -12,6 +12,7 @@
 	exit_delay = 40
 	operation_req_access = list(ACCESS_THEATRE)
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_THEATRE)
+	internal_damage_threshold = 20
 	wreckage = /obj/structure/mecha_wreckage/honker
 	mecha_flags = CANSTRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE
 	mech_type = EXOSUIT_MODULE_HONK

--- a/code/modules/vehicles/mecha/combat/honker.dm
+++ b/code/modules/vehicles/mecha/combat/honker.dm
@@ -12,7 +12,7 @@
 	exit_delay = 40
 	operation_req_access = list(ACCESS_THEATRE)
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_THEATRE)
-	internal_damage_threshold = 20
+	internal_damage_threshold = 18
 	wreckage = /obj/structure/mecha_wreckage/honker
 	mecha_flags = CANSTRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE
 	mech_type = EXOSUIT_MODULE_HONK
@@ -45,6 +45,7 @@
 	max_temperature = 35000
 	operation_req_access = list(ACCESS_SYNDICATE)
 	internals_req_access = list(ACCESS_SYNDICATE)
+	internal_damage_threshold = 20
 	wreckage = /obj/structure/mecha_wreckage/honker/dark
 	max_equip_by_category = list(
 		MECHA_UTILITY = 1,

--- a/code/modules/vehicles/mecha/combat/marauder.dm
+++ b/code/modules/vehicles/mecha/combat/marauder.dm
@@ -12,6 +12,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	operation_req_access = list(ACCESS_CENT_SPECOPS)
 	internals_req_access = list(ACCESS_CENT_SPECOPS)
+	internal_damage_threshold = 20
 	wreckage = /obj/structure/mecha_wreckage/marauder
 	mecha_flags = CANSTRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE
 	mech_type = EXOSUIT_MODULE_MARAUDER

--- a/code/modules/vehicles/mecha/combat/phazon.dm
+++ b/code/modules/vehicles/mecha/combat/phazon.dm
@@ -9,6 +9,7 @@
 	armor_type = /datum/armor/mecha_phazon
 	max_temperature = 25000
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)
+	internal_damage_threshold = 25
 	destruction_sleep_duration = 40
 	exit_delay = 40
 	wreckage = /obj/structure/mecha_wreckage/phazon

--- a/code/modules/vehicles/mecha/combat/reticence.dm
+++ b/code/modules/vehicles/mecha/combat/reticence.dm
@@ -13,6 +13,7 @@
 	wreckage = /obj/structure/mecha_wreckage/reticence
 	operation_req_access = list(ACCESS_THEATRE)
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_THEATRE)
+	internal_damage_threshold = 23
 	mecha_flags = CANSTRAFE | IS_ENCLOSED | HAS_LIGHTS | QUIET_STEPS | QUIET_TURNS | MMI_COMPATIBLE
 	mech_type = EXOSUIT_MODULE_RETICENCE
 	max_equip_by_category = list(

--- a/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
+++ b/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
@@ -23,6 +23,7 @@
 	mech_type = EXOSUIT_MODULE_SAVANNAH
 	movedelay = 3
 	max_integrity = 450 //really tanky, like damn
+	internal_damage_threshold = 20
 	armor_type = /datum/armor/mecha_savannah_ivanov
 	max_temperature = 30000
 	force = 30

--- a/code/modules/vehicles/mecha/medical/odysseus.dm
+++ b/code/modules/vehicles/mecha/medical/odysseus.dm
@@ -11,6 +11,7 @@
 	mech_type = EXOSUIT_MODULE_ODYSSEUS
 	step_energy_drain = 6
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_MEDICAL)
+	internal_damage_threshold = 22
 
 /obj/vehicle/sealed/mecha/odysseus/moved_inside(mob/living/carbon/human/H)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Increases the threshold of damage (thru armour) required for internal damage on some mechs, chiefly the lighter combat mechas, and the Odysseus plus the 'unique' mechas like the Savannah, or Marauders to reflect pre-TGUI mech damage.



## Why It's Good For The Game

Currently, the internal threshold on every mech is 15, meaning any damage received that's 15 or over will result in a 20% chance for internal damage, and a 5% chance (roughly) for a coordination failure, regardless of the mech's initial health.

While this encourages mech to be specialized to a specific type of combat (melee OR ranged, not both), it also punishes lightweight mechs for their relatively low max armor, e.g. the Phazon which has a max of 60% melee resistance, will still take over 15 damage when hit by an energy sword, a relatively common traitor item. 

Raising the internal threshold doesn't affect how many hits it'll take to destroy a mech, only if the mech will roll for intenral damage - a fully-armoured Phazon or Gygax will still die in about 13 hits, and probably shouldn't be literally RNG hard-stunned for this duration. This aims to somewhat reflect the internal damage thresholds of mechs before the TGUI change, e.g. lightweight mechs with lower HP/armour pools had _more_ internal resistance, (Gygax - 35%, Durand - 50%, Odysseus - 35%, Phazon - 25%), excluding Nuke/CC Mechs, and the Savannah-Ivanov.
## Changelog


:cl:
balance: Increases the internal threshold of various mecha across the board.
/:cl:
