### PR TITLE
Goliath-Infused Tendril Hammer uses an internal cooldown for the its special attack instead of a universal click cooldown

### DIFF
--- a/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_one_entries.dm
+++ b/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_one_entries.dm
@@ -10,10 +10,10 @@
 	desc = "The guy who said 'Whoever fights monsters should see to it that in the process he does not become a monster' clearly didn't see what a goliath miner can do!"
 	threshold_desc = "you can walk on lava!"
 	qualities = list(
-		"can breath both the station and lavaland air but can't deal with pure O2",
+		"can breath both the station and lavaland air, but be careful around pure 02",
 		"immune to ashstorms",
 		"eyes that can see in the dark",
-		"a tendril hand can easily dig through basalt and obliterate hostile fauna, won't be fitting on gloves any time soon tho...",
+		"a tendril hand can easily dig through basalt and obliterate hostile fauna, but your glove-wearing days are behind you...",
 	)
 	input_obj_or_mob = list(
 		/mob/living/simple_animal/hostile/asteroid/goliath,

--- a/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_one_entries.dm
+++ b/code/game/machinery/dna_infuser/infuser_entries/infuser_tier_one_entries.dm
@@ -10,7 +10,7 @@
 	desc = "The guy who said 'Whoever fights monsters should see to it that in the process he does not become a monster' clearly didn't see what a goliath miner can do!"
 	threshold_desc = "you can walk on lava!"
 	qualities = list(
-		"can breath both the station and lavaland air, but be careful around pure 02",
+		"can breath both the station and lavaland air, but be careful around pure oxygen",
 		"immune to ashstorms",
 		"eyes that can see in the dark",
 		"a tendril hand can easily dig through basalt and obliterate hostile fauna, but your glove-wearing days are behind you...",

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -123,25 +123,25 @@
 	. = ..()
 	. += "You can use your tendril hammer arm to deliver a devastating blow against mining fauna by <b>right-clicking</b> them with the arm."
 
-/obj/item/goliath_infuser_hammer/afterattack_secondary(atom/target, mob/living/user, proximity_flag, click_parameters)
+/obj/item/goliath_infuser_hammer/attack(mob/living/target, mob/living/carbon/human/user, proximity_flag, click_parameters)
 	. = ..()
 	if(!proximity_flag)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		return
 
 	//If we're on cooldown, we'll do a normal attack.
 	if(!COOLDOWN_FINISHED(src, tendril_hammer_cd))
-		return SECONDARY_ATTACK_CALL_NORMAL
+		return
 
 	//do a normal attack if our target isn't living, since we're gonna define them after this.
 	if(!isliving(target))
-		return SECONDARY_ATTACK_CALL_NORMAL
+		return
 
 	var/mob/living/fresh_pancake = target
 
 	// Check for nemesis factions on the target.
 	if(!(FACTION_MINING in fresh_pancake.faction) && !(FACTION_BOSS in fresh_pancake.faction))
 		// Target is not a nemesis, so attack normally.
-		return SECONDARY_ATTACK_CALL_NORMAL
+		return
 
 	// Apply nemesis-specific effects.
 	nemesis_effects(user, fresh_pancake)
@@ -149,8 +149,6 @@
 	// Target is a nemesis, and so now we do the extra big damage and go on cooldown
 	fresh_pancake.apply_damage(mining_bonus_force, damtype) //smush
 	COOLDOWN_START(src, tendril_hammer_cd, 2 SECONDS)
-
-	return SECONDARY_ATTACK_CALL_NORMAL //we're still doing a normal attack!
 
 /obj/item/goliath_infuser_hammer/proc/nemesis_effects(mob/living/user, mob/living/target)
 	if(istype(target, /mob/living/simple_animal/hostile/asteroid/elite))

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -122,7 +122,7 @@
 
 /obj/item/goliath_infuser_hammer/examine(mob/user)
 	. = ..()
-	. += "You can use your tendril hammer arm to deliver a devastating blow against mining fauna by <b>right-clicking</b> them with the arm."
+	. += "You can use your tendril hammer arm to deliver a devastating blow against mining fauna, but only once every two seconds."
 
 /obj/item/goliath_infuser_hammer/attack(mob/living/target, mob/living/carbon/human/user, proximity_flag, click_parameters)
 	. = ..()

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -119,6 +119,10 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 
+/obj/item/goliath_infuser_hammer/examine(mob/user)
+	. = ..()
+	. += "You can use your tendril hammer arm to deliver a devastating blow against mining fauna by <b>right-clicking</b> them with the arm."
+
 /obj/item/goliath_infuser_hammer/afterattack_secondary(atom/target, mob/living/user, proximity_flag, click_parameters)
 	. = ..()
 	if(!proximity_flag)

--- a/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/goliath_organs.dm
@@ -113,6 +113,7 @@
 	toolspeed = 0.1
 	/// Amount of damage we deal to the mining and boss factions.
 	var/mining_bonus_force = 80
+	/// Our cooldown declare for our special knockback hit
 	COOLDOWN_DECLARE(tendril_hammer_cd)
 
 /obj/item/goliath_infuser_hammer/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Rather than using a click cooldown, the tendril hammer instead can make its special heavy attack every 2 seconds.

## Why It's Good For The Game

In my newfound quest to try and eliminate universal click cooldowns or weird non-interactivity timers as balancing factors, this definitely is one of the biggest standout offenders. Lemme make an argument for universal click cooldowns increases being an ineffective limitation. 

I'll use the problems presented by the tendril hammer to highlight some of those problems, as well as unique problems to the tendril hammer itself.

<details>
  <summary>da big discussion</summary>

A) The functionality of the hammer actively inhibits all in-game handuse interaction for several seconds, without explaining this to a player. As a player, you won't know why this is happening, as universal click cooldown is not present as a UI element.

B) Since universal click cooldowns are not visible to players, it might feel more like the game is malfunctioning rather than being a deliberate mechanic. Even if click cooldowns were visible, players probably would think that the cooldown applies to the hammer, and not handuse interactivity with the game world as a whole for several seconds.

C) The functionality of the hammer could work fine as an internal cooldown on the hammer, only relevant to the hammer. This ensures that its special effects are exclusive, without the need to interrupt player interaction as a whole.

D) Since we're talking about miners. If someone is concerned about the hammer being used on the station against carbon players; you need someone to help mutate you into goliath mutant, which cannot be bypassed whatsoever. An excellent example of something similar is the chainsaw arm, created right next door to genetics in robotics, which does even more force than the arm and is sharp. With the limitations that exist, I think it probably discourages most powergaming, if that was even a realistic concern (it really isn't).

E) You lose both a hand AND your gloves slot when you get the hammer. No modsuits, no glove equipment, no two-handed equipment, and you now have to juggle everything with one hand assuming you're not on your, once again, universal click cooldown for several precious seconds. Miners live or die in their rapid response to problems. This is also the total sum of what you lose as a miner. That's a steep cost and it just doesn't justify its own value compared to what you lose.

</details>

TL;DR - There is no offset to the cost of this weapon, it is strictly a detriment because of poorly conceived implementation.

This is maybe one of the coolest ideas conceptually for the infusions so far, heavily hampered by what seems to be an intense fear of the mutation being _too useful_. So it was made _borderline masochistic to willingly seek out and use_.

I want to see this actually be useful. I can't see this with the restrictions it has. Hopefully this is enough to make it worthwhile getting.

## Changelog
:cl:
balance: Changes the universal click cooldown of the tendril hammer from the goliath infusion into an internal cooldown just for the special heavy attack.
/:cl:
