### PR TITLE
Drawing from an empty tarot card deck no longer causes runtimes

### DIFF
--- a/code/modules/cards/deck/tarot.dm
+++ b/code/modules/cards/deck/tarot.dm
@@ -23,6 +23,9 @@
 	. = ..()
 	if(prob(50))
 		var/obj/item/toy/singlecard/card = .
+		if(!card)
+			return FALSE
+
 		var/matrix/M = matrix()
 		M.Turn(180)
 		card.transform = M


### PR DESCRIPTION

## About The Pull Request
Does as the title says. When drawing from an empty deck, the deck would have a chance to preform a transformation on a card that doesn't exist. This PR makes it so that if there is no card, the code returns `FALSE`. 
### Mapping March
Ckey to receive rewards: N/A

## Why It's Good For The Game
Runtimes aren't a good thing to have in the game.
## Changelog
:cl:
fix: drawing from an empty tarot card deck no longer causes runtimes
/:cl:
