### PR TITLE
adds lights to the tramstation head of personnel's office

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -33460,6 +33460,7 @@
 /obj/item/pen{
 	pixel_x = -4
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "kHZ" = (
@@ -60696,6 +60697,7 @@
 /obj/structure/sign/poster/official/love_ian{
 	pixel_x = -32
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
 "uyA" = (


### PR DESCRIPTION
## About The Pull Request
Adds two lights to the tramstation head of personnel's office.

<details>
<summary>Pictures:</summary>

Before:
![before](https://user-images.githubusercontent.com/94711066/226740643-31c92210-8a19-45f3-9265-97b6a91dfe4f.PNG)

After:
![after](https://user-images.githubusercontent.com/94711066/226740657-ae2898c5-2f4a-49d4-82e7-abc51719224d.PNG)
</details>

## Why It's Good For The Game
The tramstation HOP office currently has no lights of its own. You do get some decent light coming in through the windows, but the corner is a bit dim especially. With this you can keep things well lit in your office, even when the lights in the surrounding hallways are on night shift mode or broken.

## Changelog
:cl:
fix: added lights to the tramstation head of personnel's office
/:cl:
