### PR TITLE
Fixes gondola meatslab not being able to be placed into infuser

### DIFF
--- a/code/game/objects/items/food/meatslab.dm
+++ b/code/game/objects/items/food/meatslab.dm
@@ -352,7 +352,7 @@
 		/datum/reagent/consumable/cooking_oil = 3,
 	)
 	tastes = list("meat" = 4, "tranquility" = 1)
-	foodtypes = RAW | MEAT
+	foodtypes = RAW | MEAT | GORE
 
 /obj/item/food/meat/slab/gondola/make_processable()
 	AddElement(/datum/element/processable, TOOL_KNIFE, /obj/item/food/meat/rawcutlet/gondola, 3, 3 SECONDS, table_required = TRUE, screentip_verb = "Cut")


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/73796 Seems to have made it so that gondola meat is used in the infuser instead of its body, which turns into meat on death. The issue with that is the meat slab does not have the `GORE` flag and so was rejected by the infuser. 

As per https://github.com/tgstation/tgstation/blob/afe6ecc353eef0db92a23dd1928768651071d11e/code/game/machinery/dna_infuser/dna_infuser.dm#L294-L297

Looking at the code this should fix it right up.

## Why It's Good For The Game

Bugfix

## Changelog
:cl:
fix: fixes gondola meatslab not being able to be placed into the DNA infuser
/:cl:
