### PR TITLE
Bioscrambler scrambles your organs again

### DIFF
--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -17,16 +17,19 @@
 #define ANOMALY_MOVECHANCE 45
 
 /// Blacklist of parts which should not appear when bioscrambled, largely because they will make you look totally fucked up
-GLOBAL_LIST_INIT(bioscrambler_parts_blacklist, list(
+GLOBAL_LIST_INIT(bioscrambler_parts_blacklist, typecacheof(list(
 	/obj/item/bodypart/chest/larva,
 	/obj/item/bodypart/head/larva,
+	// Re-add the ones below this line when the bug with offset is fixed
+	/obj/item/bodypart/leg/left/monkey,
+	/obj/item/bodypart/leg/right/monkey,
 	/obj/item/bodypart/leg/left/tallboy,
 	/obj/item/bodypart/leg/right/tallboy,
-))
+)))
 
 /// Blacklist of organs which should not appear when bioscrambled.
 /// Either will look terrible outside of intended host, give you magical powers, are irreversible, or kill you
-GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, list (
+GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, typecacheof(list (
 	/obj/item/organ/external/pod_hair,
 	/obj/item/organ/external/spines,
 	/obj/item/organ/external/wings/functional,
@@ -40,7 +43,7 @@ GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, list (
 	/obj/item/organ/internal/monster_core,
 	/obj/item/organ/internal/vocal_cords/colossus,
 	/obj/item/organ/internal/zombie_infection,
-))
+)))
 
 /// List of body parts we can apply to people
 GLOBAL_LIST_EMPTY(bioscrambler_valid_parts)

--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -15,3 +15,34 @@
 
 /// Chance of anomalies moving every process tick
 #define ANOMALY_MOVECHANCE 45
+
+/// Blacklist of parts which should not appear when bioscrambled, largely because they will make you look totally fucked up
+GLOBAL_LIST_INIT(bioscrambler_parts_blacklist, list(
+	/obj/item/bodypart/chest/larva,
+	/obj/item/bodypart/head/larva,
+	/obj/item/bodypart/leg/left/tallboy,
+	/obj/item/bodypart/leg/right/tallboy,
+))
+
+/// Blacklist of organs which should not appear when bioscrambled.
+/// Either will look terrible outside of intended host, give you magical powers, are irreversible, or kill you
+GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, list (
+	/obj/item/organ/external/pod_hair,
+	/obj/item/organ/external/spines,
+	/obj/item/organ/external/wings/functional,
+	/obj/item/organ/internal/alien,
+	/obj/item/organ/internal/brain,
+	/obj/item/organ/internal/body_egg,
+	/obj/item/organ/internal/cyberimp,
+	/obj/item/organ/internal/heart/cursed,
+	/obj/item/organ/internal/heart/demon,
+	/obj/item/organ/internal/lungs,
+	/obj/item/organ/internal/monster_core,
+	/obj/item/organ/internal/vocal_cords/colossus,
+	/obj/item/organ/internal/zombie_infection,
+))
+
+/// List of body parts we can apply to people
+GLOBAL_LIST_EMPTY(bioscrambler_valid_parts)
+/// List of organs we can apply to people
+GLOBAL_LIST_EMPTY(bioscrambler_valid_organs)

--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -134,20 +134,8 @@
 		return FALSE
 	// Valid organ successfully picked.
 	new_organ = new new_organ()
-	if(!istype(new_organ, /obj/item/organ/internal/brain))
-		// Organ ISN'T brain, insert normally.
-		new_organ.Insert(target, special = TRUE, drop_if_replaced = FALSE)
-		check_tier_progression(target)
-		return TRUE
-	// Organ IS brain, insert via special logic:
-	var/obj/item/organ/internal/brain/old_brain = target.getorganslot(ORGAN_SLOT_BRAIN)
-	// Brains REALLY like ghosting people. we need special tricks to avoid that, namely removing the old brain with no_id_transfer
-	old_brain.Remove(target, special = TRUE, no_id_transfer = TRUE)
-	qdel(old_brain)
-	var/obj/item/organ/internal/brain/new_brain = new_organ
-	new_brain.Insert(target, special = TRUE, drop_if_replaced = FALSE, no_id_transfer = TRUE)
+	new_organ.replace_into(target)
 	check_tier_progression(target)
-	return TRUE
 
 /// Picks a random mutated organ from the infuser entry which is also compatible with the target mob.
 /// Tries to return a typepath of a valid mutant organ if all of the following criteria are true:

--- a/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
@@ -54,14 +54,13 @@
 
 /obj/effect/anomaly/bioscrambler/anomalyEffect(delta_time)
 	. = ..()
-
 	if(!COOLDOWN_FINISHED(src, pulse_cooldown))
 		return
 
 	COOLDOWN_START(src, pulse_cooldown, pulse_delay)
-
 	swap_parts(range)
 
+/// Replaces your limbs and organs with something else
 /obj/effect/anomaly/bioscrambler/proc/swap_parts(swap_range)
 	for(var/mob/living/carbon/nearby in range(swap_range, src))
 		if (nearby.run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [src]!") >= 100)
@@ -70,6 +69,11 @@
 		var/obj/item/organ/new_organ = pick(organs)
 		new_organ = new new_organ()
 		new_organ.replace_into(nearby)
+
+		if (islarva(nearby))
+			nearby.update_body(TRUE)
+			balloon_alert(nearby, "something has changed about you")
+			continue
 
 		var/obj/item/bodypart/new_part = pick(body_parts)
 		new_part = new new_part()

--- a/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
@@ -10,47 +10,6 @@
 	var/pulse_delay = 15 SECONDS
 	/// Range of the anomaly pulse
 	var/range = 5
-	/// List of body parts which can be inserted
-	var/static/list/body_parts
-	/// Blacklist of parts which should not appear, largely because they will make you look totally fucked up
-	var/static/list/parts_blacklist = list(
-		/obj/item/bodypart/chest/larva,
-		/obj/item/bodypart/head/larva,
-		/obj/item/bodypart/leg/left/tallboy,
-		/obj/item/bodypart/leg/right/tallboy,
-	)
-	/// List of organs which can be inserted
-	var/static/list/organs
-	/// Blacklist of organs which should not appear. Either will look terrible outside of intended, give you magical powers, or kill you
-	var/static/list/organs_blacklist = list(
-		/obj/item/organ/external/pod_hair,
-		/obj/item/organ/external/spines,
-		/obj/item/organ/external/wings/functional,
-		/obj/item/organ/internal/body_egg,
-		/obj/item/organ/internal/cyberimp,
-		/obj/item/organ/internal/heart/cursed,
-		/obj/item/organ/internal/heart/demon,
-		/obj/item/organ/internal/lungs,
-		/obj/item/organ/internal/monster_core,
-		/obj/item/organ/internal/vocal_cords/colossus,
-		/obj/item/organ/internal/zombie_infection,
-	)
-
-/obj/effect/anomaly/bioscrambler/Initialize(mapload, new_lifespan, drops_core)
-	. = ..()
-	if (!body_parts)
-		body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
-		for (var/obj/item/bodypart/part as anything in body_parts)
-			if (!is_path_in_list(part, parts_blacklist) && !(initial(part.bodytype) & BODYTYPE_ROBOTIC))
-				continue
-			body_parts -= part
-
-	if(!organs)
-		organs = subtypesof(/obj/item/organ/internal) + subtypesof(/obj/item/organ/external)
-		for (var/obj/item/organ/organ_type as anything in organs)
-			if (!is_path_in_list(organ_type, organs_blacklist) && !(initial(organ_type.organ_flags) & ORGAN_SYNTHETIC))
-				continue
-			organs -= organ_type
 
 /obj/effect/anomaly/bioscrambler/anomalyEffect(delta_time)
 	. = ..()
@@ -58,29 +17,5 @@
 		return
 
 	COOLDOWN_START(src, pulse_cooldown, pulse_delay)
-	swap_parts(range)
-
-/// Replaces your limbs and organs with something else
-/obj/effect/anomaly/bioscrambler/proc/swap_parts(swap_range)
-	for(var/mob/living/carbon/nearby in range(swap_range, src))
-		if (nearby.run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [src]!") >= 100)
-			continue //We are protected
-
-		var/obj/item/organ/new_organ = pick(organs)
-		new_organ = new new_organ()
-		new_organ.replace_into(nearby)
-
-		if (islarva(nearby))
-			nearby.update_body(TRUE)
-			balloon_alert(nearby, "something has changed about you")
-			continue
-
-		var/obj/item/bodypart/new_part = pick(body_parts)
-		new_part = new new_part()
-		var/obj/item/bodypart/picked_user_part = nearby.get_bodypart(new_part.body_zone)
-		new_part.replace_limb(nearby, TRUE)
-		if (picked_user_part)
-			qdel(picked_user_part)
-
-		nearby.update_body(TRUE)
-		balloon_alert(nearby, "something has changed about you")
+	for(var/mob/living/carbon/nearby in range(range, src))
+		nearby.bioscramble(name)

--- a/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
@@ -10,29 +10,47 @@
 	var/pulse_delay = 15 SECONDS
 	/// Range of the anomaly pulse
 	var/range = 5
-	///Lists for zones and bodyparts to swap and randomize
-	var/static/list/zones = list(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
-	var/static/list/chests
-	var/static/list/heads
-	var/static/list/l_arms
-	var/static/list/r_arms
-	var/static/list/l_legs
-	var/static/list/r_legs
+	/// List of body parts which can be inserted
+	var/static/list/body_parts
+	/// Blacklist of parts which should not appear, largely because they will make you look totally fucked up
+	var/static/list/parts_blacklist = list(
+		/obj/item/bodypart/chest/larva,
+		/obj/item/bodypart/head/larva,
+		/obj/item/bodypart/leg/left/tallboy,
+		/obj/item/bodypart/leg/right/tallboy,
+	)
+	/// List of organs which can be inserted
+	var/static/list/organs
+	/// Blacklist of organs which should not appear. Either will look terrible outside of intended, give you magical powers, or kill you
+	var/static/list/organs_blacklist = list(
+		/obj/item/organ/external/pod_hair,
+		/obj/item/organ/external/spines,
+		/obj/item/organ/external/wings/functional,
+		/obj/item/organ/internal/body_egg,
+		/obj/item/organ/internal/cyberimp,
+		/obj/item/organ/internal/heart/cursed,
+		/obj/item/organ/internal/heart/demon,
+		/obj/item/organ/internal/lungs,
+		/obj/item/organ/internal/monster_core,
+		/obj/item/organ/internal/vocal_cords/colossus,
+		/obj/item/organ/internal/zombie_infection,
+	)
 
 /obj/effect/anomaly/bioscrambler/Initialize(mapload, new_lifespan, drops_core)
 	. = ..()
-	if(!chests)
-		chests = typesof(/obj/item/bodypart/chest)
-	if(!heads)
-		heads = typesof(/obj/item/bodypart/head)
-	if(!l_arms)
-		l_arms = typesof(/obj/item/bodypart/arm/left)
-	if(!r_arms)
-		r_arms = typesof(/obj/item/bodypart/arm/right)
-	if(!l_legs)
-		l_legs = typesof(/obj/item/bodypart/leg/left)
-	if(!r_legs)
-		r_legs = typesof(/obj/item/bodypart/leg/right)
+	if (!body_parts)
+		body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
+		for (var/obj/item/bodypart/part as anything in body_parts)
+			if (!is_path_in_list(part, parts_blacklist) && !(initial(part.bodytype) & BODYTYPE_ROBOTIC))
+				continue
+			body_parts -= part
+
+	if(!organs)
+		organs = subtypesof(/obj/item/organ/internal) + subtypesof(/obj/item/organ/external)
+		for (var/obj/item/organ/organ_type as anything in organs)
+			if (!is_path_in_list(organ_type, organs_blacklist) && !(initial(organ_type.organ_flags) & ORGAN_SYNTHETIC))
+				continue
+			organs -= organ_type
 
 /obj/effect/anomaly/bioscrambler/anomalyEffect(delta_time)
 	. = ..()
@@ -46,27 +64,19 @@
 
 /obj/effect/anomaly/bioscrambler/proc/swap_parts(swap_range)
 	for(var/mob/living/carbon/nearby in range(swap_range, src))
-		if(nearby.run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [src]!") >= 100)
+		if (nearby.run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [src]!") >= 100)
 			continue //We are protected
-		var/picked_zone = pick(zones)
-		var/obj/item/bodypart/picked_user_part = nearby.get_bodypart(picked_zone)
-		var/obj/item/bodypart/picked_part
-		switch(picked_zone)
-			if(BODY_ZONE_HEAD)
-				picked_part = pick(heads)
-			if(BODY_ZONE_CHEST)
-				picked_part = pick(chests)
-			if(BODY_ZONE_L_ARM)
-				picked_part = pick(l_arms)
-			if(BODY_ZONE_R_ARM)
-				picked_part = pick(r_arms)
-			if(BODY_ZONE_L_LEG)
-				picked_part = pick(l_legs)
-			if(BODY_ZONE_R_LEG)
-				picked_part = pick(r_legs)
-		var/obj/item/bodypart/new_part = new picked_part()
+
+		var/obj/item/organ/new_organ = pick(organs)
+		new_organ = new new_organ()
+		new_organ.replace_into(nearby)
+
+		var/obj/item/bodypart/new_part = pick(body_parts)
+		new_part = new new_part()
+		var/obj/item/bodypart/picked_user_part = nearby.get_bodypart(new_part.body_zone)
 		new_part.replace_limb(nearby, TRUE)
-		if(picked_user_part)
+		if (picked_user_part)
 			qdel(picked_user_part)
+
 		nearby.update_body(TRUE)
 		balloon_alert(nearby, "something has changed about you")

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -406,29 +406,7 @@
 	for(var/mob/living/carbon/nearby in range(range, get_turf(src)))
 		if(!can_hit_owner && nearby == owner)
 			continue
-		if(nearby.run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [src]!") >= 100)
-			continue //We are protected
-		var/picked_zone = pick(zones)
-		var/obj/item/bodypart/picked_user_part = nearby.get_bodypart(picked_zone)
-		var/obj/item/bodypart/picked_part
-		switch(picked_zone)
-			if(BODY_ZONE_HEAD)
-				picked_part = pick(heads)
-			if(BODY_ZONE_CHEST)
-				picked_part = pick(chests)
-			if(BODY_ZONE_L_ARM)
-				picked_part = pick(l_arms)
-			if(BODY_ZONE_R_ARM)
-				picked_part = pick(r_arms)
-			if(BODY_ZONE_L_LEG)
-				picked_part = pick(l_legs)
-			if(BODY_ZONE_R_LEG)
-				picked_part = pick(r_legs)
-		var/obj/item/bodypart/new_part = new picked_part()
-		new_part.replace_limb(nearby, TRUE)
-		qdel(picked_user_part)
-		nearby.update_body(TRUE)
-		balloon_alert(nearby, "something has changed about you")
+		nearby.bioscramble(name)
 
 // When the wearer gets hit, this armor will push people nearby and spawn some blocking objects.
 /obj/item/clothing/suit/armor/reactive/barricade

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -496,3 +496,10 @@
 		var/obj/item/bodypart/found_bodypart = owner.get_bodypart((active_hand.held_index % 2) ? BODY_ZONE_L_LEG : BODY_ZONE_R_LEG)
 		return found_bodypart || active_hand
 	return active_hand
+
+/// Brains REALLY like ghosting people. we need special tricks to avoid that, namely removing the old brain with no_id_transfer
+/obj/item/organ/internal/brain/replace_into(mob/living/carbon/new_owner)
+	var/obj/item/organ/internal/brain/old_brain = new_owner.getorganslot(ORGAN_SLOT_BRAIN)
+	old_brain.Remove(new_owner, special = TRUE, no_id_transfer = TRUE)
+	qdel(old_brain)
+	Insert(new_owner, special = TRUE, drop_if_replaced = FALSE, no_id_transfer = TRUE)

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -74,3 +74,7 @@
 
 /mob/living/carbon/alien/larva/canBeHandcuffed()
 	return TRUE
+
+/// Don't scramble a larva's body parts, it doesn't have any
+/mob/living/carbon/alien/larva/bioscramble(scramble_source)
+	return

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -77,4 +77,4 @@
 
 /// Don't scramble a larva's body parts, it doesn't have any
 /mob/living/carbon/alien/larva/bioscramble(scramble_source)
-	return
+	return TRUE

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -794,14 +794,14 @@
 /mob/living/carbon/proc/init_bioscrambler_lists()
 	var/list/body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
 	for (var/obj/item/bodypart/part as anything in body_parts)
-		if (!is_path_in_list(part, GLOB.bioscrambler_parts_blacklist) && !(initial(part.bodytype) & BODYTYPE_ROBOTIC))
+		if (!is_type_in_typecache(part, GLOB.bioscrambler_parts_blacklist) && !(initial(part.bodytype) & BODYTYPE_ROBOTIC))
 			continue
 		body_parts -= part
 	GLOB.bioscrambler_valid_parts = body_parts
 
 	var/list/organs = subtypesof(/obj/item/organ/internal) + subtypesof(/obj/item/organ/external)
 	for (var/obj/item/organ/organ_type as anything in organs)
-		if (!is_path_in_list(organ_type, GLOB.bioscrambler_organs_blacklist) && !(initial(organ_type.organ_flags) & ORGAN_SYNTHETIC))
+		if (!is_type_in_typecache(organ_type, GLOB.bioscrambler_organs_blacklist) && !(initial(organ_type.organ_flags) & ORGAN_SYNTHETIC))
 			continue
 		organs -= organ_type
 	GLOB.bioscrambler_valid_organs = organs

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -779,7 +779,7 @@
 	if (!(picked_user_part?.bodytype & BODYTYPE_ROBOTIC))
 		changed_something = TRUE
 		new_part = new new_part()
-		new_part.replace_limb(src, TRUE)
+		new_part.replace_limb(src, special = TRUE)
 		if (picked_user_part)
 			qdel(picked_user_part)
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -758,4 +758,52 @@
 	playsound(get_turf(src), 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 	return TRUE
 
+/// Randomise a body part and organ of this mob
+/mob/living/carbon/proc/bioscramble(scramble_source)
+	if (run_armor_check(attack_flag = BIO, absorb_text = "Your armor protects you from [scramble_source]!") >= 100)
+		return FALSE
+
+	if (!length(GLOB.bioscrambler_valid_organs) || !length(GLOB.bioscrambler_valid_parts))
+		init_bioscrambler_lists()
+
+	var/changed_something = FALSE
+	var/obj/item/organ/new_organ = pick(GLOB.bioscrambler_valid_organs)
+	var/obj/item/organ/replaced = getorganslot(initial(new_organ.slot))
+	if (!(replaced?.organ_flags & ORGAN_SYNTHETIC))
+		changed_something = TRUE
+		new_organ = new new_organ()
+		new_organ.replace_into(src)
+
+	var/obj/item/bodypart/new_part = pick(GLOB.bioscrambler_valid_parts)
+	var/obj/item/bodypart/picked_user_part = get_bodypart(initial(new_part.body_zone))
+	if (!(picked_user_part?.bodytype & BODYTYPE_ROBOTIC))
+		changed_something = TRUE
+		new_part = new new_part()
+		new_part.replace_limb(src, TRUE)
+		if (picked_user_part)
+			qdel(picked_user_part)
+
+	if (!changed_something)
+		to_chat(src, span_notice("Your augmented body protects you from [scramble_source]!"))
+		return FALSE
+	update_body(TRUE)
+	balloon_alert(src, "something has changed about you")
+	return TRUE
+
+/// Fill in the lists of things we can bioscramble into people
+/mob/living/carbon/proc/init_bioscrambler_lists()
+	var/list/body_parts = typesof(/obj/item/bodypart/chest) + typesof(/obj/item/bodypart/head) + subtypesof(/obj/item/bodypart/arm) + subtypesof(/obj/item/bodypart/leg)
+	for (var/obj/item/bodypart/part as anything in body_parts)
+		if (!is_path_in_list(part, GLOB.bioscrambler_parts_blacklist) && !(initial(part.bodytype) & BODYTYPE_ROBOTIC))
+			continue
+		body_parts -= part
+	GLOB.bioscrambler_valid_parts = body_parts
+
+	var/list/organs = subtypesof(/obj/item/organ/internal) + subtypesof(/obj/item/organ/external)
+	for (var/obj/item/organ/organ_type as anything in organs)
+		if (!is_path_in_list(organ_type, GLOB.bioscrambler_organs_blacklist) && !(initial(organ_type.organ_flags) & ORGAN_SYNTHETIC))
+			continue
+		organs -= organ_type
+	GLOB.bioscrambler_valid_organs = organs
+
 #undef SHAKE_ANIMATION_OFFSET

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -104,7 +104,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 	for(var/datum/action/action as anything in actions)
 		action.Grant(organ_owner)
-	
+
 	for(var/datum/status_effect/effect as anything in organ_effects)
 		organ_owner.apply_status_effect(effect, type)
 
@@ -143,7 +143,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 	for(var/datum/action/action as anything in actions)
 		action.Remove(organ_owner)
-	
+
 	for(var/datum/status_effect/effect as anything in organ_effects)
 		organ_owner.remove_status_effect(effect, type)
 
@@ -376,3 +376,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 		status = "<font color='#ffcc33'>Mildly Damaged</font>"
 
 	return status
+
+/// Tries to replace the existing organ on the passed mob with this one, with special handling for replacing a brain without ghosting target
+/obj/item/organ/proc/replace_into(mob/living/carbon/new_owner)
+	Insert(new_owner, special = TRUE, drop_if_replaced = FALSE)


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/7483112/226889819-931b82c0-2d3a-4896-a1b4-30a25b9e3e68.png)

It looks like this task has fallen to me.

The reason this was originally removed was threefold:
- Having your brain replaced would ghost you.
- Having your lungs replaced would often instantly kill you in a way that people would take a long time to notice.
- Several abstract or otherwise inappropriate organs could end up inside someone.

I have solved all three of these problems using a blacklist.

Lungs are simply never touched. Brains, sadly, are also never touched. 
We _can_ modify your brain without ghosting you and originally I implemented it that way, but the fact of the matter is that having your brain scrambled is essentially irreversible except via DNA infuser, if you had your brain replaced with a monkey brain which renders you unable to use complex machinery (or worse, a Psyker brain) there is very little that can be done about it.
If people think that this is good to have anyway I can put it back in but it's probably for the best to leave it off.

I moved the code that the DNA infuser used to safely implant a brain into a proc on organs when I originally expected that brain replacement would be a feature of this PR, but I've left it there in case anything else wants to do convenient brain replacement in the future (or already does and can be updated to use this method).

The reason I didn't use a _white_list is because it seems like this list would easily become incredibly long and nobody would maintain it. A blacklist is slightly less safe, but reviewing the list it generates it seems fine.

I also noted that the anomaly and the armour both implemented exactly the same code in two places, so I moved that into a proc on `carbon` instead. Now you don't need to apply changes in two places, and if anything else needs to do this in the future once anyone adds literally any items which use a bioscrambler core as material then it's easy for them too.

Finally I scrubbed all cybernetics from the list and also made the anomaly not affect cybernetics.
No strong reason for this one, just seemed like how it should work given that it's also blocked by bio armour.

## Why It's Good For The Game

The bioscrambler in its current state doesn't do a whole lot, half of the things it changes are invisible under your clothes and often won't come up as a mechanical change unless you have developed chunky fingers or a sunlight allergy.
This makes them somewhat more potentially dangerous and means people who are negatively effected might turn up at medbay asking for new eyes or a new stomach.
Like the Dimensional anomaly it also introduces somewhat of a gamble feature. Some of the things on the list are _good_, and standing next to it might help you rather than harm you. Or more likely, both. As the infuser mechanic continues to add new organs with benefits and downsides it also makes this anomaly more interesting.

Finally this gives the bioscrambler reactive armour a purpose, because now it means that people attacking you have a chance to spontaneously grow cat ears or snail eyes.

## Changelog

:cl:
add: Bioscrambler anomalies will once again swap your organs with other organs.
balance: Bioscrambler anomalies no longer affect synthetic parts.
/:cl:
