### PR TITLE
Painting don't get finalized when naming is cancelled.

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -332,10 +332,14 @@
 		return FALSE
 	if(new_name != painting_metadata.title && user.can_perform_action(src))
 		painting_metadata.title = new_name
-	var/sign_choice = tgui_alert(user, "Do you want to sign it or remain anonymous?", "Sign painting?", list("Yes", "No"))
-	if(sign_choice != "Yes")
-		painting_metadata.creator_name = "Anonymous"
-	return TRUE
+	switch(tgui_alert(user, "Do you want to sign it or remain anonymous?", "Sign painting?", list("Yes", "No", "Cancel")))
+		if("Yes")
+			return TRUE
+		if("No")
+			painting_metadata.creator_name = "Anonymous"
+			return TRUE
+
+	return FALSE
 
 /obj/item/canvas/nineteen_nineteen
 	name = "canvas (19x19)"

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -179,13 +179,17 @@
 /obj/item/canvas/proc/finalize(mob/user)
 	if(painting_metadata.loaded_from_json || finalized)
 		return
-	finalized = TRUE
+	if(!try_rename(user))
+		return
+
 	painting_metadata.creator_ckey = user.ckey
 	painting_metadata.creator_name = user.real_name
 	painting_metadata.creation_date = time2text(world.realtime)
 	painting_metadata.creation_round_id = GLOB.round_id
 	generate_proper_overlay()
-	try_rename(user)
+	finalized = TRUE
+
+	SStgui.update_uis(src)
 
 /obj/item/canvas/proc/patron(mob/user)
 	if(!finalized || !isliving(user))
@@ -322,15 +326,16 @@
 
 /obj/item/canvas/proc/try_rename(mob/user)
 	if(painting_metadata.loaded_from_json) // No renaming old paintings
-		return
+		return TRUE
 	var/new_name = tgui_input_text(user, "What do you want to name the painting?", "Title Your Masterpiece")
-	if(new_name != painting_metadata.title && new_name && user.can_perform_action(src))
+	if(isnull(new_name))
+		return FALSE
+	if(new_name != painting_metadata.title && user.can_perform_action(src))
 		painting_metadata.title = new_name
 	var/sign_choice = tgui_alert(user, "Do you want to sign it or remain anonymous?", "Sign painting?", list("Yes", "No"))
 	if(sign_choice != "Yes")
 		painting_metadata.creator_name = "Anonymous"
-	SStgui.update_uis(src)
-
+	return TRUE
 
 /obj/item/canvas/nineteen_nineteen
 	name = "canvas (19x19)"
@@ -455,7 +460,8 @@
 	if(!current_canvas && istype(I, /obj/item/canvas))
 		frame_canvas(user,I)
 	else if(current_canvas && current_canvas.painting_metadata.title == initial(current_canvas.painting_metadata.title) && istype(I,/obj/item/pen))
-		try_rename(user)
+		if(try_rename(user))
+			SStgui.update_uis(src)
 	else
 		return ..()
 
@@ -501,8 +507,11 @@
 	return FALSE
 
 /obj/structure/sign/painting/proc/try_rename(mob/user)
-	if(current_canvas.painting_metadata.title == initial(current_canvas.painting_metadata.title))
-		current_canvas.try_rename(user)
+	if(current_canvas.painting_metadata.title != initial(current_canvas.painting_metadata.title))
+		return
+	if(!current_canvas.try_rename(user))
+		return
+	SStgui.update_uis(current_canvas)
 
 /obj/structure/sign/painting/update_icon_state(updates=ALL)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes #71975

If you cancel naming the painting, it doesn't get finalized now instead of getting untitled art work.
## Changelog
:cl:
fix: canvas getting finalized with untitled name when naming is cancelled
/:cl: