### PR TITLE
Access Keys list and destroy proc

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -44,7 +44,6 @@ GLOBAL_LIST_EMPTY(stairs)
 GLOBAL_LIST_EMPTY(janitor_devices)
 GLOBAL_LIST_EMPTY(trophy_cases)
 GLOBAL_LIST_EMPTY(experiment_handlers)
-GLOBAL_LIST_EMPTY(access_keys) // List of all access keys
 ///This is a global list of all signs you can change an existing sign or new sign backing to, when using a pen on them.
 GLOBAL_LIST_INIT(editable_sign_types, populate_editable_sign_types())
 

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -44,6 +44,7 @@ GLOBAL_LIST_EMPTY(stairs)
 GLOBAL_LIST_EMPTY(janitor_devices)
 GLOBAL_LIST_EMPTY(trophy_cases)
 GLOBAL_LIST_EMPTY(experiment_handlers)
+GLOBAL_LIST_EMPTY(access_keys) // List of all access keys
 ///This is a global list of all signs you can change an existing sign or new sign backing to, when using a pen on them.
 GLOBAL_LIST_INIT(editable_sign_types, populate_editable_sign_types())
 

--- a/code/game/objects/items/janitor_key.dm
+++ b/code/game/objects/items/janitor_key.dm
@@ -27,7 +27,7 @@
 /obj/item/access_key/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_ON_DEPARTMENT_ACCESS)
 	GLOB.janitor_devices -= src
-	. = ..()
+	return ..()
 
 /obj/item/access_key/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/janitor_key.dm
+++ b/code/game/objects/items/janitor_key.dm
@@ -24,7 +24,7 @@
 	RegisterSignal(SSdcs, COMSIG_ON_DEPARTMENT_ACCESS, PROC_REF(department_access_given))
 	GLOB.access_keys += src
 
-/obj/machinery/crossing_signal/Destroy()
+/obj/item/access_key/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_ON_DEPARTMENT_ACCESS)
 	GLOB.access_keys += src
 	. = ..()

--- a/code/game/objects/items/janitor_key.dm
+++ b/code/game/objects/items/janitor_key.dm
@@ -22,11 +22,11 @@
 /obj/item/access_key/Initialize(mapload)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_ON_DEPARTMENT_ACCESS, PROC_REF(department_access_given))
-	GLOB.access_keys += src
+	GLOB.janitor_devices += src
 
 /obj/item/access_key/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_ON_DEPARTMENT_ACCESS)
-	GLOB.access_keys += src
+	GLOB.janitor_devices -= src
 	. = ..()
 
 /obj/item/access_key/examine(mob/user)

--- a/code/game/objects/items/janitor_key.dm
+++ b/code/game/objects/items/janitor_key.dm
@@ -22,6 +22,12 @@
 /obj/item/access_key/Initialize(mapload)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_ON_DEPARTMENT_ACCESS, PROC_REF(department_access_given))
+	GLOB.access_keys += src
+
+/obj/machinery/crossing_signal/Destroy()
+	UnregisterSignal(SSdcs, COMSIG_ON_DEPARTMENT_ACCESS)
+	GLOB.access_keys += src
+	. = ..()
 
 /obj/item/access_key/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

- Puts recently added access key rings into the janitor devices list
- Access key rings now tracked in Custodial Locator tablet app
- Access key rings unregister their department signal when destroyed

## Why It's Good For The Game
Management of access key rings.

## Changelog

:cl: LT3
code: Access key rings added to list on creation
code: Access keys unregister signal when destroyed
/:cl: