### PR TITLE
Prosthesis organ manipulation no longer makes you harm target when you use incorrect tool

### DIFF
--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -64,14 +64,14 @@
 		try_to_fail = TRUE
 
 	var/datum/surgery_step/step = get_surgery_step()
-	if(step)
-		var/obj/item/tool = user.get_active_held_item()
-		if(step.try_op(user, target, user.zone_selected, tool, src, try_to_fail))
-			return TRUE
-		if(tool && tool.item_flags) //Mechanic organ manipulation isn't done with just surgery tools
-			to_chat(user, span_warning("This step requires a different tool!"))
-			return TRUE
-	return FALSE
+	if(isnull(step))
+		return FALSE
+	var/obj/item/tool = user.get_active_held_item()
+	if(step.try_op(user, target, user.zone_selected, tool, src, try_to_fail))
+		return TRUE
+	if(tool && tool.item_flags) //Mechanic organ manipulation isn't done with just surgery tools
+		to_chat(user, span_warning("This step requires a different tool!"))
+		return TRUE
 
 /datum/surgery/organ_manipulation/mechanic/soft
 	possible_locs = list(

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -51,6 +51,28 @@
 		/datum/surgery_step/mechanic_close,
 	)
 
+/datum/surgery/organ_manipulation/mechanic/next_step(mob/living/user, modifiers)
+	if(location != user.zone_selected)
+		return FALSE
+	if(user.combat_mode)
+		return FALSE
+	if(step_in_progress)
+		return TRUE
+
+	var/try_to_fail = FALSE
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		try_to_fail = TRUE
+
+	var/datum/surgery_step/step = get_surgery_step()
+	if(step)
+		var/obj/item/tool = user.get_active_held_item()
+		if(step.try_op(user, target, user.zone_selected, tool, src, try_to_fail))
+			return TRUE
+		if(tool && tool.item_flags) //Mechanic organ manipulation isn't done with just surgery tools
+			to_chat(user, span_warning("This step requires a different tool!"))
+			return TRUE
+	return FALSE
+
 /datum/surgery/organ_manipulation/mechanic/soft
 	possible_locs = list(
 		BODY_ZONE_PRECISE_GROIN,

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -72,6 +72,8 @@
 	if(tool && tool.item_flags) //Mechanic organ manipulation isn't done with just surgery tools
 		to_chat(user, span_warning("This step requires a different tool!"))
 		return TRUE
+		
+	return FALSE
 
 /datum/surgery/organ_manipulation/mechanic/soft
 	possible_locs = list(

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -116,14 +116,14 @@
 		try_to_fail = TRUE
 
 	var/datum/surgery_step/step = get_surgery_step()
-	if(step)
-		var/obj/item/tool = user.get_active_held_item()
-		if(step.try_op(user, target, user.zone_selected, tool, src, try_to_fail))
-			return TRUE
-		if(tool && tool.item_flags & SURGICAL_TOOL) //Just because you used the wrong tool it doesn't mean you meant to whack the patient with it
-			to_chat(user, span_warning("This step requires a different tool!"))
-			return TRUE
-	return FALSE
+	if(isnull(step))
+		return FALSE
+	var/obj/item/tool = user.get_active_held_item()
+	if(step.try_op(user, target, user.zone_selected, tool, src, try_to_fail))
+		return TRUE
+	if(tool && tool.item_flags & SURGICAL_TOOL) //Just because you used the wrong tool it doesn't mean you meant to whack the patient with it
+		to_chat(user, span_warning("This step requires a different tool!"))
+		return TRUE
 
 /datum/surgery/proc/get_surgery_step()
 	var/step_type = steps[status]

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -124,6 +124,8 @@
 	if(tool && tool.item_flags & SURGICAL_TOOL) //Just because you used the wrong tool it doesn't mean you meant to whack the patient with it
 		to_chat(user, span_warning("This step requires a different tool!"))
 		return TRUE
+		
+	return FALSE
 
 /datum/surgery/proc/get_surgery_step()
 	var/step_type = steps[status]


### PR DESCRIPTION
## About The Pull Request

currently if someone is in surgery you can only harm them with a surgical tool if you are in combat mode
the way the check works is that it only applies to tools that have the SURGICAL_TOOL item flag

prosthesis organ manipulation is the only surgery that uses normal engineering tools, and because it involves steps with normal tools, it means that if you forget or misclick you can easily hurt someone with the wrong tool

this makes that not happen anymore

## Why It's Good For The Game

i feel like it makes sense for the surgery that uses engineering tools as surgery tools to treat engineering tools as them, with the same considerations with regards to only having you bludgeon the patient if you wanted to

## Changelog

:cl:
qol: Prosthesis organ manipulation now warns you if you are using the incorrect engineering tool
/:cl:

