### PR TITLE
Fixes thrown reagent containers (like molotovs) fully splashing against mobs when they apparently shouldn't

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -195,8 +195,9 @@
 	var/mob/thrown_by = thrownby?.resolve()
 
 	if(ismob(target) && target.reagents)
+		var/splash_multiplier = 1
 		if(thrown)
-			reagents.total_volume *= rand(5,10) * 0.1 //Not all of it makes contact with the target
+			splash_multiplier *= rand(5,10) * 0.1 //Not all of it makes contact with the target
 		var/mob/M = target
 		var/R
 		target.visible_message(span_danger("[M] is splashed with something!"), \
@@ -206,7 +207,7 @@
 
 		if(thrown_by)
 			log_combat(thrown_by, M, "splashed", R)
-		reagents.expose(target, TOUCH)
+		reagents.expose(target, TOUCH, splash_multiplier)
 
 	else if(bartender_check(target) && thrown)
 		visible_message(span_notice("[src] lands onto the [target.name] without spilling a single drop."))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -197,7 +197,7 @@
 	if(ismob(target) && target.reagents)
 		var/splash_multiplier = 1
 		if(thrown)
-			splash_multiplier *= rand(5,10) * 0.1 //Not all of it makes contact with the target
+			splash_multiplier *= (rand(5,10) * 0.1) //Not all of it makes contact with the target
 		var/mob/M = target
 		var/R
 		target.visible_message(span_danger("[M] is splashed with something!"), \


### PR DESCRIPTION
## About The Pull Request
Not a mapping PR but I probably could take a crack at it anyway if I had any good ideas but anyway -
Fun fact: throwing molotovs at people, or open reagent containers in general (beakers, glasses) applies the full force of their contents at their target. (This is probably not supposed to happen.)

![image](https://user-images.githubusercontent.com/31829017/227109778-11b530fc-4b91-4cf6-b6c3-8e464b0c0a0b.png)

This is because multiplying the `total_reagents` down doesn't actually affect the reagents as stored in a list, so even if it was supposed to splash less (because of the inherent in-universe inaccuracy of hucking things), it... didn't!

This PR fixes this by making a separate variable, `splash_multiplier` (which defaults to 1), multiplying it down when it hits a mob, and passing that along to the `reagents.expose` call.

This does not affect non-thrown reagent containers.

![image](https://user-images.githubusercontent.com/31829017/227110370-b553b7e9-e19b-4c97-8014-74aa8ac9d99f.png)

## Why It's Good For The Game

Apparently, this isn't intended according to the comments; even though it says "not all of it makes contact", the first screenshot kinda shows that it does, which is suboptimal.

On second thought, I maybe could've made it so that the part of the reagents that don't hit the target get applied to the floor, instead, but that's... probably for a sequel PR (mostly applicable to stuff that splashes on floors e.g. weldfuel (puddles))? Unless a maintainer wants me to add that as a feature! And then make this less a fix.

Please advise.

## Changelog

:cl:
fix: Thrown reagent containers (beakers, molotovs) hitting mobs no longer fully splash their target with their contents, as this was unintended behavior. The intended behavior was 0-50% of the splashed reagents being ignored. Throwing stuff at floors/walls is unaffected.
/:cl: