### PR TITLE
[NO GBP] Fixed blood deficiency quirk sending the wrong blood pack to roundstart species who have exotic blood

### DIFF
--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -65,6 +65,14 @@
 	mail_goodies = list(/obj/item/reagent_containers/blood/o_minus) // universal blood type that is safe for all
 	var/min_blood = BLOOD_VOLUME_SAFE - 25 // just barely survivable without treatment
 
+/datum/quirk/blooddeficiency/post_add()
+	if(!ishuman(quirk_holder))
+		return
+
+	// for making sure the roundstart species has the right blood pack sent to them
+	var/mob/living/carbon/human/carbon_target = quirk_holder
+	carbon_target.dna.species.update_mail_goodies(carbon_target)
+
 /**
  * Makes the mob lose blood from having the blood deficiency quirk, if possible
  *

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -71,7 +71,7 @@
 
 	// for making sure the roundstart species has the right blood pack sent to them
 	var/mob/living/carbon/human/carbon_target = quirk_holder
-	carbon_target.dna.species.update_mail_goodies(carbon_target)
+	carbon_target.dna.species.update_quirk_mail_goodies(carbon_target, src)
 
 /**
  * Makes the mob lose blood from having the blood deficiency quirk, if possible

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -68,10 +68,8 @@
 /**
  * Makes the mob lose blood from having the blood deficiency quirk, if possible
  *
- 
  * Arguments:
  * * delta_time
- *
  */
 /datum/quirk/blooddeficiency/proc/lose_blood(delta_time)
 	if(quirk_holder.stat == DEAD)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -542,17 +542,17 @@ GLOBAL_LIST_EMPTY(features_by_species)
  * Proc called when mail goodies need to be updated for this species.
  *
  * Updates the mail goodies if that is required. e.g. for the blood deficiency quirk, which sends bloodbags to quirk holders, update the sent bloodpack to match the species' exotic blood.
- * Add implementation as needed for each individual species
+ * Add implementation as needed for each individual species. The base species proc should give the species the 'default' version of whatever mail goodies are required.
  * Arguments:
  * * mob/living/carbon/human/recipient - the mob receiving the mail goodies
- * * list/mail_goodies - a list of mail goodies
+ * * list/mail_goodies - a list of mail goodies. You should not be using this argument on the initial function call unless there is no other choice. You should instead add to the species' implementation of this proc.
  */
 /datum/species/proc/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
 	var/datum/quirk/blooddeficiency/blooddeficiency = recipient.get_quirk(/datum/quirk/blooddeficiency)
 	if(isnull(blooddeficiency))
 		return
-	if(isnull(mail_goodies))
-		// set mail_goodies to initial - we have to do it this way because initial will not work on lists in this version of DM
+	if(isnull(mail_goodies)) // The default case, e.g. species has no specific implementation
+		// Set blooddeficiency mail_goodies to initial, aka a type O- blood pack. We have to do it this way because initial will not work on lists in this version of DM
 		var/datum/quirk/blooddeficiency/initial_blooddeficiency = new
 		blooddeficiency.mail_goodies = initial_blooddeficiency.mail_goodies
 		qdel(initial_blooddeficiency)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -549,16 +549,16 @@ GLOBAL_LIST_EMPTY(features_by_species)
  */
 /datum/species/proc/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
 	var/datum/quirk/blooddeficiency/blooddeficiency = recipient.get_quirk(/datum/quirk/blooddeficiency)
-	if(isnull(blooddeficiency))
-		return
-	if(isnull(mail_goodies)) // The default case, e.g. species has no specific implementation
-		// Set blooddeficiency mail_goodies to initial, aka a type O- blood pack. We have to do it this way because initial will not work on lists in this version of DM
-		var/datum/quirk/blooddeficiency/initial_blooddeficiency = new
-		blooddeficiency.mail_goodies = initial_blooddeficiency.mail_goodies
-		qdel(initial_blooddeficiency)
-		return
-		
-	blooddeficiency.mail_goodies = mail_goodies
+	
+	if(!isnull(blooddeficiency))
+		if(isnull(mail_goodies)) // The default case, e.g. species has no specific implementation
+			// Set blooddeficiency mail_goodies to initial, aka a type O- blood pack. We have to do it this way because initial will not work on lists in this version of DM
+			var/datum/quirk/blooddeficiency/initial_blooddeficiency = new
+			blooddeficiency.mail_goodies = initial_blooddeficiency.mail_goodies
+			qdel(initial_blooddeficiency)
+			return
+			
+		blooddeficiency.mail_goodies = mail_goodies
 
 /**
  * Handles the body of a human

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -557,7 +557,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
  * Arguments:
  * * mob/living/carbon/human/recipient - the mob receiving the mail goodies
  * * datum/quirk/quirk - the quirk to update the mail goodies of. Use get_quirk(datum/quirk/some_quirk) to get the actual mob's quirk to pass.
-  * * list/mail_goodies - a list of mail goodies. Generally speaking you should not be using this argument on the initial function call. You should instead add to the species' implementation of this proc.
+ * * list/mail_goodies - a list of mail goodies. Generally speaking you should not be using this argument on the initial function call. You should instead add to the species' implementation of this proc.
  */
 /datum/species/proc/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies)
 	if(isnull(quirk))
@@ -573,7 +573,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		quirk.mail_goodies = initial_quirk.mail_goodies
 		qdel(initial_quirk)
 		return
-		
+
 	quirk.mail_goodies = mail_goodies
 
 /**

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -568,7 +568,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(istype(quirk, /datum/quirk/blooddeficiency))
 		if(HAS_TRAIT(recipient, TRAIT_NOBLOOD) && isnull(recipient.dna.species.exotic_blood)) // no blood packs should be sent in this case (like if a mob transforms into a plasmaman)
 			quirk.mail_goodies = list()
-			return 
+			return
 			
 	// The default case if no species implementation exists. Set quirk's mail_goodies to initial. 
 	var/datum/quirk/readable_quirk = new quirk.type

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -551,18 +551,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/datum/quirk/blooddeficiency/blooddeficiency = recipient.get_quirk(/datum/quirk/blooddeficiency)
 	if(isnull(blooddeficiency))
 		return
-	if(!isnull(mail_goodies))
-		blooddeficiency.mail_goodies = mail_goodies
-	else
-		// no blood packs should be sent if mob has TRAIT_NOBLOOD and no exotic blood (like if a mob transforms into a plasmaman)
-		if(HAS_TRAIT(recipient, TRAIT_NOBLOOD) && isnull(recipient.dna.species.exotic_blood))
-			blooddeficiency.mail_goodies = null
-			return
-			
-		// set mail_goodies to initial - we have to do this because initial will not work on lists in this version of DM
+	if(isnull(mail_goodies))
+		// set mail_goodies to initial - we have to do it this way because initial will not work on lists in this version of DM
 		var/datum/quirk/blooddeficiency/initial_blooddeficiency = new
 		blooddeficiency.mail_goodies = initial_blooddeficiency.mail_goodies
 		qdel(initial_blooddeficiency)
+		return
+		
+	blooddeficiency.mail_goodies = mail_goodies
 
 /**
  * Handles the body of a human

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -562,19 +562,19 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies)
 	if(isnull(quirk))
 		return
-	if(!length(mail_goodies))
-		if(quirk.type == /datum/quirk/blooddeficiency)
-			if(HAS_TRAIT(recipient, TRAIT_NOBLOOD) && isnull(recipient.dna.species.exotic_blood)) // no blood packs should be sent in this case (like if a mob transforms into a plasmaman)
-				quirk.mail_goodies = list()
-				return 
-		// The default case if no species implementation exists. Set quirk's mail_goodies to initial. 
-		// We have to do it this way because initial will not work on lists in this version of DM
-		var/datum/quirk/initial_quirk = new quirk.type
-		quirk.mail_goodies = initial_quirk.mail_goodies
-		qdel(initial_quirk)
+	if(length(mail_goodies))
+		quirk.mail_goodies = mail_goodies
 		return
-
-	quirk.mail_goodies = mail_goodies
+	if(istype(quirk, /datum/quirk/blooddeficiency))
+		if(HAS_TRAIT(recipient, TRAIT_NOBLOOD) && isnull(recipient.dna.species.exotic_blood)) // no blood packs should be sent in this case (like if a mob transforms into a plasmaman)
+			quirk.mail_goodies = list()
+			return 
+			
+	// The default case if no species implementation exists. Set quirk's mail_goodies to initial. 
+	var/datum/quirk/readable_quirk = new quirk.type
+	quirk.mail_goodies = readable_quirk.mail_goodies
+	qdel(readable_quirk) // We have to do it this way because initial will not work on lists in this version of DM
+	return
 
 /**
  * Handles the body of a human

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -552,6 +552,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	
 	if(!isnull(blooddeficiency))
 		if(isnull(mail_goodies)) // The default case, e.g. species has no specific implementation
+			if(HAS_TRAIT(recipient, TRAIT_NOBLOOD) && isnull(recipient.dna.species.exotic_blood)) // no blood packs should be sent in this case (like if a mob transforms into a plasmaman)
+				blooddeficiency.mail_goodies = null
+				return 
 			// Set blooddeficiency mail_goodies to initial, aka a type O- blood pack. We have to do it this way because initial will not work on lists in this version of DM
 			var/datum/quirk/blooddeficiency/initial_blooddeficiency = new
 			blooddeficiency.mail_goodies = initial_blooddeficiency.mail_goodies

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -93,7 +93,11 @@
 	return ..()
 
 
-/datum/species/ethereal/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/ethereal))
+/datum/species/ethereal/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
+	if(isnull(mail_goodies))
+		mail_goodies = list(
+			/obj/item/reagent_containers/blood/ethereal
+		)
 	return ..()
 
 /datum/species/ethereal/random_name(gender,unique,lastname)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -74,7 +74,7 @@
 	ethereal_light = ethereal.mob_light()
 	spec_updatehealth(ethereal)
 	new_ethereal.set_safe_hunger_level()
-	update_mail_goodies(ethereal, list(/obj/item/reagent_containers/blood/ethereal))
+	update_mail_goodies(ethereal)
 
 	var/obj/item/organ/internal/heart/ethereal/ethereal_heart = new_ethereal.getorganslot(ORGAN_SLOT_HEART)
 	ethereal_heart.ethereal_color = default_color
@@ -89,9 +89,12 @@
 	UnregisterSignal(former_ethereal, COMSIG_LIGHT_EATER_ACT)
 	QDEL_NULL(ethereal_light)
 	if(ishuman(former_ethereal))
-		update_mail_goodies(former_ethereal)
+		new_species.update_mail_goodies(former_ethereal)
 	return ..()
 
+
+/datum/species/ethereal/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/ethereal))
+	return ..()
 
 /datum/species/ethereal/random_name(gender,unique,lastname)
 	if(unique)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -93,9 +93,7 @@
 	return ..()
 
 /datum/species/ethereal/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
-	if(isnull(quirk))
-		return
-	if(quirk.type == /datum/quirk/blooddeficiency)
+	if(istype(quirk, /datum/quirk/blooddeficiency))
 		mail_goodies += list(
 			/obj/item/reagent_containers/blood/ethereal
 		)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -92,10 +92,11 @@
 		new_species.update_mail_goodies(former_ethereal)
 	return ..()
 
-
-/datum/species/ethereal/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
-	if(isnull(mail_goodies))
-		mail_goodies = list(
+/datum/species/ethereal/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
+	if(isnull(quirk))
+		return
+	if(quirk.type == /datum/quirk/blooddeficiency)
+		mail_goodies += list(
 			/obj/item/reagent_containers/blood/ethereal
 		)
 	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -64,7 +64,11 @@
 	
 	return ..()
 
-/datum/species/jelly/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/toxin))
+/datum/species/jelly/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
+	if(isnull(mail_goodies))
+		mail_goodies = list(
+			/obj/item/reagent_containers/blood/toxin
+		)
 	return ..()
 
 /datum/species/jelly/spec_life(mob/living/carbon/human/H, delta_time, times_fired)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -65,9 +65,7 @@
 	return ..()
 
 /datum/species/jelly/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
-	if(isnull(quirk))
-		return
-	if(quirk.type == /datum/quirk/blooddeficiency)
+	if(istype(quirk, /datum/quirk/blooddeficiency))
 		mail_goodies += list(
 			/obj/item/reagent_containers/blood/toxin
 		)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -64,9 +64,11 @@
 	
 	return ..()
 
-/datum/species/jelly/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
-	if(isnull(mail_goodies))
-		mail_goodies = list(
+/datum/species/jelly/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
+	if(isnull(quirk))
+		return
+	if(quirk.type == /datum/quirk/blooddeficiency)
+		mail_goodies += list(
 			/obj/item/reagent_containers/blood/toxin
 		)
 	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -51,7 +51,7 @@
 	if(ishuman(new_jellyperson))
 		regenerate_limbs = new
 		regenerate_limbs.Grant(new_jellyperson)
-		update_mail_goodies(new_jellyperson, list(/obj/item/reagent_containers/blood/toxin))
+		update_mail_goodies(new_jellyperson)
 	new_jellyperson.AddElement(/datum/element/soft_landing)
 
 /datum/species/jelly/on_species_loss(mob/living/carbon/former_jellyperson, datum/species/new_species, pref_load)
@@ -60,8 +60,11 @@
 	former_jellyperson.RemoveElement(/datum/element/soft_landing)
 	
 	if(ishuman(former_jellyperson))
-		update_mail_goodies(former_jellyperson)
+		new_species.update_mail_goodies(former_jellyperson)
 	
+	return ..()
+
+/datum/species/jelly/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/toxin))
 	return ..()
 
 /datum/species/jelly/spec_life(mob/living/carbon/human/H, delta_time, times_fired)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -40,12 +40,15 @@
 /datum/species/pod/on_species_gain(mob/living/carbon/new_podperson, datum/species/old_species, pref_load)
 	. = ..()
 	if(ishuman(new_podperson))
-		update_mail_goodies(new_podperson, list(/obj/item/reagent_containers/blood/podperson))
+		update_mail_goodies(new_podperson)
 
 /datum/species/pod/on_species_loss(mob/living/carbon/former_podperson, datum/species/new_species, pref_load)
 	. = ..()
 	if(ishuman(former_podperson))
-		update_mail_goodies(former_podperson)
+		new_species.update_mail_goodies(former_podperson)
+
+/datum/species/podperson/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/podperson))
+	return ..()
 
 /datum/species/pod/spec_life(mob/living/carbon/human/H, delta_time, times_fired)
 	if(H.stat == DEAD)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -47,7 +47,11 @@
 	if(ishuman(former_podperson))
 		new_species.update_mail_goodies(former_podperson)
 
-/datum/species/pod/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/podperson))
+/datum/species/pod/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
+	if(isnull(mail_goodies))
+		mail_goodies = list(
+			/obj/item/reagent_containers/blood/podperson
+		)
 	return ..()
 
 /datum/species/pod/spec_life(mob/living/carbon/human/H, delta_time, times_fired)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -47,7 +47,7 @@
 	if(ishuman(former_podperson))
 		new_species.update_mail_goodies(former_podperson)
 
-/datum/species/podperson/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/podperson))
+/datum/species/pod/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/podperson))
 	return ..()
 
 /datum/species/pod/spec_life(mob/living/carbon/human/H, delta_time, times_fired)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -47,9 +47,11 @@
 	if(ishuman(former_podperson))
 		new_species.update_mail_goodies(former_podperson)
 
-/datum/species/pod/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
-	if(isnull(mail_goodies))
-		mail_goodies = list(
+/datum/species/pod/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
+	if(isnull(quirk))
+		return
+	if(quirk.type == /datum/quirk/blooddeficiency)
+		mail_goodies += list(
 			/obj/item/reagent_containers/blood/podperson
 		)
 	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -48,9 +48,7 @@
 		new_species.update_mail_goodies(former_podperson)
 
 /datum/species/pod/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
-	if(isnull(quirk))
-		return
-	if(quirk.type == /datum/quirk/blooddeficiency)
+	if(istype(quirk, /datum/quirk/blooddeficiency))
 		mail_goodies += list(
 			/obj/item/reagent_containers/blood/podperson
 		)

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -57,7 +57,11 @@
 	if(ishuman(former_snailperson))
 		new_species.update_mail_goodies(former_snailperson)
 
-/datum/species/snail/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/snail))
+/datum/species/snail/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
+	if(isnull(mail_goodies))
+		mail_goodies = list(
+			/obj/item/reagent_containers/blood/snail
+		)
 	return ..()
 
 /obj/item/storage/backpack/snail

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -57,9 +57,11 @@
 	if(ishuman(former_snailperson))
 		new_species.update_mail_goodies(former_snailperson)
 
-/datum/species/snail/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies)
-	if(isnull(mail_goodies))
-		mail_goodies = list(
+/datum/species/snail/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
+	if(isnull(quirk))
+		return
+	if(quirk.type == /datum/quirk/blooddeficiency)
+		mail_goodies += list(
 			/obj/item/reagent_containers/blood/snail
 		)
 	return ..()

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -44,7 +44,7 @@
 			new_snailperson.equip_to_slot_or_del(new /obj/item/storage/backpack/snail(new_snailperson), ITEM_SLOT_BACK)
 	new_snailperson.AddElement(/datum/element/snailcrawl)
 	if(ishuman(new_snailperson))
-		update_mail_goodies(new_snailperson, list(/obj/item/reagent_containers/blood/snail))
+		update_mail_goodies(new_snailperson)
 
 /datum/species/snail/on_species_loss(mob/living/carbon/former_snailperson, datum/species/new_species, pref_load)
 	. = ..()
@@ -55,7 +55,10 @@
 		former_snailperson.temporarilyRemoveItemFromInventory(bag, TRUE)
 		qdel(bag)
 	if(ishuman(former_snailperson))
-		update_mail_goodies(former_snailperson)
+		new_species.update_mail_goodies(former_snailperson)
+
+/datum/species/snail/update_mail_goodies(mob/living/carbon/human/recipient, list/mail_goodies = list(/obj/item/reagent_containers/blood/snail))
+	return ..()
 
 /obj/item/storage/backpack/snail
 	name = "snail shell"

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -58,9 +58,7 @@
 		new_species.update_mail_goodies(former_snailperson)
 
 /datum/species/snail/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
-	if(isnull(quirk))
-		return
-	if(quirk.type == /datum/quirk/blooddeficiency)
+	if(istype(quirk, /datum/quirk/blooddeficiency))
 		mail_goodies += list(
 			/obj/item/reagent_containers/blood/snail
 		)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -520,7 +520,6 @@
 /**
  * Getter function for a mob's quirk
  *
- 
  * Arguments:
  * * quirktype - the type of the quirk to acquire e.g. /datum/quirk/some_quirk
  *


### PR DESCRIPTION
## About The Pull Request

I was looking over https://github.com/tgstation/tgstation/pull/74143 one last time as I tend to do with merged PR's and noticed a couple of nitpicky comment formatting things that will grate on me. Sorry about this @san7890 

Edit: Then even worse I found a bug. Roundstart species with blood deficiency should now get the appropriate blood pack mail goodies sent to them. I had completely forgotten about ethereals. Code is a bit cleaner too.

## Why It's Good For The Game

Fixes bug, dmdoc formatting 

## Changelog

:cl:
fix: fixed blood deficiency quirk sending the wrong blood pack to roundstart species who have exotic blood
/:cl: