### PR TITLE
Default RPD pipe color is omni instead of green

### DIFF
--- a/code/__HELPERS/piping_colors_lists.dm
+++ b/code/__HELPERS/piping_colors_lists.dm
@@ -1,5 +1,6 @@
 ///All colors available to pipes and atmos components
 GLOBAL_LIST_INIT(pipe_paint_colors, list(
+	"omni" = COLOR_VERY_LIGHT_GRAY,
 	"green" = COLOR_VIBRANT_LIME,
 	"blue" = COLOR_BLUE,
 	"red" = COLOR_RED,
@@ -10,8 +11,7 @@ GLOBAL_LIST_INIT(pipe_paint_colors, list(
 	"brown" = COLOR_BROWN,
 	"pink" = COLOR_LIGHT_PINK,
 	"purple" = COLOR_PURPLE,
-	"violet" = COLOR_STRONG_VIOLET,
-	"omni" = COLOR_VERY_LIGHT_GRAY
+	"violet" = COLOR_STRONG_VIOLET
 ))
 
 ///List that sorts the colors and is used for setting up the pipes layer so that they overlap correctly

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -236,7 +236,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	///Is the device of the flipped type?
 	var/p_flipped = FALSE
 	///Color of the device we are going to spawn
-	var/paint_color = "green"
+	var/paint_color = "omni"
 	///Speed of building atmos devices
 	var/atmos_build_speed = 0.5 SECONDS
 	///Speed of building disposal devices


### PR DESCRIPTION
## Why It's Good For The Game
The RPD has many colors, green is completely random as the starting color. Omni is better since it connects to everything
Just like how the default RPD layer is layer 3 (most roundstart pipes on layer 3) instead of something random like layer 1 or 5
## Changelog
:cl:
qol: RPD starting color is omni instead of green, omni comes before green in RPD TGUI
/:cl:
