### PR TITLE
OOC-ifies the Bluespace Tag

### DIFF
--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -76,12 +76,12 @@
 	if(!source.override_notes)
 		// Make sure not to divide by 0 on accident
 		if(source.force > 0)
-			readout += "[source.p_they(capitalized = TRUE)] takes about [span_warning("[HITS_TO_CRIT(source.force)] melee hit\s")] to kill."
+			readout += "[source.p_they(capitalized = TRUE)] takes about [span_warning("[HITS_TO_CRIT(source.force)] melee hit\s")] to take down an enemy."
 		else
 			readout += "[source.p_they(capitalized = TRUE)] does not deal noticeable melee damage."
 
 		if(source.throwforce > 0)
-			readout += "[source.p_they(capitalized = TRUE)] takes about [span_warning("[HITS_TO_CRIT(source.throwforce)] throwing hit\s")] to kill."
+			readout += "[source.p_they(capitalized = TRUE)] takes about [span_warning("[HITS_TO_CRIT(source.throwforce)] throwing hit\s")] to take down an enemy."
 		else
 			readout += "[source.p_they(capitalized = TRUE)] does not deal noticeable throwing damage."
 		if(source.armour_penetration > 0 || source.block_chance > 0)

--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -12,10 +12,6 @@
 	// Additional proc to be run for specific object types
 	var/attached_proc
 
-	// Flavor text crimes used in build_weapon_text()
-	var/list/crimes = list("Assaults", "Third Degree Murders", "Robberies", "Terrorist Attacks", "Different Felonies", "Felinies", "Counts of Tax Evasion", "Mutinies")
-	var/list/victims = list("a human", "a moth", "a felinid", "a lizard", "a particularly resilient slime", "a syndicate agent", "a clown", "a mime", "a mortal foe", "an innocent bystander")
-
 /datum/element/weapon_description/Attach(datum/target, attached_proc)
 	. = ..()
 	if(!isitem(target)) // Do not attach this to anything that isn't an item
@@ -44,7 +40,7 @@
 	SIGNAL_HANDLER
 
 	if(item.force >= 5 || item.throwforce >= 5 || item.override_notes || item.offensive_notes || attached_proc) /// Only show this tag for items that could feasibly be weapons, shields, or those that have special notes
-		examine_texts += span_notice("It appears to have an ever-updating bluespace <a href='?src=[REF(item)];examine=1'>warning label.</a>")
+		examine_texts += span_notice("<a href='?src=[REF(item)];examine=1'>See combat information.</a>")
 
 /**
  *
@@ -76,23 +72,20 @@
 /datum/element/weapon_description/proc/build_label_text(obj/item/source)
 	var/list/readout = list("") // Readout is used to store the text block output to the user so it all can be sent in one message
 
-	// Meaningless flavor text. The number of crimes is constantly changing because of the complex Nanotrasen legal system and the esoteric nature of time itself!
-	readout += "[span_warning("WARNING:")] This item has been marked as dangerous by the NT legal team because of its use in [span_warning("[rand(2,99)] [crimes[rand(1, crimes.len)]]")] in the past hour.\n"
-
 	// Doesn't show the base notes for items that have the override notes variable set to true
 	if(!source.override_notes)
 		// Make sure not to divide by 0 on accident
 		if(source.force > 0)
-			readout += "Our extensive research has shown that it takes a mere [span_warning("[HITS_TO_CRIT(source.force)] hit\s")] to beat down [victims[rand(1, victims.len)]] with no armor."
+			readout += "[source.p_they(capitalized = TRUE)] takes about [span_warning("[HITS_TO_CRIT(source.force)] melee hit\s")] to kill."
 		else
-			readout += "Our extensive research found that you couldn't beat anyone to death with this if you tried."
+			readout += "[source.p_they(capitalized = TRUE)] does not deal noticeable melee damage."
 
 		if(source.throwforce > 0)
-			readout += "If you decide to throw this object instead, one will take [span_warning("[HITS_TO_CRIT(source.throwforce)] hit\s")] before collapsing."
+			readout += "[source.p_they(capitalized = TRUE)] takes about [span_warning("[HITS_TO_CRIT(source.throwforce)] throwing hit\s")] to kill."
 		else
-			readout += "If you decide to throw this object instead, then you will have trouble damaging anything."
+			readout += "[source.p_they(capitalized = TRUE)] does not deal noticeable throwing damage."
 		if(source.armour_penetration > 0 || source.block_chance > 0)
-			readout += "This item has proven itself [span_warning("[weapon_tag_convert(source.armour_penetration)]")] of piercing armor and [span_warning("[weapon_tag_convert(source.block_chance)]")] of blocking attacks."
+			readout += "[source.p_they(capitalized = TRUE)] has [span_warning("[weapon_tag_convert(source.armour_penetration)]")] armor-piercing capability and [span_warning("[weapon_tag_convert(source.block_chance)]")] blocking capability."
 	// Custom manual notes
 	if(source.offensive_notes)
 		readout += source.offensive_notes
@@ -115,14 +108,14 @@
 /datum/element/weapon_description/proc/weapon_tag_convert(tag_val)
 	switch(tag_val)
 		if(0)
-			return "INCAPABLE"
+			return "NO"
 		if(1 to 25)
-			return "BARELY CAPABLE"
+			return "LITTLE"
 		if(26 to 50)
-			return "CAPABLE"
+			return "AVERAGE"
 		if(51 to 75)
-			return "VERY CAPABLE"
+			return "ABOVE-AVERAGE"
 		if(76 to INFINITY)
-			return "EXTREMELY CAPABLE"
+			return "EXCELLENT"
 		else
-			return "STRANGELY CAPABLE"
+			return "WEIRD"

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -62,7 +62,7 @@
 	. = ..()
 	// Adding an extra break for the sake of presentation
 	if(stamina_damage != 0)
-		offensive_notes = "\nVarious interviewed security forces report being able to beat criminals into exhaustion with only [span_warning("[CEILING(100 / stamina_damage, 1)] hit\s!")]"
+		offensive_notes = "It takes [span_warning("[CEILING(100 / stamina_damage, 1)] stunning hit\s")] to stun."
 
 	register_item_context()
 

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -62,7 +62,7 @@
 	. = ..()
 	// Adding an extra break for the sake of presentation
 	if(stamina_damage != 0)
-		offensive_notes = "It takes [span_warning("[CEILING(100 / stamina_damage, 1)] stunning hit\s")] to stun."
+		offensive_notes = "It takes [span_warning("[CEILING(100 / stamina_damage, 1)] stunning hit\s")] to stun an enemy."
 
 	register_item_context()
 


### PR DESCRIPTION

## About The Pull Request
De-ICs the bluespace tag, instead presenting the same information in an OOC format.
![image](https://user-images.githubusercontent.com/58124831/227378515-ccb9bfb3-bd30-4ceb-8c6c-fdc50132fb4b.png)
This does not alter the actual information shown (besides a slight change to wording for the armor-piercing/block values, though the thresholds are the same).

P.S. I don't know if this is tagged correctly- it doesn't seem to neatly fit any category. (When are we getting the Tweak tag back?)
## Why It's Good For The Game
The bluespace tag has sorta been an oddity since it was introduced. While the rationale behind its addition was sound- we want players to have information without code-diving, but not necessarily anything too concrete- the actual stuff surrounding that information has always felt off. Why exactly are we finding items that have lain undisturbed on lavaland for centuries that have a bluespace tag? What magical source of information are they drawing from? Basically, in its attempt to make OOC information IC-relevant, it creates more plot holes than it solves, and ultimately it does so to no real benefit. Hence, I feel it's best that we just stop trying to present this in an IC format.
## Changelog
:cl:
qol: Bluespace tags are gone. The information contained within is still available in the same way, just in a more out-of-character format.
/:cl:
