### PR TITLE
Ethereals now correctly list "LE" as their blood type in medical records.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -7,6 +7,7 @@
 	mutanttongue = /obj/item/organ/internal/tongue/ethereal
 	mutantheart = /obj/item/organ/internal/heart/ethereal
 	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
+	exotic_bloodtype = "LE"
 	siemens_coeff = 0.5 //They thrive on energy
 	brutemod = 1.25 //They're weak to punches
 	payday_modifier = 0.75


### PR DESCRIPTION
## About The Pull Request
Fixes #74208

One line change woo yea. How did we have this in place for vampires but not ethereals? That's wild. Yeah yeah, I tested it. Everything is nice and shiny, all works good.
## Why It's Good For The Game
So it turns out ethereals do not have AB- and what I just did is called "malpractice".
## Changelog
:cl:
fix: The intern who was recording Etheral crewmembers' bloodtypes as random human bloodtypes has been replaced with an intern who has seen the example made of the previous one.
/:cl:
