### PR TITLE
Tram signs malfunction during tram malfunction

### DIFF
--- a/code/modules/events/tram_malfunction.dm
+++ b/code/modules/events/tram_malfunction.dm
@@ -44,6 +44,9 @@
 	for(var/obj/machinery/door/window/tram/door as anything in GLOB.tram_doors)
 		door.start_malfunction()
 
+	for(var/obj/machinery/destination_sign/sign as anything in GLOB.tram_signs)
+		sign.malfunctioning = TRUE
+
 	for(var/obj/structure/industrial_lift/tram as anything in GLOB.lifts)
 		original_lethality = tram.collision_lethality
 		tram.collision_lethality = original_lethality * 1.25
@@ -55,10 +58,13 @@
 	for(var/obj/machinery/door/window/tram/door as anything in GLOB.tram_doors)
 		door.end_malfunction()
 
+	for(var/obj/machinery/destination_sign/sign as anything in GLOB.tram_signs)
+		sign.malfunctioning = FALSE
+
 	for(var/obj/structure/industrial_lift/tram as anything in GLOB.lifts)
 		tram.collision_lethality = original_lethality
 
-	priority_announce("We've successfully reset the software of the tram, normal operations are now resuming. Sorry for any inconvienence this may have caused. We hope you have a good rest of your shift.", "CentCom Engineering Division")
+	priority_announce("We've successfully reset the software on the tram, normal operations are now resuming. Sorry for any inconvienence this may have caused.", "CentCom Engineering Division")
 
 #undef TRAM_MALFUNCTION_TIME_UPPER
 #undef TRAM_MALFUNCTION_TIME_LOWER

--- a/code/modules/industrial_lift/tram/tram_machinery.dm
+++ b/code/modules/industrial_lift/tram/tram_machinery.dm
@@ -611,7 +611,8 @@ GLOBAL_LIST_EMPTY(tram_doors)
 		RegisterSignal(tram_part, COMSIG_TRAM_SET_TRAVELLING, PROC_REF(on_tram_travelling))
 		GLOB.tram_signs += src
 
-	sign_states = list("[base_icon_state][DESTINATION_WEST_ACTIVE]",
+	sign_states = list(
+		"[base_icon_state][DESTINATION_WEST_ACTIVE]",
 		"[base_icon_state][DESTINATION_WEST_IDLE]",
 		"[base_icon_state][DESTINATION_EAST_ACTIVE]",
 		"[base_icon_state][DESTINATION_EAST_IDLE]",

--- a/code/modules/industrial_lift/tram/tram_machinery.dm
+++ b/code/modules/industrial_lift/tram/tram_machinery.dm
@@ -581,6 +581,15 @@ GLOBAL_LIST_EMPTY(tram_doors)
 	var/light_mask
 	/// Is this sign malfunctioning?
 	var/malfunctioning = FALSE
+	/// A default list of possible sign states
+	var/list/sign_states = list("[base_icon_state][DESTINATION_WEST_ACTIVE]",
+		"[base_icon_state][DESTINATION_WEST_IDLE]",
+		"[base_icon_state][DESTINATION_EAST_ACTIVE]",
+		"[base_icon_state][DESTINATION_EAST_IDLE]",
+		"[base_icon_state][DESTINATION_CENTRAL_IDLE]",
+		"[base_icon_state][DESTINATION_CENTRAL_EASTBOUND_ACTIVE]",
+		"[base_icon_state][DESTINATION_CENTRAL_WESTBOUND_ACTIVE]",
+		)
 
 /obj/machinery/destination_sign/north
 	layer = BELOW_OBJ_LAYER
@@ -649,16 +658,8 @@ GLOBAL_LIST_EMPTY(tram_doors)
 	use_power(active_power_usage)
 
 	if(malfunctioning)
-		var/list/malf_sign = list("[base_icon_state][DESTINATION_WEST_ACTIVE]",
-		"[base_icon_state][DESTINATION_WEST_IDLE]",
-		"[base_icon_state][DESTINATION_EAST_ACTIVE]",
-		"[base_icon_state][DESTINATION_EAST_IDLE]",
-		"[base_icon_state][DESTINATION_CENTRAL_IDLE]",
-		"[base_icon_state][DESTINATION_CENTRAL_EASTBOUND_ACTIVE]",
-		"[base_icon_state][DESTINATION_CENTRAL_WESTBOUND_ACTIVE]",
-		)
-		icon_state = "[pick(malf_sign)]"
-		light_mask = "[pick(malf_sign)]_e"
+		icon_state = "[pick(sign_states)]"
+		light_mask = "[pick(sign_states)]_e"
 		update_appearance()
 		return PROCESS_KILL
 

--- a/code/modules/industrial_lift/tram/tram_machinery.dm
+++ b/code/modules/industrial_lift/tram/tram_machinery.dm
@@ -579,6 +579,8 @@ GLOBAL_LIST_EMPTY(tram_doors)
 	var/previous_destination
 	/// The light mask overlay we use
 	var/light_mask
+	/// Is this sign malfunctioning?
+	var/malfunctioning = FALSE
 
 /obj/machinery/destination_sign/north
 	layer = BELOW_OBJ_LAYER
@@ -645,6 +647,20 @@ GLOBAL_LIST_EMPTY(tram_doors)
 		return PROCESS_KILL
 
 	use_power(active_power_usage)
+
+	if(malfunctioning)
+		var/list/malf_sign = list("[base_icon_state][DESTINATION_WEST_ACTIVE]",
+		"[base_icon_state][DESTINATION_WEST_IDLE]",
+		"[base_icon_state][DESTINATION_EAST_ACTIVE]",
+		"[base_icon_state][DESTINATION_EAST_IDLE]",
+		"[base_icon_state][DESTINATION_CENTRAL_IDLE]",
+		"[base_icon_state][DESTINATION_CENTRAL_EASTBOUND_ACTIVE]",
+		"[base_icon_state][DESTINATION_CENTRAL_WESTBOUND_ACTIVE]",
+		)
+		icon_state = "[pick(malf_sign)]"
+		light_mask = "[pick(malf_sign)]_e"
+		update_appearance()
+		return PROCESS_KILL
 
 	if(!tram.travelling)
 		if(istype(tram.idle_platform, /obj/effect/landmark/tram/tramstation/west))

--- a/code/modules/industrial_lift/tram/tram_machinery.dm
+++ b/code/modules/industrial_lift/tram/tram_machinery.dm
@@ -582,14 +582,7 @@ GLOBAL_LIST_EMPTY(tram_doors)
 	/// Is this sign malfunctioning?
 	var/malfunctioning = FALSE
 	/// A default list of possible sign states
-	var/list/sign_states = list("[base_icon_state][DESTINATION_WEST_ACTIVE]",
-		"[base_icon_state][DESTINATION_WEST_IDLE]",
-		"[base_icon_state][DESTINATION_EAST_ACTIVE]",
-		"[base_icon_state][DESTINATION_EAST_IDLE]",
-		"[base_icon_state][DESTINATION_CENTRAL_IDLE]",
-		"[base_icon_state][DESTINATION_CENTRAL_EASTBOUND_ACTIVE]",
-		"[base_icon_state][DESTINATION_CENTRAL_WESTBOUND_ACTIVE]",
-		)
+	var/list/sign_states = list()
 
 /obj/machinery/destination_sign/north
 	layer = BELOW_OBJ_LAYER
@@ -617,6 +610,15 @@ GLOBAL_LIST_EMPTY(tram_doors)
 	if(tram_part)
 		RegisterSignal(tram_part, COMSIG_TRAM_SET_TRAVELLING, PROC_REF(on_tram_travelling))
 		GLOB.tram_signs += src
+
+	sign_states = list("[base_icon_state][DESTINATION_WEST_ACTIVE]",
+		"[base_icon_state][DESTINATION_WEST_IDLE]",
+		"[base_icon_state][DESTINATION_EAST_ACTIVE]",
+		"[base_icon_state][DESTINATION_EAST_IDLE]",
+		"[base_icon_state][DESTINATION_CENTRAL_IDLE]",
+		"[base_icon_state][DESTINATION_CENTRAL_EASTBOUND_ACTIVE]",
+		"[base_icon_state][DESTINATION_CENTRAL_WESTBOUND_ACTIVE]",
+		)
 
 /obj/machinery/destination_sign/Destroy()
 	GLOB.tram_signs -= src

--- a/code/modules/industrial_lift/tram/tram_machinery.dm
+++ b/code/modules/industrial_lift/tram/tram_machinery.dm
@@ -618,7 +618,7 @@ GLOBAL_LIST_EMPTY(tram_doors)
 		"[base_icon_state][DESTINATION_CENTRAL_IDLE]",
 		"[base_icon_state][DESTINATION_CENTRAL_EASTBOUND_ACTIVE]",
 		"[base_icon_state][DESTINATION_CENTRAL_WESTBOUND_ACTIVE]",
-		)
+	)
 
 /obj/machinery/destination_sign/Destroy()
 	GLOB.tram_signs -= src

--- a/code/modules/industrial_lift/tram/tram_machinery.dm
+++ b/code/modules/industrial_lift/tram/tram_machinery.dm
@@ -582,7 +582,7 @@ GLOBAL_LIST_EMPTY(tram_doors)
 	/// Is this sign malfunctioning?
 	var/malfunctioning = FALSE
 	/// A default list of possible sign states
-	var/list/sign_states = list()
+	var/static/list/sign_states = list()
 
 /obj/machinery/destination_sign/north
 	layer = BELOW_OBJ_LAYER


### PR DESCRIPTION
## About The Pull Request

Tram signs will now display incorrect information when malfunctioning.

## Why It's Good For The Game

For improved Frogger gameplay, no more being crafty and reading the indicator board to know if the tram is coming.

## Changelog

:cl: LT3
add: Tram signs will now malfunction when the tram is malfunctioning
/:cl: