### PR TITLE
Fixes unopenable borg recharge stations.

### DIFF
--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -101,7 +101,7 @@
 	. = ..()
 	update_use_power(IDLE_POWER_USE)
 
-/obj/machinery/recharge_station/close_machine(density_to_set = TRUE)
+/obj/machinery/recharge_station/close_machine(atom/movable/target, density_to_set = TRUE)
 	. = ..()
 	if(occupant)
 		update_use_power(ACTIVE_POWER_USE) //It always tries to charge, even if it can't.


### PR DESCRIPTION
## About The Pull Request

Broken by #74163
Fixes #74213

`/obj/machinery/recharge_station/close_machine` child proc didn't have the same params as the parent proc.

This leads to the wrong arg being passed to the parent's `atom/movable/target` param during the parent proc call. In this case, 1. Leading to various runtimes. Which prevented the machinery from being openable.

## Why It's Good For The Game

Feex.
## Changelog
:cl:
fix: Cyborg recharge stations should be much more usable again.
/:cl:
