### PR TITLE
Fixes machines not releasing their contents when opened (such as mobs), when they otherwise should.

### DIFF
--- a/code/game/machinery/dna_scanner.dm
+++ b/code/game/machinery/dna_scanner.dm
@@ -104,7 +104,7 @@
 
 	return TRUE
 
-/obj/machinery/dna_scannernew/open_machine(density_to_set = FALSE)
+/obj/machinery/dna_scannernew/open_machine(drop = TRUE, density_to_set = FALSE)
 	if(state_open)
 		return FALSE
 

--- a/code/game/machinery/sleepers.dm
+++ b/code/game/machinery/sleepers.dm
@@ -94,7 +94,7 @@
 	if (!state_open)
 		container_resist_act(user)
 
-/obj/machinery/sleeper/open_machine(density_to_set = FALSE)
+/obj/machinery/sleeper/open_machine(drop = TRUE, density_to_set = FALSE)
 	if(!state_open && !panel_open)
 		flick("[initial(icon_state)]-anim", src)
 	return ..()

--- a/code/modules/antagonists/abductor/machinery/experiment.dm
+++ b/code/modules/antagonists/abductor/machinery/experiment.dm
@@ -28,7 +28,7 @@
 		return
 	close_machine(target)
 
-/obj/machinery/abductor/experiment/open_machine(density_to_set = FALSE)
+/obj/machinery/abductor/experiment/open_machine(drop = TRUE, density_to_set = FALSE)
 	if(!state_open && !panel_open)
 		..()
 

--- a/code/modules/library/skill_learning/skill_station.dm
+++ b/code/modules/library/skill_learning/skill_station.dm
@@ -48,7 +48,7 @@
 /obj/machinery/skill_station/relaymove(mob/living/user, direction)
 	open_machine()
 
-/obj/machinery/skill_station/open_machine(density_to_set = FALSE)
+/obj/machinery/skill_station/open_machine(drop = TRUE, density_to_set = FALSE)
 	. = ..()
 	interrupt_operation()
 

--- a/code/modules/mapfluff/ruins/spaceruin_code/oldstation.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/oldstation.dm
@@ -173,7 +173,7 @@
 	mod_unit = null
 	open_machine()
 
-/obj/machinery/mod_installer/open_machine(density_to_set = FALSE)
+/obj/machinery/mod_installer/open_machine(drop = TRUE, density_to_set = FALSE)
 	if(state_open)
 		return FALSE
 	..()


### PR DESCRIPTION
## About The Pull Request

Broken by #74163

Various child procs of `/obj/machinery/proc/open_machine(drop = TRUE, density_to_set = FALSE)` didn't have the same params as the parent proc.

This leads to the wrong arg being passed to the parent's `drop = TRUE` param during the parent proc call.

In this case, 0 (FALSE). Leading to machines that never dropped their contents when opened. This is a problem when a lot of the machines I've fixed contain players, necessitating admin intervention to free them.
## Why It's Good For The Game

Feex.
## Changelog
:cl:
fix: DNA Scanners, Sleepers, Abductor Experimentors, Skill Stations and Mod Installers now appropriately release their contents when opened, fixing an issue where they could permanently absorb players and items until admins intervened.
/:cl:
