### PR TITLE
Fixed Tram's Ordnance Freezer Chamber piping not being connected.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -62297,6 +62297,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark/airless,
 /area/station/science/ordnance/freezerchamber)
 "vkd" = (


### PR DESCRIPTION
## About The Pull Request

Tram's ordnance freezer has a scrubber and injector that are not connected to anything, I've connected them to the purple pipes they should be connected to.

## Why It's Good For The Game

Bugfix
## Changelog
:cl:
fix: Tram's Ordnance Freezer is now piped correctly.
/:cl:
