### PR TITLE
Dogs will no longer harrass if they are buckled to a bed (comfy edition)

### DIFF
--- a/code/datums/ai/dog/dog_subtrees.dm
+++ b/code/datums/ai/dog/dog_subtrees.dm
@@ -22,6 +22,9 @@
 	for(var/mob/living/iter_living in oview(2, dog))
 		if(iter_living.stat != CONSCIOUS || !HAS_TRAIT(iter_living, TRAIT_HATED_BY_DOGS))
 			continue
+		if(!isnull(dog.buckled))
+			dog.audible_message(span_notice("[dog] growls at [iter_living], yet [dog.p_they()] [dog.p_are()] much too comfy to move."), hearing_distance = COMBAT_MESSAGE_RANGE)
+			continue
 		if(!targetting_datum.can_attack(dog, iter_living))
 			continue
 


### PR DESCRIPTION
## About The Pull Request

Before, dogs were somehow magically able to drag their bed to you while barking at/chasing you. that's silly, let's fix it by checking if you're buckled, and then aborting course if we're comfy on our little bed
## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/34697715/227679914-62822f93-6646-4070-8ff7-4e140e1a291a.png)

Fixes #74082

the dog is BUCKLED. it can't move. probably a better fix to this somehow on a very deep AI level but that wouldn't allow us to have such a soulful message (as well as potentially rule out a myriad of edge cases), so i'm proposing this one.
## Changelog
:cl:
fix: If you buckle a dog to a bed, it will no longer drag its bed as it goes to bark at the mailman. It will instead be comfy and chilling, as expected.
/:cl:
