### PR TITLE
Malfunctioning AIs get a discount on the Doomsday equipment by hacking Head of Staff APCs

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -140,11 +140,14 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /datum/ai_module/destructive/nuke_station
 	name = "Doomsday Device"
 	description = "Activate a weapon that will disintegrate all organic life on the station after a 450 second delay. \
-		Can only be used while on the station, will fail if your core is moved off station or destroyed."
+		Can only be used while on the station, will fail if your core is moved off station or destroyed. \
+		Obtaining control of the weapon will be easier if Head of Staff office APCs are already under your control."
 	cost = 130
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/nuke_station
 	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
+	///List of hacked head of staff office areas. Includes the vault too. Provides a 20 PT discount per (Min 50 PT cost)
+	var/list/hacked_command_areas = list()
 
 /datum/action/innate/ai/nuke_station
 	name = "Doomsday Device"

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -146,6 +146,11 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/nuke_station
 	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
+	///List of areas that grant discounts. "heads_quarters" will match any head of staff office.
+	var/list/discount_areas = list(
+		/area/station/command/heads_quarters,
+		/area/station/ai_monitored/command/nuke_storage
+	)
 	///List of hacked head of staff office areas. Includes the vault too. Provides a 20 PT discount per (Min 50 PT cost)
 	var/list/hacked_command_areas = list()
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -989,8 +989,6 @@
 
 	malf_picker.processing_time += 10
 	var/area/apcarea = apc.area
-	if(istype(apcarea, /area/station/command/heads_quarters) || istype(apcarea, /area/station/ai_monitored/command/nuke_storage))
-
 	var/datum/ai_module/destructive/nuke_station/doom_n_boom = locate(/datum/ai_module/destructive/nuke_station) in malf_picker.possible_modules["Destructive Modules"]
 	if(doom_n_boom && (is_type_in_list (apcarea, doom_n_boom.discount_areas)) && !(is_type_in_list (apcarea, doom_n_boom.hacked_command_areas)))
 		doom_n_boom.hacked_command_areas += apcarea

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -991,8 +991,7 @@
 	var/area/apcarea = apc.area
 	if(istype(apcarea, /area/station/command/heads_quarters) || istype(apcarea, /area/station/ai_monitored/command/nuke_storage))
 		var/datum/ai_module/destructive/nuke_station/doom_n_boom = locate(/datum/ai_module/destructive/nuke_station) in malf_picker.possible_modules["Destructive Modules"]
-		if(doom_n_boom)
-			if(!(apcarea in doom_n_boom.hacked_command_areas))
+		if(doom_n_boom && !(apcarea in doom_n_boom.hacked_command_areas))
 				doom_n_boom.hacked_command_areas += apcarea
 				doom_n_boom.cost = max(50, 130 - (length(doom_n_boom.hacked_command_areas) * 20))
 				var/datum/antagonist/malf_ai/malf_ai_datum = mind.has_antag_datum(/datum/antagonist/malf_ai)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -981,20 +981,34 @@
 	if(!istype(apc) || QDELETED(apc) || apc.machine_stat & BROKEN)
 		to_chat(src, span_danger("Hack aborted. The designated APC no longer exists on the power network."))
 		playsound(get_turf(src), 'sound/machines/buzz-two.ogg', 50, TRUE, ignore_walls = FALSE)
-	else if(apc.aidisabled)
+		return
+	if(apc.aidisabled)
 		to_chat(src, span_danger("Hack aborted. [apc] is no longer responding to our systems."))
 		playsound(get_turf(src), 'sound/machines/buzz-sigh.ogg', 50, TRUE, ignore_walls = FALSE)
-	else
-		malf_picker.processing_time += 10
+		return
 
-		apc.malfai = parent || src
-		apc.malfhack = TRUE
-		apc.locked = TRUE
-		apc.coverlocked = TRUE
+	malf_picker.processing_time += 10
+	var/area/apcarea = apc.area
+	if(istype(apcarea, /area/station/command/heads_quarters) || istype(apcarea, /area/station/ai_monitored/command/nuke_storage))
+		var/datum/ai_module/destructive/nuke_station/doom_n_boom = locate(/datum/ai_module/destructive/nuke_station) in malf_picker.possible_modules["Destructive Modules"]
+		if(doom_n_boom)
+			if(!(apcarea in doom_n_boom.hacked_command_areas))
+				doom_n_boom.hacked_command_areas += apcarea
+				doom_n_boom.cost = max(50, 130 - (length(doom_n_boom.hacked_command_areas) * 20))
+				var/datum/antagonist/malf_ai/malf_ai_datum = mind.has_antag_datum(/datum/antagonist/malf_ai)
+				if(malf_ai_datum)
+					malf_ai_datum.update_static_data_for_all_viewers()
+				else //combat software AIs use a different UI
+					malf_picker.update_static_data_for_all_viewers()
 
-		playsound(get_turf(src), 'sound/machines/ding.ogg', 50, TRUE, ignore_walls = FALSE)
-		to_chat(src, "Hack complete. [apc] is now under your exclusive control.")
-		apc.update_appearance()
+	apc.malfai = parent || src
+	apc.malfhack = TRUE
+	apc.locked = TRUE
+	apc.coverlocked = TRUE
+
+	playsound(get_turf(src), 'sound/machines/ding.ogg', 50, TRUE, ignore_walls = FALSE)
+	to_chat(src, "Hack complete. [apc] is now under your exclusive control.")
+	apc.update_appearance()
 
 /mob/living/silicon/ai/verb/deploy_to_shell(mob/living/silicon/robot/target)
 	set category = "AI Commands"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -990,15 +990,16 @@
 	malf_picker.processing_time += 10
 	var/area/apcarea = apc.area
 	if(istype(apcarea, /area/station/command/heads_quarters) || istype(apcarea, /area/station/ai_monitored/command/nuke_storage))
-		var/datum/ai_module/destructive/nuke_station/doom_n_boom = locate(/datum/ai_module/destructive/nuke_station) in malf_picker.possible_modules["Destructive Modules"]
-		if(doom_n_boom && !(apcarea in doom_n_boom.hacked_command_areas))
-			doom_n_boom.hacked_command_areas += apcarea
-			doom_n_boom.cost = max(50, 130 - (length(doom_n_boom.hacked_command_areas) * 20))
-			var/datum/antagonist/malf_ai/malf_ai_datum = mind.has_antag_datum(/datum/antagonist/malf_ai)
-			if(malf_ai_datum)
-				malf_ai_datum.update_static_data_for_all_viewers()
-			else //combat software AIs use a different UI
-				malf_picker.update_static_data_for_all_viewers()
+
+	var/datum/ai_module/destructive/nuke_station/doom_n_boom = locate(/datum/ai_module/destructive/nuke_station) in malf_picker.possible_modules["Destructive Modules"]
+	if(doom_n_boom && (is_type_in_list (apcarea, doom_n_boom.discount_areas)) && !(is_type_in_list (apcarea, doom_n_boom.hacked_command_areas)))
+		doom_n_boom.hacked_command_areas += apcarea
+		doom_n_boom.cost = max(50, 130 - (length(doom_n_boom.hacked_command_areas) * 20))
+		var/datum/antagonist/malf_ai/malf_ai_datum = mind.has_antag_datum(/datum/antagonist/malf_ai)
+		if(malf_ai_datum)
+			malf_ai_datum.update_static_data_for_all_viewers()
+		else //combat software AIs use a different UI
+			malf_picker.update_static_data_for_all_viewers()
 
 	apc.malfai = parent || src
 	apc.malfhack = TRUE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -992,13 +992,13 @@
 	if(istype(apcarea, /area/station/command/heads_quarters) || istype(apcarea, /area/station/ai_monitored/command/nuke_storage))
 		var/datum/ai_module/destructive/nuke_station/doom_n_boom = locate(/datum/ai_module/destructive/nuke_station) in malf_picker.possible_modules["Destructive Modules"]
 		if(doom_n_boom && !(apcarea in doom_n_boom.hacked_command_areas))
-				doom_n_boom.hacked_command_areas += apcarea
-				doom_n_boom.cost = max(50, 130 - (length(doom_n_boom.hacked_command_areas) * 20))
-				var/datum/antagonist/malf_ai/malf_ai_datum = mind.has_antag_datum(/datum/antagonist/malf_ai)
-				if(malf_ai_datum)
-					malf_ai_datum.update_static_data_for_all_viewers()
-				else //combat software AIs use a different UI
-					malf_picker.update_static_data_for_all_viewers()
+			doom_n_boom.hacked_command_areas += apcarea
+			doom_n_boom.cost = max(50, 130 - (length(doom_n_boom.hacked_command_areas) * 20))
+			var/datum/antagonist/malf_ai/malf_ai_datum = mind.has_antag_datum(/datum/antagonist/malf_ai)
+			if(malf_ai_datum)
+				malf_ai_datum.update_static_data_for_all_viewers()
+			else //combat software AIs use a different UI
+				malf_picker.update_static_data_for_all_viewers()
 
 	apc.malfai = parent || src
 	apc.malfhack = TRUE


### PR DESCRIPTION

## About The Pull Request
Reduces the price of the Doomsday equipment by 20 PT for each APC hacked in a Head of Staff office, as well as the Vault.
## Why It's Good For The Game
See #71404 for the prior PR and my full reasoning.

Long-story short, activating the Doomsday before having a plan in place is suicide, and it takes 13 APCs to unlock. Since there are few well hidden APCs in general, you'll usually be gathering APCs after going loud (such as with a borg machine). 13 APCs is 13 minutes, and by the time you've gathered your malfbux, you're either already dead or have already taken full control.

I had intended to give Doomsday a flat 70 PT price, but concerns were raised that an AI could conceivably hack only APCs on their sat (and perhaps one on the Lavaland outpost) and Doomsday without ever really touching the station*. So a compromise was proposed, we instead give the AI discounts by hacking Head of Staff areas, and the Vault, which are usually situated in well-traveled areas, and also have some fluff reasoning.

*I still think it'd be suicide to do this, but it's not a hill I want to die on.
## Changelog
:cl:
balance: Malf AIs that hack Head of Staff and Vault APCs will now find a discount issued on Doomsday.
/:cl:
