### PR TITLE
Fixes cliented brainmobs being sent to the gem room when their amputated head is reattached to a body.

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -44,6 +44,15 @@
 	if(!.)
 		return
 
+	// Transfer brainmob if we're in a head.
+	if(istype(loc, /obj/item/bodypart/head))
+		var/obj/item/bodypart/head/brain_holder = loc
+		if(brain_holder.brainmob)
+			brainmob = brain_holder.brainmob
+			brain_holder.brainmob = null
+			brainmob.container = null
+			brainmob.forceMove(src)
+
 	name = initial(name)
 
 	if(brain_owner.mind && brain_owner.mind.has_antag_datum(/datum/antagonist/changeling) && !no_id_transfer) //congrats, you're trapped in a body you don't control

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -44,7 +44,8 @@
 	if(!.)
 		return
 
-	// Transfer brainmob if we're in a head.
+	// Transfer brainmob from the head if we're being transferred from a head to a new body.
+	// And example of this ocurring is reattaching an amputated/severed head via surgery.
 	if(istype(loc, /obj/item/bodypart/head))
 		var/obj/item/bodypart/head/brain_holder = loc
 		if(brain_holder.brainmob)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -372,17 +372,10 @@
 	// These are stored before calling super. This is so that if the head is from a different body, it persists its appearance.
 	var/real_name = src.real_name
 
-	// Transfer brainmob to any brain before calling parent, which will handle brain insertion as part of organ code.
-	if(brain && brainmob)
-		brainmob.container = null
-		brainmob.forceMove(brain)
-		brain.brainmob = brainmob
-		brainmob = null
-
 	. = ..()
 
 	if(!.)
-		return .
+		return
 
 	if(brain)
 		brain = null

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -372,19 +372,20 @@
 	// These are stored before calling super. This is so that if the head is from a different body, it persists its appearance.
 	var/real_name = src.real_name
 
+	// Transfer brainmob to any brain before calling parent, which will handle brain insertion as part of organ code.
+	if(brain && brainmob)
+		brainmob.container = null
+		brainmob.forceMove(brain)
+		brain.brainmob = brainmob
+		brainmob = null
+
 	. = ..()
+
 	if(!.)
 		return .
-	//Transfer some head appearance vars over
-	if(brain)
-		if(brainmob)
-			brainmob.container = null //Reset brainmob head var.
-			brainmob.forceMove(brain) //Throw mob into brain.
-			brain.brainmob = brainmob //Set the brain to use the brainmob
-			brainmob = null //Set head brainmob var to null
-		brain.Insert(new_head_owner) //Now insert the brain proper
-		brain = null //No more brain in the head
 
+	if(brain)
+		brain = null
 	if(tongue)
 		tongue = null
 	if(ears)


### PR DESCRIPTION
## About The Pull Request

Fixes #74126

Hi vsauce, Timberpoes here!

Brains are being sent the gem room. But why???? *musical sting*

Issue was caused by #73026
![image](https://user-images.githubusercontent.com/24975989/227698989-76e96198-b000-44d5-8c71-65721f25f9df.png)

This early return added to brain Insert is the root cause.

Let's have a butcher's at some code, eh?

![image](https://user-images.githubusercontent.com/24975989/227699118-217bc7a2-160c-41a0-b75e-ef389c43f538.png)

Here we have a parent call in `. = ..()` and then a check for brains and brainmobs to do some special snowflake stuff before `brain.Insert(new_head_owner)`.

This causes a problem. But WHY???????

Well... The parent call already inserts the brain, but without any snowflake stuff done.

![image](https://user-images.githubusercontent.com/24975989/227699193-2bb29dce-c92d-4253-aa78-4f771d765bf2.png)

The parent call returns and the child proc `/obj/item/bodypart/head/try_attach_limb()` which mashes the brainmob into the brain and slams the `brain.Insert()` proc a **second** time.

This is a bug. But it worked despite being a bug, because the brain's Insert proc would still do logic even if the Insert was technically not successful.

But... We come back to this again:
![image](https://user-images.githubusercontent.com/24975989/227701040-a98b0ae7-1221-431a-8cc5-d47061372f7a.png)

If the new early return for the parent call is FALSEy, it stops all that wonderful brainmob code from being executed.

![image](https://user-images.githubusercontent.com/24975989/227699367-c6aafcf1-8c50-41fe-b90d-820cd8cd1618.png)

... And ITS parent call is FALSE because `owner == receiver` is now TRUE, as it was set the first time `Insert()` was called all the way back in `/obj/item/bodypart/proc/try_attach_limb()`.

So the first `brain.Insert()` call in the parent `/obj/item/bodypart/proc/try_attach_limb()` succeeds, but brainmob related code isn't executed because the head bodypart hasn't set up the brain's state correctly at this point.

And the second `brain.Insert()` call in the child `/obj/item/bodypart/head/try_attach_limb()` which occurs after the brain's state is correctly set, now fails because of an early return when the insertion fails (the owner is already the receiver).

So, the old code only worked because it was bugged. Fixing the bug where it worked, created a bug where it didn't.

But wait, why the gem room?

Well, since all the code that handled qdeleting the brainmob failed, it persisted in the brain **even after the brain was inserted into the body**. Where does the body store all of its organs? That's right, it transfers them all to ~~the balls~~ nullspace!

![image](https://user-images.githubusercontent.com/24975989/227700676-47b8d7ef-b77d-42f8-996a-fa994136d501.png)

And what is the brainmob? A mob! And what did it have? A client! And what happens when cliented mobs find themselves in nullspace when a Life() tick happens? A vacation to the gem room!

I have opted for a very simple fix. I've moved the code into `/obj/item/organ/internal/brain/Insert()`. It now checks to see if it's in a head when it's inserted into the new brain_owner. If it is, the brain handles setting up its own state so it can successfully transfer.

`brain.Insert()` only gets called once instead of twice and the snowflake behaviour is no longer controlled by the head.

In my testing of shearing off heads of guest clients and reattaching them, this fixes the bug without any gem room errors on the other clients.
## Why It's Good For The Game

Feex.
## Changelog
:cl:
fix: Having your severed, brain-filled head reattached to a body no longer teleports your brain to the mythical Gem Room.
/:cl:
