### PR TITLE
A fix for UO45 "no gravity" issue

### DIFF
--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -11831,7 +11831,7 @@
 /turf/open/floor/iron/white{
 	heat_capacity = 1e+006
 	},
-/area/space/nearstation)
+/area/awaymission/undergroundoutpost45/research)
 "NT" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/misc/asteroid{


### PR DESCRIPTION
## About The Pull Request

A fix for issue #72400

Screenshot №3 - what was before

<details>

![StrongDMM_JfATOPSWyj](https://user-images.githubusercontent.com/78963858/227701764-c6bfde54-0a78-4dc9-9f09-a4a75279bf6f.png)
![dreamseeker_32wgn0UxFS](https://user-images.githubusercontent.com/78963858/227701767-2293222e-bafd-40e3-95a3-e800ce95fd1c.png)
![dreamseeker_E7UNmUiid3](https://user-images.githubusercontent.com/78963858/227701768-41b92953-5a39-4b24-b26e-fb7e5603ddb3.png)

</details>

## Why It's Good For The Game

A little fix

## Changelog

:cl: SishTis
fix: Fixed gravity issue in Underground Outpost 45's research airlock.
/:cl:
