### PR TITLE
Fixes lizards with blood deficiency not getting their special blood packs in the mail, removes an unnecessary extra proc call

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -89,8 +89,6 @@
 	UnregisterSignal(former_ethereal, COMSIG_ATOM_EMP_ACT)
 	UnregisterSignal(former_ethereal, COMSIG_LIGHT_EATER_ACT)
 	QDEL_NULL(ethereal_light)
-	if(ishuman(former_ethereal))
-		new_species.update_mail_goodies(former_ethereal)
 	return ..()
 
 /datum/species/ethereal/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -58,10 +58,7 @@
 	if(regenerate_limbs)
 		regenerate_limbs.Remove(former_jellyperson)
 	former_jellyperson.RemoveElement(/datum/element/soft_landing)
-	
-	if(ishuman(former_jellyperson))
-		new_species.update_mail_goodies(former_jellyperson)
-	
+
 	return ..()
 
 /datum/species/jelly/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -53,6 +53,18 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/lizard,
 	)
 
+/datum/species/lizard/on_species_gain(mob/living/carbon/new_lizard, datum/species/old_species, pref_load)
+	. = ..()
+	if(ishuman(new_lizard))
+		update_mail_goodies(new_lizard)
+
+/datum/species/lizard/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
+	if(istype(quirk, /datum/quirk/blooddeficiency))
+		mail_goodies += list(
+			/obj/item/reagent_containers/blood/lizard
+		)
+	return ..()
+
 /// Lizards are cold blooded and do not stabilize body temperature naturally
 /datum/species/lizard/body_temperature_core(mob/living/carbon/human/humi, delta_time, times_fired)
 	return
@@ -178,19 +190,19 @@ Lizard subspecies: SILVER SCALED
 	///See above
 	var/old_eye_color_right
 
-/datum/species/lizard/silverscale/on_species_gain(mob/living/carbon/C, datum/species/old_species)
-	var/mob/living/carbon/human/new_silverscale = C
-	old_mutcolor = C.dna.features["mcolor"]
-	old_eye_color_left = new_silverscale.eye_color_left
-	old_eye_color_right = new_silverscale.eye_color_right
+/datum/species/lizard/silverscale/on_species_gain(mob/living/carbon/new_silverscale, datum/species/old_species, pref_load)
+	var/mob/living/carbon/human/silverscale = new_silverscale
+	old_mutcolor = new_silverscale.dna.features["mcolor"]
+	old_eye_color_left = silverscale.eye_color_left
+	old_eye_color_right = silverscale.eye_color_right
 	new_silverscale.dna.features["mcolor"] = "#eeeeee"
-	new_silverscale.eye_color_left = "#0000a0"
-	new_silverscale.eye_color_right = "#0000a0"
+	silverscale.eye_color_left = "#0000a0"
+	silverscale.eye_color_right = "#0000a0"
 	..()
-	new_silverscale.add_filter("silver_glint", 2, list("type" = "outline", "color" = "#ffffff63", "size" = 2))
+	silverscale.add_filter("silver_glint", 2, list("type" = "outline", "color" = "#ffffff63", "size" = 2))
 
-/datum/species/lizard/silverscale/on_species_loss(mob/living/carbon/C)
-	var/mob/living/carbon/human/was_silverscale = C
+/datum/species/lizard/silverscale/on_species_loss(mob/living/carbon/old_silverscale, datum/species/new_species, pref_load)
+	var/mob/living/carbon/human/was_silverscale = old_silverscale
 	was_silverscale.dna.features["mcolor"] = old_mutcolor
 	was_silverscale.eye_color_left = old_eye_color_left
 	was_silverscale.eye_color_right = old_eye_color_right

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -42,11 +42,6 @@
 	if(ishuman(new_podperson))
 		update_mail_goodies(new_podperson)
 
-/datum/species/pod/on_species_loss(mob/living/carbon/former_podperson, datum/species/new_species, pref_load)
-	. = ..()
-	if(ishuman(former_podperson))
-		new_species.update_mail_goodies(former_podperson)
-
 /datum/species/pod/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
 	if(istype(quirk, /datum/quirk/blooddeficiency))
 		mail_goodies += list(

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -54,8 +54,6 @@
 		bag.emptyStorage()
 		former_snailperson.temporarilyRemoveItemFromInventory(bag, TRUE)
 		qdel(bag)
-	if(ishuman(former_snailperson))
-		new_species.update_mail_goodies(former_snailperson)
 
 /datum/species/snail/update_quirk_mail_goodies(mob/living/carbon/human/recipient, datum/quirk/quirk, list/mail_goodies = list())
 	if(istype(quirk, /datum/quirk/blooddeficiency))


### PR DESCRIPTION
## About The Pull Request

Followup to #74189

What it says on the tin. This is the last time I will ping you on a blood-deficiency related PR, I swear! @san7890 

About lizards--they have a special bloodtype that isn't compatible with the generic O- that gets sent to everyone else, which I am just now realizing.

I also realized that there is never a situation when `on_species_loss` gets called without `on_species_gain` so there is no reason to call `update_mail_goodies` in each of those. I deleted the extra proc calls in `on_species_loss` to save on performance.

Also cleans up some single letter vars in the lizard species file.

## Why It's Good For The Game

Fixes an oversight, cleans up some code.

## Changelog

:cl:
qol: lizards with blood deficiency now receive the type 'L' blood packs instead of an unhelpful type 'O-' one.
/:cl:
