### PR TITLE
Felinids can actually eat mice and don't gross out

### DIFF
--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -291,7 +291,7 @@
 	bite_consumption = 3
 	eatverbs = list("devour")
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2)
-	foodtypes = GORE | MEAT | RAW
+	foodtypes = GORE | MEAT
 	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/consumable/liquidgibs = 5)
 	decomp_req_handle = TRUE
 	ant_attracting = FALSE


### PR DESCRIPTION
## About The Pull Request

Removed "RAW" flag from dead mice.
Since humans still dislike "GORE" as well as some other races, it shouldn't cause issues.

## Why It's Good For The Game

A fix for #71138

## Changelog

:cl: SishTis
qol: Felinids can eat dead mice and don't gross out.
/:cl: