### PR TITLE
Adds a syndicate docking port to Tramstation

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -58646,14 +58646,8 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "oFv" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dir = 8;
-	dwidth = 12;
-	height = 17;
-	name = "northeast of station";
-	shuttle_id = "syndicate_ne";
-	width = 23
+/obj/docking_port/stationary/syndicate/northeast{
+	dir = 8
 	},
 /turf/open/space,
 /area/space/nearstation)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -50368,14 +50368,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "pWu" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dir = 8;
-	dwidth = 12;
-	height = 17;
-	name = "northeast of station";
-	shuttle_id = "syndicate_ne";
-	width = 23
+/obj/docking_port/stationary/syndicate/northeast{
+	dir = 8
 	},
 /turf/open/genturf,
 /area/icemoon/surface/outdoors/unexplored/rivers/no_monsters)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -44913,14 +44913,8 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "oJU" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dir = 8;
-	dwidth = 12;
-	height = 17;
-	name = "northwest of station";
-	shuttle_id = "syndicate_nw";
-	width = 23
+/obj/docking_port/stationary/syndicate/northwest{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -58736,14 +58736,8 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
 "uXt" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dir = 8;
-	dwidth = 12;
-	height = 17;
-	name = "northwest of station";
-	shuttle_id = "syndicate_nw";
-	width = 23
+/obj/docking_port/stationary/syndicate/northwest{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -27594,14 +27594,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "iKN" = (
-/obj/docking_port/stationary{
-	dheight = 1;
-	dir = 8;
-	dwidth = 12;
-	height = 17;
-	name = "northwest of station";
-	shuttle_id = "syndicate_nw";
-	width = 23
+/obj/docking_port/stationary/syndicate/northwest{
+	dir = 8
 	},
 /turf/open/space/openspace,
 /area/space)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -27593,6 +27593,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"iKN" = (
+/obj/docking_port/stationary{
+	dheight = 1;
+	dir = 8;
+	dwidth = 12;
+	height = 17;
+	name = "northwest of station";
+	shuttle_id = "syndicate_nw";
+	width = 23
+	},
+/turf/open/space/openspace,
+/area/space)
 "iKY" = (
 /obj/item/experi_scanner{
 	pixel_x = 5
@@ -144795,7 +144807,7 @@ jhd
 jhd
 jhd
 jhd
-jhd
+iKN
 jhd
 jhd
 jhd

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -300,6 +300,23 @@
 	if (HAS_TRAIT(SSstation, STATION_TRAIT_BIGGER_PODS))
 		roundstart_template = /datum/map_template/shuttle/escape_pod/luxury
 
+// should fit the syndicate infiltrator, and smaller ships like the battlecruiser corvettes and fighters
+/obj/docking_port/stationary/syndicate
+	name = "near the station"
+	dheight = 1
+	dwidth = 12
+	height = 17
+	width = 23
+	shuttle_id = "syndicate_nearby"
+
+/obj/docking_port/stationary/syndicate/northwest
+	name = "northwest of station"
+	shuttle_id = "syndicate_nw"
+
+/obj/docking_port/stationary/syndicate/northeast
+	name = "northeast of station"
+	shuttle_id = "syndicate_ne"
+
 /obj/docking_port/stationary/transit
 	name = "In Transit"
 	override_can_dock_checks = TRUE


### PR DESCRIPTION
## About The Pull Request

Tram was missing its syndicate docking port, so while the Syndicate Infiltrator could use their station locked advanced navigational console to get to the station, the Starfury's Corvette and fighters could not do such a thing, as they defaulted to gaze upon the areas around the Starfury, and could not swap the camera view to the station z level, due to this missing port.

In addition, I noticed that the same values have been copy pasted on all stations, so I have decided to create some new docking port subtypes, one generic nearby the station (though no shuttles use it as of now), and one for northwest of the station (used by meta, kilo, and now, Tram), and one for northeast of station (used by delta and icebox).

### Mapping March

Ckey to receive rewards: N/A

## Why It's Good For The Game

When the traitor does enough tasks to summon the battlecruiser, the backup and extraction should arrive on every station.
Closes #72204 
Closes #73441

## Changelog

:cl:
fix: The Starfury's Corvette and Fighters can now visit Tramstation
/:cl:

