### PR TITLE
Fixes blood transfusion not working for ethereals

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -839,6 +839,10 @@
 	taste_description = "pure electricity"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
+/datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
+	if(isethereal(M))
+		M.blood_volume += 1 * delta_time
+
 /datum/reagent/consumable/liquidelectricity/enriched
 	name = "Enriched Liquid Electricity"
 
@@ -853,9 +857,7 @@
 		stomach.adjust_charge(reac_volume * 30)
 
 /datum/reagent/consumable/liquidelectricity/enriched/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
-	if(isethereal(M))
-		M.blood_volume += 1 * delta_time
-	else if(DT_PROB(10, delta_time)) //lmao at the newbs who eat energy bars
+	if(!isethereal(M) && DT_PROB(10, delta_time)) //lmao at the newbs who eat energy bars
 		M.electrocute_act(rand(5,10), "Liquid Electricity in their body", 1, SHOCK_NOGLOVES) //the shock is coming from inside the house
 		playsound(M, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -842,6 +842,7 @@
 /datum/reagent/consumable/liquidelectricity/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	if(isethereal(M))
 		M.blood_volume += 1 * delta_time
+	..()
 
 /datum/reagent/consumable/liquidelectricity/enriched
 	name = "Enriched Liquid Electricity"


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. A copy paste error made it so that `/datum/reagent/consumable/liquidelectricity/enriched` increases blood volume but the parent `/datum/reagent/consumable/liquidelectricity` (which is what the actual blood reagent) does not.

Edit: closing, this is actually fixed already. 

## Why It's Good For The Game

Bugfix

:cl:
fix: fixes liquid electricity not increasing blood volume when injected into an ethereal
/:cl:
