### PR TITLE
Stops plasmamen from being left for dead by kidnappers

### DIFF
--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -322,13 +322,12 @@
 	for(var/obj/item/belonging in victim_belongings)
 		belonging.forceMove(return_pod)
 
-	sent_mob.dna.species.give_important_for_life(sent_mob) // so plasmamen do not get left for dead
-
 	sent_mob.forceMove(return_pod)
 	sent_mob.flash_act()
 	sent_mob.adjust_confusion(10 SECONDS)
 	sent_mob.adjust_dizzy(10 SECONDS)
 	sent_mob.set_eye_blur_if_lower(100 SECONDS)
+	sent_mob.dna.species.give_important_for_life(sent_mob) // so plasmamen do not get left for dead
 
 	new /obj/effect/pod_landingzone(pick(possible_turfs), return_pod)
 

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -252,8 +252,6 @@
 			continue
 		victim_belongings.Add(belonging)
 
-	sent_mob.dna.species.give_important_for_life(sent_mob) // so plasmamen do not get left for dead
-
 	var/datum/bank_account/cargo_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
 
 	if(cargo_account) //Just in case
@@ -283,6 +281,7 @@
 	sent_mob.adjust_confusion(10 SECONDS)
 	sent_mob.adjust_dizzy(10 SECONDS)
 	sent_mob.set_eye_blur_if_lower(100 SECONDS)
+	sent_mob.dna.species.give_important_for_life(sent_mob) // so plasmamen do not get left for dead
 	to_chat(sent_mob, span_hypnophrase(span_reallybig("A million voices echo in your head... <i>\"Your mind held many valuable secrets - \
 		we thank you for providing them. Your value is expended, and you will be ransomed back to your station. We always get paid, \
 		so it's only a matter of time before we ship you back...\"</i>")))

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -252,6 +252,8 @@
 			continue
 		victim_belongings.Add(belonging)
 
+	sent_mob.dna.species.give_important_for_life(sent_mob) // so plasmamen do not get left for dead
+
 	var/datum/bank_account/cargo_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
 
 	if(cargo_account) //Just in case
@@ -320,6 +322,8 @@
 
 	for(var/obj/item/belonging in victim_belongings)
 		belonging.forceMove(return_pod)
+
+	sent_mob.dna.species.give_important_for_life(sent_mob) // so plasmamen do not get left for dead
 
 	sent_mob.forceMove(return_pod)
 	sent_mob.flash_act()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/74157

Plasmamen should be given their outfit_important_for_life after stripping them, seeing as they are supposed to be kept alive. 

## Why It's Good For The Game

No more removing plasmamen from the round due to an oversight.

## Changelog

:cl:
fix: plasmamen will now be given their internals upon being kidnapped and upon being returned.
/:cl:
