### PR TITLE
updates a tip to reflect changes to oxy healing chems

### DIFF
--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -51,7 +51,7 @@ As a Medical Doctor, corpses placed inside a freezer or morgue tray will have th
 As a Medical Doctor, corpses with the "...and their soul has departed" description no longer have a ghost attached to them and can't be revived.
 As a Medical Doctor, Critical Slash wounds are one of the most dangerous conditions someone can have. Apply gauze, epipens, sutures, cauteries, whatever you can, as soon as possible!
 As a Medical Doctor, Saline-Glucose not only acts as a temporary boost to a patient's blood level, it also speeds blood regeneration! Perfect for drained patients!
-As a Medical Doctor, treating plasmamen is not impossible! Salbutamol stops them from suffocating and showers stop them from burning alive. You can even perform surgery on them by doing the procedure on a roller bed under a shower.
+As a Medical Doctor, treating plasmamen is not impossible! Showers stop them from burning alive. You can even perform surgery on them by doing the procedure on a roller bed under a shower. Salbutamol and convermol do NOT heal their oxyloss damage.
 As a Medical Doctor, you can attempt to drain blood from a husk with a syringe to determine the cause. If you can extract blood, it was caused by extreme temperatures or lasers, if there is no blood to extract, you have confirmed the presence of changelings.
 As a Medical Doctor, you can deal with patients who have absurd amounts of wounds by putting them in cryo. This will slowly treat all of their wounds simultaneously, but is much slower than direct treatment.
 As a Medical Doctor, you can extract implants by holding an empty implant case in your offhand while performing the extraction step.


### PR DESCRIPTION
## About The Pull Request

See title.

## Why It's Good For The Game

"As a Medical Doctor, treating plasmamen is not impossible! **Salbutamol stops them from suffocating** and showers stop them from burning alive. You can even perform surgery on them by doing the procedure on a roller bed under a shower."

This is no longer the case, as for some reason, someone specifically went out of their way to make most methods of healing oxyloss not work on plasmamen and other humanoids that don't breathe oxygen. Why? I dunno, but it makes this tip outdated (and dealing with certain conditions way more annoying).

Lowkey, if I got maintainer support for it, I wouldn't mind sitting down to make a PR to completely excise required_respiration_type from the game. I don't really see what it adds to the game, other than creating these edge cases where plasmamen (and nitrogen breathers downstream) get extra-fucked over by certain mechanics.

:cl: ATHATH
spellcheck: Tweaked an outdated doctor tip to reflect that fact that salbutamol can't heal plasmamen (outside of very specific edge cases).
/:cl:
