### PR TITLE
[NO GBP] Fixes excess xenomorph teams being formed

### DIFF
--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -31,7 +31,7 @@
 /datum/antagonist/xeno/create_team(datum/team/xeno/new_team)
 	if(!new_team)
 		for(var/datum/antagonist/xeno/X in GLOB.antagonists)
-			if(!X.owner || !X.xeno_team || !istype(X.xeno_team, new_team)) //Make sure we don't add them to the wrong team
+			if(!X.owner || !X.xeno_team)
 				continue
 			xeno_team = X.xeno_team
 			return


### PR DESCRIPTION

## About The Pull Request

This removes an istype check I left in create_team() on the xeno antag datum. While the check was intended to stop regular xenomorphs from receiving captive xenomorph antag datums, it ended up being unnecessary because: 

Captive Xenomorphs got their own create_team() at a certain point, making this irrelevant

and

The check would always fail (Since, to get to this point in the code, new_team would have to be null) and lead to every xeno receiving their own team.

![image](https://user-images.githubusercontent.com/28870487/227735216-d4da7c17-4ef6-48e0-a80a-94015ec04ccd.png)

Whoops.
## Why It's Good For The Game

Makes the roundend report less UGLY. Cleans up an oopsie I made.
## Changelog
:cl:
fix: Xenomorphs will now be properly teamed together again, and will show up together on the roundend report.
/:cl:
