### PR TITLE
Swaps out the solar panel tiles on the Traveller's Rest space ruin to be airless tiles

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/travelers_rest.dmm
+++ b/_maps/RandomRuins/SpaceRuins/travelers_rest.dmm
@@ -84,7 +84,7 @@
 "gF" = (
 /obj/structure/cable,
 /obj/machinery/power/solar,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/ruin/space/has_grav/travelers_rest)
 "gN" = (
 /obj/machinery/shower/directional/east,
@@ -393,7 +393,7 @@
 /obj/structure/cable,
 /obj/machinery/power/solar,
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/ruin/space/has_grav/travelers_rest)
 "LS" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{


### PR DESCRIPTION

## About The Pull Request

The solar panel tiles of the Traveller's Rest had air, which caused roundstart active turfs. This PR fixes that.

### Mapping March

Ckey to receive rewards: N/A

## Why It's Good For The Game

Less alerts during initialization. Closes #74245

## Changelog

Nothing player facing