### PR TITLE
Cult Roundend Report No Longer Lists Post-Summon Cultists

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -472,16 +472,7 @@
 
 	if(members.len)
 		parts += "<span class='header'>The cultists were:</span>"
-		var/list/no_harvesters_cult = list()
-		for(var/datum/mind/cult_mind as anything in members)
-			if(istype(cult_mind.current, /mob/living/simple_animal/hostile/construct/harvester))
-				continue
-			if(cult_mind in true_cultists)
-				continue
-			no_harvesters_cult += cult_mind
-		for(var/datum/mind/pre_summon_cultist as anything in true_cultists)
-			no_harvesters_cult += pre_summon_cultist
-		parts += printplayerlist(no_harvesters_cult)
+		parts += printplayerlist(true_cultists)
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"
 

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -470,7 +470,12 @@
 
 	if(members.len)
 		parts += "<span class='header'>The cultists were:</span>"
-		parts += printplayerlist(members)
+		var/list/noharvesterscult = list()
+		for(var/datum/mind/cultmind in members)
+			if(istype(cultmind.current, /mob/living/simple_animal/hostile/construct/harvester))
+				continue
+			noharvesterscult += cultmind
+		parts += printplayerlist(noharvesterscult)
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"
 

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -273,6 +273,8 @@
 	var/narsie_summoned = FALSE
 	///How large were we at max size.
 	var/size_at_maximum = 0
+	///list of cultists just before summoning Narsie
+	var/list/truecult = list()
 
 /datum/team/cult/proc/check_size()
 	if(cult_ascendent)
@@ -474,7 +476,11 @@
 		for(var/datum/mind/cultmind as anything in members)
 			if(istype(cultmind.current, /mob/living/simple_animal/hostile/construct/harvester))
 				continue
+			if(cultmind in truecult)
+				continue
 			noharvesterscult += cultmind
+		for(var/datum/mind/presummoncultist as anything in truecult)
+			noharvesterscult += presummoncultist
 		parts += printplayerlist(noharvesterscult)
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -274,7 +274,7 @@
 	///How large were we at max size.
 	var/size_at_maximum = 0
 	///list of cultists just before summoning Narsie
-	var/list/truecult = list()
+	var/list/true_cultists = list()
 
 /datum/team/cult/proc/check_size()
 	if(cult_ascendent)
@@ -472,16 +472,16 @@
 
 	if(members.len)
 		parts += "<span class='header'>The cultists were:</span>"
-		var/list/noharvesterscult = list()
-		for(var/datum/mind/cultmind as anything in members)
-			if(istype(cultmind.current, /mob/living/simple_animal/hostile/construct/harvester))
+		var/list/no_harvesters_cult = list()
+		for(var/datum/mind/cult_mind as anything in members)
+			if(istype(cult_mind.current, /mob/living/simple_animal/hostile/construct/harvester))
 				continue
-			if(cultmind in truecult)
+			if(cult_mind in true_cultists)
 				continue
-			noharvesterscult += cultmind
-		for(var/datum/mind/presummoncultist as anything in truecult)
-			noharvesterscult += presummoncultist
-		parts += printplayerlist(noharvesterscult)
+			no_harvesters_cult += cult_mind
+		for(var/datum/mind/pre_summon_cultist as anything in true_cultists)
+			no_harvesters_cult += pre_summon_cultist
+		parts += printplayerlist(no_harvesters_cult)
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"
 

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -471,7 +471,7 @@
 	if(members.len)
 		parts += "<span class='header'>The cultists were:</span>"
 		var/list/noharvesterscult = list()
-		for(var/datum/mind/cultmind in members)
+		for(var/datum/mind/cultmind as anything in members)
 			if(istype(cultmind.current, /mob/living/simple_animal/hostile/construct/harvester))
 				continue
 			noharvesterscult += cultmind

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -555,8 +555,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 	..()
 	sound_to_playing_players('sound/effects/dimensional_rend.ogg')
 	var/turf/rune_turf = get_turf(src)
-	for(var/datum/mind/cultmind as anything in cult_team.members)
-		cult_team.truecult += cultmind
+	for(var/datum/mind/cult_mind as anything in cult_team.members)
+		cult_team.true_cultists += cult_mind
 	sleep(4 SECONDS)
 	if(src)
 		color = RUNE_COLOR_RED

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -555,6 +555,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 	..()
 	sound_to_playing_players('sound/effects/dimensional_rend.ogg')
 	var/turf/rune_turf = get_turf(src)
+	for(var/datum/mind/cultmind as anything in cult_team.members)
+		cult_team.truecult += cultmind
 	sleep(4 SECONDS)
 	if(src)
 		color = RUNE_COLOR_RED


### PR DESCRIPTION
## About The Pull Request
Harvesters and any other post-summon cultists aren't shown in the roundend report
## Why It's Good For The Game
Harvesters are a roundend thing, nobody cares who the harvesters were since literally everyone becomes one even ghosts who observed since roundstart
It just clogs up the roundend report
The cultists who contributed to summoning are the ones people are interested in seeing
## Changelog
:cl:
qol: Cult Roundend Report no longer lists post-summon cultists. No more 30 random Harvesters clogging up the roundend report
/:cl:
