### PR TITLE
Log Active Turfs To Mapping Log

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -616,17 +616,19 @@ SUBSYSTEM_DEF(air)
 #ifdef UNIT_TESTS
 	return
 #endif
-	var/message_to_log = "All that follows is a turf with an active air difference at roundstart. To clear this, make sure that all of the turfs listed below are connected to a turf with the same air contents.\n\
+	var/list/message_to_log = list()
+
+	message_to_log += "All that follows is a turf with an active air difference at roundstart. To clear this, make sure that all of the turfs listed below are connected to a turf with the same air contents.\n\
 	In an ideal world, this list should have enough information to help you locate the active turf(s) in question. Unfortunately, this might not be an ideal world.\n\
 	If the round is still ongoing, you can use the \"Mapping -> Show roundstart AT list\" verb to see exactly what active turfs were detected. Otherwise, good luck."
 
 	for(var/turf/active_turf as anything in GLOB.active_turfs_startlist)
 		// so we can pass along the area type for the log, making it much easier to locate the active turf for a mapper assuming all area types are unique. This is only really a problem for stuff like ruin areas.
 		var/area/turf_area = get_area(active_turf)
-		message_to_log += "Active turf: [AREACOORD(active_turf)] ([turf_area.type]).\n"
+		message_to_log += "Active turf: [AREACOORD(active_turf)] ([turf_area.type])."
 
 	message_to_log += "End of active turf list."
-	log_mapping(message_to_log)
+	log_mapping(message_to_log.Join("\n"))
 
 
 /turf/open/proc/resolve_active_graph()

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -619,8 +619,8 @@ SUBSYSTEM_DEF(air)
 	var/list/message_to_log = list()
 
 	message_to_log += "All that follows is a turf with an active air difference at roundstart. To clear this, make sure that all of the turfs listed below are connected to a turf with the same air contents.\n\
-	In an ideal world, this list should have enough information to help you locate the active turf(s) in question. Unfortunately, this might not be an ideal world.\n\
-	If the round is still ongoing, you can use the \"Mapping -> Show roundstart AT list\" verb to see exactly what active turfs were detected. Otherwise, good luck."
+		In an ideal world, this list should have enough information to help you locate the active turf(s) in question. Unfortunately, this might not be an ideal world.\n\
+		If the round is still ongoing, you can use the \"Mapping -> Show roundstart AT list\" verb to see exactly what active turfs were detected. Otherwise, good luck."
 
 	for(var/turf/active_turf as anything in GLOB.active_turfs_startlist)
 		// so we can pass along the area type for the log, making it much easier to locate the active turf for a mapper assuming all area types are unique. This is only really a problem for stuff like ruin areas.

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -651,11 +651,7 @@ SUBSYSTEM_DEF(air)
 		var/area/turf_area = get_area(active_turf)
 		message_to_log += "Active turf: [AREACOORD(active_turf)] ([turf_area.type]). Turf type: [active_turf.type]. Relevant Z-Trait(s): [english_list(level_traits)]."
 
-		var/turf_z_as_string = "[turf_z]" // I FUCKING HATE IT HERE I FUCKING HATE IT HERE I FUCKING HATE IT HERE I FUCKING HATE IT HERE
-		if(!(turf_z_as_string in tally_by_level))
-			tally_by_level[turf_z_as_string] = 0
-
-		tally_by_level[turf_z_as_string]++
+		tally_by_level["[turf_z]"]++
 
 	// Following is so we can detect which rounds were "problematic" as far as active turfs go.
 	SSblackbox.record_feedback("amount", "overall_roundstart_active_turfs", length(GLOB.active_turfs_startlist))

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -647,7 +647,7 @@ SUBSYSTEM_DEF(air)
 
 		var/turf_z_as_string = "[turf_z]" // I FUCKING HATE IT HERE I FUCKING HATE IT HERE I FUCKING HATE IT HERE I FUCKING HATE IT HERE
 		if(!(turf_z_as_string in tally_by_level))
-			tally_by_level += list(turf_z_as_string = 0)
+			tally_by_level[turf_z_as_string] = 0
 
 		tally_by_level[turf_z_as_string]++
 		for(var/trait in level_traits)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -616,16 +616,17 @@ SUBSYSTEM_DEF(air)
 #ifdef UNIT_TESTS
 	return
 #endif
-	log_mapping("All that follows is a turf with an active air difference at roundstart. To clear this, make sure that all of the turfs listed below are connected to a turf with the same air contents.\n\
+	var/message_to_log = "All that follows is a turf with an active air difference at roundstart. To clear this, make sure that all of the turfs listed below are connected to a turf with the same air contents.\n\
 	In an ideal world, this list should have enough information to help you locate the active turf(s) in question. Unfortunately, this might not be an ideal world.\n\
-	If the round is still ongoing, you can use the \"Mapping -> Show roundstart AT list\" verb to see exactly what active turfs were detected. Otherwise, good luck.")
+	If the round is still ongoing, you can use the \"Mapping -> Show roundstart AT list\" verb to see exactly what active turfs were detected. Otherwise, good luck."
 
 	for(var/turf/active_turf as anything in GLOB.active_turfs_startlist)
 		// so we can pass along the area type for the log, making it much easier to locate the active turf for a mapper assuming all area types are unique. This is only really a problem for stuff like ruin areas.
 		var/area/turf_area = get_area(active_turf)
-		log_mapping("Active turf: [AREACOORD(active_turf)] ([area.type]).")
+		message_to_log += "Active turf: [AREACOORD(active_turf)] ([area.type]).\n"
 
-	log_mapping("End of active turf list.")
+	message_to_log += "End of active turf list."
+	log_mapping(message_to_log)
 
 
 /turf/open/proc/resolve_active_graph()

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -623,7 +623,7 @@ SUBSYSTEM_DEF(air)
 	for(var/turf/active_turf as anything in GLOB.active_turfs_startlist)
 		// so we can pass along the area type for the log, making it much easier to locate the active turf for a mapper assuming all area types are unique. This is only really a problem for stuff like ruin areas.
 		var/area/turf_area = get_area(active_turf)
-		message_to_log += "Active turf: [AREACOORD(active_turf)] ([area.type]).\n"
+		message_to_log += "Active turf: [AREACOORD(active_turf)] ([turf_area.type]).\n"
 
 	message_to_log += "End of active turf list."
 	log_mapping(message_to_log)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -630,6 +630,7 @@ SUBSYSTEM_DEF(air)
 	message_to_log += "End of active turf list."
 	log_mapping(message_to_log.Join("\n"))
 
+	SSblackbox.record_feedback("tally", "roundstart_active_turfs", 1, length(GLOB.active_turfs_startlist)) // So we can detect which rounds were "problematic" as far as active turfs go.
 
 /turf/open/proc/resolve_active_graph()
 	. = list()

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -649,7 +649,7 @@ SUBSYSTEM_DEF(air)
 
 		// so we can pass along the area type for the log, making it much easier to locate the active turf for a mapper assuming all area types are unique. This is only really a problem for stuff like ruin areas.
 		var/area/turf_area = get_area(active_turf)
-		message_to_log += "Active turf: [AREACOORD(active_turf)] ([turf_area.type]). Z-Level has traits: [english_list(level_traits)]."
+		message_to_log += "Active turf: [AREACOORD(active_turf)] ([turf_area.type]). Turf type: [active_turf.type]. Relevant Z-Trait(s): [english_list(level_traits)]."
 
 		var/turf_z_as_string = "[turf_z]" // I FUCKING HATE IT HERE I FUCKING HATE IT HERE I FUCKING HATE IT HERE I FUCKING HATE IT HERE
 		if(!(turf_z_as_string in tally_by_level))

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -645,10 +645,11 @@ SUBSYSTEM_DEF(air)
 		var/list/level_traits = level.traits
 		message_to_log += "Active turf: [AREACOORD(active_turf)] ([turf_area.type]). Z-Level has traits: [english_list(level_traits)]."
 
-		if(!(turf_z in tally_by_level))
-			tally_by_level[turf_z] = 0
+		var/turf_z_as_string = "[turf_z]" // I FUCKING HATE IT HERE I FUCKING HATE IT HERE I FUCKING HATE IT HERE I FUCKING HATE IT HERE
+		if(!(turf_z_as_string in tally_by_level))
+			tally_by_level += list(turf_z_as_string = 0)
 
-		tally_by_level[turf_z]++
+		tally_by_level[turf_z_as_string]++
 		for(var/trait in level_traits)
 			if(trait in tally_by_level_trait)
 				tally_by_level_trait[trait]++

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -634,7 +634,7 @@ SUBSYSTEM_DEF(air)
 
 	var/list/message_to_log = list()
 
-	message_to_log += "All that follows is a turf with an active air difference at roundstart. To clear this, make sure that all of the turfs listed below are connected to a turf with the same air contents.\n\
+	message_to_log += "\nAll that follows is a turf with an active air difference at roundstart. To clear this, make sure that all of the turfs listed below are connected to a turf with the same air contents.\n\
 		In an ideal world, this list should have enough information to help you locate the active turf(s) in question. Unfortunately, this might not be an ideal world.\n\
 		If the round is still ongoing, you can use the \"Mapping -> Show roundstart AT list\" verb to see exactly what active turfs were detected. Otherwise, good luck."
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -643,7 +643,7 @@ SUBSYSTEM_DEF(air)
 		var/datum/space_level/level = SSmapping.z_list[turf_z]
 		var/list/level_traits = list()
 		for(var/trait in level.traits)
-			if(trait in tally_by_level_trait)
+			if(!isnull(tally_by_level_trait[trait]))
 				level_traits += trait
 				tally_by_level_trait[trait]++
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -625,7 +625,8 @@ SUBSYSTEM_DEF(air)
 	for(var/turf/active_turf as anything in GLOB.active_turfs_startlist)
 		// so we can pass along the area type for the log, making it much easier to locate the active turf for a mapper assuming all area types are unique. This is only really a problem for stuff like ruin areas.
 		var/area/turf_area = get_area(active_turf)
-		message_to_log += "Active turf: [AREACOORD(active_turf)] ([turf_area.type])."
+		var/datum/space_level/level = SSmapping.z_list[active_turf.z]
+		message_to_log += "Active turf: [AREACOORD(active_turf)] ([turf_area.type]). Z-Level has traits: [english_list(level.traits)]."
 
 	message_to_log += "End of active turf list."
 	log_mapping(message_to_log.Join("\n"))


### PR DESCRIPTION
## About The Pull Request

Was reminded of doing this via https://github.com/tgstation/tgstation/issues/74245#issuecomment-1483943979

They're mapping issues, so let's log them to the mapping log. Quite shrimple honestly.

![image](https://user-images.githubusercontent.com/34697715/227805458-5e6bcf01-629d-4b81-ab6a-b26e63d41ca3.png)
## Why It's Good For The Game

As the comments expound, the reason why we probably haven't done this in the past is because any number of things can cause active turfs (like ruin placement (either in icebox or in space)), or other silly stuff like that. Thus, finding stuff like this would only really be viable with stuff like the View Active Turfs verb, where you could visually jump to and see all of the active turfs in that dynamic configuration (and this still remains the best way to find active turfs).

This PR just makes it easier to do a "post-mortem" analysis on potential active turfs, so that if it's very blatant, it can be fixed a lot easier. It's best to try and find them during an ongoing round, but this is life. (same as the unit tests concession, not too enthused on that but we would have spontaneous errors out the ass without _something_)
## Changelog
Nothing that concerns players.
