### PR TITLE
Syndicate Lavaland Base Photocopier is now Free (Gratis)

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -955,11 +955,11 @@
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/syndicate_lava_base/cargo)
 "gP" = (
-/obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/machinery/photocopier/gratis,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/cargo)
 "gQ" = (

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -44,8 +44,12 @@
 
 /obj/machinery/photocopier/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/payment, 5, SSeconomy.get_dep_account(ACCOUNT_CIV), PAYMENT_CLINICAL)
 	toner_cartridge = new(src)
+	setup_components()
+
+/// Simply adds the necessary components for this to function.
+/obj/machinery/photocopier/proc/setup_components()
+	AddComponent(/datum/component/payment, 5, SSeconomy.get_dep_account(ACCOUNT_CIV), PAYMENT_CLINICAL)
 
 /obj/machinery/photocopier/handle_atom_del(atom/deleting_atom)
 	if(deleting_atom == object_copy)
@@ -515,6 +519,14 @@
 		return FALSE
 	else
 		return TRUE
+
+/// Subtype of photocopier that is free to use.
+/obj/machinery/photocopier/gratis
+	desc = "Does the same important paperwork, but it's free to use! The best type of free."
+
+/obj/machinery/photocopier/gratis/setup_components()
+	// it's free! no charge! very cool and gratis-pilled.
+	AddComponent(/datum/component/payment, 0, SSeconomy.get_dep_account(ACCOUNT_CIV), PAYMENT_CLINICAL)
 
 /*
  * Toner cartridge


### PR DESCRIPTION
## About The Pull Request

Closes #74196 . The syndicate ripped out the payment charger for VERY IMPORTANT BUSINESSWORK.
## Why It's Good For The Game

i dunno if the syndicate ever get a fax machine they'll be able to send people ass photos?
## Changelog
:cl:
fix: The Syndicate have gotten their hands on the most dangerous weapon: A photocopier that doesn't require any money. God save us all.
/:cl:

I decided to go with the subtype being named `gratis` because i didn't want people to confuse whatever a `free` subtype would mean... free to photocopy your own ass or anyone's ass? unlimited ass? photocopy smut? whatever i think it's funny since it gives you to the answer of the joke that i put in the desc... i'm such a master of comedy
