### PR TITLE
Curators now have D-notice newscaster access, Officers can issue warrants

### DIFF
--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -19,6 +19,10 @@
 	var/newscaster_username
 	///How much paper is contained within the newscaster?
 	var/paper_remaining = 0
+	///The access required to access D-notices.
+	var/admin_access = ACCESS_LIBRARY
+	///The access required to submit & remove wanted issues.
+	var/security_access = ACCESS_SECURITY
 
 	///What newscaster channel is currently being viewed by the player?
 	var/datum/feed_channel/current_channel
@@ -158,7 +162,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 		data["user"]["job"] = "N/A"
 		data["user"]["department"] = "N/A"
 
-	data["security_mode"] = (ACCESS_ARMORY in card?.GetAccess())
+	data["admin_mode"] = (admin_access in card?.GetAccess())
+	data["security_mode"] = (security_access in card?.GetAccess())
 	data["photo_data"] = !isnull(current_image)
 	data["creating_channel"] = creating_channel
 	data["creating_comment"] = creating_comment
@@ -329,7 +334,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			if(isliving(usr))
 				var/mob/living/living_user = usr
 				id_card = living_user.get_idcard(hand_first = TRUE)
-			if(!(ACCESS_ARMORY in id_card?.GetAccess()))
+			if(!(admin_access in id_card?.GetAccess()))
 				say("Clearance not found.")
 				return TRUE
 			var/questionable_message = params["messageID"]
@@ -343,7 +348,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			if(isliving(usr))
 				var/mob/living/living_user = usr
 				id_card = living_user.get_idcard(hand_first = TRUE)
-			if(!(ACCESS_ARMORY in id_card?.GetAccess()))
+			if(!(admin_access in id_card?.GetAccess()))
 				say("Clearance not found.")
 				return TRUE
 			var/questionable_message = params["messageID"]
@@ -357,7 +362,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			if(isliving(usr))
 				var/mob/living/living_user = usr
 				id_card = living_user.get_idcard(hand_first = TRUE)
-			if(!(ACCESS_ARMORY in id_card?.GetAccess()))
+			if(!(admin_access in id_card?.GetAccess()))
 				say("Clearance not found.")
 				return TRUE
 			var/prototype_channel = (params["channel"])
@@ -735,7 +740,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 	if(isliving(usr))
 		var/mob/living/living_user = usr
 		id_card = living_user.get_idcard(hand_first = TRUE)
-	if(!(ACCESS_ARMORY in id_card?.GetAccess()))
+	if(!(security_access in id_card?.GetAccess()))
 		say("Clearance not found.")
 		return TRUE
 	GLOB.news_network.wanted_issue.active = FALSE

--- a/code/modules/admin/verbs/admin_newscaster.dm
+++ b/code/modules/admin/verbs/admin_newscaster.dm
@@ -65,6 +65,7 @@
 	data["user"]["job"] = "Official"
 	data["user"]["department"] = "Department of News"
 
+	data["admin_mode"] = TRUE
 	data["security_mode"] = TRUE
 	data["photo_data"] = !isnull(current_image)
 	data["creating_channel"] = creating_channel

--- a/code/modules/modular_computers/file_system/programs/newscasterapp.dm
+++ b/code/modules/modular_computers/file_system/programs/newscasterapp.dm
@@ -1,7 +1,7 @@
 /datum/computer_file/program/newscaster
 	filename = "newscasterapp"
 	filedesc = "Newscaster"
-	required_access = list(ACCESS_LIBRARY)
+	transfer_access = list(ACCESS_LIBRARY)
 	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "bountyboard"
 	extended_desc = "This program allows any user to access the Newscaster network from anywhere."

--- a/tgui/packages/tgui/interfaces/Newscaster.js
+++ b/tgui/packages/tgui/interfaces/Newscaster.js
@@ -348,7 +348,7 @@ const NewscasterChannelBox = (props, context) => {
     channelAuthor,
     channelCensored,
     viewing_channel,
-    security_mode,
+    admin_mode,
     photo_data,
     paper,
     user,
@@ -393,16 +393,16 @@ const NewscasterChannelBox = (props, context) => {
               }
               onClick={() => act('togglePhoto')}
             />
-            {!!security_mode && (
+            {!!admin_mode && (
               <Button
                 icon="ban"
                 content={'D-Notice'}
                 tooltip="Censor the whole channel and it's \
                   contents as dangerous to the station. Cannot be undone."
-                disabled={!security_mode || !viewing_channel}
+                disabled={!admin_mode || !viewing_channel}
                 onClick={() =>
                   act('channelDNotice', {
-                    secure: security_mode,
+                    secure: admin_mode,
                     channel: viewing_channel,
                   })
                 }
@@ -426,7 +426,7 @@ const NewscasterChannelBox = (props, context) => {
 /** Channel select is the left-hand menu where all the channels are listed. */
 const NewscasterChannelSelector = (props, context) => {
   const { act, data } = useBackend(context);
-  const { channels = [], viewing_channel, security_mode, wanted = [] } = data;
+  const { channels = [], viewing_channel, wanted = [] } = data;
   return (
     <Section minHeight="100%" width={window.innerWidth - 410 + 'px'}>
       <Tabs vertical>
@@ -493,7 +493,7 @@ const NewscasterChannelMessages = (props, context) => {
   const {
     messages = [],
     viewing_channel,
-    security_mode,
+    admin_mode,
     channelCensored,
     channelLocked,
     channelAuthor,
@@ -533,11 +533,11 @@ const NewscasterChannelMessages = (props, context) => {
             }
             buttons={
               <>
-                {!!security_mode && (
+                {!!admin_mode && (
                   <Button
                     icon="comment-slash"
                     tooltip="Censor Story"
-                    disabled={!security_mode}
+                    disabled={!admin_mode}
                     onClick={() =>
                       act('storyCensor', {
                         messageID: message.ID,
@@ -545,11 +545,11 @@ const NewscasterChannelMessages = (props, context) => {
                     }
                   />
                 )}
-                {!!security_mode && (
+                {!!admin_mode && (
                   <Button
                     icon="user-slash"
                     tooltip="Censor Author"
-                    disabled={!security_mode}
+                    disabled={!admin_mode}
                     onClick={() =>
                       act('authorCensor', {
                         messageID: message.ID,


### PR DESCRIPTION
## About The Pull Request

Newscasters now have Library access for handing out D-Notices, and Security access for Wanted issues, instead of both being tied to Armory access.

Also allows Ntos Newscaster to work if ran by someone without Library access, so Curator can download the app for others if they want.

## Why It's Good For The Game

- Newscasters have turned into one of the Curator's largest gameplay aspects and it would be nice if they were able to moderate it as well, instead of being the Warden who has absolutely no interest in Newscasters.
- Allowing Officers to send out Wanted issues is more just in hopes it will result in it being used more, though it seems like a very similar feature to the wanted posters, maybe we can merge these two together one day.
- The Ntos Newscaster access change is more of an oversight, I like it when people can download apps for eachother as it gives a reason to seek others and lend them your PDA for an application you want, blocking the person from using the app after getting a Curator to download it for them kinda sucks in-game.

## Changelog

:cl:
balance: Curators/HoP can now manage Newscaster D-Notices (previously was Warden/HoS).
balance: Security Officers/Detectives can now issue Wanted notices on Newscasters.
balance: Ntos Newscaster now requires Library access only to download, not to run.
/:cl: