### PR TITLE
You will only be scared by phobia items equipped to players if the slot is visible on examine

### DIFF
--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -341,7 +341,6 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 		/obj/effect/heretic_rune,
 		/obj/effect/rune,
 		/obj/effect/visible_heretic_influence,
-		/obj/item/clothing/head/hooded/cult_hoodie,
 		/obj/item/clothing/head/wizard,
 		/obj/item/clothing/mask/madness_mask,
 		/obj/item/clothing/neck/heretic_focus,

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -77,8 +77,13 @@
 					return
 
 /// Returns true if this item should be scary to us
-/datum/brain_trauma/mild/phobia/proc/is_scary_item(obj/item/checked)
-	return !QDELETED(checked) && (is_type_in_typecache(checked, trigger_objs) || (phobia_type == "blood" && GET_ATOM_BLOOD_DNA_LENGTH(checked)))
+/datum/brain_trauma/mild/phobia/proc/is_scary_item(obj/checked)
+	if (QDELETED(checked) || !is_type_in_typecache(checked, trigger_objs))
+		return FALSE
+	if (!isitem(checked))
+		return TRUE
+	var/obj/item/checked_item = checked
+	return !(checked_item.item_flags & EXAMINE_SKIP)
 
 /datum/brain_trauma/mild/phobia/handle_hearing(datum/source, list/hearing_args)
 	if(!owner.can_hear() || owner == hearing_args[HEARING_SPEAKER] || !owner.has_language(hearing_args[HEARING_LANGUAGE])) 	//words can't trigger you if you can't hear them *taps head*
@@ -220,3 +225,8 @@
 /datum/brain_trauma/mild/phobia/blood
 	phobia_type = "blood"
 	random_gain = FALSE
+
+/datum/brain_trauma/mild/phobia/blood/is_scary_item(obj/checked)
+	if (GET_ATOM_BLOOD_DNA_LENGTH(checked))
+		return TRUE
+	return ..()

--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -47,15 +47,14 @@
 	COOLDOWN_START(src, check_cooldown, 5 SECONDS)
 	var/list/seen_atoms = view(7, owner)
 	if(LAZYLEN(trigger_objs))
-		for(var/obj/O in seen_atoms)
-			if(is_type_in_typecache(O, trigger_objs) || (phobia_type == "blood" && GET_ATOM_BLOOD_DNA_LENGTH(O)))
-				freak_out(O)
+		for(var/obj/seen_item in seen_atoms)
+			if(is_scary_item(seen_item))
+				freak_out(seen_item)
 				return
-		for(var/mob/living/carbon/human/HU in seen_atoms) //check equipment for trigger items
-			for(var/X in HU.get_all_worn_items() | HU.held_items)
-				var/obj/I = X
-				if(!QDELETED(I) && (is_type_in_typecache(I, trigger_objs) || (phobia_type == "blood" && GET_ATOM_BLOOD_DNA_LENGTH(I))))
-					freak_out(I)
+		for(var/mob/living/carbon/human/nearby_guy in seen_atoms) //check equipment for trigger items
+			for(var/obj/item/equipped as anything in nearby_guy.get_visible_items())
+				if(is_scary_item(equipped))
+					freak_out(equipped)
 					return
 
 	if(LAZYLEN(trigger_turfs))
@@ -76,6 +75,10 @@
 				if(LAZYLEN(trigger_species) && H.dna && H.dna.species && is_type_in_typecache(H.dna.species, trigger_species))
 					freak_out(H)
 					return
+
+/// Returns true if this item should be scary to us
+/datum/brain_trauma/mild/phobia/proc/is_scary_item(obj/item/checked)
+	return !QDELETED(checked) && (is_type_in_typecache(checked, trigger_objs) || (phobia_type == "blood" && GET_ATOM_BLOOD_DNA_LENGTH(checked)))
 
 /datum/brain_trauma/mild/phobia/handle_hearing(datum/source, list/hearing_args)
 	if(!owner.can_hear() || owner == hearing_args[HEARING_SPEAKER] || !owner.has_language(hearing_args[HEARING_LANGUAGE])) 	//words can't trigger you if you can't hear them *taps head*

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -104,6 +104,39 @@
 		s_store,
 		)
 
+/// Returns items which are currently visible on the mob
+/mob/living/carbon/human/proc/get_visible_items()
+	var/static/list/visible_slots = list(
+		ITEM_SLOT_OCLOTHING,
+		ITEM_SLOT_ICLOTHING,
+		ITEM_SLOT_GLOVES,
+		ITEM_SLOT_EYES,
+		ITEM_SLOT_EARS,
+		ITEM_SLOT_MASK,
+		ITEM_SLOT_HEAD,
+		ITEM_SLOT_FEET,
+		ITEM_SLOT_ID,
+		ITEM_SLOT_BELT,
+		ITEM_SLOT_BACK,
+		ITEM_SLOT_NECK,
+		ITEM_SLOT_HANDS,
+		ITEM_SLOT_BACKPACK,
+		ITEM_SLOT_SUITSTORE,
+		ITEM_SLOT_HANDCUFFED,
+		ITEM_SLOT_LEGCUFFED,
+	)
+	var/list/obscured = check_obscured_slots()
+	var/list/visible_items = list()
+	for (var/slot in visible_slots)
+		if (obscured & slot)
+			continue
+		var/obj/item/equipped = get_item_by_slot(slot)
+		if (equipped)
+			visible_items += equipped
+	for (var/obj/item/held in held_items)
+		visible_items += held
+	return visible_items
+
 //This is an UNSAFE proc. Use mob_can_equip() before calling this one! Or rather use equip_to_slot_if_possible() or advanced_equip_to_slot_if_possible()
 // Initial is used to indicate whether or not this is the initial equipment (job datums etc) or just a player doing it
 /mob/living/carbon/human/equip_to_slot(obj/item/I, slot, initial = FALSE, redraw_mob = FALSE)


### PR DESCRIPTION
## About The Pull Request

This PR adds a new helper proc which returns a list of all items _visible_ on a human and then applies it to phobias in place of "all items equipped on any slot of a human".
This excludes pockets at all times, and other slots if you are wearing items which cover them up.

If you have a clown phobia and the CE is storing a bananapeel in their pocket and is wearing a clown suit under their deployed MODsuit then you will not be afraid of them as there is no reason you would be aware of these facts.
As soon as they remove the banana peel from their pocket to their hands, or undeploy their suit to reveal their secret baggy pants, the terror will strike.

## Why It's Good For The Game

Phobias are annoying and debilitating by design, but they should at least only be triggered by objects which have a visible and identifiable source. 

## Changelog

:cl:
fix: Players with phobias will no longer be frightened by items equipped to players in slots which are not considered to be visible.
fix: Players with a phobia of the supernatural won't be spooked by void cloaks which are currently invisible.
/:cl:
