### PR TITLE
Streamlines/Fixes Piracy Spawner Checks - They Piss Off When Paid

### DIFF
--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -41,14 +41,16 @@
 	if(world.time > initial_send_time + RESPONSE_MAX_TIME)
 		priority_announce(chosen_gang.response_too_late, sender_override = chosen_gang.ship_name)
 		return
-	if(threat?.answered)
-		var/datum/bank_account/plundered_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
-		if(plundered_account)
-			if(plundered_account.adjust_money(-payoff))
-				chosen_gang.paid_off = TRUE
-				priority_announce(chosen_gang.response_received, sender_override = chosen_gang.ship_name)
-			else
-				priority_announce(chosen_gang.response_not_enough, sender_override = chosen_gang.ship_name)
+	if(!threat?.answered)
+		return
+
+	var/datum/bank_account/plundered_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
+	if(plundered_account)
+		if(plundered_account.adjust_money(-payoff))
+			chosen_gang.paid_off = TRUE
+			priority_announce(chosen_gang.response_received, sender_override = chosen_gang.ship_name)
+		else
+			priority_announce(chosen_gang.response_not_enough, sender_override = chosen_gang.ship_name)
 
 /proc/spawn_pirates(datum/comm_message/threat, datum/pirate_gang/chosen_gang)
 	if(chosen_gang.paid_off)

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -34,24 +34,24 @@
 	//send message
 	priority_announce("Incoming subspace communication. Secure channel opened at all communication consoles.", "Incoming Message", SSstation.announcer.get_rand_report_sound())
 	threat.answer_callback = CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pirates_answered), threat, chosen_gang, payoff, world.time)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(spawn_pirates), threat, chosen_gang, FALSE), RESPONSE_MAX_TIME)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(spawn_pirates), threat, chosen_gang), RESPONSE_MAX_TIME)
 	SScommunications.send_message(threat, unique = TRUE)
 
 /proc/pirates_answered(datum/comm_message/threat, datum/pirate_gang/chosen_gang, payoff, initial_send_time)
 	if(world.time > initial_send_time + RESPONSE_MAX_TIME)
-		priority_announce(chosen_gang.response_too_late ,sender_override = chosen_gang.ship_name)
+		priority_announce(chosen_gang.response_too_late, sender_override = chosen_gang.ship_name)
 		return
 	if(threat?.answered)
 		var/datum/bank_account/plundered_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(plundered_account)
 			if(plundered_account.adjust_money(-payoff))
+				chosen_gang.paid_off = TRUE
 				priority_announce(chosen_gang.response_received, sender_override = chosen_gang.ship_name)
 			else
 				priority_announce(chosen_gang.response_not_enough, sender_override = chosen_gang.ship_name)
-				spawn_pirates(threat, chosen_gang, TRUE)
 
-/proc/spawn_pirates(datum/comm_message/threat, datum/pirate_gang/chosen_gang, skip_answer_check)
-	if(!skip_answer_check && threat?.answered == 1)
+/proc/spawn_pirates(datum/comm_message/threat, datum/pirate_gang/chosen_gang)
+	if(chosen_gang.paid_off)
 		return
 
 	var/list/candidates = poll_ghost_candidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)

--- a/code/modules/antagonists/pirate/pirate_gangs.dm
+++ b/code/modules/antagonists/pirate/pirate_gangs.dm
@@ -42,6 +42,9 @@ GLOBAL_LIST_INIT(pirate_gangs, init_pirate_gangs())
 	///station pays the pirates... but doesn't have enough cash.
 	var/response_not_enough = "Not enough Bungopoints have been added into my bank account, rebooting world..."
 
+	/// Have the pirates been paid off?
+	var/paid_off = FALSE
+
 /datum/pirate_gang/New()
 	. = ..()
 	ship_name = pick(strings(PIRATE_NAMES_FILE, ship_name_pool))


### PR DESCRIPTION

## About The Pull Request

Fixes #74211.

I think at some point this worked, but there were just too many checks on abstract concepts and it seems that "aborting" the callback wasn't really working? Anyways everything just felt really awk to me with how `message_override` was working, so let's store a variable on `chosen_gang` since we're already reliant on that for all of our messages and stuff like that, and just slim down the number of weird checks that we do into just one simple "did we get paid"?

One consequence of this is that refusing to pay won't spawn pirates instantly, but the time-to-respond was already two minutes so I don't really see this as a major drawback.
## Why It's Good For The Game

I PAID THEM OFF NOW FUCK OFF
## Changelog
:cl:
fix: Pirates finally realized that they shouldn't risk life and limb attacking stations if they had already paid them off.
/:cl:
