### PR TITLE
Debug ID Cards Can Now Use Vending Machines

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1174,6 +1174,7 @@
 /obj/item/card/id/advanced/debug/Initialize(mapload)
 	. = ..()
 	registered_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
+	registered_account.account_job = new /datum/job/admin // so we can actually use this account without being filtered as a "departmental" card
 
 /obj/item/card/id/advanced/prisoner
 	name = "prisoner ID card"

--- a/code/modules/jobs/job_types/event/admin.dm
+++ b/code/modules/jobs/job_types/event/admin.dm
@@ -1,0 +1,2 @@
+/datum/job/admin
+	title = "Debugger"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3557,6 +3557,7 @@
 #include "code\modules\jobs\job_types\antagonists\wizard_apprentice.dm"
 #include "code\modules\jobs\job_types\antagonists\xenomorph.dm"
 #include "code\modules\jobs\job_types\ert\ert_generic.dm"
+#include "code\modules\jobs\job_types\event\admin.dm"
 #include "code\modules\jobs\job_types\event\fugitive.dm"
 #include "code\modules\jobs\job_types\event\santa.dm"
 #include "code\modules\jobs\job_types\spawner\ancient_crew.dm"


### PR DESCRIPTION

## About The Pull Request

![image](https://user-images.githubusercontent.com/34697715/227799119-abbcf947-10ef-416d-a353-239b0544f56d.png)

This always pissed me off, and has been pissing me off for the last year or so. I decided to sit down and figure out how to stop this from occurring, and got it.
## Why It's Good For The Game

When I'm debugging several types of stuff regarding payment in my pre-fabbed debug suit, I really don't want to fucking have to spawn yet another ID card with an actual job on it and transfer money to that just so I can use a vending machine, I WANT TO JUST USE THE VENDING MACHINE!!! TIME IS PRECIOUS!!!

It does still draw from the station budget, but that's fine because this is a debug card that is meant to be dangerous to hand out. It's a debugger's tool. If you're concerned on people somehow getting it from an admin and beign able to buy smokes from vending machines, they were still able to withdraw money by alt-clicking on it before this change. 
## Changelog
Nothing that really concerns players.
