### PR TITLE
Remove janitor key UnregisterSignal [NO GBP]

### DIFF
--- a/code/game/objects/items/janitor_key.dm
+++ b/code/game/objects/items/janitor_key.dm
@@ -25,7 +25,6 @@
 	GLOB.janitor_devices += src
 
 /obj/item/access_key/Destroy()
-	UnregisterSignal(SSdcs, COMSIG_ON_DEPARTMENT_ACCESS)
 	GLOB.janitor_devices -= src
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Removes UnregisterSignal when the janitor access key ring is destroyed. Signal will clean itself up. Mentions adding janitor keys to the Custodial Locator, which I forgot on the last PR https://github.com/tgstation/tgstation/pull/74181

## Changelog
:cl: LT3
qol: Janitor access keys now show up on the Custodial Locator tablet app
/:cl: