### PR TITLE
Fixes nation objectives

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -694,5 +694,4 @@
 		/datum/job_department/service,
 	)
 
-	for(var/department_type in department_types)
-		create_separatist_nation(department_type, announcement = FALSE, dangerous = FALSE, message_admins = FALSE)
+	create_separatist_nation_list(department_types, announcement = FALSE, dangerous = FALSE, message_admins = FALSE)

--- a/code/modules/antagonists/separatist/nation_creation.dm
+++ b/code/modules/antagonists/separatist/nation_creation.dm
@@ -1,37 +1,57 @@
+/**
+ * ### create_separatist_nation_list()
+ *
+ * Creates all departments in a list as nations while giving them the objective to killeachother if set.
+ * * Arguments:
+ * * revolting_departments: list of departments that will revolt. Starts as a type, then turns into the reference to the singleton.
+ * * announcement: whether to tell the station a department has gone independent.
+ * * dangerous: whether the nation will have objectives to attack other independent nations.
+ * * message_admins: whether this will admin log how the nation creation went. Errors are still put in runtime log either way.
+ */
+/proc/create_separatist_nation_list(list/revolting_departments, announcement = FALSE, dangerous = FALSE, message_admins = TRUE)
+	var/datum/team/nation/created_teams = list()
+	for(var/department_type in revolting_departments)
+		created_teams += create_separatist_nation(department_type, announcement, message_admins)
+
+	if(!created_teams.len || !dangerous)
+		return
+
+	//get a list of all independent nations to give objectives to attack eachother.
+	var/list/independent_departments = list()
+	for(var/datum/team/nation/nation_datum in GLOB.antagonist_teams)
+		independent_departments |= nation_datum.department
+
+	//get all teams we just made and give them the objectives to attack eachother, this excludes nations created elsewhere.
+	for(var/datum/team/nation/created_departments in created_teams)
+		created_departments.generate_nation_objectives(created_teams - created_departments)
 
 /**
  * ### create_separatist_nation()
  *
- * Helper called to create the separatist antagonist via making a department independent from the station.
+ * Actually creates the Nation and returns it.
  *
  * * Arguments:
- * * department: which department to revolt. if null, will pick a random non-independent department. starts as a type, then turns into the reference to the singleton.
+ * * department: which department to revolt. Starts as a type, then turns into the reference to the singleton.
  * * announcement: whether to tell the station a department has gone independent.
- * * dangerous: whether this nation will have objectives to attack other independent departments, requires more than one nation to exist obviously
  * * message_admins: whether this will admin log how the nation creation went. Errors are still put in runtime log either way.
- *
- * Returns nothing.
  */
-/proc/create_separatist_nation(datum/job_department/department, announcement = FALSE, dangerous = FALSE, message_admins = TRUE)
+/proc/create_separatist_nation(datum/job_department/department, announcement = FALSE, message_admins = TRUE)
 	var/list/jobs_to_revolt = list()
 	var/list/citizens = list()
 
-	//departments that are already independent, these will be disallowed to be randomly picked
-	var/list/independent_departments = list()
-	//reference to all independent nation teams
-	var/list/team_datums = list()
-	for(var/datum/antagonist/separatist/separatist_datum in GLOB.antagonists)
-		var/independent_department_type = separatist_datum.owner?.assigned_role.departments_list[1]
-		independent_departments |= independent_department_type
-		team_datums |= separatist_datum.nation
-
 	if(!department)
+		//departments that are already independent, these will be disallowed to be randomly picked
+		var/list/independent_departments = list()
+		for(var/datum/team/nation/nation_datum in GLOB.antagonist_teams)
+			independent_departments |= nation_datum.department
+
 		//picks a random department if none was given
-		department = pick(list(/datum/job_department/assistant, /datum/job_department/medical, /datum/job_department/engineering, /datum/job_department/science, /datum/job_department/cargo, /datum/job_department/service, /datum/job_department/security) - independent_departments)
+		department = pick(subtypesof(/datum/job_department) - independent_departments)
 		if(!department)
 			if(message_admins)
 				message_admins("Department Revolt could not create a nation, as all the departments are independent! You have created nations, you madman!")
 			CRASH("Department Revolt could not create a nation, as all the departments are independent")
+
 	department = SSjob.get_department_type(department)
 
 	for(var/datum/job/job as anything in department.department_jobs)
@@ -40,15 +60,10 @@
 		jobs_to_revolt += job.title
 
 	//setup team datum
-	var/datum/team/nation/nation = new(null, jobs_to_revolt, department)
+	var/datum/team/nation/nation = new(jobs_to_revolt, department)
 	nation.name = department.generate_nation_name()
-	var/datum/team/department_target //dodges picking from an empty list giving a runtime.
-	if(team_datums.len)
-		department_target = pick(team_datums)
-	nation.generate_nation_objectives(dangerous, department_target)
-
 	//convert current members of the department
-	for(var/mob/living/carbon/human/possible_separatist as anything in GLOB.human_list)
+	for(var/mob/living/carbon/human/possible_separatist as anything in GLOB.joined_player_list)
 		if(!possible_separatist.mind)
 			continue
 		var/datum/mind/separatist_mind = possible_separatist.mind
@@ -65,6 +80,7 @@
 		if(message_admins)
 			message_admins("The nation of [nation.name] did not have enough potential members to be created.")
 		return
+
 	var/jobs_english_list = english_list(jobs_to_revolt)
 	if(message_admins)
 		message_admins("The nation of [nation.name] has been formed. Affected jobs are [jobs_english_list]. Any new crewmembers with these jobs will join the secession.")
@@ -72,4 +88,5 @@
 		var/announce_text = "The new independent state of [nation.name] has formed from the ashes of the [department.department_name] department!"
 		if(istype(department, /datum/job_department/assistant)) //the text didn't really work otherwise
 			announce_text = "The assistants of the station have risen to form the new independent state of [nation.name]!"
-		priority_announce(announce_text, "Secession from [GLOB.station_name]",  has_important_message = TRUE)
+		priority_announce(announce_text, "Secession from [GLOB.station_name]", has_important_message = TRUE)
+	return nation

--- a/code/modules/antagonists/separatist/nation_creation.dm
+++ b/code/modules/antagonists/separatist/nation_creation.dm
@@ -9,7 +9,7 @@
  * * message_admins: whether this will admin log how the nation creation went. Errors are still put in runtime log either way.
  */
 /proc/create_separatist_nation_list(list/revolting_departments, announcement = FALSE, dangerous = FALSE, message_admins = TRUE)
-	var/datum/team/nation/created_teams = list()
+	var/list/datum/team/nation/created_teams = list()
 	for(var/department_type in revolting_departments)
 		created_teams += create_separatist_nation(department_type, announcement, message_admins)
 

--- a/code/modules/antagonists/separatist/nation_team.dm
+++ b/code/modules/antagonists/separatist/nation_team.dm
@@ -1,0 +1,71 @@
+/datum/team/nation
+	name = "\improper Nation"
+	member_name = "separatist"
+	///a list of ranks that can join this nation.
+	var/list/potential_recruits
+	///department said team is related to
+	var/datum/job_department/department
+
+/datum/team/nation/New(potential_recruits, department)
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, PROC_REF(new_possible_separatist))
+	src.potential_recruits = potential_recruits
+	src.department = department
+
+/datum/team/nation/Destroy(force, ...)
+	department = null
+	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
+	return ..()
+
+/**
+ * Signal for adding new crewmembers (players joining the game) to the revolution.
+ *
+ * Arguments:
+ * source: global signal, so this is SSdcs.
+ * crewmember: new onboarding crewmember.
+ * rank: new crewmember's rank.
+ */
+/datum/team/nation/proc/new_possible_separatist(datum/source, mob/living/crewmember, rank)
+	SIGNAL_HANDLER
+
+	if(rank in potential_recruits)
+		//surely we can trust the player who just joined the game to have a mind.
+		crewmember.mind.add_antag_datum(/datum/antagonist/separatist, src)
+
+/**
+ * Called by department revolt event to give the team some objectives.
+ *
+ * Arguments:
+ * target_nation: list of nations that they need to destroy
+ */
+/datum/team/nation/proc/generate_nation_objectives(list/target_nations)
+	for(var/datum/team/nation/individual_nations as anything in target_nations)
+		var/datum/objective/destroy = new /datum/objective/destroy_nation(null, individual_nations)
+		destroy.team = src
+		objectives += destroy
+		individual_nations.war_declared(src) //they need to possibly get an objective back
+	var/datum/objective/fluff = new /datum/objective/separatist_fluff(null, name)
+	fluff.team = src
+	objectives += fluff
+	update_all_member_objectives()
+
+/**
+ * Called when a department declares war on us, this is the response.
+ *
+ * Arguments:
+ * attacking_nation - The nation that's attacking us.
+ */
+/datum/team/nation/proc/war_declared(datum/team/nation/attacking_nation)
+	//otherwise, lets add an objective to strike them back
+	var/datum/objective/destroy = new /datum/objective/destroy_nation(null, attacking_nation)
+	destroy.team = src
+	objectives += destroy
+	update_all_member_objectives(span_danger("The nation of [attacking_nation] has declared the intent to conquer [src]! You have new objectives."))
+
+/datum/team/nation/proc/update_all_member_objectives(message)
+	for(var/datum/mind/member as anything in members)
+		var/datum/antagonist/separatist/needs_objectives = member.has_antag_datum(/datum/antagonist/separatist)
+		needs_objectives.objectives = objectives
+		if(message)
+			to_chat(member.current, message)
+		needs_objectives.owner.announce_objectives()

--- a/code/modules/antagonists/separatist/objectives.dm
+++ b/code/modules/antagonists/separatist/objectives.dm
@@ -2,6 +2,8 @@
 	name = "nation destruction"
 	explanation_text = "Make sure no member of the enemy nation escapes alive!"
 	team_explanation_text = "Make sure no member of the enemy nation escapes alive!"
+
+	///The team the nation has to destroy.
 	var/datum/team/nation/target_team
 
 /datum/objective/destroy_nation/New(text, target_department)
@@ -11,7 +13,7 @@
 
 /datum/objective/destroy_nation/Destroy()
 	target_team = null
-	. = ..()
+	return ..()
 
 
 /datum/objective/destroy_nation/update_explanation_text()
@@ -36,7 +38,7 @@
 /datum/objective/separatist_fluff
 
 /datum/objective/separatist_fluff/New(text, nation_name)
-	explanation_text = pick(list(
+	text = pick(list(
 		"The rest of the station must be taxed for their use of [nation_name]'s services.",
 		"Make statues everywhere of your glorious leader of [nation_name]. If you have nobody, crown one amongst yourselves!",
 		"[nation_name] must be absolutely blinged out.",
@@ -47,7 +49,7 @@
 		"Save the station when it needs you most. [nation_name] will be remembered as the protectors.",
 		"Arm up. The citizens of [nation_name] have a right to bear arms.",
 	))
-	..()
+	return ..()
 
 /datum/objective/separatist_fluff/check_completion()
 	return TRUE

--- a/code/modules/antagonists/separatist/separatist.dm
+++ b/code/modules/antagonists/separatist/separatist.dm
@@ -1,90 +1,22 @@
-/datum/team/nation
-	name = "\improper Nation"
-	member_name = "separatist"
-	///a list of ranks that can join this nation.
-	var/list/potential_recruits
-	///department said team is related to
-	var/datum/job_department/department
-	///whether to forge objectives attacking other nations
-	var/dangerous_nation = TRUE
-
-/datum/team/nation/New(starting_members, potential_recruits, department)
-	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, PROC_REF(new_possible_separatist))
-	src.potential_recruits = potential_recruits
-	src.department = department
-
-/datum/team/nation/Destroy(force, ...)
-	department = null
-	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
-	. = ..()
-
-/**
- * Signal for adding new crewmembers (players joining the game) to the revolution.
- *
- * Arguments:
- * source: global signal, so this is SSdcs.
- * crewmember: new onboarding crewmember.
- * rank: new crewmember's rank.
- */
-/datum/team/nation/proc/new_possible_separatist(datum/source, mob/living/crewmember, rank)
-	SIGNAL_HANDLER
-
-	if(rank in potential_recruits)
-		//surely we can trust the player who just joined the game to have a mind.
-		crewmember.mind.add_antag_datum(/datum/antagonist/separatist,src)
-
-/**
- * Called by department revolt event to give the team some objectives.
- *
- * Arguments:
- * dangerous_nation: whether this nation will get objectives that are very very bloodthirsty, like killing other departments.
- * target_nation: string of the nation they need to destroy/befriend
- */
-/datum/team/nation/proc/generate_nation_objectives(are_we_hostile = TRUE, datum/team/nation/target_nation)
-	dangerous_nation = are_we_hostile
-	if(dangerous_nation && target_nation)
-		var/datum/objective/destroy = new /datum/objective/destroy_nation(null, target_nation)
-		destroy.team = src
-		objectives += destroy
-		target_nation.war_declared(src) //they need to possibly get an objective back
-	var/datum/objective/fluff = new /datum/objective/separatist_fluff(null, name)
-	fluff.team = src
-	objectives += fluff
-	update_all_member_objectives()
-
-/datum/team/nation/proc/war_declared(datum/team/nation/attacking_nation)
-	if(!dangerous_nation) //peaceful nations do not wish to strike back
-		return
-	//otherwise, lets add an objective to strike them back
-	var/datum/objective/destroy = new /datum/objective/destroy_nation(null, attacking_nation)
-	destroy.team = src
-	objectives += destroy
-	update_all_member_objectives(span_danger("The nation of [attacking_nation] has declared the intent to conquer [src]! You have new objectives."))
-
-/datum/team/nation/proc/update_all_member_objectives(message)
-	for(var/datum/mind/member in members)
-		var/datum/antagonist/separatist/needs_objectives = member.has_antag_datum(/datum/antagonist/separatist)
-		needs_objectives.objectives |= objectives
-		if(message)
-			to_chat(member.current, message)
-		needs_objectives.owner.announce_objectives()
-
 /datum/antagonist/separatist
 	name = "\improper Separatists"
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
 	suicide_cry = "FOR THE MOTHERLAND!!"
 	ui_name = "AntagInfoSeparatist"
+
 	///team datum
 	var/datum/team/nation/nation
 	///background color of the ui
 	var/ui_color
 
 /datum/antagonist/separatist/on_gain()
-	create_objectives()
 	setup_ui_color()
-	. = ..()
+	return ..()
+
+/datum/antagonist/separatist/on_removal()
+	remove_objectives()
+	return ..()
 
 //give ais their role as UN
 /datum/antagonist/separatist/apply_innate_effects(mob/living/mob_override)
@@ -93,21 +25,6 @@
 		var/mob/living/silicon/ai/united_nations_ai = mob_override
 		united_nations_ai.laws = new /datum/ai_laws/united_nations
 		united_nations_ai.laws.associate(united_nations_ai)
-
-/datum/antagonist/separatist/on_removal()
-	remove_objectives()
-	. = ..()
-
-/datum/antagonist/separatist/proc/create_objectives()
-	objectives |= nation.objectives
-
-/datum/antagonist/separatist/proc/remove_objectives()
-	objectives -= nation.objectives
-
-/datum/antagonist/separatist/proc/setup_ui_color()
-	var/list/hsl = rgb2num(nation.department.ui_color, COLORSPACE_HSL)
-	hsl[3] = 25 //setting lightness very low
-	ui_color = rgb(hsl[1], hsl[2], hsl[3], space = COLORSPACE_HSL)
 
 /datum/antagonist/separatist/create_team(datum/team/nation/new_team)
 	if(!new_team)
@@ -123,3 +40,11 @@
 	data["nation"] = nation.name
 	data["nationColor"] = ui_color
 	return data
+
+/datum/antagonist/separatist/proc/remove_objectives()
+	objectives -= nation.objectives
+
+/datum/antagonist/separatist/proc/setup_ui_color()
+	var/list/hsl = rgb2num(nation.department.ui_color, COLORSPACE_HSL)
+	hsl[3] = 25 //setting lightness very low
+	ui_color = rgb(hsl[1], hsl[2], hsl[3], space = COLORSPACE_HSL)

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -24,7 +24,7 @@
 
 /datum/round_event/wizard/deprevolt/start()
 	// no setup needed, this proc handles empty values. God i'm good (i wrote all of this)
-	create_separatist_nation(picked_department, announce, dangerous_nation)
+	create_separatist_nation_list(list(picked_department), announce, dangerous_nation)
 
 ///which department is revolting?
 /datum/event_admin_setup/listed_options/departmental_revolt
@@ -33,7 +33,7 @@
 
 /datum/event_admin_setup/listed_options/departmental_revolt/get_list()
 	return subtypesof(/datum/job_department)
-	
+
 /datum/event_admin_setup/listed_options/departmental_revolt/apply_to_event(datum/round_event/wizard/deprevolt/event)
 	event.picked_department = chosen
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2600,6 +2600,7 @@
 #include "code\modules\antagonists\santa\santa.dm"
 #include "code\modules\antagonists\sentient_creature\sentient_creature.dm"
 #include "code\modules\antagonists\separatist\nation_creation.dm"
+#include "code\modules\antagonists\separatist\nation_team.dm"
 #include "code\modules\antagonists\separatist\objectives.dm"
 #include "code\modules\antagonists\separatist\separatist.dm"
 #include "code\modules\antagonists\shade\shade_minion.dm"


### PR DESCRIPTION
## About The Pull Request

Nations are now all created together, then receive their objectives once all nations are created. This will hopefully fix the problem of objectives not properly being given out to stop one-another because of the order the nations are made in.
Objectives also aren't made on the separatist's on_gain, it's handled by the creation of the nation itself.

Also splits nation team into their own file from the single separatist datum Also makes having war declared on you making you destroy the nation back, being a peaceful nation does not mean you cannot defend yourselves.

## Why It's Good For The Game

This hopefully will fix the problem of nations not having the objective to kill eachother properly

## Changelog

:cl:
fix: Nations should now properly all have the objective to fight eachother.
/:cl: