### PR TITLE
Minor Gravity Fixes

### DIFF
--- a/code/datums/elements/forced_gravity.dm
+++ b/code/datums/elements/forced_gravity.dm
@@ -13,11 +13,12 @@
 
 	src.gravity = gravity
 	src.ignore_turf_gravity = ignore_turf_gravity
-	ADD_TRAIT(target, TRAIT_FORCED_GRAVITY, REF(src))
 
 	RegisterSignal(target, COMSIG_ATOM_HAS_GRAVITY, PROC_REF(gravity_check))
 	if(isturf(target))
 		RegisterSignal(target, COMSIG_TURF_HAS_GRAVITY, PROC_REF(turf_gravity_check))
+
+	ADD_TRAIT(target, TRAIT_FORCED_GRAVITY, REF(src))
 
 /datum/element/forced_gravity/Detach(datum/source)
 	. = ..()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -224,4 +224,4 @@
 	var/list/imaginary_group = null
 
 	/// What our current gravity state is. Used to avoid duplicate animates and such
-	var/gravity_state = 0
+	var/gravity_state = null

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -311,14 +311,16 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 	update_use_power(ACTIVE_POWER_USE)
 
 	soundloop.start()
-	if (!gravity_in_level())
+	var/old_gravity = gravity_in_level()
+	complete_state_update()
+	gravity_field = new(src, 2, TRUE, 6)
+
+	if (!old_gravity)
 		if(SSticker.current_state == GAME_STATE_PLAYING)
 			investigate_log("was brought online and is now producing gravity for this level.", INVESTIGATE_GRAVITY)
 			message_admins("The gravity generator was brought online [ADMIN_VERBOSEJMP(src)]")
 		shake_everyone()
-	gravity_field = new(src, 2, TRUE, 6)
 
-	complete_state_update()
 
 /obj/machinery/gravity_generator/main/proc/disable()
 	charging_state = POWER_IDLE
@@ -327,13 +329,15 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 
 	soundloop.stop()
 	QDEL_NULL(gravity_field)
-	if (gravity_in_level())
+	var/old_gravity = gravity_in_level()
+	complete_state_update()
+
+	if (old_gravity)
 		if(SSticker.current_state == GAME_STATE_PLAYING)
 			investigate_log("was brought offline and there is now no gravity for this level.", INVESTIGATE_GRAVITY)
 			message_admins("The gravity generator was brought offline with no backup generator. [ADMIN_VERBOSEJMP(src)]")
 		shake_everyone()
 
-	complete_state_update()
 
 /obj/machinery/gravity_generator/main/proc/complete_state_update()
 	update_appearance()
@@ -422,11 +426,6 @@ GLOBAL_LIST_EMPTY(gravity_generators)
 		else
 			GLOB.gravity_generators["[z]"] -= src
 		SSmapping.calculate_z_level_gravity(z)
-
-/obj/machinery/gravity_generator/main/proc/change_setting(value)
-	if(value != setting)
-		setting = value
-		shake_everyone()
 
 /obj/machinery/gravity_generator/main/proc/blackout()
 	charge_count = 0


### PR DESCRIPTION

## About The Pull Request

Fixes forced gravity not updating a mob (trait was added too early, before hook signals are registered)
Fixes spawning a mob in space not causing floats (default grav was 0, so == null was wrong)
Runs shake_everyone() (Our gravity gen reaction hook) AFTER gravity changes, ensuring mobs hook into it

## Why It's Good For The Game

Closes #74271 
Closes #74272 (Caused by being in nograv but not floating)
Closes #74274 
## Changelog
:cl:
fix: Fixes a bunch of minor gravity bugs, report em if you see more yeah?
/:cl:
