### PR TITLE
Removes Starlight Config

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -125,7 +125,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ABDUCTOR_PROOF (1<<11)
 /// If blood cultists can draw runes or build structures on this AREA.
 #define CULT_PERMITTED (1<<12)
-///Whther this area is iluminated by starlight
+///Whther this area is iluminated by starlight. Used by the aurora_caelus event
 #define AREA_USES_STARLIGHT (1<<13)
 /// If engravings are persistent in this area
 #define PERSISTENT_ENGRAVINGS (1<<14)

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -319,7 +319,6 @@
 /datum/config_entry/string/overflow_job
 	default = JOB_ASSISTANT
 
-/datum/config_entry/flag/starlight
 /datum/config_entry/flag/grey_assistants
 
 /datum/config_entry/number/lavaland_budget

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -172,12 +172,6 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if(!ambientsounds)
 		ambientsounds = GLOB.ambience_assoc[ambience_index]
 
-	if(area_flags & AREA_USES_STARLIGHT && CONFIG_GET(flag/starlight))
-		// Areas lit by starlight are not supposed to be fullbright 4head
-		base_lighting_alpha = 0
-		base_lighting_color = null
-		static_lighting = TRUE
-
 	if(requires_power)
 		luminosity = 0
 	else

--- a/code/game/area/areas/misc.dm
+++ b/code/game/area/areas/misc.dm
@@ -21,6 +21,9 @@
 /area/space/nearstation
 	icon_state = "space_near"
 	area_flags = UNIQUE_AREA | AREA_USES_STARLIGHT
+	static_lighting = TRUE
+	base_lighting_alpha = 0
+	base_lighting_color = COLOR_WHITE
 
 /area/misc/start
 	name = "start area"

--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -6,7 +6,6 @@
 	icon_state = "ruins"
 	has_gravity = STANDARD_GRAVITY
 	area_flags = HIDDEN_AREA | BLOBS_ALLOWED | UNIQUE_AREA
-	static_lighting = TRUE
 	ambience_index = AMBIENCE_RUINS
 	flags_1 = CAN_BE_DIRTY_1
 	sound_environment = SOUND_ENVIRONMENT_STONEROOM

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -25,7 +25,6 @@
 	ambience_index = AMBIENCE_ENGI
 	airlock_wires = /datum/wires/airlock/engineering
 	sound_environment = SOUND_AREA_SPACE
-	base_lighting_alpha = 255
 
 /area/ruin/space/way_home
 	name = "\improper Salvation"
@@ -291,7 +290,6 @@
 	requires_power = FALSE
 	area_flags = UNIQUE_AREA | AREA_USES_STARLIGHT
 	sound_environment = SOUND_AREA_SPACE
-	base_lighting_alpha = 255
 
 /area/ruin/space/ancientstation/charlie/storage
 	name = "Charlie Station Storage"

--- a/code/game/area/areas/station.dm
+++ b/code/game/area/areas/station.dm
@@ -857,7 +857,6 @@
 	ambience_index = AMBIENCE_ENGI
 	airlock_wires = /datum/wires/airlock/engineering
 	sound_environment = SOUND_AREA_SPACE
-	base_lighting_alpha = 255
 
 /area/station/solars/fore
 	name = "\improper Fore Solar Array"

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -150,7 +150,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			lighting_object.update()
 
 	// If we're space, then we're either lit, or not, and impacting our neighbors, or not
-	if(isspaceturf(src) && CONFIG_GET(flag/starlight))
+	if(isspaceturf(src))
 		var/turf/open/space/lit_turf = src
 		// This also counts as a removal, so we need to do a full rebuild
 		if(!ispath(old_type, /turf/open/space))
@@ -161,14 +161,14 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			lit_turf.enable_starlight()
 
 	// If we're a cordon we count against a light, but also don't produce any ourselves
-	else if (istype(src, /turf/cordon) && CONFIG_GET(flag/starlight))
+	else if (istype(src, /turf/cordon))
 		// This counts as removing a source of starlight, so we need to update the space tile to inform it
 		if(!ispath(old_type, /turf/open/space))
 			for(var/turf/open/space/space_tile in RANGE_TURFS(1, src))
 				space_tile.update_starlight()
 
 	// If we're not either, but were formerly a space turf, then we want light
-	else if(ispath(old_type, /turf/open/space) && CONFIG_GET(flag/starlight))
+	else if(ispath(old_type, /turf/open/space))
 		for(var/turf/open/space/space_tile in RANGE_TURFS(1, src))
 			space_tile.enable_starlight()
 

--- a/code/modules/events/aurora_caelus.dm
+++ b/code/modules/events/aurora_caelus.dm
@@ -8,7 +8,7 @@
 	description = "A colourful display can be seen through select windows. And the kitchen."
 
 /datum/round_event_control/aurora_caelus/can_spawn_event(players, allow_magic = FALSE)
-	if(!CONFIG_GET(flag/starlight) && !(SSmapping.empty_space))
+	if(!SSmapping.empty_space)
 		return FALSE
 	return ..()
 

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -32,9 +32,8 @@ GLOBAL_LIST_EMPTY(default_lighting_underlays_by_z)
 
 	// This path is really hot. this is faster
 	// Really this should be a global var or something, but lets not think about that yes?
-	if(CONFIG_GET(flag/starlight))
-		for(var/turf/open/space/space_tile in RANGE_TURFS(1, affected_turf))
-			space_tile.enable_starlight()
+	for(var/turf/open/space/space_tile in RANGE_TURFS(1, affected_turf))
+		space_tile.enable_starlight()
 
 	needs_update = TRUE
 	SSlighting.objects_queue += src

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -419,10 +419,6 @@ OVERFLOW_JOB Assistant
 ## Overflow slot cap. Set to -1 for unlimited. If limited, it will still open up if every other job is full.
 OVERFLOW_CAP -1
 
-## Starlight for exterior walls and breaches. Uncomment for starlight!
-## This is disabled by default to make testing quicker, should be enabled on production servers or testing servers messing with lighting
-#STARLIGHT
-
 ## Uncomment to bring back old grey suit assistants instead of the now default rainbow colored assistants.
 #GREY_ASSISTANTS
 


### PR DESCRIPTION

## About The Pull Request

It was config'd off to save init time, but having it function in testing and mapping is more valuble then the time spend on it.

On that topic, we spend roughly 1.7 seconds of init on this. 
~1.3 is spent handling the light sources and their light object modifications (this is potentailly inflated since other sources could cause the same objects to need updates)
~0.3 is spent searching for space turfs around lighting_objects during init.
This will impact change_turf slightly too, costing about ~0.07 in local testing.

It does save time for live however, since we avoid these config checks.

## Why It's Good For The Game

I believe this time is worth spending. 
I've had people try to "fix" artifacts of starlight not being enabled, things that aren't bugs. 
The test environment should as much as we can make it reflect the visual reality of the game. This helps ensure that

## Changelog
:cl:
server: The starlight config has been removed, as it is enabled by default
/:cl:
