### PR TITLE
Reduced fire alarm light range [NO GBP]

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -23,9 +23,9 @@
 	power_channel = AREA_USAGE_ENVIRON
 	resistance_flags = FIRE_PROOF
 
-	light_power = 0.5
-	light_range = 3
-	light_color = LIGHT_COLOR_FAINT_BLUE
+	light_power = 1
+	light_range = 1.6
+	light_color = LIGHT_COLOR_ELECTRIC_CYAN
 
 	//Trick to get the glowing overlay visible from a distance
 	luminosity = 1
@@ -91,7 +91,7 @@
 		return
 	var/area/our_area = get_area(src)
 	RegisterSignal(our_area, COMSIG_AREA_FIRE_CHANGED, PROC_REF(handle_fire))
-	update_overlays()
+	handle_fire(our_area, our_area.fire)
 
 /obj/machinery/firealarm/on_enter_area(datum/source, area/area_to_register)
 	//were already registered to an area. exit from here first before entering into an new area
@@ -141,7 +141,7 @@
 	if((my_area?.fire || LAZYLEN(my_area?.active_firelocks)) && !(obj_flags & EMAGGED) && !(machine_stat & (BROKEN|NOPOWER)))
 		set_light(l_power = 3)
 	else
-		set_light(l_power = 0.5)
+		set_light(l_power = 1)
 
 /obj/machinery/firealarm/update_icon_state()
 	if(panel_open)
@@ -176,7 +176,7 @@
 					if(SEC_LEVEL_GREEN)
 						set_light(l_color = LIGHT_COLOR_BLUEGREEN)
 					if(SEC_LEVEL_BLUE)
-						set_light(l_color = LIGHT_COLOR_FAINT_BLUE)
+						set_light(l_color = LIGHT_COLOR_ELECTRIC_CYAN)
 					if(SEC_LEVEL_RED)
 						set_light(l_color = LIGHT_COLOR_FLARE)
 					if(SEC_LEVEL_DELTA)


### PR DESCRIPTION
## About The Pull Request

Adjusts the light range/power of the fire alarm to put it more in line with APCs and air alarms, corrects a useless update_overlays call.

![image](https://user-images.githubusercontent.com/83487515/228048625-fcb03d92-b101-45d9-aa24-1969688afcb0.png)

## Why It's Good For The Game

Fire alarms are having too great an impact on ambiance when idle.

## Changelog

:cl: LT3
fix: Reduced lighting range for idle fire alarms
/:cl: