### PR TITLE
Fixes research.dmm APC Placement

### DIFF
--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -200,6 +200,7 @@
 /area/awaymission/research/interior/maint)
 "aQ" = (
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/engineering)
 "aR" = (
@@ -231,6 +232,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/engineering)
 "bb" = (
@@ -269,9 +271,6 @@
 /turf/closed/wall/r_wall,
 /area/awaymission/research/interior/gateway)
 "bm" = (
-/obj/machinery/power/apc/highcap/ten_k/directional/east{
-	name = "Engineering APC"
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/engineering)
@@ -279,6 +278,8 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/power/apc/highcap/ten_k/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/engineering)
 "bs" = (
@@ -573,6 +574,7 @@
 	name = "Genetics Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
 "cz" = (
@@ -639,13 +641,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/awaymission/research/interior/gateway)
-"cS" = (
-/obj/machinery/power/apc/highcap/five_k/directional/east{
-	name = "Genetics APC"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/awaymission/research/interior/genetics)
 "cY" = (
 /obj/item/ammo_casing/c9mm,
 /obj/structure/cable,
@@ -697,7 +692,7 @@
 /obj/structure/closet/crate,
 /obj/item/disk/data{
 	desc = "A data disk used to store cloning and genetic records. The name on the label appears to be scratched off.";
-	genetic_makeup_buffer = list("label" = "Buffer1:Kr-$$@##", "UI" = "f8f603857000f930127c4", "SE" = "414401462231053131010241514651403453121613263463440351136366", "UE" = "340008485c321e542aed4df7032ac04d", "name" = "Krystal Symers", "blood_type" = "A+");
+	genetic_makeup_buffer = list("label"="Buffer1:Kr-$$@##","UI"="f8f603857000f930127c4","SE"="414401462231053131010241514651403453121613263463440351136366","UE"="340008485c321e542aed4df7032ac04d","name"="Krystal Symers","blood_type"="A+");
 	name = "dusty genetics data disk";
 	read_only = 1
 	},
@@ -781,7 +776,7 @@
 /obj/structure/closet/crate,
 /obj/item/disk/data{
 	desc = "A data disk used to store cloning and genetic records. The name on the label appears to be scratched off with the words 'DO NOT CLONE' hastily written over it.";
-	genetic_makeup_buffer = list("label" = "Buffer1:George Melons", "UI" = "3c300f11b5421ca7014d8", "SE" = "430431205660551642142504334461413202111310233445620533134255", "UE" = "6893e6a0b0076a41897776b10cc2b324", "name" = "George Melons", "blood_type" = "B+");
+	genetic_makeup_buffer = list("label"="Buffer1:George Melons","UI"="3c300f11b5421ca7014d8","SE"="430431205660551642142504334461413202111310233445620533134255","UE"="6893e6a0b0076a41897776b10cc2b324","name"="George Melons","blood_type"="B+");
 	name = "old genetics data disk"
 	},
 /obj/item/disk/data{
@@ -1755,6 +1750,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/security)
 "ik" = (
@@ -1835,11 +1831,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior)
-"iF" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/awaymission/research/interior/security)
 "iJ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/freezer,
@@ -2193,7 +2184,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/awaymission/research/interior/dorm)
+/area/awaymission/research/interior/maint)
 "kq" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm1";
@@ -2442,11 +2433,10 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/highcap/five_k/directional/west,
 /turf/open/floor/iron,
 /area/awaymission/research/interior/dorm)
-"ln" = (
-/turf/open/floor/iron,
-/area/space/nearstation)
 "lo" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -2642,11 +2632,6 @@
 /obj/effect/landmark/awaystart,
 /turf/open/floor/wood,
 /area/awaymission/research/interior/dorm)
-"lW" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/awaymission/research/interior/medbay)
 "lX" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/siding/yellow{
@@ -2660,11 +2645,6 @@
 	},
 /turf/open/floor/iron,
 /area/awaymission/research/interior/dorm)
-"lZ" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/awaymission/research/interior/escapepods)
 "ma" = (
 /turf/closed/wall/r_wall,
 /area/awaymission/research/interior/escapepods)
@@ -3300,6 +3280,14 @@
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior)
+"yn" = (
+/obj/item/ammo_casing/c45,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/awaymission/research/interior/medbay)
 "yM" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -3399,6 +3387,14 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/medbay)
+"CW" = (
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/awaymission/research/interior/security)
 "Dl" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -3418,6 +3414,12 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior)
+"DC" = (
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/structure/cable,
+/obj/machinery/power/apc/highcap/five_k/directional/west,
+/turf/open/floor/iron/dark,
+/area/awaymission/research/interior/genetics)
 "DO" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
@@ -3583,11 +3585,25 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/awaymission/research/interior/genetics)
+"Jb" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Genetics Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/genetics,
+/turf/open/floor/plating,
+/area/awaymission/research/interior/genetics)
 "Jc" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
+/turf/open/floor/iron,
+/area/awaymission/research/interior/dorm)
+"Jm" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/awaymission/research/interior/dorm)
 "Jp" = (
@@ -3619,6 +3635,11 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/awaymission/research/interior/genetics)
+"Kf" = (
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/awaymission/research/interior/cryo)
 "Kg" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -3662,6 +3683,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/medbay)
+"KZ" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/awaymission/research/interior/medbay)
 "Le" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -3684,6 +3714,14 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/engineering)
+"Mz" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/awaymission/research/interior/cryo)
 "MA" = (
 /obj/effect/mob_spawn/corpse/human/geneticist{
 	brute_damage = 145;
@@ -3718,6 +3756,14 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/engineering)
+"Ok" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/highcap/five_k/directional/north,
+/turf/open/floor/iron/white,
+/area/awaymission/research/interior/cryo)
 "Or" = (
 /obj/structure/chair{
 	dir = 4
@@ -3862,14 +3908,6 @@
 "SM" = (
 /turf/open/misc/asteroid,
 /area/awaymission/research/exterior)
-"Ta" = (
-/obj/machinery/power/apc/highcap/five_k/directional/east{
-	name = "Cryostasis APC"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/turf/open/floor/iron/white,
-/area/awaymission/research/interior/cryo)
 "Th" = (
 /mob/living/basic/syndicate,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -3953,11 +3991,24 @@
 	},
 /turf/open/floor/plating,
 /area/awaymission/research/interior/maint)
+"UC" = (
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/awaymission/research/interior/escapepods)
 "UO" = (
 /obj/item/stack/rods,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/engineering)
+"UU" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/awaymission/research/interior/cryo)
 "UV" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-16"
@@ -4079,6 +4130,11 @@
 /obj/item/shard,
 /turf/open/misc/asteroid,
 /area/awaymission/research/exterior)
+"Zk" = (
+/obj/effect/turf_decal/tile/green/half/contrasted,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/awaymission/research/interior/escapepods)
 "ZJ" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -34788,7 +34844,7 @@ aH
 bD
 dZ
 et
-Ta
+qp
 qp
 qp
 qp
@@ -35301,10 +35357,10 @@ aH
 aH
 bD
 ea
-eu
-fb
-fD
-HD
+Ok
+Mz
+UU
+Kf
 eu
 fb
 fD
@@ -35553,7 +35609,7 @@ ad
 aH
 bD
 bD
-cS
+bD
 bD
 bD
 bD
@@ -35569,7 +35625,7 @@ ea
 bD
 bD
 bD
-cS
+bD
 bD
 bD
 aH
@@ -36598,7 +36654,7 @@ KK
 KK
 Gk
 KK
-KK
+DC
 cy
 bD
 id
@@ -36610,7 +36666,7 @@ iX
 iX
 iX
 iX
-aP
+eH
 iX
 iX
 iX
@@ -36867,7 +36923,7 @@ jT
 iX
 kC
 kQ
-jE
+Jm
 lm
 ly
 iX
@@ -37607,7 +37663,7 @@ ad
 ad
 aH
 bD
-cy
+Jb
 KK
 KK
 Ez
@@ -38153,7 +38209,7 @@ kr
 jn
 jF
 jF
-ln
+jF
 kc
 lL
 jk
@@ -39959,7 +40015,7 @@ jE
 jE
 lX
 iX
-lZ
+bD
 mb
 ml
 OH
@@ -40170,8 +40226,8 @@ ts
 ad
 ad
 aH
-aO
-ch
+bD
+dy
 bm
 bD
 bD
@@ -40427,7 +40483,7 @@ ar
 ar
 ar
 ar
-aP
+eH
 ar
 ar
 ar
@@ -40732,7 +40788,7 @@ lY
 aP
 bD
 mb
-mi
+UC
 OH
 OH
 mG
@@ -40988,8 +41044,8 @@ iX
 iX
 iX
 bD
-aP
-mi
+eH
+Zk
 OH
 OH
 mF
@@ -46892,8 +46948,8 @@ sq
 jh
 Fl
 Bp
-kh
-aP
+yn
+eH
 bD
 aH
 ad
@@ -47149,9 +47205,9 @@ kL
 kZ
 Fl
 Th
-lD
+KZ
 iW
-lW
+aO
 aH
 ad
 ad
@@ -47391,7 +47447,7 @@ hG
 hG
 ii
 do
-iF
+bD
 aH
 ad
 aH
@@ -47646,7 +47702,7 @@ LX
 LX
 LX
 LX
-hn
+CW
 do
 bD
 aH


### PR DESCRIPTION

## About The Pull Request

This PR was initially made to resolve the following issue:

```txt
[2023-03-27 14:53:51.874] Duplicate APC created at Research Genetics Research (123,126,12) /area/awaymission/research/interior/genetics. Original at Research Genetics Research (123,142,12) /area/awaymission/research/interior/genetics.
```

However, the APC placements in this entire away mission just sucked with horrible area placement to accomodate for it. None of the areas here have sprites, so it was pretty hard to piece out. Should be much better now.
## Why It's Good For The Game
duplicate apc bad! better apc placement overall, it's more intuitive

## Changelog
it doesn't really matter as far as players are concerned
