### PR TITLE
Hermit Ruin Active Turf Fix(?)

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
@@ -2,114 +2,112 @@
 "aM" = (
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"bz" = (
-/obj/item/flashlight/lantern,
+"bp" = (
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
-"bW" = (
-/obj/item/reagent_containers/cup/bucket/wooden,
-/turf/open/floor/plating,
-/area/ruin/powered/shuttle)
-"cI" = (
-/turf/open/floor/plating,
-/area/ruin/powered/shuttle)
-"ec" = (
-/obj/item/clothing/suit/hooded/wintercoat,
-/turf/open/floor/wood,
-/area/ruin/powered/shuttle)
-"ei" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
-"gr" = (
-/turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
-"ha" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood,
-/area/ruin/powered/shuttle)
-"hv" = (
-/obj/structure/bonfire/prelit,
-/turf/open/floor/wood,
-/area/ruin/powered/shuttle)
-"hN" = (
-/turf/open/floor/wood,
-/area/ruin/powered/shuttle)
-"ii" = (
-/obj/effect/mob_spawn/ghost_role/human/hermit,
-/turf/open/floor/wood,
-/area/ruin/powered/shuttle)
-"il" = (
-/obj/structure/barricade/wooden/crude/snow,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"mN" = (
-/turf/closed/wall/mineral/wood,
-/area/ruin/powered/shuttle)
-"oJ" = (
-/obj/structure/sink/directional/south,
-/turf/open/floor/plating,
-/area/ruin/powered/shuttle)
-"pI" = (
-/obj/item/chair/wood/wings,
-/turf/open/floor/wood,
-/area/ruin/powered/shuttle)
-"sC" = (
-/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime,
-/obj/structure/table/wood,
-/obj/item/flashlight/lantern,
-/turf/open/floor/wood,
-/area/ruin/powered/shuttle)
-"sM" = (
-/obj/structure/chair/comfy/beige,
-/obj/machinery/light/directional/west,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood,
-/area/ruin/powered/shuttle)
-"wH" = (
-/obj/item/tank/internals/emergency_oxygen/engi,
-/turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
-"zd" = (
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/storage/medkit/surgery,
-/obj/item/storage/bag/ore,
-/obj/structure/table/wood,
-/turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
-"CR" = (
-/obj/item/flashlight/lantern,
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
-"GU" = (
-/obj/item/storage/toolbox/emergency,
-/turf/open/floor/plating,
-/area/ruin/powered/shuttle)
-"II" = (
-/obj/item/paper/guides/jobs/hydroponics,
-/turf/open/floor/plating,
-/area/ruin/powered/shuttle)
-"JI" = (
+/area/ruin/powered/hermit)
+"bM" = (
 /obj/machinery/door/airlock/wood{
 	name = "Frozen Shack"
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/wood,
-/area/ruin/powered/shuttle)
-"Oe" = (
-/obj/item/seeds/plump,
-/obj/item/seeds/plump,
-/obj/item/seeds/tower,
-/obj/item/seeds/reishi,
-/obj/structure/table/wood,
-/obj/item/food/grown/mushroom/glowshroom,
+/area/ruin/powered/hermit)
+"cI" = (
+/obj/item/storage/toolbox/emergency,
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
-"ON" = (
+/area/ruin/powered/hermit)
+"dY" = (
+/obj/structure/sink/directional/south,
+/turf/open/floor/plating,
+/area/ruin/powered/hermit)
+"ec" = (
+/obj/structure/chair/comfy/beige,
+/obj/machinery/light/directional/west,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/ruin/powered/hermit)
+"gr" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/grass/fairy,
+/area/ruin/powered/hermit)
+"ha" = (
+/obj/effect/mob_spawn/ghost_role/human/hermit,
+/turf/open/floor/wood,
+/area/ruin/powered/hermit)
+"hN" = (
+/obj/structure/bonfire/prelit,
+/turf/open/floor/wood,
+/area/ruin/powered/hermit)
+"ii" = (
+/obj/item/clothing/suit/hooded/wintercoat,
+/turf/open/floor/wood,
+/area/ruin/powered/hermit)
+"il" = (
+/obj/structure/barricade/wooden/crude/snow,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"io" = (
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/medkit/surgery,
+/obj/item/storage/bag/ore,
+/obj/structure/table/wood,
+/turf/open/floor/grass/fairy,
+/area/ruin/powered/hermit)
+"jG" = (
+/turf/closed/wall/mineral/wood,
+/area/icemoon/underground/explored)
+"mN" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/ruin/powered/hermit)
+"oJ" = (
+/obj/structure/glowshroom/single,
+/turf/open/floor/plating,
+/area/ruin/powered/hermit)
+"sj" = (
 /obj/machinery/hydroponics/soil,
 /obj/machinery/light/directional/north,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
+"sC" = (
+/obj/item/chair/wood/wings,
+/turf/open/floor/wood,
+/area/ruin/powered/hermit)
+"uw" = (
+/obj/machinery/hydroponics/soil,
+/turf/open/floor/grass/fairy,
+/area/ruin/powered/hermit)
+"wf" = (
+/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime,
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern,
+/turf/open/floor/wood,
+/area/ruin/powered/hermit)
+"wH" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/grass/fairy,
+/area/ruin/powered/hermit)
+"zd" = (
+/obj/item/pickaxe/improvised,
+/obj/structure/table/wood,
+/obj/item/knife/combat,
+/turf/open/floor/grass/fairy,
+/area/ruin/powered/hermit)
+"CR" = (
+/obj/item/flashlight/lantern,
+/turf/open/misc/asteroid/snow/icemoon,
+/area/icemoon/underground/explored)
+"GU" = (
+/obj/item/paper/guides/jobs/hydroponics,
+/turf/open/floor/plating,
+/area/ruin/powered/hermit)
+"JI" = (
+/turf/open/floor/wood,
+/area/ruin/powered/hermit)
+"Lf" = (
+/obj/item/shovel,
+/turf/open/floor/plating,
+/area/ruin/powered/hermit)
 "Qr" = (
 /obj/structure/barricade/wooden/snowed,
 /turf/open/misc/asteroid/snow/icemoon,
@@ -117,36 +115,41 @@
 "QD" = (
 /turf/template_noop,
 /area/template_noop)
+"Rd" = (
+/obj/item/flashlight/lantern,
+/turf/open/floor/grass/fairy,
+/area/ruin/powered/hermit)
 "Rr" = (
 /obj/structure/flora/tree/pine/style_random,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "Si" = (
-/obj/structure/glowshroom/single,
-/turf/open/floor/plating,
-/area/ruin/powered/shuttle)
-"UL" = (
-/obj/item/pickaxe/improvised,
-/obj/structure/table/wood,
-/obj/item/knife/combat,
-/turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
-"WK" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
-"Xh" = (
 /obj/structure/flora/tree/jungle/small/style_random,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
-"XI" = (
-/obj/machinery/light/directional/east,
+/area/ruin/powered/hermit)
+"TL" = (
+/turf/closed/wall/mineral/wood,
+/area/ruin/powered/hermit)
+"WK" = (
+/obj/item/tank/internals/emergency_oxygen/engi,
 /turf/open/floor/grass/fairy,
-/area/ruin/powered/shuttle)
-"Yi" = (
-/obj/item/shovel,
+/area/ruin/powered/hermit)
+"Xl" = (
 /turf/open/floor/plating,
-/area/ruin/powered/shuttle)
+/area/ruin/powered/hermit)
+"Yi" = (
+/obj/item/seeds/plump,
+/obj/item/seeds/plump,
+/obj/item/seeds/tower,
+/obj/item/seeds/reishi,
+/obj/structure/table/wood,
+/obj/item/food/grown/mushroom/glowshroom,
+/turf/open/floor/plating,
+/area/ruin/powered/hermit)
+"YA" = (
+/obj/item/reagent_containers/cup/bucket/wooden,
+/turf/open/floor/plating,
+/area/ruin/powered/hermit)
 "YN" = (
 /turf/closed/mineral/snowmountain/icemoon,
 /area/icemoon/underground/explored)
@@ -174,16 +177,16 @@ QD
 QD
 QD
 QD
-QD
-QD
 YN
-QD
-QD
-QD
-QD
-QD
+YN
+YN
+YN
+YN
+YN
+YN
+YN
+YN
 aM
-QD
 QD
 QD
 "}
@@ -191,14 +194,14 @@ QD
 QD
 QD
 QD
-QD
 YN
 YN
 YN
 YN
 YN
-QD
-QD
+YN
+YN
+YN
 YN
 YN
 YN
@@ -208,7 +211,6 @@ YN
 (4,1,1) = {"
 QD
 QD
-QD
 YN
 YN
 YN
@@ -221,11 +223,13 @@ YN
 YN
 YN
 YN
-aM
+YN
+YN
 "}
 (5,1,1) = {"
 QD
-QD
+YN
+YN
 YN
 YN
 YN
@@ -235,25 +239,24 @@ YN
 aM
 aM
 il
-YN
 aM
 aM
 aM
 aM
 "}
 (6,1,1) = {"
-QD
 YN
 YN
 YN
-cI
-mN
-mN
-mN
-mN
-mN
-mN
-aM
+YN
+Xl
+Xl
+TL
+TL
+TL
+TL
+TL
+TL
 aM
 aM
 Rr
@@ -262,34 +265,34 @@ aM
 (7,1,1) = {"
 YN
 YN
-ei
-Oe
+YN
+uw
 Yi
-mN
-sM
+Lf
+TL
 ec
 ii
 ha
 mN
+TL
 aM
 aM
 aM
 il
-aM
 "}
 (8,1,1) = {"
 YN
-ei
-gr
-II
+YN
+uw
+bp
 GU
 cI
-hv
-hN
-hN
+Xl
 hN
 JI
-aM
+JI
+JI
+bM
 aM
 aM
 Rr
@@ -297,36 +300,36 @@ aM
 "}
 (9,1,1) = {"
 YN
-ON
-gr
-Xh
+jG
+sj
+bp
 Si
 oJ
-hN
-hN
-pI
+dY
+JI
+JI
 sC
-mN
+wf
+TL
 aM
 aM
 aM
 CR
-aM
 "}
 (10,1,1) = {"
 YN
-ei
-bz
-gr
-bW
-cI
-cI
-cI
-mN
-mN
-mN
+YN
+uw
+Rd
+bp
+YA
+Xl
+Xl
+Xl
+TL
+TL
+TL
 Qr
-aM
 aM
 aM
 aM
@@ -335,41 +338,43 @@ aM
 YN
 YN
 YN
-ei
-gr
-gr
-XI
+YN
+uw
+bp
+bp
 wH
 WK
 gr
+bp
 YN
 YN
-aM
 aM
 aM
 Rr
 "}
 (12,1,1) = {"
 QD
-QD
 YN
 YN
-UL
+YN
+YN
 zd
+io
+jG
 YN
 YN
 YN
 YN
 YN
-YN
-aM
 aM
 aM
 aM
 "}
 (13,1,1) = {"
 QD
-QD
+YN
+YN
+YN
 YN
 YN
 YN
@@ -380,42 +385,40 @@ YN
 YN
 aM
 aM
-aM
-aM
-aM
+Rr
 aM
 "}
 (14,1,1) = {"
 QD
 QD
-QD
-QD
 YN
 YN
 YN
 YN
 YN
-aM
-aM
-aM
+YN
+YN
+YN
+YN
 aM
 Rr
 aM
-QD
+aM
+aM
 "}
 (15,1,1) = {"
 QD
 QD
 QD
 QD
-QD
-QD
-QD
+YN
+YN
+YN
+YN
 aM
 aM
 aM
 aM
-Rr
 aM
 aM
 aM
@@ -432,10 +435,10 @@ QD
 QD
 QD
 QD
+QD
 aM
 aM
 QD
 QD
 QD
-aM
 "}

--- a/code/game/area/areas/ruins/icemoon.dm
+++ b/code/game/area/areas/ruins/icemoon.dm
@@ -56,3 +56,6 @@
 	sound_environment = SOUND_ENVIRONMENT_DIZZY
 	mood_bonus = -8
 	mood_message = "I can feel my lifespan shortening with every breath."
+
+/area/ruin/powered/hermit
+	name = "\improper Hermit's Cabin"


### PR DESCRIPTION
Note for the future: The hypothesis presented within was later found that mobs breaking down the walls couldn't cause the active turfs. However, there is something sus about how thin the walls are and how we keep observing active turfs along those aspects (all fairy grass is placed next to the snow walls). One portion of this PR is including more tools for tracking this ruin, so we'll know if it starts to be a problem as well.

If it gets to be really bad I'll start including stuff like the turf's contents in the post-mortem report.
## About The Pull Request

On Round 202559:

```txt
[2023-03-27 07:25:21.791]
 - All that follows is a turf with an active air difference at roundstart. To clear this, make sure that all of the turfs listed below are connected to a turf with the same air contents.
 - In an ideal world, this list should have enough information to help you locate the active turf(s) in question. Unfortunately, this might not be an ideal world.
 - If the round is still ongoing, you can use the "Mapping -> Show roundstart AT list" verb to see exactly what active turfs were detected. Otherwise, good luck.
 - Active turf: Icemoon Underground (174,130,2) (/area/icemoon/underground/explored). Turf type: /turf/open/misc/asteroid/snow/icemoon. Relevant Z-Trait(s): Mining, Ice Ruins Underground and Station.
 - Active turf: Shuttle (175,130,2) (/area/ruin/powered/shuttle). Turf type: /turf/open/floor/grass/fairy. Relevant Z-Trait(s): Mining, Ice Ruins Underground and Station.
 - Active turf: Icemoon Underground (175,131,2) (/area/icemoon/underground/explored). Turf type: /turf/open/misc/asteroid/snow/icemoon. Relevant Z-Trait(s): Mining, Ice Ruins Underground and Station.
 - Active turf: Shuttle (176,131,2) (/area/ruin/powered/shuttle). Turf type: /turf/open/floor/grass/fairy. Relevant Z-Trait(s): Mining, Ice Ruins Underground and Station.
 - Z-Level 2 has 4 active turf(s).
 - Z-Level trait Ice Ruins Underground has 4 active turf(s).
 - Z-Level trait Mining has 4 active turf(s).
 - Z-Level trait Station has 4 active turf(s).
 - End of active turf list.
```

I have no idea what caused it, this is my best guess:

![image](https://user-images.githubusercontent.com/34697715/228062120-cdd414e5-6a2d-4d2f-95ac-921ddcb06d59.png)

Maybe a mob could have broken it before air loaded? unsure, this is a post-mortem examination so i don't know exactly what failed. I ran icebox with this ruin as `always_place` at least five times but never saw any active turfs. Out of an abundance of caution let's cut down how "thin" the walls are because the active turf could have been spontaneous from some ruinloader mishap? It's a bit confusing and I don't have a definite answer on what causes this, so will have to keep a closer eye on this.

I also added a new ruin area subtype tailored for the hermit's ruin so we can immediately detect if this should happen again, since I have only the one data point. i also fixed up some other placement stuff while in the area.
## Why It's Good For The Game

Hopefully cut down on the number of active turfs we get on production, since mobs breaking turfs that they can easily break leading to a failure state is very silly.
## Changelog
:cl:
fix: The hermit of the Icemoon has decided to build their hut in some deeper caves for a bit more protection from the local fauna.
/:cl:
