### PR TITLE
makes the maid in the mirror drop a real suit of armor.

### DIFF
--- a/code/modules/antagonists/heretic/mobs/maid_in_mirror.dm
+++ b/code/modules/antagonists/heretic/mobs/maid_in_mirror.dm
@@ -19,7 +19,7 @@
 	loot = list(
 		/obj/item/shard,
 		/obj/effect/decal/cleanable/ash,
-		/obj/item/clothing/suit/armor,
+		/obj/item/clothing/suit/armor/vest,
 		/obj/item/organ/internal/lungs,
 	)
 	actions_to_add = list(/datum/action/cooldown/spell/jaunt/mirror_walk)


### PR DESCRIPTION

## About The Pull Request
The maid in the mirror, upon death, drops a suit of armor with no sprite called "suit".
This makes it drop a suit/vest
## Why It's Good For The Game
Bugfix
## Changelog
:cl:
fix: Maid in the mirror no longer drops a sprite-less suit.
/:cl:
