### PR TITLE
Reverts elevator panel to retro theme

### DIFF
--- a/tgui/packages/tgui/interfaces/ElevatorPanel.tsx
+++ b/tgui/packages/tgui/interfaces/ElevatorPanel.tsx
@@ -54,7 +54,7 @@ export const ElevatorPanel = (props, context) => {
   const calculatedHeight = clamp(all_floor_data.length * 90, 400, 600);
 
   return (
-    <Window width={200} height={calculatedHeight}>
+    <Window width={200} height={calculatedHeight} theme="retro">
       <Window.Content>
         {!lift_exists && <NoLiftDimmer />}
         <Stack height="100%" vertical>


### PR DESCRIPTION
## About The Pull Request

#73576 randomly changed the elevator panel to use the base theme rather than the retro theme

I'm reverting it on the principle that was unjustified in the PR, and I would rather prefer that elevator panels could pass their desired theme in, if the contributor wanted to a certain panel to use a certain theme (like the NT theme).


## Changelog

:cl: Melbert
del: Revert elevator panel UI theme change
/:cl:
