### PR TITLE
[NO GBP] Mafia games only grant role win achievements when played with a full 12-player setup

### DIFF
--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -345,7 +345,7 @@
 		return TRUE
 	else if(alive_mafia >= anti_mafia_power && !town_can_kill)
 		start_the_end("<span class='big red'>!! MAFIA VICTORY !!</span>")
-		if(!early_start)
+		if(!early_start || !length(custom_setup))
 			for(var/datum/mafia_role/changeling in total_mafia)
 				award_role(changeling.winner_award, changeling)
 		return TRUE
@@ -358,8 +358,6 @@
  * * role: mafia_role datum to reward.
  */
 /datum/mafia_controller/proc/award_role(award, datum/mafia_role/rewarded)
-	if(custom_setup.len)
-		return
 	var/client/role_client = GLOB.directory[rewarded.player_key]
 	role_client?.give_award(award, rewarded.body)
 
@@ -404,7 +402,7 @@
 	QDEL_NULL(town_center_landmark)
 	phase = MAFIA_PHASE_SETUP
 
-	early_start = FALSE
+	early_start = initial(early_start)
 
 /**
  * After the voting and judgement phases, the game goes to night shutting the windows and beginning night with a proc.

--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -338,14 +338,16 @@
 	if(blocked_victory)
 		return FALSE
 	if(alive_mafia == 0)
-		for(var/datum/mafia_role/townie in total_town)
-			award_role(townie.winner_award, townie)
+		if(!early_start)
+			for(var/datum/mafia_role/townie in total_town)
+				award_role(townie.winner_award, townie)
 		start_the_end("<span class='big green'>!! TOWN VICTORY !!</span>")
 		return TRUE
 	else if(alive_mafia >= anti_mafia_power && !town_can_kill)
 		start_the_end("<span class='big red'>!! MAFIA VICTORY !!</span>")
-		for(var/datum/mafia_role/changeling in total_mafia)
-			award_role(changeling.winner_award, changeling)
+		if(!early_start)
+			for(var/datum/mafia_role/changeling in total_mafia)
+				award_role(changeling.winner_award, changeling)
 		return TRUE
 
 /**
@@ -356,7 +358,7 @@
  * * role: mafia_role datum to reward.
  */
 /datum/mafia_controller/proc/award_role(award, datum/mafia_role/rewarded)
-	if(custom_setup.len || early_start)
+	if(custom_setup.len)
 		return
 	var/client/role_client = GLOB.directory[rewarded.player_key]
 	role_client?.give_award(award, rewarded.body)

--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -65,6 +65,9 @@
 	///used for debugging in testing (doesn't put people out of the game, some other shit i forgot, who knows just don't set this in live) honestly kinda deprecated
 	var/debug = FALSE
 
+	///was our game forced to start early?
+	var/early_start = FALSE
+
 /datum/mafia_controller/New()
 	. = ..()
 	GLOB.mafia_game = src
@@ -353,7 +356,7 @@
  * * role: mafia_role datum to reward.
  */
 /datum/mafia_controller/proc/award_role(award, datum/mafia_role/rewarded)
-	if(custom_setup.len)
+	if(custom_setup.len || early_start)
 		return
 	var/client/role_client = GLOB.directory[rewarded.player_key]
 	role_client?.give_award(award, rewarded.body)
@@ -398,6 +401,8 @@
 	QDEL_LIST(landmarks)
 	QDEL_NULL(town_center_landmark)
 	phase = MAFIA_PHASE_SETUP
+
+	early_start = FALSE
 
 /**
  * After the voting and judgement phases, the game goes to night shutting the windows and beginning night with a proc.
@@ -977,6 +982,7 @@
 	var/list/setup = generate_forced_setup(req_players)
 
 	prepare_game(setup, filtered_keys)
+	early_start = TRUE
 	start_game()
 
 /**

--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -338,14 +338,14 @@
 	if(blocked_victory)
 		return FALSE
 	if(alive_mafia == 0)
-		if(!early_start || !length(custom_setup))
+		if(!early_start && !length(custom_setup))
 			for(var/datum/mafia_role/townie in total_town)
 				award_role(townie.winner_award, townie)
 		start_the_end("<span class='big green'>!! TOWN VICTORY !!</span>")
 		return TRUE
 	else if(alive_mafia >= anti_mafia_power && !town_can_kill)
 		start_the_end("<span class='big red'>!! MAFIA VICTORY !!</span>")
-		if(!early_start || !length(custom_setup))
+		if(!early_start && !length(custom_setup))
 			for(var/datum/mafia_role/changeling in total_mafia)
 				award_role(changeling.winner_award, changeling)
 		return TRUE

--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -338,7 +338,7 @@
 	if(blocked_victory)
 		return FALSE
 	if(alive_mafia == 0)
-		if(!early_start)
+		if(!early_start || !length(custom_setup))
 			for(var/datum/mafia_role/townie in total_town)
 				award_role(townie.winner_award, townie)
 		start_the_end("<span class='big green'>!! TOWN VICTORY !!</span>")


### PR DESCRIPTION

## About The Pull Request

Mafia games that are started early no longer grant achievements for winning as X role.
## Why It's Good For The Game

Preserves the sanctity of achievements.

Achievements get disabled when a custom setup is run. This should bring how early starts to be more in line with that.
## Changelog
:cl:
fix: mafia games only grant role win achievements when played with a full 12-player setup.
/:cl:
