### PR TITLE
Basketball Matchup - Ass Blast USA vs Soviet Bears

### DIFF
--- a/_maps/map_files/Basketball/ass_blast_usa.dmm
+++ b/_maps/map_files/Basketball/ass_blast_usa.dmm
@@ -6,20 +6,24 @@
 /turf/open/floor/iron,
 /area/centcom/basketball)
 "aE" = (
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/landmark/basketball/team_spawn/home,
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "star"
+	},
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"be" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"bA" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"be" = (
-/obj/effect/turf_decal/tile/dark_red/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half,
-/turf/open/floor/iron/white/smooth_half,
-/area/centcom/basketball)
-"bA" = (
-/turf/open/floor/iron/grimy,
 /area/centcom/basketball)
 "cz" = (
 /obj/structure/rack,
@@ -33,12 +37,113 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
-"dC" = (
+"dJ" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"dM" = (
+/obj/structure/chair/sofa/right/maroon{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"dS" = (
 /turf/closed/indestructible/riveted/plastinum{
 	color = "#FF0000"
 	},
 /area/centcom/basketball)
-"dJ" = (
+"eU" = (
+/obj/structure/showcase/machinery/tv/broken,
+/obj/structure/table/wood,
+/turf/open/floor/iron/grimy,
+/area/centcom/basketball)
+"fi" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"fj" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/condiment/bbqsauce{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/condiment/bbqsauce{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"fu" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/glass/trophy/bronze_cup,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"gk" = (
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/white/smooth_half,
+/area/centcom/basketball)
+"gq" = (
+/obj/structure/chair/sofa/right/maroon,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"jj" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/item/reagent_containers/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/food/bun,
+/obj/item/food/bun,
+/obj/item/food/bun,
+/obj/item/food/bun,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/basketball)
+"jr" = (
+/obj/effect/landmark/basketball/team_spawn/away,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/white/smooth_half,
+/area/centcom/basketball)
+"kc" = (
+/turf/closed/indestructible/riveted/plastinum{
+	color = "#0000FF"
+	},
+/area/centcom/basketball)
+"ku" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"kT" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"ly" = (
+/obj/structure/chair/sofa/left/maroon,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"lD" = (
 /obj/structure/table,
 /obj/item/reagent_containers/condiment/peppermill{
 	pixel_x = 3
@@ -48,7 +153,69 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
-"dM" = (
+"mp" = (
+/obj/structure/chair/sofa/right/maroon{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"my" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/tommygun{
+	pixel_y = 10
+	},
+/obj/item/gun/ballistic/automatic/tommygun{
+	pixel_y = 5
+	},
+/obj/item/gun/ballistic/automatic/tommygun,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"nE" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"oR" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/carpet,
+/area/centcom/basketball)
+"pu" = (
+/obj/structure/chair/sofa/left/maroon{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"qU" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/centcom/basketball)
+"rU" = (
+/obj/structure/sign/poster/official/twelve_gauge,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
+"su" = (
+/obj/machinery/door/window/right/directional/north,
+/turf/open/floor/carpet,
+/area/centcom/basketball)
+"tO" = (
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"tX" = (
+/turf/open/floor/iron/grimy,
+/area/centcom/basketball)
+"vb" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/storage/cans/sixbeer,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"vo" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/bottle/beer{
 	pixel_x = -8
@@ -70,72 +237,7 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
-"dS" = (
-/obj/structure/sign/poster/contraband/syndicate_pistol,
-/turf/closed/indestructible/fakeglass,
-/area/centcom/basketball)
-"eU" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/basketball)
-"fi" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron,
-/area/centcom/basketball)
-"fu" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/cup/glass/trophy/bronze_cup,
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"gq" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"hf" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"jr" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/condiment/bbqsauce{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/condiment/bbqsauce{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/turf/open/floor/iron,
-/area/centcom/basketball)
-"kc" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/basketball)
-"kp" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
-/obj/item/reagent_containers/condiment/enzyme{
-	layer = 5
-	},
-/obj/item/food/bun,
-/obj/item/food/bun,
-/obj/item/food/bun,
-/obj/item/food/bun,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/basketball)
-"ku" = (
+"xP" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray,
 /obj/item/food/burger/bigbite{
@@ -146,99 +248,6 @@
 	pixel_x = 4
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"kT" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/centcom/basketball)
-"ly" = (
-/obj/structure/chair/sofa/left/maroon,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"my" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/automatic/tommygun{
-	pixel_y = 10
-	},
-/obj/item/gun/ballistic/automatic/tommygun{
-	pixel_y = 5
-	},
-/obj/item/gun/ballistic/automatic/tommygun,
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"mV" = (
-/obj/structure/chair/sofa/left/maroon{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"nE" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/centcom/basketball)
-"oR" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"pu" = (
-/obj/structure/chair/sofa/right/maroon{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"qU" = (
-/obj/structure/chair/sofa/right/maroon,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"sb" = (
-/obj/structure/chair/sofa/right/maroon{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"tO" = (
-/turf/open/floor/plating,
-/area/centcom/basketball)
-"tX" = (
-/turf/open/floor/iron,
-/area/centcom/basketball)
-"uH" = (
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"vb" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/table/reinforced,
-/obj/item/storage/cans/sixbeer,
-/turf/open/floor/iron,
-/area/centcom/basketball)
-"wZ" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"xP" = (
-/obj/effect/turf_decal/tile/dark_blue/full,
-/turf/open/floor/iron/large,
 /area/centcom/basketball)
 "zr" = (
 /obj/effect/landmark/basketball/team_spawn/referee,
@@ -264,8 +273,8 @@
 /area/centcom/basketball)
 "AC" = (
 /obj/structure/table/wood,
-/obj/item/clothing/head/costume/foilhat,
-/turf/open/floor/iron/grimy,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet,
 /area/centcom/basketball)
 "AI" = (
 /obj/machinery/status_display,
@@ -274,6 +283,17 @@
 "AU" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/cup/glass/trophy/silver_cup,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Bd" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 6
+	},
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "BJ" = (
@@ -345,7 +365,29 @@
 "Hu" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/basketball)
-"HH" = (
+"Ic" = (
+/obj/effect/turf_decal/tile/dark_blue/full,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"IA" = (
+/obj/effect/landmark/basketball/team_spawn/home,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/white/smooth_half,
+/area/centcom/basketball)
+"JM" = (
+/obj/structure/chair/sofa/left/maroon,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"LI" = (
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"LS" = (
 /obj/machinery/griddle,
 /obj/item/food/raw_patty{
 	pixel_x = -9
@@ -363,89 +405,42 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/centcom/basketball)
-"IA" = (
-/obj/effect/landmark/basketball/team_spawn/home,
-/obj/effect/turf_decal/tile/dark_red/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half,
-/turf/open/floor/iron/white/smooth_half,
-/area/centcom/basketball)
-"JM" = (
-/obj/structure/chair/sofa/left/maroon,
-/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"Lu" = (
+"LU" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
+/obj/item/storage/bag/tray,
+/obj/item/food/bbqribs{
+	pixel_y = 11
 	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
+/obj/item/food/bbqribs,
 /turf/open/floor/iron,
 /area/centcom/basketball)
-"LI" = (
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"LU" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/open/floor/carpet,
+"LV" = (
+/obj/structure/sign/poster/contraband/syndicate_pistol,
+/turf/closed/indestructible/fakeglass,
 /area/centcom/basketball)
 "Ma" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/carpet,
+/obj/structure/table/wood,
+/obj/item/clothing/head/costume/foilhat,
+/turf/open/floor/iron/grimy,
 /area/centcom/basketball)
 "MW" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	pixel_x = 15;
-	pixel_y = 15;
-	dir = 8
+/obj/effect/turf_decal/tile/dark_blue/full,
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "star"
 	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	pixel_x = -15;
-	pixel_y = 15
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	pixel_x = 15;
-	pixel_y = -16;
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	pixel_x = -15;
-	pixel_y = -16;
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled,
 /turf/open/floor/iron/large,
 /area/centcom/basketball)
-"Nt" = (
-/obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = 6
-	},
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = 3
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"Om" = (
+"Oj" = (
 /obj/structure/chair/sofa/left/maroon{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "OB" = (
@@ -477,9 +472,27 @@
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "Qh" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/poster/contraband/eat,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"Qi" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Ql" = (
+/turf/open/floor/iron,
 /area/centcom/basketball)
 "Rl" = (
 /obj/machinery/deepfryer,
@@ -489,50 +502,24 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/centcom/basketball)
-"TV" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	pixel_x = 15;
-	pixel_y = 15;
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	pixel_x = -15;
-	pixel_y = 15
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	pixel_x = 15;
-	pixel_y = -16;
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	pixel_x = -15;
-	pixel_y = -16;
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled,
-/obj/effect/landmark/basketball/team_spawn/home,
-/turf/open/floor/iron/large,
-/area/centcom/basketball)
 "Uv" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/carpet,
-/area/centcom/basketball)
-"Uy" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/structure/table/reinforced,
-/obj/item/storage/bag/tray,
-/obj/item/food/bbqribs{
-	pixel_y = 11
-	},
-/obj/item/food/bbqribs,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window,
+/obj/structure/sign/poster/contraband/eat,
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "Vr" = (
-/turf/closed/indestructible/riveted/plastinum,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"WB" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet,
 /area/centcom/basketball)
 "WK" = (
 /obj/structure/rack,
@@ -540,13 +527,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "WM" = (
-/turf/closed/indestructible/riveted/plastinum{
-	color = "#0000FF"
-	},
+/turf/closed/indestructible/riveted/plastinum,
 /area/centcom/basketball)
 "Xm" = (
-/obj/machinery/door/window/right/directional/north,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "Xn" = (
 /obj/effect/turf_decal/tile/bar{
@@ -559,18 +544,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/basketball)
-"Xo" = (
-/obj/structure/sign/poster/official/twelve_gauge,
-/turf/closed/indestructible/fakeglass,
-/area/centcom/basketball)
-"YH" = (
-/obj/effect/landmark/basketball/team_spawn/away,
-/obj/effect/turf_decal/tile/dark_red/half{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half,
-/turf/open/floor/iron/white/smooth_half,
-/area/centcom/basketball)
 "YX" = (
 /obj/item/toy/basketball,
 /obj/effect/turf_decal/tile/dark_red/half{
@@ -578,11 +551,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half,
 /turf/open/floor/iron/white/smooth_half,
-/area/centcom/basketball)
-"ZM" = (
-/obj/structure/showcase/machinery/tv/broken,
-/obj/structure/table/wood,
-/turf/open/floor/iron/grimy,
 /area/centcom/basketball)
 
 (1,1,1) = {"
@@ -618,21 +586,21 @@ tO
 tO
 tO
 tO
-Vr
 WM
-dC
-Vr
+kc
+dS
 WM
-dC
-Vr
+kc
+dS
 WM
-dC
-Vr
+kc
+dS
 WM
-dC
-Vr
+kc
+dS
 WM
-dC
+kc
+dS
 tO
 tO
 tO
@@ -645,21 +613,21 @@ tO
 tO
 tO
 tO
-dC
+dS
 fi
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
 fi
-Vr
+WM
 tO
 tO
 tO
@@ -672,21 +640,21 @@ tO
 tO
 tO
 tO
-WM
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-WM
+kc
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+kc
 tO
 tO
 tO
@@ -696,12 +664,12 @@ Hu
 (5,1,1) = {"
 Hu
 tO
-Vr
 WM
-dC
-Vr
+kc
+dS
+WM
 at
-tX
+Ql
 AI
 Cw
 Cw
@@ -711,126 +679,126 @@ Cw
 Cw
 Cw
 AI
-tX
-tX
-dC
-Vr
+Ql
+Ql
+dS
 WM
-dC
+kc
+dS
 tO
 Hu
 "}
 (6,1,1) = {"
 Hu
 tO
-dC
+dS
 dr
 PU
-mV
-kc
-tX
+Oj
+Vr
+Ql
 Cw
 MW
 BJ
 MW
 Cv
-be
-be
-be
+gk
+gk
+gk
 Cw
-tX
-tX
+Ql
+Ql
 CV
-bA
-AC
-Vr
+tX
+Ma
+WM
 tO
 Hu
 "}
 (7,1,1) = {"
 Hu
 tO
-WM
-ly
-dJ
-pu
 kc
-tX
+ly
+lD
+mp
+Vr
+Ql
 Cw
-xP
-TV
-xP
-be
-be
+Ic
+aE
+Ic
+gk
+gk
 IA
-be
+gk
 Cw
-tX
-tX
+Ql
+Ql
 CV
-bA
-ZM
-WM
+tX
+eU
+kc
 tO
 Hu
 "}
 (8,1,1) = {"
 Hu
-dC
-Vr
-oR
-wZ
-uH
-eU
-tX
+dS
+WM
+Qi
+ku
+Xm
+be
+Ql
 Cw
 MW
-xP
-TV
+Ic
+aE
 IA
 IA
-be
-be
+gk
+gk
 Cw
-tX
-tX
+Ql
+Ql
+LV
+Cw
+Cw
 dS
-Cw
-Cw
-dC
-Vr
+WM
 Hu
 "}
 (9,1,1) = {"
 Hu
-WM
+kc
 nE
 nE
 nE
-Qh
+Uv
 Ev
 Ev
 Cw
-xP
+Ic
 MW
-xP
-be
-be
-be
-be
+Ic
+gk
+gk
+gk
+gk
 Cw
-tX
-tX
+Ql
+Ql
 Cw
 Gh
 my
 cz
-WM
+kc
 Hu
 "}
 (10,1,1) = {"
 Hu
-Vr
+WM
 Tc
 Dt
 Dt
@@ -839,247 +807,247 @@ Ev
 Ev
 Cw
 MW
-xP
+Ic
 MW
-be
-be
-be
-be
+gk
+gk
+gk
+gk
 Cw
-tX
-tX
+Ql
+Ql
 Cw
 LI
 LI
 LI
-dC
+dS
 Hu
 "}
 (11,1,1) = {"
 Hu
-dC
-HH
+dS
+LS
 Dt
 Dt
-Uy
+LU
 Ev
 Ev
 Cw
-xP
+Ic
 MW
-xP
-be
-be
-be
-be
+Ic
+gk
+gk
+gk
+gk
 Cw
-tX
-tX
+Ql
+Ql
 PW
 LI
 LI
 fu
-Vr
+WM
 Hu
 "}
 (12,1,1) = {"
 Hu
-WM
+kc
 OB
 Dt
-kp
+jj
 Xn
 Ev
 Ev
 AI
-be
-be
-be
+gk
+gk
+gk
 YX
-be
-be
-be
+gk
+gk
+gk
 AI
 zr
-tX
+Ql
 PW
 LI
 LI
 Ax
-WM
+kc
 Hu
 "}
 (13,1,1) = {"
 Hu
-Vr
+WM
 Rl
 Dt
 Dt
-jr
+fj
 Ev
 Ev
 Cw
-be
-be
-be
-be
-be
-be
-be
+gk
+gk
+gk
+gk
+gk
+gk
+gk
 Cw
-tX
-tX
+Ql
+Ql
 PW
 LI
 LI
 AU
-dC
+dS
 Hu
 "}
 (14,1,1) = {"
 Hu
-dC
+dS
 Gi
 Dt
 Dt
-Lu
-Ev
-Ev
-Cw
-be
-be
-be
-be
-be
-be
-be
-Cw
-tX
-tX
-Cw
-LI
-LI
-LI
-Vr
-Hu
-"}
-(15,1,1) = {"
-Hu
-WM
-nE
-nE
-nE
 Qh
 Ev
 Ev
 Cw
-be
-be
-be
-be
-be
-be
-be
+gk
+gk
+gk
+gk
+gk
+gk
+gk
 Cw
-tX
-tX
+Ql
+Ql
+Cw
+LI
+LI
+LI
+WM
+Hu
+"}
+(15,1,1) = {"
+Hu
+kc
+nE
+nE
+nE
+Uv
+Ev
+Ev
+Cw
+gk
+gk
+gk
+gk
+gk
+gk
+gk
+Cw
+Ql
+Ql
 Cw
 WK
 zZ
-Nt
-WM
+Bd
+kc
 Hu
 "}
 (16,1,1) = {"
 Hu
-Vr
-dC
-hf
-gq
-aE
+WM
+dS
+dJ
+kT
+bA
 at
-tX
+Ql
 Cw
-be
-be
-YH
-YH
-YH
-be
-be
+gk
+gk
+jr
+jr
+jr
+gk
+gk
 Cw
-tX
-tX
-Xo
+Ql
+Ql
+rU
 Cw
 Cw
-Vr
-dC
+WM
+dS
 Hu
 "}
 (17,1,1) = {"
 Hu
 tO
-WM
-qU
-ku
-Om
 kc
-tX
+gq
+xP
+pu
+Vr
+Ql
 Cw
-be
-YH
-be
-be
-be
-YH
-be
+gk
+jr
+gk
+gk
+gk
+jr
+gk
 Cw
-tX
-tX
-Xm
-Ma
-LU
-WM
+Ql
+Ql
+su
+oR
+WB
+kc
 tO
 Hu
 "}
 (18,1,1) = {"
 Hu
 tO
-Vr
+WM
 JM
+vo
 dM
-sb
-kc
-tX
+Vr
+Ql
 Cw
-be
-be
-be
+gk
+gk
+gk
 DP
-be
-be
-be
+gk
+gk
+gk
 Cw
-tX
-tX
-kT
+Ql
+Ql
+qU
 CD
-Uv
-dC
+AC
+dS
 tO
 Hu
 "}
 (19,1,1) = {"
 Hu
 tO
-dC
+dS
+kc
 WM
-Vr
-dC
-eU
-tX
+dS
+be
+Ql
 AI
 Cw
 Cw
@@ -1089,12 +1057,12 @@ Cw
 Cw
 Cw
 AI
-tX
-tX
-Vr
-dC
+Ql
+Ql
 WM
-Vr
+dS
+kc
+WM
 tO
 Hu
 "}
@@ -1104,21 +1072,21 @@ tO
 tO
 tO
 tO
-WM
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-WM
+kc
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+kc
 tO
 tO
 tO
@@ -1131,21 +1099,21 @@ tO
 tO
 tO
 tO
-Vr
+WM
 fi
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
-tX
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
+Ql
 fi
-dC
+dS
 tO
 tO
 tO
@@ -1158,21 +1126,21 @@ tO
 tO
 tO
 tO
-dC
+dS
+kc
 WM
-Vr
-dC
+dS
+kc
 WM
-Vr
-dC
+dS
+kc
 WM
-Vr
-dC
+dS
+kc
 WM
-Vr
-dC
+dS
+kc
 WM
-Vr
 tO
 tO
 tO

--- a/_maps/map_files/Basketball/ass_blast_usa.dmm
+++ b/_maps/map_files/Basketball/ass_blast_usa.dmm
@@ -171,6 +171,10 @@
 /obj/item/gun/ballistic/automatic/tommygun,
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
+"mM" = (
+/obj/structure/sign/poster/contraband/c20r,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
 "nE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -344,6 +348,10 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
+/area/centcom/basketball)
+"EW" = (
+/obj/structure/sign/poster/contraband/revolver,
+/turf/closed/indestructible/fakeglass,
 /area/centcom/basketball)
 "Gh" = (
 /obj/structure/rack,
@@ -778,7 +786,7 @@ nE
 Uv
 Ev
 Ev
-Cw
+mM
 Ic
 MW
 Ic
@@ -786,7 +794,7 @@ gk
 gk
 gk
 gk
-Cw
+EW
 Ql
 Ql
 Cw
@@ -859,7 +867,7 @@ jj
 Xn
 Ev
 Ev
-AI
+Cw
 gk
 gk
 gk
@@ -867,7 +875,7 @@ YX
 gk
 gk
 gk
-AI
+Cw
 zr
 Ql
 PW
@@ -940,7 +948,7 @@ nE
 Uv
 Ev
 Ev
-Cw
+mM
 gk
 gk
 gk
@@ -948,7 +956,7 @@ gk
 gk
 gk
 gk
-Cw
+EW
 Ql
 Ql
 Cw

--- a/_maps/map_files/Basketball/ass_blast_usa.dmm
+++ b/_maps/map_files/Basketball/ass_blast_usa.dmm
@@ -1,0 +1,1208 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"at" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"aE" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"be" = (
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/white/smooth_half,
+/area/centcom/basketball)
+"bA" = (
+/turf/open/floor/iron/grimy,
+/area/centcom/basketball)
+"cz" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/sniper_rifle,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"dr" = (
+/obj/structure/chair/sofa/right/maroon,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"dC" = (
+/turf/closed/indestructible/riveted/plastinum{
+	color = "#FF0000"
+	},
+/area/centcom/basketball)
+"dJ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"dM" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_y = 2;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_y = 12;
+	pixel_x = 10
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"dS" = (
+/obj/structure/sign/poster/contraband/syndicate_pistol,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
+"eU" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"fi" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"fu" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/glass/trophy/bronze_cup,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"gq" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"hf" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"jr" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/condiment/bbqsauce{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/condiment/bbqsauce{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"kc" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"kp" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
+/obj/item/reagent_containers/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/food/bun,
+/obj/item/food/bun,
+/obj/item/food/bun,
+/obj/item/food/bun,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/basketball)
+"ku" = (
+/obj/structure/table,
+/obj/item/storage/bag/tray,
+/obj/item/food/burger/bigbite{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/item/food/burger/bigbite{
+	pixel_x = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"kT" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/centcom/basketball)
+"ly" = (
+/obj/structure/chair/sofa/left/maroon,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"my" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/tommygun{
+	pixel_y = 10
+	},
+/obj/item/gun/ballistic/automatic/tommygun{
+	pixel_y = 5
+	},
+/obj/item/gun/ballistic/automatic/tommygun,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"mV" = (
+/obj/structure/chair/sofa/left/maroon{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"nE" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"oR" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"pu" = (
+/obj/structure/chair/sofa/right/maroon{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"qU" = (
+/obj/structure/chair/sofa/right/maroon,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"sb" = (
+/obj/structure/chair/sofa/right/maroon{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"tO" = (
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"tX" = (
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"uH" = (
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"vb" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/storage/cans/sixbeer,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"wZ" = (
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"xP" = (
+/obj/effect/turf_decal/tile/dark_blue/full,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"zr" = (
+/obj/effect/landmark/basketball/team_spawn/referee,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"zZ" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/doublebarrel{
+	pixel_y = 5
+	},
+/obj/item/gun/ballistic/shotgun/doublebarrel{
+	pixel_y = 10
+	},
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Ax" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/glass/trophy/gold_cup{
+	pixel_x = 0
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"AC" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/costume/foilhat,
+/turf/open/floor/iron/grimy,
+/area/centcom/basketball)
+"AI" = (
+/obj/machinery/status_display,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
+"AU" = (
+/obj/structure/rack,
+/obj/item/reagent_containers/cup/glass/trophy/silver_cup,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"BJ" = (
+/obj/effect/turf_decal/tile/neutral/full,
+/obj/effect/turf_decal/tile/dark_blue/full,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"Cv" = (
+/obj/effect/landmark/basketball/team_spawn/home_hoop,
+/obj/structure/hoop/minigame{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/white/smooth_half,
+/area/centcom/basketball)
+"Cw" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
+"CD" = (
+/obj/structure/table/wood,
+/obj/item/clothing/glasses/monocle,
+/turf/open/floor/carpet,
+/area/centcom/basketball)
+"CV" = (
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/iron/grimy,
+/area/centcom/basketball)
+"Dt" = (
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/basketball)
+"DP" = (
+/obj/effect/landmark/basketball/team_spawn/away_hoop,
+/obj/structure/hoop/minigame{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/white/smooth_half,
+/area/centcom/basketball)
+"Ev" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"Gh" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/automatic/pistol/deagle/gold{
+	pixel_x = 5;
+	pixel_y = -5
+	},
+/obj/item/gun/ballistic/automatic/pistol/deagle/camo{
+	pixel_x = 10;
+	pixel_y = -10
+	},
+/obj/item/gun/ballistic/automatic/pistol/deagle,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Gi" = (
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/basketball)
+"Hu" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/basketball)
+"HH" = (
+/obj/machinery/griddle,
+/obj/item/food/raw_patty{
+	pixel_x = -9
+	},
+/obj/item/food/raw_patty{
+	pixel_x = 7
+	},
+/obj/item/food/raw_patty{
+	pixel_y = 10;
+	pixel_x = -10
+	},
+/obj/item/food/raw_patty{
+	pixel_x = 6;
+	pixel_y = 11
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/basketball)
+"IA" = (
+/obj/effect/landmark/basketball/team_spawn/home,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/white/smooth_half,
+/area/centcom/basketball)
+"JM" = (
+/obj/structure/chair/sofa/left/maroon,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Lu" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"LI" = (
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"LU" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet,
+/area/centcom/basketball)
+"Ma" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/carpet,
+/area/centcom/basketball)
+"MW" = (
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	pixel_x = 15;
+	pixel_y = 15;
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	pixel_x = -15;
+	pixel_y = 15
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	pixel_x = 15;
+	pixel_y = -16;
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	pixel_x = -15;
+	pixel_y = -16;
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"Nt" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 6
+	},
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Om" = (
+/obj/structure/chair/sofa/left/maroon{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"OB" = (
+/obj/machinery/grill,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/basketball)
+"PU" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/item/storage/bag/tray,
+/obj/item/food/cheesyfries{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/item/food/cheesyfries,
+/obj/item/food/cheesyfries{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"PW" = (
+/obj/machinery/door/poddoor/shutters/window{
+	id = "armory";
+	name = "Freedom Shutters"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Qh" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/sign/poster/contraband/eat,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"Rl" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/basketball)
+"Tc" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/basketball)
+"TV" = (
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	pixel_x = 15;
+	pixel_y = 15;
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	pixel_x = -15;
+	pixel_y = 15
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	pixel_x = 15;
+	pixel_y = -16;
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	pixel_x = -15;
+	pixel_y = -16;
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled,
+/obj/effect/landmark/basketball/team_spawn/home,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"Uv" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet,
+/area/centcom/basketball)
+"Uy" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/tray,
+/obj/item/food/bbqribs{
+	pixel_y = 11
+	},
+/obj/item/food/bbqribs,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"Vr" = (
+/turf/closed/indestructible/riveted/plastinum,
+/area/centcom/basketball)
+"WK" = (
+/obj/structure/rack,
+/obj/item/storage/box/lethalshot,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"WM" = (
+/turf/closed/indestructible/riveted/plastinum{
+	color = "#0000FF"
+	},
+/area/centcom/basketball)
+"Xm" = (
+/obj/machinery/door/window/right/directional/north,
+/turf/open/floor/carpet,
+/area/centcom/basketball)
+"Xn" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/structure/table/reinforced,
+/obj/structure/desk_bell{
+	pixel_x = 7
+	},
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"Xo" = (
+/obj/structure/sign/poster/official/twelve_gauge,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
+"YH" = (
+/obj/effect/landmark/basketball/team_spawn/away,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/white/smooth_half,
+/area/centcom/basketball)
+"YX" = (
+/obj/item/toy/basketball,
+/obj/effect/turf_decal/tile/dark_red/half{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half,
+/turf/open/floor/iron/white/smooth_half,
+/area/centcom/basketball)
+"ZM" = (
+/obj/structure/showcase/machinery/tv/broken,
+/obj/structure/table/wood,
+/turf/open/floor/iron/grimy,
+/area/centcom/basketball)
+
+(1,1,1) = {"
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+"}
+(2,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+Vr
+WM
+dC
+Vr
+WM
+dC
+Vr
+WM
+dC
+Vr
+WM
+dC
+Vr
+WM
+dC
+tO
+tO
+tO
+tO
+Hu
+"}
+(3,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+dC
+fi
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+fi
+Vr
+tO
+tO
+tO
+tO
+Hu
+"}
+(4,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+WM
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+WM
+tO
+tO
+tO
+tO
+Hu
+"}
+(5,1,1) = {"
+Hu
+tO
+Vr
+WM
+dC
+Vr
+at
+tX
+AI
+Cw
+Cw
+Cw
+Cw
+Cw
+Cw
+Cw
+AI
+tX
+tX
+dC
+Vr
+WM
+dC
+tO
+Hu
+"}
+(6,1,1) = {"
+Hu
+tO
+dC
+dr
+PU
+mV
+kc
+tX
+Cw
+MW
+BJ
+MW
+Cv
+be
+be
+be
+Cw
+tX
+tX
+CV
+bA
+AC
+Vr
+tO
+Hu
+"}
+(7,1,1) = {"
+Hu
+tO
+WM
+ly
+dJ
+pu
+kc
+tX
+Cw
+xP
+TV
+xP
+be
+be
+IA
+be
+Cw
+tX
+tX
+CV
+bA
+ZM
+WM
+tO
+Hu
+"}
+(8,1,1) = {"
+Hu
+dC
+Vr
+oR
+wZ
+uH
+eU
+tX
+Cw
+MW
+xP
+TV
+IA
+IA
+be
+be
+Cw
+tX
+tX
+dS
+Cw
+Cw
+dC
+Vr
+Hu
+"}
+(9,1,1) = {"
+Hu
+WM
+nE
+nE
+nE
+Qh
+Ev
+Ev
+Cw
+xP
+MW
+xP
+be
+be
+be
+be
+Cw
+tX
+tX
+Cw
+Gh
+my
+cz
+WM
+Hu
+"}
+(10,1,1) = {"
+Hu
+Vr
+Tc
+Dt
+Dt
+vb
+Ev
+Ev
+Cw
+MW
+xP
+MW
+be
+be
+be
+be
+Cw
+tX
+tX
+Cw
+LI
+LI
+LI
+dC
+Hu
+"}
+(11,1,1) = {"
+Hu
+dC
+HH
+Dt
+Dt
+Uy
+Ev
+Ev
+Cw
+xP
+MW
+xP
+be
+be
+be
+be
+Cw
+tX
+tX
+PW
+LI
+LI
+fu
+Vr
+Hu
+"}
+(12,1,1) = {"
+Hu
+WM
+OB
+Dt
+kp
+Xn
+Ev
+Ev
+AI
+be
+be
+be
+YX
+be
+be
+be
+AI
+zr
+tX
+PW
+LI
+LI
+Ax
+WM
+Hu
+"}
+(13,1,1) = {"
+Hu
+Vr
+Rl
+Dt
+Dt
+jr
+Ev
+Ev
+Cw
+be
+be
+be
+be
+be
+be
+be
+Cw
+tX
+tX
+PW
+LI
+LI
+AU
+dC
+Hu
+"}
+(14,1,1) = {"
+Hu
+dC
+Gi
+Dt
+Dt
+Lu
+Ev
+Ev
+Cw
+be
+be
+be
+be
+be
+be
+be
+Cw
+tX
+tX
+Cw
+LI
+LI
+LI
+Vr
+Hu
+"}
+(15,1,1) = {"
+Hu
+WM
+nE
+nE
+nE
+Qh
+Ev
+Ev
+Cw
+be
+be
+be
+be
+be
+be
+be
+Cw
+tX
+tX
+Cw
+WK
+zZ
+Nt
+WM
+Hu
+"}
+(16,1,1) = {"
+Hu
+Vr
+dC
+hf
+gq
+aE
+at
+tX
+Cw
+be
+be
+YH
+YH
+YH
+be
+be
+Cw
+tX
+tX
+Xo
+Cw
+Cw
+Vr
+dC
+Hu
+"}
+(17,1,1) = {"
+Hu
+tO
+WM
+qU
+ku
+Om
+kc
+tX
+Cw
+be
+YH
+be
+be
+be
+YH
+be
+Cw
+tX
+tX
+Xm
+Ma
+LU
+WM
+tO
+Hu
+"}
+(18,1,1) = {"
+Hu
+tO
+Vr
+JM
+dM
+sb
+kc
+tX
+Cw
+be
+be
+be
+DP
+be
+be
+be
+Cw
+tX
+tX
+kT
+CD
+Uv
+dC
+tO
+Hu
+"}
+(19,1,1) = {"
+Hu
+tO
+dC
+WM
+Vr
+dC
+eU
+tX
+AI
+Cw
+Cw
+Cw
+Cw
+Cw
+Cw
+Cw
+AI
+tX
+tX
+Vr
+dC
+WM
+Vr
+tO
+Hu
+"}
+(20,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+WM
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+WM
+tO
+tO
+tO
+tO
+Hu
+"}
+(21,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+Vr
+fi
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+fi
+dC
+tO
+tO
+tO
+tO
+Hu
+"}
+(22,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+dC
+WM
+Vr
+dC
+WM
+Vr
+dC
+WM
+Vr
+dC
+WM
+Vr
+dC
+WM
+Vr
+tO
+tO
+tO
+tO
+Hu
+"}
+(23,1,1) = {"
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+"}

--- a/_maps/map_files/Basketball/soviet_bear.dmm
+++ b/_maps/map_files/Basketball/soviet_bear.dmm
@@ -5,29 +5,25 @@
 /turf/open/floor/iron,
 /area/centcom/basketball)
 "aw" = (
+/obj/structure/table,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "aE" = (
-/obj/structure/table/reinforced/titaniumglass,
-/obj/item/stack/cable_coil{
-	amount = 15;
-	pixel_x = 5;
-	pixel_y = 12
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict6"
 	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/obj/item/stack/cable_coil{
-	amount = 15
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "be" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
+/obj/machinery/power/shuttle_engine/heater,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "bA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -43,38 +39,26 @@
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "dg" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/ballistic/rifle/boltaction{
-	pixel_y = 5
-	},
-/obj/item/gun/ballistic/rifle/boltaction,
-/obj/machinery/door/window/left/directional/west{
-	base_state = "right";
-	icon_state = "right";
-	name = "Shooting Range"
-	},
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/sovietsoda,
+/turf/open/floor/iron,
 /area/centcom/basketball)
 "dr" = (
-/obj/structure/table,
-/obj/item/clothing/ears/earmuffs{
-	pixel_y = 7
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/centcom/basketball)
 "dC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict7"
 	},
-/obj/item/wrench,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "dJ" = (
-/turf/open/floor/iron/dark/small,
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/engine,
 /area/centcom/basketball)
 "dM" = (
 /obj/structure/table,
@@ -89,27 +73,26 @@
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "dS" = (
-/obj/item/crowbar,
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict9"
+	},
+/turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "eS" = (
-/obj/effect/decal/cleanable/oil/streak,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/centcom/basketball)
 "eU" = (
-/obj/machinery/power/shuttle_engine/propulsion{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "fi" = (
-/obj/machinery/vending/sovietsoda,
+/obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/centcom/basketball)
 "fj" = (
-/obj/structure/stairs/east,
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/iron/dark/small,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "fu" = (
 /obj/structure/table/reinforced/titaniumglass,
@@ -118,43 +101,21 @@
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "fB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/crayon{
-	icon_state = "cyka"
-	},
-/turf/open/floor/plating,
+/obj/structure/sign/poster/contraband/communist_state,
+/turf/closed/indestructible/fakeglass,
 /area/centcom/basketball)
 "gk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/west{
-	base_state = "right";
-	icon_state = "right";
-	name = "Shooting Range";
-	dir = 4
-	},
-/obj/item/gun/ballistic/rifle/boltaction{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"gq" = (
-/mob/living/simple_animal/hostile/bear/fightpit,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/engine,
 /area/centcom/basketball)
-"gx" = (
+"gq" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 4
 	},
-/obj/effect/decal/cleanable/oil/streak,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/shard,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "hf" = (
 /obj/effect/turf_decal/plaque{
@@ -176,18 +137,32 @@
 /turf/open/floor/iron/large,
 /area/centcom/basketball)
 "kc" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/ballistic/rifle/boltaction{
-	pixel_y = 10
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"kp" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict5"
 	},
-/obj/machinery/door/window/left/directional/west{
-	base_state = "right";
-	icon_state = "right";
-	name = "Shooting Range"
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"ku" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"kF" = (
+/obj/structure/stairs/east,
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"kT" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
-"kp" = (
+"ly" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
 	base_state = "right";
@@ -201,38 +176,20 @@
 /obj/item/gun/ballistic/rifle/boltaction,
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
-"ku" = (
-/obj/structure/stairs/east,
-/turf/open/floor/iron,
-/area/centcom/basketball)
-"kT" = (
-/obj/structure/chair/stool/directional/south,
-/turf/open/floor/plating,
-/area/centcom/basketball)
-"ly" = (
-/obj/structure/table,
-/obj/item/ammo_box/a762,
-/obj/item/ammo_box/a762,
-/obj/item/ammo_box/a762,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
 "lD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/structure/stairs/east,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
 /area/centcom/basketball)
 "lR" = (
-/obj/structure/stairs/west,
-/turf/open/floor/iron,
+/obj/structure/training_machine,
+/obj/item/target/clown,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/engine,
 /area/centcom/basketball)
 "mp" = (
-/obj/structure/stairs/west,
-/obj/structure/sign/poster/random/directional/south,
-/turf/open/floor/iron/dark/small,
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/iron/large,
 /area/centcom/basketball)
 "my" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -242,29 +199,32 @@
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "mV" = (
-/obj/effect/turf_decal/tile/dark_red/full,
-/turf/open/floor/iron/large,
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "nE" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "nW" = (
-/obj/machinery/power/shuttle_engine/heater,
-/obj/effect/turf_decal/stripes/full,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "oh" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "derelict6"
+	icon_state = "derelict14"
 	},
 /turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "oR" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict10"
-	},
-/turf/open/floor/iron/dark/small,
+/obj/item/weldingtool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"pn" = (
+/obj/structure/stairs/west,
+/turf/open/floor/iron,
 /area/centcom/basketball)
 "pu" = (
 /obj/effect/turf_decal/stripes/line{
@@ -273,60 +233,76 @@
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "qU" = (
-/obj/structure/sign/poster/contraband/soviet_propaganda,
-/turf/closed/indestructible/fakeglass,
-/area/centcom/basketball)
-"rS" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "derelict8"
+	icon_state = "derelict10"
 	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
-"rU" = (
-/obj/machinery/power/shuttle_engine/large{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/centcom/basketball)
-"sb" = (
+"rS" = (
 /obj/structure/stairs/east,
 /turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
+"rU" = (
+/obj/item/crowbar,
+/turf/open/floor/catwalk_floor,
+/area/centcom/basketball)
+"sb" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/rifle/boltaction{
+	pixel_y = 5
+	},
+/obj/item/gun/ballistic/rifle/boltaction,
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	icon_state = "right";
+	name = "Shooting Range"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
 "su" = (
-/mob/living/simple_animal/hostile/bear/fightpit,
-/turf/open/floor/engine,
+/obj/item/pushbroom,
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "tO" = (
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "tU" = (
-/turf/open/floor/engine,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "tX" = (
 /turf/open/floor/iron,
 /area/centcom/basketball)
 "uH" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/small,
-/area/centcom/basketball)
-"uR" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict4"
-	},
-/turf/open/floor/iron/dark/small,
-/area/centcom/basketball)
-"uW" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "derelict16"
 	},
 /turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
-"vo" = (
+"uR" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"uW" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "derelict9"
+	icon_state = "derelict4"
 	},
 /turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"vo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"wt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
 /area/centcom/basketball)
 "wZ" = (
 /obj/machinery/pipedispenser,
@@ -347,12 +323,16 @@
 /turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "zy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/broken_bottle,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
 /area/centcom/basketball)
 "zZ" = (
-/obj/structure/chair/stool/directional/west,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "Ax" = (
@@ -362,9 +342,9 @@
 /area/centcom/basketball)
 "AC" = (
 /obj/effect/turf_decal/stripes/corner{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/utility/hardhat/orange,
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "AI" = (
@@ -377,14 +357,17 @@
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "Bd" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict12"
-	},
-/turf/open/floor/iron/dark/small,
+/obj/structure/table,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "BJ" = (
-/obj/structure/sign/poster/contraband/communist_state,
-/turf/closed/indestructible/fakeglass,
+/obj/machinery/power/shuttle_engine/large{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "Cv" = (
 /obj/effect/landmark/basketball/team_spawn/home_hoop,
@@ -441,7 +424,7 @@
 /area/centcom/basketball)
 "Gi" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/centcom/basketball)
@@ -449,14 +432,15 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/basketball)
 "HH" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict1"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "Ic" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
+/obj/structure/stairs/east,
+/turf/open/floor/iron,
 /area/centcom/basketball)
 "IA" = (
 /obj/effect/turf_decal/tile/dark_red/full,
@@ -464,23 +448,36 @@
 /turf/open/floor/iron/large,
 /area/centcom/basketball)
 "JM" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_y = 7
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"JW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/item/wrench,
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "KH" = (
-/obj/structure/stairs/west,
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict3"
+	},
 /turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "Lu" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/dark/small,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/stack/cable_coil{
+	amount = 15;
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/item/stack/cable_coil{
+	amount = 15
+	},
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "LI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -489,14 +486,15 @@
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "LS" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/item/clothing/head/utility/hardhat/orange,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/broken_bottle,
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "LU" = (
-/turf/open/floor/catwalk_floor,
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict12"
+	},
+/turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "LV" = (
 /obj/item/kirbyplants{
@@ -506,52 +504,54 @@
 /turf/open/floor/iron,
 /area/centcom/basketball)
 "Ma" = (
-/obj/structure/stairs/east,
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/iron,
-/area/centcom/basketball)
-"MS" = (
-/obj/machinery/mech_bay_recharge_port,
-/obj/effect/turf_decal/stripes/full,
-/turf/open/floor/plating,
-/area/centcom/basketball)
-"MW" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 7
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
+"MS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/training_machine,
+/obj/item/reagent_containers/cup/glass/trophy/silver_cup,
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"MW" = (
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/plating,
+/area/centcom/basketball)
 "Nt" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict5"
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/rifle/boltaction{
+	pixel_y = 10
 	},
-/turf/open/floor/iron/dark/small,
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	icon_state = "right";
+	name = "Shooting Range"
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "Oj" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict2"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/structure/stairs/west,
+/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "Om" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict3"
+/mob/living/simple_animal/hostile/bear/fightpit,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/small,
-/area/centcom/basketball)
-"OB" = (
-/obj/structure/training_machine,
-/obj/item/target/clown,
-/obj/effect/turf_decal/stripes/box,
+/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/engine,
 /area/centcom/basketball)
-"OO" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+"OB" = (
+/mob/living/simple_animal/hostile/bear/fightpit,
+/turf/open/floor/engine,
 /area/centcom/basketball)
 "PU" = (
 /obj/structure/table,
@@ -567,28 +567,26 @@
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "PW" = (
-/obj/item/weldingtool,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "guy"
+	},
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "Qa" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict1"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark/small,
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "Qh" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "derelict14"
+	icon_state = "derelict11"
 	},
 /turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "Qi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
+/obj/structure/sign/poster/contraband/soviet_propaganda,
+/turf/closed/indestructible/fakeglass,
 /area/centcom/basketball)
 "Ql" = (
 /obj/item/kirbyplants{
@@ -597,8 +595,16 @@
 /obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/iron,
 /area/centcom/basketball)
+"QR" = (
+/obj/structure/stairs/west,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
 "Rl" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/training_machine,
+/obj/item/reagent_containers/cup/glass/trophy/gold_cup{
+	pixel_x = 0
+	},
 /turf/open/floor/engine,
 /area/centcom/basketball)
 "Se" = (
@@ -607,47 +613,39 @@
 	},
 /turf/open/floor/engine,
 /area/centcom/basketball)
-"So" = (
-/obj/structure/table/reinforced/titaniumglass,
-/obj/item/storage/belt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/turf/open/floor/plating,
-/area/centcom/basketball)
 "Tc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/small,
+/turf/closed/indestructible/riveted/plastinum,
 /area/centcom/basketball)
 "TV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/engine,
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "cyka"
+	},
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "Uq" = (
-/turf/closed/indestructible/riveted/plastinum,
-/area/centcom/basketball)
-"Uv" = (
-/obj/structure/table,
-/obj/item/ammo_box/a762,
-/obj/item/ammo_box/a762,
-/obj/item/ammo_box/a762,
-/turf/open/floor/iron/dark,
-/area/centcom/basketball)
-"Uy" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "derelict11"
+	icon_state = "derelict2"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
-"Vr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"Uv" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"Uy" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/training_machine,
+/obj/item/reagent_containers/cup/glass/trophy/bronze_cup,
 /turf/open/floor/engine,
+/area/centcom/basketball)
+"Vr" = (
+/turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "WB" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -666,27 +664,35 @@
 /turf/closed/indestructible/riveted/plastinum,
 /area/centcom/basketball)
 "Xm" = (
-/obj/item/pushbroom,
-/turf/open/floor/plating,
+/obj/structure/table,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/basketball)
 "Xn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/crayon{
-	icon_state = "guy"
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "Xo" = (
-/obj/effect/turf_decal/plaque{
-	icon_state = "derelict7"
-	},
-/turf/open/floor/iron/dark/small,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/storage/belt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/open/floor/plating,
 /area/centcom/basketball)
 "YH" = (
-/obj/structure/training_machine,
-/obj/item/target/syndicate,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/small,
 /area/centcom/basketball)
 "YX" = (
 /obj/effect/turf_decal/tile/dark_red/full,
@@ -694,6 +700,16 @@
 /turf/open/floor/iron/large,
 /area/centcom/basketball)
 "ZM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	icon_state = "right";
+	name = "Shooting Range";
+	dir = 4
+	},
+/obj/item/gun/ballistic/rifle/boltaction{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/basketball)
 
@@ -730,21 +746,21 @@ tO
 tO
 tO
 tO
-Uq
-Uq
+Tc
+Tc
 WM
-Uq
-Uq
-Uq
-Uq
-Uq
-Uq
-Uq
-Uq
-Uq
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
 WM
-Uq
-Uq
+Tc
+Tc
 tO
 tO
 tO
@@ -757,8 +773,8 @@ tO
 tO
 tO
 tO
-Uq
-fi
+Tc
+dg
 tX
 tX
 WB
@@ -770,8 +786,8 @@ tX
 WB
 tX
 tX
-HH
-Uq
+fi
+Tc
 tO
 tO
 tO
@@ -784,7 +800,7 @@ tO
 tO
 tO
 tO
-Uq
+Tc
 tX
 tX
 tX
@@ -798,7 +814,7 @@ tX
 tX
 tX
 tX
-Uq
+Tc
 tO
 tO
 tO
@@ -808,12 +824,12 @@ Hu
 (5,1,1) = {"
 Hu
 tO
-Uq
-Uq
-Uq
-Uq
-Ma
-ku
+Tc
+Tc
+Tc
+Tc
+lD
+Ic
 AI
 Cw
 Cw
@@ -823,375 +839,375 @@ Cw
 Cw
 Cw
 AI
-sb
-fj
-Uq
-Uq
-Uq
-Uq
+rS
+kF
+Tc
+Tc
+Tc
+Tc
 tO
 Hu
 "}
 (6,1,1) = {"
 Hu
 tO
-Uq
-dr
+Tc
+Ma
 PU
-MW
-ZM
-ZM
+kT
+Vr
+Vr
 Cw
-mV
-mV
-mV
+mp
+mp
+mp
 Cv
-mV
-mV
-mV
+mp
+mp
+mp
 Cw
-dJ
-Lu
+eU
+Uv
 CV
 bA
-AC
-Uq
+zZ
+Tc
 tO
 Hu
 "}
 (7,1,1) = {"
 Hu
 tO
-Uq
-Uv
-aw
-ZM
-aw
-ZM
+Tc
+Bd
+gq
+Vr
+gq
+Vr
 Cw
-mV
+mp
 IA
-mV
-mV
-mV
+mp
+mp
+mp
 IA
-mV
+mp
 Cw
-dJ
-uH
+eU
+nW
 tO
-rU
-fB
-Uq
+BJ
+TV
+Tc
 tO
 Hu
 "}
 (8,1,1) = {"
 Hu
-Uq
-Uq
+Tc
+Tc
 nE
 Ev
 nE
 Ev
 nE
 Cw
-mV
+mp
 xP
 IA
 IA
 IA
-mV
-mV
+mp
+mp
 Cw
-vo
-Qa
+dS
+HH
 tO
 tO
-dC
-Uq
-Uq
+JW
+Tc
+Tc
 Hu
 "}
 (9,1,1) = {"
 Hu
+Tc
+Tc
+ly
+Cw
+ZM
+Cw
+ly
+Cw
+mp
+mp
+mp
+mp
+mp
+mp
+mp
+Cw
+qU
 Uq
-Uq
-kp
-Cw
-gk
-Cw
-kp
-Cw
-mV
-mV
-mV
-mV
-mV
-mV
-mV
-Cw
-oR
-Oj
 Gh
 Gh
 my
 cz
-Uq
+Tc
 Hu
 "}
 (10,1,1) = {"
 Hu
-Uq
+Tc
+dr
+Dt
+Dt
+Dt
+Dt
+wt
 Qi
-Dt
-Dt
-Dt
-Dt
+mp
+mp
+mp
+mp
+mp
+mp
+mp
+fB
+Qh
+KH
 be
-qU
-mV
-mV
-mV
-mV
-mV
-mV
-mV
-BJ
-Uy
-Om
-nW
-nW
-kT
-So
-Uq
+be
+uR
+Xo
+Tc
 Hu
 "}
 (11,1,1) = {"
 Hu
-Uq
-gq
-tU
-tU
-tU
-tU
-Rl
-qU
+Tc
+Om
+kc
+kc
+kc
+kc
+Uy
+Qi
+mp
+mp
+mp
+mp
+mp
+mp
+mp
+fB
+LU
+uW
 mV
-mV
-mV
-mV
-mV
-mV
-mV
-BJ
-Bd
-uR
-OO
 LI
-eS
+tU
 fu
-Uq
+Tc
 Hu
 "}
 (12,1,1) = {"
 Hu
-Uq
+Tc
 Se
+lR
+kc
+dJ
 OB
-tU
-YH
-su
 Rl
-qU
-mV
-mV
-mV
+Qi
+mp
+mp
+mp
 YX
-mV
-mV
-mV
-BJ
+mp
+mp
+mp
+fB
 zr
-Nt
-dS
+kp
+rU
 wZ
-LU
+eS
 Ax
-Uq
+Tc
 Hu
 "}
 (13,1,1) = {"
 Hu
-Uq
-TV
-tU
-su
-tU
-tU
-Rl
-qU
-mV
-mV
-mV
-mV
-mV
-mV
-mV
-BJ
-Qh
+Tc
+gk
+kc
+OB
+kc
+kc
+MS
+Qi
+mp
+mp
+mp
+mp
+mp
+mp
+mp
+fB
 oh
-Xn
-zy
-Xm
+aE
+PW
+LS
+su
 AU
-Uq
+Tc
 Hu
 "}
 (14,1,1) = {"
 Hu
-Uq
+Tc
+JM
 Gi
-Vr
-Vr
-Vr
-Vr
-Ic
-qU
-mV
-mV
-mV
-mV
-mV
-mV
-mV
-BJ
+Gi
+Gi
+Gi
+zy
+Qi
+mp
+mp
+mp
+mp
+mp
+mp
+mp
+fB
 hf
-Xo
-PW
+dC
+oR
 hB
-kT
-aE
-Uq
+uR
+Lu
+Tc
 Hu
 "}
 (15,1,1) = {"
 Hu
-Uq
-Uq
+Tc
+Tc
 Cw
-dg
+sb
 Cw
-kc
+Nt
 Cw
 Cw
-mV
-mV
-mV
-mV
-mV
-mV
-mV
+mp
+mp
+mp
+mp
+mp
+mp
+mp
 Cw
-uW
-rS
+uH
+YH
 WK
 WK
-AC
 zZ
-Uq
+MW
+Tc
 Hu
 "}
 (16,1,1) = {"
 Hu
-Uq
-Uq
+Tc
+Tc
 Ev
 nE
 Ev
 nE
 Ev
 Cw
-mV
-mV
+mp
+mp
 jr
 jr
 jr
-mV
-mV
+mp
+mp
 Cw
-dJ
-uH
-MS
-MS
-lD
-Uq
-Uq
+eU
+nW
+Qa
+Qa
+fj
+Tc
+Tc
 Hu
 "}
 (17,1,1) = {"
 Hu
 tO
-Uq
-ly
-ZM
+Tc
+aw
+Vr
 pu
-ZM
+Vr
 pu
 Cw
-mV
+mp
 jr
-mV
-mV
-mV
+mp
+mp
+mp
 jr
-mV
+mp
 Cw
-dJ
-uH
 eU
-eU
-lD
-Uq
+nW
+Xn
+Xn
+fj
+Tc
 tO
 Hu
 "}
 (18,1,1) = {"
 Hu
 tO
-Uq
-JM
-dM
-MW
-ZM
-ZM
-Cw
-mV
-mV
-mV
-DP
-mV
-mV
-mV
-Cw
-dJ
 Tc
-gx
+Xm
+dM
+kT
+Vr
+Vr
+Cw
+mp
+mp
+mp
+DP
+mp
+mp
+mp
+Cw
+eU
+ku
+vo
 CD
-LS
-Uq
+AC
+Tc
 tO
 Hu
 "}
 (19,1,1) = {"
 Hu
 tO
-Uq
-Uq
-Uq
-Uq
+Tc
+Tc
+Tc
+Tc
 at
-lR
+pn
 AI
 Cw
 Cw
@@ -1201,12 +1217,12 @@ Cw
 Cw
 Cw
 AI
-KH
-mp
-Uq
-Uq
-Uq
-Uq
+QR
+Oj
+Tc
+Tc
+Tc
+Tc
 tO
 Hu
 "}
@@ -1216,7 +1232,7 @@ tO
 tO
 tO
 tO
-Uq
+Tc
 tX
 tX
 tX
@@ -1230,7 +1246,7 @@ tX
 tX
 tX
 tX
-Uq
+Tc
 tO
 tO
 tO
@@ -1243,8 +1259,8 @@ tO
 tO
 tO
 tO
-Uq
-HH
+Tc
+fi
 tX
 tX
 jj
@@ -1256,8 +1272,8 @@ tX
 jj
 tX
 tX
-fi
-Uq
+dg
+Tc
 tO
 tO
 tO
@@ -1270,21 +1286,21 @@ tO
 tO
 tO
 tO
-Uq
-Uq
+Tc
+Tc
 WM
-Uq
-Uq
-Uq
-Uq
-Uq
-Uq
-Uq
-Uq
-Uq
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
+Tc
 WM
-Uq
-Uq
+Tc
+Tc
 tO
 tO
 tO

--- a/_maps/map_files/Basketball/soviet_bear.dmm
+++ b/_maps/map_files/Basketball/soviet_bear.dmm
@@ -105,11 +105,8 @@
 /turf/closed/indestructible/fakeglass,
 /area/centcom/basketball)
 "gk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/engine,
+/obj/structure/sign/warning/firing_range,
+/turf/closed/indestructible/riveted/plastinum,
 /area/centcom/basketball)
 "gq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -546,7 +543,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/engine,
 /area/centcom/basketball)
 "OB" = (
@@ -938,7 +934,7 @@ Cw
 ZM
 Cw
 ly
-Cw
+Qi
 mp
 mp
 mp
@@ -946,7 +942,7 @@ mp
 mp
 mp
 mp
-Cw
+fB
 qU
 Uq
 Gh
@@ -965,7 +961,7 @@ Dt
 Dt
 Dt
 wt
-Qi
+Cw
 mp
 mp
 mp
@@ -973,7 +969,7 @@ mp
 mp
 mp
 mp
-fB
+Cw
 Qh
 KH
 be
@@ -985,14 +981,14 @@ Hu
 "}
 (11,1,1) = {"
 Hu
-Tc
+gk
 Om
 kc
 kc
 kc
 kc
 Uy
-Qi
+Cw
 mp
 mp
 mp
@@ -1000,7 +996,7 @@ mp
 mp
 mp
 mp
-fB
+Cw
 LU
 uW
 mV
@@ -1019,7 +1015,7 @@ kc
 dJ
 OB
 Rl
-Qi
+Cw
 mp
 mp
 mp
@@ -1027,7 +1023,7 @@ YX
 mp
 mp
 mp
-fB
+Cw
 zr
 kp
 rU
@@ -1039,14 +1035,14 @@ Hu
 "}
 (13,1,1) = {"
 Hu
-Tc
 gk
+Se
 kc
 OB
 kc
 kc
 MS
-Qi
+Cw
 mp
 mp
 mp
@@ -1054,7 +1050,7 @@ mp
 mp
 mp
 mp
-fB
+Cw
 oh
 aE
 PW
@@ -1073,7 +1069,7 @@ Gi
 Gi
 Gi
 zy
-Qi
+Cw
 mp
 mp
 mp
@@ -1081,7 +1077,7 @@ mp
 mp
 mp
 mp
-fB
+Cw
 hf
 dC
 oR
@@ -1100,7 +1096,7 @@ sb
 Cw
 Nt
 Cw
-Cw
+Qi
 mp
 mp
 mp
@@ -1108,7 +1104,7 @@ mp
 mp
 mp
 mp
-Cw
+fB
 uH
 YH
 WK

--- a/_maps/map_files/Basketball/soviet_bear.dmm
+++ b/_maps/map_files/Basketball/soviet_bear.dmm
@@ -1,0 +1,1320 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"at" = (
+/obj/structure/stairs/west,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"aw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"aE" = (
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/stack/cable_coil{
+	amount = 15;
+	pixel_x = 5;
+	pixel_y = 12
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/item/stack/cable_coil{
+	amount = 15
+	},
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"be" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"bA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/item/lead_pipe,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"cz" = (
+/obj/structure/chair/stool/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"dg" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/rifle/boltaction{
+	pixel_y = 5
+	},
+/obj/item/gun/ballistic/rifle/boltaction,
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	icon_state = "right";
+	name = "Shooting Range"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"dr" = (
+/obj/structure/table,
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 7
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"dC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/wrench,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"dJ" = (
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"dM" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/bottle/vodka,
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -10;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"dS" = (
+/obj/item/crowbar,
+/turf/open/floor/catwalk_floor,
+/area/centcom/basketball)
+"eS" = (
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"eU" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"fi" = (
+/obj/machinery/vending/sovietsoda,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"fj" = (
+/obj/structure/stairs/east,
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"fu" = (
+/obj/structure/table/reinforced/titaniumglass,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"fB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "cyka"
+	},
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"gk" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	icon_state = "right";
+	name = "Shooting Range";
+	dir = 4
+	},
+/obj/item/gun/ballistic/rifle/boltaction{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"gq" = (
+/mob/living/simple_animal/hostile/bear/fightpit,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"gx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"hf" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict15"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"hB" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"jj" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"jr" = (
+/obj/effect/turf_decal/tile/dark_red/full,
+/obj/effect/landmark/basketball/team_spawn/away,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"kc" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/rifle/boltaction{
+	pixel_y = 10
+	},
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	icon_state = "right";
+	name = "Shooting Range"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"kp" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/west{
+	base_state = "right";
+	icon_state = "right";
+	name = "Shooting Range";
+	dir = 4
+	},
+/obj/item/gun/ballistic/rifle/boltaction{
+	pixel_y = 10
+	},
+/obj/item/gun/ballistic/rifle/boltaction,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"ku" = (
+/obj/structure/stairs/east,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"kT" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"ly" = (
+/obj/structure/table,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"lD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"lR" = (
+/obj/structure/stairs/west,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"mp" = (
+/obj/structure/stairs/west,
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"my" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"mV" = (
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"nE" = (
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"nW" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"oh" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict6"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"oR" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict10"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"pu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"qU" = (
+/obj/structure/sign/poster/contraband/soviet_propaganda,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
+"rS" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict8"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"rU" = (
+/obj/machinery/power/shuttle_engine/large{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"sb" = (
+/obj/structure/stairs/east,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"su" = (
+/mob/living/simple_animal/hostile/bear/fightpit,
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"tO" = (
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"tU" = (
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"tX" = (
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"uH" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"uR" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict4"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"uW" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict16"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"vo" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict9"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"wZ" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/catwalk_floor,
+/area/centcom/basketball)
+"xP" = (
+/obj/effect/turf_decal/tile/dark_red/full,
+/obj/effect/decal/hammerandsickle{
+	pixel_y = -42
+	},
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"zr" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict13"
+	},
+/obj/effect/landmark/basketball/team_spawn/referee,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"zy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/broken_bottle,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"zZ" = (
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"Ax" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/catwalk_floor,
+/area/centcom/basketball)
+"AC" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"AI" = (
+/obj/machinery/status_display,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
+"AU" = (
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/clothing/head/utility/welding,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"Bd" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict12"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"BJ" = (
+/obj/structure/sign/poster/contraband/communist_state,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
+"Cv" = (
+/obj/effect/landmark/basketball/team_spawn/home_hoop,
+/obj/structure/hoop/minigame{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"Cw" = (
+/turf/closed/indestructible/fakeglass,
+/area/centcom/basketball)
+"CD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"CV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"Dt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"DP" = (
+/obj/effect/landmark/basketball/team_spawn/away_hoop,
+/obj/structure/hoop/minigame{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/dark_red/full,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"Ev" = (
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Gh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"Gi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"Hu" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/basketball)
+"HH" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"Ic" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"IA" = (
+/obj/effect/turf_decal/tile/dark_red/full,
+/obj/effect/landmark/basketball/team_spawn/home,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"JM" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"KH" = (
+/obj/structure/stairs/west,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"Lu" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"LI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"LS" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/clothing/head/utility/hardhat/orange,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"LU" = (
+/turf/open/floor/catwalk_floor,
+/area/centcom/basketball)
+"LV" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/structure/sign/poster/random/directional/west,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"Ma" = (
+/obj/structure/stairs/east,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"MS" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"MW" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Nt" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict5"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"Oj" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict2"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"Om" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict3"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"OB" = (
+/obj/structure/training_machine,
+/obj/item/target/clown,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"OO" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"PU" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/bottle/vodka{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/cup/glass/bottle/vodka{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass,
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"PW" = (
+/obj/item/weldingtool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"Qa" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict1"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"Qh" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict14"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"Qi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"Ql" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-22"
+	},
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"Rl" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"Se" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"So" = (
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/storage/belt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"Tc" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"TV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"Uq" = (
+/turf/closed/indestructible/riveted/plastinum,
+/area/centcom/basketball)
+"Uv" = (
+/obj/structure/table,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/obj/item/ammo_box/a762,
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+"Uy" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict11"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"Vr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"WB" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/iron,
+/area/centcom/basketball)
+"WK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/power/shuttle_engine/heater,
+/obj/effect/turf_decal/stripes/full,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"WM" = (
+/obj/structure/sign/poster/contraband/kss13,
+/turf/closed/indestructible/riveted/plastinum,
+/area/centcom/basketball)
+"Xm" = (
+/obj/item/pushbroom,
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"Xn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "guy"
+	},
+/turf/open/floor/plating,
+/area/centcom/basketball)
+"Xo" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "derelict7"
+	},
+/turf/open/floor/iron/dark/small,
+/area/centcom/basketball)
+"YH" = (
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/engine,
+/area/centcom/basketball)
+"YX" = (
+/obj/effect/turf_decal/tile/dark_red/full,
+/obj/item/toy/basketball,
+/turf/open/floor/iron/large,
+/area/centcom/basketball)
+"ZM" = (
+/turf/open/floor/iron/dark,
+/area/centcom/basketball)
+
+(1,1,1) = {"
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+"}
+(2,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+Uq
+Uq
+WM
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+WM
+Uq
+Uq
+tO
+tO
+tO
+tO
+Hu
+"}
+(3,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+Uq
+fi
+tX
+tX
+WB
+tX
+tX
+LV
+tX
+tX
+WB
+tX
+tX
+HH
+Uq
+tO
+tO
+tO
+tO
+Hu
+"}
+(4,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+Uq
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+Uq
+tO
+tO
+tO
+tO
+Hu
+"}
+(5,1,1) = {"
+Hu
+tO
+Uq
+Uq
+Uq
+Uq
+Ma
+ku
+AI
+Cw
+Cw
+Cw
+Cw
+Cw
+Cw
+Cw
+AI
+sb
+fj
+Uq
+Uq
+Uq
+Uq
+tO
+Hu
+"}
+(6,1,1) = {"
+Hu
+tO
+Uq
+dr
+PU
+MW
+ZM
+ZM
+Cw
+mV
+mV
+mV
+Cv
+mV
+mV
+mV
+Cw
+dJ
+Lu
+CV
+bA
+AC
+Uq
+tO
+Hu
+"}
+(7,1,1) = {"
+Hu
+tO
+Uq
+Uv
+aw
+ZM
+aw
+ZM
+Cw
+mV
+IA
+mV
+mV
+mV
+IA
+mV
+Cw
+dJ
+uH
+tO
+rU
+fB
+Uq
+tO
+Hu
+"}
+(8,1,1) = {"
+Hu
+Uq
+Uq
+nE
+Ev
+nE
+Ev
+nE
+Cw
+mV
+xP
+IA
+IA
+IA
+mV
+mV
+Cw
+vo
+Qa
+tO
+tO
+dC
+Uq
+Uq
+Hu
+"}
+(9,1,1) = {"
+Hu
+Uq
+Uq
+kp
+Cw
+gk
+Cw
+kp
+Cw
+mV
+mV
+mV
+mV
+mV
+mV
+mV
+Cw
+oR
+Oj
+Gh
+Gh
+my
+cz
+Uq
+Hu
+"}
+(10,1,1) = {"
+Hu
+Uq
+Qi
+Dt
+Dt
+Dt
+Dt
+be
+qU
+mV
+mV
+mV
+mV
+mV
+mV
+mV
+BJ
+Uy
+Om
+nW
+nW
+kT
+So
+Uq
+Hu
+"}
+(11,1,1) = {"
+Hu
+Uq
+gq
+tU
+tU
+tU
+tU
+Rl
+qU
+mV
+mV
+mV
+mV
+mV
+mV
+mV
+BJ
+Bd
+uR
+OO
+LI
+eS
+fu
+Uq
+Hu
+"}
+(12,1,1) = {"
+Hu
+Uq
+Se
+OB
+tU
+YH
+su
+Rl
+qU
+mV
+mV
+mV
+YX
+mV
+mV
+mV
+BJ
+zr
+Nt
+dS
+wZ
+LU
+Ax
+Uq
+Hu
+"}
+(13,1,1) = {"
+Hu
+Uq
+TV
+tU
+su
+tU
+tU
+Rl
+qU
+mV
+mV
+mV
+mV
+mV
+mV
+mV
+BJ
+Qh
+oh
+Xn
+zy
+Xm
+AU
+Uq
+Hu
+"}
+(14,1,1) = {"
+Hu
+Uq
+Gi
+Vr
+Vr
+Vr
+Vr
+Ic
+qU
+mV
+mV
+mV
+mV
+mV
+mV
+mV
+BJ
+hf
+Xo
+PW
+hB
+kT
+aE
+Uq
+Hu
+"}
+(15,1,1) = {"
+Hu
+Uq
+Uq
+Cw
+dg
+Cw
+kc
+Cw
+Cw
+mV
+mV
+mV
+mV
+mV
+mV
+mV
+Cw
+uW
+rS
+WK
+WK
+AC
+zZ
+Uq
+Hu
+"}
+(16,1,1) = {"
+Hu
+Uq
+Uq
+Ev
+nE
+Ev
+nE
+Ev
+Cw
+mV
+mV
+jr
+jr
+jr
+mV
+mV
+Cw
+dJ
+uH
+MS
+MS
+lD
+Uq
+Uq
+Hu
+"}
+(17,1,1) = {"
+Hu
+tO
+Uq
+ly
+ZM
+pu
+ZM
+pu
+Cw
+mV
+jr
+mV
+mV
+mV
+jr
+mV
+Cw
+dJ
+uH
+eU
+eU
+lD
+Uq
+tO
+Hu
+"}
+(18,1,1) = {"
+Hu
+tO
+Uq
+JM
+dM
+MW
+ZM
+ZM
+Cw
+mV
+mV
+mV
+DP
+mV
+mV
+mV
+Cw
+dJ
+Tc
+gx
+CD
+LS
+Uq
+tO
+Hu
+"}
+(19,1,1) = {"
+Hu
+tO
+Uq
+Uq
+Uq
+Uq
+at
+lR
+AI
+Cw
+Cw
+Cw
+Cw
+Cw
+Cw
+Cw
+AI
+KH
+mp
+Uq
+Uq
+Uq
+Uq
+tO
+Hu
+"}
+(20,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+Uq
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+tX
+Uq
+tO
+tO
+tO
+tO
+Hu
+"}
+(21,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+Uq
+HH
+tX
+tX
+jj
+tX
+tX
+Ql
+tX
+tX
+jj
+tX
+tX
+fi
+Uq
+tO
+tO
+tO
+tO
+Hu
+"}
+(22,1,1) = {"
+Hu
+tO
+tO
+tO
+tO
+Uq
+Uq
+WM
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+WM
+Uq
+Uq
+tO
+tO
+tO
+tO
+Hu
+"}
+(23,1,1) = {"
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+Hu
+"}

--- a/code/modules/basketball/basketball_map_loading.dm
+++ b/code/modules/basketball/basketball_map_loading.dm
@@ -69,3 +69,17 @@
 	mappath = "_maps/map_files/basketball/greytide_worldwide.dmm"
 	team_name = "Greytide Worldwide"
 	home_team_uniform = /datum/outfit/basketball/greytide_worldwide
+
+/datum/map_template/basketball/ass_blast_usa
+	name = "Ass Blast USA Stadium"
+	description = "The homecourt of the Ass Blast USA."
+	mappath = "_maps/map_files/basketball/ass_blast_usa.dmm"
+	team_name = "Ass Blast USA"
+	home_team_uniform = /datum/outfit/basketball/ass_blast_usa
+
+/datum/map_template/basketball/soviet_bears
+	name = "Soviet Bears Stadium"
+	description = "The homecourt of the Soviet Bears."
+	mappath = "_maps/map_files/basketball/soviet_bears.dmm"
+	team_name = "Soviet Bears"
+	home_team_uniform = /datum/outfit/basketball/soviet_bears

--- a/code/modules/basketball/basketball_teams.dm
+++ b/code/modules/basketball/basketball_teams.dm
@@ -93,3 +93,16 @@
 	idcard.registered_name = "Alien ([hive_num])"
 	idcard.update_label()
 	idcard.update_icon()
+
+/datum/outfit/basketball/ass_blast_usa
+	name = "Basketball Ass Blast USA"
+	uniform = /obj/item/clothing/under/misc/patriotsuit
+	shoes = /obj/item/clothing/shoes/sneakers/red
+	neck = /obj/item/bedsheet/patriot
+
+/datum/outfit/basketball/soviet_bears
+	name = "Basketball Soviet Bears"
+	uniform = /obj/item/clothing/under/costume/soviet
+	shoes = /obj/item/clothing/shoes/winterboots
+	head = /obj/item/clothing/head/costume/ushanka
+	gloves = /obj/item/clothing/gloves/color/brown


### PR DESCRIPTION
## About The Pull Request
Wanted to show new mappers how to easy it is to create basketball stadiums and teams.  The idea is to get more people involved in creating content similar to how CTF has had lots of people work on it.

These are the two new basketball teams and stadiums:

![dreamseeker_eooR3MZK2o](https://user-images.githubusercontent.com/5195984/228235162-fde2755d-fc50-4854-9b98-76ee538d4a32.png)

<details>
<summary>Ass Blast USA</summary>

![StrongDMM_yRkstkGlXd](https://user-images.githubusercontent.com/5195984/228399970-94b5a86b-8f07-4f1a-85fb-7beb0be6a79c.png)

</details>

<details>
<summary>Soviet Bears</summary>

![StrongDMM_xxm1FaPqMl](https://user-images.githubusercontent.com/5195984/228399902-ef345d54-622b-4247-8147-b7c1f8f7b3bb.png)

</details>

## Why It's Good For The Game
More teams equals more variety.

## Changelog
:cl:
add: Add two new basketball teams and stadiums - Ass Blast USA and Soviet Bears
/:cl:
