### PR TITLE
[NO GBP] Remove fuel tank from greytide worldwide stadium

### DIFF
--- a/_maps/map_files/Basketball/greytide_worldwide.dmm
+++ b/_maps/map_files/Basketball/greytide_worldwide.dmm
@@ -623,12 +623,6 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/basketball)
-"Sv" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/centcom/basketball)
 "SF" = (
 /mob/living/basic/cockroach,
 /turf/open/floor/plating,
@@ -1165,7 +1159,7 @@ Hu
 WM
 WM
 at
-Sv
+uW
 Vr
 lh
 Ev


### PR DESCRIPTION
## About The Pull Request
Fixes #74286

I thought the floors were indestructible on the Centcomm z-level but I was wrong.

## Why It's Good For The Game
More stability.

## Changelog
:cl:
fix: Fix Greytide Worldwide basketball stadium being able to explode from a fuel tank
/:cl:
