### PR TITLE
Fixes cycler shotgun using 64x64 sprite for inhands

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -72,6 +72,8 @@
 	inhand_icon_state = "bulldog"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
+	inhand_x_dimension = 32
+	inhand_y_dimension = 32
 	worn_icon_state = "cshotgun"
 	w_class = WEIGHT_CLASS_HUGE
 	semi_auto = TRUE


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. Setting this back to 32x32 fixes the awkwardly floating off to the side inhand sprite for these guns.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/16838

## Why It's Good For The Game

Bugfix

## Changelog

<details>
<summary>From this</summary>
  
![image](https://user-images.githubusercontent.com/13398309/228412774-4ba6447d-332a-4a07-b417-681b4c6632d6.png)

</details>

<details>
<summary>To this</summary>
  
![dreamseeker_znDdYBHocq](https://user-images.githubusercontent.com/13398309/228413267-94aa5576-d0e1-40bd-8e6f-5c3eec57f095.gif)

</details>

:cl:
fix: cycler shotguns' inhand sprites will no longer float ominously by their wielder's side
/:cl:
