### PR TITLE
Adds particles to sleeping mobs (zzz)

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -134,12 +134,15 @@
 		tick_interval = -1
 	RegisterSignal(owner, SIGNAL_ADDTRAIT(TRAIT_SLEEPIMMUNE), PROC_REF(on_owner_insomniac))
 	RegisterSignal(owner, SIGNAL_REMOVETRAIT(TRAIT_SLEEPIMMUNE), PROC_REF(on_owner_sleepy))
+	owner.particles = new /particles/sleeping_zs
+	owner.particles.position = list(8, 12, ABOVE_MOB_LAYER)
 
 /datum/status_effect/incapacitating/sleeping/on_remove()
 	UnregisterSignal(owner, list(SIGNAL_ADDTRAIT(TRAIT_SLEEPIMMUNE), SIGNAL_REMOVETRAIT(TRAIT_SLEEPIMMUNE)))
 	if(!HAS_TRAIT(owner, TRAIT_SLEEPIMMUNE))
 		REMOVE_TRAIT(owner, TRAIT_KNOCKEDOUT, TRAIT_STATUS_EFFECT(id))
 		tick_interval = initial(tick_interval)
+	owner.particles = null
 	return ..()
 
 ///If the mob is sleeping and gain the TRAIT_SLEEPIMMUNE we remove the TRAIT_KNOCKEDOUT and stop the tick() from happening

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -365,6 +365,19 @@
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 	stat_allowed = UNCONSCIOUS
 
+/datum/emote/living/snore/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(. && isliving(user))
+		var/mob/living/emoter = user
+		emoter.particles = new /particles/sleeping_zs
+		emoter.particles.position = list(8, 12, ABOVE_MOB_LAYER)
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(remove_sleepy), emoter), 5 SECONDS)
+
+/proc/remove_sleepy(mob/living/user)
+	// If we're still sleeping, don't remove the particles
+	if(!HAS_TRAIT(user, TRAIT_KNOCKEDOUT))
+		user.particles = null
+
 /datum/emote/living/stare
 	key = "stare"
 	key_third_person = "stares"

--- a/code/modules/mob/living/sleep_particles.dm
+++ b/code/modules/mob/living/sleep_particles.dm
@@ -1,0 +1,16 @@
+/particles/sleeping_zs
+	icon = 'icons/effects/particles/notes/note_sleepy.dmi'
+	icon_state = list(
+		"sleepy_9" = 1,
+	)
+	width = 100
+	height = 100
+	count = 10
+	spawning = 0.05
+	lifespan = 0.7 SECONDS
+	fade = 1 SECONDS
+	grow = -0.01
+	velocity = list(0, 0)
+	position = generator(GEN_CIRCLE, 0, 16, NORMAL_RAND)
+	drift = generator(GEN_VECTOR, list(0, -0.2), list(0, 0.2))
+	gravity = list(0, 0.5)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3785,6 +3785,7 @@
 #include "code\modules\mob\living\login.dm"
 #include "code\modules\mob\living\logout.dm"
 #include "code\modules\mob\living\navigation.dm"
+#include "code\modules\mob\living\sleep_particles.dm"
 #include "code\modules\mob\living\status_procs.dm"
 #include "code\modules\mob\living\taste.dm"
 #include "code\modules\mob\living\ventcrawling.dm"


### PR DESCRIPTION
## About The Pull Request
https://user-images.githubusercontent.com/66640614/228422600-0696defc-eb11-46e9-bd84-1a2500cded34.mp4

Adds floating particles to sleeping humanoids.

Snore emoting will also give you these particles temporarily!

## Why It's Good For The Game
It's a cute visual that communicates a status condition

## Changelog
:cl: Tattle
add: Sleeping mobs now have zzzs when they take a nap
/:cl:
