### PR TITLE
Re-fixes gem room brain shennanigans.

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -40,22 +40,9 @@
 	var/max_skillchip_slots = 5
 
 /obj/item/organ/internal/brain/Insert(mob/living/carbon/brain_owner, special = FALSE, drop_if_replaced = TRUE, no_id_transfer = FALSE)
-	// Take a snapshot of what the brain was formerly contained in.
-	// We do some special logic after the parent call if the brain_holder was a head bodypart.
-	var/brain_holder = loc
-
 	. = ..()
 	if(!.)
 		return
-
-	// We're doing a transfer from a head to a mob. This is usually stuff like reattaching dismembered/amputated heads.
-	if(istype(brain_holder, /obj/item/bodypart/head))
-		var/obj/item/bodypart/head/last_head = loc
-		if(last_head.brainmob)
-			brainmob = last_head.brainmob
-			last_head.brainmob = null
-			brainmob.container = null
-			brainmob.forceMove(src)
 
 	name = initial(name)
 
@@ -100,6 +87,20 @@
 
 	//Update the body's icon so it doesnt appear debrained anymore
 	brain_owner.update_body_parts()
+
+/obj/item/organ/internal/brain/on_insert(mob/living/carbon/organ_owner, special)
+	// Are we inserting into a new mob from a head?
+	// If yes, we want to quickly steal the brainmob from the head before we do anything else.
+	// This is usually stuff like reattaching dismembered/amputated heads.
+	if(istype(loc, /obj/item/bodypart/head))
+		var/obj/item/bodypart/head/brain_holder = loc
+		if(brain_holder.brainmob)
+			brainmob = brain_holder.brainmob
+			brain_holder.brainmob = null
+			brainmob.container = null
+			brainmob.forceMove(src)
+
+	return ..()
 
 /obj/item/organ/internal/brain/Remove(mob/living/carbon/brain_owner, special = 0, no_id_transfer = FALSE)
 	// Delete skillchips first as parent proc sets owner to null, and skillchips need to know the brain's owner.


### PR DESCRIPTION

## About The Pull Request

Fixes #74326

Did a little uwupsie in #74227 - While writing up the PR body, I moved around some tested code to better follow the logic flow of the procs. And in the process that tested code was now in an untested position.

Parent call from `/obj/item/organ/internal/brain/Insert()` to `/obj/item/organ/proc/Insert()` calls the `/obj/item/organ/proc/on_insert()` proc.

This proc moves the organ to nullspace immediately.

So one of my commits moving the brain loc check from pre-parent call to post-parent call meant the entire system broke, because the brain was moved to nullspace and lost any reference to its former head.

Since `on_insert()` is the proc that handles moving the brain to nullspace, and is a proc only run when an insert is successful, I can sneak the code moving the brainmob from the head bodypart back into the brain on the brain's `on_insert()` before the parent call.

This broadly makes the order of operations:
Attempt to insert brain, calling `Insert()`
If successful, call `on_insert()` as parent of parent proc call chain.
In `on_insert()`, set the brain's state up for the brainmob properly.
Back up the chain for the brain's child proc of `Insert()` all the code now works properly because the brainmob's state was set up from `on_insert()` which has to have been called already to reach this point.

The rest of that code still needs to sit in `/obj/item/organ/internal/brain/Insert()` for now. This is because the key transfer portion has to be preceded by the "is the target body a ling?" code. This code relies on the bespoke `no_id_transfer` param on `/obj/item/organ/internal/brain/Insert()` and fussing around with adding a brain-specific param to the base `/obj/item/organ/proc/Insert(mob/living/carbon/receiver, special = FALSE, drop_if_replaced = TRUE)` proc is OOP gone wild.

Honestly, the entire thing needs a refactor but don't nobody got the time to do that.

In testing I sheared a person's head off and reattached it via surgery a few times. It worked. Ghosted out before surgery and could re-enter body. DC'ed after having head cut off and could still re-enter body. Seems to work.
## Why It's Good For The Game

Feeeeeeeeex.
## Changelog
:cl:
fix: Actually fixes re-attaching heads unintentionally sending brains to the gem room this time. For realsies.
/:cl:
