### PR TITLE
Fixes ntnet circuits

### DIFF
--- a/code/modules/wiremod/components/ntnet/ntnet_send.dm
+++ b/code/modules/wiremod/components/ntnet/ntnet_send.dm
@@ -35,4 +35,4 @@
 /obj/item/circuit_component/ntnet_send/input_received(datum/port/input/port)
 	if(!find_functional_ntnet_relay())
 		return
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CIRCUIT_NTNET_DATA_SENT, src, list("data" = data_package.value, "enc_key" = enc_key.value, "port" = WEAKREF(data_package)))
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CIRCUIT_NTNET_DATA_SENT, list("data" = data_package.value, "enc_key" = enc_key.value, "port" = WEAKREF(data_package)))


### PR DESCRIPTION
## About The Pull Request

I underestimated SEND_GLOBAL_SIGNAL and assumed it worked differently to SEND_SIGNAL, as in I thought it would not be sending the source as the first arg.
Because it does, it meant that the list of data was actually just ntnet sending circuit. This fixes it and makes the args work properly.

I've shamelessly stolen the circuit in the screenshot of the issue to test it in-game
![image](https://user-images.githubusercontent.com/53777086/228451819-4ffdb2e4-542e-46c1-9947-6266d8550f4a.png)

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/74327

## Changelog

:cl:
fix: NtNet receive/send circuits should work now.
/:cl: