### PR TITLE
Fugitive backstories are now selected with consideration to the number of signups

### DIFF
--- a/code/__DEFINES/events.dm
+++ b/code/__DEFINES/events.dm
@@ -42,3 +42,10 @@
 #define EVENT_PLANETARY_ONLY (1 << 1)
 /// Event timer in seconds
 #define EVENT_SECONDS *0.5
+
+///Backstory key for the fugitive solo backstory
+#define FUGITIVE_BACKSTORY_WALDO "waldo"
+///Backstory keys for the fugitive team backstories
+#define FUGITIVE_BACKSTORY_PRISONER "prisoner"
+#define FUGITIVE_BACKSTORY_CULTIST "cultist"
+#define FUGITIVE_BACKSTORY_SYNTH "synth"

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -52,18 +52,18 @@
 	backstory = back_story
 	var/message = "<span class='warningplain'>"
 	switch(backstory)
-		if("prisoner")
+		if(FUGITIVE_BACKSTORY_PRISONER)
 			message += "<BR><B>I can't believe we managed to break out of a Nanotrasen superjail! Sadly though, our work is not done. The emergency teleport at the station logs everyone who uses it, and where they went.</B>"
 			message += "<BR><B>It won't be long until CentCom tracks where we've gone off to. I need to work with my fellow escapees to prepare for the troops Nanotrasen is sending, I'm not going back.</B>"
-		if("cultist")
+		if(FUGITIVE_BACKSTORY_CULTIST)
 			message += "<BR><B>Blessed be our journey so far, but I fear the worst has come to our doorstep, and only those with the strongest faith will survive.</B>"
 			message += "<BR><B>Our religion has been repeatedly culled by Nanotrasen because it is categorized as an \"Enemy of the Corporation\", whatever that means.</B>"
 			message += "<BR><B>Now there are only four of us left, and Nanotrasen is coming. When will our god show itself to save us from this hellish station?!</B>"
-		if("waldo")
+		if(FUGITIVE_BACKSTORY_WALDO)
 			message += "<BR><B>Hi, Friends!</B>"
 			message += "<BR><B>My name is Waldo. I'm just setting off on a galaxywide hike. You can come too. All you have to do is find me.</B>"
 			message += "<BR><B>By the way, I'm not traveling on my own. wherever I go, there are lots of other characters for you to spot. First find the people trying to capture me! They're somewhere around the station!</B>"
-		if("synth")
+		if(FUGITIVE_BACKSTORY_SYNTH)
 			message += "<BR>[span_danger("ALERT: Wide-range teleport has scrambled primary systems.")]"
 			message += "<BR>[span_danger("Initiating diagnostics...")]"
 			message += "<BR>[span_danger("ERROR ER0RR $R0RRO$!R41.%%!! loaded.")]"

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -24,13 +24,13 @@
 	var/turf/landing_turf = pick(possible_spawns)
 	var/list/possible_backstories = list()
 	var/list/candidates = get_candidates(ROLE_FUGITIVE, ROLE_FUGITIVE)
-	if(candidates.len >= 1) //solo refugees
-		if(prob(30))
-			possible_backstories.Add("waldo") //less common as it comes with magicks and is kind of immershun shattering
+	if(length(candidates) >= 1) //solo refugees
+		if(prob(30) - (length(candidates) * 2)) //Having more candidates makes solo backstories less likely to be selected. At
+			possible_backstories += list("waldo") //less common as it comes with magicks and is kind of immershun shattering
 		else //For accurate deadchat feedback
 			minimum_required = 4
-	if(candidates.len >= 4)//group refugees
-		possible_backstories.Add("prisoner", "cultist", "synth")
+	if(length(candidates) >= 4)//group refugees
+		possible_backstories += list("prisoner", "cultist", "synth")
 	if(!possible_backstories.len)
 		return NOT_ENOUGH_PLAYERS
 
@@ -51,8 +51,9 @@
 		members += pick_n_take(candidates)
 
 	for(var/mob/dead/selected in members)
-		var/mob/living/carbon/human/S = gear_fugitive(selected, landing_turf, backstory)
-		spawned_mobs += S
+		var/mob/living/carbon/human/human_to_gear = gear_fugitive(selected, landing_turf, backstory)
+		spawned_mobs += human_to_gear
+
 	if(!isnull(leader))
 		gear_fugitive_leader(leader, landing_turf, backstory)
 

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -1,3 +1,5 @@
+#define LARGE_BACKSTORY_SIZE 4
+
 /datum/round_event_control/fugitives
 	name = "Spawn Fugitives"
 	typepath = /datum/round_event/ghost_role/fugitives
@@ -24,14 +26,14 @@
 	var/turf/landing_turf = pick(possible_spawns)
 	var/list/possible_backstories = list()
 	var/list/candidates = get_candidates(ROLE_FUGITIVE, ROLE_FUGITIVE)
-	if(length(candidates) >= 1) //solo refugees
-		if(prob(30) - (length(candidates) * 2)) //Having more candidates makes solo backstories less likely to be selected. At
-			possible_backstories += list("waldo") //less common as it comes with magicks and is kind of immershun shattering
-		else //For accurate deadchat feedback
-			minimum_required = 4
-	if(length(candidates) >= 4)//group refugees
+
+	if(length(candidates) < LARGE_BACKSTORY_SIZE || prob(30 - (length(candidates) * 2))) //Solo backstories are always considered if a larger backstory cannot be filled out. Otherwise, it's a rare chance that gets rarer if more people sign up.
+		possible_backstories += list("waldo") //less common as it comes with magicks and is kind of immershun shattering
+
+	if(length(candidates) >= LARGE_BACKSTORY_SIZE)//group refugees
 		possible_backstories += list("prisoner", "cultist", "synth")
-	if(!possible_backstories.len)
+
+	if(!length(possible_backstories))
 		return NOT_ENOUGH_PLAYERS
 
 	var/backstory = pick(possible_backstories)
@@ -118,3 +120,5 @@
 	if(!ship.load(T))
 		CRASH("Loading [backstory] ship failed!")
 	priority_announce("Unidentified ship detected near the station.")
+
+#undef LARGE_BACKSTORY_SIZE

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -31,18 +31,18 @@
 		return NOT_ENOUGH_PLAYERS
 
 	if(length(candidates) < TEAM_BACKSTORY_SIZE || prob(30 - (length(candidates) * 2))) //Solo backstories are always considered if a larger backstory cannot be filled out. Otherwise, it's a rare chance that gets rarer if more people sign up.
-		possible_backstories += list("waldo") //less common as it comes with magicks and is kind of immershun shattering
+		possible_backstories += list(FUGITIVE_BACKSTORY_WALDO) //less common as it comes with magicks and is kind of immershun shattering
 
 	if(length(candidates) >= TEAM_BACKSTORY_SIZE)//group refugees
-		possible_backstories += list("prisoner", "cultist", "synth")
+		possible_backstories += list(FUGITIVE_BACKSTORY_PRISONER, FUGITIVE_BACKSTORY_CULTIST, FUGITIVE_BACKSTORY_SYNTH)
 
 	var/backstory = pick(possible_backstories)
 	var/member_size = 3
 	var/leader
 	switch(backstory)
-		if("synth")
+		if(FUGITIVE_BACKSTORY_SYNTH)
 			leader = pick_n_take(candidates)
-		if("waldo")
+		if(FUGITIVE_BACKSTORY_WALDO)
 			member_size = 0 //solo refugees have no leader so the member_size gets bumped to one a bit later
 	var/list/members = list()
 	var/list/spawned_mobs = list()
@@ -77,13 +77,13 @@
 	fugitiveantag.greet(backstory)
 
 	switch(backstory)
-		if("prisoner")
+		if(FUGITIVE_BACKSTORY_PRISONER)
 			S.equipOutfit(/datum/outfit/prisoner)
-		if("cultist")
+		if(FUGITIVE_BACKSTORY_CULTIST)
 			S.equipOutfit(/datum/outfit/yalp_cultist)
-		if("waldo")
+		if(FUGITIVE_BACKSTORY_WALDO)
 			S.equipOutfit(/datum/outfit/waldo)
-		if("synth")
+		if(FUGITIVE_BACKSTORY_SYNTH)
 			S.equipOutfit(/datum/outfit/synthetic)
 	message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Fugitive by an event.")
 	S.log_message("was spawned as a Fugitive by an event.", LOG_GAME)

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -1,4 +1,4 @@
-#define LARGE_BACKSTORY_SIZE 4
+#define TEAM_BACKSTORY_SIZE 4
 
 /datum/round_event_control/fugitives
 	name = "Spawn Fugitives"
@@ -17,9 +17,9 @@
 
 /datum/round_event/ghost_role/fugitives/spawn_role()
 	var/list/possible_spawns = list()//Some xeno spawns are in some spots that will instantly kill the refugees, like atmos
-	for(var/turf/X in GLOB.xeno_spawn)
-		if(istype(X.loc, /area/station/maintenance))
-			possible_spawns += X
+	for(var/turf/spawn_turf in GLOB.xeno_spawn)
+		if(istype(get_area(spawn_turf), /area/station/maintenance) && is_safe_turf(spawn_turf))
+			possible_spawns += spawn_turf
 	if(!possible_spawns.len)
 		message_admins("No valid spawn locations found, aborting...")
 		return MAP_ERROR
@@ -30,10 +30,10 @@
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 
-	if(length(candidates) < LARGE_BACKSTORY_SIZE || prob(30 - (length(candidates) * 2))) //Solo backstories are always considered if a larger backstory cannot be filled out. Otherwise, it's a rare chance that gets rarer if more people sign up.
+	if(length(candidates) < TEAM_BACKSTORY_SIZE || prob(30 - (length(candidates) * 2))) //Solo backstories are always considered if a larger backstory cannot be filled out. Otherwise, it's a rare chance that gets rarer if more people sign up.
 		possible_backstories += list("waldo") //less common as it comes with magicks and is kind of immershun shattering
 
-	if(length(candidates) >= LARGE_BACKSTORY_SIZE)//group refugees
+	if(length(candidates) >= TEAM_BACKSTORY_SIZE)//group refugees
 		possible_backstories += list("prisoner", "cultist", "synth")
 
 	var/backstory = pick(possible_backstories)
@@ -55,7 +55,6 @@
 	for(var/mob/dead/selected in members)
 		var/mob/living/carbon/human/S = gear_fugitive(selected, landing_turf, backstory)
 		spawned_mobs += S
-
 	if(!isnull(leader))
 		gear_fugitive_leader(leader, landing_turf, backstory)
 
@@ -121,4 +120,4 @@
 		CRASH("Loading [backstory] ship failed!")
 	priority_announce("Unidentified ship detected near the station.")
 
-#undef LARGE_BACKSTORY_SIZE
+#undef TEAM_BACKSTORY_SIZE

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -27,14 +27,14 @@
 	var/list/possible_backstories = list()
 	var/list/candidates = get_candidates(ROLE_FUGITIVE, ROLE_FUGITIVE)
 
+	if(!length(candidates))
+		return NOT_ENOUGH_PLAYERS
+
 	if(length(candidates) < LARGE_BACKSTORY_SIZE || prob(30 - (length(candidates) * 2))) //Solo backstories are always considered if a larger backstory cannot be filled out. Otherwise, it's a rare chance that gets rarer if more people sign up.
 		possible_backstories += list("waldo") //less common as it comes with magicks and is kind of immershun shattering
 
 	if(length(candidates) >= LARGE_BACKSTORY_SIZE)//group refugees
 		possible_backstories += list("prisoner", "cultist", "synth")
-
-	if(!length(possible_backstories))
-		return NOT_ENOUGH_PLAYERS
 
 	var/backstory = pick(possible_backstories)
 	var/member_size = 3
@@ -53,8 +53,8 @@
 		members += pick_n_take(candidates)
 
 	for(var/mob/dead/selected in members)
-		var/mob/living/carbon/human/human_to_gear = gear_fugitive(selected, landing_turf, backstory)
-		spawned_mobs += human_to_gear
+		var/mob/living/carbon/human/S = gear_fugitive(selected, landing_turf, backstory)
+		spawned_mobs += S
 
 	if(!isnull(leader))
 		gear_fugitive_leader(leader, landing_turf, backstory)


### PR DESCRIPTION
## About The Pull Request

Adjusts how the fugitives event decides to select its backstories.

Formerly, the game would decide if it was polling for a solo (Waldo) or team (4 player) backstory first, meaning the event could fail if only 3 people signed up when the event decided to run a team backstory. It also meant that, even with thirty people signed up, a solo backstory (still just Waldo for now) could be selected. What a waste!

Now, the event receives its signups and uses them to decide which backstory to choose. If there aren't enough players for a team, a solo backstory is chosen. If a team can be formed, the event may still decide to run a solo backstory, but the chance scales inversely with the number of candidates.

This also adds an atmos safety check to their spawn location finder, because I was in the area.
## Why It's Good For The Game

Helps a deadchat sink even be more of a deadchat sink. Waldo is a bastard.
## Changelog
:cl:
balance: Fugitive team backstories will now be selected with consideration to the number of people who sign up. 
qol: Fugitives can no longer spawn in atmos-unsafe areas.
/:cl:
