### PR TITLE
Fixes the graph in power monitor consoles being tiny [NO GBP]

### DIFF
--- a/tgui/packages/tgui/interfaces/PowerMonitor.js
+++ b/tgui/packages/tgui/interfaces/PowerMonitor.js
@@ -91,7 +91,7 @@ export const PowerMonitorContent = (props, context) => {
           </Section>
         </Flex.Item>
         <Flex.Item mx={0.5} grow={1}>
-          <Section position="relative" height="100%">
+          <Section position="relative" height="100%" fill="true">
             <Chart.Line
               fillPositionedParent
               data={supplyData}


### PR DESCRIPTION
## About The Pull Request

Fixes an issue with the power monitor console/AmpCheck's graph. Fix found by @CRITAWAKETS 

fixed (from critawakets and i's dms)
![image](https://user-images.githubusercontent.com/49667761/228999734-3d23760f-7ea9-45ce-aee6-19d67f64b3ab.png)


## Why It's Good For The Game

it before (taken from issue ticket) 
![image](https://user-images.githubusercontent.com/49667761/228999690-d4b6c766-0277-49a9-ad56-93e4d5bb61f2.png)


Fixes #67541

## Changelog

:cl: Deranging
fix: The graph in Power Monitor consoles is no longer under half its normal size.
/:cl:
