### PR TITLE
The Lance Hits As Hard As It Should [NO GBP]

### DIFF
--- a/_maps/shuttles/emergency_lance.dmm
+++ b/_maps/shuttles/emergency_lance.dmm
@@ -582,6 +582,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
+"tk" = (
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/station_crash/devastating,
+/turf/open/floor/iron/checker,
+/area/shuttle/escape)
 "tx" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -683,16 +690,6 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/shuttle/escape)
-"wD" = (
-/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
-	dir = 4
-	},
-/obj/effect/station_crash/devastating,
-/turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "xa" = (
 /obj/structure/table/reinforced,
@@ -2116,7 +2113,7 @@ cz
 (10,1,1) = {"
 jo
 Sg
-wD
+Yq
 ce
 jM
 jY
@@ -2126,7 +2123,7 @@ Yq
 Yq
 Hq
 cw
-Hd
+tk
 Hd
 Hd
 JN


### PR DESCRIPTION

## About The Pull Request
The Lance Crew Evacuation System doesn't penetrate the station enough to do it's job properly. When I removed one of the doubled markers, I removed the wrong one.
![image](https://user-images.githubusercontent.com/73589390/228704137-4d6e6ccd-42b7-440f-8b23-f360a1862403.png)
### Mapping March
Ckey to receive rewards: Cheshify but this is literally nothing don't count it

## Why It's Good For The Game
The shuttle that slams into the station should slam more. In earlier screenshots of the shuttle you can see how hard it's supposed to hit.
![image](https://user-images.githubusercontent.com/73589390/228704732-4abfb77d-37a7-4fcf-a56d-90d7310f3849.png)
## Changelog
:cl:
fix: The Lance goes deeper into the station when it docks.
/:cl:
