### PR TITLE
Fixes the emissive blockers from the body parts layering over everything

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -168,7 +168,7 @@
 /obj/item/clothing/suit/hazardvest/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
 	. = ..()
 	if(!isinhands)
-		. += emissive_appearance(standing, "[icon_state]-emissive", src, alpha = src.alpha)
+		. += emissive_appearance(standing.icon, "[icon_state]-emissive", src, alpha = src.alpha)
 
 //Lawyer
 /obj/item/clothing/suit/toggle/lawyer

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -168,7 +168,7 @@
 /obj/item/clothing/suit/hazardvest/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
 	. = ..()
 	if(!isinhands)
-		. += emissive_appearance(icon_file, "[icon_state]-emissive", src, alpha = src.alpha)
+		. += emissive_appearance(standing, "[icon_state]-emissive", src, alpha = src.alpha)
 
 //Lawyer
 /obj/item/clothing/suit/toggle/lawyer

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -168,7 +168,7 @@
 /obj/item/clothing/suit/hazardvest/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
 	. = ..()
 	if(!isinhands)
-		. += emissive_appearance(standing.icon, "[icon_state]-emissive", src, alpha = src.alpha)
+		. += emissive_appearance(icon_file, "[icon_state]-emissive", src, alpha = src.alpha)
 
 //Lawyer
 /obj/item/clothing/suit/toggle/lawyer

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -869,12 +869,12 @@
 		// to be able to mask it proper in case this limb is a leg.
 		if(blocks_emissive)
 			var/atom/location = loc || owner || src
-			var/mutable_appearance/limb_em_block = emissive_blocker(limb.icon, limb.icon_state, location, alpha = limb.alpha)
+			var/mutable_appearance/limb_em_block = emissive_blocker(limb.icon, limb.icon_state, location, layer = limb.layer, alpha = limb.alpha)
 			limb_em_block.dir = image_dir
 			. += limb_em_block
 
 			if(aux_zone)
-				var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, alpha = aux.alpha)
+				var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, layer = limb.layer, alpha = aux.alpha)
 				aux_em_block.dir = image_dir
 				. += aux_em_block
 		//EMISSIVE CODE END

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -874,7 +874,7 @@
 			. += limb_em_block
 
 			if(aux_zone)
-				var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, layer = limb.layer, alpha = aux.alpha)
+				var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, layer = aux.layer, alpha = aux.alpha)
 				aux_em_block.dir = image_dir
 				. += aux_em_block
 		//EMISSIVE CODE END


### PR DESCRIPTION
## About The Pull Request

As it says, this PR will stop bodypart emissive blockers from layering over all the things.

This will fix any emissives that were not displaying on clothing, such as the safety vest.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/19531

https://github.com/tgstation/tgstation/issues/62442 and https://github.com/tgstation/tgstation/issues/64098 are not fixed by this, these are separate issues.

## Why It's Good For The Game

The pretty lights return to dazzle us once more.

<details>
<summary>Safety vest emissives</summary>
  
![dreamseeker_6vwaJOkpHR](https://user-images.githubusercontent.com/13398309/228765863-0ef65eff-60c9-496d-b289-6723716d1b2c.gif)

</details>

## Changelog

:cl:
fix: fixes emissives blocker layering issue that was causing emissives on clothing to not display at all
/:cl:
