### PR TITLE
Adds CI check to detect if byond starts requiring 515 clients before we want that

### DIFF
--- a/.github/max_required_byond_client.txt
+++ b/.github/max_required_byond_client.txt
@@ -1,0 +1,8 @@
+# Highest byond client version allowed to be required by the byond world. Set to 9999 to disable the check flat out.
+# If the compiled world requires clients use a version higher than this, ci will fail.
+#   for instance: if this is set to 514, and a pr uses a 515 client feature, an alert will trigger
+# If you have to update this number for your pr, you should make it VERY CLEAR in the pr body that you did so.
+#   (Requiring clients update to connect to the game server is not something we like to spring on them with no notice, 
+#   especially for beta builds where the pager/updater won't let them update without additional configuration.)
+
+514

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -89,6 +89,11 @@ jobs:
           bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
+      - name: Check client Compatibility
+        uses: MrStonedOne/byond-client-compatibility-check@v1
+        with:
+          dmb-location: tgstation.dmb
+          max-required-client-version: 514
 
   find_all_maps:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -91,7 +91,7 @@ jobs:
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
       - name: Check client Compatibility
-        uses: MrStonedOne/byond-client-compatibility-check@v3
+        uses: tgstation/byond-client-compatibility-check@v3
         with:
           dmb-location: tgstation.dmb
           max-required-client-version: ${{needs.collect_data.outputs.max_required_byond_client}}

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -73,6 +73,7 @@ jobs:
   compile_all_maps:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Compile Maps
+    needs: [collect_data]
     runs-on: ubuntu-20.04
     concurrency:
       group: compile_all_maps-${{ github.head_ref || github.run_id }}
@@ -90,18 +91,19 @@ jobs:
           source $HOME/BYOND/byond/bin/byondsetup
           tools/build/build --ci dm -DCIBUILDING -DCITESTING -DALL_MAPS
       - name: Check client Compatibility
-        uses: MrStonedOne/byond-client-compatibility-check@v1
+        uses: MrStonedOne/byond-client-compatibility-check@v3
         with:
           dmb-location: tgstation.dmb
-          max-required-client-version: 514
+          max-required-client-version: ${{needs.collect_data.outputs.max_required_byond_client}}
 
-  find_all_maps:
+  collect_data:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    name: Find Maps to Test
+    name: Collect data for other tasks
     runs-on: ubuntu-20.04
     outputs:
       maps: ${{ steps.map_finder.outputs.maps }}
       alternate_tests: ${{ steps.alternate_test_finder.outputs.alternate_tests }}
+      max_required_byond_client: ${{ steps.max_required_byond_client.outputs.max_required_byond_client }}
     concurrency:
       group: find_all_maps-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
@@ -119,28 +121,36 @@ jobs:
         run: |
           ALTERNATE_TESTS_JSON=$(jq -nRc '[inputs | capture("^(?<major>[0-9]+)\\.(?<minor>[0-9]+): (?<map>.+)$")]' .github/alternate_byond_versions.txt)
           echo "alternate_tests=$ALTERNATE_TESTS_JSON" >> $GITHUB_OUTPUT
+      - name: Collect byond client version configuration
+        id: max_required_byond_client
+        #the regex here does not filter out non-numbers because error messages about no input are less helpful then error messages about bad input (which includes the bad input)
+        run: |
+          echo "max_required_byond_client=$(grep -Ev '^[[:blank:]]{0,}#{1,}|^[[:blank:]]{0,}$' .github/max_required_byond_client.txt | tail -n1)" >> $GITHUB_OUTPUT
+        
   run_all_tests:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Integration Tests
-    needs: [find_all_maps]
+    needs: [collect_data]
     strategy:
       fail-fast: false
       matrix:
-        map: ${{ fromJSON(needs.find_all_maps.outputs.maps).paths }}
+        map: ${{ fromJSON(needs.collect_data.outputs.maps).paths }}
     concurrency:
       group: run_all_tests-${{ github.head_ref || github.run_id }}-${{ matrix.map }}
       cancel-in-progress: true
     uses: ./.github/workflows/run_integration_tests.yml
     with:
       map: ${{ matrix.map }}
+      max_required_byond_client: ${{needs.collect_data.outputs.max_required_byond_client}}
+
   run_alternate_tests:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && needs.find_all_maps.outputs.alternate_tests != '[]'"
     name: Alternate Tests
-    needs: [find_all_maps]
+    needs: [collect_data]
     strategy:
       fail-fast: false
       matrix:
-        setup: ${{ fromJSON(needs.find_all_maps.outputs.alternate_tests) }}
+        setup: ${{ fromJSON(needs.collect_data.outputs.alternate_tests) }}
     concurrency:
       group: run_all_tests-${{ github.head_ref || github.run_id }}-${{ matrix.setup.major }}.${{ matrix.setup.minor }}-${{ matrix.setup.map }}
       cancel-in-progress: true
@@ -149,6 +159,8 @@ jobs:
       map: ${{ matrix.setup.map }}
       major: ${{ matrix.setup.major }}
       minor: ${{ matrix.setup.minor }}
+      max_required_byond_client: ${{needs.collect_data.outputs.max_required_byond_client}}
+
   check_alternate_tests:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && needs.find_all_maps.outputs.alternate_tests != '[]'"
     name: Check Alternate Tests
@@ -156,6 +168,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - run: echo Alternate tests passed.
+
   compare_screenshots:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && (success() || failure())"
     needs: [run_all_tests, run_alternate_tests]
@@ -194,6 +207,7 @@ jobs:
   test_windows:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Windows Build
+    needs: [collect_data]
     runs-on: windows-latest
     concurrency:
       group: test_windows-${{ github.head_ref || github.run_id }}
@@ -208,7 +222,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+          max_required_byond_client: ${{needs.collect_data.outputs.max_required_byond_client}}
       - name: Compile
         run: pwsh tools/ci/build.ps1
         env:
           DM_EXE: "C:\\byond\\bin\\dm.exe"
+      - name: Check client Compatibility
+        uses: MrStonedOne/byond-client-compatibility-check@v3
+        with:
+          dmb-location: tgstation.dmb
+          max-required-client-version: ${{needs.collect_data.outputs.max_required_byond_client}}

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -222,7 +222,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-          max_required_byond_client: ${{needs.collect_data.outputs.max_required_byond_client}}
       - name: Compile
         run: pwsh tools/ci/build.ps1
         env:

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -73,7 +73,7 @@ jobs:
           path: data/screenshots_new/
           retention-days: 1
       - name: Check client Compatibility
-        if: always() && steps.compile_tests.outcome == "success"
+        if: always() && steps.compile_tests.outcome == 'success'
         uses: MrStonedOne/byond-client-compatibility-check@v3
         with:
           dmb-location: tgstation.dmb

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -13,6 +13,9 @@ on:
       minor:
         required: false
         type: string
+      max_required_byond_client:
+        required: true
+        type: string
 jobs:
   run_integration_tests:
     runs-on: ubuntu-20.04
@@ -53,6 +56,7 @@ jobs:
           echo "BYOND_MINOR=${{ inputs.minor }}" >> $GITHUB_ENV
         if: ${{ inputs.major }}
       - name: Compile Tests
+        id: compile_tests
         run: |
           bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
@@ -68,3 +72,9 @@ jobs:
           name: test_artifacts_${{ inputs.map }}
           path: data/screenshots_new/
           retention-days: 1
+      - name: Check client Compatibility
+        if: always() && steps.compile_tests.outcome == "success"
+        uses: MrStonedOne/byond-client-compatibility-check@v3
+        with:
+          dmb-location: tgstation.dmb
+          max-required-client-version: ${{inputs.max_required_byond_client}}


### PR DESCRIPTION
todo: (i'm going to bed or i'd do them before opening the pr)
fork the action over to the org
~~make this more configurable as mothblocks requested~~
~~add this to the windows build and integration test steps (if it generates a dmb, we gonna validate its got the expected value for client compatibility)~~
~~test 515 client required fails.~~

https://github.com/MrStonedOne/byond-client-compatibility-check
