### PR TITLE
Formaldehyde now consumes only 0.05 units of silver for 1 unit of production

### DIFF
--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -1,7 +1,8 @@
 
 /datum/chemical_reaction/formaldehyde
 	results = list(/datum/reagent/toxin/formaldehyde = 3)
-	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1, /datum/reagent/silver = 1)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1)
+	required_catalysts = list(/datum/reagent/silver = 1)
 	mix_message = "The mixture fizzles and gives off a fierce smell."
 	is_cold_recipe = FALSE
 	required_temp = 420

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -1,8 +1,7 @@
 
 /datum/chemical_reaction/formaldehyde
 	results = list(/datum/reagent/toxin/formaldehyde = 1)
-	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1)
-	required_catalysts = list(/datum/reagent/silver = 2)
+	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1, /datum/reagent/silver = 0.05)
 	mix_message = "The mixture fizzles and gives off a fierce smell."
 	is_cold_recipe = FALSE
 	required_temp = 420

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -1,6 +1,6 @@
 
 /datum/chemical_reaction/formaldehyde
-	results = list(/datum/reagent/toxin/formaldehyde = 3)
+	results = list(/datum/reagent/toxin/formaldehyde = 2)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1)
 	required_catalysts = list(/datum/reagent/silver = 1)
 	mix_message = "The mixture fizzles and gives off a fierce smell."

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -1,8 +1,8 @@
 
 /datum/chemical_reaction/formaldehyde
-	results = list(/datum/reagent/toxin/formaldehyde = 2)
+	results = list(/datum/reagent/toxin/formaldehyde = 1)
 	required_reagents = list(/datum/reagent/consumable/ethanol = 1, /datum/reagent/oxygen = 1)
-	required_catalysts = list(/datum/reagent/silver = 1)
+	required_catalysts = list(/datum/reagent/silver = 2)
 	mix_message = "The mixture fizzles and gives off a fierce smell."
 	is_cold_recipe = FALSE
 	required_temp = 420


### PR DESCRIPTION
## About The Pull Request
Read Title

Now only 0.05 units of silver is required to create 1 unit of formaldehyde OR 1 unit of silver can produce 20 units of formaldehyde i.e. you can now make more with less silver

## Why It's Good For The Game
1. Silver is a rare metal that requires miners. 1 slab/ore of silver gives 2000 worth of material, but grinding one slab of silver only gives 20 units of liquid silver. So consuming 2000 units of precious silver to create just one vile of formaldehyde is a huge waste of material for all departments.

2. In the event say all stasis beds in medbay are destroyed and the station is very low on materials(say silver) and everyone is either dead/injured, Formaldehyde is a life saver in this situation as it can preserve dead bodies for revival and can also heal injured crew members via [medical suture](https://tgstation13.org/wiki/Guide_to_chemistry#Medicated_Suture). So mass producing formaldehyde without consuming too much silver will allow other departments to use more for their purposes.

3. Formaldehyde has a large variety of applications such as in the creation of Herapin, Pentaerythritol, Acetaldehyde, and Pentetic Acid And medicated sutures so large amounts of formaldehyde will get consumed per shift, so its good to conserve silver

## Changelog
:cl:
balance: formaldehyde now consumes only 0.05 units of silver to create 1 unit
/:cl:
