### PR TITLE
Fixes floating point inaccuracies in numeric preferences

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -9,7 +9,7 @@
 /proc/sanitize_float(number, min=0, max=1, accuracy=1, default=0)
 	if(isnum(number))
 		number = round(number, accuracy)
-		if(min <= number && number <= max)
+		if(round(min, accuracy) <= number && number <= round(max, accuracy))
 			return number
 	return default
 

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -34,25 +34,16 @@
 	admin_headset_message(M)
 
 /client/proc/admin_headset_message(mob/M in GLOB.mob_list, sender = null)
-	var/mob/living/carbon/human/human_recipient
-	var/mob/living/silicon/silicon_recipient
+	var/mob/living/carbon/human/H = M
 
 	if(!check_rights(R_ADMIN))
 		return
 
-
-	if(ishuman(M))
-		human_recipient = M
-		if(!istype(human_recipient.ears, /obj/item/radio/headset))
-			to_chat(usr, "The person you are trying to contact is not wearing a headset.", confidential = TRUE)
-			return
-	else if(issilicon(M))
-		silicon_recipient = M
-		if(!istype(silicon_recipient.radio, /obj/item/radio))
-			to_chat(usr, "The silicon you are trying to contact does not have a radio installed.", confidential = TRUE)
-			return
-	else
-		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human or /mob/living/silicon", confidential = TRUE)
+	if(!istype(H))
+		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human", confidential = TRUE)
+		return
+	if(!istype(H.ears, /obj/item/radio/headset))
+		to_chat(usr, "The person you are trying to contact is not wearing a headset.", confidential = TRUE)
 		return
 
 	if (!sender)
@@ -60,16 +51,16 @@
 		if(!sender)
 			return
 
-	message_admins("[key_name_admin(src)] has started answering [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] request.")
-	var/input = input("Please enter a message to reply to [key_name(human_recipient ? human_recipient : silicon_recipient)] via their headset.","Outgoing message from [sender]", "") as text|null
+	message_admins("[key_name_admin(src)] has started answering [key_name_admin(H)]'s [sender] request.")
+	var/input = input("Please enter a message to reply to [key_name(H)] via their headset.","Outgoing message from [sender]", "") as text|null
 	if(!input)
-		message_admins("[key_name_admin(src)] decided not to answer [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] request.")
+		message_admins("[key_name_admin(src)] decided not to answer [key_name_admin(H)]'s [sender] request.")
 		return
 
-	log_directed_talk(mob, M, input, LOG_ADMIN, "reply")
-	message_admins("[key_name_admin(src)] replied to [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] message with: \"[input]\"")
-	M.balloon_alert(M, "you hear a voice")
-	to_chat(M, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
+	log_directed_talk(mob, H, input, LOG_ADMIN, "reply")
+	message_admins("[key_name_admin(src)] replied to [key_name_admin(H)]'s [sender] message with: \"[input]\"")
+	H.balloon_alert(H, "you hear a voice")
+	to_chat(H, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Headset Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -34,16 +34,25 @@
 	admin_headset_message(M)
 
 /client/proc/admin_headset_message(mob/M in GLOB.mob_list, sender = null)
-	var/mob/living/carbon/human/H = M
+	var/mob/living/carbon/human/human_recipient
+	var/mob/living/silicon/silicon_recipient
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	if(!istype(H))
-		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human", confidential = TRUE)
-		return
-	if(!istype(H.ears, /obj/item/radio/headset))
-		to_chat(usr, "The person you are trying to contact is not wearing a headset.", confidential = TRUE)
+
+	if(ishuman(M))
+		human_recipient = M
+		if(!istype(human_recipient.ears, /obj/item/radio/headset))
+			to_chat(usr, "The person you are trying to contact is not wearing a headset.", confidential = TRUE)
+			return
+	else if(issilicon(M))
+		silicon_recipient = M
+		if(!istype(silicon_recipient.radio, /obj/item/radio))
+			to_chat(usr, "The silicon you are trying to contact does not have a radio installed.", confidential = TRUE)
+			return
+	else
+		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human or /mob/living/silicon", confidential = TRUE)
 		return
 
 	if (!sender)
@@ -51,16 +60,16 @@
 		if(!sender)
 			return
 
-	message_admins("[key_name_admin(src)] has started answering [key_name_admin(H)]'s [sender] request.")
-	var/input = input("Please enter a message to reply to [key_name(H)] via their headset.","Outgoing message from [sender]", "") as text|null
+	message_admins("[key_name_admin(src)] has started answering [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] request.")
+	var/input = input("Please enter a message to reply to [key_name(human_recipient ? human_recipient : silicon_recipient)] via their headset.","Outgoing message from [sender]", "") as text|null
 	if(!input)
-		message_admins("[key_name_admin(src)] decided not to answer [key_name_admin(H)]'s [sender] request.")
+		message_admins("[key_name_admin(src)] decided not to answer [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] request.")
 		return
 
-	log_directed_talk(mob, H, input, LOG_ADMIN, "reply")
-	message_admins("[key_name_admin(src)] replied to [key_name_admin(H)]'s [sender] message with: \"[input]\"")
-	H.balloon_alert(H, "you hear a voice")
-	to_chat(H, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
+	log_directed_talk(mob, M, input, LOG_ADMIN, "reply")
+	message_admins("[key_name_admin(src)] replied to [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] message with: \"[input]\"")
+	M.balloon_alert(M, "you hear a voice")
+	to_chat(M, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Headset Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -511,7 +511,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	return rand(minimum, maximum)
 
 /datum/preference/numeric/is_valid(value)
-	return isnum(value) && value >= minimum && value <= maximum
+	return isnum(value) && value >= round(minimum, step) && value <= round(maximum, step)
 
 /datum/preference/numeric/compile_constant_data()
 	return list(


### PR DESCRIPTION
## About The Pull Request

Floating point inaccuracy fun.

Since it's possible to have a `minimum`,`maximum`, and `step` that are floats we need to round everything to `step` to ensure the comparison operations work.

If we do not do this, there is no guarantee that `if(min <= number && number <= max)` will work correctly. 

For example, in the linked issues, this manifested as the minimum value (0.8) being considered invalid when the input was also 0.8.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/9507
Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/14394

## Why It's Good For The Game

Fixes an obscure bug that has gone unnoticed for a couple years.

## Changelog

:cl:
fix: fixes floating point inaccuracies in numeric prefs
/:cl:

