### PR TITLE
Fix MetaStation cargo table

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13388,7 +13388,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "eYL" = (
-/obj/structure/table,
+/obj/structure/table/reinforced,
 /obj/item/multitool{
 	pixel_x = -3;
 	pixel_y = -4


### PR DESCRIPTION
## About The Pull Request

Table in the cargo office is half reinforced half regular, fixes that.

![image](https://user-images.githubusercontent.com/83487515/229038663-2a8220a9-fd69-4c37-b894-427307268376.png)

## Changelog

:cl: LT3
fix: The missing table reinforcement for MetaStation's cargo office has been found
/:cl: