### PR TITLE
Two small throw impact things

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -792,7 +792,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 		var/mob/living/L = hit_atom
 		L.ignite_mob()
 	var/itempush = 1
-	if(w_class < 4)
+	if(w_class < WEIGHT_CLASS_BULKY)
 		itempush = 0 //too light to push anything
 	if(isliving(hit_atom)) //Living mobs handle hit sounds differently.
 		var/volume = get_volume_by_throwforce_and_or_w_class()

--- a/code/modules/food_and_drinks/plate.dm
+++ b/code/modules/food_and_drinks/plate.dm
@@ -75,6 +75,7 @@
 #define PLATE_SHARD_PIECES 5
 
 /obj/item/plate/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	. = ..()
 	if(.)
 		return
 	var/generator/scatter_gen = generator(GEN_CIRCLE, 0, 48, NORMAL_RAND)


### PR DESCRIPTION
## About The Pull Request

- No use of weight class define in item throw impact
- No parent call in plate throw impact, despite checking `.`

## Changelog

:cl: Melbert
fix: Plates are no longer ephemeral when throwing at people. 
/:cl:
