### PR TITLE
Makes silicons able to receive headset messages from admins

### DIFF
--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -33,7 +33,7 @@
 
 	admin_headset_message(M)
 
-/client/proc/admin_headset_message(mob/M in GLOB.mob_list, sender = null)
+/client/proc/admin_headset_message(mob/target in GLOB.mob_list, sender = null)
 	var/mob/living/carbon/human/human_recipient
 	var/mob/living/silicon/silicon_recipient
 
@@ -41,13 +41,13 @@
 		return
 
 
-	if(ishuman(M))
-		human_recipient = M
+	if(ishuman(target))
+		human_recipient = target
 		if(!istype(human_recipient.ears, /obj/item/radio/headset))
 			to_chat(usr, "The person you are trying to contact is not wearing a headset.", confidential = TRUE)
 			return
-	else if(issilicon(M))
-		silicon_recipient = M
+	else if(issilicon(target))
+		silicon_recipient = target
 		if(!istype(silicon_recipient.radio, /obj/item/radio))
 			to_chat(usr, "The silicon you are trying to contact does not have a radio installed.", confidential = TRUE)
 			return
@@ -60,16 +60,16 @@
 		if(!sender)
 			return
 
-	message_admins("[key_name_admin(src)] has started answering [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] request.")
-	var/input = input("Please enter a message to reply to [key_name(human_recipient ? human_recipient : silicon_recipient)] via their headset.","Outgoing message from [sender]", "") as text|null
+	message_admins("[key_name_admin(src)] has started answering [key_name_admin(target)]'s [sender] request.")
+	var/input = input("Please enter a message to reply to [key_name(target)] via their headset.","Outgoing message from [sender]", "") as text|null
 	if(!input)
-		message_admins("[key_name_admin(src)] decided not to answer [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] request.")
+		message_admins("[key_name_admin(src)] decided not to answer [key_name_admin(target)]'s [sender] request.")
 		return
 
-	log_directed_talk(mob, M, input, LOG_ADMIN, "reply")
+	log_directed_talk(mob, target, input, LOG_ADMIN, "reply")
 	message_admins("[key_name_admin(src)] replied to [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] message with: \"[input]\"")
-	M.balloon_alert(M, "you hear a voice")
-	to_chat(M, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
+	target.balloon_alert(target, "you hear a voice")
+	to_chat(target, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Headset Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -67,7 +67,7 @@
 		return
 
 	log_directed_talk(mob, target, input, LOG_ADMIN, "reply")
-	message_admins("[key_name_admin(src)] replied to [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] message with: \"[input]\"")
+	message_admins("[key_name_admin(src)] replied to [key_name_admin(target]'s [sender] message with: \"[input]\"")
 	target.balloon_alert(target, "you hear a voice")
 	to_chat(target, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
 

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -67,7 +67,7 @@
 		return
 
 	log_directed_talk(mob, target, input, LOG_ADMIN, "reply")
-	message_admins("[key_name_admin(src)] replied to [key_name_admin(target]'s [sender] message with: \"[input]\"")
+	message_admins("[key_name_admin(src)] replied to [key_name_admin(target)]'s [sender] message with: \"[input]\"")
 	target.balloon_alert(target, "you hear a voice")
 	to_chat(target, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
 

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -69,7 +69,7 @@
 	log_directed_talk(mob, target, input, LOG_ADMIN, "reply")
 	message_admins("[key_name_admin(src)] replied to [key_name_admin(target)]'s [sender] message with: \"[input]\"")
 	target.balloon_alert(target, "you hear a voice")
-	to_chat(target, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
+	to_chat(target, span_hear("You hear something crackle in your [human_recipient ? "ears" : "radio receiver"] for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Headset Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -34,16 +34,25 @@
 	admin_headset_message(M)
 
 /client/proc/admin_headset_message(mob/M in GLOB.mob_list, sender = null)
-	var/mob/living/carbon/human/H = M
+	var/mob/living/carbon/human/human_recipient
+	var/mob/living/silicon/silicon_recipient
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	if(!istype(H))
-		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human", confidential = TRUE)
-		return
-	if(!istype(H.ears, /obj/item/radio/headset))
-		to_chat(usr, "The person you are trying to contact is not wearing a headset.", confidential = TRUE)
+
+	if(ishuman(M))
+		human_recipient = M
+		if(!istype(human_recipient.ears, /obj/item/radio/headset))
+			to_chat(usr, "The person you are trying to contact is not wearing a headset.", confidential = TRUE)
+			return
+	else if(issilicon(M))
+		silicon_recipient = M
+		if(!istype(silicon_recipient.radio, /obj/item/radio))
+			to_chat(usr, "The silicon you are trying to contact does not have a radio installed.", confidential = TRUE)
+			return
+	else
+		to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human or /mob/living/silicon", confidential = TRUE)
 		return
 
 	if (!sender)
@@ -51,16 +60,16 @@
 		if(!sender)
 			return
 
-	message_admins("[key_name_admin(src)] has started answering [key_name_admin(H)]'s [sender] request.")
-	var/input = input("Please enter a message to reply to [key_name(H)] via their headset.","Outgoing message from [sender]", "") as text|null
+	message_admins("[key_name_admin(src)] has started answering [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] request.")
+	var/input = input("Please enter a message to reply to [key_name(human_recipient ? human_recipient : silicon_recipient)] via their headset.","Outgoing message from [sender]", "") as text|null
 	if(!input)
-		message_admins("[key_name_admin(src)] decided not to answer [key_name_admin(H)]'s [sender] request.")
+		message_admins("[key_name_admin(src)] decided not to answer [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] request.")
 		return
 
-	log_directed_talk(mob, H, input, LOG_ADMIN, "reply")
-	message_admins("[key_name_admin(src)] replied to [key_name_admin(H)]'s [sender] message with: \"[input]\"")
-	H.balloon_alert(H, "you hear a voice")
-	to_chat(H, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
+	log_directed_talk(mob, M, input, LOG_ADMIN, "reply")
+	message_admins("[key_name_admin(src)] replied to [key_name_admin(human_recipient ? human_recipient : silicon_recipient)]'s [sender] message with: \"[input]\"")
+	M.balloon_alert(M, "you hear a voice")
+	to_chat(M, span_hear("You hear something crackle in your ears for a moment before a voice speaks. \"Please stand by for a message from [sender == "Syndicate" ? "your benefactor" : "Central Command"]. Message as follows[sender == "Syndicate" ? ", agent." : ":"] <b>[input].</b> Message ends.\""), confidential = TRUE)
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Headset Message") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
## About The Pull Request

This just makes silicons able to receive headset messages from admins, as stated in the title.

It doesn't really make sense from a technical point of view why a silicon mob should not be able to receive headset messages from admins, seeing as they have a built in radio. As long as their radio is intact they will get the message.

Some testing screenshots-- it is working as intended.

<details>
<summary>Balloon alert still displays</summary>
  
![image](https://user-images.githubusercontent.com/13398309/229042590-b9511db7-1072-469d-9ca8-b64b0b208e0d.png)

</details>


<details>
<summary>No radio/headset still prevents message from being sent</summary>
  
![image](https://user-images.githubusercontent.com/13398309/229042446-241c1ffa-11f5-4050-b6fe-beabcddb79fe.png)


![image](https://user-images.githubusercontent.com/13398309/229042420-d6414fc2-b64c-4a6f-af41-7ac364815cdc.png)

</details>


Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/14164

## Why It's Good For The Game

Fixes an oversight, more tools for admins to play with is always nice.

## Changelog

:cl:
fix: admins may now send headset messages to silicon mobs as long as they have a radio
/:cl:
