### PR TITLE
Properly accounts for byond tick fuckery in runechat code

### DIFF
--- a/code/__DEFINES/_tick.dm
+++ b/code/__DEFINES/_tick.dm
@@ -20,6 +20,11 @@
 /// runs stoplag if tick_usage is above the limit
 #define CHECK_TICK ( TICK_CHECK ? stoplag() : 0 )
 
+/// Checks if a sleeping proc is running before or after the master controller
+#define RUNNING_BEFORE_MASTER ( Master.last_run != null && Master.last_run != world.time )
+/// Returns true if a verb ought to yield to the MC (IE: queue up to be processed by a subsystem)
+#define VERB_SHOULD_YIELD ( TICK_CHECK || RUNNING_BEFORE_MASTER )
+
 /// Returns true if tick usage is above 95, for high priority usage
 #define TICK_CHECK_HIGH_PRIORITY ( TICK_USAGE > 95 )
 /// runs stoplag if tick_usage is above 95, for high priority usage

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -173,7 +173,7 @@
 	WXH_TO_HEIGHT(owned_by.MeasureText(complete_text, null, CHAT_MESSAGE_WIDTH), mheight)
 
 
-	if(!TICK_CHECK)
+	if(!VERB_SHOULD_YIELD)
 		return finish_image_generation(mheight, target, owner, complete_text, lifespan)
 
 	var/datum/callback/our_callback = CALLBACK(src, PROC_REF(finish_image_generation), mheight, target, owner, complete_text, lifespan)


### PR DESCRIPTION

## About The Pull Request

Ok so like, the agreed upon assumption for "verb like code" (stuff that triggers when a client sents a network packet to the server), is it runs in verb time, that sliver of time between maptick and the start of the next tick.
We thought MeasureText worked like this. It doesn't.

It will, occasionally, resume not during verb time but as a sleeping proc, at the start of the next tick. 
Before the MC has started working.
This appears to only happen when the tick is already overloaded.

Unfortunately, it doesn't invoke after all sleeping procs as we were lead to believe, but just like, like any sleeping proc.

This means it fights with the mc for cpu time, and doesn't respect the TICK_CHECK macro we use to ensure this situation doesn't happen.

SOOO lets use a var off the MC instead, tracking when it last fired.
 We can use this in companion with TICK_CHECK to ensure verbs schedule properly if they invoke before the MC runs.

Hopefully this should fix 0 cpu when running at highpop

Thanks to @Kylerace and @MrStonedOne for suffering together with me on this, I hate this engine.