### PR TITLE
April fools PRs can now be marked with [april fools] to automatically tag them as april fools PRs.

### DIFF
--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -273,6 +273,7 @@ function tag_pr($payload, $opened) {
 
 	check_tag_and_replace($payload, '[dnm]', 'Do Not Merge', $tags);
 	check_tag_and_replace($payload, '[no gbp]', 'GBP: No Update', $tags);
+	check_tag_and_replace($payload, '[april fools]', 'April Fools', $tags);
 
 	return array($tags, $remove);
 }


### PR DESCRIPTION
## About The Pull Request

Really minor change that should make the April fools PR experience better for PR creators/maints. Not sure if this has any notable performance implications with the git bot going over its normal stuff, if it does close this since this is pretty minor.

## Why It's Good For The Game

Its not, anything that encourages april fools PRs makes the game so much worse.

