### PR TITLE
Fixes errant newscaster

### DIFF
--- a/_maps/map_files/tramstation/maintenance_modules/dormmedupper_1.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/dormmedupper_1.dmm
@@ -384,10 +384,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
-"Wp" = (
-/obj/machinery/newscaster/directional/south,
-/turf/closed/wall,
-/area/station/maintenance/department/crew_quarters/dorms)
 
 (1,1,1) = {"
 LS
@@ -553,7 +549,7 @@ SD
 vL
 PV
 uH
-Wp
+SD
 Oi
 Oi
 Oi


### PR DESCRIPTION

## About The Pull Request

There was an errant newscaster in the asteroid walls near the dorms in Tramstation. This removes it.

## Changelog

:cl:
fix: Removes errant newscaster in the dorm maints of Tramstation.
/:cl:
