### PR TITLE
Fixes Dark Matteor

### DIFF
--- a/code/__HELPERS/level_traits.dm
+++ b/code/__HELPERS/level_traits.dm
@@ -11,6 +11,7 @@ GLOBAL_VAR(station_level_z_scratch)
 // Called a lot, somewhat slow, so has its own cache
 #define is_station_level(z) \
 	( \
+		z && \
 		( \
 			/* The right hand side of this guarantees that we'll have the space to fill later on, while also not failing the condition */ \
 			(GLOB.station_levels_cache.len < (GLOB.station_level_z_scratch = z) && (GLOB.station_levels_cache.len = GLOB.station_level_z_scratch)) \

--- a/code/modules/antagonists/traitor/objectives/final_objective/objective_dark_matteor.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/objective_dark_matteor.dm
@@ -38,7 +38,7 @@
 /datum/traitor_objective/ultimate/dark_matteor/ui_perform_action(mob/living/user, action)
 	. = ..()
 	switch(action)
-		if("satellites")
+		if("satellite")
 			if(sent_satellites)
 				return
 			var/area/delivery_area = get_area(user)


### PR DESCRIPTION
## About The Pull Request

Fixes #74376
Fixes #69714
This fixes a spelling error which prevented traitors from spawning the gear they were being given.
Additionally it adds a check for z level 0 in `is_station_level` because during my testing it was sometimes picking up a dummy mob in presumably the CI test area and runtiming? This prevented the meteor from spawning at all.

## Why It's Good For The Game

Makes event work.

## Changelog

:cl:
fix: Traitors should be able to summon their satellite hacking supply kit.
fix: Dark Matteor shouldn't crash on spawn and fail to arrive.
/:cl:
