### PR TITLE
Removes dead clotting once more

### DIFF
--- a/code/__DEFINES/wounds.dm
+++ b/code/__DEFINES/wounds.dm
@@ -79,8 +79,6 @@ GLOBAL_LIST_INIT(global_all_wound_types, list(/datum/wound/blunt/critical, /datu
 #define WOUND_BURN_SANITIZATION_RATE 0.075
 /// how much blood you can lose per tick per slash max.
 #define WOUND_SLASH_MAX_BLOODFLOW 4.5
-/// dead people don't bleed, but they can clot! this is the minimum amount of clotting per tick on dead people, so even critical cuts will slowly clot in dead people
-#define WOUND_SLASH_DEAD_CLOT_MIN 0.025
 /// further slash attacks on a bodypart with a slash wound have their blood_flow further increased by damage * this (10 damage slash adds .25 flow)
 #define WOUND_SLASH_DAMAGE_FLOW_COEFF 0.025
 /// if we suffer a bone wound to the head that creates brain traumas, the timer for the trauma cycle is +/- by this percent (0-100)

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -111,15 +111,6 @@
 /datum/wound/slash/handle_process(delta_time, times_fired)
 	// in case the victim has the NOBLOOD trait, the wound will simply not clot on it's own
 	if(!no_bleeding)
-		if(victim.stat == DEAD)
-			adjust_blood_flow(-max(clot_rate, WOUND_SLASH_DEAD_CLOT_MIN) * delta_time)
-			if(blood_flow < minimum_flow)
-				if(demotes_to)
-					replace_wound(demotes_to)
-					return
-				qdel(src)
-				return
-
 		set_blood_flow(min(blood_flow, WOUND_SLASH_MAX_BLOODFLOW))
 
 		if(HAS_TRAIT(victim, TRAIT_BLOODY_MESS))


### PR DESCRIPTION
## About The Pull Request

It's very likely that wound clotting while dead was in fact broken all the way until #66037 was merged.

Why do I think that? Well, if you've played medical for a long time, you may have noticed that you haven't seen a single dead body with slash wounds on it within the last, well, almost a year now. Why? Because #66037 updated the dead clotting code to use the proper proc, very likely fixing it in the process.

Turns out, dead clotting isn't actually that fun. I personally enjoyed fixing people's wounds back when they didn't magically disappear while you're dead. It's also a snowflake since it only applies to slash wounds and nothing else.
## Why It's Good For The Game

Removing some snowflake code that's explained nowhere is pretty good.

It also happens to be unrealistic, not to mention the fact it removes from the fun of playing medical.
## Changelog
:cl:
balance: Slash wounds no longer clot while dead.
/:cl:
