### PR TITLE
Fixes natural wigs potentially getting a broken icon

### DIFF
--- a/code/modules/clothing/head/wig.dm
+++ b/code/modules/clothing/head/wig.dm
@@ -27,6 +27,7 @@
 /obj/item/clothing/head/wig/update_icon_state()
 	var/datum/sprite_accessory/hair_style = GLOB.hairstyles_list[hairstyle]
 	if(hair_style)
+		icon = hair_style.icon
 		icon_state = hair_style.icon_state
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. I came across this bug while doing some testing. The bald quirk gave me a natural wig and it had a broken icon because the icon path was different from the default one. Makes wigs far more downstream friendly.

## Why It's Good For the Game

This is my hair

<details>
<summary>I don't wear wigs</summary>
  
![image](https://user-images.githubusercontent.com/13398309/229259716-c8a179d2-1193-4065-b6ff-94d2bc846792.png)

</details>

## Changelog


:cl:
fix: the 'natural wig' item will no longer show a broken icon when it mimics a hairstyle whose icon path something other than the default 'icons/mob/species/human/human_face.dmi'
/:cl:
