### PR TITLE
Adds the Cloning Records Mishap station trait that fully randomizes people who spawn because Manuel kept vote kicking me

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -964,6 +964,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_BIRTHDAY "station_trait_birthday"
 #define STATION_TRAIT_SPIDER_INFESTATION "station_trait_spider_infestation"
 #define STATION_TRAIT_REVOLUTIONARY_TRASHING "station_trait_revolutionary_trashing"
+#define STATION_TRAIT_RANDOM_APPEARANCE "station_trait_random_appearance"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -1,3 +1,10 @@
+/datum/station_trait/random_appearance
+	name = "Cloning Records Mishap"
+	trait_type = STATION_TRAIT_NEUTRAL
+	weight = 5
+	report_message = "Due to a records mishap, the crew DNA profiles used during the reconstitution process into flesh automatons powered by neurotransmitters were scrambled."
+	trait_to_give = STATION_TRAIT_RANDOM_APPEARANCE
+
 /datum/station_trait/bananium_shipment
 	name = "Bananium Shipment"
 	trait_type = STATION_TRAIT_NEUTRAL

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -466,7 +466,7 @@
 
 
 /mob/living/carbon/human/apply_prefs_job(client/player_client, datum/job/job)
-	var/fully_randomize = GLOB.current_anonymous_theme || player_client.prefs.should_be_random_hardcore(job, player_client.mob.mind) || is_banned_from(player_client.ckey, "Appearance")
+	var/fully_randomize = GLOB.current_anonymous_theme || player_client.prefs.should_be_random_hardcore(job, player_client.mob.mind) || is_banned_from(player_client.ckey, "Appearance") || HAS_TRAIT(SSstation, STATION_TRAIT_RANDOM_APPEARANCE)
 	if(!player_client)
 		return // Disconnected while checking for the appearance ban.
 


### PR DESCRIPTION
## About The Pull Request

Adds the Cloning Records Mishap station trait that fully randomizes people who spawn because Manuel kept vote kicking me
![9SVnxBawov](https://user-images.githubusercontent.com/4081722/229309615-3dde9950-7e02-4ba7-adf3-b719fb81c8bb.png)
Not an april fools PR.
## Why It's Good For The Game

Manuel kept kicking me so I coded a trait idea that I've had for some time.

## Changelog

:cl:
add: Adds the Cloning Records Mishap station trait that fully randomizes people who spawn.
/:cl:
