### PR TITLE
Removes opacity from non fulltile tinted windows

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -657,7 +657,6 @@
 /obj/structure/window/reinforced/tinted
 	name = "tinted window"
 	icon_state = "twindow"
-	opacity = TRUE
 /obj/structure/window/reinforced/tinted/frosted
 	name = "frosted window"
 	icon_state = "fwindow"
@@ -738,6 +737,8 @@
 	smoothing_groups = SMOOTH_GROUP_WINDOW_FULLTILE
 	canSmoothWith = SMOOTH_GROUP_WINDOW_FULLTILE
 	glass_amount = 2
+	// Not on the parent because directional opacity does NOT WORK
+	opacity = TRUE
 
 /obj/structure/window/reinforced/fulltile/ice
 	icon = 'icons/obj/smooth_structures/rice_window.dmi'


### PR DESCRIPTION
## About The Pull Request

IT DOESN'T WORK, OPACITY IS NOT DIRECTIONAL, IT JUST LOOKS FUCKING STUPID

WHY DO WE USE THIS 48 TIMES WHY ARE YOU PEOPLE LIKE THIS

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/58055496/229333339-78f1c4d8-51e2-4370-a9a9-b9ecf045a7c4.png)


## Changelog
:cl:
fix: Directional frosted/tinted windows will no longer fuck up vision
/:cl:
