### PR TITLE
Print Cultist Names If Cult Failed

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -472,7 +472,7 @@
 
 	if(members.len)
 		parts += "<span class='header'>The cultists were:</span>"
-		if(locate(/obj/narsie) in SSpoints_of_interest.narsies)
+		if(length(true_cultists))
 			parts += printplayerlist(true_cultists)
 		else
 			parts += printplayerlist(members)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -472,7 +472,10 @@
 
 	if(members.len)
 		parts += "<span class='header'>The cultists were:</span>"
-		parts += printplayerlist(true_cultists)
+		if(locate(/obj/narsie) in SSpoints_of_interest.narsies)
+			parts += printplayerlist(true_cultists)
+		else
+			parts += printplayerlist(members)
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"
 


### PR DESCRIPTION

## About The Pull Request
Fix, roundend report wasn't printing names of cultists if Narsie didn't get summoned and they failed
## Why It's Good For The Game
Fix
## Changelog
:cl:
fix: Roundend Report properly lists cultist names if the cult failed and didn't summon Narsie
/:cl:
