### PR TITLE
Fixes the basketball and thunderdome baseturf issue.

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -143,6 +143,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 					qdel(obj) //Clear objects
 
 			var/datum/map_template/thunderdome_template = SSmapping.map_templates[THUNDERDOME_TEMPLATE_FILE]
+			thunderdome_template.should_place_on_top = FALSE
 			var/turf/thunderdome_corner = locate(thunderdome.x - 3, thunderdome.y - 1, 1) // have to do a little bit of coord manipulation to get it in the right spot
 			thunderdome_template.load(thunderdome_corner)
 

--- a/code/modules/basketball/basketball_map_loading.dm
+++ b/code/modules/basketball/basketball_map_loading.dm
@@ -41,6 +41,7 @@
 	var/team_name
 	/// The basketball teams home stadium uniform
 	var/home_team_uniform
+	should_place_on_top = FALSE
 
 /datum/map_template/basketball/stadium
 	name = "Stadium"

--- a/code/modules/basketball/basketball_map_loading.dm
+++ b/code/modules/basketball/basketball_map_loading.dm
@@ -36,12 +36,12 @@
 	area_flags = UNIQUE_AREA | NOTELEPORT | NO_DEATH_MESSAGE | BLOCK_SUICIDE
 
 /datum/map_template/basketball
+	should_place_on_top = FALSE
 	var/description = ""
 	/// The name of the basketball team
 	var/team_name
 	/// The basketball teams home stadium uniform
 	var/home_team_uniform
-	should_place_on_top = FALSE
 
 /datum/map_template/basketball/stadium
 	name = "Stadium"

--- a/code/modules/capture_the_flag/ctf_map_loading.dm
+++ b/code/modules/capture_the_flag/ctf_map_loading.dm
@@ -64,6 +64,7 @@ GLOBAL_DATUM(ctf_spawner, /obj/effect/landmark/ctf)
 
 /datum/map_template/ctf
 	var/description = ""
+	should_place_on_top = FALSE
 
 /datum/map_template/ctf/classic
 	name = "Classic"

--- a/code/modules/capture_the_flag/ctf_map_loading.dm
+++ b/code/modules/capture_the_flag/ctf_map_loading.dm
@@ -63,8 +63,8 @@ GLOBAL_DATUM(ctf_spawner, /obj/effect/landmark/ctf)
 	return TRUE
 
 /datum/map_template/ctf
-	var/description = ""
 	should_place_on_top = FALSE
+	var/description = ""
 
 /datum/map_template/ctf/classic
 	name = "Classic"

--- a/code/modules/mafia/map_pieces.dm
+++ b/code/modules/mafia/map_pieces.dm
@@ -42,6 +42,7 @@
 	var/description = ""
 	///What costume will this map force players to start with?
 	var/custom_outfit
+	should_place_on_top = FALSE
 
 /datum/map_template/mafia/summerball
 	name = "Summerball 2020"

--- a/code/modules/mafia/map_pieces.dm
+++ b/code/modules/mafia/map_pieces.dm
@@ -38,11 +38,11 @@
 	area_flags = BLOCK_SUICIDE | UNIQUE_AREA
 
 /datum/map_template/mafia
+	should_place_on_top = FALSE
 	///A brief background tidbit
 	var/description = ""
 	///What costume will this map force players to start with?
 	var/custom_outfit
-	should_place_on_top = FALSE
 
 /datum/map_template/mafia/summerball
 	name = "Summerball 2020"


### PR DESCRIPTION

## About The Pull Request

Simply modifies the should_place_on_top value on these maps templates so that they overwrite their baseturfs rather that creating an evergrowing stack. I've also done the same for Mafia and CTF which should also not be creating stacked baseturfs.
Fixes #69711
Should fix #74443 too since its the same issue.
## Why It's Good For The Game

Bugfix good.
## Changelog
:cl:
fix: Basketball and Thunderdome maps should not load with broken turfs are several resets of their maps.
/:cl:
