### PR TITLE
[WEBEDIT]Reagent reactions account for heat capacity changes properly.

### DIFF
--- a/code/modules/reagents/chemistry/equilibrium.dm
+++ b/code/modules/reagents/chemistry/equilibrium.dm
@@ -371,7 +371,7 @@
 		holder.chem_temp += clamp((reaction.thermic_constant* total_step_added*thermic_mod), 0, CHEMICAL_MAXIMUM_TEMPERATURE) //old method - for every bit added, the whole temperature is adjusted
 	else //Standard mechanics
 		var/heat_energy = reaction.thermic_constant * total_step_added * thermic_mod * SPECIFIC_HEAT_DEFAULT
-		holder.adjust_thermal_energy(heat_energy, TCMB, CHEMICAL_MAXIMUM_TEMPERATURE, old_heat_capacity = cached_heat_capacity) //heat is relative to the beaker conditions
+		holder.adjust_thermal_energy(delta_energy = heat_energy, old_heat_capacity = cached_heat_capacity) //heat is relative to the beaker conditions
 
 	//Give a chance of sounds
 	if(prob(5))

--- a/code/modules/reagents/chemistry/equilibrium.dm
+++ b/code/modules/reagents/chemistry/equilibrium.dm
@@ -258,6 +258,7 @@
 	delta_ph = 0 //How far off the pH we are
 	var/cached_ph = holder.ph
 	var/cached_temp = holder.chem_temp
+	var/cached_heat_capacity = holder.heat_capacity()
 	var/purity = 1 //purity of the current step
 
 	//Begin checks
@@ -370,7 +371,7 @@
 		holder.chem_temp += clamp((reaction.thermic_constant* total_step_added*thermic_mod), 0, CHEMICAL_MAXIMUM_TEMPERATURE) //old method - for every bit added, the whole temperature is adjusted
 	else //Standard mechanics
 		var/heat_energy = reaction.thermic_constant * total_step_added * thermic_mod * SPECIFIC_HEAT_DEFAULT
-		holder.adjust_thermal_energy(heat_energy, 0, CHEMICAL_MAXIMUM_TEMPERATURE) //heat is relative to the beaker conditions
+		holder.adjust_thermal_energy(heat_energy, TCMB, CHEMICAL_MAXIMUM_TEMPERATURE, old_heat_capacity = cached_heat_capacity) //heat is relative to the beaker conditions
 
 	//Give a chance of sounds
 	if(prob(5))

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1438,7 +1438,7 @@
  * - max_temp: The maximum temperature that can be reached.
  * - old_heat_capacity: Heat capacity before thermal energy change if they are part of the reaction.
  */
-/datum/reagents/proc/adjust_thermal_energy(delta_energy, min_temp = 2.7, max_temp = 1000, old_heat_capacity)
+/datum/reagents/proc/adjust_thermal_energy(delta_energy, min_temp = TCMB, max_temp = CHEMICAL_MAXIMUM_TEMPERATURE, old_heat_capacity)
 	var/heat_capacity = heat_capacity()
 	if(!heat_capacity)
 		return // no div/0 please

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1444,7 +1444,7 @@
 		return // no div/0 please
 	if(!old_heat_capacity)
 		old_heat_capacity = heat_capacity
-	set_temperature(clamp((chem_temp * old_heat_capacity + delta_energy) / heat_capacity), min_temp, max_temp)
+	set_temperature(clamp((chem_temp * old_heat_capacity + delta_energy) / heat_capacity, min_temp, max_temp))
 
 /// Applies heat to this holder
 /datum/reagents/proc/expose_temperature(temperature, coeff=0.02)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1436,12 +1436,15 @@
  * - delta_energy: The amount to change the thermal energy by.
  * - min_temp: The minimum temperature that can be reached.
  * - max_temp: The maximum temperature that can be reached.
+ * - old_heat_capacity: Heat capacity before thermal energy change if they are part of the reaction.
  */
-/datum/reagents/proc/adjust_thermal_energy(delta_energy, min_temp = 2.7, max_temp = 1000)
+/datum/reagents/proc/adjust_thermal_energy(delta_energy, min_temp = 2.7, max_temp = 1000, old_heat_capacity)
 	var/heat_capacity = heat_capacity()
 	if(!heat_capacity)
 		return // no div/0 please
-	set_temperature(clamp(chem_temp + (delta_energy / heat_capacity), min_temp, max_temp))
+	if(!old_heat_capacity)
+		old_heat_capacity = heat_capacity
+	set_temperature(clamp((chem_temp * old_heat_capacity + delta_energy) / heat_capacity), min_temp, max_temp)
 
 /// Applies heat to this holder
 /datum/reagents/proc/expose_temperature(temperature, coeff=0.02)


### PR DESCRIPTION
## About The Pull Request
Reagent reactions account for heat capacity changes properly. If heat capacity increases and energy doesn't change, temperature decreases. If heat capacity decreases, temperature increases. Also sets lower limit to TCMB. Changes adjust_thermal_energy() min_temp and max_temp to use TCMB and CHEMICAL_MAXIMUM_TEMPERATURE defines instead, respectively. This does change the max_temp default value though.
## Why It's Good For The Game
Conserves energy better. Things shouldn't reach 0 Kelvin. Magic numbers bad.
## Changelog
:cl:
fix: Reagent reactions properly conserve energy when heat capacity changes.
fix: Fix reagents being able to reach absolute zero.
code: adjust_thermal_energy() uses defines for default parameter values.
/:cl:
