### PR TITLE
Removes chunky fingers from Atmospheric glvoes

### DIFF
--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -141,5 +141,5 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
 	siemens_coefficient = 0.3
-	clothing_traits = list(TRAIT_QUICKER_CARRY, TRAIT_CHUNKYFINGERS)
+	clothing_traits = list(TRAIT_QUICKER_CARRY)
 	clothing_flags = THICKMATERIAL


### PR DESCRIPTION
## About The Pull Request

Removes atmos gloves making your fingers chunky, very minor PR.

This is an alternative to https://github.com/tgstation/tgstation/pull/74507 - Please close this one if that one is merged instead.

## Why It's Good For The Game

The point of the gloves is to go with the full firesuit for fire protection, however using this means you can't use flamethrowers, which requires using a trigger.

This allows firesuits to use flamethrowers and be used for what they're intended to be used for, protecting yourself against fire, regardless of who is spreading it, while I guess also giving Atmos techs the ability to re-use their modular computers. They aren't Engineers, they don't have Insulated gloves, stop trying to make these jobs similar damnit.

## Changelog

:cl:
balance: Atmos gloves no longer make your fingers chunky.
/:cl: