### PR TITLE
Adds better parts for syndie mechs, some tooltips to mech maintenance mode and some little changes.

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -442,16 +442,16 @@
 /obj/vehicle/sealed/mecha/examine(mob/user)
 	. = ..()
 	if(LAZYLEN(flat_equipment))
-		. += "It's equipped with:"
+		. += span_notice("It's equipped with:")
 		for(var/obj/item/mecha_parts/mecha_equipment/ME as anything in flat_equipment)
-			. += "[icon2html(ME, user)] \A [ME]."
+			. += span_notice("[icon2html(ME, user)] \A [ME].")
 	if(enclosed)
 		return
 	if(mecha_flags & SILICON_PILOT)
-		. += "[src] appears to be piloting itself..."
+		. += span_notice("[src] appears to be piloting itself...")
 	else
 		for(var/occupante in occupants)
-			. += "You can see [occupante] inside."
+			. += span_notice("You can see [occupante] inside.")
 		if(ishuman(user))
 			var/mob/living/carbon/human/H = user
 			for(var/held_item in H.held_items)

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -71,6 +71,7 @@
 	operation_req_access = list(ACCESS_SYNDICATE)
 	internals_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/gygax/dark
+	mecha_flags = CANSTRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE
 	max_equip_by_category = list(
 		MECHA_UTILITY = 2,
 		MECHA_POWER = 1,
@@ -98,9 +99,11 @@
 	. = ..()
 	max_ammo()
 
-/obj/vehicle/sealed/mecha/gygax/dark/add_cell(obj/item/stock_parts/cell/C=null)
-	if(C)
-		C.forceMove(src)
-		cell = C
-		return
+/obj/vehicle/sealed/mecha/gygax/dark/add_cell()
 	cell = new /obj/item/stock_parts/cell/bluespace(src)
+
+/obj/vehicle/sealed/mecha/gygax/dark/add_scanmod()
+	scanmod = new /obj/item/stock_parts/scanning_module/triphasic(src)
+
+/obj/vehicle/sealed/mecha/gygax/dark/add_capacitor()
+	capacitor = new /obj/item/stock_parts/capacitor/quadratic(src)

--- a/code/modules/vehicles/mecha/combat/honker.dm
+++ b/code/modules/vehicles/mecha/combat/honker.dm
@@ -69,12 +69,14 @@
 	fire = 100
 	acid = 100
 
-/obj/vehicle/sealed/mecha/honker/dark/add_cell(obj/item/stock_parts/cell/C)
-	if(C)
-		C.forceMove(src)
-		cell = C
-		return
+/obj/vehicle/sealed/mecha/honker/dark/add_cell()
 	cell = new /obj/item/stock_parts/cell/hyper(src)
+
+/obj/vehicle/sealed/mecha/honker/dark/add_scanmod()
+	scanmod = new /obj/item/stock_parts/scanning_module/phasic(src)
+
+/obj/vehicle/sealed/mecha/honker/dark/add_capacitor()
+	capacitor = new /obj/item/stock_parts/capacitor/super(src)
 
 /obj/structure/mecha_wreckage/honker/dark
 	name = "\improper Dark H.O.N.K wreckage"

--- a/code/modules/vehicles/mecha/combat/marauder.dm
+++ b/code/modules/vehicles/mecha/combat/marauder.dm
@@ -137,3 +137,12 @@
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(/obj/item/mecha_parts/mecha_equipment/armor/antiproj_armor_booster),
 	)
+
+/obj/vehicle/sealed/mecha/marauder/add_cell()
+	cell = new /obj/item/stock_parts/cell/bluespace(src)
+
+/obj/vehicle/sealed/mecha/marauder/add_scanmod()
+	scanmod = new /obj/item/stock_parts/scanning_module/triphasic(src)
+
+/obj/vehicle/sealed/mecha/marauder/add_capacitor()
+	capacitor = new /obj/item/stock_parts/capacitor/quadratic(src)

--- a/code/modules/vehicles/mecha/combat/reticence.dm
+++ b/code/modules/vehicles/mecha/combat/reticence.dm
@@ -39,3 +39,12 @@
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(),
 	)
+
+/obj/vehicle/sealed/mecha/reticence/add_cell()
+	cell = new /obj/item/stock_parts/cell/bluespace(src)
+
+/obj/vehicle/sealed/mecha/reticence/add_scanmod()
+	scanmod = new /obj/item/stock_parts/scanning_module/triphasic(src)
+
+/obj/vehicle/sealed/mecha/reticence/add_capacitor()
+	capacitor = new /obj/item/stock_parts/capacitor/quadratic(src)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -245,7 +245,7 @@
 	if(istype(W, /obj/item/stock_parts/scanning_module))
 		if(construction_state == MECHA_OPEN_HATCH)
 			if(!scanmod)
-				if(!user.transferItemToLoc(W, src))
+				if(!user.transferItemToLoc(W, src, silent = FALSE))
 					return
 				to_chat(user, span_notice("You install the scanning module."))
 				playsound(src, 'sound/items/screwdriver2.ogg', 50, FALSE)
@@ -259,7 +259,7 @@
 	if(istype(W, /obj/item/stock_parts/capacitor))
 		if(construction_state == MECHA_OPEN_HATCH)
 			if(!capacitor)
-				if(!user.transferItemToLoc(W, src))
+				if(!user.transferItemToLoc(W, src, silent = FALSE))
 					return
 				to_chat(user, span_notice("You install the capacitor."))
 				playsound(src, 'sound/items/screwdriver2.ogg', 50, FALSE)
@@ -300,31 +300,46 @@
 	if(.)
 		try_damage_component(., user.zone_selected)
 
-/obj/vehicle/sealed/mecha/wrench_act(mob/living/user, obj/item/I)
+/obj/vehicle/sealed/mecha/examine(mob/user)
+	.=..()
+	if(construction_state > MECHA_LOCKED)
+		switch(construction_state)
+			if(MECHA_SECURE_BOLTS)
+				. += span_notice("Use a <b>wrench</b> to adjust bolts securing the cover.")
+			if(MECHA_LOOSE_BOLTS)
+				. += span_notice("Use a <b>crowbar</b> to unlock the hatch to the power unit.")
+			if(MECHA_OPEN_HATCH)
+				. += span_notice("Use <b>interface</b> to eject stock parts from the mech.")
+
+/obj/vehicle/sealed/mecha/wrench_act(mob/living/user, obj/item/tool)
 	..()
 	. = TRUE
 	if(construction_state == MECHA_SECURE_BOLTS)
 		construction_state = MECHA_LOOSE_BOLTS
 		to_chat(user, span_notice("You undo the securing bolts."))
+		tool.play_tool_sound(src)
 		return
 	if(construction_state == MECHA_LOOSE_BOLTS)
 		construction_state = MECHA_SECURE_BOLTS
 		to_chat(user, span_notice("You tighten the securing bolts."))
+		tool.play_tool_sound(src)
 
-/obj/vehicle/sealed/mecha/crowbar_act(mob/living/user, obj/item/I)
+/obj/vehicle/sealed/mecha/crowbar_act(mob/living/user, obj/item/tool)
 	..()
 	. = TRUE
-	if(istype(I, /obj/item/crowbar/mechremoval))
-		var/obj/item/crowbar/mechremoval/remover = I
+	if(istype(tool, /obj/item/crowbar/mechremoval))
+		var/obj/item/crowbar/mechremoval/remover = tool
 		remover.empty_mech(src, user)
 		return
 	if(construction_state == MECHA_LOOSE_BOLTS)
 		construction_state = MECHA_OPEN_HATCH
 		to_chat(user, span_notice("You open the hatch to the power unit."))
+		tool.play_tool_sound(src)
 		return
 	if(construction_state == MECHA_OPEN_HATCH)
 		construction_state = MECHA_LOOSE_BOLTS
 		to_chat(user, span_notice("You close the hatch to the power unit."))
+		tool.play_tool_sound(src)
 
 /obj/vehicle/sealed/mecha/welder_act(mob/living/user, obj/item/W)
 	if(user.combat_mode)

--- a/code/modules/vehicles/mecha/mecha_helpers.dm
+++ b/code/modules/vehicles/mecha/mecha_helpers.dm
@@ -1,27 +1,27 @@
 ///Adds a cell, for use in Map-spawned mechs, Nuke Ops mechs, and admin-spawned mechs. Mechs built by hand will replace this.
-/obj/vehicle/sealed/mecha/proc/add_cell(obj/item/stock_parts/cell/C=null)
+/obj/vehicle/sealed/mecha/proc/add_cell(obj/item/stock_parts/cell/new_cell)
 	QDEL_NULL(cell)
-	if(C)
-		C.forceMove(src)
-		cell = C
+	if(new_cell)
+		new_cell.forceMove(src)
+		cell = new_cell
 		return
 	cell = new /obj/item/stock_parts/cell/high(src)
 
 ///Adds a scanning module, for use in Map-spawned mechs, Nuke Ops mechs, and admin-spawned mechs. Mechs built by hand will replace this.
-/obj/vehicle/sealed/mecha/proc/add_scanmod(obj/item/stock_parts/scanning_module/sm=null)
+/obj/vehicle/sealed/mecha/proc/add_scanmod(obj/item/stock_parts/scanning_module/new_scanmod)
 	QDEL_NULL(scanmod)
-	if(sm)
-		sm.forceMove(src)
-		scanmod = sm
+	if(new_scanmod)
+		new_scanmod.forceMove(src)
+		scanmod = new_scanmod
 		return
 	scanmod = new /obj/item/stock_parts/scanning_module(src)
 
 ///Adds a capacitor, for use in Map-spawned mechs, Nuke Ops mechs, and admin-spawned mechs. Mechs built by hand will replace this.
-/obj/vehicle/sealed/mecha/proc/add_capacitor(obj/item/stock_parts/capacitor/cap=null)
+/obj/vehicle/sealed/mecha/proc/add_capacitor(obj/item/stock_parts/capacitor/new_capacitor)
 	QDEL_NULL(capacitor)
-	if(cap)
-		cap.forceMove(src)
-		capacitor = cap
+	if(new_capacitor)
+		new_capacitor.forceMove(src)
+		capacitor = new_capacitor
 	else
 		capacitor = new /obj/item/stock_parts/capacitor(src)
 

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -195,17 +195,17 @@
 			if("drop_cell")
 				if(construction_state != MECHA_OPEN_HATCH)
 					return
-				cell.forceMove(get_turf(src))
+				usr.put_in_hands(cell)
 				cell = null
 			if("drop_scanning")
-				if(construction_state == MECHA_OPEN_HATCH)
+				if(construction_state != MECHA_OPEN_HATCH)
 					return
-				scanmod.forceMove(get_turf(src))
+				usr.put_in_hands(scanmod)
 				scanmod = null
 			if("drop_capacitor")
-				if(construction_state == MECHA_OPEN_HATCH)
+				if(construction_state != MECHA_OPEN_HATCH)
 					return
-				capacitor.forceMove(get_turf(src))
+				usr.put_in_hands(capacitor)
 				capacitor = null
 			if("set_pressure")
 				var/new_pressure = tgui_input_number(usr, "Enter new pressure", "Cabin pressure change", internal_tank_valve)


### PR DESCRIPTION
## About The Pull Request
Kinda resusticates #72442 cause the whole conflict was stupid.
Adds t4 parts for dark gygax, mauler and reticence (for the sake of shitspawn) and t3 for dark honker.
Formulas of better parts to understand the difference:
https://github.com/tgstation/tgstation/blob/aff9cf1b434c7a95d156ea20108d8b2bc015083d/code/modules/vehicles/mecha/_mecha.dm#L427-L439


Made examine text into span_notices so it's not just plane text.
Also added tooltips for maintenance. Screens to compare:
![image](https://user-images.githubusercontent.com/93882977/229368394-23ca7388-2640-4a82-8134-36a18878b687.png)
![image](https://user-images.githubusercontent.com/93882977/229368398-d4654b56-78e9-4321-80cc-cad31cfabef8.png)


Dark gygax will now spawn without access adding regime.
Tool interactions with mech will now have sounds. (wrench and crowbar)
Removing parts from mech will now put them in your hands, and not just under the mech.
When inserting parts in mech they won't make some noisy noise, already forgot which noise it was, but i changed it for some reason, so meh.

Also fixed that you can remove capacitors and scanning mods from mech without proper maintenance as it works with cell. Closes https://github.com/tgstation/tgstation/issues/71577
## Why It's Good For The Game
Syndie mechs are still week. Didn't see them in half a year.
## Changelog
:cl:
qol: changed mech description to span_notices and just slightly comfier to use.
qol: added tooltips for mech's maintenance mode.
balance: added t4 parts for mauler and dark gygax. And t3 parts for dark honker.
fix: fixed that you can remove capacitor and scanmod from mech without proper maintenance steps. Now you can't
/:cl:
