### PR TITLE
Laser guns will fire hitscan lasers.

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -12,14 +12,12 @@
 	e_cost = 100
 
 /obj/item/ammo_casing/energy/lasergun
-	projectile_type = /obj/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser/hitscan
 	e_cost = 62.5
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old
-	projectile_type = /obj/projectile/beam/laser
 	e_cost = 200
-	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hos
 	e_cost = 120

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -27,6 +27,9 @@
 	wound_bonus = -30
 	bare_wound_bonus = 40
 
+/obj/projectile/beam/laser/hitscan
+	hitscan = TRUE
+
 //overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
 /obj/projectile/beam/laser/hellfire
 	name = "hellfire laser"


### PR DESCRIPTION

## About The Pull Request
Laser guns (only laser, not the energy and other ones) will fire hitscan lasers.
## Why It's Good For The Game
Laser guns and energy guns were very similar, with laser just being a variant with slightly more ammo but no disable option. This lets the laser gun be a unique gun with a more obvious difference. It's also fun.
## Changelog
:cl:
balance: Laser guns now fire hitscan lasers.
/:cl:
