### PR TITLE
Gives plasmamen proper masks depending on their job.

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -120,6 +120,9 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	fire = 20
 	acid = 10
 
+/obj/item/clothing/mask/gas/atmos/plasmaman
+	starting_filter_type = /obj/item/gas_filter/plasmaman
+
 /obj/item/clothing/mask/gas/atmos/captain
 	name = "captain's gas mask"
 	desc = "Nanotrasen cut corners and repainted a spare atmospheric gas mask, but don't tell anyone."

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -64,6 +64,9 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	var/broken_hailer = FALSE
 	var/safety = TRUE
 
+/obj/item/clothing/mask/gas/sechailer/plasmaman
+	starting_filter_type = /obj/item/gas_filter/plasmaman
+
 /obj/item/clothing/mask/gas/sechailer/swat
 	name = "\improper SWAT mask"
 	desc = "A close-fitting tactical mask with an especially aggressive Compli-o-nator 3000."

--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -14,6 +14,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/security
 	gloves = /obj/item/clothing/gloves/color/plasmaman/black
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security
+	mask = /obj/item/clothing/mask/gas/sechailer/plasmaman
 
 /datum/outfit/plasmaman/detective
 	name = "Detective Plasmaman"
@@ -28,6 +29,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/security/warden
 	gloves = /obj/item/clothing/gloves/color/plasmaman/black
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security/warden
+	mask = /obj/item/clothing/mask/gas/sechailer/plasmaman
 
 /datum/outfit/plasmaman/prisoner
 	name = "Prisoner Plasmaman"
@@ -42,6 +44,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/medical
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 	head = /obj/item/clothing/head/helmet/space/plasmaman/medical
+	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/paramedic
 	name = "Paramedic Plasmaman"
@@ -49,6 +52,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/paramedic
 	gloves = /obj/item/clothing/gloves/color/plasmaman/plasmanitrile
 	head = /obj/item/clothing/head/helmet/space/plasmaman/paramedic
+	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/viro
 	name = "Virology Plasmaman"
@@ -56,6 +60,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/viro
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 	head = /obj/item/clothing/head/helmet/space/plasmaman/viro
+	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/chemist
 	name = "Chemist Plasmaman"
@@ -63,6 +68,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/chemist
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 	head = /obj/item/clothing/head/helmet/space/plasmaman/chemist
+	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/science
 	name = "Science Plasmaman"
@@ -112,6 +118,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/mining
 	gloves = /obj/item/clothing/gloves/color/plasmaman/explorer
 	head = /obj/item/clothing/head/helmet/space/plasmaman/mining
+	mask = /obj/item/clothing/mask/gas/explorer/plasmaman
 
 /datum/outfit/plasmaman/chaplain
 	name = "Chaplain Plasmaman"
@@ -198,6 +205,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/security/head_of_security
 	gloves = /obj/item/clothing/gloves/color/plasmaman/black
 	head = /obj/item/clothing/head/helmet/space/plasmaman/security/head_of_security
+	mask = /obj/item/clothing/mask/gas/sechailer/plasmaman
 
 /datum/outfit/plasmaman/chief_engineer
 	name = "Chief Engineer Plasmaman"
@@ -212,6 +220,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/chief_medical_officer
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 	head = /obj/item/clothing/head/helmet/space/plasmaman/chief_medical_officer
+	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/research_director
 	name = "Research Director Plasmaman"
@@ -226,7 +235,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/centcom_commander
 	gloves = /obj/item/clothing/gloves/color/plasmaman/centcom_commander
 	head = /obj/item/clothing/head/helmet/space/plasmaman/centcom_commander
-	mask = /obj/item/clothing/mask/gas/sechailer
+	mask = /obj/item/clothing/mask/gas/sechailer/plasmaman
 
 /datum/outfit/plasmaman/centcom_official
 	name = "CentCom Official Plasmaman"
@@ -262,7 +271,7 @@
 	uniform = /obj/item/clothing/under/plasmaman/engineering
 	gloves = /obj/item/clothing/gloves/color/plasmaman/engineer
 	head = /obj/item/clothing/head/helmet/space/plasmaman/engineering
-	mask = /obj/item/clothing/mask/gas/atmos
+	mask = /obj/item/clothing/mask/gas/atmos/plasmaman
 
 /datum/outfit/plasmaman/party_comedian
 	name = "ERP Comedian Plasmaman"

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -81,6 +81,9 @@
 	acid = 40
 	wound = 5
 
+/obj/item/clothing/mask/gas/explorer/plasmaman
+	starting_filter_type = /obj/item/gas_filter/plasmaman
+
 /obj/item/clothing/mask/gas/explorer/attack_self(mob/user)
 	adjustmask(user)
 


### PR DESCRIPTION
## About The Pull Request
Adds gasmasks plasma filter subtypes for sechailer, explorer and atmos. Atmosians won't have any updates, it's just to fix ERP Constructor Plasmaman loadout spawning with mask that won't allow you to breath.

And so med plasmamen will have medical masks. There will be sechailers for sec (except for the detective). And the miners will have explorer masks.
Oriented on job_boxes and what jobs spawn with which boxes.
## Why It's Good For The Game
Some love for living plasma mold. And i just think that it should be this way.
## Changelog
:cl:
add: Plasmamen will now spawn with proper masks depending on the job.
/:cl:
