### PR TITLE
Admin Verb - Break & Fix all lights split option

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -354,7 +354,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 					station_only = FALSE
 				if("Station Z Only")
 					station_only = TRUE
-				if("Cancel")
+				else
 					return
 			message_admins("[key_name_admin(holder)] broke [station_only ? "all station" : "all"] lights")
 			for(var/obj/machinery/light/L in GLOB.machines)
@@ -372,7 +372,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 					station_only = FALSE
 				if("Station Z Only")
 					station_only = TRUE
-				if("Cancel")
+				else
 					return
 			message_admins("[key_name_admin(holder)] fixed [station_only ? "all station" : "all"] lights")
 			for(var/obj/machinery/light/L in GLOB.machines)

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -348,8 +348,16 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 			if(!is_funmin)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Break All Lights"))
-			message_admins("[key_name_admin(holder)] broke all lights")
+			var/station_only = tgui_alert(usr,"Break which lights?", "And the lord said...", list("All Lights", "Station Z Only"))
+			switch(station_only)
+				if("All Lights")
+					station_only = FALSE
+				if("Station Z Only")
+					station_only = TRUE
+			message_admins("[key_name_admin(holder)] broke [station_only ? "all station" : "all"] lights")
 			for(var/obj/machinery/light/L in GLOB.machines)
+				if(station_only && !is_station_level(L.z))
+					continue
 				L.break_light_tube()
 				stoplag()
 		if("whiteout")

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -354,7 +354,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 					station_only = FALSE
 				if("Station Z Only")
 					station_only = TRUE
-				if("Cancel")
+				else
 					return
 			message_admins("[key_name_admin(holder)] broke [station_only ? "all station" : "all"] lights")
 			for(var/obj/machinery/light/L in GLOB.machines)

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -348,12 +348,14 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 			if(!is_funmin)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Break All Lights"))
-			var/station_only = tgui_alert(usr,"Break which lights?", "And the lord said...", list("All Lights", "Station Z Only"))
+			var/station_only = tgui_alert(usr,"Break which lights?", "And the lord said...", list("All Lights", "Station Z Only", "Cancel"))
 			switch(station_only)
 				if("All Lights")
 					station_only = FALSE
 				if("Station Z Only")
 					station_only = TRUE
+				if("Cancel")
+					return
 			message_admins("[key_name_admin(holder)] broke [station_only ? "all station" : "all"] lights")
 			for(var/obj/machinery/light/L in GLOB.machines)
 				if(station_only && !is_station_level(L.z))
@@ -364,8 +366,18 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 			if(!is_funmin)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Fix All Lights"))
-			message_admins("[key_name_admin(holder)] fixed all lights")
+			var/station_only = tgui_alert(usr,"Fix which lights?", "And the lord said...", list("All Lights", "Station Z Only", "Cancel"))
+			switch(station_only)
+				if("All Lights")
+					station_only = FALSE
+				if("Station Z Only")
+					station_only = TRUE
+				if("Cancel")
+					return
+			message_admins("[key_name_admin(holder)] fixed [station_only ? "all station" : "all"] lights")
 			for(var/obj/machinery/light/L in GLOB.machines)
+				if(station_only && !is_station_level(L.z))
+					continue
 				L.fix()
 				stoplag()
 		if("customportal")

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -354,6 +354,8 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 					station_only = FALSE
 				if("Station Z Only")
 					station_only = TRUE
+				if("Cancel")
+					return
 				else
 					return
 			message_admins("[key_name_admin(holder)] broke [station_only ? "all station" : "all"] lights")
@@ -372,6 +374,8 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 					station_only = FALSE
 				if("Station Z Only")
 					station_only = TRUE
+				if("Cancel")
+					return
 				else
 					return
 			message_admins("[key_name_admin(holder)] fixed [station_only ? "all station" : "all"] lights")


### PR DESCRIPTION
## About The Pull Request

Purpose of this is to give an option to split the Break All Lights command to just the station layer or _all_ layers, since some ruins kind of get messed up when their built in lights suddenly poof.

![image](https://user-images.githubusercontent.com/22140677/229383410-558e5889-8e9a-4e34-bc08-d21799d8617d.png)


## Why It's Good For The Game

mostly a QOL for admins during events (or trolling) so there's an option for it to only affect the station's Z level.

## Changelog
:cl:Zergspower
admin: Changed the 'Break/Fix all lights' Secret verb to have an option for Station Only or All Z levels
/:cl:
