### PR TITLE
Changes halon formation to require BZ. Halon combustion produces pluoxium.

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -176,12 +176,8 @@
 #define REACTION_OPPRESSION_THRESHOLD 5
 
 // Halon:
-/// The minimum temperature required for halon to form from tritium and BZ.
-#define HALON_FORMATION_MIN_TEMPERATURE 30
-/// The maximum temperature required for halon to form from tritium and BZ.
-#define HALON_FORMATION_MAX_TEMPERATURE 55
-/// The amount of energy 4.25 moles of halon forming from tritium and BZ releases.
-#define HALON_FORMATION_ENERGY 300
+/// Energy released per mole of BZ consumed during halon formation.
+#define HALON_FORMATION_ENERGY 90685.8
 
 /// How much energy a mole of halon combusting consumes.
 #define HALON_COMBUSTION_ENERGY 2500

--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -177,7 +177,7 @@
 
 // Halon:
 /// Energy released per mole of BZ consumed during halon formation.
-#define HALON_FORMATION_ENERGY 90685.8
+#define HALON_FORMATION_ENERGY 91232.1
 
 /// How much energy a mole of halon combusting consumes.
 #define HALON_COMBUSTION_ENERGY 2500

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -829,10 +829,10 @@
 		return NO_REACTION
 
 	var/old_heat_capacity = air.heat_capacity()
-	ASSERT_GAS(/datum/gas/carbon_dioxide, air)
+	ASSERT_GAS(/datum/gas/pluoxium, air)
 	cached_gases[/datum/gas/halon][MOLES] -= heat_efficency
 	cached_gases[/datum/gas/oxygen][MOLES] -= heat_efficency * 20
-	cached_gases[/datum/gas/carbon_dioxide][MOLES] += heat_efficency * 5
+	cached_gases[/datum/gas/pluoxium][MOLES] += heat_efficency * 2.5
 
 	SET_REACTION_RESULTS(heat_efficency * 5)
 	var/energy_used = heat_efficency * HALON_COMBUSTION_ENERGY

--- a/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
+++ b/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
@@ -89,30 +89,27 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
 /datum/electrolyzer_reaction/halon_generation
 	name = "Halon generation"
 	id = "halon_generation"
-	desc = "Production of halon from CO2 and N2O"
+	desc = "Production of halon from the electrolysis of BZ."
 	requirements = list(
-		/datum/gas/carbon_dioxide = MINIMUM_MOLE_COUNT,
-		/datum/gas/nitrous_oxide = MINIMUM_MOLE_COUNT,
-		"MAX_TEMP" = 230
+		/datum/gas/bz = MINIMUM_MOLE_COUNT,
 	)
 	factor = list(
-		/datum/gas/carbon_dioxide = "2 moles of CO2 get consumed",
-		/datum/gas/nitrous_oxide = "1 mole of N2O gets consumed",
-		/datum/gas/halon = "1 mole of Halon gets produced",
-		"Energy" = "300 joules of energy is released per mole",
-		"Temperature" = "Can only occur under 230 kelvin.",
+		/datum/gas/bz = "Consumed during reaction.",
+		/datum/gas/oxygen = "0.2 moles of oxygen gets produced per mole of BZ consumed.",
+		/datum/gas/halon = "2 moles of Halon gets produced per mole of BZ consumed.",
+		"Energy" = "300 joules of energy is released per mole of BZ consumed.",
+		"Temperature" = "Reaction efficiency is proportional to temperature.",
 		"Location" = "Can only happen on turfs with an active Electrolyzer.",
 	)
 
 /datum/electrolyzer_reaction/halon_generation/react(turf/location, datum/gas_mixture/air_mixture, working_power)
 
 	var/old_heat_capacity = air_mixture.heat_capacity()
-	air_mixture.assert_gases(/datum/gas/carbon_dioxide, /datum/gas/nitrous_oxide, /datum/gas/halon)
-	var/pressure = air_mixture.return_pressure()
-	var/reaction_efficency = min(1 / ((pressure / (0.5 * ONE_ATMOSPHERE)) * (max(air_mixture.gases[/datum/gas/carbon_dioxide][MOLES] / air_mixture.gases[/datum/gas/nitrous_oxide][MOLES], 1))), air_mixture.gases[/datum/gas/nitrous_oxide][MOLES], air_mixture.gases[/datum/gas/carbon_dioxide][MOLES] * INVERSE(2))
-	air_mixture.gases[/datum/gas/carbon_dioxide][MOLES] -= reaction_efficency * 2
-	air_mixture.gases[/datum/gas/nitrous_oxide][MOLES] -= reaction_efficency
-	air_mixture.gases[/datum/gas/halon][MOLES] += reaction_efficency
+	air_mixture.assert_gases(/datum/gas/bz, /datum/gas/oxygen, /datum/gas/halon)
+	var/reaction_efficency = min(air_mixture.gases[/datum/gas/bz][MOLES] * (1 - NUM_E ** (-air_mixture.temperature / FIRE_MINIMUM_TEMPERATURE_TO_EXIST)), air_mixture.gases[/datum/gas/bz][MOLES])
+	air_mixture.gases[/datum/gas/bz][MOLES] -= reaction_efficency
+	air_mixture.gases[/datum/gas/oxygen][MOLES] += reaction_efficency * 0.2
+	air_mixture.gases[/datum/gas/halon][MOLES] += reaction_efficency * 2
 	var/energy_used = reaction_efficency * HALON_FORMATION_ENERGY
 	var/new_heat_capacity = air_mixture.heat_capacity()
 	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)

--- a/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
+++ b/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer_reactions.dm
@@ -106,7 +106,7 @@ GLOBAL_LIST_INIT(electrolyzer_reactions, electrolyzer_reactions_list())
 
 	var/old_heat_capacity = air_mixture.heat_capacity()
 	air_mixture.assert_gases(/datum/gas/bz, /datum/gas/oxygen, /datum/gas/halon)
-	var/reaction_efficency = min(air_mixture.gases[/datum/gas/bz][MOLES] * (1 - NUM_E ** (-air_mixture.temperature / FIRE_MINIMUM_TEMPERATURE_TO_EXIST)), air_mixture.gases[/datum/gas/bz][MOLES])
+	var/reaction_efficency = min(air_mixture.gases[/datum/gas/bz][MOLES] * (1 - NUM_E ** (-0.5 * air_mixture.temperature * working_power / FIRE_MINIMUM_TEMPERATURE_TO_EXIST)), air_mixture.gases[/datum/gas/bz][MOLES])
 	air_mixture.gases[/datum/gas/bz][MOLES] -= reaction_efficency
 	air_mixture.gases[/datum/gas/oxygen][MOLES] += reaction_efficency * 0.2
 	air_mixture.gases[/datum/gas/halon][MOLES] += reaction_efficency * 2


### PR DESCRIPTION

## About The Pull Request
Changes halon formation to require BZ, instead of CO2 and N2O. It no longer has a maximum temperature limit. Higher temperature increases reaction speed. Changes energy release to 91.2321kJ per mole of BZ consumed. Halon gets produced at 2 moles per BZ consumed. Oxygen a tenth of that.

Halon combustion will release 2.5 moles of pluoxium per mole of halon consumed, instead of 5 moles of CO2.
## Why It's Good For The Game
Halon took too much effort to make for something that won't be used for most rounds. Creating something that won't be used for most rounds can get repetitive very quickly. The effort can now be spent on making BZ instead, which is a precursor to other atmospheric projects. Not much extra effort will be needed to dump BZ into an electrolyzer in an emergency. Releasing pluoxium during halon combustion can allow atmospheric technicians to use halon for things outside of firefighting, though it will still primarily be a firefighting gas.
## Changelog
:cl:
balance: Halon formation is made from the electrolysis of BZ. 2 moles of halon, and 0.2 moles of oxygen gets produced per mole of BZ electrolyzed. Temperature increases reaction speed.
balance: Halon formation energy set to 91.2321kJ per mole of BZ consumed.
balance: Halon combustion releases 2.5 moles of pluoxium per mole of halon, instead of releasing CO2..
/:cl:
