### PR TITLE
Icemoon Hermit Ruin Active Turf Fix - For Real This Time

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
@@ -151,7 +151,7 @@
 /turf/open/floor/plating,
 /area/ruin/powered/hermit)
 "YN" = (
-/turf/closed/mineral/snowmountain/icemoon,
+/turf/closed/mineral/snowmountain/icemoon/unscrapeable,
 /area/icemoon/underground/explored)
 
 (1,1,1) = {"
@@ -400,7 +400,7 @@ YN
 YN
 YN
 YN
-aM
+YN
 Rr
 aM
 aM

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -97,6 +97,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define NO_RUST (1<<5)
 /// Is this turf is "solid". Space and lava aren't for instance
 #define IS_SOLID (1<<6)
+/// This turf will never be scraped away.
+#define NO_SCRAPING (1<<7)
 
 ////////////////Area flags\\\\\\\\\\\\\\
 /// If it's a valid territory for cult summoning or the CRAB-17 phone to spawn

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -97,8 +97,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define NO_RUST (1<<5)
 /// Is this turf is "solid". Space and lava aren't for instance
 #define IS_SOLID (1<<6)
-/// This turf will never be scraped away.
-#define NO_SCRAPING (1<<7)
+/// This turf will never be cleared away by other objects on Initialize.
+#define NO_CLEARING (1<<7)
 
 ////////////////Area flags\\\\\\\\\\\\\\
 /// If it's a valid territory for cult summoning or the CRAB-17 phone to spawn

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -67,10 +67,10 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/polarbear)
 
 /obj/structure/spawner/ice_moon/polarbear/clear_rock()
-	for(var/turf/F in RANGE_TURFS(1, src))
-		if(ismineralturf(F))
-			var/turf/closed/mineral/M = F
-			M.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
+	for(var/turf/potential in RANGE_TURFS(1, src))
+		if(ismineralturf(potential))
+			var/turf/closed/mineral/clearable = potential
+			clearable.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
 
 /obj/structure/spawner/ice_moon/demonic_portal
 	name = "demonic portal"
@@ -85,12 +85,12 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	AddComponent(/datum/component/gps, "Netheric Signal")
 
 /obj/structure/spawner/ice_moon/demonic_portal/clear_rock()
-	for(var/turf/F in RANGE_TURFS(3, src))
-		if(abs(src.x - F.x) + abs(src.y - F.y) > 5)
+	for(var/turf/potential in RANGE_TURFS(3, src))
+		if(abs(src.x - potential.x) + abs(src.y - potential.y) > 5)
 			continue
-		if(ismineralturf(F))
-			var/turf/closed/mineral/M = F
-			M.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
+		if(ismineralturf(potential))
+			var/turf/closed/mineral/clearable = potential
+			clearable.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
 
 /obj/structure/spawner/ice_moon/demonic_portal/destroy_effect()
 	new /obj/effect/collapsing_demonic_portal(loc)

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -33,7 +33,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	for(var/turf/potential in RANGE_TURFS(2, src))
 		if(abs(src.x - potential.x) + abs(src.y - potential.y) > 3)
 			continue
-		if(ismineralturf(potential))
+		if(ismineralturf(potential) && !(potential.turf_flags & NO_CLEARING))
 			var/turf/closed/mineral/clearable = potential
 			clearable.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
 
@@ -68,7 +68,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 
 /obj/structure/spawner/ice_moon/polarbear/clear_rock()
 	for(var/turf/potential in RANGE_TURFS(1, src))
-		if(ismineralturf(potential))
+		if(ismineralturf(potential) && !(potential.turf_flags & NO_CLEARING))
 			var/turf/closed/mineral/clearable = potential
 			clearable.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
 
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	for(var/turf/potential in RANGE_TURFS(3, src))
 		if(abs(src.x - potential.x) + abs(src.y - potential.y) > 5)
 			continue
-		if(ismineralturf(potential))
+		if(ismineralturf(potential) && !(potential.turf_flags & NO_CLEARING))
 			var/turf/closed/mineral/clearable = potential
 			clearable.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
 

--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -26,16 +26,16 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	clear_rock()
 
 /**
- * Clears rocks around the spawner when it is created
+ * Clears rocks around the spawner when it is created. Ignore any rocks that explicitly do not want to be cleared.
  *
  */
 /obj/structure/spawner/ice_moon/proc/clear_rock()
-	for(var/turf/F in RANGE_TURFS(2, src))
-		if(abs(src.x - F.x) + abs(src.y - F.y) > 3)
+	for(var/turf/potential in RANGE_TURFS(2, src))
+		if(abs(src.x - potential.x) + abs(src.y - potential.y) > 3)
 			continue
-		if(ismineralturf(F))
-			var/turf/closed/mineral/M = F
-			M.ScrapeAway(null, CHANGETURF_IGNORE_AIR)
+		if(ismineralturf(potential))
+			var/turf/closed/mineral/clearable = potential
+			clearable.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
 
 /obj/structure/spawner/ice_moon/deconstruct(disassembled)
 	destroy_effect()
@@ -70,7 +70,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	for(var/turf/F in RANGE_TURFS(1, src))
 		if(ismineralturf(F))
 			var/turf/closed/mineral/M = F
-			M.ScrapeAway(null, CHANGETURF_IGNORE_AIR)
+			M.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
 
 /obj/structure/spawner/ice_moon/demonic_portal
 	name = "demonic portal"
@@ -90,7 +90,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 			continue
 		if(ismineralturf(F))
 			var/turf/closed/mineral/M = F
-			M.ScrapeAway(null, CHANGETURF_IGNORE_AIR)
+			M.ScrapeAway(flags = CHANGETURF_IGNORE_AIR)
 
 /obj/structure/spawner/ice_moon/demonic_portal/destroy_effect()
 	new /obj/effect/collapsing_demonic_portal(loc)

--- a/code/game/turfs/baseturfs.dm
+++ b/code/game/turfs/baseturfs.dm
@@ -1,6 +1,6 @@
 /// Take off the top layer turf and replace it with the next baseturf down
 /turf/proc/ScrapeAway(amount=1, flags)
-	if(!amount || (turf_flags & NO_SCRAPING))
+	if(!amount)
 		return
 	if(length(baseturfs))
 		var/list/new_baseturfs = baseturfs.Copy()

--- a/code/game/turfs/baseturfs.dm
+++ b/code/game/turfs/baseturfs.dm
@@ -1,6 +1,6 @@
 /// Take off the top layer turf and replace it with the next baseturf down
 /turf/proc/ScrapeAway(amount=1, flags)
-	if(!amount)
+	if(!amount || (turf_flags & NO_SCRAPING))
 		return
 	if(length(baseturfs))
 		var/list/new_baseturfs = baseturfs.Copy()

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -601,7 +601,7 @@
 
 /// This snowy mountain will never be scraped away for any reason what so ever.
 /turf/closed/mineral/snowmountain/icemoon/unscrapeable
-	turf_flags = IS_SOLID | NO_SCRAPING
+	turf_flags = IS_SOLID | NO_CLEARING
 	turf_type = /turf/open/misc/asteroid/snow/icemoon/do_not_scrape
 	baseturfs = /turf/open/misc/asteroid/snow/icemoon/do_not_scrape
 

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -599,6 +599,13 @@
 	baseturfs = /turf/open/misc/asteroid/snow/icemoon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 
+/// This snowy mountain will never be scraped away for any reason what so ever.
+/turf/closed/mineral/snowmountain/icemoon/unscrapeable
+	turf_flags = IS_SOLID | NO_SCRAPING
+	// using the do_not_chasm subtypes because they provide both functions that we both need and want here.
+	turf_type = /turf/open/misc/asteroid/snow/icemoon/do_not_chasm
+	baseturfs = /turf/open/misc/asteroid/snow/icemoon/do_not_chasm
+
 /turf/closed/mineral/snowmountain/cavern
 	name = "ice cavern rock"
 	icon = MAP_SWITCH('icons/turf/walls/icerock_wall.dmi', 'icons/turf/mining.dmi')

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -602,9 +602,8 @@
 /// This snowy mountain will never be scraped away for any reason what so ever.
 /turf/closed/mineral/snowmountain/icemoon/unscrapeable
 	turf_flags = IS_SOLID | NO_SCRAPING
-	// using the do_not_chasm subtypes because they provide both functions that we both need and want here.
-	turf_type = /turf/open/misc/asteroid/snow/icemoon/do_not_chasm
-	baseturfs = /turf/open/misc/asteroid/snow/icemoon/do_not_chasm
+	turf_type = /turf/open/misc/asteroid/snow/icemoon/do_not_scrape
+	baseturfs = /turf/open/misc/asteroid/snow/icemoon/do_not_scrape
 
 /turf/closed/mineral/snowmountain/cavern
 	name = "ice cavern rock"

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -200,7 +200,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 
 /// Exact subtype as parent, just used in ruins to prevent other ruins/chasms from spawning on top of it.
 /turf/open/misc/asteroid/snow/icemoon/do_not_chasm
-	turf_flags = NO_RUINS
+	turf_flags = NO_RUINS | NO_SCRAPING
 
 /turf/open/lava/plasma/ice_moon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -200,7 +200,10 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 
 /// Exact subtype as parent, just used in ruins to prevent other ruins/chasms from spawning on top of it.
 /turf/open/misc/asteroid/snow/icemoon/do_not_chasm
-	turf_flags = NO_RUINS | NO_SCRAPING
+	turf_flags = CAN_BE_DIRTY_1 | IS_SOLID | NO_RUST | NO_RUINS
+
+/turf/open/misc/asteroid/snow/icemoon/do_not_scrape
+	turf_flags = CAN_BE_DIRTY_1 | IS_SOLID | NO_RUST | NO_SCRAPING
 
 /turf/open/lava/plasma/ice_moon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS

--- a/code/game/turfs/open/asteroid.dm
+++ b/code/game/turfs/open/asteroid.dm
@@ -203,7 +203,7 @@ GLOBAL_LIST_EMPTY(dug_up_basalt)
 	turf_flags = CAN_BE_DIRTY_1 | IS_SOLID | NO_RUST | NO_RUINS
 
 /turf/open/misc/asteroid/snow/icemoon/do_not_scrape
-	turf_flags = CAN_BE_DIRTY_1 | IS_SOLID | NO_RUST | NO_SCRAPING
+	turf_flags = CAN_BE_DIRTY_1 | IS_SOLID | NO_RUST | NO_CLEARING
 
 /turf/open/lava/plasma/ice_moon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS


### PR DESCRIPTION
## About The Pull Request

In #74306, I _thought_ I knew what the cause was, and I both attempted a potential fix _and_ made tracking it easier. The fruits of my labor paid off, I know exactly what caused it now. 

![image](https://user-images.githubusercontent.com/34697715/229420637-ff4ff886-fa34-4962-8019-d3105bf3d3c3.png)

Basically, the demonic portal will scrape away all turfs in a 5-tile radius on its `Initialize()`, and if a spawner spawned right next to the hermit ruin... it would count it as a mineral turf and scrape it away as well. That's so fucking silly. At least we know now.
## Why It's Good For The Game

The fix is to just make those tiles unscrapeable, which is accomplished via another turf_flag and filtering those out in the `Initialize()` of the demonic portals.

I also cleaned up the calls to scrapeaway being `null`, which is really weird because it just defaulted to the normal proc behavior. Naming the arguments instead does the same thing (I checked):

![image](https://user-images.githubusercontent.com/34697715/229421028-ffe9c2dd-eaec-4c71-ac8e-96d3a7fa9a0f.png)

The hermit's shelter is finally intact.
## Changelog
Nothing that really concerns players.
