### PR TITLE
[No GBP] Removes bonus corpse from the prey pod space ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/prey_pod.dmm
+++ b/_maps/RandomRuins/SpaceRuins/prey_pod.dmm
@@ -56,12 +56,6 @@
 /obj/effect/mob_spawn/corpse/human/prey_pod,
 /turf/open/floor/mineral/titanium/white/airless,
 /area/ruin/space/has_grav)
-"R" = (
-/obj/effect/mob_spawn/corpse/human/roboticist{
-	husk = 1
-	},
-/turf/closed/wall/mineral/titanium,
-/area/ruin/space/has_grav)
 "S" = (
 /mob/living/simple_animal/hostile/asteroid/hivelord,
 /turf/open/floor/mineral/titanium/white/airless,
@@ -182,7 +176,7 @@ X
 X
 X
 X
-R
+P
 k
 Y
 Y


### PR DESCRIPTION

## About The Pull Request

When I fixed up the Prey Pod's corpse spawner not working properly, I accidentally placed down a second corpse spawner, without somehow noticing? This fixes that.

## Why It's Good For The Game

There is meant to be only one corpse.

## Changelog

:cl:
fix: The prey pod ruin no longer has two corpses, only one.
/:cl:

