### PR TITLE
Adds tele access to the QM

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -785,7 +785,9 @@
 		ACCESS_EVA,
 		ACCESS_BRIG_ENTRANCE,
 		)
-	extra_access = list()
+	extra_access = list(
+		ACCESS_TELEPORTER,
+		)
 	minimal_wildcard_access = list(
 		ACCESS_QM,
 	)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -691,7 +691,7 @@
 
 	if(registered_account)
 		. += "The account linked to the ID belongs to '[registered_account.account_holder]' and reports a balance of [registered_account.account_balance] cr."
-		if((ACCESS_COMMAND in access) || (ACCESS_QM in access))
+		if(ACCESS_COMMAND in access)
 			var/datum/bank_account/linked_dept = SSeconomy.get_dep_account(registered_account.account_job.paycheck_department)
 			. += "The [linked_dept.account_holder] linked to the ID reports a balance of [linked_dept.account_balance] cr."
 


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/54560 gave all command staff access to the Teleporter room on lowpop, however this was forgotten about for the QM when they were turned into a head of staff.

I also removed a QM-access check for budget examining since the QM now has Command access instead.

## Why It's Good For The Game

Better consistency with what access to expect when playing as Command. It also was bugging me a little bit.

## Changelog

:cl:
fix: QM's now get teleporter access on lowpop, like every other Command does.
/:cl: