### PR TITLE
Fixes coderbus item layering

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bus.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bus.dmm
@@ -19,7 +19,7 @@
 "an" = (
 /obj/structure/fluff/bus/passable/seat,
 /obj/item/toy/plush/pkplush{
-	pixel_y = 17
+	pixel_z = 17
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -27,7 +27,7 @@
 /area/ruin/space)
 "ao" = (
 /obj/machinery/telecomms/server{
-	pixel_y = 12;
+	pixel_z = 12;
 	layer = 2.91;
 	name = "tgsv3";
 	desc = "It's, uh... pending an upgrade."
@@ -39,7 +39,7 @@
 	pixel_y = 15
 	},
 /obj/item/toy/plush/lizard_plushie/green{
-	pixel_y = 17
+	pixel_z = 17
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -49,7 +49,7 @@
 /obj/structure/fluff/bus/passable/seat,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/helmet/knight{
-	pixel_y = 16
+	pixel_z = 16
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -58,10 +58,13 @@
 "ar" = (
 /obj/structure/fluff/bus/passable/seat,
 /obj/item/grown/novaflower{
-	pixel_y = 25
+	offset_at_init = 0;
+	pixel_z = 24;
+	pixel_y = 1
 	},
 /obj/item/food/grown/watermelon{
-	pixel_y = 17
+	offset_at_init = 0;
+	pixel_z = 17
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -71,13 +74,16 @@
 /obj/structure/fluff/bus/passable/seat/driver,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/plush/moth{
-	pixel_y = 28
+	pixel_z = 26;
+	pixel_y = 2
 	},
 /obj/item/food/grown/citrus/orange{
-	pixel_y = 19
+	offset_at_init = 0;
+	pixel_z = 18;
+	pixel_y = 1
 	},
 /obj/item/toy/talking/ai{
-	pixel_y = 16
+	pixel_z = 16
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -141,11 +147,12 @@
 /obj/structure/fluff/bus/passable/seat,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bodypart/arm/right{
-	pixel_y = 26;
+	pixel_z = 25;
+	pixel_y = 1;
 	pixel_x = -4
 	},
 /obj/item/food/meat/slab/penguin{
-	pixel_y = 13
+	pixel_z = 13
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -162,7 +169,7 @@
 /obj/structure/fluff/bus/passable/seat/driver,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/banhammer{
-	pixel_y = 22
+	pixel_z = 22
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -178,16 +185,19 @@
 "ba" = (
 /obj/structure/fluff/bus/passable/seat,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/ants{
-	pixel_y = 8;
-	pixel_x = 9
-	},
 /obj/item/food/grown/tomato{
-	pixel_y = 25
+	offset_at_init = 0;
+	pixel_z = 23;
+	pixel_y = 2
 	},
 /obj/item/food/donut/plain{
-	pixel_y = 16;
+	pixel_z = 15;
+	pixel_y = 1;
 	pixel_x = 1
+	},
+/obj/effect/decal/cleanable/ants{
+	pixel_z = 8;
+	pixel_x = 9
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -279,14 +289,15 @@
 /area/ruin/space)
 "FZ" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/item/toy/plush/awakenedplushie{
+	pixel_z = 26;
+	pixel_y = 1
+	},
 /obj/machinery/telecomms/server{
-	pixel_y = 12;
+	pixel_z = 12;
 	layer = 2.91;
 	name = "tgsv3";
 	desc = "It's, uh... pending an upgrade."
-	},
-/obj/item/toy/plush/awakenedplushie{
-	pixel_y = 27
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"
@@ -371,11 +382,13 @@
 /obj/structure/fluff/bus/passable/seat,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/singlecard{
-	pixel_y = 25;
+	pixel_z = 24;
+	pixel_y = 1;
 	pixel_x = 0
 	},
 /obj/item/food/grown/potato{
-	pixel_y = 15
+	offset_at_init = 0;
+	pixel_z = 15
 	},
 /turf/open/floor/iron/dark/airless{
 	icon_state = "bus"

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -40,6 +40,8 @@
 	var/filling_color
 	/// If the grown food has an alternaitve icon state to use in places.
 	var/alt_icon
+	/// Should we pixel offset ourselves at init? for mapping
+	var/offset_at_init = TRUE
 
 /obj/item/food/grown/Initialize(mapload, obj/item/seeds/new_seed)
 	if(!tastes)
@@ -56,8 +58,9 @@
 		stack_trace("Grown object created without a seed. WTF")
 		return INITIALIZE_HINT_QDEL
 
-	pixel_x = base_pixel_x + rand(-5, 5)
-	pixel_y = base_pixel_y + rand(-5, 5)
+	if(offset_at_init)
+		pixel_x = base_pixel_x + rand(-5, 5)
+		pixel_y = base_pixel_y + rand(-5, 5)
 
 	make_dryable()
 

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -8,6 +8,8 @@
 	worn_icon = 'icons/mob/clothing/head/hydroponics.dmi'
 	resistance_flags = FLAMMABLE
 	var/obj/item/seeds/seed = null // type path, gets converted to item on New(). It's safe to assume it's always a seed item.
+	/// Should we pixel offset ourselves at init? for mapping
+	var/offset_at_init = TRUE
 
 /obj/item/grown/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()
@@ -21,8 +23,9 @@
 		seed = new seed()
 		seed.adjust_potency(50-seed.potency)
 
-	pixel_x = base_pixel_x + rand(-5, 5)
-	pixel_y = base_pixel_y + rand(-5, 5)
+	if(offset_at_init)
+		pixel_x = base_pixel_x + rand(-5, 5)
+		pixel_y = base_pixel_y + rand(-5, 5)
 
 	if(seed)
 		// Go through all traits in their genes and call on_new_plant from them.

--- a/tools/maplint/lints/pixel_varedits.yml
+++ b/tools/maplint/lints/pixel_varedits.yml
@@ -1,6 +1,4 @@
 "*":
   banned_variables:
-  - pixel_w
-  - pixel_z
   - step_x
   - step_y


### PR DESCRIPTION
## About The Pull Request

Pixel y offsets were causing the items to draw behind the seats, which is cringe, and the grown items randomly offset themselves, which lead to more shitfuck. This solves those two issues.

Yes I did add bespoke code for the snowflake reference ruin. Neener neener.

[Allows pixel_w and pixel_z var edits, since sidemap is used now they do actually do something different](https://github.com/tgstation/tgstation/pull/74481/commits/481ab455a88257dfe8f7ade019539263ec82f75c)
[481ab45](https://github.com/tgstation/tgstation/pull/74481/commits/481ab455a88257dfe8f7ade019539263ec82f75c)

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/58055496/229493901-6fdb5d71-3456-47dc-a042-62b5c85102e6.png)

## Changelog
:cl:
fix: The coderbus passengers layer properly again
/:cl:
