### PR TITLE
Mobile ports wont connect itself to shuttles

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -622,7 +622,7 @@
 /obj/docking_port/mobile/proc/linkup(obj/docking_port/stationary/dock)
 	for(var/area/place as anything in shuttle_areas)
 		place.connect_to_shuttle(TRUE, src, dock)
-		for(var/atom/individual_atoms in place)
+		for(var/atom/individual_atoms in place.contents - src)
 			individual_atoms.connect_to_shuttle(TRUE, src, dock)
 
 //this is a hook for custom behaviour. Maybe at some point we could add checks to see if engines are intact


### PR DESCRIPTION
## About The Pull Request

Mobile ports no longer connect themselves to shuttles. 
This is a minor change that has no in-game effects as it just returns currently.

## Why It's Good For The Game

If functionality is ever added, the mobile port should not be connecting itself to the shuttle through linkup, because there's no order to what's being connected first, which makes it a very unsafe way of handling it, especially when the port is very important to the ship.

## Changelog

No player-facing changes.