### PR TITLE
Blink is no longer a forbidden school spell??

### DIFF
--- a/code/modules/spells/spell_types/teleport/blink.dm
+++ b/code/modules/spells/spell_types/teleport/blink.dm
@@ -4,7 +4,7 @@
 	button_icon_state = "blink"
 	sound = 'sound/magic/blink.ogg'
 
-	school = SCHOOL_FORBIDDEN
+	school = SCHOOL_TRANSLOCATION
 	cooldown_time = 2 SECONDS
 	cooldown_reduction_per_rank = 0.4 SECONDS
 


### PR DESCRIPTION

## About The Pull Request

Turns blink's school from forbidden to translocation. This has some incredibly minor changes nobody is going to notice:
- Changes the blink's invocations when mixed with a CERTAIN spell
- If you were very specifically a chaplain with the holy crusade sect and you casted blink, before it would excommunicate you, now it will just smite you, as translocation spells are seen as less bad than forbidden magic
- probably some more niche interactions but that's all I can remember

## Why It's Good For The Game

Guys, I know blink is a very annoying spell but come on now it's not forbidden magic, that's for heretics and super duper evil stuffs

## Changelog
:cl:
fix: blink is now a translocation spell
/:cl:
