### PR TITLE
Clients can't OOC until they have fully gone through `New()`

### DIFF
--- a/code/__DEFINES/client.dm
+++ b/code/__DEFINES/client.dm
@@ -1,2 +1,11 @@
 /// Checks if the given target is either a client or a mock client
 #define IS_CLIENT_OR_MOCK(target) (istype(target, /client) || istype(target, /datum/client_interface))
+
+/// Ensures that the client has been fully initialized via New(), and can't somehow execute actions before that. Security measure.
+/// WILL RETURN OUT OF THE ENTIRE PROC COMPLETELY IF THE CLIENT IS NOT FULLY INITIALIZED. BE WARNED IF YOU WANT RETURN VALUES.
+#define VALIDATE_CLIENT(target)\
+	if (!target.fully_created) {\
+		to_chat(target, span_warning("You are not fully initialized yet! Please wait a moment."));\
+		log_filter_raw("Client [key_name(target)] attempted to execute a verb before being fully initialized.");\
+		return\
+	}

--- a/code/__DEFINES/client.dm
+++ b/code/__DEFINES/client.dm
@@ -6,6 +6,6 @@
 #define VALIDATE_CLIENT(target)\
 	if (!target.fully_created) {\
 		to_chat(target, span_warning("You are not fully initialized yet! Please wait a moment."));\
-		log_filter_raw("Client [key_name(target)] attempted to execute a verb before being fully initialized.");\
+		log_access("Client [key_name(target)] attempted to execute a verb before being fully initialized.");\
 		return\
 	}

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -38,9 +38,9 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(!usr || usr != mob) //stops us calling Topic for somebody else's client. Also helps prevent usr=null
 		return
 
-#ifndef TESTING	
+#ifndef TESTING
 	if (lowertext(hsrc_command) == "_debug") //disable the integrated byond vv in the client side debugging tools since it doesn't respect vv read protections
-		return 
+		return
 #endif
 
 	// asset_cache
@@ -1313,6 +1313,18 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 				continue
 
 		screen -= object
+
+
+/// Ensures that the client has been fully initialized via New(), and can't somehow execute actions before that. Security measure.
+/// Returns TRUE if we can prove the client is fully initialized, FALSE otherwise. This is explicitly set up this way to ensure that we always default to "FALSE" or other falsey values (null).
+/client/proc/validate_client()
+	if (fully_created)
+		return TRUE
+
+	var/message = "Client [key_name(src)] attempted to execute a verb before being fully initialized."
+	log_filter_raw(message)
+	tgui_alert(src, "Your client is not fully initialized yet! Please wait a few seconds.", "Client Initialization Check")
+	return FALSE
 
 #undef ADMINSWARNED_AT
 #undef CURRENT_MINUTE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1314,18 +1314,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 		screen -= object
 
-
-/// Ensures that the client has been fully initialized via New(), and can't somehow execute actions before that. Security measure.
-/// Returns TRUE if we can prove the client is fully initialized, FALSE otherwise. This is explicitly set up this way to ensure that we always default to "FALSE" or other falsey values (null).
-/client/proc/validate_client()
-	if (fully_created)
-		return TRUE
-
-	var/message = "Client [key_name(src)] attempted to execute a verb before being fully initialized."
-	log_filter_raw(message)
-	tgui_alert(src, "Your client is not fully initialized yet! Please wait a few seconds.", "Client Initialization Check")
-	return FALSE
-
 #undef ADMINSWARNED_AT
 #undef CURRENT_MINUTE
 #undef CURRENT_SECOND

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -13,8 +13,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if(!mob)
 		return
 
-	if(!client.fully_created)
+	if(!fully_created)
 		to_chat(usr, span_danger("Please wait while we validate your client before you use OOC."))
+		return
 
 	if(!holder)
 		if(!GLOB.ooc_allowed)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -13,6 +13,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if(!mob)
 		return
 
+	if(!client.fully_created)
+		to_chat(usr, span_danger("Please wait while we validate your client before you use OOC."))
+
 	if(!holder)
 		if(!GLOB.ooc_allowed)
 			to_chat(src, span_danger("OOC is globally muted."))

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -13,9 +13,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if(!mob)
 		return
 
-	if(!validate_client())
-		to_chat(usr, span_danger("Please wait while we validate your client before you use OOC."))
-		return
+	VALIDATE_CLIENT(src)
 
 	if(!holder)
 		if(!GLOB.ooc_allowed)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -13,7 +13,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if(!mob)
 		return
 
-	if(!fully_created)
+	if(!validate_client())
 		to_chat(usr, span_danger("Please wait while we validate your client before you use OOC."))
 		return
 


### PR DESCRIPTION
People are able to send OOC messages before `client/New()` is able to fully set itself up. Let's guard against this by re-using the variable we set at the end of New() and blocking any usage of the OOC verb if they aren't set up. I made it a define so we can use it in other spots as well if the occasion should call for it.

Define included in this PR can be (and probably should be when someone has time) replicated in other spots where we need it.