### PR TITLE
Block connections to the server from new ckeys if the panic bunker is up and not in interview mode

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -46,9 +46,7 @@
 			var/reject_message = "Failed Login: [key] - New Account attempting to connect during panic bunker, but was rejected due to no prior connections to game servers (no database entry)"
 			log_access(reject_message)
 			message_admins(span_adminnotice("[reject_message]"))
-			var/message = "Sorry but the server is currently not accepting connections from never before seen players"
-			
-			return list("reason"="panicbunker", "desc" = message)
+			return list("reason"="panicbunker", "desc" = "Sorry but the server is currently not accepting connections from never before seen players")
 
 	//Whitelist
 	if(!real_bans_only && !C && CONFIG_GET(flag/usewhitelist))

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -32,6 +32,23 @@
 	if(GLOB.admin_datums[ckey] || GLOB.deadmins[ckey])
 		admin = TRUE
 
+	if(!admin && CONFIG_GET(flag/panic_bunker) && !CONFIG_GET(flag/panic_bunker_interview))
+		var/datum/db_query/query_client_in_db = SSdbcore.NewQuery(
+			"SELECT 1 FROM [format_table_name("player")] WHERE ckey = :ckey",
+			list("ckey" = ckey)
+		)
+		if(!query_client_in_db.Execute())
+			qdel(query_client_in_db)
+			return
+
+		var/client_is_in_db = query_client_in_db.NextRow()
+		if(!client_is_in_db)
+			var/reject_message = "Failed Login: [key] - New Account attempting to connect during panic bunker, but was rejected due to no prior connections to game servers (no database entry)"
+			log_access(reject_message)
+			message_admins(span_adminnotice("[reject_message]"))
+			var/message = "Sorry but the server is currently not accepting connections from never before seen players"
+			
+			return list("reason"="panicbunker", "desc" = message)
 
 	//Whitelist
 	if(!real_bans_only && !C && CONFIG_GET(flag/usewhitelist))

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -32,7 +32,7 @@
 	if(GLOB.admin_datums[ckey] || GLOB.deadmins[ckey])
 		admin = TRUE
 
-	if(!admin && CONFIG_GET(flag/panic_bunker) && !CONFIG_GET(flag/panic_bunker_interview))
+	if(!real_bans_only && !admin && CONFIG_GET(flag/panic_bunker) && !CONFIG_GET(flag/panic_bunker_interview))
 		var/datum/db_query/query_client_in_db = SSdbcore.NewQuery(
 			"SELECT 1 FROM [format_table_name("player")] WHERE ckey = :ckey",
 			list("ckey" = ckey)
@@ -43,9 +43,11 @@
 
 		var/client_is_in_db = query_client_in_db.NextRow()
 		if(!client_is_in_db)
+			
 			var/reject_message = "Failed Login: [key] - New Account attempting to connect during panic bunker, but was rejected due to no prior connections to game servers (no database entry)"
 			log_access(reject_message)
-			message_admins(span_adminnotice("[reject_message]"))
+			if (message)
+				message_admins(span_adminnotice("[reject_message]"))
 			return list("reason"="panicbunker", "desc" = "Sorry but the server is currently not accepting connections from never before seen players")
 
 	//Whitelist

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -44,7 +44,7 @@
 		var/client_is_in_db = query_client_in_db.NextRow()
 		if(!client_is_in_db)
 			
-			var/reject_message = "Failed Login: [key] - New Account attempting to connect during panic bunker, but was rejected due to no prior connections to game servers (no database entry)"
+			var/reject_message = "Failed Login: [key] [address]-[computer_id] - New Account attempting to connect during panic bunker, but was rejected due to no prior connections to game servers (no database entry)"
 			log_access(reject_message)
 			if (message)
 				message_admins(span_adminnotice("[reject_message]"))


### PR DESCRIPTION
The living hours check in client/New is still valid, this only cares about never before seen players without regard for that config.