### PR TITLE
Disables auxtools

### DIFF
--- a/code/__HELPERS/_auxtools_api.dm
+++ b/code/__HELPERS/_auxtools_api.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST_EMPTY(auxtools_initialized)
 #define AUXTOOLS_CHECK(LIB)\
 	if (GLOB.auxtools_initialized[LIB] != AUXTOOLS_FULL_INIT) {\
 		CRASH("aux tools has been disabled by order of the host");if (fexists(LIB)) {\
-			var/string /*= LIBCALL(LIB,"auxtools_init")();*/\
+			var/string /*= LIBCALL(LIB,"auxtools_init")()*/;\
 			if(findtext(string, "SUCCESS")) {\
 				GLOB.auxtools_initialized[LIB] = AUXTOOLS_FULL_INIT;\
 			} else {\
@@ -19,7 +19,7 @@ GLOBAL_LIST_EMPTY(auxtools_initialized)
 
 #define AUXTOOLS_SHUTDOWN(LIB)\
 	if (GLOB.auxtools_initialized[LIB] == AUXTOOLS_FULL_INIT && fexists(LIB)){\
-		CRASH("aux tools has been disabled by order of the host");LIBCALL(LIB,"auxtools_shutdown")();\
+		CRASH("aux tools has been disabled by order of the host");/*LIBCALL(LIB,"auxtools_shutdown")();*/\
 		GLOB.auxtools_initialized[LIB] = AUXTOOLS_PARTIAL_INIT;\
 	}\
 

--- a/code/__HELPERS/_auxtools_api.dm
+++ b/code/__HELPERS/_auxtools_api.dm
@@ -5,8 +5,8 @@ GLOBAL_LIST_EMPTY(auxtools_initialized)
 
 #define AUXTOOLS_CHECK(LIB)\
 	if (GLOB.auxtools_initialized[LIB] != AUXTOOLS_FULL_INIT) {\
-		if (fexists(LIB)) {\
-			var/string = LIBCALL(LIB,"auxtools_init")();\
+		CRASH("aux tools has been disabled by order of the host");if (fexists(LIB)) {\
+			var/string /*= LIBCALL(LIB,"auxtools_init")();*/\
 			if(findtext(string, "SUCCESS")) {\
 				GLOB.auxtools_initialized[LIB] = AUXTOOLS_FULL_INIT;\
 			} else {\
@@ -19,13 +19,13 @@ GLOBAL_LIST_EMPTY(auxtools_initialized)
 
 #define AUXTOOLS_SHUTDOWN(LIB)\
 	if (GLOB.auxtools_initialized[LIB] == AUXTOOLS_FULL_INIT && fexists(LIB)){\
-		LIBCALL(LIB,"auxtools_shutdown")();\
+		CRASH("aux tools has been disabled by order of the host");LIBCALL(LIB,"auxtools_shutdown")();\
 		GLOB.auxtools_initialized[LIB] = AUXTOOLS_PARTIAL_INIT;\
 	}\
 
 #define AUXTOOLS_FULL_SHUTDOWN(LIB)\
 	if (GLOB.auxtools_initialized[LIB] && fexists(LIB)){\
-		LIBCALL(LIB,"auxtools_full_shutdown")();\
+		CRASH("aux tools has been disabled by order of the host");/*LIBCALL(LIB,"auxtools_full_shutdown")();*/\
 		GLOB.auxtools_initialized[LIB] = FALSE;\
 	}
 


### PR DESCRIPTION
This pr will remain test merged until somebody makes a config that allows a server owner to prevent this dll from ever being loaded.

I didn't bother to look into this for the threading tests because i thought it was broken on 515 but thats only linux i guess.

anywho a crash traced to something that could have *maybe* been from lua accessing something as a mapthread was fucking with it.

either way its not proper to directly access byond memory while testing debug builds.