### PR TITLE
Fix floating fire alarm in the vacant commissary in delta

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4823,7 +4823,6 @@
 /area/station/commons/dorms)
 "bhm" = (
 /obj/machinery/light/small/directional/west,
-/obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/plating,
 /area/station/commons/toilet/locker)
 "bhn" = (
@@ -27602,6 +27601,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "gMR" = (
@@ -80059,7 +80059,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "tXF" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -64758,7 +64758,6 @@
 "qfe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
-/obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
@@ -80060,6 +80059,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "tXF" = (


### PR DESCRIPTION
## About The Pull Request
Moves the floating fire alarm in the vacant commissary on Delta Station to the adjacent wall and two tiles north, and removes the random poster on that wall.
## Why It's Good For The Game
Restores immersion and looks nicer.
## Changelog
:cl:
fix: The fire alarm in the vacant commissary on Delta Station now longer defies gravity.
/:cl:
