### PR TITLE
Adds VERB_REF and derivative

### DIFF
--- a/.github/guides/STANDARDS.md
+++ b/.github/guides/STANDARDS.md
@@ -142,7 +142,7 @@ Example:
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(funny)), 100))
 ```
 
-Note that the same rules go for verbs too! We have VERB_REF() and TYPE_VERB_REF() as you need it in these same cases. There's likely no reason to use GLOBAL_VERB_REF() though.
+Note that the same rules go for verbs too! We have VERB_REF() and TYPE_VERB_REF() as you need it in these same cases. GLOBAL_VERB_REF() isn't a thing however, as verbs are not global.
 
 #### Signal Handlers
 

--- a/.github/guides/STANDARDS.md
+++ b/.github/guides/STANDARDS.md
@@ -100,7 +100,7 @@ While we normally encourage (and in some cases, even require) bringing out of da
 ### RegisterSignal()
 
 #### PROC_REF Macros
-When referencing procs in RegisterSignal, Callback and other procs you should use PROC_REF,TYPE_PROC_REF and GLOBAL_PROC_REF macros. 
+When referencing procs in RegisterSignal, Callback and other procs you should use PROC_REF, TYPE_PROC_REF and GLOBAL_PROC_REF macros. 
 They ensure compilation fails if the reffered to procs change names or get removed.
 The macro to be used depends on how the proc you're in relates to the proc you want to use:
 
@@ -142,6 +142,7 @@ Example:
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(funny)), 100))
 ```
 
+Note that the same rules go for verbs too! We have VERB_REF() and TYPE_VERB_REF() as you need it in these same cases. There's likely no reason to use GLOBAL_VERB_REF() though.
 
 #### Signal Handlers
 

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -27,39 +27,19 @@
 #define LIBCALL call_ext
 #endif
 
-// So we want to have compile time guarantees these methods exist on local type, unfortunately 515 killed the .proc/procname and .verb/verbname syntax so we have to use nameof()
-
-// These are the generic defines that wrap for the either the sub-515 or post-515 syntax.
-
-/// Call by name proc references, checks if the proc exists on this type or as a global proc.
-#define PROC_REF(X) GENERIC_REF(##X, proc)
-/// Call by name verb references, checks if the verb exists on this type or as a global verb.
-#define VERB_REF(X) GENERIC_REF(##X, verb)
-
-/// Call by name proc reference, checks if the proc exists on given type or as a global proc
-#define TYPE_PROC_REF(TYPE, X) TYPE_GENERIC_REF(##TYPE, ##X, proc)
-/// Call by name verb reference, checks if the verb exists on given type or as a global verb
-#define TYPE_VERB_REF(TYPE, X) TYPE_GENERIC_REF(##TYPE, ##X, verb)
-
-/// Call by name proc reference, checks if the proc is AN existing global proc
-#define GLOBAL_PROC_REF(X) GLOBAL_GENERIC_REF(##X, proc)
-/// Call by name verb reference, checks if the verb is AN existing global verb. Note: This is only here for completeness, and will probably not actually ever be used in practice. (update this comment if you do use it)
-#define GLOBAL_VERB_REF(X) GLOBAL_GENERIC_REF(##X, verb)
-
-// Now, these are what actually performs the compile-level analysis we want.
 
 #if DM_VERSION < 515
-/// Call by name method reference, checks if the method exists on this type or as a global method
-#define GENERIC_REF(X, INVOKE_METHOD) (.##INVOKE_METHOD/##X)
-/// Call by name method reference, checks if the method exists on given type or as a global method
-#define TYPE_GENERIC_REF(TYPE, X, INVOKE_METHOD) (##TYPE.##INVOKE_METHOD/##X)
-/// Call by name method reference, checks if the proc is AN existing global proc
-#define GLOBAL_GENERIC_REF(X, INVOKE_METHOD) (/##INVOKE_METHOD/##X)
+/// Call by name proc reference, checks if the proc exists on this type or as a global proc
+#define PROC_REF(X) (.proc/##X)
+/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) (##TYPE.proc/##X)
+/// Call by name proc reference, checks if the proc is existing global proc
+#define GLOBAL_PROC_REF(X) (/proc/##X)
 #else
-/// Call by name method reference, checks if the method exists on this type or as a global method
-#define GENERIC_REF(X, INVOKE_METHOD) (nameof(.##INVOKE/##X))
-/// Call by name method reference, checks if the method exists on given type or as a global method
-#define TYPE_GENERIC_REF(TYPE, X, INVOKE_METHOD) (nameof(##TYPE.##INVOKE_METHOD/##X))
-/// Call by name method reference, checks if the method is AN existing global method
-#define GLOBAL_GENERIC_REF(X, INVOKE_METHOD) (/##INVOKE_METHOD/##X)
+/// Call by name proc reference, checks if the proc exists on this type or as a global proc
+#define PROC_REF(X) (nameof(.proc/##X))
+/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) (nameof(##TYPE.proc/##X))
+/// Call by name proc reference, checks if the proc is existing global proc
+#define GLOBAL_PROC_REF(X) (/proc/##X)
 #endif

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -32,32 +32,32 @@
 
 #if DM_VERSION < 515
 
-/// Call by name proc references, checks if the proc exists on this type or as a global proc.
+/// Call by name proc references, checks if the proc exists on either this type or as a global proc.
 #define PROC_REF(X) (.proc/##X)
-/// Call by name verb references, checks if the verb exists on this type or as a global verb.
+/// Call by name verb references, checks if the verb exists on either this type or as a global verb.
 #define VERB_REF(X) (.verb/##X)
 
-/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+/// Call by name proc reference, checks if the proc exists on either the given type or as a global proc
 #define TYPE_PROC_REF(TYPE, X) (##TYPE.proc/##X)
-/// Call by name verb reference, checks if the verb exists on given type or as a global verb
+/// Call by name verb reference, checks if the verb exists on either the given type or as a global verb
 #define TYPE_VERB_REF(TYPE, X) (##TYPE.verb/##X)
 
-/// Call by name proc reference, checks if the proc is AN existing global proc
+/// Call by name proc reference, checks if the proc is an existing global proc
 #define GLOBAL_PROC_REF(X) (/proc/##X)
 
 #else
 
-/// Call by name proc references, checks if the proc exists on this type or as a global proc.
+/// Call by name proc references, checks if the proc exists on either this type or as a global proc.
 #define PROC_REF(X) (nameof(.proc/##X))
-/// Call by name verb references, checks if the verb exists on this type or as a global verb.
+/// Call by name verb references, checks if the verb exists on either this type or as a global verb.
 #define VERB_REF(X) (nameof(.verb/##X))
 
-/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+/// Call by name proc reference, checks if the proc exists on either the given type or as a global proc
 #define TYPE_PROC_REF(TYPE, X) (nameof(##TYPE.proc/##X))
-/// Call by name verb reference, checks if the verb exists on given type or as a global verb
+/// Call by name verb reference, checks if the verb exists on either the given type or as a global verb
 #define TYPE_VERB_REF(TYPE, X) (nameof(##TYPE.verb/##X))
 
-/// Call by name proc reference, checks if the proc is AN existing global proc
+/// Call by name proc reference, checks if the proc is an existing global proc
 #define GLOBAL_PROC_REF(X) (/proc/##X)
 
 #endif

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -43,8 +43,7 @@
 
 /// Call by name proc reference, checks if the proc is AN existing global proc
 #define GLOBAL_PROC_REF(X) GLOBAL_GENERIC_REF(##X, proc)
-/// Call by name verb reference, checks if the verb is AN existing global verb. Note: This is only here for completeness, and will probably not actually ever be used in practice. (update this comment if you do use it)
-#define GLOBAL_VERB_REF(X) GLOBAL_GENERIC_REF(##X, verb)
+// GLOBAL_VERB_REF would be useless as verbs can't be global. It would be here though.
 
 // Now, these are what actually performs the compile-level analysis we want.
 
@@ -57,7 +56,7 @@
 #define GLOBAL_GENERIC_REF(X, INVOKE_METHOD) (/##INVOKE_METHOD/##X)
 #else
 /// Call by name method reference, checks if the method exists on this type or as a global method
-#define GENERIC_REF(X, INVOKE_METHOD) (nameof(.##INVOKE/##X))
+#define GENERIC_REF(X, INVOKE_METHOD) (nameof(.##INVOKE_METHOD/##X))
 /// Call by name method reference, checks if the method exists on given type or as a global method
 #define TYPE_GENERIC_REF(TYPE, X, INVOKE_METHOD) (nameof(##TYPE.##INVOKE_METHOD/##X))
 /// Call by name method reference, checks if the method is AN existing global method

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -28,37 +28,36 @@
 #endif
 
 // So we want to have compile time guarantees these methods exist on local type, unfortunately 515 killed the .proc/procname and .verb/verbname syntax so we have to use nameof()
-
-// These are the generic defines that wrap for the either the sub-515 or post-515 syntax.
-
-/// Call by name proc references, checks if the proc exists on this type or as a global proc.
-#define PROC_REF(X) GENERIC_REF(##X, proc)
-/// Call by name verb references, checks if the verb exists on this type or as a global verb.
-#define VERB_REF(X) GENERIC_REF(##X, verb)
-
-/// Call by name proc reference, checks if the proc exists on given type or as a global proc
-#define TYPE_PROC_REF(TYPE, X) TYPE_GENERIC_REF(##TYPE, ##X, proc)
-/// Call by name verb reference, checks if the verb exists on given type or as a global verb
-#define TYPE_VERB_REF(TYPE, X) TYPE_GENERIC_REF(##TYPE, ##X, verb)
-
-/// Call by name proc reference, checks if the proc is AN existing global proc
-#define GLOBAL_PROC_REF(X) GLOBAL_GENERIC_REF(##X, proc)
-// GLOBAL_VERB_REF would be useless as verbs can't be global. It would be here though.
-
-// Now, these are what actually performs the compile-level analysis we want.
+// For the record: GLOBAL_VERB_REF would be useless as verbs can't be global.
 
 #if DM_VERSION < 515
-/// Call by name method reference, checks if the method exists on this type or as a global method
-#define GENERIC_REF(X, INVOKE_METHOD) (.##INVOKE_METHOD/##X)
-/// Call by name method reference, checks if the method exists on given type or as a global method
-#define TYPE_GENERIC_REF(TYPE, X, INVOKE_METHOD) (##TYPE.##INVOKE_METHOD/##X)
-/// Call by name method reference, checks if the proc is AN existing global proc
-#define GLOBAL_GENERIC_REF(X, INVOKE_METHOD) (/##INVOKE_METHOD/##X)
+
+/// Call by name proc references, checks if the proc exists on this type or as a global proc.
+#define PROC_REF(X) (.proc/##X)
+/// Call by name verb references, checks if the verb exists on this type or as a global verb.
+#define VERB_REF(X) (.verb/##X)
+
+/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) (##TYPE.proc/##X)
+/// Call by name verb reference, checks if the verb exists on given type or as a global verb
+#define TYPE_VERB_REF(TYPE, X) (##TYPE.verb/##X)
+
+/// Call by name proc reference, checks if the proc is AN existing global proc
+#define GLOBAL_PROC_REF(X) (/proc/##X)
+
 #else
-/// Call by name method reference, checks if the method exists on this type or as a global method
-#define GENERIC_REF(X, INVOKE_METHOD) (nameof(.##INVOKE_METHOD/##X))
-/// Call by name method reference, checks if the method exists on given type or as a global method
-#define TYPE_GENERIC_REF(TYPE, X, INVOKE_METHOD) (nameof(##TYPE.##INVOKE_METHOD/##X))
-/// Call by name method reference, checks if the method is AN existing global method
-#define GLOBAL_GENERIC_REF(X, INVOKE_METHOD) (/##INVOKE_METHOD/##X)
+
+/// Call by name proc references, checks if the proc exists on this type or as a global proc.
+#define PROC_REF(X) (nameof(.proc/##X))
+/// Call by name verb references, checks if the verb exists on this type or as a global verb.
+#define VERB_REF(X) (nameof(.verb/##X))
+
+/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) (nameof(##TYPE.proc/##X))
+/// Call by name verb reference, checks if the verb exists on given type or as a global verb
+#define TYPE_VERB_REF(TYPE, X) (nameof(##TYPE.verb/##X))
+
+/// Call by name proc reference, checks if the proc is AN existing global proc
+#define GLOBAL_PROC_REF(X) (/proc/##X)
+
 #endif

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -27,19 +27,39 @@
 #define LIBCALL call_ext
 #endif
 
+// So we want to have compile time guarantees these methods exist on local type, unfortunately 515 killed the .proc/procname and .verb/verbname syntax so we have to use nameof()
+
+// These are the generic defines that wrap for the either the sub-515 or post-515 syntax.
+
+/// Call by name proc references, checks if the proc exists on this type or as a global proc.
+#define PROC_REF(X) GENERIC_REF(##X, proc)
+/// Call by name verb references, checks if the verb exists on this type or as a global verb.
+#define VERB_REF(X) GENERIC_REF(##X, verb)
+
+/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) TYPE_GENERIC_REF(##TYPE, ##X, proc)
+/// Call by name verb reference, checks if the verb exists on given type or as a global verb
+#define TYPE_VERB_REF(TYPE, X) TYPE_GENERIC_REF(##TYPE, ##X, verb)
+
+/// Call by name proc reference, checks if the proc is AN existing global proc
+#define GLOBAL_PROC_REF(X) GLOBAL_GENERIC_REF(##X, proc)
+/// Call by name verb reference, checks if the verb is AN existing global verb. Note: This is only here for completeness, and will probably not actually ever be used in practice. (update this comment if you do use it)
+#define GLOBAL_VERB_REF(X) GLOBAL_GENERIC_REF(##X, verb)
+
+// Now, these are what actually performs the compile-level analysis we want.
 
 #if DM_VERSION < 515
-/// Call by name proc reference, checks if the proc exists on this type or as a global proc
-#define PROC_REF(X) (.proc/##X)
-/// Call by name proc reference, checks if the proc exists on given type or as a global proc
-#define TYPE_PROC_REF(TYPE, X) (##TYPE.proc/##X)
-/// Call by name proc reference, checks if the proc is existing global proc
-#define GLOBAL_PROC_REF(X) (/proc/##X)
+/// Call by name method reference, checks if the method exists on this type or as a global method
+#define GENERIC_REF(X, INVOKE_METHOD) (.##INVOKE_METHOD/##X)
+/// Call by name method reference, checks if the method exists on given type or as a global method
+#define TYPE_GENERIC_REF(TYPE, X, INVOKE_METHOD) (##TYPE.##INVOKE_METHOD/##X)
+/// Call by name method reference, checks if the proc is AN existing global proc
+#define GLOBAL_GENERIC_REF(X, INVOKE_METHOD) (/##INVOKE_METHOD/##X)
 #else
-/// Call by name proc reference, checks if the proc exists on this type or as a global proc
-#define PROC_REF(X) (nameof(.proc/##X))
-/// Call by name proc reference, checks if the proc exists on given type or as a global proc
-#define TYPE_PROC_REF(TYPE, X) (nameof(##TYPE.proc/##X))
-/// Call by name proc reference, checks if the proc is existing global proc
-#define GLOBAL_PROC_REF(X) (/proc/##X)
+/// Call by name method reference, checks if the method exists on this type or as a global method
+#define GENERIC_REF(X, INVOKE_METHOD) (nameof(.##INVOKE/##X))
+/// Call by name method reference, checks if the method exists on given type or as a global method
+#define TYPE_GENERIC_REF(TYPE, X, INVOKE_METHOD) (nameof(##TYPE.##INVOKE_METHOD/##X))
+/// Call by name method reference, checks if the method is AN existing global method
+#define GLOBAL_GENERIC_REF(X, INVOKE_METHOD) (/##INVOKE_METHOD/##X)
 #endif

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -43,7 +43,7 @@
 
 /// Call by name proc reference, checks if the proc is AN existing global proc
 #define GLOBAL_PROC_REF(X) GLOBAL_GENERIC_REF(##X, proc)
-/// Call by name verb reference, checks if the verb is AN existing global verb
+/// Call by name verb reference, checks if the verb is AN existing global verb. Note: This is only here for completeness, and will probably not actually ever be used in practice. (update this comment if you do use it)
 #define GLOBAL_VERB_REF(X) GLOBAL_GENERIC_REF(##X, verb)
 
 // Now, these are what actually performs the compile-level analysis we want.

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -27,19 +27,39 @@
 #define LIBCALL call_ext
 #endif
 
-// So we want to have compile time guarantees these procs exist on local type, unfortunately 515 killed the .proc/procname syntax so we have to use nameof()
+// So we want to have compile time guarantees these methods exist on local type, unfortunately 515 killed the .proc/procname and .verb/verbname syntax so we have to use nameof()
+
+// These are the generic defines that wrap for the either the sub-515 or post-515 syntax.
+
+/// Call by name proc references, checks if the proc exists on this type or as a global proc.
+#define PROC_REF(X) GENERIC_REF(##X, proc)
+/// Call by name verb references, checks if the verb exists on this type or as a global verb.
+#define VERB_REF(X) GENERIC_REF(##X, verb)
+
+/// Call by name proc reference, checks if the proc exists on given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) TYPE_GENERIC_REF(##TYPE, ##X, proc)
+/// Call by name verb reference, checks if the verb exists on given type or as a global verb
+#define TYPE_VERB_REF(TYPE, X) TYPE_GENERIC_REF(##TYPE, ##X, verb)
+
+/// Call by name proc reference, checks if the proc is AN existing global proc
+#define GLOBAL_PROC_REF(X) GLOBAL_GENERIC_REF(##X, proc)
+/// Call by name verb reference, checks if the verb is AN existing global verb
+#define GLOBAL_VERB_REF(X) GLOBAL_GENERIC_REF(##X, verb)
+
+// Now, these are what actually performs the compile-level analysis we want.
+
 #if DM_VERSION < 515
-/// Call by name proc reference, checks if the proc exists on this type or as a global proc
-#define PROC_REF(X) (.proc/##X)
-/// Call by name proc reference, checks if the proc exists on given type or as a global proc
-#define TYPE_PROC_REF(TYPE, X) (##TYPE.proc/##X)
-/// Call by name proc reference, checks if the proc is existing global proc
-#define GLOBAL_PROC_REF(X) (/proc/##X)
+/// Call by name method reference, checks if the method exists on this type or as a global method
+#define GENERIC_REF(X, INVOKE_METHOD) (.##INVOKE_METHOD/##X)
+/// Call by name method reference, checks if the method exists on given type or as a global method
+#define TYPE_GENERIC_REF(TYPE, X, INVOKE_METHOD) (##TYPE.##INVOKE_METHOD/##X)
+/// Call by name method reference, checks if the proc is AN existing global proc
+#define GLOBAL_GENERIC_REF(X, INVOKE_METHOD) (/##INVOKE_METHOD/##X)
 #else
-/// Call by name proc reference, checks if the proc exists on this type or as a global proc
-#define PROC_REF(X) (nameof(.proc/##X))
-/// Call by name proc reference, checks if the proc exists on given type or as a global proc
-#define TYPE_PROC_REF(TYPE, X) (nameof(##TYPE.proc/##X))
-/// Call by name proc reference, checks if the proc is existing global proc
-#define GLOBAL_PROC_REF(X) (/proc/##X)
+/// Call by name method reference, checks if the method exists on this type or as a global method
+#define GENERIC_REF(X, INVOKE_METHOD) (nameof(.##INVOKE/##X))
+/// Call by name method reference, checks if the method exists on given type or as a global method
+#define TYPE_GENERIC_REF(TYPE, X, INVOKE_METHOD) (nameof(##TYPE.##INVOKE_METHOD/##X))
+/// Call by name method reference, checks if the method is AN existing global method
+#define GLOBAL_GENERIC_REF(X, INVOKE_METHOD) (/##INVOKE_METHOD/##X)
 #endif

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -417,9 +417,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if (!prefs.read_preference(/datum/preference/toggle/auto_fit_viewport))
 		return
 	if(fully_created)
-		INVOKE_ASYNC(src, .verb/fit_viewport)
+		INVOKE_ASYNC(src, VERB_REF(fit_viewport))
 	else //Delayed to avoid wingets from Login calls.
-		addtimer(CALLBACK(src, .verb/fit_viewport, 1 SECONDS))
+		addtimer(CALLBACK(src, VERB_REF(fit_viewport), 1 SECONDS))
 
 /client/verb/policy()
 	set name = "Show Policy"

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -417,9 +417,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if (!prefs.read_preference(/datum/preference/toggle/auto_fit_viewport))
 		return
 	if(fully_created)
-		INVOKE_ASYNC(src, name_of(.verb/fit_viewport))
+		INVOKE_ASYNC(src, nameof(.verb/fit_viewport))
 	else //Delayed to avoid wingets from Login calls.
-		addtimer(CALLBACK(src, name_of(.verb/fit_viewport), 1 SECONDS))
+		addtimer(CALLBACK(src, nameof(.verb/fit_viewport), 1 SECONDS))
 
 /client/verb/policy()
 	set name = "Show Policy"

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -417,9 +417,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if (!prefs.read_preference(/datum/preference/toggle/auto_fit_viewport))
 		return
 	if(fully_created)
-		INVOKE_ASYNC(src, nameof(.verb/fit_viewport))
+		INVOKE_ASYNC(src, VERB_REF(fit_viewport))
 	else //Delayed to avoid wingets from Login calls.
-		addtimer(CALLBACK(src, nameof(.verb/fit_viewport), 1 SECONDS))
+		addtimer(CALLBACK(src, VERB_REF(fit_viewport), 1 SECONDS))
 
 /client/verb/policy()
 	set name = "Show Policy"

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -417,9 +417,9 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	if (!prefs.read_preference(/datum/preference/toggle/auto_fit_viewport))
 		return
 	if(fully_created)
-		INVOKE_ASYNC(src, VERB_REF(fit_viewport))
+		INVOKE_ASYNC(src, name_of(.verb/fit_viewport))
 	else //Delayed to avoid wingets from Login calls.
-		addtimer(CALLBACK(src, VERB_REF(fit_viewport), 1 SECONDS))
+		addtimer(CALLBACK(src, name_of(.verb/fit_viewport), 1 SECONDS))
 
 /client/verb/policy()
 	set name = "Show Policy"


### PR DESCRIPTION
## About The Pull Request

Apparently in (one) place in the codebase, we were still using stuff like `.verb/example_verb` for stuff like `INVOKE_ASYNC()` and `CALLBACK()`s, and I'm pretty sure this is one of those things that are being phased out in 515 (like we had to deal with in 4d6a8bc5371eb61f9adb7c4dd1b8c441d3ae9251), so let's give it the same treatment as we did `PROC_REF` in November 2022.

In order to make this work, I created a generic backend of define macros, and then moved two things: `PROC_REF` and `VERB_REF` to just leverage that backend as needed. This was done just so we didn't have to copy-paste code in case we needed to update these macros in the future, let me know if I should approach this a different way.
## Why It's Good For The Game

code don't break (or at least the compile-time assertions won't break) when we inevitably fully shift to 515. whoopie!
## Changelog
Nothing players should be concerned about.
