### PR TITLE
Purity in unreacted chemicals.

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -72,7 +72,7 @@
 #define CHEMICAL_MAXIMUM_TEMPERATURE 99999
 
 ///The default purity of all non reacted reagents
-#define REAGENT_STANDARD_PURITY 0.75
+#define REAGENT_STANDARD_PURITY 1.00
 
 //reagent bitflags, used for altering how they works
 ///allows on_mob_dead() if present in a dead body


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
We work for a company. Why would they send impure chemicals to their workplaces when in about thirty minutes you can have a chemical factory pumping out pure versions, don't you think NT would have done this? How does a plant grow an unstable chemical inside itself? All this does is change the purity of unreacted chemicals to 1.00 (from 0.75), meaning making reactions inside of plants and in the chemistry lab, they can still be impure, however the base chemicals are pure, so will the ones bought from vendors.

Edit: I should clarify, because someone just asked me. This only affects standard spawning chemicals. If someone has mapped something in to be "x" percent pure, it will not change that, merely the default spawning.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If you're in medical, why would you ever use the vendors, when you can just make pure reagents quicker and cheaper.
Why grow plants with chemicals inside if they're not even worth the space in the plant, 'cause chemistry already has a factory churning out the purest meth around.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
Changes unreacted purity define to 1, from 0.75, that simple.
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Raises the default purity of chems to 1.0 (from: 0.75). Vending machine / medkit / plant chemicals are now more effective as a result. 
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
