### PR TITLE
Removes the flamethrower trigger guard

### DIFF
--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -75,9 +75,6 @@
 	. |= AFTERATTACK_PROCESSED_ITEM
 	if(flag)
 		return // too close
-	if(ishuman(user))
-		if(!can_trigger_gun(user))
-			return
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_warning("You can't bring yourself to fire \the [src]! You don't want to risk harming anyone..."))
 		return


### PR DESCRIPTION
## About The Pull Request

This was suggested by @Fikou as an alternative to https://github.com/tgstation/tgstation/pull/74463 so I thought I should put it up in case this is favored more.

This removes flamethrower's gun requirements, allowing anyone wearing atmos gloves/insulated gloves, and golems/ash walkers/monkeys to use flamethrowers.

## Why It's Good For The Game

It allows Flamethrowers to be used more, without buffing atmos gloves to using all guns and modular computers.

People using flamethrowers typically want fire proteciton, and currently you can't have both since atmos gloves (and golems I guess) can't even use them. This was not a problem in the past when you didn't need gloves for fire protection, so this will hopefully solve that.

## Changelog

:cl:
balance: Flamethrowers no longer have a trigger guard, and can be used by anyone (including if you're wearing Atmos gloves).
/:cl: