### PR TITLE
Brings back ORM part upgrades

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -209,6 +209,7 @@
 	description = "We require further testing of the stock part designs to push their efficiency and market price even further."
 	required_points = 15
 	required_atoms = list(
+		/obj/machinery/mineral/ore_redemption = 1,
 		/obj/machinery/autolathe = 1,
 		/obj/machinery/rnd/production/circuit_imprinter/department/science = 1,
 		/obj/machinery/monkey_recycler = 1,
@@ -241,6 +242,7 @@
 	description = "Our Nanotrasen High-Power Office-Ready Laser Pointer ™ isn't powerful enough to strike airborne Syndidrones out of the sky yet. Find us some diode applications for hints on how to improve them!"
 	required_points = 10
 	required_atoms = list(
+		/obj/machinery/mineral/ore_redemption = 1,
 		/obj/machinery/mecha_part_fabricator = 1,
 		/obj/machinery/rnd/experimentor = 1,
 		/obj/machinery/dna_scannernew = 1,

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -42,6 +42,17 @@
 	materials = null
 	return ..()
 
+/obj/machinery/mineral/ore_redemption/RefreshParts()
+	var/ore_multiplier_temp = 1
+	for(var/obj/item/stock_parts/matter_bin/internal_bin in component_parts)
+		ore_multiplier_temp = 0.80 + (0.20 * internal_bin.rating)
+	ore_multiplier = round(ore_multiplier_temp, 0.01)
+
+	var/point_upgrade_temp = 1
+	for(var/obj/item/stock_parts/micro_laser/internal_laser in component_parts)
+		point_upgrade_temp = 0.80 + (0.20 * internal_laser.rating)
+	point_upgrade = point_upgrade_temp
+
 /obj/machinery/mineral/ore_redemption/examine(mob/user)
 	. = ..()
 	if(panel_open)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -44,11 +44,6 @@
 
 /obj/machinery/mineral/ore_redemption/RefreshParts()
 	. = ..()
-	var/ore_multiplier_temp = 1
-	for(var/datum/stock_part/matter_bin/internal_bin in component_parts)
-		ore_multiplier_temp = 0.80 + (0.20 * internal_bin.tier)
-	ore_multiplier = round(ore_multiplier_temp, 0.01)
-
 	var/point_upgrade_temp = 1
 	for(var/datum/stock_part/micro_laser/internal_laser in component_parts)
 		point_upgrade_temp = 0.80 + (0.20 * internal_laser.tier)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -46,12 +46,12 @@
 	. = ..()
 	var/ore_multiplier_temp = 1
 	for(var/datum/stock_part/matter_bin/internal_bin in component_parts)
-		ore_multiplier_temp = 0.80 + (0.20 * internal_bin.rating)
+		ore_multiplier_temp = 0.80 + (0.20 * internal_bin.tier)
 	ore_multiplier = round(ore_multiplier_temp, 0.01)
 
 	var/point_upgrade_temp = 1
 	for(var/datum/stock_part/micro_laser/internal_laser in component_parts)
-		point_upgrade_temp = 0.80 + (0.20 * internal_laser.rating)
+		point_upgrade_temp = 0.80 + (0.20 * internal_laser.tier)
 	point_upgrade = point_upgrade_temp
 
 /obj/machinery/mineral/ore_redemption/examine(mob/user)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -43,13 +43,14 @@
 	return ..()
 
 /obj/machinery/mineral/ore_redemption/RefreshParts()
+	. = ..()
 	var/ore_multiplier_temp = 1
-	for(var/obj/item/stock_parts/matter_bin/internal_bin in component_parts)
+	for(var/datum/stock_part/matter_bin/internal_bin in component_parts)
 		ore_multiplier_temp = 0.80 + (0.20 * internal_bin.rating)
 	ore_multiplier = round(ore_multiplier_temp, 0.01)
 
 	var/point_upgrade_temp = 1
-	for(var/obj/item/stock_parts/micro_laser/internal_laser in component_parts)
+	for(var/datum/stock_part/micro_laser/internal_laser in component_parts)
 		point_upgrade_temp = 0.80 + (0.20 * internal_laser.rating)
 	point_upgrade = point_upgrade_temp
 


### PR DESCRIPTION
## About The Pull Request

Re-adds ORM upgrades, however each part now increases gain by 20% instead of the old 35%, making it not as effective as it previously was.
Also adds upgrading the ORM to 2 new Experiments, adding something for Scientists to gain out of upgrading it.

## Why It's Good For The Game

Miners have been having a harder and harder time, especially as new players, to properly survive Lavaland. Since Miners now have incentive to go through the Cargo shuttle for their equipment, then giving them more points to order more things will help people who bother to work with other departments, get more survival items.
This, on top of helping Miners become more dependent on Station jobs, will make it easier for Miners to properly do the job that so many people complain they can't do well anymore.

It also helps clear up confusion, as the machine has tiered parts, but they currently do absolutely nothing, making it a noob trap to upgrade.

## Changelog

:cl:
balance: The ORM can be upgraded again, and gives a 20% bonus mat/point gain per tier.
/:cl: