### PR TITLE
Client Compatibility Check Actually Uses Our Fork

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -126,7 +126,7 @@ jobs:
         #the regex here does not filter out non-numbers because error messages about no input are less helpful then error messages about bad input (which includes the bad input)
         run: |
           echo "max_required_byond_client=$(grep -Ev '^[[:blank:]]{0,}#{1,}|^[[:blank:]]{0,}$' .github/max_required_byond_client.txt | tail -n1)" >> $GITHUB_OUTPUT
-        
+
   run_all_tests:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Integration Tests
@@ -227,7 +227,7 @@ jobs:
         env:
           DM_EXE: "C:\\byond\\bin\\dm.exe"
       - name: Check client Compatibility
-        uses: MrStonedOne/byond-client-compatibility-check@v3
+        uses: tgstation/byond-client-compatibility-check@v3
         with:
           dmb-location: tgstation.dmb
           max-required-client-version: ${{needs.collect_data.outputs.max_required_byond_client}}

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -74,7 +74,7 @@ jobs:
           retention-days: 1
       - name: Check client Compatibility
         if: always() && steps.compile_tests.outcome == 'success'
-        uses: MrStonedOne/byond-client-compatibility-check@v3
+        uses: tgstation/byond-client-compatibility-check@v3
         with:
           dmb-location: tgstation.dmb
           max-required-client-version: ${{inputs.max_required_byond_client}}


### PR DESCRIPTION
## About The Pull Request

In #74364 (e0ac16102974fadcb5be625e01bb39101639cda0), we wanted to use the fork for this action rather than MSO's version. However, we only updated the changeover to the `tgstation` version in one location, not all occurrences in our CI suite.

This PR cleans that up real fast.