### PR TITLE
Fixes duplicate pipes in UO45

### DIFF
--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -9338,9 +9338,6 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "uW" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,

--- a/_maps/RandomZLevels/undergroundoutpost45.dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45.dmm
@@ -8268,9 +8268,6 @@
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron{
 	heat_capacity = 1e+006


### PR DESCRIPTION

## About The Pull Request

Fixes: https://github.com/tgstation/tgstation/issues/74303

Fixes duplicate piping in the Underground Outpost 45 Away Mission
## Why It's Good For The Game
Fixes some pipenet errors
## Changelog
:cl:
fix: fixed duplicate pipe in Underground Outpost 45 Away Mission
/:cl:
