### PR TITLE
(Fix) The crew manifest now properly updates after ID modifications.

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -238,6 +238,7 @@
  */
 /obj/machinery/pdapainter/proc/eject_id_card(mob/living/user)
 	if(stored_id_card)
+		GLOB.manifest.modify(stored_id_card.registered_name, stored_id_card.assignment, stored_id_card.get_trim_assignment())
 		if(user && !issilicon(user) && in_range(src, user))
 			user.put_in_hands(stored_id_card)
 		else

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -22,6 +22,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	var/obj/item/stock_parts/cell/internal_cell = /obj/item/stock_parts/cell
 	///A pAI currently loaded into the modular computer.
 	var/obj/item/pai_card/inserted_pai
+	///Does the console update the crew manifest when the ID is removed?
+	var/crew_manifest_update = FALSE
 
 	///The amount of storage space the computer starts with.
 	var/max_capacity = 128
@@ -273,13 +275,12 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
  * Removes the ID card from the computer, and puts it in loc's hand if it's a mob
  * Args:
  * user - The mob trying to remove the ID, if there is one
- * card_changed - Is the card changed? If so, the manifest will be updated to reflect the changes.
  */
-/obj/item/modular_computer/RemoveID(mob/user, card_changed = FALSE)
+/obj/item/modular_computer/RemoveID(mob/user)
 	if(!computer_id_slot)
 		return ..()
 
-	if(card_changed)
+	if(crew_manifest_update)
 		GLOB.manifest.modify(computer_id_slot.registered_name, computer_id_slot.assignment, computer_id_slot.get_trim_assignment())
 
 	if(user)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -273,10 +273,14 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
  * Removes the ID card from the computer, and puts it in loc's hand if it's a mob
  * Args:
  * user - The mob trying to remove the ID, if there is one
+ * card_changed - Is the card changed? If so, the manifest will be updated to reflect the changes.
  */
-/obj/item/modular_computer/RemoveID(mob/user)
+/obj/item/modular_computer/RemoveID(mob/user, card_changed = FALSE)
 	if(!computer_id_slot)
 		return ..()
+
+	if(card_changed)
+		GLOB.manifest.modify(computer_id_slot.registered_name, computer_id_slot.assignment, computer_id_slot.get_trim_assignment())
 
 	if(user)
 		if(!issilicon(user) && in_range(src, user))

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -73,6 +73,16 @@
 
 	return FALSE
 
+/datum/computer_file/program/card_mod/on_start(mob/living/user)
+	. = ..()
+	if(!.)
+		return FALSE
+	computer.crew_manifest_update = TRUE
+
+/datum/computer_file/program/card_mod/kill_program(forced)
+	computer.crew_manifest_update = FALSE
+	return ..()
+
 /datum/computer_file/program/card_mod/ui_act(action, params)
 	. = ..()
 	if(.)
@@ -123,7 +133,7 @@
 			return TRUE
 		if("PRG_eject_id")
 			if(inserted_auth_card)
-				return computer.RemoveID(usr, TRUE)
+				return computer.RemoveID(usr)
 			else
 				var/obj/item/I = user.get_active_held_item()
 				if(isidcard(I))

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -81,6 +81,10 @@
 
 /datum/computer_file/program/card_mod/kill_program(forced)
 	computer.crew_manifest_update = FALSE
+	var/obj/item/card/id/inserted_auth_card = computer.computer_id_slot
+	if(inserted_auth_card)
+		GLOB.manifest.modify(inserted_auth_card.registered_name, inserted_auth_card.assignment, inserted_auth_card.get_trim_assignment())
+
 	return ..()
 
 /datum/computer_file/program/card_mod/ui_act(action, params)

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -121,19 +121,9 @@
 				playsound(computer, 'sound/machines/terminal_on.ogg', 50, FALSE)
 				computer.visible_message(span_notice("\The [computer] prints out a paper."))
 			return TRUE
-		// Eject the ID used to log on to the ID app.
-		if("PRG_ejectauthid")
+		if("PRG_eject_id")
 			if(inserted_auth_card)
-				return computer.RemoveID(usr)
-			else
-				var/obj/item/I = user.get_active_held_item()
-				if(isidcard(I))
-					return computer.InsertID(I, user)
-		// Eject the ID being modified.
-		if("PRG_ejectmodid")
-			if(inserted_auth_card)
-				GLOB.manifest.modify(inserted_auth_card.registered_name, inserted_auth_card.assignment, inserted_auth_card.get_trim_assignment())
-				return computer.RemoveID(usr)
+				return computer.RemoveID(usr, TRUE)
 			else
 				var/obj/item/I = user.get_active_held_item()
 				if(isidcard(I))

--- a/tgui/packages/tgui/interfaces/NtosCard.js
+++ b/tgui/packages/tgui/interfaces/NtosCard.js
@@ -129,7 +129,7 @@ const IdCardPage = (props, context) => {
             ellipsis
             icon="eject"
             content={authIDName}
-            onClick={() => act('PRG_ejectauthid')}
+            onClick={() => act('PRG_eject_id')}
           />
         </Stack.Item>
         <Stack.Item width="100%" mt={1} ml={0}>


### PR DESCRIPTION

## About The Pull Request
This PR makes it so that the access modification program now updates the crew manifest once the inserted ID is ejected. Additionally, when the ID trim is changed, the manifest is updated.
## Why It's Good For The Game
Demoted heads would still show up on the manifest as their job pre-demotion, this fixes that.
## Changelog
:cl:
fix: The crew manifest now properly updates after ID modifications.
/:cl:
