### PR TITLE
nerfs the experimental syndie teleporter

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -396,6 +396,7 @@
 		balloon_alert(user, "malfunctioning!")
 		return
 
+	use_charge()
 	var/teleport_distance = rand(minimum_teleport_distance, maximum_teleport_distance)
 	var/turf/destination = get_teleport_loc(current_location, user, teleport_distance)
 	var/bagholdingcheck = FALSE
@@ -414,7 +415,6 @@
 	else
 		telefrag(destination, user)
 		do_teleport(user, destination, channel = TELEPORT_CHANNEL_FREE)
-		use_charge()
 		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(current_location)
 		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(destination)
 		playsound(current_location, SFX_SPARKS, 50, 1, SHORT_RANGE_SOUND_EXTRARANGE)
@@ -448,7 +448,6 @@
 	if(emergency_destination)
 		telefrag(emergency_destination, user)
 		do_teleport(user, emergency_destination, channel = TELEPORT_CHANNEL_FREE)
-		use_charge()
 		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(mobloc)
 		new /obj/effect/temp_visual/teleport_abductor/syndi_teleporter(emergency_destination)
 		balloon_alert(user, "emergency teleport triggered!")
@@ -479,6 +478,8 @@
 ///Damage and stun all mobs in fragging_location turf, called after a teleport
 /obj/item/syndicate_teleporter/proc/telefrag(turf/fragging_location, mob/user) // Don't let this gib. Never let this gib.
 	for(var/mob/living/victim in fragging_location)//Hit everything in the turf
+		if(victim == user)
+			continue
 		victim.apply_damage(20, BRUTE)
 		victim.Knockdown(5 SECONDS)
 		to_chat(victim, span_warning("[user] teleports into you, knocking you to the floor with the bluespace wave!"))


### PR DESCRIPTION
## About The Pull Request
gives a few nerfs to the experimental syndie teleporter
1. its charging system is now consistent 15 seconds per charge, using a system similar to the doorjack
2. emps instead of giving you a free teleport, just fully drain the charges
3. bumping into a person is a knockdown and a bit shorter rather than a full stun
4. the safety range has been lowered from 3 to 1.

## Why It's Good For The Game
more consistency lets you and the people against you have reliable info on your abilities (if you used the teleporter all four times, you wont regain those charges for a while)
emps draining lets you counteract the item which you cant really do currently, if you emp it they just teleport away and maybe die if youre lucky
bump stun is annoying lol
safety range being 3 completely babifies the item, removing all possible risk, cause these is no way in fuck that every tile in a 7x7 block (even wider than that) is closed. there is zero risk of using the item carelessly unless youre using a boh (lol) or got emp'd unluckily. it being 1 means there is some possibility that if you fuck up a jump into a 3x3 wall (which is already rare) you will die for your silliness

## Changelog
:cl:
balance: the experimental syndie teleporter has gotten a few nerfs
balance: its charging system is now consistent 15 seconds per charge, using a system similar to the doorjack
balance: emps instead of giving you a free teleport, just fully drain the charges
balance: bumping into a person is a knockdown and a bit shorter rather than a full stun
balance: the safety range has been lowered from 3 to 1.
/:cl:
