### PR TITLE
Fixes goliath hoods hiding your mask and leaving your face visible underneath

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -145,7 +145,6 @@
 	armor_type = /datum/armor/cloakhood_goliath
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
-	transparent_protection = HIDEMASK
 
 /datum/armor/cloakhood_goliath
 	melee = 35


### PR DESCRIPTION

## About The Pull Request
Fixes goliath cloak hoods blocking your mask sprite by removing HIDEMASK from it.
## Why It's Good For The Game
It was rather odd to put on a mask after taking it off to eat, light up a cigarette, or anything of the sort, only to have it just not appear there anymore. Now we can reset easy knowing we don't have to flip our hoods up and down to look 100% cooler anymore.
## Changelog
:cl:
fix: Goliath cloak hoods no longer block your mask
/:cl:
