### PR TITLE
Fixes the supermatter not dusting you when you fall on top of it from a z-level

### DIFF
--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -213,7 +213,8 @@
 /datum/component/supermatter_crystal/proc/intercept_z_fall(datum/source, list/falling_movables, levels)
 	SIGNAL_HANDLER
 	for(var/atom/movable/hit_object as anything in falling_movables)
-		bumped_hit(hit_object)
+		bumped_hit(parent, hit_object)
+	return FALL_INTERCEPTED | FALL_NO_MESSAGE
 
 /datum/component/supermatter_crystal/proc/dust_mob(datum/source, mob/living/nom, vis_msg, mob_msg, cause)
 	var/atom/atom_source = source


### PR DESCRIPTION

## About The Pull Request

fixes SM not dusting you if you fall on top of it from a z level
literally nobody tested the code lmao

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: SM now dusts you if you fall on top of it from another Z level
/:cl:
