### PR TITLE
Fixes critical condition not clearing up

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2072,7 +2072,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		if(CONSCIOUS)
 			if(. >= UNCONSCIOUS)
 				REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, TRAIT_KNOCKEDOUT)
-			remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_INCAPACITATED, TRAIT_FLOORED), STAT_TRAIT)
+			remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_INCAPACITATED, TRAIT_FLOORED, TRAIT_CRITICAL_CONDITION), STAT_TRAIT)
 		if(SOFT_CRIT)
 			if(pulledby)
 				ADD_TRAIT(src, TRAIT_IMMOBILIZED, PULLED_WHILE_SOFTCRIT_TRAIT) //adding trait sources should come before removing to avoid unnecessary updates


### PR DESCRIPTION

## About The Pull Request

A recent refactor accidentally removed critical condition clearing up upon becoming conscious and healthy again. This PR fixes it.

## Why It's Good For The Game

Now when you are healed, you are not considered being in crit, so you can not succumb while healthy, or will you get killed by nightwatcher's rebirth.
Fixes #74149

## Changelog

:cl:
fix: Critical condition will clear properly when you leave crit
/:cl: