### PR TITLE
Fixed Normal sized paintings not appearing on the ground

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -83,6 +83,7 @@
 	painting_metadata.creation_round_id = GLOB.round_id
 	painting_metadata.width = width
 	painting_metadata.height = height
+	ADD_KEEP_TOGETHER(src, INNATE_TRAIT)
 
 /obj/item/canvas/proc/reset_grid()
 	grid = new/list(width,height)

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -650,8 +650,6 @@
 
 /obj/structure/sign/painting/large/Initialize(mapload)
 	. = ..()
-	// Necessary so that the painting is framed correctly by the frame overlay when flipped.
-	ADD_KEEP_TOGETHER(src, INNATE_TRAIT)
 	if(mapload)
 		finalize_size()
 


### PR DESCRIPTION
## About The Pull Request
This PR fixes an issue that's been going on for a few months normal sized paintings would be completely blank when viewed on the floor 

## Why It's Good For The Game
This fixes a long standing issue with paintings and I've been a problem for a while
Closes #71142
![image](https://user-images.githubusercontent.com/13859720/230485024-a3c3c5b0-a1b2-4251-afe9-afda4def7f7c.png)

## Changelog
:cl:
fix: Fixed the drawings on normal sized paintings not appearing on the ground 
/:cl:
