### PR TITLE
Hairless felinids

### DIFF
--- a/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/mutant_bodypart_overlay.dm
@@ -110,7 +110,10 @@
 			if(!ishuman(ownerlimb.owner))
 				return
 			var/mob/living/carbon/human/human_owner = ownerlimb.owner
-			draw_color = human_owner.hair_color
+			if (human_owner.hairstyle == "Bald")
+				draw_color = skintone2hex(human_owner.skin_tone)
+			else
+				draw_color = human_owner.hair_color
 
 	return TRUE
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -814,7 +814,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 							else if(hair_color == "fixedmutcolor")
 								accessory_overlay.color = fixed_mut_color
 							else
-								accessory_overlay.color = source.hair_color
+								if (source.hairstyle == "Bald" && istype(accessory, /datum/sprite_accessory/ears/cat))
+									accessory_overlay.color = skintone2hex(source.skin_tone)
+								else
+									accessory_overlay.color = source.hair_color
 						if(FACEHAIR)
 							accessory_overlay.color = source.facial_hair_color
 						if(EYECOLOR)


### PR DESCRIPTION

## About The Pull Request

Allows hairless felinids. 
Simply choose the "bald" hair type, and felinid hair/ears will match your skintype. 

![image](https://user-images.githubusercontent.com/32695675/230230176-285f4ad2-d5eb-4cf0-993e-a1085283f0a1.png)

![image](https://user-images.githubusercontent.com/32695675/230230351-bbb9f3ff-56d7-4ffa-9732-eca94172ed08.png)
## Why It's Good For The Game

Something something allows more roleplay options.
Mostly I thought it would be funny
## Changelog
:cl: Epoc
add: Hairless felinid options (select "Bald" hairstyle)
/:cl:
