### PR TITLE
Fix tram malfunction sprites [NO GBP]

### DIFF
--- a/code/modules/industrial_lift/tram/tram_machinery.dm
+++ b/code/modules/industrial_lift/tram/tram_machinery.dm
@@ -612,13 +612,13 @@ GLOBAL_LIST_EMPTY(tram_doors)
 		GLOB.tram_signs += src
 
 	sign_states = list(
-		"[base_icon_state][DESTINATION_WEST_ACTIVE]",
-		"[base_icon_state][DESTINATION_WEST_IDLE]",
-		"[base_icon_state][DESTINATION_EAST_ACTIVE]",
-		"[base_icon_state][DESTINATION_EAST_IDLE]",
-		"[base_icon_state][DESTINATION_CENTRAL_IDLE]",
-		"[base_icon_state][DESTINATION_CENTRAL_EASTBOUND_ACTIVE]",
-		"[base_icon_state][DESTINATION_CENTRAL_WESTBOUND_ACTIVE]",
+		"[DESTINATION_WEST_ACTIVE]",
+		"[DESTINATION_WEST_IDLE]",
+		"[DESTINATION_EAST_ACTIVE]",
+		"[DESTINATION_EAST_IDLE]",
+		"[DESTINATION_CENTRAL_IDLE]",
+		"[DESTINATION_CENTRAL_EASTBOUND_ACTIVE]",
+		"[DESTINATION_CENTRAL_WESTBOUND_ACTIVE]",
 	)
 
 /obj/machinery/destination_sign/Destroy()
@@ -661,8 +661,8 @@ GLOBAL_LIST_EMPTY(tram_doors)
 	use_power(active_power_usage)
 
 	if(malfunctioning)
-		icon_state = "[pick(sign_states)]"
-		light_mask = "[pick(sign_states)]_e"
+		icon_state = "[base_icon_state][pick(sign_states)]"
+		light_mask = "[base_icon_state][pick(sign_states)]_e"
 		update_appearance()
 		return PROCESS_KILL
 


### PR DESCRIPTION
## About The Pull Request

Fixes Tram Malfunction using the wrong sprites when the event runs.

## Changelog

:cl: LT3
fix: Fixed tram malfunction event from using the wrong sprites
/:cl: