### PR TITLE
fixes medkits being mini smuggler satchels

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -174,6 +174,9 @@
 	open_status = FANCY_CONTAINER_ALWAYS_OPEN
 	contents_tag = "candle"
 
+/obj/item/storage/fancy/candle_box/Initialize(mapload)
+	. = ..()
+	atom_storage.set_holdable(list(/obj/item/flashlight/flare/candle))
 
 ////////////
 //CIG PACK//

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -21,6 +21,10 @@
 	var/empty = FALSE
 	var/damagetype_healed //defines damage type of the medkit. General ones stay null. Used for medibot healing bonuses
 
+/obj/item/storage/medkit/surgery/Initialize(mapload)
+	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
+
 /obj/item/storage/medkit/regular
 	icon_state = "medkit"
 	desc = "A first aid kit with the ability to heal common types of injuries."

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -21,7 +21,7 @@
 	var/empty = FALSE
 	var/damagetype_healed //defines damage type of the medkit. General ones stay null. Used for medibot healing bonuses
 
-/obj/item/storage/medkit/surgery/Initialize(mapload)
+/obj/item/storage/medkit/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -12,6 +12,7 @@
 
 /obj/item/storage/wallet/Initialize(mapload)
 	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_slots = 4
 	atom_storage.set_holdable(list(
 		/obj/item/stack/spacecash,


### PR DESCRIPTION
## About The Pull Request
hey there! as it turns out, the pr that made storage a datum instead of a component, changed the default value of maximum item size from small to normal. medkits (and wallets too, but they can only fit some specific items) didnt override this.
that means they could hold 4 normal sized items (and some small), kind of invalidating storage space, as you had just a box but better.
its fixed now
edit: candle boxes too

## Why It's Good For The Game
bug bad abuse bad storage bad

## Changelog
:cl:
fix: fixes medkits (and wallets, candle boxes) being able to store normal sized items
/:cl:
