### PR TITLE
Makes applies_mats on stack crafting work if the recipe result is a turf

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -390,8 +390,10 @@
 		var/turf/covered_turf = builder.drop_location()
 		if(!isturf(covered_turf))
 			return
-		covered_turf.PlaceOnTop(recipe.result_type, flags = CHANGETURF_INHERIT_AIR)
+		var/turf/created_turf = covered_turf.PlaceOnTop(recipe.result_type, flags = CHANGETURF_INHERIT_AIR)
 		builder.balloon_alert(builder, "placed [ispath(recipe.result_type, /turf/open) ? "floor" : "wall"]")
+		if(recipe.applies_mats && LAZYLEN(mats_per_unit))
+			created_turf.set_custom_materials(mats_per_unit, recipe.req_amount / recipe.res_amount)
 
 	else
 		created = new recipe.result_type(builder.drop_location())


### PR DESCRIPTION

## About The Pull Request

This doesn't happen anywhere, but I found out this didn't work when working on something stupid the other day. I figured I'd fix it here while I'm at it.
## Why It's Good For The Game

If someone wants to make a turf created directly by stack crafting for whatever reason, it should at least get materials applied if its wanted.
## Changelog
:cl:
fix: Turfs made through stack crafting (so none currently) will have materials applied if the var is set
/:cl:
