### PR TITLE
Slightly simplifies overlay lighting by just directly rendering it on the lighting plate

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -45,9 +45,8 @@
 ///Normal 1 per turf dynamic lighting underlays
 #define LIGHTING_PLANE 10
 
-///Lighting objects that are "free floating"
-#define O_LIGHTING_VISUAL_PLANE 11
-#define O_LIGHTING_VISUAL_RENDER_TARGET "O_LIGHT_VISUAL_PLANE"
+///Overlay lighting objects
+#define O_LIGHTING_PLANE 11
 
 #define EMISSIVE_PLANE 13
 /// This plane masks out lighting to create an "emissive" effect, ie for glowing lights in otherwise dark areas.
@@ -232,6 +231,11 @@
 /// Stuff that needs to draw above everything else on this plane
 #define LIGHTING_ABOVE_ALL 20
 
+// O_LIGHTING_PLANE layers
+/// Base layer
+#define O_LIGHTING_MASK_LAYER 25
+/// Cone layer
+#define O_LIGHTING_CONE_LAYER 30
 
 //---------- EMISSIVES -------------
 //Layering order of these is not particularly meaningful.

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -504,8 +504,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	plane = O_LIGHTING_PLANE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	render_relay_planes = list(RENDER_PLANE_LIGHTING)
+	blend_mode_override = BLEND_ADD
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	blend_mode = BLEND_ADD
 	critical = PLANE_CRITICAL_DISPLAY
 
 /atom/movable/screen/plane_master/above_lighting

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -495,18 +495,17 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	critical = PLANE_CRITICAL_DISPLAY
 
-/// This will not work through multiz, because of a byond bug with BLEND_MULTIPLY
-/// Bug report is up, waiting on a fix
-/atom/movable/screen/plane_master/o_light_visual
+///Contains all overlay (movable) lighting
+/atom/movable/screen/plane_master/o_light
 	name = "Overlight light visual"
 	documentation = "Holds overlay lighting objects, or the sort of lighting that's a well, overlay stuck to something.\
 		<br>Exists because lighting updating is really slow, and movement needs to feel smooth.\
-		<br>We draw to the game plane, and mask out space for ourselves on the lighting plane so any color we have has the chance to display."
-	plane = O_LIGHTING_VISUAL_PLANE
+		<br>Draws directly onto the lighting plate, on top of the turf lighting plane."
+	plane = O_LIGHTING_PLANE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
-	render_target = O_LIGHTING_VISUAL_RENDER_TARGET
+	render_relay_planes = list(RENDER_PLANE_LIGHTING)
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	blend_mode = BLEND_MULTIPLY
+	blend_mode = BLEND_ADD
 	critical = PLANE_CRITICAL_DISPLAY
 
 /atom/movable/screen/plane_master/above_lighting

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -497,7 +497,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 
 ///Contains all overlay (movable) lighting
 /atom/movable/screen/plane_master/o_light
-	name = "Overlight light visual"
+	name = "Overlight Lighting"
 	documentation = "Holds overlay lighting objects, or the sort of lighting that's a well, overlay stuck to something.\
 		<br>Exists because lighting updating is really slow, and movement needs to feel smooth.\
 		<br>Draws directly onto the lighting plate, on top of the turf lighting plane."

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -496,6 +496,8 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	critical = PLANE_CRITICAL_DISPLAY
 
 ///Contains all overlay (movable) lighting
+/// This still will not work through multiz, because of a byond bug with BLEND_MULTIPLY
+/// Bug report is up, waiting on a fix
 /atom/movable/screen/plane_master/o_lighting
 	name = "Overlight Lighting"
 	documentation = "Holds overlay lighting objects, or the sort of lighting that's a well, overlay stuck to something.\

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -496,7 +496,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	critical = PLANE_CRITICAL_DISPLAY
 
 ///Contains all overlay (movable) lighting
-/atom/movable/screen/plane_master/o_light
+/atom/movable/screen/plane_master/o_lighting
 	name = "Overlight Lighting"
 	documentation = "Holds overlay lighting objects, or the sort of lighting that's a well, overlay stuck to something.\
 		<br>Exists because lighting updating is really slow, and movement needs to feel smooth.\

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -143,7 +143,6 @@
 /atom/movable/screen/plane_master/rendering_plate/lighting/Initialize(mapload)
 	. = ..()
 	add_filter("emissives", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(EMISSIVE_RENDER_TARGET, offset), flags = MASK_INVERSE))
-	add_filter("object_lighting", 2, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(O_LIGHTING_VISUAL_RENDER_TARGET, offset), flags = MASK_INVERSE))
 	set_light_cutoff(10)
 
 /atom/movable/screen/plane_master/rendering_plate/lighting/show_to(mob/mymob)
@@ -258,7 +257,7 @@
 
 /atom/movable/screen/plane_master/rendering_plate/light_mask/hide_from(mob/oldmob)
 	. = ..()
-	var/atom/movable/screen/plane_master/overlay_lights = home.get_plane(GET_NEW_PLANE(O_LIGHTING_VISUAL_PLANE, offset))
+	var/atom/movable/screen/plane_master/overlay_lights = home.get_plane(GET_NEW_PLANE(O_LIGHTING_PLANE, offset))
 	overlay_lights.remove_filter("lighting_mask")
 	var/atom/movable/screen/plane_master/emissive = home.get_plane(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset))
 	emissive.remove_filter("lighting_mask")
@@ -268,7 +267,7 @@
 /atom/movable/screen/plane_master/rendering_plate/light_mask/proc/handle_sight(datum/source, new_sight, old_sight)
 	// If we can see something that shows "through" blackness, and we can't see turfs, disable our draw to the game plane
 	// And instead mask JUST the overlay lighting plane, since that will look fuckin wrong
-	var/atom/movable/screen/plane_master/overlay_lights = home.get_plane(GET_NEW_PLANE(O_LIGHTING_VISUAL_PLANE, offset))
+	var/atom/movable/screen/plane_master/overlay_lights = home.get_plane(GET_NEW_PLANE(O_LIGHTING_PLANE, offset))
 	var/atom/movable/screen/plane_master/emissive = home.get_plane(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset))
 	if(new_sight & SEE_AVOID_TURF_BLACKNESS && !(new_sight & SEE_TURFS))
 		remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME, offset))

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -83,13 +83,15 @@
 	. = ..()
 
 	visible_mask = image('icons/effects/light_overlays/light_32.dmi', icon_state = "light")
-	SET_PLANE_EXPLICIT(visible_mask, O_LIGHTING_VISUAL_PLANE, movable_parent)
+	SET_PLANE_EXPLICIT(visible_mask, O_LIGHTING_PLANE, movable_parent)
+	visible_mask.layer = O_LIGHTING_MASK_LAYER
 	visible_mask.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
 	visible_mask.alpha = 0
 	if(is_directional)
 		directional = TRUE
 		cone = image('icons/effects/light_overlays/light_cone.dmi', icon_state = "light")
-		SET_PLANE_EXPLICIT(cone, O_LIGHTING_VISUAL_PLANE, movable_parent)
+		SET_PLANE_EXPLICIT(cone, O_LIGHTING_PLANE, movable_parent)
+		cone.layer = O_LIGHTING_CONE_LAYER
 		cone.appearance_flags = RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM
 		cone.alpha = 110
 		cone.transform = cone.transform.Translate(-32, -32)
@@ -310,9 +312,9 @@
 	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays -= visible_mask
 		current_holder.underlays -= cone
-	SET_PLANE_EXPLICIT(visible_mask, O_LIGHTING_VISUAL_PLANE, source)
+	SET_PLANE_EXPLICIT(visible_mask, O_LIGHTING_PLANE, source)
 	if(cone)
-		SET_PLANE_EXPLICIT(cone, O_LIGHTING_VISUAL_PLANE, source)
+		SET_PLANE_EXPLICIT(cone, O_LIGHTING_PLANE, source)
 	if(current_holder && overlay_lighting_flags & LIGHTING_ON)
 		current_holder.underlays += visible_mask
 		current_holder.underlays += cone


### PR DESCRIPTION
## About The Pull Request

Instead of doing a weird little stupid filter thing, it just renders on the lighting plate, on top of turf lighting.

## Why It's Good For The Game

Simpler code and visually I don't think it made any difference.
![image](https://user-images.githubusercontent.com/82850673/230401936-015c2721-c5d0-4cce-9c54-c703af66db2c.png)

Sadly, multi-z overlay lighting still does not work.
![image](https://user-images.githubusercontent.com/82850673/230405405-91dbe2e9-bffb-4525-a27f-9cc91621f626.png)

## Changelog

Not player facing
