### PR TITLE
AOE flash fix

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -173,7 +173,7 @@
 ///from living/flash_act(), when a mob is successfully flashed.
 #define COMSIG_MOB_FLASHED "mob_flashed"
 /// from /obj/item/assembly/flash/flash_carbon, to the mob flashing another carbon
-#define COMSIG_MOB_FLASHED_CARBON "mob_flashed_carbon"
+#define COMSIG_MOB_PRE_FLASHED_CARBON "mob_pre_flashed_carbon"
 	/// Return to override deviation to be full deviation (fail the flash, usually)
 	#define DEVIATION_OVERRIDE_FULL (1<<0)
 	/// Return to override deviation to be partial deviation
@@ -182,6 +182,8 @@
 	#define DEVIATION_OVERRIDE_NONE (1<<2)
 	/// Return to stop the flash entirely
 	#define STOP_FLASH (1<<3)
+/// from /obj/item/assembly/flash/flash_carbon, to the mob flashing another carbon
+#define COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON "mob_success_flashed_carbon"
 
 /// from mob/get_status_tab_items(): (list/items)
 #define COMSIG_MOB_GET_STATUS_TAB_ITEMS "mob_get_status_tab_items"

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -187,33 +187,39 @@
 /datum/antagonist/rev/head/apply_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/real_mob = mob_override || owner.current
-	RegisterSignal(real_mob, COMSIG_MOB_FLASHED_CARBON, PROC_REF(on_flash))
+	RegisterSignal(real_mob, COMSIG_MOB_PRE_FLASHED_CARBON, PROC_REF(on_flash))
+	RegisterSignal(real_mob, COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON, PROC_REF(on_flash_success))
 
 /datum/antagonist/rev/head/remove_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/real_mob = mob_override || owner.current
-	UnregisterSignal(real_mob, COMSIG_MOB_FLASHED_CARBON)
+	UnregisterSignal(real_mob, list(COMSIG_MOB_PRE_FLASHED_CARBON, COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON))
 
-/// Signal proc for [COMSIG_MOB_FLASHED_CARBON].
-/// The bread and butter of head revolutionary conversions.
+/// Signal proc for [COMSIG_MOB_PRE_FLASHED_CARBON].
+/// Flashes will always result in partial success even if it's from behind someone
 /datum/antagonist/rev/head/proc/on_flash(mob/living/source, mob/living/carbon/flashed, obj/item/assembly/flash/flash, deviation)
+	SIGNAL_HANDLER
+
+	// Always partial flash at the very least
+	return (deviation == DEVIATION_FULL) ? DEVIATION_OVERRIDE_PARTIAL : NONE
+
+/// Signal proc for [COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON].
+/// Bread and butter of revolution conversion, successfully flashing a carbon will make them a revolutionary
+/datum/antagonist/rev/head/proc/on_flash_success(mob/living/source, mob/living/carbon/flashed, obj/item/assembly/flash/flash, deviation)
 	SIGNAL_HANDLER
 
 	// We can only flash people if we're next to them and click on them, anyway else this is invoked is invalid
 	ASSERT(source.Adjacent(flashed))
 
-	// Always partial flash at the very least
-	. = (deviation == DEVIATION_FULL) ? DEVIATION_OVERRIDE_PARTIAL : NONE
-
 	if(flashed.stat == DEAD)
-		return .
+		return
 	if(flashed.stat != CONSCIOUS)
 		to_chat(source, span_warning("[flashed.p_they(capitalized = TRUE)] must be conscious before you can convert [flashed.p_them()]!"))
-		return .
+		return
 
 	if(isnull(flashed.mind) || !GET_CLIENT(flashed))
 		to_chat(source, span_warning("[flashed]'s mind is so vacant that it is not susceptible to influence!"))
-		return .
+		return
 
 	var/holiday_meme_chance = check_holidays(APRIL_FOOLS) && prob(10)
 	if(add_revolutionary(flashed.mind, mute = !holiday_meme_chance)) // don't mute if we roll the meme holiday chance
@@ -222,8 +228,6 @@
 		flash.times_used-- // Flashes are less likely to burn out for headrevs, when used for conversion
 	else
 		to_chat(source, span_warning("[flashed] seems resistant to [flash]!"))
-
-	return .
 
 /// Used / called async from [proc/on_flash] to deliver a funny meme line
 /datum/antagonist/rev/head/proc/_async_holiday_meme_say(mob/living/carbon/flashed)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -208,9 +208,6 @@
 /datum/antagonist/rev/head/proc/on_flash_success(mob/living/source, mob/living/carbon/flashed, obj/item/assembly/flash/flash, deviation)
 	SIGNAL_HANDLER
 
-	// We can only flash people if we're next to them and click on them, anyway else this is invoked is invalid
-	ASSERT(source.Adjacent(flashed))
-
 	if(flashed.stat == DEAD)
 		return
 	if(flashed.stat != CONSCIOUS)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -199,6 +199,9 @@
 /datum/antagonist/rev/head/proc/on_flash(mob/living/source, mob/living/carbon/flashed, obj/item/assembly/flash/flash, deviation)
 	SIGNAL_HANDLER
 
+	// We can only flash people if we're next to them and click on them, anyway else this is invoked is invalid
+	ASSERT(source.Adjacent(flashed))
+
 	// Always partial flash at the very least
 	. = (deviation == DEVIATION_FULL) ? DEVIATION_OVERRIDE_PARTIAL : NONE
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -83,7 +83,7 @@
 	return TRUE
 
 //BYPASS CHECKS ALSO PREVENTS BURNOUT!
-/obj/item/assembly/flash/proc/AOE_flash(bypass_checks = FALSE, range = 3, confusion_duration = 5 SECONDS, targeted = FALSE, mob/user)
+/obj/item/assembly/flash/proc/AOE_flash(bypass_checks = FALSE, range = 3, confusion_duration = 5 SECONDS, mob/user)
 	if(!bypass_checks && !try_use_flash())
 		return FALSE
 	var/list/mob/targets = get_flash_targets(get_turf(src), range, FALSE)
@@ -91,7 +91,7 @@
 		targets -= user
 		to_chat(user, span_danger("[src] emits a blinding light!"))
 	for(var/mob/living/carbon/nearby_carbon in targets)
-		flash_carbon(nearby_carbon, user, confusion_duration = confusion_duration, targeted = targeted, generic_message = TRUE)
+		flash_carbon(nearby_carbon, user, confusion_duration, generic_message = TRUE)
 	return TRUE
 
 /obj/item/assembly/flash/proc/get_flash_targets(atom/target_loc, range = 3, override_vision_checks = FALSE)
@@ -148,7 +148,8 @@
 
 	var/deviation = calculate_deviation(flashed, user || src)
 
-	if(user)
+	// Only send a signal if this is a proper user targeted 1 on 1 flash, for simplicity
+	if(user && targeted)
 		var/sigreturn = SEND_SIGNAL(user, COMSIG_MOB_FLASHED_CARBON, flashed, src, deviation)
 		if(sigreturn & STOP_FLASH)
 			return

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -91,7 +91,7 @@
 		targets -= user
 		to_chat(user, span_danger("[src] emits a blinding light!"))
 	for(var/mob/living/carbon/nearby_carbon in targets)
-		flash_carbon(nearby_carbon, user, confusion_duration, generic_message = TRUE)
+		flash_carbon(nearby_carbon, user, confusion_duration, targeted = FALSE, generic_message = TRUE)
 	return TRUE
 
 /obj/item/assembly/flash/proc/get_flash_targets(atom/target_loc, range = 3, override_vision_checks = FALSE)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -148,9 +148,8 @@
 
 	var/deviation = calculate_deviation(flashed, user || src)
 
-	// Only send a signal if this is a proper user targeted 1 on 1 flash, for simplicity
-	if(user && targeted)
-		var/sigreturn = SEND_SIGNAL(user, COMSIG_MOB_FLASHED_CARBON, flashed, src, deviation)
+	if(user)
+		var/sigreturn = SEND_SIGNAL(user, COMSIG_MOB_PRE_FLASHED_CARBON, flashed, src, deviation)
 		if(sigreturn & STOP_FLASH)
 			return
 
@@ -172,6 +171,8 @@
 			//easy way to make sure that you can only long stun someone who is facing in your direction
 			flashed.adjustStaminaLoss(rand(80, 120) * (1 - (deviation * 0.5)))
 			flashed.Paralyze(rand(25, 50) * (1 - (deviation * 0.5)))
+			SEND_SIGNAL(user, COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON, flashed, src, deviation)
+
 		else if(user)
 			visible_message(span_warning("[user] fails to blind [flashed] with the flash!"), span_danger("[user] fails to blind you with the flash!"))
 		else


### PR DESCRIPTION
## About The Pull Request

Fixes head revolutionaries being able to convert with the AOE mode

Why did AOE flash even have a targeted arg? Dumb

## Changelog

:cl: Melbert
fix: Head revs can no longer convert with the AOE flash mode
/:cl:

