### PR TITLE
Makes AI Sat turret able to shoot silicons

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -813,7 +813,6 @@ DEFINE_BITFIELD(turret_flags, list(
 		return TRUE
 
 /obj/machinery/porta_turret/ai
-	faction = list(FACTION_SILICON)
 	turret_flags = TURRET_FLAG_SHOOT_CRIMINALS | TURRET_FLAG_SHOOT_ANOMALOUS | TURRET_FLAG_SHOOT_HEADS
 
 /obj/machinery/porta_turret/ai/assess_perp(mob/living/carbon/human/perp)


### PR DESCRIPTION

## About The Pull Request

ai sat turrets specifically would not shoot anything with FACTION_SILICON so it wouldnt even shoot them with target cyborgs mode
removes that faction from the turret, with target cyborg mode off still does not fire, turned on fires at cyborgs

## Why It's Good For The Game

Fixes #74465

## Changelog
:cl:
fix: makes ai sat turrets actually able to fire upon silicons
/:cl:
