### PR TITLE
Fixes Ceiling Generation for Lavaland Icemoon Ruin - Whoops

### DIFF
--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -42,3 +42,4 @@
 
 /datum/map_generator/cave_generator/lavaland/ruin_version
 	weighted_open_turf_types = list(/turf/open/misc/asteroid/basalt/lava_land_surface/no_ruins = 1)
+	weighted_closed_turf_types = list(/turf/closed/mineral/random/volcanic/do_not_chasm = 1)


### PR DESCRIPTION

## About The Pull Request

Forgot to do this in #74410. It's **not** the reason why we see active turfs on icebox station though, because this is just closed turfs. The active turfs never spawned as a result of this, they only spawn as a result of the open turfs of the ruin mixing with chasm air. The ceiling looks a lot better now though.
## Why It's Good For The Game

Should have always been like this.
## Changelog
doesn't really matter.
