### PR TITLE
Fixes power in the Interdyne ruin and adds a GPS signal

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/interdyne.dmm
+++ b/_maps/RandomRuins/SpaceRuins/interdyne.dmm
@@ -745,6 +745,7 @@
 /obj/item/stack/spacecash/c1000,
 /obj/item/stack/spacecash/c1000,
 /obj/item/stack/spacecash/c1000,
+/obj/item/gps/spaceruin,
 /turf/open/floor/iron/smooth,
 /area/ruin/space/has_grav/interdyne)
 "CP" = (
@@ -1058,6 +1059,7 @@
 	input_available = 100000;
 	output_level = 40000
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ruin/space/has_grav/interdyne)
 "Pj" = (


### PR DESCRIPTION
## About The Pull Request
Turns out I missed out a cable under the SMES which stopped power flowing from it entirely apparently. Also added a GPS signal for explorers to actually find it
## Why It's Good For The Game
The ruin needs power or you can't get into the vault, also puts it in line with most other ruins by giving it a signal to find with.
## Changelog
:cl:
fix: Interdyne Ruin should now have power
/:cl:
