### PR TITLE
More Cargo Techs

### DIFF
--- a/code/modules/jobs/job_types/cargo_technician.dm
+++ b/code/modules/jobs/job_types/cargo_technician.dm
@@ -5,8 +5,8 @@
 		ship bounty cubes."
 	department_head = list(JOB_QUARTERMASTER)
 	faction = FACTION_STATION
-	total_positions = 3
-	spawn_positions = 2
+	total_positions = 5
+	spawn_positions = 3
 	supervisors = SUPERVISOR_QM
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "CARGO_TECHNICIAN"

--- a/config/jobconfig.toml
+++ b/config/jobconfig.toml
@@ -55,8 +55,8 @@
 [CARGO_TECHNICIAN]
 "# Playtime Requirements" = 0
 "# Required Account Age" = 0
-"# Spawn Positions" = 2
-"# Total Positions" = 3
+"# Spawn Positions" = 3
+"# Total Positions" = 5
 
 [CHAPLAIN]
 "# Playtime Requirements" = 0


### PR DESCRIPTION
## About The Pull Request
Increases the amount of Cargo Tech slots from 3 (2 roundstart 1 latejoin) to 5 (3 roundstart and 2 latejoin)

## Why It's Good For The Game
1. We have more players, more job slots is neat to prevent assistant station.
2. Consistent with other main departmental jobs (doctor, scientist, engineer all have 5 slots)
3. Cargo tech is a newbie friendly job and it's nice for it to handle em
4. More workforce to deliver mail, sell crates etc. More excuse to play with drones and whatnot.

## Changelog
:cl:
balance: 2 More Cargo Tech slots
/:cl:
