### PR TITLE
android bodyparts no longer immune to species change

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -37,12 +37,12 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 
 	bodypart_overrides = list(
-		BODY_ZONE_HEAD = /obj/item/bodypart/head/robot,
-		BODY_ZONE_CHEST = /obj/item/bodypart/chest/robot,
-		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/robot,
-		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/robot,
-		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/robot,
-		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/robot,
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/robot/android,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/robot/android,
+		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/robot/android,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/robot/android,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/robot/android,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/robot/android,
 	)
 	examine_limb_id = SPECIES_HUMAN
 

--- a/code/modules/surgery/bodyparts/species_parts/android_parts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/android_parts.dm
@@ -5,25 +5,19 @@
  */
 
 /obj/item/bodypart/head/robot/android
-	limb_id = SPECIES_ANDROID
 	change_exempt_flags = null
 
 /obj/item/bodypart/chest/robot/android
-	limb_id = SPECIES_ANDROID
 	change_exempt_flags = null
 
 /obj/item/bodypart/arm/left/robot/android
-	limb_id = SPECIES_ANDROID
 	change_exempt_flags = null
 
 /obj/item/bodypart/arm/right/robot/android
-	limb_id = SPECIES_ANDROID
 	change_exempt_flags = null
 
 /obj/item/bodypart/leg/left/robot/android
-	limb_id = SPECIES_ANDROID
 	change_exempt_flags = null
 
 /obj/item/bodypart/leg/right/robot/android
-	limb_id = SPECIES_ANDROID
 	change_exempt_flags = null

--- a/code/modules/surgery/bodyparts/species_parts/android_parts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/android_parts.dm
@@ -1,0 +1,29 @@
+/**
+ * This is ultra stupid, but essentially androids use robotic limb subtypes that are NOT
+ * immune to being replaced on species change.
+ * Yes, that is the entire reason these exist.
+ */
+
+/obj/item/bodypart/head/robot/android
+	limb_id = SPECIES_ANDROID
+	change_exempt_flags = null
+
+/obj/item/bodypart/chest/robot/android
+	limb_id = SPECIES_ANDROID
+	change_exempt_flags = null
+
+/obj/item/bodypart/arm/left/robot/android
+	limb_id = SPECIES_ANDROID
+	change_exempt_flags = null
+
+/obj/item/bodypart/arm/right/robot/android
+	limb_id = SPECIES_ANDROID
+	change_exempt_flags = null
+
+/obj/item/bodypart/leg/left/robot/android
+	limb_id = SPECIES_ANDROID
+	change_exempt_flags = null
+
+/obj/item/bodypart/leg/right/robot/android
+	limb_id = SPECIES_ANDROID
+	change_exempt_flags = null

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4868,6 +4868,7 @@
 #include "code\modules\surgery\bodyparts\parts.dm"
 #include "code\modules\surgery\bodyparts\robot_bodyparts.dm"
 #include "code\modules\surgery\bodyparts\wounds.dm"
+#include "code\modules\surgery\bodyparts\species_parts\android_parts.dm"
 #include "code\modules\surgery\bodyparts\species_parts\ethereal_bodyparts.dm"
 #include "code\modules\surgery\bodyparts\species_parts\lizard_bodyparts.dm"
 #include "code\modules\surgery\bodyparts\species_parts\misc_bodyparts.dm"


### PR DESCRIPTION
## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/72771

## Why It's Good For The Game

more consistent species changing behavior

admittedly this is a bitch of a patchwork fix and surgically implanted limbs should be flagged as such to prevent being boofed by species changes, but ah well this is good enough for now

## Changelog

:cl:
fix: Transforming into an android and then back into another species will no longer leave you with permanent robotic limbs
/:cl: