### PR TITLE
You no longer drop the items in your pockets when your body is randomized

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -987,7 +987,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if(ITEM_SLOT_LPOCKET)
 			if(HAS_TRAIT(I, TRAIT_NODROP)) //Pockets aren't visible, so you can't move TRAIT_NODROP items into them.
 				return FALSE
-			if(H.l_store) // no pocket swaps at all
+			if(!isnull(H.l_store) && H.l_store != I) // no pocket swaps at all
 				return FALSE
 
 			var/obj/item/bodypart/O = H.get_bodypart(BODY_ZONE_L_LEG)
@@ -1000,7 +1000,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if(ITEM_SLOT_RPOCKET)
 			if(HAS_TRAIT(I, TRAIT_NODROP))
 				return FALSE
-			if(H.r_store)
+			if(!isnull(H.r_store) && H.r_store != I)
 				return FALSE
 
 			var/obj/item/bodypart/O = H.get_bodypart(BODY_ZONE_R_LEG)


### PR DESCRIPTION

## About The Pull Request

When you are randomized by things like Mulligans or, in the case that allowed me to find this bug, abductor transformation glands, the contents on your pockets drop to the floor. That's because the proc that checks if the items on your pockets fit post-transformation fails if there is anything in your pocket... including the original item. It now accounts for that and keeps your belongings safely inside your pockets
## Why It's Good For The Game

Fixes a bug. Small, but an annoying one.
## Changelog
:cl:
fix: the contents of your pockets no longer drop onto the floor when your body is randomized
/:cl:
