### PR TITLE
Piercing rounds won't infinitely recurse when fired at piggyback players

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -499,14 +499,10 @@
 	var/list/atom/considering = list()  // let's define this ONCE
 	// 3. mobs
 	for(var/mob/living/iter_possible_target in our_turf)
-		var/mob/living/checking_target = (temporary_unstoppable_movement) ? iter_possible_target : iter_possible_target.lowest_buckled_mob()
-		if(checking_target in considering)
-			continue
-		if(can_hit_target(checking_target, checking_target == original, TRUE, checking_target == bumped))
-			considering |= checking_target
+		if(can_hit_target(iter_possible_target, iter_possible_target == original, TRUE, iter_possible_target == bumped))
+			considering |= iter_possible_target
 	if(length(considering))
-		var/mob/living/hit_living = pick(considering)
-		return hit_living
+		return pick(considering)
 	// 4. objs and other dense things
 	for(var/i in our_turf)
 		if(can_hit_target(i, i == original, TRUE, i == bumped))
@@ -547,17 +543,18 @@
 		else if(!direct_target) // non dense objects do not get hit unless specifically clicked
 			return FALSE
 	else
-		var/mob/living/L = target
+		var/mob/living/living_target = target
 		if(direct_target)
 			return TRUE
-		if(L.stat == DEAD)
+		if(living_target.stat == DEAD)
 			return FALSE
-		if(HAS_TRAIT(L, TRAIT_IMMOBILIZED) && HAS_TRAIT(L, TRAIT_FLOORED) && HAS_TRAIT(L, TRAIT_HANDS_BLOCKED))
+		if(HAS_TRAIT(living_target, TRAIT_IMMOBILIZED) && HAS_TRAIT(living_target, TRAIT_FLOORED) && HAS_TRAIT(living_target, TRAIT_HANDS_BLOCKED))
 			return FALSE
 		if(!hit_prone_targets)
-			if(!L.density)
+			var/mob/living/buckled_to = living_target.lowest_buckled_mob()
+			if(!buckled_to.density) // Will just be us if we're not buckled to another mob
 				return FALSE
-			if(L.body_position != LYING_DOWN)
+			if(living_target.body_position != LYING_DOWN)
 				return TRUE
 	return TRUE
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -499,16 +499,19 @@
 	var/list/atom/considering = list()  // let's define this ONCE
 	// 3. mobs
 	for(var/mob/living/iter_possible_target in our_turf)
-		if(can_hit_target(iter_possible_target, iter_possible_target == original, TRUE, iter_possible_target == bumped))
-			considering += iter_possible_target
-	if(considering.len)
+		var/mob/living/checking_target = (temporary_unstoppable_movement) ? iter_possible_target : iter_possible_target.lowest_buckled_mob()
+		if(checking_target in considering)
+			continue
+		if(can_hit_target(checking_target, checking_target == original, TRUE, checking_target == bumped))
+			considering |= checking_target
+	if(length(considering))
 		var/mob/living/hit_living = pick(considering)
-		return hit_living.lowest_buckled_mob()
+		return hit_living
 	// 4. objs and other dense things
 	for(var/i in our_turf)
 		if(can_hit_target(i, i == original, TRUE, i == bumped))
 			considering += i
-	if(considering.len)
+	if(length(considering))
 		return pick(considering)
 	// 5. turf
 	if(can_hit_target(our_turf, our_turf == original, TRUE, our_turf == bumped))


### PR DESCRIPTION
## About The Pull Request

I noticed in a round that someone fired a honkmother staff at a guy riding a cyborg and it reported hitting them 374 times (with no effect).
Running it on local it seems like this proc was infinitely recursing because after validating its targets it would return the mob the target was buckled to, rather than the mob we actually validated, and then just do that over and over again.
I made it not do that.

Now if you shoot someone riding a cyborg with a honk staff they will fall of, as god intended.
Also now if you shoot a pair of people who are riding piggyback with penetrator rounds, it will do what the name says and shoot both of them.

## Why It's Good For The Game

Rutimes bad. Throwing people around with bananas good. Shooting a hole through two guys at a time, also good.

## Changelog

:cl:
fix: You can no longer escape the wrath of the honkmother by climbing onto a cyborg.
fix: Shooting a pair of piggybacked players with a penetrator round will penetrate both players.
/:cl:
