### PR TITLE
Fix code not compiling on prod.

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1019,7 +1019,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		#endif
 
 #if (PRELOAD_RSC == 0)
-/client/preload_vox()
+/client/proc/preload_vox()
 	for (var/name in GLOB.vox_sounds)
 		var/file = GLOB.vox_sounds[name]
 		Export("##action=load_rsc", file)


### PR DESCRIPTION
@Mothblocks idea: make alt_tests a yml file and allow more generic alt tests, like defines and shit. or we can put this on integration tests and let windows build cover the normal/dev build case of preload_rsc = 1

edit: actually, this only needs to go on the linters