### PR TITLE
Use 515 for CI, making 514 an alternate test

### DIFF
--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -6,4 +6,4 @@
 # Example:
 # 500.1337: runtimestation
 
-515.1603: runtimestation
+514.1588: runtimestation

--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "514.1588"
+byond: "515.1603"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -4,8 +4,8 @@
 #Final authority on what's required to fully build the project
 
 # byond version
-export BYOND_MAJOR=514
-export BYOND_MINOR=1588
+export BYOND_MAJOR=515
+export BYOND_MINOR=1603
 
 #rust_g git tag
 export RUST_G_VERSION=1.2.0


### PR DESCRIPTION
We are blocked on requiring 515 because of SpacemanDMM issues, which I have to figure out how to get solved.

In the meantime, let's use 515 for tests because it's significantly faster.