### PR TITLE
Final Patches for RCD related devices.

### DIFF
--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -201,17 +201,17 @@
 	return data
 
 /obj/item/construction/proc/toggle_silo(mob/user)
-	. = TRUE
-
 	if(!silo_mats)
 		to_chat(user, span_warning("no remote storage connection."))
-		return
+		return FALSE
+
 	if(!silo_mats.mat_container && !silo_link) // Allow them to turn off an invalid link.
 		to_chat(user, span_warning("no silo link detected."))
-		return
+		return FALSE
 
 	silo_link = !silo_link
 	to_chat(user, span_notice("silo link state: [silo_link ? "on" : "off"]"))
+	return TRUE
 
 ///shared action for toggling silo link rcd,rld & plumbing
 /obj/item/construction/ui_act(action, list/params)
@@ -220,7 +220,8 @@
 		return
 
 	if(action == "toggle_silo" && (upgrade & RCD_UPGRADE_SILO_LINK))
-		return toggle_silo(usr)
+		toggle_silo(usr)
+		return TRUE
 
 /obj/item/construction/proc/checkResource(amount, mob/user)
 	if(!silo_mats || !silo_mats.mat_container || !silo_link)

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -201,17 +201,17 @@
 	return data
 
 /obj/item/construction/proc/toggle_silo(mob/user)
+	. = TRUE
+
 	if(!silo_mats)
 		to_chat(user, span_warning("no remote storage connection."))
-		return FALSE
+		return
 	if(!silo_mats.mat_container && !silo_link) // Allow them to turn off an invalid link.
 		to_chat(user, span_warning("no silo link detected."))
-		return FALSE
+		return
 
 	silo_link = !silo_link
 	to_chat(user, span_notice("silo link state: [silo_link ? "on" : "off"]"))
-
-	return TRUE
 
 ///shared action for toggling silo link rcd,rld & plumbing
 /obj/item/construction/ui_act(action, list/params)

--- a/code/game/objects/items/wall_mounted.dm
+++ b/code/game/objects/items/wall_mounted.dm
@@ -11,7 +11,7 @@
 	var/pixel_shift //The amount of pixels
 
 /obj/item/wallframe/proc/try_build(turf/on_wall, mob/user)
-	if(get_dist(on_wall,user)>1)
+	if(get_dist(on_wall,user) > 1)
 		balloon_alert(user, "you are too far!")
 		return
 	var/floor_to_wall = get_dir(user, on_wall)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -188,15 +188,13 @@
 
 	add_fingerprint(user)
 
-	var/turf/T = user.loc //get user's location for delay checks
-
 	//the istype cascade has been spread among various procs for easy overriding
-	if(try_clean(W, user, T) || try_wallmount(W, user, T) || try_decon(W, user, T))
+	if(try_clean(W, user) || try_wallmount(W, user) || try_decon(W, user))
 		return
 
 	return ..()
 
-/turf/closed/wall/proc/try_clean(obj/item/W, mob/living/user, turf/T)
+/turf/closed/wall/proc/try_clean(obj/item/W, mob/living/user)
 	if((user.combat_mode) || !LAZYLEN(dent_decals))
 		return FALSE
 
@@ -214,7 +212,7 @@
 
 	return FALSE
 
-/turf/closed/wall/proc/try_wallmount(obj/item/W, mob/user, turf/T)
+/turf/closed/wall/proc/try_wallmount(obj/item/W, mob/user)
 	//check for wall mounted frames
 	if(istype(W, /obj/item/wallframe))
 		var/obj/item/wallframe/F = W
@@ -228,7 +226,7 @@
 
 	return FALSE
 
-/turf/closed/wall/proc/try_decon(obj/item/I, mob/user, turf/T)
+/turf/closed/wall/proc/try_decon(obj/item/I, mob/user)
 	if(I.tool_behaviour == TOOL_WELDER)
 		if(!I.tool_start_check(user, amount=0))
 			return FALSE

--- a/code/modules/asset_cache/assets/rcd.dm
+++ b/code/modules/asset_cache/assets/rcd.dm
@@ -12,10 +12,10 @@
 		'icons/obj/monitors.dmi' = list("alarm_bitem"),
 		'icons/obj/wallframe.dmi' = list("apc"),
 		'icons/obj/stock_parts.dmi' = list("box_1"),
-		'icons/obj/objects.dmi' = list("bed", "rack"),
+		'icons/obj/objects.dmi' = list("bed"),
 		'icons/obj/smooth_structures/catwalk.dmi' = list("catwalk-0"),
 		'icons/hud/radial.dmi' = list("cnorth", "csouth", "ceast", "cwest", "chair", "secure_windoor", "stool", "wallfloor", "windowsize", "windowtype", "windoor"),
-		'icons/obj/structures.dmi' = list("glass_table", "rwindow0", "reflector_base", "table", "window0"),
+		'icons/obj/structures.dmi' = list("glass_table", "rack", "rwindow0", "reflector_base", "table", "window0"),
 	)
 
 	var/icon/icon

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -303,18 +303,18 @@
 					return
 				qdel(target)
 		if(MODE_WALL)
-			if(isspaceturf(target))
-				var/turf/open/space/S = target
-				to_chat(source, "[icon2html(src, source)][span_notice("Building Floor...")]")
-				if(!do_after_cooldown(S, source))
-					return
-				S.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-			else if(isfloorturf(target))
+			if(isfloorturf(target))
 				var/turf/open/floor/F = target
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Wall...")]")
 				if(!do_after_cooldown(F, source))
 					return
 				F.PlaceOnTop(/turf/closed/wall)
+			else if(isopenturf(target))
+				var/turf/open/space/S = target
+				to_chat(source, "[icon2html(src, source)][span_notice("Building Floor...")]")
+				if(!do_after_cooldown(S, source))
+					return
+				S.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		if(MODE_AIRLOCK)
 			if(isfloorturf(target))
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Airlock...")]")


### PR DESCRIPTION
## About The Pull Request
Final closing act for #74527, some more bugs to squash.

1. Fixes broken sprite for rack in RCD UI
![Screenshot (153)](https://user-images.githubusercontent.com/110812394/230711179-4df6fc5f-6f6c-4680-bb0b-b1caba50152d.png)

2. Fixes #41114 mounted RCD can lay plating on chasm/ any open turf again

3. Removes unused turf argument inside `try_clean()`, `try_wallmount()`, & `try_decon()` procs because well it was unused

## Changelog
:cl:
refactor: remove unused turf var inside wallmount procs
fix: broken rack sprite inside RCD UI
fix: mounted RCD now lays plating over chasms and open turfs
/:cl:
