### PR TITLE
Removes the brute damage from rubbershot pellets

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -83,7 +83,7 @@
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 3
+	damage = 0
 	stamina = 11
 	sharpness = NONE
 	embedding = null


### PR DESCRIPTION
## About The Pull Request

Removes the brute damage from rubbershot pellets

## Why It's Good For The Game

Rubbershot pellets are intended for security to make less-than-lethal arrests. Unfortunately, our design space does not support anything between 100% lethal and 100% non-lethal, so we have to remove the less-than-lethal aspect and make it non-lethal.

## Changelog
:cl:
balance: Removes the brute damage from rubbershot pellets
/:cl: