### PR TITLE
a borg who's somehow immune to flashes will no longer still be disabled by laser pointers

### DIFF
--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -120,8 +120,7 @@
 		var/mob/living/silicon/S = target
 		log_combat(user, S, "shone in the sensors", src)
 		//chance to actually hit the eyes depends on internal component
-		if(prob(effectchance * diode.rating))
-			S.flash_act(affect_silicon = 1)
+		if(prob(effectchance * diode.rating) && S.flash_act(affect_silicon = 1))
 			S.Paralyze(rand(100,200))
 			to_chat(S, span_danger("Your sensors were overloaded by a laser!"))
 			outmsg = span_notice("You overload [S] by shining [src] at [S.p_their()] sensors.")

--- a/code/game/objects/items/devices/laserpointer.dm
+++ b/code/game/objects/items/devices/laserpointer.dm
@@ -120,7 +120,7 @@
 		var/mob/living/silicon/S = target
 		log_combat(user, S, "shone in the sensors", src)
 		//chance to actually hit the eyes depends on internal component
-		if(prob(effectchance * diode.rating) && S.flash_act(affect_silicon = 1))
+		if(prob(effectchance * diode.rating) && S.flash_act(affect_silicon = TRUE))
 			S.Paralyze(rand(100,200))
 			to_chat(S, span_danger("Your sensors were overloaded by a laser!"))
 			outmsg = span_notice("You overload [S] by shining [src] at [S.p_their()] sensors.")


### PR DESCRIPTION
## About The Pull Request

Resolves an extreme edge case where if (via adminbus or a downstream's changes) a borg is somehow immune to being flashed, a laser pointer would still be able to blind them.

## Why It's Good For The Game

Aerial rodent made its ninja cyborgs flashproof, but they're not laser pointer-proof due to this bug. I figured that fixing this bug upstream would be best, in case some insane /tg/ admin (or coder 😳) attempts to flashproof a borg at some point in the distant future.

## Changelog

:cl: ATHATH
fix: Laser pointers will no longer disable borgs that have somehow been made immune to flashes.
/:cl: