### PR TITLE
Adds simple_rotation component to bsa parts.

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -36,10 +36,6 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	density = TRUE
 	anchored = TRUE
 
-/obj/machinery/bsa/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/simple_rotation)
-
 /obj/machinery/bsa/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
 	default_unfasten_wrench(user, tool, time = 1 SECONDS)
@@ -49,6 +45,10 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	name = "Bluespace Artillery Generator"
 	desc = "Generates cannon pulse. Needs to be linked with a fusor."
 	icon_state = "power_box"
+
+/obj/machinery/bsa/back/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/bsa/back/multitool_act(mob/living/user, obj/item/I)
 	if(!multitool_check_buffer(user, I)) //make sure it has a data buffer
@@ -62,6 +62,10 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	name = "Bluespace Artillery Bore"
 	desc = "Do not stand in front of cannon during operation. Needs to be linked with a fusor."
 	icon_state = "emitter_center"
+
+/obj/machinery/bsa/front/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/bsa/front/multitool_act(mob/living/user, obj/item/I)
 	if(!multitool_check_buffer(user, I)) //make sure it has a data buffer
@@ -77,6 +81,10 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	icon_state = "fuel_chamber"
 	var/datum/weakref/back_ref
 	var/datum/weakref/front_ref
+
+/obj/machinery/bsa/middle/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/bsa/middle/multitool_act(mob/living/user, obj/item/I)
 	if(!multitool_check_buffer(user, I))

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -36,6 +36,10 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	density = TRUE
 	anchored = TRUE
 
+/obj/machinery/bsa/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/simple_rotation)
+
 /obj/machinery/bsa/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
 	default_unfasten_wrench(user, tool, time = 1 SECONDS)


### PR DESCRIPTION

## About The Pull Request
Adds simple_rotation component to bsa machinery. Setting up bsa with rotating it via moving is quite painfull.
## Why It's Good For The Game
Less pain.
## Changelog
:cl:
qol: bsa parts can now be rotated.
/:cl:
