### PR TITLE
Allows PKAs to be attached to mining MODsuits

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -327,6 +327,7 @@
 		/obj/item/kinetic_crusher,
 		/obj/item/stack/ore/plasma,
 		/obj/item/storage/bag/ore,
+		/obj/item/gun/energy/recharge/kinetic_accelerator,
 	)
 	inbuilt_modules = list(/obj/item/mod/module/ash_accretion, /obj/item/mod/module/sphere_transform)
 	skins = list(


### PR DESCRIPTION
## About The Pull Request

like the title says, this PR allows miners to attach their funny little proto-kinetic accelerator to their hard-earned modsuit

## Why It's Good For The Game

this is probably an oversight, but if not, it's a really weird design choice. if you can attach a crusher to it, there's no reason you wouldn't be able to attach a PKA. a very dumb inconvenience imo

## Changelog

:cl:
balance: PKAs can now be attached to mining MODsuits.
/:cl: