### PR TITLE
Fixes TGC decks being capped to 31 cards rather than 30.

### DIFF
--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 /obj/item/tcgcard_deck/attackby(obj/item/item, mob/living/user, params)
 	. = ..()
 	if(istype(item, /obj/item/tcgcard))
-		if(contents.len > 30)
+		if(contents.len >= 30)
 			to_chat(user, span_notice("This pile has too many cards for a regular deck!"))
 			return FALSE
 		var/obj/item/tcgcard/new_card = item


### PR DESCRIPTION

## About The Pull Request

Fixes #72701 (closed but the issue seems to have been misunderstood.)

TGC decks are limited to 30 cards when inserting cards by using the deck on individual cards (the legal amount) but using individual cards on a deck has a limit of 31 cards instead, the 30 card limit is now correctly checked on card insertions.
## Why It's Good For The Game

Bugfix.
## Changelog
:cl:
fix: TGC decks will no longer allow you to insert an illegal 31st card.
/:cl:
