### PR TITLE
Significantly speed up create & destroy by reducing the amount of time to wait for GC

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -238,6 +238,9 @@
 
 ///Calls the show_candidate_poll_window() to all eligible ghosts
 /proc/poll_candidates(question, jobban_type, be_special_flag = 0, poll_time = 300, ignore_category = null, flashwindow = TRUE, list/group = null)
+	if (group.len == 0)
+		return list()
+
 	var/time_passed = world.time
 	if (!question)
 		question = "Would you like to be a special role?"

--- a/code/__HELPERS/varset_callback.dm
+++ b/code/__HELPERS/varset_callback.dm
@@ -1,6 +1,9 @@
 #define VARSET_LIST_CALLBACK(target, var_name, var_value) CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(___callbackvarset), ##target, ##var_name, ##var_value)
 //dupe code because dm can't handle 3 level deep macros
 #define VARSET_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(___callbackvarset), ##datum, NAMEOF(##datum, ##var), ##var_value)
+/// Same as VARSET_CALLBACK, but uses a weakref to the datum.
+/// Use this if the timer is exceptionally long.
+#define VARSET_WEAK_CALLBACK(datum, var, var_value) CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(___callbackvarset), WEAKREF(##datum), NAMEOF(##datum, ##var), ##var_value)
 
 /proc/___callbackvarset(list_or_datum, var_name, var_value)
 	if(length(list_or_datum))

--- a/code/__HELPERS/varset_callback.dm
+++ b/code/__HELPERS/varset_callback.dm
@@ -6,7 +6,15 @@
 	if(length(list_or_datum))
 		list_or_datum[var_name] = var_value
 		return
+
 	var/datum/datum = list_or_datum
+
+	if (isweakref(datum))
+		var/datum/weakref/datum_weakref = datum
+		datum = datum_weakref.resolve()
+		if (isnull(datum))
+			return
+
 	if(IsAdminAdvancedProcCall())
 		datum.vv_edit_var(var_name, var_value) //same result generally, unless badmemes
 	else

--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -147,7 +147,7 @@
 	START_PROCESSING(SSobj, src)
 	INVOKE_ASYNC(src, PROC_REF(make_ghost_swarm), candidate_list)
 	playsound(src, pick(spooky_noises), 100, TRUE)
-	QDEL_IN(src, 2 MINUTES)
+	QDEL_IN(WEAKREF(src), 2 MINUTES)
 
 /obj/structure/ghost_portal/process(delta_time)
 	. = ..()

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -227,7 +227,7 @@
 		pai_card.set_personality(src)
 	forceMove(pai_card)
 	card = pai_card
-	addtimer(VARSET_CALLBACK(WEAKREF(src), holochassis_ready, TRUE), HOLOCHASSIS_INIT_TIME)
+	addtimer(VARSET_WEAK_CALLBACK(src, holochassis_ready, TRUE), HOLOCHASSIS_INIT_TIME)
 	if(!holoform)
 		add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), PAI_FOLDED)
 	desc = "A pAI hard-light holographics emitter. This one appears in the form of a [chassis]."

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -227,7 +227,7 @@
 		pai_card.set_personality(src)
 	forceMove(pai_card)
 	card = pai_card
-	addtimer(VARSET_CALLBACK(src, holochassis_ready, TRUE), HOLOCHASSIS_INIT_TIME)
+	addtimer(VARSET_CALLBACK(WEAKREF(src), holochassis_ready, TRUE), HOLOCHASSIS_INIT_TIME)
 	if(!holoform)
 		add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), PAI_FOLDED)
 	desc = "A pAI hard-light holographics emitter. This one appears in the form of a [chassis]."

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -107,6 +107,9 @@
 			summon_objective.summoned = FALSE
 			summon_objective.killed = TRUE
 
+	if (GLOB.cult_narsie == src)
+		GLOB.cult_narsie = null
+
 	return ..()
 
 /obj/narsie/attack_ghost(mob/user)

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -3,8 +3,6 @@
 	//You absolutely must run last
 	priority = TEST_CREATE_AND_DESTROY
 
-TEST_FOCUS(/datum/unit_test/create_and_destroy)
-
 GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 /datum/unit_test/create_and_destroy/Run()
 	//We'll spawn everything here

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -140,23 +140,16 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 	//Hell code, we're bound to have ended the round somehow so let's stop if from ending while we work
 	SSticker.delay_end = TRUE
 
-#if DM_VERSION >= 515
 	// Drastically lower the amount of time it takes to GC, since we don't have clients that can hold it up.
 	SSgarbage.collection_timeout[GC_QUEUE_CHECK] = 10 SECONDS
-#endif
-
 	//Prevent the garbage subsystem from harddeling anything, if only to save time
 	SSgarbage.collection_timeout[GC_QUEUE_HARDDELETE] = 10000 HOURS
 	//Clear it, just in case
 	cached_contents.Cut()
 
 	//Now that we've qdel'd everything, let's sleep until the gc has processed all the shit we care about
-#if DM_VERSION >= 515
 	// + 2 seconds to ensure that everything gets in the queue.
 	var/time_needed = SSgarbage.collection_timeout[GC_QUEUE_CHECK] + 2 SECONDS
-#else
-	var/time_needed = SSgarbage.collection_timeout[GC_QUEUE_CHECK]
-#endif
 
 	var/start_time = world.time
 	var/garbage_queue_processed = FALSE

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -3,8 +3,6 @@
 	//You absolutely must run last
 	priority = TEST_CREATE_AND_DESTROY
 
-	var/static/gc_time = 10 SECONDS
-
 TEST_FOCUS(/datum/unit_test/create_and_destroy)
 
 GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
@@ -108,8 +106,6 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 	// Always ought to have an associated escape menu. Any references it could possibly hold would need one regardless.
 	ignore += subtypesof(/atom/movable/screen/escape_menu)
 
-	rustg_time_reset("init_start_time")
-
 	var/list/cached_contents = spawn_at.contents.Copy()
 	var/original_turf_type = spawn_at.type
 	var/original_baseturfs = islist(spawn_at.baseturfs) ? spawn_at.baseturfs.Copy() : spawn_at.baseturfs
@@ -145,52 +141,29 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 	GLOB.running_create_and_destroy = FALSE
 	//Hell code, we're bound to have ended the round somehow so let's stop if from ending while we work
 	SSticker.delay_end = TRUE
+
+#if DM_VERSION >= 515
+	// Drastically lower the amount of time it takes to GC, since we don't have clients that can hold it up.
+	SSgarbage.collection_timeout[GC_QUEUE_CHECK] = 10 SECONDS
+#endif
+
 	//Prevent the garbage subsystem from harddeling anything, if only to save time
 	SSgarbage.collection_timeout[GC_QUEUE_HARDDELETE] = 10000 HOURS
 	//Clear it, just in case
 	cached_contents.Cut()
 
-	log_test("Creating and destroying took [rustg_time_milliseconds("init_start_time") / 1000]s")
-
 	//Now that we've qdel'd everything, let's sleep until the gc has processed all the shit we care about
-	var/start_time = world.time
-
 #if DM_VERSION >= 515
-	var/old_queue_check_time = SSgarbage.collection_timeout[GC_QUEUE_CHECK]
-	SSgarbage.collection_timeout[GC_QUEUE_CHECK] = gc_time
-
-	var/time_left = gc_time
-	var/list/undeleted_objects
-
-	while (time_left > 0)
-		time_left -= 5 SECONDS
-		sleep(5 SECONDS)
-
-		undeleted_objects = undeleted_objects()
-		if (undeleted_objects.len == 0)
-			break
-		else
-			log_test("[undeleted_objects.len] object\s left")
-
-	if (undeleted_objects.len > 0)
-		var/list/names = list()
-		for (var/datum/object as anything in undeleted_objects)
-			names += "\t- [object] ([object.type])"
-
-		TEST_FAIL("Some objects were not deleted after [DisplayTimeText(gc_time)].\n[names.Join("\n")]")
-
-		for (var/datum/object as anything in undeleted_objects)
-			object.find_references()
-	else
-		log_test("Everything cleaned up in [DisplayTimeText(world.time - start_time)]")
-
-	SSgarbage.collection_timeout[GC_QUEUE_CHECK] = old_queue_check_time
+	// + 2 seconds to ensure that everything gets in the queue.
+	var/time_needed = SSgarbage.collection_timeout[GC_QUEUE_CHECK] + 2 SECONDS
 #else
 	var/time_needed = SSgarbage.collection_timeout[GC_QUEUE_CHECK]
-	sleep(time_needed)
+#endif
 
+	var/start_time = world.time
 	var/garbage_queue_processed = FALSE
 
+	sleep(time_needed)
 	while(!garbage_queue_processed)
 		var/list/queue_to_check = SSgarbage.queues[GC_QUEUE_CHECK]
 		//How the hell did you manage to empty this? Good job!
@@ -214,7 +187,6 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 		SSgarbage.next_fire = 1
 		//Unless you've seriously fucked up, queue processing shouldn't take "that" long. Let her run for a bit, see if anything's changed
 		sleep(20 SECONDS)
-#endif
 
 	//Alright, time to see if anything messed up
 	var/list/cache_for_sonic_speed = SSgarbage.items
@@ -239,16 +211,5 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 
 	SSticker.delay_end = FALSE
 	//This shouldn't be needed, but let's be polite
-	SSgarbage.collection_timeout[GC_QUEUE_HARDDELETE] = 10 SECONDS
-
-/datum/unit_test/create_and_destroy/proc/undeleted_objects()
-	RETURN_TYPE(/list)
-	var/list/undeleted_objects = list()
-
-	for (var/list/queue_data in SSgarbage.queues[GC_QUEUE_CHECK])
-		var/datum/thing = queue_data[GC_QUEUE_ITEM_REF]
-		// References are `datum/thing`, and the argument passed through.
-		if (refcount(thing) != 2)
-			undeleted_objects += thing
-
-	return undeleted_objects
+	SSgarbage.collection_timeout[GC_QUEUE_CHECK] = GC_CHECK_QUEUE
+	SSgarbage.collection_timeout[GC_QUEUE_HARDDELETE] = GC_DEL_QUEUE

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -223,7 +223,7 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 
 	SSticker.force_ending = TRUE
 	//We have to call this manually because del_text can preceed us, and SSticker doesn't fire in the post game
-	SSticker.standard_reboot()
+	SSticker.declare_completion()
 
 /datum/map_template/unit_tests
 	name = "Unit Tests Zone"


### PR DESCRIPTION
The check queue is 5 minutes long because that's the longest a client can hold onto a reference. Without clients, we can drastically decrease the time we have to wait. This lowers the time down to 10 seconds (though everything right now deletes in 5). 

This will represent a 5 minute decrease in CI across the board, freeing up runners.

Makes a few changes to stuff that was being held for more than 10 seconds.
- `VARSET_CALLBACK` now works through weakrefs, to allow for pAIs to have their holochassis init timers.
- Nar'Sie cleans herself up in GLOB.cult_narsie if she's deleted.
- "Spooky portals" no longer hold onto a reference for 2 minutes.
- `poll_candidates` short circuits to an empty list if there are no candidates, to avoid several 30 second+ long timers

Originally this was going to be a more clever hack from @MrStonedOne about short circuiting if everything deletes before the wait, but we realized that basically nothing actually holds onto references for that long without clients, and that nothing really should anyway