### PR TITLE
Stops admin spawned ghost portals from mutating global lists

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -174,7 +174,7 @@
  * Ghosts are deleted two minutes after being made, and exist to punch stuff until it breaks.
  */
 
-/obj/structure/ghost_portal/proc/make_ghost_swarm(list/candidate_list)
+/obj/structure/ghost_portal/proc/make_ghost_swarm(list/candidate_list = list())
 	if(!length(candidate_list)) //If we are not passed a candidate list we just poll everyone who is dead, meaning these can also be spawned directly.
 		candidate_list += GLOB.current_observers_list
 		candidate_list += GLOB.dead_player_list


### PR DESCRIPTION
## About The Pull Request

Admin spawned ghost portals call `make_ghost_swarm(null)`

This in turn causes `!length(candidate_list)` to succeed

The intended effect of this is that the candidate list gains the entries of `GLOB.current_observers_list` and `GLOB.dead_player_list`

In actuality, what this does is that it causes `candidate_list` to be assigned to `GLOB.current_observers_list`, then adds the contents of `GLOB.dead_player_list` to `GLOB.current_observers_list`

This is because `null += list()` just sets the variable to the list, while `list() += list()` adds the contents of the latter to the former in place (does not produce a new list object) 

All this needs is a default set so that a `null` value passed uses an empty list rather than nothing 

## Why It's Good For The Game

This is very unlikely to pop up (admin only in fact), but it's mutating managed globals like this is not good.

## Changelog

:cl: Melbert
fix: Admin spawned ghost portals no longer make all dead players considered also as observers (they're two different things)
/:cl:

