### PR TITLE
Headcrab Infection Fix

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -1018,7 +1018,7 @@
 	to_chat(owner, span_boldannounce("You are a fresh changeling birthed from a headslug! \
 		You aren't as strong as a normal changeling, as you are newly born."))
 	to_chat(owner, span_userdanger("Remember, being a headslug changeling doesn't make you an antagonist. \
-		You do not have a licence to freely kill."))
+		It doesn't give you a licence to freely kill."))
 
 /datum/antagonist/changeling/space
 	name = "\improper Space Changeling"

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -1017,7 +1017,8 @@
 /datum/antagonist/changeling/headslug/greet()
 	to_chat(owner, span_boldannounce("You are a fresh changeling birthed from a headslug! \
 		You aren't as strong as a normal changeling, as you are newly born."))
-
+	to_chat(owner, span_userdanger("Remember, being a headslug changeling doesn't make you an antagonist. \
+		You do not have a licence to freely kill."))
 
 /datum/antagonist/changeling/space
 	name = "\improper Space Changeling"

--- a/code/modules/mob_spawn/corpses/nonhuman_corpses.dm
+++ b/code/modules/mob_spawn/corpses/nonhuman_corpses.dm
@@ -49,7 +49,3 @@
 	mob_type = /mob/living/simple_animal/hostile/headcrab
 	icon = 'icons/mob/simple/animal.dmi'
 	icon_state = "headcrab_dead"
-
-/obj/effect/mob_spawn/corpse/headcrab/special(mob/living/simple_animal/hostile/headcrab/crab)
-	. = ..()
-	crab.egg_lain = TRUE // Prevents using mad science to become a changeling


### PR DESCRIPTION

## About The Pull Request
There are headcrab corpses on the new meateor ruin. However, apparently you cannot infect corpses with them once you take the steps to get one all the way back to the station. This makes it so that you can infect corpses again with those headcrabs.
## Why It's Good For The Game
I think it is balanced since headcrab lings are already a nerfed version of changelings, and there are a lot of steps to take to transform yourself into a headcrab ling. You need to get rainbow slimes, lazurus injector by mining, and you need to find the meateor ruin to fetch a dead headcrab. I did this myself and was left there has a mere slug until I started praying.
## Changelog
:cl:
balance: Headcrab corpses can infect humans again.
fix: All headcrab corpses are now able to infect humans again.
/:cl:
