### PR TITLE
Removes fun from two ruins

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -240,7 +240,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 5
 	},
-/obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
+/obj/structure/alien/egg/burst,
+/obj/item/clothing/mask/facehugger/dead,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "di" = (
@@ -309,9 +310,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "dy" = (
 /obj/structure/cable,
-/obj/effect/turf_decal{
-	dir = 2
-	},
+/obj/effect/turf_decal,
 /obj/effect/turf_decal{
 	dir = 1
 	},
@@ -707,9 +706,7 @@
 /obj/effect/turf_decal{
 	dir = 1
 	},
-/obj/effect/turf_decal{
-	dir = 2
-	},
+/obj/effect/turf_decal,
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/glass{
 	icon_state = "plastitaniumtiny"
@@ -1169,7 +1166,8 @@
 /obj/item/shard{
 	icon_state = "titaniumtiny"
 	},
-/obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
+/obj/structure/alien/egg/burst,
+/obj/item/clothing/mask/facehugger/dead,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "sT" = (
@@ -1188,13 +1186,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/infested_frigate)
-"ta" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 2;
-	icon_state = "singular"
-	},
-/turf/open/space/basic,
-/area/template_noop)
 "ti" = (
 /obj/structure/cable,
 /obj/effect/turf_decal{
@@ -1259,9 +1250,7 @@
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
 "uC" = (
-/obj/effect/turf_decal{
-	dir = 2
-	},
+/obj/effect/turf_decal,
 /obj/machinery/recharge_station{
 	icon_state = "borgdecon2"
 	},
@@ -1526,8 +1515,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal{
-	icon_state = "warningline_white";
-	dir = 2
+	icon_state = "warningline_white"
 	},
 /obj/effect/turf_decal{
 	icon_state = "warninglinecorner_white";
@@ -1876,9 +1864,7 @@
 /obj/effect/turf_decal{
 	dir = 1
 	},
-/obj/effect/turf_decal{
-	dir = 2
-	},
+/obj/effect/turf_decal,
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /obj/effect/mob_spawn/corpse/human/engineer,
@@ -2109,9 +2095,7 @@
 /obj/effect/turf_decal{
 	dir = 1
 	},
-/obj/effect/turf_decal{
-	dir = 2
-	},
+/obj/effect/turf_decal,
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs{
 	icon_state = "gib1-old"
@@ -2159,9 +2143,7 @@
 /obj/effect/turf_decal{
 	icon_state = "delivery_red"
 	},
-/obj/effect/turf_decal{
-	dir = 2
-	},
+/obj/effect/turf_decal,
 /obj/structure/mecha_wreckage/gygax/dark{
 	anchored = 1
 	},
@@ -2476,9 +2458,7 @@
 /obj/effect/turf_decal{
 	dir = 1
 	},
-/obj/effect/turf_decal{
-	dir = 2
-	},
+/obj/effect/turf_decal,
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/glass,
 /obj/item/shard{
@@ -3859,7 +3839,7 @@ fl
 "}
 (22,1,1) = {"
 fl
-ta
+AU
 fl
 fl
 qF
@@ -4188,7 +4168,7 @@ fl
 fl
 fl
 fl
-ta
+AU
 fl
 fl
 fl

--- a/_maps/RandomRuins/SpaceRuins/interdyne.dmm
+++ b/_maps/RandomRuins/SpaceRuins/interdyne.dmm
@@ -467,9 +467,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/interdyne)
 "qj" = (
-/obj/item/paper/fluff/junkmail_redpill/true,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/paper/fluff/junkmail_redpill,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "qt" = (


### PR DESCRIPTION

## About The Pull Request
- The 'infested_shuttle' ruin no longer has two of the 2% xeno egg spawners.
- The 'interdyne' ruin no longer spawns with the full nuke codes on paper, only the much less useful variant.

## Why It's Good For The Game
The eggs make an announcement whenever they do spawn and probably aren't the best thing to have in space loot pool. Also giving a guaranteed spawn nuke code is bad or something idk that sounds pretty funny to me personally.


coders hate fun i'm just the messenger
