### PR TITLE
Makes space realistic and not transfer heat

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -48,6 +48,9 @@
 /turf/open/space/Initialize(mapload)
 	SHOULD_CALL_PARENT(FALSE)
 	air = space_gas
+	
+	if(check_holidays(APRIL_FOOLS))
+		thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 
 	if (PERFORM_ALL_TESTS(focus_only/multiple_space_initialization))
 		if(flags_1 & INITIALIZED_1)


### PR DESCRIPTION
...on April Fools.

## About The Pull Request

Makes space realistic and not transfer heat on April Fools.

## Why It's Good For The Game

I asked Ninja how we could make space realistic on april fools and he said that making it not transfer heat would accomplish what we want.

## Changelog

:cl:
fix: Makes space realistic and not transfer heat...on April Fools.
/:cl: