### PR TITLE
Fixes the Regal Condor's magazines being invisible

### DIFF
--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -114,6 +114,7 @@
 	caliber = CALIBER_10MM
 	max_ammo = 8
 	multiple_sprites = AMMO_BOX_PER_BULLET
+	multiple_sprite_use_base = TRUE
 
 /obj/item/ammo_box/magazine/r10mm/empty
 	icon_state = "r10mm-0"


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/31829017/230756645-6024b948-92c1-4b39-9136-fce68a9a14e4.png)
(see title.)
## Why It's Good For The Game
if you go through the entire sidequest to assemble The Doohickey (10mm 2rnd burst), i think you should probably be able to reload it

## Changelog

:cl:
fix: The Regal Condor's magazines are actually visible, and therefore useful for their intended purpose.
/:cl:
