### PR TITLE
Instant Atmos Unwrenching

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -370,14 +370,18 @@
 
 	var/unsafe_wrenching = FALSE
 	var/internal_pressure = int_air.return_pressure()-env_air.return_pressure()
+	var/empty_pipe = FALSE
+	if(!(int_air.total_moles() > 0))
+		empty_pipe = TRUE
 
-	to_chat(user, span_notice("You begin to unfasten \the [src]..."))
+	if(!empty_pipe)
+		to_chat(user, span_notice("You begin to unfasten \the [src]..."))
 
 	if (internal_pressure > 2*ONE_ATMOSPHERE)
 		to_chat(user, span_warning("As you begin unwrenching \the [src] a gush of air blows in your face... maybe you should reconsider?"))
 		unsafe_wrenching = TRUE //Oh dear oh dear
 
-	var/time_taken = unsafe_wrenching ? 20 : 0
+	var/time_taken = empty_pipe ? 0 : 20
 	if(I.use_tool(src, user, time_taken, volume=50))
 		user.visible_message( \
 			"[user] unfastens \the [src].", \

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -377,7 +377,8 @@
 		to_chat(user, span_warning("As you begin unwrenching \the [src] a gush of air blows in your face... maybe you should reconsider?"))
 		unsafe_wrenching = TRUE //Oh dear oh dear
 
-	if(I.use_tool(src, user, 20, volume=50))
+	var/time_taken = unsafe_wrenching ? 20 : 0
+	if(I.use_tool(src, user, time_taken, volume=50))
 		user.visible_message( \
 			"[user] unfastens \the [src].", \
 			span_notice("You unfasten \the [src]."), \


### PR DESCRIPTION
## About The Pull Request
Unwrenching empty atmos pipes/devices is now instant
## Why It's Good For The Game
Worst part about playing atmos is how long it takes to set up builds, especially if you want to unwrench all the ports and pipes that come after the main yellow Pure loop. Also annoying if you misclick and have to spend time unwrenching an empty pipe
Just QOL for atmos players
## Changelog
:cl:
qol: Unwrenching empty atmos pipes/devices is now INSTANT
/:cl:
