### PR TITLE
Stops station blueprints from expanding areas of non atmos adjacent turfs.

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -102,15 +102,17 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 	var/list/apc_map = list()
 	var/list/areas = list("New Area" = /area)
 	for(var/i in 1 to turf_count)
-		var/area/place = get_area(turfs[i])
+		var/turf/the_turf = turfs[i]
+		var/area/place = get_area(the_turf)
 		if(blacklisted_areas[place.type])
 			continue
 		if(!place.requires_power || (place.area_flags & NOTELEPORT) || (place.area_flags & HIDDEN_AREA))
 			continue // No expanding powerless rooms etc
+		if(!TURF_SHARES(the_turf)) // No expanding areas of walls/something blocking this turf because that defeats the whole point of them used to separate areas
+			continue
 		if(!isnull(place.apc))
 			apc_map[place.name] = place.apc
-		//If we found just one apc we can just convert that to work for our new area. But 2 or more!! nope
-		if(length(apc_map) > 1)
+		if(length(apc_map) > 1) // When merging 2 or more areas make sure we arent merging their apc into 1 area
 			creator.balloon_alert(creator, "too many conflicting APCs, only one allowed!")
 			return
 		areas[place.name] = place
@@ -136,7 +138,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 
 	//we haven't done anything. let's get outta here
 	if(newA == oldA)
-		creator.balloon_alert(creator, "no area change!")
+		to_chat(creator, span_warning("no area change."))
 		return
 
 	/**

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -113,7 +113,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 		if(!isnull(place.apc))
 			apc_map[place.name] = place.apc
 		if(length(apc_map) > 1) // When merging 2 or more areas make sure we arent merging their apc into 1 area
-			to_chat(creator, span_warning("Multiple APC's detected in the vicinity. only 1 is allowed!"))
+			to_chat(creator, span_warning("Multiple APC's detected in the vicinity. only 1 is allowed."))
 			return
 		areas[place.name] = place
 

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -113,7 +113,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 		if(!isnull(place.apc))
 			apc_map[place.name] = place.apc
 		if(length(apc_map) > 1) // When merging 2 or more areas make sure we arent merging their apc into 1 area
-			creator.balloon_alert(creator, "too many conflicting APCs, only one allowed!")
+			to_chat(creator, span_warning("Multiple APC's detected in the vicinity. only 1 is allowed!"))
 			return
 		areas[place.name] = place
 
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 
 	//we haven't done anything. let's get outta here
 	if(newA == oldA)
-		to_chat(creator, span_warning("no area change."))
+		to_chat(creator, span_warning("Selected choice is same as the area your standing in. No area changes were requested."))
 		return
 
 	/**


### PR DESCRIPTION
## About The Pull Request
Fixes #74605

the problem starts with `detect_room()` proc. This proc returns turfs even those with `atmos_adjacent_turfs` = null. This means it returns turfs that has a wall, airlock, window etc i.e. whatever that stops air from flowing through it. This coupled together with `create_area()` causes some wierdness.

Let's take an example
![Screenshot (154)](https://user-images.githubusercontent.com/110812394/230769831-e84819f2-31b2-4a67-a8bb-5e07e1c5a1cc.png)

Area A is well defined i.e. it has been created via the station blueprints and is highlighted in green, Area B however is only theoretical i.e. we haven't created it yet or we are about to create it. Now you might be thinking Area A is completely walled & sealed off, it should be physically impossible to expand it unless we broke down one of it's walls and so since we are standing in Area B it shoudn't even give me the option to expand area A Right? right? r.i.g.h.t?
![Screenshot (155)](https://user-images.githubusercontent.com/110812394/230770056-169cbab3-4516-4da7-ae2c-4f40b50be9ba.png)
Well PHFUUK. The area editor completely ignores the laws of physics and allows me expand Area A anyway.  This could cause some real power gaming shit because if you create an area next to an area having an APC you could use that area power without even making your own apc by simply expanding that area(like using someone else's wifi from outside their house without them even knowing)

#73850 accidently built on top of this as it relied on this to detect duplicate APC's but the checks became way too strict as it would check areas of surrounding walls for apc's and throw the conflicting apc error. You can now build room's next to each other even if they have fuctioning apc's however you still can't build rooms in space on top of shuttle walls because that's been the default behaviour for years and hasn't been touched one bit.

## Changelog
:cl:
fix: station blueprints no longer expands & detects areas of non atmos adjacent turfs.
/:cl: