### PR TITLE
Resets tomatoes to default instability, as it was confusing new botanists as to why their tomatoes were killing people.

### DIFF
--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -7,7 +7,6 @@
 	plantname = "Tomato Plants"
 	product = /obj/item/food/grown/tomato
 	maturation = 8
-	instability = 25
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_grow = "tomato-grow"
 	icon_dead = "tomato-dead"


### PR DESCRIPTION
## About The Pull Request

Resets tomatoes to default instability, as it was confusing new botanists as to why their tomatoes were killing people.

## Why It's Good For The Game

see this thread https://tgstation13.org/phpBB/viewtopic.php?f=10&t=33675

chef players get extremely confused because their food is hurting people and they don't know why unless they played botanist enough to know crosspollination exists
botanist players who are new get extremely confused because they don't know plants have reagents yet and also don't know crosspollination exists for reagents

it's overall an unfun experience for new players to either role who aren't up to date on the mechanical intricacies of their plants

## Changelog

:cl:
qol: Resets tomatoes to default instability, as it was confusing new botanists as to why their tomatoes were killing people.
/:cl: