### PR TITLE
adds missing baseturfs helpers in 2 space ruins

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
@@ -195,6 +195,10 @@
 /obj/item/pen,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/the_outlet/researchrooms)
+"fa" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/has_grav/the_outlet/employeesection)
 "fk" = (
 /obj/structure/cable,
 /obj/structure/sink/directional/west,
@@ -1020,6 +1024,10 @@
 	},
 /turf/open/floor/cult,
 /area/ruin/space/has_grav/the_outlet/cultinfluence)
+"yv" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/rust,
+/area/ruin/space/has_grav/the_outlet/storefront)
 "yx" = (
 /obj/item/toy/plush/narplush,
 /obj/effect/decal/cleanable/crayon,
@@ -1716,6 +1724,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/the_outlet/researchrooms)
+"NU" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/mineral/random,
+/area/ruin/space)
 "NY" = (
 /obj/effect/decal/cleanable/dirt{
 	icon_state = "dirt-143"
@@ -1723,6 +1735,10 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/the_outlet/researchrooms)
+"Od" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/open/floor/cult,
+/area/ruin/space/has_grav/the_outlet/cultinfluence)
 "Oy" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/iron/white,
@@ -1838,6 +1854,10 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/the_outlet/employeesection)
+"Rs" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/r_wall/rust,
+/area/ruin/space/has_grav/the_outlet/researchrooms)
 "Rx" = (
 /obj/structure/rack,
 /obj/item/clothing/head/costume/papersack,
@@ -2641,7 +2661,7 @@ DC
 Nb
 Ra
 Ef
-UF
+Rs
 sF
 OL
 Ps
@@ -2655,7 +2675,7 @@ yg
 jg
 Ts
 Ts
-uE
+fa
 Ts
 Ts
 uE
@@ -3388,7 +3408,7 @@ od
 zS
 FG
 od
-od
+yv
 od
 AV
 Sv
@@ -3519,7 +3539,7 @@ qy
 Aa
 Gu
 re
-Gu
+Od
 Gu
 RN
 UY
@@ -3847,7 +3867,7 @@ RN
 Er
 Er
 Er
-Er
+NU
 Er
 Er
 Er

--- a/_maps/RandomRuins/SpaceRuins/waystation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/waystation.dmm
@@ -507,6 +507,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/waystation/power)
+"iY" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall,
+/area/ruin/space/has_grav/waystation/cargobay)
 "ja" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -756,6 +760,10 @@
 /obj/structure/sign/warning/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/waystation/cargobay)
+"mV" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall,
+/area/ruin/space/has_grav/waystation)
 "nc" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/tactical,
@@ -1077,6 +1085,10 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/waystation/dorms)
+"rI" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall,
+/area/ruin/space/has_grav/waystation/cargooffice)
 "rK" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -1318,6 +1330,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/waystation)
+"wM" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall,
+/area/ruin/space/has_grav/waystation/dorms)
 "wW" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
@@ -1840,6 +1856,10 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/waystation/cargooffice)
+"HS" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall,
+/area/ruin/space/has_grav/waystation/qm)
 "Id" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron,
@@ -2238,6 +2258,10 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/waystation/cargobay)
+"NI" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/waystation/securestorage)
 "NK" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/tank/air{
@@ -2245,6 +2269,10 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/waystation)
+"NT" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall,
+/area/ruin/space/has_grav/waystation/power)
 "Of" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/light/small/directional/south,
@@ -2876,6 +2904,10 @@
 "Ya" = (
 /turf/template_noop,
 /area/template_noop)
+"Ye" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/mineral/random/low_chance,
+/area/ruin/space)
 "Yj" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
@@ -3923,7 +3955,7 @@ QN
 QN
 QN
 QN
-QN
+HS
 QN
 QN
 pK
@@ -4161,7 +4193,7 @@ Ud
 Ls
 Ls
 Ud
-Ls
+wM
 Ls
 Ud
 QN
@@ -4172,7 +4204,7 @@ uF
 TT
 TT
 TT
-TT
+mV
 TT
 pK
 pK
@@ -4299,7 +4331,7 @@ ym
 bN
 TT
 pK
-pK
+Ye
 pK
 iJ
 iJ
@@ -4642,7 +4674,7 @@ iJ
 pK
 pK
 pK
-yg
+NT
 iT
 Wm
 zd
@@ -4974,7 +5006,7 @@ UG
 UG
 UG
 UG
-UG
+rI
 UG
 mr
 mr
@@ -5386,7 +5418,7 @@ pK
 pK
 pK
 pK
-yi
+NI
 Ok
 ub
 er
@@ -5595,7 +5627,7 @@ KW
 BZ
 IQ
 mr
-mr
+iY
 ur
 ur
 ur

--- a/_maps/RandomRuins/SpaceRuins/waystation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/waystation.dmm
@@ -1139,6 +1139,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/waystation/dorms)
+"sP" = (
+/obj/effect/baseturf_helper/asteroid/airless,
+/turf/closed/wall,
+/area/ruin/space/has_grav/waystation/kitchen)
 "sX" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4744,7 +4748,7 @@ yg
 LE
 Cc
 IN
-do
+sP
 cT
 bG
 ma


### PR DESCRIPTION

## About The Pull Request

Waystation ruin was missing baseturfs since I had zero idea what it was when I made it. this PR fixes that. also fixes missing baseturf in the outlet ruin after I found it during testings

## Why It's Good For The Game
FIX GOOD!!!!!!!!!!! ME LIKE GBP!!!!
## Changelog
:cl:
fix: asteroid-based space ruins (waystation, the outlet) now has asteroids below their plating!
/:cl:
