### PR TITLE
Makes station lockdown not banbait asimov ais with combat upgrades

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -140,19 +140,11 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /datum/ai_module/destructive/nuke_station
 	name = "Doomsday Device"
 	description = "Activate a weapon that will disintegrate all organic life on the station after a 450 second delay. \
-		Can only be used while on the station, will fail if your core is moved off station or destroyed. \
-		Obtaining control of the weapon will be easier if Head of Staff office APCs are already under your control."
+		Can only be used while on the station, will fail if your core is moved off station or destroyed."
 	cost = 130
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/nuke_station
 	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
-	///List of areas that grant discounts. "heads_quarters" will match any head of staff office.
-	var/list/discount_areas = list(
-		/area/station/command/heads_quarters,
-		/area/station/ai_monitored/command/nuke_storage
-	)
-	///List of hacked head of staff office areas. Includes the vault too. Provides a 20 PT discount per (Min 50 PT cost)
-	var/list/hacked_command_areas = list()
 
 /datum/action/innate/ai/nuke_station
 	name = "Doomsday Device"
@@ -366,7 +358,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 
 /datum/action/innate/ai/lockdown
 	name = "Lockdown"
-	desc = "Closes, bolts, and depowers every airlock, firelock, and blast door on the station. After 90 seconds, they will reset themselves."
+	desc = "Closes, bolts, and electrifies every airlock, firelock, and blast door on the station. After 90 seconds, they will reset themselves."
 	button_icon_state = "lockdown"
 	uses = 1
 	/// Badmin / exploit abuse prevention.

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/nuke_station
 	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
-///List of areas that grant discounts. "heads_quarters" will match any head of staff office.
+	///List of areas that grant discounts. "heads_quarters" will match any head of staff office.
 	var/list/discount_areas = list(
 		/area/station/command/heads_quarters,
 		/area/station/ai_monitored/command/nuke_storage

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -140,11 +140,19 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 /datum/ai_module/destructive/nuke_station
 	name = "Doomsday Device"
 	description = "Activate a weapon that will disintegrate all organic life on the station after a 450 second delay. \
-		Can only be used while on the station, will fail if your core is moved off station or destroyed."
+		Can only be used while on the station, will fail if your core is moved off station or destroyed. \
+		Obtaining control of the weapon will be easier if Head of Staff office APCs are already under your control."
 	cost = 130
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/nuke_station
 	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
+///List of areas that grant discounts. "heads_quarters" will match any head of staff office.
+	var/list/discount_areas = list(
+		/area/station/command/heads_quarters,
+		/area/station/ai_monitored/command/nuke_storage
+	)
+	///List of hacked head of staff office areas. Includes the vault too. Provides a 20 PT discount per (Min 50 PT cost)
+	var/list/hacked_command_areas = list()
 
 /datum/action/innate/ai/nuke_station
 	name = "Doomsday Device"


### PR DESCRIPTION
## About The Pull Request

Changes the description of the hostile lockdown button to make the door shocking part clear.

## Why It's Good For The Game

Asimov AIs can access this with combat upgrades and we shouldn't be banbaiting them by disguising the part where every airlock on station is shocked.

## Changelog
:cl:
fix: The action button description for malf AI hostile station lockdown now makes it clear that doors will be electrified.
/:cl:
