### PR TITLE
Material Container screentips

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -477,13 +477,11 @@
 	if((held_item.flags_1 & HOLOGRAM_1) || (held_item.item_flags & NO_MAT_REDEMPTION) || (allowed_item_typecache && !is_type_in_typecache(held_item, allowed_item_typecache)))
 		return NONE
 	var/list/item_materials = held_item.get_material_composition(mat_container_flags)
-	var/has_materials = FALSE
+	if(!length(item_materials))
+		return NONE
 	for(var/material in item_materials)
-		if(!can_hold_material(material))
+		if(can_hold_material(material))
 			continue
-		has_materials = TRUE
-		break
-	if(!has_materials)
 		return NONE
 
 	context[SCREENTIP_CONTEXT_LMB] = "Insert"

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -62,6 +62,14 @@
 			mat_amt = 0
 		materials[mat_ref] += mat_amt
 
+	if(_mat_container_flags & MATCONTAINER_NO_INSERT)
+		return
+
+	var/atom/atom_target = parent
+	atom_target.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
+
+	RegisterSignal(atom_target, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, PROC_REF(on_requesting_context_from_item))
+
 /datum/component/material_container/Destroy(force, silent)
 	materials = null
 	allowed_materials = null
@@ -448,3 +456,36 @@
 		))
 
 	return data
+
+/**
+ * Adds context sensitivy directly to the material container file for screentips
+ * Arguments:
+ * * source - refers to item that will display its screentip
+ * * context - refers to, in this case, an item in the users hand hovering over the material container, such as an autolathe
+ * * held_item - refers to the item that has materials accepted by the material container
+ * * user - refers to user who will see the screentip when the proper context and tool are there
+ */
+/datum/component/material_container/proc/on_requesting_context_from_item(datum/source, list/context, obj/item/held_item, mob/living/user)
+	SIGNAL_HANDLER
+
+	if(isnull(held_item))
+		return NONE
+	if(!(mat_container_flags & MATCONTAINER_ANY_INTENT) && user.combat_mode)
+		return NONE
+	if(held_item.item_flags & ABSTRACT)
+		return NONE
+	if((held_item.flags_1 & HOLOGRAM_1) || (held_item.item_flags & NO_MAT_REDEMPTION) || (allowed_item_typecache && !is_type_in_typecache(held_item, allowed_item_typecache)))
+		return NONE
+	var/list/item_materials = held_item.get_material_composition(mat_container_flags)
+	var/has_materials = FALSE
+	for(var/material in item_materials)
+		if(!can_hold_material(material))
+			continue
+		has_materials = TRUE
+		break
+	if(!has_materials)
+		return NONE
+
+	context[SCREENTIP_CONTEXT_LMB] = "Insert"
+
+	return CONTEXTUAL_SCREENTIP_SET


### PR DESCRIPTION
## About The Pull Request

The material_container component now also grants whatever it is added to a simple screentip of "Insert" on items that it can accept, if it is a material container that can accept held items.

## Why It's Good For The Game

Now when a traitor feeds their 13 TC revolver into the autolathe they will see a screentip for a few blissful seconds before pressing left click anyway and sending an ahelp begging for their revolver back.

## Changelog

:cl:
qol: material components (such as autolathes) have contextual screentips if you can put an item inside of it
/:cl:
