### PR TITLE
Adds butchering component for heretic blades.

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -21,6 +21,13 @@
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
 	var/after_use_message = ""
 
+/obj/item/melee/sickly_blade/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/butchering, \
+	speed = 3 SECONDS, \
+	effectiveness = 95, \
+	)
+
 /obj/item/melee/sickly_blade/attack(mob/living/M, mob/living/user)
 	if(!IS_HERETIC_OR_MONSTER(user))
 		to_chat(user, span_danger("You feel a pulse of alien intellect lash out at your mind!"))


### PR DESCRIPTION

## About The Pull Request
Since heretic victims aren't gibbed on sacrifice you either need to rip and tear dead corpses (which is incredibly loud and long) or butcher monkies. And if you need something specific like appendix you can butcher several monkies for it and don't get anything because of non-defined butchering element.
## Why It's Good For The Game
Easier to be heretic.
## Changelog
:cl:
balance: Heretic blades butcher now have speed of 3 seconds and effectiveness of 95.
/:cl:
