### PR TITLE
Makes installed upgrades notices on cameras show as span_info.

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -141,15 +141,15 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 /obj/machinery/camera/examine(mob/user)
 	. = ..()
 	if(isEmpProof(TRUE)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
-		. += "It has electromagnetic interference shielding installed."
+		. += span_info("It has electromagnetic interference shielding installed.")
 	else
 		. += span_info("It can be shielded against electromagnetic interference with some <b>plasma</b>.")
 	if(isXRay(TRUE)) //don't reveal it's upgraded if was done via MALF AI Upgrade Camera Network ability
-		. += "It has an X-ray photodiode installed."
+		. += span_info("It has an X-ray photodiode installed.")
 	else
 		. += span_info("It can be upgraded with an X-ray photodiode with an <b>analyzer</b>.")
 	if(isMotion())
-		. += "It has a proximity sensor installed."
+		. += span_info("It has a proximity sensor installed.")
 	else
 		. += span_info("It can be upgraded with a <b>proximity sensor</b>.")
 

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -35,17 +35,17 @@
 	//upgrade messages
 	var/has_upgrades
 	if(emp_module)
-		. += "It has electromagnetic interference shielding installed."
+		. += span_info("It has electromagnetic interference shielding installed.")
 		has_upgrades = TRUE
 	else if(state == STATE_WIRED)
 		. += span_info("It can be shielded against electromagnetic interference with some <b>plasma</b>.")
 	if(xray_module)
-		. += "It has an X-ray photodiode installed."
+		. += span_info("It has an X-ray photodiode installed.")
 		has_upgrades = TRUE
 	else if(state == STATE_WIRED)
 		. += span_info("It can be upgraded with an X-ray photodiode with an <b>analyzer</b>.")
 	if(proxy_module)
-		. += "It has a proximity sensor installed."
+		. += span_info("It has a proximity sensor installed.")
 		has_upgrades = TRUE
 	else if(state == STATE_WIRED)
 		. += span_info("It can be upgraded with a <b>proximity sensor</b>.")


### PR DESCRIPTION

## About The Pull Request
![image](https://user-images.githubusercontent.com/93882977/230796625-298d3171-39c4-4be6-9f6d-2ac205c756dc.png)
![image](https://user-images.githubusercontent.com/93882977/230796631-b510c4d1-30ee-436f-b93f-fd64d2a73fea.png)
## Why It's Good For The Game
It looks better this way. Supposedly.
## Changelog
:cl:
qol: installed upgrades on cameras now show as blue text instead of plain white text on examine.
/:cl:
