### PR TITLE
Caps contractor baton stutter to 40s

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -382,7 +382,7 @@
 
 /obj/item/melee/baton/telescopic/contractor_baton/additional_effects_non_cyborg(mob/living/target, mob/living/user)
 	target.set_jitter_if_lower(40 SECONDS)
-	target.adjust_stutter(40 SECONDS)
+	target.adjust_stutter_up_to(40 SECONDS)
 
 /obj/item/melee/baton/security
 	name = "stun baton"

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -382,7 +382,7 @@
 
 /obj/item/melee/baton/telescopic/contractor_baton/additional_effects_non_cyborg(mob/living/target, mob/living/user)
 	target.set_jitter_if_lower(40 SECONDS)
-	target.adjust_stutter_up_to(40 SECONDS)
+	target.set_stutter_if_lower(40 SECONDS)
 
 /obj/item/melee/baton/security
 	name = "stun baton"


### PR DESCRIPTION
## About The Pull Request

title. mostly relevant for downstreams. still kinda funny to think about

## Why It's Good For The Game

no man should be banished to the stutter dimension for 40 more seconds after being batonged. also i feel like this is more of a tweak if anything but i don't see a tweak option so balance it is?

## Changelog

:cl:
fix: The contractor baton now only gives you up to 40 seconds of stuttering, instead of making you stutter for 40 seconds more after every hit.
/:cl:
