### PR TITLE
Makes the blowgun not need to windup before shooting

### DIFF
--- a/code/modules/projectiles/guns/special/syringe_gun.dm
+++ b/code/modules/projectiles/guns/special/syringe_gun.dm
@@ -190,8 +190,8 @@
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
 
 /obj/item/gun/syringe/blowgun/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
-	visible_message(span_danger("[user] starts aiming with a blowgun!"))
-	if(do_after(user, 25, target = src))
-		user.adjustStaminaLoss(20)
-		user.adjustOxyLoss(20)
-		return ..()
+	visible_message(span_danger("[user] shoots the blowgun!"))
+
+	user.adjustStaminaLoss(20)
+	user.adjustOxyLoss(20)
+	return ..()


### PR DESCRIPTION
## About The Pull Request

Removes the windup before shooting a blowgun

## Why It's Good For The Game

The blowgun already has 25 oxygen damage, and stamina drain when you fire it, which puts it way below a syringe gun. This also gets rid of the "one viable option" of ranged syringe gun that people rush, because maybe if somebody steals the syringe gun, you can still make some (worse, but viable) syringe gun. 

## Changelog

:cl: Vect0r
balance: The blowgun no longer takes time to windup before you can shoot it.
/:cl:
