### PR TITLE
Emergency Shuttle - Hug Relaxation Shuttle

### DIFF
--- a/_maps/shuttles/emergency_hugcage.dmm
+++ b/_maps/shuttles/emergency_hugcage.dmm
@@ -1,0 +1,570 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ax" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape/brig)
+"aR" = (
+/obj/item/bedsheet/random{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/pillow/random,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/machinery/light/dim/directional/east{
+	brightness = 5;
+	nightshift_brightness = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"bw" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"cb" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/plasma{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"cQ" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape/brig)
+"cW" = (
+/mob/living/simple_animal/pet/fox,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"dz" = (
+/mob/living/simple_animal/parrot/natural{
+	melee_damage_upper = 5
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"dC" = (
+/obj/structure/closet/cabinet,
+/obj/item/pillow/random,
+/obj/item/pillow/random,
+/obj/item/pillow/random,
+/obj/item/pillow/random,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"dP" = (
+/obj/structure/closet/cabinet,
+/obj/item/pillow/random,
+/obj/item/pillow/random,
+/obj/item/pillow/random,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"eE" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"eN" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"gc" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"gg" = (
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/pillow/random,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"gj" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/item/restraints/handcuffs,
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"gq" = (
+/obj/structure/window,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/item/pillow/random,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"hz" = (
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"hH" = (
+/mob/living/simple_animal/pet/penguin/baby,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"iI" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/item/pillow/random,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"jl" = (
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/shuttle/escape)
+"kB" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"kZ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/titanium,
+/area/shuttle/escape)
+"oo" = (
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/obj/item/pillow/random,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"oY" = (
+/obj/item/pillow/random,
+/obj/structure/rack,
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"px" = (
+/obj/machinery/power/shuttle_engine/heater,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"pO" = (
+/obj/structure/window/reinforced,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/catwalk_floor/titanium,
+/area/shuttle/escape)
+"pY" = (
+/turf/template_noop,
+/area/template_noop)
+"rj" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/obj/item/pillow/random,
+/turf/open/floor/mineral/titanium/purple,
+/area/shuttle/escape)
+"sx" = (
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/machinery/door/window/left/directional/west,
+/turf/open/floor/mineral/titanium/purple,
+/area/shuttle/escape)
+"sG" = (
+/mob/living/basic/pet/dog/corgi,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"up" = (
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/machinery/light/dim/directional/south{
+	brightness = 5;
+	nightshift_brightness = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ys" = (
+/obj/item/bedsheet/random{
+	dir = 4
+	},
+/obj/structure/bed{
+	dir = 1
+	},
+/obj/item/pillow/random,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/machinery/light/dim/directional/west{
+	brightness = 5;
+	nightshift_brightness = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"yF" = (
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"zt" = (
+/obj/item/bedsheet/captain,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/structure/bed/pod,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Ag" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Aw" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"AM" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"BW" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/catwalk_floor/titanium,
+/area/shuttle/escape)
+"Hf" = (
+/mob/living/simple_animal/pet/cat/kitten,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"IH" = (
+/obj/effect/fun_balloon/sentience/emergency_shuttle{
+	group_name = "a bunch of cutesy animals";
+	effect_range = 4
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/shuttle/escape)
+"IW" = (
+/turf/closed/wall,
+/area/shuttle/escape)
+"JE" = (
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Brig"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"JF" = (
+/obj/docking_port/mobile/emergency{
+	name = "Hugcage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Brig"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"KT" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"KW" = (
+/obj/item/bedsheet/random{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/item/pillow/random,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Ly" = (
+/obj/structure/window,
+/turf/open/floor/mineral/titanium/purple,
+/area/shuttle/escape)
+"LC" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Mu" = (
+/turf/open/floor/catwalk_floor/titanium,
+/area/shuttle/escape)
+"Ok" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"Qc" = (
+/obj/machinery/door/window/left/directional/east,
+/turf/open/floor/mineral/titanium/purple,
+/area/shuttle/escape)
+"QX" = (
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Rj" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"RZ" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape/brig)
+"Tw" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"TW" = (
+/obj/structure/table,
+/obj/item/bikehorn/rubberducky,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Vf" = (
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Xb" = (
+/obj/structure/window,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"XN" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"YW" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/catwalk_floor/titanium,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+cQ
+cQ
+JE
+cQ
+JF
+cQ
+pY
+pY
+gc
+kB
+gc
+kB
+gc
+gc
+pY
+pY
+pY
+pY
+"}
+(2,1,1) = {"
+RZ
+KT
+Tw
+Tw
+Tw
+cQ
+pY
+gc
+Ag
+QX
+ys
+QX
+gg
+Ag
+gc
+pY
+pY
+pY
+"}
+(3,1,1) = {"
+RZ
+KT
+Tw
+Tw
+gj
+cQ
+IW
+gc
+dC
+eN
+eN
+eN
+eN
+gg
+Ag
+gc
+pY
+pY
+"}
+(4,1,1) = {"
+RZ
+KT
+Tw
+Ok
+ax
+ax
+pY
+gc
+iI
+eN
+hH
+eN
+eN
+cW
+gg
+bw
+bw
+pY
+"}
+(5,1,1) = {"
+cQ
+cQ
+JE
+RZ
+cQ
+YW
+pY
+Ag
+Ag
+eN
+jl
+sx
+gq
+eN
+yF
+cb
+Rj
+pY
+"}
+(6,1,1) = {"
+pY
+XN
+eE
+eE
+AM
+Mu
+kZ
+BW
+AM
+eN
+hz
+IH
+Ly
+eN
+up
+bw
+px
+Rj
+"}
+(7,1,1) = {"
+gc
+gc
+Vf
+XN
+gc
+pO
+pY
+Ag
+Ag
+eN
+rj
+Qc
+Xb
+eN
+TW
+cb
+Rj
+pY
+"}
+(8,1,1) = {"
+XN
+Aw
+eN
+Aw
+Ag
+Ag
+pY
+gc
+oo
+sG
+eN
+dz
+eN
+eN
+KW
+bw
+bw
+pY
+"}
+(9,1,1) = {"
+XN
+LC
+eN
+eN
+oY
+gc
+IW
+gc
+dP
+eN
+eN
+eN
+Hf
+KW
+Ag
+gc
+pY
+pY
+"}
+(10,1,1) = {"
+XN
+Aw
+eN
+eN
+zt
+gc
+pY
+gc
+Ag
+KW
+aR
+KW
+KW
+Ag
+gc
+pY
+pY
+pY
+"}
+(11,1,1) = {"
+gc
+gc
+gc
+gc
+gc
+gc
+pY
+pY
+gc
+gc
+gc
+gc
+gc
+gc
+pY
+pY
+pY
+pY
+"}

--- a/_maps/shuttles/emergency_hugcage.dmm
+++ b/_maps/shuttles/emergency_hugcage.dmm
@@ -57,10 +57,28 @@
 /obj/effect/spawner/random/entertainment/plushie_delux,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"eb" = (
+/obj/structure/window/reinforced,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/catwalk_floor/titanium,
+/area/shuttle/escape)
 "eE" = (
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "eN" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"fG" = (
+/obj/machinery/door/airlock/medical/glass{
+	name = "Emergency Shuttle Medical"
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"fM" = (
+/obj/structure/sink/directional/north,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "gc" = (
@@ -125,13 +143,16 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "kZ" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"nZ" = (
+/obj/structure/table/optable,
+/obj/machinery/status_display/evac/directional/west,
+/obj/item/toy/plush/lizard_plushie{
+	name = "Heals-The-Patients"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/titanium,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "oo" = (
 /obj/structure/bed{
@@ -144,6 +165,13 @@
 /obj/effect/spawner/random/entertainment/plushie_delux,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"os" = (
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 32
+	},
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "oY" = (
 /obj/item/pillow/random,
 /obj/structure/rack,
@@ -155,10 +183,10 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "pO" = (
-/obj/structure/window/reinforced,
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/catwalk_floor/titanium,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "pY" = (
 /turf/template_noop,
@@ -180,6 +208,10 @@
 /area/shuttle/escape)
 "sG" = (
 /mob/living/basic/pet/dog/corgi,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"tF" = (
+/obj/machinery/light_switch/directional/north,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "up" = (
@@ -235,8 +267,40 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "BW" = (
-/obj/machinery/light/small/directional/east,
+/obj/structure/table,
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/regular{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/toxin,
+/obj/item/storage/medkit/brute,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/item/storage/pill_bottle/paxpsych,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Dl" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/catwalk_floor/titanium,
+/area/shuttle/escape)
+"FW" = (
+/obj/structure/sign/directions/security/directional/north,
+/obj/structure/sign/directions/medical/directional/north{
+	pixel_y = 40
+	},
+/obj/structure/sign/directions/command/directional/north{
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Hf" = (
 /mob/living/simple_animal/pet/cat/kitten,
@@ -250,7 +314,11 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/shuttle/escape)
 "IW" = (
-/turf/closed/wall,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "JE" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
@@ -263,12 +331,11 @@
 /obj/docking_port/mobile/emergency{
 	name = "Hugcage"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig"
+/obj/machinery/door/airlock/medical/glass{
+	name = "Emergency Shuttle Medical"
 	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/escape/brig)
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
 "KT" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/plastitanium/red,
@@ -293,6 +360,10 @@
 "Mu" = (
 /turf/open/floor/catwalk_floor/titanium,
 /area/shuttle/escape)
+"Ns" = (
+/obj/item/radio/intercom/chapel/directional/west,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
 "Ok" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -305,6 +376,14 @@
 /area/shuttle/escape)
 "QX" = (
 /turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Rg" = (
+/obj/machinery/stasis,
+/obj/machinery/light/dim/directional/south{
+	brightness = 5;
+	nightshift_brightness = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Rj" = (
 /obj/machinery/power/shuttle_engine/propulsion,
@@ -329,6 +408,28 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"VD" = (
+/obj/structure/table,
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/circular_saw,
+/obj/item/retractor{
+	pixel_x = 4
+	},
+/obj/item/hemostat{
+	pixel_x = -4
+	},
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
+/obj/machinery/light/dim/directional/south{
+	brightness = 5;
+	nightshift_brightness = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "Xb" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -340,21 +441,29 @@
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"YQ" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
 "YW" = (
-/obj/structure/window/reinforced,
-/obj/structure/rack,
-/obj/effect/spawner/random/engineering/toolbox,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/catwalk_floor/titanium,
+/obj/effect/turf_decal/siding/dark_blue{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 
 (1,1,1) = {"
 cQ
 cQ
+cQ
+cQ
 JE
 cQ
 JF
-cQ
+gc
 pY
 pY
 gc
@@ -371,10 +480,12 @@ pY
 (2,1,1) = {"
 RZ
 KT
-Tw
-Tw
+kZ
+Ns
 Tw
 cQ
+QX
+gc
 pY
 gc
 Ag
@@ -395,7 +506,9 @@ Tw
 Tw
 gj
 cQ
-IW
+fG
+gc
+XN
 gc
 dC
 eN
@@ -414,8 +527,10 @@ KT
 Tw
 Ok
 ax
-ax
-pY
+Ag
+eN
+nZ
+VD
 gc
 iI
 eN
@@ -434,11 +549,13 @@ cQ
 JE
 RZ
 cQ
+Dl
 YW
-pY
+YW
+BW
 Ag
 Ag
-eN
+tF
 jl
 sx
 gq
@@ -455,8 +572,10 @@ eE
 eE
 AM
 Mu
-kZ
-BW
+Mu
+Mu
+Mu
+Mu
 AM
 eN
 hz
@@ -474,11 +593,13 @@ gc
 Vf
 XN
 gc
+eb
 pO
-pY
+pO
+fM
 Ag
 Ag
-eN
+FW
 rj
 Qc
 Xb
@@ -495,7 +616,9 @@ eN
 Aw
 Ag
 Ag
-pY
+eN
+os
+Rg
 gc
 oo
 sG
@@ -515,7 +638,9 @@ eN
 eN
 oY
 gc
-IW
+YQ
+gc
+XN
 gc
 dP
 eN
@@ -534,6 +659,8 @@ Aw
 eN
 eN
 zt
+gc
+QX
 gc
 pY
 gc
@@ -554,6 +681,8 @@ gc
 gc
 gc
 gc
+gc
+IW
 gc
 pY
 pY

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -480,6 +480,13 @@
 	admin_notes = "it's pretty big, and comfy. Be careful when placing it down!"
 	credit_cost = CARGO_CRATE_VALUE * 25
 
+/datum/map_template/shuttle/emergency/hugcage
+	suffix = "hugcage"
+	name = "Hug-cage Relaxation Evacuation System"
+	description = "A small cozy shuttle with plenty of beds for tired spacemen, and a hug-cage for pillow-fights. Does not have a medbay, so patients cant bleed on the expensive bedsheets."
+	admin_notes = "Has a sentience fun balloon for pets. No medbay."
+	credit_cost = CARGO_CRATE_VALUE * 13
+
 /datum/map_template/shuttle/ferry/base
 	suffix = "base"
 	name = "transport ferry"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -482,10 +482,10 @@
 
 /datum/map_template/shuttle/emergency/hugcage
 	suffix = "hugcage"
-	name = "Hug-cage Relaxation Evacuation System"
-	description = "A small cozy shuttle with plenty of beds for tired spacemen, and a hug-cage for pillow-fights. Does not have a medbay, so patients cant bleed on the expensive bedsheets."
-	admin_notes = "Has a sentience fun balloon for pets. No medbay."
-	credit_cost = CARGO_CRATE_VALUE * 13
+	name = "Hug Relaxation Shuttle"
+	description = "A small cozy shuttle with plenty of beds for tired or sensitive spacemen, and a box for pillow-fights."
+	admin_notes = "Has a sentience fun balloon for pets."
+	credit_cost = CARGO_CRATE_VALUE * 16
 
 /datum/map_template/shuttle/ferry/base
 	suffix = "base"

--- a/config/unbuyableshuttles.txt
+++ b/config/unbuyableshuttles.txt
@@ -21,6 +21,7 @@
 #_maps/shuttles/emergency_cramped.dmm
 #_maps/shuttles/emergency_discoinferno.dmm
 #_maps/shuttles/emergency_goon.dmm
+#_maps/shuttles/emergency_hugcage.dmm
 #_maps/shuttles/emergency_imfedupwiththisworld.dmm
 #_maps/shuttles/emergency_lance.dmm
 #_maps/shuttles/emergency_luxury.dmm


### PR DESCRIPTION
## About The Pull Request
adds this thing
![2023 04 10-14 12 51](https://user-images.githubusercontent.com/70376633/230899694-6d540acd-f16d-4e3e-a57b-2dc412d0ddb2.png)
This is shuttle contains a pillow fight box, no violence, and a large cozy heart-shaped area for spacemen to sleep in.
Has a medical bay, brig, command. Tons of plushies, instruments, pillows, general cutesy stuff. Contains one (1) pax pill bottle.
Has an oxygen canister for quick repressurization.

Also adds it commented out to the Emergency Shuttle Blacklist, in an alphabetically-correct position

Costs 3200
## Why It's Good For The Game

Has an unique emergency shuttle shape, does not promote violence, looks cozy. And I heard some people like this shuttle so its probably good enough?
## Changelog
:cl:
add: Adds the Hug Relaxation Shuttle as an emergency shuttle
/:cl:
