### PR TITLE
Sleep immune will make you immune to N2O

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -356,7 +356,8 @@
 		n2o_euphoria = EUPHORIA_ACTIVE
 		throw_alert(ALERT_TOO_MUCH_N2O, /atom/movable/screen/alert/too_much_n2o)
 		// give them one second of grace to wake up and run away a bit!
-		Unconscious(6 SECONDS)
+		if(!HAS_TRAIT(src, TRAIT_SLEEPIMMUNE))
+			Unconscious(6 SECONDS)
 		// Enough to make the mob sleep.
 		if(n2o_pp > n2o_sleep_min)
 			Sleeping(max(AmountSleeping() + 40, 200))

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -525,7 +525,8 @@
 	n2o_euphoria = EUPHORIA_ACTIVE
 
 	// give them one second of grace to wake up and run away a bit!
-	breather.Unconscious(6 SECONDS)
+	if(!HAS_TRAIT(breather, TRAIT_SLEEPIMMUNE))
+		breather.Unconscious(6 SECONDS)
 	// Enough to make the mob sleep.
 	if(n2o_pp > n2o_sleep_min)
 		breather.Sleeping(min(breather.AmountSleeping() + 100, 200))
@@ -592,7 +593,6 @@
 
 	if(HAS_TRAIT(breather, TRAIT_NOBREATH))
 		return FALSE
-
 
 	// If the breath is falsy or "null", we can use the backup empty_breath.
 	if(!breath)


### PR DESCRIPTION
## About The Pull Request

Currently sleep immunity makes you immune to the sleeping status effect. I was originally gonna do the same for Unconscious, but I don't think we want sleep immunity to block all instances of that

![image](https://user-images.githubusercontent.com/53777086/230962330-682c996f-fced-4251-9a69-6a08f16bb382.png)

## Why It's Good For The Game

If you're immune to sleep, you shouldn't be falling asleep from the sleepy gas. N2O setting you unconscious is meant as a way to give players a chance at getting away/putting internals on, before being put to sleep, however if you're immune to sleep, you'll endlessly fall unconscious.

## Changelog

:cl:
fix: People immune to sleep will not fall asleep from N2O
/:cl: