### PR TITLE
Remove the last hardrefs from monkey AI actions

### DIFF
--- a/code/__HELPERS/ai.dm
+++ b/code/__HELPERS/ai.dm
@@ -9,7 +9,7 @@
 	for(var/obj/item/item as anything in held_weapons)
 		if(!item)
 			continue
-		if(HAS_TRAIT(item, TRAIT_NEEDS_TWO_HANDS) || controller.blackboard[BB_MONKEY_BLACKLISTITEMS][item])
+		if(HAS_TRAIT(item, TRAIT_NEEDS_TWO_HANDS) || controller.blackboard[BB_MONKEY_BLACKLISTITEMS][WEAKREF(item)])
 			continue
 		if(gun_neurons_activated && isgun(item))
 			// We have a gun, why bother looking for something inferior
@@ -22,7 +22,7 @@
 	for(var/obj/item/item as anything in choices)
 		if(!item)
 			continue
-		if(HAS_TRAIT(item, TRAIT_NEEDS_TWO_HANDS) || controller.blackboard[BB_MONKEY_BLACKLISTITEMS][item])
+		if(HAS_TRAIT(item, TRAIT_NEEDS_TWO_HANDS) || controller.blackboard[BB_MONKEY_BLACKLISTITEMS][WEAKREF(item)])
 			continue
 		if(gun_neurons_activated && isgun(item))
 			return item

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -259,6 +259,7 @@ multiple modular subtrees with behaviors
 		if(AI_STATUS_OFF)
 			STOP_PROCESSING(SSai_behaviors, src)
 			SSai_controllers.active_ai_controllers -= src
+			set_movement_target(type, null)
 			CancelActions()
 
 /datum/ai_controller/proc/PauseAi(time)

--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -13,7 +13,7 @@
 		var/obj/item/target = weak_item?.resolve()
 		if (isnull(target))
 			return
-		item_blacklist[target] = TRUE
+		item_blacklist[weak_item] = TRUE
 		if(istype(controller, /datum/ai_controller/monkey)) //What the fuck
 			controller.RegisterSignal(target, COMSIG_PARENT_QDELETING, TYPE_PROC_REF(/datum/ai_controller/monkey,target_del))
 

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -178,4 +178,4 @@ have ways of interacting with a specific mob and control it.
 
 /datum/ai_controller/monkey/proc/target_del(target)
 	SIGNAL_HANDLER
-	blackboard[BB_MONKEY_BLACKLISTITEMS] -= target
+	blackboard[BB_MONKEY_BLACKLISTITEMS] -= WEAKREF(target)

--- a/code/datums/ai/monkey/monkey_controller.dm
+++ b/code/datums/ai/monkey/monkey_controller.dm
@@ -135,7 +135,7 @@ have ways of interacting with a specific mob and control it.
 	if(weapon.force < 2) // our bite does 2 damage on avarage, no point in settling for anything less
 		return FALSE
 
-	blackboard[BB_MONKEY_PICKUPTARGET] = weapon
+	blackboard[BB_MONKEY_PICKUPTARGET] = WEAKREF(weapon)
 	set_movement_target(type, weapon)
 	if(pickpocket)
 		queue_behavior(/datum/ai_behavior/monkey_equip/pickpocket)


### PR DESCRIPTION
## About The Pull Request

Looking into this for Arm in aid of #74591
Originally I was going to try and just null the blackboard entirely when we destroy an AI controller for permanent safety but because a mob can theoretically destroy itself mid-action that opens up a whole lot of problems based on how all of our code written so far assumes that the blackboard will always exist and would continue to both try to reference and write to it, huge headache to untangle and would make future code worse to interact with.

So I've settled for just removing the last of the hard refs I could find from monkey AI, and we'll just have to make sure we are eagle-eyed for future developers inserting hard references into the blackboard.
Also when you turn the AI off I made it null the movement target because that might be a hard reference too.

I tested it on the #74591 branch too and I think it fixes the CI issue @Mothblocks was having (I could replicate it on local before but not after applying these changes to that branch).

## Why It's Good For The Game

Removes a future source of hard deletions. 
Brings older code up to newer standard

## Changelog

Not player facing