### PR TITLE
Makes anesthetic tanks useful

### DIFF
--- a/code/game/objects/items/tanks/tank_types.dm
+++ b/code/game/objects/items/tanks/tank_types.dm
@@ -64,6 +64,7 @@
 	inhand_icon_state = "an_tank"
 	tank_holder_icon_state = "holder_anesthetic"
 	force = 10
+	slot_flags = ITEM_SLOT_BACK
 
 /obj/item/tank/internals/anesthetic/populate_gas()
 	air_contents.assert_gases(/datum/gas/oxygen, /datum/gas/nitrous_oxide)


### PR DESCRIPTION

## About The Pull Request

Anesthetic tank can fit onto back shot

## Why It's Good For The Game

Now you can use the tanks for surgery that targets the chest. So when you do heart surgery, you can not be fucking AWAKE when they pull your heart out.

:cl: Vect0r
fix: Anesthetic tanks can now fit on backs.
/:cl:
