### PR TITLE
[NO GBP]Type cast, Var names, UI refactors for RCD stuff

### DIFF
--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -460,7 +460,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 
 	return data
 
-/obj/item/construction/rcd/ui_act(action, params)
+/obj/item/construction/rcd/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -214,13 +214,13 @@
 	return TRUE
 
 ///shared action for toggling silo link rcd,rld & plumbing
-/obj/item/construction/ui_act(action, list/params)
+/obj/item/construction/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
 
 	if(action == "toggle_silo" && (upgrade & RCD_UPGRADE_SILO_LINK))
-		toggle_silo(usr)
+		toggle_silo(ui.user)
 		return TRUE
 
 /obj/item/construction/proc/checkResource(amount, mob/user)

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -159,7 +159,7 @@
 
 	return data
 
-/obj/item/construction/plumbing/ui_act(action, params)
+/obj/item/construction/plumbing/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -310,11 +310,11 @@
 					return
 				F.PlaceOnTop(/turf/closed/wall)
 			else if(isopenturf(target))
-				var/turf/open/open_turf = target
+				var/turf/open/O = target
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Floor...")]")
-				if(!do_after_cooldown(open_turf, source))
+				if(!do_after_cooldown(O, source))
 					return
-				open_turf.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+				O.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		if(MODE_AIRLOCK)
 			if(isfloorturf(target))
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Airlock...")]")

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -310,7 +310,7 @@
 					return
 				F.PlaceOnTop(/turf/closed/wall)
 			else if(isopenturf(target))
-				var/turf/open/space/S = target
+				var/turf/open/S = target
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Floor...")]")
 				if(!do_after_cooldown(S, source))
 					return

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -289,39 +289,39 @@
 		if(MODE_DECONSTRUCT)
 			to_chat(source, "[icon2html(src, source)][span_notice("Deconstructing [target]...")]")
 			if(iswallturf(target))
-				var/turf/closed/wall/W = target
-				if(!do_after_cooldown(W, source))
+				var/turf/closed/wall/wall_turf = target
+				if(!do_after_cooldown(wall_turf, source))
 					return
-				W.ScrapeAway()
+				wall_turf.ScrapeAway()
 			else if(isfloorturf(target))
-				var/turf/open/floor/F = target
-				if(!do_after_cooldown(target, source))
+				var/turf/open/floor/floor_turf = target
+				if(!do_after_cooldown(floor_turf, source))
 					return
-				F.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
+				floor_turf.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 			else if (istype(target, /obj/machinery/door/airlock))
 				if(!do_after_cooldown(target, source))
 					return
 				qdel(target)
 		if(MODE_WALL)
 			if(isfloorturf(target))
-				var/turf/open/floor/F = target
+				var/turf/open/floor/floor_turf = target
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Wall...")]")
-				if(!do_after_cooldown(F, source))
+				if(!do_after_cooldown(floor_turf, source))
 					return
-				F.PlaceOnTop(/turf/closed/wall)
+				floor_turf.PlaceOnTop(/turf/closed/wall)
 			else if(isopenturf(target))
-				var/turf/open/O = target
+				var/turf/open/open_turf = target
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Floor...")]")
-				if(!do_after_cooldown(O, source))
+				if(!do_after_cooldown(open_turf, source))
 					return
-				O.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+				open_turf.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		if(MODE_AIRLOCK)
 			if(isfloorturf(target))
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Airlock...")]")
 				if(!do_after_cooldown(target, source))
 					return
-				var/obj/machinery/door/airlock/T = new /obj/machinery/door/airlock(target)
-				T.autoclose = TRUE
+				var/obj/machinery/door/airlock/airlock_door = new /obj/machinery/door/airlock(target)
+				airlock_door.autoclose = TRUE
 				playsound(target, 'sound/effects/sparks2.ogg', 50, TRUE)
 	chassis.spark_system.start()
 	playsound(target, 'sound/items/deconstruct.ogg', 50, TRUE)

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -310,11 +310,11 @@
 					return
 				F.PlaceOnTop(/turf/closed/wall)
 			else if(isopenturf(target))
-				var/turf/open/S = target
+				var/turf/open/open_turf = target
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Floor...")]")
-				if(!do_after_cooldown(S, source))
+				if(!do_after_cooldown(open_turf, source))
 					return
-				S.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+				open_turf.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 		if(MODE_AIRLOCK)
 			if(isfloorturf(target))
 				to_chat(source, "[icon2html(src, source)][span_notice("Building Airlock...")]")


### PR DESCRIPTION
## About The Pull Request
Was requested in #74592

- Properly type casts the target into `turf/open/space` for mecha rcd plating action,
- Removes single variable names throughout
- uses datum/ui component to get user for to_chat() instead of usr