### PR TITLE
Fixes two chems not updating health in expose mob

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -402,7 +402,7 @@
 /datum/reagent/hydrogen_peroxide/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)//Splashing people with h2o2 can burn them !
 	. = ..()
 	if(methods & TOUCH)
-		exposed_mob.adjustFireLoss(2, 0) // burns
+		exposed_mob.adjustFireLoss(2)
 
 /datum/reagent/fuel/unholywater //if you somehow managed to extract this from someone, dont splash it on yourself and have a smoke
 	name = "Unholy Water"
@@ -2005,14 +2005,11 @@
 	taste_description = "acid"
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-
 /datum/reagent/acetone_oxide/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)//Splashing people kills people!
 	. = ..()
 	if(methods & TOUCH)
-		exposed_mob.adjustFireLoss(2, FALSE) // burns,
+		exposed_mob.adjustFireLoss(2)
 		exposed_mob.adjust_fire_stacks((reac_volume / 10))
-
-
 
 /datum/reagent/phenol
 	name = "Phenol"


### PR DESCRIPTION
## About The Pull Request

Fixes #74652 

`expode_mob` has no API for batch updating `update_health` procs like `on_mob_life`, so these should be, well, updating health. 

## Why It's Good For The Game

Thing take damage

## Changelog

:cl: Melbert
fix: Fixed Hydrogen Peroxide and Acetone Oxide not dealing damage until you take damage again
/:cl:

