### PR TITLE
Fixes taste not existing for mobs without having their tongue changed

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -4,9 +4,6 @@
 	update_body_parts() //to update the carbon's new bodyparts appearance
 	register_context()
 
-	// Carbons cannot taste anything without a tongue; the tongue organ removes this on Insert
-	ADD_TRAIT(src, TRAIT_AGEUSIA, NO_TONGUE_TRAIT)
-
 	GLOB.carbon_list += src
 	var/static/list/loc_connections = list(
 		COMSIG_CARBON_DISARM_PRESHOVE = PROC_REF(disarm_precollide),

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -6,7 +6,7 @@
 
 	setup_mood()
 	// This needs to be called very very early in human init (before organs / species are created at the minimum)
-	setup_no_organ_effects()
+	setup_organless_effects()
 
 	create_dna()
 	dna.species.create_fresh_body(src)
@@ -43,7 +43,7 @@
 /// This proc is for holding effects applied when a mob is missing certain organs
 /// It is called very, very early in human init because all humans innately spawn with no organs and gain them during init
 /// Gaining said organs removes these effects
-/mob/living/carbon/human/proc/setup_no_organ_effects()
+/mob/living/carbon/human/proc/setup_organless_effects()
 	// All start without eyes, and get them via set species
 	become_blind(NO_EYES)
 	// Mobs cannot taste anything without a tongue; the tongue organ removes this on Insert

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -5,9 +5,8 @@
 	icon_state = "" //Remove the inherent human icon that is visible on the map editor. We're rendering ourselves limb by limb, having it still be there results in a bug where the basic human icon appears below as south in all directions and generally looks nasty.
 
 	setup_mood()
-
-	// All start without eyes, and get them via set species
-	become_blind(NO_EYES)
+	// This needs to be called very very early in human init (before organs / species are created at the minimum)
+	setup_no_organ_effects()
 
 	create_dna()
 	dna.species.create_fresh_body(src)
@@ -40,6 +39,15 @@
 	if (isdummy(src))
 		return
 	mob_mood = new /datum/mood(src)
+
+/// This proc is for holding effects applied when a mob is missing certain organs
+/// It is called very, very early in human init because all humans innately spawn with no organs and gain them during init
+/// Gaining said organs removes these effects
+/mob/living/carbon/human/proc/setup_no_organ_effects()
+	// All start without eyes, and get them via set species
+	become_blind(NO_EYES)
+	// Mobs cannot taste anything without a tongue; the tongue organ removes this on Insert
+	ADD_TRAIT(src, TRAIT_AGEUSIA, NO_TONGUE_TRAIT)
 
 /mob/living/carbon/human/proc/setup_human_dna()
 	//initialize dna. for spawned humans; overwritten by other code

--- a/code/modules/unit_tests/spawn_humans.dm
+++ b/code/modules/unit_tests/spawn_humans.dm
@@ -5,3 +5,11 @@
 		new /mob/living/carbon/human/consistent(pick(locs))
 
 	sleep(5 SECONDS)
+
+/// Tests [/mob/living/carbon/human/proc/setup_no_organ_effects], specifically that they aren't applied when init is done
+/datum/unit_test/human_default_traits
+
+/datum/unit_test/human_default_traits/Run()
+	var/mob/living/carbon/human/consistent/dummy = allocate(/mob/living/carbon/human/consistent)
+	TEST_ASSERT(!HAS_TRIAT(dummy, TRAIT_AGEUSIA), "Dummy has ageusia on init")
+	TEST_ASSERT(!dummy.is_blind(), "Dummy is blind on init")

--- a/code/modules/unit_tests/spawn_humans.dm
+++ b/code/modules/unit_tests/spawn_humans.dm
@@ -11,5 +11,5 @@
 
 /datum/unit_test/human_default_traits/Run()
 	var/mob/living/carbon/human/consistent/dummy = allocate(/mob/living/carbon/human/consistent)
-	TEST_ASSERT(!HAS_TRIAT(dummy, TRAIT_AGEUSIA), "Dummy has ageusia on init, when it should've been removed by its default tongue.")
-	TEST_ASSERT(!dummy.is_blind(), "Dummy is blind on init,  when it should've been removed by its default eyes.")
+	TEST_ASSERT(!HAS_TRAIT_FROM(dummy, TRAIT_AGEUSIA, NO_TONGUE_TRAIT), "Dummy has ageusia on init, when it should've been removed by its default tongue.")
+	TEST_ASSERT(!dummy.is_blind_from(NO_EYES), "Dummy is blind on init,  when it should've been removed by its default eyes.")

--- a/code/modules/unit_tests/spawn_humans.dm
+++ b/code/modules/unit_tests/spawn_humans.dm
@@ -11,5 +11,5 @@
 
 /datum/unit_test/human_default_traits/Run()
 	var/mob/living/carbon/human/consistent/dummy = allocate(/mob/living/carbon/human/consistent)
-	TEST_ASSERT(!HAS_TRIAT(dummy, TRAIT_AGEUSIA), "Dummy has ageusia on init")
-	TEST_ASSERT(!dummy.is_blind(), "Dummy is blind on init")
+	TEST_ASSERT(!HAS_TRIAT(dummy, TRAIT_AGEUSIA), "Dummy has ageusia on init, when it should've been removed by its default tongue.")
+	TEST_ASSERT(!dummy.is_blind(), "Dummy is blind on init,  when it should've been removed by its default eyes.")

--- a/code/modules/unit_tests/spawn_humans.dm
+++ b/code/modules/unit_tests/spawn_humans.dm
@@ -6,7 +6,7 @@
 
 	sleep(5 SECONDS)
 
-/// Tests [/mob/living/carbon/human/proc/setup_no_organ_effects], specifically that they aren't applied when init is done
+/// Tests [/mob/living/carbon/human/proc/setup_organless_effects], specifically that they aren't applied when init is done
 /datum/unit_test/human_default_traits
 
 /datum/unit_test/human_default_traits/Run()


### PR DESCRIPTION
## About The Pull Request

Fixes #74571 

Init order memes. 

All carbons innately gained the trait `TRAIT_AGEUSIA` in initialize due to not having a tongue

Then, their organs would be created and their initial tongue would remove this trait

But at some point init order changed, unsure when 

This caused this trait to be applied at an inappropriate time, causing all spawned carbons to be tastebud-less until their tongue was changed 

## Why It's Good For The Game

mmmm

## Changelog

:cl: Melbert
fix: You can now taste once again, without requiring your tongue be surgically replaced or reattached 
/:cl:
