### PR TITLE
Reverts anomaly detonation time from 75 seconds back to 99 seconds.

### DIFF
--- a/code/__DEFINES/anomaly.dm
+++ b/code/__DEFINES/anomaly.dm
@@ -4,7 +4,7 @@
  */
 
 ///Time in ticks before the anomaly goes poof/explodes depending on type.
-#define ANOMALY_COUNTDOWN_TIMER (75 SECONDS)
+#define ANOMALY_COUNTDOWN_TIMER (99 SECONDS)
 
 /**
  * Nuisance/funny anomalies


### PR DESCRIPTION

## About The Pull Request

In https://github.com/tgstation/tgstation/pull/73708, the anomaly detonation time was set to 75 seconds. As explained in that same PR, the detonation time for dangerous anomalies, the ones that have a delayed announcement, is roughly 40 seconds after announcement.

This PR brings the timer back to 99 seconds, so roughly 75 seconds to defuse for dangerous anomalies after announcement.

## Why It's Good For The Game

I'm not sure why this decision was made, and I don't know if this person tested trying to reach one of these dangerous anomalies to defuse it using this timer. By the time one of these anomalies has been announced, it's probably too late to do anything about it. You'd need someone with the ability to immediately defuse that anomaly on hand within the department itself, and be able to access it as well. If there is even a few seconds delay, or if the anomaly is on the other side of the station from either engineering or science, that anomaly is going to go off the majority of the time. This mostly just leaves players confused as to why nobody did anything about it, yet most of the time that probably wasn't an anomaly that could have been stopped. 

It's _physically impossible_ to make it there in time under many circumstances, even for someone with full access to that area. Such as a captain who just so happened to have been in science and now has to reach Delta's security office area with an anomaly neutralizer or signaller. That's probably a 40 second transit. This is much, much worse the more we start to increase our maps in size and complexity, such as North Star or Tramstation.

Anomalies prior to this change had a bad habit of being ignored until they popped. After this change, I think a lot of folk just choose to deal with the consequences rather than attempt to resolve it, even if they would have been someone diligent enough to try and defuse it. Which mostly turns this event into 'there is now a syndicate bomb/plasma flood airdropped into your department at random and you're probably unable to stop it, have fun'. I've not managed to defuse a single dangerous anomaly that didn't literally spawn right next to me in either science or cargo since this change either.

Nuisance anomalies are whatever, they're not really worth considering.

## Changelog
:cl:
balance: Returns the anomaly detonation timer from 75 seconds (40 seconds from announcement for dangerous anomalies) back to 99 seconds (75 seconds from announcement for dangerous).
/:cl:
