### PR TITLE
Fixes new players causing gravity related runtimes if they load in before SSMapping finished initialization.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1825,7 +1825,7 @@
 		gravity_turf = get_turf(src)
 
 		if(!gravity_turf)//no gravity in nullspace
-			return 0
+			return FALSE
 
 	var/list/forced_gravity = list()
 	SEND_SIGNAL(src, COMSIG_ATOM_HAS_GRAVITY, gravity_turf, forced_gravity)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -36,6 +36,9 @@
 
 	return ..()
 
+/mob/dead/new_player/mob_negates_gravity()
+	return TRUE //no need to calculate if they have gravity.
+
 /mob/dead/new_player/prepare_huds()
 	return
 


### PR DESCRIPTION
:cl: ShizCalev
fix: Fixed an annoying gravity runtime that occurred if a player was connected before mapping finished initialization.
/:cl:

Fixes https://github.com/tgstation/tgstation/issues/74532
