### PR TITLE
Mimes can no longer write without breaking their vow.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1200,6 +1200,10 @@
 		to_chat(src, span_warning("You can't write with the [writing_instrument]!"))
 		return FALSE
 
+	if(HAS_TRAIT(src, TRAIT_MIMING) && !istype(writing_instrument, /obj/item/toy/crayon/mime))
+		to_chat(src, span_warning("Your vow of silence is preventing you from talking with text."))
+		return FALSE
+
 	if(!is_literate())
 		to_chat(src, span_warning("You try to write, but don't know how to spell anything!"))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

I feel this is gonna be unpopular with the lazy mime players.

Also, this is an idea I had in my backlog for a while now
![image](https://user-images.githubusercontent.com/53777086/231355622-2c5d5d5a-813d-420c-ae42-c1bdc657f3ba.png)

This removes the Mime's ability to write on paper while they're on their vow of silence.
This can be compared to hand language, which doesn't let you speak despite not being considered "talking", and PDA messaging, which does the same.

Mimes can still write with their pen, which is a nice invisible white color. I thought I would keep it in as I find that interaction funny to have a Mime give someone just a blank paper, unknowing that there's text on it.
Spraycans/Telekinesis/Circuits are also left unaffected because they require actual effort to obtain (doing genetics, doing circuits, or printing spraycans which take a lot of inventory space and is limited), compared to paper which you can carry hundreds of papers around and is bountiful across the station.

I thought this was attempted at least once, but I can't find any PR that mentions it, so I'm shooting my shot to see if this is something we'd want.

## Why It's Good For The Game

Mimes using paper is a lazy way to bypass their one job gimmick: Emoting over talking.

If they get a job change, they can simply break their vow to access paper writing abilities, so this doesn't affect that really. It more-so hits the Mimes who uses the job for the free spells/healing abilities/etc, and bypasses the downsides (im aware its harder to get people to read paper than it is to talk to them, but you can literally get the mute quirk and itll have the same effect without being the whole job).

The point is, you don't get invisible walls for free; it comes at a cost of not being able to talk to people. If you want to talk, then break your vow, lose access to your Mime abilities, and remake it later when the cooldown is over. You're not meant to do both.

## Changelog

:cl:
balance: Mimes can no longer write on paper without breaking their vow.
/:cl:
