### PR TITLE
Text that appears when you have lost or destroyed your uplink now has information on replacement uplinks

### DIFF
--- a/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoTraitor.tsx
@@ -136,8 +136,20 @@ const UplinkSection = (props, context) => {
       <Stack fill>
         {(!has_uplink && (
           <Dimmer>
-            <Stack.Item fontSize="18px">
-              You were not supplied with an uplink.
+            <Stack.Item fontSize="16px">
+              <Section textAlign="Center">
+                Your uplink is missing or destroyed. <br />
+                Craft a Syndicate Uplink Beacon and then speak
+                <br />
+                <span style={goalstyle}>
+                  <b>{replacement_code}</b>
+                </span>{' '}
+                on frequency{' '}
+                <span style={goalstyle}>
+                  <b>{replacement_frequency}</b>
+                </span>{' '}
+                after synchronizing with the beacon.
+              </Section>
             </Stack.Item>
           </Dimmer>
         )) || (
@@ -159,18 +171,26 @@ const UplinkSection = (props, context) => {
         )}
       </Stack>
       <br />
-      <Section textAlign="Center">
-        If you lose your uplink, you can craft a Syndicate Uplink Beacon and
-        then speak{' '}
-        <span style={goalstyle}>
-          <b>{replacement_code}</b>
-        </span>{' '}
-        on radio frequency{' '}
-        <span style={goalstyle}>
-          <b>{replacement_frequency}</b>
-        </span>{' '}
-        after synchronizing with the beacon.
-      </Section>
+      {(has_uplink && (
+        <Section textAlign="Center">
+          If you lose your uplink, you can craft a Syndicate Uplink Beacon and
+          then speak{' '}
+          <span style={goalstyle}>
+            <b>{replacement_code}</b>
+          </span>{' '}
+          on radio frequency{' '}
+          <span style={goalstyle}>
+            <b>{replacement_frequency}</b>
+          </span>{' '}
+          after synchronizing with the beacon.
+        </Section>
+      )) || (
+        <Section>
+          {' '}
+          <br />
+          <br />
+        </Section>
+      )}
     </Section>
   );
 };


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/116288367/231466073-d4613595-a180-4288-94f0-6f7993820a48.png)
the text that shows up if you mulch your uplink or if you got bugged and didnt spawn with one now tells you how to get a replacement uplink instead of covering up information that you need to get your replacement uplink.

fixes #74637

## Why It's Good For The Game

If your uplink has been destroyed in some way that is when this information is most relevant, and should be highlighted and put on the forfront.

## Changelog


:cl:
qol: text that appears when you dont have an uplink in the traitor panel now tells you the codes for your replacement uplink
/:cl: