### PR TITLE
lowers costs of syndiekits to 20 TC 

### DIFF
--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -60,7 +60,7 @@
 			The Syndicate will only provide one Syndi-Kit per agent."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/storage/box/syndicate/bundle_a
-	cost = 25
+	cost = 20
 	stock_key = UPLINK_SHARED_STOCK_KITS
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
@@ -72,7 +72,7 @@
 			The Syndicate will only provide one Syndi-Kit per agent."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/storage/box/syndicate/bundle_b
-	cost = 25
+	cost = 20
 	stock_key = UPLINK_SHARED_STOCK_KITS
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 


### PR DESCRIPTION
## About The Pull Request

this pr makes syndiekits which are fun lootboxes that you spend most of your TC on for when you dont really have a plan of action or just wanna cause some ruckus the default amount of TC which is 20 instead of costing 25 TC

## Why It's Good For The Game
i think that if you are planning or want to buy a syndiekit you do not want to actually engage with secondary objectives and prog traitor, getting a box of themed toys and then using them to do your primary objectives should just be an option for traitors who are willing to either wait it out and trying to mess around without buying stuff, or who just want to do whatever objectives they can to speed it up, without having to make sure that the objectives will specifically be TC positive.

it made some sense when i originally put them back in because we did not have primary objectives back in the game

## Changelog

:cl:
balance: syndiekits cost 20 TC instead of 25 TC
/:cl:
