### PR TITLE
Fixes buildmode mapgen repressurize from breaking atmos

### DIFF
--- a/code/modules/procedural_mapping/mapGeneratorModules/helpers.dm
+++ b/code/modules/procedural_mapping/mapGeneratorModules/helpers.dm
@@ -10,12 +10,12 @@
 	if(!mother)
 		return
 	var/list/map = mother.map
-	for(var/turf/T in map)
-		SSair.remove_from_active(T)
-	for(var/turf/open/T in map)
-		if(T.air)
-			T.air = T.create_gas_mixture()
-		SSair.add_to_active(T, TRUE)
+	for(var/turf/open/target_turf in map)
+		if(target_turf.blocks_air)
+			continue
+		var/datum/gas_mixture/initial_mixture = SSair.parse_gas_string(target_turf.initial_gas_mix, /datum/gas_mixture/turf)
+		target_turf.copy_air(initial_mixture)
+		target_turf.update_visuals()
 
 /datum/map_generator_module/bottom_layer/massdelete
 	spawnableAtoms = list()


### PR DESCRIPTION

## About The Pull Request
Buildmode mapgen to repressurize the station would re-assign the air variable on turfs, which could prove problematic if the turf was a space turf. Also, it was sometimes leading to division by zero errors and atmos generally being unstable.

To fix this, I've copied the code over from "Fix Air" that allows turfs to safely and properly reset their turf back to its original gas mix.

Fixes #74678

## Why It's Good For The Game
Bugfix

## Changelog
:cl:
fix: Fixed buildmode mapgen "Block: Restore Roundstart Air Contents" option from breaking atmospherics.
/:cl:
