### PR TITLE
Syndie Tele Nerf

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -477,10 +477,10 @@
 			user.bleed(5)
 		if(2)
 			user.bleed(10)
-			user.Knockdown(3 SECONDS)
+			user.Knockdown(1 SECONDS)
 		if(3)
 			user.bleed(15)
-			user.Paralyze(3 SECONDS)
+			user.Paralyze(2 SECONDS)
 
 ///Force move victim to destination, explode destination, drop all victim's items, gib them
 /obj/item/syndicate_teleporter/proc/get_fragged(mob/living/victim, turf/destination, not_holding_tele = FALSE)


### PR DESCRIPTION
## About The Pull Request
Nerfs the syndie tele:

- charge probability is now 7+charges instead of a flat 10, so at 0 charges your probability is only 7%. using more charges at once makes it less likely to recharge
- removed the chance for EMPing to do nothing, EMPing will always do something. Heavy EMPs now decrease the panic teleport distance by 1. If you get heavy EMP'd 3 times you will never panic teleport you will always gib upon hitting a wall
- panic teleporting is not totally safe. if you panic teleported 1 tile, lose 10 blood; 2 tiles, lose 15 blood and knocked down for 1s; 3 tiles, lose 20 blood and stunned for 2s
## Why It's Good For The Game
Needed a slight nerf, I think this is an interesting nerf. I dislike the idea of making the charge a flat timer based thing, it's a fast paced item and spamming Z to desperately teleport while being chased is part of the fun. EMPs are a much better counter now. Stun/knockdown on panic teleporting makes it so you can catch up to teleporting people.

## Changelog

:cl:
balance: Syndie tele charge probability is now (7+charges %) instead of a flat 10%
balance: EMPing syndie tele will ALWAYS do something. Previously there was only a 50% or 25% chance something would actually happen
balance: Heavy EMPs will damage the syndie tele and remove 1 tile from the parallel teleport distance. Getting heavy EMP'd 3 times will disable the panic teleport system
balance: Panic teleporting with the syndie tele will make you lose blood, get knocked down, or get stunned based on how far it threw you
/:cl:
