### PR TITLE
Monkeys no longer drop items taken from storage onto the ground.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -588,7 +588,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 		return
 
 	//If the item is in a storage item, take it out
-	if(loc.atom_storage?.remove_single(user, src, user.loc, silent = TRUE))
+	if(loc.atom_storage && !loc.atom_storage.remove_single(user, src, user.loc, silent = TRUE))
 		return
 	if(QDELETED(src)) //moving it out of the storage to the floor destroyed it.
 		return


### PR DESCRIPTION
Fixes #74313.

## About The Pull Request

During a refactor to storage in #73761 , they forgot to add a check to loc.atom_storage in attack_paw to mirror the check made in attack_hand. This meant that monkeys and other mobs that used attack_paw always dropped items taken from storage onto the ground. Now, the code to check if they should go into your hand instead is properly checked.

## Why It's Good For The Game

Bugs are bad mkay

## Changelog

:cl:
fix: Monkeys and some other mobs no longer drop items they've grabbed from storage onto the ground.
/:cl:

