### PR TITLE
Adds Clever DNA Injector for Admin Use

### DIFF
--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -574,3 +574,11 @@
 /obj/item/dnainjector/antiwebbing
 	name = "\improper DNA injector (Anti-Webbing)"
 	remove_mutations = list(/datum/mutation/human/webbing)
+
+/obj/item/dnainjector/clever
+	name = "\improper DNA injector (Clever)"
+	add_mutations = list(/datum/mutation/human/clever)
+
+/obj/item/dnainjector/anticlever
+	name = "\improper DNA injector (Anti-Clever)"
+	remove_mutations = list(/datum/mutation/human/clever)


### PR DESCRIPTION
Makes DNA injector for clever for admin use.

## About The Pull Request

When the Clever mutation was made, an injector for it was never added to the dna_injector file. This means that admins didn't have a way to spawn this item in. Well, now they do. Added an anticlever one to remove it as well for good measure.

## Why It's Good For The Game

Not that big of a deal, you could use the mutation as a gene man without this, but adding more items to spawn in as an admin can't be a bad thing. Additionally, as Clever is a mutation that does some pretty unique things, so it actually seems like one that might theoretically be a bit more useful to have in the toolbelt then some of its counterparts.

## Changelog

:cl:
admin: Added clever DNA injector to admin spawn options.
fix: Added clever DNA injector.
/:cl:
