### PR TITLE
Fix null client error for balloon alert when toggling Electrolyser on/off via the UI

### DIFF
--- a/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer.dm
+++ b/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer.dm
@@ -196,7 +196,7 @@
 		return
 	toggle_power(user)
 
-/obj/machinery/electrolyzer/proc/toggle_power(user)
+/obj/machinery/electrolyzer/proc/toggle_power(mob/user)
 	if(!anchored && !cell)
 		balloon_alert(user, "insert cell or anchor!")
 		return
@@ -232,7 +232,7 @@
 		return
 	switch(action)
 		if("power")
-			toggle_power()
+			toggle_power(usr)
 			. = TRUE
 		if("eject")
 			if(panel_open && cell)

--- a/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer.dm
+++ b/code/modules/atmospherics/machinery/components/electrolyzer/electrolyzer.dm
@@ -226,13 +226,13 @@
 		data["powerLevel"] = round(cell.percent(), 1)
 	return data
 
-/obj/machinery/electrolyzer/ui_act(action, params)
+/obj/machinery/electrolyzer/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
 	switch(action)
 		if("power")
-			toggle_power(usr)
+			toggle_power(ui.user)
 			. = TRUE
 		if("eject")
 			if(panel_open && cell)


### PR DESCRIPTION
## About The Pull Request
Read Title

Start your VS code in debug mode, insert a cell inside the electrolyser and toggle it on/off via the UI(not alt click). you will get this error

## Changelog
:cl:
fix: null client error for balloon alert when toggling the electrolyser on/off via the UI
/:cl: