### PR TITLE
Fixes a runtime with circuit floors

### DIFF
--- a/code/game/turfs/open/floor/misc_floor.dm
+++ b/code/game/turfs/open/floor/misc_floor.dm
@@ -22,6 +22,7 @@
 
 /turf/open/floor/circuit/Destroy()
 	SSmapping.nuke_tiles -= src
+	UnregisterSignal(loc, COMSIG_AREA_POWER_CHANGE)
 	return ..()
 
 /turf/open/floor/circuit/update_appearance(updates)


### PR DESCRIPTION
## About The Pull Request

Runtime occurs when the turf is no longer a circuit floor and receives `COMSIG_AREA_POWER_CHANGE`.

The `COMSIG_AREA_POWER_CHANGE` signal never gets properly removed on `Destroy`.

Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20210

## Why It's Good For The Game

Bug fix

## Changelog

:cl:
fix: fixes a runtime that can occur if a circuit floor gets changed into something else.
/:cl:
