### PR TITLE
Add basketball mood events for shooting and dunking

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -310,10 +310,6 @@
 	mood_change = 2
 	timeout = 3 MINUTES
 
-/datum/mood_event/garland
-	description = "These flowers are rather soothing."
-	mood_change = 1
-
 /datum/mood_event/playing_cards/add_effects(param)
 	var/card_players = 1
 	for(var/mob/living/carbon/player in viewers(COMBAT_MESSAGE_RANGE, owner))
@@ -325,6 +321,10 @@
 
 	mood_change *= card_players
 	return ..()
+
+/datum/mood_event/garland
+	description = "These flowers are rather soothing."
+	mood_change = 1
 
 /datum/mood_event/russian_roulette_win
 	description = "I gambled my life and won! I'm lucky to be alive..."
@@ -359,3 +359,14 @@
 	mood_change = 2
 	special_screen_obj = "birthday"
 	special_screen_replace = FALSE
+
+/datum/mood_event/basketball
+	description = "Ballin on the court feels natural."
+	mood_change = 2
+	timeout = 1 MINUTES
+	
+/datum/mood_event/basketball/add_effects(goal_type)
+	if(goal_type == BASKETBALL_DUNK)
+		mood_change = 3
+		description = "
+	return ..()

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -360,13 +360,12 @@
 	special_screen_obj = "birthday"
 	special_screen_replace = FALSE
 
-/datum/mood_event/basketball
-	description = "Ballin on the court feels natural."
+/datum/mood_event/basketball_score
+	description = "Swish! Nothing but net."
 	mood_change = 2
-	timeout = 1 MINUTES
+	timeout = 5 MINUTES
 	
-/datum/mood_event/basketball/add_effects(goal_type)
-	if(goal_type == BASKETBALL_DUNK)
-		mood_change = 3
-		description = "
-	return ..()
+/datum/mood_event/basketball_dunk
+	description = "Slam dunk! Boom, shakalaka!"
+	mood_change = 2
+	timeout = 5 MINUTES

--- a/code/modules/basketball/hoop.dm
+++ b/code/modules/basketball/hoop.dm
@@ -108,6 +108,7 @@
 
 	INVOKE_ASYNC(src, PROC_REF(dunk_animation), baller, dunk_pixel_y, dunk_pixel_x)
 	visible_message(span_warning("[baller] dunks [ball] into \the [src]!"))
+	baller.add_mood_event("basketball", /datum/mood_event/basketball_dunk)
 	score(ball, baller, 2)
 
 	if(istype(ball, /obj/item/toy/basketball))
@@ -137,7 +138,6 @@
 	playsound(src, 'sound/machines/scanbuzz.ogg', 100, FALSE)
 	baller.adjustStaminaLoss(STAMINA_COST_DUNKING_MOB)
 	baller.stop_pulling()
-
 
 /obj/structure/hoop/CtrlClick(mob/living/user)
 	if(!user.can_perform_action(src, NEED_DEXTERITY|FORBID_TELEKINESIS_REACH|NEED_HANDS))
@@ -173,6 +173,7 @@
 		AM.forceMove(get_turf(src))
 		// is it a 3 pointer shot
 		var/points = (distance > 2) ? 3 : 2
+		thrower.add_mood_event("basketball", /datum/mood_event/basketball_score)
 		score(AM, thrower, points)
 		visible_message(span_warning("[click_on_hoop ? "Swish!" : ""] [AM] lands in [src]."))
 	else


### PR DESCRIPTION

## About The Pull Request
Playing basketball now gives a small mood boost depending on if you dunk or shoot.

## Why It's Good For The Game
More mood events for actions gives stuff more depth.

## Changelog
:cl:
qol: Add mood events for basketball shooting and dunking
/:cl:
