### PR TITLE
Admins can now customize the space vines event. Also fixes a space vine event bugs.

### DIFF
--- a/code/modules/events/_event_admin_setup.dm
+++ b/code/modules/events/_event_admin_setup.dm
@@ -106,7 +106,7 @@
 
 /datum/event_admin_setup/input_number
 	///Text shown when admins are queried about what number to set.
-	var/input_text = ""
+	var/input_text = "Unset text"
 	///The value the number will be set to by default
 	var/default_value
 	///The highest value setable by the admin.
@@ -161,9 +161,13 @@
 			return ADMIN_CANCEL_EVENT
 
 /datum/event_admin_setup/multiple_choice
-	var/input_text
+	///Text shown to the admin when queried about which options they want to pick.
+	var/input_text = "Unset Text"
+	///The minimum number of choices an admin must make for this event.
 	var/min_choices = 0
+	///The maximum number of choices that the admin can make for this event.
 	var/max_choices = 50
+	///List of choices returned by this setup to the event.
 	var/list/choices = list()
 
 /datum/event_admin_setup/multiple_choice/proc/get_options()

--- a/code/modules/events/_event_admin_setup.dm
+++ b/code/modules/events/_event_admin_setup.dm
@@ -159,3 +159,18 @@
 			chosen = FALSE
 		else
 			return ADMIN_CANCEL_EVENT
+
+/datum/event_admin_setup/multiple_choice
+	var/input_text
+	var/max_choices
+	var/list/choices = list()
+
+/datum/event_admin_setup/multiple_choice/proc/get_options()
+	SHOULD_CALL_PARENT(FALSE)
+	CRASH("Unimplemented get_options() on [event_control]'s admin setup.")
+
+/datum/event_admin_setup/multiple_choice/prompt_admins()
+	var/list/options = get_options()
+	choices = tgui_input_checkboxes(usr, input_text, event_control.name, options, max_choices)
+	if(!choices.len)
+		return ADMIN_CANCEL_EVENT

--- a/code/modules/events/_event_admin_setup.dm
+++ b/code/modules/events/_event_admin_setup.dm
@@ -162,7 +162,8 @@
 
 /datum/event_admin_setup/multiple_choice
 	var/input_text
-	var/max_choices
+	var/min_choices = 0
+	var/max_choices = 50
 	var/list/choices = list()
 
 /datum/event_admin_setup/multiple_choice/proc/get_options()
@@ -171,6 +172,6 @@
 
 /datum/event_admin_setup/multiple_choice/prompt_admins()
 	var/list/options = get_options()
-	choices = tgui_input_checkboxes(usr, input_text, event_control.name, options, max_choices)
-	if(!choices.len)
+	choices = tgui_input_checkboxes(usr, input_text, event_control.name, options, min_choices, max_choices)
+	if(isnull(choices))
 		return ADMIN_CANCEL_EVENT

--- a/code/modules/events/_event_admin_setup.dm
+++ b/code/modules/events/_event_admin_setup.dm
@@ -164,7 +164,7 @@
 	///Text shown to the admin when queried about which options they want to pick.
 	var/input_text = "Unset Text"
 	///The minimum number of choices an admin must make for this event.
-	var/min_choices = 0
+	var/min_choices = 1
 	///The maximum number of choices that the admin can make for this event.
 	var/max_choices = 50
 	///List of choices returned by this setup to the event.

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -52,8 +52,11 @@
 	input_text = "Select starting mutations."
 
 /datum/event_admin_setup/multiple_choice/spacevine/get_options()
-	return subtypesof(/datum/spacevine_mutation)
+	return subtypesof(/datum/spacevine_mutation/)
 
 /datum/event_admin_setup/multiple_choice/spacevine/apply_to_event(datum/round_event/spacevine/event)
-	event.override_mutations = choices
+	var/list/type_choices = list()
+	for(var/choice in choices)
+		type_choices += text2path(choice)
+	event.override_mutations = type_choices
 	

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -67,6 +67,7 @@
 	
 /datum/event_admin_setup/multiple_choice/spacevine
 	input_text = "Select starting mutations."
+	min_choices = 0
 
 /datum/event_admin_setup/multiple_choice/spacevine/prompt_admins()
 	var/customize_mutations = tgui_alert(usr, "Select mutations?", event_control.name, list("Custom", "Random", "Cancel"))

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -51,6 +51,16 @@
 /datum/event_admin_setup/multiple_choice/spacevine
 	input_text = "Select starting mutations."
 
+/datum/event_admin_setup/multiple_choice/spacevine/prompt_admins()
+	var/customize_mutations = tgui_alert(usr, "Select mutations?", event_control.name, list("Custom", "Random", "Cancel"))
+	switch(customize_mutations)
+		if("Custom")
+			return ..()
+		if("Random")
+			choices = list("[pick(subtypesof(/datum/spacevine_mutation))]")
+		else
+			return ADMIN_CANCEL_EVENT
+
 /datum/event_admin_setup/multiple_choice/spacevine/get_options()
 	return subtypesof(/datum/spacevine_mutation/)
 

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -8,12 +8,19 @@
 	description = "Kudzu begins to overtake the station. Might spawn man-traps."
 	min_wizard_trigger_potency = 4
 	max_wizard_trigger_potency = 7
-	admin_setup = list(/datum/event_admin_setup/set_location/spacevine, /datum/event_admin_setup/multiple_choice/spacevine)
+	admin_setup = list(
+		/datum/event_admin_setup/set_location/spacevine,
+		/datum/event_admin_setup/multiple_choice/spacevine,
+		/datum/event_admin_setup/input_number/spacevine_potency,
+		/datum/event_admin_setup/input_number/spacevine_production,
+	)
 
 /datum/round_event/spacevine
 	fakeable = FALSE
 	var/turf/override_turf
 	var/list/override_mutations = list()
+	var/potency
+	var/production
 
 /datum/round_event/spacevine/start()
 	var/list/turfs = list() //list of all the empty floor turfs in the hallway areas
@@ -39,8 +46,12 @@
 			selected_mutations = list(pick(subtypesof(/datum/spacevine_mutation)))
 		else
 			selected_mutations = override_mutations
+		if(isnull(potency))
+			potency = rand(50,100)
+		if(isnull(production))
+			production = rand(1, 4)
 
-		new /datum/spacevine_controller(floor, selected_mutations, rand(50,100), rand(1,4), src) //spawn a controller at turf with randomized stats and a single random mutation
+		new /datum/spacevine_controller(floor, selected_mutations, potency, production, src) //spawn a controller at turf with randomized stats and a single random mutation
 
 /datum/event_admin_setup/set_location/spacevine
 	input_text = "Spawn vines at current location?"
@@ -70,3 +81,25 @@
 		type_choices += text2path(choice)
 	event.override_mutations = type_choices
 	
+/datum/event_admin_setup/input_number/spacevine_potency
+	input_text = "Set vine's potency (effects mutation frequency + max severity)"
+	max_value = 100
+
+/datum/event_admin_setup/input_number/spacevine_potency/prompt_admins()
+	default_value = rand(50, 100)
+	. = ..()
+
+/datum/event_admin_setup/input_number/spacevine_potency/apply_to_event(datum/round_event/spacevine/event)
+	event.potency = chosen_value
+
+/datum/event_admin_setup/input_number/spacevine_production
+	input_text = "Set vine's production (effects spreading cap + speed) (lower is faster)"
+	min_value = 1
+	max_value = 10
+
+/datum/event_admin_setup/input_number/spacevine_production/prompt_admins()
+	default_value = rand(1, 4)
+	. = ..()
+
+/datum/event_admin_setup/input_number/spacevine_production/apply_to_event(datum/round_event/spacevine/event)
+	event.production = chosen_value

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -38,7 +38,7 @@
 		var/obj/structure/spacevine/vine = new()
 
 		for(var/area/station/hallway/area in GLOB.areas)
-			for(var/turf/floor as anything in area.get_contained_turfs())
+			for(var/turf/open/floor in area.get_contained_turfs())
 				if(floor.Enter(vine))
 					turfs += floor
 

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -17,9 +17,15 @@
 
 /datum/round_event/spacevine
 	fakeable = FALSE
+	///Override location the vines will spawn in.
 	var/turf/override_turf
+	///used to confirm if admin selected mutations should be used or not.
+	var/mutations_overridden = FALSE
+	///Admin selected mutations that the kudzu will spawn with, can be set to none to act as mutationless kudzu.
 	var/list/override_mutations = list()
+	///Potency of the spawned kudzu.
 	var/potency
+	///Production value of the spawned kuduz.
 	var/production
 
 /datum/round_event/spacevine/start()
@@ -42,7 +48,7 @@
 		var/turf/floor = pick(turfs)
 		var/list/selected_mutations = list()
 
-		if(override_mutations.len == 0)
+		if(mutations_overridden == FALSE)
 			selected_mutations = list(pick(subtypesof(/datum/spacevine_mutation)))
 		else
 			selected_mutations = override_mutations
@@ -79,6 +85,7 @@
 	var/list/type_choices = list()
 	for(var/choice in choices)
 		type_choices += text2path(choice)
+	event.mutations_overridden = TRUE
 	event.override_mutations = type_choices
 	
 /datum/event_admin_setup/input_number/spacevine_potency

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -33,7 +33,14 @@
 
 	if(length(turfs)) //Pick a turf to spawn at if we can
 		var/turf/floor = pick(turfs)
-		new /datum/spacevine_controller(floor, list(pick(subtypesof(/datum/spacevine_mutation))), rand(50,100), rand(1,4), src) //spawn a controller at turf with randomized stats and a single random mutation
+		var/list/selected_mutations = list()
+
+		if(override_mutations.len == 0)
+			selected_mutations = list(pick(subtypesof(/datum/spacevine_mutation)))
+		else
+			selected_mutations = override_mutations
+
+		new /datum/spacevine_controller(floor, selected_mutations, rand(50,100), rand(1,4), src) //spawn a controller at turf with randomized stats and a single random mutation
 
 /datum/event_admin_setup/set_location/spacevine
 	input_text = "Spawn vines at current location?"

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -8,22 +8,45 @@
 	description = "Kudzu begins to overtake the station. Might spawn man-traps."
 	min_wizard_trigger_potency = 4
 	max_wizard_trigger_potency = 7
+	admin_setup = list(/datum/event_admin_setup/set_location/spacevine, /datum/event_admin_setup/multiple_choice/spacevine)
 
 /datum/round_event/spacevine
 	fakeable = FALSE
+	var/turf/override_turf
+	var/list/override_mutations = list()
 
 /datum/round_event/spacevine/start()
 	var/list/turfs = list() //list of all the empty floor turfs in the hallway areas
 
-	var/obj/structure/spacevine/vine = new()
 
-	for(var/area/station/hallway/area in GLOB.areas)
-		for(var/turf/floor as anything in area.get_contained_turfs())
-			if(floor.Enter(vine))
-				turfs += floor
+	if(override_turf)
+		turfs += override_turf
+	else
+		var/obj/structure/spacevine/vine = new()
 
-	qdel(vine)
+		for(var/area/station/hallway/area in GLOB.areas)
+			for(var/turf/floor as anything in area.get_contained_turfs())
+				if(floor.Enter(vine))
+					turfs += floor
+
+		qdel(vine)
 
 	if(length(turfs)) //Pick a turf to spawn at if we can
 		var/turf/floor = pick(turfs)
 		new /datum/spacevine_controller(floor, list(pick(subtypesof(/datum/spacevine_mutation))), rand(50,100), rand(1,4), src) //spawn a controller at turf with randomized stats and a single random mutation
+
+/datum/event_admin_setup/set_location/spacevine
+	input_text = "Spawn vines at current location?"
+
+/datum/event_admin_setup/set_location/spacevine/apply_to_event(datum/round_event/spacevine/event)
+	event.override_turf = chosen_turf
+	
+/datum/event_admin_setup/multiple_choice/spacevine
+	input_text = "Select starting mutations."
+
+/datum/event_admin_setup/multiple_choice/spacevine/get_options()
+	return subtypesof(/datum/spacevine_mutation)
+
+/datum/event_admin_setup/multiple_choice/spacevine/apply_to_event(datum/round_event/spacevine/event)
+	event.override_mutations = choices
+	

--- a/code/modules/events/space_vines/vine_event.dm
+++ b/code/modules/events/space_vines/vine_event.dm
@@ -94,7 +94,7 @@
 
 /datum/event_admin_setup/input_number/spacevine_potency/prompt_admins()
 	default_value = rand(50, 100)
-	. = ..()
+	return ..()
 
 /datum/event_admin_setup/input_number/spacevine_potency/apply_to_event(datum/round_event/spacevine/event)
 	event.potency = chosen_value
@@ -106,7 +106,7 @@
 
 /datum/event_admin_setup/input_number/spacevine_production/prompt_admins()
 	default_value = rand(1, 4)
-	. = ..()
+	return ..()
 
 /datum/event_admin_setup/input_number/spacevine_production/apply_to_event(datum/round_event/spacevine/event)
 	event.production = chosen_value

--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -310,18 +310,18 @@
 
 	return expected_damage
 
-/datum/spacevine_mutation/woodening
+/datum/spacevine_mutation/hardened
 	name = "Hardened"
 	hue = "#997700"
 	quality = NEGATIVE
 	severity = SEVERITY_ABOVE_AVERAGE
 
-/datum/spacevine_mutation/woodening/on_grow(obj/structure/spacevine/holder)
+/datum/spacevine_mutation/hardened/on_grow(obj/structure/spacevine/holder)
 	if(holder.growth_stage)
 		holder.set_density(TRUE)
 	holder.modify_max_integrity(100)
 
-/datum/spacevine_mutation/woodening/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/item, expected_damage)
+/datum/spacevine_mutation/hardened/on_hit(obj/structure/spacevine/holder, mob/living/hitter, obj/item/item, expected_damage)
 	if(item?.get_sharpness())
 		return expected_damage * 0.5
 	return expected_damage

--- a/code/modules/tgui_input/checkboxes.dm
+++ b/code/modules/tgui_input/checkboxes.dm
@@ -6,7 +6,7 @@
  * message - The message inside the window
  * title - The title of the window
  * list/items - The list of items to display
- * min_checked - The minimum number of checkboxxes that must be checked (defaults to 1)
+ * min_checked - The minimum number of checkboxes that must be checked (defaults to 1)
  * max_checked - The maximum number of checkboxes that can be checked (optional)
  * timeout - The timeout for the input (optional)
  */

--- a/code/modules/tgui_input/checkboxes.dm
+++ b/code/modules/tgui_input/checkboxes.dm
@@ -6,10 +6,11 @@
  * message - The message inside the window
  * title - The title of the window
  * list/items - The list of items to display
+ * min_checked - The minimum number of checkboxxes that must be checked (defaults to 1)
  * max_checked - The maximum number of checkboxes that can be checked (optional)
  * timeout - The timeout for the input (optional)
  */
-/proc/tgui_input_checkboxes(mob/user, message, title = "Select", list/items, max_checked = 50, timeout = 0)
+/proc/tgui_input_checkboxes(mob/user, message, title = "Select", list/items, min_checked = 1, max_checked = 50, timeout = 0)
 	if (!user)
 		user = usr
 	if(!length(items))
@@ -22,7 +23,7 @@
 			return
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		return input(user, message, title) as null|anything in items
-	var/datum/tgui_checkbox_input/input = new(user, message, title, items, max_checked, timeout)
+	var/datum/tgui_checkbox_input/input = new(user, message, title, items, min_checked, max_checked, timeout)
 	input.ui_interact(user)
 	input.wait()
 	if (input)
@@ -45,13 +46,16 @@
 	var/timeout
 	/// Whether the input was closed
 	var/closed
+	/// Minimum number of checkboxes that must be checked
+	var/min_checked
 	/// Maximum number of checkboxes that can be checked
 	var/max_checked
 
-/datum/tgui_checkbox_input/New(mob/user, message, title, list/items, max_checked, timeout)
+/datum/tgui_checkbox_input/New(mob/user, message, title, list/items, min_checked, max_checked, timeout)
 	src.title = title
 	src.message = message
 	src.items = items.Copy()
+	src.min_checked = min_checked
 	src.max_checked = max_checked
 
 	if (timeout)
@@ -94,6 +98,7 @@
 	var/list/data = list()
 
 	data["items"] = items
+	data["min_checked"] = min_checked
 	data["max_checked"] = max_checked
 	data["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
 	data["message"] = message
@@ -110,7 +115,7 @@
 	switch(action)
 		if("submit")
 			var/list/selections = params["entry"]
-			if(length(selections) > 0 && length(selections) <= max_checked)
+			if(length(selections) >= min_checked && length(selections) <= max_checked)
 				set_choices(selections)
 			closed = TRUE
 			SStgui.close_uis(src)

--- a/tgui/packages/tgui/interfaces/CheckboxInput.tsx
+++ b/tgui/packages/tgui/interfaces/CheckboxInput.tsx
@@ -12,13 +12,21 @@ type Data = {
   message: string;
   title: string;
   timeout: number;
+  min_checked: number;
   max_checked: number;
 };
 
 /** Renders a list of checkboxes per items for input. */
 export const CheckboxInput = (props, context) => {
   const { data } = useBackend<Data>(context);
-  const { items = [], max_checked, message, timeout, title } = data;
+  const {
+    items = [],
+    min_checked,
+    max_checked,
+    message,
+    timeout,
+    title,
+  } = data;
 
   const [selections, setSelections] = useLocalState<string[]>(
     context,
@@ -50,6 +58,7 @@ export const CheckboxInput = (props, context) => {
           <Stack.Item>
             <NoticeBox info textAlign="center">
               {decodeHtmlEntities(message)}{' '}
+              {min_checked > 0 && ` (Min: ${min_checked})`}
               {max_checked < 50 && ` (Max: ${max_checked})`}
             </NoticeBox>
           </Stack.Item>


### PR DESCRIPTION

## About The Pull Request

Admins can now customize the location, potency and production stats for the space vines event, they can also use the new checkbox input system to select any number of mutations for the vine.
Also fixes a bug where random event kudzu was always spawning without mutations.
Also adds support for minimum number of options for the checkbox system rather than it being hardcoded to one (0 mutation kudzu support)
## Why It's Good For The Game

Space vines was practically begging to have admin customization added to it since its very impractical for admins to make custom kudzu, with this admins can create space vine threats tailored to the round by selecting interesting locations/mutations based on current station circumstances.

Also bugfix + dehardcoding a thing.
## Changelog
:cl:
admin: Admins can now control the spawn location, potency, production and starting mutations of the space vines event.
fix: The space vine event will now correctly give vines mutations when they spawn rather than always being mutation free.
code: Checkbox tgui inputs now support setting a minimum number of inputs rather than it being hardcoded to 1.
/:cl:
