### PR TITLE
Station shift start time config

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -381,7 +381,7 @@
 /datum/config_entry/flag/shift_time_realtime
 
 /datum/config_entry/number/shift_time_start_hour
-	default = 7
+	default = 12
 	min_val = 0
 	max_val = 23
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -380,6 +380,11 @@
 
 /datum/config_entry/flag/shift_time_realtime
 
+/datum/config_entry/number/shift_time_start_hour
+	default = 7
+	min_val = 0
+	max_val = 23
+
 /datum/config_entry/number/monkeycap
 	default = 64
 	min_val = 0

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -144,6 +144,8 @@ SUBSYSTEM_DEF(ticker)
 		gametime_offset = rand(0, 23) HOURS
 	else if(CONFIG_GET(flag/shift_time_realtime))
 		gametime_offset = world.timeofday
+	else
+		gametime_offset = (CONFIG_GET(number/shift_time_start_hour) HOURS)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/ticker/fire()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -484,14 +484,17 @@ ROUNDSTART_TRAITS
 ## Uncomment to disable human moods.
 #DISABLE_HUMAN_MOOD
 
-## Enable night shifts ##
+## Enable night shifts
 #ENABLE_NIGHT_SHIFTS
 
-## Enable randomized shift start times##
-#RANDOMIZE_SHIFT_TIME
+## The shift start hour in 24-hour (0-23) notation
+SHIFT_TIME_START_HOUR 7
 
-## Sets shift time to server time at roundstart. Overridden by RANDOMIZE_SHIFT_TIME ##
+## Sets shift time to server time at roundstart. Overrides SHIFT_TIME_START_HOUR
 #SHIFT_TIME_REALTIME
+
+## Enable randomized shift start times. Overrides SHIFT_TIME_REALTIME and SHIFT_TIME_START_HOUR
+#RANDOMIZE_SHIFT_TIME
 
 ## A cap on how many monkeys may be created via monkey cubes
 MONKEYCAP 64


### PR DESCRIPTION
## About The Pull Request

We have a config flag to set random shift start times or server sync'd start times, but not one to simply set the shift start time.

## Why It's Good For The Game

Control over the shift start time. This way events such as breakfast can occur during actual breakfast hours.

## Changelog

:cl: LT3
config: Station shift start time can now be set in the server config
/:cl: