### PR TITLE
North Star Merge Plaque and Requests Console for QM [NO GBP]

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -44617,6 +44617,12 @@
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/bed/double/pod,
 /obj/item/bedsheet/qm/double,
+/obj/machinery/requests_console/directional/north{
+	announcementConsole = 1;
+	department = "Quartermaster's Desk";
+	name = "Quartermaster's Requests Console";
+	supplies_requestable = 1
+	},
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/qm)
 "lTN" = (
@@ -77302,6 +77308,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/navigate_destination/bridge,
+/obj/structure/plaque/static_plaque/golden/commission/northstar,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "uMR" = (

--- a/code/game/objects/structures/plaques/static_plaques.dm
+++ b/code/game/objects/structures/plaques/static_plaques.dm
@@ -52,6 +52,9 @@
 /obj/structure/plaque/static_plaque/golden/commission/tram
 	desc = "Spinward Sector Station SS-13\n'Tram' Class Outpost\nCommissioned 11/03/2561\n'Making Moves'"
 
+// North Star: added Apr 13, 2023 (#74371)
+/obj/structure/plaque/static_plaque/golden/commission/northstar
+	desc = "Spinward Sector Ship SS-13\n'North Star' Class Vessel\nCommissioned 13/04/2563\n'New Opportunities'"
 //Removed stations
 
 // Asteroidstation: added Oct 17, 2015 (169ab09f7b52254ee505e54cdea681fab287647b), removed Jun 19, 2016 (#18661)- 8 months, 2 days


### PR DESCRIPTION

## About The Pull Request
Adds a plaque for the North Star's merge date and gives the QM a requests console.
## Why It's Good For The Game
Every map has these and I want one too, also, QM requests console. This is probably fine for No GPB? I'll take the hit if it isnt.
## Changelog
:cl:
fix: The North Star is no longer missing it's commission plaque or the QM's request console.
/:cl:
