### PR TITLE
Removes spectral saxophone from lavaland ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -15,7 +15,8 @@
 "ah" = (
 /obj/structure/sink/directional/north,
 /obj/structure/mirror/directional/south,
-/obj/item/instrument/saxophone/spectral,
+/obj/item/instrument/saxophone,
+/obj/item/clothing/head/helmet/skull,
 /turf/open/floor/iron/freezer/lavaland,
 /area/ruin/unpowered)
 "aq" = (


### PR DESCRIPTION
## About The Pull Request

The spectral saxophone is an item which you can use to turn another person into a skeleton as many times as you want, with flavour text telling them to go and convert other people into skeletons (although they are not an antagonist, so this isn't binding).

It spawns during halloween, or _very rarely_ in maintenance at random.

Admins have been upset for the past week about how this item has suddenly appeared in multiple rounds despite its supposed rarity, causing disruption they did not particularly like, the culprit is this recently revamped lavaland ruin which has one mapped into it, making it available much more often.

I have replaced it with a normal saxophone and a commemorative skull hat.

Thanks @necromanceranne for spotting it.

## Why It's Good For The Game

This ruin appears quite frequently and this item isn't supposed to be so frequently available.

## Changelog

:cl:
fix: Removes the spectral trombone from the lavaland pizza party ruin.
/:cl: