### PR TITLE
Changes the text on the spectral instrument skeleton conversion to not be written exactly like the antagonist prompts

### DIFF
--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -63,8 +63,7 @@
 				new instrument(T)
 			else
 				to_chat(H, span_boldwarning("The spooky gods forgot to ship your instrument. Better luck next unlife."))
-		to_chat(H, span_boldnotice("You are the spooky skeleton!"))
-		to_chat(H, span_boldnotice("A new life and identity has begun. Help your fellow skeletons into bringing out the spooky-pocalypse. You haven't forgotten your past life, and are still beholden to past loyalties."))
+		to_chat(C, "<span class='robot'><font size='4'>You're feeling more bony.</font></span>")
 		change_name(H) //time for a new name!
 
 /datum/element/spooky/proc/change_name(mob/living/carbon/human/spooked)

--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -63,7 +63,7 @@
 				new instrument(T)
 			else
 				to_chat(H, span_boldwarning("The spooky gods forgot to ship your instrument. Better luck next unlife."))
-		to_chat(C, "<span class='robot'><font size='4'>You're feeling more bony.</font></span>")
+		to_chat(C, "<span class='robot'><font size='4'>You're feeling more spooky.</font></span>")
 		change_name(H) //time for a new name!
 
 /datum/element/spooky/proc/change_name(mob/living/carbon/human/spooked)

--- a/code/datums/elements/spooky.dm
+++ b/code/datums/elements/spooky.dm
@@ -63,7 +63,7 @@
 				new instrument(T)
 			else
 				to_chat(H, span_boldwarning("The spooky gods forgot to ship your instrument. Better luck next unlife."))
-		to_chat(C, "<span class='robot'><font size='4'>You're feeling more spooky.</font></span>")
+		to_chat(H, "<span class='robot'><font size='4'>You're feeling more spooky.</font></span>")
 		change_name(H) //time for a new name!
 
 /datum/element/spooky/proc/change_name(mob/living/carbon/human/spooked)


### PR DESCRIPTION
## About The Pull Request

Changes the text on the spectral instrument skeleton conversion to not be written exactly like the antagonist prompts

## Why It's Good For The Game

This was causing immense confusion for players and antagonists.
![Discord_FWzGMsqNBw](https://user-images.githubusercontent.com/4081722/231905201-f6dcaaa6-93d7-4186-9de8-0ef130e755d4.png)


## Changelog
:cl:
fix: Changes the text on the spectral instrument skeleton conversion to not be written exactly like the antagonist prompts
/:cl: