### PR TITLE
Fixes eigen lockers bypassing TP protection

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -69,8 +69,10 @@
 #define COMSIG_ATOM_CREATEDBY_PROCESSING "atom_createdby_processing"
 ///when an atom is processed (mob/living/user, obj/item/I, list/atom/results)
 #define COMSIG_ATOM_PROCESSED "atom_processed"
-///called when teleporting into a protected turf: (channel, turf/origin)
-#define COMSIG_ATOM_INTERCEPT_TELEPORT "intercept_teleport"
+///called when teleporting into a possibly protected turf: (channel, turf/origin, turf/destination)
+#define COMSIG_ATOM_INTERCEPT_TELEPORTING "intercept_teleporting"
+///called after teleporting into a protected turf: (channel, turf/origin)
+#define COMSIG_ATOM_INTERCEPT_TELEPORTED "intercept_teleported"
 	#define COMPONENT_BLOCK_TELEPORT (1<<0)
 ///called when an atom is added to the hearers on get_hearers_in_view(): (list/processing_list, list/hearers)
 #define COMSIG_ATOM_HEARER_IN_VIEW "atom_hearer_in_view"

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -78,6 +78,8 @@
 #define COMSIG_MOVABLE_UPDATE_GLIDE_SIZE "movable_glide_size"
 ///Called when a movable is hit by a plunger in layer mode, from /obj/item/plunger/attack_atom()
 #define COMSIG_MOVABLE_CHANGE_DUCT_LAYER "movable_change_duct_layer"
+///Called before a movable is being teleported from `check_teleport_valid()`: (destination, channel)
+#define COMSIG_MOVABLE_TELEPORTING "movable_teleporting"
 ///Called when a movable is being teleported from `do_teleport()`: (destination, channel)
 #define COMSIG_MOVABLE_TELEPORTED "movable_teleported"
 ///Called after a movable is teleported from `do_teleport()`: ()

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -109,6 +109,8 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 #define TELEPORT_CHANNEL_MAGIC "magic"
 /// Cult teleportation, does whatever it wants (unless there's holiness)
 #define TELEPORT_CHANNEL_CULT "cult"
+/// Eigenstate teleportation, can do most things (that aren't in a teleport-prevented zone)
+#define TELEPORT_CHANNEL_EIGENSTATE "eigenstate"
 /// Anything else
 #define TELEPORT_CHANNEL_FREE "free"
 

--- a/code/controllers/subsystem/eigenstate.dm
+++ b/code/controllers/subsystem/eigenstate.dm
@@ -101,7 +101,11 @@ SUBSYSTEM_DEF(eigenstates)
 	if(!eigen_target)
 		stack_trace("No eigen target set for the eigenstate component!")
 		return FALSE
-	thing_to_send.forceMove(get_turf(eigen_target))
+	if(check_teleport_valid(thing_to_send, eigen_target, get_area(thing_to_send), get_area(eigen_target), get_turf(thing_to_send), get_turf(eigen_target), TELEPORT_CHANNEL_EIGENSTATE))
+		thing_to_send.forceMove(get_turf(eigen_target))
+	else
+		to_chat(thing_to_send, span_warning("You close the locker on yourself, only for nothing to happen."))
+		return FALSE
 	//Create ONE set of sparks for ALL times in iteration
 	if(spark_time != world.time)
 		do_sparks(5, FALSE, eigen_target)

--- a/code/controllers/subsystem/eigenstate.dm
+++ b/code/controllers/subsystem/eigenstate.dm
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(eigenstates)
 	if(check_teleport_valid(thing_to_send, eigen_target, get_area(thing_to_send), get_area(eigen_target), get_turf(thing_to_send), get_turf(eigen_target), TELEPORT_CHANNEL_EIGENSTATE))
 		thing_to_send.forceMove(get_turf(eigen_target))
 	else
-		to_chat(thing_to_send, span_warning("You close the locker on yourself, only for nothing to happen."))
+		balloon_alert(thing_to_send, "nothing happens!")
 		return FALSE
 	//Create ONE set of sparks for ALL times in iteration
 	if(spark_time != world.time)

--- a/code/controllers/subsystem/eigenstate.dm
+++ b/code/controllers/subsystem/eigenstate.dm
@@ -104,7 +104,7 @@ SUBSYSTEM_DEF(eigenstates)
 	if(check_teleport_valid(thing_to_send, eigen_target, get_area(thing_to_send), get_area(eigen_target), get_turf(thing_to_send), get_turf(eigen_target), TELEPORT_CHANNEL_EIGENSTATE))
 		thing_to_send.forceMove(get_turf(eigen_target))
 	else
-		balloon_alert(thing_to_send, "nothing happens!")
+		object_sent_from.balloon_alert(thing_to_send, "nothing happens!")
 		return FALSE
 	//Create ONE set of sparks for ALL times in iteration
 	if(spark_time != world.time)

--- a/code/controllers/subsystem/eigenstate.dm
+++ b/code/controllers/subsystem/eigenstate.dm
@@ -101,7 +101,7 @@ SUBSYSTEM_DEF(eigenstates)
 	if(!eigen_target)
 		stack_trace("No eigen target set for the eigenstate component!")
 		return FALSE
-	if(check_teleport_valid(thing_to_send, eigen_target, get_area(thing_to_send), get_area(eigen_target), get_turf(thing_to_send), get_turf(eigen_target), TELEPORT_CHANNEL_EIGENSTATE))
+	if(check_teleport_valid(thing_to_send, eigen_target, TELEPORT_CHANNEL_EIGENSTATE))
 		thing_to_send.forceMove(get_turf(eigen_target))
 	else
 		object_sent_from.balloon_alert(thing_to_send, "nothing happens!")

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -67,17 +67,7 @@
 	var/area/from_area = get_area(curturf)
 	var/area/to_area = get_area(destturf)
 	if(!forced)
-		if(HAS_TRAIT(teleatom, TRAIT_NO_TELEPORT))
-			return FALSE
-
-		if((from_area.area_flags & NOTELEPORT) || (to_area.area_flags & NOTELEPORT))
-			return FALSE
-
-		if(SEND_SIGNAL(teleatom, COMSIG_MOVABLE_TELEPORTED, destination, channel) & COMPONENT_BLOCK_TELEPORT)
-			return FALSE
-
-		if(SEND_SIGNAL(destturf, COMSIG_ATOM_INTERCEPT_TELEPORT, channel, curturf, destturf) & COMPONENT_BLOCK_TELEPORT)
-			return FALSE
+		check_teleport_valid(teleatom, destination, from_area, to_area, curturf, destturf, channel)
 
 	if(isobserver(teleatom))
 		teleatom.abstract_move(destturf)
@@ -202,3 +192,19 @@
 	var/list/turfs = get_teleport_turfs(center, precision)
 	if (length(turfs))
 		return pick(turfs)
+
+/// Validates that the teleport being attempted is valid or not
+/proc/check_teleport_valid(atom/tele_atom, atom/destination, area/from_area, area/to_area, turf/from_turf, turf/to_turf, channel)
+	if(HAS_TRAIT(tele_atom, TRAIT_NO_TELEPORT))
+		return FALSE
+
+	if((from_area.area_flags & NOTELEPORT) || (to_area.area_flags & NOTELEPORT))
+		return FALSE
+
+	if(SEND_SIGNAL(tele_atom, COMSIG_MOVABLE_TELEPORTED, destination, channel) & COMPONENT_BLOCK_TELEPORT)
+		return FALSE
+
+	if(SEND_SIGNAL(to_turf, COMSIG_ATOM_INTERCEPT_TELEPORT, channel, from_turf, to_turf) & COMPONENT_BLOCK_TELEPORT)
+		return FALSE
+
+	return TRUE

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -203,16 +203,16 @@
 	if(HAS_TRAIT(teleported_atom, TRAIT_NO_TELEPORT))
 		return FALSE
 
-	if((teleported_atom_area.area_flags & NOTELEPORT) || (destination_area.area_flags & NOTELEPORT))
+	if((origin_area.area_flags & NOTELEPORT) || (destination_area.area_flags & NOTELEPORT))
 		return FALSE
 
 	if(SEND_SIGNAL(teleported_atom, COMSIG_MOVABLE_TELEPORTING, destination, channel) & COMPONENT_BLOCK_TELEPORT)
 		return FALSE
 
-	if(SEND_SIGNAL(destination_turf, COMSIG_ATOM_INTERCEPT_TELEPORTING, channel, teleported_atom_turf, destination_turf) & COMPONENT_BLOCK_TELEPORT)
+	if(SEND_SIGNAL(destination_turf, COMSIG_ATOM_INTERCEPT_TELEPORTING, channel, origin_turf, destination_turf) & COMPONENT_BLOCK_TELEPORT)
 		return FALSE
 
 	SEND_SIGNAL(teleported_atom, COMSIG_MOVABLE_TELEPORTED, destination, channel)
-	SEND_SIGNAL(destination_turf, COMSIG_ATOM_INTERCEPT_TELEPORTED, channel, teleported_atom_turf, destination_turf)
+	SEND_SIGNAL(destination_turf, COMSIG_ATOM_INTERCEPT_TELEPORTED, channel, origin_turf, destination_turf)
 
 	return TRUE

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -64,11 +64,9 @@
 	if(!destturf || !curturf || destturf.is_transition_turf())
 		return FALSE
 
-	var/area/from_area = get_area(curturf)
-	var/area/to_area = get_area(destturf)
 	if(!forced)
-		if(!check_teleport_valid(teleatom, destination, from_area, to_area, curturf, destturf, channel))
-			return FALSE		
+		if(!check_teleport_valid(teleatom, destination, channel))
+			return FALSE
 
 	if(isobserver(teleatom))
 		teleatom.abstract_move(destturf)
@@ -195,17 +193,20 @@
 		return pick(turfs)
 
 /// Validates that the teleport being attempted is valid or not
-/proc/check_teleport_valid(atom/tele_atom, atom/destination, area/from_area, area/to_area, turf/from_turf, turf/to_turf, channel)
-	if(HAS_TRAIT(tele_atom, TRAIT_NO_TELEPORT))
+/proc/check_teleport_valid(atom/teleported_atom, atom/destination, channel)
+	var/area/teleported_atom_area = get_area(teleported_atom)
+	var/area/destination_area = get_area(destination_area)
+
+	if(HAS_TRAIT(teleported_atom, TRAIT_NO_TELEPORT))
 		return FALSE
 
-	if((from_area.area_flags & NOTELEPORT) || (to_area.area_flags & NOTELEPORT))
+	if((teleported_atom_area.area_flags & NOTELEPORT) || (destination_area.area_flags & NOTELEPORT))
 		return FALSE
 
-	if(SEND_SIGNAL(tele_atom, COMSIG_MOVABLE_TELEPORTED, destination, channel) & COMPONENT_BLOCK_TELEPORT)
+	if(SEND_SIGNAL(teleported_atom, COMSIG_MOVABLE_TELEPORTED, destination, channel) & COMPONENT_BLOCK_TELEPORT)
 		return FALSE
 
-	if(SEND_SIGNAL(to_turf, COMSIG_ATOM_INTERCEPT_TELEPORT, channel, from_turf, to_turf) & COMPONENT_BLOCK_TELEPORT)
+	if(SEND_SIGNAL(to_turf, COMSIG_ATOM_INTERCEPT_TELEPORT, channel, get_turf(teleported_atom), get_turf(destination)) & COMPONENT_BLOCK_TELEPORT)
 		return FALSE
 
 	return TRUE

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -194,9 +194,10 @@
 
 /// Validates that the teleport being attempted is valid or not
 /proc/check_teleport_valid(atom/teleported_atom, atom/destination, channel)
-	var/area/teleported_atom_area = get_area(teleported_atom)
+	var/area/origin_area = get_area(teleported_atom)
+	var/turf/origin_turf = get_turf(teleported_atom)
+
 	var/area/destination_area = get_area(destination)
-	var/turf/teleported_atom_turf = get_turf(teleported_atom)
 	var/turf/destination_turf = get_turf(destination)
 
 	if(HAS_TRAIT(teleported_atom, TRAIT_NO_TELEPORT))

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -195,7 +195,9 @@
 /// Validates that the teleport being attempted is valid or not
 /proc/check_teleport_valid(atom/teleported_atom, atom/destination, channel)
 	var/area/teleported_atom_area = get_area(teleported_atom)
-	var/area/destination_area = get_area(destination_area)
+	var/area/destination_area = get_area(destination)
+	var/turf/teleported_atom_turf = get_turf(teleported_atom)
+	var/turf/destination_turf = get_turf(destination)
 
 	if(HAS_TRAIT(teleported_atom, TRAIT_NO_TELEPORT))
 		return FALSE
@@ -203,10 +205,13 @@
 	if((teleported_atom_area.area_flags & NOTELEPORT) || (destination_area.area_flags & NOTELEPORT))
 		return FALSE
 
-	if(SEND_SIGNAL(teleported_atom, COMSIG_MOVABLE_TELEPORTED, destination, channel) & COMPONENT_BLOCK_TELEPORT)
+	if(SEND_SIGNAL(teleported_atom, COMSIG_MOVABLE_TELEPORTING, destination, channel) & COMPONENT_BLOCK_TELEPORT)
 		return FALSE
 
-	if(SEND_SIGNAL(to_turf, COMSIG_ATOM_INTERCEPT_TELEPORT, channel, get_turf(teleported_atom), get_turf(destination)) & COMPONENT_BLOCK_TELEPORT)
+	if(SEND_SIGNAL(destination_turf, COMSIG_ATOM_INTERCEPT_TELEPORTING, channel, teleported_atom_turf, destination_turf) & COMPONENT_BLOCK_TELEPORT)
 		return FALSE
+
+	SEND_SIGNAL(teleported_atom, COMSIG_MOVABLE_TELEPORTED, destination, channel)
+	SEND_SIGNAL(destination_turf, COMSIG_ATOM_INTERCEPT_TELEPORTED, channel, teleported_atom_turf, destination_turf)
 
 	return TRUE

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -67,7 +67,8 @@
 	var/area/from_area = get_area(curturf)
 	var/area/to_area = get_area(destturf)
 	if(!forced)
-		check_teleport_valid(teleatom, destination, from_area, to_area, curturf, destturf, channel)
+		if(!check_teleport_valid(teleatom, destination, from_area, to_area, curturf, destturf, channel))
+			return FALSE		
 
 	if(isobserver(teleatom))
 		teleatom.abstract_move(destturf)

--- a/code/game/objects/effects/blessing.dm
+++ b/code/game/objects/effects/blessing.dm
@@ -16,12 +16,12 @@
 		I.alpha = 64
 		I.appearance_flags = RESET_ALPHA
 		add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/blessed_aware, "blessing", I)
-	RegisterSignal(loc, COMSIG_ATOM_INTERCEPT_TELEPORT, PROC_REF(block_cult_teleport))
+	RegisterSignal(loc, COMSIG_ATOM_INTERCEPT_TELEPORTING, PROC_REF(block_cult_teleport))
 
-/obj/effect/blessing/Destroy() 
-	UnregisterSignal(loc, COMSIG_ATOM_INTERCEPT_TELEPORT)
+/obj/effect/blessing/Destroy()
+	UnregisterSignal(loc, COMSIG_ATOM_INTERCEPT_TELEPORTING)
 	return ..()
-	
+
 /obj/effect/blessing/proc/block_cult_teleport(datum/source, channel, turf/origin, turf/destination)
 	SIGNAL_HANDLER
 

--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -144,13 +144,13 @@
 /datum/status_effect/eldritch/blade/on_apply()
 	. = ..()
 	RegisterSignal(owner, COMSIG_MOVABLE_PRE_THROW, PROC_REF(on_pre_throw))
-	RegisterSignal(owner, COMSIG_MOVABLE_TELEPORTED, PROC_REF(on_teleport))
+	RegisterSignal(owner, COMSIG_MOVABLE_TELEPORTING, PROC_REF(on_teleport))
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 
 /datum/status_effect/eldritch/blade/on_remove()
 	UnregisterSignal(owner, list(
 		COMSIG_MOVABLE_PRE_THROW,
-		COMSIG_MOVABLE_TELEPORTED,
+		COMSIG_MOVABLE_TELEPORTING,
 		COMSIG_MOVABLE_MOVED,
 	))
 


### PR DESCRIPTION

## About The Pull Request
Fixes eigenlockers bypassing teleport protections.

![image](https://user-images.githubusercontent.com/41448081/231939450-42287185-48f4-4a3b-ac7a-38adc0600633.png)

Tested w/ one and multiple lockers, prevents entering or exiting from a tp-prot eigenlocker

## Why It's Good For The Game
This came up in an away mission designed to be a "one-way-trip", the only exit being at the very end of the away mission. However, people are able to bypass this with eigenlockers, thanks to them performing no teleportation checks, which I believe is an oversight.

## Changelog
:cl:
fix: Eigenstasium lockers no longer bypass teleport protection
/:cl:
