### PR TITLE
Cleanup 1 letter var names in martial arts files

### DIFF
--- a/code/datums/martial/_martial.dm
+++ b/code/datums/martial/_martial.dm
@@ -16,24 +16,24 @@
 	/// If set to true this style allows you to punch people despite being a pacifist (for instance Boxing, which does no damage)
 	var/pacifist_style = FALSE
 
-/datum/martial_art/proc/help_act(mob/living/A, mob/living/D)
+/datum/martial_art/proc/help_act(mob/living/attacker, mob/living/defender)
 	return MARTIAL_ATTACK_INVALID
 
-/datum/martial_art/proc/disarm_act(mob/living/A, mob/living/D)
+/datum/martial_art/proc/disarm_act(mob/living/attacker, mob/living/defender)
 	return MARTIAL_ATTACK_INVALID
 
-/datum/martial_art/proc/harm_act(mob/living/A, mob/living/D)
+/datum/martial_art/proc/harm_act(mob/living/attacker, mob/living/defender)
 	return MARTIAL_ATTACK_INVALID
 
-/datum/martial_art/proc/grab_act(mob/living/A, mob/living/D)
+/datum/martial_art/proc/grab_act(mob/living/attacker, mob/living/defender)
 	return MARTIAL_ATTACK_INVALID
 
 /datum/martial_art/proc/can_use(mob/living/L)
 	return TRUE
 
-/datum/martial_art/proc/add_to_streak(element, mob/living/D)
-	if(D != current_target)
-		reset_streak(D)
+/datum/martial_art/proc/add_to_streak(element, mob/living/defender)
+	if(defender != current_target)
+		reset_streak(defender)
 	streak = streak+element
 	if(length(streak) > max_streak_length)
 		streak = copytext(streak, 1 + length(streak[1]))
@@ -93,5 +93,5 @@
 	return
 
 ///Gets called when a projectile hits the owner. Returning anything other than BULLET_ACT_HIT will stop the projectile from hitting the mob.
-/datum/martial_art/proc/on_projectile_hit(mob/living/A, obj/projectile/P, def_zone)
+/datum/martial_art/proc/on_projectile_hit(mob/living/attacker, obj/projectile/P, def_zone)
 	return BULLET_ACT_HIT

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -3,57 +3,57 @@
 	id = MARTIALART_BOXING
 	pacifist_style = TRUE
 
-/datum/martial_art/boxing/disarm_act(mob/living/A, mob/living/D)
-	to_chat(A, span_warning("Can't disarm while boxing!"))
+/datum/martial_art/boxing/disarm_act(mob/living/attacker, mob/living/defender)
+	to_chat(attacker, span_warning("Can't disarm while boxing!"))
 	return TRUE
 
-/datum/martial_art/boxing/grab_act(mob/living/A, mob/living/D)
-	to_chat(A, span_warning("Can't grab while boxing!"))
+/datum/martial_art/boxing/grab_act(mob/living/attacker, mob/living/defender)
+	to_chat(attacker, span_warning("Can't grab while boxing!"))
 	return TRUE
 
-/datum/martial_art/boxing/harm_act(mob/living/A, mob/living/D)
+/datum/martial_art/boxing/harm_act(mob/living/attacker, mob/living/defender)
 
-	var/mob/living/carbon/human/attacker_human = A
+	var/mob/living/carbon/human/attacker_human = attacker
 	var/obj/item/bodypart/arm/active_arm = attacker_human.get_active_hand()
 
-	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+	attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
 
 	var/atk_verb = pick("left hook","right hook","straight punch")
 
 	var/damage = rand(5, 8) + active_arm.unarmed_damage_low
 	if(!damage)
-		playsound(D.loc, active_arm.unarmed_miss_sound, 25, TRUE, -1)
-		D.visible_message(span_warning("[A]'s [atk_verb] misses [D]!"), \
-						span_danger("You avoid [A]'s [atk_verb]!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, A)
-		to_chat(A, span_warning("Your [atk_verb] misses [D]!"))
-		log_combat(A, D, "attempted to hit", atk_verb)
+		playsound(defender.loc, active_arm.unarmed_miss_sound, 25, TRUE, -1)
+		defender.visible_message(span_warning("[attacker]'s [atk_verb] misses [defender]!"), \
+						span_danger("You avoid [attacker]'s [atk_verb]!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, attacker)
+		to_chat(attacker, span_warning("Your [atk_verb] misses [defender]!"))
+		log_combat(attacker, defender, "attempted to hit", atk_verb)
 		return FALSE
 
 
-	var/obj/item/bodypart/affecting = D.get_bodypart(D.get_random_valid_zone(A.zone_selected))
-	var/armor_block = D.run_armor_check(affecting, MELEE)
+	var/obj/item/bodypart/affecting = defender.get_bodypart(defender.get_random_valid_zone(attacker.zone_selected))
+	var/armor_block = defender.run_armor_check(affecting, MELEE)
 
-	playsound(D.loc, active_arm.unarmed_attack_sound, 25, TRUE, -1)
+	playsound(defender.loc, active_arm.unarmed_attack_sound, 25, TRUE, -1)
 
-	D.visible_message(span_danger("[A] [atk_verb]ed [D]!"), \
-					span_userdanger("You're [atk_verb]ed by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-	to_chat(A, span_danger("You [atk_verb]ed [D]!"))
+	defender.visible_message(span_danger("[attacker] [atk_verb]ed [defender]!"), \
+					span_userdanger("You're [atk_verb]ed by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+	to_chat(attacker, span_danger("You [atk_verb]ed [defender]!"))
 
-	D.apply_damage(damage, STAMINA, affecting, armor_block)
-	log_combat(A, D, "punched (boxing) ")
-	if(D.getStaminaLoss() > 50 && istype(D.mind?.martial_art, /datum/martial_art/boxing))
-		var/knockout_prob = D.getStaminaLoss() + rand(-15,15)
-		if((D.stat != DEAD) && prob(knockout_prob))
-			D.visible_message(span_danger("[A] knocks [D] out with a haymaker!"), \
-							span_userdanger("You're knocked unconscious by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-			to_chat(A, span_danger("You knock [D] out with a haymaker!"))
-			D.apply_effect(20 SECONDS,EFFECT_KNOCKDOWN,armor_block)
-			D.SetSleeping(10 SECONDS)
-			log_combat(A, D, "knocked out (boxing) ")
+	defender.apply_damage(damage, STAMINA, affecting, armor_block)
+	log_combat(attacker, defender, "punched (boxing) ")
+	if(defender.getStaminaLoss() > 50 && istype(defender.mind?.martial_art, /datum/martial_art/boxing))
+		var/knockout_prob = defender.getStaminaLoss() + rand(-15,15)
+		if((defender.stat != DEAD) && prob(knockout_prob))
+			defender.visible_message(span_danger("[attacker] knocks [defender] out with a haymaker!"), \
+							span_userdanger("You're knocked unconscious by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+			to_chat(attacker, span_danger("You knock [defender] out with a haymaker!"))
+			defender.apply_effect(20 SECONDS,EFFECT_KNOCKDOWN, armor_block)
+			defender.SetSleeping(10 SECONDS)
+			log_combat(attacker, defender, "knocked out (boxing) ")
 	return TRUE
 
 /datum/martial_art/boxing/can_use(mob/living/owner)
-	if (!ishuman(owner))
+	if(!ishuman(owner))
 		return FALSE
 	return ..()
 

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -46,189 +46,189 @@
 		restraining_mob = null
 	return ..()
 
-/datum/martial_art/cqc/proc/check_streak(mob/living/user, mob/living/target)
-	if(!can_use(user))
+/datum/martial_art/cqc/proc/check_streak(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
 		return FALSE
-	if(findtext(streak,SLAM_COMBO))
+	if(findtext(streak, SLAM_COMBO))
 		reset_streak()
-		return Slam(user, target)
-	if(findtext(streak,KICK_COMBO))
+		return Slam(attacker, defender)
+	if(findtext(streak, KICK_COMBO))
 		reset_streak()
-		return Kick(user, target)
-	if(findtext(streak,RESTRAIN_COMBO))
+		return Kick(attacker, defender)
+	if(findtext(streak, RESTRAIN_COMBO))
 		reset_streak()
-		return Restrain(user, target)
-	if(findtext(streak,PRESSURE_COMBO))
+		return Restrain(attacker, defender)
+	if(findtext(streak, PRESSURE_COMBO))
 		reset_streak()
-		return Pressure(user, target)
-	if(findtext(streak,CONSECUTIVE_COMBO))
+		return Pressure(attacker, defender)
+	if(findtext(streak, CONSECUTIVE_COMBO))
 		reset_streak()
-		return Consecutive(user, target)
+		return Consecutive(attacker, defender)
 	return FALSE
 
-/datum/martial_art/cqc/proc/Slam(mob/living/user, mob/living/target)
-	if(!can_use(user))
+/datum/martial_art/cqc/proc/Slam(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
 		return FALSE
-	if(target.body_position == STANDING_UP)
-		target.visible_message(span_danger("[user] slams [target] into the ground!"), \
-						span_userdanger("You're slammed into the ground by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, user)
-		to_chat(user, span_danger("You slam [target] into the ground!"))
-		playsound(get_turf(user), 'sound/weapons/slam.ogg', 50, TRUE, -1)
-		target.apply_damage(10, BRUTE)
-		target.Paralyze(12 SECONDS)
-		log_combat(user, target, "slammed (CQC)")
+	if(defender.body_position == STANDING_UP)
+		defender.visible_message(span_danger("[attacker] slams [defender] into the ground!"), \
+						span_userdanger("You're slammed into the ground by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+		to_chat(attacker, span_danger("You slam [defender] into the ground!"))
+		playsound(get_turf(attacker), 'sound/weapons/slam.ogg', 50, TRUE, -1)
+		defender.apply_damage(10, BRUTE)
+		defender.Paralyze(12 SECONDS)
+		log_combat(attacker, defender, "slammed (CQC)")
 		return TRUE
 
-/datum/martial_art/cqc/proc/Kick(mob/living/user, mob/living/target)
-	if(!can_use(user))
+/datum/martial_art/cqc/proc/Kick(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
 		return FALSE
-	if(!target.stat || !target.IsParalyzed())
-		target.visible_message(span_danger("[user] kicks [target] back!"), \
-						span_userdanger("You're kicked back by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
-		to_chat(user, span_danger("You kick [target] back!"))
-		playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
-		var/atom/throw_target = get_edge_target_turf(target, user.dir)
-		target.throw_at(throw_target, 1, 14, user)
-		target.apply_damage(10, user.get_attack_type())
-		log_combat(user, target, "kicked (CQC)")
+	if(!defender.stat || !defender.IsParalyzed())
+		defender.visible_message(span_danger("[attacker] kicks [defender] back!"), \
+						span_userdanger("You're kicked back by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+		to_chat(attacker, span_danger("You kick [defender] back!"))
+		playsound(get_turf(attacker), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
+		var/atom/throw_target = get_edge_target_turf(defender, attacker.dir)
+		defender.throw_at(throw_target, 1, 14, attacker)
+		defender.apply_damage(10, attacker.get_attack_type())
+		log_combat(attacker, defender, "kicked (CQC)")
 		. = TRUE
-	if(target.IsParalyzed() && !target.stat)
-		log_combat(user, target, "knocked out (Head kick)(CQC)")
-		target.visible_message(span_danger("[user] kicks [target]'s head, knocking [target.p_them()] out!"), \
-						span_userdanger("You're knocked unconscious by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, user)
-		to_chat(user, span_danger("You kick [target]'s head, knocking [target.p_them()] out!"))
-		playsound(get_turf(user), 'sound/weapons/genhit1.ogg', 50, TRUE, -1)
-		target.SetSleeping(30 SECONDS)
-		target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15, 150)
+	if(defender.IsParalyzed() && !defender.stat)
+		log_combat(attacker, defender, "knocked out (Head kick)(CQC)")
+		defender.visible_message(span_danger("[attacker] kicks [defender]'s head, knocking [defender.p_them()] out!"), \
+						span_userdanger("You're knocked unconscious by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+		to_chat(attacker, span_danger("You kick [defender]'s head, knocking [defender.p_them()] out!"))
+		playsound(get_turf(attacker), 'sound/weapons/genhit1.ogg', 50, TRUE, -1)
+		defender.SetSleeping(30 SECONDS)
+		defender.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15, 150)
 		. = TRUE
 
-/datum/martial_art/cqc/proc/Pressure(mob/living/user, mob/living/target)
-	if(!can_use(user))
+/datum/martial_art/cqc/proc/Pressure(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
 		return FALSE
-	log_combat(user, target, "pressured (CQC)")
-	target.visible_message(span_danger("[user] punches [target]'s neck!"), \
-					span_userdanger("Your neck is punched by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
-	to_chat(user, span_danger("You punch [target]'s neck!"))
-	target.adjustStaminaLoss(60)
-	playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
+	log_combat(attacker, defender, "pressured (CQC)")
+	defender.visible_message(span_danger("[attacker] punches [defender]'s neck!"), \
+					span_userdanger("Your neck is punched by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+	to_chat(attacker, span_danger("You punch [defender]'s neck!"))
+	defender.adjustStaminaLoss(60)
+	playsound(get_turf(attacker), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
 	return TRUE
 
-/datum/martial_art/cqc/proc/Restrain(mob/living/user, mob/living/target)
+/datum/martial_art/cqc/proc/Restrain(mob/living/attacker, mob/living/defender)
 	if(restraining_mob)
 		return
-	if(!can_use(user))
+	if(!can_use(attacker))
 		return FALSE
-	if(!target.stat)
-		log_combat(user, target, "restrained (CQC)")
-		target.visible_message(span_warning("[user] locks [target] into a restraining position!"), \
-						span_userdanger("You're locked into a restraining position by [user]!"), span_hear("You hear shuffling and a muffled groan!"), null, user)
-		to_chat(user, span_danger("You lock [target] into a restraining position!"))
-		target.adjustStaminaLoss(20)
-		target.Stun(10 SECONDS)
-		restraining_mob = target
+	if(!defender.stat)
+		log_combat(attacker, defender, "restrained (CQC)")
+		defender.visible_message(span_warning("[attacker] locks [defender] into a restraining position!"), \
+						span_userdanger("You're locked into a restraining position by [attacker]!"), span_hear("You hear shuffling and a muffled groan!"), null, attacker)
+		to_chat(attacker, span_danger("You lock [defender] into a restraining position!"))
+		defender.adjustStaminaLoss(20)
+		defender.Stun(10 SECONDS)
+		restraining_mob = defender
 		addtimer(VARSET_CALLBACK(src, restraining_mob, null), 50, TIMER_UNIQUE)
 		return TRUE
 
-/datum/martial_art/cqc/proc/Consecutive(mob/living/user, mob/living/target)
-	if(!can_use(user))
+/datum/martial_art/cqc/proc/Consecutive(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
 		return FALSE
-	if(!target.stat)
-		log_combat(user, target, "consecutive CQC'd (CQC)")
-		target.visible_message(span_danger("[user] strikes [target]'s abdomen, neck and back consecutively"), \
-						span_userdanger("Your abdomen, neck and back are struck consecutively by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
-		to_chat(user, span_danger("You strike [target]'s abdomen, neck and back consecutively!"))
-		playsound(get_turf(target), 'sound/weapons/cqchit2.ogg', 50, TRUE, -1)
-		var/obj/item/held_item = target.get_active_held_item()
-		if(held_item && target.temporarilyRemoveItemFromInventory(held_item))
-			user.put_in_hands(held_item)
-		target.adjustStaminaLoss(50)
-		target.apply_damage(25, user.get_attack_type())
+	if(!defender.stat)
+		log_combat(attacker, defender, "consecutive CQC'd (CQC)")
+		defender.visible_message(span_danger("[attacker] strikes [defender]'s abdomen, neck and back consecutively"), \
+						span_userdanger("Your abdomen, neck and back are struck consecutively by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+		to_chat(attacker, span_danger("You strike [defender]'s abdomen, neck and back consecutively!"))
+		playsound(get_turf(defender), 'sound/weapons/cqchit2.ogg', 50, TRUE, -1)
+		var/obj/item/held_item = defender.get_active_held_item()
+		if(held_item && defender.temporarilyRemoveItemFromInventory(held_item))
+			attacker.put_in_hands(held_item)
+		defender.adjustStaminaLoss(50)
+		defender.apply_damage(25, attacker.get_attack_type())
 		return TRUE
 
-/datum/martial_art/cqc/grab_act(mob/living/user, mob/living/target)
-	if(user != target && can_use(user)) // user != target prevents grabbing yourself
-		add_to_streak("G", target)
-		if(check_streak(user, target)) //if a combo is made no grab upgrade is done
+/datum/martial_art/cqc/grab_act(mob/living/attacker, mob/living/defender)
+	if(attacker != defender && can_use(attacker)) // attacker != defender prevents grabbing yourself
+		add_to_streak("G", defender)
+		if(check_streak(attacker, defender)) //if a combo is made no grab upgrade is done
 			return TRUE
-		old_grab_state = user.grab_state
-		target.grabbedby(user, 1)
+		old_grab_state = attacker.grab_state
+		defender.grabbedby(attacker, 1)
 		if(old_grab_state == GRAB_PASSIVE)
-			target.drop_all_held_items()
-			user.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab if on grab intent
-			log_combat(user, target, "grabbed", addition="aggressively")
-			target.visible_message(span_warning("[user] violently grabs [target]!"), \
-							span_userdanger("You're grabbed violently by [user]!"), span_hear("You hear sounds of aggressive fondling!"), COMBAT_MESSAGE_RANGE, user)
-			to_chat(user, span_danger("You violently grab [target]!"))
+			defender.drop_all_held_items()
+			attacker.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab if on grab intent
+			log_combat(attacker, defender, "grabbed", addition="aggressively")
+			defender.visible_message(span_warning("[attacker] violently grabs [defender]!"), \
+							span_userdanger("You're grabbed violently by [attacker]!"), span_hear("You hear sounds of aggressive fondling!"), COMBAT_MESSAGE_RANGE, attacker)
+			to_chat(attacker, span_danger("You violently grab [defender]!"))
 		return TRUE
 	else
 		return FALSE
 
-/datum/martial_art/cqc/harm_act(mob/living/user, mob/living/target)
-	if(!can_use(user))
+/datum/martial_art/cqc/harm_act(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
 		return FALSE
-	add_to_streak("H", target)
-	if(check_streak(user, target))
+	add_to_streak("H", defender)
+	if(check_streak(attacker, defender))
 		return TRUE
-	log_combat(user, target, "attacked (CQC)")
-	user.do_attack_animation(target)
+	log_combat(attacker, defender, "attacked (CQC)")
+	attacker.do_attack_animation(defender)
 	var/picked_hit_type = pick("CQC", "Big Boss")
 	var/bonus_damage = 13
-	if(target.body_position == LYING_DOWN)
+	if(defender.body_position == LYING_DOWN)
 		bonus_damage += 5
 		picked_hit_type = "stomp"
-	target.apply_damage(bonus_damage, BRUTE)
+	defender.apply_damage(bonus_damage, BRUTE)
 	if(picked_hit_type == "kick" || picked_hit_type == "stomp")
-		playsound(get_turf(target), 'sound/weapons/cqchit2.ogg', 50, TRUE, -1)
+		playsound(get_turf(defender), 'sound/weapons/cqchit2.ogg', 50, TRUE, -1)
 	else
-		playsound(get_turf(target), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
-	target.visible_message(span_danger("[user] [picked_hit_type]ed [target]!"), \
-					span_userdanger("You're [picked_hit_type]ed by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
-	to_chat(user, span_danger("You [picked_hit_type] [target]!"))
-	log_combat(user, target, "[picked_hit_type]s (CQC)")
-	if(user.resting && !target.stat && !target.IsParalyzed())
-		target.visible_message(span_danger("[user] leg sweeps [target]!"), \
-						span_userdanger("Your legs are sweeped by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, user)
-		to_chat(user, span_danger("You leg sweep [target]!"))
-		playsound(get_turf(user), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-		target.apply_damage(10, BRUTE)
-		target.Paralyze(6 SECONDS)
-		log_combat(user, target, "sweeped (CQC)")
+		playsound(get_turf(defender), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
+	defender.visible_message(span_danger("[attacker] [picked_hit_type]ed [defender]!"), \
+					span_userdanger("You're [picked_hit_type]ed by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+	to_chat(attacker, span_danger("You [picked_hit_type] [defender]!"))
+	log_combat(attacker, defender, "[picked_hit_type]s (CQC)")
+	if(attacker.resting && !defender.stat && !defender.IsParalyzed())
+		defender.visible_message(span_danger("[attacker] leg sweeps [defender]!"), \
+						span_userdanger("Your legs are sweeped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+		to_chat(attacker, span_danger("You leg sweep [defender]!"))
+		playsound(get_turf(attacker), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+		defender.apply_damage(10, BRUTE)
+		defender.Paralyze(6 SECONDS)
+		log_combat(attacker, defender, "sweeped (CQC)")
 	return TRUE
 
-/datum/martial_art/cqc/disarm_act(mob/living/user, mob/living/target)
-	if(!can_use(user))
+/datum/martial_art/cqc/disarm_act(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
 		return FALSE
-	add_to_streak("D", target)
+	add_to_streak("D", defender)
 	var/obj/item/held_item = null
-	if(check_streak(user, target))
+	if(check_streak(attacker, defender))
 		return TRUE
-	log_combat(user, target, "disarmed (CQC)", "[held_item ? " grabbing \the [held_item]" : ""]")
-	if(restraining_mob && user.pulling == restraining_mob)
-		log_combat(user, target, "knocked out (Chokehold)(CQC)")
-		target.visible_message(span_danger("[user] puts [target] into a chokehold!"), \
-						span_userdanger("You're put into a chokehold by [user]!"), span_hear("You hear shuffling and a muffled groan!"), null, user)
-		to_chat(user, span_danger("You put [target] into a chokehold!"))
-		target.SetSleeping(40 SECONDS)
+	log_combat(attacker, defender, "disarmed (CQC)", "[held_item ? " grabbing \the [held_item]" : ""]")
+	if(restraining_mob && attacker.pulling == restraining_mob)
+		log_combat(attacker, defender, "knocked out (Chokehold)(CQC)")
+		defender.visible_message(span_danger("[attacker] puts [defender] into a chokehold!"), \
+						span_userdanger("You're put into a chokehold by [attacker]!"), span_hear("You hear shuffling and a muffled groan!"), null, attacker)
+		to_chat(attacker, span_danger("You put [defender] into a chokehold!"))
+		defender.SetSleeping(40 SECONDS)
 		restraining_mob = null
-		if(user.grab_state < GRAB_NECK && !HAS_TRAIT(user, TRAIT_PACIFISM))
-			user.setGrabState(GRAB_NECK)
+		if(attacker.grab_state < GRAB_NECK && !HAS_TRAIT(attacker, TRAIT_PACIFISM))
+			attacker.setGrabState(GRAB_NECK)
 		return TRUE
 	if(prob(65))
-		if(!target.stat || !target.IsParalyzed() || !restraining_mob)
-			held_item = target.get_active_held_item()
-			target.visible_message(span_danger("[user] strikes [target]'s jaw with their hand!"), \
-							span_userdanger("Your jaw is struck by [user], you feel disoriented!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
-			to_chat(user, span_danger("You strike [target]'s jaw, leaving [target.p_them()] disoriented!"))
-			playsound(get_turf(target), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
-			if(held_item && target.temporarilyRemoveItemFromInventory(held_item))
-				user.put_in_hands(held_item)
-			target.set_jitter_if_lower(4 SECONDS)
-			target.apply_damage(5, user.get_attack_type())
+		if(!defender.stat || !defender.IsParalyzed() || !restraining_mob)
+			held_item = defender.get_active_held_item()
+			defender.visible_message(span_danger("[attacker] strikes [defender]'s jaw with their hand!"), \
+							span_userdanger("Your jaw is struck by [attacker], you feel disoriented!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+			to_chat(attacker, span_danger("You strike [defender]'s jaw, leaving [defender.p_them()] disoriented!"))
+			playsound(get_turf(defender), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
+			if(held_item && defender.temporarilyRemoveItemFromInventory(held_item))
+				attacker.put_in_hands(held_item)
+			defender.set_jitter_if_lower(4 SECONDS)
+			defender.apply_damage(5, attacker.get_attack_type())
 	else
-		target.visible_message(span_danger("[user] fails to disarm [target]!"), \
-						span_userdanger("You're nearly disarmed by [user]!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, user)
-		to_chat(user, span_warning("You fail to disarm [target]!"))
-		playsound(target, 'sound/weapons/punchmiss.ogg', 25, TRUE, -1)
+		defender.visible_message(span_danger("[attacker] fails to disarm [defender]!"), \
+						span_userdanger("You're nearly disarmed by [attacker]!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, attacker)
+		to_chat(attacker, span_warning("You fail to disarm [defender]!"))
+		playsound(defender, 'sound/weapons/punchmiss.ogg', 25, TRUE, -1)
 	return FALSE
 
 

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -46,189 +46,189 @@
 		restraining_mob = null
 	return ..()
 
-/datum/martial_art/cqc/proc/check_streak(mob/living/A, mob/living/D)
-	if(!can_use(A))
+/datum/martial_art/cqc/proc/check_streak(mob/living/user, mob/living/target)
+	if(!can_use(user))
 		return FALSE
 	if(findtext(streak,SLAM_COMBO))
 		reset_streak()
-		return Slam(A,D)
+		return Slam(user, target)
 	if(findtext(streak,KICK_COMBO))
 		reset_streak()
-		return Kick(A,D)
+		return Kick(user, target)
 	if(findtext(streak,RESTRAIN_COMBO))
 		reset_streak()
-		return Restrain(A,D)
+		return Restrain(user, target)
 	if(findtext(streak,PRESSURE_COMBO))
 		reset_streak()
-		return Pressure(A,D)
+		return Pressure(user, target)
 	if(findtext(streak,CONSECUTIVE_COMBO))
 		reset_streak()
-		return Consecutive(A,D)
+		return Consecutive(user, target)
 	return FALSE
 
-/datum/martial_art/cqc/proc/Slam(mob/living/A, mob/living/D)
-	if(!can_use(A))
+/datum/martial_art/cqc/proc/Slam(mob/living/user, mob/living/target)
+	if(!can_use(user))
 		return FALSE
-	if(D.body_position == STANDING_UP)
-		D.visible_message(span_danger("[A] slams [D] into the ground!"), \
-						span_userdanger("You're slammed into the ground by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-		to_chat(A, span_danger("You slam [D] into the ground!"))
-		playsound(get_turf(A), 'sound/weapons/slam.ogg', 50, TRUE, -1)
-		D.apply_damage(10, BRUTE)
-		D.Paralyze(12 SECONDS)
-		log_combat(A, D, "slammed (CQC)")
+	if(target.body_position == STANDING_UP)
+		target.visible_message(span_danger("[user] slams [target] into the ground!"), \
+						span_userdanger("You're slammed into the ground by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, user)
+		to_chat(user, span_danger("You slam [target] into the ground!"))
+		playsound(get_turf(user), 'sound/weapons/slam.ogg', 50, TRUE, -1)
+		target.apply_damage(10, BRUTE)
+		target.Paralyze(12 SECONDS)
+		log_combat(user, target, "slammed (CQC)")
 		return TRUE
 
-/datum/martial_art/cqc/proc/Kick(mob/living/A, mob/living/D)
-	if(!can_use(A))
+/datum/martial_art/cqc/proc/Kick(mob/living/user, mob/living/target)
+	if(!can_use(user))
 		return FALSE
-	if(!D.stat || !D.IsParalyzed())
-		D.visible_message(span_danger("[A] kicks [D] back!"), \
-						span_userdanger("You're kicked back by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-		to_chat(A, span_danger("You kick [D] back!"))
-		playsound(get_turf(A), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
-		var/atom/throw_target = get_edge_target_turf(D, A.dir)
-		D.throw_at(throw_target, 1, 14, A)
-		D.apply_damage(10, A.get_attack_type())
-		log_combat(A, D, "kicked (CQC)")
+	if(!target.stat || !target.IsParalyzed())
+		target.visible_message(span_danger("[user] kicks [target] back!"), \
+						span_userdanger("You're kicked back by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
+		to_chat(user, span_danger("You kick [target] back!"))
+		playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
+		var/atom/throw_target = get_edge_target_turf(target, user.dir)
+		target.throw_at(throw_target, 1, 14, user)
+		target.apply_damage(10, user.get_attack_type())
+		log_combat(user, target, "kicked (CQC)")
 		. = TRUE
-	if(D.IsParalyzed() && !D.stat)
-		log_combat(A, D, "knocked out (Head kick)(CQC)")
-		D.visible_message(span_danger("[A] kicks [D]'s head, knocking [D.p_them()] out!"), \
-						span_userdanger("You're knocked unconscious by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-		to_chat(A, span_danger("You kick [D]'s head, knocking [D.p_them()] out!"))
-		playsound(get_turf(A), 'sound/weapons/genhit1.ogg', 50, TRUE, -1)
-		D.SetSleeping(30 SECONDS)
-		D.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15, 150)
+	if(target.IsParalyzed() && !target.stat)
+		log_combat(user, target, "knocked out (Head kick)(CQC)")
+		target.visible_message(span_danger("[user] kicks [target]'s head, knocking [target.p_them()] out!"), \
+						span_userdanger("You're knocked unconscious by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, user)
+		to_chat(user, span_danger("You kick [target]'s head, knocking [target.p_them()] out!"))
+		playsound(get_turf(user), 'sound/weapons/genhit1.ogg', 50, TRUE, -1)
+		target.SetSleeping(30 SECONDS)
+		target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15, 150)
 		. = TRUE
 
-/datum/martial_art/cqc/proc/Pressure(mob/living/A, mob/living/D)
-	if(!can_use(A))
+/datum/martial_art/cqc/proc/Pressure(mob/living/user, mob/living/target)
+	if(!can_use(user))
 		return FALSE
-	log_combat(A, D, "pressured (CQC)")
-	D.visible_message(span_danger("[A] punches [D]'s neck!"), \
-					span_userdanger("Your neck is punched by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-	to_chat(A, span_danger("You punch [D]'s neck!"))
-	D.adjustStaminaLoss(60)
-	playsound(get_turf(A), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
+	log_combat(user, target, "pressured (CQC)")
+	target.visible_message(span_danger("[user] punches [target]'s neck!"), \
+					span_userdanger("Your neck is punched by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
+	to_chat(user, span_danger("You punch [target]'s neck!"))
+	target.adjustStaminaLoss(60)
+	playsound(get_turf(user), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
 	return TRUE
 
-/datum/martial_art/cqc/proc/Restrain(mob/living/A, mob/living/D)
+/datum/martial_art/cqc/proc/Restrain(mob/living/user, mob/living/target)
 	if(restraining_mob)
 		return
-	if(!can_use(A))
+	if(!can_use(user))
 		return FALSE
-	if(!D.stat)
-		log_combat(A, D, "restrained (CQC)")
-		D.visible_message(span_warning("[A] locks [D] into a restraining position!"), \
-						span_userdanger("You're locked into a restraining position by [A]!"), span_hear("You hear shuffling and a muffled groan!"), null, A)
-		to_chat(A, span_danger("You lock [D] into a restraining position!"))
-		D.adjustStaminaLoss(20)
-		D.Stun(10 SECONDS)
-		restraining_mob = D
+	if(!target.stat)
+		log_combat(user, target, "restrained (CQC)")
+		target.visible_message(span_warning("[user] locks [target] into a restraining position!"), \
+						span_userdanger("You're locked into a restraining position by [user]!"), span_hear("You hear shuffling and a muffled groan!"), null, user)
+		to_chat(user, span_danger("You lock [target] into a restraining position!"))
+		target.adjustStaminaLoss(20)
+		target.Stun(10 SECONDS)
+		restraining_mob = target
 		addtimer(VARSET_CALLBACK(src, restraining_mob, null), 50, TIMER_UNIQUE)
 		return TRUE
 
-/datum/martial_art/cqc/proc/Consecutive(mob/living/A, mob/living/D)
-	if(!can_use(A))
+/datum/martial_art/cqc/proc/Consecutive(mob/living/user, mob/living/target)
+	if(!can_use(user))
 		return FALSE
-	if(!D.stat)
-		log_combat(A, D, "consecutive CQC'd (CQC)")
-		D.visible_message(span_danger("[A] strikes [D]'s abdomen, neck and back consecutively"), \
-						span_userdanger("Your abdomen, neck and back are struck consecutively by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-		to_chat(A, span_danger("You strike [D]'s abdomen, neck and back consecutively!"))
-		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, TRUE, -1)
-		var/obj/item/I = D.get_active_held_item()
-		if(I && D.temporarilyRemoveItemFromInventory(I))
-			A.put_in_hands(I)
-		D.adjustStaminaLoss(50)
-		D.apply_damage(25, A.get_attack_type())
+	if(!target.stat)
+		log_combat(user, target, "consecutive CQC'd (CQC)")
+		target.visible_message(span_danger("[user] strikes [target]'s abdomen, neck and back consecutively"), \
+						span_userdanger("Your abdomen, neck and back are struck consecutively by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
+		to_chat(user, span_danger("You strike [target]'s abdomen, neck and back consecutively!"))
+		playsound(get_turf(target), 'sound/weapons/cqchit2.ogg', 50, TRUE, -1)
+		var/obj/item/held_item = target.get_active_held_item()
+		if(held_item && target.temporarilyRemoveItemFromInventory(held_item))
+			user.put_in_hands(held_item)
+		target.adjustStaminaLoss(50)
+		target.apply_damage(25, user.get_attack_type())
 		return TRUE
 
-/datum/martial_art/cqc/grab_act(mob/living/A, mob/living/D)
-	if(A != D && can_use(A)) // A != D prevents grabbing yourself
-		add_to_streak("G",D)
-		if(check_streak(A,D)) //if a combo is made no grab upgrade is done
+/datum/martial_art/cqc/grab_act(mob/living/user, mob/living/target)
+	if(user != target && can_use(user)) // user != target prevents grabbing yourself
+		add_to_streak("G", target)
+		if(check_streak(user, target)) //if a combo is made no grab upgrade is done
 			return TRUE
-		old_grab_state = A.grab_state
-		D.grabbedby(A, 1)
+		old_grab_state = user.grab_state
+		target.grabbedby(user, 1)
 		if(old_grab_state == GRAB_PASSIVE)
-			D.drop_all_held_items()
-			A.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab if on grab intent
-			log_combat(A, D, "grabbed", addition="aggressively")
-			D.visible_message(span_warning("[A] violently grabs [D]!"), \
-							span_userdanger("You're grabbed violently by [A]!"), span_hear("You hear sounds of aggressive fondling!"), COMBAT_MESSAGE_RANGE, A)
-			to_chat(A, span_danger("You violently grab [D]!"))
+			target.drop_all_held_items()
+			user.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab if on grab intent
+			log_combat(user, target, "grabbed", addition="aggressively")
+			target.visible_message(span_warning("[user] violently grabs [target]!"), \
+							span_userdanger("You're grabbed violently by [user]!"), span_hear("You hear sounds of aggressive fondling!"), COMBAT_MESSAGE_RANGE, user)
+			to_chat(user, span_danger("You violently grab [target]!"))
 		return TRUE
 	else
 		return FALSE
 
-/datum/martial_art/cqc/harm_act(mob/living/A, mob/living/D)
-	if(!can_use(A))
+/datum/martial_art/cqc/harm_act(mob/living/user, mob/living/target)
+	if(!can_use(user))
 		return FALSE
-	add_to_streak("H",D)
-	if(check_streak(A,D))
+	add_to_streak("H", target)
+	if(check_streak(user, target))
 		return TRUE
-	log_combat(A, D, "attacked (CQC)")
-	A.do_attack_animation(D)
+	log_combat(user, target, "attacked (CQC)")
+	user.do_attack_animation(target)
 	var/picked_hit_type = pick("CQC", "Big Boss")
 	var/bonus_damage = 13
-	if(D.body_position == LYING_DOWN)
+	if(target.body_position == LYING_DOWN)
 		bonus_damage += 5
 		picked_hit_type = "stomp"
-	D.apply_damage(bonus_damage, BRUTE)
+	target.apply_damage(bonus_damage, BRUTE)
 	if(picked_hit_type == "kick" || picked_hit_type == "stomp")
-		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, TRUE, -1)
+		playsound(get_turf(target), 'sound/weapons/cqchit2.ogg', 50, TRUE, -1)
 	else
-		playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
-	D.visible_message(span_danger("[A] [picked_hit_type]ed [D]!"), \
-					span_userdanger("You're [picked_hit_type]ed by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-	to_chat(A, span_danger("You [picked_hit_type] [D]!"))
-	log_combat(A, D, "[picked_hit_type]s (CQC)")
-	if(A.resting && !D.stat && !D.IsParalyzed())
-		D.visible_message(span_danger("[A] leg sweeps [D]!"), \
-						span_userdanger("Your legs are sweeped by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-		to_chat(A, span_danger("You leg sweep [D]!"))
-		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-		D.apply_damage(10, BRUTE)
-		D.Paralyze(6 SECONDS)
-		log_combat(A, D, "sweeped (CQC)")
+		playsound(get_turf(target), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
+	target.visible_message(span_danger("[user] [picked_hit_type]ed [target]!"), \
+					span_userdanger("You're [picked_hit_type]ed by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
+	to_chat(user, span_danger("You [picked_hit_type] [target]!"))
+	log_combat(user, target, "[picked_hit_type]s (CQC)")
+	if(user.resting && !target.stat && !target.IsParalyzed())
+		target.visible_message(span_danger("[user] leg sweeps [target]!"), \
+						span_userdanger("Your legs are sweeped by [user]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, user)
+		to_chat(user, span_danger("You leg sweep [target]!"))
+		playsound(get_turf(user), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+		target.apply_damage(10, BRUTE)
+		target.Paralyze(6 SECONDS)
+		log_combat(user, target, "sweeped (CQC)")
 	return TRUE
 
-/datum/martial_art/cqc/disarm_act(mob/living/A, mob/living/D)
-	if(!can_use(A))
+/datum/martial_art/cqc/disarm_act(mob/living/user, mob/living/target)
+	if(!can_use(user))
 		return FALSE
-	add_to_streak("D",D)
-	var/obj/item/I = null
-	if(check_streak(A,D))
+	add_to_streak("D", target)
+	var/obj/item/held_item = null
+	if(check_streak(user, target))
 		return TRUE
-	log_combat(A, D, "disarmed (CQC)", "[I ? " grabbing \the [I]" : ""]")
-	if(restraining_mob && A.pulling == restraining_mob)
-		log_combat(A, D, "knocked out (Chokehold)(CQC)")
-		D.visible_message(span_danger("[A] puts [D] into a chokehold!"), \
-						span_userdanger("You're put into a chokehold by [A]!"), span_hear("You hear shuffling and a muffled groan!"), null, A)
-		to_chat(A, span_danger("You put [D] into a chokehold!"))
-		D.SetSleeping(40 SECONDS)
+	log_combat(user, target, "disarmed (CQC)", "[held_item ? " grabbing \the [held_item]" : ""]")
+	if(restraining_mob && user.pulling == restraining_mob)
+		log_combat(user, target, "knocked out (Chokehold)(CQC)")
+		target.visible_message(span_danger("[user] puts [target] into a chokehold!"), \
+						span_userdanger("You're put into a chokehold by [user]!"), span_hear("You hear shuffling and a muffled groan!"), null, user)
+		to_chat(user, span_danger("You put [target] into a chokehold!"))
+		target.SetSleeping(40 SECONDS)
 		restraining_mob = null
-		if(A.grab_state < GRAB_NECK && !HAS_TRAIT(A, TRAIT_PACIFISM))
-			A.setGrabState(GRAB_NECK)
+		if(user.grab_state < GRAB_NECK && !HAS_TRAIT(user, TRAIT_PACIFISM))
+			user.setGrabState(GRAB_NECK)
 		return TRUE
 	if(prob(65))
-		if(!D.stat || !D.IsParalyzed() || !restraining_mob)
-			I = D.get_active_held_item()
-			D.visible_message(span_danger("[A] strikes [D]'s jaw with their hand!"), \
-							span_userdanger("Your jaw is struck by [A], you feel disoriented!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-			to_chat(A, span_danger("You strike [D]'s jaw, leaving [D.p_them()] disoriented!"))
-			playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
-			if(I && D.temporarilyRemoveItemFromInventory(I))
-				A.put_in_hands(I)
-			D.set_jitter_if_lower(4 SECONDS)
-			D.apply_damage(5, A.get_attack_type())
+		if(!target.stat || !target.IsParalyzed() || !restraining_mob)
+			held_item = target.get_active_held_item()
+			target.visible_message(span_danger("[user] strikes [target]'s jaw with their hand!"), \
+							span_userdanger("Your jaw is struck by [user], you feel disoriented!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, user)
+			to_chat(user, span_danger("You strike [target]'s jaw, leaving [target.p_them()] disoriented!"))
+			playsound(get_turf(target), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
+			if(held_item && target.temporarilyRemoveItemFromInventory(held_item))
+				user.put_in_hands(held_item)
+			target.set_jitter_if_lower(4 SECONDS)
+			target.apply_damage(5, user.get_attack_type())
 	else
-		D.visible_message(span_danger("[A] fails to disarm [D]!"), \
-						span_userdanger("You're nearly disarmed by [A]!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, A)
-		to_chat(A, span_warning("You fail to disarm [D]!"))
-		playsound(D, 'sound/weapons/punchmiss.ogg', 25, TRUE, -1)
+		target.visible_message(span_danger("[user] fails to disarm [target]!"), \
+						span_userdanger("You're nearly disarmed by [user]!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, user)
+		to_chat(user, span_warning("You fail to disarm [target]!"))
+		playsound(target, 'sound/weapons/punchmiss.ogg', 25, TRUE, -1)
 	return FALSE
 
 

--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -12,80 +12,80 @@
 	var/plasma_cap = 12 //max size explosion level
 	display_combos = TRUE
 
-/datum/martial_art/plasma_fist/proc/check_streak(mob/living/A, mob/living/D)
+/datum/martial_art/plasma_fist/proc/check_streak(mob/living/attacker, mob/living/defender)
 	if(findtext(streak,TORNADO_COMBO))
-		if(A == D)//helps using apotheosis
+		if(attacker == defender)//helps using apotheosis
 			return FALSE
 		reset_streak()
-		Tornado(A,D)
+		Tornado(attacker, defender)
 		return TRUE
 	if(findtext(streak,THROWBACK_COMBO))
-		if(A == D)//helps using apotheosis
+		if(attacker == defender)//helps using apotheosis
 			return FALSE
 		reset_streak()
-		Throwback(A,D)
+		Throwback(attacker, defender)
 		return TRUE
 	if(findtext(streak,PLASMA_COMBO))
 		reset_streak()
-		if(A == D && !nobomb)
-			Apotheosis(A,D)
+		if(attacker == defender && !nobomb)
+			Apotheosis(attacker, defender)
 		else
-			Plasma(A,D)
+			Plasma(attacker, defender)
 		return TRUE
 	return FALSE
 
-/datum/martial_art/plasma_fist/proc/Tornado(mob/living/A, mob/living/D)
-	A.say("TORNADO SWEEP!", forced="plasma fist")
-	dance_rotate(A, CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), A.loc, 'sound/weapons/punch1.ogg', 15, TRUE, -1))
+/datum/martial_art/plasma_fist/proc/Tornado(mob/living/attacker, mob/living/defender)
+	attacker.say("TORNADO SWEEP!", forced="plasma fist")
+	dance_rotate(attacker, CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(playsound), attacker.loc, 'sound/weapons/punch1.ogg', 15, TRUE, -1))
 
 	var/datum/action/cooldown/spell/aoe/repulse/tornado_spell = new(src)
-	tornado_spell.cast(A)
+	tornado_spell.cast(attacker)
 	qdel(tornado_spell)
 
-	log_combat(A, D, "tornado sweeped(Plasma Fist)")
+	log_combat(attacker, defender, "tornado sweeped(Plasma Fist)")
 	return
 
-/datum/martial_art/plasma_fist/proc/Throwback(mob/living/A, mob/living/D)
-	D.visible_message(span_danger("[A] hits [D] with Plasma Punch!"), \
-					span_userdanger("You're hit with a Plasma Punch by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-	to_chat(A, span_danger("You hit [D] with Plasma Punch!"))
-	playsound(D.loc, 'sound/weapons/punch1.ogg', 50, TRUE, -1)
-	var/atom/throw_target = get_edge_target_turf(D, get_dir(D, get_step_away(D, A)))
-	D.throw_at(throw_target, 200, 4,A)
-	A.say("HYAH!", forced="plasma fist")
-	log_combat(A, D, "threw back (Plasma Fist)")
+/datum/martial_art/plasma_fist/proc/Throwback(mob/living/attacker, mob/living/defender)
+	defender.visible_message(span_danger("[attacker] hits [defender] with Plasma Punch!"), \
+					span_userdanger("You're hit with a Plasma Punch by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+	to_chat(attacker, span_danger("You hit [defender] with Plasma Punch!"))
+	playsound(defender.loc, 'sound/weapons/punch1.ogg', 50, TRUE, -1)
+	var/atom/throw_target = get_edge_target_turf(defender, get_dir(defender, get_step_away(defender, attacker)))
+	defender.throw_at(throw_target, 200, 4,attacker)
+	attacker.say("HYAH!", forced="plasma fist")
+	log_combat(attacker, defender, "threw back (Plasma Fist)")
 	return
 
-/datum/martial_art/plasma_fist/proc/Plasma(mob/living/A, mob/living/D)
-	var/hasclient = D.client ? TRUE : FALSE
+/datum/martial_art/plasma_fist/proc/Plasma(mob/living/attacker, mob/living/defender)
+	var/hasclient = defender.client ? TRUE : FALSE
 
-	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-	playsound(D.loc, 'sound/weapons/punch1.ogg', 50, TRUE, -1)
-	A.say("PLASMA FIST!", forced="plasma fist")
-	D.visible_message(span_danger("[A] hits [D] with THE PLASMA FIST TECHNIQUE!"), \
-					span_userdanger("You're suddenly hit with THE PLASMA FIST TECHNIQUE by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-	to_chat(A, span_danger("You hit [D] with THE PLASMA FIST TECHNIQUE!"))
-	log_combat(A, D, "gibbed (Plasma Fist)")
-	var/turf/Dturf = get_turf(D)
-	D.investigate_log("has been gibbed by plasma fist.", INVESTIGATE_DEATHS)
-	D.gib()
+	attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
+	playsound(defender.loc, 'sound/weapons/punch1.ogg', 50, TRUE, -1)
+	attacker.say("PLASMA FIST!", forced="plasma fist")
+	defender.visible_message(span_danger("[attacker] hits [defender] with THE PLASMA FIST TECHNIQUE!"), \
+					span_userdanger("You're suddenly hit with THE PLASMA FIST TECHNIQUE by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+	to_chat(attacker, span_danger("You hit [defender] with THE PLASMA FIST TECHNIQUE!"))
+	log_combat(attacker, defender, "gibbed (Plasma Fist)")
+	var/turf/Dturf = get_turf(defender)
+	defender.investigate_log("has been gibbed by plasma fist.", INVESTIGATE_DEATHS)
+	defender.gib()
 	if(nobomb)
 		return
 	if(!hasclient)
-		to_chat(A, span_warning("Taking this plasma energy for your </span>[span_notice("Apotheosis")]<span class='warning'> would bring dishonor to the clan!"))
+		to_chat(attacker, span_warning("Taking this plasma energy for your </span>[span_notice("Apotheosis")]<span class='warning'> would bring dishonor to the clan!"))
 		new /obj/effect/temp_visual/plasma_soul(Dturf)//doesn't beam to you, so it just hangs around and poofs.
 		return
 	else if(plasma_power >= plasma_cap)
-		to_chat(A, span_warning("You cannot power up your </span>[span_notice("Apotheosis")]<span class='warning'> any more!"))
+		to_chat(attacker, span_warning("You cannot power up your </span>[span_notice("Apotheosis")]<span class='warning'> any more!"))
 		new /obj/effect/temp_visual/plasma_soul(Dturf)//doesn't beam to you, so it just hangs around and poofs.
 	else
 		plasma_power += plasma_increment
-		to_chat(A, span_nicegreen("Power increasing! Your </span>[span_notice("Apotheosis")]<span class='nicegreen'> is now at power level [plasma_power]!"))
-		new /obj/effect/temp_visual/plasma_soul(Dturf, A)
-		var/oldcolor = A.color
-		A.color = "#9C00FF"
-		flash_color(A, flash_color = "#9C00FF", flash_time = 3 SECONDS)
-		animate(A, color = oldcolor, time = 3 SECONDS)
+		to_chat(attacker, span_nicegreen("Power increasing! Your </span>[span_notice("Apotheosis")]<span class='nicegreen'> is now at power level [plasma_power]!"))
+		new /obj/effect/temp_visual/plasma_soul(Dturf, attacker)
+		var/oldcolor = attacker.color
+		attacker.color = "#9C00FF"
+		flash_color(attacker, flash_color = "#9C00FF", flash_time = 3 SECONDS)
+		animate(attacker, color = oldcolor, time = 3 SECONDS)
 
 
 /datum/martial_art/plasma_fist/proc/Apotheosis(mob/living/user, mob/living/target)
@@ -122,23 +122,23 @@
 	dying.investigate_log("has been killed by plasma fist apotheosis.", INVESTIGATE_DEATHS)
 	dying.death()
 
-/datum/martial_art/plasma_fist/harm_act(mob/living/A, mob/living/D)
-	add_to_streak("H",D)
-	if(check_streak(A,D))
+/datum/martial_art/plasma_fist/harm_act(mob/living/attacker, mob/living/defender)
+	add_to_streak("H", defender)
+	if(check_streak(attacker, defender))
 		return TRUE
 	return FALSE
 
-/datum/martial_art/plasma_fist/disarm_act(mob/living/A, mob/living/D)
-	add_to_streak("D",D)
-	if(check_streak(A,D))
+/datum/martial_art/plasma_fist/disarm_act(mob/living/attacker, mob/living/defender)
+	add_to_streak("defender", defender)
+	if(check_streak(attacker, defender))
 		return TRUE
-	if(A == D)//there is no disarming yourself, so we need to let plasma fist user know
-		to_chat(A, span_notice("You have added a disarm to your streak."))
+	if(attacker == defender)//there is no disarming yourself, so we need to let plasma fist user know
+		to_chat(attacker, span_notice("You have added a disarm to your streak."))
 	return FALSE
 
-/datum/martial_art/plasma_fist/grab_act(mob/living/A, mob/living/D)
-	add_to_streak("G",D)
-	if(check_streak(A,D))
+/datum/martial_art/plasma_fist/grab_act(mob/living/attacker, mob/living/defender)
+	add_to_streak("G", defender)
+	if(check_streak(attacker, defender))
 		return TRUE
 	return FALSE
 

--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -129,7 +129,7 @@
 	return FALSE
 
 /datum/martial_art/plasma_fist/disarm_act(mob/living/attacker, mob/living/defender)
-	add_to_streak("defender", defender)
+	add_to_streak("D", defender)
 	if(check_streak(attacker, defender))
 		return TRUE
 	if(attacker == defender)//there is no disarming yourself, so we need to let plasma fist user know

--- a/code/datums/martial/psychotic_brawl.dm
+++ b/code/datums/martial/psychotic_brawl.dm
@@ -2,73 +2,73 @@
 	name = "Psychotic Brawling"
 	id = MARTIALART_PSYCHOBRAWL
 
-/datum/martial_art/psychotic_brawling/disarm_act(mob/living/A, mob/living/D)
-	return psycho_attack(A,D)
+/datum/martial_art/psychotic_brawling/disarm_act(mob/living/attacker, mob/living/defender)
+	return psycho_attack(attacker, defender)
 
-/datum/martial_art/psychotic_brawling/grab_act(mob/living/A, mob/living/D)
-	return psycho_attack(A,D, TRUE)
+/datum/martial_art/psychotic_brawling/grab_act(mob/living/attacker, mob/living/defender)
+	return psycho_attack(attacker, defender, TRUE)
 
-/datum/martial_art/psychotic_brawling/harm_act(mob/living/A, mob/living/D)
-	return psycho_attack(A,D)
+/datum/martial_art/psychotic_brawling/harm_act(mob/living/attacker, mob/living/defender)
+	return psycho_attack(attacker, defender)
 
-/datum/martial_art/psychotic_brawling/proc/psycho_attack(mob/living/A, mob/living/D, grab_attack)
+/datum/martial_art/psychotic_brawling/proc/psycho_attack(mob/living/attacker, mob/living/defender, grab_attack)
 	var/atk_verb
 	switch(rand(1,8))
 		if(1)
-			if (iscarbon(D) && iscarbon(A))
-				var/mob/living/carbon/defender = D
-				defender.help_shake_act(A)
+			if(iscarbon(defender) && iscarbon(attacker))
+				var/mob/living/carbon/carbon_defender = defender
+				carbon_defender.help_shake_act(attacker)
 			atk_verb = "helped"
 		if(2)
-			A.emote("cry")
-			A.Stun(2 SECONDS)
+			attacker.emote("cry")
+			attacker.Stun(2 SECONDS)
 			atk_verb = "cried looking at"
 		if(3)
-			if(A.grab_state >= GRAB_AGGRESSIVE)
-				D.grabbedby(A, 1)
+			if(attacker.grab_state >= GRAB_AGGRESSIVE)
+				defender.grabbedby(attacker, 1)
 			else
-				A.start_pulling(D, supress_message = TRUE)
-				if(A.pulling)
-					D.drop_all_held_items()
-					D.stop_pulling()
+				attacker.start_pulling(defender, supress_message = TRUE)
+				if(attacker.pulling)
+					defender.drop_all_held_items()
+					defender.stop_pulling()
 					if(grab_attack)
-						log_combat(A, D, "grabbed", addition="aggressively")
-						D.visible_message(span_warning("[A] violently grabs [D]!"), \
-										span_userdanger("You're violently grabbed by [A]!"), span_hear("You hear sounds of aggressive fondling!"), null, A)
-						to_chat(A, span_danger("You violently grab [D]!"))
-						A.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab
+						log_combat(attacker, defender, "grabbed", addition="aggressively")
+						defender.visible_message(span_warning("[attacker] violently grabs [defender]!"), \
+										span_userdanger("You're violently grabbed by [attacker]!"), span_hear("You hear sounds of aggressive fondling!"), null, attacker)
+						to_chat(attacker, span_danger("You violently grab [defender]!"))
+						attacker.setGrabState(GRAB_AGGRESSIVE) //Instant aggressive grab
 					else
-						log_combat(A, D, "grabbed", addition="passively")
-						A.setGrabState(GRAB_PASSIVE)
+						log_combat(attacker, defender, "grabbed", addition="passively")
+						attacker.setGrabState(GRAB_PASSIVE)
 		if(4)
-			A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+			attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
 			atk_verb = "headbutt"
-			D.visible_message(span_danger("[A] [atk_verb]s [D]!"), \
-							span_userdanger("You're [atk_verb]ed by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-			to_chat(A, span_danger("You [atk_verb] [D]!"))
-			playsound(get_turf(D), 'sound/weapons/punch1.ogg', 40, TRUE, -1)
-			D.apply_damage(rand(5,10), A.get_attack_type(), BODY_ZONE_HEAD)
-			A.apply_damage(rand(5,10), A.get_attack_type(), BODY_ZONE_HEAD)
-			if (iscarbon(D))
-				var/mob/living/carbon/defender = D
-				if(!istype(defender.head,/obj/item/clothing/head/helmet/) && !istype(defender.head,/obj/item/clothing/head/utility/hardhat))
-					defender.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
-			A.Stun(rand(1 SECONDS, 4.5 SECONDS))
-			D.Stun(rand(0.5 SECONDS, 3 SECONDS))
+			defender.visible_message(span_danger("[attacker] [atk_verb]s [defender]!"), \
+							span_userdanger("You're [atk_verb]ed by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+			to_chat(attacker, span_danger("You [atk_verb] [defender]!"))
+			playsound(get_turf(defender), 'sound/weapons/punch1.ogg', 40, TRUE, -1)
+			defender.apply_damage(rand(5,10), attacker.get_attack_type(), BODY_ZONE_HEAD)
+			attacker.apply_damage(rand(5,10), attacker.get_attack_type(), BODY_ZONE_HEAD)
+			if(iscarbon(defender))
+				var/mob/living/carbon/carbon_defender = defender
+				if(!istype(carbon_defender.head, /obj/item/clothing/head/helmet/) && !istype(carbon_defender.head, /obj/item/clothing/head/utility/hardhat))
+					carbon_defender.adjustOrganLoss(ORGAN_SLOT_BRAIN, 5)
+			attacker.Stun(rand(1 SECONDS, 4.5 SECONDS))
+			defender.Stun(rand(0.5 SECONDS, 3 SECONDS))
 		if(5,6)
-			A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+			attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
 			atk_verb = pick("kick", "hit", "slam")
-			D.visible_message(span_danger("[A] [atk_verb]s [D] with such inhuman strength that it sends [D.p_them()] flying backwards!"), \
-							span_userdanger("You're [atk_verb]ed by [A] with such inhuman strength that it sends you flying backwards!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-			to_chat(A, span_danger("You [atk_verb] [D] with such inhuman strength that it sends [D.p_them()] flying backwards!"))
-			D.apply_damage(rand(15,30), A.get_attack_type())
-			playsound(get_turf(D), 'sound/effects/meteorimpact.ogg', 25, TRUE, -1)
-			var/throwtarget = get_edge_target_turf(A, get_dir(A, get_step_away(D, A)))
-			D.throw_at(throwtarget, 4, 2, A)//So stuff gets tossed around at the same time.
-			D.Paralyze(6 SECONDS)
+			defender.visible_message(span_danger("[attacker] [atk_verb]s [defender] with such inhuman strength that it sends [defender.p_them()] flying backwards!"), \
+							span_userdanger("You're [atk_verb]ed by [attacker] with such inhuman strength that it sends you flying backwards!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+			to_chat(attacker, span_danger("You [atk_verb] [defender] with such inhuman strength that it sends [defender.p_them()] flying backwards!"))
+			defender.apply_damage(rand(15,30), attacker.get_attack_type())
+			playsound(get_turf(defender), 'sound/effects/meteorimpact.ogg', 25, TRUE, -1)
+			var/throwtarget = get_edge_target_turf(attacker, get_dir(attacker, get_step_away(defender, attacker)))
+			defender.throw_at(throwtarget, 4, 2, attacker)//So stuff gets tossed around at the same time.
+			defender.Paralyze(6 SECONDS)
 		if(7,8)
 			return FALSE //Resume default behaviour
 
 	if(atk_verb)
-		log_combat(A, D, "[atk_verb] (Psychotic Brawling)")
+		log_combat(attacker, defender, "[atk_verb] (Psychotic Brawling)")
 	return TRUE

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -15,7 +15,7 @@
 		return
 	target.add_traits(list(TRAIT_NOGUNS, TRAIT_HARDLY_WOUNDED, TRAIT_NODISMEMBER), SLEEPING_CARP_TRAIT)
 	RegisterSignal(target, COMSIG_PARENT_ATTACKBY, PROC_REF(on_attackby))
-	target.faction |= FACTION_CARP //:D
+	target.faction |= FACTION_CARP //:defender
 
 /datum/martial_art/the_sleeping_carp/on_remove(mob/living/target)
 	target.remove_traits(list(TRAIT_NOGUNS, TRAIT_HARDLY_WOUNDED, TRAIT_NODISMEMBER), SLEEPING_CARP_TRAIT)
@@ -23,93 +23,93 @@
 	target.faction -= FACTION_CARP //:(
 	. = ..()
 
-/datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/A, mob/living/D)
+/datum/martial_art/the_sleeping_carp/proc/check_streak(mob/living/attacker, mob/living/defender)
 	if(findtext(streak,STRONG_PUNCH_COMBO))
 		reset_streak()
-		strongPunch(A,D)
+		strongPunch(attacker, defender)
 		return TRUE
 	if(findtext(streak,LAUNCH_KICK_COMBO))
 		reset_streak()
-		launchKick(A,D)
+		launchKick(attacker, defender)
 		return TRUE
 	if(findtext(streak,DROP_KICK_COMBO))
 		reset_streak()
-		dropKick(A,D)
+		dropKick(attacker, defender)
 		return TRUE
 	return FALSE
 
 ///Gnashing Teeth: Harm Harm, consistent 20 force punch on every second harm punch
-/datum/martial_art/the_sleeping_carp/proc/strongPunch(mob/living/A, mob/living/D)
+/datum/martial_art/the_sleeping_carp/proc/strongPunch(mob/living/attacker, mob/living/defender)
 	///this var is so that the strong punch is always aiming for the body part the user is targeting and not trying to apply to the chest before deviating
-	var/obj/item/bodypart/affecting = D.get_bodypart(D.get_random_valid_zone(A.zone_selected))
-	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+	var/obj/item/bodypart/affecting = defender.get_bodypart(defender.get_random_valid_zone(attacker.zone_selected))
+	attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
 	var/atk_verb = pick("precisely kick", "brutally chop", "cleanly hit", "viciously slam")
-	D.visible_message(span_danger("[A] [atk_verb]s [D]!"), \
-					span_userdanger("[A] [atk_verb]s you!"), null, null, A)
-	to_chat(A, span_danger("You [atk_verb] [D]!"))
-	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
-	log_combat(A, D, "strong punched (Sleeping Carp)")
-	D.apply_damage(20, A.get_attack_type(), affecting)
+	defender.visible_message(span_danger("[attacker] [atk_verb]s [defender]!"), \
+					span_userdanger("[attacker] [atk_verb]s you!"), null, null, attacker)
+	to_chat(attacker, span_danger("You [atk_verb] [defender]!"))
+	playsound(get_turf(defender), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
+	log_combat(attacker, defender, "strong punched (Sleeping Carp)")
+	defender.apply_damage(20, attacker.get_attack_type(), affecting)
 	return
 
 ///Crashing Wave Kick: Punch Shove combo, throws people seven tiles backwards
-/datum/martial_art/the_sleeping_carp/proc/launchKick(mob/living/A, mob/living/D)
-	A.do_attack_animation(D, ATTACK_EFFECT_KICK)
-	D.visible_message(span_warning("[A] kicks [D] square in the chest, sending them flying!"), \
-					span_userdanger("You are kicked square in the chest by [A], sending you flying!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-	var/atom/throw_target = get_edge_target_turf(D, A.dir)
-	D.throw_at(throw_target, 7, 4, A)
-	D.apply_damage(15, A.get_attack_type(), BODY_ZONE_CHEST, wound_bonus = CANT_WOUND)
-	log_combat(A, D, "launchkicked (Sleeping Carp)")
+/datum/martial_art/the_sleeping_carp/proc/launchKick(mob/living/attacker, mob/living/defender)
+	attacker.do_attack_animation(defender, ATTACK_EFFECT_KICK)
+	defender.visible_message(span_warning("[attacker] kicks [defender] square in the chest, sending them flying!"), \
+					span_userdanger("You are kicked square in the chest by [attacker], sending you flying!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+	playsound(get_turf(attacker), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+	var/atom/throw_target = get_edge_target_turf(defender, attacker.dir)
+	defender.throw_at(throw_target, 7, 4, attacker)
+	defender.apply_damage(15, attacker.get_attack_type(), BODY_ZONE_CHEST, wound_bonus = CANT_WOUND)
+	log_combat(attacker, defender, "launchkicked (Sleeping Carp)")
 	return
 
 ///Keelhaul: Harm Grab combo, knocks people down, deals stamina damage while they're on the floor
-/datum/martial_art/the_sleeping_carp/proc/dropKick(mob/living/A, mob/living/D)
-	A.do_attack_animation(D, ATTACK_EFFECT_KICK)
-	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-	if(D.body_position == STANDING_UP)
-		D.apply_damage(10, A.get_attack_type(), BODY_ZONE_HEAD, wound_bonus = CANT_WOUND)
-		D.apply_damage(40, STAMINA, BODY_ZONE_HEAD)
-		D.Knockdown(4 SECONDS)
-		D.visible_message(span_warning("[A] kicks [D] in the head, sending them face first into the floor!"), \
-					span_userdanger("You are kicked in the head by [A], sending you crashing to the floor!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
+/datum/martial_art/the_sleeping_carp/proc/dropKick(mob/living/attacker, mob/living/defender)
+	attacker.do_attack_animation(defender, ATTACK_EFFECT_KICK)
+	playsound(get_turf(attacker), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+	if(defender.body_position == STANDING_UP)
+		defender.apply_damage(10, attacker.get_attack_type(), BODY_ZONE_HEAD, wound_bonus = CANT_WOUND)
+		defender.apply_damage(40, STAMINA, BODY_ZONE_HEAD)
+		defender.Knockdown(4 SECONDS)
+		defender.visible_message(span_warning("[attacker] kicks [defender] in the head, sending them face first into the floor!"), \
+					span_userdanger("You are kicked in the head by [attacker], sending you crashing to the floor!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
 	else
-		D.apply_damage(5, A.get_attack_type(), BODY_ZONE_HEAD, wound_bonus = CANT_WOUND)
-		D.apply_damage(40, STAMINA, BODY_ZONE_HEAD)
-		D.drop_all_held_items()
-		D.visible_message(span_warning("[A] kicks [D] in the head!"), \
-					span_userdanger("You are kicked in the head by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-	log_combat(A, D, "dropkicked (Sleeping Carp)")
+		defender.apply_damage(5, attacker.get_attack_type(), BODY_ZONE_HEAD, wound_bonus = CANT_WOUND)
+		defender.apply_damage(40, STAMINA, BODY_ZONE_HEAD)
+		defender.drop_all_held_items()
+		defender.visible_message(span_warning("[attacker] kicks [defender] in the head!"), \
+					span_userdanger("You are kicked in the head by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+	log_combat(attacker, defender, "dropkicked (Sleeping Carp)")
 	return
 
-/datum/martial_art/the_sleeping_carp/grab_act(mob/living/A, mob/living/D)
-	add_to_streak("G",D)
-	if(check_streak(A,D))
+/datum/martial_art/the_sleeping_carp/grab_act(mob/living/attacker, mob/living/defender)
+	add_to_streak("G", defender)
+	if(check_streak(attacker, defender))
 		return TRUE
-	log_combat(A, D, "grabbed (Sleeping Carp)")
+	log_combat(attacker, defender, "grabbed (Sleeping Carp)")
 	return ..()
 
-/datum/martial_art/the_sleeping_carp/harm_act(mob/living/A, mob/living/D)
-	add_to_streak("H",D)
-	if(check_streak(A,D))
+/datum/martial_art/the_sleeping_carp/harm_act(mob/living/attacker, mob/living/defender)
+	add_to_streak("H", defender)
+	if(check_streak(attacker, defender))
 		return TRUE
-	var/obj/item/bodypart/affecting = D.get_bodypart(D.get_random_valid_zone(A.zone_selected))
-	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+	var/obj/item/bodypart/affecting = defender.get_bodypart(defender.get_random_valid_zone(attacker.zone_selected))
+	attacker.do_attack_animation(defender, ATTACK_EFFECT_PUNCH)
 	var/atk_verb = pick("kick", "chop", "hit", "slam")
-	D.visible_message(span_danger("[A] [atk_verb]s [D]!"), \
-					span_userdanger("[A] [atk_verb]s you!"), null, null, A)
-	to_chat(A, span_danger("You [atk_verb] [D]!"))
-	D.apply_damage(rand(10,15), BRUTE, affecting, wound_bonus = CANT_WOUND)
-	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
-	log_combat(A, D, "punched (Sleeping Carp)")
+	defender.visible_message(span_danger("[attacker] [atk_verb]s [defender]!"), \
+					span_userdanger("[attacker] [atk_verb]s you!"), null, null, attacker)
+	to_chat(attacker, span_danger("You [atk_verb] [defender]!"))
+	defender.apply_damage(rand(10,15), BRUTE, affecting, wound_bonus = CANT_WOUND)
+	playsound(get_turf(defender), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
+	log_combat(attacker, defender, "punched (Sleeping Carp)")
 	return TRUE
 
-/datum/martial_art/the_sleeping_carp/disarm_act(mob/living/A, mob/living/D)
-	add_to_streak("D",D)
-	if(check_streak(A,D))
+/datum/martial_art/the_sleeping_carp/disarm_act(mob/living/attacker, mob/living/defender)
+	add_to_streak("defender", defender)
+	if(check_streak(attacker, defender))
 		return TRUE
-	log_combat(A, D, "disarmed (Sleeping Carp)")
+	log_combat(attacker, defender, "disarmed (Sleeping Carp)")
 	return ..()
 
 /datum/martial_art/the_sleeping_carp/proc/can_deflect(mob/living/carp_user)
@@ -169,7 +169,7 @@
 
 /obj/item/staff/bostaff
 	name = "bo staff"
-	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts. Can be wielded to both kill and incapacitate."
+	desc = "attacker long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts. Can be wielded to both kill and incapacitate."
 	force = 10
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -15,7 +15,7 @@
 		return
 	target.add_traits(list(TRAIT_NOGUNS, TRAIT_HARDLY_WOUNDED, TRAIT_NODISMEMBER), SLEEPING_CARP_TRAIT)
 	RegisterSignal(target, COMSIG_PARENT_ATTACKBY, PROC_REF(on_attackby))
-	target.faction |= FACTION_CARP //:defender
+	target.faction |= FACTION_CARP //:D
 
 /datum/martial_art/the_sleeping_carp/on_remove(mob/living/target)
 	target.remove_traits(list(TRAIT_NOGUNS, TRAIT_HARDLY_WOUNDED, TRAIT_NODISMEMBER), SLEEPING_CARP_TRAIT)
@@ -106,7 +106,7 @@
 	return TRUE
 
 /datum/martial_art/the_sleeping_carp/disarm_act(mob/living/attacker, mob/living/defender)
-	add_to_streak("defender", defender)
+	add_to_streak("D", defender)
 	if(check_streak(attacker, defender))
 		return TRUE
 	log_combat(attacker, defender, "disarmed (Sleeping Carp)")
@@ -169,7 +169,7 @@
 
 /obj/item/staff/bostaff
 	name = "bo staff"
-	desc = "attacker long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts. Can be wielded to both kill and incapacitate."
+	desc = "A long, tall staff made of polished wood. Traditionally used in ancient old-Earth martial arts. Can be wielded to both kill and incapacitate."
 	force = 10
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -71,7 +71,7 @@ If you make a derivative work from this code, you must include this notification
 	owner.mind.martial_art.streak = "throw"
 
 /datum/action/kick
-	name = "Kick - attacker powerful kick, sends people flying away from you. Also useful for escaping from bad situations."
+	name = "Kick - A powerful kick, sends people flying away from you. Also useful for escaping from bad situations."
 	button_icon_state = "wrassle_kick"
 
 /datum/action/kick/Trigger(trigger_flags)
@@ -105,7 +105,7 @@ If you make a derivative work from this code, you must include this notification
 
 /datum/martial_art/wrestling/teach(mob/living/owner, make_temporary=FALSE)
 	if(..())
-		to_chat(owner, span_userdanger("SNAP INTO attacker THIN TIM!"))
+		to_chat(owner, span_userdanger("SNAP INTO A THIN TIM!"))
 		to_chat(owner, span_danger("Place your cursor over a move at the top of the screen to see what it does."))
 		drop.Grant(owner)
 		kick.Grant(owner)

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -24,27 +24,27 @@ If you make a derivative work from this code, you must include this notification
 	var/datum/action/strike/strike = new/datum/action/strike()
 	var/datum/action/drop/drop = new/datum/action/drop()
 
-/datum/martial_art/wrestling/proc/check_streak(mob/living/A, mob/living/D)
+/datum/martial_art/wrestling/proc/check_streak(mob/living/attacker, mob/living/defender)
 	switch(streak)
 		if("drop")
 			streak = ""
-			drop(A,D)
+			drop(attacker, defender)
 			return TRUE
 		if("strike")
 			streak = ""
-			strike(A,D)
+			strike(attacker, defender)
 			return TRUE
 		if("kick")
 			streak = ""
-			kick(A,D)
+			kick(attacker, defender)
 			return TRUE
 		if("throw")
 			streak = ""
-			throw_wrassle(A,D)
+			throw_wrassle(attacker, defender)
 			return TRUE
 		if("slam")
 			streak = ""
-			slam(A,D)
+			slam(attacker, defender)
 			return TRUE
 	return FALSE
 
@@ -71,7 +71,7 @@ If you make a derivative work from this code, you must include this notification
 	owner.mind.martial_art.streak = "throw"
 
 /datum/action/kick
-	name = "Kick - A powerful kick, sends people flying away from you. Also useful for escaping from bad situations."
+	name = "Kick - attacker powerful kick, sends people flying away from you. Also useful for escaping from bad situations."
 	button_icon_state = "wrassle_kick"
 
 /datum/action/kick/Trigger(trigger_flags)
@@ -105,7 +105,7 @@ If you make a derivative work from this code, you must include this notification
 
 /datum/martial_art/wrestling/teach(mob/living/owner, make_temporary=FALSE)
 	if(..())
-		to_chat(owner, span_userdanger("SNAP INTO A THIN TIM!"))
+		to_chat(owner, span_userdanger("SNAP INTO attacker THIN TIM!"))
 		to_chat(owner, span_danger("Place your cursor over a move at the top of the screen to see what it does."))
 		drop.Grant(owner)
 		kick.Grant(owner)
@@ -121,26 +121,26 @@ If you make a derivative work from this code, you must include this notification
 	throw_wrassle.Remove(owner)
 	strike.Remove(owner)
 
-/datum/martial_art/wrestling/harm_act(mob/living/A, mob/living/D)
-	if(check_streak(A,D))
+/datum/martial_art/wrestling/harm_act(mob/living/attacker, mob/living/defender)
+	if(check_streak(attacker, defender))
 		return 1
-	log_combat(A, D, "punched with wrestling")
+	log_combat(attacker, defender, "punched with wrestling")
 	..()
 
-/datum/martial_art/wrestling/proc/throw_wrassle(mob/living/A, mob/living/D)
-	if(!D)
+/datum/martial_art/wrestling/proc/throw_wrassle(mob/living/attacker, mob/living/defender)
+	if(!defender)
 		return
-	if(!A.pulling || A.pulling != D)
-		to_chat(A, span_warning("You need to have [D] in a cinch!"))
+	if(!attacker.pulling || attacker.pulling != defender)
+		to_chat(attacker, span_warning("You need to have [defender] in a cinch!"))
 		return
-	D.forceMove(A.loc)
-	D.setDir(get_dir(D, A))
+	defender.forceMove(attacker.loc)
+	defender.setDir(get_dir(defender, attacker))
 
-	D.Stun(8 SECONDS)
-	D.visible_message(span_danger("[A] starts spinning around with [D]!"), \
-					span_userdanger("You're spun around by [A]!"), span_hear("You hear aggressive shuffling!"), null, A)
-	to_chat(A, span_danger("You start spinning around with [D]!"))
-	A.emote("scream")
+	defender.Stun(8 SECONDS)
+	defender.visible_message(span_danger("[attacker] starts spinning around with [defender]!"), \
+					span_userdanger("You're spun around by [attacker]!"), span_hear("You hear aggressive shuffling!"), null, attacker)
+	to_chat(attacker, span_danger("You start spinning around with [defender]!"))
+	attacker.emote("scream")
 
 	for (var/i in 1 to 20)
 		var/delay = 5
@@ -156,135 +156,135 @@ If you make a derivative work from this code, you must include this notification
 			if (1 to 5)
 				delay = 3
 
-		if (A && D)
+		if (attacker && defender)
 
-			if (get_dist(A, D) > 1)
-				to_chat(A, span_warning("[D] is too far away!"))
+			if (get_dist(attacker, defender) > 1)
+				to_chat(attacker, span_warning("[defender] is too far away!"))
 				return
 
-			if (!isturf(A.loc) || !isturf(D.loc))
-				to_chat(A, span_warning("You can't throw [D] from here!"))
+			if (!isturf(attacker.loc) || !isturf(defender.loc))
+				to_chat(attacker, span_warning("You can't throw [defender] from here!"))
 				return
 
-			A.setDir(turn(A.dir, 90))
-			var/turf/T = get_step(A, A.dir)
-			var/turf/S = D.loc
-			var/direction = get_dir(D, A)
-			if ((S && isturf(S) && S.Exit(D, direction)) && (T && isturf(T) && T.Enter(A)))
-				D.forceMove(T)
-				D.setDir(direction)
+			attacker.setDir(turn(attacker.dir, 90))
+			var/turf/T = get_step(attacker, attacker.dir)
+			var/turf/S = defender.loc
+			var/direction = get_dir(defender, attacker)
+			if ((S && isturf(S) && S.Exit(defender, direction)) && (T && isturf(T) && T.Enter(attacker)))
+				defender.forceMove(T)
+				defender.setDir(direction)
 		else
 			return
 
 		sleep(delay)
 
-	if (A && D)
+	if (attacker && defender)
 		// These are necessary because of the sleep call.
 
-		if (get_dist(A, D) > 1)
-			to_chat(A, span_warning("[D] is too far away!"))
+		if (get_dist(attacker, defender) > 1)
+			to_chat(attacker, span_warning("[defender] is too far away!"))
 			return
 
-		if (!isturf(A.loc) || !isturf(D.loc))
-			to_chat(A, span_warning("You can't throw [D] from here!"))
+		if (!isturf(attacker.loc) || !isturf(defender.loc))
+			to_chat(attacker, span_warning("You can't throw [defender] from here!"))
 			return
 
-		D.forceMove(A.loc) // Maybe this will help with the wallthrowing bug.
+		defender.forceMove(attacker.loc) // Maybe this will help with the wallthrowing bug.
 
-		D.visible_message(span_danger("[A] throws [D]!"), \
-						span_userdanger("You're thrown by [A]!"), span_hear("You hear aggressive shuffling and a loud thud!"), null, A)
-		to_chat(A, span_danger("You throw [D]!"))
-		playsound(A.loc, SFX_SWING_HIT, 50, TRUE)
-		var/turf/T = get_edge_target_turf(A, A.dir)
+		defender.visible_message(span_danger("[attacker] throws [defender]!"), \
+						span_userdanger("You're thrown by [attacker]!"), span_hear("You hear aggressive shuffling and a loud thud!"), null, attacker)
+		to_chat(attacker, span_danger("You throw [defender]!"))
+		playsound(attacker.loc, SFX_SWING_HIT, 50, TRUE)
+		var/turf/T = get_edge_target_turf(attacker, attacker.dir)
 		if (T && isturf(T))
-			if (!D.stat)
-				D.emote("scream")
-			D.throw_at(T, 10, 4, A, TRUE, TRUE, callback = CALLBACK(D, TYPE_PROC_REF(/mob/living, Paralyze), 20))
-	log_combat(A, D, "has thrown with wrestling")
+			if (!defender.stat)
+				defender.emote("scream")
+			defender.throw_at(T, 10, 4, attacker, TRUE, TRUE, callback = CALLBACK(defender, TYPE_PROC_REF(/mob/living, Paralyze), 20))
+	log_combat(attacker, defender, "has thrown with wrestling")
 	return
 
-/datum/martial_art/wrestling/proc/FlipAnimation(mob/living/D)
+/datum/martial_art/wrestling/proc/FlipAnimation(mob/living/defender)
 	set waitfor = FALSE
-	if (D)
-		animate(D, transform = matrix(180, MATRIX_ROTATE), time = 1, loop = 0)
+	if (defender)
+		animate(defender, transform = matrix(180, MATRIX_ROTATE), time = 1, loop = 0)
 	sleep(1.5 SECONDS)
-	if (D)
-		animate(D, transform = null, time = 1, loop = 0)
+	if (defender)
+		animate(defender, transform = null, time = 1, loop = 0)
 
-/datum/martial_art/wrestling/proc/slam(mob/living/A, mob/living/D)
-	if(!D)
+/datum/martial_art/wrestling/proc/slam(mob/living/attacker, mob/living/defender)
+	if(!defender)
 		return
-	if(!A.pulling || A.pulling != D)
-		to_chat(A, span_warning("You need to have [D] in a cinch!"))
+	if(!attacker.pulling || attacker.pulling != defender)
+		to_chat(attacker, span_warning("You need to have [defender] in a cinch!"))
 		return
-	D.forceMove(A.loc)
-	A.setDir(get_dir(A, D))
-	D.setDir(get_dir(D, A))
+	defender.forceMove(attacker.loc)
+	attacker.setDir(get_dir(attacker, defender))
+	defender.setDir(get_dir(defender, attacker))
 
-	D.visible_message(span_danger("[A] lifts [D] up!"), \
-					span_userdanger("You're lifted up by [A]!"), span_hear("You hear aggressive shuffling!"), null, A)
-	to_chat(A, span_danger("You lift [D] up!"))
+	defender.visible_message(span_danger("[attacker] lifts [defender] up!"), \
+					span_userdanger("You're lifted up by [attacker]!"), span_hear("You hear aggressive shuffling!"), null, attacker)
+	to_chat(attacker, span_danger("You lift [defender] up!"))
 
 	FlipAnimation()
 
 	for (var/i in 1 to 3)
-		if (A && D)
-			A.pixel_y += 3
-			D.pixel_y += 3
-			A.setDir(turn(A.dir, 90))
-			D.setDir(turn(D.dir, 90))
+		if (attacker && defender)
+			attacker.pixel_y += 3
+			defender.pixel_y += 3
+			attacker.setDir(turn(attacker.dir, 90))
+			defender.setDir(turn(defender.dir, 90))
 
-			switch (A.dir)
+			switch (attacker.dir)
 				if (NORTH)
-					D.pixel_x = A.pixel_x
+					defender.pixel_x = attacker.pixel_x
 				if (SOUTH)
-					D.pixel_x = A.pixel_x
+					defender.pixel_x = attacker.pixel_x
 				if (EAST)
-					D.pixel_x = A.pixel_x - 8
+					defender.pixel_x = attacker.pixel_x - 8
 				if (WEST)
-					D.pixel_x = A.pixel_x + 8
+					defender.pixel_x = attacker.pixel_x + 8
 
-			if (get_dist(A, D) > 1)
-				to_chat(A, span_warning("[D] is too far away!"))
-				A.pixel_x = A.base_pixel_x
-				A.pixel_y = A.base_pixel_y
-				D.pixel_x = D.base_pixel_x
-				D.pixel_y = D.base_pixel_y
+			if (get_dist(attacker, defender) > 1)
+				to_chat(attacker, span_warning("[defender] is too far away!"))
+				attacker.pixel_x = attacker.base_pixel_x
+				attacker.pixel_y = attacker.base_pixel_y
+				defender.pixel_x = defender.base_pixel_x
+				defender.pixel_y = defender.base_pixel_y
 				return
 
-			if (!isturf(A.loc) || !isturf(D.loc))
-				to_chat(A, span_warning("You can't slam [D] here!"))
-				A.pixel_x = A.base_pixel_x
-				A.pixel_y = A.base_pixel_y
-				D.pixel_x = D.base_pixel_x
-				D.pixel_y = D.base_pixel_y
+			if (!isturf(attacker.loc) || !isturf(defender.loc))
+				to_chat(attacker, span_warning("You can't slam [defender] here!"))
+				attacker.pixel_x = attacker.base_pixel_x
+				attacker.pixel_y = attacker.base_pixel_y
+				defender.pixel_x = defender.base_pixel_x
+				defender.pixel_y = defender.base_pixel_y
 				return
 		else
-			if (A)
-				A.pixel_x = A.base_pixel_x
-				A.pixel_y = A.base_pixel_y
-			if (D)
-				D.pixel_x = D.base_pixel_x
-				D.pixel_y = D.base_pixel_y
+			if (attacker)
+				attacker.pixel_x = attacker.base_pixel_x
+				attacker.pixel_y = attacker.base_pixel_y
+			if (defender)
+				defender.pixel_x = defender.base_pixel_x
+				defender.pixel_y = defender.base_pixel_y
 			return
 
 		sleep(0.1 SECONDS)
 
-	if (A && D)
-		A.pixel_x = A.base_pixel_x
-		A.pixel_y = A.base_pixel_y
-		D.pixel_x = D.base_pixel_x
-		D.pixel_y = D.base_pixel_y
+	if (attacker && defender)
+		attacker.pixel_x = attacker.base_pixel_x
+		attacker.pixel_y = attacker.base_pixel_y
+		defender.pixel_x = defender.base_pixel_x
+		defender.pixel_y = defender.base_pixel_y
 
-		if (get_dist(A, D) > 1)
-			to_chat(A, span_warning("[D] is too far away!"))
+		if (get_dist(attacker, defender) > 1)
+			to_chat(attacker, span_warning("[defender] is too far away!"))
 			return
 
-		if (!isturf(A.loc) || !isturf(D.loc))
-			to_chat(A, span_warning("You can't slam [D] here!"))
+		if (!isturf(attacker.loc) || !isturf(defender.loc))
+			to_chat(attacker, span_warning("You can't slam [defender] here!"))
 			return
 
-		D.forceMove(A.loc)
+		defender.forceMove(attacker.loc)
 
 		var/fluff = "body-slam"
 		switch(pick(2,3))
@@ -293,90 +293,90 @@ If you make a derivative work from this code, you must include this notification
 			if (3)
 				fluff = "atomic [fluff]"
 
-		D.visible_message(span_danger("[A] [fluff] [D]!"), \
-						span_userdanger("You're [fluff]ed by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-		to_chat(A, span_danger("You [fluff] [D]!"))
-		playsound(A.loc, SFX_SWING_HIT, 50, TRUE)
-		if (!D.stat)
-			D.emote("scream")
-			D.Paralyze(4 SECONDS)
+		defender.visible_message(span_danger("[attacker] [fluff] [defender]!"), \
+						span_userdanger("You're [fluff]ed by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+		to_chat(attacker, span_danger("You [fluff] [defender]!"))
+		playsound(attacker.loc, SFX_SWING_HIT, 50, TRUE)
+		if (!defender.stat)
+			defender.emote("scream")
+			defender.Paralyze(4 SECONDS)
 
 			switch(rand(1,3))
 				if (2)
-					D.adjustBruteLoss(rand(20,30))
+					defender.adjustBruteLoss(rand(20,30))
 				if (3)
-					EX_ACT(D, EXPLODE_LIGHT)
+					EX_ACT(defender, EXPLODE_LIGHT)
 				else
-					D.adjustBruteLoss(rand(10,20))
+					defender.adjustBruteLoss(rand(10,20))
 		else
-			EX_ACT(D, EXPLODE_LIGHT)
+			EX_ACT(defender, EXPLODE_LIGHT)
 
 	else
-		if (A)
-			A.pixel_x = A.base_pixel_x
-			A.pixel_y = A.base_pixel_y
-		if (D)
-			D.pixel_x = D.base_pixel_x
-			D.pixel_y = D.base_pixel_y
+		if (attacker)
+			attacker.pixel_x = attacker.base_pixel_x
+			attacker.pixel_y = attacker.base_pixel_y
+		if (defender)
+			defender.pixel_x = defender.base_pixel_x
+			defender.pixel_y = defender.base_pixel_y
 
 
-	log_combat(A, D, "body-slammed")
+	log_combat(attacker, defender, "body-slammed")
 	return
 
-/datum/martial_art/wrestling/proc/CheckStrikeTurf(mob/living/A, turf/T)
-	if (A && (T && isturf(T) && get_dist(A, T) <= 1))
-		A.forceMove(T)
+/datum/martial_art/wrestling/proc/CheckStrikeTurf(mob/living/attacker, turf/T)
+	if (attacker && (T && isturf(T) && get_dist(attacker, T) <= 1))
+		attacker.forceMove(T)
 
-/datum/martial_art/wrestling/proc/strike(mob/living/A, mob/living/D)
-	if(!D)
+/datum/martial_art/wrestling/proc/strike(mob/living/attacker, mob/living/defender)
+	if(!defender)
 		return
-	var/turf/T = get_turf(A)
-	if (T && isturf(T) && D && isturf(D.loc))
+	var/turf/T = get_turf(attacker)
+	if (T && isturf(T) && defender && isturf(defender.loc))
 		for (var/i in 1 to 4)
-			A.setDir(turn(A.dir, 90))
+			attacker.setDir(turn(attacker.dir, 90))
 
-		A.forceMove(D.loc)
-		addtimer(CALLBACK(src, PROC_REF(CheckStrikeTurf), A, T), 4)
+		attacker.forceMove(defender.loc)
+		addtimer(CALLBACK(src, PROC_REF(CheckStrikeTurf), attacker, T), 4)
 
-		D.visible_message(span_danger("[A] headbutts [D]!"), \
-						span_userdanger("You're headbutted by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-		to_chat(A, span_danger("You headbutt [D]!"))
-		D.adjustBruteLoss(rand(10,20))
-		playsound(A.loc, SFX_SWING_HIT, 50, TRUE)
-		D.Unconscious(2 SECONDS)
-	log_combat(A, D, "headbutted")
+		defender.visible_message(span_danger("[attacker] headbutts [defender]!"), \
+						span_userdanger("You're headbutted by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+		to_chat(attacker, span_danger("You headbutt [defender]!"))
+		defender.adjustBruteLoss(rand(10,20))
+		playsound(attacker.loc, SFX_SWING_HIT, 50, TRUE)
+		defender.Unconscious(2 SECONDS)
+	log_combat(attacker, defender, "headbutted")
 
-/datum/martial_art/wrestling/proc/kick(mob/living/A, mob/living/D)
-	if(!D)
+/datum/martial_art/wrestling/proc/kick(mob/living/attacker, mob/living/defender)
+	if(!defender)
 		return
-	A.emote("scream")
-	A.emote("flip")
-	A.setDir(turn(A.dir, 90))
+	attacker.emote("scream")
+	attacker.emote("flip")
+	attacker.setDir(turn(attacker.dir, 90))
 
-	D.visible_message(span_danger("[A] roundhouse-kicks [D]!"), \
-					span_userdanger("You're roundhouse-kicked by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
-	to_chat(A, span_danger("You roundhouse-kick [D]!"))
-	playsound(A.loc, SFX_SWING_HIT, 50, TRUE)
-	D.adjustBruteLoss(rand(10,20))
+	defender.visible_message(span_danger("[attacker] roundhouse-kicks [defender]!"), \
+					span_userdanger("You're roundhouse-kicked by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
+	to_chat(attacker, span_danger("You roundhouse-kick [defender]!"))
+	playsound(attacker.loc, SFX_SWING_HIT, 50, TRUE)
+	defender.adjustBruteLoss(rand(10,20))
 
-	var/turf/T = get_edge_target_turf(A, get_dir(A, get_step_away(D, A)))
+	var/turf/T = get_edge_target_turf(attacker, get_dir(attacker, get_step_away(defender, attacker)))
 	if (T && isturf(T))
-		D.Paralyze(2 SECONDS)
-		D.throw_at(T, 3, 2)
-	log_combat(A, D, "roundhouse-kicked")
+		defender.Paralyze(2 SECONDS)
+		defender.throw_at(T, 3, 2)
+	log_combat(attacker, defender, "roundhouse-kicked")
 
-/datum/martial_art/wrestling/proc/drop(mob/living/A, mob/living/D)
-	if(!D)
+/datum/martial_art/wrestling/proc/drop(mob/living/attacker, mob/living/defender)
+	if(!defender)
 		return
 	var/obj/surface = null
 	var/turf/ST = null
 	var/falling = 0
 
-	for (var/obj/O in oview(1, A))
+	for (var/obj/O in oview(1, attacker))
 		if (O.density == 1)
-			if (O == A)
+			if (O == attacker)
 				continue
-			if (O == D)
+			if (O == defender)
 				continue
 			if (O.opacity)
 				continue
@@ -386,80 +386,80 @@ If you make a derivative work from this code, you must include this notification
 				break
 
 	if (surface && (ST && isturf(ST)))
-		A.forceMove(ST)
-		A.visible_message(span_danger("[A] climbs onto [surface]!"), \
+		attacker.forceMove(ST)
+		attacker.visible_message(span_danger("[attacker] climbs onto [surface]!"), \
 						span_danger("You climb onto [surface]!"))
-		A.pixel_y = A.base_pixel_y + 10
+		attacker.pixel_y = attacker.base_pixel_y + 10
 		falling = 1
 		sleep(1 SECONDS)
 
-	if (A && D)
+	if (attacker && defender)
 		// These are necessary because of the sleep call.
 
-		if ((falling == 0 && get_dist(A, D) > 1) || (falling == 1 && get_dist(A, D) > 2)) // We climbed onto stuff.
-			A.pixel_y = A.base_pixel_y
+		if ((falling == 0 && get_dist(attacker, defender) > 1) || (falling == 1 && get_dist(attacker, defender) > 2)) // We climbed onto stuff.
+			attacker.pixel_y = attacker.base_pixel_y
 			if (falling == 1)
-				A.visible_message(span_danger("...and dives head-first into the ground, ouch!"), \
+				attacker.visible_message(span_danger("...and dives head-first into the ground, ouch!"), \
 								span_userdanger("...and dive head-first into the ground, ouch!"))
-				A.adjustBruteLoss(rand(10,20))
-				A.Paralyze(60)
-			to_chat(A, span_warning("[D] is too far away!"))
+				attacker.adjustBruteLoss(rand(10,20))
+				attacker.Paralyze(60)
+			to_chat(attacker, span_warning("[defender] is too far away!"))
 			return
 
-		if (!isturf(A.loc) || !isturf(D.loc))
-			A.pixel_y = A.base_pixel_y
-			to_chat(A, span_warning("You can't drop onto [D] from here!"))
+		if (!isturf(attacker.loc) || !isturf(defender.loc))
+			attacker.pixel_y = attacker.base_pixel_y
+			to_chat(attacker, span_warning("You can't drop onto [defender] from here!"))
 			return
 
-		if(A)
-			animate(A, transform = matrix(90, MATRIX_ROTATE), time = 1, loop = 0)
+		if(attacker)
+			animate(attacker, transform = matrix(90, MATRIX_ROTATE), time = 1, loop = 0)
 		sleep(1 SECONDS)
-		if(A)
-			animate(A, transform = null, time = 1, loop = 0)
+		if(attacker)
+			animate(attacker, transform = null, time = 1, loop = 0)
 
-		A.forceMove(D.loc)
+		attacker.forceMove(defender.loc)
 
-		D.visible_message(span_danger("[A] leg-drops [D]!"), \
-						span_userdanger("You're leg-dropped by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-		to_chat(A, span_danger("You leg-drop [D]!"))
-		playsound(A.loc, SFX_SWING_HIT, 50, TRUE)
-		A.emote("scream")
+		defender.visible_message(span_danger("[attacker] leg-drops [defender]!"), \
+						span_userdanger("You're leg-dropped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+		to_chat(attacker, span_danger("You leg-drop [defender]!"))
+		playsound(attacker.loc, SFX_SWING_HIT, 50, TRUE)
+		attacker.emote("scream")
 
 		if (falling == 1)
-			if (prob(33) || D.stat)
-				EX_ACT(D, EXPLODE_LIGHT)
+			if (prob(33) || defender.stat)
+				EX_ACT(defender, EXPLODE_LIGHT)
 			else
-				D.adjustBruteLoss(rand(20,30))
+				defender.adjustBruteLoss(rand(20,30))
 		else
-			D.adjustBruteLoss(rand(20,30))
+			defender.adjustBruteLoss(rand(20,30))
 
-		D.Paralyze(4 SECONDS)
+		defender.Paralyze(4 SECONDS)
 
-		A.pixel_y = A.base_pixel_y
+		attacker.pixel_y = attacker.base_pixel_y
 
 	else
-		if (A)
-			A.pixel_y = A.base_pixel_y
-	log_combat(A, D, "leg-dropped")
+		if (attacker)
+			attacker.pixel_y = attacker.base_pixel_y
+	log_combat(attacker, defender, "leg-dropped")
 	return
 
-/datum/martial_art/wrestling/disarm_act(mob/living/A, mob/living/D)
-	if(check_streak(A,D))
+/datum/martial_art/wrestling/disarm_act(mob/living/attacker, mob/living/defender)
+	if(check_streak(attacker, defender))
 		return 1
-	log_combat(A, D, "wrestling-disarmed")
+	log_combat(attacker, defender, "wrestling-disarmed")
 	..()
 
-/datum/martial_art/wrestling/grab_act(mob/living/A, mob/living/D)
-	if(check_streak(A,D))
+/datum/martial_art/wrestling/grab_act(mob/living/attacker, mob/living/defender)
+	if(check_streak(attacker, defender))
 		return 1
-	if(A.pulling == D)
+	if(attacker.pulling == defender)
 		return 1
-	A.start_pulling(D)
-	D.visible_message(span_danger("[A] gets [D] in a cinch!"), \
-					span_userdanger("You're put into a cinch by [A]!"), span_hear("You hear aggressive shuffling!"), COMBAT_MESSAGE_RANGE, A)
-	to_chat(A, span_danger("You get [D] in a cinch!"))
-	D.Stun(rand(6 SECONDS, 10 SECONDS))
-	log_combat(A, D, "cinched")
+	attacker.start_pulling(defender)
+	defender.visible_message(span_danger("[attacker] gets [defender] in a cinch!"), \
+					span_userdanger("You're put into a cinch by [attacker]!"), span_hear("You hear aggressive shuffling!"), COMBAT_MESSAGE_RANGE, attacker)
+	to_chat(attacker, span_danger("You get [defender] in a cinch!"))
+	defender.Stun(rand(6 SECONDS, 10 SECONDS))
+	log_combat(attacker, defender, "cinched")
 	return 1
 
 /obj/item/storage/belt/champion/wrestling

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -310,6 +310,10 @@
 	mood_change = 2
 	timeout = 3 MINUTES
 
+/datum/mood_event/garland
+	description = "These flowers are rather soothing."
+	mood_change = 1
+
 /datum/mood_event/playing_cards/add_effects(param)
 	var/card_players = 1
 	for(var/mob/living/carbon/player in viewers(COMBAT_MESSAGE_RANGE, owner))
@@ -321,10 +325,6 @@
 
 	mood_change *= card_players
 	return ..()
-
-/datum/mood_event/garland
-	description = "These flowers are rather soothing."
-	mood_change = 1
 
 /datum/mood_event/russian_roulette_win
 	description = "I gambled my life and won! I'm lucky to be alive..."
@@ -359,13 +359,3 @@
 	mood_change = 2
 	special_screen_obj = "birthday"
 	special_screen_replace = FALSE
-
-/datum/mood_event/basketball_score
-	description = "Swish! Nothing but net."
-	mood_change = 2
-	timeout = 5 MINUTES
-	
-/datum/mood_event/basketball_dunk
-	description = "Slam dunk! Boom, shakalaka!"
-	mood_change = 2
-	timeout = 5 MINUTES

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -310,10 +310,6 @@
 	mood_change = 2
 	timeout = 3 MINUTES
 
-/datum/mood_event/garland
-	description = "These flowers are rather soothing."
-	mood_change = 1
-
 /datum/mood_event/playing_cards/add_effects(param)
 	var/card_players = 1
 	for(var/mob/living/carbon/player in viewers(COMBAT_MESSAGE_RANGE, owner))
@@ -325,6 +321,10 @@
 
 	mood_change *= card_players
 	return ..()
+
+/datum/mood_event/garland
+	description = "These flowers are rather soothing."
+	mood_change = 1
 
 /datum/mood_event/russian_roulette_win
 	description = "I gambled my life and won! I'm lucky to be alive..."
@@ -359,3 +359,14 @@
 	mood_change = 2
 	special_screen_obj = "birthday"
 	special_screen_replace = FALSE
+
+/datum/mood_event/basketball
+	description = "Ballin on the court feels natural."
+	mood_change = 2
+	timeout = 1 MINUTES
+	
+/datum/mood_event/basketball/add_effects(goal_type)
+	if(goal_type == BASKETBALL_DUNK)
+		mood_change = 3
+		description = "
+	return ..()

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -360,13 +360,12 @@
 	special_screen_obj = "birthday"
 	special_screen_replace = FALSE
 
-/datum/mood_event/basketball
-	description = "Ballin on the court feels natural."
+/datum/mood_event/basketball_score
+	description = "Swish! Nothing but net."
 	mood_change = 2
-	timeout = 1 MINUTES
+	timeout = 5 MINUTES
 	
-/datum/mood_event/basketball/add_effects(goal_type)
-	if(goal_type == BASKETBALL_DUNK)
-		mood_change = 3
-		description = "
-	return ..()
+/datum/mood_event/basketball_dunk
+	description = "Slam dunk! Boom, shakalaka!"
+	mood_change = 2
+	timeout = 5 MINUTES

--- a/code/modules/basketball/hoop.dm
+++ b/code/modules/basketball/hoop.dm
@@ -108,7 +108,6 @@
 
 	INVOKE_ASYNC(src, PROC_REF(dunk_animation), baller, dunk_pixel_y, dunk_pixel_x)
 	visible_message(span_warning("[baller] dunks [ball] into \the [src]!"))
-	baller.add_mood_event("basketball", /datum/mood_event/basketball_dunk)
 	score(ball, baller, 2)
 
 	if(istype(ball, /obj/item/toy/basketball))
@@ -173,7 +172,6 @@
 		AM.forceMove(get_turf(src))
 		// is it a 3 pointer shot
 		var/points = (distance > 2) ? 3 : 2
-		thrower.add_mood_event("basketball", /datum/mood_event/basketball_score)
 		score(AM, thrower, points)
 		visible_message(span_warning("[click_on_hoop ? "Swish!" : ""] [AM] lands in [src]."))
 	else

--- a/code/modules/basketball/hoop.dm
+++ b/code/modules/basketball/hoop.dm
@@ -108,6 +108,7 @@
 
 	INVOKE_ASYNC(src, PROC_REF(dunk_animation), baller, dunk_pixel_y, dunk_pixel_x)
 	visible_message(span_warning("[baller] dunks [ball] into \the [src]!"))
+	baller.add_mood_event("basketball", /datum/mood_event/basketball_dunk)
 	score(ball, baller, 2)
 
 	if(istype(ball, /obj/item/toy/basketball))
@@ -137,7 +138,6 @@
 	playsound(src, 'sound/machines/scanbuzz.ogg', 100, FALSE)
 	baller.adjustStaminaLoss(STAMINA_COST_DUNKING_MOB)
 	baller.stop_pulling()
-
 
 /obj/structure/hoop/CtrlClick(mob/living/user)
 	if(!user.can_perform_action(src, NEED_DEXTERITY|FORBID_TELEKINESIS_REACH|NEED_HANDS))
@@ -173,6 +173,7 @@
 		AM.forceMove(get_turf(src))
 		// is it a 3 pointer shot
 		var/points = (distance > 2) ? 3 : 2
+		thrower.add_mood_event("basketball", /datum/mood_event/basketball_score)
 		score(AM, thrower, points)
 		visible_message(span_warning("[click_on_hoop ? "Swish!" : ""] [AM] lands in [src]."))
 	else

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1155,7 +1155,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 						span_userdanger("You block [user]'s grab!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, user)
 		to_chat(user, span_warning("Your grab at [target] was blocked!"))
 		return FALSE
-	if(attacker_style?.grab_act(user,target) == MARTIAL_ATTACK_SUCCESS)
+	if(attacker_style?.grab_act(user, target) == MARTIAL_ATTACK_SUCCESS)
 		return TRUE
 	else
 		target.grabbedby(user)


### PR DESCRIPTION
## About The Pull Request
Cleans up var names `A` and `D` to be `attacker` and `defender`.  The same for `I` to be `held_item`.

## Why It's Good For The Game
Less illegible code is good.

## Changelog
:cl:
code: Cleanup 1 letter var names in martial arts files
/:cl:
