### PR TITLE
IV drips' default transfer rate is no longer zero.

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -5,7 +5,7 @@
 ///What the transfer rate value is rounded to
 #define IV_TRANSFER_RATE_STEP 0.01
 ///Minimum possible IV drip transfer rate in units per second
-#define MIN_IV_TRANSFER_RATE IV_TRANSFER_RATE_STEP
+#define MIN_IV_TRANSFER_RATE 0
 ///Maximum possible IV drip transfer rate in units per second
 #define MAX_IV_TRANSFER_RATE 5
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -2,12 +2,12 @@
 #define IV_TAKING 0
 ///IV drip operation mode when it injects reagents into the object
 #define IV_INJECTING 1
-///Minimum possible IV drip transfer rate in units per second
-#define MIN_IV_TRANSFER_RATE 0
-///Maximum possible IV drip transfer rate in units per second
-#define MAX_IV_TRANSFER_RATE 5
 ///What the transfer rate value is rounded to
 #define IV_TRANSFER_RATE_STEP 0.01
+///Minimum possible IV drip transfer rate in units per second
+#define MIN_IV_TRANSFER_RATE IV_TRANSFER_RATE_STEP
+///Maximum possible IV drip transfer rate in units per second
+#define MAX_IV_TRANSFER_RATE 5
 
 ///Universal IV that can drain blood or feed reagents over a period of time from or to a replaceable container
 /obj/machinery/iv_drip
@@ -28,7 +28,7 @@
 	///Are we donating or injecting?
 	var/mode = IV_INJECTING
 	///whether we feed slower
-	var/transfer_rate = MIN_IV_TRANSFER_RATE
+	var/transfer_rate = MAX_IV_TRANSFER_RATE
 	///Internal beaker
 	var/obj/item/reagent_container
 	///Set false to block beaker use and instead use an internal reagent holder


### PR DESCRIPTION
## About The Pull Request

Set default IV transfer rate to maximum (5) instead of 0.
## Why It's Good For The Game

> Set default IV transfer rate to maximum (5) instead of 0.

When you hook someone onto an IV drip, you naturally expect that to be the end of the process - you hooked someone to a drip, and now you can go about your day. Them needing to fiddle with buttons is bad for several reasons:

- It is unintuitive.
IV drips don't look like machines. Their sprite doesn't reflect the fact that you need to fiddle with the settings before they can work the same way any other machine or computer might. And to be honest, they shouldn't.
- It is separate from how every other server currently has it.
Yes, yes, I know that argument is very flawed and full of holes. But what I'm trying to say with it is, effectively speaking, an extension of the above point. In other servers, you drag-click someone to an IV drip and there we go, it's functional. In TG, it just-so-happens to not be functional due to what is almost definitely a recent oversight, which very much can, has, and will lead to unnecessary frustration.
- There is no practical reason for it to be set at 0.
Imagine if chem dispensers started at +0 units and needed to be set to +5 to continue. Or if bottles had a transfer rate of 0u. Or if guns started with their safeties on. Even if it made sense, it would just be frustrating and needless, and wouldn't improve the game in any significant manner enough to offset frustration. We're here for fun, not perfect balance or realism/verisimilitude after all.
- It's an oversight.
It was changed in #71217. Before that, it was always set to the maximum, 5u. However, presumably due to confusion (Variables that can be adjusted ingame usually are set to zero/the minimum possible) it ended up being changed to this.

Apparently an argument can be made that this is fine because fumbling to get medical aid done is a part of the game. I disagree heavily - blood bags are already stored in the cold room, something only 2/5 of the roles in medbay even have access to, with the paramedic, virologist, chemist all being unable to reach it. This is already enough 'fumbling' that's necessary. If someone moved the blood bags outside the cold room next to the IV drips, then all the better - it's a reward for medbay being prepared.

However I wouldn't mind if someone asked me to make it so the default transfer rate is, well, something below maximum. It's common practice in a lot of parts of SS13 to have things set in an unoptimized state so players can go around improving them, such as air alarms, cryogenics, etc. Just as long as it's not literally unusable otherwise, as the 'minimum basic setup' should just be slapping on a blood bag!
## Changelog
Dunno what to put here TBH. Can't tell if it's qol, fix, balance, etc.

:cl:
qol: Set default IV transfer rate to maximum (5) instead of 0.
/:cl:
