### PR TITLE
removes fov from the SWAT mask

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -78,14 +78,12 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	visor_flags_inv = 0
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
-	has_fov = TRUE
 
 /obj/item/clothing/mask/gas/sechailer/swat/spacepol
 	name = "spacepol mask"
 	desc = "A close-fitting tactical mask created in cooperation with a certain megacorporation, comes with an especially aggressive Compli-o-nator 3000."
 	icon_state = "spacepol"
 	inhand_icon_state = "spacepol_mask"
-	tint = 1.5
 	flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 	visor_flags_cover = MASKCOVERSMOUTH | MASKCOVERSEYES | PEPPERPROOF
 


### PR DESCRIPTION
## About The Pull Request
fixes the spacepol mask having 1.5 tint (this is a remnant of the old gas mask tint that got removed, im pretty sure this doesnt function correctly? no other item has decimal tint)
the swat and subtype (spacepol) masks no longer have fov

## Why It's Good For The Game
these items are unique items that are given only to the head of security and ert/death squads (+ fugitive hunters, an antag)
while its understandable that they do have fov since they have the benefits of gas masks, as unique items meant for combat purposes given to the highest ranking combat roles i think its fair for them to not suffer from the effects of fov, especially since it makes them quite a downgrade to a normal sec hailer that any ert/sec officer gets
the pepper spray protection on this item does not seem like the biggest of deals, items like the clown or mime mask which are also kinda unique have the ability to drink/eat through the mask which is basically on the same level if not better
the alternative is that this item stays very niche as a hos item while we give erts/ds just normal hailers which aint as cool

## Changelog
:cl:
balance: removes fov from the SWAT mask
/:cl:
