### PR TITLE
Actually anti glow

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -259,7 +259,7 @@
 	locked = TRUE
 
 /datum/mutation/human/glow/anti/glow_color()
-	return COLOR_VERY_LIGHT_GRAY
+	return COLOR_BLACK
 
 /datum/mutation/human/strong
 	name = "Strength"


### PR DESCRIPTION
## About The Pull Request
Now that I've realized I can fix things that's bugging me, a personal pet peeve, anti-glow weren't actually doing as advertised, instead just making it a light grey.

This is anti-glow in it's current state
![image](https://user-images.githubusercontent.com/126404225/232171576-48584926-a47f-49c7-b0f3-449687bb1d47.png)

And this is anti-glow as it probably should be.
![image](https://user-images.githubusercontent.com/126404225/232171605-70fa6da1-841e-438f-a302-911517b95a52.png)
## Why It's Good For The Game
Anti-glow does as advertised.
## Changelog
:cl:
fix: Anti-glow actually bringing some darkness instead of just a light glow.
/:cl:
