### PR TITLE
death squad officer outfit works

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -454,23 +454,33 @@
 		/obj/item/skillchip/disk_verifier,
 	)
 
-/datum/outfit/centcom/death_commando/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/centcom/death_commando/post_equip(mob/living/carbon/human/squaddie, visualsOnly = FALSE)
 	if(visualsOnly)
 		return
 
-	var/obj/item/radio/R = H.ears
-	R.set_frequency(FREQ_CENTCOM)
-	R.freqlock = RADIO_FREQENCY_LOCKED
-	var/obj/item/card/id/W = H.wear_id
-	W.registered_name = H.real_name
-	W.update_label()
-	W.update_icon()
-	..()
+	var/obj/item/radio/radio = squaddie.ears
+	radio.set_frequency(FREQ_CENTCOM)
+	radio.freqlock = RADIO_FREQENCY_LOCKED
+	var/obj/item/card/id/id = squaddie.wear_id
+	id.registered_name = squaddie.real_name
+	id.update_label()
+	id.update_icon()
+	return ..()
 
 /datum/outfit/centcom/death_commando/officer
 	name = "Death Commando Officer"
 
-	head = /obj/item/clothing/head/helmet/space/beret
+	back = /obj/item/mod/control/pre_equipped/apocryphal/officer
+
+/datum/outfit/centcom/death_commando/officer/post_equip(mob/living/carbon/human/squaddie, visualsOnly = FALSE)
+	. = ..()
+	var/obj/item/mod/control/mod = squaddie.back
+	if(!istype(mod))
+		return
+	var/obj/item/mod/module/hat_stabilizer/hat_holder = locate() in mod.modules
+	var/obj/item/clothing/head/helmet/space/beret/beret = new(hat_holder)
+	hat_holder.attached_hat = beret
+	squaddie.update_clothing(mod.slot_flags)
 
 /datum/outfit/centcom/ert/marine
 	name = "Marine Commander"

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -421,6 +421,16 @@
 		/obj/item/mod/module/jetpack,
 	)
 
+/obj/item/mod/control/pre_equipped/apocryphal/officer
+	applied_modules = list(
+		/obj/item/mod/module/storage/bluespace,
+		/obj/item/mod/module/hat_stabilizer,
+		/obj/item/mod/module/welding,
+		/obj/item/mod/module/emp_shield/advanced,
+		/obj/item/mod/module/magnetic_harness,
+		/obj/item/mod/module/jetpack,
+	)
+
 /obj/item/mod/control/pre_equipped/corporate
 	theme = /datum/mod_theme/corporate
 	applied_core = /obj/item/mod/core/infinite

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -520,6 +520,7 @@
 			/obj/item/clothing/head/utility/chefhat,
 			/obj/item/clothing/head/costume/papersack,
 			/obj/item/clothing/head/caphat/beret,
+			/obj/item/clothing/head/helmet/space/beret,
 			))
 
 /obj/item/mod/module/hat_stabilizer/on_suit_activation()


### PR DESCRIPTION

## About The Pull Request
makes the death squad officer modsuit use the hat stabilizer module to wear the beret simultaenously with the suit

## Why It's Good For The Game
it was an outfit that spawned you in a not working suit

## Changelog
:cl:
fix: death squad officer outfit works
/:cl:
