### PR TITLE
fixes lava not cleaning up the permanently on fire trait

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -134,11 +134,11 @@
 /turf/open/lava/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(isliving(gone))
-		var/mob/living/L = gone
-		if(!islava(get_step(src, direction)))
-			REMOVE_TRAIT(L, TRAIT_PERMANENTLY_ONFIRE, TURF_TRAIT)
-		if(!L.on_fire)
-			L.update_fire()
+		var/mob/living/leaving_mob = gone
+		if(!islava(leaving_mob.loc))
+			REMOVE_TRAIT(leaving_mob, TRAIT_PERMANENTLY_ONFIRE, TURF_TRAIT)
+		if(!leaving_mob.on_fire)
+			leaving_mob.update_fire()
 
 /turf/open/lava/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	if(burn_stuff(AM))


### PR DESCRIPTION

## About The Pull Request
lava checked if the tile in a direction to lava was lava to remove the on fire trait from you
obviously this fails incredibly if you move in any way that isnt a natural step to a direction. like being put in a locker or teleported or whatever
we just do a simple loc check now!

## Why It's Good For The Game
very smart baby good

## Changelog
:cl:
fix: fixes lava not cleaning up the permanently on fire trait
/:cl:
