### PR TITLE
[no gbp] Simple animals can't catch on fire

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -28,6 +28,9 @@
 /datum/status_effect/fire_handler/on_creation(mob/living/new_owner, new_stacks, forced = FALSE)
 	. = ..()
 
+	if(isanimal(owner))
+		qdel(src)
+		return
 	if(isbasicmob(owner))
 		var/mob/living/basic/basic_owner = owner
 		if(!(basic_owner.basic_mob_flags & FLAMMABLE_MOB))


### PR DESCRIPTION
## About The Pull Request

Fixes #74633
FIxes #74739

I probably broke this when I refactored spiders and it became apparent because someone added particles to it.
Simple animals didn't really do anything as a result of being on fire except perhaps invisibly pass it on to other people, but it was wasteful to apply the status effect.

## Why It's Good For The Game

No mostly-invisible fire hazards.

## Changelog

:cl:
fix: Renault and other simple animals are now correctly fireproof.
/:cl:
