### PR TITLE
Adds a deadchat orbit popup for the Stray Cargo Pod Random Event landing location

### DIFF
--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -101,7 +101,8 @@
 		crate.locked = FALSE //Unlock secure crates
 		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
-	new /obj/effect/pod_landingzone(landing_zone, pod, crate)
+	var/obj/effect/pod_landingzone/landing_marker = new(landing_zone, pod, crate)
+	announce_to_ghosts(landing_marker)
 
 ///Handles the creation of the pod, in case it needs to be modified beforehand
 /datum/round_event/stray_cargo/proc/make_pod()
@@ -170,7 +171,7 @@
 	pack_type_override = syndicate_pack
 
 /datum/event_admin_setup/syndicate_cargo_pod/apply_to_event(datum/round_event/stray_cargo/syndicate/event)
-	event.admin_override_contents = pack_type_override	
+	event.admin_override_contents = pack_type_override
 	var/log_message = "[key_name_admin(usr)] has aimed a stray syndicate cargo pod at [event.admin_override_turf ? AREACOORD(event.admin_override_turf) : "a random location"]. The pod contents are [pack_type_override ? pack_type_override : "random"]."
 	message_admins(log_message)
 	log_admin(log_message)


### PR DESCRIPTION

## About The Pull Request

Adds an announce_to_ghosts for the landing zone indicator spawned by the cargo pod event. This means that the ghosts are alerted to where the pod lands and also get to see the effects of the impact if they choose to hop over.
## Why It's Good For The Game

Gives deadchat yet another form of idle stimulation -- something for them to congregate around and have a thoughtful discussion about.

I realize that this is the third "adds a ghost orbit popup to a random event" PR, so give me a heads up if there are any other events that would benefit from having an announce_to_ghosts and I can just add them here.
## Changelog
:cl:
qol: Ghosts are now notified and given an orbit popup for the Stray Cargo Pod random event.
/:cl:
