### PR TITLE
Removes the ability for botanists to generate kudzu on-demand

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -738,7 +738,7 @@
 /obj/machinery/hydroponics/proc/mutateweed() // If the weeds gets the mutagent instead. Mind you, this pretty much destroys the old plant
 	if( weedlevel > 5 )
 		set_seed(null)
-		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel, /obj/item/seeds/nettle/death, /obj/item/seeds/kudzu)
+		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel, /obj/item/seeds/nettle/death)
 		set_seed(new newWeed(src))
 		hardmutate()
 		age = 0


### PR DESCRIPTION
## About The Pull Request

Removes the ability for botanists to generate kudzu on-demand

## Why It's Good For The Game

Botanist players are able to reliably make an event level danger to the station via using random weed generation to forcefully create kudzu. This sucks for the game because when the kudzu gets out of control, either because the botanist rolled midround antag halfway through making it or because they suck at containing kudzu and now the round is a kudzu round, especially if it's a multi-z map where kudzu spread becomes near impossible to contain, like Ice Box or North Star.

Botanists really shouldn't be able to mass produce kudzu on demand, beneficial or not. This was fine when we had players with self control and admins who enforced that self control. Nowadays, people who are spamming kudzu for their third round in a row as a non-antag are protected by the admins who tell people who ahelp the kudzu spammer to "let them cook"

direct quote btw from an admin during a round where a person, after planting their kudzu in a high traffic area, got so upset people kept walking into their kudzu farm by accident that they just planted a new patch of kudzu and left it to grow without any maintenance

Admins are once again unwilling to moderate player behavior so we have to moderate player behavior from the codebase using the hammer instead of the chisel.

## Changelog
:cl:
del: Removes the ability for botanists to generate kudzu on-demand
/:cl: