### PR TITLE
Fixes syn-c brutus and interdyne ruins runtiming on initializing.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -10,7 +10,6 @@
 /obj/structure/door_assembly/door_assembly_hatch{
 	anchored = 1
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/barricade/security,
 /obj/structure/alien/resin/membrane,
 /turf/open/floor/pod/dark,
@@ -725,7 +724,8 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	welded = 1
+	welded = 1;
+	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/infested_frigate)
@@ -887,7 +887,6 @@
 	layer = 3.1
 	},
 /obj/item/gun/ballistic/automatic/plastikov,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/mob_spawn/corpse/human/syndicatepilot,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/infested_frigate)
@@ -1289,7 +1288,6 @@
 "vx" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/infested_frigate)
 "vz" = (
@@ -1530,9 +1528,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/infested_frigate)
 "yb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
-	dir = 5
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/north{
 	equipment = 1
@@ -1841,7 +1836,6 @@
 /obj/item/clothing/under/syndicate/combat,
 /obj/item/clothing/shoes/combat,
 /obj/item/clothing/shoes/combat,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
 "CE" = (
@@ -2168,9 +2162,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "IO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/turf_decal{
 	icon_state = "warningline_white";
 	dir = 1
@@ -2188,7 +2179,6 @@
 	pixel_x = -8
 	},
 /obj/structure/table/glass/plasmaglass,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
 "IS" = (
@@ -2236,7 +2226,6 @@
 	},
 /obj/effect/spawner/random/exotic/antag_gear,
 /obj/structure/table/glass/plasmaglass,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/spawner/random/contraband/permabrig_gear,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
@@ -2678,9 +2667,6 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/infested_frigate)
 "PD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/closet/crate/trashcart/filled,
 /obj/effect/spawner/random/exotic/technology,
 /obj/effect/spawner/random/trash,
@@ -2767,6 +2753,7 @@
 "Rw" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/infested_frigate)
 "Rx" = (
@@ -2809,7 +2796,6 @@
 "RS" = (
 /obj/structure/cable,
 /obj/structure/barricade/security,
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/alien/weeds/node{
 	maximum_growtime = 240000;
@@ -2844,9 +2830,6 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/ruin/space/has_grav/infested_frigate)
 "St" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/turf_decal{
 	icon_state = "warningline_white";
 	dir = 1
@@ -3015,7 +2998,6 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/vomit/old,
 /obj/item/broken_bottle,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/infested_frigate)
 "VV" = (
@@ -3099,7 +3081,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
 /obj/item/clothing/mask/facehugger/impregnated,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/effect/spawner/random/exotic/antag_gear,
 /turf/open/floor/plating,

--- a/_maps/RandomRuins/SpaceRuins/interdyne.dmm
+++ b/_maps/RandomRuins/SpaceRuins/interdyne.dmm
@@ -52,11 +52,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "cj" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/interdyne)
 "ck" = (
 /obj/effect/decal/cleanable/glass/plastitanium,
@@ -81,6 +80,9 @@
 "dk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "dC" = (
@@ -116,10 +118,6 @@
 /obj/structure/cable,
 /obj/effect/gibspawner/generic,
 /turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/interdyne)
-"es" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "et" = (
 /obj/effect/gibspawner/human,
@@ -194,13 +192,6 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/exotic/tool,
 /turf/open/floor/iron/smooth,
-/area/ruin/space/has_grav/interdyne)
-"gr" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "gV" = (
 /obj/structure/cable,
@@ -348,7 +339,6 @@
 "me" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ruin/space/has_grav/interdyne)
 "mf" = (
@@ -620,6 +610,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "wY" = (
@@ -697,7 +688,6 @@
 "AF" = (
 /obj/machinery/light/blacklight/directional/south,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "AN" = (
@@ -1005,10 +995,10 @@
 /area/ruin/space/has_grav/interdyne)
 "Nl" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/interdyne)
 "Nr" = (
@@ -1061,12 +1051,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/ruin/space/has_grav/interdyne)
-"Pj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/interdyne)
 "PB" = (
 /obj/structure/table/reinforced/ctf,
@@ -1145,7 +1129,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/blacklight/directional/north,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "RR" = (
@@ -1163,7 +1146,6 @@
 "Sy" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
@@ -1183,11 +1165,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/red,
-/area/ruin/space/has_grav/interdyne)
-"SL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "Te" = (
 /obj/effect/decal/cleanable/glass/plastitanium,
@@ -1324,9 +1301,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "Yo" = (
-/obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "Ys" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
@@ -1343,7 +1323,6 @@
 /obj/structure/rack,
 /obj/structure/rack,
 /obj/item/storage/medkit/regular,
-/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ruin/space/has_grav/interdyne)
 "Zi" = (
@@ -1358,6 +1337,7 @@
 /obj/structure/cable,
 /obj/machinery/light/blacklight/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 
@@ -1699,8 +1679,8 @@ dU
 dU
 dU
 Zi
-SL
-gr
+KA
+NG
 Zi
 Zi
 Zi
@@ -1735,7 +1715,7 @@ Jm
 dU
 Zi
 cF
-Nb
+US
 KA
 yN
 fS
@@ -1773,9 +1753,9 @@ fj
 Ei
 Zi
 RG
-gV
+fu
 AF
-es
+Zi
 jF
 bW
 bW
@@ -1800,7 +1780,7 @@ dU
 Vp
 EM
 YB
-Yo
+oJ
 me
 dU
 Zi
@@ -1835,7 +1815,7 @@ dU
 Fe
 wE
 XD
-EM
+wE
 wE
 li
 fu
@@ -2045,11 +2025,11 @@ oO
 jA
 jA
 dk
-bV
-QD
+jA
+jA
 Zi
 Fw
-Pj
+cj
 qa
 JM
 Zi
@@ -2079,8 +2059,8 @@ Zi
 LB
 Nb
 Sy
-cj
 oO
+Yo
 oO
 SK
 qa


### PR DESCRIPTION
## About The Pull Request
Syn-C Brutus had some non-used airlock helpers, vent-pumps, pipes and duplicate apc which were runtiming.
![image](https://user-images.githubusercontent.com/93882977/232210059-b2a8ba40-7a50-483c-90c6-1dd9e5a745c3.png)

Interdyne was runtiming because of vent-pump and pipes being at the same location. And also duplicate pipe.
Also wired SMES properly because it wasn't connected and didn't made any sense for me.
![image](https://user-images.githubusercontent.com/93882977/232210071-1da11086-37b0-4315-af34-72618333e2a0.png)
## Why It's Good For The Game
No runtimes.
## Changelog
:cl:
fix: Interdyne and Syn-C Brutus ruins no longer runtime on initializing.
fix: Interdyne's smes is now properly wired to the apc.
/:cl:
