### PR TITLE
fixes a pirate swashbuckler missing their weapon in pirate_cutter.dmm

### DIFF
--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -75,7 +75,9 @@
 /turf/open/floor/plating,
 /area/shuttle/ruin/caravan/pirate)
 "iN" = (
-/mob/living/simple_animal/hostile/pirate/melee,
+/mob/living/simple_animal/hostile/pirate/melee{
+	environment_smash = 0
+	},
 /turf/open/floor/iron,
 /area/shuttle/ruin/caravan/pirate)
 "jc" = (

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -75,9 +75,7 @@
 /turf/open/floor/plating,
 /area/shuttle/ruin/caravan/pirate)
 "iN" = (
-/mob/living/simple_animal/hostile/pirate{
-	environment_smash = 0
-	},
+/mob/living/simple_animal/hostile/pirate/melee,
 /turf/open/floor/iron,
 /area/shuttle/ruin/caravan/pirate)
 "jc" = (
@@ -620,7 +618,7 @@
 	callTime = 150;
 	dir = 2;
 	shuttle_id = "caravanpirate";
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "Pirate Cutter";
 	port_direction = 8;
 	preferred_direction = 4


### PR DESCRIPTION
## About The Pull Request
for some reason someone accidentially changed the melee pirate mob in the pirate cutter ruin into a regular one? Not sure why.
fixes #74727
## Why It's Good For The Game
Zero idea why it got changed like that. past documentation does mention a pirate that drops an energy cutlass but a quick look-up at the commit history there isn't any mentions about changes to the mobs specifically.
## Changelog
:cl:
fix: a pirate shipmate aboard the pirate cutter has found their lost energy cutlass
/:cl:
