### PR TITLE
Add additional animation buttons to VV menu

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -87,6 +87,7 @@
 
 // /atom
 #define VV_HK_MODIFY_TRANSFORM "atom_transform"
+#define VV_HK_SPIN_ANIMATION "atom_spin"
 #define VV_HK_MODIFY_GREYSCALE "modify_greyscale"
 #define VV_HK_ADD_REAGENT "addreagent"
 #define VV_HK_SHOW_HIDDENPRINTS "show_hiddenprints"

--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -88,6 +88,7 @@
 // /atom
 #define VV_HK_MODIFY_TRANSFORM "atom_transform"
 #define VV_HK_SPIN_ANIMATION "atom_spin"
+#define VV_HK_STOP_ALL_ANIMATIONS "stop_animations"
 #define VV_HK_MODIFY_GREYSCALE "modify_greyscale"
 #define VV_HK_ADD_REAGENT "addreagent"
 #define VV_HK_SHOW_HIDDENPRINTS "show_hiddenprints"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -851,9 +851,9 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if(!istype(target))
 		return
-	
+
 	target.update_held_items()
-	
+
 	SEND_SIGNAL(src, COMSIG_ATOM_UPDATE_INHAND_ICON, target)
 
 /// Handles updates to greyscale value updates.
@@ -1278,6 +1278,7 @@
 		if(curturf)
 			. += "<option value='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[curturf.x];Y=[curturf.y];Z=[curturf.z]'>Jump To</option>"
 	VV_DROPDOWN_OPTION(VV_HK_MODIFY_TRANSFORM, "Modify Transform")
+	VV_DROPDOWN_OPTION(VV_HK_SPIN_ANIMATION, "SpinAnimation")
 	VV_DROPDOWN_OPTION(VV_HK_SHOW_HIDDENPRINTS, "Show Hiddenprint log")
 	VV_DROPDOWN_OPTION(VV_HK_ADD_REAGENT, "Add Reagent")
 	VV_DROPDOWN_OPTION(VV_HK_TRIGGER_EMP, "EMP Pulse")
@@ -1391,6 +1392,19 @@
 				transform = M.Turn(angle)
 
 		SEND_SIGNAL(src, COMSIG_ATOM_VV_MODIFY_TRANSFORM)
+
+	if(href_list[VV_HK_SPIN_ANIMATION] && check_rights(R_VAREDIT))
+		var/num_spins = input(usr, "How many spins?", "Spin Animation") as null|num
+		if(!num_spins)
+			return
+		var/spin_speed = input(usr, "How fast?", "Spin Animation") as null|num
+		if(!spin_speed)
+			return
+		var/direction = input(usr, "Which direction? (-1 = counter-clockwise, 1 = clockwise)", "Spin Animation") as null|num
+		if(!direction)
+			return
+		SpinAnimation(spin_speed, num_spins, direction)
+
 
 	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_VAREDIT))
 		var/newname = input(usr, "What do you want to rename this to?", "Automatic Rename") as null|text

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1395,22 +1395,30 @@
 		SEND_SIGNAL(src, COMSIG_ATOM_VV_MODIFY_TRANSFORM)
 
 	if(href_list[VV_HK_SPIN_ANIMATION] && check_rights(R_VAREDIT))
-		var/num_spins = input(usr, "How many spins?", "Spin Animation") as null|num
+		var/num_spins = input(usr, "Do you want infinite spins?", "Spin Animation") in list("Yes", "No")
+		if(num_spins == "No")
+			num_spins = input(usr, "How many spins?", "Spin Animation") as null|num
+		else
+			num_spins = -1
 		if(!num_spins)
 			return
 		var/spin_speed = input(usr, "How fast?", "Spin Animation") as null|num
 		if(!spin_speed)
 			return
-		var/direction = input(usr, "Which direction? (-1 = counter-clockwise, 1 = clockwise)", "Spin Animation") as null|num
+		var/direction = input(usr, "Which direction?", "Spin Animation") in list("Clockwise", "Counter-clockwise")
 		if(!direction)
 			return
+		if(direction == "Clockwise")
+			direction = 1
+		else
+			direction = 0
 		SpinAnimation(spin_speed, num_spins, direction)
 
 	if(href_list[VV_HK_STOP_ALL_ANIMATIONS] && check_rights(R_VAREDIT))
 		var/result = input(usr, "Are you sure?", "Stop Animating") in list("Yes", "No")
-		if(result == "No")
-			return
-		animate(src, transform = null, flags = ANIMATION_END_NOW) // Literally just fucking stop animating entirely. This tends to make stuff look bad, but admin said do the thing
+		if(result == "Yes")
+			animate(src, transform = null, flags = ANIMATION_END_NOW) // Literally just fucking stop animating entirely because admin said so
+		return
 
 	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_VAREDIT))
 		var/newname = input(usr, "What do you want to rename this to?", "Automatic Rename") as null|text

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1279,6 +1279,7 @@
 			. += "<option value='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[curturf.x];Y=[curturf.y];Z=[curturf.z]'>Jump To</option>"
 	VV_DROPDOWN_OPTION(VV_HK_MODIFY_TRANSFORM, "Modify Transform")
 	VV_DROPDOWN_OPTION(VV_HK_SPIN_ANIMATION, "SpinAnimation")
+	VV_DROPDOWN_OPTION(VV_HK_STOP_ALL_ANIMATIONS, "Stop All Animations")
 	VV_DROPDOWN_OPTION(VV_HK_SHOW_HIDDENPRINTS, "Show Hiddenprint log")
 	VV_DROPDOWN_OPTION(VV_HK_ADD_REAGENT, "Add Reagent")
 	VV_DROPDOWN_OPTION(VV_HK_TRIGGER_EMP, "EMP Pulse")
@@ -1405,6 +1406,11 @@
 			return
 		SpinAnimation(spin_speed, num_spins, direction)
 
+	if(href_list[VV_HK_STOP_ALL_ANIMATIONS] && check_rights(R_VAREDIT))
+		var/result = input(usr, "Are you sure?", "Stop Animating") in list("Yes", "No")
+		if(result == "No")
+			return
+		animate(src, transform = null, flags = ANIMATION_END_NOW) // Literally just fucking stop animating entirely. This tends to make stuff look bad, but admin said do the thing
 
 	if(href_list[VV_HK_AUTO_RENAME] && check_rights(R_VAREDIT))
 		var/newname = input(usr, "What do you want to rename this to?", "Automatic Rename") as null|text

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1406,12 +1406,13 @@
 		if(!spin_speed)
 			return
 		var/direction = input(usr, "Which direction?", "Spin Animation") in list("Clockwise", "Counter-clockwise")
-		if(!direction)
-			return
-		if(direction == "Clockwise")
-			direction = 1
-		else
-			direction = 0
+		switch(direction)
+			if("Clockwise")
+				direction = 1
+			if("Counter-clockwise")
+				direction = 0
+			else
+				return
 		SpinAnimation(spin_speed, num_spins, direction)
 
 	if(href_list[VV_HK_STOP_ALL_ANIMATIONS] && check_rights(R_VAREDIT))


### PR DESCRIPTION

## About The Pull Request
Adds in a new option in the atom VV drop-down for SpinAnimation and to stop all currently playing animations on the atom
## Why It's Good For The Game
Haha funny for the SpinAnimation, because apparently it's used often enough to warrant a want for this? Stop Animations is most definitely needed if there's a SpinAnimation option here...
## Changelog
:cl:
admin: Added a SpinAnimation option for all atoms in the View-Variables drop-down menu
admin: Added a button to stop all animations right next to the SpinAnimation option in the View-Variables drop-down menu
/:cl:
