### PR TITLE
Martial arts can no longer be used while on the floor (except wrestling) or incapacitated

### DIFF
--- a/code/datums/martial/_martial.dm
+++ b/code/datums/martial/_martial.dm
@@ -28,7 +28,10 @@
 /datum/martial_art/proc/grab_act(mob/living/A, mob/living/D)
 	return MARTIAL_ATTACK_INVALID
 
-/datum/martial_art/proc/can_use(mob/living/L)
+/datum/martial_art/proc/can_use(mob/living/user)
+	// no using martial arts while on the floor
+	if(user.body_position == LYING_DOWN || user.incapacitated())
+		return FALSE
 	return TRUE
 
 /datum/martial_art/proc/add_to_streak(element, mob/living/D)

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -164,8 +164,22 @@
 		return FALSE
 
 /datum/martial_art/cqc/harm_act(mob/living/A, mob/living/D)
-	if(!can_use(A))
+	if(A.incapacitated())
 		return FALSE
+
+	if(A.resting && !D.stat && !D.IsParalyzed())
+		D.visible_message(span_danger("[A] leg sweeps [D]!"), \
+						span_userdanger("Your legs are sweeped by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
+		to_chat(A, span_danger("You leg sweep [D]!"))
+		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+		D.apply_damage(10, BRUTE)
+		D.Paralyze(6 SECONDS)
+		log_combat(A, D, "sweeped (CQC)")
+		return TRUE
+
+	if(A.body_position == LYING_DOWN)
+		return FALSE
+
 	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return TRUE
@@ -185,14 +199,7 @@
 					span_userdanger("You're [picked_hit_type]ed by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, A)
 	to_chat(A, span_danger("You [picked_hit_type] [D]!"))
 	log_combat(A, D, "[picked_hit_type]s (CQC)")
-	if(A.resting && !D.stat && !D.IsParalyzed())
-		D.visible_message(span_danger("[A] leg sweeps [D]!"), \
-						span_userdanger("Your legs are sweeped by [A]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, A)
-		to_chat(A, span_danger("You leg sweep [D]!"))
-		playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-		D.apply_damage(10, BRUTE)
-		D.Paralyze(6 SECONDS)
-		log_combat(A, D, "sweeped (CQC)")
+
 	return TRUE
 
 /datum/martial_art/cqc/disarm_act(mob/living/A, mob/living/D)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -117,12 +117,16 @@
 	return TRUE
 
 /datum/martial_art/krav_maga/grab_act(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
+		return FALSE
 	if(check_streak(attacker, defender))
 		return TRUE
 	log_combat(attacker, defender, "grabbed (Krav Maga)")
 	..()
 
 /datum/martial_art/krav_maga/harm_act(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
+		return FALSE
 	if(check_streak(attacker, defender))
 		return TRUE
 	log_combat(attacker, defender, "punched")
@@ -146,6 +150,8 @@
 	return TRUE
 
 /datum/martial_art/krav_maga/disarm_act(mob/living/attacker, mob/living/defender)
+	if(!can_use(attacker))
+		return FALSE
 	if(check_streak(attacker, defender))
 		return TRUE
 	var/obj/item/stuff_in_hand = null

--- a/code/datums/martial/mushpunch.dm
+++ b/code/datums/martial/mushpunch.dm
@@ -3,6 +3,8 @@
 	id = MARTIALART_MUSHPUNCH
 
 /datum/martial_art/mushpunch/harm_act(mob/living/A, mob/living/D)
+	if(!can_use(A))
+		return FALSE
 	var/atk_verb
 	to_chat(A, span_spider("You begin to wind up an attack..."))
 	if(!do_after(A, 2.5 SECONDS, target = D))

--- a/code/datums/martial/plasma_fist.dm
+++ b/code/datums/martial/plasma_fist.dm
@@ -123,12 +123,16 @@
 	dying.death()
 
 /datum/martial_art/plasma_fist/harm_act(mob/living/A, mob/living/D)
+	if(!can_use(A))
+		return FALSE
 	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return TRUE
 	return FALSE
 
 /datum/martial_art/plasma_fist/disarm_act(mob/living/A, mob/living/D)
+	if(!can_use(A))
+		return FALSE
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return TRUE
@@ -137,6 +141,8 @@
 	return FALSE
 
 /datum/martial_art/plasma_fist/grab_act(mob/living/A, mob/living/D)
+	if(!can_use(A))
+		return FALSE
 	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return TRUE

--- a/code/datums/martial/psychotic_brawl.dm
+++ b/code/datums/martial/psychotic_brawl.dm
@@ -12,6 +12,9 @@
 	return psycho_attack(A,D)
 
 /datum/martial_art/psychotic_brawling/proc/psycho_attack(mob/living/A, mob/living/D, grab_attack)
+	if(!can_use(A))
+		return FALSE
+
 	var/atk_verb
 	switch(rand(1,8))
 		if(1)

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -84,6 +84,8 @@
 	return
 
 /datum/martial_art/the_sleeping_carp/grab_act(mob/living/A, mob/living/D)
+	if(!can_use(A))
+		return FALSE
 	add_to_streak("G",D)
 	if(check_streak(A,D))
 		return TRUE
@@ -91,6 +93,8 @@
 	return ..()
 
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/A, mob/living/D)
+	if(!can_use(A))
+		return FALSE
 	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return TRUE
@@ -106,6 +110,8 @@
 	return TRUE
 
 /datum/martial_art/the_sleeping_carp/disarm_act(mob/living/A, mob/living/D)
+	if(!can_use(A))
+		return FALSE
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return TRUE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1155,7 +1155,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 						span_userdanger("You block [user]'s grab!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, user)
 		to_chat(user, span_warning("Your grab at [target] was blocked!"))
 		return FALSE
-	if(attacker_style?.grab_act(user,target) == MARTIAL_ATTACK_SUCCESS)
+	if(attacker_style?.grab_act(user, target) == MARTIAL_ATTACK_SUCCESS)
 		return TRUE
 	else
 		target.grabbedby(user)

--- a/code/modules/mob/living/init_signals.dm
+++ b/code/modules/mob/living/init_signals.dm
@@ -170,6 +170,8 @@
 	SIGNAL_HANDLER
 	add_traits(list(TRAIT_UI_BLOCKED, TRAIT_PULL_BLOCKED), TRAIT_INCAPACITATED)
 	update_appearance()
+	if(mind) // reset marital art combo streaks
+		mind.martial_art.reset_streak()
 
 /// Called when [TRAIT_INCAPACITATED] is removed from the mob.
 /mob/living/proc/on_incapacitated_trait_loss(datum/source)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1066,7 +1066,7 @@
 			resist_restraints() //trying to remove cuffs.
 
 /mob/proc/resist_grab(moving_resist)
-	return 1 //returning 0 means we successfully broke free
+	return TRUE //returning FALSE means we successfully broke free
 
 /mob/living/resist_grab(moving_resist)
 	. = TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -281,6 +281,8 @@
 		return FALSE
 	if(throwing || !(mobility_flags & MOBILITY_PULL))
 		return FALSE
+	if(resting)
+		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_LIVING_TRY_PULL, AM, force) & COMSIG_LIVING_CANCEL_PULL)
 		return FALSE
 	if(SEND_SIGNAL(AM, COMSIG_LIVING_TRYING_TO_PULL, src, force) & COMSIG_LIVING_CANCEL_PULL)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -281,8 +281,6 @@
 		return FALSE
 	if(throwing || !(mobility_flags & MOBILITY_PULL))
 		return FALSE
-	if(resting)
-		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_LIVING_TRY_PULL, AM, force) & COMSIG_LIVING_CANCEL_PULL)
 		return FALSE
 	if(SEND_SIGNAL(AM, COMSIG_LIVING_TRYING_TO_PULL, src, force) & COMSIG_LIVING_CANCEL_PULL)
@@ -2260,6 +2258,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 
 /// Proc to append behavior to the condition of being floored. Called when the condition starts.
 /mob/living/proc/on_floored_start()
+	if(mind) // reset marital art combo streaks if on floor
+		mind.martial_art.reset_streak()
+
 	if(body_position == STANDING_UP) //force them on the ground
 		set_lying_angle(pick(90, 270))
 		set_body_position(LYING_DOWN)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -170,9 +170,6 @@
 /mob/living/proc/grabbedby(mob/living/carbon/user, supress_message = FALSE)
 	if(user == src || anchored || !isturf(user.loc))
 		return FALSE
-	if(user.resting)
-		to_chat(user, span_warning("[src] can't be grabbed while you are on the floor!"))
-		return FALSE
 	if(!user.pulling || user.pulling != src)
 		user.start_pulling(src, supress_message = supress_message)
 		return

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -170,6 +170,9 @@
 /mob/living/proc/grabbedby(mob/living/carbon/user, supress_message = FALSE)
 	if(user == src || anchored || !isturf(user.loc))
 		return FALSE
+	if(user.resting)
+		to_chat(user, span_warning("[src] can't be grabbed while you are on the floor!"))
+		return FALSE
 	if(!user.pulling || user.pulling != src)
 		user.start_pulling(src, supress_message = supress_message)
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes #74829

This disables martial arts attacks (except for wrestling) while a person is on the floor or incapacitated.  It also resets any combos if the above happens.

Also as someone below pointed out, leg sweeps for CQC does a double attack nearly equivalent to an esword strike.  I went and split both of these attacks into separate triggers, one that activates while you are on the floor and the other while you are standing.  No longer both at the same time.

## Why It's Good For The Game
People were getting stunned and still able to use combos despite being knocked down.  This also would happen with grabs since a victim couldn't break out of it or move away despite stunning the person.

Let's compare the combat stats:

| *Item* | Desword | Sleeping Carp | CQC |
|--------|--------|--------|--------|
| *TC Cost* | 16 | 13 | 13 |
| *Baton Hits* | 1-hit (drops item) | 2-hits (stamcrit) | 2-hits (stamcrit) |
| *Flash* | Affected | Affected | Affected |
| *Flashbang* | Affected | Immune | Immune |
| *Pepper Spray* | Affected | Immune | Immune |
| *Slips* | Affected | Immune | Immune |
| *Knockdown Ability* | - | 2-hit | 1-hit |
| *Deflection Chance* | 75% bullet / 100% energy | 100% | - |
| *Ranged Weapons* | Allowed | Forbidden | Allowed |

This omits that it's quite easy to lose a desword during fighting.  There is also the stealth value of sneaking up on someone and legsweeping them unconscious before they can use the radio. (more lethal than a sleepy pen since it's instant)

## Changelog
:cl:
balance: Martial arts can no longer be used while on the floor (except wrestling) or incapacitated
balance: Legsweeps no longer deal the same amount of damage as eswords.
fix: Fix martial arts generating runtimes while on floor
/:cl:
