### PR TITLE
Bio hoods now only have FOV if it covers your face.

### DIFF
--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -14,7 +14,8 @@
 
 /obj/item/clothing/head/bio_hood/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
+	if(flags_inv & HIDEFACE)
+		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
 
 /datum/armor/head_bio_hood
 	bio = 100


### PR DESCRIPTION
## About The Pull Request

Bio hoods now only give you an FOV if it hides your identity. The only one that doesn't currently, is the plague doctor's hat.

The original PR that added the FOV argued that it had to be added because it was replacing gas masks as ways to hide your identity, but the plague doctor helmet doesn't, so I think it was unintentional that it was added to these as well.

## Why It's Good For The Game

The plague doctor's helmet is considered a "Bio suit" but it doesn't hide your face, so it doesn't make sense that it gives you an FOV. It moreso just makes the costume less favored by Clown/Mime players and encourages it to solely be used as "just another biosuit".

## Changelog

:cl:
fix: Plague doctor hats no longer give you an FOV.
/:cl:
