### PR TITLE
[No GBP]Fixes runtimes when deconstructing floor tiles with RTD

### DIFF
--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -328,7 +328,7 @@
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	var/delay = DECONSTRUCTION_TIME(cost)
-	var/obj/effect/constructing_effect/rcd_effect = new(floor, delay, RCD_FLOORWALL)
+	var/obj/effect/constructing_effect/rcd_effect = new(floor, delay, RCD_DECONSTRUCT)
 
 	//resource sanity check before & after delay along with beam effects
 	if(!checkResource(cost * 0.7, user)) //no ballon alert for checkResource as it already spans an alert to chat
@@ -359,7 +359,7 @@
 		qdel(decal)
 	if(floor.baseturf_at_depth(1) == /turf/baseturf_bottom) //for turfs whose base is open space we put regular plating in its place else everyone dies
 		floor.ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-	else // for every other turf we scarp away exposing base turf underneath
+	else //for every other turf we scarp away exposing base turf underneath
 		floor.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 	rcd_effect.end_animation()
 

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -359,7 +359,7 @@
 		qdel(decal)
 	if(floor.baseturf_at_depth(1) == /turf/baseturf_bottom) //for turfs whose base is open space we put regular plating in its place else everyone dies
 		floor.ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
-	else //for every other turf we scarp away exposing base turf underneath
+	else //for every other turf we scrape away exposing base turf underneath
 		floor.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 	rcd_effect.end_animation()
 


### PR DESCRIPTION
## About The Pull Request
Fixes this
![Screenshot (161)](https://user-images.githubusercontent.com/110812394/232286754-cde879e1-4593-4104-9392-2cc80b845334.png)
Caused by this
![Screenshot (162)](https://user-images.githubusercontent.com/110812394/232286901-d16b055e-32e0-4ed9-9caf-35bb229ae62e.png)

Since the RTD deconstructs i.e. QDEL the floor tile, the animation effect tried to add a timer to QDEL itself on the deleted floor tile causing the runtime.

## Changelog
:cl:
fix: RTD animation effect adding a timer on deleted floor tiles.
/:cl: