### PR TITLE
[NO GBP] Fix slapper hand icon

### DIFF
--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -1,7 +1,7 @@
 /// For all of the items that are really just the user's hand used in different ways, mostly (all, really) from emotes
 /obj/item/hand_item
 	icon = 'icons/obj/weapons/hand.dmi'
-	icon_state = "latexballon"
+	icon_state = "latexballoon"
 	force = 0
 	throwforce = 0
 	item_flags = DROPDEL | ABSTRACT | HAND_ITEM


### PR DESCRIPTION

## About The Pull Request

Fixes #74759

When I split the dmi file for the large batch of icons I misspelled balloon.  Thus hand objects had a missing icon.

## Why It's Good For The Game

You can now see slappers and other hand items.

## Changelog

:cl:
fix: Fix slapper hand icon to be spelled correctly
/:cl:

