### PR TITLE
Buffs the Bulldog

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -137,6 +137,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
+	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
 	mag_type = /obj/item/ammo_box/magazine/m12g
 	can_suppress = FALSE
@@ -157,6 +158,7 @@
 	var/secondary_magazine_type
 	///the secondary magazine
 	var/obj/item/ammo_box/magazine/secondary_magazine
+	projectile_damage_multiplier = 1.2
 
 /obj/item/gun/ballistic/shotgun/bulldog/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -137,9 +137,9 @@
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
-	w_class = WEIGHT_CLASS_NORMAL
 	weapon_weight = WEAPON_MEDIUM
 	mag_type = /obj/item/ammo_box/magazine/m12g
+	projectile_damage_multiplier = 1.2
 	can_suppress = FALSE
 	burst_size = 1
 	fire_delay = 0
@@ -158,7 +158,6 @@
 	var/secondary_magazine_type
 	///the secondary magazine
 	var/obj/item/ammo_box/magazine/secondary_magazine
-	projectile_damage_multiplier = 1.2
 
 /obj/item/gun/ballistic/shotgun/bulldog/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -137,9 +137,9 @@
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
+	projectile_damage_multiplier = 1.2
 	weapon_weight = WEAPON_MEDIUM
 	mag_type = /obj/item/ammo_box/magazine/m12g
-	projectile_damage_multiplier = 1.2
 	can_suppress = FALSE
 	burst_size = 1
 	fire_delay = 0


### PR DESCRIPTION
## About The Pull Request

Buffs the Bulldog via giving it a damage modifier of 1.2.

## Why It's Good For The Game

Assuming default ammo, the C-20r is 30 damage a shot. The M-90gl is 35 damage, and has grenades as a side dish. The Saw is 30 and is fully automatic. The Sniper is 70 alongside having incredible range, stunning, and delimbing. 

The Bulldog when loaded with buckshot does a grand total of 45 damage point blank. 

That's a pretty rough comparison, and once you take into account the other types of ammo nukie guns can use, it doesn't get much better. As is the only real usecase for the Bulldog is meteor slugs, and you're not really using those for murder anyways.


## Changelog


:cl:
balance: Bulldogs now hit 20% harder with their projectiles!
/:cl: