### PR TITLE
Only checks for greyscale json config folder

### DIFF
--- a/code/datums/greyscale/_greyscale_config.dm
+++ b/code/datums/greyscale/_greyscale_config.dm
@@ -57,7 +57,7 @@
 	if(!json_config)
 		stack_trace("Greyscale config object [DebugName()] is missing a json configuration, make sure `json_config` has been assigned a value.")
 	string_json_config = "[json_config]"
-	if(findtext(string_json_config, "/greyscale/json_configs/") != 1)
+	if(findtext(string_json_config, "greyscale/json_configs/") == 0)
 		stack_trace("All greyscale json configuration files should be located within '/greyscale/json_configs/'")
 	if(!icon_file)
 		stack_trace("Greyscale config object [DebugName()] is missing an icon file, make sure `icon_file` has been assigned a value.")

--- a/code/datums/greyscale/_greyscale_config.dm
+++ b/code/datums/greyscale/_greyscale_config.dm
@@ -57,8 +57,8 @@
 	if(!json_config)
 		stack_trace("Greyscale config object [DebugName()] is missing a json configuration, make sure `json_config` has been assigned a value.")
 	string_json_config = "[json_config]"
-	if(findtext(string_json_config, "code/datums/greyscale/json_configs/") != 1)
-		stack_trace("All greyscale json configuration files should be located within 'code/datums/greyscale/json_configs/'")
+	if(findtext(string_json_config, "/greyscale/json_configs/") != 1)
+		stack_trace("All greyscale json configuration files should be located within '/greyscale/json_configs/'")
 	if(!icon_file)
 		stack_trace("Greyscale config object [DebugName()] is missing an icon file, make sure `icon_file` has been assigned a value.")
 	string_icon_file = "[icon_file]"


### PR DESCRIPTION
## About The Pull Request

@ninjanomnom 

Currently CI is set to fail if your greyscale is outside of the 'code/datums/greyscale/json_configs' folder, however if greyscale is used more often, this folder will be filled with configs and will be confusing to navigate.

## Why It's Good For The Game

I think it would be good if we can have subdirectories of /greyscale/json_configs/ for sets of clothings (like example for jumpsuits could be ``code/modules/clothing/under/greyscale/json_configs/``) to avoid having it all stuffed in one folder.

We have a ton of greyscale, and this seems to already be getting bloated
![image](https://user-images.githubusercontent.com/53777086/232353446-ad1d6d7e-6c4a-4de1-bb2b-6f3f2ad2a96c.png)

## Changelog

Nothing player-facing.