### PR TITLE
adds new emag feature to the BSA 

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -348,7 +348,9 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 		return G.gpstag
 
 /obj/machinery/computer/bsa_control/proc/get_impact_turf()
-	if(istype(target, /area))
+	if(obj_flags & EMAGGED)
+		return get_turf(src)
+	else if(istype(target, /area))
 		return pick(get_area_turfs(target))
 	else if(istype(target, /datum/component/gps))
 		var/datum/component/gps/G = target
@@ -364,8 +366,6 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 		return
 	notice = null
 	var/turf/target_turf = get_impact_turf()
-	if(obj_flags & EMAGGED)
-		target_turf = get_turf(src)
 	cannon.fire(user, target_turf)
 
 /obj/machinery/computer/bsa_control/proc/deploy(force=FALSE)
@@ -393,4 +393,4 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
-	to_chat(user, span_warning("You emag [src], you hear the focusing crystal short out."))
+	to_chat(user, span_warning("You emag [src] and hear the focusing crystal short out."))

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -363,7 +363,10 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 		notice = "Cannon unpowered!"
 		return
 	notice = null
-	cannon.fire(user, get_impact_turf())
+	var/turf/target_turf = get_impact_turf()
+	if(obj_flags & EMAGGED)
+		target_turf = get_turf(src)
+	cannon.fire(user, target_turf)
 
 /obj/machinery/computer/bsa_control/proc/deploy(force=FALSE)
 	var/obj/machinery/bsa/full/prebuilt = locate() in range(7) //In case of adminspawn
@@ -386,3 +389,8 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	QDEL_NULL(centerpiece.back_ref)
 	qdel(centerpiece)
 	return cannon
+/obj/machinery/computer/bsa_control/emag_act(mob/user, obj/item/card/emag/emag_card)
+	if(obj_flags & EMAGGED)
+		return
+	obj_flags |= EMAGGED
+	to_chat(user, span_warning("You emag [src], you hear the focusing crystal short out."))


### PR DESCRIPTION

## About The Pull Request

Adds a feature where if you emag the BSA console the next shot will re-direct the blast target to the person who fired.

## Why It's Good For The Game

Adds a funny quirky new emag feature and adds some new options for traitors to mess with the station goals.

## Changelog
:cl:
add: emagging the BSA explodes the next person to fire it.
/:cl: