### PR TITLE
Cardbaord box alert doesn't trigger on blind mobs

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -47,11 +47,15 @@
 	if(!do_alert)
 		return ..()
 
-	// Cache the list before we open the box.
-	var/list/alerted = viewers(7, src)
+	// Get mobs in view before we open the box.
+	var/list/alerted = list()
+	for(var/mob/living/alerted_mob in viewers(7, src))
+		if(alerted_mob.stat != CONSCIOUS || alerted_mob.is_blind())
+			continue
+		alerted += alerted_mob
 
 	// There are no mobs to alert?
-	if(!(locate(/mob/living) in alerted))
+	if(!length(alerted))
 		return ..()
 
 	. = ..()
@@ -62,11 +66,10 @@
 
 	COOLDOWN_START(src, alert_cooldown, time_between_alerts)
 
-	for(var/mob/living/alerted_mob in alerted)
-		if(alerted_mob.stat == CONSCIOUS)
-			if(!alerted_mob.incapacitated(IGNORE_RESTRAINTS))
-				alerted_mob.face_atom(src)
-			alerted_mob.do_alert_animation()
+	for(var/mob/living/alerted_mob as anything in alerted)
+		if(!alerted_mob.incapacitated(IGNORE_RESTRAINTS))
+			alerted_mob.face_atom(src)
+		alerted_mob.do_alert_animation()
 
 	playsound(loc, 'sound/machines/chime.ogg', 50, FALSE, -5)
 


### PR DESCRIPTION
## About The Pull Request

Cardboard box MGS alert doesn't trigger on blind mobs. 

## Why It's Good For The Game

Just makes sense I think

## Changelog

:cl: Melbert
balance: Blind people don't get alerted when someone in a cardboard box pops out nearby
/:cl:

