### PR TITLE
Second telecomms receivers are now able to function if the first one isn't properly connected

### DIFF
--- a/code/game/machinery/telecomms/machines/receiver.dm
+++ b/code/game/machinery/telecomms/machines/receiver.dm
@@ -21,8 +21,6 @@
 	if(!is_freq_listening(signal))
 		return
 
-	signal.levels = list()
-
 	// send the signal to the hub if possible, or a bus otherwise
 	if(!relay_information(signal, /obj/machinery/telecomms/hub))
 		relay_information(signal, /obj/machinery/telecomms/bus)


### PR DESCRIPTION

## About The Pull Request

Fixes #74786
Fixes #72613

Removes one line of useless code that fucked up the zlevels list for no reason, causing subsequent receivers to not pick up the signal
## Why It's Good For The Game
A receiver that is perfectly functional no longer stops working because another one in some other place is on but not functional
- Much less confusing for people trying to set up tcomms
- You can no longer build a second receiver in maint to permanently render telecomms unfixable
## Changelog
:cl:
fix: Fixed a bug where additonal receivers wouldn't work if the first one was on but disconnected
/:cl:
im so bad at coding i took hours to figure this out and it was such a simple fix
![image](https://user-images.githubusercontent.com/47338680/232368379-2c4f601a-bc8e-4689-b539-d55c09c2e02f.png)

