### PR TITLE
Moves tracy to init before everything, alongside the profiler

### DIFF
--- a/code/__DEFINES/_profile.dm
+++ b/code/__DEFINES/_profile.dm
@@ -1,4 +1,10 @@
-#if DM_BUILD >= 1506
-// We don't actually care about storing the output here, this is just an easy way to ensure the profile runs first.
-GLOBAL_REAL_VAR(world_init_profiler) = world.Profile(PROFILE_RESTART)
+// What we're doing here is hooking our profiling tools in at the very START of init, before anything else. See code/game/world.dm for more info
+// Basically globals and statics gain their values first (based off dme order), and this stuff happens right at the start
+// We don't actually care about storing the output here, this is just an easy way to ensure the profilers hit at the start
+
+#ifdef USE_BYOND_TRACY
+#warn USE_BYOND_TRACY is enabled
+GLOBAL_REAL_VAR(tracy_profiler) = world.init_byond_tracy()
 #endif
+
+GLOBAL_REAL_VAR(world_init_profiler) = world.Profile(PROFILE_RESTART)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -34,11 +34,6 @@ GLOBAL_VAR(restart_counter)
  * All atoms in both compiled and uncompiled maps are initialized()
  */
 /world/New()
-#ifdef USE_BYOND_TRACY
-	#warn USE_BYOND_TRACY is enabled
-	init_byond_tracy()
-#endif
-
 	log_world("World loaded at [time_stamp()]!")
 
 	make_datum_references_lists() //initialises global lists for referencing frequently used datums (so that we only ever do it once)


### PR DESCRIPTION

## About The Pull Request

Tracy currently hits at world/New(), but that misses on global vars and compiled in maps loading.
It's very useful to keep track of this time, so we're gonna use the same /global trick we use for profiling to hook into tracy at the very first oppertunity

Oh also removes a redundant (we require later to build) use of DM_BUILD for the profiler call in the same file