### PR TITLE
Tackling critical failure modifiers now take into account your suit and head's melee protection, not typechecks

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -378,14 +378,10 @@
 	var/danger_zone = (speed - 1) * 13 // for every extra speed we have over 1, take away 13 of the safest chance
 	danger_zone = max(min(danger_zone, 100), 1)
 
-	if(ishuman(user))
-		var/mob/living/carbon/human/S = user
-		var/head_slot = S.get_item_by_slot(ITEM_SLOT_HEAD)
-		var/suit_slot = S.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(head_slot && (istype(head_slot,/obj/item/clothing/head/helmet) || istype(head_slot,/obj/item/clothing/head/utility/hardhat)))
-			oopsie_mod -= 6
-		if(suit_slot && (istype(suit_slot,/obj/item/clothing/suit/armor/riot)))
-			oopsie_mod -= 6
+	var/head_protection = user.getarmor(BODY_ZONE_HEAD, MELEE)
+	oopsie_mod -= head_protection * 0.5
+	var/suit_protection = user.getarmor(BODY_ZONE_CHEST, MELEE)
+	oopsie_mod -= suit_protection * 0.5
 
 	if(HAS_TRAIT(user, TRAIT_CLUMSY))
 		oopsie_mod += 6 //honk!


### PR DESCRIPTION

## About The Pull Request

Tackling critical failure modifiers now take  into account your suit and head's melee protection, not typechecks.

Total protection is the melee armor halved, as it's reasonably close to the hard hat's value original final protection value (6, now 15/2 = 7.5). Can be reduced if requested.

## Why It's Good For The Game

The purely hypothetical scenario in which someone could accidentally tackle into an airlock and become a permanent paraplegic while wearing berserker armor with the hood on is no longer possible. This proc shouldn't check for types, just melee protection in general, else from the player side of things some items just arbitrarily protect for no good reason.

## Changelog

Still not sure what this would count as. Fix?

:cl:
code: Tackling critical failure modifiers now take into account your suit and head's melee protection, not typechecks
/:cl:

