### PR TITLE
Ports cool tgui menu for reflectors from Aether.

### DIFF
--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -286,8 +286,6 @@
 // tgui menu
 
 /obj/structure/reflector/ui_interact(mob/user, datum/tgui/ui)
-	if(!user.can_perform_action(src, NEED_DEXTERITY))
-		return
 	if(!finished)
 		user.balloon_alert(user, "nothing to rotate!")
 		return

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -287,7 +287,6 @@
 
 /obj/structure/reflector/ui_interact(mob/user, datum/tgui/ui)
 	if(!user.can_perform_action(src, NEED_DEXTERITY))
-		user.balloon_alert(user, "you're too monkeyish!")
 		return
 	if(!finished)
 		user.balloon_alert(user, "nothing to rotate!")

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -283,7 +283,12 @@
 /obj/item/circuit_component/reflector/input_received(datum/port/input/port)
 	attached_reflector?.set_angle(angle.value)
 
+// tgui menu
+
 /obj/structure/reflector/ui_interact(mob/user, datum/tgui/ui)
+	if(!user.can_perform_action(src, NEED_DEXTERITY))
+		user.balloon_alert(user, "you're too monkeyish!")
+		return
 	if(!finished)
 		user.balloon_alert(user, "nothing to rotate!")
 		return

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -46,9 +46,10 @@
 		. += "It is set to [rotation_angle] degrees, and the rotation is [can_rotate ? "unlocked" : "locked"]."
 		if(!admin)
 			if(can_rotate)
-				. += span_notice("Alt-click to adjust its direction.")
+				. += span_notice("Use your <b>hand</b> to adjust its direction.")
+				. += span_notice("Use a <b>screwdriver</b> to lock the rotation.")
 			else
-				. += span_notice("Use screwdriver to unlock the rotation.")
+				. += span_notice("Use <b>screwdriver</b> to unlock the rotation.")
 
 /obj/structure/reflector/proc/set_angle(new_angle)
 	if(can_rotate)
@@ -170,13 +171,6 @@
 	set_angle(SIMPLIFY_DEGREES(new_angle))
 	return TRUE
 
-/obj/structure/reflector/AltClick(mob/user)
-	if(!user.can_perform_action(src, NEED_DEXTERITY))
-		return
-	else if(finished)
-		rotate(user)
-
-
 //TYPES OF REFLECTORS, SINGLE, DOUBLE, BOX
 
 //SINGLE
@@ -288,3 +282,42 @@
 
 /obj/item/circuit_component/reflector/input_received(datum/port/input/port)
 	attached_reflector?.set_angle(angle.value)
+
+/obj/structure/reflector/ui_interact(mob/user, datum/tgui/ui)
+	if(!finished)
+		user.balloon_alert(user, "nothing to rotate!")
+		return
+	if(!can_rotate)
+		user.balloon_alert(user, "can't rotate!")
+		return
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "Reflector")
+		ui.open()
+
+/obj/structure/reflector/ui_data(mob/user)
+	var/list/data = list()
+	data["rotation_angle"] = rotation_angle
+	data["reflector_name"] = name
+
+	return data
+
+/obj/structure/reflector/ui_act(action, params)
+	. = ..()
+	if(.)
+		return
+	switch(action)
+		if("rotate")
+			if (!can_rotate || admin)
+				return FALSE
+			var/new_angle = params["rotation_angle"]
+			if(!isnull(new_angle))
+				set_angle(SIMPLIFY_DEGREES(new_angle))
+			return TRUE
+		if("calculate")
+			if (!can_rotate || admin)
+				return FALSE
+			var/new_angle = rotation_angle + params["rotation_angle"]
+			if(!isnull(new_angle))
+				set_angle(SIMPLIFY_DEGREES(new_angle))
+			return TRUE

--- a/tgui/packages/tgui/interfaces/Reflector.js
+++ b/tgui/packages/tgui/interfaces/Reflector.js
@@ -1,0 +1,201 @@
+import { useBackend } from '../backend';
+import { Box, Button, Flex, Stack, Icon, LabeledControls, Section, NumberInput, Table } from '../components';
+import { Window } from '../layouts';
+
+export const Reflector = (props, context) => {
+  const { act, data } = useBackend(context);
+  return (
+    <Window
+      title={data.reflector_name}
+      height={200}
+      width={219}>
+      <Window.Content>
+        <Flex direction="row">
+          <Flex.Item>
+            <Section
+              title="Presets"
+              textAlign="center"
+              fill>
+              <Table mt={3.5}>
+                <Table.Cell>
+                  <Table.Row>
+                    <Button
+                      icon="arrow-left"
+                      iconRotation={45}
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 315,
+                      })} />
+                  </Table.Row>
+                  <Table.Row>
+                    <Button
+                      icon="arrow-left"
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 270,
+                      })} />
+                  </Table.Row>
+                  <Table.Row>
+                    <Button
+                      icon="arrow-left"
+                      iconRotation={-45}
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 225,
+                      })} />
+                  </Table.Row>
+                </Table.Cell>
+                <Table.Cell>
+                  <Table.Row>
+                    <Button
+                      icon="arrow-up"
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 0,
+                      })} />
+                  </Table.Row>
+                  <Table.Row>
+                    <Box px={0.75}>
+                      <Icon
+                        name="angle-double-up"
+                        size={1.66}
+                        rotation={data.rotation_angle}
+                        mb={1}
+                      />
+                    </Box>
+                  </Table.Row>
+                  <Table.Row>
+                    <Button
+                      icon="arrow-down"
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 180,
+                      })} />
+                  </Table.Row>
+                </Table.Cell>
+                <Table.Cell>
+                  <Table.Row>
+                    <Button
+                      icon="arrow-right"
+                      iconRotation={-45}
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 45,
+                      })} />
+                  </Table.Row>
+                  <Table.Row>
+                    <Button
+                      icon="arrow-right"
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 90,
+                      })} />
+                  </Table.Row>
+                  <Table.Row>
+                    <Button
+                      icon="arrow-right"
+                      iconRotation={45}
+                      mb={1}
+                      onClick={() => act('rotate', {
+                        rotation_angle: 135,
+                      })} />
+                  </Table.Row>
+                </Table.Cell>
+              </Table>
+            </Section>
+          </Flex.Item>
+          <Flex.Item>
+            <Section
+              title="Angle"
+              textAlign="center"
+              fill>
+              <LabeledControls>
+                <LabeledControls.Item ml={0.5} label="Set rotation">
+                  <NumberInput
+                    value={data.rotation_angle}
+                    unit="degrees"
+                    minValue={0}
+                    maxValue={359}
+                    step={1}
+                    stepPixelSize={1}
+                    onDrag={(e, value) => act('rotate', {
+                      rotation_angle: value,
+                    })} />
+                </LabeledControls.Item>
+              </LabeledControls>
+              <Flex direction="row" grow={1}>
+                <Flex direction="column" grow={1}>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="undo-alt"
+                      content="-5"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: -5,
+                      })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="undo-alt"
+                      content="-10"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: -10,
+                      })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="undo-alt"
+                      content="-15"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: -15,
+                      })} />
+                  </Flex.Item>
+                </Flex>
+                <Flex direction="column">
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="redo-alt"
+                      iconPosition="right"
+                      content="+5"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: 5,
+                      })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="redo-alt"
+                      iconPosition="right"
+                      content="+10"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: 10,
+                      })} />
+                  </Flex.Item>
+                  <Flex.Item>
+                    <Button
+                      fluid
+                      icon="redo-alt"
+                      iconPosition="right"
+                      content="+15"
+                      mb={1}
+                      onClick={() => act('calculate', {
+                        rotation_angle: 15,
+                      })} />
+                  </Flex.Item>
+                </Flex>
+              </Flex>
+            </Section>
+          </Flex.Item>
+        </Flex>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/Reflector.js
+++ b/tgui/packages/tgui/interfaces/Reflector.js
@@ -10,8 +10,8 @@ export const Reflector = (props, context) => {
       height={200}
       width={219}>
       <Window.Content>
-        <Flex direction="row">
-          <Flex.Item>
+        <Stack direction="row">
+          <Stack.Item>
             <Section
               title="Presets"
               textAlign="center"
@@ -103,8 +103,8 @@ export const Reflector = (props, context) => {
                 </Table.Cell>
               </Table>
             </Section>
-          </Flex.Item>
-          <Flex.Item>
+          </Stack.Item>
+          <Stack>
             <Section
               title="Angle"
               textAlign="center"
@@ -123,9 +123,9 @@ export const Reflector = (props, context) => {
                     })} />
                 </LabeledControls.Item>
               </LabeledControls>
-              <Flex direction="row" grow={1}>
-                <Flex direction="column" grow={1}>
-                  <Flex.Item>
+              <Stack direction="row" grow={1}>
+                <Stack direction="column" grow={1}>
+                  <Stack.Item>
                     <Button
                       fluid
                       icon="undo-alt"
@@ -134,8 +134,8 @@ export const Reflector = (props, context) => {
                       onClick={() => act('calculate', {
                         rotation_angle: -5,
                       })} />
-                  </Flex.Item>
-                  <Flex.Item>
+                  </Stack.Item>
+                  <Stack>
                     <Button
                       fluid
                       icon="undo-alt"
@@ -144,8 +144,8 @@ export const Reflector = (props, context) => {
                       onClick={() => act('calculate', {
                         rotation_angle: -10,
                       })} />
-                  </Flex.Item>
-                  <Flex.Item>
+                  </Stack>
+                  <Stack>
                     <Button
                       fluid
                       icon="undo-alt"
@@ -154,10 +154,10 @@ export const Reflector = (props, context) => {
                       onClick={() => act('calculate', {
                         rotation_angle: -15,
                       })} />
-                  </Flex.Item>
-                </Flex>
-                <Flex direction="column">
-                  <Flex.Item>
+                  </Stack>
+                </Stack>
+                <Stack direction="column">
+                  <Stack.Item>
                     <Button
                       fluid
                       icon="redo-alt"
@@ -167,8 +167,8 @@ export const Reflector = (props, context) => {
                       onClick={() => act('calculate', {
                         rotation_angle: 5,
                       })} />
-                  </Flex.Item>
-                  <Flex.Item>
+                  </Stack.Item>
+                  <Stack>
                     <Button
                       fluid
                       icon="redo-alt"
@@ -178,8 +178,8 @@ export const Reflector = (props, context) => {
                       onClick={() => act('calculate', {
                         rotation_angle: 10,
                       })} />
-                  </Flex.Item>
-                  <Flex.Item>
+                  </Stack>
+                  <Stack>
                     <Button
                       fluid
                       icon="redo-alt"
@@ -189,12 +189,12 @@ export const Reflector = (props, context) => {
                       onClick={() => act('calculate', {
                         rotation_angle: 15,
                       })} />
-                  </Flex.Item>
-                </Flex>
-              </Flex>
+                  </Stack>
+                </Stack>
+              </Stack>
             </Section>
-          </Flex.Item>
-        </Flex>
+          </Stack>
+        </Stack>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/Reflector.js
+++ b/tgui/packages/tgui/interfaces/Reflector.js
@@ -5,17 +5,11 @@ import { Window } from '../layouts';
 export const Reflector = (props, context) => {
   const { act, data } = useBackend(context);
   return (
-    <Window
-      title={data.reflector_name}
-      height={200}
-      width={219}>
+    <Window title={data.reflector_name} height={200} width={219}>
       <Window.Content>
         <Stack direction="row">
           <Stack.Item>
-            <Section
-              title="Presets"
-              textAlign="center"
-              fill>
+            <Section title="Presets" textAlign="center" fill>
               <Table mt={3.5}>
                 <Table.Cell>
                   <Table.Row>
@@ -23,26 +17,35 @@ export const Reflector = (props, context) => {
                       icon="arrow-left"
                       iconRotation={45}
                       mb={1}
-                      onClick={() => act('rotate', {
-                        rotation_angle: 315,
-                      })} />
+                      onClick={() =>
+                        act('rotate', {
+                          rotation_angle: 315,
+                        })
+                      }
+                    />
                   </Table.Row>
                   <Table.Row>
                     <Button
                       icon="arrow-left"
                       mb={1}
-                      onClick={() => act('rotate', {
-                        rotation_angle: 270,
-                      })} />
+                      onClick={() =>
+                        act('rotate', {
+                          rotation_angle: 270,
+                        })
+                      }
+                    />
                   </Table.Row>
                   <Table.Row>
                     <Button
                       icon="arrow-left"
                       iconRotation={-45}
                       mb={1}
-                      onClick={() => act('rotate', {
-                        rotation_angle: 225,
-                      })} />
+                      onClick={() =>
+                        act('rotate', {
+                          rotation_angle: 225,
+                        })
+                      }
+                    />
                   </Table.Row>
                 </Table.Cell>
                 <Table.Cell>
@@ -50,9 +53,12 @@ export const Reflector = (props, context) => {
                     <Button
                       icon="arrow-up"
                       mb={1}
-                      onClick={() => act('rotate', {
-                        rotation_angle: 0,
-                      })} />
+                      onClick={() =>
+                        act('rotate', {
+                          rotation_angle: 0,
+                        })
+                      }
+                    />
                   </Table.Row>
                   <Table.Row>
                     <Box px={0.75}>
@@ -68,9 +74,12 @@ export const Reflector = (props, context) => {
                     <Button
                       icon="arrow-down"
                       mb={1}
-                      onClick={() => act('rotate', {
-                        rotation_angle: 180,
-                      })} />
+                      onClick={() =>
+                        act('rotate', {
+                          rotation_angle: 180,
+                        })
+                      }
+                    />
                   </Table.Row>
                 </Table.Cell>
                 <Table.Cell>
@@ -79,36 +88,42 @@ export const Reflector = (props, context) => {
                       icon="arrow-right"
                       iconRotation={-45}
                       mb={1}
-                      onClick={() => act('rotate', {
-                        rotation_angle: 45,
-                      })} />
+                      onClick={() =>
+                        act('rotate', {
+                          rotation_angle: 45,
+                        })
+                      }
+                    />
                   </Table.Row>
                   <Table.Row>
                     <Button
                       icon="arrow-right"
                       mb={1}
-                      onClick={() => act('rotate', {
-                        rotation_angle: 90,
-                      })} />
+                      onClick={() =>
+                        act('rotate', {
+                          rotation_angle: 90,
+                        })
+                      }
+                    />
                   </Table.Row>
                   <Table.Row>
                     <Button
                       icon="arrow-right"
                       iconRotation={45}
                       mb={1}
-                      onClick={() => act('rotate', {
-                        rotation_angle: 135,
-                      })} />
+                      onClick={() =>
+                        act('rotate', {
+                          rotation_angle: 135,
+                        })
+                      }
+                    />
                   </Table.Row>
                 </Table.Cell>
               </Table>
             </Section>
           </Stack.Item>
           <Stack>
-            <Section
-              title="Angle"
-              textAlign="center"
-              fill>
+            <Section title="Angle" textAlign="center" fill>
               <LabeledControls>
                 <LabeledControls.Item ml={0.5} label="Set rotation">
                   <NumberInput
@@ -118,9 +133,12 @@ export const Reflector = (props, context) => {
                     maxValue={359}
                     step={1}
                     stepPixelSize={1}
-                    onDrag={(e, value) => act('rotate', {
-                      rotation_angle: value,
-                    })} />
+                    onDrag={(e, value) =>
+                      act('rotate', {
+                        rotation_angle: value,
+                      })
+                    }
+                  />
                 </LabeledControls.Item>
               </LabeledControls>
               <Stack direction="row" grow={1}>
@@ -131,9 +149,12 @@ export const Reflector = (props, context) => {
                       icon="undo-alt"
                       content="-5"
                       mb={1}
-                      onClick={() => act('calculate', {
-                        rotation_angle: -5,
-                      })} />
+                      onClick={() =>
+                        act('calculate', {
+                          rotation_angle: -5,
+                        })
+                      }
+                    />
                   </Stack.Item>
                   <Stack>
                     <Button
@@ -141,9 +162,12 @@ export const Reflector = (props, context) => {
                       icon="undo-alt"
                       content="-10"
                       mb={1}
-                      onClick={() => act('calculate', {
-                        rotation_angle: -10,
-                      })} />
+                      onClick={() =>
+                        act('calculate', {
+                          rotation_angle: -10,
+                        })
+                      }
+                    />
                   </Stack>
                   <Stack>
                     <Button
@@ -151,9 +175,12 @@ export const Reflector = (props, context) => {
                       icon="undo-alt"
                       content="-15"
                       mb={1}
-                      onClick={() => act('calculate', {
-                        rotation_angle: -15,
-                      })} />
+                      onClick={() =>
+                        act('calculate', {
+                          rotation_angle: -15,
+                        })
+                      }
+                    />
                   </Stack>
                 </Stack>
                 <Stack direction="column">
@@ -164,9 +191,12 @@ export const Reflector = (props, context) => {
                       iconPosition="right"
                       content="+5"
                       mb={1}
-                      onClick={() => act('calculate', {
-                        rotation_angle: 5,
-                      })} />
+                      onClick={() =>
+                        act('calculate', {
+                          rotation_angle: 5,
+                        })
+                      }
+                    />
                   </Stack.Item>
                   <Stack>
                     <Button
@@ -175,9 +205,12 @@ export const Reflector = (props, context) => {
                       iconPosition="right"
                       content="+10"
                       mb={1}
-                      onClick={() => act('calculate', {
-                        rotation_angle: 10,
-                      })} />
+                      onClick={() =>
+                        act('calculate', {
+                          rotation_angle: 10,
+                        })
+                      }
+                    />
                   </Stack>
                   <Stack>
                     <Button
@@ -186,9 +219,12 @@ export const Reflector = (props, context) => {
                       iconPosition="right"
                       content="+15"
                       mb={1}
-                      onClick={() => act('calculate', {
-                        rotation_angle: 15,
-                      })} />
+                      onClick={() =>
+                        act('calculate', {
+                          rotation_angle: 15,
+                        })
+                      }
+                    />
                   </Stack>
                 </Stack>
               </Stack>

--- a/tgui/packages/tgui/interfaces/Reflector.js
+++ b/tgui/packages/tgui/interfaces/Reflector.js
@@ -1,5 +1,5 @@
 import { useBackend } from '../backend';
-import { Box, Button, Flex, Stack, Icon, LabeledControls, Section, NumberInput, Table } from '../components';
+import { Box, Button, Stack, Icon, LabeledControls, Section, NumberInput, Table } from '../components';
 import { Window } from '../layouts';
 
 export const Reflector = (props, context) => {

--- a/tgui/packages/tgui/interfaces/Reflector.js
+++ b/tgui/packages/tgui/interfaces/Reflector.js
@@ -4,8 +4,9 @@ import { Window } from '../layouts';
 
 export const Reflector = (props, context) => {
   const { act, data } = useBackend(context);
+  const { reflector_name, rotation_angle } = data;
   return (
-    <Window title={data.reflector_name} height={200} width={219}>
+    <Window title={reflector_name} height={200} width={219}>
       <Window.Content>
         <Stack direction="row">
           <Stack.Item>
@@ -65,7 +66,7 @@ export const Reflector = (props, context) => {
                       <Icon
                         name="angle-double-up"
                         size={1.66}
-                        rotation={data.rotation_angle}
+                        rotation={rotation_angle}
                         mb={1}
                       />
                     </Box>
@@ -127,7 +128,7 @@ export const Reflector = (props, context) => {
               <LabeledControls>
                 <LabeledControls.Item ml={0.5} label="Set rotation">
                   <NumberInput
-                    value={data.rotation_angle}
+                    value={rotation_angle}
                     unit="degrees"
                     minValue={0}
                     maxValue={359}

--- a/tgui/packages/tgui/interfaces/Reflector.tsx
+++ b/tgui/packages/tgui/interfaces/Reflector.tsx
@@ -2,11 +2,11 @@ import { useBackend } from '../backend';
 import { Box, Button, Stack, Icon, LabeledControls, Section, NumberInput, Table } from '../components';
 import { Window } from '../layouts';
 
+type Data = {
+  reflector_name: string;
+  rotation_angle: number;
+};
 export const Reflector = (props, context) => {
-  type Data = {
-    reflector_name: string;
-    rotation_angle: number;
-  };
   const { act, data } = useBackend<Data>(context);
   const { reflector_name, rotation_angle } = data;
   return (

--- a/tgui/packages/tgui/interfaces/Reflector.tsx
+++ b/tgui/packages/tgui/interfaces/Reflector.tsx
@@ -12,7 +12,7 @@ export const Reflector = (props, context) => {
   return (
     <Window title={reflector_name} height={200} width={219}>
       <Window.Content>
-        <Stack direction="row">
+        <Stack>
           <Stack.Item>
             <Section title="Presets" textAlign="center" fill>
               <Table mt={3.5}>
@@ -146,8 +146,8 @@ export const Reflector = (props, context) => {
                   />
                 </LabeledControls.Item>
               </LabeledControls>
-              <Stack direction="row" grow={1}>
-                <Stack direction="column" grow={1}>
+              <Stack fill>
+                <Stack fill vertical>
                   <Stack.Item>
                     <Button
                       fluid
@@ -188,7 +188,7 @@ export const Reflector = (props, context) => {
                     />
                   </Stack>
                 </Stack>
-                <Stack direction="column">
+                <Stack vertical>
                   <Stack.Item>
                     <Button
                       fluid

--- a/tgui/packages/tgui/interfaces/Reflector.tsx
+++ b/tgui/packages/tgui/interfaces/Reflector.tsx
@@ -3,7 +3,11 @@ import { Box, Button, Stack, Icon, LabeledControls, Section, NumberInput, Table 
 import { Window } from '../layouts';
 
 export const Reflector = (props, context) => {
-  const { act, data } = useBackend(context);
+  type Data = {
+    reflector_name: string;
+    rotation_angle: number;
+  };
+  const { act, data } = useBackend<Data>(context);
   const { reflector_name, rotation_angle } = data;
   return (
     <Window title={reflector_name} height={200} width={219}>


### PR DESCRIPTION

## About The Pull Request
Port of https://github.com/AetherStation/AetherStation13/pull/243 with some minor changes.
Adds the menu which looks like this:
![image](https://user-images.githubusercontent.com/93882977/232594231-c78648e9-ee7e-4f44-9fd7-2c522452c12f.png)
It has arrows so you can just press a button.
Deleted menu on alt-click as it's kinda useless with this menu.
Also changed tooltips a little.
## Why It's Good For The Game
Current rotating menu is uncomfortable.
## Changelog
:cl:
qol: Reflectors now have better rotating menu. Changed from alt-click to just lmb.
/:cl:
