### PR TITLE
Fixes Plastitanium glass duplication

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -256,7 +256,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	merge_type = /obj/item/stack/sheet/plastitaniumglass
 	tableVariant = /obj/structure/table/reinforced/plastitaniumglass
 
-/obj/item/stack/sheet/plastitaniumglass
+/obj/item/stack/sheet/plastitaniumglass/fifty
 	amount = 50
 
 /datum/armor/sheet_plastitaniumglass


### PR DESCRIPTION

## About The Pull Request
Plastitanium glass no longer always creates stacks of 50, this was caused by an accidental overload with the presized stacks used for mapping.
Fixes #74802

## Changelog
:cl:
fix:  Plastitanium glass no longer always creates stacks of 50
/:cl:
