### PR TITLE
Rolling table gets rolling sound

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -376,7 +376,11 @@
 	for(var/atom/movable/attached_movable as anything in attached_items)
 		if(!attached_movable.Move(loc))
 			RemoveItemFromTable(attached_movable, attached_movable.loc)
-
+			
+/obj/structure/table/rolling/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
+	. = ..()
+	if(has_gravity())
+		playsound(src, 'sound/effects/roll.ogg', 100, TRUE)
 /*
  * Glass tables
  */


### PR DESCRIPTION

## About The Pull Request
I realized while working on another project, that the rolling table does not play the rolling sound when it's moved. Absolutely criminal. I took it upon myself to right this wrong. And not just because it will go great with said project I'm working on. I swear.
## Why It's Good For The Game
Makes the visuals of the table moving work with the audio of the table moving, instead of wondering due to the rarity of the rolling table 'Huh, is the table bugged?' if they haven't noticed the table name.
## Changelog
:cl:
fix: The rolling table actually plays the rolling sound, as the lord intended.
/:cl:
