### PR TITLE
Misc NorthStar Fixes

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -9894,7 +9894,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
-	id = "surg_a_privacy";
+	id = "surg_b_privacy";
 	name = "Surgery Privacy Shutters"
 	},
 /turf/open/floor/plating,
@@ -19297,7 +19297,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
-	id = "surg_b_privacy";
+	id = "surg_a_privacy";
 	name = "Surgery Privacy Shutters"
 	},
 /turf/open/floor/plating,
@@ -78394,7 +78394,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /obj/machinery/button/door/directional/west{
-	id = "surg_a_shutters";
+	id = "surg_b_privacy";
 	name = "Surgery Privacy Shutters";
 	req_access = list("medical")
 	},
@@ -85446,7 +85446,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /obj/machinery/button/door/directional/west{
-	id = "surg_b_shutters";
+	id = "surg_a_privacy";
 	name = "Surgery Privacy Shutters";
 	req_access = list("medical")
 	},
@@ -85528,6 +85528,7 @@
 /area/station/security/prison/garden)
 "wQu" = (
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -85529,6 +85529,7 @@
 "wQu" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},


### PR DESCRIPTION
## About The Pull Request
Fixes #74742
Fixes #74746
The surgery room are now properly ID-ed and adds the missing APC in second deck aft hallway along with markers.
## Why It's Good For The Game
less bugs, good
## Changelog
:cl:
fix: Surgery room ID's in NorthStar are now properly ID-ed
fix: Fixes missing APC in 2nd deck aft hallway of Northstar.
/:cl:
