### PR TITLE
UDDERAPALOOZA: Moo-ving the udder component to the atom level, and subtyping the living requirements for a more dairy-able and cow-laborative codebase!

### DIFF
--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -54,17 +54,17 @@
 /datum/component/udder/living_requirements/Initialize(udder_type, datum/callback/on_milk_callback, datum/callback/on_generate_callback, reagent_produced_typepath)
 	if(!isliving(parent))
 		return COMPONENT_INCOMPATIBLE
-	. = ..()
+	return ..()
 
 /datum/component/udder/living_requirements/on_examine(mob/living/milk_source, mob/user, list/examine_list)
 	if(milk_source.stat != CONSCIOUS)
 		return //come on now
-	. = ..()
+	return ..()
 
 /datum/component/udder/living_requirements/on_attackby(mob/living/milk_source, obj/item/milking_tool, mob/user)
 	if(milk_source.stat != CONSCIOUS)
 		return //come on now x2
-	. = ..()
+	return ..()
 
 /**
  * # udder item

--- a/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/_cow.dm
@@ -49,7 +49,7 @@
 
 ///wrapper for the udder component addition so you can have uniquely uddered cow subtypes
 /mob/living/basic/cow/proc/udder_component()
-	AddComponent(/datum/component/udder)
+	AddComponent(/datum/component/udder/living_requirements)
 
 /*
  * food related components and elements are set up here for a few reasons:

--- a/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
+++ b/code/modules/mob/living/basic/farm_animals/cow/cow_moonicorn.dm
@@ -28,7 +28,7 @@
 	AddElement(/datum/element/movement_turf_changer, /turf/open/floor/grass/fairy)
 
 /mob/living/basic/cow/moonicorn/udder_component()
-	AddComponent(/datum/component/udder, /obj/item/udder, null, null, /datum/reagent/drug/mushroomhallucinogen)
+	AddComponent(/datum/component/udder/living_requirements, /obj/item/udder, null, null, /datum/reagent/drug/mushroomhallucinogen)
 
 /mob/living/basic/cow/moonicorn/setup_eating()
 	var/static/list/food_types

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -37,7 +37,7 @@
 	footstep_type = FOOTSTEP_MOB_SHOE
 
 /mob/living/simple_animal/hostile/retaliate/goat/Initialize(mapload)
-	AddComponent(/datum/component/udder)
+	AddComponent(/datum/component/udder/living_requirements)
 	. = ..()
 
 /mob/living/simple_animal/hostile/retaliate/goat/Life(seconds_per_tick = SSMOBS_DT, times_fired)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -47,7 +47,7 @@
 /mob/living/simple_animal/hostile/asteroid/gutlunch/Initialize(mapload)
 	. = ..()
 	if(wanted_objects.len)
-		AddComponent(/datum/component/udder, /obj/item/udder/gutlunch, CALLBACK(src, PROC_REF(regenerate_icons)), CALLBACK(src, PROC_REF(regenerate_icons)))
+		AddComponent(/datum/component/udder/living_requirements, /obj/item/udder/gutlunch, CALLBACK(src, PROC_REF(regenerate_icons)), CALLBACK(src, PROC_REF(regenerate_icons)))
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/CanAttack(atom/the_target) // Gutlunch-specific version of CanAttack to handle stupid stat_exclusive = true crap so we don't have to do it for literally every single simple_animal/hostile except the two that spawn in lavaland


### PR DESCRIPTION

## About The Pull Request 🥛 

Refactors the cow component to be atom level since surprisingly, only two checks were stopping it from going lower. I like it! It’s udderly amazing! And instead of doing that pattern I really don’t like where you check the types of 10 billion items and conditionally hook signals, I’ve just made the living requirements a subtype. This way, it’s more moo-dular and easier to maintain. No bull!

## Why It's Good For The Game

Add an udder to a toolbox

## Changelog
:cl:
refactor: udder component is now atom level, with a subtype for living requirements
/:cl:
