### PR TITLE
Disables logging syndicate frequency and being able to read it on the server monitoring console

### DIFF
--- a/code/game/machinery/telecomms/machines/bus.dm
+++ b/code/game/machinery/telecomms/machines/bus.dm
@@ -23,7 +23,7 @@
 	if(!istype(signal) || !is_freq_listening(signal))
 		return
 
-	if(change_frequency && signal.frequency != FREQ_SYNDICATE)
+	if(change_frequency && !(signal.frequency in banned_frequencies))
 		signal.frequency = change_frequency
 
 	if(!istype(machine_from, /obj/machinery/telecomms/processor) && machine_from != src) // Signal must be ready (stupid assuming machine), let's send it

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -15,6 +15,7 @@
 	circuit = /obj/item/circuitboard/machine/telecomms/server
 	var/list/log_entries = list()
 	var/totaltraffic = 0 // gigabytes (if > 1024, divide by 1024 -> terrabytes)
+	var/syndicate = FALSE // can the server log syndicate messages?
 
 /obj/machinery/telecomms/server/receive_information(datum/signal/subspace/vocal/signal, obj/machinery/telecomms/machine_from)
 	// can't log non-vocal signals
@@ -44,10 +45,11 @@
 		log.parameters["job"] = Gibberish(signal.data["job"], replace_characters)
 		log.parameters["message"] = Gibberish(signal.data["message"], replace_characters)
 
-	// Give the log a name and store it
-	var/identifier = num2text( rand(-1000,1000) + world.time )
-	log.name = "data packet ([md5(identifier)])"
-	log_entries.Add(log)
+	// Give the log a name and store it. If it is from a syndicate frequency, checks if it has syndicate access first
+	if(signal.frequency != FREQ_SYNDICATE || syndicate)
+		var/identifier = num2text( rand(-1000,1000) + world.time )
+		log.name = "data packet ([md5(identifier)])"
+		log_entries.Add(log)
 
 	var/can_send = relay_information(signal, /obj/machinery/telecomms/hub)
 	if(!can_send)
@@ -120,3 +122,9 @@
 /obj/machinery/telecomms/server/presets/common/birdstation/Initialize(mapload)
 	. = ..()
 	freq_listening = list()
+
+/obj/machinery/telecomms/server/presets/syndicate
+	syndicate = TRUE
+	id = "Syndicate Server"
+	freq_listening = list(FREQ_SYNDICATE)
+	autolinkers = list("syndicate")

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -45,7 +45,7 @@
 		log.parameters["job"] = Gibberish(signal.data["job"], replace_characters)
 		log.parameters["message"] = Gibberish(signal.data["message"], replace_characters)
 
-	// Give the log a name and store it. If it is from a syndicate frequency, checks if it has syndicate access first, otherwise passes on the message
+	// Give the log a name and store it. If it is from a syndicate frequency, checks if it has syndicate access
 	if(signal.frequency != FREQ_SYNDICATE || syndicate)
 		var/identifier = num2text( rand(-1000,1000) + world.time )
 		log.name = "data packet ([md5(identifier)])"

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -15,7 +15,6 @@
 	circuit = /obj/item/circuitboard/machine/telecomms/server
 	var/list/log_entries = list()
 	var/totaltraffic = 0 // gigabytes (if > 1024, divide by 1024 -> terrabytes)
-	var/syndicate = FALSE // can the server log syndicate messages?
 
 /obj/machinery/telecomms/server/receive_information(datum/signal/subspace/vocal/signal, obj/machinery/telecomms/machine_from)
 	// can't log non-vocal signals
@@ -46,7 +45,7 @@
 		log.parameters["message"] = Gibberish(signal.data["message"], replace_characters)
 
 	// Give the log a name and store it. If it is from a syndicate frequency, checks if it has syndicate access
-	if(signal.frequency != FREQ_SYNDICATE || syndicate)
+	if(!(signal.frequency in banned_frequencies))
 		var/identifier = num2text( rand(-1000,1000) + world.time )
 		log.name = "data packet ([md5(identifier)])"
 		log_entries.Add(log)
@@ -122,10 +121,3 @@
 /obj/machinery/telecomms/server/presets/common/birdstation/Initialize(mapload)
 	. = ..()
 	freq_listening = list()
-
-/obj/machinery/telecomms/server/presets/syndicate
-	syndicate = TRUE
-	id = "Syndicate Server"
-	network = "syndisat"
-	freq_listening = list(FREQ_SYNDICATE)
-	autolinkers = list("syndicate")

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -45,7 +45,7 @@
 		log.parameters["job"] = Gibberish(signal.data["job"], replace_characters)
 		log.parameters["message"] = Gibberish(signal.data["message"], replace_characters)
 
-	// Give the log a name and store it. If it is from a syndicate frequency, checks if it has syndicate access first
+	// Give the log a name and store it. If it is from a syndicate frequency, checks if it has syndicate access first, otherwise passes on the message
 	if(signal.frequency != FREQ_SYNDICATE || syndicate)
 		var/identifier = num2text( rand(-1000,1000) + world.time )
 		log.name = "data packet ([md5(identifier)])"
@@ -126,5 +126,6 @@
 /obj/machinery/telecomms/server/presets/syndicate
 	syndicate = TRUE
 	id = "Syndicate Server"
+	network = "syndisat"
 	freq_listening = list(FREQ_SYNDICATE)
 	autolinkers = list("syndicate")

--- a/code/game/machinery/telecomms/machines/server.dm
+++ b/code/game/machinery/telecomms/machines/server.dm
@@ -28,24 +28,25 @@
 	if (log_entries.len >= 400)
 		log_entries.Cut(1, 2)
 
-	var/datum/comm_log_entry/log = new
-	log.parameters["mobtype"] = signal.virt.source.type
-	log.parameters["name"] = signal.data["name"]
-	log.parameters["job"] = signal.data["job"]
-	log.parameters["message"] = signal.data["message"]
-	log.parameters["language"] = signal.language
-
-	// If the signal is still compressed, make the log entry gibberish
-	var/compression = signal.data["compression"]
-	if(compression > 0)
-		log.input_type = "Corrupt File"
-		var/replace_characters = compression >= 20 ? TRUE : FALSE
-		log.parameters["name"] = Gibberish(signal.data["name"], replace_characters)
-		log.parameters["job"] = Gibberish(signal.data["job"], replace_characters)
-		log.parameters["message"] = Gibberish(signal.data["message"], replace_characters)
-
-	// Give the log a name and store it. If it is from a syndicate frequency, checks if it has syndicate access
+	// Don't create a log if the frequency is banned from being logged
 	if(!(signal.frequency in banned_frequencies))
+		var/datum/comm_log_entry/log = new
+		log.parameters["mobtype"] = signal.virt.source.type
+		log.parameters["name"] = signal.data["name"]
+		log.parameters["job"] = signal.data["job"]
+		log.parameters["message"] = signal.data["message"]
+		log.parameters["language"] = signal.language
+
+		// If the signal is still compressed, make the log entry gibberish
+		var/compression = signal.data["compression"]
+		if(compression > 0)
+			log.input_type = "Corrupt File"
+			var/replace_characters = compression >= 20 ? TRUE : FALSE
+			log.parameters["name"] = Gibberish(signal.data["name"], replace_characters)
+			log.parameters["job"] = Gibberish(signal.data["job"], replace_characters)
+			log.parameters["message"] = Gibberish(signal.data["message"], replace_characters)
+
+		// Give the log a name and store it
 		var/identifier = num2text( rand(-1000,1000) + world.time )
 		log.name = "data packet ([md5(identifier)])"
 		log_entries.Add(log)


### PR DESCRIPTION
## About The Pull Request
Fixes #74810
Also adds the other banned frequencies to the bus frequency change thing, instead of just the syndicate frequency
## Why It's Good For The Game
Syndicate messages are supposed to be very private, this would just out all the syndies without sec even having to find an encryption key
## Changelog
:cl:
fix: You can no longer log syndicate comms (or any other banned frequencies) with a telecomms server
fix: You can no longer use tcomms buses to change messages to banned frequencies
/:cl:
