### PR TITLE
Drastically improves north star / multi-z performance by trimming down on camera upwards visibility

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -536,8 +536,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 /obj/machinery/camera/proc/can_see()
 	var/list/see = null
 	var/turf/pos = get_turf(src)
+	var/turf/directly_above = SSmapping.get_turf_above(pos)
 	var/check_lower = pos != get_lowest_turf(pos)
-	var/check_higher = pos != get_highest_turf(pos)
+	var/check_higher = directly_above && istransparentturf(directly_above) && (pos != get_highest_turf(pos))
 
 	if(isXRay())
 		see = range(view_range, pos)


### PR DESCRIPTION
## About The Pull Request

Fixes #74821 , somewhat

See the issue for more information but tldr, cameras being able to see upwards is very ugly for the North Star, and it is especially bad if a malf AI buys xray cameras

This PR resolves this by limiting camera upwards visibility. 
A camera can now only see upwards if the turf above it is transparent, rather than see all turfs upwards in range. 

Profile: 

Before (8 minutes, malf ai xray, north star)

![image](https://user-images.githubusercontent.com/51863163/232670632-fd0c3b20-8996-40a8-a828-20da85a40b77.png)

After (8 minutes, malf ai xray, north star)

![image](https://user-images.githubusercontent.com/51863163/232670641-0142f47a-7aa2-4ae8-96b1-dc629f6b91e4.png)


## Why It's Good For The Game

Better performance is an obvious one, but I think the upwards visibility they had already was kind of excessive? 

<Details> 

<summary>
As an example this camera in the turbine room of the north star
</summary>

![image](https://user-images.githubusercontent.com/51863163/232670392-9716bb23-2b1e-46a7-aac0-a120a93c783b.png)

</Details>


<Details> 

<Summary>
...Can literally see all the way to the top floor of the North Star, outside the chapel and library
</Summary> 

![image](https://user-images.githubusercontent.com/51863163/232670468-c93ff4cd-adf0-4c2a-baaa-c87ea21933e6.png)

</details>

Which just feels a little unfair? Like imagine being a nukie and being captured because a camera 2 floors away inside the station around the corner spots you. It's a little much

## Changelog

:cl: Melbert
balance: Cameras can only see vertically upwards if the turf above them is transparent. But hey, the North Star (and other multi-z maps) will now perform wayyy better (less time dilation)
/:cl:

