### PR TITLE
Relocate alarm monitor display update code to the signal handler instead of process tick

### DIFF
--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -26,22 +26,6 @@
 	QDEL_NULL(alert_control)
 	return ..()
 
-/* We don't really need an updated process_tick because we're not doing anything fancy here
-/datum/computer_file/program/alarm_monitor/process_tick(seconds_per_tick)
-	..()
-
-	if(has_alert)
-		program_icon_state = "alert-red"
-		ui_header = "alarm_red.gif"
-		update_computer_icon()
-	else
-		if(!has_alert)
-			program_icon_state = "alert-green"
-			ui_header = "alarm_green.gif"
-			update_computer_icon()
-	return 1
-*/
-
 /datum/computer_file/program/alarm_monitor/ui_data(mob/user)
 	var/list/data = list()
 	data += alert_control.ui_data(user)

--- a/code/modules/modular_computers/file_system/programs/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/alarm.dm
@@ -26,6 +26,7 @@
 	QDEL_NULL(alert_control)
 	return ..()
 
+/* We don't really need an updated process_tick because we're not doing anything fancy here
 /datum/computer_file/program/alarm_monitor/process_tick(seconds_per_tick)
 	..()
 
@@ -39,6 +40,7 @@
 			ui_header = "alarm_green.gif"
 			update_computer_icon()
 	return 1
+*/
 
 /datum/computer_file/program/alarm_monitor/ui_data(mob/user)
 	var/list/data = list()
@@ -47,9 +49,19 @@
 
 /datum/computer_file/program/alarm_monitor/proc/update_alarm_display()
 	SIGNAL_HANDLER
-	has_alert = FALSE
-	if(length(alert_control.listener.alarms))
-		has_alert = TRUE
+	// has_alert is true if there are any active alarms in our listener.
+	has_alert = (length(alert_control.listener.alarms) > 0)
+
+	if(!has_alert)
+		program_icon_state = "alert-green"
+		ui_header = "alarm_green.gif"
+	else
+		// If we don't know the status, assume the worst.
+		// Technically we should never have anything other than a truthy or falsy value
+		// but this will allow for unknown values to fall through to be an actual alert.
+		program_icon_state = "alert-red"
+		ui_header = "alarm_red.gif"
+	update_computer_icon() // Always update the icon after we check our conditional because we might've changed it
 
 /datum/computer_file/program/alarm_monitor/on_start(mob/user)
 	. = ..(user)


### PR DESCRIPTION

## About The Pull Request
This very simply makes alarm monitor UI and icon updates event based instead of updating them with the processing loop.
The original proc also included unnecessary conditionals, these have been worked out.
## Why It's Good For The Game
Instead of updating alarm monitors every single program tick, we could instead update them only when alarms actually update. This improves responsiveness for when alarms go off (we don't wait for the next program tick and instead update immediately), and prevents us from running unnecessary conditionals and icon updates.
## Changelog
:cl:
code: Update active alarm monitor computers only when alarms are actually changed instead of every program tick
/:cl:
