### PR TITLE
Cleans up thermite component code

### DIFF
--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -113,7 +113,6 @@ GLOBAL_DATUM_INIT(thermite_overlay, /mutable_appearance, mutable_appearance('ico
  */
 /datum/component/thermite/proc/thermite_melt(mob/user)
 	var/turf/parent_turf = parent
-	parent_turf.cut_overlay(overlay)
 	playsound(parent_turf, 'sound/items/welder.ogg', 100, TRUE)
 	fakefire = new(parent_turf)
 	burn_callback = CALLBACK(src, PROC_REF(burn_parent), user)

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -69,7 +69,7 @@ GLOBAL_DATUM_INIT(thermite_overlay, /mutable_appearance, mutable_appearance('ico
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(clean_react))
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(attackby_react))
 	RegisterSignal(parent, COMSIG_ATOM_FIRE_ACT, PROC_REF(flame_react))
-	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(on_destroy)) //probably necessary because turfs are wack
+	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(parent_qdeleting)) //probably necessary because turfs are wack
 	var/turf/turf_parent = parent
 	turf_parent.update_appearance()
 

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -1,76 +1,101 @@
+GLOBAL_DATUM_INIT(thermite_overlay, /mutable_appearance, mutable_appearance('icons/effects/effects.dmi', "thermite"))
+
 /datum/component/thermite
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
-	///Amoumt of thermite on parent
+	/// Amount of thermite on parent
 	var/amount
-	///Amount of thermite required to burn through parent
+	/// Amount of thermite required to burn through parent
 	var/burn_require
-	///The thermite overlay
-	var/overlay
-	///The timer for burning parent
+	/// The thermite overlay
+	var/thermite_overlay
+	/// Callback related to burning, stored so the timer can be easily reset
+	var/datum/callback/burn_callback
+	/// The timer for burning parent, calls burn_callback when done
 	var/burn_timer
-	///The thermite fire overlay
+	/// The thermite fire overlay
 	var/obj/effect/overlay/thermite/fakefire
 
-	///Blacklist of turfs that cannot have thermite on it
+	/// Blacklist of turfs that cannot have thermite on it
 	var/static/list/blacklist = typecacheof(list(
 		/turf/open/lava,
 		/turf/open/space,
 		/turf/open/water,
 		/turf/open/chasm,
 	))
-	///List of turfs that are immune to thermite
+	/// List of turfs that are immune to thermite
 	var/static/list/immunelist = typecacheof(list(
 		/turf/closed/wall/mineral/diamond,
 		/turf/closed/indestructible,
 		/turf/open/indestructible,
 	))
-	///List of turfs that take extra thermite to burn through
+	/// List of turfs that take extra thermite to burn through
 	var/static/list/resistlist = typecacheof(list(
 		/turf/closed/wall/r_wall,
 	))
 
-/datum/component/thermite/Initialize(_amount)
-	if(!istype(parent, /turf) || blacklist[parent.type])
+/datum/component/thermite/Initialize(amount, thermite_overlay = GLOB.thermite_overlay)
+	if(!isturf(parent))
 		return COMPONENT_INCOMPATIBLE
+	//not actually incompatible, but not valid
+	if(blacklist[parent.type])
+		qdel(src)
+		return
 
 	if(immunelist[parent.type])
-		amount = 0 //Yeah the overlay can still go on it and be cleaned but you arent burning down a diamond wall
+		src.amount = 0 //Yeah the overlay can still go on it and be cleaned but you arent burning down a diamond wall
 	else
-		amount = _amount
+		src.amount = amount
 		if(resistlist[parent.type])
 			burn_require = 50
 		else
 			burn_require = 30
 
-	var/turf/master = parent
-	overlay = mutable_appearance('icons/effects/effects.dmi', "thermite")
-	master.add_overlay(overlay)
+	src.thermite_overlay = thermite_overlay
 
+/datum/component/thermite/Destroy()
+	thermite_overlay = null
+	if(burn_callback)
+		QDEL_NULL(burn_callback)
+	if(burn_timer)
+		deltimer(burn_timer)
+		burn_timer = null
+	if(fakefire)
+		QDEL_NULL(fakefire)
+	return ..()
+
+/datum/component/thermite/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_update_overlays))
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(clean_react))
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(attackby_react))
 	RegisterSignal(parent, COMSIG_ATOM_FIRE_ACT, PROC_REF(flame_react))
+	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(on_destroy)) //probably necessary because turfs are wack
+	var/turf/turf_parent = parent
+	turf_parent.update_appearance()
 
 /datum/component/thermite/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT)
-	UnregisterSignal(parent, COMSIG_PARENT_ATTACKBY)
-	UnregisterSignal(parent, COMSIG_ATOM_FIRE_ACT)
-	UnregisterSignal(parent, COMSIG_PARENT_QDELETING)
+	UnregisterSignal(parent, list(
+		COMSIG_ATOM_UPDATE_OVERLAYS,
+		COMSIG_COMPONENT_CLEAN_ACT,
+		COMSIG_PARENT_ATTACKBY,
+		COMSIG_ATOM_FIRE_ACT,
+		COMSIG_PARENT_QDELETING))
+	var/turf/turf_parent = parent
+	turf_parent.update_appearance()
 
-/datum/component/thermite/Destroy()
-	var/turf/master = parent
-	master.cut_overlay(overlay)
-	return ..()
-
-/datum/component/thermite/InheritComponent(datum/component/thermite/newC, i_am_original, _amount)
+/datum/component/thermite/InheritComponent(datum/component/thermite/new_comp, i_am_original, amount)
 	if(!i_am_original)
 		return
-	if(newC)
-		amount += newC.amount
-	else
-		amount += _amount
-	if (burn_timer) // prevent people from skipping a longer timer
+	src.amount += amount
+	if(burn_timer) // prevent people from skipping a longer timer
 		deltimer(burn_timer)
-		burn_timer = addtimer(CALLBACK(src, PROC_REF(burn_parent), usr), min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
+		burn_timer = addtimer(burn_callback, min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
+
+/// Used to maintain the thermite overlay on the parent [/turf].
+/datum/component/thermite/proc/on_update_overlays(turf/parent_turf, list/overlays)
+	SIGNAL_HANDLER
+
+	if(thermite_overlay)
+		overlays += thermite_overlay
 
 /**
  * Used to begin the thermite burning process
@@ -79,13 +104,14 @@
  * * mob/user - The user igniting the thermite
  */
 /datum/component/thermite/proc/thermite_melt(mob/user)
-	var/turf/master = parent
-	master.cut_overlay(overlay)
-	playsound(master, 'sound/items/welder.ogg', 100, TRUE)
-	fakefire = new(master)
-	burn_timer = addtimer(CALLBACK(src, PROC_REF(burn_parent), user), min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
-	UnregisterFromParent()
-	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(delete_fire)) //in case parent gets deleted, get ready to delete the fire
+	var/turf/parent_turf = parent
+	parent_turf.cut_overlay(overlay)
+	playsound(parent_turf, 'sound/items/welder.ogg', 100, TRUE)
+	fakefire = new(parent_turf)
+	burn_callback = CALLBACK(src, PROC_REF(burn_parent), user)
+	burn_timer = addtimer(burn_callback, min(amount * 0.35 SECONDS, 20 SECONDS), TIMER_STOPPABLE)
+	//unregister everything mechanical, we are burning up
+	UnregisterSignal(parent, list(COMSIG_COMPONENT_CLEAN_ACT, COMSIG_PARENT_ATTACKBY))
 
 /**
  * Used to actually melt parent
@@ -94,32 +120,26 @@
  * * mob/user - The user that ignited the thermite
  */
 /datum/component/thermite/proc/burn_parent(mob/user)
-	var/turf/master = parent
-	delete_fire()
+	var/turf/parent_turf = parent
+	if(fakefire)
+		QDEL_NULL(fakefire)
 	if(user)
-		master.add_hiddenprint(user)
+		parent_turf.add_hiddenprint(user)
 	if(amount >= burn_require)
-		master = master.Melt()
-		master.burn_tile()
+		parent_turf = parent_turf.Melt()
+		parent_turf.burn_tile()
+	burn_timer = null
 	qdel(src)
 
 /**
- * Used to delete the fake fire overlay
- */
-/datum/component/thermite/proc/delete_fire()
-	SIGNAL_HANDLER
-
-	if(!QDELETED(fakefire))
-		qdel(fakefire)
-
-/**
- * wash reaction, used to clean off thermite from parent
+ * Wash reaction, used to clean off thermite from parent
  */
 /datum/component/thermite/proc/clean_react(datum/source, strength)
 	SIGNAL_HANDLER
 
 	//Thermite is just some loose powder, you could probably clean it with your hands. << todo?
 	qdel(src)
+
 	return COMPONENT_CLEANED
 
 /**
@@ -145,9 +165,15 @@
  * * mob/user - The user behind the attack
  * * params - params
  */
-
 /datum/component/thermite/proc/attackby_react(datum/source, obj/item/thing, mob/user, params)
 	SIGNAL_HANDLER
 
 	if(thing.get_temperature())
 		thermite_melt(user)
+
+/// Signal handler for COMSIG_PARENT_QDELETING, necessary because turfs can be weird with qdel()
+/datum/component/thermite/proc/parent_qdeleting(datum/source)
+	SIGNAL_HANDLER
+
+	if(!QDELING(src))
+		qdel(src)

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -1,5 +1,3 @@
-GLOBAL_DATUM_INIT(thermite_overlay, /mutable_appearance, mutable_appearance('icons/effects/effects.dmi', "thermite"))
-
 /datum/component/thermite
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	/// Amount of thermite on parent
@@ -15,6 +13,8 @@ GLOBAL_DATUM_INIT(thermite_overlay, /mutable_appearance, mutable_appearance('ico
 	/// The thermite fire overlay
 	var/obj/effect/overlay/thermite/fakefire
 
+	/// Default thermite overlay, do not touch
+	var/static/mutable_appearance/default_thermite_overlay = mutable_appearance('icons/effects/effects.dmi', "thermite")
 	/// Blacklist of turfs that cannot have thermite on it
 	var/static/list/blacklist = typecacheof(list(
 		/turf/open/lava,
@@ -33,7 +33,7 @@ GLOBAL_DATUM_INIT(thermite_overlay, /mutable_appearance, mutable_appearance('ico
 		/turf/closed/wall/r_wall,
 	))
 
-/datum/component/thermite/Initialize(amount, thermite_overlay = GLOB.thermite_overlay)
+/datum/component/thermite/Initialize(amount = 50, thermite_overlay = default_thermite_overlay)
 	if(!isturf(parent))
 		return COMPONENT_INCOMPATIBLE
 	//not actually incompatible, but not valid

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -80,7 +80,8 @@
 		COMSIG_COMPONENT_CLEAN_ACT,
 		COMSIG_PARENT_ATTACKBY,
 		COMSIG_ATOM_FIRE_ACT,
-		COMSIG_PARENT_QDELETING))
+		COMSIG_PARENT_QDELETING,
+	))
 	var/turf/turf_parent = parent
 	turf_parent.update_appearance()
 

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -64,22 +64,22 @@
 	return ..()
 
 /datum/component/thermite/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(parent, COMSIG_ATOM_FIRE_ACT, PROC_REF(on_fire_act))
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_update_overlays))
 	RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(clean_react))
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(attackby_react))
-	RegisterSignal(parent, COMSIG_ATOM_FIRE_ACT, PROC_REF(flame_react))
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(parent, COMSIG_PARENT_QDELETING, PROC_REF(parent_qdeleting)) //probably necessary because turfs are wack
 	var/turf/turf_parent = parent
 	turf_parent.update_appearance()
 
 /datum/component/thermite/UnregisterFromParent()
 	UnregisterSignal(parent, list(
-		COMSIG_PARENT_EXAMINE,
+		COMSIG_ATOM_FIRE_ACT,
 		COMSIG_ATOM_UPDATE_OVERLAYS,
 		COMSIG_COMPONENT_CLEAN_ACT,
 		COMSIG_PARENT_ATTACKBY,
-		COMSIG_ATOM_FIRE_ACT,
+		COMSIG_PARENT_EXAMINE,
 		COMSIG_PARENT_QDELETING,
 	))
 	var/turf/turf_parent = parent
@@ -158,10 +158,12 @@
  * * exposed_temperature - The temperature of the flame hitting the thermite
  * * exposed_volume - The volume of the flame
  */
-/datum/component/thermite/proc/flame_react(datum/source, exposed_temperature, exposed_volume)
+/datum/component/thermite/proc/on_fire_act(datum/source, exposed_temperature, exposed_volume)
 	SIGNAL_HANDLER
 
-	if(exposed_temperature > 1922) // This is roughly the real life requirement to ignite thermite
+	// This is roughly the real life requirement to ignite thermite
+	// (honestly not really sure what the point of this is, considering a god damn lighter can ignite this)
+	if(exposed_temperature >= 1922)
 		thermite_melt()
 
 /**
@@ -176,7 +178,7 @@
 /datum/component/thermite/proc/attackby_react(datum/source, obj/item/thing, mob/user, params)
 	SIGNAL_HANDLER
 
-	if(thing.get_temperature())
+	if(thing.get_temperature() >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		thermite_melt(user)
 
 /// Signal handler for COMSIG_PARENT_QDELETING, necessary because turfs can be weird with qdel()

--- a/code/datums/elements/rust.dm
+++ b/code/datums/elements/rust.dm
@@ -19,7 +19,7 @@
 	RegisterSignal(target, COMSIG_PARENT_EXAMINE, PROC_REF(handle_examine))
 	RegisterSignals(target, list(COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_WELDER), COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_RUSTSCRAPER)), PROC_REF(secondary_tool_act))
 	// Unfortunately registering with parent sometimes doesn't cause an overlay update
-	target.update_icon(UPDATE_OVERLAYS)
+	target.update_appearance()
 
 /datum/element/rust/Detach(atom/source)
 	. = ..()
@@ -27,19 +27,23 @@
 	UnregisterSignal(source, COMSIG_PARENT_EXAMINE)
 	UnregisterSignal(source, list(COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_WELDER), COMSIG_ATOM_SECONDARY_TOOL_ACT(TOOL_RUSTSCRAPER)))
 	REMOVE_TRAIT(source, TRAIT_RUSTY, ELEMENT_TRAIT(type))
-	source.update_icon(UPDATE_OVERLAYS)
+	source.update_appearance()
 
 /datum/element/rust/proc/handle_examine(datum/source, mob/user, list/examine_text)
 	SIGNAL_HANDLER
+
 	examine_text += span_notice("[source] is very rusty, you could probably <i>burn</i> or <i>scrape</i> it off.")
 
 /datum/element/rust/proc/apply_rust_overlay(atom/parent_atom, list/overlays)
 	SIGNAL_HANDLER
-	overlays += rust_overlay
+
+	if(rust_overlay)
+		overlays += rust_overlay
 
 /// Because do_after sleeps we register the signal here and defer via an async call
 /datum/element/rust/proc/secondary_tool_act(atom/source, mob/user, obj/item/item)
 	SIGNAL_HANDLER
+
 	INVOKE_ASYNC(src, PROC_REF(handle_tool_use), source, user, item)
 	return COMPONENT_BLOCK_TOOL_ATTACK
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -20,7 +20,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	desc = "A simple match stick, used for lighting fine smokables."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "match_unlit"
-	var/smoketime = 10 SECONDS
 	w_class = WEIGHT_CLASS_TINY
 	heat = 1000
 	grind_results = list(/datum/reagent/phosphorus = 2)
@@ -29,6 +28,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	/// Whether this match has burnt out.
 	var/burnt = FALSE
 	/// How long the match lasts in seconds
+	var/smoketime = 10 SECONDS
 
 /obj/item/match/process(seconds_per_tick)
 	smoketime -= seconds_per_tick * (1 SECONDS)

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -10,7 +10,7 @@
 /datum/reagent/thermite/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
 	if(reac_volume >= 1)
-		exposed_turf.AddComponent(/datum/component/thermite, reac_volume)
+		exposed_turf.AddComponent(/datum/component/thermite, reac_volume, GLOB.thermite_overlay)
 
 /datum/reagent/thermite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustFireLoss(1 * REM * seconds_per_tick, 0)

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -10,7 +10,7 @@
 /datum/reagent/thermite/expose_turf(turf/exposed_turf, reac_volume)
 	. = ..()
 	if(reac_volume >= 1)
-		exposed_turf.AddComponent(/datum/component/thermite, reac_volume, GLOB.thermite_overlay)
+		exposed_turf.AddComponent(/datum/component/thermite, reac_volume)
 
 /datum/reagent/thermite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustFireLoss(1 * REM * seconds_per_tick, 0)


### PR DESCRIPTION
## About The Pull Request

Nothing too interesting to be quite honest, just cleans up the thermite component code a bit because it was a bit weird.

## Why It's Good For The Game

This probably fixes a few rare bugs where the thermite overlay disappears due to an update_icon call. Slightly neater code.
Also, adds an examine message to thermite walls because small QoL stuff is neat.

## Changelog

:cl:
qol: Thermited walls now get an examine message telling you they are, in fact, thermited.
/:cl: