### PR TITLE
Fills up Northstar's Z1 maint, fixes sec outpost having the wrong locker.

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -12270,6 +12270,7 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dcI" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
@@ -12873,6 +12874,7 @@
 /area/station/hallway/floor4/fore)
 "dmi" = (
 /obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
@@ -18345,6 +18347,7 @@
 /area/station/service/library/garden)
 "eMx" = (
 /obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/starboard/aft)
 "eMA" = (
@@ -28744,6 +28747,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
 "hHI" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured_corner,
 /area/station/maintenance/floor1/starboard/aft)
 "hIa" = (
@@ -29146,6 +29150,7 @@
 /area/station/science/xenobiology)
 "hNe" = (
 /obj/structure/table_frame,
+/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
 "hNf" = (
@@ -32506,6 +32511,7 @@
 /turf/open/floor/noslip,
 /area/station/medical/virology)
 "iLZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
@@ -33932,6 +33938,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"jfi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/aft)
 "jfl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -37303,6 +37313,10 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
+"jXl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall,
+/area/station/maintenance/floor1/starboard/aft)
 "jXu" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -37958,6 +37972,7 @@
 "khb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -40516,6 +40531,7 @@
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison)
 "kPN" = (
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
@@ -41284,6 +41300,10 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor4/starboard)
+"lam" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor1/starboard/aft)
 "lao" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43427,6 +43447,7 @@
 /area/station/maintenance/floor3/port/aft)
 "lCx" = (
 /obj/effect/spawner/random/trash/bucket,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/aft)
 "lCz" = (
@@ -54302,6 +54323,7 @@
 /area/station/cargo/miningdock)
 "olm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
 	},
@@ -63337,6 +63359,7 @@
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 6
 	},
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "qHR" = (
@@ -73440,6 +73463,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"tAp" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor1/port/aft)
 "tAv" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table/reinforced,
@@ -82418,6 +82445,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"vYQ" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/fore)
 "vYV" = (
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/doppler_array{
@@ -84715,6 +84747,7 @@
 "wCg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
@@ -84850,6 +84883,7 @@
 "wDK" = (
 /obj/item/rack_parts,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/aft)
 "wDS" = (
@@ -90782,6 +90816,10 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/aft)
+"yhm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/floor1/port/aft)
 "yhn" = (
 /obj/machinery/light/cold/no_nightlight/directional/north,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -112282,7 +112320,7 @@ oic
 oic
 fHM
 dIz
-uNF
+vYQ
 oic
 rLs
 gVw
@@ -135446,7 +135484,7 @@ vcr
 owK
 xGl
 dou
-ixD
+yhm
 cll
 vcr
 vcr
@@ -140840,7 +140878,7 @@ vcr
 deF
 mKY
 mGp
-uhx
+aHt
 dEc
 fyT
 fHy
@@ -141577,7 +141615,7 @@ hxC
 dSH
 fvN
 dla
-hfm
+jfi
 hhf
 sKt
 sKt
@@ -141826,7 +141864,7 @@ pmt
 sKt
 xBZ
 wDK
-hfm
+jfi
 dSH
 dSH
 sKt
@@ -141839,7 +141877,7 @@ hhf
 ugV
 ugV
 ugV
-hfm
+jfi
 gIz
 owI
 jkM
@@ -142082,7 +142120,7 @@ tOS
 aoq
 sKt
 sbp
-hfm
+jfi
 dSH
 dSH
 sKt
@@ -142090,13 +142128,13 @@ sKt
 ieM
 jLi
 ieM
-sKt
-hfm
+jXl
+jfi
 ugV
-hfm
+jfi
 qGC
 lCx
-hfm
+jfi
 gIz
 cHX
 lhT
@@ -142352,7 +142390,7 @@ sKt
 sPZ
 sKt
 sKt
-hfm
+jfi
 kbf
 teq
 owI
@@ -142863,7 +142901,7 @@ mVN
 vxx
 ofx
 fkJ
-hfm
+jfi
 dla
 flT
 sKt
@@ -143105,7 +143143,7 @@ teq
 sKt
 eMx
 jMa
-gxE
+lam
 sOA
 jMa
 wqb
@@ -143120,8 +143158,8 @@ atK
 iLZ
 sKt
 hfm
-hfm
-hfm
+jfi
+jfi
 hfm
 glH
 jHv
@@ -143159,7 +143197,7 @@ ueS
 aZW
 pOL
 mXC
-aZW
+tAp
 pOL
 bME
 vcr

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -787,6 +787,7 @@
 "ajh" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/random/maintenance/four,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard)
 "ajq" = (
@@ -3689,6 +3690,7 @@
 "aTu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille/broken,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "aTy" = (
@@ -4239,6 +4241,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/first)
 "aZW" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/port/aft)
 "baa" = (
@@ -24473,6 +24476,7 @@
 /turf/open/floor/iron/checker,
 /area/station/cargo/miningdock)
 "gxE" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/starboard/aft)
 "gxH" = (
@@ -30009,6 +30013,11 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"iav" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "iaz" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 1
@@ -50422,6 +50431,8 @@
 /obj/effect/spawner/random/trash/graffiti{
 	pixel_y = 32
 	},
+/obj/effect/spawner/random/maintenance,
+/obj/structure/grille/broken,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "nmw" = (
@@ -68287,7 +68298,7 @@
 "scP" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/table,
-/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/facehugger/toy,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard)
 "sde" = (
@@ -74747,6 +74758,10 @@
 	dir = 4
 	},
 /area/station/hallway/floor1/aft)
+"tTu" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/station/maintenance/floor1/port)
 "tTw" = (
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 8
@@ -84392,6 +84407,7 @@
 /area/station/science/circuits)
 "wxj" = (
 /obj/effect/spawner/random/engineering/material_cheap,
+/obj/structure/grille/broken,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "wxw" = (
@@ -120039,7 +120055,7 @@ wwm
 irK
 xgH
 xgH
-xfT
+tTu
 xSl
 xgH
 dxS
@@ -122625,7 +122641,7 @@ kzE
 kzE
 kzE
 kzE
-eVk
+pur
 wVn
 xgH
 qGp
@@ -132906,7 +132922,7 @@ eVk
 aTu
 xgH
 xdN
-eVk
+iav
 aKt
 dEc
 dEc

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -30009,11 +30009,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"iav" = (
-/obj/effect/spawner/random/structure/grille,
-/obj/structure/cable,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port/aft)
 "iaz" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 1
@@ -137276,7 +137271,7 @@ ixD
 vFE
 xWv
 khQ
-iav
+snf
 vcr
 xbz
 bCM

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -1338,6 +1338,7 @@
 "aqB" = (
 /obj/effect/spawner/random/trash/mopbucket,
 /obj/effect/spawner/random/trash/soap,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "aqO" = (
@@ -1407,6 +1408,11 @@
 	name = "large pot brownie";
 	pixel_y = 6
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "arq" = (
@@ -2450,6 +2456,11 @@
 /obj/item/radio,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"aDG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/chair_flipped,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/fore)
 "aDN" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3115,8 +3126,15 @@
 /turf/open/floor/iron/large,
 /area/station/command/gateway)
 "aMx" = (
-/obj/item/melee/skateboard/improvised,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/stack/sheet/sandblock/five,
+/obj/structure/table_frame/wood,
+/obj/item/camera{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/effect/spawner/random/trash/graffiti{
+	pixel_y = 32
+	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "aMA" = (
@@ -3668,6 +3686,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab)
+"aTu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille/broken,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "aTy" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -4298,6 +4321,11 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
+"bbh" = (
+/obj/effect/spawner/random/maintenance,
+/obj/structure/grille/broken,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "bbo" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -4994,6 +5022,10 @@
 	pixel_y = 8
 	},
 /obj/item/cultivator,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "bjw" = (
@@ -6747,6 +6779,13 @@
 "bDc" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "bDg" = (
@@ -7659,11 +7698,11 @@
 	},
 /area/station/science/auxlab)
 "bPY" = (
-/obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/closet/secure_closet/security,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/first)
 "bQe" = (
@@ -8509,6 +8548,12 @@
 "ccw" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/head/rasta,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "ccF" = (
@@ -9458,6 +9503,8 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard)
 "cnW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille/broken,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "col" = (
@@ -10667,6 +10714,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Ration Storage"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/aft)
 "cHz" = (
@@ -10750,8 +10798,9 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "cIp" = (
-/obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/built/directional/east,
+/obj/item/shard,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/aft)
 "cIr" = (
@@ -11690,8 +11739,9 @@
 /turf/open/floor/engine,
 /area/station/maintenance/floor4/starboard/aft)
 "cVl" = (
-/obj/machinery/light/no_nightlight/directional/south,
-/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/two,
+/obj/machinery/light/red/dim/directional/south,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "cVm" = (
@@ -12212,6 +12262,7 @@
 "dcF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor1/port)
 "dcG" = (
@@ -12873,6 +12924,15 @@
 "dmU" = (
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/entry)
+"dnl" = (
+/obj/effect/spawner/random/trash/garbage{
+	spawn_scatter_radius = 1
+	},
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "dnx" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -13411,6 +13471,8 @@
 /area/station/security/execution/education)
 "duP" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/grille/broken,
+/obj/effect/spawner/random/engineering/material_cheap,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "duX" = (
@@ -14378,6 +14440,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/table_frame,
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "dJf" = (
@@ -14487,6 +14553,12 @@
 /obj/effect/spawner/random/contraband/landmine,
 /turf/open/floor/engine,
 /area/station/maintenance/floor4/starboard/aft)
+"dKh" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/storage/belt/utility,
+/obj/structure/rack,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port/aft)
 "dKk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/pod/dark,
@@ -16376,8 +16448,9 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "ekz" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/engineering/material,
+/obj/structure/table/wood,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "ekB" = (
@@ -16489,6 +16562,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "elM" = (
 /obj/machinery/light/broken/directional/south,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/aft)
 "elX" = (
@@ -16863,6 +16937,7 @@
 	desc = "The pile looks inert, yet you still hear a faint hum. Standinf around this makes you feel funny.";
 	name = "glob of mess"
 	},
+/obj/item/trench_tool,
 /turf/open/floor/plating/foam,
 /area/station/maintenance/floor1/port/aft)
 "epO" = (
@@ -17259,6 +17334,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/rd)
+"ewc" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate,
+/obj/item/shard,
+/obj/item/shard,
+/obj/item/stack/cable_coil,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "ewm" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
@@ -18182,6 +18265,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"eLl" = (
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "eLt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18254,6 +18343,10 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/service/library/garden)
+"eMx" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor1/starboard/aft)
 "eMA" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -18374,6 +18467,7 @@
 /area/station/maintenance/floor2/starboard/fore)
 "eOw" = (
 /obj/structure/rack,
+/obj/effect/spawner/random/medical/surgery_tool,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor1/port)
 "eOy" = (
@@ -19198,6 +19292,7 @@
 	dir = 4
 	},
 /obj/structure/rack,
+/obj/item/storage/box/pinpointer_pairs,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor1/port)
 "fcp" = (
@@ -19442,6 +19537,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"fgs" = (
+/obj/effect/spawner/random/structure/grille,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "fgz" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -19838,6 +19938,7 @@
 /area/station/service/chapel/office)
 "flT" = (
 /obj/effect/spawner/random/structure/table,
+/obj/effect/spawner/random/maintenance,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/aft)
 "fmb" = (
@@ -19868,6 +19969,11 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/station/science/ordnance/bomb)
+"fmp" = (
+/obj/structure/grille/broken,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "fmq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output,
 /obj/effect/turf_decal/trimline/purple/line,
@@ -20495,6 +20601,10 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/station/service/chapel/funeral)
+"fvN" = (
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/aft)
 "fvO" = (
 /obj/structure/sign/departments/cargo/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
@@ -20727,6 +20837,7 @@
 /area/station/hallway/floor1/aft)
 "fyS" = (
 /obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "fyT" = (
@@ -21430,6 +21541,10 @@
 /obj/machinery/light/small/red/directional/east,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
+"fHV" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/smooth,
+/area/station/hallway/floor1/fore)
 "fHW" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance Access"
@@ -21734,6 +21849,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor1/port)
 "fMc" = (
@@ -22844,8 +22960,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gbh" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "gbj" = (
@@ -25258,7 +25374,7 @@
 	},
 /area/station/hallway/floor1/fore)
 "gKM" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/port/aft)
 "gKO" = (
@@ -25362,6 +25478,13 @@
 	dir = 10
 	},
 /area/station/hallway/floor2/aft)
+"gLU" = (
+/obj/effect/spawner/random/trash/garbage{
+	spawn_scatter_radius = 1
+	},
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "gMd" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
@@ -25482,6 +25605,10 @@
 	name = "stick of 'medicated' butter";
 	pixel_y = -2
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "gNN" = (
@@ -25904,6 +26031,7 @@
 "gUv" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/showcase/perfect_employee,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "gUD" = (
@@ -27000,6 +27128,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/item/rack_parts,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "hjH" = (
@@ -27922,6 +28052,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"hxC" = (
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/aft)
 "hxF" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/decal/cleanable/dirt,
@@ -28052,10 +28186,12 @@
 	pixel_x = -6;
 	pixel_y = -4
 	},
-/obj/item/lighter{
-	pixel_y = -6
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/lighter{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/effect/spawner/random/entertainment/drugs,
 /turf/open/floor/carpet/purple,
 /area/station/maintenance/floor1/port/aft)
 "hzz" = (
@@ -28252,13 +28388,9 @@
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
 "hBY" = (
-/obj/effect/spawner/random/trash/garbage{
-	spawn_scatter_radius = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port)
+/area/station/maintenance/floor1/port/aft)
 "hCh" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/blue/warning,
@@ -29476,9 +29608,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "hTU" = (
-/obj/effect/spawner/random/structure/crate_abandoned,
 /obj/machinery/light/red/dim/directional/north,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/aft)
 "hUc" = (
@@ -29716,6 +29848,8 @@
 /area/station/cargo/miningdock)
 "hXe" = (
 /obj/effect/turf_decal/delivery,
+/obj/structure/light_construct/directional/north,
+/obj/item/bot_assembly/floorbot,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "hXm" = (
@@ -31446,6 +31580,10 @@
 /area/station/maintenance/floor3/starboard/fore)
 "ixq" = (
 /obj/effect/spawner/random/contraband/landmine,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "ixr" = (
@@ -31457,11 +31595,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
 "ixt" = (
-/obj/structure/table,
-/obj/item/clothing/head/soft/grey,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/light,
-/area/station/maintenance/floor1/starboard/fore)
+/area/station/maintenance/floor1/port)
 "ixD" = (
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
@@ -31933,6 +32070,7 @@
 "iFn" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/showcase/machinery/tv/broken,
 /turf/open/floor/carpet/purple,
 /area/station/maintenance/floor1/port/aft)
 "iFo" = (
@@ -32660,6 +32798,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor3/starboard)
+"iPa" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating/foam,
+/area/station/maintenance/floor1/port/aft)
 "iPm" = (
 /obj/machinery/food_cart,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -32974,8 +33116,8 @@
 /area/station/service/library/garden)
 "iTJ" = (
 /obj/structure/railing/corner,
-/obj/effect/spawner/random/structure/crate_abandoned,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "iTM" = (
@@ -33086,6 +33228,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
+"iVX" = (
+/obj/structure/grille/broken,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "iVY" = (
 /obj/structure/mirror/directional/west,
 /obj/structure/sink/directional/east,
@@ -33742,6 +33888,12 @@
 /obj/structure/foamedmetal,
 /turf/open/openspace,
 /area/station/maintenance/floor2/port)
+"jet" = (
+/obj/effect/spawner/random/trash/graffiti{
+	pixel_y = -32
+	},
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port/aft)
 "jeA" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34529,7 +34681,6 @@
 /area/station/security/office)
 "jpZ" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -34662,6 +34813,12 @@
 /obj/effect/turf_decal/trimline/green/line,
 /obj/machinery/light/dim/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "jrV" = (
@@ -34856,6 +35013,8 @@
 /area/station/security/prison)
 "juI" = (
 /obj/machinery/light/directional/north,
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/floor1/fore)
 "juM" = (
@@ -36812,7 +36971,14 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor2/starboard/aft)
 "jSa" = (
-/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/frame/machine,
+/obj/item/seeds/cannabis,
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "jSt" = (
@@ -39112,6 +39278,7 @@
 "kyP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "kyR" = (
@@ -41058,6 +41225,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet,
 /area/station/service/abandoned_gambling_den)
+"kZL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/graffiti{
+	pixel_x = -32
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor1/port)
 "kZS" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -41892,6 +42068,8 @@
 /turf/open/floor/plastic,
 /area/station/security/prison/shower)
 "lkD" = (
+/obj/item/rack_parts,
+/obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/pod/light,
 /area/station/maintenance/department/engine/atmos)
 "lkE" = (
@@ -42409,6 +42587,11 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/first)
+"lqq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/tank_holder,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard)
 "lqu" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -43356,6 +43539,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/shard,
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "lDM" = (
@@ -47353,6 +47537,10 @@
 "mDR" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/wrench{
+	pixel_x = -2;
+	pixel_y = 5
+	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/aft)
 "mDV" = (
@@ -49165,6 +49353,10 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/science/circuits)
+"naM" = (
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "naR" = (
 /obj/structure/frame/computer{
 	dir = 4
@@ -50210,6 +50402,12 @@
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/aft)
+"nms" = (
+/obj/effect/spawner/random/trash/graffiti{
+	pixel_y = 32
+	},
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "nmw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50792,6 +50990,7 @@
 "nsX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/red/dim/directional/south,
+/obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/aft)
 "ntn" = (
@@ -55140,6 +55339,10 @@
 /area/station/commons/dorms/room3)
 "ozL" = (
 /obj/effect/decal/cleanable/glass,
+/obj/item/reagent_containers/cup/glass/drinkingglass/filled/soda{
+	pixel_x = 5;
+	pixel_y = -3
+	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/department/engine/atmos)
 "ozO" = (
@@ -55904,7 +56107,7 @@
 /obj/effect/decal/cleanable/blood,
 /obj/structure/spider/stickyweb,
 /obj/machinery/light/broken/directional/west,
-/obj/item/storage/toolbox/mechanical,
+/obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard)
 "oKY" = (
@@ -56621,6 +56824,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/silver,
 /area/station/service/chapel/funeral)
+"oUw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "oUy" = (
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -57211,6 +57419,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/locker)
+"pfS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/trash/graffiti{
+	pixel_y = -32;
+	spawn_loot_chance = 50
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor1/port)
 "pfX" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/machinery/firealarm/directional/north,
@@ -58204,6 +58422,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/second)
+"pur" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "puw" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -58960,6 +59184,10 @@
 	dir = 8
 	},
 /area/station/hallway/floor2/fore)
+"pEN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/station/maintenance/floor1/port/fore)
 "pEQ" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/pod/dark,
@@ -59723,6 +59951,7 @@
 "pPD" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/leather,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "pPG" = (
@@ -59784,6 +60013,10 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard/fore)
+"pRb" = (
+/obj/effect/spawner/random/structure/closet_maintenance,
+/turf/open/floor/pod/light,
+/area/station/maintenance/department/engine/atmos)
 "pRk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62379,6 +62612,11 @@
 /obj/effect/turf_decal/trimline/red/corner,
 /turf/open/floor/pod/dark,
 /area/station/hallway/secondary/entry)
+"qAm" = (
+/obj/structure/grille/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "qAn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -62737,8 +62975,8 @@
 	},
 /area/station/commons/storage/primary)
 "qDA" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/wallframe/button,
+/obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "qDD" = (
@@ -65169,6 +65407,7 @@
 /area/station/hallway/floor1/aft)
 "rjB" = (
 /obj/effect/spawner/random/trash/mess,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "rjD" = (
@@ -65593,8 +65832,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "rra" = (
-/obj/structure/light_construct/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods/ten,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "rrk" = (
@@ -66601,6 +66840,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/kitchen/abandoned)
+"rGY" = (
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "rGZ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red,
@@ -67073,6 +67317,10 @@
 	},
 /obj/effect/turf_decal/trimline/green/line,
 /obj/machinery/light/dim/directional/east,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "rNw" = (
@@ -67128,6 +67376,11 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/service/chapel)
+"rOH" = (
+/obj/item/bot_assembly/medbot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "rOJ" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -67345,6 +67598,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"rSa" = (
+/obj/effect/spawner/random/engineering/flashlight,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/fore)
 "rSf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/cold/directional/east,
@@ -67534,6 +67791,7 @@
 "rUq" = (
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/aft)
 "rUr" = (
@@ -67897,6 +68155,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port)
+"sbp" = (
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/aft)
 "sbq" = (
 /obj/effect/turf_decal/trimline/green/line,
 /obj/effect/turf_decal/trimline/green/line{
@@ -67960,6 +68222,18 @@
 "scv" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal)
+"scx" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/five,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron,
+/area/station/maintenance/floor1/port/aft)
 "scG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -68556,6 +68830,10 @@
 "snd" = (
 /turf/closed/wall,
 /area/station/maintenance/solars/starboard/aft)
+"snf" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port/aft)
 "sng" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -68567,6 +68845,13 @@
 /obj/item/reagent_containers/cup/mortar,
 /obj/item/pestle,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "snp" = (
@@ -70038,6 +70323,11 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/aft)
+"sJf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port/aft)
 "sJg" = (
 /obj/machinery/button/door/directional/north{
 	id = "dorms_lux_1_bolts";
@@ -70437,13 +70727,18 @@
 	},
 /area/station/science/lobby)
 "sOw" = (
-/obj/effect/spawner/random/structure/grille,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/light,
+/obj/effect/spawner/random/structure/girder,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port)
 "sOy" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"sOA" = (
+/obj/item/storage/belt/utility,
+/obj/structure/rack,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor1/starboard/aft)
 "sOB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
@@ -71358,6 +71653,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port)
+"tac" = (
+/obj/structure/girder,
+/turf/open/floor/pod/light,
+/area/station/maintenance/department/engine/atmos)
 "tal" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -71506,9 +71805,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/tools)
+"tcF" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/item/reagent_containers/cup/bucket/wooden{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden/abandoned)
 "tcJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/bot_assembly/medbot,
+/obj/effect/spawner/random/structure/girder,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "tcM" = (
@@ -71635,6 +71943,12 @@
 /obj/effect/spawner/random/contraband/landmine,
 /turf/open/floor/pod/dark,
 /area/station/service/kitchen/abandoned)
+"tei" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "teq" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/floor1/starboard/aft)
@@ -74087,6 +74401,12 @@
 /obj/machinery/defibrillator_mount/directional/north,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
+"tPg" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/item/reagent_containers/pill/maintenance,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port/aft)
 "tPh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -74702,7 +75022,15 @@
 /area/station/maintenance/floor2/port/aft)
 "tYU" = (
 /obj/structure/sink/directional/south,
-/turf/open/floor/iron,
+/obj/item/reagent_containers/cup/bucket/wooden{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/structure/fluff/broken_flooring{
+	dir = 4;
+	icon_state = "pile"
+	},
+/turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
 "tYV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -74710,6 +75038,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
+"tYY" = (
+/obj/effect/spawner/random/structure/crate_abandoned,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor1/port)
 "tZh" = (
 /obj/machinery/door/airlock/science{
 	name = "Monkey Pen"
@@ -75052,6 +75384,12 @@
 	},
 /turf/open/floor/plating/foam,
 /area/station/maintenance/floor2/starboard/fore)
+"ued" = (
+/obj/item/bodybag,
+/obj/structure/closet/crate,
+/obj/effect/spawner/random/medical/surgery_tool,
+/turf/open/floor/pod/light,
+/area/station/maintenance/department/engine/atmos)
 "uep" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75652,6 +75990,7 @@
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
+/obj/effect/spawner/random/entertainment/plushie,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/fore)
 "umw" = (
@@ -75670,6 +76009,8 @@
 /area/station/service/hydroponics)
 "umR" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/pod/light,
 /area/station/maintenance/department/engine/atmos)
 "umT" = (
@@ -75785,6 +76126,7 @@
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/two,
 /obj/effect/spawner/random/engineering/tool,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "uoS" = (
@@ -76176,6 +76518,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/starboard)
+"uvr" = (
+/obj/item/storage/toolbox/mechanical/old,
+/turf/open/floor/plating/foam,
+/area/station/maintenance/floor1/port/aft)
 "uvv" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/emergency_shield/regenerating,
@@ -79980,6 +80326,19 @@
 	dir = 4
 	},
 /area/station/engineering/lobby)
+"vvV" = (
+/obj/effect/spawner/random/engineering/material_cheap,
+/obj/structure/table/wood,
+/obj/item/chisel{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/toy/crayon/spraycan{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/fore)
 "vvX" = (
 /obj/machinery/door_buttons/access_button{
 	idDoor = "virology_airlock_exterior";
@@ -80111,6 +80470,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/stack/sheet/mineral/coal,
+/obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "vxT" = (
@@ -80224,8 +80585,8 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/service/chapel/office)
 "vzb" = (
-/obj/machinery/light/no_nightlight/directional/south,
 /obj/machinery/space_heater,
+/obj/machinery/light/red/dim/directional/south,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "vzi" = (
@@ -80470,7 +80831,7 @@
 "vBW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
-/obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port)
 "vCm" = (
@@ -80823,6 +81184,12 @@
 "vHE" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "vHI" = (
@@ -81156,10 +81523,14 @@
 /obj/item/seeds/cannabis,
 /obj/item/seeds/cannabis,
 /obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/item/seeds/cannabis,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/spawner/random/contraband/cannabis,
 /turf/open/floor/iron,
 /area/station/maintenance/floor1/port/aft)
 "vMF" = (
@@ -82137,6 +82508,17 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
+"wax" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button/door/directional/south{
+	name = "shutters control";
+	id = "z1-maint-crates"
+	},
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "waJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -83326,6 +83708,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
+"wqb" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/flashlight,
+/turf/open/floor/pod/dark,
+/area/station/maintenance/floor1/starboard/aft)
 "wqg" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 9
@@ -83976,6 +84363,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/circuits)
+"wxj" = (
+/obj/effect/spawner/random/engineering/material_cheap,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "wxw" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/door/airlock/public/glass{
@@ -84190,6 +84581,11 @@
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
+"wAd" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/wirerod,
+/turf/open/floor/plating,
+/area/station/maintenance/floor1/port/aft)
 "wAe" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/cup/bottle/acidic_buffer{
@@ -84451,6 +84847,11 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"wDK" = (
+/obj/item/rack_parts,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/aft)
 "wDS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -85913,6 +86314,17 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/pod/light,
 /area/station/maintenance/solars/starboard/aft)
+"wVK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "z1-maint-crates";
+	name = "Abandoned Storage"
+	},
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "wVN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/meter,
@@ -86941,6 +87353,10 @@
 "xjs" = (
 /turf/open/floor/iron/dark/textured_half,
 /area/station/engineering/supermatter/room)
+"xjv" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "xjL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -86967,9 +87383,10 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
 "xkf" = (
-/obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/toy/cattoy,
 /turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port)
+/area/station/maintenance/floor1/port/fore)
 "xkn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -87028,6 +87445,7 @@
 "xkG" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/neck/fake_heretic_amulet,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/aft)
 "xkN" = (
@@ -87679,6 +88097,10 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port/aft)
+"xuq" = (
+/obj/effect/spawner/random/trash/moisture_trap,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/port)
 "xuv" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/floor2/starboard/fore)
@@ -88240,6 +88662,11 @@
 	dir = 8
 	},
 /area/station/service/chapel)
+"xBZ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/pod/light,
+/area/station/maintenance/floor1/starboard/aft)
 "xCg" = (
 /obj/structure/curtain,
 /turf/open/floor/iron/showroomfloor,
@@ -109306,7 +109733,7 @@ xVC
 mIi
 hJy
 hOV
-cnW
+fTb
 wBR
 ydm
 ydm
@@ -109824,13 +110251,13 @@ sui
 olt
 hJy
 uoP
-cnW
+yis
 hJy
 yis
 yis
 yis
 cgi
-ijs
+yis
 hJy
 hJy
 hJy
@@ -110075,13 +110502,13 @@ sZI
 vAy
 inR
 hJy
-xtY
+pEN
 xtY
 xtY
 xYb
 hJy
 hJy
-cnW
+yis
 hJy
 stV
 hJy
@@ -110333,8 +110760,8 @@ bBx
 eoQ
 hJy
 tns
-xtY
-xtY
+pEN
+pEN
 uID
 eiM
 srO
@@ -110598,7 +111025,7 @@ hJy
 eiM
 hJy
 aJk
-yis
+xkf
 gxW
 hJy
 hJy
@@ -112621,9 +113048,9 @@ oic
 oic
 sBT
 vnp
+aDG
 wGJ
-ixt
-uNF
+rSa
 oic
 jrx
 ncc
@@ -112878,7 +113305,7 @@ ekj
 oic
 sBT
 oic
-uNF
+vvV
 ekz
 oic
 oic
@@ -113428,7 +113855,7 @@ hJy
 fyS
 dmG
 hJy
-cnW
+yis
 gOz
 hJy
 hut
@@ -117024,7 +117451,7 @@ edm
 emU
 euA
 xgH
-twx
+fmp
 wVn
 wVn
 wVn
@@ -118293,7 +118720,7 @@ bzw
 ppf
 gjy
 xgH
-tCB
+gLU
 tTU
 kyP
 pLe
@@ -118305,7 +118732,7 @@ uya
 uya
 xbj
 xgH
-twx
+bbh
 dyS
 oMV
 wVn
@@ -118550,7 +118977,7 @@ jZA
 ppf
 lXX
 xgH
-eVk
+tcJ
 tTU
 hjs
 lJk
@@ -119074,7 +119501,7 @@ xgH
 dyS
 wDr
 hjs
-vkO
+oUw
 xgH
 hjs
 dyS
@@ -119849,7 +120276,7 @@ dxS
 xgH
 xgH
 xgH
-wVn
+kZL
 wVn
 xgH
 xuI
@@ -120614,7 +121041,7 @@ pVT
 jbi
 bPY
 kzE
-rTt
+ixt
 dyS
 xgH
 sFr
@@ -120853,7 +121280,7 @@ sYa
 pGW
 dts
 dpH
-mnQ
+fHV
 mnQ
 rMq
 kyR
@@ -120875,7 +121302,7 @@ okH
 dyS
 xgH
 bvi
-twx
+eVk
 lji
 xgH
 wVn
@@ -121642,7 +122069,7 @@ kzE
 kzE
 kzE
 kzE
-dxS
+fgs
 dyS
 xgH
 xgH
@@ -121907,7 +122334,7 @@ wVn
 wVn
 wVn
 wVn
-aKt
+trD
 eVk
 wVn
 xgH
@@ -122165,7 +122592,7 @@ kzE
 kzE
 kzE
 kzE
-twx
+eVk
 wVn
 xgH
 qGp
@@ -122422,7 +122849,7 @@ kOR
 jHn
 kOR
 kzE
-twx
+wxj
 wVn
 xgH
 xgH
@@ -122937,7 +123364,7 @@ hLX
 lkE
 kzE
 lJk
-twx
+qAm
 mEa
 xfT
 rYa
@@ -123177,8 +123604,8 @@ mFW
 kSN
 xgH
 wVn
-tcJ
-hBY
+bMz
+eXi
 kzE
 cgT
 gyc
@@ -123435,7 +123862,7 @@ kSN
 xgH
 wVn
 awf
-awf
+naM
 kzE
 fCc
 lsT
@@ -123450,8 +123877,8 @@ uRn
 ola
 kET
 kzE
-twx
 oTc
+eVk
 mEa
 xfT
 xfT
@@ -123691,8 +124118,8 @@ mea
 kSN
 xgH
 wVn
-twx
-eXi
+rOH
+dnl
 kzE
 fCc
 fji
@@ -123970,7 +124397,7 @@ xgH
 nar
 tCB
 twx
-wVn
+pfS
 xgH
 xgH
 owI
@@ -124198,7 +124625,7 @@ bel
 sKW
 kCF
 osQ
-tRj
+lqq
 whV
 mie
 mFW
@@ -124463,7 +124890,7 @@ mhr
 xgH
 wVn
 xgH
-hXe
+ewc
 hnU
 dNH
 kzE
@@ -124978,7 +125405,7 @@ xgH
 wVn
 xgH
 rra
-xkf
+twx
 qDA
 kzE
 kzE
@@ -125234,19 +125661,19 @@ kSN
 xgH
 wVn
 xgH
-twx
-xfT
-eVk
-vmM
-eVk
-eVk
+wVK
+wVK
+wVK
+xgH
+tei
+tcJ
 wVn
 vzb
 xgH
 aki
-hqh
+tYY
 xgH
-twx
+xCO
 jCU
 xMH
 ooC
@@ -125254,7 +125681,7 @@ pFi
 qHH
 xgH
 oBQ
-oBQ
+xgH
 xgH
 xgH
 xgH
@@ -125490,10 +125917,10 @@ mFW
 kSN
 xgH
 wVn
-xgH
-xgH
-xgH
-xgH
+naM
+xjv
+eLl
+wax
 xgH
 wVn
 wVn
@@ -125754,13 +126181,13 @@ wVn
 wVn
 wVn
 iXe
-aKt
+trD
 cVl
 xgH
 hqh
 wmG
 xgH
-twx
+trD
 lWQ
 xgH
 xCO
@@ -126539,7 +126966,7 @@ mdl
 oTc
 xgH
 lWQ
-twx
+trD
 xgH
 xgH
 owI
@@ -129073,7 +129500,7 @@ mxD
 mxD
 mxD
 hkq
-lkD
+ued
 iqa
 qSl
 aBd
@@ -129102,7 +129529,7 @@ xgH
 xgH
 xgH
 xgH
-twx
+nms
 hdA
 tIj
 lBv
@@ -129330,7 +129757,7 @@ fGi
 fGi
 fGi
 hkq
-lkD
+tac
 iqa
 qSl
 xQp
@@ -129844,7 +130271,7 @@ pno
 pno
 pno
 hkq
-lkD
+pRb
 iqa
 qSl
 lfq
@@ -130383,7 +130810,7 @@ vNY
 xgH
 jZZ
 lwW
-pgi
+tcF
 wlq
 szd
 mRq
@@ -130651,7 +131078,7 @@ xgH
 xgH
 xgH
 eVh
-eVk
+oUw
 xgH
 xgH
 owI
@@ -131165,7 +131592,7 @@ xgH
 hdA
 duP
 eVk
-twx
+rGY
 xgH
 xgH
 owI
@@ -132438,12 +132865,12 @@ xgH
 fmb
 fmb
 xgH
-aKt
-twx
-twx
+trD
+xuq
+iVX
 wxx
 eVk
-eVk
+aTu
 xgH
 xdN
 eVk
@@ -132699,7 +133126,7 @@ kzE
 xgH
 xgH
 afE
-eVk
+pur
 dEc
 dEc
 dEc
@@ -133218,7 +133645,7 @@ dEc
 nJt
 ciZ
 qpb
-xGl
+uvr
 ioL
 jEU
 dNL
@@ -134762,7 +135189,7 @@ vcr
 wtm
 wtm
 vcr
-vFE
+wAd
 oxz
 vcr
 vcr
@@ -135013,7 +135440,7 @@ msL
 vcr
 xep
 dEc
-xGl
+iPa
 nJt
 vcr
 owK
@@ -135523,7 +135950,7 @@ dEc
 bhb
 vcr
 eCr
-uhx
+jet
 vcr
 kUe
 wRM
@@ -137574,7 +138001,7 @@ klY
 kfo
 wfl
 dEc
-uhx
+dKh
 uov
 vcr
 tYU
@@ -137831,7 +138258,7 @@ bDO
 kfo
 mvg
 dEc
-ggX
+hBY
 uov
 vcr
 vHE
@@ -138348,7 +138775,7 @@ wth
 slt
 sJp
 vcr
-jSa
+scx
 lDI
 bjk
 vcr
@@ -139372,7 +139799,7 @@ kVK
 qZT
 yli
 dEc
-aHt
+tPg
 aHt
 klO
 klO
@@ -139629,7 +140056,7 @@ owI
 bOk
 owI
 dEc
-eBu
+sJf
 aHt
 rfo
 rUq
@@ -139897,8 +140324,8 @@ fTE
 gVU
 vcr
 uov
-uhx
-ggX
+snf
+hBY
 elM
 dEc
 dFq
@@ -141146,9 +141573,9 @@ sKt
 sKt
 dSH
 sKt
-hfm
+hxC
 dSH
-hfm
+fvN
 dla
 hfm
 hhf
@@ -141397,8 +141824,8 @@ gHJ
 pui
 pmt
 sKt
-hfm
-hfm
+xBZ
+wDK
 hfm
 dSH
 dSH
@@ -141654,7 +142081,7 @@ qzy
 tOS
 aoq
 sKt
-hfm
+sbp
 hfm
 dSH
 dSH
@@ -142676,12 +143103,12 @@ owI
 owI
 teq
 sKt
-gxE
+eMx
 jMa
 gxE
-gxE
+sOA
 jMa
-gxE
+wqb
 gxE
 jMa
 jFh


### PR DESCRIPTION
## About The Pull Request
@Cheshify 
First floor outpost had the brig sec locker (with batong).
In maintenance, repurposed two nothing-burger rooms. Added more crate/maint loot spawners. Added a couple of decals and trash to some maint rooms.
## Why It's Good For The Game
Feels a bit too empty for how big maintenance is.
## Changelog
:cl:
add: filled up Northstar's Z1 maint with stuff. Reworked some ugly rooms.
fix: fixed Northstar's Z1 sec outpost having the wrong sec locker
/:cl:
