### PR TITLE
Fixes a bad check in DNA infusers

### DIFF
--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -153,7 +153,7 @@
 		if(old_organ)
 			if((old_organ.type != new_organ) && (old_organ.status != ORGAN_ROBOTIC))
 				continue // Old organ can be mutated!
-		else if(isexternalorgan(new_organ))
+		else if(ispath(new_organ, /obj/item/organ/external))
 			continue // External organ can be grown!
 		// Internal organ is either missing, or is non-organic.
 		potential_new_organs -= new_organ


### PR DESCRIPTION

## About The Pull Request

`isexternalorgan(new_organ)` expects an organ instance

`ispath(new_organ, /obj/item/organ/external)` expects a path

`new_organ` is a path

## Why It's Good For The Game

Fix

## Changelog
:cl:
fix: DNA infusers now properly give felinid tails and other external organs
/:cl:
