### PR TITLE
Make sslibrary init faster by loading bookcases asynchronously in parallel 

### DIFF
--- a/code/controllers/subsystem/library.dm
+++ b/code/controllers/subsystem/library.dm
@@ -25,12 +25,17 @@ SUBSYSTEM_DEF(library)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/library/proc/load_shelves()
+	var/list/datum/callback/load_callbacks = list()
+	
 	for(var/obj/structure/bookcase/case_to_load as anything in shelves_to_load)
 		if(!case_to_load)
 			stack_trace("A null bookcase somehow ended up in SSlibrary's shelves_to_load list. Did something harddel?")
 			continue
-		case_to_load.load_shelf()
+		load_callbacks += CALLBACK(case_to_load, TYPE_PROC_REF(/obj/structure/bookcase, load_shelf))
 	shelves_to_load = null
+	
+	//Load all of the shelves asyncronously at the same time, blocking until the last one is finished.
+	callback_select(load_callbacks, savereturns = FALSE)
 
 /// Returns a list of copied book datums that we consider to be "in" the passed in area at roundstart
 /datum/controller/subsystem/library/proc/get_area_books(area/book_parent)


### PR DESCRIPTION
On terry this takes 17 to 20 seconds to init (3 seconds on servers local to the db like sybil), during which world.cpu is 4%. This is because it waits for each bookcase to do its random books sql query before initializing the next bookcase.

callback_select is a system to invoke a list of callbacks asynchronous but only return once they are all finished running, Easymode pipelining of network requests.

There is also the query side query_select that would more directly do what we want, but the query is too detached from the loop to do it that way.

There is also the fact that we could make this not do a query per-bookcase, but that just makes the code more abstract for a benefit we can get by just doing some basic pipelining of network requests using a single proc i wrote 6 years ago