### PR TITLE
North Star: Adds a directional window to disposals to reduce instances of an inlet being broken from ejected trash.

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -44532,6 +44532,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "lSE" = (


### PR DESCRIPTION

## About The Pull Request

Turns out some high force items entering the North Star's disposals room enough times will break the inlet for the stacking machine. The ejector by default spits items out at a range of 2 tiles, so items will always hit the inlet. Chesh mentioned adding a directional rwindow as an incredibly simple potential fix, so here I am.

![image](https://user-images.githubusercontent.com/33107541/232905297-f5b0781d-02a8-4ffc-abb0-4ce9156a85be.png)

Note that this will for sure not 100% prevent this from happening; if some goober keeps throwing spears or something down the trash this will eventually break. I thought about var editing the range down to one or perhaps even shifting some of the machines/walls around to prevent this entirely, but I settled on the original less invasive option.

If requested I can do one of the other options easily.


## Changelog
:cl:
fix: North Star: The disposal room machinery is slightly more resistant to damage caused by ejected trash.
/:cl:
