### PR TITLE
fixes all the issues with gondola mutants + small rat spell check

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -192,5 +192,10 @@
 /// from mob/get_status_tab_items(): (list/items)
 #define COMSIG_MOB_GET_STATUS_TAB_ITEMS "mob_get_status_tab_items"
 
+/// from /mob/living/carbon/human/can_equip(): (mob/living/carbon/human/source_human, obj/item/equip_target, slot)
+#define COMSIG_HUMAN_EQUIPPING_ITEM "mob_equipping_item"
+	/// cancels the equip.
+	#define COMPONENT_BLOCK_EQUIP (1<<0)
+
 /// from mob/proc/dropItemToGround()
 #define COMSIG_MOB_DROPPING_ITEM "mob_dropping_item"

--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -237,8 +237,8 @@
 
 // mostly good for dead mobs that turn into items like dead mice (smack to add).
 /obj/machinery/dna_infuser/proc/add_infusion_item(obj/item/target, mob/user)
-	// if the machine is closed, already has a infusion target, or the target is not valid then no adding.
-	if(!state_open || !is_valid_infusion(target, user))
+	// if the machine already has a infusion target, or the target is not valid then no adding.
+	if(!is_valid_infusion(target, user))
 		return
 	if(!user.transferItemToLoc(target, src))
 		to_chat(user, span_warning("[target] is stuck to your hand!"))
@@ -248,7 +248,7 @@
 // mostly good for dead mobs like corpses (drag to add).
 /obj/machinery/dna_infuser/MouseDrop_T(atom/movable/target, mob/user)
 	// if the machine is closed, already has a infusion target, or the target is not valid then no mouse drop.
-	if(!state_open || !is_valid_infusion(target, user))
+	if(!is_valid_infusion(target, user))
 		return
 	infusing_from = target
 	infusing_from.forceMove(src)

--- a/code/game/machinery/dna_infuser/organ_sets/gondola_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/gondola_organs.dm
@@ -101,20 +101,22 @@ Fluoride Stare: After someone says 5 words, blah blah blah...
 		to_chat(liver_owner, span_warning("You feel like something would be happening to your arms right now... if you still had them."))
 	to_chat(liver_owner, span_notice("Hugging a target will pacify them, but you won't be able to carry much of anything anymore."))
 	pax_hugs.teach(liver_owner)
-	RegisterSignal(liver_owner, COMSIG_LIVING_PICKED_UP_ITEM, PROC_REF(on_owner_picked_up_item))
+	RegisterSignal(liver_owner, COMSIG_HUMAN_EQUIPPING_ITEM, PROC_REF(on_owner_equipping_item))
 	RegisterSignal(liver_owner, COMSIG_LIVING_TRY_PULL, PROC_REF(on_owner_try_pull))
 
 /obj/item/organ/internal/liver/gondola/Remove(mob/living/carbon/liver_owner, special)
 	. = ..()
 	pax_hugs.remove(liver_owner)
-	UnregisterSignal(liver_owner, list(COMSIG_LIVING_PICKED_UP_ITEM, COMSIG_LIVING_TRY_PULL))
+	UnregisterSignal(liver_owner, list(COMSIG_HUMAN_EQUIPPING_ITEM, COMSIG_LIVING_TRY_PULL))
 
-/obj/item/organ/internal/liver/gondola/proc/on_owner_picked_up_item(mob/living/carbon/owner, obj/item/picked_up)
+/// signal sent when prompting if an item can be equipped
+/obj/item/organ/internal/liver/gondola/proc/on_owner_equipping_item(mob/living/carbon/human/owner, obj/item/equip_target, slot)
 	SIGNAL_HANDLER
-	if(picked_up.w_class > WEIGHT_CLASS_TINY)
-		owner.dropItemToGround(picked_up)
+	if(equip_target.w_class > WEIGHT_CLASS_TINY)
 		picked_up.balloon_alert(owner, "too weak to hold this!")
+		return COMPONENT_BLOCK_EQUIP
 
+/// signal sent when owner tries to pull an item
 /obj/item/organ/internal/liver/gondola/proc/on_owner_try_pull(mob/living/carbon/owner, atom/movable/target, force)
 	SIGNAL_HANDLER
 	if(isliving(target))

--- a/code/game/machinery/dna_infuser/organ_sets/gondola_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/gondola_organs.dm
@@ -113,7 +113,7 @@ Fluoride Stare: After someone says 5 words, blah blah blah...
 /obj/item/organ/internal/liver/gondola/proc/on_owner_equipping_item(mob/living/carbon/human/owner, obj/item/equip_target, slot)
 	SIGNAL_HANDLER
 	if(equip_target.w_class > WEIGHT_CLASS_TINY)
-		picked_up.balloon_alert(owner, "too weak to hold this!")
+		equip_target.balloon_alert(owner, "too weak to hold this!")
 		return COMPONENT_BLOCK_EQUIP
 
 /// signal sent when owner tries to pull an item

--- a/code/game/machinery/dna_infuser/organ_sets/rat_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/rat_organs.dm
@@ -140,7 +140,7 @@
 
 /obj/item/organ/internal/tongue/rat/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/noticable_organ, "teeth are oddly shaped and yellowing", BODY_ZONE_PRECISE_MOUTH)
+	AddElement(/datum/element/noticable_organ, "teeth are oddly shaped and yellowing.", BODY_ZONE_PRECISE_MOUTH)
 	AddElement(/datum/element/organ_set_bonus, /datum/status_effect/organ_set_bonus/rat)
 
 /obj/item/organ/internal/tongue/rat/modify_speech(datum/source, list/speech_args)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -689,7 +689,7 @@
  */
 /obj/item/proc/equipped(mob/user, slot, initial = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	SEND_SIGNAL(user, COMSIG_MOB_EQUIPPING_ITEM, src, slot)
+	SEND_SIGNAL(user, COMSIG_HUMAN_EQUIPPING_ITEM, src, slot)
 	visual_equipped(user, slot, initial)
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	SEND_SIGNAL(user, COMSIG_MOB_EQUIPPED_ITEM, src, slot)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -689,6 +689,7 @@
  */
 /obj/item/proc/equipped(mob/user, slot, initial = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
+	SEND_SIGNAL(user, COMSIG_MOB_EQUIPPING_ITEM, src, slot)
 	visual_equipped(user, slot, initial)
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	SEND_SIGNAL(user, COMSIG_MOB_EQUIPPED_ITEM, src, slot)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/human/can_equip(obj/item/equip_target, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, ignore_equipped = FALSE)
-	if(SEND_SIGNAL(src, COMSIG_MOB_EQUIPPING_ITEM, equip_target, slot) == COMPONENT_BLOCK_EQUIP)
+	if(SEND_SIGNAL(src, COMSIG_HUMAN_EQUIPPING_ITEM, equip_target, slot) == COMPONENT_BLOCK_EQUIP)
 		return FALSE
 
 	return dna.species.can_equip(equip_target, slot, disable_warning, src, bypass_equip_delay_self, ignore_equipped)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -1,5 +1,8 @@
-/mob/living/carbon/human/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, ignore_equipped = FALSE)
-	return dna.species.can_equip(I, slot, disable_warning, src, bypass_equip_delay_self, ignore_equipped)
+/mob/living/carbon/human/can_equip(obj/item/equip_target, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE, ignore_equipped = FALSE)
+	if(SEND_SIGNAL(src, COMSIG_MOB_EQUIPPING_ITEM, equip_target, slot) == COMPONENT_BLOCK_EQUIP)
+		return FALSE
+
+	return dna.species.can_equip(equip_target, slot, disable_warning, src, bypass_equip_delay_self, ignore_equipped)
 
 /mob/living/carbon/human/get_item_by_slot(slot_id)
 	switch(slot_id)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1140,6 +1140,9 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(SEND_SIGNAL(target, COMSIG_CARBON_PRE_HELP, user, attacker_style) & COMPONENT_BLOCK_HELP_ACT)
 		return TRUE
 
+	if(attacker_style?.help_act(user, target) == MARTIAL_ATTACK_SUCCESS)
+		return TRUE
+
 	if(target.body_position == STANDING_UP || target.appears_alive())
 		target.help_shake_act(user)
 		if(target != user)
@@ -1147,7 +1150,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		return TRUE
 
 	user.do_cpr(target)
-
 
 /datum/species/proc/grab(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(target.check_block())
@@ -1157,9 +1159,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		return FALSE
 	if(attacker_style?.grab_act(user, target) == MARTIAL_ATTACK_SUCCESS)
 		return TRUE
-	else
-		target.grabbedby(user)
-		return TRUE
+	target.grabbedby(user)
+	return TRUE
 
 ///This proc handles punching damage. IMPORTANT: Our owner is the TARGET and not the USER in this proc. For whatever reason...
 /datum/species/proc/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)


### PR DESCRIPTION

## About The Pull Request

list of fixes:
- dna infusers got a random check for the dna infuser to be open when adding what you're infusing from. i made it intentional that they don't require this for the infusion items, and it just seems to confuse people so i'm reverting
- gondola martial art works again, the martial arts help proc literally never worked GUHHHH
- gondola now correctly can't pick up items they're not able to hold
- adds a missing period to a rat organ examine
- small code cleanup in the species grab proc

## Why It's Good For The Game

feeexes

## Changelog
:cl:
qol: made dna infusers less confusing to use by removing the "must be opened" check
fix: fixed up gondola mutants and how to obtain them
/:cl:
