### PR TITLE
Makes ruin budget proportional to amount of space ruin z-levels

### DIFF
--- a/_maps/runtimestation.json
+++ b/_maps/runtimestation.json
@@ -4,6 +4,7 @@
 	"map_path": "map_files/debug",
 	"map_file": "runtimestation.dmm",
 	"space_ruin_levels": 1,
+	"space_empty_levels": 0,
 	"shuttles": {
 		"cargo": "cargo_delta"
 	}

--- a/_maps/runtimestation.json
+++ b/_maps/runtimestation.json
@@ -4,7 +4,6 @@
 	"map_path": "map_files/debug",
 	"map_file": "runtimestation.dmm",
 	"space_ruin_levels": 1,
-	"space_empty_levels": 0,
 	"shuttles": {
 		"cargo": "cargo_delta"
 	}

--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -172,6 +172,9 @@ Always compile, always use that verb, and always make sure that it works for wha
 #define PLACE_ISOLATED "isolated" //On isolated ruin z level
 
 ///Map generation defines
+#define DEFAULT_SPACE_RUIN_LEVELS 7
+#define DEFAULT_SPACE_EMPTY_LEVELS 1
+
 #define PERLIN_LAYER_HEIGHT "perlin_height"
 #define PERLIN_LAYER_HUMIDITY "perlin_humidity"
 #define PERLIN_LAYER_HEAT "perlin_heat"

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -129,13 +129,15 @@ SUBSYSTEM_DEF(mapping)
 
 #ifndef LOWMEMORYMODE
 	// Create space ruin levels
+	space_levels_so_far = 0
 	while (space_levels_so_far < config.space_ruin_levels)
+		add_new_zlevel("Empty Area [space_levels_so_far+1]", ZTRAITS_SPACE)
 		++space_levels_so_far
-		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
-	// and one level with no ruins
-	for (var/i in 1 to config.space_empty_levels)
+	// Create space levels with no ruins
+	space_levels_so_far = 0
+	while (space_levels_so_far < config.space_empty_levels)
+		empty_space = add_new_zlevel("Empty Area [space_levels_so_far+1]", list(ZTRAIT_LINKAGE = CROSSLINKED))
 		++space_levels_so_far
-		empty_space = add_new_zlevel("Empty Area [space_levels_so_far]", list(ZTRAIT_LINKAGE = CROSSLINKED))
 
 	// Pick a random away mission.
 	if(CONFIG_GET(flag/roundstart_away))
@@ -426,9 +428,10 @@ Used by the AI doomsday and the self-destruct nuke.
 
 #ifndef LOWMEMORYMODE
 	// TODO: remove this when the DB is prepared for the z-levels getting reordered
+	space_levels_so_far = 0
 	while (world.maxz < (5 - 1) && space_levels_so_far < config.space_ruin_levels)
+		add_new_zlevel("Empty Area [space_levels_so_far+1]", ZTRAITS_SPACE)
 		++space_levels_so_far
-		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
 
 	if(config.minetype == "lavaland")
 		LoadGroup(FailedZs, "Lavaland", "map_files/Mining", "Lavaland.dmm", default_traits = ZTRAITS_LAVALAND)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -1,6 +1,3 @@
-// Must be the same as /datum/map_config/var/space_ruin_levels
-#define DEFAULT_SPACE_RUIN_LEVELS 7
-
 SUBSYSTEM_DEF(mapping)
 	name = "Mapping"
 	init_order = INIT_ORDER_MAPPING
@@ -918,5 +915,3 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 /// Returns true if the map we're playing on is on a planet
 /datum/controller/subsystem/mapping/proc/is_planetary()
 	return config.planetary
-
-#undef DEFAULT_SPACE_RUIN_LEVELS

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -132,7 +132,7 @@ SUBSYSTEM_DEF(mapping)
 	while (space_levels_so_far < config.space_ruin_levels)
 		add_new_zlevel("Ruin Area [space_levels_so_far+1]", ZTRAITS_SPACE)
 		++space_levels_so_far
-	// and one level with no ruins
+	// Create empty space levels
 	while (space_levels_so_far < config.space_empty_levels + config.space_ruin_levels)
 		empty_space = add_new_zlevel("Empty Area [space_levels_so_far+1]", list(ZTRAIT_LINKAGE = CROSSLINKED))
 		++space_levels_so_far

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -252,8 +252,8 @@ SUBSYSTEM_DEF(mapping)
 	var/list/space_ruins = levels_by_trait(ZTRAIT_SPACE_RUINS)
 	if (space_ruins.len)
 		// Create a proportional budget by multiplying the amount of space ruin levels in the current map over the default amount
-		var/default_ruins_amount = global.config.defaultmap.space_ruin_levels
-		var/proportional_budget = CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruins_amount)
+		var/default_ruin_amount = global.config.defaultmap.space_ruin_levels
+		var/proportional_budget = CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruin_amount)
 		seedRuins(space_ruins, proportional_budget, list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS])
 
 /// Sets up rivers, and things that behave like rivers. So lava/plasma rivers, and chasms

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -131,12 +131,10 @@ SUBSYSTEM_DEF(mapping)
 	// Create space ruin levels
 	while (space_levels_so_far < config.space_ruin_levels)
 		add_new_zlevel("Ruin Area [space_levels_so_far+1]", ZTRAITS_SPACE)
-		log_world("added ruin space level [space_levels_so_far+1].")
 		++space_levels_so_far
 	// and one level with no ruins
 	while (space_levels_so_far < config.space_empty_levels + config.space_ruin_levels)
 		empty_space = add_new_zlevel("Empty Area [space_levels_so_far+1]", list(ZTRAIT_LINKAGE = CROSSLINKED))
-		log_world("added empty space level [space_levels_so_far+1].")
 		++space_levels_so_far
 
 	// Pick a random away mission.
@@ -256,7 +254,6 @@ SUBSYSTEM_DEF(mapping)
 		// Create a proportional budget by multiplying the amount of space ruin levels in the current map over the default amount
 		var/default_ruin_amount = 7
 		var/proportional_budget = round(CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruin_amount))
-		log_world("starting spawning ruins with [proportional_budget] and non rounded [CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruin_amount)].")
 		seedRuins(space_ruins, proportional_budget, list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS])
 
 /// Sets up rivers, and things that behave like rivers. So lava/plasma rivers, and chasms

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -130,12 +130,13 @@ SUBSYSTEM_DEF(mapping)
 #ifndef LOWMEMORYMODE
 	// Create space ruin levels
 	for (var/i in 0 to config.space_ruin_levels)
-		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
 		++space_levels_so_far
+		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
+
 	// Create space levels with no ruins
 	for (var/i in 0 to config.space_empty_levels)
-		empty_space = add_new_zlevel("Empty Area [space_levels_so_far]", list(ZTRAIT_LINKAGE = CROSSLINKED))
 		++space_levels_so_far
+		empty_space = add_new_zlevel("Empty Area [space_levels_so_far]", list(ZTRAIT_LINKAGE = CROSSLINKED))
 
 	// Pick a random away mission.
 	if(CONFIG_GET(flag/roundstart_away))

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -1,3 +1,6 @@
+// Must be the same as /datum/map_config/var/space_ruin_levels
+#define DEFAULT_SPACE_RUIN_LEVELS 7
+
 SUBSYSTEM_DEF(mapping)
 	name = "Mapping"
 	init_order = INIT_ORDER_MAPPING
@@ -252,8 +255,7 @@ SUBSYSTEM_DEF(mapping)
 	var/list/space_ruins = levels_by_trait(ZTRAIT_SPACE_RUINS)
 	if (space_ruins.len)
 		// Create a proportional budget by multiplying the amount of space ruin levels in the current map over the default amount
-		var/default_ruin_amount = 7
-		var/proportional_budget = round(CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruin_amount))
+		var/proportional_budget = round(CONFIG_GET(number/space_budget) * (space_ruins.len / DEFAULT_SPACE_RUIN_LEVELS))
 		seedRuins(space_ruins, proportional_budget, list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS])
 
 /// Sets up rivers, and things that behave like rivers. So lava/plasma rivers, and chasms
@@ -916,3 +918,5 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 /// Returns true if the map we're playing on is on a planet
 /datum/controller/subsystem/mapping/proc/is_planetary()
 	return config.planetary
+
+#undef DEFAULT_SPACE_RUIN_LEVELS

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -254,7 +254,7 @@ SUBSYSTEM_DEF(mapping)
 	if (space_ruins.len)
 		// Create a proportional budget by multiplying the amount of space ruin levels in the current map over the default amount
 		var/default_ruin_amount = 7
-		var/proportional_budget = CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruin_amount)
+		var/proportional_budget = CONFIG_GET(number/space_budget) * round(space_ruins.len / default_ruin_amount)
 		seedRuins(space_ruins, proportional_budget, list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS])
 
 /// Sets up rivers, and things that behave like rivers. So lava/plasma rivers, and chasms

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -426,11 +426,6 @@ Used by the AI doomsday and the self-destruct nuke.
 		qdel(query_round_map_name)
 
 #ifndef LOWMEMORYMODE
-	// TODO: remove this when the DB is prepared for the z-levels getting reordered
-	while (world.maxz < (5 - 1) && space_levels_so_far < config.space_ruin_levels)
-		++space_levels_so_far
-		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
-
 	if(config.minetype == "lavaland")
 		LoadGroup(FailedZs, "Lavaland", "map_files/Mining", "Lavaland.dmm", default_traits = ZTRAITS_LAVALAND)
 	else if (!isnull(config.minetype) && config.minetype != "none")

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -129,14 +129,12 @@ SUBSYSTEM_DEF(mapping)
 
 #ifndef LOWMEMORYMODE
 	// Create space ruin levels
-	space_levels_so_far = 0
-	while (space_levels_so_far < config.space_ruin_levels)
-		add_new_zlevel("Empty Area [space_levels_so_far+1]", ZTRAITS_SPACE)
+	for (var/i in 0 to config.space_ruin_levels)
+		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
 		++space_levels_so_far
 	// Create space levels with no ruins
-	space_levels_so_far = 0
-	while (space_levels_so_far < config.space_empty_levels)
-		empty_space = add_new_zlevel("Empty Area [space_levels_so_far+1]", list(ZTRAIT_LINKAGE = CROSSLINKED))
+	for (var/i in 0 to config.space_empty_levels)
+		empty_space = add_new_zlevel("Empty Area [space_levels_so_far]", list(ZTRAIT_LINKAGE = CROSSLINKED))
 		++space_levels_so_far
 
 	// Pick a random away mission.

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -426,6 +426,11 @@ Used by the AI doomsday and the self-destruct nuke.
 		qdel(query_round_map_name)
 
 #ifndef LOWMEMORYMODE
+	// TODO: remove this when the DB is prepared for the z-levels getting reordered
+	while (world.maxz < (5 - 1) && space_levels_so_far < config.space_ruin_levels)
+		++space_levels_so_far
+		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
+
 	if(config.minetype == "lavaland")
 		LoadGroup(FailedZs, "Lavaland", "map_files/Mining", "Lavaland.dmm", default_traits = ZTRAITS_LAVALAND)
 	else if (!isnull(config.minetype) && config.minetype != "none")

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -426,10 +426,9 @@ Used by the AI doomsday and the self-destruct nuke.
 
 #ifndef LOWMEMORYMODE
 	// TODO: remove this when the DB is prepared for the z-levels getting reordered
-	space_levels_so_far = 0
 	while (world.maxz < (5 - 1) && space_levels_so_far < config.space_ruin_levels)
-		add_new_zlevel("Empty Area [space_levels_so_far+1]", ZTRAITS_SPACE)
 		++space_levels_so_far
+		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
 
 	if(config.minetype == "lavaland")
 		LoadGroup(FailedZs, "Lavaland", "map_files/Mining", "Lavaland.dmm", default_traits = ZTRAITS_LAVALAND)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -129,14 +129,15 @@ SUBSYSTEM_DEF(mapping)
 
 #ifndef LOWMEMORYMODE
 	// Create space ruin levels
-	for (var/i in 0 to config.space_ruin_levels)
+	while (space_levels_so_far < config.space_ruin_levels)
+		add_new_zlevel("Ruin Area [space_levels_so_far+1]", ZTRAITS_SPACE)
+		log_world("added ruin space level [space_levels_so_far+1].")
 		++space_levels_so_far
-		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
-
-	// Create space levels with no ruins
-	for (var/i in 0 to config.space_empty_levels)
+	// and one level with no ruins
+	while (space_levels_so_far < config.space_empty_levels + config.space_ruin_levels)
+		empty_space = add_new_zlevel("Empty Area [space_levels_so_far+1]", list(ZTRAIT_LINKAGE = CROSSLINKED))
+		log_world("added empty space level [space_levels_so_far+1].")
 		++space_levels_so_far
-		empty_space = add_new_zlevel("Empty Area [space_levels_so_far]", list(ZTRAIT_LINKAGE = CROSSLINKED))
 
 	// Pick a random away mission.
 	if(CONFIG_GET(flag/roundstart_away))
@@ -254,7 +255,8 @@ SUBSYSTEM_DEF(mapping)
 	if (space_ruins.len)
 		// Create a proportional budget by multiplying the amount of space ruin levels in the current map over the default amount
 		var/default_ruin_amount = 7
-		var/proportional_budget = CONFIG_GET(number/space_budget) * round(space_ruins.len / default_ruin_amount)
+		var/proportional_budget = round(CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruin_amount))
+		log_world("starting spawning ruins with [proportional_budget] and non rounded [CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruin_amount)].")
 		seedRuins(space_ruins, proportional_budget, list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS])
 
 /// Sets up rivers, and things that behave like rivers. So lava/plasma rivers, and chasms
@@ -426,10 +428,6 @@ Used by the AI doomsday and the self-destruct nuke.
 		qdel(query_round_map_name)
 
 #ifndef LOWMEMORYMODE
-	// TODO: remove this when the DB is prepared for the z-levels getting reordered
-	while (world.maxz < (5 - 1) && space_levels_so_far < config.space_ruin_levels)
-		++space_levels_so_far
-		add_new_zlevel("Empty Area [space_levels_so_far]", ZTRAITS_SPACE)
 
 	if(config.minetype == "lavaland")
 		LoadGroup(FailedZs, "Lavaland", "map_files/Mining", "Lavaland.dmm", default_traits = ZTRAITS_LAVALAND)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -253,7 +253,7 @@ SUBSYSTEM_DEF(mapping)
 	var/list/space_ruins = levels_by_trait(ZTRAIT_SPACE_RUINS)
 	if (space_ruins.len)
 		// Create a proportional budget by multiplying the amount of space ruin levels in the current map over the default amount
-		var/default_ruin_amount = global.config.defaultmap.space_ruin_levels
+		var/default_ruin_amount = 7
 		var/proportional_budget = CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruin_amount)
 		seedRuins(space_ruins, proportional_budget, list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS])
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -251,7 +251,10 @@ SUBSYSTEM_DEF(mapping)
 	// Generate deep space ruins
 	var/list/space_ruins = levels_by_trait(ZTRAIT_SPACE_RUINS)
 	if (space_ruins.len)
-		seedRuins(space_ruins, CONFIG_GET(number/space_budget), list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS])
+		// Create a proportional budget by multiplying the amount of space ruin levels in the current map over the default amount
+		var/default_ruins_amount = global.config.defaultmap.space_ruin_levels
+		var/proportional_budget = CONFIG_GET(number/space_budget) * (space_ruins.len / default_ruins_amount)
+		seedRuins(space_ruins, proportional_budget, list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS])
 
 /// Sets up rivers, and things that behave like rivers. So lava/plasma rivers, and chasms
 /// It is important that this happens AFTER generating mineral walls and such, since we rely on them for river logic

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -19,8 +19,8 @@
 	var/map_file = "MetaStation.dmm"
 
 	var/traits = null
-	var/space_ruin_levels = 7
-	var/space_empty_levels = 1
+	var/space_ruin_levels = DEFAULT_SPACE_RUIN_LEVELS
+	var/space_empty_levels = DEFAULT_SPACE_EMPTY_LEVELS
 	/// Boolean that tells us if this is a planetary station. (like IceBoxStation)
 	var/planetary = FALSE
 


### PR DESCRIPTION
## About The Pull Request
Adds global define for DEFAULT_SPACE_RUIN_LEVELS and DEFAULT_SPACE_EMPTY_LEVELS

### Proportional budget
Adds proportional budget to setup_ruins
The budget is multiplied by the current amount of ruin levels over the default amount
Smaller amounts will have less ruins, while bigger maps will have more ruins
Should maintain the same amount of ruins per z-level


### Z-levels spawning fix
Z-levels didn't seem to spawn their intended amount of ruins
This was because the for loop added the count variable before doing the spawning. So for example if there was only 1 level, it would count to 1 and end the loop without spawning the level.
Also removed a loop that seemed to just make the process more complex for no reason. It even had a note to remove it. However, if it has a use then you should tell me. 

## Why It's Good For The Game

Maps with a smaller amount of ruin levels won't be completely filled
The amount of ruins will be consistent per z-level
The creator of North Star won't allow space exploration unless there's a way to proportionally reduce the space budget see #74719
## Changelog
:cl:
fix: Maps now spawn the correct amount of space levels. The bug caused them to spawn 1 less in each category
code: The space ruins budget is now proportional to the amount of ruin levels. This has no effect on the current default maps, but added maps with less than the default amount of ruin levels will see less ruins.
/:cl:
