### PR TITLE
Fixes AIs having incorrect laws and being useless on nations

### DIFF
--- a/code/datums/ai_laws/ai_laws.dm
+++ b/code/datums/ai_laws/ai_laws.dm
@@ -1,5 +1,9 @@
 #define AI_LAWS_ASIMOV "asimov"
 
+/// See [/proc/get_round_default_lawset], do not get directily.
+/// This is the default lawset for silicons.
+GLOBAL_VAR(round_default_lawset)
+
 /**
  * A getter that sets up the round default if it has not been yet.
  *
@@ -9,10 +13,9 @@
  * This requires config, so it is generated at the first request to use this var.
  */
 /proc/get_round_default_lawset()
-	var/static/round_default_lawset
-	if(!round_default_lawset)
-		round_default_lawset = setup_round_default_laws()
-	return  round_default_lawset
+	if(!GLOB.round_default_lawset)
+		GLOB.round_default_lawset = setup_round_default_laws()
+	return GLOB.round_default_lawset
 
 //different settings for configured defaults
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -696,3 +696,5 @@
 
 	for(var/department_type in department_types)
 		create_separatist_nation(department_type, announcement = FALSE, dangerous = FALSE, message_admins = FALSE)
+
+	GLOB.round_default_lawset = /datum/ai_laws/united_nations

--- a/code/modules/antagonists/separatist/nation_creation.dm
+++ b/code/modules/antagonists/separatist/nation_creation.dm
@@ -48,8 +48,8 @@
 	nation.generate_nation_objectives(dangerous, department_target)
 
 	//convert current members of the department
-	for(var/mob/living/carbon/human/possible_separatist as anything in GLOB.human_list)
-		if(!possible_separatist.mind)
+	for(var/mob/living/possible_separatist in GLOB.player_list)
+		if(isnull(possible_separatist.mind))
 			continue
 		var/datum/mind/separatist_mind = possible_separatist.mind
 		if(!(separatist_mind.assigned_role.title in jobs_to_revolt))

--- a/code/modules/antagonists/separatist/objectives.dm
+++ b/code/modules/antagonists/separatist/objectives.dm
@@ -51,3 +51,20 @@
 
 /datum/objective/separatist_fluff/check_completion()
 	return TRUE
+
+/datum/objective/united_nations
+	explanation_text = "Maintain the peace on the station. Ensure every nation has a delegate alive by the end of the round."
+	team_explanation_text = "Maintain the peace on the station. Ensure every nation has a delegate alive by the end of the round."
+
+/datum/objective/united_nations/check_completion()
+	var/list/all_separatists = list()
+	var/list/alive_separatists = list()
+
+	for(var/datum/team/nation/separatist_team in GLOB.antagonist_teams)
+		all_separatists |= separatist_team.department
+		for(var/datum/mind/separatist as anything in separatist_team.members)
+			if(considered_escaped(separatist))
+				alive_separatists |= separatist_team.department
+				break
+
+	return length(all_separatists) == length(alive_separatists)

--- a/code/modules/antagonists/separatist/separatist.dm
+++ b/code/modules/antagonists/separatist/separatist.dm
@@ -97,7 +97,7 @@
 //give ais their role as UN
 /datum/antagonist/separatist/apply_innate_effects(mob/living/mob_override)
 	. = ..()
-	var/mob/living/silicon/ai/united_nations_ai = mob_override ||  owner.current
+	var/mob/living/silicon/ai/united_nations_ai = mob_override || owner.current
 	if(isAI(united_nations_ai))
 		united_nations_ai.laws = new /datum/ai_laws/united_nations()
 		united_nations_ai.laws.associate(united_nations_ai)

--- a/code/modules/antagonists/separatist/separatist.dm
+++ b/code/modules/antagonists/separatist/separatist.dm
@@ -42,13 +42,21 @@
  * target_nation: string of the nation they need to destroy/befriend
  */
 /datum/team/nation/proc/generate_nation_objectives(are_we_hostile = TRUE, datum/team/nation/target_nation)
-	dangerous_nation = are_we_hostile
-	if(dangerous_nation && target_nation)
-		var/datum/objective/destroy = new /datum/objective/destroy_nation(null, target_nation)
-		destroy.team = src
-		objectives += destroy
-		target_nation.war_declared(src) //they need to possibly get an objective back
-	var/datum/objective/fluff = new /datum/objective/separatist_fluff(null, name)
+
+	var/datum/objective/fluff
+	if(istype(department, /datum/job_department/silicon))
+		// snowflake but silicons have their own goals
+		fluff = new /datum/objective/united_nations()
+
+	else
+		dangerous_nation = are_we_hostile
+		if(dangerous_nation && target_nation)
+			var/datum/objective/destroy = new /datum/objective/destroy_nation(null, target_nation)
+			destroy.team = src
+			objectives += destroy
+			target_nation.war_declared(src) //they need to possibly get an objective back
+		fluff = new /datum/objective/separatist_fluff(null, name)
+
 	fluff.team = src
 	objectives += fluff
 	update_all_member_objectives()
@@ -89,10 +97,11 @@
 //give ais their role as UN
 /datum/antagonist/separatist/apply_innate_effects(mob/living/mob_override)
 	. = ..()
-	if(isAI(mob_override))
-		var/mob/living/silicon/ai/united_nations_ai = mob_override
-		united_nations_ai.laws = new /datum/ai_laws/united_nations
+	var/mob/living/silicon/ai/united_nations_ai = mob_override ||  owner.current
+	if(isAI(united_nations_ai))
+		united_nations_ai.laws = new /datum/ai_laws/united_nations()
 		united_nations_ai.laws.associate(united_nations_ai)
+		united_nations_ai.show_laws()
 
 /datum/antagonist/separatist/on_removal()
 	remove_objectives()


### PR DESCRIPTION
## About The Pull Request

Fixes #74842 

So this issue is multi-part

1. Separatist antag datum used the wrong mob for applying laws to. `mob_override` is not passed usually and should default to the antag datum owner's mob if not passed

Fixes this by passing the right mob. AI still doesn't get law datums, the issue is deeper - they don't even become separatists!

2. Separatists only iterates over human mobs, and not silicon mobs

Okay, fixes this by iterating over all living players. Still not entirely fixed, new AIs don't have UN laws!

3. Changes the default law datum when nations executes to United Nations so new unlinked silicons gain the lawset

Closer, would you believe it if this still doesn't fix everything, but going further is out of scope. 
Changing the round default lawset as a part of roundstart execution does not update anything that set it from atom initialize. If we wanted we could hook signals into "default lawset changed" and then update it conditionally to circumvent ALL of these issues but whatever, someone can do that later. 

## Why It's Good For The Game

AIs stop crying on nations

## Changelog

:cl: Melbert
fix: AIs now get their proper lawset, and an objective related to said lawset, on Nations
/:cl:

