### PR TITLE
Tablet UI update (mostly fixes)

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -442,7 +442,7 @@
 	add_fingerprint(user)
 	ui_interact(user)
 
-/obj/item/ui_act(action, list/params)
+/obj/item/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	add_fingerprint(usr)
 	return ..()
 

--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -73,7 +73,9 @@
 
 		var/datum/computer_file/program/robotact/program = modularInterface.get_robotact()
 		if(program)
-			program.force_full_update()
+			var/datum/tgui/active_ui = SStgui.get_open_ui(src, program.computer)
+			if(active_ui)
+				active_ui.send_full_update()
 
 	picturesync()
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -460,7 +460,9 @@
 		modularInterface.borglog += "[station_time_timestamp()] - [string]"
 	var/datum/computer_file/program/robotact/program = modularInterface.get_robotact()
 	if(program)
-		program.force_full_update()
+		var/datum/tgui/active_ui = SStgui.get_open_ui(src, program.computer)
+		if(active_ui)
+			active_ui.send_full_update()
 
 /// Same as the normal character name replacement, but updates the contents of the modular interface.
 /mob/living/silicon/fully_replace_character_name(oldname, newname)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -581,12 +581,8 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 // Relays kill program request to currently active program. Use this to quit current program.
 /obj/item/modular_computer/proc/kill_program(forced = FALSE)
 	wipe_program(forced)
-	var/mob/user = usr
-	if(user && istype(user))
-		//Here to prevent programs sleeping in destroy
-		INVOKE_ASYNC(src, TYPE_PROC_REF(/datum, ui_interact), user) // Re-open the UI on this computer. It should show the main screen now.
 	update_appearance()
-	update_tablet_open_uis(user)
+	update_tablet_open_uis(usr)
 
 /obj/item/modular_computer/proc/open_program(mob/user, datum/computer_file/program/program)
 	if(program.computer != src)

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -453,7 +453,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		enabled = TRUE
 		update_appearance()
 		if(open_ui)
-			ui_interact(user)
+			update_tablet_open_uis(user)
 		return TRUE
 	else // Unpowered
 		if(issynth)
@@ -586,6 +586,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 		//Here to prevent programs sleeping in destroy
 		INVOKE_ASYNC(src, TYPE_PROC_REF(/datum, ui_interact), user) // Re-open the UI on this computer. It should show the main screen now.
 	update_appearance()
+	update_tablet_open_uis(user)
 
 /obj/item/modular_computer/proc/open_program(mob/user, datum/computer_file/program/program)
 	if(program.computer != src)
@@ -621,7 +622,7 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	active_program = program
 	program.alert_pending = FALSE
 	update_appearance()
-	ui_interact(user)
+	update_tablet_open_uis(user)
 	return TRUE
 
 // Returns 0 for No Signal, 1 for Low Signal and 2 for Good Signal. 3 is for wired connection (always-on)

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -1,3 +1,33 @@
+/**
+ * update_tablet_open_uis
+ *
+ * Will search the user to see if they have the tablet open.
+ * If they don't, we'll open a new UI depending on the tab the tablet is meant to be on.
+ * If they do, we'll update the interface and title, then update all static data and re-send assets.
+ *
+ * This is best called when you're actually changing the app, as we don't check
+ * if we're swapping to the current UI repeatedly.
+ * Args:
+ * user - The person whose UI we're updating.
+ */
+/obj/item/modular_computer/proc/update_tablet_open_uis(mob/user)
+	var/datum/tgui/active_ui = SStgui.get_open_ui(user, src)
+	if(!active_ui)
+		if(active_program)
+			active_ui = new(user, src, active_program.tgui_id, active_program.filedesc)
+		else
+			active_ui = new(user, src, "NtosMain")
+		return active_ui.open()
+
+	if(active_program)
+		active_ui.interface = active_program.tgui_id
+		active_ui.title = active_program.filedesc
+	else
+		active_ui.interface = "NtosMain"
+
+	update_static_data(user, active_ui)
+	active_ui.send_assets()
+
 /obj/item/modular_computer/interact(mob/user)
 	if(enabled)
 		ui_interact(user)
@@ -23,23 +53,7 @@
 
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
-		if(active_program)
-			ui = new(user, src, active_program.tgui_id, active_program.filedesc)
-		else
-			ui = new(user, src, "NtosMain")
-		ui.open()
-		return
-
-	var/old_open_ui = ui.interface
-	if(active_program)
-		ui.interface = active_program.tgui_id
-		ui.title = active_program.filedesc
-	else
-		ui.interface = "NtosMain"
-	//opened a new UI
-	if(old_open_ui != ui.interface)
-		update_static_data(user, ui)
-		ui.send_assets()
+		update_tablet_open_uis(user)
 
 /obj/item/modular_computer/ui_assets(mob/user)
 	var/list/data = list()
@@ -49,13 +63,16 @@
 	return data
 
 /obj/item/modular_computer/ui_static_data(mob/user)
-	. = ..()
 	var/list/data = list()
 	if(active_program)
 		data += active_program.ui_static_data(user)
 		return data
 
 	data["show_imprint"] = istype(src, /obj/item/modular_computer/pda)
+	data["pai"] = inserted_pai
+	data["has_light"] = has_light
+	data["light_on"] = light_on
+	data["comp_light_color"] = comp_light_color
 
 	return data
 
@@ -93,10 +110,6 @@
 			"alert" = program.alert_pending,
 		))
 
-	data["has_light"] = has_light
-	data["light_on"] = light_on
-	data["comp_light_color"] = comp_light_color
-	data["pai"] = inserted_pai
 	return data
 
 // Handles user's GUI input
@@ -105,14 +118,11 @@
 	if(.)
 		return
 
-	if(ishuman(usr) && !allow_chunky) //in /datum/computer_file/program/ui_act() too
+	if(ishuman(usr) && !allow_chunky)
 		var/mob/living/carbon/human/human_user = usr
 		if(human_user.check_chunky_fingers())
 			balloon_alert(human_user, "fingers are too big!")
 			return TRUE
-
-	if(active_program)
-		active_program.ui_act(action, params, ui, state)
 
 	switch(action)
 		if("PC_exit")
@@ -134,6 +144,7 @@
 
 			active_program = null
 			update_appearance()
+			return TRUE
 
 		if("PC_killprogram")
 			var/prog = params["name"]
@@ -144,12 +155,15 @@
 
 			killed_program.kill_program(forced = TRUE)
 			to_chat(usr, span_notice("Program [killed_program.filename].[killed_program.filetype] with PID [rand(100,999)] has been killed."))
+			return TRUE
 
 		if("PC_runprogram")
 			open_program(usr, find_file_by_name(params["name"]))
+			return TRUE
 
 		if("PC_toggle_light")
-			return toggle_flashlight()
+			toggle_flashlight()
+			return TRUE
 
 		if("PC_light_color")
 			var/mob/user = usr
@@ -161,7 +175,8 @@
 				if(is_color_dark(new_color, 50) ) //Colors too dark are rejected
 					to_chat(user, span_warning("That color is too dark! Choose a lighter one."))
 					new_color = null
-			return set_flashlight_color(new_color)
+			set_flashlight_color(new_color)
+			return TRUE
 
 		if("PC_Eject_Disk")
 			var/param = params["name"]
@@ -205,7 +220,10 @@
 					update_appearance(UPDATE_ICON)
 				if("interact")
 					inserted_pai.attack_self(usr)
-			return UI_UPDATE
+			return TRUE
+
+	if(active_program)
+		return active_program.ui_act(action, params, ui, state)
 
 /obj/item/modular_computer/ui_host()
 	if(physical)

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -69,11 +69,6 @@
 		return data
 
 	data["show_imprint"] = istype(src, /obj/item/modular_computer/pda)
-	data["pai"] = inserted_pai
-	data["has_light"] = has_light
-	data["light_on"] = light_on
-	data["comp_light_color"] = comp_light_color
-
 	return data
 
 /obj/item/modular_computer/ui_data(mob/user)
@@ -81,6 +76,11 @@
 	if(active_program)
 		data += active_program.ui_data(user)
 		return data
+
+	data["pai"] = inserted_pai
+	data["has_light"] = has_light
+	data["light_on"] = light_on
+	data["comp_light_color"] = comp_light_color
 
 	data["login"] = list(
 		IDName = saved_identification || "Unknown",

--- a/code/modules/modular_computers/file_system/program.dm
+++ b/code/modules/modular_computers/file_system/program.dm
@@ -53,6 +53,10 @@
 	temp.usage_flags = usage_flags
 	return temp
 
+///We are not calling parent as it's handled by the computer itself, this is only called after.
+/datum/computer_file/program/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
+	SHOULD_CALL_PARENT(FALSE)
+
 // Relays icon update to the computer.
 /datum/computer_file/program/proc/update_computer_icon()
 	if(computer)

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -98,11 +98,7 @@
 	return TRUE
 
 
-/datum/computer_file/program/ai_restorer/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
-
+/datum/computer_file/program/ai_restorer/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("PRG_beginReconstruction")
 			if(!stored_card || !stored_card.AI)

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -40,10 +40,7 @@
 
 	..()
 
-/datum/computer_file/program/ntnet_dos/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/ntnet_dos/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("PRG_target_relay")
 			for(var/obj/machinery/ntnet_relay/relays as anything in GLOB.ntnet_relays)

--- a/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/revelation.dm
@@ -39,10 +39,7 @@
 			var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread
 			spark_system.start()
 
-/datum/computer_file/program/revelation/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/revelation/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("PRG_arm")
 			armed = !armed

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -94,11 +94,7 @@
 	return data
 
 /datum/computer_file/program/arcade/ui_act(action, list/params)
-	. = ..()
-	if(.)
-		return
 	usr.played_game()
-
 	var/gamerSkillLevel = 0
 	var/gamerSkill = 0
 	if(usr?.mind)

--- a/code/modules/modular_computers/file_system/programs/atmosscan.dm
+++ b/code/modules/modular_computers/file_system/programs/atmosscan.dm
@@ -68,9 +68,6 @@
 	return data
 
 /datum/computer_file/program/atmosscan/ui_act(action, list/params)
-	. = ..()
-	if(.)
-		return
 	switch(action)
 		if("scantoggle")
 			if(atmozphere_mode == ATMOZPHERE_SCAN_CLICK)

--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -62,8 +62,7 @@
 			loglist.Insert(1,"System log of unit [DL_source.name]")
 		DL_progress = -1
 		DL_source = null
-		for(var/datum/tgui/window in SStgui.open_uis_by_src[REF(src)])
-			window.send_full_update()
+		update_static_data_for_all_viewers()
 		return
 
 	DL_progress += 25
@@ -108,10 +107,7 @@
 	data["borglog"] = loglist
 	return data
 
-/datum/computer_file/program/borg_monitor/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/borg_monitor/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("messagebot")
 			var/mob/living/silicon/robot/R = locate(params["ref"]) in GLOB.silicon_mobs

--- a/code/modules/modular_computers/file_system/programs/bounty_board.dm
+++ b/code/modules/modular_computers/file_system/programs/bounty_board.dm
@@ -58,9 +58,6 @@
 	return data
 
 /datum/computer_file/program/bounty_board/ui_act(action, list/params)
-	. = ..()
-	if(.)
-		return
 	var/current_ref_num = params["request"]
 	var/current_app_num = params["applicant"]
 	var/datum/bank_account/request_target

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -87,10 +87,7 @@
 
 	return ..()
 
-/datum/computer_file/program/card_mod/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/card_mod/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	var/mob/user = usr
 	var/obj/item/card/id/inserted_auth_card = computer.computer_id_slot
 

--- a/code/modules/modular_computers/file_system/programs/cargoship.dm
+++ b/code/modules/modular_computers/file_system/programs/cargoship.dm
@@ -27,9 +27,6 @@
 	return data
 
 /datum/computer_file/program/shipping/ui_act(action, list/params)
-	. = ..()
-	if(.)
-		return
 	if(!computer.computer_id_slot) //We need an ID to successfully run
 		return FALSE
 

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -17,9 +17,6 @@
 	return data
 
 /datum/computer_file/program/crew_manifest/ui_act(action, params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
 	switch(action)
 		if("PRG_print")
 			if(computer) //This option should never be called if there is no printer

--- a/code/modules/modular_computers/file_system/programs/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/file_browser.dm
@@ -13,10 +13,7 @@
 	var/open_file
 	var/error
 
-/datum/computer_file/program/filemanager/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/filemanager/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("PRG_deletefile")
 			var/datum/computer_file/file = computer.find_file_by_name(params["name"])

--- a/code/modules/modular_computers/file_system/programs/frontier.dm
+++ b/code/modules/modular_computers/file_system/programs/frontier.dm
@@ -164,10 +164,7 @@
 					data["purchaseableBoosts"][partner.type] += node_id
 	return data
 
-/datum/computer_file/program/scipaper_program/ui_act(action, params)
-	. = ..()
-	if (.)
-		return
+/datum/computer_file/program/scipaper_program/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("et_alia")
 			paper_to_be.et_alia = !paper_to_be.et_alia

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -15,7 +15,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 	var/change_position_cooldown = 30
 	///Jobs blacklisted from having their slots edited.
-	var/list/blacklisted = list(
+	var/static/list/blacklisted = list(
 		JOB_CAPTAIN,
 		JOB_HEAD_OF_PERSONNEL,
 		JOB_HEAD_OF_SECURITY,
@@ -36,7 +36,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 	var/list/opened_positions = list()
 
 /datum/computer_file/program/job_management/New()
-	..()
+	. = ..()
 	change_position_cooldown = CONFIG_GET(number/id_console_jobslot_delay)
 
 
@@ -67,9 +67,6 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 
 
 /datum/computer_file/program/job_management/ui_act(action, params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
 	var/obj/item/card/id/user_id = computer.computer_id_slot
 	if(!user_id || !(ACCESS_CHANGE_IDS in user_id.access))
 		return TRUE

--- a/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/camera.dm
@@ -49,9 +49,6 @@
 	return data
 
 /datum/computer_file/program/maintenance/camera/ui_act(action, params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
 	var/mob/living/user = usr
 	switch(action)
 		if("print_photo")

--- a/code/modules/modular_computers/file_system/programs/maintenance/modsuit.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/modsuit.dm
@@ -42,7 +42,4 @@
 	return controlled_suit?.ui_static_data()
 
 /datum/computer_file/program/maintenance/modsuit_control/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
-	if(.)
-		return
-	controlled_suit.ui_act(action, params, ui, state)
+	return controlled_suit?.ui_act(action, params, ui, state)

--- a/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
+++ b/code/modules/modular_computers/file_system/programs/maintenance/phys_scanner.dm
@@ -18,9 +18,11 @@
 	var/mob/living/carbon/carbon = tapped_atom
 	carbon.visible_message(span_notice("[user] analyzes [tapped_atom]'s vitals."))
 	last_record = healthscan(user, carbon, 1, tochat = FALSE)
+	var/datum/tgui/active_ui = SStgui.get_open_ui(user, computer)
+	if(active_ui)
+		active_ui.send_full_update(force = TRUE)
 
-/datum/computer_file/program/maintenance/phys_scanner/ui_data(mob/user)
+/datum/computer_file/program/maintenance/phys_scanner/ui_static_data(mob/user)
 	var/list/data = list()
-
 	data["last_record"] = last_record
 	return data

--- a/code/modules/modular_computers/file_system/programs/newscasterapp.dm
+++ b/code/modules/modular_computers/file_system/programs/newscasterapp.dm
@@ -22,16 +22,10 @@
 	return ..()
 
 /datum/computer_file/program/newscaster/ui_data(mob/user)
-	var/list/data = list()
-	data += newscaster_ui.ui_data(user)
-	return data
+	return newscaster_ui.ui_data(user)
 
 /datum/computer_file/program/newscaster/ui_static_data(mob/user)
-	var/list/data = newscaster_ui.ui_static_data(user)
-	return data
+	return newscaster_ui.ui_static_data(user)
 
-/datum/computer_file/program/newscaster/ui_act(action, params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
-	return newscaster_ui.ui_act(action, params, ui)
+/datum/computer_file/program/newscaster/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
+	return newscaster_ui.ui_act(action, params, ui, state)

--- a/code/modules/modular_computers/file_system/programs/notepad.dm
+++ b/code/modules/modular_computers/file_system/programs/notepad.dm
@@ -13,13 +13,10 @@
 		bringing you the best in electronics and software since 2467!"
 
 /datum/computer_file/program/notepad/ui_act(action, list/params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
 	switch(action)
 		if("UpdateNote")
 			written_note = params["newnote"]
-			return UI_UPDATE
+			return TRUE
 
 /datum/computer_file/program/notepad/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/modular_computers/file_system/programs/nt_pay.dm
+++ b/code/modules/modular_computers/file_system/programs/nt_pay.dm
@@ -18,9 +18,6 @@
 	var/wanted_token
 
 /datum/computer_file/program/nt_pay/ui_act(action, list/params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
 	switch(action)
 		if("Transaction")
 			token = params["token"]

--- a/code/modules/modular_computers/file_system/programs/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/ntdownloader.dm
@@ -98,10 +98,7 @@
 			download_netspeed = NTNETSPEED_ETHERNET
 	download_completion += download_netspeed
 
-/datum/computer_file/program/ntnetdownload/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/ntnetdownload/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("PRG_downloadfile")
 			if(!downloaded_file)
@@ -150,7 +147,7 @@
 			"installed" = !!computer.find_file_by_name(programs.filename),
 			"compatible" = check_compatibility(programs),
 			"size" = programs.size,
-			"access" = (computer.obj_flags & EMAGGED) && programs.available_on_syndinet ? TRUE : programs.can_run(user,transfer = TRUE, access = access),
+			"access" = (computer.obj_flags & EMAGGED) && programs.available_on_syndinet ? TRUE : programs.can_run(user, transfer = TRUE, access = access),
 			"verifiedsource" = programs.available_on_ntnet,
 		))
 

--- a/code/modules/modular_computers/file_system/programs/ntmessenger.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmessenger.dm
@@ -105,9 +105,6 @@
 	return GLOB.default_state
 
 /datum/computer_file/program/messenger/ui_act(action, list/params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
 	switch(action)
 		if("PDA_ringSet")
 			var/new_ringtone = tgui_input_text(usr, "Enter a new ringtone", "Ringtone", ringtone, MESSENGER_RINGTONE_MAX_LENGTH)
@@ -119,27 +116,27 @@
 				return
 
 			ringtone = new_ringtone
-			return UI_UPDATE
+			return TRUE
 
 		if("PDA_ringer_status")
 			ringer_status = !ringer_status
-			return UI_UPDATE
+			return TRUE
 
 		if("PDA_sAndR")
 			sending_and_receiving = !sending_and_receiving
-			return UI_UPDATE
+			return TRUE
 
 		if("PDA_viewMessages")
 			viewing_messages = !viewing_messages
-			return UI_UPDATE
+			return TRUE
 
 		if("PDA_clearMessages")
 			messages = list()
-			return UI_UPDATE
+			return TRUE
 
 		if("PDA_changeSortStyle")
 			sort_by_job = !sort_by_job
-			return UI_UPDATE
+			return TRUE
 
 		if("PDA_sendEveryone")
 			if(!sending_and_receiving)
@@ -158,7 +155,7 @@
 			if(targets.len > 0)
 				send_message(usr, targets, TRUE)
 
-			return UI_UPDATE
+			return TRUE
 
 		if("PDA_sendMessage")
 			if(!sending_and_receiving)
@@ -182,19 +179,20 @@
 					var/obj/item/computer_disk/virus/disk = computer.inserted_disk
 					if(istype(disk))
 						disk.send_virus(computer, target, usr)
-						return UI_UPDATE
+						update_static_data(usr, ui)
+						return TRUE
 
 				send_message(usr, list(target))
-				return UI_UPDATE
+				return TRUE
 
 		if("PDA_clearPhoto")
 			saved_image = null
 			photo_path = null
-			return UI_UPDATE
+			return TRUE
 
 		if("PDA_toggleVirus")
 			sending_virus = !sending_virus
-			return UI_UPDATE
+			return TRUE
 
 		if("PDA_selectPhoto")
 			if(!issilicon(usr))
@@ -210,18 +208,15 @@
 			return TRUE
 
 /datum/computer_file/program/messenger/ui_static_data(mob/user)
-	var/list/data = ..()
-
+	var/list/data = list()
 	data["owner"] = computer.saved_identification
-	data["sortByJob"] = sort_by_job
-	data["isSilicon"] = issilicon(user)
-
 	return data
 
 /datum/computer_file/program/messenger/ui_data(mob/user)
 	var/list/data = list()
-
 	data["messages"] = messages
+	data["sortByJob"] = sort_by_job
+	data["isSilicon"] = issilicon(user)
 	data["messengers"] = ScrubMessengerList()
 	data["ringer_status"] = ringer_status
 	data["sending_and_receiving"] = sending_and_receiving
@@ -233,7 +228,6 @@
 	if(disk && istype(disk))
 		data["virus_attach"] = TRUE
 		data["sending_virus"] = sending_virus
-
 	return data
 
 //////////////////////

--- a/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/ntnrc_client.dm
@@ -47,10 +47,7 @@
 	active_channel = new_converstaion.id
 	return new_converstaion
 
-/datum/computer_file/program/chatclient/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/chatclient/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	var/datum/ntnet_conversation/channel = SSmodular_computers.get_chat_channel_by_id(active_channel)
 	var/authed = FALSE
 	if(channel && ((channel.channel_operator == src) || netadmin_mode))
@@ -101,13 +98,13 @@
 			if(netadmin_mode)
 				netadmin_mode = FALSE
 				channel?.add_client(src)
-				return UI_UPDATE
+				return TRUE
 			var/mob/living/user = usr
-			if(can_run(user, TRUE, ACCESS_NETWORK))
+			if(can_run(user, TRUE, list(ACCESS_NETWORK)))
 				for(var/datum/ntnet_conversation/channels as anything in SSmodular_computers.chat_channels)
 					channels.remove_client(src)
 				netadmin_mode = TRUE
-				return UI_UPDATE
+				return TRUE
 		if("PRG_changename")
 			var/newname = reject_bad_chattext(params["new_name"], USERNAME_SIZE)
 			newname = replacetext(newname, " ", "_")
@@ -117,7 +114,7 @@
 				if(src in anychannel.active_clients)
 					anychannel.add_status_message("[username] is now known as [newname].")
 			username = newname
-			return UI_UPDATE
+			return TRUE
 		if("PRG_savelog")
 			if(!channel)
 				return
@@ -209,16 +206,11 @@
 
 /datum/computer_file/program/chatclient/ui_static_data(mob/user)
 	var/list/data = list()
-	data["can_admin"] = can_run(user, FALSE, ACCESS_NETWORK)
 	data["selfref"] = REF(src) //used to verify who is you, as usernames can be copied.
-	data["username"] = username
-	data["adminmode"] = netadmin_mode
 	return data
 
 /datum/computer_file/program/chatclient/ui_data(mob/user)
 	var/list/data = list()
-	if(!SSmodular_computers.chat_channels)
-		return data
 
 	var/list/all_channels = list()
 	for(var/datum/ntnet_conversation/conversations as anything in SSmodular_computers.chat_channels)
@@ -261,6 +253,9 @@
 			data["messages"] = messages
 			data["is_operator"] = (channel.channel_operator == src) || netadmin_mode
 
+	data["username"] = username
+	data["adminmode"] = netadmin_mode
+	data["can_admin"] = can_run(user, FALSE, list(ACCESS_NETWORK))
 	data["authed"] = authed
 	return data
 

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -43,10 +43,7 @@
 		get_asset_datum(/datum/asset/simple/portraits)
 	)
 
-/datum/computer_file/program/portrait_printer/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/portrait_printer/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("search")
 			if(search_string != params["to_search"])

--- a/code/modules/modular_computers/file_system/programs/radar.dm
+++ b/code/modules/modular_computers/file_system/programs/radar.dm
@@ -62,10 +62,7 @@
 		data["target"] = trackinfo
 	return data
 
-/datum/computer_file/program/radar/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/radar/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("selecttarget")
 			selected = params["ref"]

--- a/code/modules/modular_computers/file_system/programs/records.dm
+++ b/code/modules/modular_computers/file_system/programs/records.dm
@@ -63,9 +63,7 @@
 
 	return all_records
 
-
-
-/datum/computer_file/program/records/ui_data(mob/user)
+/datum/computer_file/program/records/ui_static_data(mob/user)
 	var/list/data = list()
 	data["records"] = GetRecordsReadable()
 	data["mode"] = mode

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -14,7 +14,7 @@
 	///Access granted by the used to summon robots.
 	var/list/current_access = list()
 	///List of all ping types you can annoy drones with.
-	var/list/drone_ping_types = list(
+	var/static/list/drone_ping_types = list(
 		"Low",
 		"Medium",
 		"High",
@@ -84,18 +84,15 @@
 	return data
 
 /datum/computer_file/program/robocontrol/ui_act(action, list/params, datum/tgui/ui)
-	. = ..()
-	if (.)
-		return
 	var/mob/current_user = ui.user
 	var/obj/item/card/id/id_card = computer?.computer_id_slot
 
-	var/list/standard_actions = list(
+	var/static/list/standard_actions = list(
 		"patroloff",
 		"patrolon",
 		"ejectpai",
 	)
-	var/list/MULE_actions = list(
+	var/static/list/MULE_actions = list(
 		"stop",
 		"go",
 		"home",
@@ -110,13 +107,13 @@
 	)
 	var/mob/living/simple_animal/bot/simple_bot = locate(params["robot"]) in GLOB.bots_list
 	if (action in standard_actions)
-		simple_bot.bot_control(action, current_user, current_access)
+		simple_bot.bot_control(action, current_user, id_card?.GetAccess())
 	if (action in MULE_actions)
-		simple_bot.bot_control(action, current_user, current_access, TRUE)
+		simple_bot.bot_control(action, current_user, id_card?.GetAccess(), TRUE)
 
 	switch(action)
 		if("summon")
-			simple_bot.bot_control(action, current_user, id_card ? id_card.access : current_access)
+			simple_bot.bot_control(action, current_user, id_card ? id_card.access : id_card?.GetAccess())
 		if("ejectcard")
 			if(!computer || !computer.computer_id_slot)
 				return

--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -84,10 +84,7 @@
 	data["borgUpgrades"] = cyborg.upgrades
 	return data
 
-/datum/computer_file/program/robotact/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/robotact/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	//Implied type, memes
 	var/obj/item/modular_computer/pda/silicon/tablet = computer
 	var/mob/living/silicon/robot/cyborg = tablet.silicon_owner
@@ -140,17 +137,3 @@
 				return
 			if(cyborg.emagged || istype(cyborg, /mob/living/silicon/robot/model/syndicate)) //This option shouldn't even be showing otherwise
 				cyborg.self_destruct(cyborg)
-
-/**
- * Forces a full update of the UI, if currently open.
- *
- * Forces an update that includes refreshing ui_static_data. Called by
- * law changes and borg log additions.
- */
-/datum/computer_file/program/robotact/proc/force_full_update()
-	if(!istype(computer, /obj/item/modular_computer/pda/silicon))
-		return
-	var/obj/item/modular_computer/pda/silicon/tablet = computer
-	var/datum/tgui/active_ui = SStgui.get_open_ui(tablet.silicon_owner, src)
-	if(active_ui)
-		active_ui.send_full_update()

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -83,7 +83,7 @@
 		)
 	return data
 
-/datum/computer_file/program/secureye/ui_static_data()
+/datum/computer_file/program/secureye/ui_static_data(mob/user)
 	var/list/data = list()
 	data["mapRef"] = cam_screen.assigned_map
 	var/list/cameras = get_available_cameras()
@@ -96,7 +96,7 @@
 
 	return data
 
-/datum/computer_file/program/secureye/ui_act(action, params)
+/datum/computer_file/program/secureye/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return

--- a/code/modules/modular_computers/file_system/programs/signalcommander.dm
+++ b/code/modules/modular_computers/file_system/programs/signalcommander.dm
@@ -32,9 +32,6 @@
 	return data
 
 /datum/computer_file/program/signal_commander/ui_act(action, list/params)
-	. = ..()
-	if(.)
-		return
 	switch(action)
 		if("signal")
 			INVOKE_ASYNC(src, PROC_REF(signal))

--- a/code/modules/modular_computers/file_system/programs/skill_tracker.dm
+++ b/code/modules/modular_computers/file_system/programs/skill_tracker.dm
@@ -51,9 +51,6 @@
 	return null
 
 /datum/computer_file/program/skill_tracker/ui_act(action, params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
 	switch(action)
 		if("PRG_reward")
 			var/skill_type = find_skilltype(params["skill"])

--- a/code/modules/modular_computers/file_system/programs/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/sm_monitor.dm
@@ -54,10 +54,7 @@
 	data["focus_uid"] = focused_supermatter?.uid
 	return data
 
-/datum/computer_file/program/supermatter_monitor/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/supermatter_monitor/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("PRG_refresh")
 			refresh()

--- a/code/modules/modular_computers/file_system/programs/statusdisplay.dm
+++ b/code/modules/modular_computers/file_system/programs/statusdisplay.dm
@@ -63,9 +63,6 @@
 	log_game("[key_name(usr)] has changed the station status display message to \"[picture]\" [loc_name(usr)]")
 
 /datum/computer_file/program/status/ui_act(action, list/params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
 	switch(action)
 		if("setStatusMessage")
 			upper_text = reject_bad_text(params["upperText"] || "", MAX_STATUS_LINE_LENGTH)
@@ -78,7 +75,6 @@
 /datum/computer_file/program/status/ui_static_data(mob/user)
 	var/list/data = list()
 	data["maxStatusLineLength"] = MAX_STATUS_LINE_LENGTH
-
 	return data
 
 /datum/computer_file/program/status/ui_data(mob/user)

--- a/code/modules/modular_computers/file_system/programs/techweb.dm
+++ b/code/modules/modular_computers/file_system/programs/techweb.dm
@@ -89,9 +89,6 @@
 	return data
 
 /datum/computer_file/program/science/ui_act(action, list/params)
-	. = ..()
-	if (.)
-		return
 	// Check if the console is locked to block any actions occuring
 	if (locked && action != "toggleLock")
 		computer.say("Console is locked, cannot perform further actions.")

--- a/code/modules/modular_computers/file_system/programs/theme_selector.dm
+++ b/code/modules/modular_computers/file_system/programs/theme_selector.dm
@@ -24,10 +24,7 @@
 
 	return data
 
-/datum/computer_file/program/themeify/ui_act(action, params)
-	. = ..()
-	if(.)
-		return
+/datum/computer_file/program/themeify/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)
 	switch(action)
 		if("PRG_change_theme")
 			var/selected_theme = params["selected_theme"]

--- a/code/modules/modular_computers/file_system/programs/wirecarp.dm
+++ b/code/modules/modular_computers/file_system/programs/wirecarp.dm
@@ -12,9 +12,6 @@
 	program_icon = "network-wired"
 
 /datum/computer_file/program/ntnetmonitor/ui_act(action, list/params, datum/tgui/ui)
-	. = ..()
-	if(.)
-		return
 	switch(action)
 		if("resetIDS")
 			SSmodular_computers.intrusion_detection_alarm = FALSE


### PR DESCRIPTION
## About The Pull Request

Tablet UIs are now changed when opening/closing an app, instead of constantly checking for a UI change every ui update. 

Program UI acts no longer call parent, as it was unnecessary, Computers are the ones that should be calling it.

Fixes a ton of problems with static data not updating, such as in Messenger, ID management, Siliconnect, and Chat client

Chat Client's Admin mode also works again, which was broken when accesses to check was turned into a list.

Turns a few lists in Robocontrol into static ones when we aren't changing anything, and makes it actually scan your ID's access. 

Fixes budget ordering being unable to show the cart/call the cargo shuttle.

## Why It's Good For The Game

While I can't seem to find a single issue report on any of the above, these are still problems that should be fixed.

## Changelog

:cl:
fix: SiliConnect can download borg logs again.
fix: The RD can once again enable Admin mode on Wirecarp
fix: NT IRN can once again see the shopping cart and call the cargo shuttle.
fix: Chat Client, ID Management and Messenger should now update their UIs properly.
code: PDAs will hopefully not lag as much when clicking on buttons (such as in ID management).
/:cl: