### PR TITLE
Fixes a runtime from `can_track` on mobs on the syndicate base

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1176,6 +1176,8 @@
 	..()
 	cameraFollow = null
 
+/// Checks if this mob can be actively tracked by cameras / AI.
+/// Can optionally be passed a user, which is the mob tracking.
 /mob/living/proc/can_track(mob/living/user)
 	//basic fast checks go first. When overriding this proc, I recommend calling ..() at the end.
 	if(SEND_SIGNAL(src, COMSIG_LIVING_CAN_TRACK, user) & COMPONENT_CANT_TRACK)
@@ -1187,9 +1189,9 @@
 		return FALSE
 	if(is_away_level(T.z))
 		return FALSE
-	if(onSyndieBase() && !(ROLE_SYNDICATE in user.faction))
+	if(onSyndieBase() && !(ROLE_SYNDICATE in user?.faction))
 		return FALSE
-	if(user != null && src == user)
+	if(!isnull(user) && src == user)
 		return FALSE
 	if(invisibility || alpha == 0)//cloaked
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

`user` is not guaranteed to be passed and can be `null`.

This cause a runtime, when there is a mob on the syndicate base and they are being checked for trackability. 

Fixes it with one character `null` check. 

This is safe, because `THING in null` fails. Any mobs on syndie base are default untrackable if there is no `user`. 
(Famous last words)

## Why It's Good For The Game

Runtime

## Changelog

:cl: Melbert
fix: Runtime from tracking mobs on the syndicate base
/:cl:
