### PR TITLE
Refactors and defuckulates dbcore. Adds support for min_threads rustg setting, Reduce query delay, Make unit tests faster

### DIFF
--- a/code/controllers/configuration/entries/dbconfig.dm
+++ b/code/controllers/configuration/entries/dbconfig.dm
@@ -47,7 +47,24 @@
 /datum/config_entry/number/bsql_thread_limit
 	default = 50
 	min_val = 1
+	deprecated_by = /datum/config_entry/number/pooling_max_sql_connections
+
+/datum/config_entry/number/bsql_thread_limit/DeprecationUpdate(value)
+	return value
+
+/datum/config_entry/number/pooling_min_sql_connections
+	default = 1
+	min_val = 1
+
+/datum/config_entry/number/pooling_max_sql_connections
+	default = 25
+	min_val = 1
 
 /datum/config_entry/number/max_concurrent_queries
 	default = 25
 	min_val = 1
+
+/datum/config_entry/number/max_concurrent_queries/ValidateAndSet(str_val)
+	. = ..()
+	if (.)
+		SSdbcore.max_concurrent_queries = config_entry_value

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -31,12 +31,9 @@ SUBSYSTEM_DEF(dbcore)
 
 	/// Queries currently being handled by database driver
 	var/list/datum/db_query/queries_active = list()
-	/// Queries pending execution that will be handled this controller firing
-	var/list/datum/db_query/queries_new
 	/// Queries pending execution, mapped to complete arguments
 	var/list/datum/db_query/queries_standby = list()
-	/// Queries left to handle during controller firing
-	var/list/datum/db_query/queries_current
+
 
 	var/connection  // Arbitrary handle returned from rust_g.
 
@@ -50,6 +47,34 @@ SUBSYSTEM_DEF(dbcore)
 			message_admins("Could not get schema version from database")
 
 	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/dbcore/OnConfigLoad()
+	. = ..()
+	var/datum/config_entry/min_config_datum = config.entries_by_type[/datum/config_entry/number/pooling_min_sql_connections]
+	var/datum/config_entry/max_config_datum = config.entries_by_type[/datum/config_entry/number/pooling_max_sql_connections]
+
+	var/min_sql_connections = min_config_datum.config_entry_value
+	var/max_sql_connections = max_config_datum.config_entry_value
+
+	if (max_sql_connections < min_sql_connections)
+		if (min_config_datum.modified && max_config_datum.modified)
+			log_config("ERROR: POOLING_MAX_SQL_CONNECTIONS ([max_sql_connections]) is set lower than POOLING_MIN_SQL_CONNECTIONS ([min_sql_connections]), the values will be swapped.")
+
+			CONFIG_SET(number/pooling_min_sql_connections, min_sql_connections)
+			CONFIG_SET(number/pooling_max_sql_connections, max_sql_connections)
+
+		else if (min_config_datum.modified)
+			log_config("ERROR: POOLING_MIN_SQL_CONNECTIONS ([min_sql_connections]) is set higher than POOLING_MAX_SQL_CONNECTIONS's default ([max_sql_connections]), POOLING_MAX_SQL_CONNECTIONS will be updated to match.")
+
+			CONFIG_SET(number/pooling_max_sql_connections, min_sql_connections)
+
+		else //the defaults are wrong?!?!?!
+			stack_trace("The config defaults for sql database pooling don't make sense.")
+			CONFIG_SET(number/pooling_min_sql_connections, min(min_sql_connections, max_sql_connections))
+			CONFIG_SET(number/pooling_max_sql_connections,  max(min_sql_connections, max_sql_connections))
+			log_config("ERROR: POOLING_MAX_SQL_CONNECTIONS ([max_sql_connections]) is set lower than POOLING_MIN_SQL_CONNECTIONS ([min_sql_connections]). Please check your config or the code defaults for sanity")
+
+
 
 /datum/controller/subsystem/dbcore/stat_entry(msg)
 	msg = "P:[length(all_queries)]|Active:[length(queries_active)]|Standby:[length(queries_standby)]"
@@ -66,14 +91,25 @@ SUBSYSTEM_DEF(dbcore)
 		return
 
 	if(!resumed)
-		queries_new = null
 		if(!length(queries_active) && !length(queries_standby) && !length(all_queries))
 			processing_queries = null
-			queries_current = null
 			return
-		queries_current = queries_active.Copy()
 		processing_queries = all_queries.Copy()
 
+	// First handle the already running queries
+	for (var/datum/db_query/query in queries_active)
+		if(!process_query(query))
+			queries_active -= query
+
+	// Now lets pull in standby queries if we have room.
+	if (length(queries_standby) > 0 && length(queries_active) < max_concurrent_queries)
+		var/list/queries_to_activate = queries_standby.Copy(1, min(length(queries_standby), max_concurrent_queries) + 1)
+
+		for (var/datum/db_query/query in queries_to_activate)
+			queries_standby.Remove(query)
+			create_active_query(query)
+
+	// And finally, let check queries for undeleted queries, check ticking if there is a lot of work to do.
 	while(length(processing_queries))
 		var/datum/db_query/query = popleft(processing_queries)
 		if(world.time - query.last_activity_time > (5 MINUTES))
@@ -83,28 +119,8 @@ SUBSYSTEM_DEF(dbcore)
 		if(MC_TICK_CHECK)
 			return
 
-	// First handle the already running queries
-	while(length(queries_current))
-		var/datum/db_query/query = popleft(queries_current)
-		if(!process_query(query))
-			queries_active -= query
-		if(MC_TICK_CHECK)
-			return
 
-	// Then strap on extra new queries as possible
-	if(isnull(queries_new))
-		if(!length(queries_standby))
-			return
-		queries_new = queries_standby.Copy(1, min(length(queries_standby), max_concurrent_queries) + 1)
-
-	while(length(queries_new) && length(queries_active) < max_concurrent_queries)
-		var/datum/db_query/query = popleft(queries_new)
-		queries_standby.Remove(query)
-		create_active_query(query)
-		if(MC_TICK_CHECK)
-			return
-
-/// Helper proc for handling queued new queries
+/// Helper proc for handling activating queued queries
 /datum/controller/subsystem/dbcore/proc/create_active_query(datum/db_query/query)
 	PRIVATE_PROC(TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
@@ -122,7 +138,7 @@ SUBSYSTEM_DEF(dbcore)
 		return FALSE
 	if(QDELETED(query))
 		return FALSE
-	if(query.process(wait))
+	if(query.process((TICKS2DS(wait)) / 10))
 		queries_active -= query
 		return FALSE
 	return TRUE
@@ -142,6 +158,11 @@ SUBSYSTEM_DEF(dbcore)
 /datum/controller/subsystem/dbcore/proc/queue_query(datum/db_query/query)
 	if(IsAdminAdvancedProcCall())
 		return
+
+	if (!length(queries_standby) && length(queries_active) < max_concurrent_queries)
+		create_active_query(query)
+		return
+
 	queries_standby_num++
 	queries_standby |= query
 
@@ -151,7 +172,7 @@ SUBSYSTEM_DEF(dbcore)
 /datum/controller/subsystem/dbcore/Shutdown()
 	//This is as close as we can get to the true round end before Disconnect() without changing where it's called, defeating the reason this is a subsystem
 	if(SSdbcore.Connect())
-		for(var/datum/db_query/query in queries_current)
+		for(var/datum/db_query/query in queries_standby)
 			run_query(query)
 
 		var/datum/db_query/query_round_shutdown = SSdbcore.NewQuery(
@@ -171,11 +192,9 @@ SUBSYSTEM_DEF(dbcore)
 		return FALSE
 	if(var_name == NAMEOF(src, queries_active))
 		return FALSE
-	if(var_name == NAMEOF(src, queries_new))
-		return FALSE
 	if(var_name == NAMEOF(src, queries_standby))
 		return FALSE
-	if(var_name == NAMEOF(src, queries_active))
+	if(var_name == NAMEOF(src, processing_queries))
 		return FALSE
 
 	return ..()
@@ -187,11 +206,9 @@ SUBSYSTEM_DEF(dbcore)
 		return FALSE
 	if(var_name == NAMEOF(src, queries_active))
 		return FALSE
-	if(var_name == NAMEOF(src, queries_new))
-		return FALSE
 	if(var_name == NAMEOF(src, queries_standby))
 		return FALSE
-	if(var_name == NAMEOF(src, queries_active))
+	if(var_name == NAMEOF(src, processing_queries))
 		return FALSE
 	return ..()
 
@@ -215,9 +232,8 @@ SUBSYSTEM_DEF(dbcore)
 	var/address = CONFIG_GET(string/address)
 	var/port = CONFIG_GET(number/port)
 	var/timeout = max(CONFIG_GET(number/async_query_timeout), CONFIG_GET(number/blocking_query_timeout))
-	var/thread_limit = CONFIG_GET(number/bsql_thread_limit)
-
-	max_concurrent_queries = CONFIG_GET(number/max_concurrent_queries)
+	var/min_sql_connections = CONFIG_GET(number/pooling_min_sql_connections)
+	var/max_sql_connections = CONFIG_GET(number/pooling_max_sql_connections)
 
 	var/result = json_decode(rustg_sql_connect_pool(json_encode(list(
 		"host" = address,
@@ -227,7 +243,8 @@ SUBSYSTEM_DEF(dbcore)
 		"db_name" = db,
 		"read_timeout" = timeout,
 		"write_timeout" = timeout,
-		"max_threads" = thread_limit,
+		"min_threads" = min_sql_connections,
+		"max_threads" = max_sql_connections,
 	))))
 	. = (result["status"] == "ok")
 	if (.)

--- a/config/dbconfig.txt
+++ b/config/dbconfig.txt
@@ -38,8 +38,11 @@ ASYNC_QUERY_TIMEOUT 10
 ## Must be less than or equal to ASYNC_QUERY_TIMEOUT
 BLOCKING_QUERY_TIMEOUT 5
 
-## The maximum number of additional threads BSQL is allowed to run at once
-BSQL_THREAD_LIMIT 50
+## The minimum number of sql connections to keep around in the pool. Setting this higher on servers geographically away from the database can improve performance.
+POOLING_MIN_SQL_CONNECTIONS 1
 
-## The maximum number of concurrent asynchronous queries that can run at one time, handled by DM.
+## The maximum number of sql connections to the database.
+POOLING_MAX_SQL_CONNECTIONS 25
+
+## The maximum number of concurrent asynchronous queries that can be pending a result before we start queuing further database queries.
 MAX_CONCURRENT_QUERIES 25


### PR DESCRIPTION
dbcore was very fuckulated.

It had 3 lists of queries, but they all had their own current_run style list to support mc_tick_check (as it was already being done before with the undeleted query check, so i can understand why they ~~cargo culted~~ mirrored the behavior) This was silly and confusing and unneeded given two of those loops can only process at most 25 items at a time on default config, plus these were cheap operations (ask rustg to start thread, ask rustg to check on thread).

Because of the confusingness of the 6 lists for 3 query states, The code to run pending/queued queries immediately during world shutdown was instead looking at the current_run list for active queries, **meaning those queries got ran twice.**

The queued query system only checked the current active query count in fire(), meaning even when there was nothing going on in this subsystem new queries had to wait for the next fire() to run (10 ticks, so 500ms on default config)

Those have all been fixed.

the config `BSQL_THREAD_LIMIT` has been renamed to `POOLING_MAX_SQL_CONNECTIONS` and its default was lowered to match MAX_CONCURRENT_QUERIES . 

added a new config `POOLING_MIN_SQL_CONNECTIONS`, allowing you to pre-allocate a reserve of sql threads.

The queue processing part of SSdbcore's fire() has been made to not obey mc_tick_check for clarity and to make the following change easier to do:

If there is less than `MAX_CONCURRENT_QUERIES` in the active queue, new queries activate immediately.

(its ok that there are two configs that kinda do the same thing, POOLING_MAX_SQL_CONNECTIONS maps to max-threads in the mysql crate, and it seems to only be a suggestion, meanwhile MAX_CONCURRENT_QUERIES can't do anything during init, which is when the highest amount of concurrent queries tend to happen.)

:cl:
config: database configs have been updated for better control over the connection pool
server: BSQL_THREAD_LIMIT has been renamed to POOLING_MAX_SQL_CONNECTIONS, old configs will whine but still work.
fix: fixed rare race condition that could lead to a sql query being ran twice during world shutdown.
/:cl:

I have not tested this pr.