### PR TITLE
Better UX for IV drip

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -296,7 +296,6 @@
 	if(attached)
 		visible_message(span_notice("[attached] is detached from [src]."))
 		detach_iv()
-		return
 	else if(reagent_container)
 		eject_beaker(user)
 	else

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -15,7 +15,7 @@
 /obj/machinery/iv_drip
 	name = "\improper IV drip"
 	desc = "An IV drip with an advanced infusion pump that can both drain blood into and inject liquids from attached containers."
-	desc_controls = "Right-Click to detach the IV or the attached container.\nAlt-Click to toggle transfer."
+	desc_controls = "Alt + Left-Click to toggle transfer."
 	icon = 'icons/obj/medical/iv_drip.dmi'
 	icon_state = "iv_drip"
 	base_icon_state = "iv_drip"
@@ -59,6 +59,10 @@
 		if(internal_list_reagents)
 			reagents.add_reagent_list(internal_list_reagents)
 	interaction_flags_machine |= INTERACT_MACHINE_OFFLINE
+	AddElement( \
+		/datum/element/contextual_screentip_bare_hands, \
+		rmb_text = "Detach / Eject / Configure", \
+	)
 
 /obj/machinery/iv_drip/Destroy()
 	attached = null
@@ -124,7 +128,7 @@
 
 /// Sets the transfer rate to the provided value
 /obj/machinery/iv_drip/proc/set_transfer_rate(new_rate)
-	if(!use_internal_storage && !reagent_container)
+	if(inject_from_plumbing && mode == IV_INJECTING)
 		return
 	transfer_rate = round(clamp(new_rate, MIN_IV_TRANSFER_RATE, MAX_IV_TRANSFER_RATE), IV_TRANSFER_RATE_STEP)
 	update_appearance(UPDATE_ICON)
@@ -352,17 +356,14 @@
 	if(usr.incapacitated())
 		return
 	if(inject_only)
-		if(!mode)
-			update_appearance(UPDATE_ICON)
 		mode = IV_INJECTING
 		return
 	// Prevent blood draining from non-living
 	if(attached && !isliving(attached))
-		if(!mode)
-			update_appearance(UPDATE_ICON)
 		mode = IV_INJECTING
 		return
 	mode = !mode
+	update_appearance(UPDATE_ICON)
 	to_chat(usr, span_notice("The IV drip is now [mode ? "injecting" : "taking blood"]."))
 
 /obj/machinery/iv_drip/examine(mob/user)

--- a/tgui/packages/tgui/interfaces/IVDrip.tsx
+++ b/tgui/packages/tgui/interfaces/IVDrip.tsx
@@ -133,7 +133,7 @@ export const IVDrip = (props, context) => {
             ) : (
               <LabeledList.Item label="Object">
                 <Tooltip content="Drag the cursor from the drip and drop it on an object to connect.">
-                  <NoticeBox my={0.7}>No object hasObjectAttached.</NoticeBox>
+                  <NoticeBox my={0.7}>No object attached.</NoticeBox>
                 </Tooltip>
               </LabeledList.Item>
             )}
@@ -147,13 +147,24 @@ export const IVDrip = (props, context) => {
                 !!canAdjustTransfer && (
                   <LabeledList.Item
                     label="Transfer Rate"
-                    buttons={'Units / Second'}>
+                    buttons={
+                      <Button
+                        my={1}
+                        width={8}
+                        lineHeight={2}
+                        align="center"
+                        icon="power-off"
+                        content={transferRate ? 'Stop' : 'Start'}
+                        onClick={() => act('toggleTransfer')}
+                      />
+                    }>
                     <Slider
                       step={transferStep}
                       my={1}
                       value={transferRate}
                       minValue={minTransferRate}
                       maxValue={maxTransferRate}
+                      unit="units/sec."
                       onDrag={(e, value) =>
                         act('changeRate', {
                           rate: value,

--- a/tgui/packages/tgui/interfaces/IVDrip.tsx
+++ b/tgui/packages/tgui/interfaces/IVDrip.tsx
@@ -52,42 +52,55 @@ export const IVDrip = (props, context) => {
       <Window.Content>
         <Section fill>
           <LabeledList>
-            {hasContainer || hasInternalStorage ? (
-              <LabeledList.Item
-                label="Container"
-                buttons={
-                  !hasInternalStorage &&
-                  !!canRemoveContainer && (
-                    <Button
-                      my={1}
-                      width={8}
-                      lineHeight={2}
-                      align="center"
-                      icon="eject"
-                      content="Eject"
-                      onClick={() => act('eject')}
-                    />
-                  )
-                }>
-                <ProgressBar
-                  value={containerCurrentVolume}
-                  minValue={0}
-                  maxValue={containerMaxVolume}
-                  color={containerReagentColor}>
-                  <span
-                    style={{
-                      'text-shadow': '1px 1px 0 black',
-                    }}>
-                    {`${containerCurrentVolume} of ${containerMaxVolume} units`}
-                  </span>
-                </ProgressBar>
+            {mode === MODE.injecting && injectFromPlumbing ? ( // Plumbing drip injects with the rate from network
+              <LabeledList.Item label="Flow Rate">
+                Controlled by the plumbing network
               </LabeledList.Item>
             ) : (
-              <LabeledList.Item label="Container">
-                <Tooltip content="Click the drip with a container in hand to attach.">
-                  <NoticeBox my={0.7}>No container attached.</NoticeBox>
-                </Tooltip>
-              </LabeledList.Item>
+              !!canAdjustTransfer && (
+                <LabeledList.Item
+                  label="Flow Rate"
+                  buttons={
+                    <Box>
+                      <Button
+                        width={4}
+                        lineHeight={2}
+                        align="center"
+                        icon="angles-left"
+                        onClick={() =>
+                          act('changeRate', {
+                            rate: minTransferRate,
+                          })
+                        }
+                      />
+                      <Button
+                        width={4}
+                        lineHeight={2}
+                        align="center"
+                        icon="angles-right"
+                        onClick={() =>
+                          act('changeRate', {
+                            rate: maxTransferRate,
+                          })
+                        }
+                      />
+                    </Box>
+                  }>
+                  <Slider
+                    step={transferStep}
+                    my={1}
+                    value={transferRate}
+                    minValue={minTransferRate}
+                    maxValue={maxTransferRate}
+                    unit="units/sec."
+                    onDrag={(e, value) =>
+                      act('changeRate', {
+                        rate: value,
+                      })
+                    }
+                  />
+                </LabeledList.Item>
+              )
             )}
             <LabeledList.Item
               label="Direction"
@@ -111,6 +124,44 @@ export const IVDrip = (props, context) => {
                   : 'Reagents from container'
                 : 'Blood into container'}
             </LabeledList.Item>
+            {hasContainer || hasInternalStorage ? (
+              <LabeledList.Item
+                label="Container"
+                buttons={
+                  !hasInternalStorage &&
+                  !!canRemoveContainer && (
+                    <Button
+                      my={1}
+                      width={8}
+                      lineHeight={2}
+                      align="center"
+                      icon="eject"
+                      content="Eject"
+                      onClick={() => act('eject')}
+                    />
+                  )
+                }>
+                <ProgressBar
+                  py={0.3}
+                  value={containerCurrentVolume}
+                  minValue={0}
+                  maxValue={containerMaxVolume}
+                  color={containerReagentColor}>
+                  <span
+                    style={{
+                      'text-shadow': '1px 1px 0 black',
+                    }}>
+                    {`${containerCurrentVolume} of ${containerMaxVolume} units`}
+                  </span>
+                </ProgressBar>
+              </LabeledList.Item>
+            ) : (
+              <LabeledList.Item label="Container">
+                <Tooltip content="Click the drip with a container in hand to attach.">
+                  <NoticeBox my={0.7}>No container attached.</NoticeBox>
+                </Tooltip>
+              </LabeledList.Item>
+            )}
             {hasObjectAttached ? (
               <LabeledList.Item
                 label="Object"
@@ -137,43 +188,6 @@ export const IVDrip = (props, context) => {
                 </Tooltip>
               </LabeledList.Item>
             )}
-            {!!hasObjectAttached &&
-              (mode === MODE.injecting && injectFromPlumbing ? ( // Plumbing drip injects with the rate from network
-                <LabeledList.Item label="Transfer Rate">
-                  Controlled by the plumbing network
-                </LabeledList.Item>
-              ) : (
-                (!!hasContainer || !!hasInternalStorage) &&
-                !!canAdjustTransfer && (
-                  <LabeledList.Item
-                    label="Transfer Rate"
-                    buttons={
-                      <Button
-                        my={1}
-                        width={8}
-                        lineHeight={2}
-                        align="center"
-                        icon="power-off"
-                        content={transferRate ? 'Stop' : 'Start'}
-                        onClick={() => act('toggleTransfer')}
-                      />
-                    }>
-                    <Slider
-                      step={transferStep}
-                      my={1}
-                      value={transferRate}
-                      minValue={minTransferRate}
-                      maxValue={maxTransferRate}
-                      unit="units/sec."
-                      onDrag={(e, value) =>
-                        act('changeRate', {
-                          rate: value,
-                        })
-                      }
-                    />
-                  </LabeledList.Item>
-                )
-              ))}
           </LabeledList>
         </Section>
       </Window.Content>


### PR DESCRIPTION
## About The Pull Request

Resolves #74752 with the following:

IV drip screntips now mention that you can toggle it between Min and Max transfer rate without opening UI with Alt+Click

Added buttons to min or max out the transfer rate within the UI, without the need to use slider and made this control available regardless of container and object.

<img width="300" alt="XcoPcE6Su4" src="https://user-images.githubusercontent.com/3625094/233209370-d95f32c6-6044-43b7-8379-b6130d561d32.png">

Also fixed animation states.

## Why It's Good For The Game

You couldn't start injection with the desired flow rate before this. 

## Changelog

:cl:
qol: IV drip flow rate can be changed without the container or object attached
fix: IV drip animation states fixed
/:cl:

