### PR TITLE
Fixes an exploit that allows portable chem mixer to dispense chems to a beaker from anywhere. Adds a locked check to storage hotkeys.

### DIFF
--- a/code/game/objects/items/devices/portable_chem_mixer.dm
+++ b/code/game/objects/items/devices/portable_chem_mixer.dm
@@ -208,7 +208,7 @@
 			var/reagent_name = params["reagent"]
 			var/datum/reagent/reagent = GLOB.name2reagent[reagent_name]
 			var/entry = dispensable_reagents[reagent]
-			if(beaker)
+			if(beaker && beaker.loc == src)
 				var/datum/reagents/R = beaker.reagents
 				var/actual = min(amount, 1000, R.maximum_volume - R.total_volume)
 				// todo: add check if we have enough reagent left

--- a/code/game/objects/items/devices/portable_chem_mixer.dm
+++ b/code/game/objects/items/devices/portable_chem_mixer.dm
@@ -90,6 +90,7 @@
 	if (!atom_storage.locked)
 		update_contents()
 	if (atom_storage.locked)
+		atom_storage.hide_contents(usr)
 		replace_beaker(user)
 	update_appearance()
 	playsound(src, 'sound/items/screwdriver2.ogg', 50)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -413,6 +413,9 @@
 		return
 	if(!storage.supports_smart_equip)
 		return
+	if (equipped_item.atom_storage.locked) // Determines if container is locked before trying to put something in or take something out so we dont give out information on contents (or lack of)
+		to_chat(src, span_warning("The [equipped_item.name] is locked!"))
+		return
 	if(thing) // put thing in storage item
 		if(!equipped_item.atom_storage?.attempt_insert(thing, src))
 			to_chat(src, span_warning("You can't fit [thing] into your [equipped_item.name]!"))


### PR DESCRIPTION
## About The Pull Request
Ya so I just recently learned about the portable chem mixer and after 10 minutes of playing with it I found a game breaking exploit on accident and ended up thinking part of it was intentional.

Basically this is how the portable chem mixer currently works, you put beakers with chems into it and then you change it to dispense mode which disallows opening the inventory (but doesnt close it) once you change it to dispense mode the next beaker you put in it becomes linked to it and it can dispense chems from other beakers into this linked beaker.

The problem was it doesnt close your inventory, which lead me to believe the beaker is supposed to be in your hand when you dispense chems into it.

Then someone who I was having ic conflict with stole my beaker and I noticed that the beaker still shows up in my dispense ui..... 

And how excited I was to learn that I indeed could turn them into a fireball from over a screen away..


https://www.youtube.com/watch?v=ebNJVYgVsKA

(For clarification the reaction I did was failed helgrasp which makes a (non damaging) fireblast that sets people on fire and knocks them back)


The fix is to make it so the inventory of the portable chem mixer is automatically closed when its locked so you cant take the beaker out (I dont think instant summons will work either since that teleports the container too so no need to check where the linked beaker is constantly)
## Why It's Good For The Game

This is an exploit that I firmly believe has BS murderbone potential...imagine being able to remotely dump chems into a bluespace beaker...imagine giving someone a beaker that you have linked.
## Changelog
:cl:

fix: You can no longer bypass the laws of bluespace with a portable chem mixer.
fix: You can no longer bypass container locks with storage hotkeys.

/:cl:
