### PR TITLE
Combined soundadd/sounddel and imageadd/imagedel

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,10 +20,8 @@ del: Removed old things
 qol: made something easier to use
 balance: rebalanced something
 fix: fixed a few things
-soundadd: added a new sound thingy
-sounddel: removed an old sound thingy
-imageadd: added some icons and images
-imagedel: deleted some icons and images
+sound: added/modified/removed audio or sound effects
+image: added/modified/removed some icons or images
 spellcheck: fixed a few typos
 code: changed some code
 refactor: refactored some code

--- a/tools/WebhookProcessor/github_webhook_processor.php
+++ b/tools/WebhookProcessor/github_webhook_processor.php
@@ -705,15 +705,9 @@ function checkchangelog($payload) {
 					$tags[] = 'Quality of Life';
 				}
 				break;
-			case 'soundadd':
-				if($item != 'added a new sound thingy') {
+			case 'sound':
+				if($item != 'added/modified/removed audio or sound effects') {
 					$tags[] = 'Sound';
-				}
-				break;
-			case 'sounddel':
-				if($item != 'removed an old sound thingy') {
-					$tags[] = 'Sound';
-					$tags[] = 'Removal';
 				}
 				break;
 			case 'add':
@@ -730,15 +724,9 @@ function checkchangelog($payload) {
 					$tags[] = 'Removal';
 				}
 				break;
-			case 'imageadd':
-				if($item != 'added some icons and images') {
+			case 'image':
+				if($item != 'added/modified/removed some icons or images') {
 					$tags[] = 'Sprites';
-				}
-				break;
-			case 'imagedel':
-				if($item != 'deleted some icons and images') {
-					$tags[] = 'Sprites';
-					$tags[] = 'Removal';
 				}
 				break;
 			case 'typo':

--- a/tools/pull_request_hooks/changelogConfig.js
+++ b/tools/pull_request_hooks/changelogConfig.js
@@ -40,30 +40,16 @@ export const CHANGELOG_ENTRIES = [
 	],
 
 	[
-		["soundadd"],
+		["sound"],
 		{
-			placeholders: ["added a new sound thingy"],
+			placeholders: ["added/modified/removed audio or sound effects"],
 		},
 	],
 
 	[
-		["sounddel"],
+		["image"],
 		{
-			placeholders: ["removed an old sound thingy"],
-		},
-	],
-
-	[
-		["imageadd"],
-		{
-			placeholders: ["added some icons and images"],
-		},
-	],
-
-	[
-		["imagedel"],
-		{
-			placeholders: ["deleted some icons and images"],
+			placeholders: ["added/modified/removed some icons or images"],
 		},
 	],
 


### PR DESCRIPTION
## About The Pull Request
Combines
```
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
```
into "sound," and
```
imageadd: added some icons and images
imagedel: deleted some icons and images
```
into "image" in the changelog. 

I don't think we need to have both; `sound` and `image` can represent any kind of change to their respective medium.