### PR TITLE
Stops the base random poster spawner from spawning traitor posters

### DIFF
--- a/code/game/objects/effects/poster.dm
+++ b/code/game/objects/effects/poster.dm
@@ -149,7 +149,7 @@
 	return .
 
 /obj/structure/sign/poster/proc/randomise(base_type)
-	var/list/poster_types = subtypesof(base_type)
+	var/list/poster_types = subtypesof(base_type) - typesof(/obj/structure/sign/poster/traitor)
 	var/list/approved_types = list()
 	for(var/obj/structure/sign/poster/type_of_poster as anything in poster_types)
 		if(initial(type_of_poster.icon_state) && !initial(type_of_poster.never_random))

--- a/code/game/objects/effects/poster.dm
+++ b/code/game/objects/effects/poster.dm
@@ -111,8 +111,8 @@
 	var/ruined = FALSE
 	var/random_basetype
 	var/never_random = FALSE // used for the 'random' subclasses.
-	///Exclude posters of this type from being added to the random pool
-	var/random_blacklisted_basetype
+	///Exclude posters of these types from being added to the random pool
+	var/list/random_blacklisted_basetypes
 	///Whether the poster should be printable from library management computer. Mostly exists to keep directionals from being printed.
 	var/printable = FALSE
 
@@ -295,7 +295,7 @@
 	icon_state = "random_anything"
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster
-	random_blacklisted_basetype = /obj/structure/sign/poster/traitor
+	random_blacklisted_basetypes = list(/obj/structure/sign/poster/traitor)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/random, 32)
 

--- a/code/game/objects/effects/poster.dm
+++ b/code/game/objects/effects/poster.dm
@@ -112,7 +112,7 @@
 	var/random_basetype
 	var/never_random = FALSE // used for the 'random' subclasses.
 	///Exclude posters of these types from being added to the random pool
-	var/list/random_blacklisted_basetypes
+	var/list/blacklisted_types
 	///Whether the poster should be printable from library management computer. Mostly exists to keep directionals from being printed.
 	var/printable = FALSE
 
@@ -295,7 +295,7 @@
 	icon_state = "random_anything"
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster
-	random_blacklisted_basetypes = list(/obj/structure/sign/poster/traitor)
+	blacklisted_types = list(/obj/structure/sign/poster/traitor)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/random, 32)
 

--- a/code/game/objects/effects/poster.dm
+++ b/code/game/objects/effects/poster.dm
@@ -152,8 +152,9 @@
 
 /obj/structure/sign/poster/proc/randomise(base_type)
 	var/list/poster_types = subtypesof(base_type)
-	if(random_blacklisted_basetype)
-		poster_types -= typesof(random_blacklisted_basetype)
+	if(length(blacklisted_types))
+		for(var/iterated_type in blacklisted_types)
+			poster_types -= typesof(iterated_type)
 	var/list/approved_types = list()
 	for(var/obj/structure/sign/poster/type_of_poster as anything in poster_types)
 		if(initial(type_of_poster.icon_state) && !initial(type_of_poster.never_random))

--- a/code/game/objects/effects/poster.dm
+++ b/code/game/objects/effects/poster.dm
@@ -111,6 +111,8 @@
 	var/ruined = FALSE
 	var/random_basetype
 	var/never_random = FALSE // used for the 'random' subclasses.
+	///Exclude posters of this type from being added to the random pool
+	var/random_blacklisted_basetype
 	///Whether the poster should be printable from library management computer. Mostly exists to keep directionals from being printed.
 	var/printable = FALSE
 
@@ -149,7 +151,9 @@
 	return .
 
 /obj/structure/sign/poster/proc/randomise(base_type)
-	var/list/poster_types = subtypesof(base_type) - typesof(/obj/structure/sign/poster/traitor)
+	var/list/poster_types = subtypesof(base_type)
+	if(random_blacklisted_basetype)
+		poster_types -= typesof(random_blacklisted_basetype)
 	var/list/approved_types = list()
 	for(var/obj/structure/sign/poster/type_of_poster as anything in poster_types)
 		if(initial(type_of_poster.icon_state) && !initial(type_of_poster.never_random))
@@ -290,6 +294,7 @@
 	icon_state = "random_anything"
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster
+	random_blacklisted_basetype = /obj/structure/sign/poster/traitor
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/random, 32)
 

--- a/code/game/objects/effects/poster.dm
+++ b/code/game/objects/effects/poster.dm
@@ -112,7 +112,7 @@
 	var/random_basetype
 	var/never_random = FALSE // used for the 'random' subclasses.
 	///Exclude posters of these types from being added to the random pool
-	var/list/blacklisted_types
+	var/list/blacklisted_types = list()
 	///Whether the poster should be printable from library management computer. Mostly exists to keep directionals from being printed.
 	var/printable = FALSE
 


### PR DESCRIPTION
## About The Pull Request

When the syndicate posters were added, they were intended to be a traitor objective. To quote from the original PR: 

>"If you start seeing red posters then you know there are traitors somewhere."

As an unintended consequence of how poster randomization works however they are able to spawn from the base random poster mapping object, defeating the purpose. They should only be able to be placed by actual player traitors (or a deliberate mapping decision).

This PR just removes them from the pool of posters to select from when using `/obj/structure/sign/poster/random`. You can still use `/obj/structure/sign/poster/traitor/random` to spawn random traitor posters both when mapping or ingame via commands.

This will close https://github.com/Skyrat-SS13/Skyrat-tg/issues/17956.

## Why It's Good For The Game

More control over mapping poster placement.

## Changelog

:cl:
fix: traitor objective posters will no longer be able to spawn from general random poster spawners.
/:cl:
