### PR TITLE
Changes reset wire to react from pulsing instead of cutting.

### DIFF
--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -66,7 +66,8 @@
 
 		if(WIRE_RESET_MODEL)
 			if(R.has_model())
-				R.visible_message(span_notice("[R]'s model servos twitch."), span_notice("Your model display flickers."))
+				R.ResetModel()
+				log_silicon("[key_name(usr)] reset [key_name(R)]'s module via wire")
 
 /datum/wires/robot/on_cut(wire, mend)
 	var/mob/living/silicon/robot/R = holder
@@ -100,9 +101,8 @@
 			R.logevent("Motor Controller fault [mend?"cleared":"detected"]")
 			log_silicon("[key_name(usr)] [!R.lockcharge ? "locked down" : "released"] [key_name(R)] via wire")
 		if(WIRE_RESET_MODEL)
-			if(R.has_model() && !mend)
-				R.ResetModel()
-				log_silicon("[key_name(usr)] reset [key_name(R)]'s module via wire")
+			if(R.has_model())
+				R.visible_message(span_notice("[R]'s model servos twitch."), span_notice("Your model display flickers."))
 
 /datum/wires/robot/can_reveal_wires(mob/user)
 	if(HAS_TRAIT(user, TRAIT_KNOW_CYBORG_WIRES))

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -32,7 +32,7 @@ As a Cultist, check the alert in the upper-right of your screen for all the deta
 As a Cultist, do not cause too much chaos before your objective is completed. If the shuttle gets called too soon, you may not have enough time to win.
 As a Cultist, the Blood Boil rune will deal massive amounts of brute damage to non-cultists, and some damage to fellow cultists of Nar'Sie nearby, but will create a fire where the rune stands on use.
 As a Cultist, your team starts off very weak, but if necessary can quickly convert everything they have into raw power. Make sure you have the numbers and equipment to support going loud, or the cult will fall flat on its face.
-As a Cyborg, choose your model carefully, as only cutting and mending your reset wire will let you re-pick it. If possible, refrain from choosing a model until a situation that requires one occurs.
+As a Cyborg, choose your model carefully, as pulsing your reset wire will let you re-pick it. If possible, refrain from choosing a model until a situation that requires one occurs.
 As a Cyborg, you are extremely vulnerable to EMPs as EMPs both stun you and damage you. The ion rifle in the armory or a traitor with an EMP kit can kill you in seconds.
 As a Cyborg, you are immune to most forms of stunning, and excel at almost everything far better than humans. However, flashes can easily stunlock you and you cannot do any precision work as you lack hands.
 As a Cyborg, you are impervious to fires and heat. If you are rogue, you can release plasma fires everywhere and walk through them without a care in the world!
@@ -81,7 +81,7 @@ As a Roboticist, keep an ear out for anomaly announcements. If you get your hand
 As a Roboticist, you can augment people with cyborg limbs. Augmented limbs can easily be repaired with cables and welders.
 As a Roboticist, you can greatly help out Shaft Miners by building a Clarke equipped with a hydraulic clamp and plasma cutter. The mech is ash storm proof and can even walk across lava!
 As a Roboticist, you can repair your cyborgs with a welding tool. If they have taken burn damage, you can remove their battery, expose the wiring with a screwdriver and replace their wires with a cable coil.
-As a Roboticist, you can reset a cyborg's model by cutting and mending the reset wire with a wire cutter.
+As a Roboticist, you can reset a cyborg's model by pulsing the reset wire with a multitool.
 As a Scientist, researchable stock parts can seriously improve the efficiency and speed of machines around the station. In some cases, it can even unlock new functions.
 As a Scientist, you can disable anomalies by scanning them with an analyzer, then send a signal on the frequency it gives you with a remote signaling device, or if researched, hit the anomaly an anomaly analyzer. This will leave behind an anomaly core, which can be used to construct a Phazon mech, reactive armors, or various unique and powerful weapons!
 As a Scientist, you can generate money for Science, and complete experiments by letting the tachyon-doppler array record increasingly large explosions.


### PR DESCRIPTION


## About The Pull Request

Recently in the PR that changed the way engineering borgs work (#74770), it was discussed that cyborgs should be getting their modules reset and that it should be more commonplace. If this is the case, I believe trudging back and forth to robotics whenever you need an upgrade can get tiresome. This PR hopes to alleviate some of that tedium by making the reset wire react to pulsing instead of cutting, and this alteration will allow clever roboticists to set up signaller systems to this wire if they are aware the borg will require multiple changes. 

## Why It's Good For The Game

While this feature was initially removed from the game many years ago due to it being overpowered at the time, a lot has changed regarding cyborg code since then. Most of the powerful features of borgs are now locked behind upgrades. Whenever a cyborg reset occurs, this causes said upgrades to be ejected onto the ground. Because of this, AI shells will not be functional with this feature, as it will eject the BORIS control board. 

I see this feature as being highly beneficial for lowpop rounds where a cyborg may need to fill in for multiple roles at once due to a lack of staff.

## Changelog

:cl:
balance: Cyborg reset wire is now pulsed, this allows signallers to be attached to the reset wire.
/:cl:
