### PR TITLE
Adds book burning

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -351,17 +351,17 @@
 		return TRUE
 	return ..()
 
-/obj/item/proc/burn_paper_product_attackby_check(obj/item/I, mob/living/user, bypass_clumsy)
-	var/ignition_message = I.ignition_effect(src, user)
+/obj/item/proc/burn_paper_product_attackby_check(obj/item/attacking_item, mob/living/user, bypass_clumsy = FALSE)
+	var/ignition_message = attacking_item.ignition_effect(src, user)
 	if(!ignition_message)
 		return
 	. = TRUE
 	if(!bypass_clumsy && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(10) && Adjacent(user))
 		user.visible_message(span_warning("[user] accidentally ignites [user.p_them()]self!"), \
 							span_userdanger("You miss [src] and accidentally light yourself on fire!"))
-		if(user.is_holding(I)) //checking if they're holding it in case TK is involved
-			user.dropItemToGround(I)
-		user.adjust_fire_stacks(1)
+		if(user.is_holding(attacking_item)) //checking if they're holding it in case TK is involved
+			user.dropItemToGround(attacking_item)
+		user.adjust_fire_stacks(attacking_item)
 		user.ignite_mob()
 		return
 
@@ -369,7 +369,7 @@
 		user.dropItemToGround(src)
 	user.visible_message(ignition_message)
 	add_fingerprint(user)
-	fire_act(I.get_temperature())
+	fire_act(attacking_item.get_temperature())
 
 /obj/item/paper/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(burn_paper_product_attackby_check(attacking_item, user))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -353,7 +353,7 @@
 
 /obj/item/proc/burn_paper_product_attackby_check(obj/item/attacking_item, mob/living/user, bypass_clumsy = FALSE)
 	//can't be put on fire!
-	if(resistance_flags & FIRE_PROOF)
+	if((resistance_flags & FIRE_PROOF) || !(resistance_flags & FLAMMABLE))
 		return
 	var/ignition_message = attacking_item.ignition_effect(src, user)
 	if(!ignition_message)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -366,7 +366,7 @@
 			user.dropItemToGround(attacking_item)
 		user.adjust_fire_stacks(attacking_item)
 		user.ignite_mob()
-		return
+		return TRUE
 
 	if(user.is_holding(src)) //no TK shit here.
 		user.dropItemToGround(src)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -373,6 +373,7 @@
 	user.visible_message(ignition_message)
 	add_fingerprint(user)
 	fire_act(attacking_item.get_temperature())
+	return TRUE
 
 /obj/item/paper/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(burn_paper_product_attackby_check(attacking_item, user))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -358,7 +358,6 @@
 	var/ignition_message = attacking_item.ignition_effect(src, user)
 	if(!ignition_message)
 		return FALSE
-	. = TRUE
 	if(!bypass_clumsy && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(10) && Adjacent(user))
 		user.visible_message(span_warning("[user] accidentally ignites [user.p_them()]self!"), \
 							span_userdanger("You miss [src] and accidentally light yourself on fire!"))

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -354,7 +354,7 @@
 /obj/item/proc/burn_paper_product_attackby_check(obj/item/attacking_item, mob/living/user, bypass_clumsy = FALSE)
 	//can't be put on fire!
 	if((resistance_flags & FIRE_PROOF) || !(resistance_flags & FLAMMABLE))
-		return
+		return FALSE
 	var/ignition_message = attacking_item.ignition_effect(src, user)
 	if(!ignition_message)
 		return FALSE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -357,7 +357,7 @@
 		return
 	var/ignition_message = attacking_item.ignition_effect(src, user)
 	if(!ignition_message)
-		return
+		return FALSE
 	. = TRUE
 	if(!bypass_clumsy && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(10) && Adjacent(user))
 		user.visible_message(span_warning("[user] accidentally ignites [user.p_them()]self!"), \

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -352,6 +352,9 @@
 	return ..()
 
 /obj/item/proc/burn_paper_product_attackby_check(obj/item/attacking_item, mob/living/user, bypass_clumsy = FALSE)
+	//can't be put on fire!
+	if(resistance_flags & FIRE_PROOF)
+		return
 	var/ignition_message = attacking_item.ignition_effect(src, user)
 	if(!ignition_message)
 		return


### PR DESCRIPTION
## About The Pull Request

For some reason, unlike other paper items, you couldn't ignite books with a lighter or other hot item.
Now, you can!

(Also made it so the odd obscure mechanic of cutting pages out of books can be done by any sharp item, not just wirecutters or knives)

## Why It's Good For The Game

Consistency. 
~~Burning copies of WGW.~~

## Changelog

:cl:
add: Books can now be burned just like any other paper item.
add: You can cut pages out of books with any sharp item, not just knives or wirecutters.
/:cl:
