### PR TITLE
Makes burning items actually hot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,21 +6,21 @@
 
 # MAINTAINERS
 
-# Cyberboss
+# Dominion/Cyberboss
 
+/.github/workflows/update_tgs_dmapi.yml @Cyberboss
 /.tgs.yml @Cyberboss
+/code/world.dm @Cyberboss
+/code/__DEFINES/tgs.config.dm @Cyberboss
+/code/__DEFINES/tgs.dm @Cyberboss
+/code/__DEFINES/_globals.dm @Cyberboss
+/code/__HELPERS/chat.dm @Cyberboss
 /code/__HELPERS/jatum.dm @Cyberboss
+/code/game/world.dm @Cyberboss
 /code/controllers/subsystem/atoms.dm @Cyberboss
-/code/controllers/subsystem/mapping.dm @Cyberboss
 /code/controllers/globals.dm @Cyberboss
 /code/datums/helper_datums/getrev.dm @Cyberboss
-/code/datums/map_config.dm @Cyberboss
-/code/datums/forced_movement.dm @Cyberboss
-/code/datums/holocall.dm @Cyberboss
-/code/modules/admin/verbs/adminhelp.dm @Cyberboss
-/code/modules/admin/verbs/adminpm.dm @Cyberboss
-/code/modules/mapping/ @Cyberboss
-/tools/tgs_scripts/ @Cyberboss
+/code/modules/tgs/ @Cyberboss
 /tools/tgs_test/ @Cyberboss
 
 # Dragomagol/Tattle
@@ -197,8 +197,7 @@
 /code/modules/jobs/job_types/paramedic.dm @ExcessiveUseOfCobblestone @Ryll-Ryll
 /code/modules/surgery/ @ExcessiveUseOfCobblestone @Ryll-Ryll
 /tools/build/ @MrStonedOne @stylemistake
-/tools/LinuxOneShot/ @Cyberboss @MrStonedOne
-/tools/tgs4_scripts/ @Cyberboss @MrStonedOne
+/tools/tgs_scripts/ @Cyberboss @MrStonedOne
 
 /tools/WebhookProcessor/ @BraveMole @TiviPlus
 

--- a/code/__DEFINES/atmospherics/atmos_core.dm
+++ b/code/__DEFINES/atmospherics/atmos_core.dm
@@ -131,6 +131,8 @@
 #define FIRE_MINIMUM_TEMPERATURE_TO_SPREAD (150+T0C)
 ///Minimum temperature for fire to exist on a turf (100 °C or 373 K)
 #define FIRE_MINIMUM_TEMPERATURE_TO_EXIST (100+T0C)
+///Minimum temperature for items on fire
+#define BURNING_ITEM_MINIMUM_TEMPERATURE (150+T0C)
 ///Multiplier for the temperature shared to other turfs
 #define FIRE_SPREAD_RADIOSITY_SCALE 0.85
 ///Helper for small fires to grow

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -881,7 +881,7 @@
 /obj/item/proc/get_temperature()
 	. = heat
 	if(resistance_flags & ON_FIRE)
-		. = max(., FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
+		. = max(., BURNING_ITEM_MINIMUM_TEMPERATURE)
 
 ///Returns the sharpness of src. If you want to get the sharpness of an item use this.
 /obj/item/proc/get_sharpness()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -879,7 +879,9 @@
 
 ///Returns the temperature of src. If you want to know if an item is hot use this proc.
 /obj/item/proc/get_temperature()
-	return heat
+	. = heat
+	if(resistance_flags & ON_FIRE)
+		. = max(., FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 
 ///Returns the sharpness of src. If you want to get the sharpness of an item use this.
 /obj/item/proc/get_sharpness()


### PR DESCRIPTION
## About The Pull Request

Simply put, unless overriden, items with the ON_FIRE flag will always be at least 150º C (491,15 kelvin).
I didn't want to pack this change with https://github.com/tgstation/tgstation/pull/74803 because I feel this might have some weird unintended consequences, maybe.

## Why It's Good For The Game

Emergent gameplay like lighting a cigarette with a burning piece of paper, I guess.

## Changelog

:cl:
add: Burning items are now actually considered to be at a minimum, 150 degrees celsius by the game.
/:cl: