### PR TITLE
[NO GBP] Aligns the poor people airlock on the luxury shuttle

### DIFF
--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -1133,11 +1133,9 @@
 /turf/open/floor/iron,
 /area/shuttle/escape)
 "UK" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/chair/comfy/shuttle{
-	dir = 8
-	},
+/obj/structure/chair/comfy/shuttle,
 /obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "UX" = (
@@ -1409,8 +1407,8 @@ bY
 CQ
 "}
 (8,1,1) = {"
-jy
-jH
+JV
+UK
 XU
 Nm
 ly
@@ -1431,8 +1429,8 @@ oX
 CQ
 "}
 (9,1,1) = {"
-JV
-UK
+jy
+jH
 Br
 wP
 ji


### PR DESCRIPTION

## About The Pull Request

moves the poor people airlock 1 tile to the right to match station docks on the luxury shuttle

## Why It's Good For The Game

people should be able to actually enter that area

## Changelog
:cl:
fix: Economy class airlock on the Luxury Shuttle now aligns with dock
/:cl:
