### PR TITLE
north star's asylum no longer spawns with prisoners

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -2118,9 +2118,7 @@
 "azI" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/side,
@@ -3357,9 +3355,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "aQk" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
 /turf/open/floor/carpet/red,
 /area/station/service/library/lounge)
@@ -3386,9 +3382,7 @@
 /turf/closed/wall,
 /area/station/cargo/drone_bay)
 "aQR" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /obj/structure/railing,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -5631,9 +5625,7 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "bqx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -7327,8 +7319,7 @@
 "bLW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
-	name = "Pharmacy Desk";
-	req_access = null
+	name = "Pharmacy Desk"
 	},
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
@@ -9728,9 +9719,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "csg" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/first)
@@ -10720,7 +10709,6 @@
 "cIi" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
-/obj/effect/landmark/start/prisoner,
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
@@ -15692,9 +15680,7 @@
 	},
 /area/station/commons/locker)
 "eaB" = (
-/obj/structure/chair/comfy/carp{
-	dir = 2
-	},
+/obj/structure/chair/comfy/carp,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/station/maintenance/floor2/port/fore)
@@ -17711,9 +17697,7 @@
 /turf/open/floor/plating,
 /area/station/security/prison/work)
 "eEp" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -19303,8 +19287,7 @@
 "fey" = (
 /obj/effect/turf_decal/trimline/yellow/warning,
 /obj/machinery/button/elevator/directional/west{
-	id = "fore_vator";
-	pixel_y = 0
+	id = "fore_vator"
 	},
 /obj/machinery/lift_indicator/directional/west{
 	linked_elevator_id = "fore_vator";
@@ -21239,9 +21222,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "fFB" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/siding/wood,
@@ -22819,9 +22800,7 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/green,
@@ -23664,9 +23643,7 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/solars/port/aft)
 "gmV" = (
-/obj/structure/chair/comfy/carp{
-	dir = 2
-	},
+/obj/structure/chair/comfy/carp,
 /obj/effect/decal/cleanable/glitter,
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/station/maintenance/floor2/port/fore)
@@ -28067,9 +28044,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/glass/reinforced,
 /area/station/service/library)
@@ -31968,9 +31943,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
 /turf/open/floor/glass/reinforced,
 /area/station/service/library)
@@ -34868,7 +34841,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/window/brigdoor/right/directional/south{
 	name = "Courtroom Access";
-	req_access = null;
 	req_one_access = list("security","court")
 	},
 /turf/open/floor/iron/dark/side{
@@ -36263,9 +36235,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
-/obj/machinery/door/window/right/directional/north{
-	req_access = null
-	},
+/obj/machinery/door/window/right/directional/north,
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/secondary/entry)
 "jMn" = (
@@ -40980,9 +40950,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lower)
 "kYt" = (
-/obj/structure/chair/comfy/carp{
-	dir = 2
-	},
+/obj/structure/chair/comfy/carp,
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/station/maintenance/floor2/port/fore)
 "kYv" = (
@@ -41239,7 +41207,9 @@
 /area/station/commons/fitness)
 "lbT" = (
 /obj/structure/table,
-/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
@@ -44418,8 +44388,7 @@
 /area/station/solars/port/aft)
 "lQY" = (
 /obj/machinery/button/elevator/directional/west{
-	id = "fore_vator";
-	pixel_y = 0
+	id = "fore_vator"
 	},
 /obj/effect/turf_decal/trimline/purple/warning,
 /obj/machinery/lift_indicator/directional/west{
@@ -44921,9 +44890,7 @@
 	},
 /area/station/hallway/floor2/aft)
 "lYe" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -46489,9 +46456,7 @@
 /area/station/hallway/secondary/entry)
 "mrU" = (
 /obj/structure/sign/poster/official/random/directional/east,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /obj/structure/railing,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -50747,8 +50712,7 @@
 "nsE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
-	name = "Pharmacy Desk";
-	req_access = null
+	name = "Pharmacy Desk"
 	},
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
@@ -53081,9 +53045,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/floor3/starboard)
 "nWO" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/railing,
@@ -54143,9 +54105,7 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
 "olZ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/corner,
 /obj/structure/sign/poster/contraband/grey_tide{
 	pixel_y = 32
 	},
@@ -54995,9 +54955,7 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "oyF" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55888,9 +55846,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "oKP" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /obj/structure/railing,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -56176,7 +56132,6 @@
 /area/station/security/medical)
 "oPC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/landmark/start/prisoner,
 /obj/structure/chair{
 	dir = 8
 	},
@@ -60013,8 +59968,7 @@
 /area/station/maintenance/solars/starboard/aft)
 "pUD" = (
 /obj/machinery/button/elevator/directional/west{
-	id = "fore_vator";
-	pixel_y = 0
+	id = "fore_vator"
 	},
 /obj/effect/turf_decal/trimline/green/warning,
 /obj/machinery/lift_indicator/directional/west{
@@ -61422,9 +61376,7 @@
 "qoF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/commons/storage/primary)
@@ -61465,7 +61417,6 @@
 	id = "Xenolab";
 	name = "Test Chamber Blast Doors";
 	pixel_x = 6;
-	pixel_y = 24;
 	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron/white,
@@ -62577,7 +62528,6 @@
 "qCn" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
-/obj/effect/landmark/start/prisoner,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "qCo" = (
@@ -65679,9 +65629,7 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/green,
 /area/station/service/abandoned_gambling_den)
@@ -71099,9 +71047,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "sXE" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=1-9";
 	location = "1-8"
@@ -71230,7 +71176,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/wood{
-	id_tag = null;
 	name = "Library Book Returns"
 	},
 /turf/open/floor/iron/dark,
@@ -78306,9 +78251,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor1/aft)
 "uYI" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron,
 /area/station/hallway/floor1/fore)
 "uYM" = (
@@ -80141,7 +80084,6 @@
 "vyn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/sign/poster/official/random/directional/south,
-/obj/effect/landmark/start/prisoner,
 /obj/structure/chair{
 	dir = 4
 	},
@@ -84556,7 +84498,6 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/wood{
-	id_tag = null;
 	name = "Gallery"
 	},
 /turf/open/floor/wood/large,
@@ -87190,9 +87131,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/aft)
 "xnr" = (
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -89359,9 +89298,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 2
-	},
+/obj/effect/turf_decal/siding/wood,
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/glass/reinforced,
 /area/station/service/library)


### PR DESCRIPTION
## About The Pull Request
the asylum on the north star no longer spawns prisoners, only the permabrig does
the computer in the asylum is rotated correctly

## Why It's Good For The Game
on the paper, it seems like a cool concept, but theres a few issues here
the psychologist isnt designed to handle prisoners in the first place. this is fine on mrp but it gets kinda muddy when prisoners on lrp like beating people up
prisoners are recommended as a new player role by the wiki (very stupid), this role starting in an asylum without anything to do while being asked some stuff by a psychologist seems like itd add onto confusion
players dont know what jobs are spawning with them, there very well may not be a cmo or psychologist. if theres no one in sec you can deal with that because you have a small botany and kitchen, and can possibly escape. this aint a thing here, only thing you have is reading books and maybe pen and paper rpgs if another prisoner spawns, while being stuck in an extremely tiny space

this can work in the future i think, but it requires code support we currently dont have, so it better to cut its

## Changelog
:cl:
del: prisoner spawns from the north star asylum
/:cl:
