### PR TITLE
Reduces the amount of dead bodies in the chasm when using the rescue hook

### DIFF
--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -97,7 +97,7 @@
 
 	return chasm_contents
 
-/// Body detritus is selected in favor of bodies beloning to sentient mobs
+/// Body detritus is selected in favor of bodies belonging to sentient mobs
 /// The first sentient body found in the list of contents is returned, otherwise 
 /// if none are sentient choose randomly.
 /obj/item/chasm_detritus/restricted/bodies/determine_detritus(list/chasm_stuff)

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -46,10 +46,13 @@
 		create_default_object()
 		return
 
-	var/atom/movable/detritus = pick_weight(chasm_stuff)
+	var/atom/movable/detritus = determine_detritus(chasm_stuff)
 	detritus.forceMove(get_turf(src))
 	qdel(src)
 
+/// Returns the chosen detritus from the given list of things to choose from
+/obj/item/chasm_detritus/proc/determine_detritus(list/chasm_stuff)
+	return pick(chasm_stuff)
 
 /// Instantiates something in its place from the default_contents list.
 /obj/item/chasm_detritus/proc/create_default_object()
@@ -66,12 +69,7 @@
 	var/list/chasm_storage_resolved = recursive_list_resolve(GLOB.chasm_storage)
 	for (var/obj/storage as anything in chasm_storage_resolved)
 		for (var/thing as anything in storage.contents)
-			if(ismob(thing))
-				var/mob/fallen_mob = thing
-				if(fallen_mob.mind)
-					chasm_contents += list(fallen_mob = 90) // we want to priotitize sentient mobs over say, a bunch of legion skeletons
-					continue
-			chasm_contents += list(thing = 10)
+			chasm_contents += thing
 
 	return chasm_contents
 
@@ -99,6 +97,15 @@
 
 	return chasm_contents
 
+/// Body detritus is selected in favor of bodies beloning to sentient mobs
+/// The first sentient body found in the list of contents is returned, otherwise 
+/// if none are sentient choose randomly.
+/obj/item/chasm_detritus/restricted/bodies/determine_detritus(list/chasm_stuff)
+	for(var/thing in chasm_stuff)	
+		var/mob/fallen_mob = thing
+		if(fallen_mob.mind)
+			return fallen_mob
+	return ..()
 
 /obj/item/chasm_detritus/restricted/objects
 	default_contents_chance = 12.5

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -68,7 +68,7 @@
 		for (var/thing as anything in storage.contents)
 			if(ismob(thing))
 				var/mob/fallen_mob = thing
-				if(fallen_mob.client)
+				if(fallen_mob.mind)
 					chasm_contents += list(fallen_mob = 90) // we want to priotitize sentient mobs over say, a bunch of legion skeletons
 					continue
 			chasm_contents += list(thing = 10)

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -101,7 +101,7 @@
 
 
 /obj/item/chasm_detritus/restricted/bodies
-	default_contents_chance = 50
+	default_contents_chance = 12.5
 	default_contents_key = BODIES_ONLY
 	chasm_storage_restricted_type = /mob
 

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -101,8 +101,7 @@
 /// The first sentient body found in the list of contents is returned, otherwise 
 /// if none are sentient choose randomly.
 /obj/item/chasm_detritus/restricted/bodies/determine_detritus(list/chasm_stuff)
-	for(var/thing in chasm_stuff)	
-		var/mob/fallen_mob = thing
+	for(var/mob/fallen_mob in chasm_stuff)
 		if(fallen_mob.mind)
 			return fallen_mob
 	return ..()

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -101,8 +101,7 @@
 /// The first sentient body found in the list of contents is returned, otherwise 
 /// if none are sentient choose randomly.
 /obj/item/chasm_detritus/restricted/bodies/determine_detritus(list/chasm_stuff)
-	for(var/thing in chasm_stuff)	
-		var/mob/fallen_mob = thing
+	for(var/mob/fallen_mob in chasm_stuff)	
 		if(fallen_mob.mind)
 			return fallen_mob
 	return ..()

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -46,7 +46,7 @@
 		create_default_object()
 		return
 
-	var/atom/movable/detritus = pick(chasm_stuff)
+	var/atom/movable/detritus = pick_weight(chasm_stuff)
 	detritus.forceMove(get_turf(src))
 	qdel(src)
 
@@ -66,7 +66,12 @@
 	var/list/chasm_storage_resolved = recursive_list_resolve(GLOB.chasm_storage)
 	for (var/obj/storage as anything in chasm_storage_resolved)
 		for (var/thing as anything in storage.contents)
-			chasm_contents += thing
+			if(ismob(thing))
+				var/mob/fallen_mob = thing
+				if(fallen_mob.client)
+					chasm_contents += list(fallen_mob = 90) // we want to priotitize sentient mobs over say, a bunch of legion skeletons
+					continue
+			chasm_contents += list(thing = 10)
 
 	return chasm_contents
 

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -101,7 +101,7 @@
 /// The first sentient body found in the list of contents is returned, otherwise 
 /// if none are sentient choose randomly.
 /obj/item/chasm_detritus/restricted/bodies/determine_detritus(list/chasm_stuff)
-	for(var/mob/fallen_mob in chasm_stuff)	
+	for(var/mob/fallen_mob as anything in chasm_stuff)	
 		if(fallen_mob.mind)
 			return fallen_mob
 	return ..()


### PR DESCRIPTION
## About The Pull Request

When trying to fish for bodies with a rescue hook, the chance of getting a random 'default' generic skeleton is too high. 

On top of that, there can be a number of legion skeletons clogging up the contents list, making catching a sentient mob a RNG based nightmare. 

---

This PR makes it far more likely to catch an actual person that has fallen into the chasm when using the rescue hook, which is how it's supposed to work, by doing two things:

1) Reduced the chance of getting a default skeleton regardless of the chasm's contents from 50% to 12.5%.
2) If a body that once belonged to a sentient player is down there, that will always be fished up before any of the non sentient ones are. 

## Why It's Good For The Game

Makes using a rescue hook far less annoying to use when you just want to save someone who has fallen in.

Duds can still happen as usual, and there is still a small chance of getting a generic skeleton if you fail the 87.5% chance roll...but overall, fishing someone up with the rescue rod is a lot better now.

## Changelog

:cl:
qol: the rescue hook has a much greater chance at catching actual fallen player bodies as opposed to generic skeletons/other npc corpses
/:cl:

