### PR TITLE
Config Flag to Save Generated Spritesheets to Logs

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -76,11 +76,6 @@
 /// Prefer the autowiki build target instead.
 // #define AUTOWIKI
 
-/// If this is uncommented, we will save all associated spritesheet PNGs and CSS files to a folder in the round-specific logs folder.
-/// Useful for developers to debug potential spritesheet issues to determine where the issue is cropping up (either in DM-side sprite generation or in the TGUI-side display of said spritesheet).
-/// Will only seek to waste disk space if ran on production.
-// #define SAVE_SPRITESHEETS
-
 /// If this is uncommented, will profile mapload atom initializations
 // #define PROFILE_MAPLOAD_INIT_ATOM
 

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -76,6 +76,11 @@
 /// Prefer the autowiki build target instead.
 // #define AUTOWIKI
 
+/// If this is uncommented, we will save all associated spritesheet PNGs and CSS files to a folder in the round-specific logs folder.
+/// Useful for developers to debug potential spritesheet issues to determine where the issue is cropping up (either in DM-side sprite generation or in the TGUI-side display of said spritesheet).
+/// Will only seek to waste disk space if ran on production.
+// #define SAVE_SPRITESHEETS
+
 /// If this is uncommented, will profile mapload atom initializations
 // #define PROFILE_MAPLOAD_INIT_ATOM
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -653,6 +653,9 @@
 /datum/config_entry/flag/cache_assets
 	default = TRUE
 
+/datum/config_entry/flag/save_spritesheets
+	default = FALSE
+
 /datum/config_entry/flag/station_name_in_hub_entry
 	default = FALSE
 

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	return !cross_round_cachable || !CONFIG_GET(flag/cache_assets)
 
 /// Simply takes any generated file and saves it to the round-specific /logs folder. Useful for debugging potential issues with spritesheet generation/display.
-/// Only called when SAVE_SPRITESHEETS is defined.
+/// Only called the SAVE_SPRITESHEETS config option is uncommented.
 /datum/asset/proc/save_to_logs(file_name, file_location)
 	var/asset_path = "[GLOB.log_directory]/generated_assets/[file_name]"
 	fdel(asset_path) // just in case, sadly we can't use rust_g stuff here.

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -204,7 +204,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		var/size = sizes[size_id]
 		SSassets.transport.register_asset("[name]_[size_id].png", size[SPRSZ_STRIPPED])
 	var/css_name = "spritesheet_[name].css"
-	var/file_directory = "data/spritesheets/[res_name]"
+	var/file_directory = "data/spritesheets/[css_name]"
 	fdel(file_directory)
 	text2file(generate_css(), file_directory)
 	SSassets.transport.register_asset(css_name, fcopy_rsc(file_directory))
@@ -260,19 +260,19 @@ GLOBAL_LIST_EMPTY(asset_datums)
 
 		// save flattened version
 		var/png_name = "[name]_[size_id].png"
-		var/full_file_name = "data/spritesheets/[png_name]"
-		fcopy(size[SPRSZ_ICON], full_file_name)
-		var/error = rustg_dmi_strip_metadata(full_file_name)
+		var/file_directory = "data/spritesheets/[png_name]"
+		fcopy(size[SPRSZ_ICON], file_directory)
+		var/error = rustg_dmi_strip_metadata(file_directory)
 		if(length(error))
 			stack_trace("Failed to strip [png_name]: [error]")
-		size[SPRSZ_STRIPPED] = icon(full_file_name)
+		size[SPRSZ_STRIPPED] = icon(file_directory)
 
 // this is useful here for determining if weird sprite issues (like having a white background) are a cause of what we're doing DM-side or not since we can see the full flattened thing at-a-glance.
 #ifdef SAVE_SPRITESHEETS
-	save_to_logs(file_name = png_name, file_location = full_file_name)
+		save_to_logs(file_name = png_name, file_location = file_directory)
 #endif
 
-		fdel(fname)
+		fdel(file_directory)
 
 /datum/asset/spritesheet/proc/generate_css()
 	var/list/out = list()

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -203,17 +203,17 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	for(var/size_id in sizes)
 		var/size = sizes[size_id]
 		SSassets.transport.register_asset("[name]_[size_id].png", size[SPRSZ_STRIPPED])
-	var/res_name = "spritesheet_[name].css"
-	var/fname = "data/spritesheets/[res_name]"
-	fdel(fname)
-	text2file(generate_css(), fname)
-	SSassets.transport.register_asset(res_name, fcopy_rsc(fname))
+	var/css_name = "spritesheet_[name].css"
+	var/file_directory = "data/spritesheets/[res_name]"
+	fdel(file_directory)
+	text2file(generate_css(), file_directory)
+	SSassets.transport.register_asset(css_name, fcopy_rsc(file_directory))
 
 #ifdef SAVE_SPRITESHEETS
-	save_to_logs(file_name = res_name, file_location = fname)
+	save_to_logs(file_name = css_name, file_location = file_directory)
 #endif
 
-	fdel(fname)
+	fdel(file_directory)
 
 	if (CONFIG_GET(flag/cache_assets) && cross_round_cachable)
 		write_to_cache()
@@ -259,12 +259,19 @@ GLOBAL_LIST_EMPTY(asset_datums)
 			continue
 
 		// save flattened version
-		var/fname = "data/spritesheets/[name]_[size_id].png"
-		fcopy(size[SPRSZ_ICON], fname)
-		var/error = rustg_dmi_strip_metadata(fname)
+		var/png_name = "[name]_[size_id].png"
+		var/full_file_name = "data/spritesheets/[png_name]"
+		fcopy(size[SPRSZ_ICON], full_file_name)
+		var/error = rustg_dmi_strip_metadata(full_file_name)
 		if(length(error))
-			stack_trace("Failed to strip [name]_[size_id].png: [error]")
-		size[SPRSZ_STRIPPED] = icon(fname)
+			stack_trace("Failed to strip [png_name]: [error]")
+		size[SPRSZ_STRIPPED] = icon(full_file_name)
+
+// this is useful here for determining if weird sprite issues (like having a white background) are a cause of what we're doing DM-side or not since we can see the full flattened thing at-a-glance.
+#ifdef SAVE_SPRITESHEETS
+	save_to_logs(file_name = png_name, file_location = full_file_name)
+#endif
+
 		fdel(fname)
 
 /datum/asset/spritesheet/proc/generate_css()

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -62,14 +62,12 @@ GLOBAL_LIST_EMPTY(asset_datums)
 /datum/asset/proc/should_refresh()
 	return !cross_round_cachable || !CONFIG_GET(flag/cache_assets)
 
-#ifdef SAVE_SPRITESHEETS
 /// Simply takes any generated file and saves it to the round-specific /logs folder. Useful for debugging potential issues with spritesheet generation/display.
 /// Only called when SAVE_SPRITESHEETS is defined.
 /datum/asset/proc/save_to_logs(file_name, file_location)
 	var/asset_path = "[GLOB.log_directory]/generated_assets/[file_name]"
 	fdel(asset_path) // just in case, sadly we can't use rust_g stuff here.
 	fcopy(file_location, asset_path)
-#endif
 
 /// If you don't need anything complicated.
 /datum/asset/simple
@@ -209,9 +207,8 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	text2file(generate_css(), file_directory)
 	SSassets.transport.register_asset(css_name, fcopy_rsc(file_directory))
 
-#ifdef SAVE_SPRITESHEETS
-	save_to_logs(file_name = css_name, file_location = file_directory)
-#endif
+	if(CONFIG_GET(flag/save_spritesheets))
+		save_to_logs(file_name = css_name, file_location = file_directory)
 
 	fdel(file_directory)
 
@@ -267,10 +264,9 @@ GLOBAL_LIST_EMPTY(asset_datums)
 			stack_trace("Failed to strip [png_name]: [error]")
 		size[SPRSZ_STRIPPED] = icon(file_directory)
 
-// this is useful here for determining if weird sprite issues (like having a white background) are a cause of what we're doing DM-side or not since we can see the full flattened thing at-a-glance.
-#ifdef SAVE_SPRITESHEETS
-		save_to_logs(file_name = png_name, file_location = file_directory)
-#endif
+		// this is useful here for determining if weird sprite issues (like having a white background) are a cause of what we're doing DM-side or not since we can see the full flattened thing at-a-glance.
+		if(CONFIG_GET(flag/save_spritesheets))
+			save_to_logs(file_name = png_name, file_location = file_directory)
 
 		fdel(file_directory)
 
@@ -314,9 +310,8 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	rustg_file_write(replaced_css, replaced_css_filename)
 	SSassets.transport.register_asset(finalized_name, replaced_css_filename)
 
-#ifdef SAVE_SPRITESHEETS
-	save_to_logs(file_name = finalized_name, file_location = replaced_css_filename)
-#endif
+	if(CONFIG_GET(flag/save_spritesheets))
+		save_to_logs(file_name = finalized_name, file_location = replaced_css_filename)
 
 	fdel(replaced_css_filename)
 

--- a/code/modules/asset_cache/asset_list.dm
+++ b/code/modules/asset_cache/asset_list.dm
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(asset_datums)
 	return !cross_round_cachable || !CONFIG_GET(flag/cache_assets)
 
 /// Simply takes any generated file and saves it to the round-specific /logs folder. Useful for debugging potential issues with spritesheet generation/display.
-/// Only called the SAVE_SPRITESHEETS config option is uncommented.
+/// Only called when the SAVE_SPRITESHEETS config option is uncommented.
 /datum/asset/proc/save_to_logs(file_name, file_location)
 	var/asset_path = "[GLOB.log_directory]/generated_assets/[file_name]"
 	fdel(asset_path) // just in case, sadly we can't use rust_g stuff here.

--- a/config/config.txt
+++ b/config/config.txt
@@ -623,6 +623,11 @@ MOTD motd.txt
 ## but enabled on production (the default).
 CACHE_ASSETS 0
 
+## If this is uncommented, we will save all associated spritesheet PNGs and CSS files to a folder in the round-specific logs folder.
+## Useful for developers to debug potential spritesheet issues to determine where the issue is cropping up (either in DM-side sprite generation or in the TGUI-side display of said spritesheet).
+## Will only seek to waste disk space if ran on production.
+#SAVE_SPRITESHEETS
+
 ## Uncomment to allow the station name to be in the hub entry.
 ## You should only enable this if you can guarantee a station name doesn't break BYOND's TOS.
 ## BYOND staff have gotten upset at us in the past for inappropriate station names.


### PR DESCRIPTION
## About The Pull Request

I was helping someone debug some weird bug with spritesheets a bit ago, and I didn't like having to manually comment out all of the `fdel()` stuff in order to help visualize what the potential issue might have been with the spritesheets on either their DM-side generation or their TGUI-level display. I decided to add a compile-time level flag that will automatically copy over any generated spritesheet assets (css and pngs) to the round-specific `data/logs` folder for analysis when a developer should need it.

I also had to switch around some vars and make a few new ones to reduce how copy-pasta it might get and ensure standardization/readability while also being 0.001 times faster since we benefit from the string cache (unprovable fact).
## Why It's Good For The Game

It's incredibly useful to see the actual flattened spritesheet itself sometimes when you're doing this type of work and you keep getting odd bugs here and there. Also saves headache from having to clear out the temp `/data/spritesheets` folder every time you comment shit out, as well as having an effective paper trail for A/B testing whatever bullshit you've got going on.

![image](https://user-images.githubusercontent.com/34697715/233516033-1f5dde1a-e549-4e5a-aa99-0d531b34fbb5.png)
## Changelog
Doesn't affect players.
