### PR TITLE
Makes emsisive blockers like, work

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -223,15 +223,23 @@
 		vis_contents.Cut()
 
 /atom/movable/proc/update_emissive_block()
-	if(!blocks_emissive)
-		return
-	else if (blocks_emissive == EMISSIVE_BLOCK_GENERIC)
+	// This one is incredible.
+	// `if (x) else { /* code */ }` is surprisingly fast, and it's faster than a switch, which is seemingly not a jump table.
+	// From what I can tell, a switch case checks every single branch individually, although sane, is slow in a hot proc like this.
+	// So, we make the most common `blocks_emissive` value, EMISSIVE_BLOCK_GENERIC, 0, getting to the fast else branch quickly.
+	// If it fails, then we can check over every value it can be (here, EMISSIVE_BLOCK_UNIQUE is the only one that matters).
+	// This saves several hundred milliseconds of init time.
+	if (blocks_emissive)
+		if (blocks_emissive == EMISSIVE_BLOCK_UNIQUE)
+			if(!em_block && !QDELETED(src))
+				render_target = ref(src)
+				em_block = new(src, render_target)
+			return em_block
+		// Implied else if (blocks_emissive == EMISSIVE_BLOCK_NONE) -> return
+	 // EMISSIVE_BLOCK_GENERIC == 0
+	else
 		return fast_emissive_blocker(src)
-	else if(blocks_emissive == EMISSIVE_BLOCK_UNIQUE)
-		if(!em_block && !QDELETED(src))
-			render_target = ref(src)
-			em_block = new(src, render_target)
-		return em_block
+
 
 /// Generates a space underlay for a turf
 /// This provides proper lighting support alongside just looking nice

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -236,7 +236,7 @@
 				em_block = new(src, render_target)
 			return em_block
 		// Implied else if (blocks_emissive == EMISSIVE_BLOCK_NONE) -> return
-	 // EMISSIVE_BLOCK_GENERIC == 0
+	// EMISSIVE_BLOCK_GENERIC == 0
 	else
 		return fast_emissive_blocker(src)
 

--- a/code/modules/atmospherics/machinery/pipes/pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/pipes.dm
@@ -105,9 +105,9 @@
 	icon_state = "[bitfield]_[piping_layer]"
 
 /obj/machinery/atmospherics/pipe/update_icon()
-	. = ..()
 	update_pipe_icon()
 	update_layer()
+	return ..()
 
 /obj/machinery/atmospherics/proc/update_node_icon()
 	for(var/i in 1 to device_type)


### PR DESCRIPTION
## About The Pull Request

We assumed 0 meant no emissive blocker, but moth changed that a while back, so post /atom/movable/Initialize generic emissive blockers just.. didn't work

Let's uh, fix that

Oh also makes pipes update their icon BEFORE they call update_icon parent, so their emissive blockers look right

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/58055496/233563370-ddd95534-3a49-41f7-8aa8-5b1a001f4335.png)

Closes #74905

## Changelog
:cl:
fix: Things that block glow will now like, do that again
/:cl:
