### PR TITLE
Fixes balloon alert runtime when finishing a mod suit

### DIFF
--- a/code/modules/mod/mod_construction.dm
+++ b/code/modules/mod/mod_construction.dm
@@ -231,11 +231,10 @@
 				if(!user.transferItemToLoc(part, src))
 					return
 				playsound(src, 'sound/machines/click.ogg', 30, TRUE)
-				balloon_alert(user, "suit finished")
 				var/obj/item/mod = new /obj/item/mod/control(drop_location(), external_plating.theme, null, core)
 				core = null
 				qdel(src)
-				user.put_in_hands(mod)
+				mod.balloon_alert(user, "suit finished")
 			else if(part.tool_behaviour == TOOL_SCREWDRIVER) //Construct
 				if(part.use_tool(src, user, 0, volume=30))
 					balloon_alert(user, "assembly unscrewed")

--- a/code/modules/mod/mod_construction.dm
+++ b/code/modules/mod/mod_construction.dm
@@ -234,6 +234,7 @@
 				var/obj/item/mod = new /obj/item/mod/control(drop_location(), external_plating.theme, null, core)
 				core = null
 				qdel(src)
+				user.put_in_hands(mod)
 				mod.balloon_alert(user, "suit finished")
 			else if(part.tool_behaviour == TOOL_SCREWDRIVER) //Construct
 				if(part.use_tool(src, user, 0, volume=30))


### PR DESCRIPTION
## About The Pull Request
Fixes this
![Screenshot (175)](https://user-images.githubusercontent.com/110812394/233588431-20b69bd0-2bf0-4eae-bcdf-25674b1aa4c5.png)

Caused by this
![Screenshot (176)](https://user-images.githubusercontent.com/110812394/233588470-8798a1e3-dfe8-4fbf-bfd3-989c3dec1617.png)

Which is caused when you finish a mod suit by adding plating to it. It does not show up in the stack trace because 
`/obj/item/mod/construction/shell ` is deleted when you add plating to create the final mod suit. 
https://github.com/tgstation/tgstation/blob/6a83ad76e7cdd0c63f24c402d3a25063cdec04b7/code/modules/mod/mod_construction.dm#L234-L238

because the src is deleted, by the time balloon alert executes via async it adds a timer on the deleted mod core causing the runtime.

## Changelog
:cl:
fix: balloon alert adding timer on deleted mod core after construction causing runtime.
/:cl:
