### PR TITLE
[NO GBP] Wording & Rounding tweaks for produce console

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -60,7 +60,7 @@
 	SSshuttle.shopping_list += new_order
 
 /obj/machinery/computer/order_console/mining/retrive_points(obj/item/card/id/id_card)
-	return FLOOR(id_card.registered_account.mining_points, 1)
+	return round(id_card.registered_account.mining_points)
 
 /obj/machinery/computer/order_console/mining/ui_act(action, params)
 	. = ..()

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_EMPTY(order_console_products)
  * card - The ID card we retrive these points from
  */
 /obj/machinery/computer/order_console/proc/retrive_points(obj/item/card/id/id_card)
-	return FLOOR(id_card.registered_account?.account_balance, 1)
+	return round(id_card.registered_account?.account_balance)
 
 /obj/machinery/computer/order_console/ui_data(mob/user)
 	var/list/data = list()

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -120,7 +120,7 @@ GLOBAL_LIST_EMPTY(order_console_products)
 			"desc" = item.desc,
 			"cat" = item.category_index,
 			"ref" = REF(item),
-			"cost" = FLOOR(item.cost_per_order * cargo_cost_multiplier, 1),
+			"cost" = round(item.cost_per_order * cargo_cost_multiplier),
 			"product_icon" = icon2base64(getFlatIcon(image(icon = initial(item.item_path.icon), icon_state = initial(item.item_path.icon_state)), no_anim=TRUE))
 		))
 	return data
@@ -209,7 +209,7 @@ GLOBAL_LIST_EMPTY(order_console_products)
  * returns TRUE if we can afford, FALSE otherwise.
  */
 /obj/machinery/computer/order_console/proc/purchase_items(obj/item/card/id/card, express = FALSE)
-	var/final_cost = get_total_cost() * (express ? express_cost_multiplier : cargo_cost_multiplier)
+	var/final_cost = round(get_total_cost() * (express ? express_cost_multiplier : cargo_cost_multiplier))
 	var/failure_message = !express ? "Sorry, but you do not have enough [credit_type]." : " Remember, Express upcharges the cost!"
 	if(subtract_points(final_cost, card))
 		return TRUE

--- a/code/game/machinery/computer/orders/order_computer/order_computer.dm
+++ b/code/game/machinery/computer/orders/order_computer/order_computer.dm
@@ -210,10 +210,9 @@ GLOBAL_LIST_EMPTY(order_console_products)
  */
 /obj/machinery/computer/order_console/proc/purchase_items(obj/item/card/id/card, express = FALSE)
 	var/final_cost = round(get_total_cost() * (express ? express_cost_multiplier : cargo_cost_multiplier))
-	var/failure_message = !express ? "Sorry, but you do not have enough [credit_type]." : " Remember, Express upcharges the cost!"
 	if(subtract_points(final_cost, card))
 		return TRUE
-	say(failure_message)
+	say("Sorry, but you do not have enough [credit_type].")
 	return FALSE
 
 /**

--- a/tgui/packages/tgui/interfaces/ProduceConsole.tsx
+++ b/tgui/packages/tgui/interfaces/ProduceConsole.tsx
@@ -265,7 +265,7 @@ const CheckoutTab = (props, context) => {
         <Section>
           <Stack>
             <Stack.Item grow mt={0.5}>
-              Total Cost:{total_cargo_cost}&#40;Express:
+              Total:{total_cargo_cost}&#40;Express:
               {total_cost * express_cost_multiplier}&#41;
             </Stack.Item>
             {!forced_express && (
@@ -277,7 +277,7 @@ const CheckoutTab = (props, context) => {
                   disabled={total_cargo_cost < cargo_value}
                   tooltip={
                     total_cargo_cost < cargo_value
-                      ? `Total Cost must be above or equal to ${cargo_value}`
+                      ? `Total must be above or equal to ${cargo_value}`
                       : purchase_tooltip
                   }
                   tooltipPosition="top"


### PR DESCRIPTION
## About The Pull Request
1. Rewords "Total Cost" to just "Total" so text does not overflow to the next line & improves readability
Before
![Screenshot (177)](https://user-images.githubusercontent.com/110812394/233598778-ace381b9-04a4-4801-adf8-dd2bb242032c.png)
After
![Screenshot (178)](https://user-images.githubusercontent.com/110812394/233598806-0365b9dc-cd72-4003-9dcf-bdc967036eb8.png)

2. Now  just one failure message if you don't have enough points for cargo/express mode to keep it consistent

4. Rounds the total cost before confirming your final order so you don't have decimal values left in your bank account/mining points

## Changelog

:cl:
qol: rewords "Total Cost" to just "Total" so text does not overflow to the next line and improves readability
qol: just one failure message if you don't have enough credits for cargo/express mode to keep it consistent
refactor: rounds the total cost of your produce console order so you don't have decimal values left in your bank account
/:cl:
