### PR TITLE
Makes assembly tank bombs not have devastation

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -383,9 +383,9 @@
 		strength = (fuel_moles/15)
 
 		if(strength >= 2)
-			explosion(ground_zero, devastation_range = round(strength,1), heavy_impact_range = round(strength*2,1), light_impact_range = round(strength*3,1), flash_range = round(strength*4,1), explosion_cause = src)
+			explosion(ground_zero, devastation_range = -1, heavy_impact_range = round(strength*2,1), light_impact_range = round(strength*3,1), flash_range = round(strength*4,1), explosion_cause = src)
 		else if(strength >= 1)
-			explosion(ground_zero, devastation_range = round(strength,1), heavy_impact_range = round(strength*2,1), light_impact_range = round(strength*2,1), flash_range = round(strength*3,1), explosion_cause = src)
+			explosion(ground_zero, devastation_range = -1, heavy_impact_range = round(strength*2,1), light_impact_range = round(strength*2,1), flash_range = round(strength*3,1), explosion_cause = src)
 		else if(strength >= 0.5)
 			explosion(ground_zero, heavy_impact_range = 1, light_impact_range = 2, flash_range = 4, explosion_cause = src)
 		else if(strength >= 0.2)

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -12,11 +12,6 @@
 	var/status = FALSE   //0 - not readied //1 - bomb finished with welder
 	var/obj/item/assembly_holder/bombassembly = null   //The first part of the bomb is an assembly holder, holding an igniter+some device
 	var/obj/item/tank/bombtank = null //the second part of the bomb is a plasma tank
-	var/list/times
-
-/obj/item/onetankbomb/Initialize(mapload)
-	. = ..()
-	times = list("1" = 1, "-1" = 1, "15" = 7, "[rand(30,90)]" = 3) // instant, dud, normal fuse, long random fuse
 
 /obj/item/onetankbomb/Destroy()
 	bombassembly = null
@@ -27,9 +22,7 @@
 	return TRUE
 
 /obj/item/onetankbomb/examine(mob/user)
-	. = bombtank.examine(user)
-	. += span_warning("It looks rather unreliable, you can't tell when it will explode!")
-	return .
+	return bombtank.examine(user)
 
 /obj/item/onetankbomb/update_icon(updates)
 	icon = bombtank?.icon || initial(icon)
@@ -82,16 +75,9 @@
 	return
 
 /obj/item/onetankbomb/receive_signal() //This is mainly called by the sensor through sense() to the holder, and from the holder to here.
-	var/detonation_time = text2num(pick_weight(times))
-	if(detonation_time < 0)
-		audible_message(span_warning("[icon2html(src, hearers(src))] *beep*"))
-		playsound(src, 'sound/machines/buzz-sigh.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
-		return
 	audible_message(span_warning("[icon2html(src, hearers(src))] *beep* *beep* *beep*"))
 	playsound(src, 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
-	addtimer(CALLBACK(src, PROC_REF(detonate)), detonation_time)
-
-/obj/item/onetankbomb/proc/detonate()
+	sleep(1 SECONDS)
 	if(QDELETED(src))
 		return
 	if(status)
@@ -120,6 +106,9 @@
 	. = ..()
 	if(bombassembly)
 		bombassembly.dropped()
+
+
+
 
 // ---------- Procs below are for tanks that are used exclusively in 1-tank bombs ----------
 

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -84,7 +84,7 @@
 /obj/item/onetankbomb/receive_signal() //This is mainly called by the sensor through sense() to the holder, and from the holder to here.
 	var/detonation_time = text2num(pick_weight(times))
 	if(detonation_time < 0)
-		audible_message(span_warning("[icon2html(src, hearers(src))] *buzz*"))
+		audible_message(span_warning("[icon2html(src, hearers(src))] *beep*"))
 		playsound(src, 'sound/machines/buzz-sigh.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 		return
 	audible_message(span_warning("[icon2html(src, hearers(src))] *beep* *beep* *beep*"))

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -12,6 +12,11 @@
 	var/status = FALSE   //0 - not readied //1 - bomb finished with welder
 	var/obj/item/assembly_holder/bombassembly = null   //The first part of the bomb is an assembly holder, holding an igniter+some device
 	var/obj/item/tank/bombtank = null //the second part of the bomb is a plasma tank
+	var/list/times
+
+/obj/item/onetankbomb/Initialize(mapload)
+	. = ..()
+	times = list("1" = 1, "-1" = 1, "15" = 7, "[rand(30,90)]" = 3) // instant, dud, normal fuse, long random fuse
 
 /obj/item/onetankbomb/Destroy()
 	bombassembly = null
@@ -22,7 +27,9 @@
 	return TRUE
 
 /obj/item/onetankbomb/examine(mob/user)
-	return bombtank.examine(user)
+	. = bombtank.examine(user)
+	. += span_warning("It looks rather unreliable, you can't tell when it will explode!")
+	return .
 
 /obj/item/onetankbomb/update_icon(updates)
 	icon = bombtank?.icon || initial(icon)
@@ -75,9 +82,16 @@
 	return
 
 /obj/item/onetankbomb/receive_signal() //This is mainly called by the sensor through sense() to the holder, and from the holder to here.
+	var/detonation_time = text2num(pick_weight(times))
+	if(detonation_time < 0)
+		audible_message(span_warning("[icon2html(src, hearers(src))] *beep*"))
+		playsound(src, 'sound/machines/buzz-sigh.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
+		return
 	audible_message(span_warning("[icon2html(src, hearers(src))] *beep* *beep* *beep*"))
 	playsound(src, 'sound/machines/triple_beep.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
-	sleep(1 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(detonate)), detonation_time)
+
+/obj/item/onetankbomb/proc/detonate()
 	if(QDELETED(src))
 		return
 	if(status)
@@ -106,9 +120,6 @@
 	. = ..()
 	if(bombassembly)
 		bombassembly.dropped()
-
-
-
 
 // ---------- Procs below are for tanks that are used exclusively in 1-tank bombs ----------
 

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -16,7 +16,7 @@
 
 /obj/item/onetankbomb/Initialize(mapload)
 	. = ..()
-	times = list("1" = 1, "-1" = 1, "15" = 7, "[rand(30,90)]" = 3) // instant, dud, normal fuse, long random fuse
+	times = list("1" = 1, "-1" = 1, "15" = 7, "[rand(20,50)]" = 3) // instant, dud, normal fuse, long random fuse
 
 /obj/item/onetankbomb/Destroy()
 	bombassembly = null

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -16,7 +16,7 @@
 
 /obj/item/onetankbomb/Initialize(mapload)
 	. = ..()
-	times = list("1" = 1, "-1" = 1, "15" = 7, "[rand(20,50)]" = 3) // instant, dud, normal fuse, long random fuse
+	times = list("1" = 1, "-1" = 1, "15" = 7, "[rand(30,90)]" = 3) // instant, dud, normal fuse, long random fuse
 
 /obj/item/onetankbomb/Destroy()
 	bombassembly = null

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -84,7 +84,7 @@
 /obj/item/onetankbomb/receive_signal() //This is mainly called by the sensor through sense() to the holder, and from the holder to here.
 	var/detonation_time = text2num(pick_weight(times))
 	if(detonation_time < 0)
-		audible_message(span_warning("[icon2html(src, hearers(src))] *beep*"))
+		audible_message(span_warning("[icon2html(src, hearers(src))] *buzz*"))
 		playsound(src, 'sound/machines/buzz-sigh.ogg', ASSEMBLY_BEEP_VOLUME, TRUE)
 		return
 	audible_message(span_warning("[icon2html(src, hearers(src))] *beep* *beep* *beep*"))


### PR DESCRIPTION
## About The Pull Request

Makes em not have devastation

## Why It's Good For The Game

gibbing people with easy to massproduce explosives is pretty shitty

## Changelog
:cl:
balance: Tank Assembly Bombs now dont have devastation
/:cl:
