### PR TITLE
Books now render Markdown, fixing paper importing

### DIFF
--- a/code/modules/fishing/fish_catalog.dm
+++ b/code/modules/fishing/fish_catalog.dm
@@ -5,9 +5,6 @@
 	icon_state = "fishbook"
 	starting_content = "Lot of fish stuff" //book wrappers could use cleaning so this is not necessary
 
-/obj/item/book/fish_catalog/on_read(mob/user)
-	ui_interact(user)
-
 /obj/item/book/fish_catalog/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -46,9 +46,10 @@
 	var/raw_content = ""
 
 	for(var/datum/paper_input/text_input as anything in paper.raw_text_inputs)
-		raw_content += text_input.raw_text
-
-	// Content from paper is never trusted. It it raw, unsanitised, unparsed user input.
+		if(!isnull(text_input.colour))
+			raw_content += text_input.raw_text
+		else
+			raw_content += "<font color='[text_input.colour]'>[text_input.raw_text]</font>"
 	content = trim(html_encode(raw_content), MAX_PAPER_LENGTH)
 
 /datum/book_info/proc/get_content(default="N/A")

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -112,19 +112,29 @@
 
 	AddElement(/datum/element/falling_hazard, damage = 5, wound_bonus = 0, hardhat_safety = TRUE, crushes = FALSE, impact_sound = drop_sound)
 
-/obj/item/book/proc/on_read(mob/living/user)
-	if(book_data?.content)
-		user << browse("<meta charset=UTF-8><TT><I>Penned by [book_data.author].</I></TT> <BR>" + "[book_data.content]", "window=book[window_size != null ? ";size=[window_size]" : ""]")
+/obj/item/book/ui_static_data(mob/user)
+	var/list/data = list()
+	data["author"] = book_data.get_author()
+	data["title"] = book_data.get_title()
+	data["content"] = book_data.get_content()
+	return data
 
-		LAZYINITLIST(user.mind?.book_titles_read)
-		var/has_not_read_book = isnull(user.mind?.book_titles_read[starting_title])
+/obj/item/book/ui_interact(mob/living/user, datum/tgui/ui)
+	if(!length(book_data.get_content()))
+		balloon_alert(user, "this book is blank!")
+		return
 
-		if(has_not_read_book) // any new books give bonus mood
+	if(istype(user) && !isnull(user.mind))
+		LAZYINITLIST(user.mind.book_titles_read)
+		var/has_not_read_book = !(starting_title in user.mind.book_titles_read)
+		if(has_not_read_book)
 			user.add_mood_event("book_nerd", /datum/mood_event/book_nerd)
-			user.mind?.book_titles_read[starting_title] = TRUE
-		onclose(user, "book")
-	else
-		to_chat(user, span_notice("This book is completely blank!"))
+			user.mind.book_titles_read[starting_title] = TRUE
+
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "MarkdownViewer", name)
+		ui.open()
 
 /// Generates a random icon state for the book
 /obj/item/book/proc/gen_random_icon_state()
@@ -134,10 +144,12 @@
 	if(user.is_blind())
 		to_chat(user, span_warning("You are blind and can't read anything!"))
 		return
+
 	if(!user.can_read(src))
 		return
+
 	user.visible_message(span_notice("[user] opens a book titled \"[book_data.title]\" and begins reading intently."))
-	on_read(user)
+	ui_interact(user)
 
 /obj/item/book/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/pen))

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -781,7 +781,7 @@
 	var/busy = FALSE
 
 	/// Name of the author for the book, set by scanning your ID.
-	var/scanned_id
+	var/scanned_name
 
 /obj/machinery/bookbinder/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
@@ -795,7 +795,7 @@
 
 	if(isidcard(hitby))
 		var/obj/item/card/id/idcard = hitby
-		scanned_id = idcard.registered_name
+		scanned_name = idcard.registered_name
 		balloon_alert(user, "scanned")
 		return TRUE
 
@@ -809,8 +809,8 @@
 		to_chat(user, span_warning("The book binder is busy. Please wait for completion of previous operation."))
 		return
 
-	if(!scanned_id)
-		scanned_id = "unknown author"
+	if(!scanned_name)
+		scanned_name = "unknown author"
 		say("No ID detected. Please scan your ID if you would like to be credited for this book. Otherwise please enter your paper again.")
 		return
 
@@ -836,10 +836,10 @@
 	visible_message(span_notice("[src] whirs as it prints and binds a new book."))
 	var/obj/item/book/bound_book = new(loc)
 	bound_book.book_data.set_content_using_paper(draw_from)
-	bound_book.book_data.set_author(scanned_id, trusted = FALSE)
+	bound_book.book_data.set_author(scanned_name, trusted = FALSE)
 	bound_book.name = "Print Job #" + "[rand(100, 999)]"
 	bound_book.gen_random_icon_state()
-	scanned_id = null
+	scanned_name = null
 
 	qdel(draw_from)
 

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -796,7 +796,7 @@
 	if(isidcard(hitby))
 		var/obj/item/card/id/idcard = hitby
 		scanned_id = idcard.registered_name
-		to_chat(user, span_notice("You scan your ID."))
+		balloon_alert(user, "scanned")
 		return TRUE
 
 	return ..()

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -776,7 +776,12 @@
 	icon_state = "binder"
 	desc = "Only intended for binding paper products."
 	density = TRUE
+
+	/// Are we currently binding a book?
 	var/busy = FALSE
+
+	/// Name of the author for the book, set by scanning your ID.
+	var/scanned_id
 
 /obj/machinery/bookbinder/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
@@ -786,17 +791,32 @@
 /obj/machinery/bookbinder/attackby(obj/hitby, mob/user, params)
 	if(istype(hitby, /obj/item/paper))
 		prebind_book(user, hitby)
-		return
+		return TRUE
+
+	if(isidcard(hitby))
+		var/obj/item/card/id/idcard = hitby
+		scanned_id = idcard.registered_name
+		to_chat(user, span_notice("You scan your ID."))
+		return TRUE
+
 	return ..()
 
 /obj/machinery/bookbinder/proc/prebind_book(mob/user, obj/item/paper/draw_from)
 	if(machine_stat)
 		return
+
 	if(busy)
 		to_chat(user, span_warning("The book binder is busy. Please wait for completion of previous operation."))
 		return
+
+	if(!scanned_id)
+		scanned_id = "unknown author"
+		say("No ID detected. Please scan your ID if you would like to be credited for this book. Otherwise please enter your paper again.")
+		return
+
 	if(!user.transferItemToLoc(draw_from, src))
 		return
+
 	user.visible_message(span_notice("[user] loads some paper into [src]."), span_notice("You load some paper into [src]."))
 	audible_message(span_hear("[src] begins to hum as it warms up its printing drums."))
 	busy = TRUE
@@ -808,14 +828,19 @@
 	busy = FALSE
 	if(!draw_from) //What the fuck did you do
 		return
+
 	if(machine_stat)
 		draw_from.forceMove(drop_location())
 		return
+
 	visible_message(span_notice("[src] whirs as it prints and binds a new book."))
 	var/obj/item/book/bound_book = new(loc)
 	bound_book.book_data.set_content_using_paper(draw_from)
+	bound_book.book_data.set_author(scanned_id, trusted = FALSE)
 	bound_book.name = "Print Job #" + "[rand(100, 999)]"
 	bound_book.gen_random_icon_state()
+	scanned_id = null
+
 	qdel(draw_from)
 
 #undef BOOKS_PER_PAGE

--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -10,7 +10,7 @@ type MarkdownViewerData = {
 };
 
 export const MarkdownViewer = (_: any, context: any) => {
-  let { data } = useBackend<MarkdownViewerData>(context);
+  const { data } = useBackend<MarkdownViewerData>(context);
   return (
     <Window theme="paper" title={data.title}>
       <Window.Content scrollable backgroundColor={'#FFFFFF'}>
@@ -30,7 +30,7 @@ export const MarkdownRenderer = (props: MarkdownRendererProps) => {
 
   content = marked(content);
   if (sanitize) {
-    content = sanitizeText(content, false);
+    content = sanitizeText(content, /* advHtml = */ false);
   }
 
   // eslint-disable-next-line react/no-danger

--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -1,5 +1,3 @@
-import { Component } from 'inferno';
-import { marked } from 'marked';
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
 import { sanitizeText } from '../sanitize';
@@ -26,30 +24,16 @@ type MarkdownRendererProps = {
   sanitize?: boolean;
 };
 
-export class MarkdownRenderer extends Component<MarkdownRendererProps> {
-  render() {
-    return <div id="markdown-viewer-content" />;
+export const MarkdownRenderer = (props: MarkdownRendererProps) => {
+  let { content, sanitize } = props;
+  if (sanitize) {
+    content = sanitizeText(content, false);
   }
 
-  renderMarkdown() {
-    let rendered_content = marked(this.props.content);
-    if (this.props.sanitize === undefined || this.props.sanitize) {
-      rendered_content = sanitizeText(rendered_content, false);
-    }
+  // eslint-disable-next-line react/no-danger
+  return <div dangerouslySetInnerHTML={{ __html: content }} />;
+};
 
-    let render_target = document.getElementById('markdown-viewer-content');
-    if (render_target) {
-      render_target.innerHTML = rendered_content;
-    } else {
-      throw new Error('Unable to find render target');
-    }
-  }
-
-  componentDidMount() {
-    this.renderMarkdown();
-  }
-
-  componentDidUpdate() {
-    this.renderMarkdown();
-  }
-}
+MarkdownRenderer.defaultProps = {
+  sanitize: true,
+};

--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -1,3 +1,4 @@
+import { marked } from 'marked';
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
 import { sanitizeText } from '../sanitize';
@@ -26,6 +27,8 @@ type MarkdownRendererProps = {
 
 export const MarkdownRenderer = (props: MarkdownRendererProps) => {
   let { content, sanitize } = props;
+
+  content = marked(content);
   if (sanitize) {
     content = sanitizeText(content, false);
   }

--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -1,9 +1,3 @@
-/**
- * @file MarkdownViewer.tsx
- * @author ZephyrTFA
- * @license MIT
- */
-
 import { Component } from 'inferno';
 import { marked } from 'marked';
 import { useBackend } from '../backend';
@@ -29,7 +23,7 @@ export const MarkdownViewer = (_: any, context: any) => {
 
 type MarkdownRendererProps = {
   content: string;
-  nosanitize?: boolean;
+  sanitize?: boolean = true;
 };
 
 export class MarkdownRenderer extends Component<MarkdownRendererProps> {
@@ -39,7 +33,7 @@ export class MarkdownRenderer extends Component<MarkdownRendererProps> {
 
   renderMarkdown() {
     let rendered_content = marked(this.props.content);
-    if (!this.props.nosanitize) {
+    if (this.props.sanitize) {
       rendered_content = sanitizeText(rendered_content, false);
     }
 
@@ -55,11 +49,7 @@ export class MarkdownRenderer extends Component<MarkdownRendererProps> {
     this.renderMarkdown();
   }
 
-  componentDidUpdate(
-    _prevProps: MarkdownRendererProps,
-    _prevState: {},
-    _snapshot: any
-  ): void {
+  componentDidUpdate() {
     this.renderMarkdown();
   }
 }

--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -1,0 +1,48 @@
+/**
+ * @file MarkdownViewer.tsx
+ * @author ZephyrTFA
+ * @license MIT
+ */
+
+import { Component } from 'inferno';
+import { marked } from 'marked';
+import { useBackend } from '../backend';
+import { Window } from '../layouts';
+
+type MarkdownViewerData = {
+  title: string;
+  content: string;
+  author: string;
+};
+
+export const MarkdownViewer = (props: any, context: any) => {
+  let { data } = useBackend<MarkdownViewerData>(context);
+  return (
+    <MarkdownViewerImpl
+      title={data.title || 'No Title'}
+      content={data.content || 'No Content'}
+      author={data.author || 'Unknown Author'}
+    />
+  );
+};
+
+export class MarkdownViewerImpl extends Component<MarkdownViewerData> {
+  render() {
+    return (
+      <Window title={this.props.title}>
+        <Window.Content>
+          <div id="markdown-viewer-content" />
+        </Window.Content>
+      </Window>
+    );
+  }
+
+  componentDidMount() {
+    let render_target = document.getElementById('markdown-viewer-content');
+    if (render_target) {
+      render_target.innerHTML = marked(this.props.content);
+    } else {
+      throw new Error('Unable to find render target');
+    }
+  }
+}

--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -8,6 +8,7 @@ import { Component } from 'inferno';
 import { marked } from 'marked';
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
+import { sanitizeText } from '../sanitize';
 
 type MarkdownViewerData = {
   title: string;
@@ -15,34 +16,50 @@ type MarkdownViewerData = {
   author: string;
 };
 
-export const MarkdownViewer = (props: any, context: any) => {
+export const MarkdownViewer = (_: any, context: any) => {
   let { data } = useBackend<MarkdownViewerData>(context);
   return (
-    <MarkdownViewerImpl
-      title={data.title || 'No Title'}
-      content={data.content || 'No Content'}
-      author={data.author || 'Unknown Author'}
-    />
+    <Window theme="paper" title={data.title}>
+      <Window.Content scrollable backgroundColor={'#FFFFFF'}>
+        <MarkdownRenderer content={data.content} />
+      </Window.Content>
+    </Window>
   );
 };
 
-export class MarkdownViewerImpl extends Component<MarkdownViewerData> {
+type MarkdownRendererProps = {
+  content: string;
+  nosanitize?: boolean;
+};
+
+export class MarkdownRenderer extends Component<MarkdownRendererProps> {
   render() {
-    return (
-      <Window title={this.props.title} theme="paper">
-        <Window.Content backgroundColor={'#FFFFFF'}>
-          <div id="markdown-viewer-content" />
-        </Window.Content>
-      </Window>
-    );
+    return <div id="markdown-viewer-content" />;
   }
 
-  componentDidMount() {
+  renderMarkdown() {
+    let rendered_content = marked(this.props.content);
+    if (!this.props.nosanitize) {
+      rendered_content = sanitizeText(rendered_content, false);
+    }
+
     let render_target = document.getElementById('markdown-viewer-content');
     if (render_target) {
-      render_target.innerHTML = marked(this.props.content);
+      render_target.innerHTML = rendered_content;
     } else {
       throw new Error('Unable to find render target');
     }
+  }
+
+  componentDidMount() {
+    this.renderMarkdown();
+  }
+
+  componentDidUpdate(
+    _prevProps: MarkdownRendererProps,
+    _prevState: {},
+    _snapshot: any
+  ): void {
+    this.renderMarkdown();
   }
 }

--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -29,8 +29,8 @@ export const MarkdownViewer = (props: any, context: any) => {
 export class MarkdownViewerImpl extends Component<MarkdownViewerData> {
   render() {
     return (
-      <Window title={this.props.title}>
-        <Window.Content>
+      <Window title={this.props.title} theme="paper">
+        <Window.Content backgroundColor={'#FFFFFF'}>
           <div id="markdown-viewer-content" />
         </Window.Content>
       </Window>

--- a/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
+++ b/tgui/packages/tgui/interfaces/MarkdownViewer.tsx
@@ -23,7 +23,7 @@ export const MarkdownViewer = (_: any, context: any) => {
 
 type MarkdownRendererProps = {
   content: string;
-  sanitize?: boolean = true;
+  sanitize?: boolean;
 };
 
 export class MarkdownRenderer extends Component<MarkdownRendererProps> {
@@ -33,7 +33,7 @@ export class MarkdownRenderer extends Component<MarkdownRendererProps> {
 
   renderMarkdown() {
     let rendered_content = marked(this.props.content);
-    if (this.props.sanitize) {
+    if (this.props.sanitize === undefined || this.props.sanitize) {
       rendered_content = sanitizeText(rendered_content, false);
     }
 


### PR DESCRIPTION

## About The Pull Request

Books didn't render markdown and instead just dumped the raw contents, (after a html encode), into the window.
Changes them to use tgui and support markdown rendering.
## Why It's Good For The Game

Books should should look the same as the paper used to make them.
## Changelog
:cl:
fix: Book's no longer take your formatting and throw it out the window.
refactor: Book display and rendering
/:cl:
