### PR TITLE
When failing to teleport with the veil shifter it tells you with text and sfx, and doesn't use up a charge.

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -580,23 +580,25 @@ Striking a noncultist, however, will tear their flesh."}
 	var/turf/mobloc = get_turf(C)
 	var/turf/destination = get_teleport_loc(location = mobloc, target = C, distance = 9, density_check = TRUE, errorx = 3, errory = 1, eoffsety = 1)
 
-	if(destination)
-		uses--
-		if(uses <= 0)
-			icon_state ="shifter_drained"
-		playsound(mobloc, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-		new /obj/effect/temp_visual/dir_setting/cult/phase/out(mobloc, C.dir)
+	if(!destination || !do_teleport(C, destination, channel = TELEPORT_CHANNEL_CULT))
+		playsound(src, 'sound/items/haunted/ghostitemattack.ogg', 100, TRUE)
+		balloon_alert(user, "teleport failed!")
+		return
 
-		var/atom/movable/pulled = handle_teleport_grab(destination, C)
-		if(do_teleport(C, destination, channel = TELEPORT_CHANNEL_CULT))
-			if(pulled)
-				C.start_pulling(pulled) //forcemove resets pulls, so we need to re-pull
-			new /obj/effect/temp_visual/dir_setting/cult/phase(destination, C.dir)
-			playsound(destination, 'sound/effects/phasein.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
-			playsound(destination, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	uses--
+	if(uses <= 0)
+		icon_state ="shifter_drained"
 
-	else
-		to_chat(C, span_warning("The veil cannot be torn here!"))
+	var/atom/movable/pulled = handle_teleport_grab(destination, C)
+	if(pulled)
+		C.start_pulling(pulled) //forcemove resets pulls, so we need to re-pull
+
+	new /obj/effect/temp_visual/dir_setting/cult/phase/out(mobloc, C.dir)
+	new /obj/effect/temp_visual/dir_setting/cult/phase(destination, C.dir)
+
+	playsound(mobloc, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	playsound(destination, 'sound/effects/phasein.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+	playsound(destination, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
 /obj/item/flashlight/flare/culttorch
 	name = "void torch"


### PR DESCRIPTION
## About The Pull Request

When failing to teleport with the veil shifter it tells you with text and spooky ghost sfx, and doesn't use up a charge.

## Why It's Good For The Game

> When failing to teleport with the Veil Shifter, it makes no extraneous effects, just says 'teleport failed!' and makes a noticeably different spooky ghost noise.

Failing to teleport used to consume an use, make the teleport effects, and overall act like you actually teleported. While I'm not smart enough to find out why #74757 was caused at least I can do this as a little qol for if it ever happens again.

## Changelog

:cl:
qol: When failing to teleport with the veil shifter it tells you with text and spooky ghost sfx, and doesn't use up a charge or have any unintended vfx.
/:cl:

