### PR TITLE
Non-random events now provide a cause in their deadchat broadcast

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -39,7 +39,7 @@
 #define COMSIG_GLOB_PRE_RANDOM_EVENT "!pre_random_event"
 	/// Do not allow this random event to continue.
 	#define CANCEL_PRE_RANDOM_EVENT (1<<0)
-/// Called by (/datum/round_event_control/RunEvent).
+/// Called by (/datum/round_event_control/run_event).
 #define COMSIG_GLOB_RANDOM_EVENT "!random_event"
 	/// Do not allow this random event to continue.
 	#define CANCEL_RANDOM_EVENT (1<<0)

--- a/code/__HELPERS/events.dm
+++ b/code/__HELPERS/events.dm
@@ -49,4 +49,22 @@
 
 	return pick(possible_spawns)
 
+/proc/force_event(event_typepath, cause)
+	var/datum/round_event_control/our_event = locate(event_typepath) in SSevents.control
+	if(!our_event)
+		CRASH("Attempted to force event [event_typepath], but the event path could not be found!")
+	our_event.run_event(event_cause = cause)
+
+/proc/force_event_async(event_typepath, cause)
+	var/datum/round_event_control/our_event = locate(event_typepath) in SSevents.control
+	if(!our_event)
+		CRASH("Attempted to force event [event_typepath], but the event path could not be found!")
+	INVOKE_ASYNC(our_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = cause)
+
+/proc/force_event_after(event_typepath, cause, duration)
+	var/datum/round_event_control/our_event = locate(event_typepath) in SSevents.control
+	if(!our_event)
+		CRASH("Attempted to force event [event_typepath], but the event path could not be found!")
+	addtimer(CALLBACK(our_event, TYPE_PROC_REF(/datum/round_event_control, run_event), FALSE, null, FALSE, cause), duration)
+
 #undef UNLIT_AREA_BRIGHTNESS

--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -91,7 +91,7 @@ SUBSYSTEM_DEF(events)
 	if(. == EVENT_CANT_RUN)//we couldn't run this event for some reason, set its max_occurrences to 0
 		E.max_occurrences = 0
 	else if(. == EVENT_READY)
-		E.runEvent(random = TRUE)
+		E.run_event(random = TRUE)
 
 
 /datum/controller/subsystem/events/proc/toggleWizardmode()

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -17,9 +17,7 @@
 		var/delay = rand(20 SECONDS, 1 MINUTES)
 
 		log_dynamic_and_announce("An unfavorable situation was requested, but no heavy rulesets could be drafted. Spawning [initial(round_event_control_type.name)] in [DisplayTimeText(delay)] instead.")
-
-		var/datum/round_event_control/round_event_control = new round_event_control_type
-		addtimer(CALLBACK(round_event_control, TYPE_PROC_REF(/datum/round_event_control, run_event)), delay)
+		force_event_after(round_event_control_type, "an unfavorable situation", delay)
 	else
 		var/datum/dynamic_ruleset/midround/heavy_ruleset = pick_weight(possible_heavies)
 		log_dynamic_and_announce("An unfavorable situation was requested, spawning [initial(heavy_ruleset.name)]")

--- a/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
+++ b/code/game/gamemodes/dynamic/dynamic_unfavorable_situation.dm
@@ -19,7 +19,7 @@
 		log_dynamic_and_announce("An unfavorable situation was requested, but no heavy rulesets could be drafted. Spawning [initial(round_event_control_type.name)] in [DisplayTimeText(delay)] instead.")
 
 		var/datum/round_event_control/round_event_control = new round_event_control_type
-		addtimer(CALLBACK(round_event_control, TYPE_PROC_REF(/datum/round_event_control, runEvent)), delay)
+		addtimer(CALLBACK(round_event_control, TYPE_PROC_REF(/datum/round_event_control, run_event)), delay)
 	else
 		var/datum/dynamic_ruleset/midround/heavy_ruleset = pick_weight(possible_heavies)
 		log_dynamic_and_announce("An unfavorable situation was requested, spawning [initial(heavy_ruleset.name)]")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -848,7 +848,7 @@
 			var/datum/round_event_control/pirates/pirate_event = locate() in SSevents.control
 			if(!pirate_event)
 				CRASH("hack_console() attempted to run pirates, but could not find an event controller!")
-			addtimer(CALLBACK(pirate_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), FALSE, null, FALSE, "[hacker] hacking a communications console"), rand(20 SECONDS, 1 MINUTES))
+			addtimer(CALLBACK(pirate_event, TYPE_PROC_REF(/datum/round_event_control, run_event), FALSE, null, FALSE, "[hacker] hacking a communications console"), rand(20 SECONDS, 1 MINUTES))
 
 		if(HACK_FUGITIVES) // Triggers fugitives, which can cause confusion / chaos as the crew decides which side help
 			priority_announce(
@@ -859,7 +859,7 @@
 			var/datum/round_event_control/fugitives/fugitive_event = locate() in SSevents.control
 			if(!fugitive_event)
 				CRASH("hack_console() attempted to run fugitives, but could not find an event controller!")
-			addtimer(CALLBACK(fugitive_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), FALSE, null, FALSE, "[hacker] hacking a communications console"), rand(20 SECONDS, 1 MINUTES))
+			addtimer(CALLBACK(fugitive_event, TYPE_PROC_REF(/datum/round_event_control, run_event), FALSE, null, FALSE, "[hacker] hacking a communications console"), rand(20 SECONDS, 1 MINUTES))
 
 		if(HACK_THREAT) // Force an unfavorable situation on the crew
 			priority_announce(

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -848,7 +848,7 @@
 			var/datum/round_event_control/pirates/pirate_event = locate() in SSevents.control
 			if(!pirate_event)
 				CRASH("hack_console() attempted to run pirates, but could not find an event controller!")
-			addtimer(CALLBACK(pirate_event, TYPE_PROC_REF(/datum/round_event_control, runEvent)), rand(20 SECONDS, 1 MINUTES))
+			addtimer(CALLBACK(pirate_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), FALSE, null, FALSE, "[hacker] hacking a communications console"), rand(20 SECONDS, 1 MINUTES))
 
 		if(HACK_FUGITIVES) // Triggers fugitives, which can cause confusion / chaos as the crew decides which side help
 			priority_announce(
@@ -859,7 +859,7 @@
 			var/datum/round_event_control/fugitives/fugitive_event = locate() in SSevents.control
 			if(!fugitive_event)
 				CRASH("hack_console() attempted to run fugitives, but could not find an event controller!")
-			addtimer(CALLBACK(fugitive_event, TYPE_PROC_REF(/datum/round_event_control, runEvent)), rand(20 SECONDS, 1 MINUTES))
+			addtimer(CALLBACK(fugitive_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), FALSE, null, FALSE, "[hacker] hacking a communications console"), rand(20 SECONDS, 1 MINUTES))
 
 		if(HACK_THREAT) // Force an unfavorable situation on the crew
 			priority_announce(

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -844,11 +844,7 @@
 				"Attention crew: sector monitoring reports a massive jump-trace from an enemy vessel destined for your system. Prepare for imminent hostile contact.",
 				"[command_name()] High-Priority Update",
 			)
-
-			var/datum/round_event_control/pirates/pirate_event = locate() in SSevents.control
-			if(!pirate_event)
-				CRASH("hack_console() attempted to run pirates, but could not find an event controller!")
-			addtimer(CALLBACK(pirate_event, TYPE_PROC_REF(/datum/round_event_control, run_event), FALSE, null, FALSE, "[hacker] hacking a communications console"), rand(20 SECONDS, 1 MINUTES))
+			force_event_after(/datum/round_event_control/pirates, "[hacker] hacking a communications console", rand(20 SECONDS, 1 MINUTES))
 
 		if(HACK_FUGITIVES) // Triggers fugitives, which can cause confusion / chaos as the crew decides which side help
 			priority_announce(
@@ -856,10 +852,7 @@
 				"[command_name()] High-Priority Update",
 			)
 
-			var/datum/round_event_control/fugitives/fugitive_event = locate() in SSevents.control
-			if(!fugitive_event)
-				CRASH("hack_console() attempted to run fugitives, but could not find an event controller!")
-			addtimer(CALLBACK(fugitive_event, TYPE_PROC_REF(/datum/round_event_control, run_event), FALSE, null, FALSE, "[hacker] hacking a communications console"), rand(20 SECONDS, 1 MINUTES))
+			force_event_after(/datum/round_event_control/fugitives, "[hacker] hacking a communications console", rand(20 SECONDS, 1 MINUTES))
 
 		if(HACK_THREAT) // Force an unfavorable situation on the crew
 			priority_announce(

--- a/code/modules/admin/force_event.dm
+++ b/code/modules/admin/force_event.dm
@@ -95,6 +95,6 @@
 						return
 			var/always_announce_chance = 100
 			var/no_announce_chance = 0
-			event.runEvent(announce_chance_override = announce_event ? always_announce_chance : no_announce_chance, admin_forced = TRUE)
+			event.runEvent(announce_chance_override = announce_event ? always_announce_chance : no_announce_chance, admin_forced = TRUE, event_cause = "the events panel")
 			message_admins("[key_name_admin(usr)] has triggered an event. ([event.name])")
 			log_admin("[key_name(usr)] has triggered an event. ([event.name])")

--- a/code/modules/admin/force_event.dm
+++ b/code/modules/admin/force_event.dm
@@ -95,6 +95,6 @@
 						return
 			var/always_announce_chance = 100
 			var/no_announce_chance = 0
-			event.runEvent(announce_chance_override = announce_event ? always_announce_chance : no_announce_chance, admin_forced = TRUE, event_cause = "the events panel")
+			event.run_event(announce_chance_override = announce_event ? always_announce_chance : no_announce_chance, admin_forced = TRUE, event_cause = "the events panel")
 			message_admins("[key_name_admin(usr)] has triggered an event. ([event.name])")
 			log_admin("[key_name(usr)] has triggered an event. ([event.name])")

--- a/code/modules/admin/force_event.dm
+++ b/code/modules/admin/force_event.dm
@@ -95,6 +95,6 @@
 						return
 			var/always_announce_chance = 100
 			var/no_announce_chance = 0
-			event.run_event(announce_chance_override = announce_event ? always_announce_chance : no_announce_chance, admin_forced = TRUE, event_cause = "the events panel")
+			event.run_event(announce_chance_override = announce_event ? always_announce_chance : no_announce_chance, admin_forced = TRUE)
 			message_admins("[key_name_admin(usr)] has triggered an event. ([event.name])")
 			log_admin("[key_name(usr)] has triggered an event. ([event.name])")

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -207,8 +207,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 				if("Make Your Own")
 					AdminCreateVirus(holder)
 				if("Random")
-					var/datum/round_event_control/disease_outbreak/DC = locate(/datum/round_event_control/disease_outbreak) in SSevents.control
-					E = DC.run_event()
+					force_event(/datum/round_event_control/disease_outbreak)
 				if("Choose")
 					var/virus = input("Choose the virus to spread", "BIOHAZARD") as null|anything in sort_list(typesof(/datum/disease), GLOBAL_PROC_REF(cmp_typepaths_asc))
 					var/datum/round_event_control/disease_outbreak/DC = locate(/datum/round_event_control/disease_outbreak) in SSevents.control

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -208,11 +208,11 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 					AdminCreateVirus(holder)
 				if("Random")
 					var/datum/round_event_control/disease_outbreak/DC = locate(/datum/round_event_control/disease_outbreak) in SSevents.control
-					E = DC.runEvent()
+					E = DC.run_event()
 				if("Choose")
 					var/virus = input("Choose the virus to spread", "BIOHAZARD") as null|anything in sort_list(typesof(/datum/disease), GLOBAL_PROC_REF(cmp_typepaths_asc))
 					var/datum/round_event_control/disease_outbreak/DC = locate(/datum/round_event_control/disease_outbreak) in SSevents.control
-					var/datum/round_event/disease_outbreak/DO = DC.runEvent()
+					var/datum/round_event/disease_outbreak/DO = DC.run_event()
 					DO.virus_type = virus
 					E = DO
 		if("allspecies")

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -1040,13 +1040,13 @@ structure_check() searches for nearby cultist structures required for the invoca
 		switch(outcome)
 			if(1 to 10)
 				var/datum/round_event_control/disease_outbreak/covid_2562_event = locate() in SSevents.control
-				INVOKE_ASYNC(covid_2562_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(covid_2562_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/mice_migration/stuart_big_event = locate() in SSevents.control
-				INVOKE_ASYNC(stuart_big_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(stuart_big_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 
 			if(11 to 20)
 				var/datum/round_event_control/radiation_storm/my_skin_feels_funny_event = locate() in SSevents.control
-				INVOKE_ASYNC(my_skin_feels_funny_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(my_skin_feels_funny_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 
 			if(21 to 30)
 				var/datum/round_event_control/brand_intelligence/product_placement_gone_rogue_event = locate() in SSevents.control
@@ -1054,37 +1054,37 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 			if(31 to 40)
 				var/datum/round_event_control/immovable_rod/huge_rod_event = locate() in SSevents.control //you've
-				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent)) //got
-				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent)) //a
-				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent)) //huge...
+				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune") //got
+				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune") //a
+				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune") //huge...
 
 			if(41 to 50)
 				var/datum/round_event_control/meteor_wave/dinosaur_purge_event = locate() in SSevents.control
-				INVOKE_ASYNC(dinosaur_purge_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(dinosaur_purge_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 
 			if(51 to 60)
 				var/datum/round_event_control/spider_infestation/creepy_crawly_event = locate() in SSevents.control
-				INVOKE_ASYNC(creepy_crawly_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(creepy_crawly_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 
 			if(61 to 70)
 				var/datum/round_event_control/anomaly/anomaly_flux/flux_event = locate() in SSevents.control
-				INVOKE_ASYNC(flux_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(flux_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/anomaly/anomaly_grav/grav_event = locate() in SSevents.control
-				INVOKE_ASYNC(grav_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(grav_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/anomaly/anomaly_pyro/pyro_event = locate() in SSevents.control
-				INVOKE_ASYNC(pyro_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(pyro_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/anomaly/anomaly_vortex/vortex_event = locate() in SSevents.control
-				INVOKE_ASYNC(vortex_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(vortex_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 
 			if(71 to 80)
 				var/datum/round_event_control/spacevine/ivy_event = locate() in SSevents.control
-				INVOKE_ASYNC(ivy_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(ivy_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/grey_tide/grey_tide_nation_wide = locate() in SSevents.control
-				INVOKE_ASYNC(grey_tide_nation_wide, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(grey_tide_nation_wide, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 
 			if(81 to 100)
 				var/datum/round_event_control/portal_storm_narsie/total_not_a_xen_storm_event = locate() in SSevents.control
-				INVOKE_ASYNC(total_not_a_xen_storm_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(total_not_a_xen_storm_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
 
 	qdel(src)
 

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -1039,52 +1039,37 @@ structure_check() searches for nearby cultist structures required for the invoca
 		var/outcome = rand(1,100)
 		switch(outcome)
 			if(1 to 10)
-				var/datum/round_event_control/disease_outbreak/covid_2562_event = locate() in SSevents.control
-				INVOKE_ASYNC(covid_2562_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
-				var/datum/round_event_control/mice_migration/stuart_big_event = locate() in SSevents.control
-				INVOKE_ASYNC(stuart_big_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
-
+				force_event_async(/datum/round_event_control/disease_outbreak, "an apocalypse rune")
+				force_event_async(/datum/round_event_control/mice_migration, "an apocalypse rune")
 			if(11 to 20)
-				var/datum/round_event_control/radiation_storm/my_skin_feels_funny_event = locate() in SSevents.control
-				INVOKE_ASYNC(my_skin_feels_funny_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
+				force_event_async(/datum/round_event_control/radiation_storm, "an apocalypse rune")
 
 			if(21 to 30)
-				var/datum/round_event_control/brand_intelligence/product_placement_gone_rogue_event = locate() in SSevents.control
-				INVOKE_ASYNC(product_placement_gone_rogue_event, TYPE_PROC_REF(/datum/round_event_control, run_event))
+				force_event_async(/datum/round_event_control/brand_intelligence, "an apocalypse rune")
 
 			if(31 to 40)
-				var/datum/round_event_control/immovable_rod/huge_rod_event = locate() in SSevents.control //you've
-				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune") //got
-				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune") //a
-				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune") //huge...
+				force_event_async(/datum/round_event_control/immovable_rod, "an apocalypse rune")
+				force_event_async(/datum/round_event_control/immovable_rod, "an apocalypse rune")
+				force_event_async(/datum/round_event_control/immovable_rod, "an apocalypse rune")
 
 			if(41 to 50)
-				var/datum/round_event_control/meteor_wave/dinosaur_purge_event = locate() in SSevents.control
-				INVOKE_ASYNC(dinosaur_purge_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
+				force_event_async(/datum/round_event_control/meteor_wave, "an apocalypse rune")
 
 			if(51 to 60)
-				var/datum/round_event_control/spider_infestation/creepy_crawly_event = locate() in SSevents.control
-				INVOKE_ASYNC(creepy_crawly_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
+				force_event_async(/datum/round_event_control/spider_infestation, "an apocalypse rune")
 
 			if(61 to 70)
-				var/datum/round_event_control/anomaly/anomaly_flux/flux_event = locate() in SSevents.control
-				INVOKE_ASYNC(flux_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
-				var/datum/round_event_control/anomaly/anomaly_grav/grav_event = locate() in SSevents.control
-				INVOKE_ASYNC(grav_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
-				var/datum/round_event_control/anomaly/anomaly_pyro/pyro_event = locate() in SSevents.control
-				INVOKE_ASYNC(pyro_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
-				var/datum/round_event_control/anomaly/anomaly_vortex/vortex_event = locate() in SSevents.control
-				INVOKE_ASYNC(vortex_event, TYPE_PROC_REF(/datum/round_event_control, run_event	), event_cause = "an apocalypse rune")
+				force_event_async(/datum/round_event_control/anomaly/anomaly_flux, "an apocalypse rune")
+				force_event_async(/datum/round_event_control/anomaly/anomaly_grav, "an apocalypse rune")
+				force_event_async(/datum/round_event_control/anomaly/anomaly_pyro, "an apocalypse rune")
+				force_event_async(/datum/round_event_control/anomaly/anomaly_vortex, "an apocalypse rune")
 
 			if(71 to 80)
-				var/datum/round_event_control/spacevine/ivy_event = locate() in SSevents.control
-				INVOKE_ASYNC(ivy_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
-				var/datum/round_event_control/grey_tide/grey_tide_nation_wide = locate() in SSevents.control
-				INVOKE_ASYNC(grey_tide_nation_wide, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
+				force_event_async(/datum/round_event_control/spacevine, "an apocalypse rune")
+				force_event_async(/datum/round_event_control/grey_tide, "an apocalypse rune")
 
 			if(81 to 100)
-				var/datum/round_event_control/portal_storm_narsie/total_not_a_xen_storm_event = locate() in SSevents.control
-				INVOKE_ASYNC(total_not_a_xen_storm_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
+				force_event_async(/datum/round_event_control/portal_storm_narsie, "an apocalypse rune")
 
 	qdel(src)
 

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -1040,51 +1040,51 @@ structure_check() searches for nearby cultist structures required for the invoca
 		switch(outcome)
 			if(1 to 10)
 				var/datum/round_event_control/disease_outbreak/covid_2562_event = locate() in SSevents.control
-				INVOKE_ASYNC(covid_2562_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(covid_2562_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/mice_migration/stuart_big_event = locate() in SSevents.control
-				INVOKE_ASYNC(stuart_big_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(stuart_big_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 
 			if(11 to 20)
 				var/datum/round_event_control/radiation_storm/my_skin_feels_funny_event = locate() in SSevents.control
-				INVOKE_ASYNC(my_skin_feels_funny_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(my_skin_feels_funny_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 
 			if(21 to 30)
 				var/datum/round_event_control/brand_intelligence/product_placement_gone_rogue_event = locate() in SSevents.control
-				INVOKE_ASYNC(product_placement_gone_rogue_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+				INVOKE_ASYNC(product_placement_gone_rogue_event, TYPE_PROC_REF(/datum/round_event_control, run_event))
 
 			if(31 to 40)
 				var/datum/round_event_control/immovable_rod/huge_rod_event = locate() in SSevents.control //you've
-				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune") //got
-				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune") //a
-				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune") //huge...
+				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune") //got
+				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune") //a
+				INVOKE_ASYNC(huge_rod_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune") //huge...
 
 			if(41 to 50)
 				var/datum/round_event_control/meteor_wave/dinosaur_purge_event = locate() in SSevents.control
-				INVOKE_ASYNC(dinosaur_purge_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(dinosaur_purge_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 
 			if(51 to 60)
 				var/datum/round_event_control/spider_infestation/creepy_crawly_event = locate() in SSevents.control
-				INVOKE_ASYNC(creepy_crawly_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(creepy_crawly_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 
 			if(61 to 70)
 				var/datum/round_event_control/anomaly/anomaly_flux/flux_event = locate() in SSevents.control
-				INVOKE_ASYNC(flux_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(flux_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/anomaly/anomaly_grav/grav_event = locate() in SSevents.control
-				INVOKE_ASYNC(grav_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(grav_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/anomaly/anomaly_pyro/pyro_event = locate() in SSevents.control
-				INVOKE_ASYNC(pyro_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(pyro_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/anomaly/anomaly_vortex/vortex_event = locate() in SSevents.control
-				INVOKE_ASYNC(vortex_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(vortex_event, TYPE_PROC_REF(/datum/round_event_control, run_event	), event_cause = "an apocalypse rune")
 
 			if(71 to 80)
 				var/datum/round_event_control/spacevine/ivy_event = locate() in SSevents.control
-				INVOKE_ASYNC(ivy_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(ivy_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 				var/datum/round_event_control/grey_tide/grey_tide_nation_wide = locate() in SSevents.control
-				INVOKE_ASYNC(grey_tide_nation_wide, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(grey_tide_nation_wide, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 
 			if(81 to 100)
 				var/datum/round_event_control/portal_storm_narsie/total_not_a_xen_storm_event = locate() in SSevents.control
-				INVOKE_ASYNC(total_not_a_xen_storm_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an apocalypse rune")
+				INVOKE_ASYNC(total_not_a_xen_storm_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an apocalypse rune")
 
 	qdel(src)
 

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
@@ -70,7 +70,7 @@
 	//if it's always hooked in it'll override admin choices
 	RegisterSignal(overflow_control, COMSIG_CREATED_ROUND_EVENT, PROC_REF(on_created_round_event))
 	disarm_nuke()
-	overflow_control.runEvent()
+	overflow_control.runEvent(event_cause = "a beer nuke")
 
 /// signal sent from overflow control when it fires an event
 /obj/machinery/nuclearbomb/beer/proc/on_created_round_event(datum/round_event_control/source_event_control, datum/round_event/scrubber_overflow/every_vent/created_event)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/beer_nuke.dm
@@ -70,7 +70,7 @@
 	//if it's always hooked in it'll override admin choices
 	RegisterSignal(overflow_control, COMSIG_CREATED_ROUND_EVENT, PROC_REF(on_created_round_event))
 	disarm_nuke()
-	overflow_control.runEvent(event_cause = "a beer nuke")
+	overflow_control.run_event(event_cause = "a beer nuke")
 
 /// signal sent from overflow control when it fires an event
 /obj/machinery/nuclearbomb/beer/proc/on_created_round_event(datum/round_event_control/source_event_control, datum/round_event/scrubber_overflow/every_vent/created_event)

--- a/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
@@ -11,8 +11,7 @@
 
 /datum/traitor_objective/ultimate/space_dragon/on_objective_taken(mob/user)
 	. = ..()
-	var/datum/round_event_control/carp_migration/carp_event = locate(/datum/round_event_control/carp_migration) in SSevents.control
-	carp_event.run_event(event_cause = "[handler.owner]'s final objective")
+	force_event(/datum/round_event_control/carp_migration, "[handler.owner]'s final objective")
 
 /datum/traitor_objective/ultimate/space_dragon/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	var/list/possible_areas = GLOB.the_station_areas.Copy()

--- a/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
@@ -12,7 +12,7 @@
 /datum/traitor_objective/ultimate/space_dragon/on_objective_taken(mob/user)
 	. = ..()
 	var/datum/round_event_control/carp_migration/carp_event = locate(/datum/round_event_control/carp_migration) in SSevents.control
-	carp_event.runEvent(event_cause = "[handler.owner]'s final objective")
+	carp_event.run_event(event_cause = "[handler.owner]'s final objective")
 
 /datum/traitor_objective/ultimate/space_dragon/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	var/list/possible_areas = GLOB.the_station_areas.Copy()

--- a/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
+++ b/code/modules/antagonists/traitor/objectives/final_objective/space_dragon.dm
@@ -12,7 +12,7 @@
 /datum/traitor_objective/ultimate/space_dragon/on_objective_taken(mob/user)
 	. = ..()
 	var/datum/round_event_control/carp_migration/carp_event = locate(/datum/round_event_control/carp_migration) in SSevents.control
-	carp_event.runEvent()
+	carp_event.runEvent(event_cause = "[handler.owner]'s final objective")
 
 /datum/traitor_objective/ultimate/space_dragon/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	var/list/possible_areas = GLOB.the_station_areas.Copy()

--- a/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
@@ -181,7 +181,7 @@
 		return
 
 	var/datum/round_event_control/final_event = pick (possible_events)
-	final_event.runEvent()
+	final_event.runEvent(event_cause = "a Grand Ritual Rune")
 	to_chat(user, span_notice("Your released magic afflicts the crew: [final_event.name]!"))
 
 /// Applies some local side effects to the area

--- a/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
@@ -181,7 +181,7 @@
 		return
 
 	var/datum/round_event_control/final_event = pick (possible_events)
-	final_event.runEvent(event_cause = "a Grand Ritual Rune")
+	final_event.run_event(event_cause = "a Grand Ritual Rune")
 	to_chat(user, span_notice("Your released magic afflicts the crew: [final_event.name]!"))
 
 /// Applies some local side effects to the area

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -103,7 +103,7 @@
 
 	triggering = TRUE
 
-	// We sleep HERE, in pre-event setup (because there's no sense doing it in runEvent() since the event is already running!) for the given amount of time to make an admin has enough time to cancel an event un-fitting of the present round.
+	// We sleep HERE, in pre-event setup (because there's no sense doing it in run_event() since the event is already running!) for the given amount of time to make an admin has enough time to cancel an event un-fitting of the present round.
 	if(alert_observers)
 		message_admins("Random Event triggering in [DisplayTimeText(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)]: [name]. (<a href='?src=[REF(src)];cancel=1'>CANCEL</a>)")
 		sleep(RANDOM_EVENT_ADMIN_INTERVENTION_TIME)
@@ -134,7 +134,7 @@ Runs the event
 * - random: shows if the event was triggered randomly, or by on purpose by an admin or an item
 * - announce_chance_override: if the value is not null, overrides the announcement chance when an admin calls an event
 */
-/datum/round_event_control/proc/runEvent(random = FALSE, announce_chance_override = null, admin_forced = FALSE, event_cause)
+/datum/round_event_control/proc/run_event(random = FALSE, announce_chance_override = null, admin_forced = FALSE, event_cause)
 	/*
 	* We clear our signals first so we dont cancel a wanted event by accident,
 	* the majority of time the admin will probably want to cancel a single midround spawned random events

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -134,7 +134,7 @@ Runs the event
 * - random: shows if the event was triggered randomly, or by on purpose by an admin or an item
 * - announce_chance_override: if the value is not null, overrides the announcement chance when an admin calls an event
 */
-/datum/round_event_control/proc/runEvent(random = FALSE, announce_chance_override = null, admin_forced = FALSE)
+/datum/round_event_control/proc/runEvent(random = FALSE, announce_chance_override = null, admin_forced = FALSE, event_cause)
 	/*
 	* We clear our signals first so we dont cancel a wanted event by accident,
 	* the majority of time the admin will probably want to cancel a single midround spawned random events
@@ -167,7 +167,7 @@ Runs the event
 	log_game("[random ? "Random" : "Forced"] Event triggering: [name] ([typepath]).")
 
 	if(alert_observers)
-		round_event.announce_deadchat(random)
+		round_event.announce_deadchat(random, event_cause)
 
 	SSblackbox.record_feedback("tally", "event_ran", 1, "[round_event]")
 	return round_event
@@ -214,8 +214,8 @@ Runs the event
 	return
 
 ///Annouces the event name to deadchat, override this if what an event should show to deadchat is different to its event name.
-/datum/round_event/proc/announce_deadchat(random)
-	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>[control.name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
+/datum/round_event/proc/announce_deadchat(random, cause)
+	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered[cause ? " by [cause]" : ""]!", "<b>[control.name]</b>", message_type=DEADCHAT_ANNOUNCEMENT) //STOP ASSUMING IT'S BADMINS!
 
 //Called when the tick is equal to the start_when variable.
 //Allows you to start before announcing or vice versa.

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -64,7 +64,7 @@
 	if(!forced_reagent_type)
 		//nothing out of the ordinary, so default announcement
 		return ..()
-	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered!", "<b>Scrubber Overflow: [initial(forced_reagent_type.name)]</b>", message_type=DEADCHAT_ANNOUNCEMENT)
+	deadchat_broadcast(" has just been[random ? " randomly" : ""] triggered[cause ? " by [cause]" : ""]!", "<b>Scrubber Overflow: [initial(forced_reagent_type.name)]</b>", message_type=DEADCHAT_ANNOUNCEMENT)
 
 /datum/round_event/scrubber_overflow/announce(fake)
 	priority_announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert")

--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -60,7 +60,7 @@
 	)
 	//needs to be chemid unit checked at some point
 
-/datum/round_event/scrubber_overflow/announce_deadchat(random)
+/datum/round_event/scrubber_overflow/announce_deadchat(random, cause)
 	if(!forced_reagent_type)
 		//nothing out of the ordinary, so default announcement
 		return ..()

--- a/code/modules/spells/spell_types/right_and_wrong.dm
+++ b/code/modules/spells/spell_types/right_and_wrong.dm
@@ -168,7 +168,7 @@ GLOBAL_LIST_INIT(summoned_magic_objectives, list(
 		else
 			message_admins("Summon Ghosts was triggered!")
 			log_game("Summon Ghosts was triggered!")
-		ghost_event.runEvent()
+		ghost_event.runEvent(event_cause = "a wizard's incantation")
 	else
 		stack_trace("Unable to run summon ghosts, due to being unable to locate the associated event.")
 		if(user)

--- a/code/modules/spells/spell_types/right_and_wrong.dm
+++ b/code/modules/spells/spell_types/right_and_wrong.dm
@@ -168,7 +168,7 @@ GLOBAL_LIST_INIT(summoned_magic_objectives, list(
 		else
 			message_admins("Summon Ghosts was triggered!")
 			log_game("Summon Ghosts was triggered!")
-		ghost_event.runEvent(event_cause = "a wizard's incantation")
+		ghost_event.run_event(event_cause = "a wizard's incantation")
 	else
 		stack_trace("Unable to run summon ghosts, due to being unable to locate the associated event.")
 		if(user)

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -159,10 +159,7 @@
 			priority_announce("Warning. Tampering of meteor satellites puts the station at risk of exotic, deadly meteor collisions. Please intervene by checking your GPS devices for strange signals, and dismantling the tampered meteor shields.", "Strange Meteor Signal Warning")
 		if(EMAGGED_METEOR_SHIELD_THRESHOLD_FOUR)
 			say("Warning. Warning. Dark Matt-eor on course for station.")
-			var/datum/round_event_control/dark_matteor/dark_matteor_event = locate() in SSevents.control
-			if(!dark_matteor_event)
-				CRASH("meteor shields tried to spawn a dark matteor, but there was no dark matteor event in SSevents.control?")
-			INVOKE_ASYNC(dark_matteor_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an array of tampered meteor satellites")
+			force_event_async(/datum/round_event_control/dark_matteor, "an array of tampered meteor satellites")
 
 /obj/machinery/satellite/meteor_shield/proc/change_meteor_chance(mod)
 	// Update the weight of all meteor events

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -162,7 +162,7 @@
 			var/datum/round_event_control/dark_matteor/dark_matteor_event = locate() in SSevents.control
 			if(!dark_matteor_event)
 				CRASH("meteor shields tried to spawn a dark matteor, but there was no dark matteor event in SSevents.control?")
-			INVOKE_ASYNC(dark_matteor_event, TYPE_PROC_REF(/datum/round_event_control, runEvent))
+			INVOKE_ASYNC(dark_matteor_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an array of tampered meteor satellites")
 
 /obj/machinery/satellite/meteor_shield/proc/change_meteor_chance(mod)
 	// Update the weight of all meteor events

--- a/code/modules/station_goals/meteor_shield.dm
+++ b/code/modules/station_goals/meteor_shield.dm
@@ -162,7 +162,7 @@
 			var/datum/round_event_control/dark_matteor/dark_matteor_event = locate() in SSevents.control
 			if(!dark_matteor_event)
 				CRASH("meteor shields tried to spawn a dark matteor, but there was no dark matteor event in SSevents.control?")
-			INVOKE_ASYNC(dark_matteor_event, TYPE_PROC_REF(/datum/round_event_control, runEvent), event_cause = "an array of tampered meteor satellites")
+			INVOKE_ASYNC(dark_matteor_event, TYPE_PROC_REF(/datum/round_event_control, run_event), event_cause = "an array of tampered meteor satellites")
 
 /obj/machinery/satellite/meteor_shield/proc/change_meteor_chance(mod)
 	// Update the weight of all meteor events

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -105,7 +105,7 @@
 
 /datum/uplink_item/stealthy_tools/telecomm_blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
 	var/datum/round_event_control/event = locate(/datum/round_event_control/communications_blackout) in SSevents.control
-	event.runEvent(event_cause = "a syndicate virus")
+	event.run_event(event_cause = "a syndicate virus")
 	return source //For log icon
 
 /datum/uplink_item/stealthy_tools/blackout
@@ -121,5 +121,5 @@
 
 /datum/uplink_item/stealthy_tools/blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
 	var/datum/round_event_control/event = locate(/datum/round_event_control/grid_check) in SSevents.control
-	event.runEvent(event_cause = "a syndicate virus")
+	event.run_event(event_cause = "a syndicate virus")
 	return source //For log icon

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -105,7 +105,7 @@
 
 /datum/uplink_item/stealthy_tools/telecomm_blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
 	var/datum/round_event_control/event = locate(/datum/round_event_control/communications_blackout) in SSevents.control
-	event.runEvent()
+	event.runEvent(event_cause = "a syndicate virus")
 	return source //For log icon
 
 /datum/uplink_item/stealthy_tools/blackout
@@ -121,5 +121,5 @@
 
 /datum/uplink_item/stealthy_tools/blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
 	var/datum/round_event_control/event = locate(/datum/round_event_control/grid_check) in SSevents.control
-	event.runEvent()
+	event.runEvent(event_cause = "a syndicate virus")
 	return source //For log icon

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -104,8 +104,7 @@
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/stealthy_tools/telecomm_blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
-	var/datum/round_event_control/event = locate(/datum/round_event_control/communications_blackout) in SSevents.control
-	event.run_event(event_cause = "a syndicate virus")
+	force_event(/datum/round_event_control/communications_blackout, "a syndicate virus")
 	return source //For log icon
 
 /datum/uplink_item/stealthy_tools/blackout
@@ -120,6 +119,5 @@
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/stealthy_tools/blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
-	var/datum/round_event_control/event = locate(/datum/round_event_control/grid_check) in SSevents.control
-	event.run_event(event_cause = "a syndicate virus")
+	force_event(/datum/round_event_control/grid_check, "a syndicate virus")
 	return source //For log icon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Most calls of runEvent() now provide a cause that is read out to deadchat. announce_deadchat() has been slightly adjusted to accommodate this.

Previously, everything that wasn't a truly random event would broadcast with the same generic "XYZ has just been triggered!" message. Now, you get a little bit more detail as to why/what triggered the event.

Some helpers in the __HELPERS/events.dm file have been made, for forcing events normally/async/after a delay (using an addtimer). This also moves a lot (but not all) instances of events being forced to these helpers.

Some samples:

![image](https://user-images.githubusercontent.com/28870487/233735108-aea2996b-aff4-45e2-ae0c-3e07f86de9b7.png)
Traitors using uplink viruses to turn off the power/comms.

![image](https://user-images.githubusercontent.com/28870487/233734371-18a31dff-198e-4a4a-a43f-15be6cbb545e.png)
Beer nuke!

![image](https://user-images.githubusercontent.com/28870487/233731635-7c93c1ef-641d-40df-975e-a916af4d1129.png)
For when a traitor takes an Space Dragon final objective, which summons a carp migration event.

![image](https://user-images.githubusercontent.com/28870487/233727323-e2cfc46f-909f-4754-a0f9-a2763360a376.png)
Wizard ritual events!

![image](https://user-images.githubusercontent.com/28870487/233733025-5c8284bc-02e1-41c8-aae4-76a5c2124d97.png)
Even this one!

This also changes runEvent() to run_event(), because I figured I'd be touching every single instance of the proc anyways.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better feedback, less confusion amongst deadchat's constituents. 

Some of them may be a bit self-explanatory, but in some cases (especially the apocalypse rune) it's beneficial to know that an admin isn't the one behind it.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Rhials
qol: Deadchat now gets more juicy details on what has triggered a non-randomly occurring random event.
code: There are now helpers for forcing events in a variety of ways. More events! More events!!!!!!!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
