### PR TITLE
Fixes yawns not propagating

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -463,7 +463,7 @@
 	var/propagation_distance = user.client ? 5 : 2 // mindless mobs are less able to spread yawns
 
 	for(var/mob/living/iter_living in view(user, propagation_distance))
-		if(IS_DEAD_OR_INCAP(iter_living) || TIMER_COOLDOWN_CHECK(user, COOLDOWN_YAWN_PROPAGATION))
+		if(IS_DEAD_OR_INCAP(iter_living) || TIMER_COOLDOWN_CHECK(iter_living, COOLDOWN_YAWN_PROPAGATION))
 			continue
 
 		var/dist_between = get_dist(user, iter_living)

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -436,9 +436,9 @@
 	message = "smiles weakly."
 
 /// The base chance for your yawn to propagate to someone else if they're on the same tile as you
-#define YAWN_PROPAGATE_CHANCE_BASE 60
+#define YAWN_PROPAGATE_CHANCE_BASE 40
 /// The base chance for your yawn to propagate to someone else if they're on the same tile as you
-#define YAWN_PROPAGATE_CHANCE_DECAY 10
+#define YAWN_PROPAGATE_CHANCE_DECAY 8
 
 /datum/emote/living/yawn
 	key = "yawn"
@@ -446,11 +446,11 @@
 	message = "yawns."
 	message_mime = "acts out an exaggerated silent yawn."
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
-	cooldown = 3 SECONDS
+	cooldown = 5 SECONDS
 
 /datum/emote/living/yawn/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	if(!. || !isliving(user))
+	if(!isliving(user))
 		return
 
 	if(!TIMER_COOLDOWN_CHECK(user, COOLDOWN_YAWN_PROPAGATION))


### PR DESCRIPTION

## About The Pull Request
#62639 was supposed to make it so yawning had a chance to make other nearby people yawn, depending on RNG and how close they were to you. It was also meant as a way to sniff out if someone had maybe recently examined you, by logic that watching someone yawn usually makes you yawn.

I eff'd up and used a wrong variable, making it so no one would ever propagate a yawn, because it would check when the original yawner last yawned (obviously which was immediately) instead of the person being queried for a yawn.
## Why It's Good For The Game
Makes something that got merged forever ago actually work
## Changelog
:cl: Ryll/Shaps
fix: Yawning will now have a chance of making people near you yawn as well, and is guaranteed to make them yawn if they examined you in the last 2 seconds. It was supposed to already do that, but now it'll actually do that
/:cl:
