### PR TITLE
Removes a redundant cut_overlays in basketball code

### DIFF
--- a/code/modules/basketball/hoop.dm
+++ b/code/modules/basketball/hoop.dm
@@ -56,8 +56,6 @@
 	if(dir & NORTH)
 		SET_PLANE_IMPLICIT(src, GAME_PLANE_UPPER)
 
-	cut_overlays()
-
 	var/dir_offset_x = 0
 	var/dir_offset_y = 0
 


### PR DESCRIPTION

## About The Pull Request

It doesn't like, do anything except clear our emissive blockers, since we aren't directly adding overlays anywhere here
