### PR TITLE
Adds a comment about how to run the 515 debug

### DIFF
--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -2,7 +2,7 @@
 // but that we want to be able to easily flip as well as run on CI.
 // Any flag you see here can be flipped with the `-D` CLI argument.
 // For example, if you want to enable EXPERIMENT_MY_COOL_FEATURE, compile with -DEXPERIMENT_MY_COOL_FEATURE
-// If you're looking to run these, make sure you don't have the regular debug info enbaled in compile_options.dm
+// If you're looking to run these, make sure you don't have the regular debug info enabled in compile_options.dm
 // Except for unit_tests
 
 // EXPERIMENT_515_QDEL_HARD_REFERENCE

--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -3,7 +3,6 @@
 // Any flag you see here can be flipped with the `-D` CLI argument.
 // For example, if you want to enable EXPERIMENT_MY_COOL_FEATURE, compile with -DEXPERIMENT_MY_COOL_FEATURE
 // If you're looking to run these, make sure you don't have the regular debug info enabled in compile_options.dm
-// Except for unit_tests
 
 // EXPERIMENT_515_QDEL_HARD_REFERENCE
 // - Hold a hard reference for qdeleted items, and check ref_count, rather than using refs. Requires 515+.

--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -3,6 +3,7 @@
 // Any flag you see here can be flipped with the `-D` CLI argument.
 // For example, if you want to enable EXPERIMENT_MY_COOL_FEATURE, compile with -DEXPERIMENT_MY_COOL_FEATURE
 // If you're looking to run these, make sure you don't have the regular debug info enabled in compile_options.dm
+// Only run the unit tests define. Do not test focus otherwise you may not get your expected results
 
 // EXPERIMENT_515_QDEL_HARD_REFERENCE
 // - Hold a hard reference for qdeleted items, and check ref_count, rather than using refs. Requires 515+.

--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -2,6 +2,8 @@
 // but that we want to be able to easily flip as well as run on CI.
 // Any flag you see here can be flipped with the `-D` CLI argument.
 // For example, if you want to enable EXPERIMENT_MY_COOL_FEATURE, compile with -DEXPERIMENT_MY_COOL_FEATURE
+// If you're looking to run these, make sure you don't have the regular debug info enbaled in compile_options.dm
+// Except for unit_tests
 
 // EXPERIMENT_515_QDEL_HARD_REFERENCE
 // - Hold a hard reference for qdeleted items, and check ref_count, rather than using refs. Requires 515+.


### PR DESCRIPTION
So I've been scratching my head for over a month downstream trying to debug 515 locally (mainly C&D) and kept getting back that the test passed, while on my CI its failing on a few things.

I decided to give it another whirl today and I actually got it to work.
The problem WAS I was also trying to run the regular debug commands in `compile_options.dm`. Now, I'm not a smart coder by any right, but I wouldn't have personally known to not enable them if I wanted to test 515 stuff without trying this.

So, I decided to add a comment about this just to make sure anyone dealing with this problem gets it rectified. This comment itself may not even be fruitful since 515 could be coming soon, I don't know.

Regardless, this should HOPEFULLY help people like me trying to debug their stuff a tad bit easier.