### PR TITLE
Health analyzers now warn you if someone can't survive their temperature.

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -376,13 +376,12 @@
 			if(blood_id != /datum/reagent/blood) // special blood substance
 				var/datum/reagent/R = GLOB.chemical_reagents_list[blood_id]
 				blood_type = R ? R.name : blood_id
-			var/blood_volume_message = "[blood_percent] %, [carbontarget.blood_volume] cl, type: [blood_type]"
 			if(carbontarget.blood_volume <= BLOOD_VOLUME_SAFE && carbontarget.blood_volume > BLOOD_VOLUME_OKAY)
-				render_list += "<span class='alert ml-1'>Blood level: LOW [blood_volume_message]</span>\n"
+				render_list += "<span class='alert ml-1'>Blood level: LOW [blood_percent] %, [carbontarget.blood_volume]</span> cl, type: [blood_type]\n"
 			else if(carbontarget.blood_volume <= BLOOD_VOLUME_OKAY)
-				render_list += "<span class='alert ml-1'>Blood level: <b>CRITICAL [blood_volume_message]</b></span>\n"
+				render_list += "<span class='alert ml-1'>Blood level: <b>CRITICAL [blood_percent] %, [carbontarget.blood_volume]</span> cl, type: [blood_type]</b></span>\n"
 			else
-				render_list += "<span class='info ml-1'>Blood level: [blood_volume_message]</span>\n"
+				render_list += "<span class='info ml-1'>Blood level: [blood_percent] %, [carbontarget.blood_volume] cl, type: [blood_type]</span>\n"
 
 	// Cybernetics
 	if(iscarbon(target))

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -377,9 +377,9 @@
 				var/datum/reagent/R = GLOB.chemical_reagents_list[blood_id]
 				blood_type = R ? R.name : blood_id
 			if(carbontarget.blood_volume <= BLOOD_VOLUME_SAFE && carbontarget.blood_volume > BLOOD_VOLUME_OKAY)
-				render_list += "<span class='alert ml-1'>Blood level: LOW [blood_percent] %, [carbontarget.blood_volume]</span> cl, type: [blood_type]\n"
+				render_list += "<span class='alert ml-1'>Blood level: LOW [blood_percent] %, [carbontarget.blood_volume] cl,</span> [span_info("type: [blood_type]")]\n"
 			else if(carbontarget.blood_volume <= BLOOD_VOLUME_OKAY)
-				render_list += "<span class='alert ml-1'>Blood level: <b>CRITICAL [blood_percent] %, [carbontarget.blood_volume]</span> cl, type: [blood_type]</b></span>\n"
+				render_list += "<span class='alert ml-1'>Blood level: <b>CRITICAL [blood_percent] %</b>, [carbontarget.blood_volume] cl,</span> [span_info("type: [blood_type]")]\n"
 			else
 				render_list += "<span class='info ml-1'>Blood level: [blood_percent] %, [carbontarget.blood_volume] cl, type: [blood_type]</span>\n"
 

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -323,18 +323,14 @@
 
 		render_list += "<span class='info ml-1'>Species: [targetspecies.name][mutant ? "-derived mutant" : ""]</span>\n"
 		var/core_temperature_message = "Core temperature: [round(humantarget.coretemperature-T0C, 0.1)] &deg;C ([round(humantarget.coretemperature*1.8-459.67,0.1)] &deg;F)"
-		if(humantarget.coretemperature >= humantarget.get_body_temp_heat_damage_limit())
+		if(humantarget.coretemperature >= humantarget.get_body_temp_heat_damage_limit() || humantarget.coretemperature <= humantarget.get_body_temp_cold_damage_limit())
 			render_list += "<span class='alert ml-1'>[core_temperature_message]</span>\n"
-		else if(humantarget.coretemperature <= humantarget.get_body_temp_cold_damage_limit())
-			render_list += "<span class='notice ml-1'>[core_temperature_message]</span>\n"
 		else
 			render_list += "<span class='info ml-1'>[core_temperature_message]</span>\n"
 
 	var/body_temperature_message = "Body temperature: [round(target.bodytemperature-T0C, 0.1)] &deg;C ([round(target.bodytemperature*1.8-459.67,0.1)] &deg;F)"
-	if(target.bodytemperature >= target.get_body_temp_heat_damage_limit())
+	if(target.bodytemperature >= target.get_body_temp_heat_damage_limit() || target.bodytemperature <= target.get_body_temp_cold_damage_limit())
 		render_list += "<span class='alert ml-1'>[body_temperature_message]</span>\n"
-	else if(target.bodytemperature <= target.get_body_temp_cold_damage_limit())
-		render_list += "<span class='notice ml-1'>[body_temperature_message]</span>\n"
 	else
 		render_list += "<span class='info ml-1'>[body_temperature_message]</span>\n"
 

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -323,14 +323,18 @@
 
 		render_list += "<span class='info ml-1'>Species: [targetspecies.name][mutant ? "-derived mutant" : ""]</span>\n"
 		var/core_temperature_message = "Core temperature: [round(humantarget.coretemperature-T0C, 0.1)] &deg;C ([round(humantarget.coretemperature*1.8-459.67,0.1)] &deg;F)"
-		if(humantarget.coretemperature >= humantarget.get_body_temp_heat_damage_limit() || humantarget.coretemperature <= humantarget.get_body_temp_cold_damage_limit())
-			render_list += "<span class='alert ml-1'>[core_temperature_message]</span>\n"
+		if(humantarget.coretemperature >= humantarget.get_body_temp_heat_damage_limit())
+			render_list += "<span class='alert ml-1'>☼ [core_temperature_message] ☼</span>\n"
+		else if(humantarget.coretemperature <= humantarget.get_body_temp_cold_damage_limit())
+			render_list += "<span class='alert ml-1'>❄ [core_temperature_message] ❄</span>\n"
 		else
 			render_list += "<span class='info ml-1'>[core_temperature_message]</span>\n"
 
 	var/body_temperature_message = "Body temperature: [round(target.bodytemperature-T0C, 0.1)] &deg;C ([round(target.bodytemperature*1.8-459.67,0.1)] &deg;F)"
-	if(target.bodytemperature >= target.get_body_temp_heat_damage_limit() || target.bodytemperature <= target.get_body_temp_cold_damage_limit())
-		render_list += "<span class='alert ml-1'>[body_temperature_message]</span>\n"
+	if(target.bodytemperature >= target.get_body_temp_heat_damage_limit())
+		render_list += "<span class='alert ml-1'>☼ [body_temperature_message] ☼</span>\n"
+	else if(target.bodytemperature <= target.get_body_temp_cold_damage_limit())
+		render_list += "<span class='alert ml-1'>❄ [body_temperature_message] ❄</span>\n"
 	else
 		render_list += "<span class='info ml-1'>[body_temperature_message]</span>\n"
 

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -106,7 +106,17 @@
 
 	return CONTEXTUAL_SCREENTIP_SET
 
-// Used by the PDA medical scanner too
+/**
+ * healthscan
+ * returns a list of everything a health scan should give to a player.
+ * Examples of where this is used is Health Analyzer and the Physical Scanner tablet app.
+ * Args:
+ * user - The person with the scanner
+ * target - The person being scanned
+ * mode - Uses SCANNER_CONDENSED or SCANNER_VERBOSE to decide whether to give a list of all individual limb damage
+ * advanced - Whether it will give more advanced details, such as husk source.
+ * tochat - Whether to immediately post the result into the chat of the user, otherwise it will return the results.
+ */
 /proc/healthscan(mob/user, mob/living/target, mode = SCANNER_VERBOSE, advanced = FALSE, tochat = TRUE)
 	if(user.incapacitated())
 		return
@@ -127,14 +137,14 @@
 
 	render_list += "[span_info("Analyzing results for [target]:")]\n<span class='info ml-1'>Overall status: [mob_status]</span>\n"
 
-	SEND_SIGNAL(target, COMSIG_LIVING_HEALTHSCAN, render_list, advanced, user, mode)
-
 	if(ishuman(target))
 		var/mob/living/carbon/human/humantarget = target
 		if(humantarget.undergoing_cardiac_arrest() && humantarget.stat != DEAD)
 			render_list += "<span class='alert ml-1'><b>Subject suffering from heart attack: Apply defibrillation or other electric shock immediately!</b></span>\n"
 		if(humantarget.has_reagent(/datum/reagent/inverse/technetium))
 			advanced = TRUE
+
+	SEND_SIGNAL(target, COMSIG_LIVING_HEALTHSCAN, render_list, advanced, user, mode)
 
 	// Husk detection
 	if(HAS_TRAIT(target, TRAIT_HUSK))
@@ -312,8 +322,21 @@
 			|| istype(humantarget.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS), /obj/item/organ/external/wings/functional)
 
 		render_list += "<span class='info ml-1'>Species: [targetspecies.name][mutant ? "-derived mutant" : ""]</span>\n"
-		render_list += "<span class='info ml-1'>Core temperature: [round(humantarget.coretemperature-T0C,0.1)] &deg;C ([round(humantarget.coretemperature*1.8-459.67,0.1)] &deg;F)</span>\n"
-	render_list += "<span class='info ml-1'>Body temperature: [round(target.bodytemperature-T0C,0.1)] &deg;C ([round(target.bodytemperature*1.8-459.67,0.1)] &deg;F)</span>\n"
+		var/core_temperature_message = "Core temperature: [round(humantarget.coretemperature-T0C, 0.1)] &deg;C ([round(humantarget.coretemperature*1.8-459.67,0.1)] &deg;F)"
+		if(humantarget.coretemperature >= humantarget.get_body_temp_heat_damage_limit())
+			render_list += "<span class='alert ml-1'>[core_temperature_message]</span>\n"
+		else if(humantarget.coretemperature <= humantarget.get_body_temp_cold_damage_limit())
+			render_list += "<span class='notice ml-1'>[core_temperature_message]</span>\n"
+		else
+			render_list += "<span class='info ml-1'>[core_temperature_message]</span>\n"
+
+	var/body_temperature_message = "Body temperature: [round(target.bodytemperature-T0C, 0.1)] &deg;C ([round(target.bodytemperature*1.8-459.67,0.1)] &deg;F)"
+	if(target.bodytemperature >= target.get_body_temp_heat_damage_limit())
+		render_list += "<span class='alert ml-1'>[body_temperature_message]</span>\n"
+	else if(target.bodytemperature <= target.get_body_temp_cold_damage_limit())
+		render_list += "<span class='notice ml-1'>[body_temperature_message]</span>\n"
+	else
+		render_list += "<span class='info ml-1'>[body_temperature_message]</span>\n"
 
 	// Time of death
 	if(target.tod && (target.stat == DEAD || ((HAS_TRAIT(target, TRAIT_FAKEDEATH)) && !advanced)))
@@ -346,21 +369,20 @@
 		var/mob/living/carbon/carbontarget = target
 		var/blood_id = carbontarget.get_blood_id()
 		if(blood_id)
-			if(ishuman(carbontarget))
-				var/mob/living/carbon/human/humantarget = carbontarget
-				if(humantarget.is_bleeding())
-					render_list += "<span class='alert ml-1'><b>Subject is bleeding!</b></span>\n"
-			var/blood_percent = round((carbontarget.blood_volume / BLOOD_VOLUME_NORMAL)*100)
+			if(carbontarget.is_bleeding())
+				render_list += "<span class='alert ml-1'><b>Subject is bleeding!</b></span>\n"
+			var/blood_percent = round((carbontarget.blood_volume / BLOOD_VOLUME_NORMAL) * 100)
 			var/blood_type = carbontarget.dna.blood_type
 			if(blood_id != /datum/reagent/blood) // special blood substance
 				var/datum/reagent/R = GLOB.chemical_reagents_list[blood_id]
 				blood_type = R ? R.name : blood_id
+			var/blood_volume_message = "[blood_percent] %, [carbontarget.blood_volume] cl, type: [blood_type]"
 			if(carbontarget.blood_volume <= BLOOD_VOLUME_SAFE && carbontarget.blood_volume > BLOOD_VOLUME_OKAY)
-				render_list += "<span class='alert ml-1'>Blood level: LOW [blood_percent] %, [carbontarget.blood_volume] cl,</span> [span_info("type: [blood_type]")]\n"
+				render_list += "<span class='alert ml-1'>Blood level: LOW [blood_volume_message]</span>\n"
 			else if(carbontarget.blood_volume <= BLOOD_VOLUME_OKAY)
-				render_list += "<span class='alert ml-1'>Blood level: <b>CRITICAL [blood_percent] %</b>, [carbontarget.blood_volume] cl,</span> [span_info("type: [blood_type]")]\n"
+				render_list += "<span class='alert ml-1'>Blood level: <b>CRITICAL [blood_volume_message]</b></span>\n"
 			else
-				render_list += "<span class='info ml-1'>Blood level: [blood_percent] %, [carbontarget.blood_volume] cl, type: [blood_type]</span>\n"
+				render_list += "<span class='info ml-1'>Blood level: [blood_volume_message]</span>\n"
 
 	// Cybernetics
 	if(iscarbon(target))


### PR DESCRIPTION
## About The Pull Request

Health analyzers are now red/blue if the temperature of the person is too hot/cold
![image](https://user-images.githubusercontent.com/53777086/233828353-5c40ecbc-032b-4de6-8ea7-70607375f16f.png)
![image](https://user-images.githubusercontent.com/53777086/233828355-5e831236-6961-41d7-909a-67ae2f8036ff.png)
![image](https://user-images.githubusercontent.com/53777086/233828366-f31e82c5-075d-441d-b747-47990cbf3c3f.png)

Also because I just noticed it, I moved the signal for health scan down, meaning that things that are registered to it now work with inverse technetium setting it to advanced mode.
I also removed the ishuman check for bleeding because it's a carbon proc. This has no game-effects as xenos don't have DNA.

## Why It's Good For The Game

We currently expect doctors to see all the important information with red text to know what needs to be fixed, however this is not the case for temperature, we are currently expecting them to pay attention to a body's temperature, and what their species can handle. I think this is quite lame, and I think it would be better if it worked like everything else in the analyzer.

## Changelog

:cl:
qol: Health analyzers now show body temperature in red/blue if the temperature of the body can't sustain it's own life.
fix: Inverse technetium now properly gives advanced details in genetics/radiation analyzing.
/:cl:
