### PR TITLE
Fixes the biogenerator displaying item costs that were being divided by the machine's efficiency twice

### DIFF
--- a/tgui/packages/tgui/interfaces/Biogenerator.tsx
+++ b/tgui/packages/tgui/interfaces/Biogenerator.tsx
@@ -213,11 +213,7 @@ const ItemList = (props, context) => {
         <Button
           fluid
           align="right"
-          content={
-            parseFloat(
-              ((item.cost * item.amount) / props.efficiency).toFixed(2)
-            ) + ' BIO'
-          }
+          content={parseFloat((item.cost * item.amount).toFixed(2)) + ' BIO'}
           disabled={item.disabled}
           onClick={() =>
             act('create', {


### PR DESCRIPTION
## About The Pull Request
It was really bugging me that I would see a price being displayed in my biogenerator, only for it to then cost me far more than what was displayed. Looking into it, I realized that it was simply an issue with it dividing the cost by the efficiency in the TGUI, when that math was already done DM-side.

## Why It's Good For The Game
Being charged the cost you see on the machine is good.

## Changelog

:cl: GoldenAlpharex
fix: Biogenerators now display the accurate price of their products after having been upgraded, as they no longer visually apply the efficiency discount twice. 
/:cl: