### PR TITLE
Allows custom say emote (prefix*words) prefixes to be uppercase.

### DIFF
--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -163,7 +163,7 @@
 		return message
 	if (is_banned_from(ckey, "Emote"))
 		return copytext(message, customsaypos + 1)
-	mods[MODE_CUSTOM_SAY_EMOTE] = lowertext(copytext_char(message, 1, customsaypos))
+	mods[MODE_CUSTOM_SAY_EMOTE] = copytext_char(message, 1, customsaypos)
 	message = copytext(message, customsaypos + 1)
 	if (!message)
 		mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE


### PR DESCRIPTION

## About The Pull Request
Title. Removes a lowertext() call that forced custom say emotes to be lowercase.


![image](https://user-images.githubusercontent.com/59709059/233858949-71e472b4-7778-4a65-8359-a118fb4f1568.png)
## Why It's Good For The Game

1. I fail to see a reason as to why custom say emotes must be forced to be lowercase. It was brought up that this breaks the formatting of normal say prefixes, but I would counter by saying this _isn't_ a normal prefix. In effect, it's more of an emote, and people can already make differently-cased prefixes by just emoting.
2. Radio emotes (; blah blah blah*) use this system, however, due to the fact that the way a radio emote is used is to make the entire emote a prefix (nothing is put after the *), the entire thing is always forced lowercase.

Allowing radio emotes to be uppercase (and, to an extent, prefixes) simply increases the amount of fluidity in what people can say, and improves the control players have over their characters actions by unlocking more aspects of the english language.
## Changelog
:cl:
add: Say emote prefixes are no longer forced to be lowercase. This includes radio emotes!
/:cl:
