### PR TITLE
Adjusts the SWAT crate description to be more accurate

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -299,7 +299,7 @@
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof suits designed in a joint \
 		effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, \
-		and combat gloves."
+		and gorilla gloves."
 	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/clothing/head/helmet/swat/nanotrasen = 2,
 					/obj/item/clothing/suit/armor/swat = 2,


### PR DESCRIPTION

## About The Pull Request
Changes the description of the Swat crate to mention gorilla gloves specifically instead of combat.
## Why It's Good For The Game
Its kind of misleading as most would assume it means the insulated kind, not the 'throw yourself into someone at mach 5' kind.
## Changelog
:cl:
fix: Swat crate's description now lists the correct kind of gloves
/:cl:
