### PR TITLE
Fixes spawners being forcemoved during crafting

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -462,7 +462,8 @@
 				if(ismob(user) && isitem(result)) //In case the user is actually possessing a non mob like a machine
 					user.put_in_hands(result)
 				else
-					result.forceMove(user.drop_location())
+					if(!istype(result, /obj/effect/spawner))
+						result.forceMove(user.drop_location())
 				to_chat(user, span_notice("[crafting_recipe.name] constructed."))
 				user.investigate_log("crafted [crafting_recipe]", INVESTIGATE_CRAFTING)
 				crafting_recipe.on_craft_completion(user, result)


### PR DESCRIPTION
## About The Pull Request

Lizard skin boots create a spawner as their crafting result. The spawner works fine and creates the boots, but then then the crafting system moves the spawner into the world after it has been marked for deletion. So you end up with both the boots and the spawner, with the spawner covering up the boots and being non-interactive.

![dreamseeker_0l714SdfxT](https://user-images.githubusercontent.com/13398309/233877092-98831311-3b3d-4df8-ae74-788470ed4f55.png)

This PR just adds a check for spawners to ensure that doesn't happen.

Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20728

## Why It's Good For The Game

Fixes some jank. It's a pain to craft these, so having this be the payoff is disappointing.

## Changelog
:cl:
fix: crafting lizard skin cowboy boots no longer places a spawner object over the created boot item
/:cl:
