### PR TITLE
Fixes medisim combatants falling to the lower z-level on Icebox

### DIFF
--- a/_maps/shuttles/emergency_medisim.dmm
+++ b/_maps/shuttles/emergency_medisim.dmm
@@ -933,6 +933,13 @@
 	},
 /turf/closed/indestructible/iron,
 /area/shuttle/escape/simulation)
+"Mc" = (
+/obj/structure/fluff/big_chain{
+	pixel_y = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/chasm/true,
+/area/shuttle/escape/simulation)
 "Mj" = (
 /obj/structure/railing{
 	dir = 1
@@ -1122,7 +1129,7 @@
 /turf/open/floor/iron/chapel,
 /area/shuttle/escape/simulation)
 "TE" = (
-/turf/open/chasm,
+/turf/open/chasm/true,
 /area/shuttle/escape/simulation)
 "TI" = (
 /obj/item/binoculars,
@@ -1192,7 +1199,7 @@
 /obj/structure/fluff/big_chain{
 	pixel_y = 9
 	},
-/turf/open/chasm,
+/turf/open/chasm/true,
 /area/shuttle/escape/simulation)
 "WA" = (
 /obj/structure/closet/crate/large,
@@ -2107,7 +2114,7 @@ xP
 Et
 TE
 rX
-lg
+Mc
 Io
 Cr
 YV
@@ -2210,7 +2217,7 @@ sK
 TE
 TE
 TE
-lg
+Mc
 VG
 pF
 pF

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -7,6 +7,8 @@ GLOBAL_LIST_INIT(chasm_storage, list())
 	var/obj/effect/abstract/chasm_storage/storage
 	var/fall_message = "GAH! Ah... where are you?"
 	var/oblivion_message = "You stumble and stare into the abyss before you. It stares back, and you fall into the enveloping dark."
+	///Will we try to drop anything that falls into us down a z-level, or do they just get sent to the pit.
+	var/respect_zlevel = TRUE
 
 	/// List of refs to falling objects -> how many levels deep we've fallen
 	var/static/list/falling_atoms = list()
@@ -131,7 +133,7 @@ GLOBAL_LIST_INIT(chasm_storage, list())
 	if(falling_atoms[falling_ref] > 1)
 		return // We're already handling this
 
-	if(below_turf)
+	if(below_turf && respect_zlevel)
 		// send to the turf below
 		dropped_thing.visible_message(span_boldwarning("[dropped_thing] falls into [parent]!"), span_userdanger("[fall_message]"))
 		below_turf.visible_message(span_boldwarning("[dropped_thing] falls from above!"))
@@ -207,6 +209,10 @@ GLOBAL_LIST_INIT(chasm_storage, list())
 /datum/component/chasm/proc/left_chasm(atom/source, atom/movable/gone)
 	SIGNAL_HANDLER
 	UnregisterSignal(gone, COMSIG_LIVING_REVIVE)
+
+///A type of chasm that bypasses the check to drop objects down a z-level, throwing whatever falls straight into the chasm contents.
+/datum/component/chasm/offstage
+	respect_zlevel = FALSE
 
 #define CHASM_TRAIT "chasm trait"
 

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -7,8 +7,6 @@ GLOBAL_LIST_INIT(chasm_storage, list())
 	var/obj/effect/abstract/chasm_storage/storage
 	var/fall_message = "GAH! Ah... where are you?"
 	var/oblivion_message = "You stumble and stare into the abyss before you. It stares back, and you fall into the enveloping dark."
-	///Will we try to drop anything that falls into us down a z-level, or do they just get sent to the pit.
-	var/respect_zlevel = TRUE
 
 	/// List of refs to falling objects -> how many levels deep we've fallen
 	var/static/list/falling_atoms = list()
@@ -133,7 +131,7 @@ GLOBAL_LIST_INIT(chasm_storage, list())
 	if(falling_atoms[falling_ref] > 1)
 		return // We're already handling this
 
-	if(below_turf && respect_zlevel)
+	if(below_turf)
 		// send to the turf below
 		dropped_thing.visible_message(span_boldwarning("[dropped_thing] falls into [parent]!"), span_userdanger("[fall_message]"))
 		below_turf.visible_message(span_boldwarning("[dropped_thing] falls from above!"))
@@ -209,10 +207,6 @@ GLOBAL_LIST_INIT(chasm_storage, list())
 /datum/component/chasm/proc/left_chasm(atom/source, atom/movable/gone)
 	SIGNAL_HANDLER
 	UnregisterSignal(gone, COMSIG_LIVING_REVIVE)
-
-///A type of chasm that bypasses the check to drop objects down a z-level, throwing whatever falls straight into the chasm contents.
-/datum/component/chasm/offstage
-	respect_zlevel = FALSE
 
 #define CHASM_TRAIT "chasm trait"
 

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -14,7 +14,7 @@
 
 /turf/open/chasm/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/chasm, SSmapping.get_turf_below(src))
+	apply_components()
 
 /// Lets people walk into chasms.
 /turf/open/chasm/CanAllowThrough(atom/movable/mover, border_dir)
@@ -75,6 +75,10 @@
 	else if(istype(C, /obj/item/stack/tile/iron))
 		build_with_floor_tiles(C, user)
 
+/// Handles adding the chasm component to the turf (So stuff falls into it!)
+/turf/open/chasm/proc/apply_components()
+	AddComponent(/datum/component/chasm, SSmapping.get_turf_below(src))
+
 // Chasms for Lavaland, with planetary atmos and lava glow
 /turf/open/chasm/lavaland
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS
@@ -109,3 +113,10 @@
 	underlay_appearance.icon = 'icons/turf/floors.dmi'
 	underlay_appearance.icon_state = "dirt"
 	return TRUE
+
+// Chasm that doesn't do any z-level nonsense and just kills/stores whoever steps into it.
+/turf/open/chasm/true
+	desc = "There's nothing at the bottom. Absolutely nothing."
+
+/turf/open/chasm/true/apply_components()
+	AddComponent(/datum/component/chasm/offstage)

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -119,4 +119,4 @@
 	desc = "There's nothing at the bottom. Absolutely nothing."
 
 /turf/open/chasm/true/apply_components()
-	AddComponent(/datum/component/chasm/offstage)
+	AddComponent(/datum/component/chasm) //Don't pass anything for below_turf.


### PR DESCRIPTION

## About The Pull Request

This adds a subtype of the chasm turf, which skips over attempting any z-level stuff and skips to the Part Where It Kills You.

This replaces the chasms in the medisim shuttle, because knights kept falling down the chasms and escaping containment.
## Why It's Good For The Game

Closes #56695.
## Changelog
:cl: Rhials
fix: Falling down one of the stage hazard chasms on the medisim shuttle will now properly kill you on Icebox, instead of dropping you into the z-level below.
/:cl:
