### PR TITLE
Fixes redundant code & runtime in RPD

### DIFF
--- a/code/game/objects/items/rcd/RPD.dm
+++ b/code/game/objects/items/rcd/RPD.dm
@@ -310,12 +310,6 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/attack_self(mob/user)
 	ui_interact(user)
 
-/obj/item/pipe_dispenser/pre_attack(atom/target, mob/user, params)
-	if(istype(target, /obj/item/rpd_upgrade/unwrench))
-		install_upgrade(target, user)
-		return TRUE
-	return ..()
-
 /obj/item/pipe_dispenser/pre_attack_secondary(obj/machinery/atmospherics/target, mob/user, params)
 	if(istype(target, /obj/machinery/air_sensor))
 		if(!do_after(user, destroy_speed, target))
@@ -330,12 +324,6 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		piping_layer = target.piping_layer
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-/obj/item/pipe_dispenser/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/rpd_upgrade))
-		install_upgrade(W, user)
-		return TRUE
-	return ..()
-
 /obj/item/pipe_dispenser/add_item_context(obj/item/source, list/context, atom/target, mob/living/user)
 	. = ..()
 	if(istype(target, /obj/machinery/atmospherics))
@@ -344,21 +332,6 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			context[SCREENTIP_CONTEXT_RMB] = "Copy piping color and layer"
 	return CONTEXTUAL_SCREENTIP_SET
 
-/**
- * Installs an upgrade into the RPD
- *
- * Installs an upgrade into the RPD checking if it is already installed
- * Arguments:
- * * rpd_up - RPD upgrade
- * * user - mob that use upgrade on RPD
- */
-/obj/item/pipe_dispenser/proc/install_upgrade(obj/item/rpd_upgrade/rpd_up, mob/user)
-	if(rpd_up.upgrade_flags& upgrade_flags)
-		balloon_alert(user, "already installed!")
-		return
-	upgrade_flags |= rpd_up.upgrade_flags
-	playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
-	qdel(rpd_up)
 
 /obj/item/pipe_dispenser/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] points the end of the RPD down [user.p_their()] throat and presses a button! It looks like [user.p_theyre()] trying to commit suicide..."))
@@ -486,6 +459,20 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	if(!ISADVANCEDTOOLUSER(user) || istype(A, /turf/open/space/transit))
 		return ..()
 
+	if(istype(A, /obj/item/rpd_upgrade))
+		var/obj/item/rpd_upgrade/rpd_up = A
+
+		//already installed
+		if(rpd_up.upgrade_flags & upgrade_flags)
+			balloon_alert(user, "already installed!")
+			return TRUE
+
+		//install & delete upgrade
+		upgrade_flags |= rpd_up.upgrade_flags
+		playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
+		qdel(rpd_up)
+		return TRUE
+
 	var/atom/attack_target = A
 
 	//So that changing the menu settings doesn't affect the pipes already being built.
@@ -496,8 +483,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	//Unwrench pipe before we build one over/paint it, but only if we're not already running a do_after on it already to prevent a potential runtime.
 	if((mode & DESTROY_MODE) && (upgrade_flags & RPD_UPGRADE_UNWRENCH) && istype(attack_target, /obj/machinery/atmospherics) && !(DOING_INTERACTION_WITH_TARGET(user, attack_target)))
 		attack_target = attack_target.wrench_act(user, src)
-		if(!isatom(attack_target))
-			CRASH("When attempting to call [A.type].wrench_act(), received the following non-atom return value: [attack_target]")
+		if(!isatom(attack_target)) //can return null, FALSE if do_after() fails see /obj/machinery/atmospherics/wrench_act()
+			return TRUE
 
 	//make sure what we're clicking is valid for the current category
 	var/static/list/make_pipe_whitelist

--- a/code/game/objects/items/rcd/RPD.dm
+++ b/code/game/objects/items/rcd/RPD.dm
@@ -455,7 +455,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 50, FALSE)
 	return TRUE
 
-/obj/item/pipe_dispenser/pre_attack(atom/A, mob/user)
+/obj/item/pipe_dispenser/pre_attack(atom/A, mob/user, params)
 	if(!ISADVANCEDTOOLUSER(user) || istype(A, /turf/open/space/transit))
 		return ..()
 

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -369,7 +369,7 @@
 	add_fingerprint(user)
 
 	var/unsafe_wrenching = FALSE
-	var/internal_pressure = int_air.return_pressure()-env_air.return_pressure()
+	var/internal_pressure = int_air.return_pressure() - env_air.return_pressure()
 	var/empty_pipe = FALSE
 	if(istype(src, /obj/machinery/atmospherics/components))
 		var/list/datum/gas_mixture/all_gas_mixes = return_analyzable_air()
@@ -386,12 +386,12 @@
 	if(!empty_pipe)
 		to_chat(user, span_notice("You begin to unfasten \the [src]..."))
 
-	if (internal_pressure > 2*ONE_ATMOSPHERE)
+	if (internal_pressure > 2 * ONE_ATMOSPHERE)
 		to_chat(user, span_warning("As you begin unwrenching \the [src] a gush of air blows in your face... maybe you should reconsider?"))
 		unsafe_wrenching = TRUE //Oh dear oh dear
 
 	var/time_taken = empty_pipe ? 0 : 20
-	if(I.use_tool(src, user, time_taken, volume=50))
+	if(I.use_tool(src, user, time_taken, volume = 50))
 		user.visible_message( \
 			"[user] unfastens \the [src].", \
 			span_notice("You unfasten \the [src]."), \
@@ -402,7 +402,8 @@
 		if(unsafe_wrenching)
 			unsafe_pressure_release(user, internal_pressure)
 		return deconstruct(TRUE)
-	return TRUE
+
+	return ..()
 
 /**
  * Getter for can_unwrench


### PR DESCRIPTION
## About The Pull Request
1. `pre_attack()` was defined twice, removed one
2. `attackby()` does the exact same thing as `pre_attack()` for installing upgrades so removed that
3. Fixes runtime
![Screenshot (180)](https://user-images.githubusercontent.com/110812394/233941512-c2e23e40-cd53-4ed4-87be-59bcaea373d3.png)
When you attempt to unwrench a pipe via the RPD but you interrupt the `do_after()` proc by moving. it doesn't need to crash but simply return if unwrenching was unsuccessful see `/obj/machinery/atmospherics/wrench_act()`

## Changelog
:cl:
refactor: removed duplicate `pre_attack()` & redundant `attackby()` procs which did the same thing
fix: unnecessary crash when unwrenching pipes/devices with the RPD
/:cl: