### PR TITLE
social anxiety is incompatible with mute

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -29,6 +29,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Prosthetic Limb", "Quadruple Amputee", "Body Purist"),
 		list("Quadruple Amputee", "Paraplegic"),
 		list("Quadruple Amputee", "Frail"),
+		list("Social Anxiety", "Mute"),
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()


### PR DESCRIPTION

## About The Pull Request
quirk called social anxiety is no longer compatible with mute as mute is a more severe option of that quirk

## Why It's Good For The Game
free points are bad

## Changelog
:cl:
fix: social anxiety is incompatible with mute
/:cl:
