### PR TITLE
Allows the surgery body zone selector to use other UI themes

### DIFF
--- a/code/modules/asset_cache/assets/body_zones.dm
+++ b/code/modules/asset_cache/assets/body_zones.dm
@@ -5,7 +5,7 @@
 /datum/asset/simple/body_zones
 
 /datum/asset/simple/body_zones/register()
-	assets["body_zones.base.png"] = icon('icons/hud/screen_midnight.dmi', "zone_sel")
+	assets["body_zones.base_midnight.png"] = icon('icons/hud/screen_midnight.dmi', "zone_sel")
 
 	add_limb(BODY_ZONE_HEAD)
 	add_limb(BODY_ZONE_CHEST)

--- a/tgui/packages/tgui/components/BodyZoneSelector.tsx
+++ b/tgui/packages/tgui/components/BodyZoneSelector.tsx
@@ -57,6 +57,7 @@ type BodyZoneSelectorProps = {
   onClick?: (zone: BodyZone) => void;
   scale?: number;
   selectedZone: BodyZone | null;
+  theme: string;
 };
 
 type BodyZoneSelectorState = {
@@ -74,7 +75,7 @@ export class BodyZoneSelector extends Component<
 
   render() {
     const { hoverZone } = this.state;
-    const { scale = 3, selectedZone } = this.props;
+    const { scale = 3, selectedZone, theme = 'midnight' } = this.props;
 
     return (
       <div
@@ -86,7 +87,7 @@ export class BodyZoneSelector extends Component<
         }}>
         <Box
           as="img"
-          src={resolveAsset('body_zones.base.png')}
+          src={resolveAsset(`body_zones.base_${theme}.png`)}
           onClick={() => {
             const onClick = this.props.onClick;
             if (onClick && this.state.hoverZone) {

--- a/tgui/packages/tgui/components/BodyZoneSelector.tsx
+++ b/tgui/packages/tgui/components/BodyZoneSelector.tsx
@@ -57,7 +57,7 @@ type BodyZoneSelectorProps = {
   onClick?: (zone: BodyZone) => void;
   scale?: number;
   selectedZone: BodyZone | null;
-  theme: string;
+  theme?: string;
 };
 
 type BodyZoneSelectorState = {

--- a/tgui/packages/tgui/interfaces/SurgeryInitiator.tsx
+++ b/tgui/packages/tgui/interfaces/SurgeryInitiator.tsx
@@ -79,7 +79,6 @@ class SurgeryInitiatorInner extends Component<
               <BodyZoneSelector
                 onClick={(zone) => act('change_zone', { new_zone: zone })}
                 selectedZone={selected_zone}
-                theme="midnight"
               />
             </Stack.Item>
 

--- a/tgui/packages/tgui/interfaces/SurgeryInitiator.tsx
+++ b/tgui/packages/tgui/interfaces/SurgeryInitiator.tsx
@@ -79,6 +79,7 @@ class SurgeryInitiatorInner extends Component<
               <BodyZoneSelector
                 onClick={(zone) => act('change_zone', { new_zone: zone })}
                 selectedZone={selected_zone}
+                theme="midnight"
               />
             </Stack.Item>
 


### PR DESCRIPTION

## About The Pull Request
Allows uses of the body zone selector for non-base TGUI themes (that look good, that is), doesn't add any to the asset cache, however, as this is just groundwork

## Why It's Good For The Game
The potential of things for looking better for other TGUI themes

## Changelog
Nothing player-facing
