### PR TITLE
Sentient Disease spawning safeguards

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -130,6 +130,8 @@
 		sortTim(advance_diseases, GLOBAL_PROC_REF(cmp_advdisease_resistance_asc))
 		for(var/i in 1 to replace_num)
 			var/datum/disease/advance/competition = advance_diseases[i]
+			if(istype(competition, /datum/disease/advance/sentient_disease))
+				continue //Sentient diseases are built different and cannot be overwritten.
 			if(totalTransmittable() > competition.totalResistance())
 				competition.cure(FALSE)
 			else

--- a/code/modules/events/ghost_role/sentient_disease.dm
+++ b/code/modules/events/ghost_role/sentient_disease.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/sentient_disease
 	name = "Spawn Sentient Disease"
 	typepath = /datum/round_event/ghost_role/sentient_disease
-	weight = 7
+	earliest_start = 15 MINUTES
 	max_occurrences = 1
 	min_players = 25
 	category = EVENT_CATEGORY_HEALTH
@@ -22,11 +22,11 @@
 			continue
 		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER)) //We're only checking crew here.
 			continue
-		if(!length(candidate.diseases))
+		if(length(candidate.diseases))
 			continue
 		host_counter++
 
-	if(((length(GLOB.player_list) / host_counter) * 100) < 75) //If over 75% of our crew are uninfected, potential hosts, we run as normal.
+	if(((host_counter / length(GLOB.player_list)) * 100) < 75) //If under 75% of the crew is infected with something or ineligible, maybe it's not the best time to introduce a sentient disease.
 		return FALSE
 
 /datum/round_event/ghost_role/sentient_disease

--- a/code/modules/events/ghost_role/sentient_disease.dm
+++ b/code/modules/events/ghost_role/sentient_disease.dm
@@ -14,19 +14,18 @@
 	if(!.)
 		return .
 
-	var/host_counter = 0 //Counts how many potential hosts we have
+	var/host_counter = 0
 
-	//If 75% of the crew are potential hosts, we send in a sentient disease.
 	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list))
 		if(candidate.stat == DEAD)
 			continue
-		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER)) //We're only checking crew here.
+		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER))
 			continue
 		if(length(candidate.diseases))
 			continue
 		host_counter++
 
-	if(((host_counter / length(GLOB.player_list)) * 100) < 75) //If under 75% of the crew is infected with something or ineligible, maybe it's not the best time to introduce a sentient disease.
+	if((host_counter / length(GLOB.player_list)) < 0.75) //If under 75% of the crew is infected with something or ineligible, maybe it's not the best time to introduce a sentient disease.
 		return FALSE
 
 /datum/round_event/ghost_role/sentient_disease

--- a/code/modules/events/ghost_role/sentient_disease.dm
+++ b/code/modules/events/ghost_role/sentient_disease.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/sentient_disease
 	name = "Spawn Sentient Disease"
 	typepath = /datum/round_event/ghost_role/sentient_disease
-	earliest_start = 15 MINUTES
+	weight = 7
 	max_occurrences = 1
 	min_players = 25
 	category = EVENT_CATEGORY_HEALTH

--- a/code/modules/events/ghost_role/sentient_disease.dm
+++ b/code/modules/events/ghost_role/sentient_disease.dm
@@ -11,15 +11,23 @@
 
 /datum/round_event_control/sentient_disease/can_spawn_event(players_amt, allow_magic)
 	. = ..()
-	var/sick_counter = 0 //Counts how many infected we have.
+	if(!.)
+		return .
 
-	//If 75% of the crew are already infected with something, maybe a sentient disease isn't the best choice.
+	var/host_counter = 0 //Counts how many potential hosts we have
+
+	//If 75% of the crew are potential hosts, we send in a sentient disease.
 	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list))
 		if(candidate.stat == DEAD)
 			continue
-		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER))//We're only checking crew here.
+		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER)) //We're only checking crew here.
 			continue
+		if(!length(candidate.diseases))
+			continue
+		host_counter++
 
+	if(((length(GLOB.player_list) / host_counter) * 100) < 75) //If over 75% of our crew are uninfected, potential hosts, we run as normal.
+		return FALSE
 
 /datum/round_event/ghost_role/sentient_disease
 	role_name = "sentient disease"

--- a/code/modules/events/ghost_role/sentient_disease.dm
+++ b/code/modules/events/ghost_role/sentient_disease.dm
@@ -9,6 +9,18 @@
 	min_wizard_trigger_potency = 4
 	max_wizard_trigger_potency = 7
 
+/datum/round_event_control/sentient_disease/can_spawn_event(players_amt, allow_magic)
+	. = ..()
+	var/sick_counter = 0 //Counts how many infected we have.
+
+	//If 75% of the crew are already infected with something, maybe a sentient disease isn't the best choice.
+	for(var/mob/living/carbon/human/candidate in shuffle(GLOB.player_list))
+		if(candidate.stat == DEAD)
+			continue
+		if(!(candidate.mind.assigned_role.job_flags & JOB_CREW_MEMBER))//We're only checking crew here.
+			continue
+
+
 /datum/round_event/ghost_role/sentient_disease
 	role_name = "sentient disease"
 


### PR DESCRIPTION
## About The Pull Request

Makes two minor changes to prevent the Sentient Disease antagonist from being totally screwed/invalid upon creation.

The first prevents sentient diseases from being overwritten by other advanced diseases. This should help make them behave a bit more _parallel_ to the automated diseases, without making them outright override them.

The second prevents the Sentient Disease antagonist from rolling whilst less than 75% of the crew is infected with something already or is otherwise "ineligible" for infection.
## Why It's Good For The Game

Prevents sentient disease from getting bulldozed by high transmission viruses. It won't be able to override them or compete with them, but it can still coexist with those diseases and use those bodies as hosts to spread from. 

Avoids sentient disease rolling in situations where it would either A: Not make the current "holy shit everyone is sick medical please fix this" situation any more interesting (unbearable), or B: Die because someone is playing virology and everyone has a hypergigamaxxed happy virus in their body already.

This isn't a buff, so much as it is trying to prevent the moments where Sentient Disease spawns and has so little impact on the round that it remains unperceived until the roundend reveal.
## Changelog
:cl:
balance: Sentient disease will no longer be overridden by other advanced diseases.
balance: Sentient disease will not spawn unless 75% or more of the station are viable hosts for a sentient disease.
/:cl:
