### PR TITLE
Removes a duped `whiteshipruin_box` entry in `spaceruinblacklist.txt`

### DIFF
--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -84,4 +84,3 @@
 #_maps/RandomRuins/SpaceRuins/travelers_rest.dmm
 #_maps/RandomRuins/SpaceRuins/phonebooth.dmm
 #_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
-#_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
I'm merging PRs downstream and saw this :)
I don't know if dupes cause errors or whatever but we should have only one entry!!

## Changelog
N/A