### PR TITLE
Fixes lack of CMO stamp on tram

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -59302,6 +59302,7 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/stamp/cmo,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "udk" = (


### PR DESCRIPTION
## About The Pull Request
Fixes the CMOs severe lack of stamp on Tramstation
(https://github.com/tgstation/tgstation/issues/74964)
## Why It's Good For The Game
CMOs need their stamps!
## Changelog
:cl:
fix: Fixes the Tramstation CMO office lack of CMO stamp
/:cl:
