### PR TITLE
Subtype of tools can be used too

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -150,9 +150,11 @@
 		if(contained_item.atom_storage)
 			for(var/obj/item/subcontained_item in contained_item.contents)
 				available_tools[subcontained_item.type] = TRUE
+				available_tools[subcontained_item.parent_type] = TRUE
 				if(subcontained_item.tool_behaviour)
 					present_qualities[subcontained_item.tool_behaviour] = TRUE
 		available_tools[contained_item.type] = TRUE
+		available_tools[contained_item.parent_type] = TRUE
 		if(contained_item.tool_behaviour)
 			present_qualities[contained_item.tool_behaviour] = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Now you can use sub-object in craft, for example, in Filet Migrawr craft, you can use any lighter not only zippo

## Why It's Good For The Game
more possibilities

## Changelog
:cl: Vishenka0704
qol: Allows you to use item subtypes in crafting
/:cl:
