### PR TITLE
Replaces mining shuttle console on the Icebox bridge with an ID console

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8603,8 +8603,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "cGY" = (
-/obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/modular_computer/console/preset/id,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "cGZ" = (


### PR DESCRIPTION
## About The Pull Request

Replaces the mining shuttle console on the Icebox bridge. Icebox doesn't HAVE a mining shuttle, so this console has laid dormant and useless on the bridge.

In its place is an identification console (the modular prefab one), since they're pretty common on other bridge designs and the Icebox bridge only has 1 other modular computer.

Old:
![image](https://user-images.githubusercontent.com/28870487/234329763-08ab8f8b-caac-4afb-adcb-adb402d3eb8f.png)

New:
![image](https://user-images.githubusercontent.com/28870487/234329625-0b9b8bae-8ae8-4347-aaa4-48fe589b1572.png)

The difference is staggering.
## Why It's Good For The Game

It doesn't even do anything! That single tile of real estate could be put to way better use!
## Changelog
:cl: Rhials
fix: Replaces the purely decorative mining shuttle console on the Icebox bridge with an ID console.
/:cl:
