### PR TITLE
Electrolysis works with enriched liquid electricity

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -593,7 +593,7 @@
 //water electrolysis
 /datum/chemical_reaction/electrolysis
 	results = list(/datum/reagent/oxygen = 1.5, /datum/reagent/hydrogen = 3)
-	required_reagents = list(/datum/reagent/consumable/liquidelectricity = 1, /datum/reagent/water = 5)
+	required_reagents = list(/datum/reagent/consumable/liquidelectricity/enriched = 1, /datum/reagent/water = 5)
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_CHEMICAL
 
 //butterflium


### PR DESCRIPTION
## About The Pull Request

Electrolysis reaction seems to be overlooked with introduction of enriched version of LE.

## Why It's Good For The Game

Reaction actually works for LE from Jupiter Cups, Energy Bars, Empowered burgers - the common sources of LE.

## Changelog

:cl:
fix: Electrolysis chemical reaction works with enriched liquid electricity
/:cl:


