### PR TITLE
Candles and flares can now set mobs on fire

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -345,6 +345,16 @@
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 
+/obj/item/flashlight/flare/attack(mob/living/carbon/victim, mob/living/carbon/user)
+	if(!isliving(victim))
+		return ..()
+
+	if(on && victim.ignite_mob())
+		message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(victim)] on fire with [src] at [AREACOORD(user)]")
+		user.log_message("set [key_name(victim)] on fire with [src]", LOG_ATTACK)
+		
+	return ..()
+
 /obj/item/flashlight/flare/toggle_light()
 	if(on || !fuel)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

Exactly what it says. You want to set people on fire using a candle or a flare now? No problem.

## Why It's Good For The Game

Not sure why you could never do this.

## Changelog

:cl:
fix: mobs can now be set on fire using flares and candles if they are covered in something flammable
/:cl:
