### PR TITLE
Fixes pirates not spawning if summoned through comms console

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -840,11 +840,16 @@
 	hacker.log_message("hacked a communications console, resulting in: [picked_option].", LOG_GAME, log_globally = TRUE)
 	switch(picked_option)
 		if(HACK_PIRATE) // Triggers pirates, which the crew may be able to pay off to prevent
+			var/datum/game_mode/dynamic/dynamic = SSticker.mode
+			var/list/pirate_rulesets = list(
+				/datum/dynamic_ruleset/midround/pirates,
+				/datum/dynamic_ruleset/midround/dangerous_pirates,
+			)
 			priority_announce(
 				"Attention crew: sector monitoring reports a massive jump-trace from an enemy vessel destined for your system. Prepare for imminent hostile contact.",
 				"[command_name()] High-Priority Update",
 			)
-			force_event_after(/datum/round_event_control/pirates, "[hacker] hacking a communications console", rand(20 SECONDS, 1 MINUTES))
+			dynamic.picking_specific_rule(pick(pirate_rulesets), forced = TRUE, ignore_cost = TRUE)
 
 		if(HACK_FUGITIVES) // Triggers fugitives, which can cause confusion / chaos as the crew decides which side help
 			priority_announce(


### PR DESCRIPTION
## About The Pull Request

When #73881 was merged, it didn't change the threat spawn code when you hack a comms console.
Before, it simply called the round event control which worked. However after the PR, it'd always return because `gang_list` wasn't populated and there was a check that returned if that was the case , and it only ever was populated when pirates were spawned through dynamic or by admins.

## Why It's Good For The Game

pirates spawning is good i think

## Changelog
:cl:
fix: Pirates summoned through hacking a comms console should actually spawn now.
/:cl:
