### PR TITLE
Fixes Infinite Slime Extract Explosions

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -920,6 +920,7 @@
 /datum/status_effect/stabilized/oil/tick()
 	if(owner.stat == DEAD)
 		explosion(owner, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, flame_range = 5, explosion_cause = src)
+		qdel(linked_extract)
 	return ..()
 
 /datum/status_effect/stabilized/oil/get_examine_text()


### PR DESCRIPTION

## About The Pull Request
Fixes #74984 by making oil extracts get deleted after they explode
Technically you can still explode multiple times by carrying multiple extracts but that shouldn't be an issue, it takes all your inventory space and you still only explode a limited number of times which can devastate a department but it's nothing you couldn't do with other explosives.

## Why It's Good For The Game
Rocket Propelled Research Director bad

## Changelog

:cl:
fix: Stabilized Oil extracts no longer explode infinitely if your corpse is immune to gibbing
/:cl:

