### PR TITLE
Paradox clone no longer duplicates object.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -855,9 +855,9 @@
 	player_mind.active = TRUE
 
 	var/mob/living/carbon/human/clone_victim = find_original()
-
 	var/mob/living/carbon/human/clone = clone_victim.make_full_human_copy(pick(possible_spawns))
 	player_mind.transfer_to(clone)
+
 	var/datum/antagonist/paradox_clone/new_datum = player_mind.add_antag_datum(/datum/antagonist/paradox_clone)
 	new_datum.original_ref = WEAKREF(clone_victim.mind)
 	new_datum.setup_clone()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -855,11 +855,9 @@
 	player_mind.active = TRUE
 
 	var/mob/living/carbon/human/clone_victim = find_original()
-	var/mob/living/carbon/human/clone = duplicate_object(clone_victim, pick(possible_spawns))
 
+	var/mob/living/carbon/human/clone = clone_victim.make_full_human_copy(pick(possible_spawns))
 	player_mind.transfer_to(clone)
-	player_mind.set_assigned_role(SSjob.GetJobType(/datum/job/paradox_clone))
-
 	var/datum/antagonist/paradox_clone/new_datum = player_mind.add_antag_datum(/datum/antagonist/paradox_clone)
 	new_datum.original_ref = WEAKREF(clone_victim.mind)
 	new_datum.setup_clone()

--- a/code/modules/antagonists/paradox_clone/paradox_clone.dm
+++ b/code/modules/antagonists/paradox_clone/paradox_clone.dm
@@ -50,26 +50,17 @@
 	kill.update_explanation_text()
 	objectives += kill
 
-	var/mob/living/carbon/human/original_human = original_mind.current
-	var/mob/living/carbon/human/clone_human = owner.current
-
 	owner.set_assigned_role(SSjob.GetJobType(/datum/job/paradox_clone))
 
-	//equip them in the original's clothes
-	if(!isplasmaman(original_human))
-		clone_human.equipOutfit(original_human.mind.assigned_role.outfit)
-	else
-		clone_human.equipOutfit(original_human.mind.assigned_role.plasmaman_outfit)
-		clone_human.internal = clone_human.get_item_for_held_index(2)
-
 	//clone doesnt show up on message lists
-	var/obj/item/modular_computer/pda/messenger = locate() in clone_human
+	var/obj/item/modular_computer/pda/messenger = locate() in owner.current
 	if(messenger)
 		var/datum/computer_file/program/messenger/message_app = locate() in messenger.stored_files
 		if(message_app)
 			message_app.invisible = TRUE
 
 	//dont want anyone noticing there's two now
+	var/mob/living/carbon/human/clone_human = owner.current
 	var/obj/item/clothing/under/sensor_clothes = clone_human.w_uniform
 	if(sensor_clothes)
 		sensor_clothes.sensor_mode = SENSOR_OFF

--- a/code/modules/antagonists/paradox_clone/paradox_clone.dm
+++ b/code/modules/antagonists/paradox_clone/paradox_clone.dm
@@ -50,8 +50,10 @@
 	kill.update_explanation_text()
 	objectives += kill
 
-	var/mob/living/carbon/human/clone_human = owner.current
 	var/mob/living/carbon/human/original_human = original_mind.current
+	var/mob/living/carbon/human/clone_human = owner.current
+
+	owner.set_assigned_role(SSjob.GetJobType(/datum/job/paradox_clone))
 
 	//equip them in the original's clothes
 	if(!isplasmaman(original_human))

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -292,10 +292,12 @@
 /**
  * Makes a full copy of src and returns it.
  * Attempts to copy as much as possible to be a close to the original.
+ * This includes job outfit (which handles skillchips), quirks, and mutations.
+ * We do not set a mind here, so this is purely the body.
  * Args:
  * location - The turf the human will be spawned on.
  */
-/mob/living/carbon/human/proc/make_full_human_copy(turf/location)
+/mob/living/carbon/human/proc/make_full_human_copy(turf/location, client/quirk_client)
 	RETURN_TYPE(/mob/living/carbon/human)
 
 	var/mob/living/carbon/human/clone = new(location)
@@ -305,13 +307,14 @@
 	clone.age = age
 	dna.transfer_identity(clone, transfer_SE = TRUE, transfer_species = TRUE)
 
-	for(var/datum/quirk/quirks as anything in quirks)
-		clone.add_quirk(quirks.type)
-	for(var/datum/mutation/human/mutations as anything in dna.mutations)
+	clone.dress_up_as_job(SSjob.GetJob(job))
+
+	for(var/datum/quirk/original_quircks as anything in quirks)
+		clone.add_quirk(original_quircks.type, override_client = client)
+	for(var/datum/mutation/human/mutations in dna.mutations)
 		clone.dna.add_mutation(mutations)
 
 	clone.updateappearance(mutcolor_update = TRUE, mutations_overlay_update = TRUE)
-	clone.update_body()
 	clone.domutcheck()
 
 	return clone

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -288,3 +288,30 @@
 		return HUMAN_HEIGHT_DWARF
 
 	return mob_height
+
+/**
+ * Makes a full copy of src and returns it.
+ * Attempts to copy as much as possible to be a close to the original.
+ * Args:
+ * location - The turf the human will be spawned on.
+ */
+/mob/living/carbon/human/proc/make_full_human_copy(turf/location)
+	RETURN_TYPE(/mob/living/carbon/human)
+
+	var/mob/living/carbon/human/clone = new(location)
+
+	clone.fully_replace_character_name(null, dna.real_name)
+	copy_clothing_prefs(clone)
+	clone.age = age
+	dna.transfer_identity(clone, transfer_SE = TRUE, transfer_species = TRUE)
+
+	for(var/datum/quirk/quirks as anything in quirks)
+		clone.add_quirk(quirks.type)
+	for(var/datum/mutation/human/mutations as anything in dna.mutations)
+		clone.dna.add_mutation(mutations)
+
+	clone.updateappearance(mutcolor_update = TRUE, mutations_overlay_update = TRUE)
+	clone.update_body()
+	clone.domutcheck()
+
+	return clone


### PR DESCRIPTION
## About The Pull Request

Paradox clone no longer duplicates object, we instead try to copy as much as possible over to a newly created human

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/74124
Closes https://github.com/tgstation/tgstation/issues/74122
Closes https://github.com/tgstation/tgstation/issues/73973
Closes https://github.com/tgstation/tgstation/issues/73972
Closes https://github.com/tgstation/tgstation/issues/72437 (hopefully)

## Changelog

:cl:
fix: Paradox clones are now attempted manual copies of humans, rather than straight-up copying everything. They should no longer have bugs related to being unable to use UIs, having FOV, or visual bugs.
/:cl: