### PR TITLE
Ore silo will put machines off its level on hold, instead of disconnecting

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movement.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movement.dm
@@ -13,6 +13,8 @@
 #define COMSIG_ATOM_INTERCEPT_Z_FALL "movable_intercept_z_impact"
 ///signal sent out by an atom upon onZImpact : (turf/impacted_turf, levels)
 #define COMSIG_ATOM_ON_Z_IMPACT "movable_on_z_impact"
+///Signal sent after an atom movable moves on shuttle.
+#define COMSIG_ATOM_AFTER_SHUTTLE_MOVE "movable_after_shuttle_move"
 ///called on a movable (NOT living) when it starts pulling (atom/movable/pulled, state, force)
 #define COMSIG_ATOM_START_PULL "movable_start_pull"
 ///called on /living when someone starts pulling (atom/movable/pulled, state, force)

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -28,7 +28,6 @@ handles linking back and forth.
 
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(OnAttackBy))
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(OnMultitool))
-	RegisterSignal(parent, COMSIG_ATOM_AFTER_SHUTTLE_MOVE, PROC_REF(check_z_level))
 
 	var/turf/T = get_turf(parent)
 	if (force_connect || (mapload && is_station_level(T.z)))
@@ -76,6 +75,17 @@ handles linking back and forth.
 
 	mat_container = parent.AddComponent(/datum/component/material_container, allowed_mats, local_size, mat_container_flags, allowed_items=/obj/item/stack)
 
+/datum/component/remote_materials/proc/toggle_holding(force_hold = FALSE)
+	if(!silo)
+		return
+
+	if(force_hold)
+		silo.holds[src] = TRUE
+	else if(!silo.holds[src])
+		silo.holds[src] = TRUE
+	else
+		silo.holds[src] -= src
+
 /datum/component/remote_materials/proc/set_local_size(size)
 	local_size = size
 	if (!silo && mat_container)
@@ -108,9 +118,7 @@ handles linking back and forth.
 		if (silo == M.buffer)
 			to_chat(user, span_warning("[parent] is already connected to [silo]!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
-		var/turf/silo_turf = get_turf(M.buffer)
-		var/turf/user_loc = get_turf(user)
-		if(!is_valid_z_level(silo_turf, user_loc))
+		if(!check_z_level(M.buffer))
 			to_chat(user, span_warning("[parent] is too far away to get a connection signal!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
 		if (silo)
@@ -126,18 +134,23 @@ handles linking back and forth.
 		to_chat(user, span_notice("You connect [parent] to [silo] from the multitool's buffer."))
 		return COMPONENT_BLOCK_TOOL_ATTACK
 
-/datum/component/remote_materials/proc/check_z_level(datum/source)
+/datum/component/remote_materials/proc/check_z_level(obj/silo_to_check)
 	SIGNAL_HANDLER
-	if(!silo)
-		return
+	if(!silo_to_check)
+		if(!silo)
+			return FALSE
+		silo_to_check = silo
 
 	var/turf/current_turf = get_turf(parent)
-	var/turf/silo_turf = get_turf(silo)
+	var/turf/silo_turf = get_turf(silo_to_check)
 	if(!is_valid_z_level(silo_turf, current_turf))
-		disconnect_from(silo)
+		return FALSE
+	return TRUE
 
 /datum/component/remote_materials/proc/on_hold()
-	return silo?.holds["[get_area(parent)]/[category]"]
+	if(!check_z_level())
+		return FALSE
+	return silo.holds["[get_area(parent)]/[category]"]
 
 /datum/component/remote_materials/proc/silo_log(obj/machinery/M, action, amount, noun, list/mats)
 	if (silo)

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -84,7 +84,7 @@ handles linking back and forth.
 	else if(!silo.holds[src])
 		silo.holds[src] = TRUE
 	else
-		silo.holds[src] -= src
+		silo.holds -= src
 
 /datum/component/remote_materials/proc/set_local_size(size)
 	local_size = size

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -76,7 +76,7 @@ handles linking back and forth.
 	mat_container = parent.AddComponent(/datum/component/material_container, allowed_mats, local_size, mat_container_flags, allowed_items=/obj/item/stack)
 
 /datum/component/remote_materials/proc/toggle_holding(force_hold = FALSE)
-	if(!silo)
+	if(isnull(silo))
 		return
 
 	if(force_hold)
@@ -137,7 +137,7 @@ handles linking back and forth.
 /datum/component/remote_materials/proc/check_z_level(obj/silo_to_check)
 	SIGNAL_HANDLER
 	if(!silo_to_check)
-		if(!silo)
+		if(isnull(silo))
 			return FALSE
 		silo_to_check = silo
 

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -28,7 +28,7 @@ handles linking back and forth.
 
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(OnAttackBy))
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(OnMultitool))
-	RegisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(check_z_level))
+	RegisterSignal(parent, COMSIG_ATOM_AFTER_SHUTTLE_MOVE, PROC_REF(check_z_level))
 
 	var/turf/T = get_turf(parent)
 	if (force_connect || (mapload && is_station_level(T.z)))
@@ -85,6 +85,7 @@ handles linking back and forth.
 /datum/component/remote_materials/proc/disconnect_from(obj/machinery/ore_silo/old_silo)
 	if (!old_silo || silo != old_silo)
 		return
+	silo.ore_connected_machines -= src
 	silo = null
 	mat_container = null
 	if (allow_standalone)
@@ -125,13 +126,14 @@ handles linking back and forth.
 		to_chat(user, span_notice("You connect [parent] to [silo] from the multitool's buffer."))
 		return COMPONENT_BLOCK_TOOL_ATTACK
 
-/datum/component/remote_materials/proc/check_z_level(datum/source, turf/old_turf, turf/new_turf)
+/datum/component/remote_materials/proc/check_z_level(datum/source)
 	SIGNAL_HANDLER
 	if(!silo)
 		return
 
+	var/turf/current_turf = get_turf(parent)
 	var/turf/silo_turf = get_turf(silo)
-	if(!is_valid_z_level(silo_turf, new_turf))
+	if(!is_valid_z_level(silo_turf, current_turf))
 		disconnect_from(silo)
 
 /datum/component/remote_materials/proc/on_hold()

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -238,12 +238,15 @@
 				"amount" = can_smelt_alloy(alloy),
 			))
 
+	data["disconnected"] = null
 	if (!mat_container)
-		data["disconnected"] = "local mineral storage is unavailable"
+		data["disconnected"] = "Local mineral storage is unavailable"
 	else if (!materials.silo)
-		data["disconnected"] = "no ore silo connection is available; storing locally"
+		data["disconnected"] = "No ore silo connection is available; storing locally"
+	else if (!materials.check_z_level())
+		data["disconnected"] = "Unable to connect to ore silo, too far away"
 	else if (materials.on_hold())
-		data["disconnected"] = "mineral withdrawal is on hold"
+		data["disconnected"] = "Mineral withdrawal is on hold"
 
 	var/obj/item/card/id/card
 	if(isliving(user))
@@ -297,6 +300,8 @@
 			if(isliving(usr))
 				var/mob/living/user = usr
 				user_id_card = user.get_idcard(TRUE)
+			if(!materials.check_z_level())
+				return TRUE
 			if(points)
 				if(user_id_card)
 					user_id_card.registered_account.mining_points += points

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -117,9 +117,8 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	ui += "</div><div class='statusDisplay'><h2>Connected Machines:</h2>"
 	for(var/datum/component/remote_materials/mats as anything in ore_connected_machines)
 		var/atom/parent = mats.parent
-		var/hold_key = "[get_area(parent)]/[mats.category]"
 		ui += "<a href='?src=[REF(src)];remove=[REF(mats)]'>Remove</a>"
-		ui += "<a href='?src=[REF(src)];hold=[url_encode(hold_key)]'>[holds[hold_key] ? "Allow" : "Hold"]</a>"
+		ui += "<a href='?src=[REF(src)];hold=[REF(mats)]'>[holds[mats] ? "Allow" : "Hold"]</a>"
 		ui += " <b>[parent.name]</b> in [get_area_name(parent, TRUE)]<br>"
 	if(!ore_connected_machines.len)
 		ui += "Nothing!"
@@ -158,7 +157,6 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		var/datum/component/remote_materials/mats = locate(href_list["remove"]) in ore_connected_machines
 		if (mats)
 			mats.disconnect_from(src)
-			ore_connected_machines -= mats
 			updateUsrDialog()
 			return TRUE
 	else if(href_list["hold"])

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		var/atom/parent = mats.parent
 		var/hold_key = "[get_area(parent)]/[mats.category]"
 		ui += "<a href='?src=[REF(src)];remove=[REF(mats)]'>Remove</a>"
-		ui += "<a href='?src=[REF(src)];hold[!holds[hold_key]]=[url_encode(hold_key)]'>[holds[hold_key] ? "Allow" : "Hold"]</a>"
+		ui += "<a href='?src=[REF(src)];hold=[url_encode(hold_key)]'>[holds[hold_key] ? "Allow" : "Hold"]</a>"
 		ui += " <b>[parent.name]</b> in [get_area_name(parent, TRUE)]<br>"
 	if(!ore_connected_machines.len)
 		ui += "Nothing!"
@@ -161,12 +161,9 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 			ore_connected_machines -= mats
 			updateUsrDialog()
 			return TRUE
-	else if(href_list["hold1"])
-		holds[href_list["hold1"]] = TRUE
-		updateUsrDialog()
-		return TRUE
-	else if(href_list["hold0"])
-		holds -= href_list["hold0"]
+	else if(href_list["hold"])
+		var/datum/component/remote_materials/mats = locate(href_list["hold"]) in ore_connected_machines
+		mats.toggle_holding()
 		updateUsrDialog()
 		return TRUE
 	else if(href_list["ejectsheet"])

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -113,6 +113,7 @@ All ShuttleMove procs go here
 
 // Called on atoms after everything has been moved
 /atom/movable/proc/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
+	SEND_SIGNAL(src, COMSIG_ATOM_AFTER_SHUTTLE_MOVE)
 	if(light)
 		update_light()
 	if(rotation)

--- a/tgui/packages/tgui/interfaces/OreRedemptionMachine.js
+++ b/tgui/packages/tgui/interfaces/OreRedemptionMachine.js
@@ -6,7 +6,7 @@ import { formatSiUnit } from '../format';
 
 export const OreRedemptionMachine = (props, context) => {
   const { act, data } = useBackend(context);
-  const { unclaimedPoints, materials, user } = data;
+  const { disconnected, unclaimedPoints, materials, user } = data;
   const [tab, setTab] = useSharedState(context, 'tab', 1);
   const [searchItem, setSearchItem] = useLocalState(context, 'searchItem', '');
   const [compact, setCompact] = useSharedState(context, 'compact', false);
@@ -64,7 +64,8 @@ export const OreRedemptionMachine = (props, context) => {
                 <Button
                   ml={2}
                   content="Claim"
-                  disabled={unclaimedPoints === 0}
+                  disabled={unclaimedPoints === 0 || disconnected}
+                  tooltip={disconnected}
                   onClick={() => act('Claim')}
                 />
               </Box>


### PR DESCRIPTION
## About The Pull Request

There's a problem where people would try to rebuild a whiteship and use an Ore Silo for it. However, it would automatically unlink everything when moving, because it's checking for z level as soon as it changes z level itself, before the Ore silo has 'moved' as well.

~~To fix this, I'm now only disconnecting ore silos when a shuttle moves. This mostly does the same as before, but technically you can sync an unwrenchable connected machine and bring it to space with you (without using a shuttle) to stay connected, but I don't see this as a problem, and my original point of the PR was to prevent Lavaland ORMs.~~

I decided against this, instead I've made it so machines that aren't on a valid level (either both on the same z level or both on the station level) will be considered 'on-hold', much like if the QM has set it to hold through the silo directly. This means that machines no longer disconnect from the Ore silo on moving, they just can't access the materials in it. This affects gameplay in 2 ways:

1. You no longer need to resync when you bring the machine back
2. It won't unsync itself every time you move station z-level with its silo (such as on a whiteship).

I also made disconnecting from an ore silo actually remove them from the ore silo's list of connected machines.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/69863

## Changelog

:cl:
balance: Machines (such as ORM and Techfabs) will no longer unsync from Ore silos when it moves Z-level, instead it will prevent materials from being used, as if it was on hold.
/:cl: