### PR TITLE
Crashedship Space Ruin - Replaces the away mission areas with ruin ones

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -2,17 +2,17 @@
 "am" = (
 /obj/machinery/power/port_gen/pacman/super,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "au" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 2
 	},
 /turf/open/floor/bamboo,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "aH" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "aM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23,24 +23,24 @@
 /obj/structure/firelock_frame,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "bc" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "bj" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Checkpoint"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "ck" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "cE" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/command{
@@ -49,20 +49,20 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /turf/open/floor/iron/white/corner,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "cR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right,
 /turf/open/floor/iron/dark,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "cY" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "db" = (
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "di" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -74,15 +74,15 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "dD" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "dZ" = (
 /obj/item/stack/ore/glass,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "eh" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -92,7 +92,7 @@
 	dir = 4
 	},
 /turf/open/floor/pod/light,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "eC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -102,44 +102,44 @@
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/textured,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "eU" = (
 /obj/machinery/teleport/hub,
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "fc" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "fm" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "fp" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "fA" = (
 /obj/machinery/light/broken/directional/south,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "fI" = (
 /obj/structure/closet/mini_fridge,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "fQ" = (
 /turf/open/floor/iron,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "fY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "gC" = (
 /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty{
 	pixel_x = 11;
@@ -147,23 +147,19 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "gH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/shrink_cw,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "hh" = (
-/obj/structure/lattice,
-/obj/item/shard{
-	icon_state = "small"
-	},
-/turf/template_noop,
-/area/template_noop)
+/turf/closed/mineral/random/high_chance,
+/area/ruin/space/has_grav/crashedship/fore)
 "hv" = (
 /obj/item/stack/ore/gold,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "hI" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -176,21 +172,21 @@
 /obj/effect/spawner/random/maintenance/two,
 /obj/machinery/light/small/broken/directional/south,
 /turf/open/floor/pod/light,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "ip" = (
 /obj/machinery/light/broken/directional/north,
 /turf/open/floor/iron,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "iI" = (
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "iU" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "iW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/cable,
@@ -198,46 +194,46 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "ja" = (
 /turf/closed/mineral/random/high_chance,
-/area/awaymission/bmpship/fore)
+/area/space)
 "kc" = (
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "km" = (
 /obj/structure/girder/displaced,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "kM" = (
 /obj/item/bedsheet/yellow,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "kZ" = (
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "le" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/broken{
 	dir = 4
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "lf" = (
 /obj/structure/cable,
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "lg" = (
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "lx" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north{
@@ -245,25 +241,25 @@
 	},
 /obj/effect/mapping_helpers/apc/unlocked,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "lG" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "lR" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "mb" = (
 /obj/item/stack/ore/glass,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "mu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/item/gps/spaceruin,
 /turf/open/floor/catwalk_floor,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "mP" = (
 /obj/machinery/door/firedoor/closed,
 /obj/effect/turf_decal/stripes/line,
@@ -275,7 +271,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "nb" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -283,7 +279,7 @@
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "nh" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 9
@@ -291,15 +287,15 @@
 /obj/effect/turf_decal/trimline/brown/corner,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "nl" = (
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "nI" = (
 /obj/structure/girder/displaced,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "nY" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/crate_abandoned,
@@ -307,21 +303,21 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "om" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "on" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/captain,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "oM" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
@@ -329,21 +325,21 @@
 /obj/effect/turf_decal/trimline/brown/line,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "oT" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "pb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/shrink_cw,
 /obj/structure/cable,
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "pe" = (
 /obj/machinery/door/firedoor/closed,
 /obj/effect/turf_decal/stripes/line{
@@ -356,7 +352,7 @@
 	name = "Entry Hall"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "pO" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 10
@@ -365,7 +361,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "pP" = (
 /obj/machinery/porta_turret{
 	dir = 8;
@@ -380,7 +376,7 @@
 	},
 /obj/effect/turf_decal/trimline/brown/line,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "pT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -391,12 +387,12 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 10
 	},
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "pZ" = (
 /obj/structure/girder/displaced,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "qm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -405,11 +401,11 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 4
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "qo" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "qu" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/effect/turf_decal/trimline/brown/line{
@@ -417,7 +413,7 @@
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "qB" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -425,45 +421,45 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/structure/closet/firecloset,
 /turf/open/floor/pod/light,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "qI" = (
 /obj/item/stack/ore/silver,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "qO" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "rb" = (
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "rm" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "rt" = (
 /obj/item/chair,
 /turf/open/misc/asteroid/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "rX" = (
 /obj/item/stack/rods,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "rZ" = (
 /turf/closed/mineral/random,
-/area/awaymission/bmpship/fore)
+/area/space)
 "sr" = (
 /obj/effect/spawner/random/maintenance/four,
 /obj/structure/closet/crate,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/electronics/airlock,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "tb" = (
 /obj/item/kirbyplants,
 /turf/open/floor/wood/tile,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "tm" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
@@ -478,7 +474,7 @@
 	target_type = /obj/machinery/porta_turret
 	},
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "tn" = (
 /obj/structure/chair{
 	dir = 4
@@ -489,46 +485,46 @@
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "ts" = (
 /obj/machinery/teleport/station,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "tN" = (
 /obj/structure/table/wood,
 /obj/item/paper/fluff/ruins/crashedship/captains_log,
 /turf/open/floor/wood/tile,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "uf" = (
 /obj/machinery/suit_storage_unit/open,
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "um" = (
 /turf/open/floor/plating,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "ut" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "uz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "uF" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "vg" = (
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "vk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "vJ" = (
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 1
@@ -544,14 +540,14 @@
 /turf/open/floor/iron/airless{
 	icon_state = "podfloor_dark"
 	},
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "vX" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "wi" = (
 /turf/open/floor/bamboo,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "xa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -561,7 +557,7 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 1
 	},
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "xb" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
@@ -569,7 +565,7 @@
 /obj/effect/turf_decal/trimline/brown/line,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "xy" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/large,
@@ -578,14 +574,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "xF" = (
 /turf/closed/wall/mineral/titanium,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "xJ" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "xU" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -594,17 +590,17 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "yb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/end,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "yk" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "yB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -615,46 +611,46 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 4
 	},
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "yL" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark/side/airless{
 	dir = 8
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "za" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "zg" = (
 /obj/item/stack/tile/wood,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "zm" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/decoration,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/parquet,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "zA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/catwalk_floor,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "zC" = (
 /obj/structure/grille/broken,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "zD" = (
 /turf/closed/wall/mineral/titanium,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "zO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "zW" = (
 /obj/structure/closet,
 /obj/item/dice/d6,
@@ -662,12 +658,12 @@
 	dir = 1
 	},
 /turf/open/floor/iron/checker/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Af" = (
 /obj/item/chair,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Ak" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/command{
@@ -678,15 +674,19 @@
 /turf/open/floor/iron/white/side{
 	dir = 6
 	},
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Au" = (
-/turf/closed/mineral/random,
-/area/awaymission/bmpship)
+/obj/structure/lattice,
+/obj/item/shard{
+	icon_state = "small"
+	},
+/turf/template_noop,
+/area/space)
 "AF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "AM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -697,7 +697,7 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 6
 	},
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Bw" = (
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 1
@@ -713,7 +713,7 @@
 /turf/open/floor/iron/airless{
 	icon_state = "podfloor_dark"
 	},
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "BM" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
@@ -724,37 +724,37 @@
 /turf/open/floor/iron/edge{
 	dir = 4
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "BS" = (
 /obj/structure/girder,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Cg" = (
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Cj" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/line,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Cz" = (
 /obj/effect/turf_decal/siding/blue/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "CK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/bamboo,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "CM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/corner{
@@ -762,7 +762,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "CN" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -774,15 +774,15 @@
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "CP" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "CT" = (
 /obj/item/stack/ore/glass,
 /turf/open/misc/asteroid/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "CU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -791,14 +791,14 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 5
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "DY" = (
 /obj/item/pen/fountain,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "EA" = (
 /turf/open/misc/asteroid/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "EB" = (
 /obj/item/chair,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -808,22 +808,22 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 1
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "EL" = (
 /obj/item/stack/ore/silver,
 /turf/open/misc/asteroid/airless,
-/area/awaymission/bmpship/midship)
+/area/space)
 "EM" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "EO" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
 	dir = 8
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/engine,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "EW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -831,7 +831,7 @@
 	name = "Emergency Supplies"
 	},
 /turf/open/floor/pod/dark,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Ff" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -842,7 +842,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Fg" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
@@ -852,7 +852,7 @@
 /turf/open/floor/iron/textured_edge{
 	dir = 1
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Fy" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -861,11 +861,11 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/pod/light,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "FP" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "FY" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/tile/blue{
@@ -874,7 +874,7 @@
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Gf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -885,7 +885,7 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 5
 	},
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Gv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -893,16 +893,16 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 9
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "GH" = (
 /obj/structure/frame/machine,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "GM" = (
 /obj/effect/spawner/random/structure/girder,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Hb" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
@@ -912,11 +912,11 @@
 	dir = 8
 	},
 /turf/open/floor/engine/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Ho" = (
 /obj/effect/spawner/random/structure/girder,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "HM" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -928,43 +928,43 @@
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "HT" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "HZ" = (
 /obj/structure/grille/broken,
 /obj/item/shard,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "ID" = (
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "IG" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/parquet,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "IM" = (
 /obj/item/shard,
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "Jr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/side/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Jv" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "JN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -975,7 +975,7 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 8
 	},
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Kd" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 4
@@ -983,13 +983,13 @@
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Ko" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Ku" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/end{
@@ -1010,18 +1010,18 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "KD" = (
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "KF" = (
 /obj/item/stack/cable_coil/cut,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "KO" = (
 /obj/item/light/tube/broken,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "Ln" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/effect/turf_decal/trimline/brown/line{
@@ -1036,7 +1036,7 @@
 	target_type = /obj/machinery/porta_turret
 	},
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Lo" = (
 /obj/machinery/door/airlock/command{
 	emergency = 1;
@@ -1045,12 +1045,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "LX" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "Me" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
@@ -1059,7 +1059,7 @@
 /obj/structure/cable,
 /obj/machinery/light/broken/directional/south,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Mg" = (
 /obj/machinery/door/firedoor/closed,
 /obj/effect/turf_decal/stripes/line,
@@ -1070,20 +1070,20 @@
 	name = "Entry Hall"
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Mi" = (
 /obj/structure/table_frame/wood,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood/parquet,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "Mw" = (
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "MC" = (
 /obj/effect/mob_spawn/corpse/human/laborer,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "Nc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1091,7 +1091,7 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 4
 	},
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Nn" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 9
@@ -1099,7 +1099,7 @@
 /obj/effect/turf_decal/trimline/brown/corner,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "NB" = (
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 1
@@ -1111,7 +1111,7 @@
 /turf/open/floor/iron/airless{
 	icon_state = "podfloor_dark"
 	},
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "NF" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/door/airlock/external/ruin,
@@ -1119,13 +1119,13 @@
 	dir = 1
 	},
 /turf/open/floor/iron/textured_edge,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "NM" = (
 /obj/machinery/power/shuttle_engine/large{
 	dir = 8
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "Oy" = (
 /obj/machinery/door/firedoor/closed,
 /obj/effect/turf_decal/stripes/line{
@@ -1139,12 +1139,12 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "OZ" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/midship)
 "Pb" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -1153,21 +1153,21 @@
 /obj/structure/table,
 /obj/item/door_seal,
 /turf/open/floor/pod/light,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Ph" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Pp" = (
 /obj/structure/lattice/catwalk,
 /obj/item/shard{
 	icon_state = "medium"
 	},
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "Pu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -1177,16 +1177,16 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Qy" = (
 /obj/structure/door_assembly/door_assembly_com,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "RA" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "RL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -1195,25 +1195,22 @@
 /turf/open/floor/iron/dark/side/airless{
 	dir = 9
 	},
-/area/awaymission/bmpship/midship)
-"RU" = (
-/turf/closed/mineral/random/high_chance,
-/area/awaymission/bmpship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Tj" = (
 /obj/effect/turf_decal/trimline/neutral/filled/shrink_ccw,
 /obj/structure/cable,
 /obj/machinery/light/broken/directional/south,
 /turf/open/floor/iron,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "To" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Ty" = (
 /obj/effect/spawner/random/structure/girder,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "TP" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -1221,14 +1218,14 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/pod/light,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Uc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/end{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Uk" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -1236,17 +1233,17 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/pod/light,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Uz" = (
 /turf/closed/mineral/gibtonite,
-/area/awaymission/bmpship/fore)
+/area/space)
 "UA" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "UC" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "UH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1256,12 +1253,12 @@
 	dir = 1
 	},
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "US" = (
 /obj/machinery/light/broken/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Vp" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -1269,7 +1266,7 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "VH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1280,11 +1277,11 @@
 /obj/structure/door_assembly/door_assembly_med,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "VL" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/midship)
+/area/ruin/space/has_grav/crashedship/midship)
 "Wi" = (
 /obj/machinery/light/broken/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -1292,12 +1289,12 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/side/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Xu" = (
 /obj/item/shard,
 /obj/item/stack/rods,
 /turf/template_noop,
-/area/template_noop)
+/area/space)
 "Xy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -1306,19 +1303,19 @@
 /obj/structure/table,
 /obj/item/stock_parts/cell/lead,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "XW" = (
 /turf/open/floor/wood/parquet,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "Ya" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Ye" = (
 /obj/effect/turf_decal/trimline/neutral/line,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Yl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1329,36 +1326,36 @@
 /obj/structure/firelock_frame,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/mineral/plastitanium/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "Yp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/bamboo,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "Yw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/pod/dark,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "YU" = (
 /obj/item/stack/rods,
 /turf/open/misc/asteroid,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "Zl" = (
 /obj/machinery/power/floodlight,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating/airless,
-/area/awaymission/bmpship/aft)
+/area/ruin/space/has_grav/crashedship/aft)
 "Zm" = (
 /obj/item/stack/ore/diamond,
 /turf/open/misc/asteroid/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 "ZA" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
-/area/awaymission/bmpship/fore)
+/area/ruin/space/has_grav/crashedship/fore)
 
 (1,1,1) = {"
 kc
@@ -1382,7 +1379,7 @@ kc
 kc
 kc
 kc
-Au
+rZ
 kc
 kc
 kc
@@ -1409,8 +1406,8 @@ kc
 kc
 kc
 mb
-Au
-Au
+rZ
+rZ
 kc
 kc
 kc
@@ -1435,11 +1432,11 @@ kc
 kc
 kc
 kc
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 kc
@@ -1463,11 +1460,11 @@ kc
 kc
 kc
 kc
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 kc
@@ -1492,10 +1489,10 @@ kc
 kc
 kc
 kc
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 kc
@@ -1521,8 +1518,8 @@ kc
 kc
 kc
 kc
-Au
-Au
+rZ
+rZ
 kc
 kc
 kc
@@ -1549,8 +1546,8 @@ kc
 kc
 kc
 kc
-Au
-Au
+rZ
+rZ
 kc
 kc
 kc
@@ -1577,7 +1574,7 @@ kc
 kc
 kc
 kc
-Au
+rZ
 kc
 kc
 kc
@@ -2013,7 +2010,7 @@ kc
 kc
 kc
 ID
-hh
+Au
 bc
 Cz
 Ho
@@ -2277,20 +2274,20 @@ fp
 fp
 fp
 EL
-Au
-Au
-Au
+rZ
+rZ
+rZ
 fp
-Au
+rZ
 kc
 "}
 (34,1,1) = {"
 kc
 kc
 kc
-Au
-Au
-Au
+rZ
+rZ
+rZ
 kc
 HZ
 Bw
@@ -2303,24 +2300,24 @@ zm
 XW
 rZ
 rZ
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 "}
 (35,1,1) = {"
 kc
 kc
+rZ
+rZ
+rZ
+rZ
+rZ
 Au
-Au
-Au
-Au
-Au
-hh
 kZ
 yk
 fA
@@ -2331,23 +2328,23 @@ Mi
 RA
 dZ
 FP
-ja
-Au
-Au
-Au
-Au
-Au
-Au
-Au
+hh
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 "}
 (36,1,1) = {"
 kc
-Au
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 rZ
 CT
 EA
@@ -2359,81 +2356,81 @@ um
 IG
 YU
 KD
-ja
-Au
-Au
-Au
-Au
-Au
+hh
+rZ
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 "}
 (37,1,1) = {"
 kc
-Au
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 rZ
 Zm
 rt
 CT
-ja
+hh
 fI
 dZ
 qo
 dZ
 CP
 hv
-ja
-Au
-Au
-Au
-Au
-Au
+hh
+rZ
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 "}
 (38,1,1) = {"
 kc
-Au
-Au
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 rZ
 EA
-ja
-ja
+hh
+hh
 qI
 zC
 FP
 kM
 qI
-ja
-Au
-Au
-Au
-Au
-Au
+hh
+rZ
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 kc
 "}
 (39,1,1) = {"
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 rZ
 rZ
 rZ
@@ -2441,68 +2438,68 @@ db
 FP
 YU
 Uz
+hh
+rZ
+rZ
+rZ
 ja
-Au
-Au
-Au
-RU
-Au
-Au
+rZ
+rZ
 kc
 kc
 kc
 "}
 (40,1,1) = {"
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-RU
-RU
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 rZ
 ja
+ja
+rZ
+rZ
+rZ
+hh
 DY
 hv
 rZ
-Au
-Au
-RU
-RU
-RU
-Au
-Au
+rZ
+rZ
+ja
+ja
+ja
+rZ
+rZ
 kc
 kc
 kc
 "}
 (41,1,1) = {"
 kc
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-RU
-RU
 rZ
 rZ
 rZ
-Au
-Au
-RU
-RU
-RU
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+ja
+ja
+rZ
+rZ
+rZ
+rZ
+rZ
+ja
+ja
+ja
+rZ
+rZ
 kc
 kc
 kc
@@ -2510,27 +2507,27 @@ kc
 "}
 (42,1,1) = {"
 kc
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-RU
-Au
-Au
-Au
-Au
-RU
-RU
-RU
-Au
-RU
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+ja
+rZ
+rZ
+rZ
+rZ
+ja
+ja
+ja
+rZ
+ja
+rZ
+rZ
+rZ
 kc
 kc
 kc
@@ -2539,24 +2536,24 @@ kc
 (43,1,1) = {"
 kc
 kc
-Au
-Au
+rZ
+rZ
 kc
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-RU
-RU
-RU
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+ja
+ja
+ja
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 kc
@@ -2571,19 +2568,19 @@ kc
 kc
 kc
 kc
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 kc
@@ -2601,15 +2598,15 @@ kc
 kc
 kc
 kc
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 kc
@@ -2630,12 +2627,12 @@ kc
 kc
 kc
 kc
-Au
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 kc
@@ -2658,11 +2655,11 @@ kc
 kc
 kc
 kc
-Au
-Au
-Au
-Au
-Au
+rZ
+rZ
+rZ
+rZ
+rZ
 kc
 kc
 kc
@@ -2687,9 +2684,9 @@ kc
 kc
 kc
 kc
-Au
-Au
-Au
+rZ
+rZ
+rZ
 kc
 kc
 kc

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -212,6 +212,17 @@
 /area/ruin/space/has_grav/interdyne
 	name = "\improper Interdyne Research Base"
 
+//Ruin of Crashed Ship
+
+/area/ruin/space/has_grav/crashedship/aft
+	name = "\improper Crashed Aft"
+
+/area/ruin/space/has_grav/crashedship/midship
+	name = "\improper Crashed Midship"
+
+/area/ruin/space/has_grav/crashedship/fore
+	name = "\improper Crashed Fore"
+
 //Ruin of ancient Space Station (OldStation)
 
 /area/ruin/space/ancientstation


### PR DESCRIPTION
## About The Pull Request
 
A little bit of an odd annoyance i've had with this particular ruin, mostly since due to it having away mission areas it teleblocked you from attempting to rebuild and use the one there. Replaced the away mission areas with ruin has_grav ones.

![image](https://user-images.githubusercontent.com/22140677/234639172-5e4898fe-bd34-431c-b918-ee3d34a42764.png)


![image](https://user-images.githubusercontent.com/22140677/234639182-3f3b3191-0719-4094-99b3-a559f99fe72a.png)

Area regions are the same with the exception of the away ones that were in space just being converted to space like normal ruins are

## Why It's Good For The Game

Let's spessmen utlize the teleporter that was left behind, giving the option that really should be there if the area wasnt being silly.

## Changelog
:cl:Zergspower
fix: Crashedship Ruin - You can now use the teleport
/:cl:
