### PR TITLE
Adds a macro for checking map job changes, makes captain outfit more runtime resilient

### DIFF
--- a/code/__DEFINES/maps.dm
+++ b/code/__DEFINES/maps.dm
@@ -222,3 +222,6 @@ Always compile, always use that verb, and always make sure that it works for wha
 
 //All
 #define CLUSTER_CHECK_ALL 30 //!Don't let anything cluster, like, at all
+
+/// Checks the job changes in the map config for the passed change key.
+#define CHECK_MAP_JOB_CHANGE(job, change) SSmapping.config.job_changes?[job]?[change]

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -254,18 +254,7 @@
 
 /// Refreshes the valid areas from the cook's mapping config, adding areas in config to the list of possible areas.
 /datum/martial_art/cqc/under_siege/proc/refresh_valid_areas()
-	var/list/job_changes = SSmapping.config.job_changes
-
-	if(!length(job_changes))
-		return
-
-	var/list/cook_changes = job_changes[JOB_COOK]
-
-	if(!length(cook_changes))
-		return
-
-	var/list/additional_cqc_areas = cook_changes["additional_cqc_areas"]
-
+	var/list/additional_cqc_areas = CHECK_MAP_JOB_CHANGE(JOB_COOK, "additional_cqc_areas")
 	if(!additional_cqc_areas)
 		return
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -130,19 +130,12 @@
 
 /datum/job/New()
 	. = ..()
-	var/list/job_changes = SSmapping.config.job_changes
-	if(!job_changes[title])
-		return TRUE
-
-	var/list/job_positions_edits = job_changes[title]
-	if(!job_positions_edits)
-		return TRUE
-
-	if(isnum(job_positions_edits["spawn_positions"]))
-		spawn_positions = job_positions_edits["spawn_positions"]
-	if(isnum(job_positions_edits["total_positions"]))
-		total_positions = job_positions_edits["total_positions"]
-
+	var/new_spawn_positions = CHECK_MAP_JOB_CHANGE(title, "spawn_positions")
+	if(isnum(new_spawn_positions))
+		spawn_positions = new_spawn_positions
+	var/new_total_positions = CHECK_MAP_JOB_CHANGE(title, "total_positions")
+	if(isnum(new_total_positions))
+		total_positions = new_total_positions
 
 /// Executes after the mob has been spawned in the map. Client might not be yet in the mob, and is thus a separate variable.
 /datum/job/proc/after_spawn(mob/living/spawned, client/player_client)
@@ -247,19 +240,14 @@
  * If they have 0 spawn and total positions in the config, the job is entirely removed from occupations prefs for the round.
  */
 /datum/job/proc/map_check()
-	var/list/job_changes = SSmapping.config.job_changes
-	if(!job_changes[title]) //no edits made
-		return TRUE
-
-	var/list/job_positions_edits = job_changes[title]
-	if(!job_positions_edits)
-		return TRUE
-
 	var/available_roundstart = TRUE
 	var/available_latejoin = TRUE
-	if(!isnull(job_positions_edits["spawn_positions"]) && (job_positions_edits["spawn_positions"] == 0))
+
+	var/edited_spawn_positions = CHECK_MAP_JOB_CHANGE(title, "spawn_positions")
+	if(!isnull(edited_spawn_positions) && (edited_spawn_positions == 0))
 		available_roundstart = FALSE
-	if(!isnull(job_positions_edits["total_positions"]) && (job_positions_edits["total_positions"] == 0))
+	var/edited_total_positions = CHECK_MAP_JOB_CHANGE(title, "total_positions")
+	if(!isnull(edited_total_positions) && (edited_total_positions == 0))
 		available_latejoin = FALSE
 
 	if(!available_roundstart && !available_latejoin) //map config disabled the job

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -88,23 +88,27 @@
 
 /datum/outfit/job/captain/pre_equip(mob/living/carbon/human/H, visualsOnly)
 	. = ..()
-	var/list/job_changes = SSmapping.config.job_changes
-	if(!length(job_changes))
-		return
-	var/list/captain_changes = job_changes[JOB_CAPTAIN]
-	if(!length(captain_changes))
-		return
-	special_charter = captain_changes["special_charter"]
+	special_charter = CHECK_MAP_JOB_CHANGE(JOB_CAPTAIN, "special_charter")
 	if(!special_charter)
 		return
-	backpack_contents.Remove(/obj/item/station_charter)
-	l_hand = /obj/item/station_charter/banner
+
+	backpack_contents -= /obj/item/station_charter
+
+	if(!l_hand)
+		l_hand = /obj/item/station_charter/banner
+	else if(!r_hand)
+		r_hand = /obj/item/station_charter/banner
 
 /datum/outfit/job/captain/post_equip(mob/living/carbon/human/equipped, visualsOnly)
 	. = ..()
-	var/obj/item/station_charter/banner/celestial_charter = equipped.held_items[LEFT_HANDS]
-	if(!celestial_charter)
+	if(visualsOnly || !special_charter)
 		return
+
+	var/obj/item/station_charter/banner/celestial_charter = locate() in equipped.held_items
+	if(isnull(celestial_charter))
+		// failed to give out the unique charter, plop on the ground
+		celestial_charter = new(get_turf(equipped))
+
 	celestial_charter.name_type = special_charter
 
 /datum/outfit/job/captain/mod


### PR DESCRIPTION
## About The Pull Request

- Makes captain outfit more runtime resilient
    -  The initial reason for this PR was that the captain's outfit was not very resistant to the case that something else changes the outfit's left hand before `post_equip`. It would runtime due to assuming the left hand is always the unique banner, and also cause no banner to be spawned. 

- Adds a macro for accessing the map config job changes, to reduce boilerplate. 
    - While I was fixing the above bug, I noticed that we had pretty bad boilerplate copy pasted around for accessing job config changes. This code is not ran so often that the job config needed to be cached locally, nor was all this safety very necessary. So I added a wrapper to handle it for the end user. 

## Why It's Good For The Game

More runtime resistance is always nice, allows for future coders (or me) to tread the area without worry. 

## Changelog

:cl: Melbert
fix: Fixes rare occasions in which the captain can fail to spawn with their banner on certain maps if their left hand was holding something else. 
/:cl:
