### PR TITLE
Allows the book binder to remember font typing

### DIFF
--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -44,12 +44,9 @@
 /datum/book_info/proc/set_content_using_paper(obj/item/paper/paper)
 	// Just the paper's raw data.
 	var/raw_content = ""
-
 	for(var/datum/paper_input/text_input as anything in paper.raw_text_inputs)
-		if(!isnull(text_input.colour))
-			raw_content += text_input.raw_text
-		else
-			raw_content += "<font color='[text_input.colour]'>[text_input.raw_text]</font>"
+		raw_content += text_input.to_raw_html()
+
 	content = trim(html_encode(raw_content), MAX_PAPER_LENGTH)
 
 /datum/book_info/proc/get_content(default="N/A")

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -695,6 +695,17 @@
 		advanced_html = advanced_html,
 	)
 
+/// Returns the raw contents of the input as html, with **ZERO SANITIZATION**
+/datum/paper_input/proc/to_raw_html()
+	var/final = raw_text
+	if(font)
+		final = "<font face='[font]'>[final]</font>"
+	if(colour)
+		final = "<font color='[colour]'>[final]</font>"
+	if(bold)
+		final = "<b>[final]</b>"
+	return final
+
 /// A single instance of a saved stamp on paper.
 /datum/paper_stamp
 	/// Asset class of the for rendering in tgui


### PR DESCRIPTION
use that for book binding
## About The Pull Request

Closes https://github.com/tgstation/tgstation/issues/74996
## Why It's Good For The Game
## Changelog
:cl:
fix: Bookbinder no longer takes your pen's font and throws it out the nearest window
/:cl:
