### PR TITLE
Anomaly refinery no longer lets you insert cores of insufficient quality

### DIFF
--- a/code/modules/research/anomaly/anomaly_refinery.dm
+++ b/code/modules/research/anomaly/anomaly_refinery.dm
@@ -85,6 +85,7 @@
 		var/obj/item/raw_anomaly_core/raw_core = tool
 		if(!get_required_radius(raw_core.anomaly_type))
 			say("Unfortunately, due to diminishing supplies of condensed anomalous matter, [raw_core] and any cores of its type are no longer of a sufficient quality level to be compressed into a working core.")
+			return
 		inserted_core = raw_core
 		to_chat(user, span_notice("You insert [raw_core] into [src]."))
 		return


### PR DESCRIPTION
## About The Pull Request

Pretty self explanatory. Someone just forgot a return statement after the error message here.

Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20803

## Why It's Good For The Game

Bugfix/oversight

## Changelog
:cl:
fix: the anomaly refinery will no longer let you insert cores of insufficient quality to refine
/:cl:
