### PR TITLE
Space Ruin - Dangerous Research with dangerous areas

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -98,7 +98,7 @@
 /turf/open/misc/asteroid/airless{
 	icon_state = "asteroid5"
 	},
-/area/ruin/space)
+/area/space)
 "bl" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -233,7 +233,7 @@
 /turf/open/misc/asteroid/airless{
 	icon_state = "asteroid10"
 	},
-/area/ruin/space)
+/area/space)
 "dw" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -770,7 +770,7 @@
 /turf/open/misc/asteroid/airless{
 	icon_state = "asteroid9"
 	},
-/area/ruin/space)
+/area/space)
 "jR" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/dangerous_research/maint)
@@ -1154,7 +1154,7 @@
 /turf/open/misc/asteroid/airless{
 	icon_state = "asteroid6"
 	},
-/area/ruin/space)
+/area/space)
 "pO" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 8
@@ -1637,7 +1637,7 @@
 /area/ruin/space/has_grav/dangerous_research/medical)
 "us" = (
 /turf/closed/wall,
-/area/ruin/space)
+/area/space)
 "uB" = (
 /obj/structure/fluff/paper/stack{
 	dir = 1
@@ -1663,7 +1663,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/purple,
 /turf/template_noop,
-/area/ruin/space)
+/area/template_noop)
 "uP" = (
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
@@ -2027,11 +2027,11 @@
 /turf/open/misc/asteroid/airless{
 	icon_state = "asteroid12"
 	},
-/area/ruin/space)
+/area/space)
 "zY" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/ruin/space)
+/area/template_noop)
 "zZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -2156,7 +2156,7 @@
 /area/ruin/space/has_grav/dangerous_research/lab)
 "Bg" = (
 /turf/closed/mineral/random,
-/area/ruin/space)
+/area/space)
 "Bm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2309,7 +2309,7 @@
 /turf/open/misc/asteroid/airless{
 	icon_state = "asteroid2"
 	},
-/area/ruin/space)
+/area/space)
 "CL" = (
 /obj/effect/turf_decal/stripes/asteroid{
 	dir = 4
@@ -2403,7 +2403,7 @@
 	dir = 1
 	},
 /turf/open/misc/asteroid/airless,
-/area/ruin/space)
+/area/space)
 "DX" = (
 /obj/structure/sign/poster/official/moth_piping{
 	pixel_y = 32
@@ -2430,11 +2430,11 @@
 "Ep" = (
 /obj/structure/lattice,
 /turf/open/misc/asteroid/airless,
-/area/ruin/space)
+/area/space)
 "Ey" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/ruin/space)
+/area/template_noop)
 "EA" = (
 /turf/open/floor/plating/rust,
 /area/ruin/space/has_grav/dangerous_research/lab)
@@ -2482,7 +2482,7 @@
 "Fq" = (
 /obj/structure/flora/rock/icy/style_2,
 /turf/open/misc/asteroid/airless,
-/area/ruin/space)
+/area/space)
 "Fw" = (
 /obj/structure/door_assembly/door_assembly_vault,
 /obj/effect/turf_decal/stripes/full,
@@ -2846,7 +2846,7 @@
 "Lc" = (
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/asteroid/airless,
-/area/ruin/space)
+/area/space)
 "Lk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
@@ -3077,7 +3077,7 @@
 /area/ruin/space/has_grav/dangerous_research/dorms)
 "On" = (
 /turf/open/misc/asteroid/airless,
-/area/ruin/space)
+/area/space)
 "Oo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3098,7 +3098,7 @@
 "Oy" = (
 /obj/structure/flora/rock/icy/style_random,
 /turf/open/misc/asteroid/airless,
-/area/ruin/space)
+/area/space)
 "OB" = (
 /obj/structure/table,
 /obj/structure/microscope,
@@ -3285,7 +3285,7 @@
 /turf/open/misc/asteroid/airless{
 	icon_state = "asteroid1"
 	},
-/area/ruin/space)
+/area/space)
 "QE" = (
 /obj/item/clothing/suit/jacket/straight_jacket,
 /obj/item/clothing/suit/jacket/straight_jacket,
@@ -3393,7 +3393,7 @@
 /turf/open/misc/asteroid/airless{
 	icon_state = "asteroid8"
 	},
-/area/ruin/space)
+/area/space)
 "RB" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/effect/turf_decal/tile/dark_red/half{
@@ -3663,7 +3663,7 @@
 "VD" = (
 /obj/structure/flora/rock/icy/style_3,
 /turf/open/misc/asteroid/airless,
-/area/ruin/space)
+/area/space)
 "VL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8

--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -1662,7 +1662,7 @@
 "uI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/purple,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "uP" = (
 /obj/effect/turf_decal/trimline/purple/line{
@@ -2030,7 +2030,7 @@
 /area/ruin/space)
 "zY" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "zZ" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -2277,7 +2277,7 @@
 /area/ruin/space/has_grav/dangerous_research/dorms)
 "CB" = (
 /obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("asrc_b" = "Air Supply B");
+	atmos_chambers = list("asrc_b"="Air Supply B");
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2433,7 +2433,7 @@
 /area/ruin/space)
 "Ey" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "EA" = (
 /turf/open/floor/plating/rust,
@@ -3061,7 +3061,7 @@
 /area/ruin/space/has_grav/dangerous_research)
 "Ob" = (
 /obj/machinery/computer/atmos_control/noreconnect{
-	atmos_chambers = list("asrc_a" = "Air Supply A")
+	atmos_chambers = list("asrc_a"="Air Supply A")
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -3270,7 +3270,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/dangerous_research/lab)
 "Qv" = (
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Qy" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -5123,8 +5123,8 @@ Bg
 Bg
 Bg
 Bg
-nB
-nB
+Bg
+Bg
 GZ
 GZ
 nB
@@ -5165,8 +5165,8 @@ Qv
 Bg
 Bg
 Bg
-nB
-nB
+Bg
+Bg
 xK
 xd
 xd
@@ -5207,8 +5207,8 @@ Qv
 Bg
 Bg
 Bg
-nB
-nB
+Bg
+Bg
 Zv
 Zv
 iw


### PR DESCRIPTION

## About The Pull Request

Comical but needed fix, changed the turf from space to turf passthrough so when it eats the next ruin it at least brings it partly through. 

Small shrink at the top right as the inside area was inside the rocks which just looked dorky

![2023 04 28-02 19 59](https://user-images.githubusercontent.com/22140677/235081781-e79ef29c-a15b-40ef-a6ef-c1707572773a.png)

![image](https://user-images.githubusercontent.com/22140677/235081962-cdeb5e07-b50c-4220-bed5-50117e871935.png)


Question for the maptainers - it seems split that exterior rocky areas are either the space area or the  ruin space area which one has the 'ship ambient' while the other is silent. I changed this one to the space one since, to me, it's still airless and hearing the ship hum is... weird?


## Why It's Good For The Game

No more vored ruins that get too close, but also silence when silence should be there

## Changelog
:cl:Zergspower
qol: Dangerous Research Ruin - Area redefines
/:cl:
