### PR TITLE
RUNLEVEL_INIT does not exist

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -233,7 +233,6 @@
 
 // SS runlevels
 
-#define RUNLEVEL_INIT 0
 #define RUNLEVEL_LOBBY 1
 #define RUNLEVEL_SETUP 2
 #define RUNLEVEL_GAME 4

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -351,8 +351,8 @@ GLOBAL_REAL(Master, /datum/controller/master)
 	testing("MC: Runlevel changed from [isnull(old_runlevel) ? "NULL" : old_runlevel] to [new_runlevel]")
 	current_runlevel = log(2, new_runlevel) + 1
 	if(current_runlevel < 1)
-		CRASH("Attempted to set invalid runlevel: [new_runlevel]")
 		current_runlevel = old_runlevel
+		CRASH("Attempted to set invalid runlevel: [new_runlevel]")
 
 // Starts the mc, and sticks around to restart it if the loop ever ends.
 /datum/controller/master/proc/StartProcessing(delay)

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -241,7 +241,7 @@ GLOBAL_REAL(Master, /datum/controller/master)
 		if (!mc_started)
 			mc_started = TRUE
 			if (!current_runlevel)
-				SetRunLevel(1)
+				SetRunLevel(1) // Intentionally not using the defines here because the MC doesn't care about them
 			// Loop.
 			Master.StartProcessing(0)
 
@@ -347,13 +347,12 @@ GLOBAL_REAL(Master, /datum/controller/master)
 
 /datum/controller/master/proc/SetRunLevel(new_runlevel)
 	var/old_runlevel = current_runlevel
-	if(isnull(old_runlevel))
-		old_runlevel = "NULL"
 
-	testing("MC: Runlevel changed from [old_runlevel] to [new_runlevel]")
+	testing("MC: Runlevel changed from [isnull(old_runlevel) ? "NULL" : old_runlevel] to [new_runlevel]")
 	current_runlevel = log(2, new_runlevel) + 1
 	if(current_runlevel < 1)
 		CRASH("Attempted to set invalid runlevel: [new_runlevel]")
+		current_runlevel = old_runlevel
 
 // Starts the mc, and sticks around to restart it if the loop ever ends.
 /datum/controller/master/proc/StartProcessing(delay)

--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(dbcore)
 	name = "Database"
 	flags = SS_TICKER
 	wait = 10 // Not seconds because we're running on SS_TICKER
-	runlevels = RUNLEVEL_INIT|RUNLEVEL_LOBBY|RUNLEVELS_DEFAULT
+	runlevels = RUNLEVEL_LOBBY|RUNLEVELS_DEFAULT
 	init_order = INIT_ORDER_DBCORE
 	priority = FIRE_PRIORITY_DATABASE
 

--- a/code/controllers/subsystem/ping.dm
+++ b/code/controllers/subsystem/ping.dm
@@ -9,8 +9,7 @@ SUBSYSTEM_DEF(ping)
 	init_stage = INITSTAGE_EARLY
 	wait = 4 SECONDS
 	flags = SS_NO_INIT
-	runlevels = RUNLEVEL_LOBBY | RUNLEVEL_SETUP | RUNLEVEL_GAME | RUNLEVEL_POSTGAME
-
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/currentrun = list()
 
 /datum/controller/subsystem/ping/stat_entry()

--- a/code/controllers/subsystem/verb_manager.dm
+++ b/code/controllers/subsystem/verb_manager.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(verb_manager)
 	wait = 1
 	flags = SS_TICKER | SS_NO_INIT
 	priority = FIRE_PRIORITY_DELAYED_VERBS
-	runlevels = RUNLEVEL_INIT | RUNLEVELS_DEFAULT
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 
 	///list of callbacks to procs called from verbs or verblike procs that were executed when the server was overloaded and had to delay to the next tick.
 	///this list is ran through every tick, and the subsystem does not yield until this queue is finished.


### PR DESCRIPTION
This define shouldn't have been added (by me when I created runlevels) people get it confused with RUNLEVEL_LOBBY and misuse it, like in this verb subsystem I have no knowledge of.

- Removes RUNLEVEL_INIT.
- Fixed SSverb_manager not running during the lobby phase.
- Fixed Master.SetRunLevel having the potential to accept a scuffed runlevel.
- Other standardizing cleanups to runlevels usage.