### PR TITLE
Delete blank line from the combat information box

### DIFF
--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -69,7 +69,7 @@
  *  * source - The object whose stats are being examined
  */
 /datum/element/weapon_description/proc/build_label_text(obj/item/source)
-	var/list/readout = list("") // Readout is used to store the text block output to the user so it all can be sent in one message
+	var/list/readout = list() // Readout is used to store the text block output to the user so it all can be sent in one message
 
 	// Doesn't show the base notes for items that have the override notes variable set to true
 	if(!source.override_notes)


### PR DESCRIPTION

## About The Pull Request

I asked eobgames to do it in #74203 but he didnt and i forgot to do it until now
## Why It's Good For The Game

Since there's a box around it now, we don't need a blank line to separate it anymore

Old:
![image](https://user-images.githubusercontent.com/47338680/235238660-951de8f1-ecc6-4466-b130-450f76cc4e40.png)


New:
![image](https://user-images.githubusercontent.com/47338680/235237497-9d2d05b3-70eb-4d05-8b07-8f518076e928.png)
## Changelog
:cl:
spellcheck: Deleted the extra line in combat information
/:cl:
