### PR TITLE
Move dirt

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -24,7 +24,6 @@ Mineral Sheets
  */
 
 GLOBAL_LIST_INIT(sandstone_recipes, list ( \
-	new/datum/stack_recipe("pile of dirt", /obj/machinery/hydroponics/soil, 3, time = 1 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_TOOLS), \
 	new/datum/stack_recipe("sandstone door", /obj/structure/mineral_door/sandstone, 10, time = 5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, applies_mats = TRUE, category = CAT_DOORS), \
 	new/datum/stack_recipe("Breakdown into sand", /obj/item/stack/ore/glass, 1, one_per_turf = FALSE, on_solid_ground = TRUE, category = CAT_MISC) \
 	))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1166,13 +1166,13 @@
 	balloon_alert(user, "clearing up soil...")
 	if(weapon.use_tool(src, user, 1 SECONDS, volume=50))
 		balloon_alert(user, "cleared")
-		qdel(src)
+		deconstruct(disassembled = TRUE)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/hydroponics/soil/CtrlClick(mob/user)
 	return //Soil has no electricity.
 
-/obj/machinery/hydroponics/soil/Destroy()
+/obj/machinery/hydroponics/soil/deconstruct(disassembled)
 	new /obj/item/stack/ore/glass(drop_location(), 3)
 	return ..()
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -11,7 +11,7 @@
 	circuit = /obj/item/circuitboard/machine/hydroponics
 	use_power = NO_POWER_USE
 	///The amount of water in the tray (max 100)
-	var/waterlevel = 100
+	var/waterlevel = 0
 	///The maximum amount of water in the tray
 	var/maxwater = 100
 	///How many units of nutrients will be drained in the tray.
@@ -59,7 +59,9 @@
 	//ALRIGHT YOU DEGENERATES. YOU HAD REAGENT HOLDERS FOR AT LEAST 4 YEARS AND NONE OF YOU MADE HYDROPONICS TRAYS HOLD NUTRIENT CHEMS INSTEAD OF USING "Points".
 	//SO HERE LIES THE "nutrilevel" VAR. IT'S DEAD AND I PUT IT OUT OF IT'S MISERY. USE "reagents" INSTEAD. ~ArcaneMusic, accept no substitutes.
 	create_reagents(maxnutri, INJECTABLE)
-	reagents.add_reagent(/datum/reagent/plantnutriment/eznutriment, 10) //Half filled nutrient trays for dirt trays to have more to grow with in prison/lavaland.
+	if(mapload)
+		reagents.add_reagent(/datum/reagent/plantnutriment/eznutriment, 10) //Half filled nutrient trays for dirt trays to have more to grow with in prison/lavaland.
+		waterlevel = 100
 	. = ..()
 
 	var/static/list/hovering_item_typechecks = list(

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1163,6 +1163,7 @@
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	balloon_alert(user, "clearing up soil...")
 	if(weapon.use_tool(src, user, 1 SECONDS, volume=50))
+		new /obj/item/stack/ore/glass(drop_location(), 3)
 		balloon_alert(user, "cleared")
 		qdel(src)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1163,7 +1163,6 @@
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	balloon_alert(user, "clearing up soil...")
 	if(weapon.use_tool(src, user, 1 SECONDS, volume=50))
-		new /obj/item/stack/ore/glass(drop_location(), 3)
 		balloon_alert(user, "cleared")
 		qdel(src)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
@@ -1171,6 +1170,9 @@
 /obj/machinery/hydroponics/soil/CtrlClick(mob/user)
 	return //Soil has no electricity.
 
+/obj/machinery/hydroponics/soil/Destroy()
+	new /obj/item/stack/ore/glass(drop_location(), 3)
+	return ..()
 
 ///The usb port circuit
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -107,6 +107,7 @@
 	merge_type = /obj/item/stack/ore/glass
 
 GLOBAL_LIST_INIT(sand_recipes, list(\
+		new /datum/stack_recipe("pile of dirt", /obj/machinery/hydroponics/soil, 3, time = 1 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_TOOLS), \
 		new /datum/stack_recipe("sandstone", /obj/item/stack/sheet/mineral/sandstone, 1, 1, 50, check_density = FALSE, category = CAT_MISC),\
 		new /datum/stack_recipe("aesthetic volcanic floor tile", /obj/item/stack/tile/basalt, 2, 1, 50, check_density = FALSE, category = CAT_TILES)\
 ))


### PR DESCRIPTION
## About The Pull Request

Changed the recipe for dirt piles from 3 sandstone bricks to 3 sand. 
And made the dirt pile drop these 3 sand on deconstruction instead of just disappearing.

![dreamseeker_Lj6jELZPjb](https://user-images.githubusercontent.com/3625094/235268536-c9835fa0-ce31-4bd3-a75c-ef2f3dcc7da7.gif)

Also fixed hydrotrays resetting their water and nutriments on construction.

## Why It's Good For The Game

You could accidentally click on the wrong mouse button and loose your dirt pile instead of uprooting a plant.
And it didn't make sense why you would need to turn sand into bricks before making a pile out of it.

## Changelog

:cl:
qol: Dirt pile is crafted from sand instead of sandstone and drops it on deconstruction
fix: You can't have free water and nutriments by rebuilding hydrotray
/:cl:

