### PR TITLE
Allows TGUI input datums to accept a ui_state as an argument

### DIFF
--- a/code/modules/tgui_input/alert.dm
+++ b/code/modules/tgui_input/alert.dm
@@ -75,6 +75,7 @@
 
 /datum/tgui_alert/Destroy(force, ...)
 	SStgui.close_uis(src)
+	state = null
 	QDEL_NULL(buttons)
 	return ..()
 

--- a/code/modules/tgui_input/alert.dm
+++ b/code/modules/tgui_input/alert.dm
@@ -10,7 +10,7 @@
  * * timeout - The timeout of the alert, after which the modal will close and qdel itself. Set to zero for no timeout.
  * * autofocus - The bool that controls if this alert should grab window focus.
  */
-/proc/tgui_alert(mob/user, message = "", title, list/buttons = list("Ok"), timeout = 0, autofocus = TRUE)
+/proc/tgui_alert(mob/user, message = "", title, list/buttons = list("Ok"), timeout = 0, autofocus = TRUE, ui_state = GLOB.always_state)
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -29,7 +29,7 @@
 			return alert(user, message, title, buttons[1], buttons[2])
 		if(length(buttons) == 3)
 			return alert(user, message, title, buttons[1], buttons[2], buttons[3])
-	var/datum/tgui_alert/alert = new(user, message, title, buttons, timeout, autofocus)
+	var/datum/tgui_alert/alert = new(user, message, title, buttons, timeout, autofocus, ui_state)
 	alert.ui_interact(user)
 	alert.wait()
 	if (alert)
@@ -59,12 +59,15 @@
 	var/autofocus
 	/// Boolean field describing if the tgui_alert was closed by the user.
 	var/closed
+	/// The TGUI UI state that will be returned in ui_state(). Default: always_state
+	var/datum/ui_state/state
 
-/datum/tgui_alert/New(mob/user, message, title, list/buttons, timeout, autofocus)
+/datum/tgui_alert/New(mob/user, message, title, list/buttons, timeout, autofocus, ui_state)
 	src.autofocus = autofocus
 	src.buttons = buttons.Copy()
 	src.message = message
 	src.title = title
+	src.state = ui_state
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time
@@ -94,7 +97,7 @@
 	closed = TRUE
 
 /datum/tgui_alert/ui_state(mob/user)
-	return GLOB.always_state
+	return state
 
 /datum/tgui_alert/ui_static_data(mob/user)
 	var/list/data = list()

--- a/code/modules/tgui_input/checkboxes.dm
+++ b/code/modules/tgui_input/checkboxes.dm
@@ -68,6 +68,7 @@
 
 /datum/tgui_checkbox_input/Destroy(force, ...)
 	SStgui.close_uis(src)
+	state = null
 	QDEL_NULL(items)
 
 	return ..()

--- a/code/modules/tgui_input/checkboxes.dm
+++ b/code/modules/tgui_input/checkboxes.dm
@@ -10,7 +10,7 @@
  * max_checked - The maximum number of checkboxes that can be checked (optional)
  * timeout - The timeout for the input (optional)
  */
-/proc/tgui_input_checkboxes(mob/user, message, title = "Select", list/items, min_checked = 1, max_checked = 50, timeout = 0)
+/proc/tgui_input_checkboxes(mob/user, message, title = "Select", list/items, min_checked = 1, max_checked = 50, timeout = 0, ui_state = GLOB.always_state)
 	if (!user)
 		user = usr
 	if(!length(items))
@@ -23,7 +23,7 @@
 			return
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		return input(user, message, title) as null|anything in items
-	var/datum/tgui_checkbox_input/input = new(user, message, title, items, min_checked, max_checked, timeout)
+	var/datum/tgui_checkbox_input/input = new(user, message, title, items, min_checked, max_checked, timeout, ui_state)
 	input.ui_interact(user)
 	input.wait()
 	if (input)
@@ -50,13 +50,16 @@
 	var/min_checked
 	/// Maximum number of checkboxes that can be checked
 	var/max_checked
+	/// The TGUI UI state that will be returned in ui_state(). Default: always_state
+	var/datum/ui_state/state
 
-/datum/tgui_checkbox_input/New(mob/user, message, title, list/items, min_checked, max_checked, timeout)
+/datum/tgui_checkbox_input/New(mob/user, message, title, list/items, min_checked, max_checked, timeout, ui_state)
 	src.title = title
 	src.message = message
 	src.items = items.Copy()
 	src.min_checked = min_checked
 	src.max_checked = max_checked
+	src.state = ui_state
 
 	if (timeout)
 		src.timeout = timeout
@@ -84,7 +87,7 @@
 	closed = TRUE
 
 /datum/tgui_checkbox_input/ui_state(mob/user)
-	return GLOB.always_state
+	return state
 
 /datum/tgui_checkbox_input/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/tgui_input/list.dm
+++ b/code/modules/tgui_input/list.dm
@@ -10,7 +10,7 @@
  * * default - If an option is already preselected on the UI. Current values, etc.
  * * timeout - The timeout of the input box, after which the menu will close and qdel itself. Set to zero for no timeout.
  */
-/proc/tgui_input_list(mob/user, message, title = "Select", list/items, default, timeout = 0)
+/proc/tgui_input_list(mob/user, message, title = "Select", list/items, default, timeout = 0, ui_state = GLOB.always_state)
 	if (!user)
 		user = usr
 	if(!length(items))
@@ -24,7 +24,7 @@
 	/// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		return input(user, message, title, default) as null|anything in items
-	var/datum/tgui_list_input/input = new(user, message, title, items, default, timeout)
+	var/datum/tgui_list_input/input = new(user, message, title, items, default, timeout, ui_state)
 	input.ui_interact(user)
 	input.wait()
 	if (input)
@@ -56,13 +56,16 @@
 	var/timeout
 	/// Boolean field describing if the tgui_list_input was closed by the user.
 	var/closed
+	/// The TGUI UI state that will be returned in ui_state(). Default: always_state
+	var/datum/ui_state/state
 
-/datum/tgui_list_input/New(mob/user, message, title, list/items, default, timeout)
+/datum/tgui_list_input/New(mob/user, message, title, list/items, default, timeout, ui_state)
 	src.title = title
 	src.message = message
 	src.items = list()
 	src.items_map = list()
 	src.default = default
+	src.state = ui_state
 	var/list/repeat_items = list()
 	// Gets rid of illegal characters
 	var/static/regex/whitelistedWords = regex(@{"([^\u0020-\u8000]+)"})
@@ -103,7 +106,7 @@
 	closed = TRUE
 
 /datum/tgui_list_input/ui_state(mob/user)
-	return GLOB.always_state
+	return state
 
 /datum/tgui_list_input/ui_static_data(mob/user)
 	var/list/data = list()

--- a/code/modules/tgui_input/list.dm
+++ b/code/modules/tgui_input/list.dm
@@ -84,6 +84,7 @@
 
 /datum/tgui_list_input/Destroy(force, ...)
 	SStgui.close_uis(src)
+	state = null
 	QDEL_NULL(items)
 	return ..()
 

--- a/code/modules/tgui_input/number.dm
+++ b/code/modules/tgui_input/number.dm
@@ -89,6 +89,7 @@
 
 /datum/tgui_input_number/Destroy(force, ...)
 	SStgui.close_uis(src)
+	state = null
 	return ..()
 
 /**

--- a/code/modules/tgui_input/number.dm
+++ b/code/modules/tgui_input/number.dm
@@ -62,6 +62,8 @@
 	var/timeout
 	/// The title of the TGUI window
 	var/title
+	/// The TGUI UI state that will be returned in ui_state(). Default: always_state
+	var/datum/ui_state/state
 
 /datum/tgui_input_number/New(mob/user, message, title, default, max_value, min_value, timeout, round_value)
 	src.default = default
@@ -108,7 +110,7 @@
 	closed = TRUE
 
 /datum/tgui_input_number/ui_state(mob/user)
-	return GLOB.always_state
+	return state
 
 /datum/tgui_input_number/ui_static_data(mob/user)
 	var/list/data = list()

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -88,6 +88,7 @@
 
 /datum/tgui_input_text/Destroy(force, ...)
 	SStgui.close_uis(src)
+	state = null
 	return ..()
 
 /**

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -15,7 +15,7 @@
  * * encode - Toggling this determines if input is filtered via html_encode. Setting this to FALSE gives raw input.
  * * timeout - The timeout of the textbox, after which the modal will close and qdel itself. Set to zero for no timeout.
  */
-/proc/tgui_input_text(mob/user, message = "", title = "Text Input", default, max_length = MAX_MESSAGE_LEN, multiline = FALSE, encode = TRUE, timeout = 0)
+/proc/tgui_input_text(mob/user, message = "", title = "Text Input", default, max_length = MAX_MESSAGE_LEN, multiline = FALSE, encode = TRUE, timeout = 0, ui_state = GLOB.always_state)
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -36,7 +36,7 @@
 				return input(user, message, title, default) as message|null
 			else
 				return input(user, message, title, default) as text|null
-	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, timeout)
+	var/datum/tgui_input_text/text_input = new(user, message, title, default, max_length, multiline, encode, timeout, ui_state)
 	text_input.ui_interact(user)
 	text_input.wait()
 	if (text_input)
@@ -70,14 +70,17 @@
 	var/timeout
 	/// The title of the TGUI window
 	var/title
+	/// The TGUI UI state that will be returned in ui_state(). Default: always_state
+	var/datum/ui_state/state
 
-/datum/tgui_input_text/New(mob/user, message, title, default, max_length, multiline, encode, timeout)
+/datum/tgui_input_text/New(mob/user, message, title, default, max_length, multiline, encode, timeout, ui_state)
 	src.default = default
 	src.encode = encode
 	src.max_length = max_length
 	src.message = message
 	src.multiline = multiline
 	src.title = title
+	src.state = ui_state
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time
@@ -106,7 +109,7 @@
 	closed = TRUE
 
 /datum/tgui_input_text/ui_state(mob/user)
-	return GLOB.always_state
+	return state
 
 /datum/tgui_input_text/ui_static_data(mob/user)
 	var/list/data = list()


### PR DESCRIPTION

## About The Pull Request

Title. Adds a new argument to the factory proc, the New(), adds a variable, and changes ui_state() to return that variable. The variable is always_state by default.

## Why It's Good For The Game
It allows custom behavior to be injected into the ui_state logic of the basic input datums. This is good because there are circumstances where always_state isn't acceptable. Ex. you open tgui_input_list(mob/user), and the mob dies or is deleted. The list stays open, the contents can be picked, despite this not being what the author wants. With this PR, you can make sure the list closes and inputs are invalid in circumstances of your choosing without having to completely re-make the input procs via copypasting.
## Changelog
:cl:
code: TGUI input datums can now accept custom ui_states
/:cl:
