### PR TITLE
Removes butcher knife from autolathe.

### DIFF
--- a/code/modules/research/designs/autolathe/multi-department_designs.dm
+++ b/code/modules/research/designs/autolathe/multi-department_designs.dm
@@ -376,17 +376,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/cleaver
-	name = "Butcher's Cleaver"
-	id = "cleaver"
-	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 18000)
-	build_path = /obj/item/knife/butcher
-	category = list(
-		RND_CATEGORY_HACKED,
-		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SERVICE,
-	)
-
 /datum/design/spraycan
 	name = "Spraycan"
 	id = "spraycan"


### PR DESCRIPTION
## About The Pull Request
Salt pr.
Current meta sucks.
It's still obtainable in-game by hacking cook's vendor. And you can find it on space ruins.
## Why It's Good For The Game
Station will have metal (of course only if roboticists are dead).
15 damage with 15 wound bonus weapon is quite too good for something you can just get from autolathe.
## Changelog
:cl:
balance: You can no longer make butcher knives in autolathe.
/:cl:
