### PR TITLE
Fixes CI issues with birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -938,6 +938,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/project)
+"auB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/storage/gas)
 "auG" = (
 /obj/structure/chair{
 	dir = 1
@@ -4510,6 +4518,8 @@
 "bUv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/aft)
 "bUy" = (
@@ -6009,9 +6019,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "cBn" = (
@@ -6043,6 +6052,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "cCb" = (
@@ -6069,9 +6079,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "cCD" = (
@@ -8962,6 +8970,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/pumproom)
+"dGO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "dHk" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
@@ -10819,6 +10833,8 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/engineering/atmos/storage/gas)
 "eqS" = (
@@ -11189,6 +11205,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "ewW" = (
@@ -11215,6 +11233,8 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "exK" = (
@@ -13082,6 +13102,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "fiD" = (
@@ -14302,6 +14323,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "fDk" = (
@@ -14823,6 +14845,7 @@
 	pixel_y = 7
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "fMj" = (
@@ -15430,6 +15453,8 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "fVG" = (
@@ -17431,6 +17456,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "gJo" = (
@@ -19434,6 +19461,8 @@
 /area/station/science/ordnance/storage)
 "hoo" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "hop" = (
@@ -19449,6 +19478,8 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "hoN" = (
@@ -19466,6 +19497,8 @@
 "hpc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "hpl" = (
@@ -19685,6 +19718,9 @@
 "htO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "htV" = (
@@ -21271,8 +21307,7 @@
 	name = "Hull Breach Emergency Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/commons/storage/tools)
 "hXh" = (
@@ -22189,6 +22224,7 @@
 /area/station/security/tram)
 "imE" = (
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/plating,
 /area/station/service/library/abandoned)
 "imM" = (
@@ -22425,6 +22461,8 @@
 	dir = 4
 	},
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "iqF" = (
@@ -23117,6 +23155,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
 "iEF" = (
@@ -26213,11 +26252,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"jKr" = (
-/obj/structure/lattice,
-/obj/effect/landmark/observer_start,
-/turf/open/space/basic,
-/area/space/nearstation)
 "jKu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28609,6 +28643,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "kCJ" = (
@@ -29517,6 +29552,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"kSN" = (
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
+/turf/open/floor/eighties/red,
+/area/station/service/abandoned_gambling_den/gaming)
 "kSO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31581,6 +31620,8 @@
 "lFG" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lFJ" = (
@@ -32640,6 +32681,8 @@
 	name = "Security Post - Cargo"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/security/checkpoint/supply)
 "lXd" = (
@@ -33390,6 +33433,10 @@
 "mkF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/depsec/supply,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
 "mkJ" = (
@@ -34794,6 +34841,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/depsec/supply,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
 "mLm" = (
@@ -34824,6 +34872,9 @@
 /area/station/maintenance/hallway/abandoned_recreation)
 "mLH" = (
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "mLO" = (
@@ -36426,6 +36477,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/supply,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
 "nsO" = (
@@ -36680,6 +36734,8 @@
 	dir = 6
 	},
 /obj/structure/fireaxecabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "nxu" = (
@@ -37696,6 +37752,8 @@
 /obj/effect/turf_decal/siding/green{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "nQx" = (
@@ -38337,6 +38395,11 @@
 /obj/machinery/computer/records/security,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
+"odk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
+/turf/open/floor/iron/grimy,
+/area/station/commons/vacant_room/office)
 "odA" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -40389,6 +40452,10 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
+"oRm" = (
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
+/turf/closed/mineral/random/stationside,
+/area/station/ai_monitored/aisat/exterior)
 "oRr" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -40464,6 +40531,8 @@
 /area/station/command/bridge)
 "oSx" = (
 /obj/effect/turf_decal/siding/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "oSG" = (
@@ -41001,6 +41070,8 @@
 	dir = 6
 	},
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/circuits)
 "pcN" = (
@@ -41113,6 +41184,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"peI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "peN" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion/directional/north{
@@ -51611,6 +51690,7 @@
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "svG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
 "svP" = (
@@ -52849,6 +52929,8 @@
 /area/station/service/theater)
 "sQS" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
 "sQU" = (
@@ -53120,6 +53202,8 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medical Cold Room"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/small,
 /area/station/medical/coldroom)
 "sTT" = (
@@ -53599,6 +53683,8 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Experimentation Chamber"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/science/explab)
 "tbq" = (
@@ -53756,6 +53842,8 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
 "tec" = (
@@ -54119,6 +54207,10 @@
 "tns" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/science/explab)
 "tnt" = (
@@ -58673,6 +58765,7 @@
 /area/station/science/xenobiology)
 "uLf" = (
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
 /turf/open/floor/carpet/orange,
 /area/station/service/abandoned_gambling_den)
 "uLh" = (
@@ -61733,6 +61826,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
 	},
+/obj/effect/landmark/observer_start,
 /turf/open/floor/glass,
 /area/station/hallway/secondary/spacebridge)
 "vHV" = (
@@ -62700,7 +62794,7 @@
 	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Prison Isolation Cell";
-	network = list("ss13", "prison", "isolation")
+	network = list("ss13","prison","isolation")
 	},
 /turf/open/floor/iron/white/small,
 /area/station/security/prison/safe)
@@ -65201,6 +65295,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"wKD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos/storage/gas)
 "wKG" = (
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
@@ -65735,6 +65837,15 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/garden)
+"wRM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "wRN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -65757,6 +65868,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
+"wRW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/atmospheric_sanity/ignore_area,
+/turf/open/floor/plating/rust,
+/area/station/engineering/atmos/project)
 "wSf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
@@ -66027,6 +66143,10 @@
 /area/station/hallway/primary/port)
 "wWs" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/coldroom)
 "wWz" = (
@@ -66042,6 +66162,8 @@
 	name = "SM Bleed to Turbine"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "wWS" = (
@@ -70989,6 +71111,11 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"yic" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/atmos/storage/gas)
 "yig" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -79803,7 +79930,7 @@ ayi
 acu
 adR
 acl
-aem
+wRW
 agY
 ayi
 ayi
@@ -85491,7 +85618,7 @@ wIv
 eUX
 lPf
 fLz
-gJe
+auB
 gJe
 eqM
 ewU
@@ -85748,7 +85875,7 @@ wIv
 dso
 lPf
 cqo
-glB
+yic
 iTG
 eqS
 exJ
@@ -86005,7 +86132,7 @@ wIv
 dsq
 lPf
 fMi
-iTG
+wKD
 cAC
 eqS
 hoo
@@ -87035,8 +87162,8 @@ nOI
 xNU
 gpS
 cBc
-gTL
-hXt
+wRM
+dGO
 eIk
 eTL
 eTL
@@ -87549,7 +87676,7 @@ col
 fNH
 grM
 cCw
-gTL
+peI
 htO
 eIk
 cUF
@@ -95583,7 +95710,7 @@ ffX
 tJG
 xli
 blb
-jKr
+blb
 qtl
 qTM
 vHL
@@ -96281,7 +96408,7 @@ yjV
 yjV
 fpY
 fpY
-fpY
+oRm
 uTA
 fEb
 csq
@@ -111495,7 +111622,7 @@ xXT
 vUS
 xQJ
 mbV
-rdw
+kSN
 rdw
 xMo
 xQJ
@@ -125932,7 +126059,7 @@ oGQ
 qkp
 rfZ
 sEB
-sEB
+odk
 sEB
 eLn
 xlx

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2518,7 +2518,7 @@
 "bhG" = (
 /obj/effect/turf_decal/siding/wood,
 /mob/living/simple_animal/hostile/russian/ranged{
-	loot = null
+	loot = list()
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
@@ -37375,7 +37375,7 @@
 "nIu" = (
 /obj/structure/chair/stool/directional/west,
 /mob/living/simple_animal/hostile/russian/ranged{
-	loot = null
+	loot = list()
 	},
 /turf/open/floor/carpet/orange,
 /area/station/service/abandoned_gambling_den)


### PR DESCRIPTION
## About The Pull Request

Moves the observer landmark to be on-station (for nuke cinematic unit test)
Fixes an error in access for some EVA door (its now EVA or construction, it used to have Engineering but all jobs have Construction anyways).
Connects some rooms to the station pipenet where convenient (or intentional), adds the atmos sanity ignore helper otherwise.

## Why It's Good For The Game

CI should now pass again, Birdshot should now function as God intended.

## Changelog

:cl:
fix: Birdshot's observers now spawn on-station.
fix: Birdshot's EVA door now properly works.
fix: Birdshot now has a few extra rooms connected to the station's distro (atmos canister storage, medical coldroom)
/:cl: