### PR TITLE
Fixes Insulated Gloves over sight damaging you for touching light bulbs

### DIFF
--- a/code/modules/clothing/gloves/insulated.dm
+++ b/code/modules/clothing/gloves/insulated.dm
@@ -12,8 +12,6 @@
 	resistance_flags = NONE
 	custom_price = PAYCHECK_CREW * 10
 	custom_premium_price = PAYCHECK_COMMAND * 6
-	cold_protection = HANDS
-	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	cut_type = /obj/item/clothing/gloves/cut

--- a/code/modules/clothing/gloves/insulated.dm
+++ b/code/modules/clothing/gloves/insulated.dm
@@ -12,6 +12,10 @@
 	resistance_flags = NONE
 	custom_price = PAYCHECK_CREW * 10
 	custom_premium_price = PAYCHECK_COMMAND * 6
+	cold_protection = HANDS
+	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
+	heat_protection = HANDS
+	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	cut_type = /obj/item/clothing/gloves/cut
 	clothing_traits = list(TRAIT_CHUNKYFINGERS)
 


### PR DESCRIPTION
## About The Pull Request
Insulated Gloves the ones that stop electrical discharges are unable to protect engineers from god damn light bulbs which is stupid for various reasons

1. They do so and would do so in real life
2. if they are able to stop electrical energy of course they would be able to stop a small amount of heat essentially the same thing
3. Engineers are meant to fix up the station this includes moving lights and such so they need to be able to do this
4.  Insulated gloves have the chunky finger trait which means they are extremely chunky by so it means there are plenty of layers before they hit the actual hand these layers WILL protect the user from heat damage and let them grab the lightbulb 
## Why It's Good For The Game
Fixes a game oversight that's always good
![WshjuIo](https://user-images.githubusercontent.com/84478872/235327753-e0dc42e4-62d5-4cde-88d7-2d4957545f41.gif)
## Changelog
:cl:
qol: insulated gloves no longer burn our engineers fingers 
/:cl:
