### PR TITLE
Bows no longer randomly become unusable

### DIFF
--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -30,7 +30,8 @@
 	var/click_cooldown_override = 0
 	///the visual effect appearing when the ammo is fired.
 	var/firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect
-	var/heavy_metal = TRUE
+	///Does this leave a casing behind?
+	var/is_cased_ammo = TRUE
 	///pacifism check for boolet, set to FALSE if bullet is non-lethal
 	var/harmful = TRUE
 
@@ -130,7 +131,7 @@
 	return ..()
 
 /obj/item/ammo_casing/proc/bounce_away(still_warm = FALSE, bounce_delay = 3)
-	if(!heavy_metal)
+	if(!is_cased_ammo)
 		return
 	update_appearance()
 	SpinAnimation(10, 1)

--- a/code/modules/projectiles/ammunition/caseless/_caseless.dm
+++ b/code/modules/projectiles/ammunition/caseless/_caseless.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/caseless
 	desc = "A caseless bullet casing."
 	firing_effect_type = null
-	heavy_metal = FALSE
+	is_cased_ammo = FALSE
 
 /obj/item/ammo_casing/caseless/fire_casing(atom/target, mob/living/user, params, distro, quiet, zone_override, spread, atom/fired_from)
 	if (!..()) //failed firing

--- a/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -8,4 +8,4 @@
 	var/select_name = CALIBER_ENERGY
 	fire_sound = 'sound/weapons/laser.ogg'
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
-	heavy_metal = FALSE
+	is_cased_ammo = FALSE

--- a/code/modules/projectiles/ammunition/special/magic.dm
+++ b/code/modules/projectiles/ammunition/special/magic.dm
@@ -4,7 +4,7 @@
 	slot_flags = null
 	projectile_type = /obj/projectile/magic
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/magic
-	heavy_metal = FALSE
+	is_cased_ammo = FALSE
 
 /obj/item/ammo_casing/magic/change
 	projectile_type = /obj/projectile/magic/change

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -401,6 +401,10 @@
 
 	if (sawn_off)
 		bonus_spread += SAWN_OFF_ACC_PENALTY
+
+	if(!chambered.is_cased_ammo)
+		magazine.stored_ammo -= chambered
+
 	return ..()
 
 /obj/item/gun/ballistic/shoot_live_shot(mob/living/user, pointblank = 0, atom/pbtarget = null, message = 1)

--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -10,7 +10,7 @@
 	throwforce = 1
 	firing_effect_type = null
 	caliber = CALIBER_ARROW
-	heavy_metal = FALSE
+	is_cased_ammo = FALSE
 
 /obj/item/ammo_casing/caseless/arrow/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Fixes bows randomly becoming unusable.

On firing bows were leaving behind a reference to their casing in the internal magazine. As arrows are technically caseless ammo there was no way to remove this casing, and eventually it would turn into a null, rendering the magazine unable to load any new arrows.

This is fixed by adding a check for whether the ammo is cased to all ballistic guns in `process_fire()`. Caseless ammo has its casing removed from the magazine's `stored_ammo` list to prevent it rotting away to a null down the line.

While I was here renamed and autodocced the var `heavy_metal` which appears to be exactly the var for having a casing that I needed.

## Why It's Good For The Game

Bows becoming randomly useless because of leftover vars is bad and silly, and so are mystery meat vars with undescriptive names and no autodoc.

## Changelog
:cl:
fix: Bows will no longer randomly stop taking new arrows.
/:cl:
