### PR TITLE
Very late arrivals can arrive with toast

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -1,3 +1,5 @@
+#define VERY_LATE_ARRIVAL_TOAST_PROB 20
+
 SUBSYSTEM_DEF(job)
 	name = "Jobs"
 	init_order = INIT_ORDER_JOBS
@@ -551,6 +553,8 @@ SUBSYSTEM_DEF(job)
 		var/mob/living/carbon/human/wageslave = equipping
 		wageslave.add_mob_memory(/datum/memory/key/account, remembered_id = wageslave.account_id)
 
+		if(EMERGENCY_PAST_POINT_OF_NO_RETURN && prob(VERY_LATE_ARRIVAL_TOAST_PROB))
+			equipping.equip_to_slot_or_del(new /obj/item/food/griddle_toast(equipping), ITEM_SLOT_MASK)
 
 	job.after_spawn(equipping, player_client)
 
@@ -1091,3 +1095,5 @@ SUBSYSTEM_DEF(job)
 		return JOB_UNAVAILABLE_GENERIC
 
 	return JOB_AVAILABLE
+
+#undef VERY_LATE_ARRIVAL_TOAST_PROB


### PR DESCRIPTION

## About The Pull Request

https://user-images.githubusercontent.com/5479091/235362295-89b9e21b-abe0-4fb6-b404-a7e02b04dfe6.mp4

Late joiners who arrive after the emergency shuttle has already passed no return have a 20% chance of having toast (If the mask slot isn't already full (I think this is just detectives))

## Why It's Good For The Game

It's a funny anime reference.

## Changelog
:cl:
add: Crewmembers arriving very late will not always have time to finish their breakfast.
/:cl:
