### PR TITLE
Adds attribution for a sound

### DIFF
--- a/sound/attributions.txt
+++ b/sound/attributions.txt
@@ -51,3 +51,6 @@ https://freesound.org/s/431740/ (CC 0)
 chainsaw_stop.ogg is adapted from kyles "chainsaw sawing short cuts +stop.flac" (CC 0)
 https://freesound.org/people/kyles/sounds/453256/
 
+ark_activation.ogg is taken from ScottFerguson1's "Cucko Clock edited version", which is licensed under CC Attribution 3.0
+https://freesound.org/people/ScottFerguson1/sounds/132846/
+


### PR DESCRIPTION
## About The Pull Request

Adds attribution to ark_activation which turns out, is taken from freesounds, and furthermore, is using a license that requires attribution (as if you shouldnt be doing it anyways!!)

I found this while searching for other sounds and immediately recognized it, @Fikou found which file it was so thank you

## Why It's Good For The Game

## Changelog
