### PR TITLE
Add one-way access out of birdshot cryo

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -44680,6 +44680,9 @@
 	},
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/cryo)
 "qiX" = (


### PR DESCRIPTION
## About The Pull Request

Adds directional unrestricted access to the rightmost door of birdshot cryo. 
## Why It's Good For The Game

Allows patients to leave cryo into the medbay lobby, but not into the medbay main hall, instead of being trapped in there. As it is right now you need medbay access to leave. Fixes: #75071
## Changelog
:cl:
fix: birdshot cryo no longer needs medbay access to leave
/:cl:
