### PR TITLE
Removes the RD's gloves and jackboots

### DIFF
--- a/code/modules/jobs/job_types/research_director.dm
+++ b/code/modules/jobs/job_types/research_director.dm
@@ -64,8 +64,7 @@
 	belt = /obj/item/modular_computer/pda/heads/rd
 	head = /obj/item/clothing/head/beret/science/rd
 	ears = /obj/item/radio/headset/heads/rd
-	shoes = /obj/item/clothing/shoes/jackboots
-	gloves = /obj/item/clothing/gloves/color/black
+	shoes = /obj/item/clothing/shoes/laceup
 	l_pocket = /obj/item/laser_pointer/purple
 	l_hand = /obj/item/clipboard
 


### PR DESCRIPTION
## About The Pull Request
Removes the RD's black gloves and replaces the jackboots with laceup shoes.
## Why It's Good For The Game
The Research Director is the Head of Staff for a department full of scientists (nerds), they do not need starting gloves and jackboots that are fit for an security officer. RD's used to spawn with brown shoes, this just puts them up to the level of Captains and Heads of Personnel in terms of shoewear and removes the gloves they have no need for.
## Changelog
:cl: Googles_Hands
balance: Research Directors no longer get security-grade gloves and boots.
/:cl: