### PR TITLE
Some Bolt-Action Fixes (sniper rifle mag manip independent of bolt, among other things)

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -31,12 +31,6 @@
 		return FALSE
 	return ..()
 
-/obj/item/gun/ballistic/rifle/attackby(obj/item/A, mob/user, params)
-	if (!bolt_locked && !istype(A, /obj/item/stack/sheet/cloth))
-		balloon_alert(user, "[bolt_wording] is closed!")
-		return
-	return ..()
-
 /obj/item/gun/ballistic/rifle/examine(mob/user)
 	. = ..()
 	. += "The bolt is [bolt_locked ? "open" : "closed"]."
@@ -100,19 +94,20 @@
 	return ..()
 
 /obj/item/gun/ballistic/rifle/boltaction/attackby(obj/item/item, mob/user, params)
-	. = ..()
-	if(!can_jam)
-		balloon_alert(user, "can't jam!")
-		return
-
-	if(!bolt_locked)
+	if(!bolt_locked && !istype(item, /obj/item/knife))
 		balloon_alert(user, "bolt closed!")
 		return
 
-	if(istype(item, /obj/item/gun_maintenance_supplies) && do_after(user, 10 SECONDS, target = src))
-		user.visible_message(span_notice("[user] finishes maintenance of [src]."))
-		jamming_chance = initial(jamming_chance)
-		qdel(item)
+	. = ..()
+
+	if(istype(item, /obj/item/gun_maintenance_supplies))
+		if(!can_jam)
+			balloon_alert(user, "can't jam!")
+			return
+		if(do_after(user, 10 SECONDS, target = src))
+			user.visible_message(span_notice("[user] finishes maintaining [src]."))
+			jamming_chance = initial(jamming_chance)
+			qdel(item)
 
 /obj/item/gun/ballistic/rifle/boltaction/blow_up(mob/user)
 	. = FALSE
@@ -178,7 +173,6 @@
 	initial_fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
 	alternative_fire_sound = 'sound/weapons/gun/shotgun/shot.ogg'
 	can_modify_ammo = TRUE
-	can_misfire = FALSE
 	can_bayonet = TRUE
 	knife_y_offset = 11
 	can_be_sawn_off = FALSE


### PR DESCRIPTION
## About The Pull Request
- because pipeguns can no longer misfire, removes the code relevant to cleaning them with a cloth
- the above makes it so that you can insert/remove a sniper rifle's magazine regardless of bolt open/close status, which is neat
- also nudges some code around so that affixing a bayonet or whacking your gun with any item no longer spams it with "can't jam!" or "bolt closed!"
## Why It's Good For The Game
less random irrelevant popups, and also the magazine on sniper rifles thing just kind of irked me

## Changelog

:cl:
fix: Bolt-action rifles (the Mosin-Nagant) will no longer spam "can't jam!" when attempting to smack it with just about anything.
fix: Anti-materiel rifles (the .50 BMG ones) can now have their magazines manipulated independent of bolt status.
/:cl:
