### PR TITLE
Golems can now redeem points from their ORM

### DIFF
--- a/_maps/shuttles/ruin_cyborg_mothership.dmm
+++ b/_maps/shuttles/ruin_cyborg_mothership.dmm
@@ -216,7 +216,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/ruin/cyborg_mothership)
 "mC" = (
-/obj/machinery/mineral/ore_redemption{
+/obj/machinery/mineral/ore_redemption/offstation{
 	input_dir = 4
 	},
 /obj/structure/lattice/catwalk,

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1248,7 +1248,7 @@
 	needs_anchored = FALSE
 
 /obj/item/circuitboard/machine/ore_redemption/offstation
-	build_path = /obj/machinery/mineral/ore_redemption/offstatiom
+	build_path = /obj/machinery/mineral/ore_redemption/offstation
 
 /obj/item/circuitboard/machine/ore_silo
 	name = "Ore Silo"

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1247,6 +1247,9 @@
 		/obj/item/assembly/igniter = 1)
 	needs_anchored = FALSE
 
+/obj/item/circuitboard/machine/ore_redemption/offstation
+	build_path = /obj/machinery/mineral/ore_redemption/offstatiom
+
 /obj/item/circuitboard/machine/ore_silo
 	name = "Ore Silo"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -317,7 +317,7 @@
 			if(isliving(usr))
 				var/mob/living/user = usr
 				user_id_card = user.get_idcard(TRUE)
-			if(!materials.check_z_level() && (requires_silo || user_id_card.registered_account.replaceable))
+			if(!materials.check_z_level() && (requires_silo || !user_id_card.registered_account.replaceable))
 				return TRUE
 			if(points)
 				if(user_id_card)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -15,6 +15,8 @@
 	needs_item_input = TRUE
 	processing_flags = START_PROCESSING_MANUALLY
 
+	///Boolean on whether the ORM can claim points without being connected to an ore silo.
+	var/can_claim_siloless = FALSE
 	/// The current amount of unclaimed points in the machine
 	var/points = 0
 	/// Smelted ore's amount is multiplied by this
@@ -22,13 +24,27 @@
 	/// Increases the amount of points the miners gain
 	var/point_upgrade = 1
 	/// Details how many credits each smelted ore is worth
-	var/list/ore_values = list(/datum/material/iron = 1, /datum/material/glass = 1,  /datum/material/plasma = 15,  /datum/material/silver = 16, /datum/material/gold = 18, /datum/material/titanium = 30, /datum/material/uranium = 30, /datum/material/diamond = 50, /datum/material/bluespace = 50, /datum/material/bananium = 60)
+	var/static/list/ore_values = list(
+		/datum/material/iron = 1,
+		/datum/material/glass = 1,
+		/datum/material/plasma = 15,
+		/datum/material/silver = 16,
+		/datum/material/gold = 18,
+		/datum/material/titanium = 30,
+		/datum/material/uranium = 30,
+		/datum/material/diamond = 50,
+		/datum/material/bluespace = 50,
+		/datum/material/bananium = 60,
+	)
 	/// Variable that holds a timer which is used for callbacks to `send_console_message()`. Used for preventing multiple calls to this proc while the ORM is eating a stack of ores.
 	var/console_notify_timer
 	/// References the alloys the smelter can create
 	var/datum/techweb/stored_research
 	/// Linkage to the ORM silo
 	var/datum/component/remote_materials/materials
+
+/obj/machinery/mineral/ore_redemption/offstation
+	can_claim_siloless = TRUE
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
 	. = ..()
@@ -300,7 +316,7 @@
 			if(isliving(usr))
 				var/mob/living/user = usr
 				user_id_card = user.get_idcard(TRUE)
-			if(!materials.check_z_level())
+			if(!materials.check_z_level() && (!can_claim_siloless || user_id_card.registered_account.account_job))
 				return TRUE
 			if(points)
 				if(user_id_card)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -258,9 +258,9 @@
 	data["disconnected"] = null
 	if (!mat_container)
 		data["disconnected"] = "Local mineral storage is unavailable"
-	else if (!materials.silo)
+	else if (!materials.silo && requires_silo)
 		data["disconnected"] = "No ore silo connection is available; storing locally"
-	else if (!materials.check_z_level())
+	else if (!materials.check_z_level() && requires_silo)
 		data["disconnected"] = "Unable to connect to ore silo, too far away"
 	else if (materials.on_hold())
 		data["disconnected"] = "Mineral withdrawal is on hold"
@@ -317,7 +317,7 @@
 			if(isliving(usr))
 				var/mob/living/user = usr
 				user_id_card = user.get_idcard(TRUE)
-			if(!materials.check_z_level() && (requires_silo || user_id_card.registered_account.account_job))
+			if(!materials.check_z_level() && (requires_silo || user_id_card.registered_account.replaceable))
 				return TRUE
 			if(points)
 				if(user_id_card)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -44,6 +44,7 @@
 	var/datum/component/remote_materials/materials
 
 /obj/machinery/mineral/ore_redemption/offstation
+	circuit = /obj/item/circuitboard/machine/ore_redemption/offstation
 	requires_silo = FALSE
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -16,7 +16,7 @@
 	processing_flags = START_PROCESSING_MANUALLY
 
 	///Boolean on whether the ORM can claim points without being connected to an ore silo.
-	var/can_claim_siloless = FALSE
+	var/requires_silo = TRUE
 	/// The current amount of unclaimed points in the machine
 	var/points = 0
 	/// Smelted ore's amount is multiplied by this
@@ -44,7 +44,7 @@
 	var/datum/component/remote_materials/materials
 
 /obj/machinery/mineral/ore_redemption/offstation
-	can_claim_siloless = TRUE
+	requires_silo = FALSE
 
 /obj/machinery/mineral/ore_redemption/Initialize(mapload)
 	. = ..()
@@ -316,7 +316,7 @@
 			if(isliving(usr))
 				var/mob/living/user = usr
 				user_id_card = user.get_idcard(TRUE)
-			if(!materials.check_z_level() && (!can_claim_siloless || user_id_card.registered_account.account_job))
+			if(!materials.check_z_level() && (requires_silo || user_id_card.registered_account.account_job))
 				return TRUE
 			if(points)
 				if(user_id_card)


### PR DESCRIPTION
## About The Pull Request

Golems can now redeem points from their ORM. There's a check for bank job, so only the blank ID cards golems get will work. Miners theoretically can use one of the cards to get points themselves, but then they need to carry that card around and get all points through it, because their starting ID cannot claim it.

## Why It's Good For The Game

Golems can now properly get their R&D shit up.

## Changelog

:cl:
fix: Golems can redeem points through their ORM without an Ore silo.
/:cl: