### PR TITLE
Fixes some eye of god bugs

### DIFF
--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -806,7 +806,7 @@
 	scan_ability = new(src)
 
 /obj/item/clothing/glasses/godeye/Destroy()
-	scan_ability?.Remove(user)
+	scan_ability?.Remove(scan_ability.owner)
 	QDEL_NULL(scan_ability)
 	return ..()
 

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -806,6 +806,7 @@
 	scan_ability = new(src)
 
 /obj/item/clothing/glasses/godeye/Destroy()
+	scan_ability?.Remove(user)
 	QDEL_NULL(scan_ability)
 	return ..()
 
@@ -846,13 +847,14 @@
 	return ..() && isliving(owner)
 
 /datum/action/cooldown/scan/Activate(atom/scanned)
-	StartCooldown(15 SECONDS)
 
 	if(owner.stat != CONSCIOUS)
 		return FALSE
 	if(!isliving(scanned) || scanned == owner)
 		owner.balloon_alert(owner, "invalid scanned!")
 		return FALSE
+
+	StartCooldown(15 SECONDS)
 
 	var/mob/living/living_owner = owner
 	var/mob/living/living_scanned = scanned


### PR DESCRIPTION

## About The Pull Request

Eye of god now auto removes its scan ability from owner when qdeleted, to hopefully prevent the mouse pointer from staying stuck as 'eye of god'

Cooldowns are only applied after a successful use of the ability, not after an attempt to utilize it. This means that trying to use the ability while KO or hitting a turf/object/yourself with it won't put the action on cooldown, which also left you with the mouse pointer until it went off cooldown.

## Why It's Good For The Game

Bugs bad! Weak, niche ability being further crippled by what is either a bug or a very buggy, bad feature bad!

## Changelog

:cl:
fix: Eye of god now auto removes its scan ability from owner when qdeleted, to hopefully prevent the mouse pointer from staying stuck as 'eye of god'
fix: Cooldowns are only applied after a successful use of the ability, not after an attempt to utilize it. This means that trying to use the ability while KO or hitting a turf/object/yourself with it won't put the action on cooldown, which also left you with the mouse pointer until it went off cooldown.
/:cl:

