### PR TITLE
Fixes a broken arcade on north star

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -6551,7 +6551,7 @@
 /area/station/science/xenobiology/hallway)
 "bzU" = (
 /obj/effect/turf_decal/tile/green,
-/obj/machinery/computer/arcade,
+/obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces a non-functional generic arcade in north star's departures with the random arcade spawner.

Fixes #75085

## Why It's Good For The Game

The people demand working video games

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The acrade cabinet in North Star's departure lounge now works.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
