### PR TITLE
[NO GBP] Style meter fixes

### DIFF
--- a/code/datums/components/style/style.dm
+++ b/code/datums/components/style/style.dm
@@ -113,7 +113,7 @@
 	RegisterSignal(parent, COMSIG_LIVING_CRUSHER_DETONATE, PROC_REF(on_crusher_detonate))
 	RegisterSignal(parent, COMSIG_LIVING_DISCOVERED_GEYSER, PROC_REF(on_geyser_discover))
 
-	projectile_parry = WEAKREF(AddComponent(\
+	projectile_parry = WEAKREF(parent.AddComponent(\
 		/datum/component/projectile_parry,\
 		list(\
 			/obj/projectile/colossus,\
@@ -226,7 +226,7 @@
 /datum/component/style/proc/update_meter(new_rank, go_back)
 	if(!isnull(go_back))
 		animate(meter_image.get_filter("meter_mask"), time = 0 SECONDS, flags = ANIMATION_END_NOW, x = go_back)
-	animate(meter_image.get_filter("meter_mask"), time = 1 SECONDS, x = (rank > new_rank ? 0 : (rank < new_rank ? 100 : (style_points % 100) + 1)))
+	animate(meter_image.get_filter("meter_mask"), time = 1 SECONDS, x = (rank > new_rank ? 0 : ((rank < new_rank) || (style_points >= 500) ? 100 : (style_points % 100) + 1)))
 	if(!isnull(new_rank) && new_rank != rank && !timerid)
 		timerid = addtimer(CALLBACK(src, PROC_REF(update_screen), new_rank), 1 SECONDS)
 
@@ -422,6 +422,9 @@
 
 /datum/component/style/proc/on_crusher_detonate(datum/source, mob/living/target, obj/item/kinetic_crusher/crusher, backstabbed)
 	SIGNAL_HANDLER
+
+	if(target.stat == DEAD)
+		return
 
 	var/has_brimdemon_trophy = locate(/obj/item/crusher_trophy/brimdemon_fang) in crusher.trophies
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -402,13 +402,14 @@
 	return FALSE
 
 
-/// Called when a mob with PARRY_TRAIT clicks on this projectile or the tile its on, reflecting the projectile within 17 degrees and increasing the bullet's stats.
+/// Called when a mob with PARRY_TRAIT clicks on this projectile or the tile its on, reflecting the projectile within 7 degrees and increasing the bullet's stats.
 /obj/projectile/proc/on_parry(mob/user, list/modifiers)
 	if(SEND_SIGNAL(user, COMSIG_LIVING_PROJECTILE_PARRIED, src) & INTERCEPT_PARRY_EFFECTS)
 		return
 
 	parried = TRUE
 	set_angle(dir2angle(user.dir) + rand(-3, 3))
+	firer = user
 	speed *= 0.8 // Go 20% faster when parried
 	damage *= 1.15 // And do 15% more damage
 	add_atom_colour(COLOR_RED_LIGHT, TEMPORARY_COLOUR_PRIORITY)


### PR DESCRIPTION

## About The Pull Request
Fixes:

- Crusher mark score applying to attacked corpses
- Parrying not working, in 2 different forms
- The style bar not being accurate with >= 600 style points

## Why It's Good For The Game
Bugs bad

## Changelog
:cl:
fix: Style meter parrying works again
fix: Style meter bar now works correctly with very high style point count
/:cl:
