### PR TITLE
Tonguespike buff, chemspike slight nerf

### DIFF
--- a/code/datums/mutations/tongue_spike.dm
+++ b/code/datums/mutations/tongue_spike.dm
@@ -46,10 +46,11 @@
 	icon = 'icons/obj/weapons/thrown.dmi'
 	icon_state = "tonguespike"
 	force = 2
-	throwforce = 15 //15 + 2 (WEIGHT_CLASS_SMALL) * 4 (EMBEDDED_IMPACT_PAIN_MULTIPLIER) = i didnt do the math
+	throwforce = 25
 	throw_speed = 4
 	embedding = list(
-		"embedded_pain_multiplier" = 4,
+		"impact_pain_mult" = 0,
+		"embedded_pain_multiplier" = 15,
 		"embed_chance" = 100,
 		"embedded_fall_chance" = 0,
 		"embedded_ignore_throwspeed_threshold" = TRUE,
@@ -107,8 +108,9 @@
 	name = "chem spike"
 	desc = "Hardened biomass, shaped into... something."
 	icon_state = "tonguespikechem"
-	throwforce = 2 //2 + 2 (WEIGHT_CLASS_SMALL) * 0 (EMBEDDED_IMPACT_PAIN_MULTIPLIER) = i didnt do the math again but very low or smthin
+	throwforce = 2
 	embedding = list(
+		"impact_pain_mult" = 0,
 		"embedded_pain_multiplier" = 0,
 		"embed_chance" = 100,
 		"embedded_fall_chance" = 0,

--- a/code/datums/mutations/tongue_spike.dm
+++ b/code/datums/mutations/tongue_spike.dm
@@ -15,7 +15,7 @@
 	button_icon = 'icons/mob/actions/actions_genetic.dmi'
 	button_icon_state = "spike"
 
-	cooldown_time = 10 SECONDS
+	cooldown_time = 1 SECONDS
 	spell_requirements = SPELL_REQUIRES_HUMAN
 
 	/// The type-path to what projectile we spawn to throw at someone.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1061,6 +1061,7 @@
 	if(!shrapnel_type || !LAZYLEN(embedding))
 		return
 
+	// fuck whoever did this btw
 	AddElement(/datum/element/embed,\
 		embed_chance = (!isnull(embedding["embed_chance"]) ? embedding["embed_chance"] : EMBED_CHANCE),\
 		fall_chance = (!isnull(embedding["fall_chance"]) ? embedding["fall_chance"] : EMBEDDED_ITEM_FALLOUT),\

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1061,7 +1061,6 @@
 	if(!shrapnel_type || !LAZYLEN(embedding))
 		return
 
-	// sigh
 	AddElement(/datum/element/embed,\
 		embed_chance = (!isnull(embedding["embed_chance"]) ? embedding["embed_chance"] : EMBED_CHANCE),\
 		fall_chance = (!isnull(embedding["fall_chance"]) ? embedding["fall_chance"] : EMBEDDED_ITEM_FALLOUT),\

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1061,7 +1061,7 @@
 	if(!shrapnel_type || !LAZYLEN(embedding))
 		return
 
-	// fuck whoever did this btw
+	// sigh
 	AddElement(/datum/element/embed,\
 		embed_chance = (!isnull(embedding["embed_chance"]) ? embedding["embed_chance"] : EMBED_CHANCE),\
 		fall_chance = (!isnull(embedding["fall_chance"]) ? embedding["fall_chance"] : EMBEDDED_ITEM_FALLOUT),\


### PR DESCRIPTION
## About The Pull Request

Increases the tonguespike damage.
impact damage: 15 -> 25
pain damage (leaving tonguespike embedded damage): 4 -> 15
cooldown time = 10 seconds -> 1 seconds

Decreases the chemspike damage
impact damage: 4? -> 2
pain damage: 4 -> 0

## Why It's Good For The Game

These values were eyeballed when I originally added them, fuck embedding code, uuuh... these values make more sense. At the very least tonguespike was nearly unusuable being a 15 damage item that pain-ticked for a pitiful 4.
The cooldown was just unnecessary and killed unnecessary organ regeneration strategies

Chemspike ticked for too much when it wasn't really meant to deal much damage.

## Changelog
:cl:
balance: Tonguespike is better, chemspike deals slightly less damage
/:cl:
