### PR TITLE
Adds in some missing words for the hallucinatory anomaly announcement

### DIFF
--- a/code/modules/events/anomaly/anomaly_hallucination.dm
+++ b/code/modules/events/anomaly/anomaly_hallucination.dm
@@ -15,4 +15,4 @@
 	anomaly_path = /obj/effect/anomaly/hallucination
 
 /datum/round_event/anomaly/anomaly_hallucination/announce(fake)
-	priority_announce("Hallucinatory event [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name].", "Anomaly Alert")
+	priority_announce("Hallucinatory event detected on [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name].", "Anomaly Alert")


### PR DESCRIPTION

## About The Pull Request

Fixes a small grammatical error with the anomaly announcement text.
## Why It's Good For The Game

Words words words words words words words.
## Changelog
:cl:
spellcheck: The hallucinatory anomaly announcement is no longer missing words.
/:cl:
