### PR TITLE
Reduce Ion Law Announcements

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -295,7 +295,7 @@
 	var/datum/antagonist/malf_ai/malf_antag_datum = new
 	new_malf_ai.mind.special_role = antag_flag
 	new_malf_ai.mind.add_antag_datum(malf_antag_datum)
-	if(prob(MALF_ION_PROB))
+	if(prob(MALF_ION_PROB) && prob(25))
 		priority_announce("Ion storm detected near the station. Please check all AI-controlled equipment for errors.", "Anomaly Alert", ANNOUNCER_IONSTORM)
 		if(prob(REPLACE_LAW_WITH_ION_PROB))
 			new_malf_ai.replace_random_law(generate_ion_law(), list(LAW_INHERENT, LAW_SUPPLIED, LAW_ION), LAW_ION)

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -16,7 +16,7 @@
 	var/botEmagChance = 1
 	var/ionMessage = null
 	announce_when = 1
-	announce_chance = 33
+	announce_chance = 0
 
 /datum/round_event/ion_storm/add_law_only // special subtype that adds a law only
 	replaceLawsetChance = 0


### PR DESCRIPTION
## About The Pull Request

Reduces chance of announcing a random event Ion law change from 33% to 0%.
Reduces chance of announcing a dynamic midround Ion law change from 100% to 25%.

Leaves the announcement in the round event code so that it can still be triggered by admins in the event panel and the false alarm event.

## Why It's Good For The Game

Makes the round more interesting by giving the AI an improved chance of acting on their new laws by not immediately giving away that the laws have changed.

Currently as soon as the announcement happens crewmembers yell "AI STATE LAWS" which takes the fun out of it.

## Changelog

:cl: LT3
balance: Reduced chance for Ion Storm law changes to be announced to the station
/:cl:
