### PR TITLE
Meta lounge/theater regained area

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -432,6 +432,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "aja" = (
@@ -8006,6 +8007,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "daT" = (
@@ -41276,6 +41279,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "oXl" = (
@@ -58633,9 +58637,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "uYg" = (
-/obj/structure/cable,
 /obj/structure/sink/kitchen/directional/west,
-/obj/machinery/power/apc/auto_name/directional/north,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -134,9 +134,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/service/library)
-"adp" = (
-/turf/closed/wall,
-/area/station/hallway/primary/starboard)
 "adD" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance,
@@ -1325,19 +1322,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "aAb" = (
-/obj/structure/table/wood,
-/obj/item/lipstick{
-	pixel_y = 5
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Theater - Stage"
 	},
-/obj/machinery/light/small/directional/east,
-/obj/effect/spawner/random/entertainment/musical_instrument,
-/obj/structure/sign/poster/random/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
+/obj/machinery/light/small/directional/south,
+/obj/item/radio/intercom/directional/east,
+/obj/structure/table/wood,
+/obj/item/clothing/glasses/monocle,
+/obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "aAg" = (
@@ -2265,7 +2260,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aPF" = (
-/obj/machinery/firealarm/directional/south,
 /obj/machinery/camera/directional/south{
 	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage"
 	},
@@ -2690,8 +2684,8 @@
 	pixel_y = 2
 	},
 /obj/item/lipstick/black,
-/obj/structure/mirror/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "aXE" = (
@@ -3972,10 +3966,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "btI" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "btL" = (
@@ -4308,13 +4302,11 @@
 /turf/closed/wall,
 /area/station/cargo/sorting)
 "bzI" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "bzV" = (
@@ -4411,12 +4403,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
-"bCk" = (
-/obj/structure/chair/stool/directional/north,
-/obj/machinery/light/directional/east,
-/obj/machinery/newscaster/directional/east,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "bCo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -4482,10 +4468,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"bDR" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "bDW" = (
 /turf/closed/wall,
 /area/station/maintenance/department/engine)
@@ -5845,13 +5827,13 @@
 "cjP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cke" = (
@@ -6249,10 +6231,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms)
 "crT" = (
-/obj/structure/closet/emcloset,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/station/service/theater)
 "csb" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -7003,11 +6986,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cGL" = (
@@ -7051,6 +7034,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
 /area/station/commons/toilet/auxiliary)
+"cHC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "cHE" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -7522,14 +7512,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cRC" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/wood/large,
+/turf/closed/wall,
 /area/station/service/theater)
 "cRW" = (
 /obj/machinery/light/directional/south,
@@ -8080,7 +8066,6 @@
 /area/station/maintenance/port/aft)
 "dbH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -8096,9 +8081,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/office)
 "dce" = (
-/obj/effect/landmark/start/hangover,
-/obj/machinery/holopad,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/light/small/directional/south,
+/obj/structure/table/wood,
+/obj/item/food/pie/cream,
+/turf/open/floor/wood/large,
 /area/station/service/theater)
 "dcF" = (
 /obj/effect/landmark/event_spawn,
@@ -10101,6 +10091,17 @@
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"dPb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "dPh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/corner,
@@ -11716,6 +11717,13 @@
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"eqv" = (
+/obj/machinery/newscaster/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/service/theater)
 "eqz" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
@@ -12349,7 +12357,7 @@
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "eCS" = (
@@ -12431,7 +12439,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central)
 "eEN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -13229,11 +13236,7 @@
 /area/station/engineering/atmospherics_engine)
 "eWG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light_switch/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
+/obj/structure/mirror/directional/west,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "eWO" = (
@@ -13660,9 +13663,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "fge" = (
-/obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/wood/poker,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "fgl" = (
@@ -13929,11 +13932,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"fjY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
-/area/station/service/theater)
 "fkb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -15419,6 +15417,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"fNX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "fOb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/maintenance,
@@ -15559,9 +15563,6 @@
 /area/station/maintenance/port/aft)
 "fQT" = (
 /obj/effect/landmark/start/mime,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "fQW" = (
@@ -15749,13 +15750,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "fVr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/wood/wings{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/effect/landmark/start/clown,
-/turf/open/floor/carpet,
+/obj/machinery/firealarm/directional/south,
+/obj/structure/table/wood,
+/obj/item/stack/sheet/cloth/ten,
+/obj/item/toy/crayon/spraycan,
+/obj/item/stack/rods/ten,
+/turf/open/floor/wood/large,
 /area/station/service/theater)
 "fVA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -16162,20 +16165,10 @@
 /turf/open/floor/grass,
 /area/station/science/research)
 "gcW" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Theater Stage"
-	},
-/obj/effect/turf_decal/siding/wood{
+/obj/structure/window{
 	dir = 8
 	},
-/obj/structure/sign/poster/random/directional/north,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet,
 /area/station/service/theater)
 "gdb" = (
 /turf/closed/wall/r_wall,
@@ -16381,14 +16374,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "ghq" = (
-/obj/effect/landmark/start/hangover,
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
+/obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
+/turf/open/floor/carpet,
 /area/station/service/theater)
 "ghw" = (
 /obj/effect/landmark/start/clown,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "ghC" = (
@@ -16587,12 +16579,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "glJ" = (
-/obj/structure/table/wood,
-/obj/item/clothing/glasses/monocle,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/carpet,
 /area/station/service/theater)
 "glW" = (
 /obj/structure/showcase/machinery/microwave{
@@ -18529,13 +18521,6 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
-"gXj" = (
-/obj/structure/cable,
-/obj/structure/table/wood,
-/obj/item/clothing/mask/cigarette/pipe,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "gXl" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/floor/grass,
@@ -19112,10 +19097,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
-"hht" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/storage/tech)
 "hhN" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -20130,6 +20111,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"hzV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/effect/spawner/random/trash/soap,
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/wood/large,
+/area/station/service/theater)
 "hAc" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/bar,
@@ -20778,13 +20768,6 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
-"hNC" = (
-/obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "hND" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20852,6 +20835,10 @@
 	},
 /turf/open/floor/grass,
 /area/station/science/genetics)
+"hPp" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "hPu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
 	dir = 5
@@ -21736,17 +21723,6 @@
 /obj/structure/window,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"iga" = (
-/obj/machinery/door/airlock{
-	name = "Theater Stage"
-	},
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "igh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -21900,13 +21876,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
 "iin" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Bar - Starboard"
 	},
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
+/obj/structure/cable,
+/obj/effect/spawner/random/entertainment/arcade,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "iio" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office"
@@ -22197,15 +22174,13 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "inI" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/processor{
-	pixel_y = 12
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/table,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 9
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -22714,11 +22689,6 @@
 /obj/machinery/mechpad,
 /turf/open/floor/circuit/green,
 /area/station/science/robotics/mechbay)
-"iuh" = (
-/obj/machinery/light/small/directional/south,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "iui" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/textured,
@@ -22737,10 +22707,6 @@
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"iuM" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "iva" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance"
@@ -23301,15 +23267,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iDC" = (
-/obj/structure/table/wood,
-/obj/item/radio/intercom/directional/east,
-/obj/machinery/light/small/directional/south,
-/obj/structure/sign/poster/random/directional/south,
-/obj/item/food/pie/cream,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/wood/large,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/wood,
 /area/station/service/theater)
 "iDG" = (
 /obj/structure/table,
@@ -23485,11 +23451,14 @@
 /area/station/service/cafeteria)
 "iHh" = (
 /obj/machinery/light/directional/east,
-/obj/structure/table,
 /obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 10
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -23933,6 +23902,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"iMH" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/theater)
 "iMJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -24466,6 +24441,19 @@
 "iUm" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/exit/departure_lounge)
+"iUp" = (
+/obj/structure/table/wood,
+/obj/item/lipstick{
+	pixel_y = 5
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/structure/sign/poster/random/directional/east,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/theater)
 "iUq" = (
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -24510,6 +24498,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"iUL" = (
+/obj/structure/chair/wood/wings,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "iVi" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cabin6";
@@ -24804,6 +24796,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"jbi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "jbk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -25554,7 +25551,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "job" = (
-/obj/item/stock_parts/cell/high,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "joj" = (
@@ -25745,8 +25742,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "jsn" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/restaurant_portal/restaurant,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "jso" = (
@@ -26394,8 +26390,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "jDh" = (
-/obj/machinery/griddle,
-/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "jDk" = (
@@ -27001,15 +26996,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "jNV" = (
-/obj/structure/table/wood,
-/obj/item/staff/broom,
-/obj/item/wrench,
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/light/small/directional/north,
-/obj/structure/sign/poster/random/directional/north,
-/obj/effect/turf_decal/siding/wood/corner{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "jOb" = (
@@ -27659,16 +27653,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
-"jYi" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "jYu" = (
 /mob/living/basic/cow{
 	name = "Betsy";
@@ -27867,26 +27851,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"kcs" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/chisel{
-	pixel_y = 7
-	},
-/obj/machinery/camera/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
 "kcu" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron{
@@ -28852,12 +28816,8 @@
 "kuA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "kuD" = (
@@ -31334,6 +31294,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"loG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/station/commons/storage/art)
 "loQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33309,15 +33273,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"mbf" = (
-/obj/structure/table/wood/poker,
-/obj/effect/spawner/random/entertainment/deck,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/commons/lounge)
 "mbk" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/cable,
@@ -33357,17 +33312,11 @@
 /area/station/engineering/atmos)
 "mcn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "mcP" = (
@@ -34253,11 +34202,14 @@
 "mvk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/wood/large,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/wood,
 /area/station/service/theater)
 "mvR" = (
 /turf/closed/wall/r_wall,
@@ -34315,8 +34267,8 @@
 /area/station/cargo/sorting)
 "mwS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "mxg" = (
@@ -36470,6 +36422,18 @@
 /obj/structure/chair/office,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
+"njG" = (
+/obj/structure/table/wood,
+/obj/item/staff/broom,
+/obj/item/wrench,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/wood/large,
+/area/station/service/theater)
 "njP" = (
 /obj/machinery/door/window{
 	name = "Captain's Desk";
@@ -37907,15 +37871,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "nIo" = (
-/obj/machinery/door/airlock{
-	name = "Theater Backstage"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/wood,
 /area/station/service/theater)
 "nIt" = (
@@ -38011,8 +37969,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "nJY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/station/service/theater)
@@ -39170,9 +39126,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "ohn" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/landmark/start/clown,
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/station/service/theater)
 "ohp" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -41027,6 +40988,12 @@
 	},
 /turf/open/floor/holofloor/dark,
 /area/station/science/cytology)
+"oQr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/station/commons/storage/art)
 "oQx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/industrial/loader,
@@ -41743,12 +41710,16 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "pek" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock{
+	name = "Theater Backstage"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/theatre,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
 /area/station/service/theater)
 "peF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42095,6 +42066,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"plZ" = (
+/obj/machinery/light/directional/north,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "pma" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
@@ -42223,6 +42199,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
+"poV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "ppi" = (
 /obj/structure/transit_tube/curved/flipped,
 /obj/effect/turf_decal/tile/blue{
@@ -42750,10 +42734,6 @@
 /obj/item/gavelhammer,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"pyc" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "pyd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -42762,11 +42742,12 @@
 /area/station/maintenance/aft/greater)
 "pyh" = (
 /obj/structure/cable,
-/obj/structure/window{
-	dir = 8
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Theater Stage"
 	},
-/obj/structure/chair/wood/wings,
-/obj/effect/landmark/start/mime,
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "pyv" = (
@@ -42776,6 +42757,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"pyE" = (
+/obj/machinery/door/airlock{
+	name = "Theater Stage"
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "pyI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -43353,14 +43346,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
-"pIz" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "pID" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -43495,13 +43480,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
-"pKw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
 "pKB" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/mining,
@@ -44248,6 +44226,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "qag" = (
@@ -46713,6 +46692,31 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"qSr" = (
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
+"qSD" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/chisel{
+	pixel_y = 7
+	},
+/obj/machinery/camera/directional/south,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/storage/art)
 "qSJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
@@ -46997,6 +47001,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"qXR" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "qXU" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/north,
@@ -47456,6 +47466,13 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/grass,
 /area/station/science/ordnance/office)
+"rhh" = (
+/obj/machinery/newscaster/directional/north,
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "rhn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47510,10 +47527,8 @@
 /turf/open/floor/plating/airless,
 /area/station/solars/port/fore)
 "riL" = (
-/obj/machinery/computer/slot_machine{
-	pixel_y = 2
-	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "riW" = (
@@ -47650,7 +47665,6 @@
 /area/station/hallway/primary/starboard)
 "rls" = (
 /obj/structure/dresser,
-/obj/machinery/newscaster/directional/north,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -48038,6 +48052,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "rul" = (
@@ -48296,6 +48311,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"rxW" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "rxY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -48877,11 +48896,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "rIk" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/station/service/theater)
 "rIG" = (
@@ -49325,10 +49339,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "rPg" = (
-/obj/effect/spawner/random/entertainment/arcade,
-/obj/machinery/camera/directional/north{
-	c_tag = "Bar - Starboard"
-	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "rPh" = (
@@ -49799,10 +49810,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "rXF" = (
-/obj/machinery/computer/slot_machine{
-	pixel_y = 2
+/obj/machinery/light/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "rXJ" = (
@@ -49823,12 +49837,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"rYd" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "rYm" = (
 /obj/machinery/light/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -50303,21 +50311,9 @@
 /area/station/medical/psychology)
 "sfD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 6
-	},
-/obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/machinery/button/door/directional/north{
-	id = "kitchen_counter";
-	name = "Counter Shutters Control";
-	req_access = list("kitchen")
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
@@ -52150,6 +52146,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"sMM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "sMS" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
@@ -53995,6 +54003,11 @@
 /obj/structure/cable,
 /turf/open/space,
 /area/space/nearstation)
+"tte" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "tth" = (
 /obj/item/paper_bin/carbon,
 /obj/item/pen/fountain,
@@ -54257,9 +54270,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/cook,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -54994,6 +55004,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"tLe" = (
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "tLg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -56071,7 +56084,6 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "uey" = (
-/obj/structure/chair/stool/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -56130,14 +56142,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"ugs" = (
-/obj/structure/chair/stool/directional/east,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
-/area/station/commons/lounge)
 "ugE" = (
 /obj/structure/chair{
 	name = "Judge"
@@ -56990,6 +56994,11 @@
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"uvZ" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "uwa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59059,16 +59068,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"vhI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "vhS" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/directional/west,
@@ -59690,8 +59689,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "vqN" = (
-/obj/effect/landmark/event_spawn,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet,
 /area/station/service/theater)
 "vqU" = (
@@ -60345,6 +60346,12 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"vDX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "vEd" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/processor{
@@ -60403,19 +60410,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "vEO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/south,
-/obj/structure/table/wood,
-/obj/effect/spawner/random/entertainment/musical_instrument,
-/obj/item/clothing/glasses/regular/hipster{
-	name = "Hipster Glasses"
+/obj/machinery/button/door/directional/east,
+/obj/machinery/light/directional/east,
+/obj/structure/table,
+/obj/machinery/processor{
+	pixel_y = 12
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/wood/large,
-/area/station/service/theater)
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "vET" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61117,9 +61120,12 @@
 /area/station/engineering/atmos)
 "vSa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
 /area/station/service/theater)
 "vSo" = (
 /obj/machinery/light/small/directional/south,
@@ -61158,6 +61164,13 @@
 "vSI" = (
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"vSJ" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "vSP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -61804,6 +61817,20 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"wdE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/sign/poster/random/directional/north,
+/obj/effect/spawner/random/structure/musician/piano/random_piano,
+/turf/open/floor/wood/large,
+/area/station/service/theater)
 "wdG" = (
 /obj/machinery/door/airlock{
 	id_tag = "Cabin3";
@@ -61822,14 +61849,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/construction/storage_wing)
-"wei" = (
-/obj/effect/landmark/start/hangover,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/turf/open/floor/carpet,
-/area/station/service/theater)
 "wek" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/mess,
@@ -62531,6 +62550,17 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/primary/aft)
+"wrk" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/station/commons/storage/art)
 "wrn" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -62865,6 +62895,18 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
+"wyb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "wyn" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/shovel/spade,
@@ -62908,13 +62950,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "wyV" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/random/trash/soap,
-/obj/structure/sign/poster/random/directional/east,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood/large,
+/turf/closed/wall,
 /area/station/service/theater)
 "wza" = (
 /obj/structure/disposalpipe/segment{
@@ -62989,8 +63028,16 @@
 /obj/structure/window{
 	dir = 8
 	},
-/obj/effect/spawner/random/structure/musician/piano/random_piano,
-/turf/open/floor/carpet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/musical_instrument,
+/obj/item/clothing/glasses/regular/hipster{
+	name = "Hipster Glasses"
+	},
+/turf/open/floor/wood/large,
 /area/station/service/theater)
 "wAp" = (
 /obj/item/radio/intercom/directional/west,
@@ -63542,15 +63589,6 @@
 	dir = 8
 	},
 /area/station/medical/medbay/central)
-"wMk" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "wMx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -63726,6 +63764,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
+"wOV" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/computer/slot_machine{
+	pixel_y = 2
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "wPi" = (
 /obj/machinery/vending/wardrobe/det_wardrobe,
 /turf/open/floor/iron/grimy,
@@ -63986,6 +64031,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"wSH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "wSI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -64063,6 +64120,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
+"wTQ" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/structure/table/wood,
+/obj/item/clothing/mask/cigarette/pipe,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "wUc" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
@@ -65487,6 +65550,12 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"xux" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/service/kitchen)
 "xuA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -65538,8 +65607,10 @@
 /area/station/maintenance/aft/lesser)
 "xva" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sign/poster/contraband/random/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/station/service/theater)
 "xvd" = (
@@ -66465,10 +66536,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xMY" = (
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/station/service/theater)
 "xNb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66616,7 +66688,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xPg" = (
-/obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/table/wood/poker,
+/obj/effect/spawner/random/entertainment/gambling,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "xPh" = (
@@ -66718,14 +66791,11 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "xQS" = (
-/obj/machinery/light/small/directional/north,
-/obj/structure/table/wood,
-/obj/structure/sign/poster/random/directional/north,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/rods/ten,
-/obj/item/toy/crayon/spraycan,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
+/obj/structure/chair/wood/wings{
+	dir = 8
+	},
+/obj/effect/landmark/start/mime,
+/turf/open/floor/carpet,
 /area/station/service/theater)
 "xQT" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -67116,6 +67186,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain/private)
+"xXY" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "xYl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67491,6 +67565,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
+"yec" = (
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "yeq" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -67704,16 +67782,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
-"yiK" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "yiN" = (
 /obj/effect/spawner/random/maintenance,
 /obj/structure/cable,
@@ -102720,9 +102788,9 @@ qXB
 mSD
 vFB
 kFp
-twN
+dPb
 bvJ
-pIz
+lWm
 kdN
 wSs
 lAA
@@ -102971,12 +103039,12 @@ cBf
 qXB
 qnK
 qXB
-qXB
-qXB
-qXB
-qXB
-vFB
-fRS
+khA
+khA
+khA
+khA
+wSH
+tqU
 cGw
 rac
 rXF
@@ -103227,18 +103295,18 @@ uUl
 qJH
 qXB
 wzK
-psZ
-kbo
-psZ
-rYd
-yiK
-dOw
+rxW
+khA
+qSD
+bEU
+rAg
+vFB
 fRS
 tUv
 rac
 riL
-bCk
-bDR
+hkG
+hkG
 qpM
 qVt
 yiX
@@ -103484,20 +103552,20 @@ cLe
 wLx
 qXB
 eHR
-qXB
-qXB
-wRT
-qXB
-qXB
+wrn
+wrk
+loG
+oQr
+feQ
 cjP
-tqU
-vhI
-khA
-khA
-khA
-khA
+fRS
+tUv
+rac
+rhh
+hkG
+yec
 jsn
-qVt
+fNX
 jFD
 aPV
 tXH
@@ -103741,21 +103809,21 @@ qXB
 qXB
 qXB
 hHd
-qXB
-aaa
-aaa
-aaa
-adp
+xXY
+khA
+oeQ
+uwU
+rAg
 vFB
 fRS
 tUv
-rAg
-bEU
-kcs
-khA
-gXj
+rac
+wOV
+hkG
+tte
+jsn
 btI
-vFV
+yiX
 gwc
 vBB
 ows
@@ -104000,16 +104068,16 @@ psZ
 wzK
 tCS
 xww
-hht
+xww
 xww
 xww
 vFB
 pKi
 axU
-feQ
+rac
 iin
-pKw
-khA
+rPg
+rPg
 rPg
 mwS
 tIj
@@ -104260,20 +104328,20 @@ uGt
 vlh
 jpr
 xww
-vFB
+wyb
 fRS
 tUv
-rAg
-uwU
-oeQ
-khA
-pyc
-qVt
-ugs
+rac
+plZ
+hkG
+nGK
+nGK
+vDX
+vFV
 gwc
 wPv
 ows
-dzp
+xux
 txi
 iCY
 gXo
@@ -104520,13 +104588,13 @@ xww
 jsv
 tlZ
 aPF
-unL
-unL
-unL
-unL
+rac
+wTQ
+yec
+wSs
 xPg
 fge
-mbf
+vFV
 cLi
 reS
 jDh
@@ -104776,18 +104844,18 @@ xww
 xww
 aEr
 sDs
-jYi
-unL
-ydq
-vmE
-unL
+tUv
+obG
+wdE
+gcW
+vSJ
 gcW
 fzO
 pyh
 wAm
-wei
 obG
-obG
+uvZ
+tLe
 sfD
 ebK
 sLp
@@ -105031,20 +105099,20 @@ ihx
 jtp
 pua
 cdX
-vFB
+sMM
 fRS
 tUv
-unL
+obG
 ohn
-iuh
-unL
+wBT
+iUL
 ghq
-yaO
+poV
 nJY
 fVr
-fjY
-vEO
 obG
+vEO
+qXR
 inI
 iHh
 aNN
@@ -105291,15 +105359,15 @@ cdX
 vFB
 usY
 huX
-hNC
-hCl
+obG
+iMH
 xMY
-unL
+hPp
 xQS
 yaO
 vqN
 dce
-wBT
+obG
 cRC
 obG
 obG
@@ -105548,10 +105616,10 @@ cdX
 pYL
 gaN
 iqB
-unL
+obG
 crT
-hCl
-unL
+jbi
+jbi
 glJ
 kuA
 pZQ
@@ -105805,17 +105873,17 @@ cdX
 vFB
 fRS
 tUv
-unL
-unL
-wMk
-unL
+obG
+njG
+dLY
+iUp
 jNV
 bzI
-dLY
+hzV
 aAb
 wyV
 iDC
-obG
+eqv
 rIk
 fQT
 eCQ
@@ -106063,11 +106131,11 @@ dOw
 fRS
 tUv
 unL
-iuM
-hCl
 unL
 unL
-iga
+unL
+pyE
+unL
 unL
 unL
 unL
@@ -106323,9 +106391,9 @@ oDl
 ggM
 ggM
 ggM
-lzL
 dLq
 lzL
+cHC
 lzL
 lzL
 scG
@@ -106840,7 +106908,7 @@ pab
 nlP
 nsJ
 fWA
-goZ
+ydq
 yaf
 pEs
 lzL
@@ -107099,10 +107167,10 @@ rTg
 fWA
 jsL
 nnf
-izp
+vmE
 xZb
 guD
-izp
+qSr
 mTB
 unL
 unL

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11084,9 +11084,8 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "eft" = (
@@ -19616,6 +19615,7 @@
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "hrG" = (
@@ -39140,6 +39140,8 @@
 "ogs" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "ogL" = (
@@ -46615,7 +46617,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/service/bar)
@@ -47539,11 +47540,12 @@
 /turf/open/floor/plating/airless,
 /area/station/solars/port/fore)
 "riL" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/machinery/restaurant_portal/restaurant,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "riW" = (
@@ -49829,8 +49831,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "rXF" = (
-/obj/machinery/light/directional/north,
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk{
@@ -50194,14 +50194,6 @@
 "sdb" = (
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
-"sdf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Bar"
-	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/station/commons/lounge)
 "sdn" = (
 /obj/item/target,
 /obj/structure/training_machine,
@@ -58190,7 +58182,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "uOO" = (
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
@@ -66327,7 +66318,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "xIC" = (
-/obj/machinery/light/directional/west,
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
 	},
@@ -101488,7 +101478,7 @@ rEr
 vFB
 fRS
 twN
-bvJ
+rac
 ogs
 wCL
 gPh
@@ -102002,7 +101992,7 @@ dZm
 wAA
 fRS
 tLx
-sdf
+bvJ
 dYK
 hkG
 gae
@@ -102516,7 +102506,7 @@ dZm
 cNd
 fRS
 twN
-bvJ
+qFo
 lWm
 gvm
 vLM
@@ -103030,7 +103020,7 @@ qXB
 vFB
 fRS
 cGw
-rac
+bvJ
 rXF
 uey
 fSd

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4296,6 +4296,8 @@
 	},
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/poster/random/directional/east,
+/obj/structure/table/wood,
+/obj/item/food/pie/cream,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "bzV" = (
@@ -8118,8 +8120,6 @@
 	},
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/light/small/directional/south,
-/obj/structure/table/wood,
-/obj/item/food/pie/cream,
 /turf/open/floor/wood/large,
 /area/station/service/theater)
 "dcF" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1217,18 +1217,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
-"axU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "axW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -19774,16 +19762,6 @@
 "huG" = (
 /turf/closed/wall,
 /area/station/service/kitchen/coldroom)
-"huX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "huZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -42072,11 +42050,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"plZ" = (
-/obj/machinery/light/directional/north,
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "pma" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
@@ -43466,12 +43439,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"pKi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "pKs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon{
@@ -56843,11 +56810,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"usY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "uta" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/security_space_law{
@@ -64132,6 +64094,7 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/pipe,
+/obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "wUc" = (
@@ -104080,8 +104043,8 @@ xww
 xww
 xww
 vFB
-pKi
-axU
+fRS
+tUv
 rac
 iin
 rPg
@@ -104339,8 +104302,8 @@ xww
 wyb
 fRS
 tUv
-rac
-plZ
+bvJ
+hkG
 hkG
 nGK
 nGK
@@ -105365,8 +105328,8 @@ vzX
 vQv
 cdX
 vFB
-usY
-huX
+fRS
+tUv
 obG
 iMH
 xMY

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -6979,9 +6979,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
@@ -26216,6 +26213,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/warden)
+"jyo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "jyq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -102754,7 +102757,7 @@ jMo
 uUl
 jtb
 qXB
-fGp
+wzK
 qXB
 pzQ
 pRe
@@ -103272,11 +103275,11 @@ wzK
 bEU
 khA
 bEU
-bEU
+jyo
 rAg
 cjP
 fRS
-tUv
+cGw
 rac
 riL
 pkj

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -20277,6 +20277,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hDq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "hDX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -21885,7 +21891,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/spawner/random/entertainment/arcade,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
 /area/station/commons/lounge)
 "iio" = (
 /obj/machinery/door/airlock/command{
@@ -25195,6 +25202,13 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
+"jhu" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "jhv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35452,6 +35466,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"mRx" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "mRy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -42014,6 +42034,12 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
+"pkj" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "pkH" = (
 /obj/structure/rack,
 /obj/item/restraints/handcuffs,
@@ -47456,7 +47482,8 @@
 /obj/machinery/computer/slot_machine{
 	pixel_y = 2
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
 /area/station/commons/lounge)
 "rhn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47514,6 +47541,9 @@
 "riL" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/machinery/restaurant_portal/restaurant,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "riW" = (
@@ -63729,7 +63759,8 @@
 /obj/machinery/computer/slot_machine{
 	pixel_y = 2
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron,
 /area/station/commons/lounge)
 "wPi" = (
 /obj/machinery/vending/wardrobe/det_wardrobe,
@@ -103258,7 +103289,7 @@ fRS
 tUv
 rac
 riL
-hkG
+pkj
 hkG
 qpM
 qVt
@@ -103515,7 +103546,7 @@ tqU
 kyg
 rac
 rhh
-hkG
+hDq
 yec
 jsn
 fNX
@@ -103772,7 +103803,7 @@ fRS
 tUv
 rac
 wOV
-hkG
+hDq
 tte
 jsn
 btI
@@ -104029,7 +104060,7 @@ fRS
 tUv
 rac
 iin
-rPg
+jhu
 rPg
 rPg
 mwS
@@ -104285,8 +104316,8 @@ vFB
 fRS
 tUv
 bvJ
-hkG
-hkG
+mRx
+kSw
 nGK
 nGK
 vDX

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4491,17 +4491,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "bEU" = (
-/obj/structure/table,
-/obj/item/hand_labeler,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "bFr" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -5484,15 +5477,24 @@
 /turf/closed/wall,
 /area/station/cargo/storage)
 "cce" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 4
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/stack/pipe_cleaner_coil/random,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/canvas,
+/obj/item/chisel{
+	pixel_y = 7
 	},
-/obj/effect/spawner/random/trash/garbage{
-	spawn_scatter_radius = 1
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "ccD" = (
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
@@ -6979,7 +6981,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "cGL" = (
@@ -7059,6 +7060,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/genetics)
+"cIi" = (
+/obj/machinery/light_switch/directional/east,
+/obj/structure/easel,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "cIM" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -7220,6 +7228,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/library)
+"cLK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "cLN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm/directional/west,
@@ -7259,6 +7274,22 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"cNd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/sign/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "cNk" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -7955,6 +7986,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"cZY" = (
+/obj/structure/table,
+/obj/item/hand_labeler,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "dac" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9329,15 +9370,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"dAn" = (
-/obj/structure/closet/emcloset,
-/obj/structure/sign/map/left{
-	icon_state = "map-left-MS";
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
 "dAr" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
@@ -13599,16 +13631,6 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos)
-"feQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Art Storage"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
 "feV" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/latex,
@@ -23311,6 +23333,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "iEm" = (
@@ -23667,6 +23690,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"iKc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/storage/tech)
 "iKJ" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -28084,8 +28111,14 @@
 /turf/open/floor/plating,
 /area/station/security/checkpoint/engineering)
 "khA" = (
-/turf/closed/wall,
-/area/station/commons/storage/art)
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/spawner/random/trash/garbage{
+	spawn_scatter_radius = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "khD" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Crematorium Maintenance"
@@ -28929,9 +28962,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/random/trash/garbage{
-	spawn_scatter_radius = 1
-	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "kxz" = (
@@ -28986,6 +29016,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"kyg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "kyh" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -30277,6 +30317,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
+"kWu" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall,
+/area/station/commons/lounge)
 "kWL" = (
 /obj/structure/sign/directions/command{
 	dir = 4;
@@ -31277,10 +31321,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"loG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
 "loQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34345,9 +34385,8 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "myP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "myS" = (
@@ -34640,6 +34679,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"mDE" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Art Storage"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "mDL" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/delivery,
@@ -34657,6 +34705,9 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"mDW" = (
+/turf/closed/wall,
+/area/station/hallway/primary/starboard)
 "mDX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -35443,15 +35494,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "mSD" = (
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security in red at the top, you see engineering in yellow, science in purple, escape in checkered red-and-white, medbay in green, arrivals in checkered red-and-blue, and then cargo in brown.";
-	icon_state = "map-right-MS";
-	pixel_y = 32
-	},
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
+/obj/structure/sign/map/right,
+/turf/closed/wall,
+/area/station/commons/storage/tools)
 "mSM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -37185,6 +37230,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "nwa" = (
@@ -38990,14 +39036,6 @@
 "oew" = (
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"oeQ" = (
-/obj/structure/table,
-/obj/item/paper_bin/construction,
-/obj/item/airlock_painter,
-/obj/machinery/airalarm/directional/east,
-/obj/item/rcl/pre_loaded,
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
 "oeR" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -40971,12 +41009,6 @@
 	},
 /turf/open/floor/holofloor/dark,
 /area/station/science/cytology)
-"oQr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
 "oQx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/industrial/loader,
@@ -42820,13 +42852,12 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "pzQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/generic_maintenance_landmark,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/structure/table,
+/obj/item/paper_bin/construction,
+/obj/item/airlock_painter,
+/obj/item/rcl/pre_loaded,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "pzT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -43830,11 +43861,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "pRe" = (
+/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron,
+/area/station/commons/storage/tools)
 "pRu" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
@@ -46669,27 +46702,6 @@
 /obj/item/storage/box/lights/mixed,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"qSD" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/canvas,
-/obj/item/chisel{
-	pixel_y = 7
-	},
-/obj/machinery/camera/directional/south,
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
 "qSJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall,
@@ -48284,10 +48296,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"rxW" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "rxY" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -48445,9 +48453,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "rAg" = (
-/obj/effect/spawner/structure/window,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/commons/storage/art)
+/area/station/maintenance/starboard/fore)
 "rAo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
@@ -50036,15 +50052,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"sbf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage Room"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "sbl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
@@ -52270,6 +52277,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "sOZ" = (
@@ -57080,14 +57088,6 @@
 "uwQ" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"uwU" = (
-/obj/machinery/light_switch/directional/east,
-/obj/machinery/light/small/directional/east,
-/obj/structure/easel,
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/canvas/twentythree_twentythree,
-/turf/open/floor/iron,
-/area/station/commons/storage/art)
 "uxa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -62116,10 +62116,10 @@
 /area/station/hallway/secondary/entry)
 "wiQ" = (
 /obj/structure/closet/toolcloset,
-/obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "wiS" = (
@@ -62520,16 +62520,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/primary/aft)
-"wrk" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/commons/storage/art)
 "wrn" = (
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
@@ -63468,6 +63458,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "wKu" = (
@@ -64090,7 +64081,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
 "wTQ" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/pipe,
 /obj/machinery/light/directional/north,
@@ -67156,10 +67146,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/captain,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain/private)
-"xXY" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "xYl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67496,14 +67482,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "ydr" = (
-/obj/machinery/camera/directional/east{
-	c_tag = "Auxiliary Tool Storage"
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "ydv" = (
@@ -102238,9 +102221,9 @@ tPw
 gvG
 fhp
 qXB
-qXB
-qXB
-qXB
+ksk
+mDE
+ksk
 dZm
 mta
 pxl
@@ -102496,10 +102479,10 @@ qXB
 wzK
 qXB
 cce
-dOY
-qXB
-dAn
-vFB
+cLK
+cIi
+dZm
+cNd
 fRS
 twN
 bvJ
@@ -102751,10 +102734,10 @@ uUl
 jtb
 qXB
 fGp
-sbf
+qXB
 pzQ
 pRe
-qXB
+cZY
 mSD
 vFB
 kFp
@@ -103009,12 +102992,12 @@ cBf
 qXB
 qnK
 qXB
-khA
-khA
-khA
-khA
-wSH
-tqU
+qXB
+qXB
+qXB
+qXB
+vFB
+fRS
 cGw
 rac
 rXF
@@ -103265,12 +103248,12 @@ uUl
 qJH
 qXB
 wzK
-rxW
+bEU
 khA
-qSD
+bEU
 bEU
 rAg
-vFB
+cjP
 fRS
 tUv
 rac
@@ -103522,14 +103505,14 @@ cLe
 wLx
 qXB
 eHR
-wrn
-wrk
-loG
-oQr
-feQ
-cjP
-fRS
-tUv
+qXB
+qXB
+wRT
+qXB
+qXB
+wSH
+tqU
+kyg
 rac
 rhh
 hkG
@@ -103779,12 +103762,12 @@ qXB
 qXB
 qXB
 hHd
-xXY
-khA
-oeQ
-uwU
-rAg
-vFB
+qXB
+aaa
+aaa
+aaa
+mDW
+wyb
 fRS
 tUv
 rac
@@ -104033,12 +104016,12 @@ hvO
 ktl
 rkA
 qXB
-psZ
+edC
 psZ
 wzK
 tCS
 xww
-xww
+iKc
 xww
 xww
 vFB
@@ -104298,7 +104281,7 @@ uGt
 vlh
 jpr
 xww
-wyb
+vFB
 fRS
 tUv
 bvJ
@@ -104558,7 +104541,7 @@ xww
 jsv
 tlZ
 aPF
-rac
+kWu
 wTQ
 yec
 wSs

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -22174,7 +22174,6 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "inI" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -22182,6 +22181,7 @@
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 9
 	},
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "inL" = (
@@ -26390,7 +26390,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "jDh" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "jDk" = (
@@ -47003,8 +47005,8 @@
 /area/station/medical/chemistry)
 "qXR" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "qXU" = (
@@ -56995,8 +56997,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uvZ" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "uwa" = (
@@ -60411,7 +60418,6 @@
 /area/station/engineering/atmos/storage/gas)
 "vEO" = (
 /obj/machinery/button/door/directional/east,
-/obj/machinery/light/directional/east,
 /obj/structure/table,
 /obj/machinery/processor{
 	pixel_y = 12

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -62522,7 +62522,6 @@
 /area/station/hallway/primary/aft)
 "wrk" = (
 /obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{


### PR DESCRIPTION
## About The Pull Request

The recent expansion of kitchen screwed lounge and theater hard by making the cafeteria next to the kitchen into a hallway and the theater got screwed because the audience would have to use this hallway to watch a performance.

This PR moves art storage to another side of the hallway towards engineering, and cuts one maints room to make space for proper lounge and theater as before the kitchen expansion.

Before:
![Labor Platform Nineteen 2023-05-02 015051](https://user-images.githubusercontent.com/3625094/235545742-9bb17b03-ad8d-4b84-9f45-941e785f4700.png)

After:
![Draconic Hub Juliet 2023-05-02 133458](https://user-images.githubusercontent.com/3625094/235644203-58dd79ad-4acb-4c4f-97b4-5f6b8fa5a5aa.png)

## Why It's Good For The Game

Even if Chefs know CQC, they should respect other professions.

## Changelog

:cl:
balance: Meta lounge and theater are back to original sizes, art storage moved to aux tools storage
/:cl:
