### PR TITLE
Fixes the Chef not having CQC outside the kitchen on Tramstation

### DIFF
--- a/_maps/icebox.json
+++ b/_maps/icebox.json
@@ -46,9 +46,6 @@
 	"minetype": "none",
 	"blacklist_file": "iceruinblacklist.txt",
 	"job_changes": {
-		"Cook": {
-			"additional_cqc_areas": ["/area/station/service/kitchen/diner"]
-		},
 		"Captain": {
 			"special_charter": "moon"
 		}

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -23,7 +23,7 @@
 	],
 	"job_changes": {
 		"Cook": {
-			"additional_cqc_areas": ["/area/station/service/kitchen/diner"]
+			"additional_cqc_areas": ["/area/station/commmons/lounge"]
 		},
 		"Captain": {
 			"special_charter": "asteroid"

--- a/_maps/tramstation.json
+++ b/_maps/tramstation.json
@@ -23,7 +23,7 @@
 	],
 	"job_changes": {
 		"Cook": {
-			"additional_cqc_areas": ["/area/station/commmons/lounge"]
+			"additional_cqc_areas": ["/area/station/commons/lounge"]
 		},
 		"Captain": {
 			"special_charter": "asteroid"


### PR DESCRIPTION
## About The Pull Request

The additional areas were broken in #68084 because the area around the bar was changed from /area/station/service/kitchen/diner to /area/station/commons/lounge. However, the cqc addtional areas was never updated to reflect this change in the area.

I found this while looking back at #73878 (Were they just doing another coder meme I don't know about or something?) 

The visible areas are where the Chef gets CQC now

![image](https://user-images.githubusercontent.com/47338680/235769482-e952032e-e89f-4d49-ac81-9f0ad270541a.png)

It might be a bit big, but compared to how big the area is on other maps I think it's fine.   



Additionally, removes additional cqc areas being defined as /area/station/service/kitchen/diner for icebox for a minor code improvement, it was pointless since the diner is a subtype of kitchen


## Why It's Good For The Game

Chef has the CQC in the area they should

They're supposed to be able to protect the bot portal with it. 

## Changelog
:cl:
fix: Fixed the Chef not having CQC outside the kitchen on Tramstation
/:cl:
