### PR TITLE
Fixes ducky shoes having clown shoe slowdown

### DIFF
--- a/code/modules/clothing/shoes/clown.dm
+++ b/code/modules/clothing/shoes/clown.dm
@@ -61,3 +61,4 @@
 	icon_state = "ducky_shoes"
 	inhand_icon_state = "ducky_shoes"
 	squeak_sound = list('sound/effects/quack.ogg'=1) //quack quack quack quack
+	slowdown = SHOES_SLOWDOWN


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/53100513/235573548-0326fea9-348a-4b04-ac04-f18f9d748bda.png)
![image](https://user-images.githubusercontent.com/53100513/235573577-37cc5b80-d011-4f49-9805-40ffffae9c0c.png)

This is unintended and so it's a fix!
## Why It's Good For The Game

More incentive to quack quack quack quack. Clown shoes have slowdown for the clown, not for ducks. The subtype just inherited it.
## Changelog
:cl:
fix: Fixes ducky shoes having clown shoe slowdown
/:cl:
