### PR TITLE
Health Analyzer now lists embeds

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -251,6 +251,8 @@
 						dmgreport += "<tr><td><font color='#cc3333'>[capitalize(limb.plaintext_zone)]:</font></td>"
 					dmgreport += "<td><font color='#cc3333'>[(limb.brute_dam > 0) ? "[CEILING(limb.brute_dam,1)]" : "0"]</font></td>"
 					dmgreport += "<td><font color='#ff9933'>[(limb.burn_dam > 0) ? "[CEILING(limb.burn_dam,1)]" : "0"]</font></td></tr>"
+					for(var/obj/item/embed as anything in limb.embedded_objects)
+						dmgreport += "<td><font color='#f3e746'>Embedded object: [embed]</font></td></tr>"
 			dmgreport += "</font></table>"
 			render_list += dmgreport // tables do not need extra linebreak
 

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -251,10 +251,11 @@
 						dmgreport += "<tr><td><font color='#cc3333'>[capitalize(limb.plaintext_zone)]:</font></td>"
 					dmgreport += "<td><font color='#cc3333'>[(limb.brute_dam > 0) ? "[CEILING(limb.brute_dam,1)]" : "0"]</font></td>"
 					dmgreport += "<td><font color='#ff9933'>[(limb.burn_dam > 0) ? "[CEILING(limb.burn_dam,1)]" : "0"]</font></td></tr>"
-					for(var/obj/item/embed as anything in limb.embedded_objects)
-						dmgreport += "<td><font color='#f3e746'>Embedded object: [embed]</font></td></tr>"
 			dmgreport += "</font></table>"
 			render_list += dmgreport // tables do not need extra linebreak
+		for(var/obj/item/bodypart/limb as anything in carbontarget.bodyparts)
+			for(var/obj/item/embed as anything in limb.embedded_objects)
+				render_list += "<span class='alert ml-1'>Embedded object: [embed] located in \the [limb.plaintext_zone]</span>\n"
 
 	if(ishuman(target))
 		var/mob/living/carbon/human/humantarget = target


### PR DESCRIPTION
## About The Pull Request

Health analyzer now shows off any embeds in the limbs, right under their damage.

![image](https://user-images.githubusercontent.com/53777086/235578742-9ebf71ff-5c8f-44d7-96b0-5784e18ae07b.png)

## Why It's Good For The Game

Currently the only way to tell there's an embed in a bodypart is by examining them, and Doctors have their health analyzer to examine FOR them. Knowing embeds is an important part of treatment, so I think it's justified to have the analyzer show them this info.

## Changelog

:cl:
qol: Health Analyzers now show embeds in bodyparts on examine.
/:cl: