### PR TITLE
Hierophant club appearance updates properly; works if summoned into hand.

### DIFF
--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -129,6 +129,7 @@
 				user.visible_message(span_hierophant_warning("[user] places a strange machine beneath [user.p_their()] feet!"), \
 				"[span_hierophant("You detach the hierophant beacon, allowing you to teleport yourself and any allies to it at any time!")]\n\
 				[span_notice("You can remove the beacon to place it again by striking it with the club.")]")
+				update_icon_state()
 		else
 			to_chat(user, span_warning("You need to be on solid ground to detach the beacon!"))
 		return
@@ -219,7 +220,7 @@
 	if(user != teleporting && success)
 		log_combat(user, teleporting, "teleported", null, "from [AREACOORD(source)]")
 
-/obj/item/hierophant_club/pickup(mob/living/user)
+/obj/item/hierophant_club/equipped(mob/user)
 	. = ..()
 	blink.Grant(user, src)
 	user.update_icons()

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -87,11 +87,11 @@
 	new/obj/effect/temp_visual/hierophant/telegraph(get_turf(user))
 	playsound(user,'sound/machines/airlockopen.ogg', 75, TRUE)
 	user.visible_message(span_hierophant_warning("[user] fades out, leaving [user.p_their()] belongings behind!"))
-	for(var/obj/item/I in user)
-		if(I != src)
-			user.dropItemToGround(I)
-	for(var/turf/T in RANGE_TURFS(1, user))
-		new /obj/effect/temp_visual/hierophant/blast/visual(T, user, TRUE)
+	for(var/obj/item/user_item in user)
+		if(user_item != src)
+			user.dropItemToGround(user_item)
+	for(var/turf/blast_turf in RANGE_TURFS(1, user))
+		new /obj/effect/temp_visual/hierophant/blast/visual(blast_turf, user, TRUE)
 	user.dropItemToGround(src) //Drop us last, so it goes on top of their stuff
 	qdel(user)
 
@@ -121,15 +121,15 @@
 			user.visible_message(span_hierophant_warning("[user] starts fiddling with [src]'s pommel..."), \
 			span_notice("You start detaching the hierophant beacon..."))
 			if(do_after(user, 50, target = user) && !beacon)
-				var/turf/T = get_turf(user)
-				playsound(T,'sound/magic/blind.ogg', 200, TRUE, -4)
-				new /obj/effect/temp_visual/hierophant/telegraph/teleport(T, user)
-				beacon = new/obj/effect/hierophant(T)
+				var/turf/user_turf = get_turf(user)
+				playsound(user_turf,'sound/magic/blind.ogg', 200, TRUE, -4)
+				new /obj/effect/temp_visual/hierophant/telegraph/teleport(user_turf, user)
+				beacon = new/obj/effect/hierophant(user_turf)
 				user.update_mob_action_buttons()
 				user.visible_message(span_hierophant_warning("[user] places a strange machine beneath [user.p_their()] feet!"), \
 				"[span_hierophant("You detach the hierophant beacon, allowing you to teleport yourself and any allies to it at any time!")]\n\
 				[span_notice("You can remove the beacon to place it again by striking it with the club.")]")
-				update_icon_state()
+				update_appearance(UPDATE_ICON_STATE)
 		else
 			to_chat(user, span_warning("You need to be on solid ground to detach the beacon!"))
 		return
@@ -147,20 +147,20 @@
 	user.update_mob_action_buttons()
 	user.visible_message(span_hierophant_warning("[user] starts to glow faintly..."))
 	beacon.icon_state = "hierophant_tele_on"
-	var/obj/effect/temp_visual/hierophant/telegraph/edge/TE1 = new /obj/effect/temp_visual/hierophant/telegraph/edge(user.loc)
-	var/obj/effect/temp_visual/hierophant/telegraph/edge/TE2 = new /obj/effect/temp_visual/hierophant/telegraph/edge(beacon.loc)
+	var/obj/effect/temp_visual/hierophant/telegraph/edge/user_telegraph = new /obj/effect/temp_visual/hierophant/telegraph/edge(user.loc)
+	var/obj/effect/temp_visual/hierophant/telegraph/edge/beacon_telegraph = new /obj/effect/temp_visual/hierophant/telegraph/edge(beacon.loc)
 	if(do_after(user, 40, target = user) && user && beacon)
-		var/turf/T = get_turf(beacon)
+		var/turf/destination = get_turf(beacon)
 		var/turf/source = get_turf(user)
-		if(T.is_blocked_turf(TRUE))
+		if(destination.is_blocked_turf(TRUE))
 			teleporting = FALSE
 			to_chat(user, span_warning("The beacon is blocked by something, preventing teleportation!"))
 			user.update_mob_action_buttons()
 			beacon.icon_state = "hierophant_tele_off"
 			return
-		new /obj/effect/temp_visual/hierophant/telegraph(T, user)
+		new /obj/effect/temp_visual/hierophant/telegraph(destination, user)
 		new /obj/effect/temp_visual/hierophant/telegraph(source, user)
-		playsound(T,'sound/magic/wand_teleport.ogg', 200, TRUE)
+		playsound(destination,'sound/magic/wand_teleport.ogg', 200, TRUE)
 		playsound(source,'sound/machines/airlockopen.ogg', 200, TRUE)
 		if(!do_after(user, 3, target = user) || !user || !beacon || QDELETED(beacon)) //no walking away shitlord
 			teleporting = FALSE
@@ -169,27 +169,27 @@
 			if(beacon)
 				beacon.icon_state = "hierophant_tele_off"
 			return
-		if(T.is_blocked_turf(TRUE))
+		if(destination.is_blocked_turf(TRUE))
 			teleporting = FALSE
 			to_chat(user, span_warning("The beacon is blocked by something, preventing teleportation!"))
 			user.update_mob_action_buttons()
 			beacon.icon_state = "hierophant_tele_off"
 			return
 		user.log_message("teleported self from [AREACOORD(source)] to [beacon].", LOG_GAME)
-		new /obj/effect/temp_visual/hierophant/telegraph/teleport(T, user)
+		new /obj/effect/temp_visual/hierophant/telegraph/teleport(destination, user)
 		new /obj/effect/temp_visual/hierophant/telegraph/teleport(source, user)
-		for(var/t in RANGE_TURFS(1, T))
-			new /obj/effect/temp_visual/hierophant/blast/visual(t, user, TRUE)
-		for(var/t in RANGE_TURFS(1, source))
-			new /obj/effect/temp_visual/hierophant/blast/visual(t, user, TRUE)
-		for(var/mob/living/L in range(1, source))
-			INVOKE_ASYNC(src, PROC_REF(teleport_mob), source, L, T, user)
+		for(var/turf_near_beacon in RANGE_TURFS(1, destination))
+			new /obj/effect/temp_visual/hierophant/blast/visual(turf_near_beacon, user, TRUE)
+		for(var/turf_near_source in RANGE_TURFS(1, source))
+			new /obj/effect/temp_visual/hierophant/blast/visual(turf_near_source, user, TRUE)
+		for(var/mob/living/mob_to_teleport in range(1, source))
+			INVOKE_ASYNC(src, PROC_REF(teleport_mob), source, mob_to_teleport, destination, user)
 		sleep(0.6 SECONDS) //at this point the blasts detonate
 		if(beacon)
 			beacon.icon_state = "hierophant_tele_off"
 	else
-		qdel(TE1)
-		qdel(TE2)
+		qdel(user_telegraph)
+		qdel(beacon_telegraph)
 	if(beacon)
 		beacon.icon_state = "hierophant_tele_off"
 	teleporting = FALSE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -760,7 +760,7 @@ Difficulty: Hard
 				new /obj/effect/temp_visual/hierophant/telegraph/teleport(get_turf(src), user)
 				to_chat(user, span_hierophant_warning("You collect [src], reattaching it to the club!"))
 				club.beacon = null
-				club.update_icon_state()
+				club.update_appearance(UPDATE_ICON_STATE)
 				user.update_mob_action_buttons()
 				qdel(src)
 		else

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -750,17 +750,17 @@ Difficulty: Hard
 	layer = LOW_OBJ_LAYER
 	anchored = TRUE
 
-/obj/effect/hierophant/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/hierophant_club))
-		var/obj/item/hierophant_club/H = I
-		if(H.beacon == src)
+/obj/effect/hierophant/attackby(obj/item/attacking_item, mob/user, params)
+	if(istype(attacking_item, /obj/item/hierophant_club))
+		var/obj/item/hierophant_club/club = attacking_item
+		if(club.beacon == src)
 			to_chat(user, span_notice("You start removing your hierophant beacon..."))
 			if(do_after(user, 50, target = src))
 				playsound(src,'sound/magic/blind.ogg', 200, TRUE, -4)
 				new /obj/effect/temp_visual/hierophant/telegraph/teleport(get_turf(src), user)
 				to_chat(user, span_hierophant_warning("You collect [src], reattaching it to the club!"))
-				H.beacon = null
-				H.update_appearance()
+				club.beacon = null
+				club.update_icon_state()
 				user.update_mob_action_buttons()
 				qdel(src)
 		else


### PR DESCRIPTION
## About The Pull Request

Fixed a pair of bugs with the hierophant club.

First, the appearance of the club would not update properly to display whether or not the beacon is attached. The icon state was only ever updated when the blink action was used, rather than when the beacon was actually manipulated. It now updates at sensible times.

Second, the blink action was granted when the hierophant club was _picked up,_ rather than equipped into hand. This meant that if the club was placed in your hand by any means other than picking up (most relevantly, by casting Instant Summons, something miners can reasonably get their hands on), the blink action would not work unless you drop it and pick it up again. It now uses the `equipped()` proc to do this correctly.
## Why It's Good For The Game

Visual feedback is useful to know whether or not you have a beacon deployed - since the UI button doesn't change at all to tell you this information.

The summoning bug is minor, but could cause problems for miners who have acquired both the club and Instant Summons - the bug could ruin a perfectly good getaway plan.
## Changelog
:cl:
fix: The hierophant club's sprite updates when it should
fix: The hierophant club grants the blink action when summoned into hand
/:cl:
