### PR TITLE
Gives stairs infinite move resistance

### DIFF
--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -11,6 +11,7 @@
 	icon = 'icons/obj/stairs.dmi'
 	icon_state = "stairs"
 	anchored = TRUE
+	move_resist = INFINITY
 
 	var/force_open_above = FALSE // replaces the turf above this stair obj with /turf/open/openspace
 	var/terminator_mode = STAIR_TERMINATOR_AUTOMATIC


### PR DESCRIPTION
## About The Pull Request

Gives stairs `move_resist = INFINITY`, preventing anything with above-average move force from moving them.

Fixes, only partially, #75093 . 

## Why It's Good For The Game

Currently, mobs with above average move forces, like Goliaths and Megafauna will break stairs on their first use, not by destroying them but by physically moving the stairs one tile. 

While funny, this really does mess with a few maps, opens up easy grief, and doesn't make too much sense. 

## Changelog

:cl: Melbert
fix: Stairs are now resistant to being shoved by mobs with high move force. 
/:cl:
