### PR TITLE
Changes the blast doors for Icebox's Pharmacy and Medical Sec Outpost to shutters

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1205,8 +1205,8 @@
 "aur" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
-	id = "chemistry_lower_shutters";
-	name = "Chemistry Exterior Shutters"
+	id = "pharmacy_shutters3";
+	name = "Pharmacy Shutters"
 	},
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
@@ -12518,11 +12518,12 @@
 /area/station/security/prison/safe)
 "dSC" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "medsecprivacy";
-	name = "Privacy Shutter"
-	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "medsecprivacy";
+	name = "Privacy Shutters"
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
 "dSI" = (
@@ -20258,7 +20259,7 @@
 "gtq" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
-	id = "hop";
+	id = "medsecprivacy";
 	name = "Privacy Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
@@ -22217,9 +22218,9 @@
 /area/station/command/meeting_room)
 "hbC" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "pharmacy_shutters2";
-	name = "Pharmacy Shutter"
+	name = "Pharmacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
@@ -27217,6 +27218,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"iKI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "pharmacy_shutters3";
+	name = "Pharmacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/medical/pharmacy)
 "iKQ" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/openspace,
@@ -34767,14 +34777,15 @@
 /obj/item/pen{
 	pixel_x = -5
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "pharmacy_shutters";
-	name = "Pharmacy Shutter"
-	},
 /obj/structure/desk_bell{
 	pixel_x = 7
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pharmacy_shutters";
+	name = "Pharmacy Shutters";
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
 "lca" = (
@@ -36043,10 +36054,6 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/machinery/door/poddoor/preopen{
-	id = "pharmacy_shutters2";
-	name = "Pharmacy Shutter"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/right/directional/east{
 	base_state = "left";
@@ -36056,6 +36063,11 @@
 	req_access = list("pharmacy")
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pharmacy_shutters3";
+	name = "Pharmacy Shutters";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
 "lxn" = (
@@ -39738,7 +39750,7 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 8;
-	id = "hop";
+	id = "medsecprivacy";
 	name = "Privacy Shutters"
 	},
 /obj/structure/desk_bell{
@@ -40913,9 +40925,10 @@
 /area/station/security/brig)
 "neo" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "pharmacy_shutters3";
-	name = "Pharmacy Shutter"
+	name = "Pharmacy Shutters";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
@@ -43333,6 +43346,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"nNj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pharmacy_shutters2";
+	name = "Pharmacy Shutters"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pharmacy_shutters2";
+	name = "Pharmacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/medical/pharmacy)
 "nNn" = (
 /turf/closed/wall,
 /area/station/security/prison/rec)
@@ -45010,8 +45035,9 @@
 "onv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchencounter";
-	name = "Kitchen Counter Shutters"
+	id = "pharmacy_shutters3";
+	name = "Pharmacy Shutters";
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/service/kitchen)
@@ -45857,11 +45883,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oAp" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "pharmacy_shutters";
-	name = "Pharmacy Shutter"
-	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pharmacy_shutters";
+	name = "Pharmacy Shutters";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
 "oAz" = (
@@ -48592,9 +48619,10 @@
 	dir = 4;
 	req_access = list("brig_entrance")
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "medsecprivacy";
-	name = "Privacy Shutter"
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
@@ -48762,7 +48790,7 @@
 "pxV" = (
 /obj/machinery/chem_master,
 /obj/machinery/button/door/directional/north{
-	id = "pharmacy_shutters";
+	id = "pharmacy_shutters"s;
 	name = "Pharmacy Shutter Controls";
 	req_access = list("pharmacy")
 	},
@@ -61252,9 +61280,10 @@
 	dir = 4;
 	req_access = list("brig_entrance")
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
 	id = "medsecprivacy";
-	name = "Privacy Shutter"
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
@@ -240827,7 +240856,7 @@ hWP
 ocj
 azw
 azw
-neo
+iKI
 azw
 azw
 gIY
@@ -242374,7 +242403,7 @@ aMP
 scY
 oQD
 hHI
-hbC
+nNj
 niu
 fKi
 tHr

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -36064,9 +36064,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "pharmacy_shutters3";
+	id = "pharmacy_shutters2";
 	name = "Pharmacy Shutters";
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -48790,7 +48790,7 @@
 "pxV" = (
 /obj/machinery/chem_master,
 /obj/machinery/button/door/directional/north{
-	id = "pharmacy_shutters"s;
+	id = "pharmacy_shutters";
 	name = "Pharmacy Shutter Controls";
 	req_access = list("pharmacy")
 	},


### PR DESCRIPTION
## About The Pull Request

I thought it was weird that those used blast doors instead of shutters, like most other places do.
So it has been changed.

## Why It's Good For The Game

Blast doors don't really make sense for the sec outpost. I can see reasons why for the pharmacy, but IMO shutters fit better anyways.

## Changelog
:cl:
qol: The Ice Box pharmacy and Med Sec Outpost blast doors have been replaced with shutters.
/:cl:
