### PR TITLE
Fixes organs not spilling out

### DIFF
--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -45,26 +45,26 @@
 				if(no_brain || !istype(X, /obj/item/organ/internal/brain))
 					qdel(X)
 		else //we're going to drop all bodyparts except chest, so the only organs that needs spilling are those inside it.
-			for(var/obj/item/organ/organs as anything in organs)
-				if(no_brain && istype(organs, /obj/item/organ/internal/brain))
-					qdel(organs) //so the brain isn't transfered to the head when the head drops.
+			for(var/obj/item/organ/organ as anything in organs)
+				if(no_brain && istype(organ, /obj/item/organ/internal/brain))
+					qdel(organ) //so the brain isn't transfered to the head when the head drops.
 					continue
-				var/org_zone = check_zone(organs.zone) //both groin and chest organs.
+				var/org_zone = check_zone(organ.zone) //both groin and chest organs.
 				if(org_zone == BODY_ZONE_CHEST)
-					organs.Remove(src)
-					organs.forceMove(Tsec)
-					organs.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+					organ.Remove(src)
+					organ.forceMove(Tsec)
+					organ.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
 	else
-		for(var/obj/item/organ/organs as anything in organs)
-			if(no_brain && istype(organs, /obj/item/organ/internal/brain))
-				qdel(organs)
+		for(var/obj/item/organ/organ as anything in organs)
+			if(no_brain && istype(organ, /obj/item/organ/internal/brain))
+				qdel(organ)
 				continue
-			if(no_organs && !istype(organs, /obj/item/organ/internal/brain))
-				qdel(organs)
+			if(no_organs && !istype(organ, /obj/item/organ/internal/brain))
+				qdel(organ)
 				continue
-			organs.Remove(src)
-			organs.forceMove(Tsec)
-			organs.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+			organ.Remove(src)
+			organ.forceMove(Tsec)
+			organ.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
 
 /// Launches all bodyparts away from the mob. skip_head will keep the head attached.
 /mob/living/carbon/spread_bodyparts(skip_head = FALSE)


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/20797

I was tracking an issue related to an IPC brain not dropping and was led on a wild goose chase through brain code. Brain code is bad times.

Anyway the issue ended up not having anything to do with brain code. During https://github.com/tgstation/tgstation/pull/73918 there was a refactor to change the name of the internal organs list from 'internal_organs' to just 'organs'.

This is all good and cool, but one problem:

https://github.com/tgstation/tgstation/blob/c8982bfb1cd103539d0be86689f40a023dbb7f22/code/modules/mob/living/carbon/death.dm#L48

The `spill_organs` proc was iterating through the (previously named) `internal_organs` list using a var called `organs`. Which is now currently the name of the list itself. Derp.

<details><summary>We are back to this now.</summary>

![image](https://user-images.githubusercontent.com/13398309/235855290-bf5ad54b-cfa5-4bb6-8162-870e032af6cc.png)

</details>

## Why It's Good For The Game

Bugfix, now organs will spill again when a mob gets gibbed. In case you missed getting hit in the face by a flying liver.

## Changelog
:cl:
fix: a mob will now once again spill their organs when they are gibbed
/:cl:
