### PR TITLE
Fixes runtime when toggling engineering meson scanners

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -578,7 +578,7 @@
 			set_invis_see(min(glasses.invis_view, see_invisible))
 		if(!isnull(glasses.lighting_cutoff))
 			lighting_cutoff = max(lighting_cutoff, glasses.lighting_cutoff)
-		if(!isnull(glasses.color_cutoffs))
+		if(length(glasses.color_cutoffs))
 			lighting_color_cutoffs = blend_cutoff_colors(lighting_color_cutoffs, glasses.color_cutoffs)
 
 


### PR DESCRIPTION
## About The Pull Request
Fixes this
![Screenshot (190)](https://user-images.githubusercontent.com/110812394/235924099-df5020bc-0100-4e2e-b7ba-7d44f4969654.png)

Caused by the highlighted line
![Screenshot (191)](https://user-images.githubusercontent.com/110812394/235924142-4de0edef-1ec0-47ed-aa07-1a2feadb3a47.png)

when switching modes the glasses `color_cutoffs` becomes an empty list, not null
When glass color is yellow
![Screenshot (188)](https://user-images.githubusercontent.com/110812394/235924541-4b452c9a-dd5b-4ebc-85c9-f9a4ef7f2128.png)
When it's blue or off
![Screenshot (189)](https://user-images.githubusercontent.com/110812394/235924613-bd1ed78d-dd11-4760-9a83-c1f3d1203288.png)
So, blending an empty list causes the exception


## Changelog
:cl:
fix: runtime when toggling engineering meson scanners
/:cl:
