### PR TITLE
adds an error message to movables not being removed from the grid... again

### DIFF
--- a/code/__DEFINES/spatial_gridmap.dm
+++ b/code/__DEFINES/spatial_gridmap.dm
@@ -23,11 +23,12 @@
 #ifdef UNIT_TESTS
 #define UPDATE_GRID_METADATA(movable_or_list, cell) \
 	do { \
+		var/list/_definitely_list = movable_or_list
 		if(!istype(movable_or_list, /list)) { \
-			movable_or_list = list(movable_or_list) \
+			_definitely_list = list(movable_or_list) \
 		} \
 		var/list/all_contents = ALL_CHANNELS_OF_CELL(cell); \
-		for(var/atom/movable/_thing in movable_or_list) { \
+		for(var/atom/movable/_thing in _definitely_list) { \
 			if(_thing in all_contents) { \
 				LAZYOR(_thing.in_spatial_grid_cells, cell) \
 			} else { \

--- a/code/__DEFINES/spatial_gridmap.dm
+++ b/code/__DEFINES/spatial_gridmap.dm
@@ -23,7 +23,7 @@
 #ifdef UNIT_TESTS
 #define UPDATE_GRID_METADATA(movable_or_list, cell) \
 	do { \
-		var/list/_definitely_list = movable_or_list
+		var/list/_definitely_list = movable_or_list; \
 		if(!istype(movable_or_list, /list)) { \
 			_definitely_list = list(movable_or_list) \
 		} \

--- a/code/__DEFINES/spatial_gridmap.dm
+++ b/code/__DEFINES/spatial_gridmap.dm
@@ -24,7 +24,7 @@
 #define UPDATE_GRID_METADATA(movable_or_list, cell) \
 	do { \
 		var/list/_definitely_list = movable_or_list; \
-		if(!istype(movable_or_list, /list)) { \
+		if(!islist(movable_or_list)) { \
 			_definitely_list = list(movable_or_list) \
 		} \
 		var/list/all_contents = ALL_CHANNELS_OF_CELL(cell); \

--- a/code/__DEFINES/spatial_gridmap.dm
+++ b/code/__DEFINES/spatial_gridmap.dm
@@ -15,31 +15,58 @@
 ///all atmos machines are stored in this channel (I'm sorry kyler)
 #define SPATIAL_GRID_CONTENTS_TYPE_ATMOS "spatial_grid_contents_type_atmos"
 
+#define ALL_CHANNELS_OF_CELL(cell) (cell.hearing_contents | cell.client_contents | cell.atmos_contents)
+
 ///whether movable is itself or containing something which should be in one of the spatial grid channels.
 #define HAS_SPATIAL_GRID_CONTENTS(movable) (movable.spatial_grid_key)
+
+#ifdef UNIT_TESTS
+#define UPDATE_GRID_METADATA(movable_or_list, cell) \
+	do { \
+		if(!istype(movable_or_list, /list)) { \
+			movable_or_list = list(movable_or_list) \
+		} \
+		var/list/all_contents = ALL_CHANNELS_OF_CELL(cell); \
+		for(var/atom/movable/_thing in movable_or_list) { \
+			if(_thing in all_contents) { \
+				LAZYOR(_thing.in_spatial_grid_cells, cell) \
+			} else { \
+				LAZYREMOVE(_thing.in_spatial_grid_cells, cell) \
+			} \
+		} \
+	} while(FALSE)
+
+#else
+
+#define UPDATE_GRID_METADATA(movable_or_list, cell)
+
+#endif
 
 // macros meant specifically to add/remove movables from the internal lists of /datum/spatial_grid_cell,
 // when empty they become references to a single list in SSspatial_grid and when filled they become their own list
 // this is to save memory without making them lazylists as that slows down iteration through them
-#define GRID_CELL_ADD(cell_contents_list, movable_or_list) \
+#define GRID_CELL_ADD(cell, cell_contents_list, movable_or_list) \
 	if(!length(cell_contents_list)) { \
 		cell_contents_list = list(); \
 		cell_contents_list += movable_or_list; \
 	} else { \
 		cell_contents_list += movable_or_list; \
-	};
+	};\
+	UPDATE_GRID_METADATA(movable_or_list, cell)
 
-#define GRID_CELL_SET(cell_contents_list, movable_or_list) \
+#define GRID_CELL_SET(cell, cell_contents_list, movable_or_list) \
 	if(!length(cell_contents_list)) { \
 		cell_contents_list = list(); \
 		cell_contents_list += movable_or_list; \
 	} else { \
 		cell_contents_list |= movable_or_list; \
-	};
+	};\
+	UPDATE_GRID_METADATA(movable_or_list, cell)
 
 //dont use these outside of SSspatial_grid's scope use the procs it has for this purpose
-#define GRID_CELL_REMOVE(cell_contents_list, movable_or_list) \
+#define GRID_CELL_REMOVE(cell, cell_contents_list, movable_or_list) \
 	cell_contents_list -= movable_or_list; \
 	if(!length(cell_contents_list)) {\
 		cell_contents_list = dummy_list; \
-	};
+	}; \
+	UPDATE_GRID_METADATA(movable_or_list, cell)

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -63,7 +63,7 @@
 #endif // REFERENCE_DOING_IT_LIVE
 
 // If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
-// #define UNIT_TESTS
+//#define UNIT_TESTS
 
 // If this is uncommented, will attempt to load and initialize prof.dll/libprof.so.
 // We do not ship byond-tracy. Build it yourself here: https://github.com/mafemergency/byond-tracy/

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -63,7 +63,7 @@
 #endif // REFERENCE_DOING_IT_LIVE
 
 // If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
-//#define UNIT_TESTS
+// #define UNIT_TESTS
 
 // If this is uncommented, will attempt to load and initialize prof.dll/libprof.so.
 // We do not ship byond-tracy. Build it yourself here: https://github.com/mafemergency/byond-tracy/

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -493,9 +493,11 @@ SUBSYSTEM_DEF(spatial_grid)
 
 		#ifdef UNIT_TESTS
 
-		var/input_cell_cords = "([input_cell.cell_x], [input_cell.cell_y], [input_cell.cell_z])"
+		var/input_cell_coords = "NONE!"
+		if(input_cell)
+			input_cell_coords = "([input_cell.cell_x], [input_cell.cell_y], [input_cell.cell_z])"
 
-		if(input_cell && !(input_cell in to_remove.in_spatial_grid_cells))
+		if(input_cell && length(to_remove.in_spatial_grid_cells) && !(input_cell in to_remove.in_spatial_grid_cells))
 			var/error_data = ""
 			for(var/datum/spatial_grid_cell/cell in to_remove.in_spatial_grid_cells)
 				var/coords = "([cell.cell_x], [cell.cell_y], [cell.cell_z])"
@@ -521,7 +523,7 @@ SUBSYSTEM_DEF(spatial_grid)
 				else
 					error_data = "{[coords] in: [contents]}"
 
-			stack_trace("[to_remove] at cell indices: [input_cell_cords], found in [length(to_remove.in_spatial_grid_cells)] spatial grid cells and they wouldnt have been caught by force_remove_by()! cells: [error_data]")
+			stack_trace("[to_remove] at cell indices: [input_cell_coords], found in [length(to_remove.in_spatial_grid_cells)] spatial grid cells and they wouldnt have been caught by force_remove_by()! cells: [error_data]")
 
 			find_hanging_cell_refs_for_movable(to_remove, TRUE)
 			return

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -528,12 +528,11 @@ SUBSYSTEM_DEF(spatial_grid)
 			find_hanging_cell_refs_for_movable(to_remove, TRUE)
 			return
 
-		#else
+		#endif
+
 		if(!input_cell)
 			find_hanging_cell_refs_for_movable(to_remove, TRUE)
 			return
-
-		#endif
 
 	GRID_CELL_REMOVE(input_cell, input_cell.client_contents, to_remove)
 	GRID_CELL_REMOVE(input_cell, input_cell.hearing_contents, to_remove)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -505,7 +505,7 @@ SUBSYSTEM_DEF(spatial_grid)
 	if(!input_cell)
 		input_cell = get_cell_of(to_remove)
 
-		#ifdef UNIT_TEST
+		#ifdef UNIT_TESTS
 
 		var/input_cell_cords = "([input_cell.x], [input_cell.y], [input_cell.z])"
 

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -482,20 +482,6 @@ SUBSYSTEM_DEF(spatial_grid)
 
 	return TRUE
 
-#ifdef UNIT_TESTS
-/mob/living/carbon/human/species/lizard/trolls_the_maintainer
-	name = "trolls-the-maintainer"
-
-/mob/living/carbon/human/species/lizard/trolls_the_maintainer/Initialize(mapload)
-	. = ..()
-	become_hearing_sensitive()
-	var/list/datum/spatial_grid_cell/nearby_cells = SSspatial_grid.get_cells_in_range(src, 30)
-
-	for(var/datum/spatial_grid_cell/nearby_cell in nearby_cells)
-		GRID_CELL_ADD(nearby_cell, nearby_cell.hearing_contents, src)
-		GRID_CELL_ADD(nearby_cell, nearby_cell.hearing_contents, src)
-#endif
-
 ///find the cell this movable is associated with and removes it from all lists
 /datum/controller/subsystem/spatial_grid/proc/force_remove_from_cell(atom/movable/to_remove, datum/spatial_grid_cell/input_cell)
 	if(!initialized)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -493,7 +493,7 @@ SUBSYSTEM_DEF(spatial_grid)
 
 		#ifdef UNIT_TESTS
 
-		if(input_cell && (!(input_cell in to_remove.in_spatial_grid_cells) || length(to_remove.spatial_grid_cells) > 1))
+		if(input_cell && (!(input_cell in to_remove.in_spatial_grid_cells) || length(to_remove.in_spatial_grid_cells) > 1))
 			var/input_cell_coords = "([input_cell.cell_x], [input_cell.cell_y], [input_cell.cell_z])"
 
 			var/error_data = ""

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -367,16 +367,16 @@ SUBSYSTEM_DEF(spatial_grid)
 		switch(type)
 			if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
 				var/list/new_target_contents = new_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-				GRID_CELL_SET(intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
+				GRID_CELL_SET(intersecting_cell, intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 			if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
 				var/list/new_target_contents = new_target.important_recursive_contents
-				GRID_CELL_SET(intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+				GRID_CELL_SET(intersecting_cell, intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_HEARING), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 
 			if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-				GRID_CELL_SET(intersecting_cell.atmos_contents, new_target)
+				GRID_CELL_SET(intersecting_cell, intersecting_cell.atmos_contents, new_target)
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_ATMOS), new_target)
 
 ///acts like enter_cell() but only adds the target to a specified type of grid cell contents list
@@ -397,16 +397,16 @@ SUBSYSTEM_DEF(spatial_grid)
 	switch(exclusive_type)
 		if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
 			var/list/new_target_contents = new_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-			GRID_CELL_SET(intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
+			GRID_CELL_SET(intersecting_cell, intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 		if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
 			var/list/new_target_contents = new_target.important_recursive_contents
-			GRID_CELL_SET(intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+			GRID_CELL_SET(intersecting_cell, intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_HEARING), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 
 		if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-			GRID_CELL_SET(intersecting_cell.atmos_contents, new_target)
+			GRID_CELL_SET(intersecting_cell, intersecting_cell.atmos_contents, new_target)
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_ATMOS), new_target)
 
 	return intersecting_cell
@@ -436,16 +436,16 @@ SUBSYSTEM_DEF(spatial_grid)
 		switch(type)
 			if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
 				var/list/old_target_contents = old_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-				GRID_CELL_REMOVE(intersecting_cell.client_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
+				GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.client_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS), old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 			if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
 				var/list/old_target_contents = old_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-				GRID_CELL_REMOVE(intersecting_cell.hearing_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+				GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.hearing_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(SPATIAL_GRID_CONTENTS_TYPE_HEARING), old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 
 			if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-				GRID_CELL_REMOVE(intersecting_cell.atmos_contents, old_target)
+				GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.atmos_contents, old_target)
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(SPATIAL_GRID_CONTENTS_TYPE_ATMOS), old_target)
 
 	return TRUE
@@ -468,19 +468,33 @@ SUBSYSTEM_DEF(spatial_grid)
 	switch(exclusive_type)
 		if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
 			var/list/old_target_contents = old_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-			GRID_CELL_REMOVE(intersecting_cell.client_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
+			GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.client_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 		if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
 			var/list/old_target_contents = old_target.important_recursive_contents
-			GRID_CELL_REMOVE(intersecting_cell.hearing_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+			GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.hearing_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 
 		if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-			GRID_CELL_REMOVE(intersecting_cell.atmos_contents, old_target)
+			GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.atmos_contents, old_target)
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target)
 
 	return TRUE
+
+#ifdef UNIT_TESTS
+/mob/living/carbon/human/species/lizard/trolls_the_maintainer
+	name = "trolls-the-maintainer"
+
+/mob/living/carbon/human/species/lizard/trolls_the_maintainer/Initialize(mapload)
+	. = ..()
+	become_hearing_sensitive()
+	var/list/datum/spatial_grid_cell/nearby_cells = SSspatial_grid.get_cells_in_range(src, 30)
+
+	for(var/datum/spatial_grid_cell/nearby_cell in nearby_cells)
+		GRID_CELL_ADD(nearby_cell, nearby_cell.hearing_contents, src)
+		GRID_CELL_ADD(nearby_cell, nearby_cell.hearing_contents, src)
+#endif
 
 ///find the cell this movable is associated with and removes it from all lists
 /datum/controller/subsystem/spatial_grid/proc/force_remove_from_cell(atom/movable/to_remove, datum/spatial_grid_cell/input_cell)
@@ -490,13 +504,56 @@ SUBSYSTEM_DEF(spatial_grid)
 
 	if(!input_cell)
 		input_cell = get_cell_of(to_remove)
+
+		#ifdef UNIT_TEST
+
+		var/input_cell_cords = "([input_cell.x], [input_cell.y], [input_cell.z])"
+
+		if(input_cell && !(input_cell in to_remove.in_spatial_grid_cells))
+			var/error_data = ""
+			for(var/datum/spatial_grid_cell/cell in to_remove.in_spatial_grid_cells)
+				var/coords = "([cell.x], [cell.y], [cell.z])"
+				var/contents = ""
+
+				if(to_remove in cell.hearing_contents)
+					contents = "hearing contents"
+
+				if(to_remove in cell.client_contents)
+					if(length(contents) > 0)
+						contents = "[contents], client contents"
+					else
+						contents = "client contents"
+
+				if(to_remove in cell.atmos_contents)
+					if(length(contents) > 0)
+						contents = "[contents], atmos contents"
+					else
+						contents = "atmos contents"
+
+				if(length(error_data) > 0)
+					error_data = "[error_data], {[coords] in [contents]}"
+				else
+					error_data = "{[coords] in: [contents]}"
+
+			stack_trace("[to_remove] at cell indices: [input_cell_cords], found in [length(to_remove.in_spatial_grid_cells)] spatial grid cells and they wouldnt have been caught by force_remove_by()! cells: [error_data]")
+
+			find_hanging_cell_refs_for_movable(to_remove, TRUE)
+			return
+
+		#else
 		if(!input_cell)
 			find_hanging_cell_refs_for_movable(to_remove, TRUE)
 			return
 
-	GRID_CELL_REMOVE(input_cell.client_contents, to_remove)
-	GRID_CELL_REMOVE(input_cell.hearing_contents, to_remove)
-	GRID_CELL_REMOVE(input_cell.atmos_contents, to_remove)
+		#endif
+
+	GRID_CELL_REMOVE(input_cell, input_cell.client_contents, to_remove)
+	GRID_CELL_REMOVE(input_cell, input_cell.hearing_contents, to_remove)
+	GRID_CELL_REMOVE(input_cell, input_cell.atmos_contents, to_remove)
+
+	#ifdef UNIT_TESTS
+	to_remove.in_spatial_grid_cells = null
+	#endif
 
 ///if shit goes south, this will find hanging references for qdeleting movables inside the spatial grid
 /datum/controller/subsystem/spatial_grid/proc/find_hanging_cell_refs_for_movable(atom/movable/to_remove, remove_from_cells = TRUE)
@@ -758,7 +815,5 @@ SUBSYSTEM_DEF(spatial_grid)
 
 #undef BOUNDING_BOX_MAX
 #undef BOUNDING_BOX_MIN
-#undef GRID_CELL_ADD
-#undef GRID_CELL_REMOVE
-#undef GRID_CELL_SET
+
 #undef NUMBER_OF_PREGENERATED_ORANGES_EARS

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -493,11 +493,9 @@ SUBSYSTEM_DEF(spatial_grid)
 
 		#ifdef UNIT_TESTS
 
-		var/input_cell_coords = "NONE!"
-		if(input_cell)
-			input_cell_coords = "([input_cell.cell_x], [input_cell.cell_y], [input_cell.cell_z])"
+		if(input_cell && (!(input_cell in to_remove.in_spatial_grid_cells) || length(to_remove.spatial_grid_cells) > 1))
+			var/input_cell_coords = "([input_cell.cell_x], [input_cell.cell_y], [input_cell.cell_z])"
 
-		if(input_cell && length(to_remove.in_spatial_grid_cells) && !(input_cell in to_remove.in_spatial_grid_cells))
 			var/error_data = ""
 			for(var/datum/spatial_grid_cell/cell in to_remove.in_spatial_grid_cells)
 				var/coords = "([cell.cell_x], [cell.cell_y], [cell.cell_z])"

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -507,12 +507,12 @@ SUBSYSTEM_DEF(spatial_grid)
 
 		#ifdef UNIT_TESTS
 
-		var/input_cell_cords = "([input_cell.x], [input_cell.y], [input_cell.z])"
+		var/input_cell_cords = "([input_cell.cell_x], [input_cell.cell_y], [input_cell.cell_z])"
 
 		if(input_cell && !(input_cell in to_remove.in_spatial_grid_cells))
 			var/error_data = ""
 			for(var/datum/spatial_grid_cell/cell in to_remove.in_spatial_grid_cells)
-				var/coords = "([cell.x], [cell.y], [cell.z])"
+				var/coords = "([cell.cell_x], [cell.cell_y], [cell.cell_z])"
 				var/contents = ""
 
 				if(to_remove in cell.hearing_contents)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -486,7 +486,6 @@ SUBSYSTEM_DEF(spatial_grid)
 /// this will error. this checks every grid cell in the world so dont call this on live unless you have to.
 /// returns TRUE if this movable is untracked, FALSE otherwise
 /datum/controller/subsystem/spatial_grid/proc/untracked_movable_error(atom/movable/movable_to_check)
-
 	if(!movable_to_check?.spatial_grid_key)
 		return FALSE
 

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -556,9 +556,6 @@ SUBSYSTEM_DEF(spatial_grid)
 
 		return TRUE
 
-	else if(istype(movable_to_check, /mob/living/trolls_the_maintainer))//TODOKYLER: remove
-		stack_trace("somehow trolls_the_maintainer didnt fail the check!")
-
 	return FALSE
 
 /**

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -488,13 +488,9 @@ SUBSYSTEM_DEF(spatial_grid)
 /datum/controller/subsystem/spatial_grid/proc/untracked_movable_error(atom/movable/movable_to_check)
 
 	if(!movable_to_check?.spatial_grid_key)
-		if(istype(movable_to_check, /mob/living/trolls_the_maintainer))
-			stack_trace("untracked_movable_error() trolls_the_maintainer doesnt have a grid key!")
 		return FALSE
 
 	if(!initialized)
-		if(istype(movable_to_check, /mob/living/trolls_the_maintainer))
-			stack_trace("untracked_movable_error() not initialized!")
 		return FALSE
 
 	var/datum/spatial_grid_cell/loc_cell = get_cell_of(movable_to_check)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -546,9 +546,8 @@ SUBSYSTEM_DEF(spatial_grid)
 		 * {coords: (221, 170, 3), within channels: hearing},
 		 * {coords: (255, 153, 11), within channels: hearing},
 		 * {coords: (136, 136, 14), within channels: hearing}.
-		 * ping @KylerAce in discord if you see this
 		 */
-		stack_trace("[movable_to_check.type] instance, [location_string], [error_explanation] [error_data]. ping @KylerAce in discord if you see this")
+		stack_trace("[movable_to_check.type] instance, [location_string], [error_explanation] [error_data].")
 
 		return TRUE
 

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -493,7 +493,7 @@ SUBSYSTEM_DEF(spatial_grid)
 		return FALSE
 
 	var/datum/spatial_grid_cell/loc_cell = get_cell_of(movable_to_check)
-	var/list/containing_cells = find_hanging_cell_refs_for_movable(movable_to_check, FALSE)
+	var/list/containing_cells = find_hanging_cell_refs_for_movable(movable_to_check, remove_from_cells=FALSE)
 	//if we're in multiple cells, throw an error.
 	//if we're in 1 cell but it cant be deduced by our location, throw an error.
 	if(length(containing_cells) > 1 || (length(containing_cells) == 1 && loc_cell && containing_cells[1] != loc_cell && containing_cells[1] != null))
@@ -565,7 +565,7 @@ SUBSYSTEM_DEF(spatial_grid)
 
 #ifdef UNIT_TESTS
 	if(untracked_movable_error(to_remove))
-		find_hanging_cell_refs_for_movable(to_remove, TRUE)
+		find_hanging_cell_refs_for_movable(to_remove, remove_from_cells=TRUE)
 		return
 #endif
 
@@ -574,7 +574,7 @@ SUBSYSTEM_DEF(spatial_grid)
 	if(loc_cell)
 		GRID_CELL_REMOVE_ALL(loc_cell, to_remove)
 	else
-		find_hanging_cell_refs_for_movable(to_remove, TRUE)
+		find_hanging_cell_refs_for_movable(to_remove, remove_from_cells=TRUE)
 
 ///remove this movable from the given spatial_grid_cell
 /datum/controller/subsystem/spatial_grid/proc/force_remove_from_cell(atom/movable/to_remove, datum/spatial_grid_cell/input_cell)

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -539,7 +539,7 @@ SUBSYSTEM_DEF(spatial_grid)
 				if(length(error_data) > 0)
 					error_data = "[error_data], {coords: [coords], within channels: [contents]}"
 				else
-					error_data = "within the contents of the following cells: {[coords], within channels: [contents]}"
+					error_data = "within the contents of the following cells: {coords: [coords], within channels: [contents]}"
 
 		/**
 		 * example:

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -367,16 +367,16 @@ SUBSYSTEM_DEF(spatial_grid)
 		switch(type)
 			if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
 				var/list/new_target_contents = new_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-				GRID_CELL_SET(intersecting_cell, intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
+				GRID_CELL_SET(intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 			if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
 				var/list/new_target_contents = new_target.important_recursive_contents
-				GRID_CELL_SET(intersecting_cell, intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+				GRID_CELL_SET(intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_HEARING), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 
 			if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-				GRID_CELL_SET(intersecting_cell, intersecting_cell.atmos_contents, new_target)
+				GRID_CELL_SET(intersecting_cell.atmos_contents, new_target)
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_ATMOS), new_target)
 
 ///acts like enter_cell() but only adds the target to a specified type of grid cell contents list
@@ -397,16 +397,16 @@ SUBSYSTEM_DEF(spatial_grid)
 	switch(exclusive_type)
 		if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
 			var/list/new_target_contents = new_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-			GRID_CELL_SET(intersecting_cell, intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
+			GRID_CELL_SET(intersecting_cell.client_contents, new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 		if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
 			var/list/new_target_contents = new_target.important_recursive_contents
-			GRID_CELL_SET(intersecting_cell, intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+			GRID_CELL_SET(intersecting_cell.hearing_contents, new_target.important_recursive_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_HEARING), new_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 
 		if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-			GRID_CELL_SET(intersecting_cell, intersecting_cell.atmos_contents, new_target)
+			GRID_CELL_SET(intersecting_cell.atmos_contents, new_target)
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_ENTERED(SPATIAL_GRID_CONTENTS_TYPE_ATMOS), new_target)
 
 	return intersecting_cell
@@ -436,16 +436,16 @@ SUBSYSTEM_DEF(spatial_grid)
 		switch(type)
 			if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
 				var/list/old_target_contents = old_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-				GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.client_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
+				GRID_CELL_REMOVE(intersecting_cell.client_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS), old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 			if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
 				var/list/old_target_contents = old_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-				GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.hearing_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+				GRID_CELL_REMOVE(intersecting_cell.hearing_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(SPATIAL_GRID_CONTENTS_TYPE_HEARING), old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 
 			if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-				GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.atmos_contents, old_target)
+				GRID_CELL_REMOVE(intersecting_cell.atmos_contents, old_target)
 				SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(SPATIAL_GRID_CONTENTS_TYPE_ATMOS), old_target)
 
 	return TRUE
@@ -468,77 +468,130 @@ SUBSYSTEM_DEF(spatial_grid)
 	switch(exclusive_type)
 		if(SPATIAL_GRID_CONTENTS_TYPE_CLIENTS)
 			var/list/old_target_contents = old_target.important_recursive_contents //cache for sanic speeds (lists are references anyways)
-			GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.client_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
+			GRID_CELL_REMOVE(intersecting_cell.client_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_CLIENTS])
 
 		if(SPATIAL_GRID_CONTENTS_TYPE_HEARING)
 			var/list/old_target_contents = old_target.important_recursive_contents
-			GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.hearing_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
+			GRID_CELL_REMOVE(intersecting_cell.hearing_contents, old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target_contents[SPATIAL_GRID_CONTENTS_TYPE_HEARING])
 
 		if(SPATIAL_GRID_CONTENTS_TYPE_ATMOS)
-			GRID_CELL_REMOVE(intersecting_cell, intersecting_cell.atmos_contents, old_target)
+			GRID_CELL_REMOVE(intersecting_cell.atmos_contents, old_target)
 			SEND_SIGNAL(intersecting_cell, SPATIAL_GRID_CELL_EXITED(exclusive_type), old_target)
 
 	return TRUE
 
-///find the cell this movable is associated with and removes it from all lists
-/datum/controller/subsystem/spatial_grid/proc/force_remove_from_cell(atom/movable/to_remove, datum/spatial_grid_cell/input_cell)
+/// if for whatever reason this movable is "untracked" e.g. it breaks the assumption that a movable is only inside the contents of any grid cell associated with its loc,
+/// this will error. this checks every grid cell in the world so dont call this on live unless you have to.
+/// returns TRUE if this movable is untracked, FALSE otherwise
+/datum/controller/subsystem/spatial_grid/proc/untracked_movable_error(atom/movable/movable_to_check)
+
+	if(!movable_to_check?.spatial_grid_key)
+		if(istype(movable_to_check, /mob/living/trolls_the_maintainer))
+			stack_trace("untracked_movable_error() trolls_the_maintainer doesnt have a grid key!")
+		return FALSE
+
+	if(!initialized)
+		if(istype(movable_to_check, /mob/living/trolls_the_maintainer))
+			stack_trace("untracked_movable_error() not initialized!")
+		return FALSE
+
+	var/datum/spatial_grid_cell/loc_cell = get_cell_of(movable_to_check)
+	var/list/containing_cells = find_hanging_cell_refs_for_movable(movable_to_check, FALSE)
+	//if we're in multiple cells, throw an error.
+	//if we're in 1 cell but it cant be deduced by our location, throw an error.
+	if(length(containing_cells) > 1 || (length(containing_cells) == 1 && loc_cell && containing_cells[1] != loc_cell && containing_cells[1] != null))
+
+		var/error_data = ""
+
+		var/location_string = "which is in nullspace, and thus not be within the contents of any spatial grid cell"
+		if(loc_cell)
+			location_string = "which is supposed to only be in the contents of a spatial grid cell at coords: ([GRID_INDEX_TO_COORDS(loc_cell.cell_x)], [GRID_INDEX_TO_COORDS(loc_cell.cell_y)], [loc_cell.cell_z])"
+
+		var/error_explanation = "was in the contents of [length(containing_cells)] spatial grid cells when it was only supposed to be in one!"
+		if(length(containing_cells) == 1)
+			error_explanation = "was in the contents of 1 spatial grid cell but it was inside the area handled by another grid cell!"
+			var/datum/spatial_grid_cell/bad_cell = containing_cells[1]
+
+			error_data = "within the contents of a cell at coords: ([GRID_INDEX_TO_COORDS(bad_cell.cell_x)], [GRID_INDEX_TO_COORDS(bad_cell.cell_y)], [bad_cell.cell_z])"
+
+		if(!error_data)
+			for(var/datum/spatial_grid_cell/cell in containing_cells)
+				var/coords = "([GRID_INDEX_TO_COORDS(cell.cell_x)], [GRID_INDEX_TO_COORDS(cell.cell_y)], [cell.cell_z])"
+				var/contents = ""
+
+				if(movable_to_check in cell.hearing_contents)
+					contents = "hearing"
+
+				if(movable_to_check in cell.client_contents)
+					if(length(contents) > 0)
+						contents = "[contents], client"
+					else
+						contents = "client"
+
+				if(movable_to_check in cell.atmos_contents)
+					if(length(contents) > 0)
+						contents = "[contents], atmos"
+					else
+						contents = "atmos"
+
+				if(length(error_data) > 0)
+					error_data = "[error_data], {coords: [coords], within channels: [contents]}"
+				else
+					error_data = "within the contents of the following cells: {[coords], within channels: [contents]}"
+
+		/**
+		 * example:
+		 *
+		 * /mob/living/trolls_the_maintainer instance, which is supposed to only be in the contents of a spatial grid cell at coords: (136, 136, 14),
+		 * was in the contents of 3 spatial grid cells when it was only supposed to be in one! within the contents of the following cells:
+		 * {(68, 153, 2), within channels: hearing},
+		 * {coords: (221, 170, 3), within channels: hearing},
+		 * {coords: (255, 153, 11), within channels: hearing},
+		 * {coords: (136, 136, 14), within channels: hearing}.
+		 * ping @KylerAce in discord if you see this
+		 */
+		stack_trace("[movable_to_check.type] instance, [location_string], [error_explanation] [error_data]. ping @KylerAce in discord if you see this")
+
+		return TRUE
+
+	else if(istype(movable_to_check, /mob/living/trolls_the_maintainer))//TODOKYLER: remove
+		stack_trace("somehow trolls_the_maintainer didnt fail the check!")
+
+	return FALSE
+
+/**
+ * remove this movable from the grid by finding the grid cell its in and removing it from that.
+ * if it cant infer a grid cell its located in (e.g. if its in nullspace but it can happen if the grid isnt expanded to a z level), search every grid cell.
+ */
+/datum/controller/subsystem/spatial_grid/proc/force_remove_from_grid(atom/movable/to_remove)
+	if(!to_remove?.spatial_grid_key)
+		return
+
 	if(!initialized)
 		remove_from_pre_init_queue(to_remove)//the spatial grid doesnt exist yet, so just take it out of the queue
 		return
 
+#ifdef UNIT_TESTS
+	if(untracked_movable_error(to_remove))
+		find_hanging_cell_refs_for_movable(to_remove, TRUE)
+		return
+#endif
+
+	var/datum/spatial_grid_cell/loc_cell = get_cell_of(to_remove)
+
+	if(loc_cell)
+		GRID_CELL_REMOVE_ALL(loc_cell, to_remove)
+	else
+		find_hanging_cell_refs_for_movable(to_remove, TRUE)
+
+///remove this movable from the given spatial_grid_cell
+/datum/controller/subsystem/spatial_grid/proc/force_remove_from_cell(atom/movable/to_remove, datum/spatial_grid_cell/input_cell)
 	if(!input_cell)
-		input_cell = get_cell_of(to_remove)
+		return
 
-		#ifdef UNIT_TESTS
-
-		if(input_cell && (!(input_cell in to_remove.in_spatial_grid_cells) || length(to_remove.in_spatial_grid_cells) > 1))
-			var/input_cell_coords = "([input_cell.cell_x], [input_cell.cell_y], [input_cell.cell_z])"
-
-			var/error_data = ""
-			for(var/datum/spatial_grid_cell/cell in to_remove.in_spatial_grid_cells)
-				var/coords = "([cell.cell_x], [cell.cell_y], [cell.cell_z])"
-				var/contents = ""
-
-				if(to_remove in cell.hearing_contents)
-					contents = "hearing contents"
-
-				if(to_remove in cell.client_contents)
-					if(length(contents) > 0)
-						contents = "[contents], client contents"
-					else
-						contents = "client contents"
-
-				if(to_remove in cell.atmos_contents)
-					if(length(contents) > 0)
-						contents = "[contents], atmos contents"
-					else
-						contents = "atmos contents"
-
-				if(length(error_data) > 0)
-					error_data = "[error_data], {[coords] in [contents]}"
-				else
-					error_data = "{[coords] in: [contents]}"
-
-			stack_trace("[to_remove] at cell indices: [input_cell_coords], found in [length(to_remove.in_spatial_grid_cells)] spatial grid cells and they wouldnt have been caught by force_remove_by()! cells: [error_data]")
-
-			find_hanging_cell_refs_for_movable(to_remove, TRUE)
-			return
-
-		#endif
-
-		if(!input_cell)
-			find_hanging_cell_refs_for_movable(to_remove, TRUE)
-			return
-
-	GRID_CELL_REMOVE(input_cell, input_cell.client_contents, to_remove)
-	GRID_CELL_REMOVE(input_cell, input_cell.hearing_contents, to_remove)
-	GRID_CELL_REMOVE(input_cell, input_cell.atmos_contents, to_remove)
-
-	#ifdef UNIT_TESTS
-	to_remove.in_spatial_grid_cells = null
-	#endif
+	GRID_CELL_REMOVE_ALL(input_cell, to_remove)
 
 ///if shit goes south, this will find hanging references for qdeleting movables inside the spatial grid
 /datum/controller/subsystem/spatial_grid/proc/find_hanging_cell_refs_for_movable(atom/movable/to_remove, remove_from_cells = TRUE)
@@ -568,7 +621,7 @@ SUBSYSTEM_DEF(spatial_grid)
 ///debug proc for checking if a movable is in multiple cells when it shouldnt be (ie always unless multitile entering is implemented)
 /atom/proc/find_all_cells_containing(remove_from_cells = FALSE)
 	var/datum/spatial_grid_cell/real_cell = SSspatial_grid.get_cell_of(src)
-	var/list/containing_cells = SSspatial_grid.find_hanging_cell_refs_for_movable(src, FALSE, remove_from_cells)
+	var/list/containing_cells = SSspatial_grid.find_hanging_cell_refs_for_movable(src, remove_from_cells)
 
 	message_admins("[src] is located in the contents of [length(containing_cells)] spatial grid cells")
 

--- a/code/controllers/subsystem/spatial_gridmap.dm
+++ b/code/controllers/subsystem/spatial_gridmap.dm
@@ -497,7 +497,6 @@ SUBSYSTEM_DEF(spatial_grid)
 	//if we're in multiple cells, throw an error.
 	//if we're in 1 cell but it cant be deduced by our location, throw an error.
 	if(length(containing_cells) > 1 || (length(containing_cells) == 1 && loc_cell && containing_cells[1] != loc_cell && containing_cells[1] != null))
-
 		var/error_data = ""
 
 		var/location_string = "which is in nullspace, and thus not be within the contents of any spatial grid cell"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -99,6 +99,11 @@
 	/// Will not automatically apply to the turf below you, you need to apply /datum/element/block_explosives in conjunction with this
 	var/explosion_block = 0
 
+#ifdef UNIT_TESTS
+	///lazylist of every spatial grid cell this movable is currently in
+	var/list/in_spatial_grid_cells = null
+#endif
+
 /mutable_appearance/emissive_blocker
 
 /mutable_appearance/emissive_blocker/New()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -99,11 +99,6 @@
 	/// Will not automatically apply to the turf below you, you need to apply /datum/element/block_explosives in conjunction with this
 	var/explosion_block = 0
 
-#ifdef UNIT_TESTS
-	///lazylist of every spatial grid cell this movable is currently in
-	var/list/in_spatial_grid_cells = null
-#endif
-
 /mutable_appearance/emissive_blocker
 
 /mutable_appearance/emissive_blocker/New()
@@ -192,7 +187,7 @@
 		move_packet = null
 
 	if(spatial_grid_key)
-		SSspatial_grid.force_remove_from_cell(src)
+		SSspatial_grid.force_remove_from_grid(src)
 
 	LAZYCLEARLIST(client_mobs_in_contents)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
## About The Pull Request
I swear i didnt fail at this like 3 times i tested it this time.

adds a descriptive error of what spatial grid cells a movable is stuck in, and in what channels. This only runs during unit tests. hopefully this should be enough information to go off of to fix the spurious cockroach error. if its not then i can try tracking all grid cell changes during unit tests. 
error looks like this:
```
[2023-05-03 04:16:34.009] runtime error: /mob/living/trolls_the_maintainer instance, which is in nullspace, and thus not be within the contents of any spatial grid cell, was in the contents of 2 spatial grid cells when it was only supposed to be in one! within the contents of the following cells: {(221, 119, 11), within channels: hearing}, {coords: (136, 136, 14), within channels: hearing}. (code/controllers/subsystem/spatial_gridmap.dm:581)
```
for something located in nullspace but still in the contents of >0 cells and:
```
runtime error: /mob/living/trolls_the_maintainer instance, which is supposed to only be in the contents of a spatial grid cell at coords: (136, 136, 14), was in the contents of 6 spatial grid cells when it was only supposed to be in one! within the contents of the following cells: {(68, 153, 2), within channels: hearing}, {coords: (221, 170, 3), within channels: hearing}, {coords: (255, 153, 11), within channels: hearing}, {coords: (170, 238, 13), within channels: hearing}, {coords: (204, 119, 14), within channels: hearing}, {coords: (136, 136, 14), within channels: hearing}. 
```
if its not in nullspace but its within more than 1 grid cell. 

the coordinates here are translated from the index of the given cell to world coordinates. 
## Why It's Good For The Game
mothblocks has been standing outside my house for weeks i am fearing for my life
