### PR TITLE
Ectoplasm Anomaly Name and Icon Bugfix

### DIFF
--- a/code/modules/research/anomaly/raw_anomaly.dm
+++ b/code/modules/research/anomaly/raw_anomaly.dm
@@ -69,10 +69,10 @@
 	icon_state = "rawcore_dimensional"
 
 /obj/item/raw_anomaly_core/ectoplasm //Has no cargo order option, but can sometimes be a roundstart pick
-	name = "\improper ectoplasm anomaly core"
+	name = "raw ectoplasm core"
 	desc = "The raw core of an ectoplasmic anomaly. It wants to share its secrets with you."
 	anomaly_type = /obj/item/assembly/signaler/anomaly/ectoplasm
-	icon_state = "dimensional_core"
+	icon_state = "rawcore_dimensional"
 
 /obj/item/raw_anomaly_core/random/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Does as the name states. I found it weird that the ectoplasm anomaly core is not referred to as raw when you have to refine it and instead used both the normally refined core icon as well as the name not saying it was a raw anomaly core at all.
## Why It's Good For The Game
Oversights are bad right? This aims to solve one of them.
## Changelog
:cl:
fix: fixed unrefined ectoplasm anomaly cores not appearing as unrefined
/:cl:
