### PR TITLE
High Luminosity Eyes: register signal to Move

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -443,10 +443,12 @@
 /obj/item/organ/internal/eyes/robotic/glow/on_insert(mob/living/carbon/eye_owner)
 	. = ..()
 	RegisterSignal(eye_owner, COMSIG_ATOM_DIR_CHANGE, PROC_REF(update_visuals))
+	RegisterSignal(eye_owner, COMSIG_MOVABLE_MOVED, PROC_REF(update_visuals))
 
 /obj/item/organ/internal/eyes/robotic/glow/on_remove(mob/living/carbon/eye_owner)
 	. = ..()
 	UnregisterSignal(eye_owner, COMSIG_ATOM_DIR_CHANGE)
+	UnregisterSignal(eye_owner, COMSIG_MOVABLE_MOVED)
 
 /obj/item/organ/internal/eyes/robotic/glow/Destroy()
 	QDEL_NULL(mobhook) // mobhook is not our component

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -442,13 +442,11 @@
 
 /obj/item/organ/internal/eyes/robotic/glow/on_insert(mob/living/carbon/eye_owner)
 	. = ..()
-	RegisterSignal(eye_owner, COMSIG_ATOM_DIR_CHANGE, PROC_REF(update_visuals))
-	RegisterSignal(eye_owner, COMSIG_MOVABLE_MOVED, PROC_REF(update_visuals))
+	RegisterSignal(eye_owner, list(COMSIG_ATOM_DIR_CHANGE, COMSIG_MOVABLE_MOVED), PROC_REF(update_visuals))
 
 /obj/item/organ/internal/eyes/robotic/glow/on_remove(mob/living/carbon/eye_owner)
 	. = ..()
-	UnregisterSignal(eye_owner, COMSIG_ATOM_DIR_CHANGE)
-	UnregisterSignal(eye_owner, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(eye_owner, list(COMSIG_ATOM_DIR_CHANGE, COMSIG_MOVABLE_MOVED))
 
 /obj/item/organ/internal/eyes/robotic/glow/Destroy()
 	QDEL_NULL(mobhook) // mobhook is not our component


### PR DESCRIPTION

## About The Pull Request
Now eyes "lights" update on owner's Move signal, instead of only direction.

## Why It's Good For The Game
You can have light while moving! 

## Changelog
:cl:
qol: High Luminosity Eyes' glow now moves with owner
/:cl:
