### PR TITLE
Removes current destination for a shuttle in transit from the destination list

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -118,11 +118,14 @@
 /obj/machinery/computer/shuttle/proc/get_valid_destinations()
 	var/list/destination_list = params2list(possible_destinations)
 	var/obj/docking_port/mobile/mobile_docking_port = SSshuttle.getShuttle(shuttleId)
+	var/obj/docking_port/stationary/current_destination = mobile_docking_port.destination
 	var/list/valid_destinations = list()
 	for(var/obj/docking_port/stationary/stationary_docking_port in SSshuttle.stationary_docking_ports)
 		if(!destination_list.Find(stationary_docking_port.port_destinations))
 			continue
 		if(!mobile_docking_port.check_dock(stationary_docking_port, silent = TRUE))
+			continue
+		if(stationary_docking_port == current_destination)
 			continue
 		var/list/location_data = list(
 			id = stationary_docking_port.shuttle_id,


### PR DESCRIPTION
## About The Pull Request

Shuttles with multiple destinations will no longer show the current destination as a selectable choice during transit.

<details>
<summary>Example</summary>
A shuttle has two possible destinations. A and B. <br>
While at A, the only valid destination is B and vice-versa. <br>
But while in transit to B, _both_ A and B can be chosen as destinations. <br><br>
The change now hides B as a valid destination, as you are already going there. <br>
It has the nice side effect of making shuttles with only two destinations never showing a dropdown list while in transit.
</details>

## Why It's Good For The Game

Telling the shuttle to go to the same place as you're going to doesn't do anything.

## Changelog
:cl:
qol: Shuttles will no longer show their current destination as a choice while in transit.
/:cl:
