### PR TITLE
Mildly buffs Active Sonar module

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -592,7 +592,7 @@
 	var/mob/living/looker = mod_man?.resolve()
 	var/mob/living/creature = pinged_person?.resolve()
 	if(isnull(looker) || isnull(creature))
-	    return PROCESS_KILL
+		return PROCESS_KILL
 	modsuit_image.loc = looker.loc
 	modsuit_image.pixel_x = ((creature.x - looker.x) * 32)
 	modsuit_image.pixel_y = ((creature.y - looker.y) * 32)

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -553,6 +553,8 @@
 	var/image/modsuit_image
 	/// The person in the modsuit at the moment, really just used to remove this from their screen
 	var/datum/weakref/mod_man
+	/// The creature we're placing this on
+	var/datum/weakref/pinged_person
 	/// The icon state applied to the image created for this ping.
 	var/real_icon_state = "sonar_ping"
 
@@ -564,12 +566,15 @@
 	modsuit_image.plane = ABOVE_LIGHTING_PLANE
 	SET_PLANE_EXPLICIT(modsuit_image, ABOVE_LIGHTING_PLANE, creature)
 	mod_man = WEAKREF(looker)
+	pinged_person = WEAKREF(creature)
 	add_mind(looker)
+	START_PROCESSING(SSfastprocess, src)
 
 /obj/effect/temp_visual/sonar_ping/Destroy()
 	var/mob/living/previous_user = mod_man?.resolve()
 	if(previous_user)
 		remove_mind(previous_user)
+	STOP_PROCESSING(SSfastprocess, src)
 	// Null so we don't shit the bed when we delete
 	modsuit_image = null
 	return ..()
@@ -581,3 +586,11 @@
 /// Remove the image from the modsuit wearer's screen
 /obj/effect/temp_visual/sonar_ping/proc/remove_mind(mob/living/looker)
 	looker?.client?.images -= modsuit_image
+
+/// Update the position of the ping while it's still up. Not sure if i need to use the full proc but just being safe
+/obj/effect/temp_visual/sonar_ping/process(seconds_per_tick)
+	var/mob/living/looker = mod_man?.resolve()
+	var/mob/living/creature = pinged_person?.resolve()
+	modsuit_image.loc = looker.loc
+	modsuit_image.pixel_x = ((creature.x - looker.x) * 32)
+	modsuit_image.pixel_y = ((creature.y - looker.y) * 32)

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -591,6 +591,8 @@
 /obj/effect/temp_visual/sonar_ping/process(seconds_per_tick)
 	var/mob/living/looker = mod_man?.resolve()
 	var/mob/living/creature = pinged_person?.resolve()
+	if(isnull(looker) || isnull(creature))
+	    return PROCESS_KILL
 	modsuit_image.loc = looker.loc
 	modsuit_image.pixel_x = ((creature.x - looker.x) * 32)
 	modsuit_image.pixel_y = ((creature.y - looker.y) * 32)

--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -364,10 +364,10 @@
 		Its loud ping is much harder to hide in an indoor station than in the outdoor operations it was designed for."
 	icon_state = "active_sonar"
 	module_type = MODULE_USABLE
-	use_power_cost = DEFAULT_CHARGE_DRAIN * 5
+	use_power_cost = DEFAULT_CHARGE_DRAIN * 4
 	complexity = 3
 	incompatible_modules = list(/obj/item/mod/module/active_sonar)
-	cooldown_time = 25 SECONDS
+	cooldown_time = 15 SECONDS
 
 /obj/item/mod/module/active_sonar/on_use()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Lowers the cooldown from 25 seconds to 15 seconds
Lowers the power drain from 25 to 20
Sonar visuals now move for the duration of their existence (see below)

https://user-images.githubusercontent.com/66052067/236366039-3290b293-1382-4929-951f-4013ac3a9cd4.mp4

It looks a little visually jagged due to the fact that I don't have the mathematical knowledge nor patience to calculate the pixel shifting **_on top of_** the location shifting. If anyone else would happen to be able to do that, I would gladly add it to this PR.
## Why It's Good For The Game
I looked for some both current & past feedback on how people feel about the sonar, and while it was never intended to be a massive boon, it was still far too weak for what it was meant to be: a side-grade to the thermal vision genetics mutation.
Hopefully this will put it more in line with those intentions without making it too powerful.
## Changelog
:cl: Wallem
balance: Buffs the Active Sonar module for modsuits with a shorter cooldown & moving pings.
/:cl:
