### PR TITLE
Fixes prosthetic limbs leaving the old one behind

### DIFF
--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -555,7 +555,7 @@
 		if(BODY_ZONE_R_LEG)
 			prosthetic = new /obj/item/bodypart/leg/right/robot/surplus
 			slot_string = "right leg"
-	old_limb = human_holder.return_and_replace_bodypart(prosthetic)
+	old_limb = human_holder.return_and_replace_bodypart(prosthetic, special = TRUE)
 
 /datum/quirk/prosthetic_limb/post_add()
 	to_chat(quirk_holder, span_boldannounce("Your [slot_string] has been replaced with a surplus prosthetic. It is fragile and will easily come apart under duress. Additionally, \
@@ -563,7 +563,7 @@
 
 /datum/quirk/prosthetic_limb/remove()
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	human_holder.del_and_replace_bodypart(old_limb)
+	human_holder.del_and_replace_bodypart(old_limb, special = TRUE)
 	old_limb = null
 
 /datum/quirk/quadruple_amputee

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -577,10 +577,10 @@
 
 /datum/quirk/quadruple_amputee/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/left/robot/surplus)
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/right/robot/surplus)
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/surplus)
-	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/surplus)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/left/robot/surplus, special = TRUE)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/arm/right/robot/surplus, special = TRUE)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/left/robot/surplus, special = TRUE)
+	human_holder.del_and_replace_bodypart(new /obj/item/bodypart/leg/right/robot/surplus, special = TRUE)
 
 /datum/quirk/quadruple_amputee/post_add()
 	to_chat(quirk_holder, span_boldannounce("All your limbs have been replaced with surplus prosthetics. They are fragile and will easily come apart under duress. Additionally, \

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -19,11 +19,14 @@
 	new_limb.try_attach_limb(src, special = special)
 
 /// Replaces a single limb and returns the old one if there was one
-/// Note: the old limb gets sent to nullspace during try_attach_limb
 /mob/living/carbon/proc/return_and_replace_bodypart(obj/item/bodypart/new_limb, special)
 	var/obj/item/bodypart/old_limb = get_bodypart(new_limb.body_zone)
+	if(!isnull(old_limb))
+		old_limb.drop_limb(special = special)
+		old_limb.moveToNullspace()
+
 	new_limb.try_attach_limb(src, special = special)
-	return old_limb
+	return old_limb // can be null
 
 /mob/living/carbon/has_hand_for_held_index(i)
 	if(!i)


### PR DESCRIPTION
## About The Pull Request

Fixes #75153
Caused by #75050 

`Note: the old limb gets sent to nullspace during try_attach_limb`
...This assertion is completely wrong, and I'm not sure where it came from. Perhaps it's different on their downstream. 

`try_attach_limb` does not care about limbs that occupy the same body zone and will happy attach itself, giving you two left arms or two right legs. 

`del_and_replace_bodypart` handles this by deleting the existing limb, `return_and_replace_bodypart` did not handle this whatsoever. So I added that missing handling. 

I'm not sure if we *actually want* `try_attach_limb` to disregard limbs that occupy that slot already. It seems like weird behavior but also consumers should probably know what they're doing in regards to that?

While I was here, I made both prosthetic related quirks use `special = TRUE`. The application of these limbs are supposed to be quick swapping no-side-effects, since it's done at mob creation, so it should be using special. 

## Why It's Good For The Game

Three arms is bad, okay?

## Changelog

:cl: Melbert
fix: Fixed Prosthetic Quirk not removing the limb before giving the prosthetic
/:cl:
