### PR TITLE
Makes the divine bow renamable

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bows/bow_types.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_types.dm
@@ -13,6 +13,7 @@
 	base_icon_state = "holybow"
 	worn_icon_state = "holybow"
 	slot_flags = ITEM_SLOT_BACK
+	obj_flags = UNIQUE_RENAME
 	mag_type = /obj/item/ammo_box/magazine/internal/bow/holy
 
 /obj/item/ammo_box/magazine/internal/bow/holy


### PR DESCRIPTION

## About The Pull Request

Adds the UNIQUE_RENAME flag to the divine bow to allow the name/description to be modified.

## Why It's Good For The Game

Consistency with every other null rod option (all of which inherit the flag from `/obj/item/nullrod`

## Changelog
:cl:
fix: The chaplain's divine bow can now be renamed like all other null rod variants.
/:cl:
