### PR TITLE
[NO GBP] Deletes unused airlock helper from Syn-c Brutus.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -571,9 +571,6 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/infested_frigate)
 "jk" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /obj/structure/barricade/security,
 /obj/structure/door_assembly/door_assembly_ext{
 	anchored = 1


### PR DESCRIPTION
## About The Pull Request
Kinda continues https://github.com/tgstation/tgstation/pull/74751
![image](https://user-images.githubusercontent.com/93882977/236552739-1d39cc34-25ef-49d6-997b-d72c14fc669d.png)
I didn't notice it as it was just 1 line.
## Changelog
:cl:
fix: deleted unused airlock helper from syn-c brutus.
/:cl:
