### PR TITLE
fix: Basic mobs' multiplicative movespeed

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -197,6 +197,7 @@
 	key_mode = KEY_MODE_TYPE
 	value_mode = VALUE_MODE_NUM
 	default = list( //DEFAULTS
+	/mob/living/basic = 1,
 	/mob/living/simple_animal = 1,
 	/mob/living/silicon/pai = 1,
 	/mob/living/carbon/alien/adult/hunter = -1,

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -45,6 +45,7 @@ WALK_DELAY 4
 ##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/alien 0
 ##MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal/slime 0
 MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 0
+MULTIPLICATIVE_MOVESPEED /mob/living/basic 0
 
 
 ## NAMES ###


### PR DESCRIPTION
## About The Pull Request
Adds default multiplicative movespeed for basic mobs, so their speed is configurable via config.

## Why It's Good For The Game
Closing things which were probably missed in the development of basic mobs

## Changelog
:cl:
code: Adds default multiplicative movespeed for basic mobs, to make them editable in config
config: Default multiplicative movespeed for basic mobs in example config
/:cl:
