### PR TITLE
Deadchat announcement for guaranteed tram hits

### DIFF
--- a/code/modules/industrial_lift/tram/tram_floors.dm
+++ b/code/modules/industrial_lift/tram/tram_floors.dm
@@ -84,5 +84,6 @@
 		return FALSE
 
 	// Finally the interesting part where they ACTUALLY get hit!
+	notify_ghosts("[future_tram_victim] has fallen in the path of an oncoming tram!", source = future_tram_victim, action = NOTIFY_ORBIT, header = "Electrifying!")
 	future_tram_victim.electrocute_act(15, src, 1)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Another to add to https://github.com/tgstation/tgstation/pull/75140 The bad luck omen has an event where you're electrocuted and guaranteed to be hit by the tram. This lets them get a few seconds notice.

![image](https://user-images.githubusercontent.com/83487515/236582851-cdf55726-0990-4811-bb37-124aac4c59d2.png)


## Why It's Good For The Game

Watch them go flying, hit a vending machine, and the vending machine falls on them gibbing their body.

## Changelog

:cl: LT3
qol: Ghosts will now get a notification when someone is about to be hit by the tram
/:cl: