### PR TITLE
Adds space ruins to Northstar

### DIFF
--- a/_maps/northstar.json
+++ b/_maps/northstar.json
@@ -10,7 +10,7 @@
 		"cargo": "cargo_northstar",
 		"whiteship": "whiteship_delta"
 	},
-	"space_ruin_levels": 0,
+	"space_ruin_levels": 3,
 	"space_empty_levels": 2,
 	"traits": [
 		{


### PR DESCRIPTION

## About The Pull Request
Adds three z-levels to explore on northstar (Assuming I did this right)
## Why It's Good For The Game
Chesh (The map creator) said it was fine to, and asked me to do it now that the support for ruin generation based on number of z levels exists.
## Changelog
:cl:
add: Ruins are now available in the region around the Northstar, Curators are now no longer jobless!
/:cl:
