### PR TITLE
Make paint cans limited use again

### DIFF
--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -15,6 +15,8 @@
 	var/paint_color = COLOR_WHITE
 	/// How many uses are left
 	var/paintleft = 10
+	/// Whether or not the paint is infinite
+	var/infinite_use = 0
 
 /obj/item/paint/Initialize(mapload)
 	. = ..()
@@ -59,6 +61,9 @@
 	gender = PLURAL
 	name = "adaptive paint"
 	icon_state = "paint_neutral"
+
+/obj/item/paint/anycolor/cyborg
+	infinite_use = 1
 
 /obj/item/paint/anycolor/attack_self(mob/user)
 	if(paintleft <= 0)
@@ -118,7 +123,8 @@
 		return
 	if(!isturf(target) || isspaceturf(target))
 		return
-	paintleft--
+	if(!infinite_use)
+		paintleft--
 	target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 
 /obj/item/paint/paint_remover

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -61,6 +61,9 @@
 	icon_state = "paint_neutral"
 
 /obj/item/paint/anycolor/attack_self(mob/user)
+	if(paintleft <= 0)
+		to_chat(usr, span_warning("There's no paint left in the can!"));
+		return	// Don't do any of the following because there's no paint left to be able to change the color of
 	var/list/possible_colors = list(
 		"black" = image(icon = src.icon, icon_state = "paint_black"),
 		"blue" = image(icon = src.icon, icon_state = "paint_blue"),
@@ -115,6 +118,7 @@
 		return
 	if(!isturf(target) || isspaceturf(target))
 		return
+	paintleft--
 	target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 
 /obj/item/paint/paint_remover

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -15,8 +15,6 @@
 	var/paint_color = COLOR_WHITE
 	/// How many uses are left
 	var/paintleft = 10
-	/// Whether or not the paint is infinite
-	var/infinite_use = FALSE
 
 /obj/item/paint/Initialize(mapload)
 	. = ..()
@@ -63,11 +61,11 @@
 	icon_state = "paint_neutral"
 
 /obj/item/paint/anycolor/cyborg
-	infinite_use = TRUE
+	paintleft = INFINITY
 
 /obj/item/paint/anycolor/attack_self(mob/user)
 	if(paintleft <= 0)
-		to_chat(usr, span_warning("There's no paint left in the can!"));
+		to_chat(user, span_warning("There's no paint left in the can!"));
 		return	// Don't do any of the following because there's no paint left to be able to change the color of
 	var/list/possible_colors = list(
 		"black" = image(icon = src.icon, icon_state = "paint_black"),
@@ -123,8 +121,7 @@
 		return
 	if(!isturf(target) || isspaceturf(target))
 		return
-	if(!infinite_use)
-		paintleft--
+	paintleft--
 	target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 
 /obj/item/paint/paint_remover

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -65,7 +65,7 @@
 
 /obj/item/paint/anycolor/attack_self(mob/user)
 	if(paintleft <= 0)
-		to_chat(user, span_warning("There's no paint left in the can!"));
+		balloon_alert(user, "no paint left!")
 		return	// Don't do any of the following because there's no paint left to be able to change the color of
 	var/list/possible_colors = list(
 		"black" = image(icon = src.icon, icon_state = "paint_black"),

--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -16,7 +16,7 @@
 	/// How many uses are left
 	var/paintleft = 10
 	/// Whether or not the paint is infinite
-	var/infinite_use = 0
+	var/infinite_use = FALSE
 
 /obj/item/paint/Initialize(mapload)
 	. = ..()
@@ -63,7 +63,7 @@
 	icon_state = "paint_neutral"
 
 /obj/item/paint/anycolor/cyborg
-	infinite_use = 1
+	infinite_use = TRUE
 
 /obj/item/paint/anycolor/attack_self(mob/user)
 	if(paintleft <= 0)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -319,7 +319,7 @@
 		/obj/item/stamp/clown,
 		/obj/item/bikehorn,
 		/obj/item/bikehorn/airhorn,
-		/obj/item/paint/anycolor,
+		/obj/item/paint/anycolor/cyborg,
 		/obj/item/soap/nanotrasen/cyborg,
 		/obj/item/pneumatic_cannon/pie/selfcharge/cyborg,
 		/obj/item/razor, //killbait material


### PR DESCRIPTION
## About The Pull Request
Apparently paint cans were never decrementing their `paintleft` variable. They do this now, plus an error message for the funny multicolor paint can when you try changing the color while it's empty. Fixes #75110 by decrementing the variable.
This also makes sure clown borgs aren't hampered by their inability to just get a new paint can by making their specifically infinite use.
## Why It's Good For The Game
Apparently paint cans were supposed to be limited use in the first place, considering they had a `paintleft` variable that was never decremented. We could also look at a few different options for refilling these cans in the future that could further the creativity available with them.
## Changelog
:cl:
fix: Paint cans have become limited use as intended by the gods of code
fix: Clown borgs get unlimited paint, as a treat.
/:cl:
