### PR TITLE
Fixes the Golemship having the wrong orm subtype

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -81,9 +81,9 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "p" = (
-/obj/item/circuitboard/machine/ore_redemption,
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/five,
+/obj/item/circuitboard/machine/ore_redemption/offstation,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "q" = (


### PR DESCRIPTION

## About The Pull Request
See title here
## Why It's Good For The Game
Makes golems actually able to redeem stuff
## Changelog
:cl:
fix: Fixes the orm board in the golem ship being the wrong subtype
/:cl:
