### PR TITLE
fix: Infinite slowdown due to stamina

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -298,7 +298,7 @@
 		return
 	staminaloss = clamp((staminaloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, max_stamina)
 	if(updating_stamina)
-		update_stamina()
+		updatehealth()
 	return
 
 /mob/living/proc/setStaminaLoss(amount, updating_stamina = TRUE, forced = FALSE, required_biotype)
@@ -306,7 +306,7 @@
 		return FALSE
 	staminaloss = amount
 	if(updating_stamina)
-		update_stamina()
+		updatehealth()
 
 /**
  * heal ONE external organ, organ gets randomly selected from damaged ones.


### PR DESCRIPTION
## About The Pull Request
On staminaloss (adjust/set), now it updates health instead of stamina. updatehealth calls update_stamina

It removes a bug, where getting stamina damage (baton/disabler) was not actually calling `updatehealth()`, and this proc on `human` changes `datum/movespeed_modifier/damage_slowdown`

 So, if you were hit for 99 stamina, you get no slowdown. If you get 55 stamina damage and 1 brute damage, you get a permanent slowdown modifier for having 56 total damage, unless you receive any damage other than stamina.

## Why It's Good For The Game
Stamina damage is now slowing people down
Less punches to yourself to remove the permanent speed debuff

## Changelog
:cl:
fix: Stamina damage and healing now correctly applies movement slowdown
/:cl:
