### PR TITLE
Makes dissection easier to do with ghetto tools

### DIFF
--- a/code/modules/surgery/dissection.dm
+++ b/code/modules/surgery/dissection.dm
@@ -34,6 +34,7 @@
 	time = 16 SECONDS
 	implements = list(
 		/obj/item/autopsy_scanner = 100,
+		/obj/item/healthanalyzer = 50,
 	)
 
 /datum/surgery_step/dissection/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/dissection.dm
+++ b/code/modules/surgery/dissection.dm
@@ -34,7 +34,7 @@
 	time = 16 SECONDS
 	implements = list(
 		/obj/item/autopsy_scanner = 100,
-		/obj/item/healthanalyzer = 50,
+		/obj/item/healthanalyzer = 10,
 	)
 
 /datum/surgery_step/dissection/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION

## About The Pull Request

The pr adds health analyzer as a slower alternative to autopsy scanner for the dissection surgery. It lets you do it in a ghetto way, and potentially allows you to make it off stationwithout having to hunt down the one exact item.
## Why It's Good For The Game
Ghetto surgery is cool. Also forcing an experiment to use one specific item made it very hard for cyborgs, robos, and other people to do the surgery if medical didn't. This allows them to circumvent that, albeit with a time penalty


## Changelog
:cl:
qol: adds ghetto dissection option
/:cl:
