### PR TITLE
[NO GBP] Adds another EVA suit to the psyker shuttle

### DIFF
--- a/_maps/shuttles/hunter_psyker.dmm
+++ b/_maps/shuttles/hunter_psyker.dmm
@@ -173,7 +173,7 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/decal/cleanable/ants/fire,
+/obj/effect/decal/cleanable/ants,
 /turf/open/floor/plating,
 /area/shuttle/hunter)
 "jl" = (

--- a/_maps/shuttles/hunter_psyker.dmm
+++ b/_maps/shuttles/hunter_psyker.dmm
@@ -19,7 +19,9 @@
 /area/shuttle/hunter)
 "bx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/broken_bottle,
+/obj/item/broken_bottle{
+	pixel_x = -6
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron,
 /area/shuttle/hunter)
@@ -28,11 +30,10 @@
 /turf/open/floor/iron/kitchen/small,
 /area/shuttle/hunter)
 "bV" = (
-/obj/machinery/computer/monitor{
-	dir = 1
-	},
+/obj/machinery/suit_storage_unit/pirate,
 /obj/effect/turf_decal/box/white,
-/turf/open/floor/iron/dark/textured,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
 /area/shuttle/hunter)
 "bX" = (
 /obj/item/reagent_containers/blood,
@@ -58,6 +59,7 @@
 /obj/effect/mob_spawn/ghost_role/human/fugitive/bounty/psyker/seer{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/engine,
 /area/shuttle/hunter)
 "eq" = (
@@ -78,6 +80,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/iron/freezer,
+/area/shuttle/hunter)
+"fd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/engine,
 /area/shuttle/hunter)
 "gj" = (
 /obj/structure/table/wood/fancy/blue,
@@ -150,9 +158,24 @@
 /turf/open/floor/grass,
 /area/shuttle/hunter)
 "hE" = (
-/obj/effect/turf_decal/tile/dark_blue/diagonal_centre,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/iron/white/diagonal,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/trash/popcorn{
+	pixel_y = 3;
+	pixel_x = 3
+	},
+/obj/item/trash/raisins{
+	pixel_y = 1;
+	pixel_x = -2
+	},
+/obj/item/trash/shrimp_chips{
+	pixel_x = 6
+	},
+/obj/item/trash/boritos/green{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/decal/cleanable/ants/fire,
+/turf/open/floor/plating,
 /area/shuttle/hunter)
 "jl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -570,6 +593,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/railing/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white/diagonal,
 /area/shuttle/hunter)
 "Ea" = (
@@ -612,6 +638,9 @@
 "GT" = (
 /obj/effect/turf_decal/tile/dark_blue/diagonal_edge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/iron/white/diagonal,
 /area/shuttle/hunter)
 "Hd" = (
@@ -718,7 +747,11 @@
 /turf/open/floor/iron/freezer,
 /area/shuttle/hunter)
 "Nb" = (
-/obj/machinery/light/directional/south,
+/obj/machinery/computer/monitor{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/white,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/hunter)
 "Ne" = (
@@ -749,6 +782,12 @@
 /obj/machinery/light/floor,
 /obj/structure/curtain/bounty,
 /turf/open/floor/engine,
+/area/shuttle/hunter)
+"Oa" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/plating,
 /area/shuttle/hunter)
 "Oc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -824,7 +863,7 @@
 "PT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit/old,
-/obj/structure/sign/departments/restroom/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/plating,
 /area/shuttle/hunter)
 "QI" = (
@@ -889,10 +928,6 @@
 /obj/effect/turf_decal/arrows{
 	dir = 4;
 	pixel_y = -4
-	},
-/obj/effect/turf_decal/arrows{
-	dir = 4;
-	pixel_y = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/hunter)
@@ -1145,11 +1180,11 @@ lu
 Xa
 bK
 XX
-rF
-bV
 CW
-yd
-oL
+CW
+CW
+CW
+CW
 yd
 yd
 oL
@@ -1173,9 +1208,9 @@ lu
 LI
 XX
 CW
-CW
-CW
-CW
+am
+Xp
+eZ
 CW
 CW
 CW
@@ -1199,10 +1234,10 @@ CW
 CW
 CW
 vu
-CW
-am
-Xp
-eZ
+na
+Ne
+Mk
+QI
 CW
 ZW
 ZC
@@ -1227,9 +1262,9 @@ kN
 mP
 Vw
 na
-Ne
-Mk
-QI
+Jz
+na
+na
 CW
 lI
 yg
@@ -1253,10 +1288,10 @@ rS
 SG
 WU
 ke
-na
-Jz
-na
-CW
+HI
+tH
+hE
+bV
 CW
 GT
 Dw
@@ -1281,11 +1316,11 @@ mz
 IE
 ah
 PT
-tH
+Oa
 bx
+fd
 Ea
 Id
-hE
 yg
 RA
 CW
@@ -1310,9 +1345,9 @@ cp
 aV
 Ja
 Ss
+HI
 EM
 mR
-yg
 lI
 gE
 CW

--- a/_maps/shuttles/hunter_psyker.dmm
+++ b/_maps/shuttles/hunter_psyker.dmm
@@ -59,7 +59,6 @@
 /obj/effect/mob_spawn/ghost_role/human/fugitive/bounty/psyker/seer{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/engine,
 /area/shuttle/hunter)
 "eq" = (
@@ -160,12 +159,12 @@
 "hE" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/item/trash/popcorn{
-	pixel_y = 3;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 3
 	},
 /obj/item/trash/raisins{
-	pixel_y = 1;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 1
 	},
 /obj/item/trash/shrimp_chips{
 	pixel_x = 6
@@ -375,6 +374,11 @@
 	},
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/iron/dark/textured,
+/area/shuttle/hunter)
+"ug" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/departments/restroom/directional/west,
+/turf/open/floor/plating,
 /area/shuttle/hunter)
 "uy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -1288,7 +1292,7 @@ rS
 SG
 WU
 ke
-HI
+ug
 tH
 hE
 bV


### PR DESCRIPTION
## About The Pull Request

I forgot to give the Psyker Seer their own suit storage/suit.

I didn't know where to throw it in, so I just expanded the alcove I threw the Seer into. This was accomplished by moving the entire bathroom one tile to the right.

They also get a pile of garbage and ants in their little alcove, to make it feel more homey.

old:

![image](https://user-images.githubusercontent.com/28870487/236648256-6659d780-fa38-40f5-a98b-74de445e3bb6.png)

new:

![image](https://user-images.githubusercontent.com/28870487/236648254-2cf5eb1e-47e3-4756-9178-8ef933a94565.png)

This changes nothing else, other than making the armory/bathroom hallway a bit more spacious as a side-effect.
## Why It's Good For The Game

The Seer might not be a psyker, but that doesn't mean they aren't part of the family. They deserve a suit too!
## Changelog
:cl:
fix: The psyker shuttle now has a suit for the psyker seer.
/:cl:
