### PR TITLE
Removes ELITE SYNDICATE MODSUIT from Space Ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -79,9 +79,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
-"bd" = (
-/turf/open/space/basic,
-/area/ruin/space/has_grav/infested_frigate)
 "bg" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -791,7 +788,6 @@
 "nk" = (
 /obj/item/storage/medkit/o2,
 /obj/item/storage/medkit/toxin,
-/obj/item/defibrillator/compact/combat,
 /obj/item/clothing/glasses/hud/health/night,
 /obj/item/storage/pill_bottle/stimulant,
 /obj/item/clothing/suit/apron/surgical,
@@ -805,7 +801,7 @@
 	},
 /obj/structure/closet/syndicate,
 /obj/structure/cable,
-/obj/item/gun/syringe/syndicate,
+/obj/item/gun/syringe,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
 "nm" = (
@@ -2856,7 +2852,7 @@
 	},
 /mob/living/simple_animal/hostile/alien/queen/large{
 	del_on_death = 1;
-	loot = list(/obj/effect/gibspawner/xeno,/obj/item/ammo_box/magazine/plastikov9mm,/obj/effect/mob_spawn/corpse/human/syndicatestormtrooper);
+	loot = list(/obj/effect/gibspawner/xeno,/obj/item/ammo_box/magazine/plastikov9mm,/obj/effect/mob_spawn/corpse/human/syndicatecommando/soft_suit);
 	desc = "What you saw in your dreams last night.";
 	faction = list("syndicate","xenomorph")
 	},
@@ -3265,7 +3261,7 @@ fl
 fl
 fl
 fl
-bd
+fl
 "}
 (2,1,1) = {"
 fl

--- a/code/modules/mob_spawn/corpses/mob_corpses.dm
+++ b/code/modules/mob_spawn/corpses/mob_corpses.dm
@@ -42,8 +42,20 @@
 	outfit = /datum/outfit/syndicatecommandocorpse/lessenedgear
 
 /datum/outfit/syndicatecommandocorpse/lessenedgear
-	name = "Syndicate Commando Corpse"
+	name = "Syndicate Commando Corpse (Less Antag Gear)"
 	gloves = /obj/item/clothing/gloves/tackler
+	back = null
+	id = null
+	id_trim = null
+
+/obj/effect/mob_spawn/corpse/human/syndicatecommando/soft_suit
+	outfit = /datum/outfit/syndicatecommandocorpse/soft_suit
+
+/datum/outfit/syndicatecommandocorpse/soft_suit
+	name = "Syndicate Commando Corpse (Softsuit)"
+	suit = /obj/item/clothing/suit/space/syndicate/black
+	head = /obj/item/clothing/head/helmet/space/syndicate/black
+	gloves = /obj/item/clothing/gloves/color/black
 	back = null
 	id = null
 	id_trim = null


### PR DESCRIPTION
## About The Pull Request

- Removes an ELITE SYNDICATE MODSUIT SPAWN from infested_frigate.dmm
- Removes a Combat Defibrillator from infested_frigate.dmm
- Removes Dart Pistol from infested_frigate.dmm

## Why It's Good For The Game

We will never learn. Space Loot should not be put in control of easily cheesable simplemobs, and we shouldn't be straight up putting NUKIE STUFF in Space

## Changelog

:cl: Melbert
del: You can't get an Elite Syndie Modsuit (or combat defib, or dart pistol) from Space Ruins
/:cl:


