### PR TITLE
Swaps the vault credit machine in the HoP's Northstar office with the correct accounting console, and adds a handy piece of paper to the Brig.

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -33768,6 +33768,8 @@
 /area/station/engineering/atmos)
 "jak" = (
 /obj/effect/turf_decal/tile/red/half,
+/obj/item/paper/fluff/genpop_instructions,
+/obj/structure/table,
 /turf/open/floor/iron/dark/side,
 /area/station/security/brig)
 "jas" = (
@@ -50390,7 +50392,7 @@
 /area/station/ai_monitored/security/armory)
 "nkw" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/computer/bank_machine{
+/obj/machinery/computer/accounting{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,


### PR DESCRIPTION

## About The Pull Request
HoP had the bank vault machine in their office instead of the account lookup console so I swapped it out. Also added a genpop instructions paper to the brig so non-tram enjoyers understand how it works.
## Why It's Good For The Game
The console thing was apparently unintentional, plus the instructions are helpful for the reason above.
## Changelog
:cl:
fix: Northstar HoP can no longer commit fraud
qol: Northstar brig now has genpop instructions
/:cl:
