### PR TITLE
[NO GBP] temperature-proofs ghost basic mobs

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/ghost.dm
+++ b/code/modules/mob/living/basic/space_fauna/ghost.dm
@@ -17,6 +17,8 @@
 	attack_verb_continuous = "grips"
 	attack_verb_simple = "grip"
 	unsuitable_atmos_damage = 0
+	unsuitable_cold_damage = 0
+	unsuitable_heat_damage = 0
 	attack_sound = 'sound/hallucinations/growl1.ogg'
 	death_message = "wails, disintegrating into a pile of ectoplasm!"
 	gold_core_spawnable = NO_SPAWN //too spooky for science


### PR DESCRIPTION

## About The Pull Request

I forgot to make them temperature immune and only made it atmos immune when converting them to basic mobs. WHOOPS.

This may or may not have also been killing the ghosts in the space diner ruin this whole time.
## Why It's Good For The Game

Closes #75203.
## Changelog
:cl:
fix: Ghosts mobs are now temperature immune.
/:cl:
