### PR TITLE
Makes it harder to cheese infested_frigate.dm, downgrades the loot.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -796,7 +796,6 @@
 "nk" = (
 /obj/item/storage/medkit/o2,
 /obj/item/storage/medkit/toxin,
-/obj/item/defibrillator/compact/combat,
 /obj/item/clothing/glasses/hud/health/night,
 /obj/item/storage/pill_bottle/stimulant,
 /obj/item/clothing/suit/apron/surgical,
@@ -811,6 +810,7 @@
 /obj/structure/closet/syndicate,
 /obj/structure/cable,
 /obj/item/gun/syringe/syndicate,
+/obj/item/defibrillator/compact/loaded,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
 "nm" = (
@@ -2872,7 +2872,7 @@
 	},
 /mob/living/simple_animal/hostile/alien/queen/large{
 	del_on_death = 1;
-	loot = list(/obj/effect/gibspawner/xeno,/obj/item/ammo_box/magazine/plastikov9mm,/obj/effect/mob_spawn/corpse/human/syndicatestormtrooper);
+	loot = list(/obj/effect/gibspawner/xeno,/obj/item/ammo_box/magazine/plastikov9mm,/obj/effect/mob_spawn/corpse/human/syndicatecommando);
 	desc = "What you saw in your dreams last night.";
 	faction = list("syndicate","xenomorph")
 	},

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -1239,7 +1239,6 @@
 	closingLayer = 2.65
 	},
 /obj/structure/window/reinforced/plasma/plastitanium/indestructible,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "vm" = (
@@ -1585,7 +1584,6 @@
 /area/ruin/space/has_grav/infested_frigate)
 "yZ" = (
 /obj/structure/window/reinforced/plasma/plastitanium/indestructible,
-/obj/structure/grille,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "zE" = (
@@ -2787,15 +2785,6 @@
 /obj/item/ammo_casing/spent,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/infested_frigate)
-"RO" = (
-/obj/machinery/door/poddoor{
-	id = "Brutusexterior";
-	closingLayer = 2.65
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced/plasma/plastitanium/indestructible,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/infested_frigate)
 "RQ" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 4;
@@ -3552,7 +3541,7 @@ fl
 fl
 fl
 fl
-RO
+vj
 yJ
 wP
 wP

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -2872,7 +2872,7 @@
 	},
 /mob/living/simple_animal/hostile/alien/queen/large{
 	del_on_death = 1;
-	loot = list(/obj/effect/gibspawner/xeno,/obj/item/ammo_box/magazine/plastikov9mm,/obj/effect/mob_spawn/corpse/human/syndicatecommando);
+	loot = list(/obj/effect/gibspawner/xeno,/obj/item/ammo_box/magazine/plastikov9mm,/obj/effect/mob_spawn/corpse/human/syndicatestormtrooper);
 	desc = "What you saw in your dreams last night.";
 	faction = list("syndicate","xenomorph")
 	},

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -721,14 +721,6 @@
 	},
 /turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
-"lL" = (
-/obj/machinery/door/poddoor{
-	id = "Brutusexterior";
-	closingLayer = 2.65
-	},
-/obj/structure/window/reinforced/plasma/plastitanium/indestructible,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/infested_frigate)
 "lO" = (
 /obj/structure/fluff/broken_flooring{
 	icon_state = "pile"
@@ -1247,7 +1239,8 @@
 	closingLayer = 2.65
 	},
 /obj/structure/window/reinforced/plasma/plastitanium/indestructible,
-/turf/closed/indestructible/grille,
+/obj/structure/grille,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "vm" = (
 /obj/machinery/door/airlock/external/ruin,
@@ -1592,6 +1585,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "yZ" = (
 /obj/structure/window/reinforced/plasma/plastitanium/indestructible,
+/obj/structure/grille,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "zE" = (
@@ -2793,6 +2787,15 @@
 /obj/item/ammo_casing/spent,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/infested_frigate)
+"RO" = (
+/obj/machinery/door/poddoor{
+	id = "Brutusexterior";
+	closingLayer = 2.65
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced/plasma/plastitanium/indestructible,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/infested_frigate)
 "RQ" = (
 /obj/structure/fluff/broken_flooring{
 	dir = 4;
@@ -3549,7 +3552,7 @@ fl
 fl
 fl
 fl
-vj
+RO
 yJ
 wP
 wP
@@ -3576,7 +3579,7 @@ fl
 fl
 fl
 fl
-lL
+vj
 OC
 OC
 qE
@@ -3603,7 +3606,7 @@ fl
 fl
 fl
 fl
-lL
+vj
 xp
 ab
 Cm

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -79,9 +79,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
-"bd" = (
-/turf/open/space/basic,
-/area/ruin/space/has_grav/infested_frigate)
 "bg" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -130,7 +127,7 @@
 /obj/effect/turf_decal{
 	icon_state = "warningline_white"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "bS" = (
 /obj/effect/decal/cleanable/blood/gibs{
@@ -144,7 +141,7 @@
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "cv" = (
 /obj/effect/turf_decal{
@@ -427,7 +424,7 @@
 	max_integrity = 60;
 	faction = list("syndicate","xenomorph")
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "hu" = (
 /obj/structure/barricade/security,
@@ -657,7 +654,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "ki" = (
 /obj/effect/turf_decal/tile/bar,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "kp" = (
 /obj/machinery/light/broken/directional/west,
@@ -722,7 +719,15 @@
 	max_integrity = 60;
 	faction = list("syndicate","xenomorph")
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
+/area/ruin/space/has_grav/infested_frigate)
+"lL" = (
+/obj/machinery/door/poddoor{
+	id = "Brutusexterior";
+	closingLayer = 2.65
+	},
+/obj/structure/window/reinforced/plasma/plastitanium/indestructible,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "lO" = (
 /obj/structure/fluff/broken_flooring{
@@ -1241,10 +1246,8 @@
 	id = "Brutusexterior";
 	closingLayer = 2.65
 	},
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
-	layer = 2.9
-	},
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/plasma/plastitanium/indestructible,
+/turf/closed/indestructible/grille,
 /area/ruin/space/has_grav/infested_frigate)
 "vm" = (
 /obj/machinery/door/airlock/external/ruin,
@@ -1401,7 +1404,7 @@
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
 "wP" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "wX" = (
 /obj/machinery/porta_turret/syndicate/pod{
@@ -1409,7 +1412,7 @@
 	max_integrity = 60;
 	faction = list("syndicate","xenomorph")
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "xi" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -1588,9 +1591,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/infested_frigate)
 "yZ" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
-	layer = 2.9
-	},
+/obj/structure/window/reinforced/plasma/plastitanium/indestructible,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "zE" = (
@@ -1714,7 +1715,7 @@
 	light_power = 0.5;
 	light_range = 3
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "AM" = (
 /obj/item/ammo_casing/spent,
@@ -2144,7 +2145,7 @@
 	max_integrity = 60;
 	faction = list("syndicate","xenomorph")
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "Iu" = (
 /obj/effect/turf_decal{
@@ -2253,7 +2254,7 @@
 	dir = 8;
 	max_integrity = 2000
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "JO" = (
 /obj/structure/sign/departments/engineering/directional/west,
@@ -2272,7 +2273,7 @@
 /obj/item/shard{
 	icon_state = "titaniumtiny"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "Kl" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -2387,7 +2388,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "LF" = (
 /obj/structure/cable,
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "LO" = (
 /obj/effect/turf_decal{
@@ -2407,7 +2408,7 @@
 /obj/structure/mirror{
 	icon_state = "mirror_broke"
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "Mp" = (
 /obj/effect/turf_decal{
@@ -2458,23 +2459,38 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/infested_frigate)
 "ML" = (
-/obj/item/grenade/smokebomb{
-	pixel_x = 5
+/obj/structure/cable,
+/obj/effect/decal/cleanable/glass{
+	icon_state = "plasmatiny"
 	},
-/obj/item/grenade/smokebomb{
-	pixel_x = 5
+/obj/effect/decal/cleanable/glass{
+	icon_state = "plasmalarge"
 	},
-/obj/item/suppressor,
-/obj/item/gun/energy/e_gun/mini,
-/obj/structure/closet/crate/secure/weapon{
-	req_access = list("syndicate")
+/obj/item/shard{
+	icon_state = "titaniumtiny"
 	},
-/obj/item/grenade/c4,
+/obj/structure/closet/crate/large{
+	anchored = 1;
+	name = "crew supplies"
+	},
+/obj/effect/spawner/random/aimodule/harmful,
+/obj/effect/spawner/random/decoration,
+/obj/effect/spawner/random/decoration,
+/obj/effect/spawner/random/decoration/paint,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/entertainment/toy_figure,
+/obj/machinery/nuclearbomb/beer,
+/obj/item/fuel_pellet,
+/obj/item/fuel_pellet,
+/obj/item/fuel_pellet,
+/obj/effect/spawner/random/exotic/languagebook,
+/obj/effect/spawner/random/entertainment/lighter,
+/obj/effect/spawner/random/entertainment/lighter,
+/obj/effect/spawner/random/special_lighter,
 /obj/effect/turf_decal{
 	icon_state = "warningline_white";
 	dir = 1
 	},
-/obj/effect/spawner/random/exotic/antag_gear,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/infested_frigate)
 "MW" = (
@@ -2818,7 +2834,7 @@
 	icon_state = "warningline_white";
 	dir = 1
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/indestructible/syndicate,
 /area/ruin/space/has_grav/infested_frigate)
 "St" = (
 /obj/effect/turf_decal{
@@ -3001,36 +3017,20 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/infested_frigate)
 "Wk" = (
-/obj/structure/alien/weeds,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/glass{
-	icon_state = "plasmatiny"
+/obj/item/grenade/smokebomb{
+	pixel_x = 5
 	},
-/obj/effect/decal/cleanable/glass{
-	icon_state = "plasmalarge"
+/obj/item/grenade/smokebomb{
+	pixel_x = 5
 	},
-/obj/item/shard{
-	icon_state = "titaniumtiny"
+/obj/item/suppressor,
+/obj/item/gun/energy/e_gun/mini,
+/obj/structure/closet/crate/secure/weapon{
+	req_access = list("syndicate")
 	},
-/obj/structure/closet/crate/large{
-	anchored = 1;
-	name = "crew supplies"
-	},
-/obj/effect/spawner/random/aimodule/harmful,
-/obj/effect/spawner/random/decoration,
-/obj/effect/spawner/random/decoration,
-/obj/effect/spawner/random/decoration/paint,
-/obj/effect/spawner/random/entertainment/plushie_delux,
-/obj/effect/spawner/random/entertainment/toy_figure,
-/obj/machinery/nuclearbomb/beer,
+/obj/item/grenade/c4,
+/obj/effect/spawner/random/exotic/antag_gear,
 /obj/structure/sign/warning/electric_shock/directional/west,
-/obj/item/fuel_pellet,
-/obj/item/fuel_pellet,
-/obj/item/fuel_pellet,
-/obj/effect/spawner/random/exotic/languagebook,
-/obj/effect/spawner/random/entertainment/lighter,
-/obj/effect/spawner/random/entertainment/lighter,
-/obj/effect/spawner/random/special_lighter,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/infested_frigate)
 "WG" = (
@@ -3265,7 +3265,7 @@ fl
 fl
 fl
 fl
-bd
+fl
 "}
 (2,1,1) = {"
 fl
@@ -3576,7 +3576,7 @@ fl
 fl
 fl
 fl
-vj
+lL
 OC
 OC
 qE
@@ -3603,7 +3603,7 @@ fl
 fl
 fl
 fl
-vj
+lL
 xp
 ab
 Cm

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -817,6 +817,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/plasma/spawner, 0)
 	rad_insulation = RAD_EXTREME_INSULATION
 	glass_material_datum = /datum/material/alloy/plastitaniumglass
 
+/obj/structure/window/reinforced/plasma/plastitanium/indestructible
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	desc= "A durable looking window made of an alloy of of plasma and titanium. It's seems to be extremely reinforced, Impervious to anything that isn't military-grade ship weapons."
+
 /datum/armor/plasma_plastitanium
 	melee = 95
 	bomb = 50

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -38,6 +38,10 @@
 	death_message = "lets out a waning guttural screech, green blood bubbling from its maw..."
 	footstep_type = FOOTSTEP_MOB_CLAW
 
+/mob/living/simple_animal/hostile/alien/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_SPACEWALK, INNATE_TRAIT)
+
 /mob/living/simple_animal/hostile/alien/drone
 	name = "alien drone"
 	icon_state = "aliend"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Alternative PR to #75213
Makes it so that you can't easily cheese the ruin by:
1. Makes the walls and windows indestructible
2. Xenos now have the ability to spacewalk
3. SIMPLEMOBS xenos now able to spacewalk

Downgrades the combat defib --> Compact defib (one hit stun is quite scuffed. especially with not having to fight the queen in the first place)

Also swapped crew supplies crate and weapons crate location. (you have to fight through the queen first)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You can't cheese it by:
You used to be able to very easily cheese this ruin by removing an engine and a wall, spacing the xenos one by one, killing the space queen in range with a PKA as she hopelessly drift into space. Ignoring the entire ruin
![image](https://user-images.githubusercontent.com/127663818/236661681-f89d26de-dd7f-4895-b994-a05e25bd5c60.png)

The PR made it so that you HAVE to clear at least half the ship before being able to get the precious loot (8 xenos + queen minimum). the shortcut is either punching through 1500HP resin wall or destroying the unpowered bolted airlocks. (@massaheartsu made the whole ruin and by god you will see the entire ruin)
![image](https://user-images.githubusercontent.com/127663818/236662539-c8fe7f5c-9a2c-4b9a-8c40-ad2a10f22081.png)
You can't just space the xenos and watch them drift into space anymore. Even if you get them to space you need to at least duel them in space one by one. 

Downgrades the loot:
1. Combat defib is a bit excessive. the stun and ability to cause cardiac arrest is bonkers

All of this changes combined would make clearing the Brutus much _much_ harder and rarer. you wouldn't see powergamers space explorers abuse the loot every single round
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Cheesing SYN-C "Brutus" is now far far harder than before
balance: Slightly downgrades loot in the SYN-C "Brutus"
balance: SIMPLEMOBS aliens are now capable of spacewalk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
