### PR TITLE
Makes organs not double on delimbing

### DIFF
--- a/code/modules/surgery/organs/external/_external_organs.dm
+++ b/code/modules/surgery/organs/external/_external_organs.dm
@@ -90,10 +90,9 @@
 /obj/item/organ/external/Remove(mob/living/carbon/organ_owner, special, moving)
 	. = ..()
 
-	if(ownerlimb && !moving)
+	if(ownerlimb)
 		remove_from_limb()
-
-		if(use_mob_sprite_as_obj_sprite)
+		if(!moving && use_mob_sprite_as_obj_sprite) //so we're being taken out and dropped
 			update_appearance(UPDATE_OVERLAYS)
 
 	if(organ_owner)

--- a/code/modules/surgery/organs/external/restyling.dm
+++ b/code/modules/surgery/organs/external/restyling.dm
@@ -31,7 +31,7 @@
 ///Asks the external organs inside the limb if they can restyle
 /obj/item/bodypart/proc/attempt_feature_restyle(atom/source, mob/living/trimmer, atom/movable/original_target, body_zone, restyle_type, style_speed)
 	var/list/valid_features = list()
-	for(var/obj/item/organ/external/feature in contents)
+	for(var/obj/item/organ/external/feature in external_organs)
 		if(feature.restyle_flags & restyle_type)
 			valid_features.Add(feature)
 


### PR DESCRIPTION
A bugfix and a refactor from a while back kinda clashed and caused some weird behaviour. Extorgans would be double-referencd upon delimbing and feature restyling looked at the wrong list (technically the right list at the time because stuff was a bit fucked)

:cl:
fix: Loose limbs will not duplicate organs anymore
/:cl: