### PR TITLE
Replaces raw anomaly core with a ready anomaly core in anomaly ruin

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
@@ -252,7 +252,7 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/item/raw_anomaly_core/random{
+/obj/effect/spawner/random/anomaly_core{
 	pixel_x = -7
 	},
 /obj/machinery/light/small/directional/north,

--- a/code/modules/mapfluff/ruins/spaceruin_code/anomalyresearch.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/anomalyresearch.dm
@@ -42,8 +42,7 @@
 
 /obj/effect/spawner/random/anomaly_core/Initialize(mapload)
 	loot = subtypesof(/obj/item/assembly/signaler/anomaly)
-
-	. = ..()
+	return ..()
 
 /obj/item/paper/fluff/ruins/anomaly_research/intro
 	name = "revelation"

--- a/code/modules/mapfluff/ruins/spaceruin_code/anomalyresearch.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/anomalyresearch.dm
@@ -29,10 +29,21 @@
 	var/obj/effect/anomaly/anomaly = .
 	anomaly.stabilize(anchor = anchor_anomaly, has_core = FALSE)
 
+///Spawns an unmoving anomaly that cannot harm the environment (can harm mobs though)
 /obj/effect/spawner/random/environmentally_safe_anomaly/immobile
 	name = "stationary safe anomaly spawner"
 	icon_state = "anomaly_stationary"
 	anchor_anomaly = TRUE
+
+///Spawn a random, ready-to-go, anomaly core. Please use extremely sparingly (if at all)
+/obj/effect/spawner/random/anomaly_core
+	name = "finished anomaly core spawner"
+	icon_state = "anomaly"
+
+/obj/effect/spawner/random/anomaly_core/Initialize(mapload)
+	loot = subtypesof(/obj/item/assembly/signaler/anomaly)
+
+	. = ..()
 
 /obj/item/paper/fluff/ruins/anomaly_research/intro
 	name = "revelation"


### PR DESCRIPTION
:cl:
balance: The raw anomaly core in the anomaly ruin has been replaced by a random, ready-to-go, anomaly core
/:cl:

### Why it's good for the game
The anomaly ruin has been out for a bit already, and I think a ready anomaly core can safely be added to the ruin. The loot inside the ruin is, in the end, kinda useless without an anomaly core. This would be the only anomaly core that can be found in the game without making it. This does not reduce the amount of cores you can get from research. It's also random, so it can be a useful anomaly or one of the meme anomalies. 

The core is protected by a vault door (or walls) and an array of anomalies that can all kill you very easily kill you. The ruin also has no beacon to consistently hunting it down isn't very viable. It's also not a guaranteed spawn