### PR TITLE
Deletes unnecessary text from supply pod beacons desciption.

### DIFF
--- a/code/modules/cargo/supplypod_beacon.dm
+++ b/code/modules/cargo/supplypod_beacon.dm
@@ -1,7 +1,6 @@
 /obj/item/supplypod_beacon
 	name = "Supply Pod Beacon"
 	desc = "A device that can be linked to an Express Supply Console for precision supply pod deliveries."
-	desc_controls = "Alt-click to remove link."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "supplypod_beacon"
 	inhand_icon_state = "radio"


### PR DESCRIPTION

## About The Pull Request
It has 2 phrases which represent the same.
![image](https://user-images.githubusercontent.com/93882977/236689067-9bff8636-3a91-4227-96f6-26a2d78eb71b.png)
![image](https://user-images.githubusercontent.com/93882977/236689086-15efa873-5c7c-4d8d-858e-8c766259a278.png)
## Why It's Good For The Game
Less text to read
## Changelog
:cl:
qol: Deleted unnecessary text from description of supply pod beacon.
/:cl:
