### PR TITLE
Nerfs the firing speed of Syndicate/Russian mobs

### DIFF
--- a/code/modules/mob/living/basic/syndicate/syndicate_ai.dm
+++ b/code/modules/mob/living/basic/syndicate/syndicate_ai.dm
@@ -29,12 +29,14 @@
 /datum/ai_controller/basic_controller/syndicate/ranged
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/simple_find_target,
-		/datum/ai_planning_subtree/basic_ranged_attack_subtree/syndicate
+		/datum/ai_planning_subtree/basic_ranged_attack_subtree/syndicate,
 	)
+
 /datum/ai_planning_subtree/basic_ranged_attack_subtree/syndicate
 	ranged_attack_behavior = /datum/ai_behavior/basic_ranged_attack/syndicate
 
 /datum/ai_behavior/basic_ranged_attack/syndicate
+	action_cooldown = 2.5 SECONDS
 	required_distance = 5
 
 /datum/ai_controller/basic_controller/syndicate/ranged/burst


### PR DESCRIPTION
## About The Pull Request

Nerfs their firing speed from once every 0.2 seconds to once every 2.5 seconds

## Why It's Good For The Game

1. The mob that is NOT a 'burst' type mob, is firing every 0.2 seconds. Kinda defeats the point of having them as two separate mobs, so this aims to fix that.
2. Russian mobs. Turns out that letting them fire their strong-ass gun every 0.2 seconds was kinda not a good idea. I had assumed making them a Syndicate mob would be safe, and it technically is, it's just that Syndicate mob is fucked itself.

## Changelog

:cl:
balance: Default Syndicate and Russian gunners now fire every 2.5 seconds instead of every 0.2
/:cl: