### PR TITLE
Drones can access computers and air alarms by default

### DIFF
--- a/code/__DEFINES/drone.dm
+++ b/code/__DEFINES/drone.dm
@@ -1,6 +1,6 @@
 
 /// If drones are blacklisted from certain sensitive machines
-GLOBAL_VAR_INIT(drone_machine_blacklist_enabled, TRUE)
+GLOBAL_VAR_INIT(drone_machine_blacklist_enabled, FALSE)
 
 #define DRONE_HANDS_LAYER 1
 #define DRONE_HEAD_LAYER 2


### PR DESCRIPTION
## About The Pull Request

Drones by default can now interact with:
- Wires in Air alarms
- Computers
- Air alarms

## Why It's Good For The Game

This is something the CE had to enable, however this feature is very obscure and there's **no way for a drone to ask a CE to do this**, so I think we should instead have drones be able to use it by default, and they can take it away if the CE ever wants to for any reason.
I think this would make drones more tolerable to play, since they can now repair the station in ways they previously weren't able to without a CE psychically knowing the drones wanted access.

## Changelog

:cl:
balance: Drones can now access computers and air alarms by default, and the CE has the option to turn it off through the BotKeeper app (it used to be backwards).
/:cl: