### PR TITLE
Fix custom say emotes (prefix*words) with non-ASCII characters

### DIFF
--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -163,7 +163,7 @@
 		return message
 	if (is_banned_from(ckey, "Emote"))
 		return copytext(message, customsaypos + 1)
-	mods[MODE_CUSTOM_SAY_EMOTE] = copytext_char(message, 1, customsaypos)
+	mods[MODE_CUSTOM_SAY_EMOTE] = copytext(message, 1, customsaypos)
 	message = copytext(message, customsaypos + 1)
 	if (!message)
 		mods[MODE_CUSTOM_SAY_ERASE_INPUT] = TRUE


### PR DESCRIPTION

## About The Pull Request
Custom say emotes work incorrectly, if there's any non-ASCII symbols in "prefix" part of it.
E.g. for input `test*test` and `тест*тест` the results are (notice messed up prefix in the second case):
![image](https://user-images.githubusercontent.com/5000549/236725577-87f8f0fc-8c60-4e72-b768-c10f5643b5c4.png)
In order to fix it, this PR replaces `copytext_char` (working with **character** position) with `copytext` (working with **byte** position), so it works correctly with `customsaypos` found by `findtext` (working with **byte** position). With this fix the results become expected:
![image](https://user-images.githubusercontent.com/5000549/236726258-f9aabf40-c84e-49ba-921f-9f328f1d8057.png)
## Why It's Good For The Game
It fixes custom say emotes bug with non-ASCII characters and slightly increases performance (since `copytext` is said to work faster than `copytext_char`)
## Changelog
:cl:
fix: fixed custom say emotes with non-ASCII characters
/:cl:
