### PR TITLE
Prevent division by zero runtimes for gas equalization

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -269,7 +269,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		assert_gas(gas_id)
 		other.assert_gas(gas_id)
 		//math is under the assumption temperatures are equal
-		// we check for either volume being zero, as this will cause division by zero runtimes.
+
 		if(abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > min_p_delta / (R_IDEAL_GAS_EQUATION * temperature))
 			. = TRUE
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -251,6 +251,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 ///Distributes the contents of two mixes equally between themselves
 //Returns: bool indicating whether gases moved between the two mixes
 /datum/gas_mixture/proc/equalize(datum/gas_mixture/other)
+	if(!volume || !other.volume) // how did we even get here?
+		
 	. = FALSE
 	if(abs(return_temperature() - other.return_temperature()) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
 		. = TRUE
@@ -269,7 +271,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		//math is under the assumption temperatures are equal
 		// we check for either volume being zero, as this will cause division by zero runtimes.
 		// they can have zero volume due to one not having the gas, and then we assert it initializing it with zero moles.
-		if(volume == 0 || other.volume == 0 || abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > min_p_delta / (R_IDEAL_GAS_EQUATION * temperature))
+		if(abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > min_p_delta / (R_IDEAL_GAS_EQUATION * temperature))
 			. = TRUE
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]
 			gases[gas_id][MOLES] = total_moles * (volume/total_volume)

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -269,7 +269,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		assert_gas(gas_id)
 		other.assert_gas(gas_id)
 		//math is under the assumption temperatures are equal
-
 		if(abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > min_p_delta / (R_IDEAL_GAS_EQUATION * temperature))
 			. = TRUE
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -252,7 +252,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 //Returns: bool indicating whether gases moved between the two mixes
 /datum/gas_mixture/proc/equalize(datum/gas_mixture/other)
 	if(!volume || !other.volume) // how did we even get here?
-		
+		return FALSE
 	. = FALSE
 	if(abs(return_temperature() - other.return_temperature()) > MINIMUM_TEMPERATURE_DELTA_TO_SUSPEND)
 		. = TRUE

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -270,7 +270,6 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		other.assert_gas(gas_id)
 		//math is under the assumption temperatures are equal
 		// we check for either volume being zero, as this will cause division by zero runtimes.
-		// they can have zero volume due to one not having the gas, and then we assert it initializing it with zero moles.
 		if(abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > min_p_delta / (R_IDEAL_GAS_EQUATION * temperature))
 			. = TRUE
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -267,7 +267,9 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		assert_gas(gas_id)
 		other.assert_gas(gas_id)
 		//math is under the assumption temperatures are equal
-		if(abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > min_p_delta / (R_IDEAL_GAS_EQUATION * temperature))
+		// we check for either volume being zero, as this will cause division by zero runtimes.
+		// they can have zero volume due to one not having the gas, and then we assert it initializing it with zero moles.
+		if(volume == 0 || other.volume == 0 || abs(gases[gas_id][MOLES] / volume - other.gases[gas_id][MOLES] / other.volume) > min_p_delta / (R_IDEAL_GAS_EQUATION * temperature))
 			. = TRUE
 			var/total_moles = gases[gas_id][MOLES] + other.gases[gas_id][MOLES]
 			gases[gas_id][MOLES] = total_moles * (volume/total_volume)


### PR DESCRIPTION

## About The Pull Request

See title.
## Why It's Good For The Game

Runtimes bad, this can also theoretically cause gasses to appear stuck in one tile; although I've never seen any reports of that.
## Changelog
