### PR TITLE
Grilling items now only smoke when the griddle is on

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_food.dm
+++ b/code/__DEFINES/dcs/signals/signals_food.dm
@@ -32,7 +32,11 @@
 
 // Grilling foods (griddle, grill, and bonfire)
 ///Called when an object is placed onto a griddle
-#define COMSIG_ITEM_GRILL_PLACED_ON "item_placed_on_griddle"
+#define COMSIG_ITEM_GRILL_PLACED "item_placed_on_griddle"
+///Called when a griddle is turned on
+#define COMSIG_ITEM_GRILL_TURNED_ON "item_grill_turned_on"
+///Called when a griddle is turned off
+#define COMSIG_ITEM_GRILL_TURNED_OFF "item_grill_turned_off"
 ///Called when an object is grilled ontop of a griddle
 #define COMSIG_ITEM_GRILL_PROCESS "item_griddled"
 	/// Return to not burn the item

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -33,10 +33,10 @@
 /datum/component/grillable/UnregisterFromParent()
 	UnregisterSignal(parent, list(
 		COMSIG_PARENT_EXAMINE,
+		COMSIG_ITEM_GRILL_TURNED_ON,
+		COMSIG_ITEM_GRILL_TURNED_OFF,
 		COMSIG_ITEM_GRILL_PROCESS,
 		COMSIG_ITEM_GRILL_PLACED,
-		COMSIG_ITEM_GRILL_PLACED_ON,
-		COMSIG_ITEM_GRILL_PLACED_OFF,
 	))
 
 // Inherit the new values passed to the component

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -31,7 +31,13 @@
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 
 /datum/component/grillable/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_ITEM_GRILL_PLACED, COMSIG_ITEM_GRILL_TURNED_ON, COMSIG_ITEM_GRILL_TURNED_OFF, COMSIG_ITEM_GRILL_PROCESS, COMSIG_PARENT_EXAMINE))
+	UnregisterSignal(parent, list(
+		COMSIG_PARENT_EXAMINE,
+		COMSIG_ITEM_GRILL_PROCESS,
+		COMSIG_ITEM_GRILL_PLACED,
+		COMSIG_ITEM_GRILL_PLACED_ON,
+		COMSIG_ITEM_GRILL_PLACED_OFF,
+	))
 
 // Inherit the new values passed to the component
 /datum/component/grillable/InheritComponent(datum/component/grillable/new_comp, original, cook_result, required_cook_time, positive_result, use_large_steam_sprite)

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -24,12 +24,14 @@
 	src.use_large_steam_sprite = use_large_steam_sprite
 
 /datum/component/grillable/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_ITEM_GRILL_PLACED_ON, PROC_REF(on_grill_start))
+	RegisterSignal(parent, COMSIG_ITEM_GRILL_PLACED, PROC_REF(on_grill_placed))
+	RegisterSignal(parent, COMSIG_ITEM_GRILL_TURNED_ON, PROC_REF(on_grill_turned_on))
+	RegisterSignal(parent, COMSIG_ITEM_GRILL_TURNED_OFF, PROC_REF(on_grill_turned_off))
 	RegisterSignal(parent, COMSIG_ITEM_GRILL_PROCESS, PROC_REF(on_grill))
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 
 /datum/component/grillable/UnregisterFromParent()
-	UnregisterSignal(parent, list(COMSIG_ITEM_GRILL_PLACED_ON, COMSIG_ITEM_GRILL_PROCESS, COMSIG_PARENT_EXAMINE))
+	UnregisterSignal(parent, list(COMSIG_ITEM_GRILL_PLACED, COMSIG_ITEM_GRILL_TURNED_ON, COMSIG_ITEM_GRILL_TURNED_OFF, COMSIG_ITEM_GRILL_PROCESS, COMSIG_PARENT_EXAMINE))
 
 // Inherit the new values passed to the component
 /datum/component/grillable/InheritComponent(datum/component/grillable/new_comp, original, cook_result, required_cook_time, positive_result, use_large_steam_sprite)
@@ -44,15 +46,25 @@
 	if(use_large_steam_sprite)
 		src.use_large_steam_sprite = use_large_steam_sprite
 
-/// Signal proc for [COMSIG_ITEM_GRILL_PLACED_ON], starts the grilling process.
-/datum/component/grillable/proc/on_grill_start(datum/source, mob/griller)
+/// Signal proc for [COMSIG_ITEM_GRILL_PLACED], item is placed on the grill.
+/datum/component/grillable/proc/on_grill_placed(datum/source, mob/griller)
 	SIGNAL_HANDLER
 
 	if(griller && griller.mind)
 		who_placed_us = REF(griller.mind)
 
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+
+/// Signal proc for [COMSIG_ITEM_GRILL_TURNED_ON], starts the grilling process.
+/datum/component/grillable/proc/on_grill_turned_on(datum/source)
 	RegisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(add_grilled_item_overlay))
+
+	var/atom/atom_parent = parent
+	atom_parent.update_appearance()
+
+/// Signal proc for [COMSIG_ITEM_GRILL_TURNED_OFF], stops the grilling process.
+/datum/component/grillable/proc/on_grill_turned_off(datum/source)
+	UnregisterSignal(parent, COMSIG_ATOM_UPDATE_OVERLAYS)
 
 	var/atom/atom_parent = parent
 	atom_parent.update_appearance()

--- a/code/modules/food_and_drinks/machinery/griddle.dm
+++ b/code/modules/food_and_drinks/machinery/griddle.dm
@@ -91,6 +91,15 @@
 	update_appearance()
 	update_grill_audio()
 
+/obj/machinery/griddle/begin_processing()
+	. = ..()
+	for(var/obj/item/item_to_grill as anything in griddled_objects)
+		SEND_SIGNAL(item_to_grill, COMSIG_ITEM_GRILL_TURNED_ON)
+
+/obj/machinery/griddle/end_processing()
+	. = ..()
+	for(var/obj/item/item_to_grill as anything in griddled_objects)
+		SEND_SIGNAL(item_to_grill, COMSIG_ITEM_GRILL_TURNED_OFF)
 
 /obj/machinery/griddle/proc/AddToGrill(obj/item/item_to_grill, mob/user)
 	vis_contents += item_to_grill
@@ -98,7 +107,9 @@
 	item_to_grill.flags_1 |= IS_ONTOP_1
 	item_to_grill.vis_flags |= VIS_INHERIT_PLANE
 
-	SEND_SIGNAL(item_to_grill, COMSIG_ITEM_GRILL_PLACED_ON, user)
+	SEND_SIGNAL(item_to_grill, COMSIG_ITEM_GRILL_PLACED, user)
+	if(on)
+		SEND_SIGNAL(item_to_grill, COMSIG_ITEM_GRILL_TURNED_ON)
 	RegisterSignal(item_to_grill, COMSIG_MOVABLE_MOVED, PROC_REF(ItemMoved))
 	RegisterSignal(item_to_grill, COMSIG_ITEM_GRILLED, PROC_REF(GrillCompleted))
 	RegisterSignal(item_to_grill, COMSIG_PARENT_QDELETING, PROC_REF(ItemRemovedFromGrill))


### PR DESCRIPTION
## About The Pull Request

Prior to this change, if you put an item on the griddle, it immediately began to smoke, regardless of whether the griddle was on or not. Now smoke will only appear when the griddle is turned on.

## Why It's Good For The Game
Graphic QoL for chefs

https://user-images.githubusercontent.com/10997188/236855447-8912a689-bec3-4cba-a6f3-45c428d7af29.mp4


## Changelog
:cl:
fix: fixed griddle code so that the smoke over the grilling items appears only when the griddle is on
/:cl:
