### PR TITLE
Makes receive_signal async

### DIFF
--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -200,6 +200,7 @@ GLOBAL_LIST_INIT(reverseradiochannels, list(
 			devices -= devices_filter
 
 /obj/proc/receive_signal(datum/signal/signal)
+	set waitfor = FALSE
 	return
 
 /datum/signal


### PR DESCRIPTION
Should have always been this way. Fixes a ton of SHOULD_NOT_SLEEP hits.

See #75232