### PR TITLE
Hunter pounces are now knockdown based, instead of paralyzing.

### DIFF
--- a/code/modules/mob/living/carbon/alien/adult/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/adult/caste/hunter.dm
@@ -75,11 +75,10 @@
 					blocked = TRUE
 			if(!blocked)
 				L.visible_message(span_danger("[src] pounces on [L]!"), span_userdanger("[src] pounces on you!"))
-				L.Paralyze(100)
-				sleep(0.2 SECONDS)//Runtime prevention (infinite bump() calls on hulks)
+				L.Knockdown(10 SECONDS)
 				step_towards(src,L)
 			else
-				Paralyze(40, ignore_canstun = TRUE)
+				Knockdown(4 SECONDS)
 
 			toggle_leap(0)
 		else if(hit_atom.density && !hit_atom.CanPass(src, get_dir(hit_atom, src)))


### PR DESCRIPTION
## About The Pull Request

Hunter pounces are now knockdown based, instead of paralyzing.

## Why It's Good For The Game

Fighting aliens fucking sucks. Everyone agrees on this. A ten second knockdown is still dangerous as hell while not being literal 2010 level "balance".

I have not enjoyed a single round of aliens I have ever played on this server, and it's fucking stupid that we refuse to do anything about it. I'm going to keep opening these nerf PRs until we quit hanging onto ancient badly balanced design decisions because "aliens are dangerous" without accepting that this isn't how we make something dangerous in fucking 2023, this is how we made something dangerous in 2010 when we were newbies who had no idea how to do good game design.

This will make aliens less fucking cancer.

## Changelog
:cl:
balance: Hunter pounces are now knockdown based, instead of paralyzing.
/:cl: