### PR TITLE
Fixes a runtime from foam in a weird loc / improves the stack trace (somewhat)

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -84,7 +84,9 @@
 		return
 
 	if(ismob(loc))
-		CRASH("A foam effect ([type]) was created within a mob! (Actual location: [loc] ([loc.type]))")
+		stack_trace("A foam effect ([type]) was created within a mob! (Actual location: [loc] ([loc.type]))")
+		qdel(src)
+		return
 
 	var/fraction = (ds_seconds_per_tick * MINIMUM_FOAM_DILUTION) / (initial(lifetime) * max(MINIMUM_FOAM_DILUTION, group.total_size))
 

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -83,22 +83,27 @@
 		kill_foam()
 		return
 
+	if(ismob(loc))
+		CRASH("A foam effect ([type]) was created within a mob! (Actual location: [loc] ([loc.type]))")
+
 	var/fraction = (ds_seconds_per_tick * MINIMUM_FOAM_DILUTION) / (initial(lifetime) * max(MINIMUM_FOAM_DILUTION, group.total_size))
-	var/turf/location = loc
-	for(var/obj/object in location)
-		if(object == src)
-			continue
-		if(location.underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(object, TRAIT_T_RAY_VISIBLE))
-			continue
-		reagents.expose(object, VAPOR, fraction)
+
+	if(isturf(loc))
+		var/turf/turf_location = loc
+		for(var/obj/object in turf_location)
+			if(object == src)
+				continue
+			if(turf_location.underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(object, TRAIT_T_RAY_VISIBLE))
+				continue
+			reagents.expose(object, VAPOR, fraction)
 
 	var/hit = 0
-	for(var/mob/living/foamer in location)
+	for(var/mob/living/foamer in loc)
 		hit += foam_mob(foamer, seconds_per_tick)
 	if(hit)
 		lifetime += ds_seconds_per_tick //this is so the decrease from mobs hit and the natural decrease don't cumulate.
 
-	reagents.expose(location, VAPOR, fraction)
+	reagents.expose(loc, VAPOR, fraction)
 
 /**
  * Applies the effect of this foam to a mob.

--- a/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
+++ b/code/modules/clothing/under/jobs/Plasmaman/civilian_service.dm
@@ -139,5 +139,5 @@
 			var/datum/effect_system/fluid_spread/foam/foam = new
 			var/datum/reagents/foamreagent = new /datum/reagents(15)
 			foamreagent.add_reagent(/datum/reagent/lube, 15)
-			foam.set_up(4, holder = src, location = loc, carry = foamreagent)
+			foam.set_up(4, holder = src, location = H.loc, carry = foamreagent)
 			foam.start() //Truly terrifying.


### PR DESCRIPTION
## About The Pull Request

- Fixes a runtime from foam being created inside plasmamen, instead of at the plasmamen's loc, from the clown plasmaman suit

![image](https://user-images.githubusercontent.com/51863163/236899740-1d5ccca3-43c4-455b-9bb2-3206ce433df8.png)

- Adds a stack trace for mobs having foam created inside of them
   - So, in the past foam would runtime if created in a non-turf at all, mobs or otherwise. I changed it so it creates a more helpful stack trace.
   - While tackling this, however, I realized that we may want to support foam in non-turf, non-mob locs? Like closets? That is to say, if you release a foam reaction while stuck in a locker and it floods the locker, it would stay in the locker until it is opened, and affect other people in the locker itself? Unsure, so I left it as an option, albeit it may not function entirely correctly. 
   - This may also false-positive in some places, such as a mob within mob. I'm unsure if it should have its own case, or of it should act like closets are implied to do above? But that may produce some silent errors. So eh. 

## Why It's Good For The Game

Less runtimes, more intended code. 

## Changelog

:cl: Melbert
fix: Fixes a runtime with plasmaman clown suit lube spray
/:cl:
