### PR TITLE
Makes it so coroner is only listed in medical department instead of both service and medical

### DIFF
--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -41,7 +41,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 				)
 			continue
 		for(var/department_type as anything in job.departments_list)
-			if(job.department_for_prefs && job.department_for_prefs != department_type && department_type != /datum/job_department/command)
+			if(job.department_for_prefs && job.department_for_prefs != department_type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 			var/datum/job_department/department = departments_by_type[department_type]
 			if(!department)

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -40,19 +40,9 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 				"rank" = rank,
 				)
 			continue
-		if(job.department_for_prefs && !(/datum/job_department/command in job.departments_list))
-			var/datum/job_department/department = departments_by_type[job.department_for_prefs]
-			if(!department)
-				stack_trace("get_manifest() failed to get job department for [job.department_for_prefs] of [job.type]")
-				continue
-			var/list/entry = list(
-				"name" = name,
-				"rank" = rank,
-				)
-			var/list/department_list = manifest_out[department.department_name]
-			department_list[++department_list.len] = entry
-			continue
 		for(var/department_type as anything in job.departments_list)
+			if(job.department_for_prefs && job.department_for_prefs != department_type && department_type != /datum/job_department/command)
+				continue
 			var/datum/job_department/department = departments_by_type[department_type]
 			if(!department)
 				stack_trace("get_manifest() failed to get job department for [department_type] of [job.type]")

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -41,7 +41,8 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 				)
 			continue
 		for(var/department_type as anything in job.departments_list)
-			if(job.department_for_prefs && job.department_for_prefs != department_type && !(job.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			//Only show the job for its main department or the command department
+			if(job_datum.departments_list[1] != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 			var/datum/job_department/department = departments_by_type[department_type]
 			if(!department)

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -41,7 +41,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 				)
 			continue
 		for(var/department_type as anything in job.departments_list)
-			//Only show the job for its main department or the command department
+			//Jobs under multiple departments should only be displayed if this is their first department or the command department
 			if(job_datum.departments_list[1] != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 			var/datum/job_department/department = departments_by_type[department_type]

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -40,6 +40,18 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 				"rank" = rank,
 				)
 			continue
+		if(job.department_for_prefs && !(/datum/job_department/command in job.departments_list))
+			var/datum/job_department/department = departments_by_type[job.department_for_prefs]
+			if(!department)
+				stack_trace("get_manifest() failed to get job department for [job.department_for_prefs] of [job.type]")
+				continue
+			var/list/entry = list(
+				"name" = name,
+				"rank" = rank,
+				)
+			var/list/department_list = manifest_out[department.department_name]
+			department_list[++department_list.len] = entry
+			continue
 		for(var/department_type as anything in job.departments_list)
 			var/datum/job_department/department = departments_by_type[department_type]
 			if(!department)

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -42,7 +42,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 			continue
 		for(var/department_type as anything in job.departments_list)
 			//Jobs under multiple departments should only be displayed if this is their first department or the command department
-			if(job_datum.departments_list[1] != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			if(job.departments_list[1] != department_type && !(job.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 			var/datum/job_department/department = departments_by_type[department_type]
 			if(!department)

--- a/code/datums/records/manifest.dm
+++ b/code/datums/records/manifest.dm
@@ -41,7 +41,7 @@ GLOBAL_DATUM_INIT(manifest, /datum/manifest, new)
 				)
 			continue
 		for(var/department_type as anything in job.departments_list)
-			if(job.department_for_prefs && job.department_for_prefs != department_type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			if(job.department_for_prefs && job.department_for_prefs != department_type && !(job.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 			var/datum/job_department/department = departments_by_type[department_type]
 			if(!department)

--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -20,6 +20,7 @@
 	bounty_types = CIV_JOB_MED
 	department_for_prefs = /datum/job_department/medical
 	departments_list = list(
+		/datum/job_department/medical,
 		/datum/job_department/service,
 	)
 

--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -20,7 +20,6 @@
 	bounty_types = CIV_JOB_MED
 	department_for_prefs = /datum/job_department/medical
 	departments_list = list(
-		/datum/job_department/medical,
 		/datum/job_department/service,
 	)
 

--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -20,7 +20,7 @@
 	bounty_types = CIV_JOB_MED
 	department_for_prefs = /datum/job_department/medical
 	departments_list = list(
-		/datum/job_department/service,
+		/datum/job_department/medical,
 	)
 
 	mail_goodies = list(

--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -20,7 +20,7 @@
 	bounty_types = CIV_JOB_MED
 	department_for_prefs = /datum/job_department/medical
 	departments_list = list(
-		/datum/job_department/medical,
+		/datum/job_department/service,
 	)
 
 	mail_goodies = list(

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -67,6 +67,9 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		departments[department.department_name] = department_data
 
 		for(var/datum/job/job_datum as anything in department.department_jobs)
+			if(job_datum.department_for_prefs && job_datum.department_for_prefs != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+				continue
+
 			var/job_availability = owner.IsJobUnavailable(job_datum.title, latejoin = TRUE)
 
 			var/list/job_data = list(
@@ -101,6 +104,9 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		departments[department.department_name] = department_data
 
 		for(var/datum/job/job_datum as anything in department.department_jobs)
+			if(job_datum.department_for_prefs && job_datum.department_for_prefs != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+				continue
+
 			var/list/job_data = list(
 				"command" = !!(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND),
 				"description" = job_datum.description,

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -67,7 +67,8 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		departments[department.department_name] = department_data
 
 		for(var/datum/job/job_datum as anything in department.department_jobs)
-			if(job_datum.department_for_prefs && job_datum.department_for_prefs != department.type && !!(LAZYLEN(job_datum.departments_list)) && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			//Only show the job for its main department or the command department
+			if(!!(LAZYLEN(job_datum.departments_list)) && job_datum.departments_list[1] != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 
 			var/job_availability = owner.IsJobUnavailable(job_datum.title, latejoin = TRUE)
@@ -104,7 +105,8 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		departments[department.department_name] = department_data
 
 		for(var/datum/job/job_datum as anything in department.department_jobs)
-			if(job_datum.department_for_prefs && job_datum.department_for_prefs != department.type && !!(LAZYLEN(job_datum.departments_list)) && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			//Only show the job for its main department or the command department
+			if(!!(LAZYLEN(job_datum.departments_list)) && job_datum.departments_list[1] != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 
 			var/list/job_data = list(

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -67,8 +67,8 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		departments[department.department_name] = department_data
 
 		for(var/datum/job/job_datum as anything in department.department_jobs)
-			//Only show the job for its main department or the command department
-			if(!!(LAZYLEN(job_datum.departments_list)) && job_datum.departments_list[1] != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			//Jobs under multiple departments should only be displayed if this is their first department or the command department
+			if(LAZYLEN(job_datum.departments_list) > 1 && job_datum.departments_list[1] != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 
 			var/job_availability = owner.IsJobUnavailable(job_datum.title, latejoin = TRUE)
@@ -105,8 +105,8 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		departments[department.department_name] = department_data
 
 		for(var/datum/job/job_datum as anything in department.department_jobs)
-			//Only show the job for its main department or the command department
-			if(!!(LAZYLEN(job_datum.departments_list)) && job_datum.departments_list[1] != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			//Jobs under multiple departments should only be displayed if this is their first department or the command department
+			if(LAZYLEN(job_datum.departments_list) > 1 && job_datum.departments_list[1] != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 
 			var/list/job_data = list(

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -67,7 +67,7 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		departments[department.department_name] = department_data
 
 		for(var/datum/job/job_datum as anything in department.department_jobs)
-			if(job_datum.department_for_prefs && job_datum.department_for_prefs != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			if(job_datum.department_for_prefs && job_datum.department_for_prefs != department.type && !!(LAZYLEN(job_datum.departments_list)) && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 
 			var/job_availability = owner.IsJobUnavailable(job_datum.title, latejoin = TRUE)
@@ -104,7 +104,7 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		departments[department.department_name] = department_data
 
 		for(var/datum/job/job_datum as anything in department.department_jobs)
-			if(job_datum.department_for_prefs && job_datum.department_for_prefs != department.type && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
+			if(job_datum.department_for_prefs && job_datum.department_for_prefs != department.type && !!(LAZYLEN(job_datum.departments_list)) && !(job_datum.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND))
 				continue
 
 			var/list/job_data = list(


### PR DESCRIPTION
## About The Pull Request

Fixes #75261

Removes coroner from being under service in the crew manifest and latejoin menu
<details>
  <summary>Unnecessary Images</summary>

![image](https://user-images.githubusercontent.com/47338680/236925618-63b83a28-ed68-4238-b476-b65cb3b4d24d.png)
![image](https://user-images.githubusercontent.com/47338680/236925761-73e08922-7a07-4fe4-a1e0-566e4aee1173.png)
</details>

I believe it would also make it so getting banned from Service jobs wouldn't ban you from coroner. (Don't know if that ban type would ever be used) 
## Why It's Good For The Game

More in line with jobs like Psychologist and Lawyer which are only listed in a single department. (The service department)
Otherwise it mostly depends on JohnFulpWillard, since idk if they intended for it to be listed under medical or service. I just assumed medical made more sense for the Coroner. 
## Changelog
:cl:
fix: For the purposes of the crew manifest, Coroner is now considered a medical job rather than both service and medical. 
/:cl:
