### PR TITLE
The ghost verb no longer tries to succumb first if you are conscious

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -320,7 +320,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Ghost"
 	set desc = "Relinquish your life and enter the land of the dead."
 
-	if(stat != DEAD)
+	if(stat != CONSCIOUS && stat != DEAD)
 		succumb()
 	if(stat == DEAD)
 		if(!HAS_TRAIT(src, TRAIT_CORPSELOCKED)) //corpse-locked have to confirm with the alert below


### PR DESCRIPTION

## About The Pull Request

Makes it so the ghost verb doesn't try to succumb if you are conscious and therefore can't succumb. 
## Why It's Good For The Game

No more mildy annoying "You are unable to succumb to death! This life continues." message when you press the ghost verb.

Even if you are a zombie and press the ghost verb while conscious you're probably intending to ghost instead of succumb. So I don't think there's any need for this message to exist while conscious. 
## Changelog
:cl:
qol: The ghost verb no longer says you are unable to succumb to death if you're pressing it while conscious
/:cl:
