### PR TITLE
[Ruins] `podcrash` now uses `template_noop` instead of general space turf

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/pod_crash.dmm
+++ b/_maps/RandomRuins/SpaceRuins/pod_crash.dmm
@@ -51,7 +51,7 @@
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)
 "n" = (
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "o" = (
 /obj/structure/closet/crate/cardboard/tiziran,
@@ -86,18 +86,18 @@
 "y" = (
 /obj/structure/girder/displaced,
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "A" = (
 /obj/structure/girder/displaced,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "C" = (
 /turf/closed/wall/mineral/titanium,
 /area/ruin/space)
 "E" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "I" = (
 /obj/structure/billboard/nanotrasen/defaced,
@@ -106,7 +106,7 @@
 "J" = (
 /obj/structure/grille/broken,
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "L" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -114,7 +114,7 @@
 /area/ruin/space)
 "O" = (
 /obj/structure/grille/broken,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "P" = (
 /obj/machinery/power/shuttle_engine/propulsion/right{
@@ -137,7 +137,7 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 
 (1,1,1) = {"


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
It was using general space turf. It now uses `template_noop`, which every other ruin uses.

## Changelog

:cl: Jolly
fix: [Ruins] Pod Crash now uses the ruins-specific space turf. This doesn't change anything visually, but ships can land here and not have their areas viciously rip off.
/:cl:


