### PR TITLE
fixes spatial grid error, adds a loc setter proc (again), and fixes off-by-one error in the stuck-in-grid error message

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -104,3 +104,6 @@
 	#define MOVABLE_SAY_QUOTE_MESSAGE 1
 	#define MOVABLE_SAY_QUOTE_MESSAGE_SPANS 2
 	#define MOVABLE_SAY_QUOTE_MESSAGE_MODS 3
+
+/// Sent from /atom/movable/proc/change_loc() (atom/old_loc)
+#define COMSIG_MOVABLE_LOC_CHANGED "movable_loc_changed"

--- a/code/__DEFINES/spatial_gridmap.dm
+++ b/code/__DEFINES/spatial_gridmap.dm
@@ -1,11 +1,12 @@
-///each cell in a spatial_grid is this many turfs in length and width
+/// each cell in a spatial_grid is this many turfs in length and width (with world.max(x or y) being 255, 15 of these fit on each side of a z level)
 #define SPATIAL_GRID_CELLSIZE 17
-///Takes a coordinate, and spits out the spatial grid index (x or y) it's inside
+/// Takes a coordinate, and spits out the spatial grid index (x or y) it's inside
 #define GET_SPATIAL_INDEX(coord) ROUND_UP((coord) / SPATIAL_GRID_CELLSIZE)
-#define GRID_INDEX_TO_COORDS(index) (index * SPATIAL_GRID_CELLSIZE)
+/// changes the cell_(x or y) vars on /datum/spatial_grid_cell to the x or y coordinate on the map for the LOWER LEFT CORNER of the grid cell.
+/// index is from 1 to SPATIAL_GRID_CELLS_PER_SIDE
+#define GRID_INDEX_TO_COORDS(index) ((((index) - 1) * SPATIAL_GRID_CELLSIZE) + 1)
+/// number of grid cells per x or y side of all z levels. pass in world.maxx or world.maxy
 #define SPATIAL_GRID_CELLS_PER_SIDE(world_bounds) GET_SPATIAL_INDEX(world_bounds)
-
-#define SPATIAL_GRID_CHANNELS 2
 
 //grid contents channels
 

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -128,6 +128,7 @@
 	initial_gas_mix = AIRLESS_ATMOS
 
 /turf/open/lava/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	. = ..()
 	if(burn_stuff(arrived))
 		START_PROCESSING(SSobj, src)
 

--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -479,16 +479,14 @@ GLOBAL_LIST_EMPTY(lifts)
 		mover_old_loc = mover.loc
 		mover_old_area = mover_old_loc.loc
 
-		mover.loc = (mover_new_loc = get_step(mover, movement_direction))
+		mover.change_loc((mover_new_loc = get_step(mover, movement_direction)))
 		mover_new_area = mover_new_loc.loc
-
 
 		if(mover_old_area != mover_new_area)
 			mover_old_area.Exited(mover, movement_direction)
 			mover_new_area.Entered(mover, mover_new_area)
 
 		mover.Moved(mover_old_loc, movement_direction, TRUE, null, FALSE)
-
 
 	return TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -598,6 +598,7 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/closet/stasis/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	. = ..()
 	if(isliving(arrived) && holder_animal)
 		var/mob/living/L = arrived
 		L.notransform = 1


### PR DESCRIPTION

## About The Pull Request
fixes #75206 (might also fix the cockroach-in-grid error entirely but i doubt it)
adds /atom/movable/proc/change_loc() and puts that in place of loc assignment in all movement procs, and moves spatial grid cell movement to that proc. this is because we need to update grid cells before any potential side effects from Entered() or Exited() or even Moved() can happen that either depend on or change src's current grid cell loc. so as soon as loc changes we check grid cell loc.

also there was an off-by-one error in the unit test error message that made it report the coordinates of the grid cell's upper right corner instead of its lower left corner, thats fixed. 

also fixes some Entered() overrides not calling parent when they should
## Why It's Good For The Game
it's more correct than the current implementation
