### PR TITLE
Mortidrobe Restocks are now in Medical Wardrobe Supply Crates

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -31,7 +31,7 @@
 	crate_name = "medipen crate"
 
 /datum/supply_pack/medical/coroner_crate
-	name = "Autospy Kit"
+	name = "Autopsy Kit"
 	desc = "Contains an autopsy scanner, when you lose your own and really \
 		need to complete your dissection experiments."
 	cost = CARGO_CRATE_VALUE * 2.5

--- a/code/modules/cargo/packs/vending_restock.dm
+++ b/code/modules/cargo/packs/vending_restock.dm
@@ -192,6 +192,7 @@
 	contains = list(/obj/item/vending_refill/wardrobe/medi_wardrobe,
 					/obj/item/vending_refill/wardrobe/chem_wardrobe,
 					/obj/item/vending_refill/wardrobe/viro_wardrobe,
+					/obj/item/vending_refill/wardrobe/coroner_wardrobe,
 				)
 	crate_name = "medical department wardrobe supply crate"
 


### PR DESCRIPTION
## About The Pull Request
I noticed the mortidrobe restock wasn't actually in the medical wardrobe supply crate, so i added it to that. now coroners can get restocks for their clothes through cargo. the restock item itself, and the part to make it work with the vending machine were already done, so it was likely intended to be obtainable via this crate.
Also fixes a typo of "autospy" to "autopsy" in the autopsy kit crate.
## Why It's Good For The Game
consistency with the other job specific wardrobes is good. typos are less good.
## Changelog
:cl:
fix: the mortidrobe restock is now orderable from cargo, in the medical wardrobe supply crate.
spellcheck: fixes typo in autopsy kit crate name
/:cl:
