### PR TITLE
Stops SSmachines processing lighting updates for lights stored inside a hilbert hotel storage container

### DIFF
--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -452,6 +452,9 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	var/obj/item/hilbertshotel/parentSphere
 
 /obj/item/abstracthotelstorage/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	if(istype(arrived, /obj/machinery/light))
+		var/obj/machinery/light/entered_light = arrived
+		entered_light.end_processing()
 	. = ..()
 	if(ismob(arrived))
 		var/mob/M = arrived
@@ -462,6 +465,9 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	if(ismob(gone))
 		var/mob/M = gone
 		M.notransform = FALSE
+	if(istype(gone, /obj/machinery/light))
+		var/obj/machinery/light/exited_light = gone
+		exited_light.begin_processing()
 
 //Space Ruin stuff
 /area/ruin/space/has_grav/powered/hilbertresearchfacility


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/6209658/2616baa4-927f-4868-8a9e-1b5dd0ad20ff)
![image](https://github.com/tgstation/tgstation/assets/6209658/dd81498d-c043-48d0-97f0-b72303074b23)

this has been spamming runtime logs for yeaaaaaaarrrrrrrrrrrsssssssss. above screenshot is from just the last week.
fixes #63850
closes #75305

:cl: ShizCalev
fix: Lighting inside of a Hilbert Hotel storage room no longer constantly fails to update, clearing up some log spam and getting back some free lag.
/:cl:
