### PR TITLE
Fixes AI's trying to light up cameras in areas with no cameras

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -783,7 +783,7 @@
 	for (var/datum/camerachunk/chunk as anything in eyeobj.visibleCameraChunks)
 		for (var/z_key in chunk.cameras)
 			for(var/obj/machinery/camera/camera as anything in chunk.cameras[z_key])
-				if (!camera.can_use() || get_dist(camera, eyeobj) > 7 || !camera.internal_light)
+				if (!camera || !camera.can_use() || get_dist(camera, eyeobj) > 7 || !camera.internal_light)
 					continue
 				visible |= camera
 


### PR DESCRIPTION
This check is present throughout cameranet code as chunk camera lists can be empty lists by design, it was just missing for the AI camera light-up proc since that's in a separate area. 

![image](https://github.com/tgstation/tgstation/assets/6209658/4a15444d-28c1-445d-b76e-0f67a939cbf3)
![image](https://github.com/tgstation/tgstation/assets/6209658/f9ef88fa-c102-4482-95ff-ed2fc1867696)

fixes #70901

:cl: ShizCalev
fix: Fixed a bunch of log spam related to null.can_use() when AIs move their cameras around with toggle camera lights enabled Honk.
/:cl:
