### PR TITLE
Temporarily pause ALL machines from processing while inside a Hilbert Storage container

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1072,3 +1072,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define SPEAKING_FROM_TONGUE "tongue"
 ///trait source that sign language should use
 #define SPEAKING_FROM_HANDS "hands"
+
+//This atom temporarily has its processing paused. Example: It's currently stored in a Hilbert Storage Container / technically in bluespace and shouldn't be functional till it's back outside.
+#define TRAIT_PROCESSING_PAUSED "processing_paused"

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -452,6 +452,11 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	var/obj/item/hilbertshotel/parentSphere
 
 /obj/item/abstracthotelstorage/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	if(ismachinery(arrived) && (arrived.datum_flags & DF_ISPROCESSING))
+		ADD_TRAIT(arrived, TRAIT_PROCESSING_PAUSED, REF(src))
+		var/obj/machinery/arrived_machine = arrived
+		arrived_machine.end_processing()
+
 	. = ..()
 	if(ismob(arrived))
 		var/mob/M = arrived
@@ -462,6 +467,13 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	if(ismob(gone))
 		var/mob/M = gone
 		M.notransform = FALSE
+
+	if(ismachinery(gone) && HAS_TRAIT_FROM(gone, TRAIT_PROCESSING_PAUSED, REF(src)))
+		REMOVE_TRAIT(gone, TRAIT_PROCESSING_PAUSED, REF(src))
+		if(HAS_TRAIT(gone, TRAIT_PROCESSING_PAUSED))
+			return
+		var/obj/machinery/exited_machine = gone
+		exited_machine.begin_processing()
 
 //Space Ruin stuff
 /area/ruin/space/has_grav/powered/hilbertresearchfacility


### PR DESCRIPTION
Alternative version of #75301 which covers ALL machinery inside of it. This is kinda a nightmare to test, so I'm leaving the far more focused one that only affects lights up too. 

Fixes #63850
Closes #75301

:cl: ShizCalev
fix: Machinery inside a Hilbert Hotel storage container no longer processes/updates until it's back out, freeing up some wasted processing.
/:cl:
