### PR TITLE
Fix: Fixed dropdown buttons empty selected case

### DIFF
--- a/tgui/packages/tgui/components/Dropdown.tsx
+++ b/tgui/packages/tgui/components/Dropdown.tsx
@@ -251,27 +251,41 @@ export class Dropdown extends Component<DropdownProps, DropdownState> {
   }
 
   toPrevious(): void {
-    const selectedIndex = this.getSelectedIndex();
-
-    if (selectedIndex < 0) {
+    if (this.props.options.length < 1) {
       return;
     }
 
+    let selectedIndex = this.getSelectedIndex();
+    const startIndex = 0;
     const endIndex = this.props.options.length - 1;
-    const previousIndex = selectedIndex === 0 ? endIndex : selectedIndex - 1;
+
+    const hasSelected = selectedIndex >= 0;
+    if (!hasSelected) {
+      selectedIndex = startIndex;
+    }
+
+    const previousIndex =
+      selectedIndex === startIndex ? endIndex : selectedIndex - 1;
 
     this.setSelected(this.getOptionValue(this.props.options[previousIndex]));
   }
 
   toNext(): void {
-    const selectedIndex = this.getSelectedIndex();
-
-    if (selectedIndex < 0) {
+    if (this.props.options.length < 1) {
       return;
     }
 
+    let selectedIndex = this.getSelectedIndex();
+    const startIndex = 0;
     const endIndex = this.props.options.length - 1;
-    const nextIndex = selectedIndex === endIndex ? 0 : selectedIndex + 1;
+
+    const hasSelected = selectedIndex >= 0;
+    if (!hasSelected) {
+      selectedIndex = endIndex;
+    }
+
+    const nextIndex =
+      selectedIndex === endIndex ? startIndex : selectedIndex + 1;
 
     this.setSelected(this.getOptionValue(this.props.options[nextIndex]));
   }


### PR DESCRIPTION

## About The Pull Request

If dropdown not receive `selected` prop, buttons will be change value to first(when press next) or last element(when press back)

## Changelog
:cl:
fix: Fixed dropdown buttons empty selected case
/:cl:
