### PR TITLE
Outfit manager now searches more thoroughly for the user's ID

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -196,11 +196,15 @@
 		EQUIP_OUTFIT_ITEM(id, ITEM_SLOT_ID)
 	if(!visualsOnly && id_trim && H.wear_id)
 		var/obj/item/card/id/id_card = H.wear_id
-		id_card.registered_age = H.age
-		if(id_trim)
-			if(!SSid_access.apply_trim_to_card(id_card, id_trim))
-				WARNING("Unable to apply trim [id_trim] to [id_card] in outfit [name].")
-			H.sec_hud_set_ID()
+		if(!istype(id_card)) //If an ID wasn't found in their ID slot, it's probably something holding their ID like a wallet or PDA
+			id_card = locate() in H.wear_id
+
+		if(istype(id_card)) //Make sure that we actually found an ID to modify, otherwise this runtimes and cancels equipping the outfit
+			id_card.registered_age = H.age
+			if(id_trim)
+				if(!SSid_access.apply_trim_to_card(id_card, id_trim))
+					WARNING("Unable to apply trim [id_trim] to [id_card] in outfit [name].")
+				H.sec_hud_set_ID()
 
 	if(suit_store)
 		EQUIP_OUTFIT_ITEM(suit_store, ITEM_SLOT_SUITSTORE)
@@ -249,7 +253,7 @@
 				var/obj/item/tank/internals/internals = H.is_holding_item_of_type(/obj/item/tank/internals)
 				if(internals)
 					H.open_internals(internals)
-			else 
+			else
 				H.open_internals(H.get_item_by_slot(internals_slot))
 		if(implants)
 			for(var/implant_type in implants)


### PR DESCRIPTION
## About The Pull Request

The outfit manager will now search more thoroughly for a user's ID when attempting to change its trim. This prevents a runtime when attempting this on a user with a PDA/Wallet/non-ID item in their ID slot.

The instance causing problems in my case was the nuclear operative outfit -- Attempting to make a player a nuclear operative from the player panel while they are wearing a wallet would fuck up the outfitting process.

If you are wearing a wallet it will modify the trim of whichever ID is in the wallet's first slot.
## Why It's Good For The Game

Fixes a bug I found while testing something else.
## Changelog
:cl: Rhials
fix: Outfit changes will now properly change your ID trim if wearing a non-ID item in your ID slot.
/:cl:
