### PR TITLE
Gives psychologists morgue access on lowpop

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -784,6 +784,7 @@
 		ACCESS_SERVICE,
 	)
 	extra_access = list(
+		ACCESS_MORGUE,
 		ACCESS_MORGUE_SECURE,
 	)
 	template_access = list(


### PR DESCRIPTION
## About The Pull Request

i gave Psychologists access to the Coroner's office on lowpop so the Psych and Coroner can replace eachother when the other is missing, however I forgot to give Morgue access to the Psychologist so they can do this.

## Why It's Good For The Game

Fixes my own oversight.

## Changelog

:cl:
fix: Psychologists have Morgue access on lowpop, on top of their existing Coroner office access.
/:cl: