### PR TITLE
Buffs Lasers

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -13,7 +13,7 @@
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 62.5
+	e_cost = 52
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_casing/energy/laser
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 83
+	e_cost = 63
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hellfire

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -24,14 +24,15 @@
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
-	wound_bonus = -30
+	wound_bonus = -20
+	damage = 25
 	bare_wound_bonus = 40
 
 //overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
 /obj/projectile/beam/laser/hellfire
 	name = "hellfire laser"
 	wound_bonus = 0
-	damage = 25
+	damage = 30
 	speed = 0.6 // higher power = faster, that's how light works right
 
 /obj/projectile/beam/laser/hellfire/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request
This increases laser wound chance, increases the damage and also makes them use less energy.

## Why It's Good For The Game
Lasers cannot reload so they're not as convenient as a gun, so this will maybe make them more cool, honestly I just want to try this to see what happens.

## Changelog
:cl: oranges
balance: increased laser damage, decreased energy cost and increased wound chance
/:cl: