### PR TITLE
Nerfs MECH RCD's ability to build anywhere within 3 tiles of you

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -281,7 +281,7 @@
 /obj/item/mecha_parts/mecha_equipment/rcd/action(mob/source, atom/target, list/modifiers)
 	if(!isturf(target) && !istype(target, /obj/machinery/door/airlock))
 		target = get_turf(target)
-	if(!action_checks(target) || get_dist(chassis, target)>3 || istype(target, /turf/open/space/transit))
+	if(!action_checks(target) || !target in view(3, chassis) || istype(target, /turf/open/space/transit))
 		return
 	playsound(chassis, 'sound/machines/click.ogg', 50, TRUE)
 

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -281,7 +281,7 @@
 /obj/item/mecha_parts/mecha_equipment/rcd/action(mob/source, atom/target, list/modifiers)
 	if(!isturf(target) && !istype(target, /obj/machinery/door/airlock))
 		target = get_turf(target)
-	if(!action_checks(target) || !target in view(3, chassis) || istype(target, /turf/open/space/transit))
+	if(!action_checks(target) || !(target in view(3, chassis)) || istype(target, /turf/open/space/transit))
 		return
 	playsound(chassis, 'sound/machines/click.ogg', 50, TRUE)
 


### PR DESCRIPTION
you must now be able to see what you're trying to build on

## About The Pull Request
MECH RCD now requires you to actually see the thing you're trying to build on

## Why It's Good For The Game
It is very powerful to be able to build in places you cant see
## Changelog

:cl: oranges
balance: MECH RCD is no longer magic
/:cl:
