### PR TITLE
[NO GBP]Final Closet, Crate & Access Patches

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -89,7 +89,9 @@
 /obj/structure/closet/Initialize(mapload)
 	. = ..()
 
-	var/static/list/closet_paint_jobs = list(
+	var/static/list/closet_paint_jobs
+	if(isnull(closet_paint_jobs))
+		closet_paint_jobs = list(
 		"Cargo" = list("icon_state" = "qm"),
 		"Engineering" = list("icon_state" = "ce"),
 		"Engineering Secure" = list("icon_state" = "eng_secure"),
@@ -107,9 +109,15 @@
 	if(paint_jobs)
 		paint_jobs = closet_paint_jobs
 
+	var/static/list/card_reader_choices
+	if(isnull(card_reader_choices))
+		card_reader_choices = list(
+			"Personal",
+			"Departmental",
+			"None"
+			)
 	if(access_choices)
-		var/static/list/choices = list("Personal", "Departmental", "None")
-		access_choices = choices
+		access_choices = card_reader_choices
 
 	// if closed, any item at the crate's loc is put in the contents
 	if (mapload && !opened)
@@ -819,7 +827,7 @@
 	else if(!user.combat_mode)
 		var/item_is_id = weapon.GetID()
 		if(!item_is_id)
-			return
+			return FALSE
 		if((item_is_id || !toggle(user)) && !opened)
 			togglelock(user)
 	else

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -1,5 +1,5 @@
 /obj/structure/closet/secure_closet/personal
-	desc = "It's a secure locker for personnel. The first person to open this closet gains control."
+	desc = "It's a secure locker for personnel. The first person to swipe their ID gains control."
 	name = "personal closet"
 	req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
 	card_reader_installed = TRUE
@@ -10,6 +10,14 @@
 	if(isnull(choices))
 		choices = list("Personal")
 	access_choices = choices
+
+/obj/structure/closet/secure_closet/personal/can_unlock(mob/living/user, obj/item/card/id/player_id, obj/item/card/id/registered_id)
+	if(isnull(registered_id)) //first time anyone can unlock
+		return TRUE
+	else
+		if(allowed(user)) //players with ACCESS_ALL_PERSONAL_LOCKERS can override your ID
+			return TRUE
+		return player_id == registered_id
 
 /obj/structure/closet/secure_closet/personal/PopulateContents()
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -6,7 +6,9 @@
 
 /obj/structure/closet/secure_closet/personal/Initialize(mapload)
 	. = ..()
-	var/static/list/choices = list("Personal")
+	var/static/list/choices
+	if(isnull(choices))
+		choices = list("Personal")
 	access_choices = choices
 
 /obj/structure/closet/secure_closet/personal/PopulateContents()

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -33,7 +33,9 @@
 	AddElement(/datum/element/climbable, climb_time = crate_climb_time, climb_stun = 0) //add element in closed state before parent init opens it(if it does)
 	. = ..()
 
-	var/static/list/crate_paint_jobs = list(
+	var/static/list/crate_paint_jobs
+	if(isnull(crate_paint_jobs))
+		crate_paint_jobs = list(
 		"Internals" = list("icon_state" = "o2crate"),
 		"Medical" = list("icon_state" = "medicalcrate"),
 		"Radiation" = list("icon_state" = "radiation"),
@@ -42,7 +44,7 @@
 		"Solar" = list("icon_state" = "engi_e_crate"),
 		"Engineering" = list("icon_state" = "engi_crate")
 	)
-	if(!isnull(paint_jobs))
+	if(paint_jobs)
 		paint_jobs = crate_paint_jobs
 
 /obj/structure/closet/crate/Destroy()

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -32,6 +32,12 @@
 	//if they are carying a card that has access, that works
 	else if(isliving(accessor))
 		var/mob/living/being = accessor
+		//humans can carry wallets that combine accesses so check for those as well.
+		if(ishuman(accessor))
+			var/mob/living/carbon/human/human_accessor = being
+			if(check_access(human_accessor.wear_id))
+				return TRUE
+		//check for id carried in hands, inside PDA's etc.
 		if(check_access(being.get_idcard(TRUE)))
 			return TRUE
 	else if(isbrain(accessor) && istype(accessor.loc, /obj/item/mmi))

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -29,10 +29,6 @@
 	//If the mob is holding a valid ID, we let them in. get_active_held_item() is on the mob level, so no need to copypasta everywhere.
 	else if(check_access(accessor.get_active_held_item()))
 		return TRUE
-	//if they are carying a card that has access, that works
-	else if(isliving(accessor))
-		var/mob/living/being = accessor
-	//if they are wearing a card that has access, that works
 	else if(ishuman(accessor))
 		var/mob/living/carbon/human/human_accessor = accessor
 		if(check_access(human_accessor.wear_id))
@@ -41,7 +37,6 @@
 	else if(isanimal(accessor))
 		var/mob/living/simple_animal/animal = accessor
 		if(check_access(animal.access_card))
-		if(check_access(being.get_idcard(TRUE)))
 			return TRUE
 	else if(isbrain(accessor) && istype(accessor.loc, /obj/item/mmi))
 		var/obj/item/mmi/brain_mmi = accessor.loc

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -32,12 +32,15 @@
 	//if they are carying a card that has access, that works
 	else if(isliving(accessor))
 		var/mob/living/being = accessor
-		//humans can carry wallets that combine accesses so check for those as well.
-		if(ishuman(accessor))
-			var/mob/living/carbon/human/human_accessor = being
-			if(check_access(human_accessor.wear_id))
-				return TRUE
-		//check for id carried in hands, inside PDA's etc.
+	//if they are wearing a card that has access, that works
+	else if(ishuman(accessor))
+		var/mob/living/carbon/human/human_accessor = accessor
+		if(check_access(human_accessor.wear_id))
+			return TRUE
+	//if they have a hacky abstract animal ID with the required access, let them in i guess...
+	else if(isanimal(accessor))
+		var/mob/living/simple_animal/animal = accessor
+		if(check_access(animal.access_card))
 		if(check_access(being.get_idcard(TRUE)))
 			return TRUE
 	else if(isbrain(accessor) && istype(accessor.loc, /obj/item/mmi))


### PR DESCRIPTION
## About The Pull Request

1. Ensures the static list closet & crate paint job vars & the `access_choices` list vars are initialized only once. Since they are defined inside `Initialize()` they were initialized many times and need to be set only once when null

2. Fixes #75313
Closets & Crates can be wrapped again

3. Fixes #75349
Personal closets can be claimed again by anyone without ACCESS_ALL_PERSONAL_LOCKERS if it's currently unclaimed. 

4. Fixes #75351
Wallet with combined access are accepted again

**Note:** To claim a personal closet swipe once to unlock it, then swipe again to claim it

:cl:
fix: closets & crates can be wrapped with wrapping paper again
fix: personal closets can be claimed again by players without personal access level
fix: wallets with combined access work again
refactor: closet & crate paint jobs static list vars, access_choices static list var are initialized only once during init
/:cl:
