### PR TITLE
Fixes a runtime with stable / "hollow" anomalies

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -74,8 +74,7 @@
 /obj/effect/anomaly/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(countdown)
-	if(aSignal)
-		QDEL_NULL(aSignal)
+	QDEL_NULL(aSignal)
 	return ..()
 
 /obj/effect/anomaly/proc/anomalyEffect(seconds_per_tick)
@@ -96,8 +95,11 @@
 	new /obj/effect/particle_effect/fluid/smoke/bad(loc)
 
 	if(drops_core)
-		aSignal.forceMove(drop_location())
-		aSignal = null
+		if(isnull(aSignal))
+			stack_trace("An anomaly ([src]) exists that drops a core, yet has no core!")
+		else
+			aSignal.forceMove(drop_location())
+			aSignal = null
 	// else, anomaly core gets deleted by qdel(src).
 
 	qdel(src)
@@ -113,6 +115,7 @@
 /obj/effect/anomaly/proc/stabilize(anchor = FALSE, has_core = TRUE)
 	immortal = TRUE
 	name = (has_core ? "stable " : "hollow ") + name
-	aSignal = has_core ? aSignal : null
+	if(!has_core)
+		drops_core = FALSE
+		QDEL_NULL(aSignal)
 	immobile = anchor
-


### PR DESCRIPTION
## About The Pull Request

Setting `aSignal = null` wasn't the most proper way to make an anomaly not drop a core, `drops_core` should've also been set to `FALSE`.

Changed it to set `drops_core = FALSE`. Also changed it to `QDEL_NULL` the core rather than just null it. Adds a better stack trace and did a minor cleanup thing. 

![image](https://github.com/tgstation/tgstation/assets/51863163/96bdeba8-18c4-434d-9f25-7bb279b6b301)


## Why It's Good For The Game

Runtimes

## Changelog

:cl: Melbert
fix: Runtime from neutralizing "hollow" anomalies
/:cl:
