### PR TITLE
Fixes burning black slime spell skipping some of the cast chain

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -282,7 +282,7 @@ Burning extracts:
 	var/datum/action/cooldown/spell/shapeshift/slime_form/transform = new(user.mind || user)
 	transform.remove_on_restore = TRUE
 	transform.Grant(user)
-	transform.Trigger(target = user)
+	transform.Activate(user)
 	return ..()
 
 /obj/item/slimecross/burning/lightpink

--- a/code/modules/research/xenobiology/crossbreeding/burning.dm
+++ b/code/modules/research/xenobiology/crossbreeding/burning.dm
@@ -282,7 +282,7 @@ Burning extracts:
 	var/datum/action/cooldown/spell/shapeshift/slime_form/transform = new(user.mind || user)
 	transform.remove_on_restore = TRUE
 	transform.Grant(user)
-	transform.cast(user)
+	transform.Trigger(target = user)
 	return ..()
 
 /obj/item/slimecross/burning/lightpink


### PR DESCRIPTION
## About The Pull Request

Shapeshift needs to go through `before_cast` to select the shapeshift type.

So, instead of just doing `cast`, we do `Activate`, to go through the entire cast chain. 

At first I was going to run `Trigger`, but by using `Activate` we can skip some checks. Likely makes it a bit more consistent and less likely to fail. 

## Why It's Good For The Game

Runtime

## Changelog

:cl:  Melbert
fix: Runtime with burning black slime transformation
/:cl:

