### PR TITLE
Icebox elevator fixes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3313,14 +3313,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating/icemoon,
 /area/station/engineering/atmos)
-"bed" = (
-/obj/machinery/light/floor,
-/obj/structure/industrial_lift,
-/obj/effect/landmark/lift_id{
-	specific_lift_id = "publicElevator"
-	},
-/turf/open/openspace,
-/area/station/commons/storage/mining)
 "beh" = (
 /obj/machinery/firealarm/directional/north{
 	pixel_x = -26
@@ -3342,12 +3334,15 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "beo" = (
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_y = -25
+/obj/machinery/button/elevator/directional/north{
+	id = "publicElevator"
 	},
-/obj/machinery/door/window/left/directional/south{
-	dir = 8
+/obj/machinery/lift_indicator/directional/north{
+	linked_elevator_id = "publicElevator"
+	},
+/obj/machinery/door/window/elevator/left/directional/west{
+	elevator_linked_id = "publicElevator";
+	elevator_mode = 1
 	},
 /turf/open/floor/iron/dark,
 /area/mine/storage)
@@ -16173,6 +16168,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/industrial_lift{
+	radial_travel = 0
+	},
+/obj/structure/railing{
+	dir = 6
+	},
 /turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
 "fab" = (
@@ -16509,13 +16510,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/science/genetics)
-"fhk" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/openspace,
-/area/station/commons/storage/mining)
 "fhu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -19583,7 +19577,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "ghl" = (
-/obj/structure/industrial_lift,
+/obj/machinery/light/directional/west,
 /turf/open/openspace,
 /area/station/commons/storage/mining)
 "ghx" = (
@@ -27192,16 +27186,21 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "iIh" = (
-/obj/machinery/button/elevator{
-	id = "publicElevator";
-	pixel_y = -25
-	},
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/machinery/button/elevator/directional/north{
+	id = "publicElevator"
+	},
+/obj/machinery/door/window/elevator/left/directional/west{
+	elevator_linked_id = "publicElevator";
+	elevator_mode = 1
+	},
+/obj/machinery/lift_indicator/directional/north{
+	linked_elevator_id = "publicElevator"
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/mining)
@@ -40503,6 +40502,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/industrial_lift{
+	radial_travel = 0
+	},
 /turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
 "mXD" = (
@@ -43658,13 +43660,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"nRu" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/openspace,
-/area/station/commons/storage/mining)
 "nRx" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -49129,6 +49124,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/industrial_lift{
+	radial_travel = 0
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/machinery/elevator_control_panel/directional/north{
+	linked_elevator_id = "publicElevator";
+	preset_destination_names = list("3"="Icemoon Level","4"="Station Level")
+	},
 /turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
 "pDQ" = (
@@ -49435,6 +49440,12 @@
 	dir = 9
 	},
 /obj/structure/sign/poster/contraband/random/directional/north,
+/obj/structure/industrial_lift{
+	radial_travel = 0
+	},
+/obj/structure/railing{
+	dir = 9
+	},
 /turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
 "pIF" = (
@@ -52946,10 +52957,6 @@
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qPP" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 9
-	},
 /turf/open/openspace,
 /area/station/commons/storage/mining)
 "qPY" = (
@@ -54556,6 +54563,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
+"rrG" = (
+/obj/structure/sign/warning/xeno_mining,
+/turf/closed/wall,
+/area/mine/storage)
 "rrV" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating,
@@ -55972,7 +55983,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/sign/warning/xeno_mining/directional/south,
+/obj/structure/industrial_lift{
+	radial_travel = 0
+	},
+/obj/structure/railing{
+	dir = 10
+	},
 /turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
 "rQf" = (
@@ -67743,13 +67759,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"vEH" = (
-/obj/structure/industrial_lift,
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/openspace,
-/area/station/commons/storage/mining)
 "vEJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -74807,6 +74816,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/industrial_lift{
+	radial_travel = 0
+	},
+/obj/effect/landmark/lift_id{
+	specific_lift_id = "publicElevator"
+	},
+/obj/machinery/light/floor,
 /turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
 "xMM" = (
@@ -170454,7 +170470,7 @@ ijn
 vWz
 vWz
 beo
-vWz
+rrG
 vcj
 aaD
 qtS
@@ -235476,7 +235492,7 @@ bln
 kta
 qPP
 ghl
-nRu
+qPP
 clE
 jQI
 nFR
@@ -235731,9 +235747,9 @@ ybv
 ybv
 clE
 kta
-fhk
-bed
-vEH
+qPP
+qPP
+qPP
 clE
 qQC
 qQC

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -33246,6 +33246,10 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks,
 /turf/open/floor/wood,
 /area/station/maintenance/port/aft)
+"kCa" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/openspace,
+/area/station/commons/storage/mining)
 "kCb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49439,7 +49443,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/sign/poster/contraband/random/directional/north,
 /obj/structure/industrial_lift{
 	radial_travel = 0
 	},
@@ -55486,6 +55489,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"rFY" = (
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/openspace,
+/area/station/commons/storage/mining)
 "rGd" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -235490,9 +235497,9 @@ ybv
 ybv
 bln
 kta
-qPP
+rFY
 ghl
-qPP
+kCa
 clE
 jQI
 nFR

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3342,7 +3342,8 @@
 	},
 /obj/machinery/door/window/elevator/left/directional/west{
 	elevator_linked_id = "publicElevator";
-	elevator_mode = 1
+	elevator_mode = 1;
+	req_access = null
 	},
 /turf/open/floor/iron/dark,
 /area/mine/storage)


### PR DESCRIPTION
## About The Pull Request

Minor fixes for Icebox's elevator:
- Sets Z2 as lower floor, Z3 as upper (was backwards)
- Adds the elevator control panel
- Adds indicators
- Links elevator doors to elevator panel
- Moved sign that's getting dragged along with the platform, now it stays on the lower/upper floor

![image](https://github.com/tgstation/tgstation/assets/83487515/d57163f5-db0b-444b-a6a1-a466a2b39576)

## Changelog

:cl: LT3
fix: Minor fixes to Icebox's elevator
/:cl: