### PR TITLE
[MetaStation] Chefs can now toggle the counter shutters

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -52047,7 +52047,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "sEx" = (
-/obj/machinery/button/door/directional/east,
+/obj/machinery/button/door/directional/east{
+	id = "kitchen_counter";
+	name = "Kitchen Counter Shutters";
+	req_access = list("kitchen")
+	},
 /obj/structure/table,
 /obj/machinery/processor{
 	pixel_y = 12

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -52049,7 +52049,7 @@
 "sEx" = (
 /obj/machinery/button/door/directional/east{
 	id = "kitchen_counter";
-	name = "Kitchen Counter Shutters";
+	name = "Kitchen Counter Shutters Control";
 	req_access = list("kitchen")
 	},
 /obj/structure/table,


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Between #74653 and #75098 (not sure who did it) there was just a generic EAST button near the food processor, and the shutters couldn't be closed presumably (the ones on the counter). Accidents happen!

Saw this downstream while I was remapping something.

## Changelog

:cl: Jolly
fix: [MetaStation] Chefs may now brutally murder- I mean deny service to the station patrons once again, the shutters over the counter may now be closed once again.
/:cl:

