### PR TITLE
Reambiguates a ternary

### DIFF
--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -689,7 +689,7 @@
 				//figure out which pair type the character belongs to
 				pair_str = ((at_str[1] == char || at_str[2] == char) ? at_str : ((cg_str[1] == char || cg_str[2] == char) ? cg_str : null))
 				//Valid pair from character
-				new_pair = (pair_str ? char + (pair_str[1] == char ? pair_str[2] : pair_str[1]) : null)
+				new_pair = (pair_str ? char + (pair_str[1]==char?pair_str[2]:pair_str[1]) : null)
 				// every second letter in the sequence represents a valid pair of the new sequence, otherwise it belongs to old
 				if(new_pair)
 					if(i%2 == 0)


### PR DESCRIPTION
Reverts tgstation/tgstation#70121

OpenDream can parse this now, so I want to be able to say we can parse unmodified TG again.

~~Ignore the current OD compile error due to a preprocessor bug.~~