### PR TITLE
Fixes runtime when armed cleanbots encounter a mindless human.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -205,7 +205,7 @@
 		return
 
 	var/mob/living/carbon/stabbed_carbon = AM
-	if(!(stabbed_carbon.mind.assigned_role.title in stolen_valor))
+	if(stabbed_carbon.mind && !(stabbed_carbon.mind.assigned_role.title in stolen_valor))
 		stolen_valor += stabbed_carbon.mind.assigned_role.title
 		update_titles()
 


### PR DESCRIPTION

![image](https://github.com/tgstation/tgstation/assets/6209658/bb52e143-6a3c-4938-9170-5deb769a1a4e)


:cl: ShizCalev
fix: Armed cleanbots no longer break when they encounter a mindless human.
/:cl:
