### PR TITLE
Fixes material sniffers not being able to find materials properly

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -227,7 +227,7 @@ GLOBAL_LIST_EMPTY(sniffable_sheets)
 	worn_icon_state = "pinpointer_black"
 
 /obj/item/pinpointer/material_sniffer/scan_for_target()
-	if(target)
+	if(target || !GLOB.sniffable_sheets.len)
 		return
 	var/obj/item/stack/sheet/new_sheet_target
 	var/closest_distance = INFINITY

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -24,8 +24,8 @@
 	. = ..()
 	pixel_x = rand(-4, 4)
 	pixel_y = rand(-4, 4)
-	if(sniffable && is_station_level(z) && amount < 10)
-		GLOB.sniffable_sheets += src
+	if(sniffable && amount >= 10 && is_station_level(z))
+		GLOB.sniffable_sheets |= src
 
 /obj/item/stack/sheet/Destroy(force)
 	if(sniffable)
@@ -34,8 +34,8 @@
 
 /obj/item/stack/sheet/add(_amount)
 	. = ..()
-	if(sniffable && is_station_level(z) && amount > 10)
-		GLOB.sniffable_sheets += src
+	if(sniffable && amount >= 10 && is_station_level(z))
+		GLOB.sniffable_sheets |= src
 
 /// removing from sniffable handled by the sniffer itself when it checks for targets
 


### PR DESCRIPTION

![image](https://github.com/tgstation/tgstation/assets/6209658/d91d07ba-32b3-4580-a22a-616e0aab55e2)

stack/init was adding stacks to the global list if they had LESS THAN 10 units, though the sniffer only looks for things >= 10  units. Flipped bracket, gg. add() was also using += instead of |=, which resulted in duplicate entries for the same object in the global list when adding stuff to a stack. 

:cl: ShizCalev
fix: The materials sniffer now actually works!
/:cl: