### PR TITLE
Fixes jetpack "Cannot modify null.oldposition" runtimes

### DIFF
--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -92,7 +92,6 @@
 
 /datum/component/jetpack/proc/deactivate(datum/source)
 	SIGNAL_HANDLER
-	QDEL_NULL(trail)
 	var/mob/moving = get_mover.Invoke()
 	if(moving)
 		UnregisterSignal(moving, COMSIG_MOVABLE_MOVED)
@@ -100,6 +99,7 @@
 		UnregisterSignal(moving, COMSIG_MOVABLE_SPACEMOVE)
 		UnregisterSignal(moving, COMSIG_MOVABLE_DRIFT_VISUAL_ATTEMPT)
 		UnregisterSignal(moving, COMSIG_MOVABLE_DRIFT_BLOCK_INPUT)
+	QDEL_NULL(trail) //delete AFTER unregistering the mob, otherwise you'll get runtimes.
 
 /datum/component/jetpack/proc/move_react(mob/user)
 	SIGNAL_HANDLER


### PR DESCRIPTION
Order of operations. We were deleting the trail effect BEFORE unregistering the mob from the signals that controlled its behavior, so it was trying to do the thing to something that didn't exist anymore. Honk.

![image](https://github.com/tgstation/tgstation/assets/6209658/6d7c2eec-547c-47f5-9093-7df42514932c)
