### PR TITLE
fixes a "Attempted to add a new component of type [/datum/component/rot] to a qdeleting parent of type [/mob/living/carbon/human]" runtime

### DIFF
--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -11,7 +11,7 @@
 
 	. = ..()
 
-	if(!gibbed && !QDELING(src))
+	if(!gibbed && !QDELING(src)) //double check they didn't start getting deleted in ..()
 		attach_rot()
 
 	for(var/T in get_traumas())

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -11,7 +11,7 @@
 
 	. = ..()
 
-	if(!gibbed)
+	if(!gibbed && !QDELING(src))
 		attach_rot()
 
 	for(var/T in get_traumas())
@@ -35,7 +35,7 @@
 	for(var/mob/M in src)
 		M.forceMove(Tsec)
 		visible_message(span_danger("[M] bursts out of [src]!"))
-	. = ..()
+	return ..()
 
 /mob/living/carbon/spill_organs(no_brain, no_organs, no_bodyparts)
 	var/atom/Tsec = drop_location()


### PR DESCRIPTION
https://github.com/tgstation/tgstation/blob/a1a2b0fa9074069ea1048faa5e503ddb1f63ed04/code/modules/mob/living/carbon/death.dm#L1-L19

The mob can start qdeling @ L12 / in living/death() (if say, for example, they had an explosive implant. )

This is accounted for in human/death(), but someone forgot it here.
https://github.com/tgstation/tgstation/blob/a1a2b0fa9074069ea1048faa5e503ddb1f63ed04/code/modules/mob/living/carbon/human/death.dm#L20-L34
