### PR TITLE
Fixes ghosts & AI's detonating landmines, and jaunting mobs setting them off without first stepping on them

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -64,15 +64,24 @@
 /obj/effect/mine/proc/can_trigger(atom/movable/on_who)
 	if(triggered || !isturf(loc) || iseffect(on_who) || !armed)
 		return FALSE
+
+	if(isdead(on_who) || iscameramob(on_who)) //no ghosts.
+		return FALSE
+
+	var/is_incorpreal_mob
+	if(isliving(on_who))
+		var/mob/living/living_mob = on_who
+		is_incorpreal_mob = living_mob.incorporeal_move
+
+	if(is_incorpreal_mob || on_who.movement_type & FLYING)
+		return foot_on_mine ? IS_WEAKREF_OF(on_who, foot_on_mine) : FALSE //Only go boom if their foot was on the mine PRIOR to flying/phasing. You fucked up, you live with the consequences.
+
 	return TRUE
 
 /obj/effect/mine/proc/on_entered(datum/source, atom/movable/arrived)
 	SIGNAL_HANDLER
 
 	if(!can_trigger(arrived))
-		return
-	// Flying = can't step on a mine
-	if(arrived.movement_type & FLYING)
 		return
 	// Someone already on it
 	if(foot_on_mine?.resolve())

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -65,15 +65,13 @@
 	if(triggered || !isturf(loc) || iseffect(on_who) || !armed)
 		return FALSE
 
-	if(isdead(on_who) || iscameramob(on_who)) //no ghosts.
-		return FALSE
+	var/mob/living/living_mob
+	if(ismob(on_who))
+		if(!isliving(on_who)) //no ghosties.
+			return FALSE
+		living_mob = on_who
 
-	var/is_incorpreal_mob
-	if(isliving(on_who))
-		var/mob/living/living_mob = on_who
-		is_incorpreal_mob = living_mob.incorporeal_move
-
-	if(is_incorpreal_mob || on_who.movement_type & FLYING)
+	if(living_mob?.incorporeal_move || on_who.movement_type & FLYING)
 		return foot_on_mine ? IS_WEAKREF_OF(on_who, foot_on_mine) : FALSE //Only go boom if their foot was on the mine PRIOR to flying/phasing. You fucked up, you live with the consequences.
 
 	return TRUE


### PR DESCRIPTION
Fixes #75049

:cl: ShizCalev
fix: Ghosts & camera mobs (ie blobs & AI's) will no longer set off landmines.
fix: Jaunting mobs will now only set off landmines if they stepped on them BEFORE jaunting.
fix: Flying mobs will no longer detonate landmines that were not first stepped on.
/:cl:
