### PR TITLE
Makes the component menu in the integrated circuit interface more intuitive.

### DIFF
--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -196,6 +196,7 @@
 	if(istype(weapon, /obj/item/integrated_circuit) && !user.combat_mode)
 		var/obj/item/integrated_circuit/circuit = weapon
 		circuit.linked_component_printer = WEAKREF(src)
+		circuit.update_static_data_for_all_viewers()
 		balloon_alert(user, "successfully linked to the integrated circuit")
 		return
 	return ..()

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/ComponentMenu.js
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/ComponentMenu.js
@@ -1,4 +1,4 @@
-import { Section, Button, Dropdown, Stack, Input } from '../../components';
+import { Section, Button, Dropdown, Stack, Input, NoticeBox } from '../../components';
 import { Component } from 'inferno';
 import { shallowDiffers } from 'common/react';
 import { fetchRetry } from '../../http';
@@ -87,7 +87,6 @@ export class ComponentMenu extends Component {
     // Limit the maximum amount of shown components to prevent a lagspike
     // when you open the menu
     shownComponents.length = currentLimit;
-
     return (
       <Section
         title="Component Menu"
@@ -133,6 +132,15 @@ export class ComponentMenu extends Component {
           </Stack.Item>
           <Stack.Item>
             <Stack vertical fill>
+              {trueLength === 0 && (
+                <Stack.Item mt={1} fontSize={1}>
+                  <NoticeBox info>
+                    You can hit this integrated circuit onto a component printer
+                    to link it so that you&apos;re able to remotely create and
+                    add components to this circuit.
+                  </NoticeBox>
+                </Stack.Item>
+              )}
               {shownComponents.map((val) => (
                 <Stack.Item
                   key={val.type}

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/ComponentMenu.js
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/ComponentMenu.js
@@ -138,6 +138,10 @@ export class ComponentMenu extends Component {
                     You can hit this integrated circuit onto a component printer
                     to link it so that you&apos;re able to remotely create and
                     add components to this circuit.
+                    <br />
+                    <br />
+                    Close and re-open the integrated circuit interface once
+                    linked to fully complete the linking.
                   </NoticeBox>
                 </Stack.Item>
               )}

--- a/tgui/packages/tgui/interfaces/IntegratedCircuit/ComponentMenu.js
+++ b/tgui/packages/tgui/interfaces/IntegratedCircuit/ComponentMenu.js
@@ -138,10 +138,6 @@ export class ComponentMenu extends Component {
                     You can hit this integrated circuit onto a component printer
                     to link it so that you&apos;re able to remotely create and
                     add components to this circuit.
-                    <br />
-                    <br />
-                    Close and re-open the integrated circuit interface once
-                    linked to fully complete the linking.
                   </NoticeBox>
                 </Stack.Item>
               )}


### PR DESCRIPTION
## About The Pull Request
Added a notice box to the component menu in the integrated circuit interface explaining how to link an integrated circuit to a component printer to allow for integrated circuit programming away from the component printer.

![image](https://github.com/tgstation/tgstation/assets/37270891/6a7ed31a-7d45-49a6-8025-09564ef099d2)

Last sentence in the above image has been removed. Integrated circuits will now update their static data once linked so closing and re-opening the UI is unnecessary.

## Why It's Good For The Game
It wasn't clear anywhere in game that you could link integrated circuits to component printers. I've run into players being completely unaware of this feature, so this should help to make it more clear that players don't need to print out components manually from the component printer and slap them into an integrated circuit each time.

## Changelog
:cl:
qol: Added a message to the component menu in the integrated circuit interface that explains how to link an integrated circuit to a component printer.
/:cl:
