### PR TITLE
Icon font size & rotation are applied correctly

### DIFF
--- a/tgui/packages/tgui/components/Icon.tsx
+++ b/tgui/packages/tgui/components/Icon.tsx
@@ -28,13 +28,13 @@ export const Icon = (props: IconProps) => {
   const { name, size, spin, className, rotation, ...rest } = restlet;
 
   if (size) {
-    if (!style) {
+    if (!rest.style) {
       rest.style = {};
     }
     rest.style['font-size'] = size * 100 + '%';
   }
   if (rotation) {
-    if (!style) {
+    if (!rest.style) {
       rest.style = {};
     }
     rest.style['transform'] = `rotate(${rotation}deg)`;

--- a/tgui/packages/tgui/components/Icon.tsx
+++ b/tgui/packages/tgui/components/Icon.tsx
@@ -29,15 +29,15 @@ export const Icon = (props: IconProps) => {
 
   if (size) {
     if (!style) {
-      style = {};
+      rest.style = {};
     }
-    style['font-size'] = size * 100 + '%';
+    rest.style['font-size'] = size * 100 + '%';
   }
   if (rotation) {
     if (!style) {
-      style = {};
+      rest.style = {};
     }
-    style['transform'] = `rotate(${rotation}deg)`;
+    rest.style['transform'] = `rotate(${rotation}deg)`;
   }
 
   const boxProps = computeBoxProps(rest);

--- a/tgui/packages/tgui/components/Icon.tsx
+++ b/tgui/packages/tgui/components/Icon.tsx
@@ -28,17 +28,18 @@ export const Icon = (props: IconProps) => {
   const { name, size, spin, className, rotation, ...rest } = restlet;
 
   if (size) {
-    if (!rest.style) {
-      rest.style = {};
+    if (!style) {
+      style = {};
     }
-    rest.style['font-size'] = size * 100 + '%';
+    style['font-size'] = size * 100 + '%';
   }
   if (rotation) {
-    if (!rest.style) {
-      rest.style = {};
+    if (!style) {
+      style = {};
     }
-    rest.style['transform'] = `rotate(${rotation}deg)`;
+    style['transform'] = `rotate(${rotation}deg)`;
   }
+  rest.style = style;
 
   const boxProps = computeBoxProps(rest);
 


### PR DESCRIPTION
## About The Pull Request
Fixes #75264

GPS arrows work again
![Screenshot (208)](https://github.com/tgstation/tgstation/assets/110812394/0d9b76f9-389e-4936-b576-b85e3fdd10e0)

Fixes #75292

All icons using `font-size` are back to normal size
![Screenshot (207)](https://github.com/tgstation/tgstation/assets/110812394/58b7c6bd-1c3d-4789-8bf8-5e67f24e8c01)

Also fixes reflector UI. That bottom arrow that is out of place
Before
![Before](https://github.com/tgstation/tgstation/assets/110812394/b02f06f7-5524-443c-a263-7e9dbd1144a9)
After
![After](https://github.com/tgstation/tgstation/assets/110812394/68f9af02-6a8c-4d9e-ba66-fe4415245131)



Broken by #75164

## Changelog
:cl:
fix: gps arrows rotate correctly
fix: icons have their correct sizes applied again
/:cl: