### PR TITLE
HoP flash button in Northstar now actually works

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -42105,7 +42105,9 @@
 /obj/effect/turf_decal/trimline/blue/arrow_cw{
 	dir = 5
 	},
-/obj/machinery/flasher/directional/east,
+/obj/machinery/flasher/directional/east{
+	id = "hopflash"
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "lik" = (
@@ -66637,7 +66639,9 @@
 /obj/effect/turf_decal/trimline/blue/arrow_cw{
 	dir = 9
 	},
-/obj/machinery/flasher/directional/west,
+/obj/machinery/flasher/directional/west{
+	id = "hopflash"
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "ryQ" = (


### PR DESCRIPTION
## About The Pull Request
flashes for hop line werent ID-ed correctly. this PR fixes that
## Why It's Good For The Game
fixes le good?!?!?!?
## Changelog
:cl:
fix: HoP on northstar can now disperse troublemakers with ease.
/:cl:
