### PR TITLE
Smart runtime screen tool tip fix

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -121,15 +121,22 @@
 		return FALSE
 
 /obj/machinery/smartfridge/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(isnull(held_item))
+		return NONE
+
+	var/tool_tip_set = FALSE
 	if(held_item.tool_behaviour == TOOL_WELDER && !istype(src, /obj/machinery/smartfridge/drying_rack))
 		if(welded_down)
 			context[SCREENTIP_CONTEXT_LMB] = "Unweld"
+			tool_tip_set = TRUE
 		else if (!welded_down && anchored)
 			context[SCREENTIP_CONTEXT_LMB] = "Weld down"
+			tool_tip_set = TRUE
 		if(machine_stat & BROKEN)
 			context[SCREENTIP_CONTEXT_RMB] = "Repair"
+			tool_tip_set = TRUE
 
-	return CONTEXTUAL_SCREENTIP_SET
+	return tool_tip_set ? CONTEXTUAL_SCREENTIP_SET : NONE
 
 /obj/machinery/smartfridge/RefreshParts()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes This
![Screenshot (212)](https://github.com/tgstation/tgstation/assets/110812394/b1f4493d-5e95-4115-822c-112c2c27fc56)

Caused when the player is not holding anything in hand, Also only return CONTEXTUAL_SCREENTIP_SET when you have actually set the tooltip and not otherwise.

## Changelog
:cl:
fix: runtime with smart fridge tooltip
/:cl: