### PR TITLE
Cargo category cleanup

### DIFF
--- a/code/__DEFINES/exports.dm
+++ b/code/__DEFINES/exports.dm
@@ -1,4 +1,0 @@
-#define EXPORT_CARGO 1
-#define EXPORT_EMAG 2
-#define EXPORT_CONTRABAND 4
-#define EXPORT_PIRATE 8

--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -281,7 +281,7 @@
 	for(var/atom/movable/AM in get_turf(pad))
 		if(AM == pad)
 			continue
-		export_item_and_contents(AM, EXPORT_PIRATE | EXPORT_CARGO | EXPORT_CONTRABAND | EXPORT_EMAG, apply_elastic = FALSE, delete_unsold = FALSE, external_report = ex)
+		export_item_and_contents(AM, apply_elastic = FALSE, delete_unsold = FALSE, external_report = ex)
 
 	status_report = "Sold: "
 	var/value = 0

--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/machines/dominator.dmi'
 	icon_state = "dominator"
 	density = TRUE
-	/// Is the machine syphoning right now
+	/// Is the machine siphoning right now
 	var/active = FALSE
 	/// The amount of money stored in the machine
 	var/credits_stored = 0

--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -6,8 +6,11 @@
 	icon = 'icons/obj/machines/dominator.dmi'
 	icon_state = "dominator"
 	density = TRUE
+	/// Is the machine syphoning right now
 	var/active = FALSE
+	/// The amount of money stored in the machine
 	var/credits_stored = 0
+	/// The amount of money removed per tick
 	var/siphon_per_tick = 5
 
 /obj/machinery/shuttle_scrambler/Initialize(mapload)
@@ -17,10 +20,10 @@
 /obj/machinery/shuttle_scrambler/process()
 	if(active)
 		if(is_station_level(z))
-			var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-			if(D)
-				var/siphoned = min(D.account_balance,siphon_per_tick)
-				D.adjust_money(-siphoned)
+			var/datum/bank_account/account = SSeconomy.get_dep_account(ACCOUNT_CAR)
+			if(account)
+				var/siphoned = min(account.account_balance,siphon_per_tick)
+				account.adjust_money(-siphoned)
 				credits_stored += siphoned
 			interrupt_research()
 		else
@@ -28,6 +31,7 @@
 	else
 		STOP_PROCESSING(SSobj,src)
 
+///Turns on the siphoning, and its various side effects
 /obj/machinery/shuttle_scrambler/proc/toggle_on(mob/user)
 	SSshuttle.registerTradeBlockade(src)
 	AddComponent(/datum/component/gps, "Nautical Signal")
@@ -49,14 +53,15 @@
 	update_appearance()
 	send_notification()
 
-//interrupt_research
+/// Handles interrupting research
 /obj/machinery/shuttle_scrambler/proc/interrupt_research()
-	for(var/obj/machinery/rnd/server/S as anything in SSresearch.science_tech.techweb_servers)
-		if(S.machine_stat & (NOPOWER|BROKEN|EMPED))
+	for(var/obj/machinery/rnd/server/research_server as anything in SSresearch.science_tech.techweb_servers)
+		if(research_server.machine_stat & (NOPOWER|BROKEN|EMPED))
 			continue
-		S.emp_act(EMP_LIGHT)
-		new /obj/effect/temp_visual/emp(get_turf(S))
+		research_server.emp_act(EMP_LIGHT)
+		new /obj/effect/temp_visual/emp(get_turf(research_server))
 
+/// Handles expelling all the siphoned credits as holochips
 /obj/machinery/shuttle_scrambler/proc/dump_loot(mob/user)
 	if(credits_stored) // Prevents spamming empty holochips
 		new /obj/item/holochip(drop_location(), credits_stored)
@@ -65,9 +70,11 @@
 	else
 		to_chat(user,span_notice("There's nothing to withdraw."))
 
+/// Alerts the crew about the siphon
 /obj/machinery/shuttle_scrambler/proc/send_notification()
 	priority_announce("Data theft signal detected; source registered on local GPS units.")
 
+/// Switches off the siphon
 /obj/machinery/shuttle_scrambler/proc/toggle_off(mob/user)
 	SSshuttle.clearTradeBlockade(src)
 	active = FALSE
@@ -124,24 +131,25 @@
 		to_chat(user,span_warning("[src] is recharging."))
 		return
 	next_use = world.time + cooldown
-	var/atom/movable/AM = find_random_loot()
-	if(!AM)
+	var/atom/movable/found_loot = find_random_loot()
+	if(!found_loot)
 		say("No valuables located. Try again later.")
 	else
-		say("Located: [AM.name] at [get_area_name(AM)]")
+		say("Located: [found_loot.name] at [get_area_name(found_loot)]")
 
+/// Looks across the station for items that are pirate specific exports
 /obj/machinery/loot_locator/proc/find_random_loot()
 	if(!GLOB.exports_list.len)
 		setupExports()
 	var/list/possible_loot = list()
-	for(var/datum/export/pirate/E in GLOB.exports_list)
-		possible_loot += E
-	var/datum/export/pirate/P
-	var/atom/movable/AM
-	while(!AM && possible_loot.len)
-		P = pick_n_take(possible_loot)
-		AM = P.find_loot()
-	return AM
+	for(var/datum/export/pirate/possible_export in GLOB.exports_list)
+		possible_loot += possible_export
+	var/datum/export/pirate/selected_export
+	var/atom/movable/found_loot
+	while(!found_loot && possible_loot.len)
+		selected_export = pick_n_take(possible_loot)
+		found_loot = selected_export.find_loot()
+	return found_loot
 
 //Pad & Pad Terminal
 /obj/machinery/piratepad
@@ -250,57 +258,59 @@
 			stop_sending()
 			. = TRUE
 
+/// Calculates the predicted value of the items on the pirate pad
 /obj/machinery/computer/piratepad_control/proc/recalc()
 	if(sending)
 		return
 
 	status_report = "Predicted value: "
 	var/value = 0
-	var/datum/export_report/ex = new
+	var/datum/export_report/report = new
 	var/obj/machinery/piratepad/pad = pad_ref?.resolve()
 	for(var/atom/movable/AM in get_turf(pad))
 		if(AM == pad)
 			continue
-		export_item_and_contents(AM, apply_elastic = FALSE, dry_run = TRUE, external_report = ex)
+		export_item_and_contents(AM, apply_elastic = FALSE, dry_run = TRUE, external_report = report)
 
-	for(var/datum/export/E in ex.total_amount)
-		status_report += E.total_printout(ex,notes = FALSE)
+	for(var/datum/export/exported_datum in report.total_amount)
+		status_report += exported_datum.total_printout(report,notes = FALSE)
 		status_report += " "
-		value += ex.total_value[E]
+		value += report.total_value[exported_datum]
 
 	if(!value)
 		status_report += "0"
 
+/// Deletes and sells the item
 /obj/machinery/computer/piratepad_control/proc/send()
 	if(!sending)
 		return
 
-	var/datum/export_report/ex = new
+	var/datum/export_report/report = new
 	var/obj/machinery/piratepad/pad = pad_ref?.resolve()
 
-	for(var/atom/movable/AM in get_turf(pad))
-		if(AM == pad)
+	for(var/atom/movable/item_on_pad in get_turf(pad))
+		if(item_on_pad == pad)
 			continue
-		export_item_and_contents(AM, apply_elastic = FALSE, delete_unsold = FALSE, external_report = ex)
+		export_item_and_contents(item_on_pad, apply_elastic = FALSE, delete_unsold = FALSE, external_report = report)
 
 	status_report = "Sold: "
 	var/value = 0
-	for(var/datum/export/E in ex.total_amount)
-		var/export_text = E.total_printout(ex,notes = FALSE) //Don't want nanotrasen messages, makes no sense here.
+	for(var/datum/export/exported_datum in report.total_amount)
+		var/export_text = exported_datum.total_printout(report,notes = FALSE) //Don't want nanotrasen messages, makes no sense here.
 		if(!export_text)
 			continue
 
 		status_report += export_text
 		status_report += " "
-		value += ex.total_value[E]
+		value += report.total_value[exported_datum]
 
 	if(!total_report)
-		total_report = ex
+		total_report = report
 	else
-		total_report.exported_atoms += ex.exported_atoms
-		for(var/datum/export/E in ex.total_amount)
-			total_report.total_amount[E] += ex.total_amount[E]
-			total_report.total_value[E] += ex.total_value[E]
+		total_report.exported_atoms += report.exported_atoms
+		for(var/datum/export/exported_datum in report.total_amount)
+			total_report.total_amount[exported_datum] += report.total_amount[exported_datum]
+			total_report.total_value[exported_datum] += report.total_value[exported_datum]
 		playsound(loc, 'sound/machines/wewewew.ogg', 70, TRUE)
 
 	points += value
@@ -313,6 +323,7 @@
 	pad.icon_state = pad.idle_state
 	sending = FALSE
 
+/// Prepares to sell the items on the pad
 /obj/machinery/computer/piratepad_control/proc/start_sending()
 	var/obj/machinery/piratepad/pad = pad_ref?.resolve()
 	if(!pad)
@@ -331,6 +342,7 @@
 	pad.icon_state = pad.warmup_state
 	sending_timer = addtimer(CALLBACK(src, PROC_REF(send)),warmup_time, TIMER_STOPPABLE)
 
+/// Finishes the sending state of the pad
 /obj/machinery/computer/piratepad_control/proc/stop_sending(custom_report)
 	if(!sending)
 		return
@@ -342,7 +354,7 @@
 	pad.icon_state = pad.idle_state
 	deltimer(sending_timer)
 
-//Attempts to find the thing on station
+/// Attempts to find the thing on station
 /datum/export/pirate/proc/find_loot()
 	return
 
@@ -359,13 +371,13 @@
 	if(head_mobs.len)
 		return pick(head_mobs)
 
-/datum/export/pirate/ransom/get_cost(atom/movable/AM)
-	var/mob/living/carbon/human/H = AM
-	if(H.stat != CONSCIOUS || !H.mind) //mint condition only
+/datum/export/pirate/ransom/get_cost(atom/movable/exported_item)
+	var/mob/living/carbon/human/ransomee = exported_item
+	if(ransomee.stat != CONSCIOUS || !ransomee.mind) //mint condition only
 		return 0
-	else if(FACTION_PIRATE in H.faction) //can't ransom your fellow pirates to CentCom!
+	else if(FACTION_PIRATE in ransomee.faction) //can't ransom your fellow pirates to CentCom!
 		return 0
-	else if(H.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
+	else if(ransomee.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
 		return 3000
 	else
 		return 1000
@@ -376,25 +388,25 @@
 	export_types = list(/mob/living/simple_animal/parrot)
 
 /datum/export/pirate/parrot/find_loot()
-	for(var/mob/living/simple_animal/parrot/P in GLOB.alive_mob_list)
-		var/turf/T = get_turf(P)
-		if(T && is_station_level(T.z))
-			return P
+	for(var/mob/living/simple_animal/parrot/current_parrot in GLOB.alive_mob_list)
+		var/turf/parrot_turf = get_turf(current_parrot)
+		if(parrot_turf && is_station_level(parrot_turf.z))
+			return current_parrot
 
 /datum/export/pirate/cash
 	cost = 1
 	unit_name = "bills"
 	export_types = list(/obj/item/stack/spacecash)
 
-/datum/export/pirate/cash/get_amount(obj/O)
-	var/obj/item/stack/spacecash/C = O
-	return ..() * C.amount * C.value
+/datum/export/pirate/cash/get_amount(obj/exported_item)
+	var/obj/item/stack/spacecash/cash = exported_item
+	return ..() * cash.amount * cash.value
 
 /datum/export/pirate/holochip
 	cost = 1
 	unit_name = "holochip"
 	export_types = list(/obj/item/holochip)
 
-/datum/export/pirate/holochip/get_cost(atom/movable/AM)
-	var/obj/item/holochip/H = AM
-	return H.credits
+/datum/export/pirate/holochip/get_cost(atom/movable/exported_item)
+	var/obj/item/holochip/chip = exported_item
+	return chip.credits

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -62,13 +62,6 @@
 	else
 		return ..()
 
-/obj/machinery/computer/cargo/proc/get_export_categories()
-	. = EXPORT_CARGO
-	if(contraband)
-		. |= EXPORT_CONTRABAND
-	if(obj_flags & EMAGGED)
-		. |= EXPORT_EMAG
-
 /obj/machinery/computer/cargo/emag_act(mob/user)
 	if(obj_flags & EMAGGED)
 		return
@@ -327,7 +320,6 @@
 				requisition_paper.update_appearance()
 
 			if(SSshuttle.supply.getDockedId() == docking_home)
-				SSshuttle.supply.export_categories = get_export_categories()
 				SSshuttle.moveShuttle(cargo_shuttle, docking_away, TRUE)
 				say("The supply shuttle is departing.")
 				usr.investigate_log("sent the supply shuttle away.", INVESTIGATE_CARGO)

--- a/code/modules/cargo/universal_scanner.dm
+++ b/code/modules/cargo/universal_scanner.dm
@@ -169,10 +169,10 @@
 /obj/item/universal_scanner/proc/export_scan(obj/target, mob/user)
 	// Before you fix it:
 	// yes, checking manifests is a part of intended functionality.
-	var/datum/export_report/ex = export_item_and_contents(target, dry_run = TRUE)
+	var/datum/export_report/report = export_item_and_contents(target, dry_run = TRUE)
 	var/price = 0
-	for(var/x in ex.total_amount)
-		price += ex.total_value[x]
+	for(var/exported_datum in report.total_amount)
+		price += report.total_value[exported_datum]
 	if(price)
 		to_chat(user, span_notice("Scanned [target], value: <b>[price]</b> credits[target.contents.len ? " (contents included)" : ""]."))
 	else

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -33,9 +33,6 @@
 	///The account this console processes and displays. Independent from the account the shuttle processes.
 	var/cargo_account = ACCOUNT_CAR
 
-/datum/computer_file/program/budgetorders/proc/get_export_categories()
-	. = EXPORT_CARGO
-
 /datum/computer_file/program/budgetorders/proc/is_visible_pack(mob/user, paccess_to_check, list/access, contraband)
 	if(issilicon(user)) //Borgs can't buy things.
 		return FALSE
@@ -169,7 +166,6 @@
 				computer.say(blockade_warning)
 				return
 			if(SSshuttle.supply.getDockedId() == docking_home)
-				SSshuttle.supply.export_categories = get_export_categories()
 				SSshuttle.moveShuttle(cargo_shuttle, docking_away, TRUE)
 				computer.say("The supply shuttle is departing.")
 				usr.investigate_log("sent the supply shuttle away.", INVESTIGATE_CARGO)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -226,7 +226,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 				continue
 			if(AM.anchored)
 				continue
-			export_item_and_contents(AM, export_categories, dry_run = FALSE, external_report = ex)
+			export_item_and_contents(AM, apply_elastic = TRUE, dry_run = FALSE, external_report = ex)
 
 	if(ex.exported_atoms)
 		ex.exported_atoms += "." //ugh

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -93,10 +93,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 	var/list/empty_turfs = list()
 	for(var/area/shuttle/shuttle_area as anything in shuttle_areas)
-		for(var/turf/open/floor/T in shuttle_area)
-			if(T.is_blocked_turf())
+		for(var/turf/open/floor/shuttle_turf in shuttle_area)
+			if(shuttle_turf.is_blocked_turf())
 				continue
-			empty_turfs += T
+			empty_turfs += shuttle_turf
 
 	//quickly and greedily handle chef's grocery runs first, there are a few reasons why this isn't attached to the rest of cargo...
 	//but the biggest reason is that the chef requires produce to cook and do their job, and if they are using this system they
@@ -176,9 +176,9 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 	// we handle packing all the goodies last, since the type of crate we use depends on how many goodies they ordered. If it's more than GOODY_FREE_SHIPPING_MAX
 	// then we send it in a crate (including the CRATE_TAX cost), otherwise send it in a free shipping case
-	for(var/D in goodies_by_buyer)
-		var/list/buying_account_orders = goodies_by_buyer[D]
-		var/datum/bank_account/buying_account = D
+	for(var/buyer_key in goodies_by_buyer)
+		var/list/buying_account_orders = goodies_by_buyer[buyer_key]
+		var/datum/bank_account/buying_account = buyer_key
 		var/buyer = buying_account.account_holder
 
 		if(buying_account_orders.len > GOODY_FREE_SHIPPING_MAX) // no free shipping, send a crate
@@ -199,49 +199,50 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 			misc_costs[buyer] += our_order.pack.cost
 			misc_order_num[buyer] = "[misc_order_num[buyer]]#[our_order.id] "
 
-	for(var/I in miscboxes)
-		var/datum/supply_order/SO = new/datum/supply_order()
-		SO.id = misc_order_num[I]
-		SO.generateCombo(miscboxes[I], I, misc_contents[I], misc_costs[I])
-		qdel(SO)
+	for(var/miscbox in miscboxes)
+		var/datum/supply_order/order = new/datum/supply_order()
+		order.id = misc_order_num[miscbox]
+		order.generateCombo(miscboxes[miscbox], miscbox, misc_contents[miscbox], misc_costs[miscbox])
+		qdel(order)
 
 	SSeconomy.import_total += value
 	var/datum/bank_account/cargo_budget = SSeconomy.get_dep_account(ACCOUNT_CAR)
 	investigate_log("[purchases] orders in this shipment, worth [value] credits. [cargo_budget.account_balance] credits left.", INVESTIGATE_CARGO)
 
+/// Deletes and sells the items on the shuttle
 /obj/docking_port/mobile/supply/proc/sell()
-	var/datum/bank_account/D = SSeconomy.get_dep_account(ACCOUNT_CAR)
-	var/presale_points = D.account_balance
+	var/datum/bank_account/cargo_budget = SSeconomy.get_dep_account(ACCOUNT_CAR)
+	var/presale_points = cargo_budget.account_balance
 
 	if(!GLOB.exports_list.len) // No exports list? Generate it!
 		setupExports()
 
 	var/msg = ""
 
-	var/datum/export_report/ex = new
+	var/datum/export_report/report = new
 
 	for(var/area/shuttle/shuttle_area as anything in shuttle_areas)
-		for(var/atom/movable/AM in shuttle_area)
-			if(iscameramob(AM))
+		for(var/atom/movable/exporting_atom in shuttle_area)
+			if(iscameramob(exporting_atom))
 				continue
-			if(AM.anchored)
+			if(exporting_atom.anchored)
 				continue
-			export_item_and_contents(AM, apply_elastic = TRUE, dry_run = FALSE, external_report = ex)
+			export_item_and_contents(exporting_atom, apply_elastic = TRUE, dry_run = FALSE, external_report = report)
 
-	if(ex.exported_atoms)
-		ex.exported_atoms += "." //ugh
+	if(report.exported_atoms)
+		report.exported_atoms += "." //ugh
 
-	for(var/datum/export/E in ex.total_amount)
-		var/export_text = E.total_printout(ex)
+	for(var/datum/export/exported_datum in report.total_amount)
+		var/export_text = exported_datum.total_printout(report)
 		if(!export_text)
 			continue
 
 		msg += export_text + "\n"
-		D.adjust_money(ex.total_value[E])
+		cargo_budget.adjust_money(report.total_value[exported_datum])
 
-	SSeconomy.export_total += (D.account_balance - presale_points)
+	SSeconomy.export_total += (cargo_budget.account_balance - presale_points)
 	SSshuttle.centcom_message = msg
-	investigate_log("contents sold for [D.account_balance - presale_points] credits. Contents: [ex.exported_atoms ? ex.exported_atoms.Join(",") + "." : "none."] Message: [SSshuttle.centcom_message || "none."]", INVESTIGATE_CARGO)
+	investigate_log("contents sold for [cargo_budget.account_balance - presale_points] credits. Contents: [report.exported_atoms ? report.exported_atoms.Join(",") + "." : "none."] Message: [SSshuttle.centcom_message || "none."]", INVESTIGATE_CARGO)
 
 /*
 	Generates a box of mail depending on our exports and imports.

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -48,9 +48,6 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	port_direction = EAST
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 
-	//Export categories for this run, this is set by console sending the shuttle.
-	var/export_categories = EXPORT_CARGO
-
 /obj/docking_port/mobile/supply/register()
 	. = ..()
 	SSshuttle.supply = src

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -92,7 +92,6 @@
 #include "code\__DEFINES\exosuit_fab.dm"
 #include "code\__DEFINES\experisci.dm"
 #include "code\__DEFINES\explosions.dm"
-#include "code\__DEFINES\exports.dm"
 #include "code\__DEFINES\external_organs.dm"
 #include "code\__DEFINES\fantasy_affixes.dm"
 #include "code\__DEFINES\firealarm.dm"


### PR DESCRIPTION
## About The Pull Request

I accidentally discovered that when #55504 removed cargo export categories being a thing during export value evaluation, in two instances, they forgot to remove passing over the now defunct export categories, causing it to be passed in as the elasticity value, and by sheer coincidence, this was not causing problems (due to being overriden by a named argument in the pirates case, and cargo_exports being evaluated as true in another).

This PR fixes the arguments, preventing possible bugs in the future. This also removes the code that set if the cargo shuttle could sell contraband and emagged items, as that is no longer a thing. I talked with @ArcaneMusic about this, and they agreed, albeit with the caveat that if someone finds a good use case for this feature, it could be saved.

This PR also autodocs several export related files, and cleans up various single and two letter vars.

## Why It's Good For The Game

Cleaner code, unused code removed.

## Changelog

:cl:
code: cleaned up cargo export code a bit
/:cl:
