### PR TITLE
Arms memory management

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -990,6 +990,8 @@
 
 /// Called when a new hand is added
 /mob/living/carbon/proc/on_added_hand(obj/item/bodypart/arm/new_hand, hand_index)
+	if(hand_index > hand_bodyparts.len)
+		hand_bodyparts.len = hand_index
 	hand_bodyparts[hand_index] = new_hand
 	RegisterSignals(new_hand, list(COMSIG_PARENT_QDELETING, COMSIG_BODYPART_REMOVED), PROC_REF(on_lost_hand))
 
@@ -997,6 +999,7 @@
 /mob/living/carbon/proc/on_lost_hand(obj/item/bodypart/arm/lost_hand)
 	SIGNAL_HANDLER
 	hand_bodyparts -= lost_hand
+	UnregisterSignal(lost_hand, list(COMSIG_PARENT_QDELETING, COMSIG_BODYPART_REMOVED))
 
 ///Proc to hook behavior on bodypart additions. Do not directly call. You're looking for [/obj/item/bodypart/proc/try_attach_limb()].
 /mob/living/carbon/proc/add_bodypart(obj/item/bodypart/new_bodypart)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -982,12 +982,21 @@
 			if(ARM_LEFT)
 				l_arm_index_next += 2
 				bodypart_instance.held_index = l_arm_index_next //1, 3, 5, 7...
-				hand_bodyparts += bodypart_instance
+				on_added_hand(bodypart_instance, l_arm_index_next)
 			if(ARM_RIGHT)
 				r_arm_index_next += 2
 				bodypart_instance.held_index = r_arm_index_next //2, 4, 6, 8...
-				hand_bodyparts += bodypart_instance
+				on_added_hand(bodypart_instance, r_arm_index_next)
 
+/// Called when a new hand is added
+/mob/living/carbon/proc/on_added_hand(obj/item/bodypart/arm/new_hand, hand_index)
+	hand_bodyparts[hand_index] = new_hand
+	RegisterSignals(new_hand, list(COMSIG_PARENT_QDELETING, COMSIG_BODYPART_REMOVED), PROC_REF(on_lost_hand))
+
+/// Cleans up references to an arm when it is dismembered or deleted
+/mob/living/carbon/proc/on_lost_hand(obj/item/bodypart/arm/lost_hand)
+	SIGNAL_HANDLER
+	hand_bodyparts -= lost_hand
 
 ///Proc to hook behavior on bodypart additions. Do not directly call. You're looking for [/obj/item/bodypart/proc/try_attach_limb()].
 /mob/living/carbon/proc/add_bodypart(obj/item/bodypart/new_bodypart)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -998,7 +998,7 @@
 /// Cleans up references to an arm when it is dismembered or deleted
 /mob/living/carbon/proc/on_lost_hand(obj/item/bodypart/arm/lost_hand)
 	SIGNAL_HANDLER
-	hand_bodyparts -= lost_hand
+	hand_bodyparts[lost_hand.held_index] = null
 	UnregisterSignal(lost_hand, list(COMSIG_PARENT_QDELETING, COMSIG_BODYPART_REMOVED))
 
 ///Proc to hook behavior on bodypart additions. Do not directly call. You're looking for [/obj/item/bodypart/proc/try_attach_limb()].

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -245,7 +245,6 @@
 		// We only want to do this if the limb being removed is the active hand part.
 		// This catches situations where limbs are "hot-swapped" such as augmentations and roundstart prosthetics.
 		arm_owner.dropItemToGround(arm_owner.get_item_for_held_index(held_index), 1)
-		arm_owner.hand_bodyparts[held_index] = null
 	if(arm_owner.handcuffed)
 		arm_owner.handcuffed.forceMove(drop_location())
 		arm_owner.handcuffed.dropped(arm_owner)
@@ -331,7 +330,7 @@
 	if(held_index)
 		if(held_index > new_limb_owner.hand_bodyparts.len)
 			new_limb_owner.hand_bodyparts.len = held_index
-		new_limb_owner.hand_bodyparts[held_index] = src
+		new_limb_owner.on_added_hand(held_index, src)
 		if(new_limb_owner.hud_used)
 			var/atom/movable/screen/inventory/hand/hand = new_limb_owner.hud_used.hand_slots["[held_index]"]
 			if(hand)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -328,9 +328,7 @@
 	set_owner(new_limb_owner)
 	new_limb_owner.add_bodypart(src)
 	if(held_index)
-		if(held_index > new_limb_owner.hand_bodyparts.len)
-			new_limb_owner.hand_bodyparts.len = held_index
-		new_limb_owner.on_added_hand(held_index, src)
+		new_limb_owner.on_added_hand(src, held_index)
 		if(new_limb_owner.hud_used)
 			var/atom/movable/screen/inventory/hand/hand = new_limb_owner.hud_used.hand_slots["[held_index]"]
 			if(hand)


### PR DESCRIPTION
## About The Pull Request

Fixes #75251 
Fixes #75376
Fixes #75377 
Fixes #75394

uh... I think?

Here's the thing, is that golem arms are not actually particularly different to other kinds of arms, so I have been struggling to find a reason that this test is flaking _only_ for golem arms, in relation to a list that I didn't touch. 
My best guess is that the reason they're sometimes sticking to the "available hands" list is related to golems not being dismemberable and thereby skipping the code path which would remove a removed arm from the hand list, which sounds plausible except that nightmares are also NODISMEMBER and don't have the same problem.

Regardless, I made some boilerplate for when you give someone an arm which registers to the destruction and dismember signals and removes them from your available hand list when either of those things happen under any circumstances, whereas before it was reliant on passing through a much more specific pipeline.

Notably the text which set this also remarked `We only want to do this if the limb being removed is the active hand part.` which certainly does not sound true to me (although it does for the other line scoped inside that if check) and now also isn't, but this didn't seem to be widely affecting arms in general anyway.

I couldn't replicate the test failing after making these changes but as a flaky result that doesn't really tell us very much because to some extent it might just have been down to luck.

## Why It's Good For The Game

Memory management, hopefully will stop randomly triggering CI failures.

## Changelog

Not player facing