### PR TITLE
Prevents desert eagles from loading sniper rounds (and vice versa)

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -26,8 +26,10 @@
 #define CALIBER_77 ".77"
 /// The caliber used by the C-20r SMG, the tommygun, and the M1911 pistol.
 #define CALIBER_45 ".45"
-/// The caliber used by sniper rifles and the desert eagle.
-#define CALIBER_50 ".50"
+/// The caliber used by sniper rifles.
+#define CALIBER_50BMG ".50BMG"
+/// The caliber used by the desert eagle.
+#define CALIBER_50AE ".50AE"
 /// The caliber used by the gyrojet pistol.
 #define CALIBER_75 ".75"
 /// The caliber used by [one revolver variant][/obj/item/gun/ballistic/revolver/nagant].

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -50,5 +50,5 @@
 /obj/item/ammo_casing/a50ae
 	name = ".50AE bullet casing"
 	desc = "A .50AE bullet casing."
-	caliber = CALIBER_50
+	caliber = CALIBER_50AE
 	projectile_type = /obj/projectile/bullet/a50ae

--- a/code/modules/projectiles/ammunition/ballistic/sniper.dm
+++ b/code/modules/projectiles/ammunition/ballistic/sniper.dm
@@ -3,7 +3,7 @@
 /obj/item/ammo_casing/p50
 	name = ".50 BMG bullet casing"
 	desc = "A .50 BMG bullet casing."
-	caliber = CALIBER_50
+	caliber = CALIBER_50BMG
 	projectile_type = /obj/projectile/bullet/p50
 	icon_state = ".50"
 

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -102,7 +102,7 @@
 	name = "handgun magazine (.50ae)"
 	icon_state = "50ae"
 	ammo_type = /obj/item/ammo_casing/a50ae
-	caliber = CALIBER_50
+	caliber = CALIBER_50AE
 	max_ammo = 7
 	multiple_sprites = AMMO_BOX_PER_BULLET
 

--- a/code/modules/projectiles/boxes_magazines/external/sniper.dm
+++ b/code/modules/projectiles/boxes_magazines/external/sniper.dm
@@ -4,7 +4,7 @@
 	base_icon_state = ".50mag"
 	ammo_type = /obj/item/ammo_casing/p50
 	max_ammo = 6
-	caliber = CALIBER_50
+	caliber = CALIBER_50BMG
 
 /obj/item/ammo_box/magazine/sniper_rounds/update_icon_state()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

This splits CALIBER_50 into CALIBER_50BMG and CALIBER_50AE, setting the sniper rifle to use the former and the deagle to use the latter.
## Why It's Good For The Game

Prevents each of these weapons from loading calibers that they are not intended to.

Recorded from yogs:

![teS5bum](https://github.com/tgstation/tgstation/assets/28408322/856a8af0-2fd4-40a2-b473-0bea160028e4)
## Changelog
:cl:
fix: Desert Eagles can no longer load .50 BMG sniper rifle rounds and vice versa.
/:cl:
