### PR TITLE
Adds One Single Space to Unlocking and Locking Closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1046,7 +1046,7 @@
 	if(iscarbon(user))
 		add_fingerprint(user)
 	locked = !locked
-	user.visible_message(span_notice("[user] [locked ? "locks" : "unlocks"][src]."),
+	user.visible_message(span_notice("[user] [locked ? "locks" : "unlocks"] [src]."),
 				span_notice("You [locked ? "locked" : "unlocked"] [src]."))
 	update_appearance()
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1046,8 +1046,10 @@
 	if(iscarbon(user))
 		add_fingerprint(user)
 	locked = !locked
-	user.visible_message(span_notice("[user] [locked ? "locks" : "unlocks"] [src]."),
-				span_notice("You [locked ? "locked" : "unlocked"] [src]."))
+	user.visible_message(
+		span_notice("[user] [locked ? "locks" : "unlocks"] [src]."),
+		span_notice("You [locked ? "locked" : "unlocked"] [src]."),
+	)
 	update_appearance()
 
 /obj/structure/closet/emag_act(mob/user)


### PR DESCRIPTION

## About The Pull Request
Title. I added one single space bar to the third-person display message when you witness someone else lock or unlock a locker.

## Why It's Good For The Game
Before:
<img src="https://i.ibb.co/RCWTTcq/Closet-Space-Bar-Before.png">
After:
<img src="https://i.ibb.co/Wfm7hvR/Closet-Space-Bar-After.png">
Highlighting unrelated shoutout to my fellow based AI enjoyers.
Grammar is good.
## Changelog
No changelog necessary.
