### PR TITLE
Anchors mapping helpers so they don't get put inside crates

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -103,6 +103,7 @@
 /obj/effect/mapping_helpers
 	icon = 'icons/effects/mapping_helpers.dmi'
 	icon_state = ""
+	anchored = TRUE
 	var/late = FALSE
 
 /obj/effect/mapping_helpers/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Persistent Birdshot CI failure was caused by broken floor helper sharing a tile with a random loot spawner, which would sometimes spawn a maintenance crate which deletes itself, but only after the crate eats the mapping helper. This causes the mapping helper to delete before it has initialised.

There's no reason for a mapper to assume this would cause a problem so the fix isn't to edit the map, instead I just anchored all mapping helpers so that closets won't try to contain them.

## Why It's Good For The Game

I'm really tired of birdshot failing CI
This probably fixes some other really niche bug nobody has noticed

## Changelog

Not player facing