### PR TITLE
Fixed fake grid check events failing to announce

### DIFF
--- a/code/modules/events/grid_check.dm
+++ b/code/modules/events/grid_check.dm
@@ -17,8 +17,11 @@
 
 /datum/round_event/grid_check/announce(fake)
 	var/datum/round_event_control/grid_check/controller = control
-	if(!COOLDOWN_FINISHED(controller, announcement_spam_protection) && !fake)
-		return
+	if(!fake)
+		if(!controller)
+			CRASH("event started without controller!")
+		if(!COOLDOWN_FINISHED(controller, announcement_spam_protection))
+			return
 	priority_announce("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure", ANNOUNCER_POWEROFF)
 	if(!fake) // Only start the CD if we're real
 		COOLDOWN_START(controller, announcement_spam_protection, 30 SECONDS)


### PR DESCRIPTION
```
Exception has occurred: Cannot read null.announcement_spam_protection
 - proc name: announce (/datum/round_event/grid_check/announce)
 -   source file: grid_check.dm,20
 -   usr: null
 -   src: /datum/round_event/grid_check (/datum/round_event/grid_check)
 -   call stack:
 - /datum/round_event/grid_check (/datum/round_event/grid_check): announce(1)
 - /datum/round_event/falsealarm (/datum/round_event/falsealarm): announce(0)
 - /datum/round_event/falsealarm (/datum/round_event/falsealarm): process(2)
 - Events (/datum/controller/subsystem/events): fire(0)
 - Events (/datum/controller/subsystem/events): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```
Caused by #73277
Fake events don't have controllers.

:cl: ShizCalev
fix: Fixed fake grid check events failing to announce properly. 
/:cl:
