### PR TITLE
Warn admins about active Internet sounds

### DIFF
--- a/code/__DEFINES/cooldowns.dm
+++ b/code/__DEFINES/cooldowns.dm
@@ -58,6 +58,9 @@
 // mob cooldowns
 #define COOLDOWN_YAWN_PROPAGATION "yawn_propagation_cooldown"
 
+// admin verb cooldowns
+#define COOLDOWN_INTERNET_SOUND "internet_sound"
+
 //Shared cooldowns for actions
 #define MOB_SHARED_COOLDOWN_1 (1<<0)
 #define MOB_SHARED_COOLDOWN_2 (1<<1)

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -222,9 +222,7 @@
 		var/client/C = M.client
 		C?.tgui_panel?.stop_music()
 
-	if(S_TIMER_COOLDOWN_TIMELEFT(SStimer, COOLDOWN_INTERNET_SOUND))
-		S_TIMER_COOLDOWN_RESET(SStimer, COOLDOWN_INTERNET_SOUND)
-
+	S_TIMER_COOLDOWN_RESET(SStimer, COOLDOWN_INTERNET_SOUND)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Stop All Playing Sounds") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
 
 //world/proc/shelleo

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -81,6 +81,8 @@
 	var/web_sound_url = ""
 	var/stop_web_sounds = FALSE
 	var/list/music_extra_data = list()
+	var/duration = 0
+
 	if(istext(input))
 		var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[input]\"")
 		var/errorlevel = output[SHELLEO_ERRORLEVEL]
@@ -108,7 +110,7 @@
 		music_extra_data["artist"] = data["artist"]
 		music_extra_data["upload_date"] = data["upload_date"]
 		music_extra_data["album"] = data["album"]
-		var/duration = data["duration"] * 1 SECONDS
+		duration = data["duration"] * 1 SECONDS
 		if (duration > 10 MINUTES)
 			if((tgui_alert(user, "This song is over 10 minutes long. Are you sure you want to play it?", "Length Warning!", list("No", "Yes", "Cancel")) != "Yes"))
 				return
@@ -161,6 +163,8 @@
 				else
 					C.tgui_panel?.stop_music()
 
+	S_TIMER_COOLDOWN_START(SStimer, COOLDOWN_INTERNET_SOUND, duration)
+
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Internet Sound")
 
 
@@ -174,6 +178,11 @@
 	if(!ytdl)
 		to_chat(src, span_boldwarning("Youtube-dl was not configured, action unavailable"), confidential = TRUE) //Check config.txt for the INVOKE_YOUTUBEDL value
 		return
+
+	if(S_TIMER_COOLDOWN_TIMELEFT(SStimer, COOLDOWN_INTERNET_SOUND))
+		if(tgui_alert(usr, "Someone else is already playing an Internet sound! It has [DisplayTimeText(S_TIMER_COOLDOWN_TIMELEFT(SStimer, COOLDOWN_INTERNET_SOUND))] remaining. \
+		Would you like to override?", "Musicalis Interruptus", list("No","Yes")) != "Yes")
+			return
 
 	var/web_sound_input = tgui_input_text(usr, "Enter content URL (supported sites only, leave blank to stop playing)", "Play Internet Sound", null)
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -180,7 +180,7 @@
 		return
 
 	if(S_TIMER_COOLDOWN_TIMELEFT(SStimer, COOLDOWN_INTERNET_SOUND))
-		if(tgui_alert(usr, "Someone else is already playing an Internet sound! It has [DisplayTimeText(S_TIMER_COOLDOWN_TIMELEFT(SStimer, COOLDOWN_INTERNET_SOUND))] remaining. \
+		if(tgui_alert(usr, "Someone else is already playing an Internet sound! It has [DisplayTimeText(S_TIMER_COOLDOWN_TIMELEFT(SStimer, COOLDOWN_INTERNET_SOUND), 1)] remaining. \
 		Would you like to override?", "Musicalis Interruptus", list("No","Yes")) != "Yes")
 			return
 

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -221,6 +221,10 @@
 		SEND_SOUND(M, sound(null))
 		var/client/C = M.client
 		C?.tgui_panel?.stop_music()
+
+	if(S_TIMER_COOLDOWN_TIMELEFT(SStimer, COOLDOWN_INTERNET_SOUND))
+		S_TIMER_COOLDOWN_RESET(SStimer, COOLDOWN_INTERNET_SOUND)
+
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Stop All Playing Sounds") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
 
 //world/proc/shelleo

--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.js
@@ -44,7 +44,7 @@ export const NowPlayingWidget = (props, context) => {
               <Section>
                 {URL !== 'Song Link Hidden' && (
                   <Flex.Item grow={1} color="label">
-                    Url: {URL}
+                    URL: {URL}
                   </Flex.Item>
                 )}
                 <Flex.Item grow={1} color="label">


### PR DESCRIPTION
## About The Pull Request

For various reasons an admin may not be aware there is currently an Internet sound playing. (Usually TGUI related or just recently logged in.)

This provides a warning and optional override if they try to start an Internet sound while one is already running.

https://github.com/tgstation/tgstation/assets/83487515/af4197c9-bf9d-43e4-a407-a556b88a6d30

## Why It's Good For The Game

Less "HEY I WAS ALREADY PLAYING SOMETHING!"

## Changelog

:cl: LT3
admin: Admins are now warned if they are going to override a currently playing admin midi
/:cl: