### PR TITLE
adds a oxy tank dispenser to the bounty ert shuttle

### DIFF
--- a/_maps/shuttles/ert_bounty.dmm
+++ b/_maps/shuttles/ert_bounty.dmm
@@ -2,6 +2,10 @@
 "a" = (
 /turf/template_noop,
 /area/template_noop)
+"b" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/pod/dark,
+/area/shuttle/hunter)
 "d" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/mineral/plastitanium,
@@ -181,7 +185,7 @@
 	width = 17
 	},
 /obj/docking_port/mobile{
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "hunter shuttle";
 	rechargeTime = 1800;
 	shuttle_id = "huntership"
@@ -289,7 +293,7 @@ n
 v
 n
 n
-O
+b
 X
 D
 n


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/tgstation/tgstation/assets/75904284/7c7340b4-c30e-4796-9352-7ba42a5459c4)
## Why It's Good For The Game
It's the perfect place for one and more oxygen on the ship will help out bounty hunters a lil' when going on space chases. Plus, its just QoL.
## Changelog
:cl:
qol: Added a Oxy Tank dispenser to the bounty ship for a lil' more general QoL
/:cl:
