### PR TITLE
adds two missing mech camera sanity checks

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -479,7 +479,7 @@ Diagnostic HUDs!
 	var/image/holder = hud_list[DIAG_CAMERA_HUD]
 	var/icon/I = icon(icon, icon_state, dir)
 	holder.pixel_y = I.Height() - world.icon_size
-	if(chassis_camera.is_emp_scrambled)
+	if(chassis_camera?.is_emp_scrambled)
 		holder.icon_state = "hudcamera_empd"
 		return
 	holder.icon_state = "hudcamera"

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -245,7 +245,7 @@
 				to_chat(usr, span_notice("You rename [name] to... well, [userinput]."))
 				return
 			name = userinput
-			chassis_camera.update_c_tag(src)
+			chassis_camera?.update_c_tag(src)
 		if("toggle_safety")
 			set_safety(usr)
 			return


### PR DESCRIPTION
```
[00:11:38] Runtime in mecha_ui.dm, line 248: Cannot execute null.update c tag().
 proc name: ui act (/obj/vehicle/sealed/mecha/ui_act)
src.loc: the floor (105,144,2) (/turf/open/floor/iron)
call stack:
(/obj/vehicle/sealed/mecha/working/ripley): ui act("changename", /list (/list), /datum/tgui (/datum/tgui), /datum/ui_state/default (/datum/ui_state/default))
/datum/tgui (/datum/tgui): on act message("changename", /list (/list), /datum/ui_state/default (/datum/ui_state/default))
/datum/callback/verb_callback (/datum/callback/verb_callback): Invoke()
world: push usr((/mob/living/carbon/human), /datum/callback/verb_callback (/datum/callback/verb_callback))
/datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
```

:cl: ShizCalev
fix: Fixed a minor runtime when renaming mechs that don't have a camera attached to them.
/:cl: