### PR TITLE
Fixes runtime when qdel'ing self-recharging guns with bayonets attached

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -99,10 +99,15 @@
 	if(A == chambered)
 		chambered = null
 		update_appearance()
-	if(A == bayonet)
-		clear_bayonet()
 	if(A == suppressed)
 		clear_suppressor()
+	return ..()
+
+/obj/item/gun/Exited(atom/movable/gone, direction)
+	if(gone == bayonet)
+		bayonet = null
+		if(!QDELING(src))
+			update_appearance()
 	return ..()
 
 ///Clears var and updates icon. In the case of ballistic weapons, also updates the gun's weight.
@@ -454,7 +459,13 @@
 		return
 
 	if(bayonet && can_bayonet) //if it has a bayonet, and the bayonet can be removed
-		return remove_bayonet(user, I)
+		I.play_tool_sound(src)
+		to_chat(user, span_notice("You unfix [bayonet] from [src]."))
+		bayonet.forceMove(drop_location())
+
+		if(Adjacent(user) && !issilicon(user))
+			user.put_in_hands(bayonet)
+		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 	else if(pin?.pin_removable && user.is_holding(src))
 		user.visible_message(span_warning("[user] attempts to remove [pin] from [src] with [I]."),
@@ -465,7 +476,7 @@
 			user.visible_message(span_notice("[pin] is pried out of [src] by [user], destroying the pin in the process."),
 								span_warning("You pry [pin] out with [I], destroying the pin in the process."), null, 3)
 			QDEL_NULL(pin)
-			return TRUE
+			return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/gun/welder_act(mob/living/user, obj/item/I)
 	. = ..()
@@ -500,23 +511,6 @@
 								span_warning("You rip [pin] out of [src] with [I], mangling the pin in the process."), null, 3)
 			QDEL_NULL(pin)
 			return TRUE
-
-/obj/item/gun/proc/remove_bayonet(mob/living/user, obj/item/tool_item)
-	tool_item?.play_tool_sound(src)
-	to_chat(user, span_notice("You unfix [bayonet] from [src]."))
-	bayonet.forceMove(drop_location())
-
-	if(Adjacent(user) && !issilicon(user))
-		user.put_in_hands(bayonet)
-
-	return clear_bayonet()
-
-/obj/item/gun/proc/clear_bayonet()
-	if(!bayonet)
-		return
-	bayonet = null
-	update_appearance()
-	return TRUE
 
 /obj/item/gun/update_overlays()
 	. = ..()


### PR DESCRIPTION
```
[00:29:34] Runtime in energy.dm, line 161: cannot read from list
proc name: can shoot (/obj/item/gun/energy/can_shoot)
src: the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator)
src.loc: the plating (81,77,2) (/turf/open/floor/plating)
call stack:
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): can shoot()
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): update overlays(16777215)
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): update icon(16777215)
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): update appearance(16777215)
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): clear bayonet()
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): handle atom del(the survival knife (/obj/item/knife/combat/survival))
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): handle atom del(the survival knife (/obj/item/knife/combat/survival))
the survival knife (/obj/item/knife/combat/survival): Destroy(0)
the survival knife (/obj/item/knife/combat/survival): Destroy(0)
the survival knife (/obj/item/knife/combat/survival): Destroy(0)
...
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): deconstruct(0)
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): atom destruction("melee")
the proto-kinetic accelerator (/obj/item/gun/energy/recharge/kinetic_accelerator): blob act(the normal blob (/obj/structure/blob/normal))
the normal blob (/obj/structure/blob/normal): ConsumeTile()
the normal blob (/obj/structure/blob/normal): Be Pulsed()
the blobola (/obj/structure/blob/special/core): pulse area(the blobola overmind (/mob/camera/blob), 12, 4, 3)
Objects (/datum/controller/subsystem/processing/obj): fire(1)
Objects (/datum/controller/subsystem/processing/obj): ignite(1)
Master (/datum/controller/master): Loop(2)
Master (/datum/controller/master): StartProcessing(0)
```

:cl: ShizCalev
fix: Fixed a runtime which occured when a self-recharging gun (ie proto-kinetic accelerator) with a bayonet attached was deleted.
/:cl:
