### PR TITLE
FIXES RUNTIME CAUSING GUNS WITHOUT A MAGAZINE INSERTED TO NOT FIRE

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -402,7 +402,7 @@
 	if (sawn_off)
 		bonus_spread += SAWN_OFF_ACC_PENALTY
 
-	if(!chambered.is_cased_ammo)
+	if(magazine && !chambered.is_cased_ammo)
 		magazine.stored_ammo -= chambered
 
 	return ..()


### PR DESCRIPTION
Caused by #75058

:cl: ShizCalev
fix: Guns without magazines inserted can now fire again!
/:cl: