### PR TITLE
Fix SHOULD_NOT_SLEEP hit in infra assemblies

### DIFF
--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -75,7 +75,7 @@
 	if(holder)
 		holder_movement() //sync the dir of the device as well if it's contained in a TTV or an assembly holder
 	else
-		refreshBeam()
+		INVOKE_ASYNC(src, PROC_REF(refreshBeam))
 
 /obj/item/assembly/infra/process()
 	if(!on || !secured)


### PR DESCRIPTION
See #75232 

refreshBeam() is a sleeping proc, dropped gets called on Destroy()