### PR TITLE
Fix several SHOULD_NOT_SLEEP hits in SStgui.update_uis()

### DIFF
--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -200,7 +200,7 @@ SUBSYSTEM_DEF(tgui)
 	for(var/datum/tgui/ui in open_uis_by_src[key])
 		// Check if UI is valid.
 		if(ui?.src_object && ui.user && ui.src_object.ui_host(ui.user))
-			ui.process(wait * 0.1, force = 1)
+			INVOKE_ASYNC(ui, TYPE_PROC_REF(/datum/tgui, process), wait * 0.1, TRUE)
 			count++
 	return count
 


### PR DESCRIPTION
There are several esoteric code paths that lead to `winexists` calls or sleeps in `ui_data`. This proc is meant to be a command without sleeping.

See #75232
![image](https://github.com/tgstation/tgstation/assets/8171642/8becd881-d7e8-4fe5-90af-2c2657934d07)
