### PR TITLE
Fix SHOULD_NOT_SLEEP hit in silicon death

### DIFF
--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -6,7 +6,7 @@
 
 /mob/living/silicon/death(gibbed)
 	if(!gibbed)
-		emote("deathgasp")
+		INVOKE_ASYNC(src, PROC_REF(emote), "deathgasp")
 	diag_hud_set_status()
 	diag_hud_set_health()
 	update_health_hud()


### PR DESCRIPTION
This is how we do it in [carbons](https://github.com/tgstation/tgstation/blob/94d37c97972550327b025f9a7d499cf91f7636d2/code/modules/mob/living/carbon/death.dm#L8).

See #75232