### PR TITLE
Removes renameable flag from Death Sandwich

### DIFF
--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -254,10 +254,13 @@
 	)
 	tastes = list("bread" = 1, "meat" = 1, "tomato sauce" = 1, "death" = 1)
 	foodtypes = GRAIN | MEAT
-	obj_flags = NONE
 	food_flags = FOOD_FINGER_FOOD
 	w_class = WEIGHT_CLASS_SMALL
 	eat_time = 4 SECONDS // Makes it harder to force-feed this to people as a weapon, as funny as that is.
+
+/obj/item/food/death_sandwich/Initialize(mapload)
+	. = ..()
+	obj_flags &= ~UNIQUE_RENAME // You shouldn't be able to disguise this on account of how it kills you
 
 ///Override for checkliked callback
 /obj/item/food/death_sandwich/make_edible()

--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -254,6 +254,7 @@
 	)
 	tastes = list("bread" = 1, "meat" = 1, "tomato sauce" = 1, "death" = 1)
 	foodtypes = GRAIN | MEAT
+	obj_flags = NONE
 	food_flags = FOOD_FINGER_FOOD
 	w_class = WEIGHT_CLASS_SMALL
 	eat_time = 4 SECONDS // Makes it harder to force-feed this to people as a weapon, as funny as that is.


### PR DESCRIPTION
## About The Pull Request

Removes the flag from the Death Sandwich which allows you to rename it (and change its description) using a pen.

## Why It's Good For The Game

This sandwich kills you.
This is fine if it is called "Death Sandwich" and has the description "Eat it wrong, or you die!" because people eating it know what they are getting into.
It's less fine if someone has renamed it to "yummy sandwich" and it has the description "mmm yummy tasty".
Memorising sandwich sprites to avoid being killed by a disease (as punishment for not having a mullet and wearing jorts) should not be an important knowledge check.

## Changelog

:cl:
balance: The Death Sandwich can no longer be renamed
/:cl:
