### PR TITLE
Fixes runtimes in gas_mixture/proc/equalize

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -21,13 +21,14 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /datum/gas_mixture
 	var/list/gases
-	/// The temperature of the gas mix in kelvin, this should never be 0.
-	var/temperature = TCMB //kelvins
-	/// Archived temperature, so we don't need to recalculate
+	/// The temperature of the gas mix in kelvin. Should never be lower then TCMB
+	var/temperature = TCMB
+	/// Used, like all archived variables, to ensure turf sharing is consistent inside a tick, no matter
+	/// The order of operations
 	var/tmp/temperature_archived = TCMB
-	/// Volume of the gas mix in liters
+	/// Volume in liters (duh)
 	var/volume = CELL_VOLUME
-	/// The last tick this gas mixture shared on. See `/datum/gas_mixture/proc/share`
+	/// The last tick this gas mixture shared on. A counter that turfs use to manage activity
 	var/last_share = 0
 	/// Tells us what reactions have happened in our gasmix. Assoc list of reaction - moles reacted pair.
 	var/list/reaction_results

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -21,9 +21,13 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /datum/gas_mixture
 	var/list/gases
-	var/temperature = 0 //kelvins
-	var/tmp/temperature_archived = 0
-	var/volume = CELL_VOLUME //liters
+	/// The temperature of the gas mix in kelvin, this should never be 0.
+	var/temperature = TCMB //kelvins
+	/// Archived temperature, so we don't need to recalculate
+	var/tmp/temperature_archived = TCMB
+	/// Volume of the gas mix in liters
+	var/volume = CELL_VOLUME
+	/// The last tick this gas mixture shared on. See `/datum/gas_mixture/proc/share`
 	var/last_share = 0
 	/// Tells us what reactions have happened in our gasmix. Assoc list of reaction - moles reacted pair.
 	var/list/reaction_results


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/58055496/f124ccc1-9e8d-4701-b9cf-9635e1a1f1b2)

Basically, a gasmix's temp starts out at 0, and untouched the spacemix is not updated until something shares with it.
Even if this doesn't for sure fix it, this is v dumb and worth doing regardless

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/58055496/be8999ab-3da9-4e1d-93e3-88732faf2a8c)
Should close #75260, it's 4am I'm not gonna test this rn
