### PR TITLE
Fixes ducky shoes having clown shoe slowdown and being a clown shoe subtype

### DIFF
--- a/code/modules/clothing/shoes/clown.dm
+++ b/code/modules/clothing/shoes/clown.dm
@@ -53,10 +53,3 @@
 	desc = "The adorable sound they make when you walk will mean making friends is more likely."
 	icon_state = "meown_shoes"
 	squeak_sound = list('sound/effects/footstep/meowstep1.ogg'=1) //mew mew mew mew
-
-/obj/item/clothing/shoes/clown_shoes/ducky_shoes
-	name = "ducky shoes"
-	desc = "I got boots, that go *quack quack quack quack quack."
-	icon_state = "ducky_shoes"
-	inhand_icon_state = "ducky_shoes"
-	squeak_sound = list('sound/effects/quack.ogg'=1) //quack quack quack quack

--- a/code/modules/clothing/shoes/costume.dm
+++ b/code/modules/clothing/shoes/costume.dm
@@ -83,3 +83,24 @@
 	desc = "Officially branded Saints sneakers. Incredibly valuable!"
 	icon_state = "saints_shoes"
 	inhand_icon_state = null
+
+/obj/item/clothing/shoes/ducky_shoes
+	name = "ducky shoes"
+	desc = "I got boots, that go *quack quack quack quack quack."
+	icon_state = "ducky_shoes"
+	inhand_icon_state = "ducky_shoes"
+
+/obj/item/clothing/shoes/ducky_shoes/Initialize(mapload)
+	. = ..()
+
+	create_storage(storage_type = /datum/storage/pockets/shoes)
+	LoadComponent(/datum/component/squeak, list('sound/effects/quack.ogg' = 1), 50, falloff_exponent = 20)
+
+/obj/item/clothing/shoes/ducky_shoes/equipped(mob/living/user, slot)
+	. = ..()
+	if(slot & ITEM_SLOT_FEET)
+		user.AddElement(/datum/element/waddling)
+
+/obj/item/clothing/shoes/ducky_shoes/dropped(mob/living/user)
+	. = ..()
+	user.RemoveElement(/datum/element/waddling)

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -200,7 +200,7 @@
 		/obj/item/clothing/head/costume/powdered_wig = 1,
 		/obj/item/clothing/head/costume/tv_head = 1,
 		/obj/item/clothing/mask/muzzle = 2,
-		/obj/item/clothing/shoes/clown_shoes/ducky_shoes = 1,
+		/obj/item/clothing/shoes/ducky_shoes = 1,
 		/obj/item/clothing/shoes/clown_shoes/meown_shoes = 1,
 		/obj/item/clothing/suit/costume/judgerobe = 1,
 		/obj/item/clothing/head/costume/lobsterhat = 1,


### PR DESCRIPTION
## About The Pull Request

![image](https://user-images.githubusercontent.com/53100513/235573548-0326fea9-348a-4b04-ac04-f18f9d748bda.png)
![image](https://user-images.githubusercontent.com/53100513/235573577-37cc5b80-d011-4f49-9805-40ffffae9c0c.png)

This is unintended and so it's a fix!

Remade because i pushed to the wrong branch like a DUMBASS

## Why It's Good For The Game

More incentive to quack quack quack quack. Clown shoes have slowdown for the clown, not for ducks. The subtype just inherited it.
## Changelog
:cl:
fix: Fixes ducky shoes having clown shoe slowdown
/:cl:
