### PR TITLE
Holopad no longer hangs on failed connections

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -340,7 +340,9 @@ Possible to do for anyone motivated enough:
 				if(usr.loc == loc)
 					var/input = text2num(params["headcall"])
 					var/headcall = input == 1 ? TRUE : FALSE
-					new /datum/holocall(usr, src, callnames[result], headcall)
+					var/datum/holocall/holo_call = new(usr, src, callnames[result], headcall)
+					if(QDELETED(holo_call)) //can delete itself if the target pad was destroyed
+						return FALSE
 					calling = TRUE
 					return TRUE
 			else


### PR DESCRIPTION
## About The Pull Request

Fixes #74801

So the Holopad displays an TGUI input list from which the player can select which holopad to connect to. During the time they spend scrolling this list an holopad say in "Atmospherics" could be destroyed, but the list is never updated so when they connect to that destroyed Holopad picked from the list, the UI hangs.

No longer

## Changelog
:cl:
fix: Holopad UI will not hang when connection fails
/:cl: