### PR TITLE
Update emoji remover workflow for node16

### DIFF
--- a/.github/workflows/pr_emoji.yml
+++ b/.github/workflows/pr_emoji.yml
@@ -10,7 +10,7 @@ jobs:
   title_and_changelog:
     runs-on: ubuntu-20.04
     steps:
-    - uses: Wayland-Smithy/emoji-stripper-action@8f4c2fe9748bb9b02f105be4e72a1a42b0f34d84
+    - uses: Wayland-Smithy/emoji-stripper-action@de0c1d158edee50700583d6454aa5f5117337599
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         title: true


### PR DESCRIPTION
## About The Pull Request

Bumps the emoji remover action's commit hash +1 to [the current one](https://github.com/Wayland-Smithy/emoji-stripper-action/commit/de0c1d158edee50700583d6454aa5f5117337599) which has passed my node16 testing.
Necessary for when github intends to disable node12 later this year.

## Why It's Good For The Repo

Paying off some tech debt so the action continues to help maintain maintainer sanity into 2024 and byond,

## Changelog
Non player/admin facing change.