### PR TITLE
Fixes Birdshot Station's Missing Pimpin' Ride Key

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -27564,6 +27564,10 @@
 /obj/item/stack/tile/iron{
 	pixel_y = 18
 	},
+/obj/item/key/janitor{
+	pixel_x = -3;
+	pixel_y = 6
+	},
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "kkL" = (


### PR DESCRIPTION

## About The Pull Request
Fixes Birdshot Station's missing janicart key by adding it.
![圖片](https://github.com/tgstation/tgstation/assets/64306407/e7cb013e-1445-41bc-8175-81186c8239b5)

I thought I was idiot for not being able to find it
## Why It's Good For The Game
The station should have the key.
## Changelog
:cl:
fix: Fixes Birdshot Station's Missing Pimpin' Ride Key
/:cl:
