### PR TITLE
Experimental Mineral Balance PR.

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -75,11 +75,11 @@
 
 // Defines related to the custom materials used on objects.
 ///The amount of materials you get from a sheet of mineral like iron/diamond/glass etc. 2000 Units.
-#define SHEET_MATERIAL_AMOUNT 2000
+#define SHEET_MATERIAL_AMOUNT 1000
 ///The amount of materials you get from half a sheet. Used in standard object quantities. 1000 units.
 #define HALF_SHEET_MATERIAL_AMOUNT (SHEET_MATERIAL_AMOUNT/2)
 ///The amount of materials used in the smallest of objects, like pens and screwdrivers. 100 units.
-#define SMALL_MATERIAL_AMOUNT (HALF_SHEET_MATERIAL_AMOUNT/10)
+#define SMALL_MATERIAL_AMOUNT (HALF_SHEET_MATERIAL_AMOUNT/5)
 
 //The maximum size of a stack object.
 #define MAX_STACK_SIZE 50

--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -74,11 +74,11 @@
 #define NARSIE_WINDOW_COLOUR "#7D1919"
 
 // Defines related to the custom materials used on objects.
-///The amount of materials you get from a sheet of mineral like iron/diamond/glass etc. 1000 Units.
-#define SHEET_MATERIAL_AMOUNT 1000
-///The amount of materials you get from half a sheet. Used in standard object quantities. 500 units.
+///The amount of materials you get from a sheet of mineral like iron/diamond/glass etc. 100 Units.
+#define SHEET_MATERIAL_AMOUNT 100
+///The amount of materials you get from half a sheet. Used in standard object quantities. 50 units.
 #define HALF_SHEET_MATERIAL_AMOUNT (SHEET_MATERIAL_AMOUNT/2)
-///The amount of materials used in the smallest of objects, like pens and screwdrivers. 100 units.
+///The amount of materials used in the smallest of objects, like pens and screwdrivers. 10 units.
 #define SMALL_MATERIAL_AMOUNT (HALF_SHEET_MATERIAL_AMOUNT/5)
 
 //The maximum size of a stack object.

--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -74,9 +74,9 @@
 #define NARSIE_WINDOW_COLOUR "#7D1919"
 
 // Defines related to the custom materials used on objects.
-///The amount of materials you get from a sheet of mineral like iron/diamond/glass etc. 2000 Units.
+///The amount of materials you get from a sheet of mineral like iron/diamond/glass etc. 1000 Units.
 #define SHEET_MATERIAL_AMOUNT 1000
-///The amount of materials you get from half a sheet. Used in standard object quantities. 1000 units.
+///The amount of materials you get from half a sheet. Used in standard object quantities. 500 units.
 #define HALF_SHEET_MATERIAL_AMOUNT (SHEET_MATERIAL_AMOUNT/2)
 ///The amount of materials used in the smallest of objects, like pens and screwdrivers. 100 units.
 #define SMALL_MATERIAL_AMOUNT (HALF_SHEET_MATERIAL_AMOUNT/5)

--- a/tools/silo_grapher/silo_graph_script.py
+++ b/tools/silo_grapher/silo_graph_script.py
@@ -1,0 +1,127 @@
+# Silo graphing tool by ArcaneMusic.
+# This tool is designed to parse the Silo's logs and graph the total quantity of each material over time. Silo logs can be obtained from https://tgstation13.org/parsed-logs/
+# Useful utility for determining the amount of materials used in a round, and how much of each material is left at the end of the round.
+# To run, throw silo.json files into the logs folder one level down, then run this python script.
+# Remember to install imports if you don't have them already. (pip install matplotlib)
+# Terminal will hold numerical averages of every round
+# Lastly throw on show_json_figures to True if you want to see all the graphs for each individual round log you have saved.
+
+import json
+import os
+import matplotlib.pyplot as plt
+
+show_json_figures = False  # Set to True to show all JSON-specific figures at the end
+
+materials = {
+    "iron": {"total": 0, "spent": 0, "obtained": 0},
+    "glass": {"total": 0, "spent": 0, "obtained": 0},
+    "silver": {"total": 0, "spent": 0, "obtained": 0},
+    "gold": {"total": 0, "spent": 0, "obtained": 0},
+    "uranium": {"total": 0, "spent": 0, "obtained": 0},
+    "titanium": {"total": 0, "spent": 0, "obtained": 0},
+    "bluespace crystal": {"total": 0, "spent": 0, "obtained": 0},
+    "diamond": {"total": 0, "spent": 0, "obtained": 0},
+    "plasma": {"total": 0, "spent": 0, "obtained": 0},
+    "bananium": {"total": 0, "spent": 0, "obtained": 0},
+    "plastic": {"total": 0, "spent": 0, "obtained": 0},
+}
+
+grand_total = {
+    "iron": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "glass": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "silver": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "gold": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "uranium": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "titanium": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "bluespace crystal": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "diamond": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "plasma": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "bananium": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+    "plastic": {"grand_total": 0, "grand_spent": 0, "grand_obtained": 0},
+}
+
+log_folder = "logs"
+total_files = 0
+first_time_value = None
+first_time_setup = True
+
+for filename in os.listdir(log_folder):
+    with open(os.path.join(log_folder, filename), "r") as file:
+        total_files += 1
+        time = {}
+        y = {}
+
+        for material in materials:
+            time[material] = []
+            y[material] = []
+
+        for line in file:
+            try:
+                log = json.loads(line)
+                raw_materials = log.get("data", {}).get("raw_materials", "")
+                if first_time_setup:
+                    first_time_value = log["timestamp"]
+                    first_time_setup = False
+                if not raw_materials:
+                    continue
+
+                for raw_material in raw_materials.split(", "):
+                    quantity, material = raw_material.split(" ", 1)
+                    if quantity.startswith("-"):
+                        materials[material]["spent"] += int(quantity[1:])
+                        materials[material]["total"] -= int(quantity[1:])
+                    else:
+                        materials[material]["obtained"] += int(quantity[1:])
+                        materials[material]["total"] += int(quantity[1:])
+                    time[material].append((int(log["timestamp"]) - int(first_time_value)) / 10)
+                    y[material].append(int(materials[material]["total"]))
+
+            except Exception as e:
+                print(f"Failed to parse line: {line}")
+                print(f"Error: {e}")
+
+        for material, values in materials.items():
+            total = values["total"]
+            spent = values["spent"]
+            obtained = values["obtained"]
+            grand_total[material]["grand_total"] += values["total"]
+            grand_total[material]["grand_spent"] += values["spent"]
+            grand_total[material]["grand_obtained"] += values["obtained"]
+
+        for material in materials:
+            materials[material]["total"] = 0
+            materials[material]["spent"] = 0
+            materials[material]["obtained"] = 0
+        first_time_setup = True
+
+        if show_json_figures:
+            fig, ax = plt.subplots()
+            for material in materials:
+                ax.plot(time[material], y[material], label=material)
+
+            ax.set_xlabel("Time")
+            ax.set_ylabel("Total Quantity")
+            ax.set_title(f"Material Quantity Changes - {filename}")
+            ax.legend()
+
+fig, ax = plt.subplots()
+for material in materials:
+    ax.plot(time[material], y[material], label=material)
+
+ax.set_xlabel("Time")
+ax.set_ylabel("Total Quantity")
+ax.set_title("Overall Material Quantity Changes")
+ax.legend()
+plt.show()
+
+for material, values in grand_total.items():
+    if values["grand_obtained"] != 0:
+        grand_total[material]["grand_spent_percentage"] = values["grand_spent"] / values["grand_obtained"] * 100
+    else:
+        grand_total[material]["grand_spent_percentage"] = 0
+
+print("Grand totals:")
+for material, values in grand_total.items():
+    print(
+        f"{material} total: {values['grand_total']} | spent total: {values['grand_spent']} | obtained total: {values['grand_obtained']} | percentage spent: {values['grand_spent_percentage']:.2f}%"
+    )


### PR DESCRIPTION
## About The Pull Request

Good morning fokes, this PR is going to attempt to tweak around some of the values of mineral costs in-game in the hopes of making the mineral economy more engaging to the base gameplay loop, in the hopes that by making it more self-realized, it would allow for better integration with the rest of the gameplay loop as well as so that it doesn't completely overshadow the credit economy. That said, **this pr only makes changes to mined and station minerals**.

So, the base change is as follows: items with designated costs of minerals below 1000 minerals, as designated in #75052 as `SMALL_MATERIAL_AMOUNT`, have been left alone. Any item above 1000 or 2000, from `HALF_SHEET_MATERIAL_AMOUNT` and `SHEET_MATERIAL_AMOUNT` have been adjusted, as sheets will now contain **100 minerals each**.

For example, if an object costed 4000 iron, 1000 glass, and 500 diamond with the old numbers, with the changes to these defines, that item would cost 2000 iron, 500 glass, and 500 diamond.

## Why It's Good For The Game

Arcane has been doing some statistics now that he's back in the land of the living. So, I broke down a 40 round aggregate of silo logs, excluding rounds where the silo was left untouched (as, I can't imagine a round where nothing was both lathed or mined would be statistically relevant). These rounds had their minerals obtained tallied, and the amount spent and obtained were compared, giving a net total. The amount consumed as a percentage was then obtained as an average of all rounds, as a measurement of average "health" of that mineral within the material economy.

The results were as follows:
![image](https://github.com/tgstation/tgstation/assets/41715314/712d4468-2340-4b77-9992-9bc8a71d7d61)

In the average round, iron and glass being the most consumed mineral makes sense, since the most useful and most bountiful items are typically iron/glass exclusives. Not to mention, if a tool has to be obtained later in the shift, it's either research locked or it has to be very, VERY good to warrant waiting for it. So that value makes sense. Iron is also typically the most in-demand mineral, as well as the most requested material as a result of having to fix hull breaches. Glass by comparison has issues on some maps like icebox, but overall it's useful enough that it has a much MUCH higher quantity obtained than other materials.

Other mined minerals typically don't break over 50 sheets (100,000 in this metric), and are also consumed less than 30% at maximum, and 14% at the lowest. This is for a number of reasons, but the big two are as follows:
* "Rare" resources are rarely taken in quantities greater than the previous SMALL_MATERIAL_AMOUNT on their most valuable parts, which means that despite the quantity that they come in at, there's no real scarcity of the resource, which makes the bulk of rare material acquisition meaningless after the first load of ores comes in.
* "Rare" resources don't have the same level of usefulness as iron/glass, as they are unique, those unique properties don't help the station actually function more effectively. Gold can't patch a hole the size of medbay, and silver cannot help to refill oxygen to a station doomed to recall. This is hyperbole, I know, but there's nothing that really drives needing specific rare materials due to them not having a truly unique identity within the game. IE: If high cost silver items were a driving force in making sterile workshops in medical, seeing an empty silver reserve becomes an indicator of medical department's state.

So, where am I going with all this?

This PR should serve as an experiment in order to see if by pushing the lower end of mineral consumption, usually taken up by "rare" minerals, we see a better percentage of mineral usage causing trade-offs in gameplay after the first 15 minutes of a shift. By normalizing regular sheets to a standard 1000 units, it also means that finally one unit of a sheet can be a "millisheet", as we've all been demanding for years (this is sarcasm but the uniformity is rather nice).

DNM until it's been testmerged and we can compare some logged rounds silo data, both from an LRP server as well as from MRP. (MRP rounds, being longer in general, gave much higher values while also showing a higher level of surplus, where LRP would be much shorter logs by far, but could have a much wider range of values due to the volatile nature of rounds ending earlier than expected).

## Changelog

:cl:
balance: In general, mineral recipe costs for items in larger amounts has been decreased by 2x.
balance: One sheet now contains a total of 100 units of material, down from 2000. Proportionally the costs of items should remain the same, except for the smaller costs of certain recipes. 
code: Added a python script to the tools folder, letting you see a mineral breakdown of one/several rounds using silo logs.
/:cl:

