### PR TITLE
Fix very common smoothing groups runtime by deferring icon smoothing until all atom initializations are complete

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -178,6 +178,10 @@ SUBSYSTEM_DEF(atoms)
 	if(!initialized_changed)
 		initialized = old_initialized
 
+/// Returns TRUE if anything is currently being initialized
+/datum/controller/subsystem/atoms/proc/initializing_something()
+	return initialized_changed > 0
+
 /datum/controller/subsystem/atoms/Recover()
 	initialized = SSatoms.initialized
 	if(initialized == INITIALIZATION_INNEW_MAPLOAD)

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -11,6 +11,13 @@ SUBSYSTEM_DEF(icon_smooth)
 	var/list/deferred = list()
 
 /datum/controller/subsystem/icon_smooth/fire()
+	// We do not want to smooth icons of atoms whose neighbors are not initialized yet,
+	// this causes runtimes.
+	// Icon smoothing SS runs after atoms, so this only happens for something like shuttles.
+	// This kind of map loading shouldn't take too long, so the delay is not a problem.
+	if (SSatoms.initializing_something())
+		return
+
 	var/list/smooth_queue_cache = smooth_queue
 	while(length(smooth_queue_cache))
 		var/atom/smoothing_atom = smooth_queue_cache[length(smooth_queue_cache)]


### PR DESCRIPTION
## About The Pull Request
Fixes the "bad index" runtime that shows up on 80% of rounds.

![image](https://github.com/tgstation/tgstation/assets/35135081/8b8a7b6a-90b6-4c07-8e3b-47f31e4864c5)

The issue is that during dynamic maploading, the initialization of objects is split over several ticks. However, before the initialization is complete, an object's smoothing groups is still in its string form (as per [the smoothing group optimizations](https://github.com/tgstation/tgstation/pull/71989)). Thus, code later down the line attempts to read from this string, and errors.

It would be expensive to check all nearby neighbors every time in any place in this code, so instead we defer icon smoothing if there are any initializations currently in progress. Because this only happens for dynamic loading, the stuff being loaded dynamically is usually small, and icon smoothing already has a somewhat visible delay for shuttles, this delay doesn't matter.

## Changelog


:cl:
fix: Fixed an issue where objects on something that loaded dynamically, like shuttles, would not be smoothed.
/:cl:

