### PR TITLE
Fix two sources of color_cutoffs runtimes, then give it a better error

### DIFF
--- a/code/__HELPERS/colors.dm
+++ b/code/__HELPERS/colors.dm
@@ -84,6 +84,10 @@
 /// But paired down and modified to work for our color range
 /// Accepts the color cutoffs as two 3 length list(0-100,...) arguments
 /proc/blend_cutoff_colors(list/first_color, list/second_color)
+	// These runtimes usually mean that either the eye or the glasses have an incorrect color_cutoffs
+	ASSERT(first_color?.len == 3, "First color must be a 3 length list, received [json_encode(first_color)]")
+	ASSERT(second_color?.len == 3, "Second color must be a 3 length list, received [json_encode(second_color)]")
+
 	var/list/output = new /list(3)
 
 	// Invert the colors, multiply to "darken" (actually lights), then uninvert to get back to what we want

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -51,7 +51,7 @@
 
 		if(MODE_TRAY) //undoes the last mode, meson
 			vision_flags = NONE
-			color_cutoffs = list()
+			color_cutoffs = null
 			change_glass_color(user, /datum/client_colour/glass_colour/lightblue)
 
 		if(MODE_PIPE_CONNECTABLE)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -228,7 +228,7 @@
 			color_cutoffs = high_light_cutoff.Copy()
 			light_level = NIGHTVISION_LIGHT_HIG
 		else
-			color_cutoffs = list()
+			color_cutoffs = null
 			light_level = NIGHTVISION_LIGHT_OFF
 	owner.update_sight()
 


### PR DESCRIPTION
50% of rounds.

`color_cutoffs` must always be a 3-item list. I couldn't find any more cases where this assumption could be wrong.

```
[2023-05-05 04:04:21.144] runtime error: list index out of bounds
 - proc name: blend cutoff colors (/proc/blend_cutoff_colors)
 -   source file: colors.dm,91
 -   usr: Varuna Maddox (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the plating (122,145,2) (/turf/open/floor/plating)
 -   call stack:
 - blend cutoff colors(/list (/list), /list (/list))
 - Varuna Maddox (/mob/living/carbon/human): update sight()
 - the pressure-resistant enginee... (/obj/item/clothing/glasses/meson/engine): toggle mode(Varuna Maddox (/mob/living/carbon/human), 1)
 - the pressure-resistant enginee... (/obj/item/clothing/glasses/meson/engine): attack self(Varuna Maddox (/mob/living/carbon/human))
 - the pressure-resistant enginee... (/obj/item/clothing/glasses/meson/engine): ui action click(Varuna Maddox (/mob/living/carbon/human), Toggle Mode (/datum/action/item_action/toggle_mode))
 - Toggle Mode (/datum/action/item_action/toggle_mode): Trigger(null)
 - Toggle Mode (/atom/movable/screen/movable/action_button): Click(null, "mapwindow.map", "icon-x=10;icon-y=15;left=1;but...")
 - Toggle Mode (/atom/movable/screen/movable/action_button):  Click(null, "mapwindow.map", "icon-x=10;icon-y=15;left=1;but...")
 - /datum/callback/verb_callback (/datum/callback/verb_callback): Invoke()
 - world: push usr(Varuna Maddox (/mob/living/carbon/human), /datum/callback/verb_callback (/datum/callback/verb_callback))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - Input (/datum/controller/subsystem/verb_manager/input): run verb queue()
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```