### PR TITLE
Fixes Guide to Mimery from pulling up Book Page

### DIFF
--- a/code/game/objects/items/granters/_granters.dm
+++ b/code/game/objects/items/granters/_granters.dm
@@ -14,6 +14,8 @@
 	var/reading = FALSE
 	/// The amount of uses on the granter.
 	var/uses = 1
+	/// The time it takes to read the book
+	var/reading_time = 5 SECONDS
 	/// The sounds played as the user's reading the book.
 	var/list/book_sounds = list(
 		'sound/effects/pageturn1.ogg',
@@ -44,7 +46,7 @@
 			on_reading_stopped()
 			reading = FALSE
 			return
-	if(do_after(user, 5 SECONDS, src))
+	if(do_after(user, reading_time, src))
 		uses--
 		on_reading_finished(user)
 	reading = FALSE
@@ -67,7 +69,7 @@
 /obj/item/book/granter/proc/turn_page(mob/living/user)
 	playsound(user, pick(book_sounds), 30, TRUE)
 
-	if(!do_after(user, 5 SECONDS, src))
+	if(!do_after(user, reading_time, src))
 		return FALSE
 
 	to_chat(user, span_notice("[length(remarks) ? pick(remarks) : "You keep reading..."]"))

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -26,7 +26,7 @@
 		/obj/item/food/baguette = 15,
 		/obj/item/food/cheese/wheel = 10,
 		/obj/item/reagent_containers/cup/glass/bottle/bottleofnothing = 10,
-		/obj/item/book/mimery = 1,
+		/obj/item/book/granter/action/spell/mime/mimery = 1,
 	)
 	rpg_title = "Fool"
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
@@ -52,7 +52,7 @@
 	uniform = /obj/item/clothing/under/rank/civilian/mime
 	suit = /obj/item/clothing/suit/toggle/suspenders
 	backpack_contents = list(
-		/obj/item/book/mimery = 1,
+		/obj/item/book/granter/action/spell/mime/mimery = 1,
 		/obj/item/reagent_containers/cup/glass/bottle/bottleofnothing = 1,
 		/obj/item/stamp/mime = 1,
 		)
@@ -83,47 +83,39 @@
 	var/datum/atom_hud/fan = GLOB.huds[DATA_HUD_FAN]
 	fan.show_to(H)
 
-/obj/item/book/mimery
+/obj/item/book/granter/action/spell/mime/mimery
 	name = "Guide to Dank Mimery"
 	desc = "Teaches one of three classic pantomime routines, allowing a practiced mime to conjure invisible objects into corporeal existence. One use only."
-	icon_state = "bookmime"
-	starting_title = "Guide to Dank Mimery"
+	pages_to_mastery = 0
+	reading_time = 0
 
-/obj/item/book/mimery/attack_self(mob/user)
-	if(.)
-		return
-
-	var/list/spell_icons = list(
-		"Invisible Wall" = image(icon = 'icons/mob/actions/actions_mime.dmi', icon_state = "invisible_wall"),
-		"Invisible Chair" = image(icon = 'icons/mob/actions/actions_mime.dmi', icon_state = "invisible_chair"),
-		"Invisible Box" = image(icon = 'icons/mob/actions/actions_mime.dmi', icon_state = "invisible_box")
-		)
+/obj/item/book/granter/action/spell/mime/mimery/on_reading_start(mob/living/user)
+	var/list/spell_icons = list()
+	var/list/name_to_spell = list()
+	for(var/datum/action/type as anything in list(/datum/action/cooldown/spell/conjure/invisible_wall, /datum/action/cooldown/spell/conjure/invisible_chair, /datum/action/cooldown/spell/conjure_item/invisible_box))
+		if(!(locate(type) in user.actions))
+			spell_icons[initial(type.name)] = image(icon = initial(type.button_icon), icon_state = initial(type.button_icon_state))
+		name_to_spell[initial(type.name)] = type
 	var/picked_spell = show_radial_menu(user, src, spell_icons, custom_check = CALLBACK(src, PROC_REF(check_menu), user), radius = 36, require_near = TRUE)
-	var/datum/action/cooldown/spell/picked_spell_type
-	switch(picked_spell)
-		if("Invisible Wall")
-			picked_spell_type = /datum/action/cooldown/spell/conjure/invisible_wall
+	granted_action = name_to_spell[picked_spell]
 
-		if("Invisible Chair")
-			picked_spell_type = /datum/action/cooldown/spell/conjure/invisible_chair
+/obj/item/book/granter/action/spell/mime/mimery/on_reading_finished(mob/living/user)
+	// Gives the user a vow ability too, if they don't already have one
+	var/datum/action/cooldown/spell/vow_of_silence/vow = locate() in user.actions
+	if(!vow && user.mind)
+		vow = new(user.mind)
+		vow.Grant(user)
+	var/datum/action/new_action = new granted_action(user.mind || user)
+	new_action.Grant(user)
+	to_chat(user, span_warning("The book disappears into thin air."))
+	qdel(src)
 
-		if("Invisible Box")
-			picked_spell_type = /datum/action/cooldown/spell/conjure_item/invisible_box
-
-	if(ispath(picked_spell_type))
-		// Gives the user a vow ability too, if they don't already have one
-		var/datum/action/cooldown/spell/vow_of_silence/vow = locate() in user.actions
-		if(!vow && user.mind)
-			vow = new(user.mind)
-			vow.Grant(user)
-
-		picked_spell_type = new picked_spell_type(user.mind || user)
-		picked_spell_type.Grant(user)
-
-		to_chat(user, span_warning("The book disappears into thin air."))
-		qdel(src)
-
-	return TRUE
+/obj/item/book/granter/action/spell/mime/mimery/can_learn(mob/living/user)
+	for(var/type in list(/datum/action/cooldown/spell/conjure/invisible_wall, /datum/action/cooldown/spell/conjure/invisible_chair, /datum/action/cooldown/spell/conjure_item/invisible_box))
+		if(!(locate(type) in user.actions))
+			return TRUE
+	to_chat(user, span_warning("You already know the secrets of mimery!"))
+	return FALSE
 
 /**
  * Checks if we are allowed to interact with a radial menu
@@ -131,7 +123,7 @@
  * Arguments:
  * * user The human mob interacting with the menu
  */
-/obj/item/book/mimery/proc/check_menu(mob/living/carbon/human/user)
+/obj/item/book/granter/action/spell/mime/mimery/proc/check_menu(mob/living/carbon/human/user)
 	if(!istype(user))
 		return FALSE
 	if(!user.is_holding(src))

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -90,7 +90,6 @@
 	starting_title = "Guide to Dank Mimery"
 
 /obj/item/book/mimery/attack_self(mob/user)
-	. = ..()
 	if(.)
 		return
 


### PR DESCRIPTION
## About The Pull Request

The Guide to Dank Mimery pulled up a book page due to calling back to the /obj/item/book attack_self proc.

## Why It's Good For The Game

Fixes an issue that can make it difficult to pick an ability, also just a blatant issue.

## Changelog
:cl:
fix: fixes the guide to mimery radial menu.
refactor: refactors how the mime book works.
/:cl:
