### PR TITLE
uses correct helper for light_cameras() sanity check

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -783,7 +783,7 @@
 	for (var/datum/camerachunk/chunk as anything in eyeobj.visibleCameraChunks)
 		for (var/z_key in chunk.cameras)
 			for(var/obj/machinery/camera/camera as anything in chunk.cameras[z_key])
-				if (!camera || !camera.can_use() || get_dist(camera, eyeobj) > 7 || !camera.internal_light)
+				if(isnull(camera) || !camera.can_use() || get_dist(camera, eyeobj) > 7 || !camera.internal_light)
 					continue
 				visible |= camera
 


### PR DESCRIPTION
Touched it in #75302, just being explicit about what's intended here.