### PR TITLE
morgue trays can now be emagged

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -216,6 +216,12 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	beeper = !beeper
 	to_chat(user, span_notice("You turn the speaker function [beeper ? "on" : "off"]."))
 
+/obj/structure/bodycontainer/morgue/emag_act(mob/user)
+	if(obj_flags & EMAGGED)
+		return
+	to_chat(user, span_warning("You overload [src]'s alert system."))
+	obj_flags |= EMAGGED
+
 /obj/structure/bodycontainer/morgue/update_icon_state()
 	if(!connected || connected.loc != src) // Open or tray is gone.
 		icon_state = "morgue0"
@@ -229,10 +235,12 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	if(!length(compiled)) // No mobs?
 		icon_state = "morgue3"
 		return ..()
-
-	for(var/mob/living/M in compiled)
-		var/mob/living/mob_occupant = get_mob_or_brainmob(M)
-		if(mob_occupant.client && !(HAS_TRAIT(mob_occupant, TRAIT_SUICIDED))&& !(HAS_TRAIT(mob_occupant, TRAIT_BADDNA)))
+	
+	if(!(obj_flags & EMAGGED))
+		for(var/mob/living/occupant as anything in compiled)
+			var/mob/living/mob_occupant = get_mob_or_brainmob(occupant)
+			if(!mob_occupant.client || HAS_TRAIT(mob_occupant, TRAIT_SUICIDED) || HAS_TRAIT(mob_occupant, TRAIT_BADDNA))
+				continue
 			icon_state = "morgue4" // Revivable
 			if(mob_occupant.stat == DEAD && beeper && COOLDOWN_FINISHED(src, next_beep))
 				playsound(src, 'sound/weapons/gun/general/empty_alarm.ogg', 50, FALSE) //Revive them you blind fucks


### PR DESCRIPTION

## About The Pull Request
you can emag morgue trays disabling the alarm system

## Why It's Good For The Game
keeps your enemies dead :J

## Changelog
:cl:
add: You can emag morgue trays to disable their life alerts.
/:cl:
