### PR TITLE
Fixes Tramstation Genetics Pen Chasm Dirt

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -4776,7 +4776,9 @@
 	c_tag = "Science - Monkey Pit";
 	network = list("ss13","rd")
 	},
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/jungle{
+	baseturfs = /turf/open/misc/dirt
+	},
 /area/station/science/explab)
 "aBo" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -41001,7 +41003,9 @@
 /area/station/solars/port)
 "nzO" = (
 /mob/living/carbon/human/species/monkey,
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/jungle{
+	baseturfs = /turf/open/misc/dirt
+	},
 /area/station/science/explab)
 "nzR" = (
 /turf/open/floor/engine/vacuum,
@@ -47461,7 +47465,9 @@
 /area/station/security/checkpoint/escape)
 "pTj" = (
 /obj/structure/flora/bush/fullgrass/style_random,
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/jungle{
+	baseturfs = /turf/open/misc/dirt
+	},
 /area/station/science/explab)
 "pTl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55052,7 +55058,9 @@
 /turf/open/floor/plating,
 /area/station/solars/starboard/fore)
 "sGF" = (
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/jungle{
+	baseturfs = /turf/open/misc/dirt
+	},
 /area/station/science/explab)
 "sGG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -56504,7 +56512,9 @@
 /area/station/commons/dorms/laundry)
 "tdY" = (
 /obj/structure/flora/bush/jungle/c/style_random,
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/jungle{
+	baseturfs = /turf/open/misc/dirt
+	},
 /area/station/science/explab)
 "tdZ" = (
 /obj/machinery/door/firedoor,
@@ -63812,7 +63822,9 @@
 "vDg" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/effect/landmark/event_spawn,
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/jungle{
+	baseturfs = /turf/open/misc/dirt
+	},
 /area/station/science/explab)
 "vDE" = (
 /obj/machinery/light/small/directional/west,


### PR DESCRIPTION

## About The Pull Request

Tramstation genetics pen no loner uses jungle dirt that has a base_turf of chasm.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/75054

## Changelog
:cl:
fix: fixed Tramstation genetics pen chasms
/:cl:
