### PR TITLE
Drunk slurring scales based on how drunk you are

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -102,10 +102,10 @@
 #define set_derpspeech(duration) set_timed_status_effect(duration, /datum/status_effect/speech/stutter/derpspeech)
 #define set_derpspeech_if_lower(duration) set_timed_status_effect(duration, /datum/status_effect/speech/stutter/derpspeech, TRUE)
 
-#define adjust_slurring(duration) adjust_timed_status_effect(duration, /datum/status_effect/speech/slurring/drunk)
-#define adjust_slurring_up_to(duration, up_to) adjust_timed_status_effect(duration, /datum/status_effect/speech/slurring/drunk, up_to)
-#define set_slurring(duration) set_timed_status_effect(duration, /datum/status_effect/speech/slurring/drunk)
-#define set_slurring_if_lower(duration) set_timed_status_effect(duration, /datum/status_effect/speech/slurring/drunk, TRUE)
+#define adjust_slurring(duration) adjust_timed_status_effect(duration, /datum/status_effect/speech/slurring/generic)
+#define adjust_slurring_up_to(duration, up_to) adjust_timed_status_effect(duration, /datum/status_effect/speech/slurring/generic, up_to)
+#define set_slurring(duration) set_timed_status_effect(duration, /datum/status_effect/speech/slurring/generic)
+#define set_slurring_if_lower(duration) set_timed_status_effect(duration, /datum/status_effect/speech/slurring/generic, TRUE)
 
 #define adjust_dizzy(duration) adjust_timed_status_effect(duration, /datum/status_effect/dizziness)
 #define adjust_dizzy_up_to(duration, up_to) adjust_timed_status_effect(duration, /datum/status_effect/dizziness, up_to)

--- a/code/datums/diseases/advance/symptoms/sensory.dm
+++ b/code/datums/diseases/advance/symptoms/sensory.dm
@@ -45,7 +45,10 @@
 	if(A.stage >= 3)
 		M.adjust_dizzy(-4 SECONDS)
 		M.adjust_drowsiness(-4 SECONDS)
-		M.adjust_slurring(-1 SECONDS)
+		// All slurring effects get reduced down a bit
+		for(var/datum/status_effect/speech/slurring/slur in M.status_effects)
+			slur.remove_duration(1 SECONDS)
+
 		M.adjust_confusion(-2 SECONDS)
 		if(purge_alcohol)
 			M.reagents.remove_all_type(/datum/reagent/consumable/ethanol, 3)

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -144,16 +144,13 @@
 		if(drunk_value > BALLMER_PEAK_WINDOWS_ME) // by this point you're into windows ME territory
 			owner.say(pick_list_replacements(VISTA_FILE, "ballmer_windows_me_msg"), forced = "ballmer")
 
-	// There's always a 30% chance to gain some drunken slurring
-	if(prob(30))
-		owner.adjust_slurring(4 SECONDS)
+	// Apply drunk slurring
+	// Drunk slurring scales in intensity based on how drunk we are, so at the starting point it's barely noticable
+	if(drunk_value >= 21)
+		owner.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/speech/slurring/drunk, max_duration = 20 SECONDS)
 
 	// And drunk people will always lose jitteriness
 	owner.adjust_jitter(-6 SECONDS)
-
-	// Over 11, we will constantly gain slurring up to 10 seconds of slurring.
-	if(drunk_value >= 11)
-		owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
 
 	// Over 41, we have a 30% chance to gain confusion, and we will always have 20 seconds of dizziness.
 	if(drunk_value >= 41)

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -144,9 +144,9 @@
 		if(drunk_value > BALLMER_PEAK_WINDOWS_ME) // by this point you're into windows ME territory
 			owner.say(pick_list_replacements(VISTA_FILE, "ballmer_windows_me_msg"), forced = "ballmer")
 
-	// Apply drunk slurring
-	// Drunk slurring scales in intensity based on how drunk we are, so at the starting point it's barely noticable
-	if(drunk_value >= 21)
+	// Drunk slurring scales in intensity based on how drunk we are -at 16 you will likely not even notice it,
+	// but when we start to scale up you definitely will
+	if(drunk_value >= 16)
 		owner.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/speech/slurring/drunk, max_duration = 20 SECONDS)
 
 	// And drunk people will always lose jitteriness

--- a/code/datums/status_effects/debuffs/speech_debuffs.dm
+++ b/code/datums/status_effects/debuffs/speech_debuffs.dm
@@ -191,13 +191,35 @@
 
 	return modified_char
 
-/datum/status_effect/speech/slurring/drunk
-	id = "drunk_slurring"
+/datum/status_effect/speech/slurring/generic
+	id = "generic_slurring"
 	common_prob = 33
-	uncommon_prob = 5
+	uncommon_prob = 0
 	replacement_prob = 5
 	doubletext_prob = 10
 	text_modification_file = "slurring_drunk_text.json"
+
+/datum/status_effect/speech/slurring/drunk
+	id = "drunk_slurring"
+	// These defaults are updated when speech event occur.
+	common_prob = -1
+	uncommon_prob = -1
+	replacement_prob = -1
+	doubletext_prob = -1
+	text_modification_file = "slurring_drunk_text.json"
+
+/datum/status_effect/speech/slurring/drunk/handle_message(datum/source, list/message_args)
+	var/current_drunkness = owner.get_drunk_amount()
+	// These numbers are arbitarily picked
+	// Common replacements start at about 20, and maxes out at about 85
+	common_prob = clamp((current_drunkness * 0.8) - 16, 0, 50)
+	// Uncommon replacements (burping) start at 50 and max out at 110 (when you are dying)
+	uncommon_prob = clamp((current_drunkness * 0.2) - 10, 0, 12)
+	// Replacements start at 20 and max out at about 60
+	replacement_prob = clamp((current_drunkness * 0.4) - 8, 0, 12)
+	// Double texting start out at about 25 and max out at about 60
+	doubletext_prob = clamp((current_drunkness * 0.5) - 12, 0, 20)
+	return ..()
 
 /datum/status_effect/speech/slurring/cult
 	id = "cult_slurring"


### PR DESCRIPTION
## About The Pull Request

The strength of the slurring effect drunkness applies on you now scales based on how drunk you are. 

Being "a little" drunk still changes your saymod, and makes you occasionally slur your words...

![image](https://github.com/tgstation/tgstation/assets/51863163/1b21b359-a1f9-428a-8e10-d2028ac59728)

But being "a lot" drunk kicks it up to 11

![image](https://github.com/tgstation/tgstation/assets/51863163/9d593c80-75ff-4d02-8e7c-e48c738154bb)

Additionally, drunk slurring was separated into "generic slurring" and "drunk slurring", the former which does not scale but less closely resembles drunkness. Generic slurring is used in places such as concussions, so this is an added bonus. 

As a result of the split, I had to update mind restoration. Now it heals all types of slurring, which does include cult slurs. 

## Why It's Good For The Game

I, and many other people, always found it very annoying when you became completely illegible from taking one sip of a drink. This seeks to amend that by making low levels of drunkness still for the most part be legible and sane. Average drunkness is roughly the same / equal to the old slurring effect, while "very drunk" is even more illegible and silly (which I find funny). 

This has the added bonus of separating out "drunk slurring" and "generic slurring", allowing effects to slur your words without going full ham on drunkness (burping and "huhh"s). 

## Changelog

:cl: Melbert
add: When you are drunk, the strength of your slurring now varies based on how drunk you are. Being "a little drunk" only rarely slurs your words, being average drunk is the same as the old effect, while being very drunk now slurs your words even more. 
add: Some non-alcohol sources of slurring, such as concussions, now give "generic slurring" rather than "drunk slurring", which less resemble being drunk (ie, no burping). 
add: Mind restoration now heals ALL slurring, rather than only drunk slurring (which includes cult / heretic slurring). 
/:cl:
