### PR TITLE
Makes glass shattering not fail create and destroy situationally

### DIFF
--- a/code/datums/elements/shatters_when_thrown.dm
+++ b/code/datums/elements/shatters_when_thrown.dm
@@ -22,8 +22,8 @@
 	src.number_of_shards = number_of_shards
 	src.shattering_sound = shattering_sound
 
-	RegisterSignal(target, COMSIG_MOVABLE_IMPACT, PROC_REF(on_throw_impact))
-	RegisterSignal(target, COMSIG_ATOM_ON_Z_IMPACT, PROC_REF(on_z_impact))
+	RegisterSignal(target, COMSIG_MOVABLE_IMPACT, PROC_REF(on_throw_impact), override = TRUE)
+	RegisterSignal(target, COMSIG_ATOM_ON_Z_IMPACT, PROC_REF(on_z_impact), override = TRUE)
 
 /datum/element/shatters_when_thrown/Detach(datum/target)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Something the tests didn't pick up, but something that definitely showed up downstream, is that glass shattering will make create and destroy fail when mixed with certain other things.
## Why It's Good For The Game

There's a lot of red x on tests downstream i imagine failing create and destroy is a bad thing
## Changelog
:cl:
fix: glass shattering element no longer causes create and destroy to fail occasionally 
/:cl:
