### PR TITLE
Glass bottles can be used as ghetto rolling pins

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -25,6 +25,8 @@
 	age_restricted = TRUE // wrryy can't set an init value to see if drink_type contains ALCOHOL so here we go
 	///Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
 	var/bottle_knockdown_duration = BOTTLE_KNOCKDOWN_DEFAULT_DURATION
+	tool_behaviour = TOOL_ROLLINGPIN // Used to knock out the Chef.
+	toolspeed = 1.3 //it's a little awkward to use, but it's a cylinder alright.
 
 /obj/item/reagent_containers/cup/glass/bottle/small
 	name = "small glass bottle"


### PR DESCRIPTION

## About The Pull Request

Glass bottles are long cylinders and functionally identical to a rolling pin, so they work as one just in case you're too lazy to go find some wood planks, or you're multitasking as the Bartender. Ever so slightly slower to use than just getting a normal rolling pin.

## Why It's Good For The Game

Ghetto alternative just in case the librarian is threatening to gut you if you keep trying to crowbar the shelves.
Makes sense from a realistic standpoint and I don't think it'll cause any issues with reagents since rollingpin tool use is pretty niche.

## Changelog
:cl:
qol: Bar bottles now work as makeshift rolling pins
/:cl:
