### PR TITLE
Fix Photographs

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -189,8 +189,8 @@
 	var/blueprints = FALSE
 	var/clone_area = SSmapping.RequestBlockReservation(size_x * 2 + 1, size_y * 2 + 1)
 
-	var/width = size_x * 2
-	var/height = size_y * 2
+	var/width = size_x * 2 + 1
+	var/height = size_y * 2 + 1
 	for(var/turf/placeholder as anything in CORNER_BLOCK_OFFSET(target_turf, width, height, -size_x, -size_y))
 		while(istype(placeholder, /turf/open/openspace)) //Multi-z photography
 			placeholder = SSmapping.get_turf_below(placeholder)


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/74869 by adding a 1 to the width and height for the borders of photos which fixes the bug. Upon examining the code it seems like clone_area is found via size_x/y * 2 + 1 while the height and width of the photos were only set to size_x/y * 2. 
## Why It's Good For The Game
When you take a photo you expect to be able to see the content of the things in the photo.
## Changelog
:cl:Reality Overseer
fix: fixed photographs having black borders in photos
/:cl:
