### PR TITLE
Makes elder atmosian statue craftable

### DIFF
--- a/code/datums/components/crafting/atmospheric.dm
+++ b/code/datums/components/crafting/atmospheric.dm
@@ -340,8 +340,9 @@
 	name = "Elder Atmosian Statue"
 	result = /obj/structure/statue/elder_atmosian
 	time = 6 SECONDS
-	reqs = list(/obj/item/stack/sheet/mineral/metal_hydrogen = 20,
-				/obj/item/stack/sheet/mineral/zaukerite = 15,
-				/obj/item/stack/sheet/iron = 30,
-				)
+	reqs = list(
+		/obj/item/stack/sheet/mineral/metal_hydrogen = 20,
+		/obj/item/stack/sheet/mineral/zaukerite = 15,
+		/obj/item/stack/sheet/iron = 30,
+	)
 	category = CAT_STRUCTURE

--- a/code/datums/components/crafting/atmospheric.dm
+++ b/code/datums/components/crafting/atmospheric.dm
@@ -335,3 +335,13 @@
 		/obj/item/stock_parts/water_recycler = 1,
 	)
 	category = CAT_ATMOSPHERIC
+
+/datum/crafting_recipe/elder_atmosian_statue
+	name = "Elder Atmosian Statue"
+	result = /obj/structure/statue/elder_atmosian
+	time = 6 SECONDS
+	reqs = list(/obj/item/stack/sheet/mineral/metal_hydrogen = 20,
+				/obj/item/stack/sheet/mineral/zaukerite = 15,
+				/obj/item/stack/sheet/iron = 30,
+				)
+	category = CAT_STRUCTURE

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -466,6 +466,7 @@ GLOBAL_LIST_INIT(metalhydrogen_recipes, list(
 	new /datum/stack_recipe("ancient armor", /obj/item/clothing/suit/armor/elder_atmosian, req_amount = 5, res_amount = 1, check_density = FALSE, category = CAT_CLOTHING),
 	new /datum/stack_recipe("ancient helmet", /obj/item/clothing/head/helmet/elder_atmosian, req_amount = 3, res_amount = 1, check_density = FALSE, category = CAT_CLOTHING),
 	new /datum/stack_recipe("metallic hydrogen axe", /obj/item/fireaxe/metal_h2_axe, req_amount = 15, res_amount = 1, check_density = FALSE, category = CAT_WEAPON_MELEE),
+	new /datum/stack_recipe("elder atmosian statue", /obj/structure/statue/elder_atmosian, 10, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_ENTERTAINMENT),
 	))
 
 /obj/item/stack/sheet/mineral/metal_hydrogen

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -466,7 +466,6 @@ GLOBAL_LIST_INIT(metalhydrogen_recipes, list(
 	new /datum/stack_recipe("ancient armor", /obj/item/clothing/suit/armor/elder_atmosian, req_amount = 5, res_amount = 1, check_density = FALSE, category = CAT_CLOTHING),
 	new /datum/stack_recipe("ancient helmet", /obj/item/clothing/head/helmet/elder_atmosian, req_amount = 3, res_amount = 1, check_density = FALSE, category = CAT_CLOTHING),
 	new /datum/stack_recipe("metallic hydrogen axe", /obj/item/fireaxe/metal_h2_axe, req_amount = 15, res_amount = 1, check_density = FALSE, category = CAT_WEAPON_MELEE),
-	new /datum/stack_recipe("elder atmosian statue", /obj/structure/statue/elder_atmosian, req_amount = 10, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_STRUCTURE),
 	))
 
 /obj/item/stack/sheet/mineral/metal_hydrogen

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -466,7 +466,7 @@ GLOBAL_LIST_INIT(metalhydrogen_recipes, list(
 	new /datum/stack_recipe("ancient armor", /obj/item/clothing/suit/armor/elder_atmosian, req_amount = 5, res_amount = 1, check_density = FALSE, category = CAT_CLOTHING),
 	new /datum/stack_recipe("ancient helmet", /obj/item/clothing/head/helmet/elder_atmosian, req_amount = 3, res_amount = 1, check_density = FALSE, category = CAT_CLOTHING),
 	new /datum/stack_recipe("metallic hydrogen axe", /obj/item/fireaxe/metal_h2_axe, req_amount = 15, res_amount = 1, check_density = FALSE, category = CAT_WEAPON_MELEE),
-	new /datum/stack_recipe("elder atmosian statue", /obj/structure/statue/elder_atmosian, 10, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_ENTERTAINMENT),
+	new /datum/stack_recipe("elder atmosian statue", /obj/structure/statue/elder_atmosian, req_amount = 10, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_STRUCTURE),
 	))
 
 /obj/item/stack/sheet/mineral/metal_hydrogen


### PR DESCRIPTION

## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/74534 by making elder atmosian statue craftable. I am not 100% sure if this is the intended way for it to be able to be made or if it's even the right amount of materials but if I need to change it please let me know.
## Why It's Good For The Game
Fixing issues is good, having uncraftable things is bad.
## Changelog
:cl:Reality Overseer
fix: makes elder atmosian statue craftable
/:cl:
