### PR TITLE
Cursed quirk doesn't go away after triggering a single time

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -24,7 +24,8 @@
 	if(istype(vessel))
 		src.vessel = vessel
 		RegisterSignal(vessel, COMSIG_PARENT_QDELETING, PROC_REF(vessel_qdeleting))
-	src.permanent = permanent
+	if(!isnull(permanent))
+		src.permanent = permanent
 	if(!isnull(luck_mod))
 		src.luck_mod = luck_mod
 	if(!isnull(damage_mod))


### PR DESCRIPTION
## About The Pull Request

Fixes #75471
Someone added some optional initialise arguments and forgot to make an important one optional, leading to it always setting the "permanent" value to "null", which of course evaluates falsily to FALSE.

## Why It's Good For The Game

If you take this quirk you _want_ to be repeatedly pulverised by vending machines until your skull pops. We shouldn't deny people their agency.

## Changelog

:cl:
fix: The Cursed quirk will once more plague you with bad luck for your entire shift rather than just once.
/:cl:
