### PR TITLE
[MetaStation] Adds `nearstation` to some lattice and the sec jouch

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -685,8 +685,9 @@
 	name = "couch";
 	dir = 1
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "aok" = (
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -44467,10 +44468,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"pTz" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "pTS" = (
 /turf/closed/wall,
 /area/station/service/bar)
@@ -104783,7 +104780,7 @@ rrt
 lMJ
 dwJ
 aaa
-pTz
+lMJ
 aaa
 nvn
 qWw
@@ -105040,7 +105037,7 @@ aaa
 aaa
 rrt
 aaa
-pTz
+lMJ
 aaa
 szp
 szp


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Missed `nearstation` on some lattice and the now moved sec jouce. I also added lattice under one portion of the sec jouch.

I know its a couch but calling it a jouch is funnier.

## Changelog

:cl: Jolly
fix: [MetaStation] The abandoned sec couch should now be covered by nearstation.
fix: [MetaStation] Lattice adjacent to the newly added fitness room is now covered by nearstation.
/:cl:

