### PR TITLE
Fugitive hunters gather candidates with a deadchat poll

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -330,7 +330,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 // If this flag is enabled the antagonist datum allows the antagonist to be inducted into a nuclear operative team.
 #define FLAG_ANTAG_CAN_BE_INDUCTED (1 << 0)
 
-#define HUNTER_PACK_COPS "cop_hunters"
-#define HUNTER_PACK_RUSSIAN "russian_hunters"
-#define HUNTER_PACK_BOUNTY "bounty_hunters"
-#define HUNTER_PACK_PSYKER "psyker_hunters"
+#define HUNTER_PACK_COPS "Spacepol Fugitive Hunters"
+#define HUNTER_PACK_RUSSIAN "Russian Fugitive Hunters"
+#define HUNTER_PACK_BOUNTY "Bounty Fugitive Hunters"
+#define HUNTER_PACK_PSYKER "Psyker Fugitive Hunters"

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -56,7 +56,12 @@
 	//after spawning
 	playsound(src, 'sound/weapons/emitter.ogg', 50, TRUE)
 	new /obj/item/storage/toolbox/mechanical(landing_turf) //so they can actually escape maint
-	var/hunter_backstory = pick(HUNTER_PACK_COPS, HUNTER_PACK_RUSSIAN, HUNTER_PACK_BOUNTY, HUNTER_PACK_PSYKER)
+	var/hunter_backstory = pick(
+		HUNTER_PACK_COPS,
+		HUNTER_PACK_RUSSIAN,
+		HUNTER_PACK_BOUNTY,
+		HUNTER_PACK_PSYKER,
+	)
 	addtimer(CALLBACK(src, PROC_REF(spawn_hunters), hunter_backstory), 10 MINUTES)
 	role_name = "fugitive hunter"
 	return SUCCESSFUL_SPAWN
@@ -125,7 +130,7 @@
 
 	for(var/turf/shuttle_turf in ship.get_affected_turfs(placement_turf))
 		for(var/obj/effect/mob_spawn/ghost_role/human/fugitive/spawner in shuttle_turf)
-			if(length(candidates) > 0)
+			if(length(candidates))
 				var/mob/our_candidate = candidates[1]
 				var/mob/spawned_mob = spawner.create_from_ghost(our_candidate)
 				candidates -= our_candidate

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -56,7 +56,8 @@
 	//after spawning
 	playsound(src, 'sound/weapons/emitter.ogg', 50, TRUE)
 	new /obj/item/storage/toolbox/mechanical(landing_turf) //so they can actually escape maint
-	addtimer(CALLBACK(src, PROC_REF(spawn_hunters)), 10 MINUTES)
+	var/hunter_backstory = pick(HUNTER_PACK_COPS, HUNTER_PACK_RUSSIAN, HUNTER_PACK_BOUNTY, HUNTER_PACK_PSYKER)
+	addtimer(CALLBACK(src, PROC_REF(spawn_hunters), hunter_backstory), 10 SECONDS)
 	role_name = "fugitive hunter"
 	return SUCCESSFUL_SPAWN
 
@@ -98,9 +99,11 @@
 	new /obj/item/autosurgeon(landing_turf)
 
 //security team gets called in after 10 minutes of prep to find the refugees
-/datum/round_event/ghost_role/fugitives/proc/spawn_hunters()
-	var/backstory = pick(HUNTER_PACK_COPS, HUNTER_PACK_RUSSIAN, HUNTER_PACK_BOUNTY, HUNTER_PACK_PSYKER)
-	var/datum/map_template/shuttle/ship
+/datum/round_event/ghost_role/fugitives/proc/spawn_hunters(backstory)
+	var/list/candidates = poll_ghost_candidates("Do you wish to be considered for a fugitive hunting crew?", ROLE_FUGITIVE_HUNTER)
+	shuffle_inplace(candidates)
+
+	var/datum/map_template/shuttle/hunter/ship
 	switch(backstory)
 		if(HUNTER_PACK_COPS)
 			ship = new /datum/map_template/shuttle/hunter/space_cop
@@ -114,11 +117,22 @@
 	var/x = rand(TRANSITIONEDGE,world.maxx - TRANSITIONEDGE - ship.width)
 	var/y = rand(TRANSITIONEDGE,world.maxy - TRANSITIONEDGE - ship.height)
 	var/z = SSmapping.empty_space.z_value
-	var/turf/T = locate(x,y,z)
-	if(!T)
+	var/turf/placement_turf = locate(x,y,z)
+	if(!placement_turf)
 		CRASH("Fugitive Hunters (Created from fugitive event) found no turf to load in")
-	if(!ship.load(T))
+	if(!ship.load(placement_turf))
 		CRASH("Loading [backstory] ship failed!")
+
+	for(var/turf/shuttle_turf in ship.get_affected_turfs(placement_turf))
+		for(var/obj/effect/mob_spawn/ghost_role/human/fugitive/spawner in shuttle_turf)
+			if(length(candidates) > 0)
+				var/mob/our_candidate = candidates[1]
+				var/mob/spawned_mob = spawner.create_from_ghost(our_candidate)
+				candidates -= our_candidate
+				notify_ghosts("[spawner.prompt_name] has awoken: [spawned_mob]!", source = spawned_mob, action = NOTIFY_ORBIT, header="Come look!")
+			else
+				notify_ghosts("[spawner.prompt_name] spawner has been created!", source = spawner, action = NOTIFY_ORBIT, header="Spawn Here!")
+
 	priority_announce("Unidentified ship detected near the station.")
 
 #undef TEAM_BACKSTORY_SIZE

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -105,7 +105,7 @@
 
 //security team gets called in after 10 minutes of prep to find the refugees
 /datum/round_event/ghost_role/fugitives/proc/spawn_hunters(backstory)
-	var/list/candidates = poll_ghost_candidates("Do you wish to be considered for a fugitive hunting crew?", ROLE_FUGITIVE_HUNTER)
+	var/list/candidates = poll_ghost_candidates("Do you wish to be considered for a group of [backstory]?", ROLE_FUGITIVE_HUNTER)
 	shuffle_inplace(candidates)
 
 	var/datum/map_template/shuttle/hunter/ship

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -57,7 +57,7 @@
 	playsound(src, 'sound/weapons/emitter.ogg', 50, TRUE)
 	new /obj/item/storage/toolbox/mechanical(landing_turf) //so they can actually escape maint
 	var/hunter_backstory = pick(HUNTER_PACK_COPS, HUNTER_PACK_RUSSIAN, HUNTER_PACK_BOUNTY, HUNTER_PACK_PSYKER)
-	addtimer(CALLBACK(src, PROC_REF(spawn_hunters), hunter_backstory), 10 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(spawn_hunters), hunter_backstory), 10 MINUTES)
 	role_name = "fugitive hunter"
 	return SUCCESSFUL_SPAWN
 

--- a/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
@@ -9,7 +9,6 @@
 
 /obj/effect/mob_spawn/ghost_role/human/fugitive/Initialize(mapload)
 	. = ..()
-	notify_ghosts("Hunters are waking up looking for refugees!", source = src, action=NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_FUGITIVE)
 
 /obj/effect/mob_spawn/ghost_role/human/fugitive/special(mob/living/carbon/human/spawned_human)
 	. = ..()

--- a/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
@@ -7,9 +7,6 @@
 	show_flavor = FALSE
 	var/back_story = "error"
 
-/obj/effect/mob_spawn/ghost_role/human/fugitive/Initialize(mapload)
-	. = ..()
-
 /obj/effect/mob_spawn/ghost_role/human/fugitive/special(mob/living/carbon/human/spawned_human)
 	. = ..()
 	var/datum/antagonist/fugitive_hunter/fughunter = new


### PR DESCRIPTION

## About The Pull Request

Fugitive Hunter spawning now works a lot more like it does for Pirates.

Rather than just using the spawners, it collects candidates from a ghost poll, and leaves the remaining spawners to be used if any are left.
## Why It's Good For The Game

The only way this event gathered candidates was through the notify_ghosts that hunter spawners threw on Initialize(). This easily flies under the radar (and I think also stopped working after lazyloading was implemented??), contributing to how infrequently hunter rolls are taken.

The hunters are an important part of fugitives as a whole, so making sure they're properly filled out is good.

Closes #74625.
## Changelog
:cl:
qol: Fugitive hunters now get a deadchat poll and notify deadchat properly.
/:cl:
