### PR TITLE
Adjust stowaway changeling requirements to look more like roundstart Changelings

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -239,7 +239,7 @@
 	required_candidates = 1
 	weight = 2
 	cost = 12
-	requirements = list(101,101,40,40,20,20,10,10,10,10)
+	requirements = list(101,101,60,50,40,20,20,10,10,10)
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/latejoin/stowaway_changeling/execute()


### PR DESCRIPTION
Copies the weights of roundstart changelings, these were too low and I was linked some reasonably low threat rounds on low pop getting them.

## Changelog
:cl:
balance: Adjusted stowaway changeling requirements to be closer to roundstart Changelings.
/:cl:
