### PR TITLE
Prevents silent station wipe from tritium poisoning

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -25,6 +25,8 @@
 #define MIASMA_CORPSE_MOLES 0.02
 #define MIASMA_GIBS_MOLES 0.005
 
+/// Minimum amount of toxic gas moles in a single breath required to receive damage
+#define TOXIC_GAS_DAMAGE_MIN_MOLES (MOLES_GAS_VISIBLE * BREATH_PERCENTAGE)
 #define MIN_TOXIC_GAS_DAMAGE 1
 #define MAX_TOXIC_GAS_DAMAGE 10
 

--- a/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
+++ b/code/__DEFINES/atmospherics/atmos_mob_interaction.dm
@@ -25,8 +25,6 @@
 #define MIASMA_CORPSE_MOLES 0.02
 #define MIASMA_GIBS_MOLES 0.005
 
-/// Minimum amount of toxic gas moles in a single breath required to receive damage
-#define TOXIC_GAS_DAMAGE_MIN_MOLES (MOLES_GAS_VISIBLE * BREATH_PERCENTAGE)
 #define MIN_TOXIC_GAS_DAMAGE 1
 #define MAX_TOXIC_GAS_DAMAGE 10
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -555,8 +555,9 @@
 /// Radioactive, green gas. Toxin damage, and a radiation chance
 /obj/item/organ/internal/lungs/proc/too_much_tritium(mob/living/carbon/breather, datum/gas_mixture/breath, trit_pp, old_trit_pp)
 	var/gas_breathed = breathe_gas_volume(breath, /datum/gas/tritium)
+	var/moles_visible = GLOB.meta_gas_info[/datum/gas/tritium][META_GAS_MOLES_VISIBLE] * BREATH_PERCENTAGE
 	// Tritium side-effects.
-	if(gas_breathed > gas_breathed.moles_visible * BREATH_PERCENTAGE)
+	if(gas_breathed > moles_visible)
 		var/ratio = gas_breathed * 15
 		breather.adjustToxLoss(clamp(ratio, MIN_TOXIC_GAS_DAMAGE, MAX_TOXIC_GAS_DAMAGE))
 	// If you're breathing in half an atmosphere of radioactive gas, you fucked up.

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -79,7 +79,6 @@
 	var/plas_breath_dam_max = MAX_TOXIC_GAS_DAMAGE
 	var/plas_damage_type = TOX
 
-	var/tritium_damage_moles_min = TOXIC_GAS_DAMAGE_MIN_MOLES
 	var/tritium_irradiation_moles_min = 1
 	var/tritium_irradiation_moles_max = 15
 	var/tritium_irradiation_probability_min = 10
@@ -557,7 +556,7 @@
 /obj/item/organ/internal/lungs/proc/too_much_tritium(mob/living/carbon/breather, datum/gas_mixture/breath, trit_pp, old_trit_pp)
 	var/gas_breathed = breathe_gas_volume(breath, /datum/gas/tritium)
 	// Tritium side-effects.
-	if(gas_breathed > tritium_damage_moles_min)
+	if(gas_breathed > gas_breathed.moles_visible * BREATH_PERCENTAGE)
 		var/ratio = gas_breathed * 15
 		breather.adjustToxLoss(clamp(ratio, MIN_TOXIC_GAS_DAMAGE, MAX_TOXIC_GAS_DAMAGE))
 	// If you're breathing in half an atmosphere of radioactive gas, you fucked up.

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -79,7 +79,7 @@
 	var/plas_breath_dam_max = MAX_TOXIC_GAS_DAMAGE
 	var/plas_damage_type = TOX
 
-	var/tritium_damage_moles_min = MINIMUM_MOLE_COUNT
+	var/tritium_damage_moles_min = TOXIC_GAS_DAMAGE_MIN_MOLES
 	var/tritium_irradiation_moles_min = 1
 	var/tritium_irradiation_moles_max = 15
 	var/tritium_irradiation_probability_min = 10

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -79,6 +79,7 @@
 	var/plas_breath_dam_max = MAX_TOXIC_GAS_DAMAGE
 	var/plas_damage_type = TOX
 
+	var/tritium_damage_moles_min = MINIMUM_MOLE_COUNT
 	var/tritium_irradiation_moles_min = 1
 	var/tritium_irradiation_moles_max = 15
 	var/tritium_irradiation_probability_min = 10
@@ -556,8 +557,9 @@
 /obj/item/organ/internal/lungs/proc/too_much_tritium(mob/living/carbon/breather, datum/gas_mixture/breath, trit_pp, old_trit_pp)
 	var/gas_breathed = breathe_gas_volume(breath, /datum/gas/tritium)
 	// Tritium side-effects.
-	var/ratio = gas_breathed * 15
-	breather.adjustToxLoss(clamp(ratio, MIN_TOXIC_GAS_DAMAGE, MAX_TOXIC_GAS_DAMAGE))
+	if(gas_breathed > tritium_damage_moles_min)
+		var/ratio = gas_breathed * 15
+		breather.adjustToxLoss(clamp(ratio, MIN_TOXIC_GAS_DAMAGE, MAX_TOXIC_GAS_DAMAGE))
 	// If you're breathing in half an atmosphere of radioactive gas, you fucked up.
 	if((trit_pp > tritium_irradiation_moles_min) && SSradiation.can_irradiate_basic(breather))
 		var/lerp_scale = min(tritium_irradiation_moles_max, trit_pp - tritium_irradiation_moles_min) / (tritium_irradiation_moles_max - tritium_irradiation_moles_min)


### PR DESCRIPTION
## About The Pull Request

Right now you can cull the entire station by releasing a few moles of tritium in a hall.

This amount is non-scrubbable, invisible and people don't get any notification that they're choking, they just silently take 1 toxin damage with each breath. Air alarms do not consider this amount as dangerous either.

People just start vomiting for unknown reason and eventually die if they won't figure out that it's due to air being bad.

This PR makes it so that take damage only when tritium is visible in the air.

## Why It's Good For The Game

Prevents easy silent murdering. I'm not sure that it's good actually.

Fixes #74760 

## Changelog

:cl:
fix: You receive damage from tritium only when there are enough moles to make it visible
/:cl:

