### PR TITLE
[NO GBP] Adds missing wrappers to request consoles  messages

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -191,7 +191,7 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 			if(!(announcement_authenticated || isAdminGhostAI(usr)))
 				return
 
-			var/message = reject_bad_text(params["message"], ascii_only = FALSE)
+			var/message = reject_bad_text(trim(html_encode(params["message"]), MAX_MESSAGE_LEN), ascii_only = FALSE)
 			if(!message)
 				to_chat(usr, span_alert("Invalid message."))
 				return
@@ -226,7 +226,7 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 			var/priority = params["priority"]
 			if(!priority)
 				return
-			var/message = reject_bad_text(params["message"], ascii_only = FALSE)
+			var/message = reject_bad_text(trim(html_encode(params["message"]), MAX_MESSAGE_LEN), ascii_only = FALSE)
 			if(!message)
 				to_chat(usr, span_alert("Invalid message."))
 				has_mail_send_error = TRUE


### PR DESCRIPTION

## About The Pull Request

Request consoles messages and announcement were not trimmed and sanitized properly. This PR fixes this, sorry about that.

Sadly, does not solve #75494. Is there a proc that trims excess whitespace _inside_ messages? There are many places that needs this.

## Why It's Good For The Game
Whitespace after and before texts should be trimmed, and HTML stuff should be encoded and stripped properly for safety.

## Changelog

:cl:
fix: fixes request console messages not being trimmed and encoded properly
/:cl: