### PR TITLE
Double clicking on your corpse (or something containing it) no longer makes you automatically re-enter it

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -2,11 +2,6 @@
 	if(check_click_intercept(params, A))
 		return
 
-	if(can_reenter_corpse && mind?.current)
-		if(A == mind.current || (mind.current in A)) // double click your corpse or whatever holds it
-			reenter_corpse() // (body bag, closet, mech, etc)
-			return // seems legit.
-
 	// Things you might plausibly want to follow
 	if(ismovable(A))
 		ManualFollow(A)


### PR DESCRIPTION

## About The Pull Request

Removes the check for reentering your body when double clicking on things as a ghost.

## Why It's Good For The Game

Perhaps my experience is not universal, but I have never found an occasion where I did this and wanted to re-enter my corpse, and conversely many occasions where I want to orbit my corpse and find myself re-entering it instead.

Any form of revival will pull you back into your body automatically these days and there's no real benefit to being in your corpse, and in the rare circumstance someone wants to do this the verb is still available.

## Changelog
:cl:
qol: Double clicking your corpse or something containing it as a ghost will now orbit as in other cases instead of re-entering your corpse.
/:cl:
