### PR TITLE
Ashwalker Tribe roundend reporting revamp

### DIFF
--- a/code/__DEFINES/span.dm
+++ b/code/__DEFINES/span.dm
@@ -49,6 +49,7 @@
 #define span_greenteamradio(str) ("<span class='greenteamradio'>" + str + "</span>")
 #define span_greentext(str) ("<span class='greentext'>" + str + "</span>")
 #define span_grey(str) ("<span class='grey'>" + str + "</span>")
+#define span_header(str) ("<span class='header'>" + str + "</span>")
 #define span_hear(str) ("<span class='hear'>" + str + "</span>")
 #define span_hidden(str) ("<span class='hidden'>" + str + "</span>")
 #define span_hierophant(str) ("<span class='hierophant'>" + str + "</span>")

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -709,6 +709,7 @@ GLOBAL_LIST_EMPTY(possible_items)
 
 /datum/objective/protect_object/proc/set_target(obj/O)
 	protect_target = O
+	RegisterSignal(protect_target, COMSIG_PARENT_QDELETING, PROC_REF(on_objective_qdel))
 	update_explanation_text()
 
 /datum/objective/protect_object/update_explanation_text()
@@ -719,7 +720,11 @@ GLOBAL_LIST_EMPTY(possible_items)
 		explanation_text = "Free objective."
 
 /datum/objective/protect_object/check_completion()
-	return !QDELETED(protect_target)
+	return !isnull(protect_target)
+
+/datum/objective/protect_object/proc/on_objective_qdel()
+	SIGNAL_HANDLER
+	protect_target = null
 
 //Changeling Objectives
 

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -42,30 +42,36 @@
 /datum/team/ashwalkers
 	name = "Ashwalker Tribe"
 	member_name = "Ashwalker"
+	///A list of "worthy" (meat-bearing) sacrifices made to the Necropolis
+	var/sacrifices_made = 0
+	///A list of how many eggs were created by the Necropolis
+	var/eggs_created = 0
 
 /datum/team/ashwalkers/roundend_report()
 	var/list/report = list()
 
 	report += "<span class='header'>An Ashwalker Tribe inhabited the wastes...</span><br>"
-	if(!length(members)) //The team is generated alongside the tendril, and it's entirely possible that nobody takes the role.
+	if(length(members)) //The team is generated alongside the tendril, and it's entirely possible that nobody takes the role.
+		report += "The [member_name]s were:"
+		report += printplayerlist(members)
+
+		var/datum/objective/protect_object/necropolis_objective = locate(/datum/objective/protect_object) in objectives
+
+		if(necropolis_objective)
+			objectives -= necropolis_objective //So we don't count it in the check for other objectives.
+			report += "<b>The [name] was tasked with defending the Necropolis:</b>"
+			if(necropolis_objective.check_completion())
+				report += span_greentext("<span class='header'>The nest stands! Glory to the Necropolis!</span><br>")
+			else
+				report += span_redtext("<span class='header'>The Necropolis was destroyed, the tribe has fallen...</span><br>")
+
+		if(length(objectives))
+			report += "<span class='header'>The [name]'s other objectives were:</span>"
+			printobjectives(objectives)
+
+		report += "The [name] managed to perform <b>[sacrifices_made]</b> sacrifices to the Necropolis. From this, the Necropolis produced <b>[eggs_created]</b> Ashwalker eggs."
+
+	else
 		report += "<b>But none of it's eggs hatched!</b>"
-		return "<div class='panel redborder'>[report.Join("<br>")]</div>"
-
-	report += "The [member_name]s were:"
-	report += printplayerlist(members)
-
-	var/datum/objective/protect_object/necropolis_objective = locate(/datum/objective/protect_object) in objectives
-
-	if(necropolis_objective)
-		objectives -= necropolis_objective //So we don't count it in the check for other objectives.
-		report += "<b>The [name] was tasked with defending the Necropolis:</b>"
-		if(necropolis_objective.check_completion())
-			report += span_greentext("<span class='header'>The nest stands! Glory to the Necropolis!</span><br>")
-		else
-			report += span_redtext("<span class='header'>The Necropolis was destroyed...</span><br>")
-
-	if(length(objectives))
-		report += "<span class='header'>The [name]'s other objectives were:</span>"
-		printobjectives(objectives)
 
 	return "<div class='panel redborder'>[report.Join("<br>")]</div>"

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -5,7 +5,7 @@
 	show_to_ghosts = TRUE
 	prevent_roundtype_conversion = FALSE
 	antagpanel_category = ANTAG_GROUP_ASHWALKERS
-	suicide_cry = "FOR THE NECROPOLIS!!"
+	suicide_cry = "I HAVE NO IDEA WHAT THIS THING DOES!!"
 	count_against_dynamic_roll_chance = FALSE
 	var/datum/team/ashwalkers/ashie_team
 

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -1,7 +1,3 @@
-/datum/team/ashwalkers
-	name = "Ashwalkers"
-	show_roundend_report = FALSE
-
 /datum/antagonist/ashwalker
 	name = "\improper Ash Walker"
 	job_rank = ROLE_LAVALAND
@@ -9,13 +5,13 @@
 	show_to_ghosts = TRUE
 	prevent_roundtype_conversion = FALSE
 	antagpanel_category = ANTAG_GROUP_ASHWALKERS
-	suicide_cry = "I HAVE NO IDEA WHAT THIS THING DOES!!"
+	suicide_cry = "FOR THE NECROPOLIS!!"
 	count_against_dynamic_roll_chance = FALSE
 	var/datum/team/ashwalkers/ashie_team
 
-/datum/antagonist/ashwalker/create_team(datum/team/team)
-	if(team)
-		ashie_team = team
+/datum/antagonist/ashwalker/create_team(datum/team/ashwalkers/ashwalker_team)
+	if(ashwalker_team)
+		ashie_team = ashwalker_team
 		objectives |= ashie_team.objectives
 	else
 		ashie_team = new
@@ -42,3 +38,7 @@
 
 	if(istype(A, /obj/structure/headpike))
 		owner.current.add_mood_event("oogabooga", /datum/mood_event/sacrifice_good)
+
+/datum/team/ashwalkers
+	name = "Ashwalkers"
+	show_roundend_report = FALSE

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -40,5 +40,28 @@
 		owner.current.add_mood_event("oogabooga", /datum/mood_event/sacrifice_good)
 
 /datum/team/ashwalkers
-	name = "Ashwalkers"
-	show_roundend_report = FALSE
+	name = "Ashwalker Tribe"
+	member_name = "Ashwalker"
+
+/datum/team/ashwalkers/roundend_report()
+	var/list/report = list()
+
+	report += "<span class='header'>An Ashwalker Tribe was discovered in the wastes:</span><br>"
+	report += "The [member_name]s were:"
+	report += printplayerlist(members)
+
+	var/datum/objective/protect_object/necropolis_objective = locate(/datum/objective/protect_object) in objectives
+
+	if(necropolis_objective)
+		objectives -= necropolis_objective //So we don't count it in the check for other objectives.
+		report += "<span class='header'>The [name] was tasked with defending their Necropolis:</span><br>"
+		if(necropolis_objective.check_completion())
+			report += span_greentext("The [name] successfully defended and served the Necropolis!")
+		else
+			report += span_redtext("The [name] failed to defend the Necropolis!")
+
+	if(length(objectives))
+		report += "<span class='header'>The [name]'s other objectives were:</span>"
+		printobjectives(objectives)
+
+	return "<div class='panel redborder'>[report.Join("<br>")]</div>"

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -40,8 +40,8 @@
 		owner.current.add_mood_event("oogabooga", /datum/mood_event/sacrifice_good)
 
 /datum/team/ashwalkers
-	name = "Ashwalker Tribe"
-	member_name = "Ashwalker"
+	name = "Ash Walker Tribe"
+	member_name = "Ash Walker"
 	///A list of "worthy" (meat-bearing) sacrifices made to the Necropolis
 	var/sacrifices_made = 0
 	///A list of how many eggs were created by the Necropolis
@@ -50,7 +50,7 @@
 /datum/team/ashwalkers/roundend_report()
 	var/list/report = list()
 
-	report += "<span class='header'>An Ashwalker Tribe inhabited the wastes...</span><br>"
+	report += "<span class='header'>An Ash Walker Tribe inhabited the wastes...</span><br>"
 	if(length(members)) //The team is generated alongside the tendril, and it's entirely possible that nobody takes the role.
 		report += "The [member_name]s were:"
 		report += printplayerlist(members)
@@ -69,7 +69,7 @@
 			report += "<span class='header'>The [name]'s other objectives were:</span>"
 			printobjectives(objectives)
 
-		report += "The [name] managed to perform <b>[sacrifices_made]</b> sacrifices to the Necropolis. From this, the Necropolis produced <b>[eggs_created]</b> Ashwalker eggs."
+		report += "The [name] managed to perform <b>[sacrifices_made]</b> sacrifices to the Necropolis. From this, the Necropolis produced <b>[eggs_created]</b> Ash Walker eggs."
 
 	else
 		report += "<b>But none of its eggs hatched!</b>"

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -46,7 +46,11 @@
 /datum/team/ashwalkers/roundend_report()
 	var/list/report = list()
 
-	report += "<span class='header'>An Ashwalker Tribe was discovered in the wastes:</span><br>"
+	report += "<span class='header'>An Ashwalker Tribe inhabited the wastes...</span><br>"
+	if(!length(members)) //The team is generated alongside the tendril, and it's entirely possible that nobody takes the role.
+		report += "<b>But none of it's eggs hatched!</b>"
+		return "<div class='panel redborder'>[report.Join("<br>")]</div>"
+
 	report += "The [member_name]s were:"
 	report += printplayerlist(members)
 
@@ -54,11 +58,11 @@
 
 	if(necropolis_objective)
 		objectives -= necropolis_objective //So we don't count it in the check for other objectives.
-		report += "<span class='header'>The [name] was tasked with defending their Necropolis:</span><br>"
+		report += "<b>The [name] was tasked with defending the Necropolis:</b>"
 		if(necropolis_objective.check_completion())
-			report += span_greentext("The [name] successfully defended and served the Necropolis!")
+			report += span_greentext("<span class='header'>The nest stands! Glory to the Necropolis!</span><br>")
 		else
-			report += span_redtext("The [name] failed to defend the Necropolis!")
+			report += span_redtext("<span class='header'>The Necropolis was destroyed...</span><br>")
 
 	if(length(objectives))
 		report += "<span class='header'>The [name]'s other objectives were:</span>"

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -50,7 +50,7 @@
 /datum/team/ashwalkers/roundend_report()
 	var/list/report = list()
 
-	report += "<span class='header'>An Ash Walker Tribe inhabited the wastes...</span><br>"
+	report += span_header("An Ash Walker Tribe inhabited the wastes...</span><br>")
 	if(length(members)) //The team is generated alongside the tendril, and it's entirely possible that nobody takes the role.
 		report += "The [member_name]s were:"
 		report += printplayerlist(members)
@@ -66,7 +66,7 @@
 				report += span_redtext("<span class='header'>The Necropolis was destroyed, the tribe has fallen...</span><br>")
 
 		if(length(objectives))
-			report += "<span class='header'>The [name]'s other objectives were:</span>"
+			report += span_header("The [name]'s other objectives were:")
 			printobjectives(objectives)
 
 		report += "The [name] managed to perform <b>[sacrifices_made]</b> sacrifices to the Necropolis. From this, the Necropolis produced <b>[eggs_created]</b> Ash Walker eggs."

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -72,6 +72,6 @@
 		report += "The [name] managed to perform <b>[sacrifices_made]</b> sacrifices to the Necropolis. From this, the Necropolis produced <b>[eggs_created]</b> Ashwalker eggs."
 
 	else
-		report += "<b>But none of it's eggs hatched!</b>"
+		report += "<b>But none of its eggs hatched!</b>"
 
 	return "<div class='panel redborder'>[report.Join("<br>")]</div>"

--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -24,6 +24,7 @@
 	ashies = new /datum/team/ashwalkers()
 	var/datum/objective/protect_object/objective = new
 	objective.set_target(src)
+	objective.team = ashies
 	linked_objective = objective
 	ashies.objectives += objective
 	START_PROCESSING(SSprocessing, src)

--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -31,6 +31,7 @@
 
 /obj/structure/lavaland/ash_walker/Destroy()
 	ashies = null
+	linked_objective = null
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 

--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -31,7 +31,6 @@
 
 /obj/structure/lavaland/ash_walker/Destroy()
 	ashies = null
-	QDEL_NULL(linked_objective)
 	STOP_PROCESSING(SSprocessing, src)
 	return ..()
 

--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -91,6 +91,7 @@
 					L.add_mood_event("oogabooga", /datum/mood_event/sacrifice_good)
 				else
 					L.add_mood_event("oogabooga", /datum/mood_event/sacrifice_bad)
+			ashies.sacrifices_made++
 
 /obj/structure/lavaland/ash_walker/proc/remake_walker(datum/mind/oldmind, oldname)
 	var/mob/living/carbon/human/M = new /mob/living/carbon/human(get_step(loc, pick(GLOB.alldirs)))
@@ -109,5 +110,6 @@
 		new /obj/effect/mob_spawn/ghost_role/human/ash_walker(get_step(loc, pick(GLOB.alldirs)), ashies)
 		visible_message(span_danger("One of the eggs swells to an unnatural size and tumbles free. It's ready to hatch!"))
 		meat_counter -= ASH_WALKER_SPAWN_THRESHOLD
+		ashies.eggs_created++
 
 #undef ASH_WALKER_SPAWN_THRESHOLD

--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -30,7 +30,6 @@
 	START_PROCESSING(SSprocessing, src)
 
 /obj/structure/lavaland/ash_walker/Destroy()
-	ashies.objectives -= linked_objective
 	ashies = null
 	QDEL_NULL(linked_objective)
 	STOP_PROCESSING(SSprocessing, src)


### PR DESCRIPTION
## About The Pull Request

This PR changes how ashwalkers are listed in the roundend report. Originally, they would be listed as individual "other" antagonists, which isn't a particularly great way of handling it and leads to weirdness like this:

![image](https://github.com/tgstation/tgstation/assets/28870487/c00a2cfc-3f08-46f6-a290-ef632cac0371)

_(That's an authentic ninja greentext from a live server, by the by)_

Now, the roundend report gives each ashwalker team their own section within the report, whether or not they succeeded, and some bonus stats.

![image](https://github.com/tgstation/tgstation/assets/28870487/c2dc3c00-62a7-4784-90be-5a8bb5cc5a50)

This new roundend report handling also supports having multiple Necropolises (Necropoli?) in the same round. Each tribe has their stats and success reported individually. 

This also slightly modifies the protect_object objective, preventing hard deletes when linked to objects that don't clear their own references.

## Why It's Good For The Game

Gives Ashwalkers a much better roundend report, and handles how the reporting is done in a much more sensible manner.

Reduces how much space that large nests take up with their individual listings.
## Changelog
:cl: Rhials
qol: Ashwalker roundend reporting has been revamped. Glory to the Necropolis!
/:cl:
