### PR TITLE
Fixes needless area placements on Lavaland

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -2883,7 +2883,7 @@
 	network = list("labor")
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp/security)
+/area/lavaland/surface/outdoors)
 "pZ" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -3464,7 +3464,7 @@
 "tL" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp/production)
+/area/lavaland/surface/outdoors)
 "tM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3502,12 +3502,6 @@
 	dir = 8
 	},
 /area/mine/laborcamp)
-"ub" = (
-/obj/machinery/camera/autoname/directional/east{
-	network = list("labor")
-	},
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/mine/laborcamp/production)
 "ui" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22240,7 +22234,7 @@ pU
 pU
 tL
 pU
-ub
+pV
 pU
 pU
 uU


### PR DESCRIPTION

## About The Pull Request

We don't need cameras to be placed in the area as long as they're connected to a wall in the area, this was just an old workaround that never got cleaned up.
## Why It's Good For The Game

We don't see weirdness with weather effects like this anymore, especially now that we don't need them anymore.

![image](https://github.com/tgstation/tgstation/assets/34697715/26ec90c3-3978-4c49-bb0f-927549575e27)

(this is removed)
## Changelog
I don't think it concerns players in any noticeable way.
