### PR TITLE
Monkey limb replacement fixes

### DIFF
--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -67,7 +67,7 @@
 	is_dimorphic = FALSE
 	wound_resistance = -10
 	bodytype = BODYTYPE_MONKEY | BODYTYPE_ORGANIC
-	acceptable_bodytype = BODYTYPE_HUMANOID
+	acceptable_bodytype = BODYTYPE_MONKEY
 	dmg_overlay_type = SPECIES_MONKEY
 
 /obj/item/bodypart/chest/alien

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -332,6 +332,7 @@
 	desc = "This item shouldn't exist. Talk about breaking a leg. Badum-Tss!"
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
+	bodytype = BODYTYPE_HUMANOID | BODYTYPE_MONKEY | BODYTYPE_ORGANIC
 	max_damage = 50
 	body_damage_coeff = 0.75
 	can_be_disabled = TRUE


### PR DESCRIPTION

## About The Pull Request
Fixes some problems that seem to have originated from #73325, allowing you to once again reattach severed monkey limbs and heads to monkey torsos. 

At time of writing, humanoid limbs are the ONLY candidates for prosthetic replacement surgeries on monkeys. This includes arms and heads which as far as I can tell is an unintended level of body horror.

This continues to let monkeys be given humanoid legs since the previously mentioned pr explicitly added support and tests for such.
## Why It's Good For The Game
Fix bugs/restore intended behavior 
Let me fix punpun, they deserve better
## Changelog
:cl:

fix: You can no longer attach humanoid heads/arms to monkeys
fix: You can once again attach monkey limbs to monkeys

/:cl:
