### PR TITLE
Fixes medical kiosk showing you random blood parameters if you have no blood/dna.

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -218,7 +218,7 @@
 			sickness = "Warning: Patient is harboring some form of viral disease. Seek further medical attention."
 			sickness_data = "\nName: [D.name].\nType: [D.spread_text].\nStage: [D.stage]/[D.max_stages].\nPossible Cure: [D.cure_text]"
 
-	if(patient.has_dna()) //Blood levels Information
+	if(!HAS_TRAIT(patient, TRAIT_GENELESS) && !HAS_TRAIT(patient, TRAIT_NOBLOOD)) //Blood levels Information
 		if(patient.is_bleeding())
 			bleed_status = "Patient is currently bleeding!"
 		if(blood_percent <= 80)


### PR DESCRIPTION

## About The Pull Request
Apparentely `if(patient.has_dna())` wasn't checking for anything so i replaced it with checks for traits such as TRAIT_GENELESS and TRAIT_NOBLOOD
## Why It's Good For The Game
You no longer have blood if you have no blood.
## Changelog
:cl:
fix: fixed medical kiosk showing you that you have blood if you don't have one.
/:cl:
