### PR TITLE
Abductees strapped to the abductor operating table are now properly layed down

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -842,7 +842,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	framestackamount = 1
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "bed"
-	can_buckle = 1
+	can_buckle = TRUE
+	buckle_lying = 90
 	/// Amount to inject per second
 	var/inject_am = 0.5
 


### PR DESCRIPTION

## About The Pull Request

This gives the abductor surgery table a buckle angle, so buckled humans lie down on it properly.

This wasn't an issue for sleeping test subjects, but awake ones would look like they're standing on the table instead of buckled.

This also changes a the table's can_buckle boolean arg from a 1 to a TRUE, because I was right next to it.
## Why It's Good For The Game

Reduces confusion, goofiness, etc.
## Changelog
:cl: Rhials
fix: Humans who wake up buckled to the abductor surgery table will no longer look as if they are standing on it.
/:cl:
