### PR TITLE
Adds a var to chemical reactions that allows them to take place in subtypes of their required container

### DIFF
--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -32,6 +32,7 @@
 	required_reagents = null
 	mob_react = FALSE
 	required_other = TRUE
+	required_container_accepts_subtypes = TRUE
 	required_container = /obj/item/reagent_containers/cup/soup_pot
 	mix_message = "You smell something good coming from the steaming pot of soup."
 	reaction_tags = REACTION_TAG_FOOD | REACTION_TAG_EASY

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -933,7 +933,10 @@
 					break
 				total_matching_catalysts++
 			if(cached_my_atom)
-				matching_container = reaction.required_container ? (cached_my_atom.type == reaction.required_container) : TRUE
+				if(reaction.required_container_accepts_subtypes)
+					matching_container = reaction.required_container ? (istype(cached_my_atom, reaction.required_container)) : TRUE
+				else
+					matching_container = reaction.required_container ? (cached_my_atom.type == reaction.required_container) : TRUE
 
 				if(isliving(cached_my_atom) && !reaction.mob_react) //Makes it so certain chemical reactions don't occur in mobs
 					matching_container = FALSE

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -934,9 +934,9 @@
 				total_matching_catalysts++
 			if(cached_my_atom)
 				if(reaction.required_container_accepts_subtypes)
-					matching_container = reaction.required_container ? (istype(cached_my_atom, reaction.required_container)) : TRUE
+					matching_container = !reaction.required_container || istype(cached_my_atom, reaction.required_container)
 				else
-					matching_container = reaction.required_container ? (cached_my_atom.type == reaction.required_container) : TRUE
+					matching_container = !reaction.required_container || cached_my_atom.type == reaction.required_container
 
 				if(isliving(cached_my_atom) && !reaction.mob_react) //Makes it so certain chemical reactions don't occur in mobs
 					matching_container = FALSE

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -13,7 +13,9 @@
 	///Required chemicals that must be present in the container but are not USED.
 	var/list/required_catalysts = new/list()
 
-	/// the exact container path required for the reaction to happen, typepath
+	/// If required_container will check for the exact type, or will also accept subtypes
+	var/required_container_accepts_subtypes = FALSE
+	/// If required_container_accepts_subtypes is FALSE, the exact type of what container this reaction can take place in. Otherwise, what type including subtypes are acceptable.
 	var/atom/required_container
 	/// an integer required for the reaction to happen
 	var/required_other = FALSE


### PR DESCRIPTION
## About The Pull Request

As the title may imply, a variable has been added to chemical reactions that'll make them check istype on the required container, rather than looking for the exact type path.
## Why It's Good For The Game

In my specific example, lets say I want to have sybtypes of soup pots. The current behavior doesn't allow for these subtypes of soup pots to actually make soup, which is sub-optimal.
