### PR TITLE
You can tip flashed borgs

### DIFF
--- a/code/datums/components/tippable.dm
+++ b/code/datums/components/tippable.dm
@@ -104,7 +104,7 @@
  * tipper - the mob tipping the tipped_mob
  */
 /datum/component/tippable/proc/try_tip(mob/living/tipped_mob, mob/tipper)
-	if(tipped_mob.stat != CONSCIOUS)
+	if(tipped_mob.stat != CONSCIOUS && !HAS_TRAIT(tipped_mob, TRAIT_FORCED_STANDING))
 		return
 
 	if(pre_tipped_callback?.Invoke(tipper))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -3,7 +3,7 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 
-	ADD_TRAIT(src, TRAIT_CAN_STRIP, INNATE_TRAIT)
+	add_traits(list(TRAIT_CAN_STRIP, TRAIT_FORCED_STANDING), INNATE_TRAIT)
 	AddComponent(/datum/component/tippable, \
 		tip_time = 3 SECONDS, \
 		untip_time = 2 SECONDS, \


### PR DESCRIPTION
## About The Pull Request

Fixes tippable not working on flashed mobs by letting it work on those who are forced standing even if they aren't conscious, then gives that trait to borgs.
I thought this would be the best fix for it because borgs technically are just forced standing anyways, and I didn't want to just add an issilicon check.

## Why It's Good For The Game

Fixes an old bug that I should've fixed a long time ago, makes tipping something that can realistically happen in-game.

## Changelog

:cl:
fix: Borgs can be tipped over while flashed.
/:cl: