### PR TITLE
Engineering, janitor and medical holosign projector changes. Much faster, more capacity, less integrity.

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -86,7 +86,7 @@
 	name = "custodial holobarrier projector"
 	desc = "A holographic projector that creates hard light wet floor barriers."
 	holosign_type = /obj/structure/holosign/barrier/wetsign
-	creation_time = 20
+	creation_time = 6
 	max_signs = 12
 
 /obj/item/holosign_creator/security
@@ -102,8 +102,8 @@
 	desc = "A holographic projector that creates holographic engineering barriers."
 	icon_state = "signmaker_engi"
 	holosign_type = /obj/structure/holosign/barrier/engineering
-	creation_time = 30
-	max_signs = 6
+	creation_time = 6
+	max_signs = 12
 
 /obj/item/holosign_creator/atmos
 	name = "ATMOS holofan projector"
@@ -118,8 +118,8 @@
 	desc = "A holographic projector that creates PENLITE holobarriers. Useful during quarantines since they halt those with malicious diseases."
 	icon_state = "signmaker_med"
 	holosign_type = /obj/structure/holosign/barrier/medical
-	creation_time = 30
-	max_signs = 3
+	creation_time = 6
+	max_signs = 6
 
 /obj/item/holosign_creator/cyborg
 	name = "Energy Barrier Projector"

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -86,7 +86,7 @@
 	name = "custodial holobarrier projector"
 	desc = "A holographic projector that creates hard light wet floor barriers."
 	holosign_type = /obj/structure/holosign/barrier/wetsign
-	creation_time = 0.6 SECONDS
+	creation_time = 1 SECONDS
 	max_signs = 12
 
 /obj/item/holosign_creator/security

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -102,7 +102,7 @@
 	desc = "A holographic projector that creates holographic engineering barriers."
 	icon_state = "signmaker_engi"
 	holosign_type = /obj/structure/holosign/barrier/engineering
-	creation_time = 0.6 SECONDS
+	creation_time = 1 SECONDS
 	max_signs = 12
 
 /obj/item/holosign_creator/atmos

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -86,7 +86,7 @@
 	name = "custodial holobarrier projector"
 	desc = "A holographic projector that creates hard light wet floor barriers."
 	holosign_type = /obj/structure/holosign/barrier/wetsign
-	creation_time = 6
+	creation_time = 0.6 SECONDS
 	max_signs = 12
 
 /obj/item/holosign_creator/security
@@ -94,7 +94,7 @@
 	desc = "A holographic projector that creates holographic security barriers."
 	icon_state = "signmaker_sec"
 	holosign_type = /obj/structure/holosign/barrier
-	creation_time = 30
+	creation_time = 3 SECONDS
 	max_signs = 6
 
 /obj/item/holosign_creator/engineering
@@ -102,7 +102,7 @@
 	desc = "A holographic projector that creates holographic engineering barriers."
 	icon_state = "signmaker_engi"
 	holosign_type = /obj/structure/holosign/barrier/engineering
-	creation_time = 6
+	creation_time = 0.6 SECONDS
 	max_signs = 12
 
 /obj/item/holosign_creator/atmos
@@ -118,13 +118,13 @@
 	desc = "A holographic projector that creates PENLITE holobarriers. Useful during quarantines since they halt those with malicious diseases."
 	icon_state = "signmaker_med"
 	holosign_type = /obj/structure/holosign/barrier/medical
-	creation_time = 6
+	creation_time = 0.6 SECONDS
 	max_signs = 6
 
 /obj/item/holosign_creator/cyborg
 	name = "Energy Barrier Projector"
 	desc = "A holographic projector that creates fragile energy fields."
-	creation_time = 15
+	creation_time = 1.5 SECONDS
 	max_signs = 9
 	holosign_type = /obj/structure/holosign/barrier/cyborg
 	var/shock = 0

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -118,7 +118,7 @@
 	desc = "A holographic projector that creates PENLITE holobarriers. Useful during quarantines since they halt those with malicious diseases."
 	icon_state = "signmaker_med"
 	holosign_type = /obj/structure/holosign/barrier/medical
-	creation_time = 0.6 SECONDS
+	creation_time = 1 SECONDS
 	max_signs = 6
 
 /obj/item/holosign_creator/cyborg

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -84,6 +84,7 @@
 	desc = "When it says walk it means walk."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "holosign"
+	max_integrity = 1
 
 /obj/structure/holosign/barrier/wetsign/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
@@ -97,6 +98,7 @@
 /obj/structure/holosign/barrier/engineering
 	icon_state = "holosign_engi"
 	rad_insulation = RAD_LIGHT_INSULATION
+	max_integrity = 1
 
 /obj/structure/holosign/barrier/atmos
 	name = "holofirelock"
@@ -150,6 +152,7 @@
 	desc = "A holobarrier that uses biometrics to detect human viruses. Denies passing to personnel with easily-detected, malicious viruses. Good for quarantines."
 	icon_state = "holo_medical"
 	alpha = 125 //lazy :)
+	max_integrity = 1
 	var/force_allaccess = FALSE
 	var/buzzcd = 0
 


### PR DESCRIPTION

## About The Pull Request
The engineering, janitor and medical holosign projectors can project their holosigns in 1 second. The holosign integrity has been reduced to 1. Engineering max capacity increased to 12, medical to 6.
## Why It's Good For The Game
The long time to project made these projectors, especially the engineering ones, impractical to use during an emergency that warrents their usage. Medical capacity increase allows them to block off a typical hallway, which could be used if there's a biohazard (60 gibbed monkeys, or botanist). Engineering capacity increase is warrented due to the nature of breaches and how large they can get.

The integrity reduction should help prevent them from being used to Fortnite people.
## Changelog
:cl:
balance: Engineering, janitor and medical holosign projector projection time reduced to 1 second.
balance: Engineering, janitor, and medical holosign integrity reduced to 1.
balance: Engineering holosign projector max capacity increased to 12.
balance: Medical holosign projector max capacity increased to 6.
/:cl:
