### PR TITLE
Gives plasmamen helmets maskless internals support

### DIFF
--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -4,7 +4,6 @@
 	uniform = /obj/item/clothing/under/plasmaman
 	gloves = /obj/item/clothing/gloves/color/plasmaman
 	head = /obj/item/clothing/head/helmet/space/plasmaman
-	mask = /obj/item/clothing/mask/breath
 	r_hand= /obj/item/tank/internals/plasmaman/belt/full
 	internals_slot = ITEM_SLOT_HANDS
 
@@ -44,7 +43,6 @@
 	uniform = /obj/item/clothing/under/plasmaman/medical
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 	head = /obj/item/clothing/head/helmet/space/plasmaman/medical
-	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/coroner
 	name = "Coroner Plasmaman"
@@ -52,7 +50,6 @@
 	uniform = /obj/item/clothing/under/plasmaman/coroner
 	gloves = /obj/item/clothing/gloves/color/plasmaman/black
 	head = /obj/item/clothing/head/helmet/space/plasmaman/coroner
-	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/paramedic
 	name = "Paramedic Plasmaman"
@@ -60,7 +57,6 @@
 	uniform = /obj/item/clothing/under/plasmaman/paramedic
 	gloves = /obj/item/clothing/gloves/color/plasmaman/plasmanitrile
 	head = /obj/item/clothing/head/helmet/space/plasmaman/paramedic
-	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/viro
 	name = "Virology Plasmaman"
@@ -68,7 +64,6 @@
 	uniform = /obj/item/clothing/under/plasmaman/viro
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 	head = /obj/item/clothing/head/helmet/space/plasmaman/viro
-	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/chemist
 	name = "Chemist Plasmaman"
@@ -76,7 +71,6 @@
 	uniform = /obj/item/clothing/under/plasmaman/chemist
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 	head = /obj/item/clothing/head/helmet/space/plasmaman/chemist
-	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/science
 	name = "Science Plasmaman"
@@ -228,7 +222,6 @@
 	uniform = /obj/item/clothing/under/plasmaman/chief_medical_officer
 	gloves = /obj/item/clothing/gloves/color/plasmaman/white
 	head = /obj/item/clothing/head/helmet/space/plasmaman/chief_medical_officer
-	mask = /obj/item/clothing/mask/breath/medical
 
 /datum/outfit/plasmaman/research_director
 	name = "Research Director Plasmaman"

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -44,7 +44,7 @@
 	desc = "A special containment helmet that allows plasma-based lifeforms to exist safely in an oxygenated environment. It is space-worthy, and may be worn in tandem with other EVA gear."
 	icon = 'icons/obj/clothing/head/plasmaman_hats.dmi'
 	worn_icon = 'icons/mob/clothing/head/plasmaman_head.dmi'
-	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT | PLASMAMAN_PREVENT_IGNITION
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT | PLASMAMAN_PREVENT_IGNITION | HEADINTERNALS
 	icon_state = "plasmaman-helm"
 	inhand_icon_state = "plasmaman-helm"
 	strip_delay = 80


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This allows plasmamen helmets to work for internals without needing breathing masks, just like most EVA helmets, and removes the masks from the plasmamen outfits that don't have a mask with unique features.

So Plasmamen still spawn with sechailers and clown masks with the plasma filter, but medical masks are gone as they don't have any utility outside of some disease protection interactions, which the helmet already covers, I think... tell me if I'm dumb and I will revert this one.

It was really silly that the species that is complete sealed from the enviroment or they would burn to death had the "Your helmet is not sealed!!!" error message when they tried to use their complete atmos sealed helmet without a mask.

I assume this was mostly an oversight with the PR that added maskless internal supports for helmets, EVA helmets all have it, even biosuits do, but plasmamen were left out.

Maint approval for species change:
![thank you John](https://github.com/tgstation/tgstation/assets/55374212/9784aec4-7092-451f-b682-ffc008d3a345)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This frees the mask slots of plasmamen that have been blocked forever, we won't have plasmamen chefs depressed they don't get to enjoy their moustache's accent, we also don't need to make plasmamen version of any job specific mask in the future (Tho that never happens, they were always left down...)

Pretty clear buff to Plasmamens as they can now be smokers, eat bubblegum, run around with a toast in their mouth, but the fungus people deserve to enjoy these "mostly" cute features without having to swap helmets.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
balance: Plasmamen won't spawn with breathing masks anymore as their helmet has maskless internals support now. Enjoy your moustache's accent plasmacooks!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
