### PR TITLE
Fixes  'Paintings leaving their frames #74707'

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -652,6 +652,8 @@
 
 /obj/structure/sign/painting/large/Initialize(mapload)
 	. = ..()
+	// Necessary so that the painting is framed correctly by the frame overlay when flipped.
+	ADD_KEEP_TOGETHER(src, INNATE_TRAIT)
 	if(mapload)
 		finalize_size()
 


### PR DESCRIPTION
## About The Pull Request
See the title and the relative bug report. Yes, this is a webedit.

The relative lines were removed by #74538. The author of that PR had apparently read the typepath wrong and therefore thought it was redundant (they were adding the TRAIT_KEEP_TOGETHER to canvases).

## Why It's Good For The Game
This will close #74707. Bugfix.

## Changelog

:cl:
fix: Fixed large paintings looking pretty off while flipped E/W.
/:cl:

~~My master branch might be quite outdated btw, I'll update it soon. >_>~~