### PR TITLE
Book patches

### DIFF
--- a/code/modules/library/bibles.dm
+++ b/code/modules/library/bibles.dm
@@ -246,6 +246,9 @@ GLOBAL_LIST_INIT(bibleitemstates, list(
 		playsound(target_mob, SFX_PUNCH, 25, TRUE, -1)
 		log_combat(user, target_mob, "attacked", src)
 
+/obj/item/book/bible/attackby_storage_insert(datum/storage, atom/storage_holder, mob/user)
+	return !istype(storage_holder, /obj/item/book/bible)
+
 /obj/item/book/bible/afterattack(atom/bible_smacked, mob/user, proximity_flag, click_parameters)
 	. = ..()
 	if(!proximity_flag)

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -179,14 +179,13 @@
 		return FALSE
 	//special check for wirecutter's because they don't have a sharp edge
 	if((carving_item.sharpness & SHARP_EDGED) || (carving_item.tool_behaviour == TOOL_WIRECUTTER))
-		return FALSE
-	//i love balloon alerts i love them sooo much
-	balloon_alert(user, "carving out...")
-	if(!do_after(user, 3 SECONDS, target = src))
-		balloon_alert(user, "interrupted!")
-		return FALSE
-	carve_out(carving_item, user)
-	return TRUE
+		//i love balloon alerts i love them sooo much
+		balloon_alert(user, "carving out...")
+		if(!do_after(user, 3 SECONDS, target = src))
+			balloon_alert(user, "interrupted!")
+			return FALSE
+		carve_out(carving_item, user)
+		return TRUE
 
 /// Called when the book gets carved successfully
 /obj/item/book/proc/carve_out(obj/item/carving_item, mob/living/user)

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -178,7 +178,7 @@
 	if(!user.combat_mode)
 		return FALSE
 	//special check for wirecutter's because they don't have a sharp edge
-	if((carving_item.tool_behaviour != TOOL_WIRECUTTER) && !(carving_item.sharpness & SHARP_EDGED))
+	if((carving_item.sharpness & SHARP_EDGED) || (carving_item.tool_behaviour == TOOL_WIRECUTTER))
 		return FALSE
 	//i love balloon alerts i love them sooo much
 	balloon_alert(user, "carving out...")

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -186,6 +186,7 @@
 			return FALSE
 		carve_out(carving_item, user)
 		return TRUE
+	return FALSE
 
 /// Called when the book gets carved successfully
 /obj/item/book/proc/carve_out(obj/item/carving_item, mob/living/user)

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -179,7 +179,6 @@
 		return FALSE
 	//special check for wirecutter's because they don't have a sharp edge
 	if((carving_item.sharpness & SHARP_EDGED) || (carving_item.tool_behaviour == TOOL_WIRECUTTER))
-		//i love balloon alerts i love them sooo much
 		balloon_alert(user, "carving out...")
 		if(!do_after(user, 3 SECONDS, target = src))
 			balloon_alert(user, "interrupted!")

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -177,11 +177,9 @@
 		return FALSE
 	if(!user.combat_mode)
 		return FALSE
-	//if it's not a knife or wirecutter(whose sharpness = null for some reason) check if it's any item that has a sharpe edge
-	if((carving_item.tool_behaviour != TOOL_KNIFE) && (carving_item.tool_behaviour != TOOL_WIRECUTTER))
-		//if not sharp enough return
-		if(!(carving_item.sharpness & SHARP_EDGED))
-			return FALSE
+	//special check for wirecutter's because they don't have a sharp edge
+	if((carving_item.tool_behaviour != TOOL_WIRECUTTER) && !(carving_item.sharpness & SHARP_EDGED))
+		return FALSE
 	//i love balloon alerts i love them sooo much
 	balloon_alert(user, "carving out...")
 	if(!do_after(user, 3 SECONDS, target = src))

--- a/code/modules/library/book.dm
+++ b/code/modules/library/book.dm
@@ -177,9 +177,12 @@
 		return FALSE
 	if(!user.combat_mode)
 		return FALSE
-	if(!((carving_item.sharpness & SHARP_EDGED) && (carving_item.tool_behaviour != TOOL_KNIFE) && (carving_item.tool_behaviour != TOOL_WIRECUTTER)))
-		return FALSE
-	//i hate balloon alerts i hate them so god damn much
+	//if it's not a knife or wirecutter(whose sharpness = null for some reason) check if it's any item that has a sharpe edge
+	if((carving_item.tool_behaviour != TOOL_KNIFE) && (carving_item.tool_behaviour != TOOL_WIRECUTTER))
+		//if not sharp enough return
+		if(!(carving_item.sharpness & SHARP_EDGED))
+			return FALSE
+	//i love balloon alerts i love them sooo much
 	balloon_alert(user, "carving out...")
 	if(!do_after(user, 3 SECONDS, target = src))
 		balloon_alert(user, "interrupted!")


### PR DESCRIPTION
## About The Pull Request
1. Fixes #75555 knives already have their `sharpness = SHARP_EDGED` so there's no need to explicitly type check for them and overall that if condition was just a mind blender, so it's better now
2. Fixes #75577 bibles can convert other bibles again and will not attempt to store it inside. Carrying over the fix that was implemented in #73137

## Changelog
:cl:
fix: wire cutter's can carve out book's again.
fix: bibles can convert other bibles
/:cl: