### PR TITLE
Adds new fire alarms to Birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -869,6 +869,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Cafeteria"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/security/prison/workout)
 "asn" = (
@@ -15421,7 +15422,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/light_switch/directional/east,
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
@@ -16369,7 +16369,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light_switch/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white/small,
 /area/station/science/cubicle)
 "gpS" = (
@@ -22368,6 +22368,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "iri" = (
@@ -24670,6 +24671,7 @@
 "jfQ" = (
 /obj/structure/cable,
 /obj/machinery/light/dim/directional/east,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "jfT" = (
@@ -26439,6 +26441,7 @@
 /turf/open/misc/sandy_dirt,
 /area/station/hallway/primary/central/fore)
 "jNZ" = (
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/smooth_half,
 /area/station/hallway/primary/central/fore)
 "jOb" = (
@@ -26646,6 +26649,11 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_recreation)
+"jSl" = (
+/obj/structure/filingcabinet/filingcabinet,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/grimy,
+/area/station/science/cubicle)
 "jSn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/bed,
@@ -28372,6 +28380,10 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
+"kxp" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/station/hallway/primary/starboard)
 "kxL" = (
 /turf/open/floor/iron/dark/small,
 /area/station/hallway/secondary/entry)
@@ -31173,6 +31185,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Garden"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half{
 	dir = 8
 	},
@@ -33117,6 +33130,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "mbp" = (
@@ -34184,6 +34198,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"mwN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "mwP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34344,7 +34366,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/sign/departments/cargo/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mAs" = (
@@ -39803,6 +39825,7 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/directional/south,
+/obj/structure/sign/departments/cargo/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
 "oAF" = (
@@ -40075,6 +40098,7 @@
 	name = "Warehouse"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_half,
 /area/station/cargo/storage)
 "oGm" = (
@@ -42426,6 +42450,14 @@
 "pwN" = (
 /turf/open/floor/iron/dark/small,
 /area/station/service/chapel/storage)
+"pwO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "pxj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42792,7 +42824,6 @@
 /area/station/security/execution/education)
 "pBV" = (
 /obj/structure/filingcabinet/filingcabinet,
-/obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "pCa" = (
@@ -43095,6 +43126,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light/cold/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "pHn" = (
@@ -44007,6 +44039,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
 "pVq" = (
@@ -45394,7 +45427,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/service/theater)
 "qrP" = (
@@ -48141,6 +48173,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "rld" = (
@@ -52621,6 +52654,7 @@
 	dir = 6
 	},
 /obj/machinery/light/small/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/station/service/theater)
 "sFW" = (
@@ -53048,6 +53082,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "sOp" = (
@@ -53476,6 +53511,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "sTR" = (
@@ -54448,6 +54484,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"tmQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "tmT" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two";
@@ -55133,6 +55180,7 @@
 "txl" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/machinery/camera/autoname/directional/north,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/hallway/primary/starboard)
 "txp" = (
@@ -57671,6 +57719,15 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"uny" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/fore)
 "unK" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -62208,6 +62265,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Cafeteria"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/security/prison/rec)
 "vJN" = (
@@ -63170,6 +63228,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/solars/starboard/fore)
+"vWA" = (
+/obj/effect/turf_decal/tile/brown/opposingcorners,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "vWF" = (
 /obj/docking_port/stationary/laborcamp_home/kilo{
 	dir = 4
@@ -66219,6 +66282,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Prison Workshop"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/security/prison/work)
 "wTu" = (
@@ -82536,8 +82600,8 @@ kdN
 ioJ
 kOq
 leI
-hNA
-lPi
+vWA
+lOj
 mnZ
 kdH
 nJU
@@ -88315,7 +88379,7 @@ gjm
 wjZ
 lka
 rYG
-oPV
+txN
 mbn
 ayV
 qRG
@@ -90785,7 +90849,7 @@ ofo
 mLi
 xJR
 sNL
-xJR
+uny
 xJR
 frI
 ldZ
@@ -91793,7 +91857,7 @@ lWk
 xRV
 vrn
 nAx
-wQB
+tmQ
 xRV
 xRV
 xRV
@@ -98218,7 +98282,7 @@ jOs
 mAv
 khS
 dIN
-vpI
+mwN
 jVM
 vMV
 oZr
@@ -99246,7 +99310,7 @@ mak
 tsF
 vrn
 uFG
-wQB
+tmQ
 tgl
 lut
 pbd
@@ -100535,13 +100599,13 @@ wNW
 lcn
 vpI
 vpI
-vpI
+pwO
 sfK
 vpI
 vpI
 nMW
 tEL
-vpI
+pwO
 vpI
 pjr
 vpI
@@ -100551,7 +100615,7 @@ vpI
 oXZ
 vpI
 vpI
-vpI
+pwO
 sIG
 vpI
 xDs
@@ -111348,7 +111412,7 @@ vDX
 gaU
 wbq
 vMC
-ygu
+kxp
 tSu
 uhj
 xSZ
@@ -116757,7 +116821,7 @@ wHg
 mbZ
 tpl
 xYK
-wHg
+jSl
 mbZ
 kse
 mUz


### PR DESCRIPTION

## About The Pull Request

ITPR I add a bunch of fire alarms all over birdshot to prevent (most) mantraps created by being stuck in a room with no fire alarm and no crowbar.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/75510

## Changelog
:cl:
fix: adds more fire alarms to birdshot.
/:cl:
