### PR TITLE
Adds a eye-dropper right-click function to the painting canvas.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_painting.dm
+++ b/code/__DEFINES/dcs/signals/signals_painting.dm
@@ -5,3 +5,6 @@
 
 /// from base of /item/canvas/ui_data(): (data)
 #define COMSIG_PAINTING_TOOL_GET_ADDITIONAL_DATA "painting_tool_get_data"
+
+///from base of /item/canvas/ui_act(), "change_color" action: (chosen_color, color_index)
+#define COMSIG_PAINTING_TOOL_PALETTE_COLOR_CHANGED "painting_tool_palette_color_changed"

--- a/code/datums/components/palette.dm
+++ b/code/datums/components/palette.dm
@@ -38,6 +38,7 @@
 	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(parent, COMSIG_PAINTING_TOOL_SET_COLOR, PROC_REF(on_painting_tool_set_color))
 	RegisterSignal(parent, COMSIG_PAINTING_TOOL_GET_ADDITIONAL_DATA, PROC_REF(get_palette_data))
+	RegisterSignal(parent, COMSIG_PAINTING_TOOL_PALETTE_COLOR_CHANGED, PROC_REF(palette_color_changed))
 
 /datum/component/palette/Destroy()
 	QDEL_NULL(color_picker_menu)
@@ -128,3 +129,14 @@
 			"is_selected" = hexcolor == selected_color
 		))
 	data["paint_tool_palette"] = painting_data
+
+/datum/component/palette/proc/palette_color_changed(datum/source, chosen_color, index)
+	SIGNAL_HANDLER
+
+	var/was_selected_color = selected_color == colors[index]
+	colors[index] = chosen_color
+	if(was_selected_color)
+		var/obj/item/parent_item = parent
+		parent_item.set_painting_tool_color(chosen_color)
+	else
+		update_radial_list()

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -128,11 +128,11 @@
 	.["editable"] = !finalized //Ideally you should be able to draw moustaches on existing paintings in the gallery but that's not implemented yet
 	.["show_plaque"] = istype(loc,/obj/structure/sign/painting)
 	var/obj/item/painting_implement = user.get_active_held_item()
+	if(!painting_implement)
+		return
 	.["paint_tool_color"] = get_paint_tool_color(painting_implement)
 	// Clearing additional data so that it doesn't linger around if the painting tool is dropped.
 	.["paint_tool_palette"] = null
-	if(!painting_implement)
-		return
 	SEND_SIGNAL(painting_implement, COMSIG_PAINTING_TOOL_GET_ADDITIONAL_DATA, .)
 
 /obj/item/canvas/examine(mob/user)

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -174,8 +174,8 @@
 			var/obj/item/painting_implement = user.get_active_held_item()
 			if(!painting_implement)
 				return FALSE
-			var/x = text2num(params["point_x"])
-			var/y = text2num(params["point_y"])
+			var/x = text2num(params["px"])
+			var/y = text2num(params["py"])
 			painting_implement.set_painting_tool_color(grid[x][y])
 			. = TRUE
 		if("change_palette")

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -169,6 +169,26 @@
 		if("select_color")
 			var/obj/item/painting_implement = user.get_active_held_item()
 			painting_implement?.set_painting_tool_color(params["selected_color"])
+			. = TRUE
+		if("select_color_from_coords")
+			var/obj/item/painting_implement = user.get_active_held_item()
+			if(!painting_implement)
+				return FALSE
+			var/x = text2num(params["point_x"])
+			var/y = text2num(params["point_y"])
+			painting_implement.set_painting_tool_color(grid[x][y])
+			. = TRUE
+		if("change_palette")
+			var/obj/item/painting_implement = user.get_active_held_item()
+			if(!painting_implement)
+				return FALSE
+			//I'd have this done inside the signal, but that'd have to be asynced,
+			//while we want the UI to be updated after the color is chosen, not before.
+			var/chosen_color = input(user, "Pick new color", painting_implement, params["old_color"]) as color|null
+			if(!chosen_color || IS_DEAD_OR_INCAP(user) || !user.is_holding(painting_implement))
+				return FALSE
+			SEND_SIGNAL(painting_implement, COMSIG_PAINTING_TOOL_PALETTE_COLOR_CHANGED, chosen_color, params["color_index"])
+			. = TRUE
 		if("finalize")
 			. = TRUE
 			finalize(user)

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -187,8 +187,7 @@ class PaintCanvas extends Component<PaintCanvasProps> {
         onMouseMove={this.handleDrawing}
         onMouseUp={this.handleEndDrawing}
         onMouseOut={this.handleEndDrawing}
-        onContextMenu={this.handleDropper}
-      >
+        onContextMenu={this.handleDropper}>
         Canvas failed to render.
       </canvas>
     );
@@ -236,8 +235,7 @@ export const Canvas = (props, context) => {
         75 +
         (data.show_plaque ? average_plaque_height : 0) +
         (data.editable && data.paint_tool_palette ? palette_height : 0)
-      }
-    >
+      }>
       <Window.Content>
         <Box textAlign="center">
           <PaintCanvas
@@ -303,8 +301,7 @@ export const Canvas = (props, context) => {
                 textColor="black"
                 textAlign="left"
                 backgroundColor="white"
-                style={{ 'border-style': 'inset' }}
-              >
+                style={{ 'border-style': 'inset' }}>
                 <Box mb={1} fontSize="18px" bold>
                   {decodeHtmlEntities(data.name)}
                 </Box>

--- a/tgui/packages/tgui/interfaces/Canvas.tsx
+++ b/tgui/packages/tgui/interfaces/Canvas.tsx
@@ -1,8 +1,8 @@
 import { Color } from 'common/color';
-import { decodeHtmlEntities } from 'common/string';
+import { multiline, decodeHtmlEntities } from 'common/string';
 import { Component, createRef, RefObject } from 'inferno';
 import { useBackend } from '../backend';
-import { Box, Button, Flex } from '../components';
+import { Tooltip, Icon, Box, Button, Flex } from '../components';
 import { Window } from '../layouts';
 
 const LEFT_CLICK = 0;
@@ -17,6 +17,7 @@ type PaintCanvasProps = Partial<{
   imageHeight: number;
   editable: boolean;
   drawing_color: string | null;
+  has_palette: boolean;
 }>;
 
 type PointData = {
@@ -164,6 +165,9 @@ class PaintCanvas extends Component<PaintCanvasProps> {
 
   handleDropper(event: MouseEvent) {
     event.preventDefault();
+    if (!this.props.has_palette) {
+      return;
+    }
     const coords = this.eventToCoords(event);
     this.onCanvasDropper(coords.x + 1, coords.y + 1); // 1-based index dm side
   }
@@ -226,7 +230,7 @@ export const Canvas = (props, context) => {
   const scaled_width = width * data.px_per_unit;
   const scaled_height = height * data.px_per_unit;
   const average_plaque_height = 90;
-  const palette_height = 36;
+  const palette_height = 44;
   return (
     <Window
       width={scaled_width + 72}
@@ -237,6 +241,31 @@ export const Canvas = (props, context) => {
         (data.editable && data.paint_tool_palette ? palette_height : 0)
       }>
       <Window.Content>
+        {!!data.paint_tool_palette && (
+          <Tooltip
+            content={
+              multiline`
+              You can Right-Click the canvas to change the color of  
+              the painting tool to that of the clicked pixel. 
+            ` +
+              (data.editable
+                ? multiline` 
+              \n You can also select a color from the 
+              palette at the bottom of the UI, 
+              or input a new one with Right-Click.
+            `
+                : '')
+            }>
+            <Icon
+              name="question-circle"
+              position="relative"
+              color="blue"
+              size={1.5}
+              m={0.5}
+            />
+            <br />
+          </Tooltip>
+        )}
         <Box textAlign="center">
           <PaintCanvas
             value={data.grid}
@@ -252,6 +281,7 @@ export const Canvas = (props, context) => {
               act('select_color_from_coords', { px: x, py: y })
             }
             editable={data.editable}
+            has_palette={!!data.paint_tool_palette}
           />
           <Flex align="center" justify="center" direction="column">
             {!!data.editable && !!data.paint_tool_palette && (


### PR DESCRIPTION
## About The Pull Request
Having used the painting UI to kill some time during long rounds for a decent chunk of the past year, the need of a quicker and less tedious way to fix a misclick or mistake like drawing over the wrong pixel has become clear to me, as well as getting some feedback on the palette component I made last year.

As the title suggests, this PR adds an eye-dropper function to the canvas. Right-Click a pixel on the canvas, and the painting tool will copy its color. Simple as, works on both finished and unfinished paintings. 

As a bonus, you can also right-click one of those selectable white/colored squares on the color scheme near the bottom of the UI (if using spraycan/palette) to change its color without having to go back to main game window and a radial menu.

EDIT: With the tooltip added to the UI, I can say it's ready.

## Why It's Good For The Game
This PR aims to add better options to change colors on the go and improve the user experience on the painting UI.

## Changelog

:cl:
qol: Adds a eye-dropper-like right-click function to the painting canvas UI. Right-Click a pixel on the canvas while holding a painting tool to have it copy its color.
qol: Also adds a right-click function to the color palette at the bottom of the UI to allow users to set its colors without having to alternate between the game window and the UI.
qol: Lastly, a tooltip has been added near the top-left corner of the same UI to let players know of these features.
/:cl:
