### PR TITLE
Install curl before attempting to install rust in TGS deps script

### DIFF
--- a/tools/tgs_scripts/InstallDeps.sh
+++ b/tools/tgs_scripts/InstallDeps.sh
@@ -3,6 +3,7 @@
 #find out what we have (+e is important for this)
 set +e
 has_git="$(command -v git)"
+has_curl="$(command -v curl)"
 has_cargo="$(command -v ~/.cargo/bin/cargo)"
 has_sudo="$(command -v sudo)"
 has_youtubedl="$(command -v youtube-dl)"
@@ -10,25 +11,25 @@ has_pip3="$(command -v pip3)"
 set -e
 set -x
 
+# apt packages, libssl needed by rust-g but not included in TGS barebones install
+if ! ( [ -x "$has_git" ] && [ -x "$has_curl" ] && [ -f "/usr/lib/i386-linux-gnu/libssl.so" ] ); then
+	echo "Installing apt dependencies..."
+	if ! [ -x "$has_sudo" ]; then
+		dpkg --add-architecture i386
+		apt-get update
+		apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386 curl
+	else
+		sudo dpkg --add-architecture i386
+		sudo apt-get update
+		sudo apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386 curl
+	fi
+fi
+
 # install cargo if needed
 if ! [ -x "$has_cargo" ]; then
 	echo "Installing rust..."
 	curl https://sh.rustup.rs -sSf | sh -s -- -y
 	. ~/.profile
-fi
-
-# apt packages, libssl needed by rust-g but not included in TGS barebones install
-if ! ( [ -x "$has_git" ] && [ -f "/usr/lib/i386-linux-gnu/libssl.so" ] ); then
-	echo "Installing apt dependencies..."
-	if ! [ -x "$has_sudo" ]; then
-		dpkg --add-architecture i386
-		apt-get update
-		apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386
-	else
-		sudo dpkg --add-architecture i386
-		sudo apt-get update
-		sudo apt-get install -y lib32z1 git pkg-config libssl-dev:i386 libssl-dev zlib1g-dev:i386
-	fi
 fi
 
 # install or update youtube-dl when not present, or if it is present with pip3,


### PR DESCRIPTION
TGS docker image had to drop libssl1.0.0 which it installed with a curl of a now 404'ing .deb.

Transitively, curl isn't installed in the TGS docker image anymore.

This fixes CI for changes that trigger the TGS integration job. i.e. #75570 and #75572 <- Please update master on these PRs after merging

I fucking despise distro package managers.

All in all we should have done this from the get-go.