### PR TITLE
Adds tracking for commendation hearts

### DIFF
--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -127,7 +127,7 @@
 #define STYLE_SCORE "Style Score"
 
 // DB ID for hearts received
-#define HEARTED_SCORE "Hearted Score"
+#define HEARTED_SCORE "Hearts Received"
 
 // Tourist related achievements and scores
 

--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -126,6 +126,9 @@
 // DB ID for style point count
 #define STYLE_SCORE "Style Score"
 
+// DB ID for hearts received
+#define HEARTED_SCORE "Hearted Score"
+
 // Tourist related achievements and scores
 
 //centcom grades (achievement)

--- a/code/__HELPERS/hearted.dm
+++ b/code/__HELPERS/hearted.dm
@@ -91,6 +91,7 @@
 /mob/proc/receive_heart(mob/heart_sender, duration = 24 HOURS, instant = FALSE)
 	if(!client)
 		return
+	client.give_award(/datum/award/score/hearted, src)
 	to_chat(heart_sender, span_nicegreen("Commendation sent!"))
 	message_admins("[key_name(heart_sender)] commended [key_name(src)] [instant ? "(instant)" : ""]")
 	log_admin("[key_name(heart_sender)] commended [key_name(src)] [instant ? "(instant)" : ""]")

--- a/code/datums/achievements/misc_scores.dm
+++ b/code/datums/achievements/misc_scores.dm
@@ -21,3 +21,9 @@
 	name = "Style Score"
 	desc = "You might not be a robot, but you were damn close."
 	database_id = STYLE_SCORE
+
+/// How many people have hearted you?
+/datum/award/score/hearted
+	name = "Hearts Received"
+	desc = "Nobody Loves Me."
+	database_id = HEARTED_SCORE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -1129,7 +1129,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	var/new_duration = world.realtime + duration
 	if(prefs.hearted_until > new_duration)
 		return
-	to_chat(src, span_nicegreen("Someone awarded you a heart!"))
+	to_chat(src, span_nicegreen("Someone awarded you a heart! You've received [get_award_status(/datum/award/score/hearted)] in total!"))
 	prefs.hearted_until = new_duration
 	prefs.hearted = TRUE
 	prefs.save_preferences()


### PR DESCRIPTION
## About The Pull Request

Adds tracking of how many commendation hearts a player has received.

## Why It's Good For The Game

Those end of round commendations don't vanish into the ether, instead you can see how many you have... or lack.

## Changelog

:cl: LT3
add: Earn those hearts! Hearts received are now added to the leaderboard
/:cl: