### PR TITLE
Fixes bypassing integrated circuit cooldowns with module components.

### DIFF
--- a/code/modules/wiremod/components/action/soundemitter.dm
+++ b/code/modules/wiremod/components/action/soundemitter.dm
@@ -84,7 +84,10 @@
 	else
 		ui_color = initial(ui_color)
 
-	if(TIMER_COOLDOWN_CHECK(parent, COOLDOWN_CIRCUIT_SOUNDEMITTER))
+	if(!parent.shell)
+		return
+
+	if(TIMER_COOLDOWN_CHECK(parent.shell, COOLDOWN_CIRCUIT_SOUNDEMITTER))
 		return
 
 	var/sound_to_play = options_map[sound_file.value]
@@ -99,4 +102,4 @@
 
 	playsound(src, sound_to_play, actual_volume, TRUE, frequency = actual_frequency)
 
-	TIMER_COOLDOWN_START(parent, COOLDOWN_CIRCUIT_SOUNDEMITTER, sound_cooldown)
+	TIMER_COOLDOWN_START(parent.shell, COOLDOWN_CIRCUIT_SOUNDEMITTER, sound_cooldown)

--- a/code/modules/wiremod/components/action/speech.dm
+++ b/code/modules/wiremod/components/action/speech.dm
@@ -30,10 +30,6 @@
 		return
 
 	if(message.value)
-		var/atom/movable/shell = parent
-		// Prevents appear as the individual component if there is a shell.
-		if(shell)
-			shell.say(message.value, forced = "circuit speech | [key_name(parent.get_creator())]")
-		else
-			say(message.value, forced = "circuit speech | [parent.get_creator()]")
+		var/atom/movable/shell = parent.shell
+		shell.say(message.value, forced = "circuit speech | [key_name(parent.get_creator())]")
 		TIMER_COOLDOWN_START(parent.shell, COOLDOWN_CIRCUIT_SPEECH, speech_cooldown)

--- a/code/modules/wiremod/components/action/speech.dm
+++ b/code/modules/wiremod/components/action/speech.dm
@@ -23,15 +23,17 @@
 	message = add_input_port("Message", PORT_TYPE_STRING, trigger = null)
 
 /obj/item/circuit_component/speech/input_received(datum/port/input/port)
+	if(!parent.shell)
+		return
 
-	if(TIMER_COOLDOWN_CHECK(parent, COOLDOWN_CIRCUIT_SPEECH))
+	if(TIMER_COOLDOWN_CHECK(parent.shell, COOLDOWN_CIRCUIT_SPEECH))
 		return
 
 	if(message.value)
-		var/atom/movable/shell = parent.shell
+		var/atom/movable/shell = parent
 		// Prevents appear as the individual component if there is a shell.
 		if(shell)
 			shell.say(message.value, forced = "circuit speech | [key_name(parent.get_creator())]")
 		else
 			say(message.value, forced = "circuit speech | [parent.get_creator()]")
-		TIMER_COOLDOWN_START(parent, COOLDOWN_CIRCUIT_SPEECH, speech_cooldown)
+		TIMER_COOLDOWN_START(parent.shell, COOLDOWN_CIRCUIT_SPEECH, speech_cooldown)

--- a/code/modules/wiremod/components/action/speech.dm
+++ b/code/modules/wiremod/components/action/speech.dm
@@ -32,4 +32,4 @@
 	if(message.value)
 		var/atom/movable/shell = parent.shell
 		shell.say(message.value, forced = "circuit speech | [key_name(parent.get_creator())]")
-		TIMER_COOLDOWN_START(parent.shell, COOLDOWN_CIRCUIT_SPEECH, speech_cooldown)
+		TIMER_COOLDOWN_START(shell, COOLDOWN_CIRCUIT_SPEECH, speech_cooldown)

--- a/code/modules/wiremod/components/bci/hud/target_intercept.dm
+++ b/code/modules/wiremod/components/bci/hud/target_intercept.dm
@@ -35,11 +35,14 @@
 	if(!bci)
 		return
 
+	if(!parent.shell)
+		return
+
 	var/mob/living/owner = bci.owner
 	if(!owner || !istype(owner) || !owner.client)
 		return
 
-	if(TIMER_COOLDOWN_CHECK(parent, COOLDOWN_CIRCUIT_TARGET_INTERCEPT))
+	if(TIMER_COOLDOWN_CHECK(parent.shell, COOLDOWN_CIRCUIT_TARGET_INTERCEPT))
 		return
 
 	to_chat(owner, "<B>Left-click to trigger target interceptor!</B>")
@@ -55,7 +58,8 @@
 	user.client.click_intercept = null
 	clicked_atom.set_output(object)
 	trigger_output.set_output(COMPONENT_SIGNAL)
-	TIMER_COOLDOWN_START(parent, COOLDOWN_CIRCUIT_TARGET_INTERCEPT, intercept_cooldown)
+	if(parent.shell)
+		TIMER_COOLDOWN_START(parent.shell, COOLDOWN_CIRCUIT_TARGET_INTERCEPT, intercept_cooldown)
 
 /obj/item/circuit_component/target_intercept/get_ui_notices()
 	. = ..()

--- a/code/modules/wiremod/components/sensors/view_sensor.dm
+++ b/code/modules/wiremod/components/sensors/view_sensor.dm
@@ -34,7 +34,10 @@
 	. += create_ui_notice("Scan Cooldown: [DisplayTimeText(view_cooldown)]", "orange", "stopwatch")
 
 /obj/item/circuit_component/view_sensor/input_received(datum/port/input/port)
-	if(TIMER_COOLDOWN_CHECK(parent, COOLDOWN_CIRCUIT_VIEW_SENSOR))
+	if(!parent.shell)
+		return
+
+	if(TIMER_COOLDOWN_CHECK(parent.shell, COOLDOWN_CIRCUIT_VIEW_SENSOR))
 		result.set_output(null)
 		cooldown.set_output(COMPONENT_SIGNAL)
 		return
@@ -66,4 +69,4 @@
 		object_list += target
 
 	result.set_output(object_list)
-	TIMER_COOLDOWN_START(parent, COOLDOWN_CIRCUIT_VIEW_SENSOR, view_cooldown)
+	TIMER_COOLDOWN_START(parent.shell, COOLDOWN_CIRCUIT_VIEW_SENSOR, view_cooldown)


### PR DESCRIPTION

## About The Pull Request
See title.
In order for this change to work, these components will not work if there is no shell, but this will change nothing user-facing because all player-facing circuits require shells to function in the first place anyways.

## Why It's Good For The Game
Fixes a cooldown bypass bug.

Closes #75580

## Changelog
:cl:
fix: Fixed bypassing component cooldowns with module components.
/:cl:
