### PR TITLE
Makes golems unaugmentable (the surgery) + makes amputation check for nodismember trait

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -7,6 +7,7 @@
 		NOTRANSSTING,
 		NO_UNDERWEAR,
 		NOEYEHOLES,
+		NOAUGMENTS,
 	)
 	inherent_traits = list(
 		TRAIT_GENELESS,

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -18,6 +18,11 @@
 		/datum/surgery_step/sever_limb,
 	)
 
+/datum/surgery/amputation/can_start(mob/user, mob/living/patient)
+	if(HAS_TRAIT(target, TRAIT_NODISMEMBER))
+		return FALSE
+	return ..()
+
 /datum/surgery_step/sever_limb
 	name = "sever limb (circular saw)"
 	implements = list(
@@ -33,9 +38,6 @@
 	success_sound = 'sound/surgery/organ2.ogg'
 
 /datum/surgery_step/sever_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(HAS_TRAIT(target, TRAIT_NODISMEMBER))
-		to_chat(user, span_warning("You fail to amputate [target]'s [parse_zone(target_zone)]!"))
-		return SURGERY_STEP_FAIL
 	display_results(
 		user,
 		target,

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -18,7 +18,6 @@
 		/datum/surgery_step/sever_limb,
 	)
 
-
 /datum/surgery_step/sever_limb
 	name = "sever limb (circular saw)"
 	implements = list(
@@ -34,6 +33,9 @@
 	success_sound = 'sound/surgery/organ2.ogg'
 
 /datum/surgery_step/sever_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(HAS_TRAIT(target, TRAIT_NODISMEMBER))
+		to_chat(user, span_warning("You fail to amputate [target]'s [parse_zone(target_zone)]!"))
+		return SURGERY_STEP_FAIL
 	display_results(
 		user,
 		target,


### PR DESCRIPTION
## About The Pull Request
golems get the NOAUGMENTS species trait (stops augmentation surgery)
amputation surgery checks for TRAIT_NODISMEMBER when finishing
## Why It's Good For The Game

goofy ahh whip and naenae armor
i shit you not i watched 5 people one with a desword and several with rather good weaponry take 25 seconds to kill a stunned golem with augments

## Changelog
:cl:
balance: You can no longer augment golems
balance: You can no longer amputate undismemberable traits
/:cl:
