### PR TITLE
Hulk can no longer two shot dragon portals

### DIFF
--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -90,6 +90,9 @@
 	fire = 100
 	acid = 100
 
+/obj/structure/carp_rift/hulk_damage()
+	return 30
+
 /obj/structure/carp_rift/Initialize(mapload)
 	. = ..()
 


### PR DESCRIPTION

## About The Pull Request
Drops the damage carp rifts take from hulk to 30 (Was 150).
## Why It's Good For The Game
Closes #74925

Dragon is supposed to be a round ending threat if left unchecked. But at the moment there's a number of ways you can cheese it completely if you get within spitting distance of the portal. This pretty much prevents dragon from getting blue balled because one guy in an EVA suit rushed their portal before they could intercept without making hulk worthless  (30 damage is still nothing to sneeze at when welders and other melee weapons barely break 20).
## Changelog
:cl:
balance: Hulk damage to portals lowered to 30 (Was 150)
/:cl:
