### PR TITLE
Newly created areas are no longer cult permitted

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -500,8 +500,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	power_light = FALSE
 	power_environ = FALSE
 	always_unpowered = FALSE
-	area_flags &= ~VALID_TERRITORY
-	area_flags &= ~BLOBS_ALLOWED
+	area_flags &= ~(VALID_TERRITORY|BLOBS_ALLOWED|CULT_PERMITTED)
 	require_area_resort()
 /**
  * Set the area size of the area


### PR DESCRIPTION
## About The Pull Request

This is a continuation of https://github.com/tgstation/tgstation/pull/73757 because I messed up and didn't bother removing this as well.
The reasoning for it is the same as that, so this is basically a copy paste of it.

## Why It's Good For The Game

One of the drawbacks of Cult is that they get stronger throughout a round, at the cost of slowly becoming easier to spot due to their base locations, so being to completely bypass the negative part makes it unfair to fight cult if there's a single player between them that can take the aux base's mats and make a 4x4 rom in space or on icemoon.

Finally closes https://github.com/tgstation/tgstation/issues/47747

## Changelog

:cl:
balance: Newly created areas in Icemoon and Space are no longer valid Cult areas for Runes and such.
/:cl: