### PR TITLE
Fixes the sparring contract.

### DIFF
--- a/code/modules/religion/sparring/sparring_contract.dm
+++ b/code/modules/religion/sparring/sparring_contract.dm
@@ -39,6 +39,7 @@
 	data["set_area"] = arena?.name
 	data["set_stakes"] = stakes_condition
 	data["possible_areas"] = get_possible_areas()
+	data["stakes_holy_match"] = STAKES_HOLY_MATCH
 
 	return data
 

--- a/tgui/packages/tgui/interfaces/SparringContract.tsx
+++ b/tgui/packages/tgui/interfaces/SparringContract.tsx
@@ -50,7 +50,7 @@ export const SparringContract = (props, context) => {
     right_sign,
     in_area,
     no_chaplains,
-	stakes_holy_match,
+    stakes_holy_match,
   } = data;
   const [weapon, setWeapon] = useLocalState(context, 'weapon', set_weapon);
   const [area, setArea] = useLocalState(context, 'area', set_area);

--- a/tgui/packages/tgui/interfaces/SparringContract.tsx
+++ b/tgui/packages/tgui/interfaces/SparringContract.tsx
@@ -35,6 +35,7 @@ type Info = {
   right_sign: string;
   in_area: BooleanLike;
   no_chaplains: BooleanLike;
+  stakes_holy_match: number;
   possible_areas: Array<string>;
 };
 

--- a/tgui/packages/tgui/interfaces/SparringContract.tsx
+++ b/tgui/packages/tgui/interfaces/SparringContract.tsx
@@ -4,9 +4,6 @@ import { useBackend, useLocalState } from '../backend';
 import { BlockQuote, Button, Dropdown, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
-// defined this so the code is more readable
-const STAKES_HOLY_MATCH = 1;
-
 const weaponlist = [
   'Fist Fight',
   'Ceremonial Weapons',
@@ -52,6 +49,7 @@ export const SparringContract = (props, context) => {
     right_sign,
     in_area,
     no_chaplains,
+	stakes_holy_match,
   } = data;
   const [weapon, setWeapon] = useLocalState(context, 'weapon', set_weapon);
   const [area, setArea] = useLocalState(context, 'area', set_area);
@@ -185,7 +183,7 @@ export const SparringContract = (props, context) => {
                   <Button
                     disabled={
                       !in_area ||
-                      (no_chaplains && set_stakes === STAKES_HOLY_MATCH)
+                      (no_chaplains && set_stakes === stakes_holy_match)
                     }
                     icon="fist-raised"
                     onClick={() => act('fight')}>


### PR DESCRIPTION
## About The Pull Request
SparringContract.tsx was using its own constant STAKES_HOLY_MATCH, **not** imported from dm data and of a different value, which resulted in players being unable to use it unless one of the two contestants happened to be a chaplain.

## Why It's Good For The Game
This will fix #75530.

## Changelog

:cl:
fix: Fixes the sparring contract. You can now spar with no stakes and just for fun.
/:cl:

