### PR TITLE
Fixes mind traits (Curator, Miner, Clown)

### DIFF
--- a/code/datums/elements/befriend_petting.dm
+++ b/code/datums/elements/befriend_petting.dm
@@ -36,7 +36,7 @@
 	if (user.combat_mode)
 		return // We'll deal with this later
 	if (owner.stat == DEAD)
-		var/additional_text = HAS_TRAIT(user, TRAIT_NAIVE) || HAS_TRAIT(user.mind, TRAIT_NAIVE) ? "It looks like [owner.p_theyre()] sleeping." : "[owner.p_they(capitalized = TRUE)] seem[owner.p_s()] to be dead."
+		var/additional_text = HAS_TRAIT(user.mind, TRAIT_NAIVE) ? "It looks like [owner.p_theyre()] sleeping." : "[owner.p_they(capitalized = TRUE)] seem[owner.p_s()] to be dead."
 		to_chat(user, span_warning("[owner] feels cold to the touch. [additional_text]"))
 		return
 	if (owner.stat != CONSCIOUS)

--- a/code/datums/status_effects/debuffs/tower_of_babel.dm
+++ b/code/datums/status_effects/debuffs/tower_of_babel.dm
@@ -15,7 +15,8 @@
 	owner.add_blocked_language(GLOB.all_languages - random_language, source = LANGUAGE_BABEL)
 	// this lets us bypass tongue language restrictions except for people who have stuff like mute,
 	// no tongue, tongue tied, etc. curse of babel shouldn't let people who have a tongue disability speak
-	ADD_TRAIT(owner.mind, TRAIT_TOWER_OF_BABEL, trait_source)
+	if(owner.mind)
+		ADD_TRAIT(owner.mind, TRAIT_TOWER_OF_BABEL, trait_source)
 	owner.add_mood_event(id, /datum/mood_event/tower_of_babel)
 	return ..()
 
@@ -25,7 +26,8 @@
 	owner.remove_blocked_language(GLOB.all_languages, source = LANGUAGE_BABEL)
 	owner.remove_all_languages(source = LANGUAGE_BABEL)
 	owner.update_atom_languages()
-	REMOVE_TRAIT(owner.mind, TRAIT_TOWER_OF_BABEL, trait_source)
+	if(owner.mind)
+		REMOVE_TRAIT(owner.mind, TRAIT_TOWER_OF_BABEL, trait_source)
 	return ..()
 
 // Used by wizard magic and tower of babel event

--- a/code/datums/status_effects/debuffs/tower_of_babel.dm
+++ b/code/datums/status_effects/debuffs/tower_of_babel.dm
@@ -15,7 +15,7 @@
 	owner.add_blocked_language(GLOB.all_languages - random_language, source = LANGUAGE_BABEL)
 	// this lets us bypass tongue language restrictions except for people who have stuff like mute,
 	// no tongue, tongue tied, etc. curse of babel shouldn't let people who have a tongue disability speak
-	ADD_TRAIT(owner, TRAIT_TOWER_OF_BABEL, trait_source)
+	ADD_TRAIT(owner.mind, TRAIT_TOWER_OF_BABEL, trait_source)
 	owner.add_mood_event(id, /datum/mood_event/tower_of_babel)
 	return ..()
 
@@ -25,7 +25,7 @@
 	owner.remove_blocked_language(GLOB.all_languages, source = LANGUAGE_BABEL)
 	owner.remove_all_languages(source = LANGUAGE_BABEL)
 	owner.update_atom_languages()
-	REMOVE_TRAIT(owner, TRAIT_TOWER_OF_BABEL, trait_source)
+	REMOVE_TRAIT(owner.mind, TRAIT_TOWER_OF_BABEL, trait_source)
 	return ..()
 
 // Used by wizard magic and tower of babel event

--- a/code/datums/weather/weather_types/snow_storm.dm
+++ b/code/datums/weather/weather_types/snow_storm.dm
@@ -39,7 +39,7 @@
 	if(isobserver(player))
 		return TRUE
 
-	if(HAS_TRAIT(player, TRAIT_DETECT_STORM))
+	if(HAS_TRAIT(player, TRAIT_DETECT_STORM) || HAS_TRAIT(player.mind, TRAIT_DETECT_STORM))
 		return TRUE
 
 	if(istype(get_area(player), /area/mine))

--- a/code/modules/antagonists/clown_ops/clownop.dm
+++ b/code/modules/antagonists/clown_ops/clownop.dm
@@ -19,11 +19,11 @@
 /datum/antagonist/nukeop/clownop/apply_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/L = owner.current || mob_override
-	ADD_TRAIT(L, TRAIT_NAIVE, CLOWNOP_TRAIT)
+	ADD_TRAIT(L.mind, TRAIT_NAIVE, CLOWNOP_TRAIT)
 
 /datum/antagonist/nukeop/clownop/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/L = owner.current || mob_override
-	REMOVE_TRAIT(L, TRAIT_NAIVE, CLOWNOP_TRAIT)
+	REMOVE_TRAIT(L.mind, TRAIT_NAIVE, CLOWNOP_TRAIT)
 	return ..()
 
 /datum/antagonist/nukeop/clownop/equip_op()
@@ -51,11 +51,11 @@
 /datum/antagonist/nukeop/leader/clownop/apply_innate_effects(mob/living/mob_override)
 	. = ..()
 	var/mob/living/L = owner.current || mob_override
-	ADD_TRAIT(L, TRAIT_NAIVE, CLOWNOP_TRAIT)
+	ADD_TRAIT(L.mind, TRAIT_NAIVE, CLOWNOP_TRAIT)
 
 /datum/antagonist/nukeop/leader/clownop/remove_innate_effects(mob/living/mob_override)
 	var/mob/living/L = owner.current || mob_override
-	REMOVE_TRAIT(L, TRAIT_NAIVE, CLOWNOP_TRAIT)
+	REMOVE_TRAIT(L.mind, TRAIT_NAIVE, CLOWNOP_TRAIT)
 	return ..()
 
 /datum/antagonist/nukeop/leader/clownop/equip_op()

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -284,7 +284,7 @@
 	..()
 	if(visualsOnly)
 		return
-	ADD_TRAIT(H, TRAIT_NAIVE, INNATE_TRAIT)
+	ADD_TRAIT(H.mind, TRAIT_NAIVE, INNATE_TRAIT)
 	H.dna.add_mutation(/datum/mutation/human/clumsy)
 	for(var/datum/mutation/human/clumsy/M in H.dna.mutations)
 		M.mutadone_proof = TRUE

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -20,7 +20,7 @@
 
 	user.grant_language(language)
 	user.remove_blocked_language(language, source=LANGUAGE_ALL)
-	ADD_TRAIT(user, TRAIT_TOWER_OF_BABEL, MAGIC_TRAIT) // this makes you immune to babel effects
+	ADD_TRAIT(user.mind, TRAIT_TOWER_OF_BABEL, MAGIC_TRAIT) // this makes you immune to babel effects
 
 	use_charge(user)
 

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -505,7 +505,7 @@
 	cure_curse_of_babel(user) // removes tower of babel if we have it
 	user.grant_all_languages(source=LANGUAGE_BABEL)
 	user.remove_blocked_language(GLOB.all_languages, source = LANGUAGE_ALL)
-	ADD_TRAIT(user, TRAIT_TOWER_OF_BABEL, MAGIC_TRAIT) // this makes you immune to babel effects
+	ADD_TRAIT(user.mind, TRAIT_TOWER_OF_BABEL, MAGIC_TRAIT) // this makes you immune to babel effects
 	new /obj/effect/decal/cleanable/ash(get_turf(user))
 	qdel(src)
 

--- a/code/modules/mob/living/carbon/carbon_say.dm
+++ b/code/modules/mob/living/carbon/carbon_say.dm
@@ -10,6 +10,6 @@
 	var/obj/item/organ/internal/tongue/spoken_with = get_organ_slot(ORGAN_SLOT_TONGUE)
 	if(spoken_with)
 		// the tower of babel needs to bypass the tongue language restrictions without giving omnitongue
-		return HAS_TRAIT(src, TRAIT_TOWER_OF_BABEL) || spoken_with.could_speak_language(language_path)
+		return HAS_TRAIT(mind, TRAIT_TOWER_OF_BABEL) || spoken_with.could_speak_language(language_path)
 
 	return initial(language_path.flags) & TONGUELESS_SPEECH

--- a/code/modules/mob/living/carbon/carbon_say.dm
+++ b/code/modules/mob/living/carbon/carbon_say.dm
@@ -10,6 +10,6 @@
 	var/obj/item/organ/internal/tongue/spoken_with = get_organ_slot(ORGAN_SLOT_TONGUE)
 	if(spoken_with)
 		// the tower of babel needs to bypass the tongue language restrictions without giving omnitongue
-		return HAS_TRAIT(mind, TRAIT_TOWER_OF_BABEL) || spoken_with.could_speak_language(language_path)
+		return (mind && HAS_TRAIT(mind, TRAIT_TOWER_OF_BABEL)) || spoken_with.could_speak_language(language_path)
 
 	return initial(language_path.flags) & TONGUELESS_SPEECH

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -115,7 +115,7 @@
 		var/obj/item/clothing/glasses/G = get_item_by_slot(ITEM_SLOT_EYES)
 		var/are_we_in_weekend_at_bernies = G?.tint && buckled && istype(buckled, /obj/vehicle/ridden/wheelchair)
 
-		if(isliving(user) && (HAS_TRAIT(user, TRAIT_NAIVE) || are_we_in_weekend_at_bernies))
+		if(isliving(user) && (HAS_TRAIT(user.mind, TRAIT_NAIVE) || are_we_in_weekend_at_bernies))
 			just_sleeping = TRUE
 
 		if(!just_sleeping)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -141,7 +141,7 @@
 /mob/living/simple_animal/parrot/examine(mob/user)
 	. = ..()
 	if(stat)
-		if(HAS_TRAIT(user, TRAIT_NAIVE))
+		if(HAS_TRAIT(user.mind, TRAIT_NAIVE))
 			. += pick("It seems tired and shagged out after a long squawk.", "It seems to be pining for the fjords.", "It's resting. It's a beautiful bird. Lovely plumage.")
 		else
 			. += pick("This parrot is no more.","This is a late parrot.","This is an ex-parrot.")

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -140,11 +140,21 @@
 
 /mob/living/simple_animal/parrot/examine(mob/user)
 	. = ..()
-	if(stat)
-		if(HAS_TRAIT(user.mind, TRAIT_NAIVE))
-			. += pick("It seems tired and shagged out after a long squawk.", "It seems to be pining for the fjords.", "It's resting. It's a beautiful bird. Lovely plumage.")
-		else
-			. += pick("This parrot is no more.","This is a late parrot.","This is an ex-parrot.")
+	if(stat != DEAD)
+		return
+
+	if(HAS_TRAIT(user.mind, TRAIT_NAIVE))
+		. += pick(
+			"It seems tired and shagged out after a long squawk.",
+			"It seems to be pining for the fjords.",
+			"It's resting. It's a beautiful bird. Lovely plumage.",
+		)
+	else
+		. += pick(
+			"This parrot is no more.",
+			"This is a late parrot.",
+			"This is an ex-parrot.",
+		)
 
 /mob/living/simple_animal/parrot/death(gibbed)
 	if(held_item)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -227,7 +227,7 @@
 /mob/living/simple_animal/examine(mob/user)
 	. = ..()
 	if(stat == DEAD)
-		if(HAS_TRAIT(user, TRAIT_NAIVE))
+		if(HAS_TRAIT(user.mind, TRAIT_NAIVE))
 			. += span_deadsay("Upon closer examination, [p_they()] appear[p_s()] to be asleep.")
 		else
 			. += span_deadsay("Upon closer examination, [p_they()] appear[p_s()] to be dead.")

--- a/code/modules/spells/spell_types/tower_of_babel.dm
+++ b/code/modules/spells/spell_types/tower_of_babel.dm
@@ -15,7 +15,7 @@ GLOBAL_DATUM(tower_of_babel, /datum/tower_of_babel)
 		if(IS_WIZARD(target) && !badmin)
 			// wizards are not only immune but can speak all languages to taunt their victims over the radio
 			target.grant_all_languages(source=LANGUAGE_BABEL)
-			ADD_TRAIT(target, TRAIT_TOWER_OF_BABEL, MAGIC_TRAIT)
+			ADD_TRAIT(target.mind, TRAIT_TOWER_OF_BABEL, MAGIC_TRAIT)
 			to_chat(target, span_reallybig(span_hypnophrase("You feel a magical force improving your speech patterns!")))
 			continue
 
@@ -45,7 +45,7 @@ GLOBAL_DATUM(tower_of_babel, /datum/tower_of_babel)
 	if(!iscarbon(to_curse))
 		return
 
-	if(to_curse.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND) || HAS_TRAIT(to_curse, TRAIT_TOWER_OF_BABEL))
+	if(to_curse.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND) || HAS_TRAIT(to_curse.mind, TRAIT_TOWER_OF_BABEL))
 		to_chat(to_curse, span_notice("You have a strange feeling for a moment, but then it passes."))
 		return
 
@@ -58,7 +58,7 @@ GLOBAL_DATUM(tower_of_babel, /datum/tower_of_babel)
 		return
 
 	// anyone who has this trait from another source is immune to being cursed by tower of babel
-	if(!HAS_TRAIT_FROM(to_cure, TRAIT_TOWER_OF_BABEL, TRAUMA_TRAIT))
+	if(!HAS_TRAIT_FROM(to_cure.mind, TRAIT_TOWER_OF_BABEL, TRAUMA_TRAIT))
 		return
 
 	to_cure.remove_status_effect(/datum/status_effect/tower_of_babel/magical)

--- a/code/modules/spells/spell_types/tower_of_babel.dm
+++ b/code/modules/spells/spell_types/tower_of_babel.dm
@@ -12,6 +12,8 @@ GLOBAL_DATUM(tower_of_babel, /datum/tower_of_babel)
 	deadchat_broadcast("The [span_name("Tower of Babel")] has stricken the station, people will struggle to communicate.", message_type=DEADCHAT_ANNOUNCEMENT)
 
 	for(var/mob/living/carbon/target in GLOB.player_list)
+		if(!target.mind)
+			continue
 		if(IS_WIZARD(target) && !badmin)
 			// wizards are not only immune but can speak all languages to taunt their victims over the radio
 			target.grant_all_languages(source=LANGUAGE_BABEL)
@@ -44,6 +46,8 @@ GLOBAL_DATUM(tower_of_babel, /datum/tower_of_babel)
 	// silicon mobs are immune
 	if(!iscarbon(to_curse))
 		return
+	if(!to_curse.mind)
+		return
 
 	if(to_curse.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND) || HAS_TRAIT(to_curse.mind, TRAIT_TOWER_OF_BABEL))
 		to_chat(to_curse, span_notice("You have a strange feeling for a moment, but then it passes."))
@@ -55,6 +59,8 @@ GLOBAL_DATUM(tower_of_babel, /datum/tower_of_babel)
 /// Mainly so admin triggered tower of babel can be undone
 /proc/cure_curse_of_babel(mob/living/carbon/to_cure)
 	if(!iscarbon(to_cure))
+		return
+	if(!to_cure.mind)
 		return
 
 	// anyone who has this trait from another source is immune to being cursed by tower of babel


### PR DESCRIPTION
## About The Pull Request

Tower of Babel (Curator), Naive (Clown), and Storm detector (Shaft Miner), are all traits that are given to your mind upon taking these jobs.
However, we have been checking the body for these traits, not the mind. This meant that Shaft miners werent alerted of ice storms, Clowns didnt have their unique examine text, and Curators were affected by Tower of Babel.
This fixes all those issues.

Naive and Tower of Babel realistically should only be on the mind, so I changed all instances to check the mind. Storm detection is something you can get through analyzers, so I left it as a check for both your body and mind traits.

Clown's Naive:
![image](https://github.com/tgstation/tgstation/assets/53777086/30e92026-5d1d-44a5-9969-206df99c5e8f)

Tower of Babel:
![image](https://github.com/tgstation/tgstation/assets/53777086/b1d41f9d-e020-495c-89de-0d4e2c953442)

## Why It's Good For The Game

Fixes several bugs for 3 jobs all at once. I don't see any issue reports on any of these, but they existed.

## Changelog

:cl:
fix: Shaft Miners are now alerted of Icemoon storms, Clowns are naive, and Curators are immune to the Tower of Babel again.
/:cl: