### PR TITLE
Potted plant revival

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -181,9 +181,7 @@
 /area/ruin/space/ancientstation/delta/ai)
 "aO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
@@ -444,9 +442,7 @@
 /area/ruin/space/ancientstation/charlie/hall)
 "bP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
@@ -4114,9 +4110,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "od" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -4222,9 +4216,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "ow" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/light/small/broken/directional/west,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -5098,9 +5090,7 @@
 /area/ruin/space/ancientstation/charlie/hydro)
 "vp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -5715,9 +5705,7 @@
 /turf/closed/mineral/plasma,
 /area/ruin/space/ancientstation/beta/hall)
 "Ay" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
@@ -5745,9 +5733,7 @@
 /area/ruin/space/ancientstation/beta/medbay)
 "AM" = (
 /obj/machinery/light/small/directional/east,
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
@@ -5940,9 +5926,7 @@
 /area/ruin/space/ancientstation/charlie/kitchen)
 "Cz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -7572,9 +7556,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/ancientstation/beta/hall)
 "PZ" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8319,9 +8301,7 @@
 /area/ruin/space/ancientstation/charlie/sec)
 "XU" = (
 /obj/machinery/light/small/directional/west,
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 1
 	},

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -71574,7 +71574,7 @@
 "ykY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/east,
-/obj/item/kirbyplants/dead/rd,
+/obj/item/kirbyplants/dead/research_director,
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/rd)
 "ykZ" = (

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -71574,7 +71574,7 @@
 "ykY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/east,
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/dead/rd,
 /turf/open/floor/iron/dark/small,
 /area/station/command/heads_quarters/rd)
 "ykZ" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2116,7 +2116,7 @@
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/item/kirbyplants/dead/rd,
+/obj/item/kirbyplants/dead/research_director,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2116,7 +2116,7 @@
 /obj/effect/mapping_helpers/requests_console/ore_update,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/dead/rd,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -14310,7 +14310,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/dead/rd,
 /obj/machinery/computer/security/telescreen/rd{
 	dir = 4;
 	pixel_x = -26

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -14310,7 +14310,7 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/item/kirbyplants/dead/rd,
+/obj/item/kirbyplants/dead/research_director,
 /obj/machinery/computer/security/telescreen/rd{
 	dir = 4;
 	pixel_x = -26

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -43414,7 +43414,7 @@
 /obj/effect/turf_decal/siding{
 	dir = 4
 	},
-/obj/item/kirbyplants/dead/rd,
+/obj/item/kirbyplants/dead/research_director,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -43414,7 +43414,7 @@
 /obj/effect/turf_decal/siding{
 	dir = 4
 	},
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/dead/rd,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
 	},

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -60566,9 +60566,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-25"
-	},
+/obj/item/kirbyplants/dead,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "pPr" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -309,7 +309,7 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/meeting_room)
 "adj" = (
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/dead/rd,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -309,7 +309,7 @@
 /turf/open/floor/carpet/blue,
 /area/station/command/meeting_room)
 "adj" = (
-/obj/item/kirbyplants/dead/rd,
+/obj/item/kirbyplants/dead/research_director,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -32473,7 +32473,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/tram/mid)
 "kxF" = (
-/obj/item/kirbyplants/dead,
+/obj/item/kirbyplants/dead/rd,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -32473,7 +32473,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/tram/mid)
 "kxF" = (
-/obj/item/kirbyplants/dead/rd,
+/obj/item/kirbyplants/dead/research_director,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/code/game/objects/items/kirbyplants.dm
+++ b/code/game/objects/items/kirbyplants.dm
@@ -3,6 +3,7 @@
 	name = "potted plant"
 	icon = 'icons/obj/flora/plants.dmi'
 	icon_state = "plant-01"
+	base_icon_state = "plant-01"
 	desc = "A little bit of nature contained in a pot."
 	layer = ABOVE_MOB_LAYER
 	plane = GAME_PLANE_UPPER
@@ -15,6 +16,8 @@
 
 	/// Can this plant be trimmed by someone with TRAIT_BONSAI
 	var/trimmable = TRUE
+	/// Whether this plant is dead and requires a seed to revive
+	var/dead = FALSE
 	var/list/static/random_plant_states
 
 /obj/item/kirbyplants/Initialize(mapload)
@@ -23,13 +26,23 @@
 	AddComponent(/datum/component/two_handed, require_twohands=TRUE, force_unwielded=10, force_wielded=10)
 	AddElement(/datum/element/beauty, 500)
 
+/obj/item/kirbyplants/update_icon_state()
+	. = ..()
+	icon_state = dead ? "plant-25" : base_icon_state
+
 /obj/item/kirbyplants/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
-	if(trimmable && HAS_TRAIT(user,TRAIT_BONSAI) && isturf(loc) && I.get_sharpness())
+	if(!dead && trimmable && HAS_TRAIT(user,TRAIT_BONSAI) && isturf(loc) && I.get_sharpness())
 		to_chat(user,span_notice("You start trimming [src]."))
 		if(do_after(user,3 SECONDS,target=src))
 			to_chat(user,span_notice("You finish trimming [src]."))
 			change_visual()
+	if(dead && istype(I, /obj/item/seeds))
+		to_chat(user,span_notice("You start planting a new seed into the pot."))
+		if(do_after(user,3 SECONDS,target=src))
+			qdel(I)
+			dead = FALSE
+			update_appearance(UPDATE_ICON)
 
 /// Cycle basic plant visuals
 /obj/item/kirbyplants/proc/change_visual()
@@ -52,7 +65,7 @@
 
 /obj/item/kirbyplants/proc/generate_states()
 	random_plant_states = list()
-	for(var/i in 1 to 25)
+	for(var/i in 1 to 24)
 		var/number
 		if(i < 10)
 			number = "0[i]"
@@ -61,23 +74,12 @@
 		random_plant_states += "plant-[number]"
 	random_plant_states += "applebush"
 
-
 /obj/item/kirbyplants/dead
 	name = "dead potted plant"
 	desc = "The unidentifiable plant remnants make you feel like planting something new in the pot."
-	icon_state = "plant-25"
-	trimmable = FALSE
+	dead = TRUE
 
-/obj/item/kirbyplants/dead/attackby(obj/item/I, mob/living/user, params)
-	. = ..()
-	if(istype(I, /obj/item/seeds))
-		to_chat(user,span_notice("You start planting a new seed into the pot."))
-		if(do_after(user,3 SECONDS,target=src))
-			new /obj/item/kirbyplants(get_turf(src))
-			qdel(I)
-			qdel(src)
-
-/obj/item/kirbyplants/dead/rd
+/obj/item/kirbyplants/dead/research_director
 	name = "RD's potted plant"
 	desc = "A gift from the botanical staff, presented after the RD's reassignment. There's a tag on it that says \"Y'all come back now, y'hear?\"\nIt doesn't look very healthy..."
 

--- a/code/game/objects/items/kirbyplants.dm
+++ b/code/game/objects/items/kirbyplants.dm
@@ -63,10 +63,23 @@
 
 
 /obj/item/kirbyplants/dead
-	name = "RD's potted plant"
-	desc = "A gift from the botanical staff, presented after the RD's reassignment. There's a tag on it that says \"Y'all come back now, y'hear?\"\nIt doesn't look very healthy..."
+	name = "dead potted plant"
+	desc = "The unidentifiable plant remnants make you feel like planting something new in the pot."
 	icon_state = "plant-25"
 	trimmable = FALSE
+
+/obj/item/kirbyplants/dead/rd
+	name = "RD's potted plant"
+	desc = "A gift from the botanical staff, presented after the RD's reassignment. There's a tag on it that says \"Y'all come back now, y'hear?\"\nIt doesn't look very healthy..."
+
+/obj/item/kirbyplants/dead/attackby(obj/item/I, mob/living/user, params)
+	. = ..()
+	if(istype(I, /obj/item/seeds))
+		to_chat(user,span_notice("You start planting a new seed into the pot."))
+		if(do_after(user,3 SECONDS,target=src))
+			new /obj/item/kirbyplants(get_turf(src))
+			qdel(I)
+			qdel(src)
 
 /obj/item/kirbyplants/photosynthetic
 	name = "photosynthetic potted plant"

--- a/code/game/objects/items/kirbyplants.dm
+++ b/code/game/objects/items/kirbyplants.dm
@@ -68,10 +68,6 @@
 	icon_state = "plant-25"
 	trimmable = FALSE
 
-/obj/item/kirbyplants/dead/rd
-	name = "RD's potted plant"
-	desc = "A gift from the botanical staff, presented after the RD's reassignment. There's a tag on it that says \"Y'all come back now, y'hear?\"\nIt doesn't look very healthy..."
-
 /obj/item/kirbyplants/dead/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
 	if(istype(I, /obj/item/seeds))
@@ -80,6 +76,10 @@
 			new /obj/item/kirbyplants(get_turf(src))
 			qdel(I)
 			qdel(src)
+
+/obj/item/kirbyplants/dead/rd
+	name = "RD's potted plant"
+	desc = "A gift from the botanical staff, presented after the RD's reassignment. There's a tag on it that says \"Y'all come back now, y'hear?\"\nIt doesn't look very healthy..."
 
 /obj/item/kirbyplants/photosynthetic
 	name = "photosynthetic potted plant"

--- a/tools/UpdatePaths/Scripts/75602_replace_dead_plants.txt
+++ b/tools/UpdatePaths/Scripts/75602_replace_dead_plants.txt
@@ -1,0 +1,1 @@
+/obj/item/kirbyplants{icon_state = "plant-25"} : /obj/item/kirbyplants/dead{@OLD;icon_state=@SKIP}


### PR DESCRIPTION
![dreamseeker_0JH7yYpKEq](https://github.com/tgstation/tgstation/assets/3625094/dc586ae5-8ace-4272-a93f-f18578ac15bd)

## About The Pull Request

Dead potted plant seems to be originating from RD's office, but it's widely used in abandoned areas for mood. 
This PR makes the dead plant more generic, making RD's plant a subtype.

Also now you can turn dead plant into a living one by using any seed on it.

## Why It's Good For The Game

No more RD's plants in space ruins.
And now there is a way to do something with those dead plants again (they could be sheared into a living plant with bonsai skill previously)

## Changelog

:cl:
qol: dead potted plant can be revived with a seed
/:cl:

