### PR TITLE
[NO GBP] Fixes Plumbing RCD

### DIFF
--- a/tgui/packages/tgui/interfaces/PlumbingService.tsx
+++ b/tgui/packages/tgui/interfaces/PlumbingService.tsx
@@ -83,19 +83,13 @@ const LayerIconSection = (props, context) => {
   const { data } = useBackend<Data>(context);
   const { layer_icon } = data;
   return (
-    <Section
-      backgroundColor="green"
+    <Box
+      m={1}
+      className={classes(['plumbing-tgui32x32', layer_icon])}
       style={{
-        width: '50px',
-        height: '50px',
-      }}>
-      <Box
-        className={classes(['plumbing-tgui32x32', layer_icon])}
-        style={{
-          transform: 'scale(1.5) translate(9%, 9.5%)',
-        }}
-      />
-    </Section>
+        transform: 'scale(2)',
+      }}
+    />
   );
 };
 

--- a/tgui/packages/tgui/interfaces/PlumbingService.tsx
+++ b/tgui/packages/tgui/interfaces/PlumbingService.tsx
@@ -79,26 +79,6 @@ const PlumbingTypeSection = (props, context) => {
   );
 };
 
-const StaticSection = (props, context) => {
-  const { data } = useBackend<Data>(context);
-  const { silo_upgraded } = data;
-  return (
-    <Section>
-      <MatterItem />
-      {silo_upgraded ? <SiloItem /> : ''}
-      <ColorItem space />
-    </Section>
-  );
-};
-
-const LayerSection = (props, context) => {
-  return (
-    <Section>
-      <LayerSelect />
-    </Section>
-  );
-};
-
 const LayerIconSection = (props, context) => {
   const { data } = useBackend<Data>(context);
   const { layer_icon } = data;
@@ -120,29 +100,29 @@ const LayerIconSection = (props, context) => {
 };
 
 export const PlumbingService = (props, context) => {
+  const { data } = useBackend<Data>(context);
+  const { silo_upgraded } = data;
   return (
-    <Window width={450} height={575}>
+    <Window width={480} height={575}>
       <Window.Content>
         <Stack vertical fill>
           <Stack.Item>
-            <StaticSection />
+            <Section>
+              <Stack>
+                <Stack.Item>
+                  <ColorItem />
+                  <LayerSelect />
+                  <MatterItem />
+                  {silo_upgraded ? <SiloItem /> : ''}
+                </Stack.Item>
+                <Stack.Item>
+                  <LayerIconSection />
+                </Stack.Item>
+              </Stack>
+            </Section>
           </Stack.Item>
           <Stack.Item grow>
-            <Stack fill>
-              <Stack.Item>
-                <Stack vertical fill>
-                  <Stack.Item>
-                    <LayerSection />
-                  </Stack.Item>
-                  <Stack.Item grow>
-                    <LayerIconSection />
-                  </Stack.Item>
-                </Stack>
-              </Stack.Item>
-              <Stack.Item grow>
-                <PlumbingTypeSection />
-              </Stack.Item>
-            </Stack>
+            <PlumbingTypeSection />
           </Stack.Item>
         </Stack>
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/PlumbingService.tsx
+++ b/tgui/packages/tgui/interfaces/PlumbingService.tsx
@@ -107,7 +107,7 @@ export const PlumbingService = (props, context) => {
                   <ColorItem />
                   <LayerSelect />
                   <MatterItem />
-                  {silo_upgraded ? <SiloItem /> : ''}
+                  {!!silo_upgraded && <SiloItem />}
                 </Stack.Item>
                 <Stack.Item>
                   <LayerIconSection />


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/3625094/c046222f-9766-4d14-8538-40aabdd15645)

## About The Pull Request

Fixes #75618 

Regression after #75540 

I didn't know that it reuses some components of RPD when I updated its UI. It led to layers breaking UI.

## Changelog

:cl:
fix: Plumbing RCD UI fixed
/:cl:
