### PR TITLE
Allows test tubes in chemistry/virology smart fridges

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -621,6 +621,7 @@
 /obj/machinery/smartfridge/chemistry/accept_check(obj/item/O)
 	var/static/list/chemfridge_typecache = typecacheof(list(
 					/obj/item/reagent_containers/syringe,
+					/obj/item/reagent_containers/cup/tube,
 					/obj/item/reagent_containers/cup/bottle,
 					/obj/item/reagent_containers/cup/beaker,
 					/obj/item/reagent_containers/spray,


### PR DESCRIPTION

## About The Pull Request
Pretty simple, whitelists the new chemistry test tubes in the chemistry smart fridges.
## Why It's Good For The Game
In short, because you used to be able to bottle things and store said bottles in fridges, and now you can't. And I didn't see any indication in #75179 that the difference was intentional.

Perhaps the most problematic case is in virology, where the PanD.E.M.I.C will produce samples which no longer fit in the smart fridge, making for an absurd amount of clutter for any virologist that intends to do any sort of virus bookkeeping.

As a personal example, I tend to produce an excess of intermediate products when working in the pharmacy, to be kept for myself or others to use in future recipes. Generally in bottles in a smart fridge, for convenience in crafting.

I'm not a huge fan of existing solutions to these problems. Leaving them on counters will produce a lot of clutter. Test tube racks only somewhat reduce clutter, but at the cost of requiring wood to make and making specific samples/chemicals much harder to find.
## Changelog
:cl:
fix: Test tubes can now be stored in chemistry smart fridges
/:cl:
