### PR TITLE
Adds ai_retaliate element to chickens

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/chicken.dm
+++ b/code/modules/mob/living/basic/farm_animals/chicken.dm
@@ -44,6 +44,7 @@ GLOBAL_VAR_INIT(chicken_count, 0)
 	. = ..()
 	GLOB.chicken_count++
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
+	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/pet_bonus, "clucks happily!")
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW)
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_CHICKEN, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)


### PR DESCRIPTION

## About The Pull Request

Whoops, forgot to add this in #75592.
## Why It's Good For The Game

Chickens were meant to bite back if you attacked them. This slipped my mind to test for some reason.
## Changelog
:cl:
fix: Chickens should now, once again, peck you in case you hit them.
/:cl:
