### PR TITLE
Reverts qdel logging to a raw text file

### DIFF
--- a/code/__HELPERS/logging/debug.dm
+++ b/code/__HELPERS/logging/debug.dm
@@ -35,8 +35,9 @@
 	WRITE_LOG_NO_FORMAT(GLOB.perf_log, .)
 
 /// Logging for hard deletes
-/proc/log_qdel(text, list/data)
-	logger.Log(LOG_CATEGORY_DEBUG_QDEL, text, data)
+/// Done once, at roundend. Really just a text file
+/proc/log_qdel(text)
+	WRITE_LOG(GLOB.world_qdel_log, "QDEL: [text]")
 
 /* Log to the logfile only. */
 /proc/log_runtime(text, list/data)

--- a/code/_globalvars/logging.dm
+++ b/code/_globalvars/logging.dm
@@ -32,6 +32,7 @@ GLOBAL_PROTECT(##log_var_name);\
 // These should be used where the log category cannot easily be a json log file.
 DECLARE_LOG(config_error_log, DONT_START_LOG)
 DECLARE_LOG(perf_log, DONT_START_LOG) // Declared here but name is set in time_track subsystem
+DECLARE_LOG_NAMED(world_qdel_log, "qdel", START_LOG)
 
 #ifdef REFERENCE_DOING_IT_LIVE
 DECLARE_LOG_NAMED(harddel_log, "harddels", START_LOG)


### PR DESCRIPTION

## About The Pull Request

We log this information once, on SSgarbage shutdown. Putting it in a json is kinda pointless, it exists to be read when we see massive overtime from ssgarbage, that's all.

Something something reee my workflow.

## Changelog
:cl:
server: qdel statistics are once again logged in qdel.log, instead of the otherwise typical json logging system
/:cl:
