### PR TITLE
Fixes being unable to spraypaint

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1186,6 +1186,23 @@
 	atom_colours[colour_priority] = null
 	update_atom_colour()
 
+/**
+ * Checks if this atom has the passed color
+ * Can optionally be supplied with a range of priorities, IE only checking "washable" or above
+ */
+/atom/proc/is_atom_colour(looking_for_color, min_priority_index = 1, max_priority_index = COLOUR_PRIORITY_AMOUNT)
+	// make sure uppertext hex strings don't mess with lowertext hex strings
+	looking_for_color = lowertext(looking_for_color)
+
+	if(!LAZYLEN(atom_colours))
+		// no atom colors list has been set up, just check the color var
+		return lowertext(color) == looking_for_color
+
+	for(var/i in min_priority_index to max_priority_index)
+		if(lowertext(atom_colours[i]) == looking_for_color)
+			return TRUE
+
+	return FALSE
 
 ///Resets the atom's color to null, and then sets it to the highest priority colour available
 /atom/proc/update_atom_colour()

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -824,8 +824,8 @@
 		var/fraction = min(1, . / reagents.maximum_volume)
 		reagents.expose(carbon_target, VAPOR, fraction * volume_multiplier)
 
-	else if(actually_paints && target.atom_colours[atom_colours] == paint_color)
-		balloon_alert(user, "[target.p_theyre()] already of that color.")
+	else if(actually_paints && (target.color == paint_color || target.atom_colours?[WASHABLE_COLOUR_PRIORITY] == paint_color))
+		balloon_alert(user, "[target.p_theyre()] already that color!")
 		return FALSE
 
 	if(ismob(target) && (HAS_TRAIT(target, TRAIT_SPRAY_PAINTABLE)))

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -824,7 +824,7 @@
 		var/fraction = min(1, . / reagents.maximum_volume)
 		reagents.expose(carbon_target, VAPOR, fraction * volume_multiplier)
 
-	else if(actually_paints && (target.color == paint_color || target.atom_colours?[WASHABLE_COLOUR_PRIORITY] == paint_color))
+	else if(actually_paints && target.is_atom_colour(paint_color, min_priority_index = WASHABLE_COLOUR_PRIORITY))
 		balloon_alert(user, "[target.p_theyre()] already that color!")
 		return FALSE
 


### PR DESCRIPTION
## About The Pull Request

`.atom_colours[atom_colours]` seems like a copy paste error.

I assume it was either intending to check for same color, or check washable color for same color. So I put in both

## Changelog

:cl: Melbert
fix: Fixed being unable to spraypaint things
/:cl: