### PR TITLE
Connects xenobio to the power network on Birdshot

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -19679,6 +19679,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
+"hua" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "huc" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/rack,
@@ -108860,8 +108865,8 @@ ssz
 ssz
 xQI
 qRO
-xGw
-xGw
+hua
+hua
 yiV
 rUR
 qTv


### PR DESCRIPTION

## About The Pull Request
adds two pieces of wire to connect xenobio to the rest of the powernet.

## Why It's Good For The Game

closes #75624 

## Changelog

fix: birdshots xenobio is connected to the powernet

:cl: Vect0r
fix: Birdshots xenobio should now be getting power from the rest of the powergrid.
/:cl:
