### PR TITLE
Fixes glove offsets not working with negative numbers

### DIFF
--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -192,7 +192,7 @@ There are several things that need to be remembered:
 		var/feature_y_offset = 0
 		for (var/obj/item/bodypart/arm/my_hand as anything in hand_bodyparts)
 			var/list/glove_offset = my_hand.worn_glove_offset?.get_offset()
-			if (glove_offset && glove_offset["y"] > feature_y_offset)
+			if (glove_offset && (!feature_y_offset || glove_offset["y"] > feature_y_offset)))
 				feature_y_offset = glove_offset["y"]
 
 		gloves_overlay.pixel_y += feature_y_offset

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -192,7 +192,7 @@ There are several things that need to be remembered:
 		var/feature_y_offset = 0
 		for (var/obj/item/bodypart/arm/my_hand as anything in hand_bodyparts)
 			var/list/glove_offset = my_hand.worn_glove_offset?.get_offset()
-			if (glove_offset && (!feature_y_offset || glove_offset["y"] > feature_y_offset)))
+			if (glove_offset && (!feature_y_offset || glove_offset["y"] > feature_y_offset))
 				feature_y_offset = glove_offset["y"]
 
 		gloves_overlay.pixel_y += feature_y_offset


### PR DESCRIPTION
## About The Pull Request

This was changed in the Golem rework - https://github.com/tgstation/tgstation/pull/74197

If you have a species that have arms that go longer than normal, you can set the offsets of in-hands to negative y value to lower it. This isn't an option for gloves however, because it starts at 0 and only increases if the value is larger.
This fixes it by letting it set a negative number, and comparing your other hands' offsets to that.

## Why It's Good For The Game

Fixes species that have arms that go longer than normal.

## Changelog

:cl:
fix: Species that have longer arms than normal can now properly set their glove offset to go low and meet their hand.
/:cl: