### PR TITLE
Re-moves Cobby back to maintainer section of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,11 @@
 /code/ze_genesis_call/ @Cyberboss
 /tools/tgs_test/ @Cyberboss
 
+# Cobby
+
+/code/modules/reagents/ @ExcessiveUseOfCobblestone
+/code/modules/research/designs/medical_designs.dm @ExcessiveUseOfCobblestone
+/code/game/objects/items/storage/medkit.dm @ExcessiveUseOfCobblestone
 
 # Fikou
 
@@ -138,12 +143,6 @@
 
 
 # CONTRIBUTORS
-
-# Cobby
-
-/code/modules/reagents/ @ExcessiveUseOfCobblestone
-/code/modules/research/designs/medical_designs.dm @ExcessiveUseOfCobblestone
-/code/game/objects/items/storage/medkit.dm @ExcessiveUseOfCobblestone
 
 # Jordie0608
 


### PR DESCRIPTION
## About The Pull Request

Cobby seemed annoyed at just how much they've been pinged for codeowner stuff, but I don't want to remove them without their permission, so instead I'm moving them back to the Maintainers section since they're a Maintainer now.