### PR TITLE
Solar control panel UI tweaks

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -389,13 +389,27 @@
 	var/obj/machinery/power/tracker/connected_tracker = null
 	var/list/connected_panels = list()
 
+	///History of power supply
+	var/list/history = list()
+	///Size of history, should be equal or bigger than the solar cycle
+	var/record_size = 120
+	///Interval between records
+	var/record_interval = 60 SECONDS
+	///History record timer
+	var/next_record = 0
+
 /obj/machinery/power/solar_control/Initialize(mapload)
 	. = ..()
-	azimuth_rate = SSsun.base_rotation
 	RegisterSignal(SSsun, COMSIG_SUN_MOVED, PROC_REF(timed_track))
 	connect_to_network()
 	if(powernet)
 		set_panels(azimuth_target)
+	azimuth_rate = SSsun.base_rotation
+	/// History contains full sun cycle
+	record_size = ROUND_UP(360 / (azimuth_rate * abs(SSsun.azimuth_mod)))
+	record_interval = SSsun.wait
+	history["supply"] = list()
+	history["capacity"] = list()
 
 /obj/machinery/power/solar_control/Destroy()
 	for(var/obj/machinery/power/solar/M in connected_panels)
@@ -423,6 +437,23 @@
 					if(!T.control) //i.e unconnected
 						T.set_control(src)
 
+///Record the generated power supply and capacity for history
+/obj/machinery/power/solar_control/proc/record()
+	if(world.time >= next_record)
+		next_record = world.time + record_interval
+
+		var/list/supply = history["supply"]
+		if(powernet)
+			supply += round(lastgen)
+		if(supply.len > record_size)
+			supply.Cut(1, 2)
+
+		var/list/capacity = history["capacity"]
+		if(powernet)
+			capacity += round(max(connected_panels.len, 1) * SOLAR_GEN_RATE)
+		if(capacity.len > record_size)
+			capacity.Cut(1, 2)
+
 /obj/machinery/power/solar_control/update_overlays()
 	. = ..()
 	if(machine_stat & NOPOWER)
@@ -443,14 +474,15 @@
 
 /obj/machinery/power/solar_control/ui_data()
 	var/data = list()
-	data["generated"] = round(lastgen)
-	data["generated_ratio"] = data["generated"] / round(max(connected_panels.len, 1) * SOLAR_GEN_RATE)
+	data["supply"] = round(lastgen)
+	data["capacity"] = connected_panels.len * SOLAR_GEN_RATE
 	data["azimuth_current"] = azimuth_target
 	data["azimuth_rate"] = azimuth_rate
 	data["max_rotation_rate"] = SSsun.base_rotation * 2
 	data["tracking_state"] = track
 	data["connected_panels"] = connected_panels.len
 	data["connected_tracker"] = (connected_tracker ? TRUE : FALSE)
+	data["history"] = history
 	return data
 
 /obj/machinery/power/solar_control/ui_act(action, params)
@@ -538,9 +570,9 @@
 /obj/machinery/power/solar_control/process()
 	lastgen = gen
 	gen = 0
-
 	if(connected_tracker && (!powernet || connected_tracker.powernet != powernet))
 		connected_tracker.unset_control()
+	record()
 
 ///Ran every time the sun updates.
 /obj/machinery/power/solar_control/proc/timed_track()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -392,7 +392,7 @@
 	///History of power supply
 	var/list/history = list()
 	///Size of history, should be equal or bigger than the solar cycle
-	var/record_size = 120
+	var/record_size = 0
 	///Interval between records
 	var/record_interval = 60 SECONDS
 	///History record timer
@@ -405,8 +405,6 @@
 	if(powernet)
 		set_panels(azimuth_target)
 	azimuth_rate = SSsun.base_rotation
-	/// History contains full sun cycle
-	record_size = ROUND_UP(360 / (azimuth_rate * abs(SSsun.azimuth_mod)))
 	record_interval = SSsun.wait
 	history["supply"] = list()
 	history["capacity"] = list()
@@ -439,6 +437,9 @@
 
 ///Record the generated power supply and capacity for history
 /obj/machinery/power/solar_control/proc/record()
+	if(record_size == 0)
+		record_size = 1 + ROUND_UP(360 / (azimuth_rate * abs(SSsun.azimuth_mod))) //History contains full sun cycle
+
 	if(world.time >= next_record)
 		next_record = world.time + record_interval
 

--- a/tgui/packages/tgui/interfaces/PowerMonitor.js
+++ b/tgui/packages/tgui/interfaces/PowerMonitor.js
@@ -69,7 +69,7 @@ export const PowerMonitorContent = (props, context) => {
         <Flex.Item mx={0.5} width="200px">
           <Section>
             <LabeledList>
-              <LabeledList.Item label="Supply">
+              <LabeledList.Item label="Supplya">
                 <ProgressBar
                   value={supply}
                   minValue={0}

--- a/tgui/packages/tgui/interfaces/PowerMonitor.js
+++ b/tgui/packages/tgui/interfaces/PowerMonitor.js
@@ -69,7 +69,7 @@ export const PowerMonitorContent = (props, context) => {
         <Flex.Item mx={0.5} width="200px">
           <Section>
             <LabeledList>
-              <LabeledList.Item label="Supplya">
+              <LabeledList.Item label="Supply">
                 <ProgressBar
                   value={supply}
                   minValue={0}

--- a/tgui/packages/tgui/interfaces/SolarControl.tsx
+++ b/tgui/packages/tgui/interfaces/SolarControl.tsx
@@ -35,7 +35,7 @@ export const SolarControl = (props, context) => {
   } = data;
   const supplyData = history.supply.map((value, i) => [i, value]);
   const capacityData = history.capacity.map((value, i) => [i, value]);
-  const maxValue = Math.max(...history.capacity, ...history.supply);
+  const maxValue = Math.max(1, ...history.capacity, ...history.supply);
 
   return (
     <Window width={330} height={330}>

--- a/tgui/packages/tgui/interfaces/SolarControl.tsx
+++ b/tgui/packages/tgui/interfaces/SolarControl.tsx
@@ -1,6 +1,6 @@
 import { BooleanLike } from 'common/react';
 import { useBackend } from '../backend';
-import { Box, Button, LabeledList, NumberInput, ProgressBar, Chart, Section, Stack } from '../components';
+import { Box, Button, LabeledList, NumberInput, ProgressBar, Chart, Section, Stack, Icon } from '../components';
 import { Window } from '../layouts';
 
 type Data = {
@@ -135,6 +135,7 @@ export const SolarControl = (props, context) => {
               />
             </LabeledList.Item>
             <LabeledList.Item label="Azimuth">
+              <Icon mr={1} name="arrow-up" rotation={azimuth_current} />
               {(tracking_state === 0 || tracking_state === 1) && (
                 <NumberInput
                   width="52px"

--- a/tgui/packages/tgui/interfaces/SolarControl.tsx
+++ b/tgui/packages/tgui/interfaces/SolarControl.tsx
@@ -1,24 +1,110 @@
+import { BooleanLike } from 'common/react';
 import { useBackend } from '../backend';
-import { Box, Button, Grid, LabeledList, NumberInput, ProgressBar, Section } from '../components';
+import { Box, Button, LabeledList, NumberInput, ProgressBar, Chart, Section, Stack } from '../components';
 import { Window } from '../layouts';
 
+type Data = {
+  supply: number;
+  capacity: number;
+  azimuth_current: number;
+  azimuth_rate: number;
+  max_rotation_rate: number;
+  tracking_state: number;
+  connected_panels: number;
+  connected_tracker: BooleanLike;
+  history: History;
+};
+
+type History = {
+  supply: number[];
+  capacity: number[];
+};
+
 export const SolarControl = (props, context) => {
-  const { act, data } = useBackend(context);
+  const { act, data } = useBackend<Data>(context);
   const {
-    generated,
-    generated_ratio,
+    supply,
+    capacity,
     azimuth_current,
     azimuth_rate,
     max_rotation_rate,
     tracking_state,
     connected_panels,
     connected_tracker,
+    history,
   } = data;
+  const supplyData = history.supply.map((value, i) => [i, value]);
+  const capacityData = history.capacity.map((value, i) => [i, value]);
+  const maxValue = Math.max(...history.capacity, ...history.supply);
+
   return (
-    <Window width={380} height={230}>
+    <Window width={330} height={330}>
       <Window.Content>
+        <Section title="Status">
+          <Box
+            mb={1}
+            position="relative"
+            overflow="visible"
+            height="64px"
+            backgroundColor={'black'}>
+            <Chart.Line
+              p={1}
+              fillPositionedParent
+              data={capacityData}
+              rangeX={[0, capacityData.length - 1]}
+              rangeY={[0, maxValue]}
+              strokeColor="rgba(150, 117, 39, 1)"
+              fillColor="rgba(150, 117, 39, 0.5)"
+            />
+            <Chart.Line
+              p={1}
+              fillPositionedParent
+              data={supplyData}
+              rangeX={[0, supplyData.length - 1]}
+              rangeY={[0, maxValue]}
+              strokeColor="rgba(235, 210, 52, 1)"
+              fillColor="rgba(235, 210, 52, 0.5)"
+            />
+          </Box>
+          <Stack>
+            <Stack.Item>
+              <LabeledList>
+                <LabeledList.Item label="Power output">
+                  <ProgressBar
+                    value={capacity > 0 ? supply / capacity : 0}
+                    minValue={0}
+                    maxValue={1}
+                    ranges={{
+                      good: [0.66, Infinity],
+                      average: [0.33, 0.66],
+                      bad: [-Infinity, 0.33],
+                    }}>
+                    {capacity > 0
+                      ? Math.round(supply).toLocaleString() +
+                      ' of ' +
+                      Math.round(capacity).toLocaleString() +
+                      ' W (' +
+                      Math.round((100 * supply) / capacity) +
+                      '%)'
+                      : 0 + ' W'}
+                  </ProgressBar>
+                </LabeledList.Item>
+                <LabeledList.Item
+                  label="Solar panels"
+                  color={connected_panels > 0 ? 'good' : 'bad'}>
+                  {connected_panels}
+                </LabeledList.Item>
+                <LabeledList.Item
+                  label="Solar tracker"
+                  color={connected_tracker ? 'good' : 'bad'}>
+                  {connected_tracker ? 'OK' : 'N/A'}
+                </LabeledList.Item>
+              </LabeledList>
+            </Stack.Item>
+          </Stack>
+        </Section>
         <Section
-          title="Status"
+          title="Controls"
           buttons={
             <Button
               icon="sync"
@@ -26,41 +112,6 @@ export const SolarControl = (props, context) => {
               onClick={() => act('refresh')}
             />
           }>
-          <Grid>
-            <Grid.Column>
-              <LabeledList>
-                <LabeledList.Item
-                  label="Solar tracker"
-                  color={connected_tracker ? 'good' : 'bad'}>
-                  {connected_tracker ? 'OK' : 'N/A'}
-                </LabeledList.Item>
-                <LabeledList.Item
-                  label="Solar panels"
-                  color={connected_panels > 0 ? 'good' : 'bad'}>
-                  {connected_panels}
-                </LabeledList.Item>
-              </LabeledList>
-            </Grid.Column>
-            <Grid.Column size={1.5}>
-              <LabeledList>
-                <LabeledList.Item label="Power output">
-                  <ProgressBar
-                    ranges={{
-                      good: [0.66, Infinity],
-                      average: [0.33, 0.66],
-                      bad: [-Infinity, 0.33],
-                    }}
-                    minValue={0}
-                    maxValue={1}
-                    value={generated_ratio}>
-                    {generated + ' W'}
-                  </ProgressBar>
-                </LabeledList.Item>
-              </LabeledList>
-            </Grid.Column>
-          </Grid>
-        </Section>
-        <Section title="Controls">
           <LabeledList>
             <LabeledList.Item label="Tracking">
               <Button


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/3625094/03af9b5f-e346-483f-80a6-f4c84e7081b5)

## About The Pull Request

Added a chart that shows generated power and potential power.

## Why It's Good For The Game

You can now see how well the panels perform throughout the solar cycle.

## Changelog

:cl:
qol: Solar control console now shows power generation history
/:cl:

