### PR TITLE
Rubber duck now quacks, not honks

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -268,7 +268,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	worn_icon_state = "duck"
-	sound_file = 'sound/items/quack.ogg'
+	sound_file = 'sound/effects/quack.ogg'
 
 /obj/structure/sink
 	name = "sink"

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -268,6 +268,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/urinal, 32)
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	worn_icon_state = "duck"
+	sound_file = 'sound/items/quack.ogg'
 
 /obj/structure/sink
 	name = "sink"


### PR DESCRIPTION

## About The Pull Request
I stepped on a rubber duck while testing #75672 and got very sad when it honked.
Makes rubber ducks use the rubber ducky shoes sound effect instead of a clown honk sound effect.
## Why It's Good For The Game
Ducks are supposed to quack, not honk. It's not a goose, after all.
## Changelog
:cl: Stalkeros
sound: Rubber duck now quacks.
/:cl:
