### PR TITLE
Stabilized metal slime extract now properly add's a sheet to a random stack

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -558,10 +558,9 @@
 			if(S.amount < S.max_amount)
 				sheets += S
 
-		if(sheets.len > 0)
+		if(sheets.len)
 			var/obj/item/stack/sheet/S = pick(sheets)
-			S.amount++
-			S.update_custom_materials()
+			S.add(1)
 			to_chat(owner, span_notice("[linked_extract] adds a layer of slime to [S], which metamorphosizes into another sheet of material!"))
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

`/obj/item/stack/sheet/add()` proc not only increments the `amount` var but also
1. updates the stack's appearance
2. updates it's weight
3. inform's global material sniffer's about it's presense
4. also updates it's custom material's

So let the slime extract use this proc instead of doing a partial incomplete job ourselves

## Changelog
:cl:
fix: stabilized metal slime extract properly increments stacks so that it's appearance & weight are updated correctly & is picked up by material sniffers.
/:cl:
