### PR TITLE
basic mobs & co no longer indiscriminately perform close-range actions in the presence of obstacles.

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -16,14 +16,16 @@
 
 ///Does this task require movement from the AI before it can be performed?
 #define AI_BEHAVIOR_REQUIRE_MOVEMENT (1<<0)
+///Does this require the current_movement_target to be adjacent and in reach?
+#define AI_BEHAVIOR_REQUIRE_REACH (1<<1)
 ///Does this task let you perform the action while you move closer? (Things like moving and shooting)
-#define AI_BEHAVIOR_MOVE_AND_PERFORM (1<<1)
+#define AI_BEHAVIOR_MOVE_AND_PERFORM (1<<2)
 ///Does finishing this task not null the current movement target?
-#define AI_BEHAVIOR_KEEP_MOVE_TARGET_ON_FINISH (1<<2)
+#define AI_BEHAVIOR_KEEP_MOVE_TARGET_ON_FINISH (1<<3)
 ///Does finishing this task make the AI stop moving towards the target?
-#define AI_BEHAVIOR_KEEP_MOVING_TOWARDS_TARGET_ON_FINISH (1<<3)
+#define AI_BEHAVIOR_KEEP_MOVING_TOWARDS_TARGET_ON_FINISH (1<<4)
 ///Does this behavior NOT block planning?
-#define AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION (1<<4)
+#define AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION (1<<5)
 
 ///AI flags
 /// Don't move if being pulled

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -200,7 +200,10 @@ multiple modular subtrees with behaviors
 			if(!current_movement_target)
 				stack_trace("[pawn] wants to perform action type [current_behavior.type] which requires movement, but has no current movement target!")
 				return //This can cause issues, so don't let these slide.
-			if(current_behavior.required_distance >= get_dist(pawn, current_movement_target)) ///Are we close enough to engage?
+			///Stops pawns from performing such actions that should require the target to be adjacent.
+			var/atom/movable/moving_pawn = pawn
+			var/can_reach = !(current_behavior.behavior_flags & AI_BEHAVIOR_REQUIRE_REACH) || moving_pawn.CanReach(current_movement_target)
+			if(can_reach && current_behavior.required_distance >= get_dist(moving_pawn, current_movement_target)) ///Are we close enough to engage?
 				if(ai_movement.moving_controllers[src] == current_movement_target) //We are close enough, if we're moving stop.
 					ai_movement.stop_moving_towards(src)
 

--- a/code/datums/ai/babies/babies_behaviors.dm
+++ b/code/datums/ai/babies/babies_behaviors.dm
@@ -46,7 +46,7 @@
  */
 /datum/ai_behavior/make_babies
 	action_cooldown = 40 SECONDS
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_REQUIRE_REACH
 
 /datum/ai_behavior/make_babies/setup(datum/ai_controller/controller, target_key, child_types_key)
 	var/atom/target = controller.blackboard[target_key]

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -1,6 +1,6 @@
 /datum/ai_behavior/basic_melee_attack
 	action_cooldown = 2 SECONDS
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_REQUIRE_REACH | AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 
 /datum/ai_behavior/basic_melee_attack/setup(datum/ai_controller/controller, target_key, targetting_datum_key, hiding_location_key)
 	. = ..()

--- a/code/datums/ai/basic_mobs/pet_commands/fetch.dm
+++ b/code/datums/ai/basic_mobs/pet_commands/fetch.dm
@@ -21,7 +21,6 @@
 	if (QDELETED(fetch_thing))
 		finish_action(controller, FALSE, target_key, delivery_key)
 		return
-	var/mob/living/living_pawn = controller.pawn
 	// We can't pick this up
 	if (fetch_thing.anchored)
 		finish_action(controller, FALSE, target_key, delivery_key)

--- a/code/datums/ai/basic_mobs/pet_commands/fetch.dm
+++ b/code/datums/ai/basic_mobs/pet_commands/fetch.dm
@@ -3,7 +3,7 @@
  * If we can't do that, add it to a list of ignored items.
  */
 /datum/ai_behavior/fetch_seek
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT|AI_BEHAVIOR_REQUIRE_REACH
 
 /datum/ai_behavior/fetch_seek/setup(datum/ai_controller/controller, target_key, delivery_key)
 	. = ..()
@@ -23,7 +23,7 @@
 		return
 	var/mob/living/living_pawn = controller.pawn
 	// We can't pick this up
-	if (fetch_thing.anchored || !living_pawn.Adjacent(fetch_thing))
+	if (fetch_thing.anchored)
 		finish_action(controller, FALSE, target_key, delivery_key)
 		return
 
@@ -44,7 +44,7 @@
  * The second half of fetching, deliver the item to a target.
  */
 /datum/ai_behavior/deliver_fetched_item
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT|AI_BEHAVIOR_REQUIRE_REACH
 
 /datum/ai_behavior/deliver_fetched_item/setup(datum/ai_controller/controller, delivery_key, storage_key)
 	. = ..()
@@ -102,16 +102,18 @@
 /datum/ai_behavior/eat_fetched_snack/perform(seconds_per_tick, datum/ai_controller/controller, target_key, delivery_key)
 	. = ..()
 	var/obj/item/snack = controller.blackboard[target_key]
-	if(QDELETED(snack) || !isturf(snack.loc) || ishuman(snack.loc))
+	if(QDELETED(snack))
+		finish_action(controller, FALSE) // Where did it go?
+	var/is_living_loc = isliving(snack.loc)
+	if(QDELETED(snack) || (!isturf(snack.loc) && !is_living_loc))
 		finish_action(controller, FALSE) // Where did it go?
 
 	var/mob/living/basic/basic_pawn = controller.pawn
-	if(!basic_pawn.Adjacent(snack))
-		return
-
-	if(isturf(snack.loc))
+	if(!is_living_loc)
+		if(!basic_pawn.Adjacent(snack))
+			return
 		basic_pawn.melee_attack(snack) // snack attack!
-	else if(iscarbon(snack.loc) && SPT_PROB(10, seconds_per_tick))
+	else if(SPT_PROB(10, seconds_per_tick))
 		basic_pawn.manual_emote("Stares at [snack.loc]'s [snack.name] intently.")
 
 	if(QDELETED(snack)) // we ate it!

--- a/code/datums/ai/basic_mobs/pet_commands/fetch.dm
+++ b/code/datums/ai/basic_mobs/pet_commands/fetch.dm
@@ -101,19 +101,21 @@
 /datum/ai_behavior/eat_fetched_snack/perform(seconds_per_tick, datum/ai_controller/controller, target_key, delivery_key)
 	. = ..()
 	var/obj/item/snack = controller.blackboard[target_key]
-	if(QDELETED(snack))
-		finish_action(controller, FALSE) // Where did it go?
 	var/is_living_loc = isliving(snack.loc)
 	if(QDELETED(snack) || (!isturf(snack.loc) && !is_living_loc))
 		finish_action(controller, FALSE) // Where did it go?
+		return
 
 	var/mob/living/basic/basic_pawn = controller.pawn
-	if(!is_living_loc)
-		if(!basic_pawn.Adjacent(snack))
-			return
-		basic_pawn.melee_attack(snack) // snack attack!
-	else if(SPT_PROB(10, seconds_per_tick))
-		basic_pawn.manual_emote("Stares at [snack.loc]'s [snack.name] intently.")
+	if(is_living_loc)
+		if(SPT_PROB(10, seconds_per_tick))
+			basic_pawn.manual_emote("Stares at [snack.loc]'s [snack.name] intently.")
+		return
+
+	if(!basic_pawn.Adjacent(snack))
+		return
+
+	basic_pawn.melee_attack(snack) // snack attack!
 
 	if(QDELETED(snack)) // we ate it!
 		finish_action(controller, TRUE, target_key, delivery_key)

--- a/code/datums/ai/basic_mobs/pet_commands/fetch.dm
+++ b/code/datums/ai/basic_mobs/pet_commands/fetch.dm
@@ -23,7 +23,7 @@
 		return
 	var/mob/living/living_pawn = controller.pawn
 	// We can't pick this up
-	if (fetch_thing.anchored || !isturf(fetch_thing.loc) || !living_pawn.CanReach(fetch_thing))
+	if (fetch_thing.anchored || !living_pawn.Adjacent(fetch_thing))
 		finish_action(controller, FALSE, target_key, delivery_key)
 		return
 
@@ -106,7 +106,7 @@
 		finish_action(controller, FALSE) // Where did it go?
 
 	var/mob/living/basic/basic_pawn = controller.pawn
-	if(!in_range(basic_pawn, snack))
+	if(!basic_pawn.Adjacent(snack))
 		return
 
 	if(isturf(snack.loc))

--- a/code/datums/ai/dog/dog_behaviors.dm
+++ b/code/datums/ai/dog/dog_behaviors.dm
@@ -22,7 +22,7 @@
 		finish_action(controller, FALSE, target_key, targetting_datum_key, hiding_location_key)
 		return
 
-	if (!in_range(living_pawn, target))
+	if (!living_pawn.Adjacent(target))
 		growl_at(living_pawn, target, seconds_per_tick)
 		return
 

--- a/code/datums/ai/generic/generic_behaviors.dm
+++ b/code/datums/ai/generic/generic_behaviors.dm
@@ -25,7 +25,7 @@
 
 
 /datum/ai_behavior/break_spine
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_REQUIRE_REACH
 	action_cooldown = 0.7 SECONDS
 	var/give_up_distance = 10
 
@@ -89,7 +89,7 @@
 /// Use the currently held item, or unarmed, on a weakref to an object in the world
 /datum/ai_behavior/use_on_object
 	required_distance = 1
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_REQUIRE_REACH
 
 /datum/ai_behavior/use_on_object/setup(datum/ai_controller/controller, target_key)
 	. = ..()
@@ -103,7 +103,7 @@
 	var/mob/living/pawn = controller.pawn
 	var/obj/item/held_item = pawn.get_item_by_slot(pawn.get_active_hand())
 	var/atom/target = controller.blackboard[target_key]
-	if(QDELETED(target) || !pawn.CanReach(target))
+	if(QDELETED(target))
 		finish_action(controller, FALSE)
 		return
 
@@ -116,8 +116,7 @@
 	finish_action(controller, TRUE)
 
 /datum/ai_behavior/give
-	required_distance = 1
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_REQUIRE_REACH
 
 
 /datum/ai_behavior/give/setup(datum/ai_controller/controller, target_key)
@@ -134,7 +133,7 @@
 		finish_action(controller, TRUE)
 		return
 
-	if(!target || !pawn.CanReach(target) || !isliving(target))
+	if(!target || !isliving(target))
 		finish_action(controller, FALSE)
 		return
 
@@ -181,8 +180,7 @@
 
 
 /datum/ai_behavior/consume
-	required_distance = 1
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_REQUIRE_REACH
 	action_cooldown = 2 SECONDS
 
 /datum/ai_behavior/consume/setup(datum/ai_controller/controller, target_key)
@@ -227,8 +225,7 @@
 
 /// This behavior involves attacking a target.
 /datum/ai_behavior/attack
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_MOVE_AND_PERFORM
-	required_distance = 1
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_MOVE_AND_PERFORM | AI_BEHAVIOR_REQUIRE_REACH
 
 /datum/ai_behavior/attack/perform(seconds_per_tick, datum/ai_controller/controller)
 	. = ..()
@@ -263,7 +260,6 @@
 /// This behavior involves attacking a target.
 /datum/ai_behavior/follow
 	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_MOVE_AND_PERFORM
-	required_distance = 1
 
 /datum/ai_behavior/follow/perform(seconds_per_tick, datum/ai_controller/controller)
 	. = ..()

--- a/code/datums/ai/hunting_behavior/hunting_behaviors.dm
+++ b/code/datums/ai/hunting_behavior/hunting_behaviors.dm
@@ -71,7 +71,7 @@
 
 /// Hunts down a specific atom type.
 /datum/ai_behavior/hunt_target
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_REQUIRE_REACH
 	/// How long do we have to wait after a successful hunt?
 	var/hunt_cooldown = 5 SECONDS
 	/// Do we reset the target after attacking something, so we can check for status changes.

--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -2,7 +2,7 @@
 	screeches = list("roar","screech")
 
 /datum/ai_behavior/monkey_equip
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_REQUIRE_REACH
 
 /datum/ai_behavior/monkey_equip/finish_action(datum/ai_controller/controller, success)
 	. = ..()
@@ -75,7 +75,7 @@
 	var/mob/living/victim = target.loc
 	var/mob/living/living_pawn = controller.pawn
 
-	if(!istype(victim) || !living_pawn.CanReach(victim))
+	if(!istype(victim))
 		finish_action(controller, FALSE)
 		return
 

--- a/code/datums/ai/oldhostile/hostile_tameable.dm
+++ b/code/datums/ai/oldhostile/hostile_tameable.dm
@@ -74,7 +74,7 @@
 	if(old_friend)
 		unfriend(old_friend)
 
-	if(in_range(pawn, new_friend))
+	if(pawn.Adjacent(pawn, new_friend))
 		new_friend.visible_message("<b>[pawn]</b> looks at [new_friend] in a friendly manner!", span_notice("[pawn] looks at you in a friendly manner!"))
 	set_blackboard_key(BB_HOSTILE_FRIEND, new_friend)
 	RegisterSignal(new_friend, COMSIG_MOB_POINTED, PROC_REF(check_point))

--- a/code/datums/ai/robot_customer/robot_customer_behaviors.dm
+++ b/code/datums/ai/robot_customer/robot_customer_behaviors.dm
@@ -113,8 +113,7 @@
 		customer_pawn.say(pick(customer_data.leave_mad_lines))
 
 /datum/ai_behavior/leave_venue
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
-	required_distance = 1
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_REQUIRE_REACH
 
 /datum/ai_behavior/leave_venue/setup(datum/ai_controller/controller, venue_key)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Currently, we don't have any such thing as a general ai_behavior flag for behaviors that need a check for if the current_movement_target is within reach or not. We could fix it case by case by slapping a `CanReach()` check in the `performBehavior()` definition of every `ai_behavior` datum that warrants it, the general issue will keep resurfacing as long as new behaviors are added to the game anyhow, while there's a lot less copypasta involved easier to apply solution to current and future instances of such issue.

Worth mentioning not all ai_behaviors with required_range of 1 have this flag. Some are fairly innocuous, such as the follow command, some others kind of handle it already in a more peculiar or complex way, which is also an argument against making it a hardcoded heck for when the required_range is 1 or 0.

This has been tested, though there are some rough edges and oddities also unrelated to his PR that might have evaded scrutiny.

## Why It's Good For The Game
This should fix #74823, fix #69254, and fix #74713 (I guess? it could have been phrased better).

## Changelog

:cl:
fix: basic mobs & co no longer indiscriminately perform close-range actions in the presence of obstacles such as directional windows between them and their target.
fix: Doggos should look at you with longing eyes once again if you dare pick up an edible they are trying to eat.
/:cl:
