### PR TITLE
Removes poseur tag graffiti (it's been dead for ~6 years Edition)

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -320,7 +320,6 @@
 		"guy",
 		"matt",
 		"peace",
-		"poseur tag",
 		"prolizard",
 		"radiation",
 		"revolution",

--- a/code/game/objects/effects/spawners/random/trash.dm
+++ b/code/game/objects/effects/spawners/random/trash.dm
@@ -157,7 +157,7 @@
 	var/graffiti_icons = list(
 		"rune1", "rune2", "rune3", "rune4", "rune5", "rune6",
 		"amyjon", "face", "matt", "revolution", "engie", "guy",
-		"end", "dwarf", "uboa", "body", "cyka", "star", "poseur tag",
+		"end", "dwarf", "uboa", "body", "cyka", "star",
 		"prolizard", "antilizard", "danger", "firedanger", "electricdanger",
 		"biohazard", "radiation", "safe", "evac", "space", "med", "trade", "shop",
 		"food", "peace", "like", "skull", "nay", "heart", "credit",

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -102,7 +102,6 @@
 		"face",
 		"guy",
 		"matt",
-		"poseur tag",
 		"prolizard",
 		"revolution",
 		"star",


### PR DESCRIPTION
## About The Pull Request
The _poseur tag_ graffiti option was not removed in the gang gamemode removal back in #30056. Back then it would have chosen one of the gangs' tags to mimic. Now, if selected, it will create an empty graffiti. This will also apply to any mapped/generated graffiti. This sucks and this derailed me from my other thing I was doing in the crayons.dm vicinity.

## Why It's Good For The Game
Removes a 6-year-old non-functioning graffiti option.

## Changelog
:cl:
fix: exorcised a ghost of the gang gamemode from graffiti
/:cl: