### PR TITLE
Fixed a vulnerability introduced by the Request Music PR

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -83,8 +83,8 @@
 	var/list/music_extra_data = list()
 	var/duration = 0
 	if(istext(input))
-		input = shell_url_scrub(input)
-		var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[input]\"")
+		var/shell_scrubbed_input = shell_url_scrub(input)
+		var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
 		var/errorlevel = output[SHELLEO_ERRORLEVEL]
 		var/stdout = output[SHELLEO_STDOUT]
 		var/stderr = output[SHELLEO_STDERR]

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -78,13 +78,12 @@
 	if(!ytdl)
 		to_chat(user, span_boldwarning("Youtube-dl was not configured, action unavailable"), confidential = TRUE) //Check config.txt for the INVOKE_YOUTUBEDL value
 		return
-	input = shell_url_scrub(input)
 	var/web_sound_url = ""
 	var/stop_web_sounds = FALSE
 	var/list/music_extra_data = list()
 	var/duration = 0
-
 	if(istext(input))
+		input = shell_url_scrub(input)
 		var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[input]\"")
 		var/errorlevel = output[SHELLEO_ERRORLEVEL]
 		var/stdout = output[SHELLEO_STDOUT]

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -78,6 +78,7 @@
 	if(!ytdl)
 		to_chat(user, span_boldwarning("Youtube-dl was not configured, action unavailable"), confidential = TRUE) //Check config.txt for the INVOKE_YOUTUBEDL value
 		return
+	input = shell_url_scrub(input)
 	var/web_sound_url = ""
 	var/stop_web_sounds = FALSE
 	var/list/music_extra_data = list()
@@ -192,8 +193,7 @@
 			to_chat(src, span_boldwarning("Non-http(s) URIs are not allowed."), confidential = TRUE)
 			to_chat(src, span_warning("For youtube-dl shortcuts like ytsearch: please use the appropriate full URL from the website."), confidential = TRUE)
 			return
-		var/shell_scrubbed_input = shell_url_scrub(web_sound_input)
-		web_sound(usr, shell_scrubbed_input)
+		web_sound(usr, web_sound_input)
 	else
 		web_sound(usr, null)
 

--- a/code/modules/admin/verbs/request_internet_sound.dm
+++ b/code/modules/admin/verbs/request_internet_sound.dm
@@ -20,7 +20,6 @@
 		to_chat(usr, span_danger("Invalid URL. Please use a URL from one of the following sites: [replacetext(CONFIG_GET(string/request_internet_allowed), "\\", "")]"), confidential = TRUE)
 		return
 
-	request_url = shell_url_scrub(request_url)
 	log_internet_request("[src.key]/([src.name]): [request_url]")
 	if(usr.client)
 		if(usr.client.prefs.muted & MUTE_INTERNET_REQUEST)


### PR DESCRIPTION
## About The Pull Request
Admins can proccall the web_sound proc, completely bypassing the shell_url_scrub done in other procs. Additionally, admins could just directly modify the request URL stored in the request manager so that it, again, bypasses the shell_url_scrub.

This PR just moves the shell scrubbing directly inside the proc, right before the world.shelleo call, so that admins can't get around it with a proccall.

PR that introduced the vulnerability: #74170

## Why It's Good For The Game
Fixes a vulnerability that allows admins to execute shell commands via proccall.
