### PR TITLE
Bluespace poly crystals can be used to complete machine frames

### DIFF
--- a/code/datums/storage/subtypes/rped.dm
+++ b/code/datums/storage/subtypes/rped.dm
@@ -29,8 +29,6 @@
 	 */
 	var/static/list/allowed_bluespace_types = list(
 		/obj/item/stack/ore/bluespace_crystal,
-		/obj/item/stack/ore/bluespace_crystal/refined,
-		/obj/item/stack/ore/bluespace_crystal/artificial,
 		/obj/item/stack/sheet/bluespace_crystal,
 	)
 
@@ -58,9 +56,9 @@
 		//we try to count & limit how much the user can insert of each type to prevent them from using it as an normal storage medium
 		for(var/obj/item/stack/stack_content in resolve_location.contents)
 			//is user trying to insert any of these listed bluespace stuff
-			if(is_type_in_list(to_insert,allowed_bluespace_types))
+			if(is_type_in_list(to_insert, allowed_bluespace_types))
 				//if yes count total bluespace stuff is the RPED and then compare the total amount to the value the user is trying to insert
-				if(is_type_in_list(stack_content,allowed_bluespace_types))
+				if(is_type_in_list(stack_content, allowed_bluespace_types))
 					present_amount += stack_content.amount
 			//count other normal stack stuff
 			else if(istype(to_insert,stack_content.type))

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -316,7 +316,7 @@
 						target_path = path
 
 					var/obj/item/part
-					while(req_components[path] > 0 && (part = locate(target_path) in part_list))
+					while(req_components[path] > 0 && (part = look_for(part_list, target_path, ispath(path, /obj/item/stack/ore/bluespace_crystal) ? /obj/item/stack/sheet/bluespace_crystal : null)))
 						part_list -= part
 						if(istype(part,/obj/item/stack))
 							var/obj/item/stack/S = part
@@ -349,16 +349,19 @@
 
 				var/stock_part_path
 
-				if (ispath(stock_part_base, /obj/item))
+				if(ispath(stock_part_base, /obj/item))
 					stock_part_path = stock_part_base
-				else if (ispath(stock_part_base, /datum/stock_part))
+				else if(ispath(stock_part_base, /datum/stock_part))
 					var/datum/stock_part/stock_part_datum_type = stock_part_base
 					stock_part_path = initial(stock_part_datum_type.physical_object_type)
 				else
 					stack_trace("Bad stock part in req_components: [stock_part_base]")
 					continue
 
-				if (!istype(P, stock_part_path))
+				//if we require an bluespace crystall and we have an full sheet of them we can allow that
+				if(ispath(stock_part_path, /obj/item/stack/ore/bluespace_crystal) && istype(P, /obj/item/stack/sheet/bluespace_crystal))
+					//allow it
+				else if(!istype(P, stock_part_path))
 					continue
 
 				if(isstack(P))
@@ -401,6 +404,18 @@
 			return FALSE
 	if(user.combat_mode)
 		return ..()
+
+/// returns instance of path1 in list else path2 in list
+/obj/structure/frame/machine/proc/look_for(list/parts, path1, path2 = null)
+	//look for path1 in list
+	var/part = locate(path1) in parts
+	if(!isnull(part))
+		return part
+
+	//optional look for path2 in list
+	if(!isnull(path2))
+		part = locate(path2) in parts
+	return part
 
 /obj/structure/frame/machine/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))


### PR DESCRIPTION
## About The Pull Request
Fixes #47650

Either by hand or by RPED you can now use blue space poly crystal to finish a machine. If you are using a RPED then it will attempt to look for singular bluespace crystals first and only if it cannot find it will it then look for the bluespace poly crystals

Also removed some redundant types from the RPED allowed bluespace types list cause they were not necessary

## Changelog
:cl:
fix: bluespace poly crystals can be used to complete machine frames either by hand or by RPED
/:cl: