### PR TITLE
Splits debug logging into private and public log file

### DIFF
--- a/code/__DEFINES/logging.dm
+++ b/code/__DEFINES/logging.dm
@@ -101,7 +101,8 @@
 #define LOG_CATEGORY_ADMIN_PRIVATE_ASAY "adminprivate-asay"
 
 // Debug categories
-#define LOG_CATEGORY_DEBUG "debug"
+#define LOG_CATEGORY_DEBUG_PRIVATE "debug-private"
+#define LOG_CATEGORY_DEBUG_PUBLIC "debug-public"
 #define LOG_CATEGORY_DEBUG_ASSET "debug-asset"
 #define LOG_CATEGORY_DEBUG_HREF "debug-href"
 #define LOG_CATEGORY_DEBUG_JOB "debug-job"

--- a/code/modules/logging/categories/log_category_debug.dm
+++ b/code/modules/logging/categories/log_category_debug.dm
@@ -1,21 +1,25 @@
-/datum/log_category/debug
-	category = LOG_CATEGORY_DEBUG
+//////Debug logs that should be privately viewable (admins/keyholders only)
+/datum/log_category/debug_private
+	category = LOG_CATEGORY_DEBUG_PRIVATE
 
+///Debug logs that should be publicly viewable (parsed-logs)
+/datum/log_category/debug_public
+	category = LOG_CATEGORY_DEBUG_PUBLIC
 /datum/log_category/debug_tgui
 	category = LOG_CATEGORY_DEBUG_TGUI
-	master_category = /datum/log_category/debug
+	master_category = /datum/log_category/debug_private
 
 /datum/log_category/debug_sql
 	category = LOG_CATEGORY_DEBUG_SQL
-	master_category = /datum/log_category/debug
+	master_category = /datum/log_category/debug_private
 
 /datum/log_category/debug_lua
 	category = LOG_CATEGORY_DEBUG_LUA
-	master_category = /datum/log_category/debug
+	master_category = /datum/log_category/debug_private
 
 /datum/log_category/debug_href
 	category = LOG_CATEGORY_DEBUG_HREF
-	master_category = /datum/log_category/debug
+	master_category = /datum/log_category/debug_private
 
 // This is not in the debug master category on purpose, do not add it
 /datum/log_category/debug_runtime
@@ -24,18 +28,18 @@
 
 /datum/log_category/debug_mapping
 	category = LOG_CATEGORY_DEBUG_MAPPING
-	master_category = /datum/log_category/debug
+	master_category = /datum/log_category/debug_public
 
 /datum/log_category/debug_job
 	category = LOG_CATEGORY_DEBUG_JOB
 	config_flag = /datum/config_entry/flag/log_job_debug
-	master_category = /datum/log_category/debug
+	master_category = /datum/log_category/debug_public
 
 /datum/log_category/debug_mobtag
 	category = LOG_CATEGORY_DEBUG_MOBTAG
-	master_category = /datum/log_category/debug
+	master_category = /datum/log_category/debug_public
 
 /datum/log_category/debug_asset
 	category = LOG_CATEGORY_DEBUG_ASSET
 	config_flag = /datum/config_entry/flag/log_asset
-	master_category = /datum/log_category/debug
+	master_category = /datum/log_category/debug_private


### PR DESCRIPTION

## About The Pull Request
Splits the debug.log file into debug-private.log and debug-public.log
This allows for logging like mob_tag logs that was previously available at parsed-logs to be publicly viewable again.
## Why It's Good For The Game
Logs that were previously publicly available will be available again
## Changelog
:cl:Gamer025
server: Splits debug.log into debug-private.log and debug-public.log
/:cl:
