### PR TITLE
Re-adds anesthetic tanks to Robotics labs on all maps 

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2911,6 +2911,7 @@
 /obj/item/lighter{
 	pixel_x = 15
 	},
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/augments)
 "boY" = (
@@ -19367,6 +19368,7 @@
 "hnP" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/status_display/evac/directional/south,
+/obj/structure/tank_holder/anesthetic,
 /turf/open/floor/iron,
 /area/station/science/robotics/augments)
 "hnV" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9585,6 +9585,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
+/obj/structure/tank_holder/anesthetic,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/science/robotics/lab)
 "cnl" = (
@@ -43807,6 +43808,7 @@
 	pixel_x = -10;
 	pixel_y = -4
 	},
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "kSc" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -7766,6 +7766,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"ctY" = (
+/obj/structure/tank_holder/anesthetic,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "cum" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
 	dir = 1
@@ -69704,6 +69708,7 @@
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
 /obj/item/pen,
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "wkV" = (
@@ -250418,7 +250423,7 @@ apM
 uvt
 kBT
 pra
-pra
+ctY
 mtI
 uxj
 eNK

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -12393,6 +12393,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/north,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "eEV" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17685,6 +17685,7 @@
 /obj/item/scalpel{
 	pixel_y = 11
 	},
+/obj/item/clothing/mask/breath/medical,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "eRb" = (
@@ -31287,6 +31288,7 @@
 /area/station/medical/chemistry)
 "jZa" = (
 /obj/machinery/light/small/directional/west,
+/obj/structure/tank_holder/anesthetic,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "jZb" = (


### PR DESCRIPTION
## About The Pull Request

I'm not 100% sure when these were removed, but at some point somebody went through and removed the N2O cans from all of the robotics surgery suites. That never really sat well with me, so I'm re-adding them. This enables some good RP around not causing pain for those who are adverse to it and also creates nefarious opportunities for those who aren't.

## Why It's Good For The Game

Supporting good RP is always a good thing and I feel like roboticist antags could use some help in doing further evil things that aren't just emagging borgs.

## Changelog

:cl:
add: As a result of a recent safety lawsuit, Nanotrasen has mandated the return of anesthetic canisters and masks to robotics research on all stations that are not currently equipped with them.
/:cl:

