### PR TITLE
Replaces the syndicate corpse Legions can drop with one without a MODSuit

### DIFF
--- a/code/modules/mob_spawn/corpses/mining_corpses.dm
+++ b/code/modules/mob_spawn/corpses/mining_corpses.dm
@@ -54,7 +54,7 @@
 		if("Golem")
 			outfit = /datum/outfit/consumed_golem
 		if("Operative")
-			outfit = /datum/outfit/syndicatecommandocorpse
+			outfit = /datum/outfit/syndicatecommandocorpse/lessenedgear
 		if("Shadow")
 			outfit = /datum/outfit/consumed_shadowperson
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
This is part of a pass I'm working on doing where I go through and remove instances of antag gear outside of their normal context. This is mostly going to involve replacing space/Lavaland ruin gear with something close to the same power level but not distinctly something only antags should be able to get. I want to keep ruins rewarding but I don't want explicit antag gear to be something you can obtain without needing an uplink.

The first part of this is me removing the MODSuit from the syndicate operative corpse. The new one drops a turtleneck, a syndicate gas mask, and gripper gloves.

## Why It's Good For The Game
It's my opinion that antag gear should probably stay in antag hands unless you manage to kill one or steal an uplink. The main impetus for this was a discussion I had a while back about how blood red hardsuits used to _just_ be an antag thing. I kind of miss that general feeling of paranoia that came from seeing someone wearing it, as opposed to seeing it these days and just thinking "Yeah, it's probably someone who got it from space".

In this specific instance, Syndicate MODSuits are pretty strong anyway and, regardless of the low odds of getting one, I really don't think it should be available as loot off a fairly easy-to-kill mob.

## Changelog
:cl:
balance: Syndicate corpses dropped from killing a Legion no longer come with a MODSuit.
/:cl:
