### PR TITLE
Fix "None" gas names in gas filter

### DIFF
--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -183,7 +183,7 @@ const GASES = [
     color: 'lightsteelblue',
   },
   {
-    id: 'nob',
+    id: 'hypernoblium',
     path: '/datum/gas/hypernoblium',
     name: 'Hyper-noblium',
     label: 'Hyper-nob',
@@ -218,7 +218,7 @@ const GASES = [
     color: 'mediumpurple',
   },
   {
-    id: 'pluox',
+    id: 'pluoxium',
     path: '/datum/gas/pluoxium',
     name: 'Pluoxium',
     label: 'Pluoxium',


### PR DESCRIPTION
## About The Pull Request

There's a problem
![Screenshot (229)](https://github.com/tgstation/tgstation/assets/110812394/60d00297-496d-44f1-b471-bc7ca61ae196)

But it's fixed now
![Screenshot (230)](https://github.com/tgstation/tgstation/assets/110812394/fbdcbe01-b040-42ff-b343-3ec62041117b)

Broken in #75542. The gas id's didn't match those defined in the UI constant's

## Changelog
:cl:
fix: fix "none" gas names in gas filter
/:cl: