### PR TITLE
Mecha fixes: plasma generator, internal damage report & repair

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -273,19 +273,20 @@
 
 /obj/item/mecha_parts/mecha_equipment/generator
 	name = "plasma engine"
-	desc = "An exosuit module that generates power using solid plasma as fuel. Pollutes the environment."
+	desc = "An exosuit module that generates power using solid plasma as fuel."
 	icon_state = "tesla"
 	range = MECHA_MELEE
 	equipment_slot = MECHA_POWER
 	activated = FALSE
-	var/coeff = 100
-	var/obj/item/stack/sheet/fuel
-	var/max_fuel = 150000
-	/// Fuel used per second while idle, not generating
+	///Type of fuel the generator is using. Is set in generator_init() to add the starting amount of fuel
+	var/obj/item/stack/sheet/fuel = null
+	///Fuel used per second while idle, not generating, in units
 	var/fuelrate_idle = 12.5
-	/// Fuel used per second while actively generating
+	///Fuel used per second while actively generating, in units
 	var/fuelrate_active = 100
-	/// Energy recharged per second
+	///Maximum fuel capacity of the generator, in units
+	var/max_fuel = 150000
+	///Energy recharged per second
 	var/rechargerate = 10
 
 /obj/item/mecha_parts/mecha_equipment/generator/Initialize(mapload)
@@ -295,9 +296,6 @@
 /obj/item/mecha_parts/mecha_equipment/generator/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	return ..()
-
-/obj/item/mecha_parts/mecha_equipment/generator/proc/generator_init()
-	fuel = new /obj/item/stack/sheet/mineral/plasma(src, 0)
 
 /obj/item/mecha_parts/mecha_equipment/generator/detach()
 	STOP_PROCESSING(SSobj, src)
@@ -323,28 +321,11 @@
 			log_message("Deactivated.", LOG_MECHA)
 		return TRUE
 
-/obj/item/mecha_parts/mecha_equipment/generator/attackby(weapon, mob/user, params)
+/obj/item/mecha_parts/mecha_equipment/generator/attackby(obj/item/weapon, mob/user, params)
 	. = ..()
+	if(!istype(weapon, fuel))
+		return FALSE
 	load_fuel(weapon, user)
-
-/obj/item/mecha_parts/mecha_equipment/generator/proc/load_fuel(obj/item/stack/sheet/P, mob/user)
-	if(P.type == fuel.type && P.amount > 0)
-		var/to_load = max(max_fuel - fuel.amount*SHEET_MATERIAL_AMOUNT,0)
-		if(to_load)
-			var/units = min(max(round(to_load / SHEET_MATERIAL_AMOUNT),1),P.amount)
-			fuel.amount += units
-			P.use(units)
-			to_chat(user, "[icon2html(src, user)][span_notice("[units] unit\s of [fuel] successfully loaded.")]")
-			return units
-		else
-			to_chat(user, "[icon2html(src, user)][span_notice("Unit is full.")]")
-			return 0
-	else
-		to_chat(user, "[icon2html(src, user)][span_warning("[fuel] traces in target minimal! [P] cannot be used as fuel.")]")
-		return
-
-/obj/item/mecha_parts/mecha_equipment/generator/attackby(weapon,mob/user, params)
-	load_fuel(weapon)
 
 /obj/item/mecha_parts/mecha_equipment/generator/process(seconds_per_tick)
 	if(!chassis)
@@ -355,17 +336,38 @@
 		log_message("Deactivated - no fuel.", LOG_MECHA)
 		to_chat(chassis.occupants, "[icon2html(src, chassis.occupants)][span_notice("Fuel reserves depleted.")]")
 		return PROCESS_KILL
-	var/cur_charge = chassis.get_charge()
-	if(isnull(cur_charge))
+	var/current_charge = chassis.get_charge()
+	if(isnull(current_charge))
 		activated = FALSE
 		to_chat(chassis.occupants, "[icon2html(src, chassis.occupants)][span_notice("No power cell detected.")]")
 		log_message("Deactivated.", LOG_MECHA)
 		return PROCESS_KILL
-	var/use_fuel = fuelrate_idle
-	if(cur_charge < chassis.cell.maxcharge)
-		use_fuel = fuelrate_active
+	//how much fuel are we using per tick
+	var/fuel_usage_rate = fuelrate_idle
+	if(current_charge < chassis.cell.maxcharge)
+		fuel_usage_rate = fuelrate_active
 		chassis.give_power(rechargerate * seconds_per_tick)
-	fuel.amount -= min(seconds_per_tick * use_fuel / SHEET_MATERIAL_AMOUNT, fuel.amount)
+	fuel.amount -= min(seconds_per_tick * fuel_usage_rate / SHEET_MATERIAL_AMOUNT, fuel.amount)
+
+///Try to insert more fuel into the generator
+/obj/item/mecha_parts/mecha_equipment/generator/proc/load_fuel(obj/item/stack/sheet/inserted_fuel, mob/user)
+	if(inserted_fuel.amount == 0) //if we somehow have a sheet of 0 fuel
+		to_chat(user, "[icon2html(src, user)][span_warning("[fuel] traces in target minimal! [inserted_fuel] cannot be used as fuel.")]")
+		return
+	//how much fuel is needed to fill the generator to its max capacity, in units
+	var/units_to_load = max(max_fuel - fuel.amount * SHEET_MATERIAL_AMOUNT, 0)
+	if(!units_to_load)
+		to_chat(user, "[icon2html(src, user)][span_notice("Unit is full.")]")
+		return
+	//how much new fuel are we inserting, in sheets
+	var/fuel_to_load = min(max(round(units_to_load / SHEET_MATERIAL_AMOUNT), 1), inserted_fuel.amount)
+	fuel.amount += fuel_to_load
+	inserted_fuel.use(fuel_to_load)
+	to_chat(user, "[icon2html(src, user)][span_notice("[fuel_to_load] unit\s of [fuel] successfully loaded.")]")
+
+///Introduces the actual fuel type to be used, as well as the starting amount of said fuel
+/obj/item/mecha_parts/mecha_equipment/generator/proc/generator_init()
+	fuel = new /obj/item/stack/sheet/mineral/plasma(src, 0)
 
 /////////////////////////////////////////// THRUSTERS /////////////////////////////////////////////
 

--- a/code/modules/vehicles/mecha/mecha_damage.dm
+++ b/code/modules/vehicles/mecha/mecha_damage.dm
@@ -102,6 +102,8 @@
 				to_chat(occupants, "[icon2html(src, occupants)][span_boldnotice("Internal fire extinguished.")]")
 			if(MECHA_INT_TANK_BREACH)
 				to_chat(occupants, "[icon2html(src, occupants)][span_boldnotice("Damaged internal tank has been sealed.")]")
+			if(MECHA_INT_CONTROL_LOST)
+				to_chat(occupants, "[icon2html(src, occupants)][span_boldnotice("Control module reactivated.")]")
 			if(MECHA_INT_SHORT_CIRCUIT)
 				to_chat(occupants, "[icon2html(src, occupants)][span_boldnotice("Internal capacitor has been reset successfully.")]")
 	internal_damage &= ~int_dam_flag

--- a/code/modules/vehicles/mecha/mecha_ui.dm
+++ b/code/modules/vehicles/mecha/mecha_ui.dm
@@ -29,7 +29,7 @@
 /obj/vehicle/sealed/mecha/ui_static_data(mob/user)
 	var/list/data = list()
 	data["cabin_dangerous_highpressure"] = WARNING_HIGH_PRESSURE
-	data["SHEET_MATERIAL_AMOUNT"] = SHEET_MATERIAL_AMOUNT
+	data["sheet_material_amount"] = SHEET_MATERIAL_AMOUNT
 	//map of relevant flags to check tgui side, not every flag needs to be here
 	data["mechflag_keys"] = list(
 		"ADDING_ACCESS_POSSIBLE" = ADDING_ACCESS_POSSIBLE,

--- a/tgui/packages/tgui/interfaces/Mecha/PowerModulesPane.tsx
+++ b/tgui/packages/tgui/interfaces/Mecha/PowerModulesPane.tsx
@@ -5,7 +5,7 @@ import { toFixed } from 'common/math';
 
 export const PowerModulesPane = (props, context) => {
   const { act, data } = useBackend<OperatorData>(context);
-  const { mech_equipment, mineral_material_amount } = data;
+  const { mech_equipment, sheet_material_amount } = data;
   return (
     <LabeledList>
       {mech_equipment['power'].map((module, i) => (
@@ -16,7 +16,7 @@ export const PowerModulesPane = (props, context) => {
             (module.snowflake.fuel === null
               ? ''
               : ': ' +
-              toFixed(module.snowflake.fuel * mineral_material_amount, 0.1) +
+              toFixed(module.snowflake.fuel * sheet_material_amount, 0.1) +
               ' cm³')
           }>
           <Button

--- a/tgui/packages/tgui/interfaces/Mecha/data.ts
+++ b/tgui/packages/tgui/interfaces/Mecha/data.ts
@@ -14,6 +14,7 @@ export const InternalDamageToNormalDesc = {
   'MECHA_INT_TEMP_CONTROL': 'Temperature control active',
   'MECHA_INT_TANK_BREACH': 'Air tank intact',
   'MECHA_INT_CONTROL_LOST': 'Control module active',
+  'MECHA_INT_SHORT_CIRCUIT': 'Internal capacitor operational',
 };
 
 export type AccessData = {
@@ -87,7 +88,7 @@ export type OperatorData = {
   weapons_safety: boolean;
   mech_equipment: string[];
   mech_view: string;
-  mineral_material_amount: number;
+  sheet_material_amount: number;
 };
 
 export type MechaUtility = {


### PR DESCRIPTION
## About The Pull Request
Cleans up the plasma generator to actually work & make more sense:
* was not accepting any fuel, made that work; will also accept subtypes of fuel e.g. a mapped-in stack of 5 plasma
* was not displaying the amount of fuel left in mecha stats UI, was broken in #75052 
* plasma pollution was removed a long time ago in #42908, scrubs mention of that

Also adds some fluff text to the internal damage tracker to the short circuit entry, as it was lacking a "system nominal" one. Also added a `to_chat` to fixing navigation internal damage, as it was the only one with no message for some reason.

## Why It's Good For The Game
Fixes #75613
Hopefully easier to read code.
Not quite sure whether I want to make the generator a base item and move the plasma generator to a subtype or not but eh not like there's another energy module available (nuclear engine rip in pasta)

## Changelog

:cl:
fix: fixed mecha plasma generator not accepting fuel
fix: fixed mecha ui incorrectly displaying fuel remaining when using an energy module
fix: fixed mecha ui missing fluff text for short circuit repair control (5th option)
qol: fixing mecha control module internal damage will print out a chat message like fixing other damage does
del: did you know that for 4 years now mecha plasma generators did not, in fact, pollute the environment when in use? removed that bit from its description
/:cl:
