### PR TITLE
[NO GBP] Modular Shield Generator Fixes 

### DIFF
--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -165,7 +165,7 @@
 
 ///generates the forcefield based on the given radius and calls calculate_regen to update the regen value accordingly
 /obj/machinery/modular_shield_generator/proc/activate_shields()
-	if(active)//bug or did admin call proc on already active shield gen?
+	if(active || (machine_stat & NOPOWER))//bug or did admin call proc on already active shield gen?
 		return
 	if(radius < 0)//what the fuck are admins doing
 		radius = initial(radius)

--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -178,7 +178,7 @@
 
 		if(exterior_only)
 			for(var/turf/target_tile as anything in list_of_turfs)
-				if(isspaceturf(target_tile) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
+				if(!(isfloorturf(target_tile)) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
 					var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
 					deploying_shield.shield_generator = src
 					LAZYADD(deployed_shields, deploying_shield)
@@ -187,7 +187,7 @@
 			return
 
 		for(var/turf/target_tile as anything in list_of_turfs)
-			if(isopenturf(target_tile) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
+			if(isopenturf(target_tile) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
 				var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
 				deploying_shield.shield_generator = src
 				LAZYADD(deployed_shields, deploying_shield)
@@ -199,7 +199,7 @@
 	LAZYADD(inside_shield, circle_range_turfs(src, radius - 1))//in the future we might want to apply an effect to the turfs inside the shield
 	if(exterior_only)
 		for(var/turf/target_tile as anything in circle_range_turfs(src, radius))
-			if(isspaceturf(target_tile) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
+			if(!(isfloorturf(target_tile)) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
 				var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
 				deploying_shield.shield_generator = src
 				LAZYADD(deployed_shields, deploying_shield)


### PR DESCRIPTION

## About The Pull Request
This pr is a small fix for 2 things.

1. It will now stop you from being able to pulse the wire on an unpowered generator to activate it, this bug wasnt gamebreaking because regeneration is off when the generator has no power but it still shouldnt be functional at all.
2. The external setting on the shield generator now just blacklists constructed floor turfs to make it compatible with outdoor areas such as lavaland or an asteroid.

## Why It's Good For The Game
The inability to use the external function on maps such as icebox meant that you would be stuck with the alternative which can block internal passageways within whatever structure you built the shield generator in, this fixes that and makes the shield generator more compatible with future maps that take place on a planet or asteroid.
## Changelog
:cl:
fix: You can no longer pulse the wire on an unpowered shield generator to activate shields
fix: External only setting on modular shield generators now properly uses terrestrial turfs such as lavawastes.
/:cl:
