### PR TITLE
Adds missing window to tramstation departures

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -186217,7 +186217,7 @@ aGq
 fmy
 pEx
 pEx
-may
+pEx
 fmy
 dbV
 seY


### PR DESCRIPTION
## About The Pull Request
 
Adds a window to the existing row of windows separating tram departures from the rest of the station.

![image](https://github.com/tgstation/tgstation/assets/62126254/37e67314-c654-48c5-bf97-e29227f9be2b)

![image](https://github.com/tgstation/tgstation/assets/62126254/74c0f10b-ee9a-442c-9ba0-9723dd825972)

## Why It's Good For The Game

Because having a random opening in a row of glass windows at round start with no sign of damage or anything looks pretty random and bad.
## Changelog
:cl:

fix: Tramstation departures is no longer missing a window

/:cl:
