### PR TITLE
makes snow legions from portals drop skeletons (like tendril legions)

### DIFF
--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -102,7 +102,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/ice_whelp)
 
 /obj/structure/spawner/ice_moon/demonic_portal/snowlegion
-	mob_types = list(/mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow)
+	mob_types = list(/mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow/portal)
 
 /obj/effect/collapsing_demonic_portal
 	name = "collapsing demonic portal"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -217,4 +217,4 @@
 			L.apply_status_effect(/datum/status_effect/freon/watcher)
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher/tendril
-	fromtendril = TRUE
+	from_spawner = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -178,7 +178,7 @@
 				cached_tentacle_turfs -= t
 
 /mob/living/simple_animal/hostile/asteroid/goliath/beast/tendril
-	fromtendril = TRUE
+	from_spawner = TRUE
 
 //tentacles
 /obj/effect/temp_visual/goliath_tentacle

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -154,7 +154,7 @@
 		if(stored_mob)
 			stored_mob.forceMove(get_turf(src))
 			stored_mob = null
-		else if(fromtendril)
+		else if(from_spawner)
 			new /obj/effect/mob_spawn/corpse/human/charredskeleton(T)
 		else if(dwarf_mob)
 			new /obj/effect/mob_spawn/corpse/human/legioninfested/dwarf(T)
@@ -163,7 +163,7 @@
 	..(gibbed)
 
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril
-	fromtendril = TRUE
+	from_spawner = TRUE
 
 //Legion skull
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion
@@ -307,6 +307,9 @@
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/snow/make_legion(mob/living/carbon/human/H)
 	return new /mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow(H.loc)
+
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow/portal
+	from_spawner = TRUE
 
 // Snow Legion skull
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/snow

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -14,7 +14,8 @@
 	status_flags = 0
 	combat_mode = TRUE
 	var/throw_message = "bounces off of"
-	var/fromtendril = FALSE
+	/// Is this mob subtype from a spawner (e.g. necropolis tendril, demonic portal)? Can be used to affect what it drops (e.g. legions force-dropping ashen skeletons).
+	var/from_spawner = FALSE
 	// Pale purple, should be red enough to see stuff on lavaland
 	lighting_cutoff_red = 25
 	lighting_cutoff_green = 15

--- a/code/modules/unit_tests/simple_animal_freeze.dm
+++ b/code/modules/unit_tests/simple_animal_freeze.dm
@@ -91,6 +91,7 @@
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/random,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow,
+		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow/portal,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril,
 		/mob/living/simple_animal/hostile/asteroid/hivelordbrood,
 		/mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion,


### PR DESCRIPTION
## About The Pull Request
Exactly what it says on the tin (snow legions only dropping ashen skeletons, like tendril legions).

Also changes the name of the "fromtendril" variable to "from_spawner", and comments it. Not sure if that warrants a changelong comment, but I'll go ahead and assume no.

## Why It's Good For The Game
being able to farm snow legion portals for an endless tide of bodies and/or equipment is a bit weird. also puts it a bit more in line with the legions of Lavaland

## Changelog

:cl:
balance: The source of the demonic portals that endlessly deposits snow legions onto the Icemoon no longer preserves the bodies nor gear of the damned (read: demon portal snow legions now only drop skeletons).
/:cl:
