### PR TITLE
Generic and crew-available status readout module

### DIFF
--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -290,8 +290,8 @@
 ///Status Readout - Puts a lot of information including health, nutrition, fingerprints, temperature to the suit TGUI.
 /obj/item/mod/module/status_readout
 	name = "MOD status readout module"
-	desc = "A once-common module, this technology went unfortunately out of fashion; \
-		and right into the arachnid grip of the Spider Clan. This hooks into the suit's spine, \
+	desc = "A once-common module, this technology went unfortunately out of fashion around the safer regions of space; \
+		and right into the research networks of the Periphery. This hooks into the suit's spine, \
 		capable of capturing and displaying all possible biometric data of the wearer; sleep, nutrition, fitness, fingerprints, \
 		and even useful information such as their overall health and wellness."
 	icon_state = "status"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1906,7 +1906,6 @@
 		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_MEDICAL
 	)
 
-
 /datum/design/module/patienttransport
 	name = "Patient Transport Module"
 	id = "mod_patienttransport"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1897,6 +1897,16 @@
 		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_MEDICAL
 	)
 
+/datum/design/module/statusreadout
+	name = "Status Readout Module"
+	id = "mod_statusreadout"
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT * 3, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/titanium = SMALL_MATERIAL_AMOUNT * 2)
+	build_path = /obj/item/mod/module/status_readout
+	category = list(
+		RND_CATEGORY_MODSUIT_MODULES + RND_SUBCATEGORY_MODSUIT_MODULES_MEDICAL
+	)
+
+
 /datum/design/module/patienttransport
 	name = "Patient Transport Module"
 	id = "mod_patienttransport"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1692,6 +1692,7 @@
 		"mod_defib",
 		"mod_threadripper",
 		"mod_surgicalprocessor",
+		"mod_statusreadout"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1692,7 +1692,7 @@
 		"mod_defib",
 		"mod_threadripper",
 		"mod_surgicalprocessor",
-		"mod_statusreadout"
+		"mod_statusreadout",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3500)
 


### PR DESCRIPTION

## About The Pull Request
Ninja's health-and-nutrition-and-such status readout module is no longer ninja-exclusive; added to the advanced medical research techweb. As such, its description has been slightly edited to affect its status.
![image](https://github.com/tgstation/tgstation/assets/42087567/a6fc6a43-fcd0-469f-bede-c7a33e0de404)
## Why It's Good For The Game
This module always felt like it shouldn't be locked behind and thus only use by a relatively rare antagonist: it was, just, super convenient, and useful for uuuh... I'd say anyone on station, to view their accurate health status on the spot. And with the health analyzer module doing the exact same thing, and more, -being able to check other people's health whoa!-, I don't think it'd be out of the norm to make the ninja's module station-available too.
## Changelog
:cl: Stalkeros
add: Status readout module: now generic, additionally station-available.
/:cl:
