### PR TITLE
Significantly lowers Golem's innate armor

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -23,6 +23,7 @@
 	mutantlungs = null
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	liked_food = STONE
+	armor = 10
 	payday_modifier = 0.75
 	siemens_coeff = 0
 	no_equip_flags = ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING | ITEM_SLOT_SUITSTORE

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -24,7 +24,6 @@
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	liked_food = STONE
 	payday_modifier = 0.75
-	armor = 55
 	siemens_coeff = 0
 	no_equip_flags = ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING | ITEM_SLOT_SUITSTORE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC


### PR DESCRIPTION
## About The Pull Request

Lowers Golem's 55% innate species armor to 10%.

## Why It's Good For The Game

The Golem rework has fixed a lot of problems I had with Golems, but this was by far the most important thing for me. I thought the Golem rework itself would fix it, but instead I feel it was made worse due to their speed increase.
Innately, Golems have 55% armor from their species, that is not even comparable to any other species. There's only 2 other species that have this innate armor; Zombies at 20%, and Silverscales at 10%, but both of these are Antagonist roles while Golems aren't always going to be.

Golems also now revolve around eating Matierials for their buffs, so paired with their speed increase to match Humans, I don't think this free 55% armor is justified, or fair for people they get in a fight with.
They also already have alternatives to this, the Titanium food Golem buff, which gives them brute resistance and harder punches.

## Changelog

:cl:
balance: Golems' 55% species innate armor has been lowered to 10%
/:cl: