### PR TITLE
Adds a variable that allows invisible portals

### DIFF
--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -28,6 +28,8 @@
 	var/last_effect = 0
 	/// Does this portal bypass teleport restrictions? like TRAIT_NO_TELEPORT and NOTELEPORT flags.
 	var/force_teleport = FALSE
+	//does this portal create spark effect when teleporting?
+	var/sparkless = FALSE
 
 /obj/effect/portal/anom
 	name = "wormhole"
@@ -115,7 +117,7 @@
 	if(!force && (!ismecha(M) && !isprojectile(M) && M.anchored && !allow_anchored))
 		return
 	var/no_effect = FALSE
-	if(last_effect == world.time)
+	if(last_effect == world.time || sparkless)
 		no_effect = TRUE
 	else
 		last_effect = world.time


### PR DESCRIPTION

## About The Pull Request
Adds simple var that allows a portal to be without the spark effect
## Why It's Good For The Game
Because I am going to make an noneuclidean station with portals, and sparks make it too obvious
## Changelog
:cl:
qol: Admins can make a portal not spark when teleporting
/:cl:
