### PR TITLE
[NO GBP] Fixes alarms not shutting up.

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -553,8 +553,14 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 		if(pressure <= WARNING_LOW_PRESSURE && temp <= BODYTEMP_COLD_WARNING_1+10)
 			warning_message = "Danger! Low pressure and temperature detected."
 			return
-		if(pressure <= WARNING_HIGH_PRESSURE && temp >= BODYTEMP_HEAT_WARNING_1-27)
+		if(pressure <= WARNING_LOW_PRESSURE && temp >= BODYTEMP_HEAT_WARNING_1-27)
+			warning_message = "Danger! Low pressure and high temperature detected."
+			return
+		if(pressure >= WARNING_HIGH_PRESSURE && temp >= BODYTEMP_HEAT_WARNING_1-27)
 			warning_message = "Danger! High pressure and temperature detected."
+			return
+		if(pressure >= WARNING_HIGH_PRESSURE && temp <= BODYTEMP_COLD_WARNING_1+10)
+			warning_message = "Danger! High pressure and low temperature detected."
 			return
 		if(pressure <= WARNING_LOW_PRESSURE)
 			warning_message = "Danger! Low pressure detected."
@@ -568,10 +574,10 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 		if(temp >= BODYTEMP_HEAT_WARNING_1-27)
 			warning_message = "Danger! High temperature detected."
 			return
-		warning_message = "Danger! Atmospheric issue detected."
 
 	else
 		alarm_manager.clear_alarm(ALARM_ATMOS)
+		warning_message = null
 
 	if(old_danger != danger_level)
 		update_appearance()
@@ -679,6 +685,5 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 
 	update_appearance()
 	update_name()
-	check_danger()
 
 #undef AIRALARM_WARNING_COOLDOWN


### PR DESCRIPTION
## About The Pull Request
While trying to turn the base system into a separete proc I thought I had commited this fix in, but did not...
Also removed a redundant check_danger() I left in while fixing merge conflicts because I'm good at gitfu.

And thanks for Zxaber for letting me know about this issue as soon as possible.
## Why It's Good For The Game
Air alarms talking forever do be bad...
## Changelog
:cl: Guillaume Prata
fix: Air Alarms will properly shut up when atmos is fixed.
/:cl:
