### PR TITLE
fixes some missing disposals pipes on tramstation

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -25273,6 +25273,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "hPW" = (
@@ -35774,6 +35777,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock/cafeteria)
 "lDy" = (
@@ -46084,7 +46088,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/openspace,
+/turf/open/floor/iron/dark,
 /area/station/security/courtroom/holding)
 "pum" = (
 /obj/effect/turf_decal/sand/plating,


### PR DESCRIPTION

## About The Pull Request
See title. Adds some missing disposals pipes on tram.
Also adds a floor under a door in the courtroom holding cells.
## Why It's Good For The Game
Pipes work.
![image](https://github.com/tgstation/tgstation/assets/6972764/680e78bf-0432-418b-916b-6de9be731911)

![image](https://github.com/tgstation/tgstation/assets/6972764/0147d8e0-af29-40c5-8c4a-c75419a18bee)
## Changelog
:cl:
fix: Disposals pipes for the Detective's office & Mining cafeteria now work on tram.
fix: Replaced an open space with a floor at the courtroom holding area.
/:cl:
