### PR TITLE
Fix radio playback on non-common frequencies

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -159,7 +159,7 @@
 	for(var/channel_name in channels)
 		add_radio(src, GLOB.radiochannels[channel_name])
 
-	add_radio(src, FREQ_COMMON)
+	add_radio(src, frequency)
 
 /obj/item/radio/proc/make_syndie() // Turns normal radios into Syndicate radios!
 	qdel(keyslot)


### PR DESCRIPTION

## About The Pull Request
When enabling the speaker on a radio, it gets set to listen for signals specifically on FREQ_COMMON, instead of whatever frequency it's programmed to, which stops you from hearing talking on said channel. This fixes that. 

This applies to all the selectable frequencies on bounced radios and headsets, and is something that has probably often messed with AIs that try to talk to people on AI Private. Changing the frequency while the speaker is enabled gets around this bug, until the speaker is reset again.
## Why It's Good For The Game
Fix bugs, stop accidentally gaslighting people into thinking you're ignoring them on the radio
## Changelog
:cl:
fix: Radios tuned to things other than common respond properly to turning on the speaker
/:cl:
