### PR TITLE
No more un-pulsable syndicate anomalies

### DIFF
--- a/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/code/game/objects/effects/anomalies/_anomalies.dm
@@ -41,10 +41,7 @@
 		aSignal.code = rand(1,100)
 		aSignal.anomaly_type = type
 
-		var/frequency = rand(MIN_FREE_FREQ, MAX_FREE_FREQ)
-		if(ISMULTIPLE(frequency, 2))//signaller frequencies are always uneven!
-			frequency++
-		aSignal.set_frequency(frequency)
+		aSignal.set_frequency(sanitize_frequency(rand(MIN_FREE_FREQ, MAX_FREE_FREQ), free = TRUE))
 
 	if(new_lifespan)
 		lifespan = new_lifespan


### PR DESCRIPTION

## About The Pull Request
Prevents anomalies from spawning with the frequency 121.3, which you can't select using signalers since it's a syndicate frequency. Switches to using the sanitize_frequency proc since it covers this and the "only uneven frequencies" check.

Alternatively, it might make sense to remove the frequency limitation with signalers, as I don't believe there's any non-radio devices that rely on signals on the syndicate frequency, and it's rather unintuitive to have a frequency that just can't be selected without any feedback. But I don't know enough about the relevant functionality to know if that might break something.
## Why It's Good For The Game
Fix bugs. We can't let the syndicate keep getting away with this.
## Changelog
:cl:
fix: Anomalies shouldn't spawn with frequencies that can't be selected on signalers anymore
/:cl:
