### PR TITLE
Being moved around by conveyor belt or tram no longer plays footsteps and wheelchair sounds.

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -36,6 +36,10 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 #define MOVEMENT_LOOP_IGNORE_GLIDE (1<<2)
 ///Should we not update our movables dir on move?
 #define MOVEMENT_LOOP_NO_DIR_UPDATE (1<<3)
+///Should we consider the loop to be dragging movables rather than making them walk? e.g. footsteps won't play if enabled
+#define MOVEMENT_LOOP_DRAGGING (1<<4)
+///Added to the move packet `processing_move_loop_flags` so we know when a loop is behind movement even in absence of other flags
+#define MOVED_BY_MOVEMENT_LOOP (1<<5)
 
 //Index defines for movement bucket data packets
 #define MOVEMENT_BUCKET_TIME 1

--- a/code/controllers/subsystem/movement/move_handler.dm
+++ b/code/controllers/subsystem/movement/move_handler.dm
@@ -52,8 +52,15 @@ SUBSYSTEM_DEF(move_manager)
 /datum/movement_packet
 	///Our parent atom
 	var/atom/movable/parent
-	///The move loop that's currently running
+	///The move loop that's currently running, excluding those that ignore priority.
 	var/datum/move_loop/running_loop
+	/**
+	 * Flags passed from the move loop before it calls move() and unset right after.
+	 * Allows for properties of a move loop to be easily checked by mechanics outside of it.
+	 * Having this a bitfield rather than a type var means we don't get screwed over
+	 * if the move loop gets deleted mid-move, FYI.
+	 */
+	var/processing_move_loop_flags = NONE
 	///Assoc list of subsystems -> loop datum. Only one datum is allowed per subsystem
 	var/list/existing_loops = list()
 

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -13,7 +13,7 @@
 	var/atom/movable/moving
 	///Defines how different move loops override each other. Higher numbers beat lower numbers
 	var/priority = MOVEMENT_DEFAULT_PRIORITY
-	///Bitfield of different things that affect how a loop operates
+	///Bitfield of different things that affect how a loop operates, and other mechanics around it as well.
 	var/flags
 	///Time till we stop processing in deci-seconds, defaults to forever
 	var/lifetime = INFINITY
@@ -113,7 +113,10 @@
 		return
 
 	var/visual_delay = controller.visual_delay
+
+	owner.processing_move_loop_flags = flags|MOVED_BY_MOVEMENT_LOOP
 	var/result = move() //Result is an enum value. Enums defined in __DEFINES/movement.dm
+	owner.processing_move_loop_flags = NONE
 
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay)
 

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -114,9 +114,9 @@
 
 	var/visual_delay = controller.visual_delay
 
-	owner.processing_move_loop_flags = flags|MOVED_BY_MOVEMENT_LOOP
+	owner?.processing_move_loop_flags = flags|MOVED_BY_MOVEMENT_LOOP
 	var/result = move() //Result is an enum value. Enums defined in __DEFINES/movement.dm
-	owner.processing_move_loop_flags = NONE
+	owner?.processing_move_loop_flags = NONE
 
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay)
 

--- a/code/datums/components/conveyor_movement.dm
+++ b/code/datums/components/conveyor_movement.dm
@@ -15,7 +15,7 @@
 	if(!start_delay)
 		start_delay = speed
 	var/atom/movable/moving_parent = parent
-	var/datum/move_loop/loop = SSmove_manager.move(moving_parent, direction, delay = start_delay, subsystem = SSconveyors, flags=MOVEMENT_LOOP_IGNORE_PRIORITY)
+	var/datum/move_loop/loop = SSmove_manager.move(moving_parent, direction, delay = start_delay, subsystem = SSconveyors, flags=MOVEMENT_LOOP_IGNORE_PRIORITY|MOVEMENT_LOOP_DRAGGING)
 	RegisterSignal(loop, COMSIG_MOVELOOP_PREPROCESS_CHECK, PROC_REF(should_move))
 	RegisterSignal(loop, COMSIG_PARENT_QDELETING, PROC_REF(loop_ended))
 

--- a/code/datums/components/drift.dm
+++ b/code/datums/components/drift.dm
@@ -19,7 +19,7 @@
 		return COMPONENT_INCOMPATIBLE
 	. = ..()
 
-	var/flags = NONE
+	var/flags = MOVEMENT_LOOP_DRAGGING
 	if(instant)
 		flags |= MOVEMENT_LOOP_START_FAST
 	var/atom/movable/movable_parent = parent

--- a/code/datums/components/shuttle_cling.dm
+++ b/code/datums/components/shuttle_cling.dm
@@ -43,7 +43,7 @@
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_PICKUP, PROC_REF(do_remove))
 
-	hyperloop = SSmove_manager.move(moving = parent, direction = direction, delay = not_clinging_move_delay, subsystem = SShyperspace_drift, priority = MOVEMENT_ABOVE_SPACE_PRIORITY, flags = MOVEMENT_LOOP_NO_DIR_UPDATE)
+	hyperloop = SSmove_manager.move(moving = parent, direction = direction, delay = not_clinging_move_delay, subsystem = SShyperspace_drift, priority = MOVEMENT_ABOVE_SPACE_PRIORITY, flags = MOVEMENT_LOOP_NO_DIR_UPDATE|MOVEMENT_LOOP_DRAGGING)
 
 	update_state(parent) //otherwise we'll get moved 1 tile before we can correct ourselves, which isnt super bad but just looks jank
 

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -64,7 +64,7 @@
 	if(!istype(turf))
 		return
 
-	if(!turf.footstep || source.buckled || source.throwing || source.movement_type & (VENTCRAWLING | FLYING) || HAS_TRAIT(source, TRAIT_IMMOBILIZED))
+	if(!turf.footstep || source.buckled || source.throwing || source.movement_type & (VENTCRAWLING | FLYING) || HAS_TRAIT(source, TRAIT_IMMOBILIZED) || source.check_move_loop_flags(MOVEMENT_LOOP_DRAGGING))
 		return
 
 	if(source.body_position == LYING_DOWN) //play crawling sound if we're lying
@@ -91,10 +91,10 @@
 		return
 	return turf
 
-/datum/element/footstep/proc/play_simplestep(mob/living/source)
+/datum/element/footstep/proc/play_simplestep(mob/living/source, atom/oldloc, direction, forced, list/old_locs, momentum_change)
 	SIGNAL_HANDLER
 
-	if (SHOULD_DISABLE_FOOTSTEPS(source))
+	if (forced || SHOULD_DISABLE_FOOTSTEPS(source))
 		return
 
 	var/turf/open/source_loc = prepare_step(source)
@@ -120,7 +120,7 @@
 /datum/element/footstep/proc/play_humanstep(mob/living/carbon/human/source, atom/oldloc, direction, forced, list/old_locs, momentum_change)
 	SIGNAL_HANDLER
 
-	if (SHOULD_DISABLE_FOOTSTEPS(source) || !momentum_change)
+	if (forced || SHOULD_DISABLE_FOOTSTEPS(source) || !momentum_change)
 		return
 
 	var/volume_multiplier = 1
@@ -162,15 +162,19 @@
 
 
 ///Prepares a footstep for machine walking
-/datum/element/footstep/proc/play_simplestep_machine(atom/movable/source)
+/datum/element/footstep/proc/play_simplestep_machine(atom/movable/source, atom/oldloc, direction, forced, list/old_locs, momentum_change)
 	SIGNAL_HANDLER
 
-	if (SHOULD_DISABLE_FOOTSTEPS(source))
+	if (forced || SHOULD_DISABLE_FOOTSTEPS(source))
 		return
 
-	var/turf/open/source_loc = get_turf(source)
-	if(!istype(source_loc))
+	var/turf/open/turf = get_turf(source)
+	if(!istype(turf))
 		return
-	playsound(source_loc, footstep_sounds, 50, falloff_distance = 1, vary = sound_vary)
+
+	if(source.check_move_loop_flags(MOVEMENT_LOOP_DRAGGING))
+		return
+
+	playsound(turf, footstep_sounds, 50, falloff_distance = 1, vary = sound_vary)
 
 #undef SHOULD_DISABLE_FOOTSTEPS

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -168,13 +168,13 @@
 	if (forced || SHOULD_DISABLE_FOOTSTEPS(source))
 		return
 
-	var/turf/open/turf = get_turf(source)
-	if(!istype(turf))
+	var/turf/open/source_loc = get_turf(source)
+	if(!istype(source_loc))
 		return
 
 	if(source.check_move_loop_flags(MOVEMENT_LOOP_DRAGGING))
 		return
 
-	playsound(turf, footstep_sounds, 50, falloff_distance = 1, vary = sound_vary)
+	playsound(source_loc, footstep_sounds, 50, falloff_distance = 1, vary = sound_vary)
 
 #undef SHOULD_DISABLE_FOOTSTEPS

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -932,6 +932,15 @@
 						SSspatial_grid.add_grid_awareness(location, channel)
 			recursive_contents[channel] |= arrived.important_recursive_contents[channel]
 
+/**
+ * Returns a bitfield containing flags both present in `flags` arg and the `processing_move_loop_flags` move_packet variable.
+ * Has no use outside of procs called within the movement proc chain.
+ */
+/atom/movable/proc/check_move_loop_flags(flags)
+	if(!move_packet)
+		return NONE
+	return flags & move_packet.processing_move_loop_flags
+
 ///allows this movable to hear and adds itself to the important_recursive_contents list of itself and every movable loc its in
 /atom/movable/proc/become_hearing_sensitive(trait_source = TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_HEARING_SENSITIVE, trait_source)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -45,7 +45,8 @@
 
 /obj/vehicle/ridden/wheelchair/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
-	playsound(src, 'sound/effects/roll.ogg', 75, TRUE)
+	if(!forced && !check_move_loop_flags(MOVEMENT_LOOP_DRAGGING))
+		playsound(src, 'sound/effects/roll.ogg', 75, TRUE)
 
 /obj/vehicle/ridden/wheelchair/post_buckle_mob(mob/living/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
More or less a triviality, currently footstep/wheelchai sounds are played even when the mob is moved by a conveyor belt, or riding the tram. This PR puts an end to that.

To clarify, this doesn't stop these sounds from being played if you're walking/running/rolling along or against a belt, or inside the tram.

But more than that, I made this PR because, afaik, we don't have a good way to tell if a given movement proc chain was caused by a move loop or not, and I need one for something I'm working on. This is more of an implementation and reason for this PR to be made.

Tested, no issue. Waiting for a review, specially from @LemonInTheDark, since they're the mind behind the movement loop code. Hopefully I'm right saying what I said.

## Why It's Good For The Game
This fixes a consistency issue (if it can be called such) and the lack of a simple way to tell if a movable is being moved by a move loop outside of its own code.

## Changelog

:cl:
fix: Being moved around by conveyor belt or tram no longer play footsteps and wheelchair sounds.
/:cl:
