### PR TITLE
Fix IV drip connecting to non-living [NO GBP]

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -317,7 +317,8 @@
 	log_combat(usr, target, "attached", src, "containing: ([container.get_reagent_log_string()])")
 	add_fingerprint(usr)
 	if(isliving(target))
-		INVOKE_ASYNC(target, TYPE_PROC_REF(/mob/living, throw_alert), ALERT_IV_CONNECTED, /atom/movable/screen/alert/iv_connected)
+		var/mob/living/target_mob = target
+		target_mob.throw_alert(ALERT_IV_CONNECTED, /atom/movable/screen/alert/iv_connected)
 	attached = target
 	START_PROCESSING(SSmachines, src)
 	update_appearance(UPDATE_ICON)
@@ -329,7 +330,8 @@
 	if(attached)
 		visible_message(span_notice("[attached] is detached from [src]."))
 		if(isliving(attached))
-			INVOKE_ASYNC(attached, TYPE_PROC_REF(/mob/living, clear_alert), ALERT_IV_CONNECTED, /atom/movable/screen/alert/iv_connected)
+			var/mob/living/attached_mob = attached
+			attached_mob.clear_alert(ALERT_IV_CONNECTED, /atom/movable/screen/alert/iv_connected)
 	SEND_SIGNAL(src, COMSIG_IV_DETACH, attached)
 	attached = null
 	update_appearance(UPDATE_ICON)

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -28,7 +28,7 @@
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	use_power = NO_POWER_USE
 	///What are we sticking our needle in?
-	var/mob/attached
+	var/atom/attached
 	///Are we donating or injecting?
 	var/mode = IV_INJECTING
 	///The chemicals flow speed
@@ -305,7 +305,7 @@
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 ///called when an IV is attached
-/obj/machinery/iv_drip/proc/attach_iv(mob/target, mob/user)
+/obj/machinery/iv_drip/proc/attach_iv(atom/target, mob/user)
 	if(isliving(target))
 		user.visible_message(span_warning("[usr] begins attaching [src] to [target]..."), span_warning("You begin attaching [src] to [target]."))
 		if(!do_after(usr, 1 SECONDS, target))
@@ -316,7 +316,8 @@
 	var/datum/reagents/container = get_reagents()
 	log_combat(usr, target, "attached", src, "containing: ([container.get_reagent_log_string()])")
 	add_fingerprint(usr)
-	target.throw_alert(ALERT_IV_CONNECTED, /atom/movable/screen/alert/iv_connected)
+	if(isliving(target))
+		INVOKE_ASYNC(target, TYPE_PROC_REF(/mob/living, throw_alert), ALERT_IV_CONNECTED, /atom/movable/screen/alert/iv_connected)
 	attached = target
 	START_PROCESSING(SSmachines, src)
 	update_appearance(UPDATE_ICON)
@@ -327,7 +328,8 @@
 /obj/machinery/iv_drip/proc/detach_iv()
 	if(attached)
 		visible_message(span_notice("[attached] is detached from [src]."))
-		attached.clear_alert(ALERT_IV_CONNECTED, /atom/movable/screen/alert/iv_connected)
+		if(isliving(attached))
+			INVOKE_ASYNC(attached, TYPE_PROC_REF(/mob/living, clear_alert), ALERT_IV_CONNECTED, /atom/movable/screen/alert/iv_connected)
 	SEND_SIGNAL(src, COMSIG_IV_DETACH, attached)
 	attached = null
 	update_appearance(UPDATE_ICON)


### PR DESCRIPTION
## About The Pull Request

In PR https://github.com/tgstation/tgstation/pull/75646 I broke https://github.com/tgstation/tgstation/pull/71217 

## Changelog

:cl: LT3
fix: IVs again work with non-living containers
/:cl: