### PR TITLE
You can now sweep garbage into open trash bins (the crate subtype), not just disposal bins.

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_turf.dm
+++ b/code/__DEFINES/dcs/signals/signals_turf.dm
@@ -25,3 +25,6 @@
 
 ///from /datum/element/decal/Detach(): (description, cleanable, directional, mutable_appearance/pic)
 #define COMSIG_TURF_DECAL_DETACHED "turf_decal_detached"
+
+///from /obj/item/pushbroom/sweep(): (broom, user, items_to_sweep)
+#define COMSIG_TURF_RECEIVE_SWEEPED_ITEMS "turf_receive_sweeped_items"

--- a/code/game/objects/items/broom.dm
+++ b/code/game/objects/items/broom.dm
@@ -68,22 +68,26 @@
 	if (!isturf(current_item_loc))
 		return
 	var/turf/new_item_loc = get_step(current_item_loc, user.dir)
-	var/obj/machinery/disposal/bin/target_bin = locate(/obj/machinery/disposal/bin) in new_item_loc.contents
+
+	var/list/items_to_sweep = list()
 	var/i = 1
 	for (var/obj/item/garbage in current_item_loc.contents)
-		if (!garbage.anchored)
-			if (target_bin)
-				garbage.forceMove(target_bin)
-			else
-				garbage.Move(new_item_loc, user.dir)
-			i++
-		if (i > BROOM_PUSH_LIMIT)
+		if(garbage.anchored)
+			continue
+		items_to_sweep += garbage
+		i++
+		if(i > BROOM_PUSH_LIMIT)
 			break
-	if (i > 1)
-		if (target_bin)
-			target_bin.update_appearance()
-			to_chat(user, span_notice("You sweep the pile of garbage into [target_bin]."))
-		playsound(loc, 'sound/weapons/thudswoosh.ogg', 30, TRUE, -1)
+
+	SEND_SIGNAL(new_item_loc, COMSIG_TURF_RECEIVE_SWEEPED_ITEMS, src, user, items_to_sweep)
+
+	if(!length(items_to_sweep))
+		return
+
+	for (var/obj/item/garbage in items_to_sweep)
+		garbage.Move(new_item_loc, user.dir)
+
+	playsound(loc, 'sound/weapons/thudswoosh.ogg', 30, TRUE, -1)
 
 
 /obj/item/pushbroom/cyborg

--- a/code/game/objects/structures/crates_lockers/crates/bins.dm
+++ b/code/game/objects/structures/crates_lockers/crates/bins.dm
@@ -14,6 +14,10 @@
 /obj/structure/closet/crate/bin/Initialize(mapload)
 	. = ..()
 	update_appearance()
+	var/static/list/loc_connections = list(
+		COMSIG_TURF_RECEIVE_SWEEPED_ITEMS = PROC_REF(ready_for_trash),
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/structure/closet/crate/bin/update_overlays()
 	. = ..()
@@ -45,3 +49,17 @@
 /obj/structure/closet/crate/bin/proc/do_close()
 	playsound(loc, close_sound, 15, TRUE, -3)
 	update_appearance()
+
+/obj/structure/closet/crate/bin/proc/ready_for_trash(datum/source, obj/item/pushbroom/broom, mob/user, list/items_to_sweep)
+	SIGNAL_HANDLER
+
+	if(!items_to_sweep || !opened)
+		return
+
+	for (var/obj/item/garbage in items_to_sweep)
+		garbage.forceMove(loc)
+
+	items_to_sweep.Cut()
+
+	to_chat(user, span_notice("You sweep the pile of garbage into [src]."))
+	playsound(broom.loc, 'sound/weapons/thudswoosh.ogg', 30, TRUE, -1)

--- a/code/game/objects/structures/crates_lockers/crates/bins.dm
+++ b/code/game/objects/structures/crates_lockers/crates/bins.dm
@@ -50,6 +50,7 @@
 	playsound(loc, close_sound, 15, TRUE, -3)
 	update_appearance()
 
+///Called when a push broom is trying to sweep items onto the turf this object is standing on. Garbage will be moved inside.
 /obj/structure/closet/crate/bin/proc/ready_for_trash(datum/source, obj/item/pushbroom/broom, mob/user, list/items_to_sweep)
 	SIGNAL_HANDLER
 

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -62,6 +62,7 @@
 	RegisterSignal(src, COMSIG_STORAGE_DUMP_CONTENT, PROC_REF(on_storage_dump))
 	var/static/list/loc_connections = list(
 		COMSIG_CARBON_DISARM_COLLIDE = PROC_REF(trash_carbon),
+		COMSIG_TURF_RECEIVE_SWEEPED_ITEMS = PROC_REF(ready_for_trash),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	return INITIALIZE_HINT_LATELOAD //we need turfs to have air
@@ -561,5 +562,18 @@
 	to_chat(src, span_danger("You shove [target.name] into \the [src]!"))
 	log_combat(src, target, "shoved", "into [src] (disposal bin)")
 	return COMSIG_CARBON_SHOVE_HANDLED
+
+/obj/machinery/disposal/proc/ready_for_trash(datum/source, obj/item/pushbroom/broom, mob/user, list/items_to_sweep)
+	SIGNAL_HANDLER
+	if(!items_to_sweep)
+		return
+	for (var/obj/item/garbage in items_to_sweep)
+		garbage.forceMove(src)
+
+	items_to_sweep.Cut()
+
+	update_appearance()
+	to_chat(user, span_notice("You sweep the pile of garbage into [src]."))
+	playsound(broom.loc, 'sound/weapons/thudswoosh.ogg', 30, TRUE, -1)
 
 #undef SEND_PRESSURE

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -563,6 +563,7 @@
 	log_combat(src, target, "shoved", "into [src] (disposal bin)")
 	return COMSIG_CARBON_SHOVE_HANDLED
 
+///Called when a push broom is trying to sweep items onto the turf this object is standing on. Garbage will be moved inside.
 /obj/machinery/disposal/proc/ready_for_trash(datum/source, obj/item/pushbroom/broom, mob/user, list/items_to_sweep)
 	SIGNAL_HANDLER
 	if(!items_to_sweep)


### PR DESCRIPTION
## About The Pull Request
Re-read the title. I had to add a dcs signal to do this.

## Why It's Good For The Game
Empowering trash bins for the sake of consistency.

## Changelog

:cl:
balance: You can now sweep garbage into open trash bins (the crate subtype).
/:cl:
