### PR TITLE
Adds a proper name and description for the base variant bow

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bows/_bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/_bow.dm
@@ -12,6 +12,7 @@
 	fire_sound = null
 	mag_type = /obj/item/ammo_box/magazine/internal/bow
 	force = 15
+	pinless = TRUE
 	attack_verb_continuous = list("whipped", "cracked")
 	attack_verb_simple = list("whip", "crack")
 	weapon_weight = WEAPON_HEAVY

--- a/code/modules/projectiles/guns/ballistic/bows/_bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/_bow.dm
@@ -3,6 +3,8 @@
 	icon = 'icons/obj/weapons/guns/bows/bows.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons/bows_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/bows_righthand.dmi'
+	name = "bow"
+	desc = "Seems out-of-place in this day and age, but at least it's reliable."
 	icon_state = "bow"
 	inhand_icon_state = "bow"
 	base_icon_state = "bow"


### PR DESCRIPTION

## About The Pull Request
Fixes #75711.

Someone forgot to add a name and description for the base bow, so it uses the default projectile/gun one. 

## Why It's Good For The Game
I'm not certain you're intended to get this version of the bow, but there's literally no reason to not have it look normal if someone gets it.

## Changelog
:cl:
fix: Added a name and description for the basic version of the bow.
/:cl:
