### PR TITLE
Prevent abstract items from being put onto others

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -82,6 +82,9 @@
 		to_chat(user, span_warning("You can't put [equipping] on [source], it's stuck to your hand!"))
 		return FALSE
 
+	if (equipping.item_flags & ABSTRACT)
+		return FALSE //I don't know a sane-sounding feedback message for trying to put a slap into someone's hand
+
 	return TRUE
 
 /// Start the equipping process. This is the proc you should yield in.


### PR DESCRIPTION

## About The Pull Request
Items with the abstract flag are stopped from being given to others using the strip UI. This cleans up some general weirdness with being able to put hand items like kiss or slap into people's hands just to see them immediately vanish and cause a harddel.

https://github.com/tgstation/tgstation/assets/25628932/2f27a4d6-64f1-4e26-a5b5-219805f57875

Though perhaps a bit less subtle, this fixes a silly and somewhat terrifying bug, that allows a body to be rapidly thrown without being picked up or grabbed, or tableslammed through z-levels.

https://github.com/tgstation/tgstation/assets/25628932/0cd587ac-12dc-4ea3-9bf2-fc29603b1cda
## Why It's Good For The Game
Bugs bad, doesn't really make sense for abstract items to be physical enough to placed into someone's hand or pocket.
We all know what the assistants will do with this
## Changelog
:cl:
fix: Abstract items can no longer be placed in others' hands.
/:cl:
