### PR TITLE
Removes deep frying held mobs

### DIFF
--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -11,6 +11,7 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/delivery,
 	/obj/item/his_grace,
 	/obj/item/bodybag/bluespace,
+	/obj/item/clothing/head/mob_holder,
 )))
 
 /obj/machinery/deepfryer


### PR DESCRIPTION
## About The Pull Request
Adds held mobs (simplemobs like station pets, PAIs, drones, etc) to the "do not fry" list so they can't be used for infinite salad creation, hiding station pets, GBJing PAIs, etc. 

## Why It's Good For The Game
Bugs bad also GBJing PAI's in salad is silly. If this is too "no fun allowed" please close it, I don't want to remove bugs that people think are funny and don't ruin the game. (people should totally put animals in washing machines more, though)

## Changelog
:cl:
Fix: Disallows deep frying held animals (station pets, PAIs, etc) due to Animal Rights Consortium complaints. 
/:cl: