### PR TITLE
[MetaStation] Resecures some walls in science

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2856,7 +2856,7 @@
 /area/station/command/teleporter)
 "bcb" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/science/research)
 "bcf" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -35991,7 +35991,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
-/turf/closed/wall/r_wall,
+/turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "mYX" = (
 /obj/structure/table,
@@ -103511,9 +103511,9 @@ wXF
 wXF
 wXF
 wXF
-xKK
+gFQ
 wto
-xKK
+gFQ
 oWk
 xuD
 qZg

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -35991,7 +35991,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
-/turf/open/floor/iron/white,
+/turf/closed/wall/r_wall,
 /area/station/science/ordnance)
 "mYX" = (
 /obj/structure/table,
@@ -45827,7 +45827,7 @@
 /area/station/commons/locker)
 "qCY" = (
 /obj/structure/sign/directions/evac,
-/turf/closed/wall/r_wall,
+/turf/closed/wall,
 /area/station/maintenance/department/science/central)
 "qDa" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -95547,7 +95547,7 @@ fma
 fma
 fma
 fma
-ujJ
+kor
 aQS
 qCY
 kQe
@@ -95807,7 +95807,7 @@ wOS
 orv
 dPY
 xWJ
-kQe
+oIg
 cId
 rQl
 oIg
@@ -95816,7 +95816,7 @@ neA
 vLU
 kZf
 jxW
-dKC
+svS
 rhU
 pjX
 mGI
@@ -96060,11 +96060,11 @@ ose
 tzq
 njW
 eLY
-eut
-kor
-kor
-kor
-kQe
+fma
+ujJ
+ujJ
+ujJ
+oIg
 cDM
 poS
 byf
@@ -96073,7 +96073,7 @@ oir
 wal
 tzg
 jxW
-dKC
+svS
 tjE
 rDB
 nFa


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game

<details>
<summary>Images</summary>

I always found it funny how this little maintenance area was unsecured. Swaps the reinforced/regular walls around.
![image](https://github.com/tgstation/tgstation/assets/70232195/87e86ba3-6ab1-4d81-b3a1-8a19002ef03d)

Genetics monkey pen wasn't secured, patched that up.
![image](https://github.com/tgstation/tgstation/assets/70232195/63658fab-96be-49aa-afd8-87387dadf855)

This hall connecting XB and science wasn't secured, yet, the rooms themselves were in maintenance. Secures the science adjacent rooms. 
![image](https://github.com/tgstation/tgstation/assets/70232195/d18c2cb6-d64c-4759-99ba-bc0c2204dbc5)

</details>

## Changelog


:cl: Jolly
fix: [MetaStation] - Secured some walls in science that weren't secured properly (reinforced). 
/:cl:

