### PR TITLE
Fixes missing delammination counter in Northstar

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -30154,6 +30154,12 @@
 	dir = 1
 	},
 /area/station/command/gateway)
+"hOP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/structure/cable,
+/obj/structure/sign/delamination_counter/directional/east,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "hOR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/meter,
@@ -138687,7 +138693,7 @@ oqA
 bNR
 klY
 klY
-klY
+hOP
 nHv
 cAf
 klY


### PR DESCRIPTION

## About The Pull Request
It's been bugging me that Northstar didn't have a counter for SM delams.
## Why It's Good For The Game
## Changelog
:cl:
fix: Nanotrasen engineers has installed delamination counters for all Northstar class expeditionary vessels to increase the pressure for engineers not to fuck up
/:cl:
