### PR TITLE
[NO GBP] Stops External Shields From Generating On Solid Walls 

### DIFF
--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -177,8 +177,8 @@
 		LAZYADD(list_of_turfs, get_perimeter(src, radius))
 
 		if(exterior_only)
-			for(var/turf/target_tile as anything in list_of_turfs)
-				if(!(isfloorturf(target_tile)) && isopenturf(target_tile) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
+			for(var/turf/open/target_tile in list_of_turfs)
+				if(!(isfloorturf(target_tile)) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
 					var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
 					deploying_shield.shield_generator = src
 					LAZYADD(deployed_shields, deploying_shield)
@@ -186,7 +186,7 @@
 			calculate_regeneration()
 			return
 
-		for(var/turf/target_tile as anything in list_of_turfs)
+		for(var/turf/target_tile in list_of_turfs)
 			if(isopenturf(target_tile) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
 				var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
 				deploying_shield.shield_generator = src
@@ -198,8 +198,8 @@
 	//this code only runs on radius less than 10 and gives us a more accurate circle that is more compatible with decimal values
 	LAZYADD(inside_shield, circle_range_turfs(src, radius - 1))//in the future we might want to apply an effect to the turfs inside the shield
 	if(exterior_only)
-		for(var/turf/target_tile as anything in circle_range_turfs(src, radius))
-			if(!(isfloorturf(target_tile)) && isopenturf(target_tile) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
+		for(var/turf/open/target_tile in circle_range_turfs(src, radius))
+			if(!(isfloorturf(target_tile)) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
 				var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
 				deploying_shield.shield_generator = src
 				LAZYADD(deployed_shields, deploying_shield)
@@ -207,7 +207,7 @@
 		calculate_regeneration()
 		return
 
-	for(var/turf/target_tile as anything in circle_range_turfs(src, radius))
+	for(var/turf/target_tile in circle_range_turfs(src, radius))
 		if(isopenturf(target_tile) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
 			var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
 			deploying_shield.shield_generator = src

--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -178,7 +178,7 @@
 
 		if(exterior_only)
 			for(var/turf/target_tile as anything in list_of_turfs)
-				if(!(isfloorturf(target_tile)) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
+				if(!(isfloorturf(target_tile)) && isopenturf(target_tile) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
 					var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
 					deploying_shield.shield_generator = src
 					LAZYADD(deployed_shields, deploying_shield)
@@ -199,7 +199,7 @@
 	LAZYADD(inside_shield, circle_range_turfs(src, radius - 1))//in the future we might want to apply an effect to the turfs inside the shield
 	if(exterior_only)
 		for(var/turf/target_tile as anything in circle_range_turfs(src, radius))
-			if(!(isfloorturf(target_tile)) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
+			if(!(isfloorturf(target_tile)) && isopenturf(target_tile) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
 				var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
 				deploying_shield.shield_generator = src
 				LAZYADD(deployed_shields, deploying_shield)

--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -178,19 +178,25 @@
 
 		if(exterior_only)
 			for(var/turf/open/target_tile in list_of_turfs)
-				if(!(isfloorturf(target_tile)) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
-					var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
-					deploying_shield.shield_generator = src
-					LAZYADD(deployed_shields, deploying_shield)
+				if(isfloorturf(target_tile))
+					continue
+				if(locate(/obj/structure/emergency_shield/modular) in target_tile)
+					continue
+				var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
+				deploying_shield.shield_generator = src
+				LAZYADD(deployed_shields, deploying_shield)
+
 			addtimer(CALLBACK(src, PROC_REF(finish_field)), 2 SECONDS)
 			calculate_regeneration()
 			return
 
-		for(var/turf/target_tile in list_of_turfs)
-			if(isopenturf(target_tile) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
-				var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
-				deploying_shield.shield_generator = src
-				LAZYADD(deployed_shields, deploying_shield)
+		for(var/turf/open/target_tile in list_of_turfs)
+			if(locate(/obj/structure/emergency_shield/modular) in target_tile)
+				continue
+			var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
+			deploying_shield.shield_generator = src
+			LAZYADD(deployed_shields, deploying_shield)
+
 		addtimer(CALLBACK(src, PROC_REF(finish_field)), 2 SECONDS)
 		calculate_regeneration()
 		return
@@ -199,19 +205,29 @@
 	LAZYADD(inside_shield, circle_range_turfs(src, radius - 1))//in the future we might want to apply an effect to the turfs inside the shield
 	if(exterior_only)
 		for(var/turf/open/target_tile in circle_range_turfs(src, radius))
-			if(!(isfloorturf(target_tile)) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
-				var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
-				deploying_shield.shield_generator = src
-				LAZYADD(deployed_shields, deploying_shield)
+			if(isfloorturf(target_tile))
+				continue
+			if(target_tile in inside_shield)
+				continue
+			if(locate(/obj/structure/emergency_shield/modular) in target_tile)
+				continue
+			var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
+			deploying_shield.shield_generator = src
+			LAZYADD(deployed_shields, deploying_shield)
+
 		addtimer(CALLBACK(src, PROC_REF(finish_field)), 2 SECONDS)
 		calculate_regeneration()
 		return
 
-	for(var/turf/target_tile in circle_range_turfs(src, radius))
-		if(isopenturf(target_tile) && !(target_tile in inside_shield) && !(locate(/obj/structure/emergency_shield/modular) in target_tile))
-			var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
-			deploying_shield.shield_generator = src
-			LAZYADD(deployed_shields, deploying_shield)
+	for(var/turf/open/target_tile in circle_range_turfs(src, radius))
+		if(target_tile in inside_shield)
+			continue
+		if(locate(/obj/structure/emergency_shield/modular) in target_tile)
+			continue
+		var/obj/structure/emergency_shield/modular/deploying_shield = new(target_tile)
+		deploying_shield.shield_generator = src
+		LAZYADD(deployed_shields, deploying_shield)
+
 	addtimer(CALLBACK(src, PROC_REF(finish_field)), 2 SECONDS)
 	calculate_regeneration()
 


### PR DESCRIPTION
## About The Pull Request

#75705 (I swear to god i tested this) caused external shields to generate over solid walls, this adds the check necessary to prevent that and I tested to make sure it was fixed WITHOUT CAUSING UNINTENDED BEHAVIORS
## Why It's Good For The Game

Okay so ya this bug is not really impactful and it does actually play into the role of external shields which is to not block internal pathways and instead protect the already existing physical structure of the station/provide separate structures with further autonomy. 

The problem mainly is its not intended and its completely different behavior than what was proposed in the original pr that added shield gens

That and it just looks really bad and ugly to have forcefields appear over solid walls.

## Changelog
:cl:

fix: external shields no longer generate over walls

/:cl:
