### PR TITLE
Self-used fulton extraction packs autostoring in any back storage

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -62,9 +62,8 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 		to_chat(user, span_notice("You start attaching the pack to [A]..."))
 		if(do_after(user,50,target=A))
 			to_chat(user, span_notice("You attach the pack to [A] and activate it."))
-			if(loc == user && istype(user.back, /obj/item/storage/backpack))
-				var/obj/item/storage/backpack/B = user.back
-				B.atom_storage?.attempt_insert(src, user)
+			if(loc == user)
+				user.back?.atom_storage?.attempt_insert(src, user)
 			uses_left--
 			if(uses_left <= 0)
 				user.transferItemToLoc(src, A, TRUE)


### PR DESCRIPTION
## About The Pull Request

when fultoning yourself, adjusts the fulton autobag check from "is there a backpack on this guy" to "can we try shoving stuff into their back-slot item's atom storage"

not sure if this is qol, fix, or god forbid balance but let's go with the maybe least offensive option first

...if it was an oversight can i legally flag this as a fix?
closes #75327
## Why It's Good For The Game
makes the autobagging feature work for other back-mounted storage options. like MODs.
![image](https://github.com/tgstation/tgstation/assets/31829017/47b3d7f7-d042-465a-b3e0-11c8e7c3cb0b)
## Changelog

:cl:
qol: Fulton extraction packs (when used on yourself) now automatically shove themselves into any back-mounted storage, like MODsuit storage modules.
/:cl:
