### PR TITLE
Fixes formula with spatial instability and energetic chromosome

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -347,7 +347,7 @@
 		warpchance = 0
 		owner.visible_message(span_danger("[owner] appears out of nowhere!"))
 	else
-		warpchance += 0.0625 * GET_MUTATION_ENERGY(src) * seconds_per_tick
+		warpchance += 0.0625 * (1 / GET_MUTATION_ENERGY(src)) * seconds_per_tick
 
 /datum/mutation/human/acidflesh
 	name = "Acidic Flesh"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -347,7 +347,7 @@
 		warpchance = 0
 		owner.visible_message(span_danger("[owner] appears out of nowhere!"))
 	else
-		warpchance += 0.0625 * (1 / GET_MUTATION_ENERGY(src)) * seconds_per_tick
+		warpchance += 0.0625 * seconds_per_tick / GET_MUTATION_ENERGY(src)
 
 /datum/mutation/human/acidflesh
 	name = "Acidic Flesh"


### PR DESCRIPTION
## About The Pull Request

Doubles the growth rate of the warpchance rather than halves when an energetic chromosome is present

For numbers 

It now grows by roughly 0.5 per update (every 2 seconds) rather than 0.0625 with an energetic chromosome

The base growth rate (unchanged) is 0.25 (every 2 seconds) or 0.0625 per second
## Why It's Good For The Game

Energetic chromosome`s identity is that it speeds up the cooldown between abilities or in this case the chance that your spatial instability will go off so Im convinced this is an oversight / bug with writing the equation of the warpchance gain.
## Changelog
:cl:
fix: Spatial instability now gets properly energized by energetic chromosomes
/:cl:
