### PR TITLE
Allows field generators to contain explosions.

### DIFF
--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -21,6 +21,7 @@
 	var/obj/machinery/field/generator/field_gen_2 = null
 
 /obj/machinery/field/containment/Initialize(mapload)
+	AddElement(/datum/element/blocks_explosives)
 	. = ..()
 	air_update_turf(TRUE, TRUE)
 	RegisterSignal(src, COMSIG_ATOM_SINGULARITY_TRY_MOVE, PROC_REF(block_singularity))
@@ -28,7 +29,6 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
-	AddElement(/datum/element/blocks_explosives)
 
 /obj/machinery/field/containment/Destroy()
 	if(field_gen_1)

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -14,6 +14,7 @@
 	can_atmos_pass = ATMOS_PASS_NO
 	light_range = 4
 	layer = ABOVE_OBJ_LAYER
+	explosion_block = INFINITY
 	///First of the generators producing the containment field
 	var/obj/machinery/field/generator/field_gen_1 = null
 	///Second of the generators producing the containment field
@@ -27,6 +28,7 @@
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
+	AddElement(/datum/element/blocks_explosives)
 
 /obj/machinery/field/containment/Destroy()
 	if(field_gen_1)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -72,9 +72,9 @@ no power level overlay is currently in the overlays list.
 
 
 /obj/machinery/field/generator/Initialize(mapload)
+	AddElement(/datum/element/blocks_explosives)
 	. = ..()
 	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_WIRES)
-	AddElement(/datum/element/blocks_explosives)
 	RegisterSignal(src, COMSIG_ATOM_SINGULARITY_TRY_MOVE, PROC_REF(block_singularity_if_active))
 
 /obj/machinery/field/generator/anchored/Initialize(mapload)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -59,6 +59,7 @@ no power level overlay is currently in the overlays list.
 	energy = 100
 	fire = 50
 	acid = 70
+	bomb = 100 //Explosive resistance only protects the turfs behind itself from the epicenter.
 
 /obj/machinery/field/generator/update_overlays()
 	. = ..()

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -74,6 +74,7 @@ no power level overlay is currently in the overlays list.
 /obj/machinery/field/generator/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF | EMP_PROTECT_WIRES)
+	AddElement(/datum/element/blocks_explosives)
 	RegisterSignal(src, COMSIG_ATOM_SINGULARITY_TRY_MOVE, PROC_REF(block_singularity_if_active))
 
 /obj/machinery/field/generator/anchored/Initialize(mapload)
@@ -279,6 +280,7 @@ no power level overlay is currently in the overlays list.
 		turn_off()
 		return
 	move_resist = INFINITY
+	set_explosion_block(INFINITY)
 	can_atmos_pass = ATMOS_PASS_NO
 	air_update_turf(TRUE, TRUE)
 	addtimer(CALLBACK(src, PROC_REF(setup_field), 1), 1)
@@ -356,6 +358,7 @@ no power level overlay is currently in the overlays list.
 	update_appearance()
 
 	move_resist = initial(move_resist)
+	set_explosion_block(0)
 
 /obj/machinery/field/generator/proc/shield_floor(create)
 	if(connected_gens.len < 2)


### PR DESCRIPTION

## About The Pull Request
Allows field generators to contain explosions. The fields will not let the explosion propagate past them.
## Why It's Good For The Game
Allows people to contain the tesla for fun, or on station bomb testing if they so desire.
## Changelog
:cl:
balance: Field generators can parry explosions.
/:cl:
