### PR TITLE
fix: Gun overlays are now one with gun's icon

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -10,6 +10,7 @@
 	inhand_icon_state = "gun"
 	worn_icon_state = "gun"
 	flags_1 = CONDUCT_1
+	appearance_flags = TILE_BOUND|PIXEL_SCALE|LONG_GLIDE|KEEP_TOGETHER
 	slot_flags = ITEM_SLOT_BELT
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT)
 	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Adds `KEEP_TOGETHER` flag to the gun's `appearance_flags`, so overlays are now one with gun's icon.

Before:
![Screenshot_23](https://github.com/tgstation/tgstation/assets/31931237/df47ace7-bccd-4847-bf44-47bd1facae05) ![Screenshot_24](https://github.com/tgstation/tgstation/assets/31931237/7b0bbc57-6e6e-4092-9a7f-a87b9500373a)

After:
![image](https://github.com/tgstation/tgstation/assets/31931237/7b238bd0-3e2c-4514-abfd-b4cdd54cfc23) ![image](https://github.com/tgstation/tgstation/assets/31931237/07a057ff-a26c-4a08-b530-20e69f39beea)


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Better visuals. Also required, when guns are forced to be placed in 90 degree

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Gun overlays (energy ammo counter, flashlights, bayonette, etc) are now one with gun's icon, which makes said overlays to transform correctly with gun's transform (ie, throwing)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
