### PR TITLE
Bounty Hunters, Fugitives, and Paradox Clones now have orbit menu categories

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -325,6 +325,9 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define ANTAG_GROUP_SYNDICATE "Syndicate"
 #define ANTAG_GROUP_WIZARDS "Wizard Federation"
 #define ANTAG_GROUP_XENOS "Xenomorph Infestation"
+#define ANTAG_GROUP_FUGITIVES "Escaped Fugitives"
+#define ANTAG_GROUP_HUNTERS "Bounty Hunters"
+#define ANTAG_GROUP_PARADOX "Spacetime Aberrations"
 
 
 // If this flag is enabled the antagonist datum allows the antagonist to be inducted into a nuclear operative team.

--- a/code/modules/antagonists/fugitive/fugitive.dm
+++ b/code/modules/antagonists/fugitive/fugitive.dm
@@ -5,6 +5,8 @@
 	job_rank = ROLE_FUGITIVE
 	silent = TRUE //greet called by the event
 	show_in_antagpanel = FALSE
+	show_to_ghosts = TRUE
+	antagpanel_category = ANTAG_GROUP_FUGITIVES
 	prevent_roundtype_conversion = FALSE
 	antag_hud_name = "fugitive"
 	suicide_cry = "FOR FREEDOM!!"

--- a/code/modules/antagonists/fugitive/hunters/hunter.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter.dm
@@ -4,6 +4,8 @@
 	roundend_category = "Fugitive"
 	silent = TRUE //greet called by the spawn
 	show_in_antagpanel = FALSE
+	show_to_ghosts = TRUE
+	antagpanel_category = ANTAG_GROUP_HUNTERS
 	prevent_roundtype_conversion = FALSE
 	antag_hud_name = "fugitive_hunter"
 	suicide_cry = "FOR GLORY!!"

--- a/code/modules/antagonists/paradox_clone/paradox_clone.dm
+++ b/code/modules/antagonists/paradox_clone/paradox_clone.dm
@@ -2,7 +2,9 @@
 	name = "\improper Paradox Clone"
 	roundend_category = "Paradox Clone"
 	job_rank = ROLE_PARADOX_CLONE
+	antagpanel_category = ANTAG_GROUP_PARADOX
 	antag_hud_name = "paradox_clone"
+	show_to_ghosts = TRUE
 	suicide_cry = "THERE CAN BE ONLY ONE!!"
 	preview_outfit = /datum/outfit/paradox_clone
 

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 
 /datum/antagonist/wizard_minion
 	name = "Wizard Minion"
-	antagpanel_category = "Wizard Federation"
+	antagpanel_category = ANTAG_GROUP_WIZARDS
 	antag_hud_name = "apprentice"
 	show_in_roundend = FALSE
 	show_name_in_check_antagonists = TRUE

--- a/tgui/packages/tgui/interfaces/Orbit/constants.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/constants.ts
@@ -4,6 +4,9 @@ export const ANTAG2COLOR = {
   'Biohazards': 'brown',
   'CentCom': 'teal',
   'Emergency Response Team': 'teal',
+  'Escaped Fugitives': 'orange',
+  'Bounty Hunters': 'yellow',
+  'Xenomorph Infestation': 'violet',
 } as const;
 
 export const THREAT = {

--- a/tgui/packages/tgui/interfaces/Orbit/constants.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/constants.ts
@@ -6,7 +6,6 @@ export const ANTAG2COLOR = {
   'Emergency Response Team': 'teal',
   'Escaped Fugitives': 'orange',
   'Bounty Hunters': 'yellow',
-  'Xenomorph Infestation': 'violet',
 } as const;
 
 export const THREAT = {


### PR DESCRIPTION

## About The Pull Request

This adds Paradox Clones, Fugitives, and Bounty Hunters to their own orbit category.

Paradox Clones use the hostile red color for the dropdown menu, while Fugitives use orange and Hunters use yellow.

Here's how it looks:

![image](https://github.com/tgstation/tgstation/assets/28870487/1b3642da-ec0e-40e6-abd5-c21c7302010f)

This also fixes the wizard minion antag datum's antagpanel_category being text, rather than the proper define.
## Why It's Good For The Game

Tracking these guys down doesn't need to be as hard as it is.
## Changelog
:cl:
qol: Fugitives, Bounty Hunters, and Paradox Clones will now appear in the orbit menu.
/:cl:
