### PR TITLE
[NO GBP] Fixes dead plant missing icon state 

### DIFF
--- a/code/game/objects/items/kirbyplants.dm
+++ b/code/game/objects/items/kirbyplants.dm
@@ -77,6 +77,7 @@
 /obj/item/kirbyplants/dead
 	name = "dead potted plant"
 	desc = "The unidentifiable plant remnants make you feel like planting something new in the pot."
+	icon_state = "plant-25"
 	dead = TRUE
 
 /obj/item/kirbyplants/dead/research_director


### PR DESCRIPTION
## About The Pull Request

I assumed that it will run update_appearance on init, and didn't bother to test my shit after the feedback. Sorry.

## Changelog

:cl:
fix: fixed dead plant having wrong icon roundstart
/:cl:
