### PR TITLE
Late adjustments to my previous move_loop PR. [NO GBP]

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -36,10 +36,14 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 #define MOVEMENT_LOOP_IGNORE_GLIDE (1<<2)
 ///Should we not update our movables dir on move?
 #define MOVEMENT_LOOP_NO_DIR_UPDATE (1<<3)
-///Should we consider the loop to be dragging movables rather than making them walk? e.g. footsteps won't play if enabled
-#define MOVEMENT_LOOP_DRAGGING (1<<4)
-///Added to the move packet `processing_move_loop_flags` so we know when a loop is behind movement even in absence of other flags
-#define MOVED_BY_MOVEMENT_LOOP (1<<5)
+///Is the loop moving the movable outside its control, like it's an external force? e.g. footsteps won't play if enabled.
+#define MOVEMENT_LOOP_OUTSIDE_CONTROL (1<<4)
+
+/**
+ * Returns a bitfield containing flags both present in `flags` arg and the `processing_move_loop_flags` move_packet variable.
+ * Has no use outside of procs called within the movement proc chain.
+ */
+#define CHECK_MOVE_LOOP_FLAGS(movable, flags) (movable.move_packet?.processing_move_loop_flags & flags)
 
 //Index defines for movement bucket data packets
 #define MOVEMENT_BUCKET_TIME 1

--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -43,7 +43,7 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
  * Returns a bitfield containing flags both present in `flags` arg and the `processing_move_loop_flags` move_packet variable.
  * Has no use outside of procs called within the movement proc chain.
  */
-#define CHECK_MOVE_LOOP_FLAGS(movable, flags) (movable.move_packet?.processing_move_loop_flags & flags)
+#define CHECK_MOVE_LOOP_FLAGS(movable, flags) (movable.move_packet ? (movable.move_packet.processing_move_loop_flags & flags) : NONE)
 
 //Index defines for movement bucket data packets
 #define MOVEMENT_BUCKET_TIME 1

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -114,7 +114,7 @@
 
 	var/visual_delay = controller.visual_delay
 
-	owner?.processing_move_loop_flags = flags|MOVED_BY_MOVEMENT_LOOP
+	owner?.processing_move_loop_flags = flags
 	var/result = move() //Result is an enum value. Enums defined in __DEFINES/movement.dm
 	owner?.processing_move_loop_flags = NONE
 

--- a/code/datums/components/conveyor_movement.dm
+++ b/code/datums/components/conveyor_movement.dm
@@ -15,7 +15,7 @@
 	if(!start_delay)
 		start_delay = speed
 	var/atom/movable/moving_parent = parent
-	var/datum/move_loop/loop = SSmove_manager.move(moving_parent, direction, delay = start_delay, subsystem = SSconveyors, flags=MOVEMENT_LOOP_IGNORE_PRIORITY|MOVEMENT_LOOP_DRAGGING)
+	var/datum/move_loop/loop = SSmove_manager.move(moving_parent, direction, delay = start_delay, subsystem = SSconveyors, flags=MOVEMENT_LOOP_IGNORE_PRIORITY|MOVEMENT_LOOP_OUTSIDE_CONTROL)
 	RegisterSignal(loop, COMSIG_MOVELOOP_PREPROCESS_CHECK, PROC_REF(should_move))
 	RegisterSignal(loop, COMSIG_PARENT_QDELETING, PROC_REF(loop_ended))
 

--- a/code/datums/components/drift.dm
+++ b/code/datums/components/drift.dm
@@ -19,7 +19,7 @@
 		return COMPONENT_INCOMPATIBLE
 	. = ..()
 
-	var/flags = MOVEMENT_LOOP_DRAGGING
+	var/flags = MOVEMENT_LOOP_OUTSIDE_CONTROL
 	if(instant)
 		flags |= MOVEMENT_LOOP_START_FAST
 	var/atom/movable/movable_parent = parent

--- a/code/datums/components/shuttle_cling.dm
+++ b/code/datums/components/shuttle_cling.dm
@@ -43,7 +43,7 @@
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_PICKUP, PROC_REF(do_remove))
 
-	hyperloop = SSmove_manager.move(moving = parent, direction = direction, delay = not_clinging_move_delay, subsystem = SShyperspace_drift, priority = MOVEMENT_ABOVE_SPACE_PRIORITY, flags = MOVEMENT_LOOP_NO_DIR_UPDATE|MOVEMENT_LOOP_DRAGGING)
+	hyperloop = SSmove_manager.move(moving = parent, direction = direction, delay = not_clinging_move_delay, subsystem = SShyperspace_drift, priority = MOVEMENT_ABOVE_SPACE_PRIORITY, flags = MOVEMENT_LOOP_NO_DIR_UPDATE|MOVEMENT_LOOP_OUTSIDE_CONTROL)
 
 	update_state(parent) //otherwise we'll get moved 1 tile before we can correct ourselves, which isnt super bad but just looks jank
 

--- a/code/datums/components/squeak.dm
+++ b/code/datums/components/squeak.dm
@@ -79,9 +79,12 @@
 		else
 			playsound(parent, pick_weight(override_squeak_sounds), volume, TRUE, sound_extra_range, sound_falloff_exponent, falloff_distance = sound_falloff_distance)
 
-/datum/component/squeak/proc/step_squeak()
+/datum/component/squeak/proc/step_squeak(obj/item/clothing/shoes/source)
 	SIGNAL_HANDLER
 
+	var/mob/living/carbon/human/owner = source.loc
+	if(CHECK_MOVE_LOOP_FLAGS(owner, MOVEMENT_LOOP_OUTSIDE_CONTROL))
+		return
 	if(steps > step_delay)
 		play_squeak()
 		steps = 0

--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -64,7 +64,7 @@
 	if(!istype(turf))
 		return
 
-	if(!turf.footstep || source.buckled || source.throwing || source.movement_type & (VENTCRAWLING | FLYING) || HAS_TRAIT(source, TRAIT_IMMOBILIZED) || source.check_move_loop_flags(MOVEMENT_LOOP_DRAGGING))
+	if(!turf.footstep || source.buckled || source.throwing || source.movement_type & (VENTCRAWLING | FLYING) || HAS_TRAIT(source, TRAIT_IMMOBILIZED) || CHECK_MOVE_LOOP_FLAGS(source, MOVEMENT_LOOP_OUTSIDE_CONTROL))
 		return
 
 	if(source.body_position == LYING_DOWN) //play crawling sound if we're lying
@@ -172,7 +172,7 @@
 	if(!istype(source_loc))
 		return
 
-	if(source.check_move_loop_flags(MOVEMENT_LOOP_DRAGGING))
+	if(CHECK_MOVE_LOOP_FLAGS(source, MOVEMENT_LOOP_OUTSIDE_CONTROL))
 		return
 
 	playsound(source_loc, footstep_sounds, 50, falloff_distance = 1, vary = sound_vary)

--- a/code/datums/elements/waddling.dm
+++ b/code/datums/elements/waddling.dm
@@ -14,17 +14,22 @@
 	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
 
 
-/datum/element/waddling/proc/LivingWaddle(mob/living/target)
+/datum/element/waddling/proc/LivingWaddle(mob/living/targetmob, atom/oldloc, direction, forced)
 	SIGNAL_HANDLER
 
-	if(target.incapacitated() || target.body_position == LYING_DOWN || CHECK_MOVE_LOOP_FLAGS(target, MOVEMENT_LOOP_OUTSIDE_CONTROL))
+	if(forced || target.incapacitated() || target.body_position == LYING_DOWN || CHECK_MOVE_LOOP_FLAGS(target, MOVEMENT_LOOP_OUTSIDE_CONTROL))
 		return
-	Waddle(target)
+	waddling_animation(target)
 
 
-/datum/element/waddling/proc/Waddle(atom/movable/target)
+/datum/element/waddling/proc/Waddle(atom/movable/target, atom/oldloc, direction, forced)
 	SIGNAL_HANDLER
 
+	if(forced || CHECK_MOVE_LOOP_FLAGS(target, MOVEMENT_LOOP_OUTSIDE_CONTROL))
+		return
+	waddling_animation(target)
+
+/datum/element/waddling/proc/waddling_animation(atom/movable/target)
 	animate(target, pixel_z = 4, time = 0)
 	var/prev_trans = matrix(target.transform)
 	animate(pixel_z = 0, transform = turn(target.transform, pick(-12, 0, 12)), time=2)

--- a/code/datums/elements/waddling.dm
+++ b/code/datums/elements/waddling.dm
@@ -14,7 +14,7 @@
 	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
 
 
-/datum/element/waddling/proc/LivingWaddle(mob/living/targetmob, atom/oldloc, direction, forced)
+/datum/element/waddling/proc/LivingWaddle(mob/living/target, atom/oldloc, direction, forced)
 	SIGNAL_HANDLER
 
 	if(forced || target.incapacitated() || target.body_position == LYING_DOWN || CHECK_MOVE_LOOP_FLAGS(target, MOVEMENT_LOOP_OUTSIDE_CONTROL))

--- a/code/datums/elements/waddling.dm
+++ b/code/datums/elements/waddling.dm
@@ -17,7 +17,7 @@
 /datum/element/waddling/proc/LivingWaddle(mob/living/target)
 	SIGNAL_HANDLER
 
-	if(target.incapacitated() || target.body_position == LYING_DOWN)
+	if(target.incapacitated() || target.body_position == LYING_DOWN || CHECK_MOVE_LOOP_FLAGS(target, MOVEMENT_LOOP_OUTSIDE_CONTROL))
 		return
 	Waddle(target)
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -931,15 +931,6 @@
 						SSspatial_grid.add_grid_awareness(location, channel)
 			recursive_contents[channel] |= arrived.important_recursive_contents[channel]
 
-/**
- * Returns a bitfield containing flags both present in `flags` arg and the `processing_move_loop_flags` move_packet variable.
- * Has no use outside of procs called within the movement proc chain.
- */
-/atom/movable/proc/check_move_loop_flags(flags)
-	if(!move_packet)
-		return NONE
-	return flags & move_packet.processing_move_loop_flags
-
 ///allows this movable to hear and adds itself to the important_recursive_contents list of itself and every movable loc its in
 /atom/movable/proc/become_hearing_sensitive(trait_source = TRAIT_GENERIC)
 	ADD_TRAIT(src, TRAIT_HEARING_SENSITIVE, trait_source)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -247,7 +247,7 @@
 
 /obj/structure/chair/office/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
-	if(has_gravity())
+	if(!forced && CHECK_MOVE_LOOP_FLAGS(src, MOVEMENT_LOOP_OUTSIDE_CONTROL) && has_gravity())
 		playsound(src, 'sound/effects/roll.ogg', 100, TRUE)
 
 /obj/structure/chair/office/electrify_self(obj/item/assembly/shock_kit/input_shock_kit, mob/user, list/overlays_from_child_procs)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -45,7 +45,7 @@
 
 /obj/vehicle/ridden/wheelchair/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
-	if(!forced && !check_move_loop_flags(MOVEMENT_LOOP_DRAGGING))
+	if(!forced && CHECK_MOVE_LOOP_FLAGS(src, MOVEMENT_LOOP_OUTSIDE_CONTROL) && has_gravity())
 		playsound(src, 'sound/effects/roll.ogg', 75, TRUE)
 
 /obj/vehicle/ridden/wheelchair/post_buckle_mob(mob/living/user)


### PR DESCRIPTION
## About The Pull Request
Lemon guy was a bit too late in reviewing #75732 because it got already merged by someone else, and I too hadn't managed to make some adjustment to that PR in time.

This PR applies suggested changes, turns a simple proc into a macro, and makes it so that also waddling, squeaky shoes and swivel chair sounds don't running when moved by conveyor belt.

This doesn't stop squeaking from happening when other conveyor-belt-moved objects or mobs cross its tile. That'd be hacky and I'm not here to fight sfx-spamming machines.

## Why It's Good For The Game
These are changes that should have been included in #75732 but couldn't. See that PR for the general idea.

## Changelog

:cl:
fix: waddling, squeaky shoes and swivel chair sound effects no longer run when moved by conveyor belt.
/:cl: