### PR TITLE
Reinstates grilled cheese sandwich taste and fixes a typo. [NO GBP]

### DIFF
--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -40,7 +40,7 @@
 		/datum/reagent/consumable/nutriment/vitamin = 1,
 		/datum/reagent/carbon = 4,
 	)
-	foodtypes = GRAIN | DAIRY
+	tastes = list("toast" = 2, "cheese" = 3, "butter" = 1)
 	burns_on_grill = TRUE
 
 /obj/item/food/sandwich/jelly

--- a/tools/UpdatePaths/Scripts/75750_sandwich_types.txt
+++ b/tools/UpdatePaths/Scripts/75750_sandwich_types.txt
@@ -4,7 +4,7 @@
 /obj/item/food/notasandwich : /obj/item/food/sandwich/notasandwich{@OLD}
 /obj/item/food/blt : /obj/item/food/sandwich/blt{@OLD}
 /obj/item/food/peanut_butter_jelly_sandwich : /obj/item/food/sandwich/peanut_butter_jelly{@OLD}
-/obj/item/food/peanut_butter_banana_sandwich : /obj/item/food/sandwich/peanut_banana_banana{@OLD}
+/obj/item/food/peanut_butter_banana_sandwich : /obj/item/food/sandwich/peanut_butter_banana{@OLD}
 /obj/item/food/philly_cheesesteak : /obj/item/food/sandwich/philly_cheesesteak{@OLD}
 /obj/item/food/toast_sandwich : /obj/item/food/sandwich/toast_sandwich{@OLD}
 /obj/item/food/death_sandwich : /obj/item/food/sandwich/death{@OLD}


### PR DESCRIPTION
## About The Pull Request
I've done a couple, almost untangible mistakes in #75750.

One, I deleted the wrong variable definition (tastes, when it should've been foodtypes, which had same value as parent) in the path for grilled cheese sandwiches. 

Two, a typo in the peanut butter banana sandwich path in the relative UpdatePath script.

Both are fixed now.

## Why It's Good For The Game
Fixing human error.

## Changelog
N/A