### PR TITLE
Adds species quirk blacklist structure + blacklists plasmaman from being able to pick blood deficiency and frail

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -136,3 +136,5 @@
 #define PLAYTIME_HARDCORE_RANDOM 120 // 2 hours
 /// The time needed to unlock the gamer cloak in preferences
 #define PLAYTIME_VETERAN 300000 // 5,000 hours
+
+#define SAVEFILE_KEY_NAME_SPECIES "species"

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -18,7 +18,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	/// An assoc list of quirks that can be obtained as a hardcore character, and their hardcore value.
 	var/list/hardcore_quirks = list()
 
-	/// A list of quirks that can not be used with each other. Format: list(quirk1,quirk2), list(quirk3,quirk4)
+	/// A list of quirks that can not be used with each other.
 	var/static/list/quirk_blacklist = list(
 		list("Blind", "Nearsighted"),
 		list("Jolly", "Depression", "Apathetic", "Hypersensitive"),
@@ -34,10 +34,10 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Social Anxiety", "Mute"),
 	)
 
-	/// A list of quirks that cannot be used by specific species. Format: species = list(quirk1, quirk2)
+	/// A list of quirks that cannot be used by specific species.
 	var/static/list/species_quirk_blacklist = list(
-		/datum/species/plasmaman = list(
-			/datum/quirk/blooddeficiency,
+		SPECIES_PLASMAMAN = list(
+			"Blood Deficiency",
 		),
 	)
 

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -11,9 +11,11 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	runlevels = RUNLEVEL_GAME
 	wait = 1 SECONDS
 
-	var/list/quirks = list() //Assoc. list of all roundstart quirk datum types; "name" = /path/
-	var/list/quirk_points = list() //Assoc. list of quirk names and their "point cost"; positive numbers are good traits, and negative ones are bad
-	///An assoc list of quirks that can be obtained as a hardcore character, and their hardcore value.
+	/// Assoc. list of all roundstart quirk datum types; "name" = /path/
+	var/list/quirks = list()
+	/// Assoc. list of quirk names and their "point cost"; positive numbers are good traits, and negative ones are bad
+	var/list/quirk_points = list()
+	/// An assoc list of quirks that can be obtained as a hardcore character, and their hardcore value.
 	var/list/hardcore_quirks = list()
 
 	/// A list of quirks that can not be used with each other. Format: list(quirk1,quirk2),list(quirk3,quirk4)
@@ -30,6 +32,11 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Quadruple Amputee", "Paraplegic"),
 		list("Quadruple Amputee", "Frail"),
 		list("Social Anxiety", "Mute"),
+	)
+
+	/// A list of quirks that cannot be used by specific species. Format: "quirk" = list(species1, species2)
+	var/static/list/species_quirk_blacklist = list(
+		"Blood Deficiency" = list(/datum/species/plasmaman)
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()
@@ -144,7 +151,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 /// be valid.
 /// If no changes need to be made, will return the same list.
 /// Expects all quirk names to be unique, but makes no other expectations.
-/datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks)
+/datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks, datum/preferences/supplied_prefs)
 	var/list/new_quirks = list()
 	var/list/positive_quirks = list()
 	var/balance = 0
@@ -174,6 +181,9 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 				break
 
 		if (blacklisted)
+			continue
+
+		if(species_quirk_blacklist[quirk_name] && (supplied_prefs.read_preference(/datum/preference/choiced/species) in species_quirk_blacklist[quirk_name]))
 			continue
 
 		var/value = initial(quirk.value)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -34,10 +34,11 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Social Anxiety", "Mute"),
 	)
 
-	/// A list of quirks that cannot be used by specific species.
+	/// A list of quirks that cannot be used by specific species, through their species ID.
 	var/static/list/species_quirk_blacklist = list(
 		SPECIES_PLASMAMAN = list(
 			"Blood Deficiency",
+			"Frail",
 		),
 	)
 
@@ -169,13 +170,13 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 			continue
 
 		var/datum/species/user_species = supplied_prefs.read_preference(/datum/preference/choiced/species)
-		if(quirk in species_quirk_blacklist[user_species])
+		if(quirk_name in species_quirk_blacklist[initial(user_species.id)])
 			continue
 
 		var/blacklisted = FALSE
 
 		for (var/list/blacklist as anything in quirk_blacklist)
-			if (!(quirk in blacklist))
+			if (!(quirk_name in blacklist))
 				continue
 
 			for (var/other_quirk in blacklist)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -36,7 +36,9 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 	/// A list of quirks that cannot be used by specific species. Format: "quirk" = list(species1, species2)
 	var/static/list/species_quirk_blacklist = list(
-		"Blood Deficiency" = list(/datum/species/plasmaman)
+		/datum/species/plasmaman = list(
+			/datum/quirk/blooddeficiency,
+		)
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()
@@ -166,6 +168,10 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		if ((initial(quirk.quirk_flags) & QUIRK_MOODLET_BASED) && CONFIG_GET(flag/disable_human_mood))
 			continue
 
+		var/datum/species/user_species = supplied_prefs.read_preference(/datum/preference/choiced/species)
+		if(quirk in species_quirk_blacklist[user_species])
+			continue
+
 		var/blacklisted = FALSE
 
 		for (var/list/blacklist as anything in quirk_blacklist)
@@ -181,9 +187,6 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 				break
 
 		if (blacklisted)
-			continue
-
-		if(species_quirk_blacklist[quirk_name] && (supplied_prefs.read_preference(/datum/preference/choiced/species) in species_quirk_blacklist[quirk_name]))
 			continue
 
 		var/value = initial(quirk.value)

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -154,7 +154,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 /// be valid.
 /// If no changes need to be made, will return the same list.
 /// Expects all quirk names to be unique, but makes no other expectations.
-/datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks, datum/preferences/supplied_prefs)
+/datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks, datum/preferences/supplied_prefs, species_type, give_warning)
 	var/list/new_quirks = list()
 	var/list/positive_quirks = list()
 	var/balance = 0
@@ -169,8 +169,17 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		if ((initial(quirk.quirk_flags) & QUIRK_MOODLET_BASED) && CONFIG_GET(flag/disable_human_mood))
 			continue
 
-		var/datum/species/user_species = supplied_prefs.read_preference(/datum/preference/choiced/species)
+		var/datum/species/user_species = species_type || supplied_prefs.read_preference(/datum/preference/choiced/species)
 		if(quirk_name in species_quirk_blacklist[initial(user_species.id)])
+			if(give_warning)
+				var/warning_tgui_alert = tgui_alert(
+					user = supplied_prefs.parent,
+					message = "The species you are changing to cannot use some quirks you have. Changing species will have them removed.",
+					title = "Species Changing",
+					buttons = list("Change Species", "Nevermind"),
+				)
+				if(warning_tgui_alert != "Change Species")
+					return FALSE
 			continue
 
 		var/blacklisted = FALSE

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -154,7 +154,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 /// be valid.
 /// If no changes need to be made, will return the same list.
 /// Expects all quirk names to be unique, but makes no other expectations.
-/datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks, datum/preferences/supplied_prefs, species_type, give_warning)
+/datum/controller/subsystem/processing/quirks/proc/filter_invalid_quirks(list/quirks, datum/preferences/supplied_prefs, datum/species/species_type, give_warning = FALSE)
 	var/list/new_quirks = list()
 	var/list/positive_quirks = list()
 	var/balance = 0

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -18,7 +18,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	/// An assoc list of quirks that can be obtained as a hardcore character, and their hardcore value.
 	var/list/hardcore_quirks = list()
 
-	/// A list of quirks that can not be used with each other. Format: list(quirk1,quirk2),list(quirk3,quirk4)
+	/// A list of quirks that can not be used with each other. Format: list(quirk1,quirk2), list(quirk3,quirk4)
 	var/static/list/quirk_blacklist = list(
 		list("Blind", "Nearsighted"),
 		list("Jolly", "Depression", "Apathetic", "Hypersensitive"),
@@ -34,11 +34,11 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Social Anxiety", "Mute"),
 	)
 
-	/// A list of quirks that cannot be used by specific species. Format: "quirk" = list(species1, species2)
+	/// A list of quirks that cannot be used by specific species. Format: species = list(quirk1, quirk2)
 	var/static/list/species_quirk_blacklist = list(
 		/datum/species/plasmaman = list(
 			/datum/quirk/blooddeficiency,
-		)
+		),
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -171,15 +171,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 		var/datum/species/user_species = species_type || supplied_prefs.read_preference(/datum/preference/choiced/species)
 		if(quirk_name in species_quirk_blacklist[initial(user_species.id)])
-			if(give_warning)
-				var/warning_tgui_alert = tgui_alert(
-					user = supplied_prefs.parent,
-					message = "The species you are changing to cannot use some quirks you have. Changing species will have them removed.",
-					title = "Species Changing",
-					buttons = list("Change Species", "Nevermind"),
-				)
-				if(warning_tgui_alert != "Change Species")
-					return FALSE
+			if(give_warning && give_quirk_removal_warning(supplied_prefs))
+				return FALSE
 			continue
 
 		var/blacklisted = FALSE
@@ -225,6 +218,25 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		return quirks
 
 	return new_quirks
+
+/**
+ * give_quirk_removal_warning
+ *
+ * Gives a tgui alert to the user about their quirks not being compatible.
+ * This is meant to be triggered by players manually, never called on its own.
+ * Args:
+ * - supplied_prefs: The preferences of the person we're warning of this.
+ */
+/datum/controller/subsystem/processing/quirks/proc/give_quirk_removal_warning(datum/preferences/supplied_prefs)
+	var/warning_tgui_alert = tgui_alert(
+		user = supplied_prefs.parent,
+		message = "The species you are changing to cannot use some quirks you have. Changing species will have them removed.",
+		title = "Species Changing",
+		buttons = list("Change Species", "Nevermind"),
+	)
+	if(warning_tgui_alert == "Change Species")
+		return TRUE
+	return FALSE
 
 #undef EXP_ASSIGN_WAYFINDER
 #undef RANDOM_QUIRK_BONUS

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -171,7 +171,8 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 		var/datum/species/user_species = species_type || supplied_prefs.read_preference(/datum/preference/choiced/species)
 		if(quirk_name in species_quirk_blacklist[initial(user_species.id)])
-			if(give_warning && give_quirk_removal_warning(supplied_prefs))
+			if(give_warning)
+				INVOKE_ASYNC(src, PROC_REF(give_quirk_removal_warning), supplied_prefs)
 				return FALSE
 			continue
 
@@ -228,15 +229,9 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
  * - supplied_prefs: The preferences of the person we're warning of this.
  */
 /datum/controller/subsystem/processing/quirks/proc/give_quirk_removal_warning(datum/preferences/supplied_prefs)
-	var/warning_tgui_alert = tgui_alert(
-		user = supplied_prefs.parent,
-		message = "The species you are changing to cannot use some quirks you have. Changing species will have them removed.",
-		title = "Species Changing",
-		buttons = list("Change Species", "Nevermind"),
-	)
-	if(warning_tgui_alert == "Change Species")
-		return TRUE
-	return FALSE
+	var/datum/species/species_name = supplied_prefs.read_preference(/datum/preference/choiced/species)
+	tgui_alert(usr, "The species you're trying to change to ([species_name.name]) cannot use the following quirk(s): [species_quirk_blacklist[initial(species_name.id)]]. Please modify your quirks.")
+	return
 
 #undef EXP_ASSIGN_WAYFINDER
 #undef RANDOM_QUIRK_BONUS

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -26,10 +26,12 @@
 
 	return data
 
-/datum/preference_middleware/quirks/get_constant_data()
+/datum/preference_middleware/quirks/get_constant_data(datum/preferences/supplied_prefs)
 	var/list/quirk_info = list()
 
 	var/list/quirks = SSquirks.get_quirks()
+
+	var/datum/species/user_species = supplied_prefs.read_preference(/datum/preference/choiced/species)
 
 	for (var/quirk_name in quirks)
 		var/datum/quirk/quirk = quirks[quirk_name]
@@ -44,6 +46,8 @@
 		"max_positive_quirks" = MAX_QUIRKS,
 		"quirk_info" = quirk_info,
 		"quirk_blacklist" = SSquirks.quirk_blacklist,
+		"species_quirk_blacklist" = SSquirks.species_quirk_blacklist,
+		"species_blacklist" = user_species
 	)
 
 /datum/preference_middleware/quirks/on_new_character(mob/user)

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -26,12 +26,12 @@
 
 	return data
 
-/datum/preference_middleware/quirks/get_constant_data(datum/preferences/supplied_prefs)
+/datum/preference_middleware/quirks/get_constant_data()
 	var/list/quirk_info = list()
 
 	var/list/quirks = SSquirks.get_quirks()
 
-	var/datum/species/user_species = supplied_prefs.read_preference(/datum/preference/choiced/species)
+	var/datum/species/user_species = preferences.read_preference(/datum/preference/choiced/species)
 
 	for (var/quirk_name in quirks)
 		var/datum/quirk/quirk = quirks[quirk_name]

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -31,8 +31,6 @@
 
 	var/list/quirks = SSquirks.get_quirks()
 
-	var/datum/species/user_species = preferences.read_preference(/datum/preference/choiced/species)
-
 	for (var/quirk_name in quirks)
 		var/datum/quirk/quirk = quirks[quirk_name]
 		quirk_info[sanitize_css_class_name(quirk_name)] = list(
@@ -47,7 +45,6 @@
 		"quirk_info" = quirk_info,
 		"quirk_blacklist" = SSquirks.quirk_blacklist,
 		"species_quirk_blacklist" = SSquirks.species_quirk_blacklist,
-		"species_blacklist" = user_species
 	)
 
 /datum/preference_middleware/quirks/on_new_character(mob/user)

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -53,7 +53,7 @@
 	var/quirk_name = params["quirk"]
 
 	var/list/new_quirks = preferences.all_quirks | quirk_name
-	if (SSquirks.filter_invalid_quirks(new_quirks) != new_quirks)
+	if (SSquirks.filter_invalid_quirks(new_quirks, preferences) != new_quirks)
 		// If the client is sending an invalid give_quirk, that means that
 		// something went wrong with the client prediction, so we should
 		// catch it back up to speed.
@@ -71,7 +71,7 @@
 	var/list/new_quirks = preferences.all_quirks - quirk_name
 	if ( \
 		!(quirk_name in preferences.all_quirks) \
-		|| SSquirks.filter_invalid_quirks(new_quirks) != new_quirks \
+		|| SSquirks.filter_invalid_quirks(new_quirks, preferences) != new_quirks \
 	)
 		// If the client is sending an invalid remove_quirk, that means that
 		// something went wrong with the client prediction, so we should

--- a/code/modules/client/preferences/middleware/species.dm
+++ b/code/modules/client/preferences/middleware/species.dm
@@ -15,7 +15,9 @@
 	var/quirk_response = SSquirks.filter_invalid_quirks(SANITIZE_LIST(preferences.all_quirks), preferences, species_type = GLOB.species_list[value], give_warning = TRUE)
 	if(!quirk_response)
 		return TRUE
-	preferences.all_quirks = quirk_response
+	if(preferences.all_quirks != quirk_response)
+		preferences.all_quirks = quirk_response
+		preferences.update_static_data(user)
 	return FALSE
 
 /datum/asset/spritesheet/species

--- a/code/modules/client/preferences/middleware/species.dm
+++ b/code/modules/client/preferences/middleware/species.dm
@@ -1,4 +1,4 @@
-/// Handles the assets for species icons
+/// Handles the assets for species icons and ensuring quirks are compatible with species we change into.
 /datum/preference_middleware/species
 
 /datum/preference_middleware/species/get_ui_assets()
@@ -6,8 +6,20 @@
 		get_asset_datum(/datum/asset/spritesheet/species),
 	)
 
+//We only come into effect if our pref key (species) is changed.
+//We will filter invalid quirks. If it is cancelled out then we will not change anything and not allow the change through.
+//Otherwise we will accept the incoming changes and change the species.
+/datum/preference_middleware/species/pre_set_preference(mob/user, requested_preference_key, value)
+	if(requested_preference_key != SAVEFILE_KEY_NAME_SPECIES)
+		return FALSE
+	var/quirk_response = SSquirks.filter_invalid_quirks(SANITIZE_LIST(preferences.all_quirks), preferences, species_type = GLOB.species_list[value], give_warning = TRUE)
+	if(!quirk_response)
+		return TRUE
+	preferences.all_quirks = quirk_response
+	return FALSE
+
 /datum/asset/spritesheet/species
-	name = "species"
+	name = SAVEFILE_KEY_NAME_SPECIES
 	early = TRUE
 	cross_round_cachable = TRUE
 

--- a/code/modules/client/preferences/species.dm
+++ b/code/modules/client/preferences/species.dm
@@ -38,6 +38,7 @@
 
 		data[species_id] = list()
 		data[species_id]["name"] = species.name
+		data[species_id]["plural_form"] = species.plural_form
 		data[species_id]["desc"] = species.get_species_description()
 		data[species_id]["lore"] = species.get_species_lore()
 		data[species_id]["icon"] = sanitize_css_class_name(species.name)

--- a/code/modules/client/preferences/species.dm
+++ b/code/modules/client/preferences/species.dm
@@ -1,7 +1,7 @@
 /// Species preference
 /datum/preference/choiced/species
 	savefile_identifier = PREFERENCE_CHARACTER
-	savefile_key = "species"
+	savefile_key = SAVEFILE_KEY_NAME_SPECIES
 	priority = PREFERENCE_PRIORITY_SPECIES
 	randomize_by_default = FALSE
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -313,7 +313,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		if(job_preferences[j] != JP_LOW && job_preferences[j] != JP_MEDIUM && job_preferences[j] != JP_HIGH)
 			job_preferences -= j
 
-	all_quirks = SSquirks.filter_invalid_quirks(SANITIZE_LIST(all_quirks))
+	all_quirks = SSquirks.filter_invalid_quirks(SANITIZE_LIST(all_quirks), src)
 	validate_quirks()
 
 	return TRUE

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -134,7 +134,7 @@ export const QuirksPage = (props, context) => {
     `selectedQuirks_${data.active_slot}`,
     data.selected_quirks
   );
-
+  const chosenSpecies = data.character_preferences.misc.species;
   return (
     <ServerPreferencesFetcher
       render={(data) => {
@@ -202,20 +202,13 @@ export const QuirksPage = (props, context) => {
                 return `This is incompatible with ${incompatibleQuirk}!`;
               }
             }
+          }
 
-            for (const speciesblacklist of speciesquirkBlacklist) {
-              if (speciesblacklist.indexOf(quirk.name) === -1) {
-                continue;
-              }
-
-              for (const speciesquirkBlacklist of speciesblacklist) {
-                if (
-                  speciesquirkBlacklist !== quirk.name &&
-                  selectedQuirkNames.indexOf(speciesquirkBlacklist) !== -1
-                ) {
-                  return `This is incompatible with ${speciesquirkBlacklist}!`;
-                }
-              }
+          if (chosenSpecies in speciesquirkBlacklist) {
+            if (
+              speciesquirkBlacklist[chosenSpecies].indexOf(quirk.name) !== -1
+            ) {
+              return `This is incompatible with the species ${data.species[chosenSpecies].name}!`;
             }
           }
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -145,7 +145,7 @@ export const QuirksPage = (props, context) => {
         const {
           max_positive_quirks: maxPositiveQuirks,
           quirk_blacklist: quirkBlacklist,
-          species_quirk_blacklist: speciesquirkBlacklist,
+          species_quirk_blacklist: speciesQuirkBlacklist,
           quirk_info: quirkInfo,
         } = data.quirks;
 
@@ -204,12 +204,11 @@ export const QuirksPage = (props, context) => {
             }
           }
 
-          if (chosenSpecies in speciesquirkBlacklist) {
-            if (
-              speciesquirkBlacklist[chosenSpecies].indexOf(quirk.name) !== -1
-            ) {
-              return `This is incompatible with the species ${data.species[chosenSpecies].name}!`;
-            }
+          if (
+            chosenSpecies in speciesQuirkBlacklist &&
+            speciesQuirkBlacklist[chosenSpecies].indexOf(quirk.name) !== -1
+          ) {
+            return `${quirk.name} is not compatible with ${data.species[chosenSpecies].plural_form}!`;
           }
 
           return undefined;

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -145,6 +145,7 @@ export const QuirksPage = (props, context) => {
         const {
           max_positive_quirks: maxPositiveQuirks,
           quirk_blacklist: quirkBlacklist,
+          species_quirk_blacklist: speciesquirkBlacklist,
           quirk_info: quirkInfo,
         } = data.quirks;
 
@@ -199,6 +200,21 @@ export const QuirksPage = (props, context) => {
                 selectedQuirkNames.indexOf(incompatibleQuirk) !== -1
               ) {
                 return `This is incompatible with ${incompatibleQuirk}!`;
+              }
+            }
+
+            for (const speciesblacklist of speciesquirkBlacklist) {
+              if (speciesblacklist.indexOf(quirk.name) === -1) {
+                continue;
+              }
+
+              for (const speciesquirkBlacklist of speciesblacklist) {
+                if (
+                  speciesquirkBlacklist !== quirk.name &&
+                  selectedQuirkNames.indexOf(speciesquirkBlacklist) !== -1
+                ) {
+                  return `This is incompatible with ${speciesquirkBlacklist}!`;
+                }
               }
             }
           }

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -88,6 +88,7 @@ export type QuirkInfo = {
   max_positive_quirks: number;
   quirk_info: Record<string, Quirk>;
   quirk_blacklist: string[][];
+  species_quirk_blacklist: string[][];
 };
 
 export enum RandomSetting {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -43,6 +43,7 @@ export type Species = {
   desc: string;
   lore: string[];
   icon: string;
+  plural_form: string;
 
   use_skintones: BooleanLike;
   sexes: BooleanLike;

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -88,7 +88,7 @@ export type QuirkInfo = {
   max_positive_quirks: number;
   quirk_info: Record<string, Quirk>;
   quirk_blacklist: string[][];
-  species_quirk_blacklist: string[][];
+  species_quirk_blacklist: Record<string, string[]>;
 };
 
 export enum RandomSetting {


### PR DESCRIPTION
## About The Pull Request
Adds backend support for blacklisting species from picking specific quirks if so desired. 

Also if this is a genuine species changes Willard said it was okay.
![image](https://github.com/tgstation/tgstation/assets/70232195/a5dd7ec0-a0fd-4a71-b52d-581df4cf73b1)


## Why It's Good For The Game
1. See above.
2. Plasmamen do not have blood, and as such, its a free 8 quirk points .

Fixes: https://github.com/TaleStation/TaleStation/issues/4039 

## Changelog

:cl: Jolly, JohnFulpWillard, _distrilul for TGUI
fix: Plasmaman can no longer pick the Blood Deficiency OR Frail quirks.
/:cl:

