### PR TITLE
Fixes Tram Morgue APC not being wired roundstart

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -27318,6 +27318,7 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iEz" = (


### PR DESCRIPTION
## About The Pull Request
Adds a missing cable for the APC in Tram morgue
![image](https://github.com/tgstation/tgstation/assets/66163761/a7857859-4356-47a6-a73d-21afb74d223e)

## Why It's Good For The Game
Mapping skill issue resolved.
## Changelog
:cl:
fix: Tram morgue APC is now properly wired.
/:cl:
