### PR TITLE
Allows foam to spread through anything that is not blocking air.

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -137,7 +137,7 @@
 	if(!istype(location))
 		return FALSE
 
-	for(var/turf/spread_turf as anything in location.reachableAdjacentTurfs(no_id = TRUE))
+	for(var/turf/spread_turf as anything in location.get_atmos_adjacent_turfs())
 		var/obj/effect/particle_effect/fluid/foam/foundfoam = locate() in spread_turf //Don't spread foam where there's already foam!
 		if(foundfoam)
 			continue

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -137,7 +137,7 @@
 	if(!istype(location))
 		return FALSE
 
-	for(var/turf/spread_turf as anything in location.get_atmos_adjacent_turfs())
+	for(var/turf/spread_turf as anything in location.reachableAdjacentTurfs(no_id = TRUE) | location.get_atmos_adjacent_turfs())
 		var/obj/effect/particle_effect/fluid/foam/foundfoam = locate() in spread_turf //Don't spread foam where there's already foam!
 		if(foundfoam)
 			continue


### PR DESCRIPTION

## About The Pull Request
Allows foam to spread through anything gas can spread through. This allows it to spread through tables, some machinery, water tanks, crates, other structures, whatever. It is still able to spread through atmos holosigns and space.
## Why It's Good For The Game
It makes sense for foam to spread through these things. Makes firefighting with foam based methods (resin) while carrying a water tank a little less silly. Also easier to extinguish a bar fire because of all the tables.
## Changelog
:cl:
balance: Foam can spread through anything that does not block air.
/:cl:
