### PR TITLE
block_explosives remove remnants when detached.

### DIFF
--- a/code/datums/elements/blocks_explosives.dm
+++ b/code/datums/elements/blocks_explosives.dm
@@ -20,6 +20,13 @@
 
 /datum/element/blocks_explosives/Detach(datum/source)
 	. = ..()
+	if(ismovable(source))
+		var/atom/movable/target = target
+		if(length(target.locs) > 1)
+			for(var/atom/location as anything in target.locs)
+				unblock_loc(location, target.explosion_block)
+		else if(target.loc)
+			unblock_loc(location, target.explosion_block)
 	REMOVE_TRAIT(source, TRAIT_BLOCKING_EXPLOSIVES, TRAIT_GENERIC)
 
 /// Call this when our blocking well, changes. we'll update our turf(s) with the details

--- a/code/datums/elements/blocks_explosives.dm
+++ b/code/datums/elements/blocks_explosives.dm
@@ -21,7 +21,7 @@
 /datum/element/blocks_explosives/Detach(datum/source)
 	. = ..()
 	if(ismovable(source))
-		var/atom/movable/target = target
+		var/atom/movable/target = source
 		if(length(target.locs) > 1)
 			for(var/atom/location as anything in target.locs)
 				unblock_loc(location, target.explosion_block)

--- a/code/datums/elements/blocks_explosives.dm
+++ b/code/datums/elements/blocks_explosives.dm
@@ -19,15 +19,13 @@
 	else if(moving_target.loc)
 		block_loc(moving_target.loc, moving_target.explosion_block)
 
-/datum/element/blocks_explosives/Detach(datum/source)
+/datum/element/blocks_explosives/Detach(atom/movable/source)
 	. = ..()
-	if(ismovable(source))
-		var/atom/movable/target = source
-		if(length(target.locs) > 1)
-			for(var/atom/location as anything in target.locs)
-				unblock_loc(location, target.explosion_block)
-		else if(target.loc)
-			unblock_loc(target.loc, target.explosion_block)
+	if(length(source.locs) > 1)
+		for(var/atom/location as anything in source.locs)
+			unblock_loc(location, source.explosion_block)
+	else if(source.loc)
+		unblock_loc(source.loc, source.explosion_block)
 	REMOVE_TRAIT(source, TRAIT_BLOCKING_EXPLOSIVES, TRAIT_GENERIC)
 
 /// Call this when our blocking well, changes. we'll update our turf(s) with the details

--- a/code/datums/elements/blocks_explosives.dm
+++ b/code/datums/elements/blocks_explosives.dm
@@ -26,7 +26,7 @@
 			for(var/atom/location as anything in target.locs)
 				unblock_loc(location, target.explosion_block)
 		else if(target.loc)
-			unblock_loc(location, target.explosion_block)
+			unblock_loc(target.loc, target.explosion_block)
 	REMOVE_TRAIT(source, TRAIT_BLOCKING_EXPLOSIVES, TRAIT_GENERIC)
 
 /// Call this when our blocking well, changes. we'll update our turf(s) with the details

--- a/code/datums/elements/blocks_explosives.dm
+++ b/code/datums/elements/blocks_explosives.dm
@@ -1,6 +1,7 @@
 /// Apply this element to a movable atom when you want it to block explosions
 /// It will mirror the blocking down to that movable's turf, keeping explosion work cheap
 /datum/element/blocks_explosives
+	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
 
 /datum/element/blocks_explosives/Attach(datum/target)
 	if(!ismovable(target))


### PR DESCRIPTION
Removes the explosive resistance remnants on the turf(s) if blocks_explosives gets detached.
## About The Pull Request
Closes #75793

Also this is an untested webedit.
## Why It's Good For The Game
hhhhhhhhhhhhhhhhh
## Changelog
:cl:
fix: Fix movable explosive blockers leaving remnants of explosive protection on turfs after they get destroyed.
/:cl:
