### PR TITLE
[NO GBP]Air alarms will properly reset their warning messages.

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -574,6 +574,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 		if(temp >= BODYTEMP_HEAT_WARNING_1-27)
 			warning_message = "Danger! High temperature detected."
 			return
+		else
+			warning_message = null
 
 	else
 		alarm_manager.clear_alarm(ALARM_ATMOS)


### PR DESCRIPTION

## About The Pull Request
I didn't realize that an edge case could keep the alarms from reseting their warning message.

The issue happened when a warning message was stored, like a low temperature one, a second air alarm issue *without* a warning message was triggered, like Plasma, and then the first issue was fixed.

Alarms kept repeating the first warning message as long as the second issue was up.

This fixes that, alarms will reset their message individually, ignoring other issues the alarm is triggering.

Thanks Colovorat and Potato for letting me know about my fuck up.
## Why It's Good For The Game
Edge case that shouldn't happen outside of plasma floods is fixed and fixes are good!
## Changelog
:cl: Guillaume Prata
fix: Fixes an edge case of an air alarm warning not reseting properly and being repeated when another atmos issue without a warning message, like Plasma in the air, triggered the alarm.
/:cl:
