### PR TITLE
Laptops give a slowdown when dragged

### DIFF
--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -14,13 +14,13 @@
 
 	// No running around with open laptops in hands.
 	item_flags = SLOWS_WHILE_IN_HAND
-	drag_slowdown = 1.5
 
 	screen_on = FALSE // Starts closed
 	var/start_open = TRUE // unless this var is set to 1
 	var/icon_state_closed = "laptop-closed"
 	var/w_class_open = WEIGHT_CLASS_BULKY
 	var/slowdown_open = 1
+	drag_slowdown = 0
 
 /obj/item/modular_computer/laptop/examine(mob/user)
 	. = ..()
@@ -102,19 +102,23 @@
 
 /obj/item/modular_computer/laptop/proc/toggle_open(mob/living/user=null)
 	if(screen_on)
-		if(iscarbon(loc))
-			to_chat(user, span_notice("You close \the [src]."))
-			var/mob/living/carbon/wielder = loc
-			slowdown = initial(slowdown)
-			w_class = initial(w_class)
-			wielder.update_equipment_speed_mods()
+		to_chat(user, span_notice("You close \the [src]."))
+		slowdown = initial(slowdown)
+		w_class = initial(w_class)
+		drag_slowdown = 0
+		if(ismob(loc))
+			var/mob/living/localmob = loc
+			localmob.update_equipment_speed_mods()
+			localmob.update_pull_movespeed()
 	else
 		to_chat(user, span_notice("You open \the [src]."))
-		if(iscarbon(loc))
-			var/mob/living/carbon/wielder = loc
-			slowdown = slowdown_open
-			w_class = w_class_open
-			wielder.update_equipment_speed_mods()
+		slowdown = slowdown_open
+		w_class = w_class_open
+		drag_slowdown = 1
+		if(ismob(loc))
+			var/mob/living/localmob = loc
+			localmob.update_equipment_speed_mods()
+			localmob.update_pull_movespeed()
 
 	screen_on = !screen_on
 	update_appearance()

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -20,7 +20,7 @@
 	var/start_open = TRUE // unless this var is set to 1
 	var/icon_state_closed = "laptop-closed"
 	var/w_class_open = WEIGHT_CLASS_BULKY
-	var/slowdown_open = TRUE
+	var/slowdown_open = 1
 
 /obj/item/modular_computer/laptop/examine(mob/user)
 	. = ..()
@@ -102,13 +102,19 @@
 
 /obj/item/modular_computer/laptop/proc/toggle_open(mob/living/user=null)
 	if(screen_on)
-		to_chat(user, span_notice("You close \the [src]."))
-		slowdown = initial(slowdown)
-		w_class = initial(w_class)
+		if(iscarbon(loc))
+			to_chat(user, span_notice("You close \the [src]."))
+			var/mob/living/carbon/wielder = loc
+			slowdown = initial(slowdown)
+			w_class = initial(w_class)
+			wielder.update_equipment_speed_mods()
 	else
 		to_chat(user, span_notice("You open \the [src]."))
-		slowdown = slowdown_open
-		w_class = w_class_open
+		if(iscarbon(loc))
+			var/mob/living/carbon/wielder = loc
+			slowdown = slowdown_open
+			w_class = w_class_open
+			wielder.update_equipment_speed_mods()
 
 	screen_on = !screen_on
 	update_appearance()

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -15,12 +15,12 @@
 	// No running around with open laptops in hands.
 	item_flags = SLOWS_WHILE_IN_HAND
 
+	drag_slowdown = 0
 	screen_on = FALSE // Starts closed
 	var/start_open = TRUE // unless this var is set to 1
 	var/icon_state_closed = "laptop-closed"
 	var/w_class_open = WEIGHT_CLASS_BULKY
 	var/slowdown_open = 1
-	drag_slowdown = 0
 
 /obj/item/modular_computer/laptop/examine(mob/user)
 	. = ..()
@@ -105,20 +105,16 @@
 		to_chat(user, span_notice("You close \the [src]."))
 		slowdown = initial(slowdown)
 		w_class = initial(w_class)
-		drag_slowdown = 0
-		if(ismob(loc))
-			var/mob/living/localmob = loc
-			localmob.update_equipment_speed_mods()
-			localmob.update_pull_movespeed()
+		drag_slowdown = initial(drag_slowdown)
 	else
 		to_chat(user, span_notice("You open \the [src]."))
 		slowdown = slowdown_open
 		w_class = w_class_open
-		drag_slowdown = 1
-		if(ismob(loc))
-			var/mob/living/localmob = loc
-			localmob.update_equipment_speed_mods()
-			localmob.update_pull_movespeed()
+		drag_slowdown = slowdown_open
+	if(isliving(loc))
+		var/mob/living/localmob = loc
+		localmob.update_equipment_speed_mods()
+		localmob.update_pull_movespeed()
 
 	screen_on = !screen_on
 	update_appearance()

--- a/code/modules/modular_computers/computers/item/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop.dm
@@ -14,6 +14,7 @@
 
 	// No running around with open laptops in hands.
 	item_flags = SLOWS_WHILE_IN_HAND
+	drag_slowdown = 1.5
 
 	screen_on = FALSE // Starts closed
 	var/start_open = TRUE // unless this var is set to 1


### PR DESCRIPTION

## About The Pull Request
Laptops have a slowdown when held in hand that could easily be bypassed by just dragging the laptop instead so you can interact with it with no slowdown.

It is the same slowdown from dragging lockers with 1.5, and by tests, looks like the same slowdown given to laptop when held even if I couldn't easily find the value properly defined anywhere...
## Why It's Good For The Game
If we designed Laptops to be better PDAs but with a bulkyness side effect, kinda silly to let it be easily bypassed like this...
## Changelog
:cl: Guillaume Prata
fix: Laptops now give a slowdown when dragged, patching the easy trick of dragging a laptop to bypass the slowdown for carrying it on hand.
/:cl:
