### PR TITLE
Allow admins to enable non-clowns to drive the clown car

### DIFF
--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -21,6 +21,8 @@
 	var/thankscount = 0
 	///Current status of the cannon, alternates between CLOWN_CANNON_INACTIVE, CLOWN_CANNON_BUSY and CLOWN_CANNON_READY
 	var/cannonmode = CLOWN_CANNON_INACTIVE
+	///Does the driver require the clown role to drive it
+	var/enforce_clown_role = TRUE
 
 /datum/armor/car_clowncar
 	melee = 70
@@ -48,7 +50,7 @@
 /obj/vehicle/sealed/car/clowncar/auto_assign_occupant_flags(mob/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(is_clown_job(H.mind?.assigned_role)) //Ensures only clowns can drive the car. (Including more at once)
+		if(is_clown_job(H.mind?.assigned_role) || !enforce_clown_role) //Ensures only clowns can drive the car. (Including more at once)
 			add_control_flags(H, VEHICLE_CONTROL_DRIVE)
 			RegisterSignal(H, COMSIG_MOB_CLICKON, PROC_REF(fire_cannon_at))
 			M.log_message("has entered [src] as a possible driver", LOG_GAME)


### PR DESCRIPTION

## About The Pull Request
Allows admin to varedit clown cars to allow non-clowns to be the drivers. At the moment the current workaround is to assign the clown role to people who we want to drive it which is a bit weird.

## Why It's Good For The Game
More admin powers = good.

## Changelog
:cl:
admin: allow admins to allow non-clowns to drive clown cars
/:cl:
