### PR TITLE
Latejoining crew start with emergency large crowbars if arrivals is not powered

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -228,6 +228,9 @@
 	if((job.job_flags & JOB_ASSIGN_QUIRKS) && humanc && CONFIG_GET(flag/roundstart_traits))
 		SSquirks.AssignQuirks(humanc, humanc.client)
 
+	var/area/station/arrivals = GLOB.areas_by_type[/area/station/hallway/secondary/entry]
+	if(humanc && !arrivals.power_environ) //arrivals depowered
+		humanc.put_in_hands(new /obj/item/crowbar/large/emergency(humanc))
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CREWMEMBER_JOINED, character, rank)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -230,7 +230,7 @@
 
 	var/area/station/arrivals = GLOB.areas_by_type[/area/station/hallway/secondary/entry]
 	if(humanc && !arrivals.power_environ) //arrivals depowered
-		humanc.put_in_hands(new /obj/item/crowbar/large/emergency(humanc))
+		humanc.put_in_hands(new /obj/item/crowbar/large/emergency(get_turf(humanc))) //if hands full then just drops on the floor
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CREWMEMBER_JOINED, character, rank)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -229,7 +229,7 @@
 		SSquirks.AssignQuirks(humanc, humanc.client)
 
 	var/area/station/arrivals = GLOB.areas_by_type[/area/station/hallway/secondary/entry]
-	if(humanc && !arrivals.power_environ) //arrivals depowered
+	if(humanc && arrivals && !arrivals.power_environ) //arrivals depowered
 		humanc.put_in_hands(new /obj/item/crowbar/large/emergency(get_turf(humanc))) //if hands full then just drops on the floor
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 


### PR DESCRIPTION
## About The Pull Request

If you latejoin, and arrivals environmental power is off (airlocks depowered), you start with an emergency large crowbar in your hands (or floor if both hands are full already)

## Why It's Good For The Game

Some arrival shuttles start with a crowbar, but its not enough if someone already took it before you arrived.
Being stuck in airlock + firelock CBT especially with no air is very shit (unless youre the CE or an Engineer who start with tools, unlikely)
Having a crowbar resolves movement

## Changelog
:cl:
qol: Latejoining crew start with crowbars if arrivals enviromental power is OFF
/:cl:
