### PR TITLE
Fixes Beach bum Badsketball, adds a missing gulag reclaimer console to Birdshot's gulag.

### DIFF
--- a/_maps/map_files/Basketball/beach_bums.dmm
+++ b/_maps/map_files/Basketball/beach_bums.dmm
@@ -15,24 +15,17 @@
 	pixel_x = 10;
 	pixel_y = -4
 	},
-/turf/open/misc/beach/coastline_t{
-	dir = 1
-	},
-/area/centcom/basketball)
-"aw" = (
-/turf/open/misc/beach/coastline_b{
-	dir = 10
-	},
+/turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "bA" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/sign/poster/contraband/have_a_puff/directional/east,
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "cc" = (
 /obj/structure/flora/bush/stalky/style_random,
 /obj/structure/sign/poster/contraband/have_a_puff/directional/west,
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "cw" = (
 /obj/structure/flora/rock/style_random{
@@ -43,43 +36,23 @@
 	desc = "It can't be smoked.";
 	name = "sea weed"
 	},
-/turf/open/indestructible/binary{
-	density = 1;
-	desc = "I can't move through this.";
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "water";
-	name = "deep ocean water"
-	},
+/turf/open/water/beach,
 /area/centcom/basketball)
 "cX" = (
 /obj/effect/landmark/basketball/team_spawn/referee,
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
-"dg" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/misc/beach/coastline_t/sandwater_inner{
-	dir = 4
-	},
-/area/centcom/basketball)
 "dC" = (
 /obj/structure/fluff/beach_umbrella/cap,
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
-"eD" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/misc/beach/coastline_t/sandwater_inner{
-	dir = 1
-	},
+"eC" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "eM" = (
 /obj/item/storage/cans/sixbeer,
-/turf/open/misc/beach/coastline_t{
-	dir = 8
-	},
+/turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "fj" = (
 /obj/effect/overlay/coconut,
@@ -90,46 +63,19 @@
 	pixel_x = 15;
 	pixel_y = -7
 	},
-/turf/open/misc/beach/coastline_t{
-	dir = 1
-	},
-/area/centcom/basketball)
-"fT" = (
-/obj/item/toy/plush/carpplushie,
-/turf/open/misc/beach/coastline_b{
-	dir = 4
-	},
+/turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "gY" = (
 /turf/open/floor/plating,
 /area/centcom/basketball)
-"hn" = (
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/obj/item/fishing_rod{
-	pixel_x = 18
-	},
-/turf/open/misc/beach/coastline_t{
-	dir = 5
-	},
-/area/centcom/basketball)
 "hZ" = (
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 4
 	},
 /area/centcom/basketball)
 "ie" = (
 /obj/effect/landmark/basketball/team_spawn/away,
-/turf/open/misc/beach/coastline_t,
-/area/centcom/basketball)
-"ix" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/misc/beach/coastline_t/sandwater_inner{
-	dir = 8
-	},
+/turf/open/misc/beach/coast,
 /area/centcom/basketball)
 "iB" = (
 /obj/item/reagent_containers/cup/glass/colocup{
@@ -152,25 +98,13 @@
 /area/centcom/basketball)
 "jq" = (
 /obj/structure/fence,
-/turf/open/misc/beach/coastline_t{
-	dir = 9
+/turf/open/misc/beach/coast{
+	dir = 1
 	},
-/area/centcom/basketball)
-"ku" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/misc/beach/coastline_t,
 /area/centcom/basketball)
 "kv" = (
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/indestructible/binary{
-	density = 1;
-	desc = "I can't move through this.";
-	icon = 'icons/misc/beach.dmi';
-	icon_state = "water";
-	name = "deep ocean water"
-	},
+/turf/open/water/beach,
 /area/centcom/basketball)
 "ld" = (
 /obj/effect/turf_decal/sand,
@@ -190,46 +124,20 @@
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
-"mk" = (
-/obj/effect/overlay/palmtree_l,
-/turf/open/misc/beach/coastline_t{
-	dir = 9
-	},
-/area/centcom/basketball)
-"mW" = (
-/turf/open/misc/beach/coastline_b,
-/area/centcom/basketball)
-"nv" = (
-/turf/open/misc/beach/coastline_t,
-/area/centcom/basketball)
 "nE" = (
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/centcom/basketball)
 "oR" = (
 /obj/effect/landmark/basketball/team_spawn/home,
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 1
-	},
-/area/centcom/basketball)
-"pV" = (
-/obj/structure/fence,
-/turf/open/misc/beach/coastline_t{
-	dir = 6
 	},
 /area/centcom/basketball)
 "qF" = (
 /obj/structure/fence/corner{
 	dir = 1
 	},
-/turf/open/misc/beach/coastline_t{
-	dir = 10
-	},
-/area/centcom/basketball)
-"ru" = (
-/obj/structure/fluff/beach_umbrella,
-/turf/open/misc/beach/coastline_t{
-	dir = 1
-	},
+/turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "rU" = (
 /obj/structure/table,
@@ -240,11 +148,6 @@
 /obj/item/reagent_containers/cup/glass/bottle/beer,
 /obj/item/reagent_containers/cup/glass/bottle/beer,
 /turf/open/misc/beach/sand,
-/area/centcom/basketball)
-"sb" = (
-/turf/open/misc/beach/coastline_b{
-	dir = 5
-	},
 /area/centcom/basketball)
 "un" = (
 /obj/effect/overlay/palmtree_r,
@@ -258,7 +161,8 @@
 /turf/open/floor/vault/sandstone,
 /area/centcom/basketball)
 "vo" = (
-/turf/open/misc/beach/coastline_b{
+/obj/item/toy/plush/carpplushie,
+/turf/open/misc/beach/coast{
 	dir = 4
 	},
 /area/centcom/basketball)
@@ -266,26 +170,25 @@
 /obj/structure/fence/corner{
 	dir = 8
 	},
-/turf/open/misc/beach/coastline_t{
-	dir = 9
-	},
+/turf/open/misc/beach/sand,
+/area/centcom/basketball)
+"wg" = (
+/turf/open/misc/beach/coast,
 /area/centcom/basketball)
 "wN" = (
 /obj/machinery/jukebox,
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "xe" = (
-/turf/open/misc/beach/coastline_t/sandwater_inner{
-	dir = 1
+/turf/open/misc/beach/coast/corner{
+	dir = 8
 	},
 /area/centcom/basketball)
 "xG" = (
 /obj/structure/fence/corner{
 	dir = 5
 	},
-/turf/open/misc/beach/coastline_t{
-	dir = 5
-	},
+/turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "xI" = (
 /obj/structure/table,
@@ -302,13 +205,11 @@
 	desc = "A volcanic rock.";
 	name = "coastal rock"
 	},
-/turf/open/misc/beach/coastline_b{
-	dir = 1
-	},
+/turf/open/water/beach,
 /area/centcom/basketball)
 "yO" = (
 /obj/effect/landmark/basketball/team_spawn/home,
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 8
 	},
 /area/centcom/basketball)
@@ -317,33 +218,31 @@
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "zk" = (
-/turf/open/misc/beach/coastline_t/sandwater_inner{
-	dir = 8
+/turf/open/misc/beach/coast/corner{
+	dir = 1
 	},
 /area/centcom/basketball)
 "zU" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/sign/poster/contraband/have_a_puff/directional/west,
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "zZ" = (
 /obj/structure/fence,
-/turf/open/misc/beach/coastline_t{
-	dir = 8
-	},
+/turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "Aj" = (
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "Aw" = (
-/turf/open/misc/beach/coastline_t/sandwater_inner{
+/turf/open/misc/beach/coast/corner{
 	dir = 4
 	},
 /area/centcom/basketball)
 "BD" = (
 /obj/structure/flora/bush/stalky/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "BM" = (
 /turf/closed/indestructible/sandstone,
@@ -355,19 +254,13 @@
 	},
 /turf/open/floor/vault/sandstone,
 /area/centcom/basketball)
-"Ct" = (
-/obj/structure/fence,
-/turf/open/misc/beach/coastline_t{
-	dir = 5
-	},
-/area/centcom/basketball)
 "Cv" = (
 /obj/structure/hoop/minigame{
 	dir = 4
 	},
 /obj/effect/landmark/basketball/team_spawn/home_hoop,
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "Cw" = (
 /obj/structure/chair/plastic{
@@ -376,21 +269,14 @@
 /obj/item/fishing_rod{
 	pixel_x = 18
 	},
-/turf/open/misc/beach/coastline_t{
-	dir = 4
-	},
+/turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "CI" = (
 /obj/structure/flora/bush/stalky/style_random,
 /obj/structure/sign/picture_frame{
 	pixel_y = 32
 	},
-/turf/open/water/beach/biodome,
-/area/centcom/basketball)
-"Dc" = (
-/turf/open/misc/beach/coastline_b{
-	dir = 9
-	},
+/turf/open/water/beach,
 /area/centcom/basketball)
 "Di" = (
 /obj/item/clothing/neck/necklace/dope,
@@ -402,7 +288,7 @@
 /area/centcom/basketball)
 "DN" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/water/beach/biodome,
+/turf/open/misc/beach/coast,
 /area/centcom/basketball)
 "DP" = (
 /obj/effect/landmark/basketball/team_spawn/away_hoop,
@@ -410,7 +296,7 @@
 	dir = 8
 	},
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "Eb" = (
 /obj/effect/overlay/palmtree_l,
@@ -418,9 +304,7 @@
 /area/centcom/basketball)
 "EX" = (
 /obj/structure/fence/corner,
-/turf/open/misc/beach/coastline_t{
-	dir = 6
-	},
+/turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "Fh" = (
 /obj/structure/fluff/beach_umbrella/security,
@@ -430,7 +314,7 @@
 /obj/structure/sign/picture_frame{
 	pixel_y = 32
 	},
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "Fy" = (
 /mob/living/simple_animal/crab/kreb,
@@ -442,9 +326,7 @@
 /area/centcom/basketball)
 "Ho" = (
 /obj/structure/fence,
-/turf/open/misc/beach/coastline_t{
-	dir = 10
-	},
+/turf/open/misc/beach/coast,
 /area/centcom/basketball)
 "Hu" = (
 /turf/closed/indestructible/riveted,
@@ -456,6 +338,12 @@
 	},
 /turf/open/floor/vault/sandstone,
 /area/centcom/basketball)
+"HA" = (
+/obj/structure/flora/bush/stalky/style_random,
+/turf/open/misc/beach/coast{
+	dir = 1
+	},
+/area/centcom/basketball)
 "IM" = (
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
@@ -465,11 +353,6 @@
 	pixel_y = 11
 	},
 /turf/open/floor/carpet/red,
-/area/centcom/basketball)
-"JX" = (
-/turf/open/misc/beach/coastline_b{
-	dir = 1
-	},
 /area/centcom/basketball)
 "Kf" = (
 /obj/effect/turf_decal/sand,
@@ -487,17 +370,11 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/centcom/basketball)
-"Lx" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/misc/beach/coastline_t/sandwater_inner,
-/area/centcom/basketball)
 "LV" = (
 /obj/item/clothing/head/collectable/paper{
 	desc = "What looks like an ordinary paper hat is actually a rare and valuable collector's edition paper hat. Keep away from fire, Curators, and ocean waves."
 	},
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "MA" = (
 /obj/item/flashlight/flare/torch{
@@ -511,16 +388,16 @@
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "Nc" = (
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 9
 	},
 /area/centcom/basketball)
 "Nt" = (
 /obj/effect/landmark/basketball/team_spawn/home,
-/turf/open/misc/beach/coastline_t,
+/turf/open/misc/beach/coast,
 /area/centcom/basketball)
 "Nw" = (
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 6
 	},
 /area/centcom/basketball)
@@ -541,14 +418,9 @@
 /obj/item/reagent_containers/cup/soda_cans/tonic,
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
-"OB" = (
-/turf/open/misc/beach/coastline_b{
-	dir = 8
-	},
-/area/centcom/basketball)
 "OF" = (
 /obj/structure/flora/bush/stalky/style_random,
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "OG" = (
 /obj/structure/closet/crate/freezer{
@@ -583,7 +455,7 @@
 /area/centcom/basketball)
 "Ql" = (
 /obj/item/toy/plush/carpplushie,
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "QF" = (
 /obj/item/bait_can/worm{
@@ -598,7 +470,7 @@
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "Rc" = (
-/turf/open/misc/beach/coastline_t/sandwater_inner,
+/turf/open/misc/beach/coast/corner,
 /area/centcom/basketball)
 "Ry" = (
 /obj/item/reagent_containers/cup/glass/trophy/bronze_cup,
@@ -610,18 +482,14 @@
 	desc = "It can't be smoked.";
 	name = "sea weed"
 	},
-/turf/open/misc/beach/coastline_b{
-	dir = 1
-	},
+/turf/open/water/beach,
 /area/centcom/basketball)
 "Se" = (
 /obj/item/reagent_containers/cup/glass/trophy/gold_cup{
 	pixel_x = 0
 	},
 /obj/structure/flora/rock/pile/jungle/style_random,
-/turf/open/misc/beach/coastline_b{
-	dir = 1
-	},
+/turf/open/water/beach,
 /area/centcom/basketball)
 "Tc" = (
 /obj/item/flashlight/flare/torch{
@@ -630,17 +498,12 @@
 	},
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
-"Ue" = (
-/turf/open/misc/beach/coastline_b{
-	dir = 6
-	},
-/area/centcom/basketball)
 "Ul" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "Uv" = (
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 1
 	},
 /area/centcom/basketball)
@@ -650,7 +513,7 @@
 /area/centcom/basketball)
 "UT" = (
 /obj/effect/landmark/basketball/team_spawn/away,
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 1
 	},
 /area/centcom/basketball)
@@ -660,27 +523,19 @@
 /area/centcom/basketball)
 "Vf" = (
 /obj/structure/fence,
-/turf/open/water/beach/biodome,
+/turf/open/water/beach,
 /area/centcom/basketball)
 "Vm" = (
 /obj/structure/sign/picture_frame{
 	pixel_y = -32
 	},
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 4
-	},
-/area/centcom/basketball)
-"Vr" = (
-/obj/structure/fence{
-	dir = 8
-	},
-/turf/open/misc/beach/coastline_t{
-	dir = 1
 	},
 /area/centcom/basketball)
 "VI" = (
 /obj/effect/landmark/basketball/team_spawn/away,
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 4
 	},
 /area/centcom/basketball)
@@ -695,18 +550,12 @@
 /obj/structure/sign/picture_frame{
 	pixel_y = -32
 	},
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 8
 	},
 /area/centcom/basketball)
-"WE" = (
-/obj/structure/fence,
-/turf/open/misc/beach/coastline_t{
-	dir = 4
-	},
-/area/centcom/basketball)
 "WH" = (
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 10
 	},
 /area/centcom/basketball)
@@ -715,7 +564,7 @@
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "XQ" = (
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 8
 	},
 /area/centcom/basketball)
@@ -724,7 +573,7 @@
 /turf/open/misc/beach/sand,
 /area/centcom/basketball)
 "Yl" = (
-/turf/open/misc/beach/coastline_t{
+/turf/open/misc/beach/coast{
 	dir = 5
 	},
 /area/centcom/basketball)
@@ -742,12 +591,6 @@
 	dir = 8
 	},
 /turf/open/floor/vault/sandstone,
-/area/centcom/basketball)
-"YX" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
-/turf/open/misc/beach/coastline_t{
-	dir = 8
-	},
 /area/centcom/basketball)
 "Zc" = (
 /obj/structure/stone_tile/slab,
@@ -843,17 +686,17 @@ gY
 gY
 BM
 Aj
-sb
-OB
-OB
-OB
-Ue
+Nc
+XQ
+XQ
+WH
 Aj
-sb
-OB
-OB
-OB
-Ue
+Aj
+Aj
+Nc
+XQ
+XQ
+WH
 Aj
 BM
 gY
@@ -870,7 +713,7 @@ BM
 BM
 BM
 Aj
-OF
+HA
 vq
 zZ
 Ho
@@ -880,7 +723,7 @@ Vf
 jq
 zZ
 qF
-Aj
+wg
 Ql
 BM
 BM
@@ -896,18 +739,18 @@ BM
 Aj
 Aj
 Aj
-DN
-Aj
-Vr
+eC
+Uv
+lD
 IM
-nv
-mW
+wg
+Aj
 Cv
-JX
+Aj
 Uv
 Ul
-ku
-Aj
+lD
+wg
 BD
 Aj
 Aj
@@ -921,20 +764,20 @@ Hu
 gY
 BM
 Aj
-aw
-sb
-OB
-Ue
-Vr
+Nc
+XQ
+XQ
+Aw
+lD
 fj
 Nt
-sb
-OB
-Ue
+Aj
+Aj
+Aj
 oR
 IM
-ku
-Aj
+lD
+wg
 Nc
 XQ
 WH
@@ -948,11 +791,11 @@ Hu
 BM
 BM
 Fi
-JX
-mk
+Uv
+Eb
 eM
-YX
-dg
+Ul
+lD
 IM
 zk
 yO
@@ -960,8 +803,8 @@ yO
 yO
 Aw
 IM
-ix
-XQ
+lD
+zk
 Aw
 IM
 zk
@@ -975,8 +818,8 @@ Hu
 BM
 cw
 Aj
-JX
 Uv
+IM
 IM
 IM
 lD
@@ -1000,10 +843,10 @@ Hu
 (10,1,1) = {"
 Hu
 BM
-aw
+Aj
 Ql
-JX
 Uv
+IM
 MA
 IM
 lD
@@ -1028,8 +871,8 @@ Hu
 Hu
 BM
 Ry
-DN
-JX
+eC
+Uv
 at
 MR
 Tc
@@ -1056,8 +899,8 @@ Hu
 Zc
 Se
 Aj
-JX
 Uv
+IM
 Dt
 IM
 lD
@@ -1083,7 +926,7 @@ Hu
 BM
 yk
 Aj
-JX
+Uv
 fu
 MR
 jb
@@ -1108,10 +951,10 @@ Hu
 (14,1,1) = {"
 Hu
 BM
-Ue
+Aj
 Ql
-JX
 Uv
+IM
 VM
 IM
 lD
@@ -1137,8 +980,8 @@ Hu
 BM
 kv
 Aj
-JX
-ru
+Uv
+Yv
 QF
 Yv
 lD
@@ -1164,11 +1007,11 @@ Hu
 BM
 BM
 CI
-JX
-hn
+Uv
 Cw
 Cw
-eD
+Cw
+lD
 Ul
 Rc
 VI
@@ -1176,8 +1019,8 @@ VI
 VI
 xe
 IM
-Lx
-hZ
+lD
+Rc
 xe
 un
 Rc
@@ -1191,19 +1034,19 @@ Hu
 gY
 BM
 Aj
-Ue
-Dc
-vo
-aw
-Vr
+Yl
+hZ
+hZ
+xe
+lD
 Ul
 ie
-Dc
-vo
-aw
+Aj
+Aj
+Aj
 UT
 IM
-ku
+lD
 DN
 Yl
 hZ
@@ -1218,20 +1061,20 @@ Hu
 gY
 BM
 Aj
-DN
+eC
 Aj
-DN
-Aj
-Vr
+eC
+Uv
+lD
 IM
-nv
-mW
+wg
+Aj
 DP
-JX
+Aj
 Uv
 fj
-ku
-Aj
+lD
+wg
 Aj
 Aj
 OF
@@ -1248,17 +1091,17 @@ BM
 BM
 BM
 Aj
-Aj
+Uv
 xG
-WE
-pV
+zZ
+Ho
 Vf
 Vf
 Vf
-Ct
-WE
+jq
+zZ
 EX
-Aj
+wg
 OF
 BM
 BM
@@ -1275,17 +1118,17 @@ gY
 gY
 BM
 Ql
-Dc
-vo
-vo
-vo
-aw
+Yl
+hZ
+hZ
+Nw
 Aj
-Dc
-fT
+Aj
+Aj
+Yl
 vo
-vo
-aw
+hZ
+Nw
 Aj
 BM
 gY

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -37168,6 +37168,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "nBq" = (
@@ -89584,7 +89587,7 @@ xur
 bCf
 xur
 xLl
-xsF
+xur
 nBo
 xzE
 wuc
@@ -89841,7 +89844,7 @@ xur
 xur
 xur
 qcY
-xsF
+xur
 leB
 dYj
 wuc


### PR DESCRIPTION

## About The Pull Request

Adds a gulag reclaimer to birdshot's gulag, so your stuff isn't just dropped on the ground. Also, fixed the space tiles on the beach bum basketball map, which got broken with the beach sprites updates.
## Why It's Good For The Game

Fixes #75822 and ends what i started on #75119 
## Changelog
:cl:
fix: Beach Bum Basketball Team has water again.
fix: Birdshot's gulag now has an item reclaimer, no more will your items fall on the ground!
/:cl:
