### PR TITLE
Norfstar plushies get names

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -31413,7 +31413,10 @@
 /area/station/command/heads_quarters/cmo)
 "ihg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/toy/plush/lizard_plushie/green,
+/obj/item/toy/plush/lizard_plushie/green{
+	name = "Bites-The-Wires";
+	desc = "A stuffed toy which resembles a wayward Ashlander. This one fills you with hope for the future."
+	},
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 10
 	},
@@ -67443,7 +67446,9 @@
 /obj/effect/turf_decal/tile/green/full,
 /obj/machinery/light/directional/east,
 /obj/structure/table/reinforced,
-/obj/item/instrument/musicalmoth,
+/obj/item/instrument/musicalmoth{
+	name = "Congo Ralis"
+	},
 /obj/item/clothing/head/mothcap,
 /turf/open/floor/iron/smooth_large,
 /area/station/hallway/secondary/entry)
@@ -81930,7 +81935,10 @@
 /area/station/science/cytology)
 "vpU" = (
 /obj/structure/rack,
-/obj/item/toy/plush/plasmamanplushie,
+/obj/item/toy/plush/plasmamanplushie{
+	name = "Nitrous II";
+	desc = "A stuffed toy that resembles your plasma coworkers. It is cute despite itself."
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/fore)
 "vqb" = (
@@ -87118,7 +87126,10 @@
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
-/obj/item/toy/plush/beeplushie,
+/obj/item/toy/plush/beeplushie{
+	name = "Bee Haave";
+	desc = "A cute bee toy to calm down hysteric patients."
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "wFT" = (


### PR DESCRIPTION
## About The Pull Request
Adds names to a few stuffed toys to be found around Northstar.

## Why It's Good For The Game

Adding uniqueness to the plushies that are found around Northstar adds further character and charm to the map.
Adding this detail will make the station feel more lived-in.

## Changelog
qol: adds further flavor to the Northstar Plushies


