### PR TITLE
Fixes colossus possessor crystal cockroaches/animals not dumping the user's body upon death/gibbing

### DIFF
--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -44,7 +44,7 @@
 /mob/living/basic/cockroach/death(gibbed)
 	if(GLOB.station_was_nuked) //If the nuke is going off, then cockroaches are invincible. Keeps the nuke from killing them, cause cockroaches are immune to nukes.
 		return
-	..()
+	. = ..()
 
 /mob/living/basic/cockroach/ex_act() //Explosions are a terrible way to handle a cockroach.
 	return FALSE

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -44,7 +44,7 @@
 /mob/living/basic/cockroach/death(gibbed)
 	if(GLOB.station_was_nuked) //If the nuke is going off, then cockroaches are invincible. Keeps the nuke from killing them, cause cockroaches are immune to nukes.
 		return
-	. = ..()
+	return ..()
 
 /mob/living/basic/cockroach/ex_act() //Explosions are a terrible way to handle a cockroach.
 	return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -586,7 +586,7 @@
 /obj/structure/closet/stasis/process()
 	if(holder_animal)
 		if(holder_animal.stat == DEAD)
-			dump_contents()
+			dump_contents(TRUE)
 			holder_animal.investigate_log("has been gibbed by [src].", INVESTIGATE_DEATHS)
 			holder_animal.gib()
 			return

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -581,7 +581,8 @@
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | ACID_PROOF | INDESTRUCTIBLE
 	paint_jobs = null
-	var/mob/living/simple_animal/holder_animal
+	///The animal the closet (and the user's body) is inside of
+	var/mob/living/holder_animal
 
 /obj/structure/closet/stasis/Initialize(mapload)
 	. = ..()
@@ -592,11 +593,11 @@
 /obj/structure/closet/stasis/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(isliving(arrived) && holder_animal)
-		var/mob/living/L = arrived
-		L.notransform = 1
-		ADD_TRAIT(L, TRAIT_MUTE, STASIS_MUTE)
-		L.status_flags |= GODMODE
-		L.mind.transfer_to(holder_animal)
+		var/mob/living/possessor = arrived
+		possessor.notransform = TRUE
+		ADD_TRAIT(possessor, TRAIT_MUTE, STASIS_MUTE)
+		possessor.status_flags |= GODMODE
+		possessor.mind.transfer_to(holder_animal)
 		var/datum/action/exit_possession/escape = new(holder_animal)
 		escape.Grant(holder_animal)
 		remove_verb(holder_animal, /mob/living/verb/pulled)
@@ -624,6 +625,7 @@
 /obj/structure/closet/stasis/ex_act()
 	return FALSE
 
+///When our host animal dies in any way, we empty the stasis closet out.
 /obj/structure/closet/stasis/proc/on_holder_animal_death()
 	SIGNAL_HANDLER
 	dump_contents()


### PR DESCRIPTION
## About The Pull Request
Hooks the stasis closet thingamajing into `COMSIG_LIVING_DEATH` instead of checking the animal's stat on `process()`, which makes possessed animals properly dump the stasis closet's contents upon death or gibbing (which is death but cooler).
yeah uh this method is hilarious but it does protect the user's body quite reliably at least lol

## Why It's Good For The Game
Fixes #75829
also probably makes cockroach death saner in some unreported way, this `. = ..()` vs `..()` is above my non-existent paygrade but it keeps popping up from time to time

## Changelog
:cl:
fix: gibbing colossus possessor crystal possessed animals will no longer stick the user's body and their stuff into the shadow realm. the animals will properly drop your corpse when killed or gibbed
/:cl:
