### PR TITLE
Changes syndicate surgery duffelbags to contain advanced tools

### DIFF
--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -1014,10 +1014,8 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/eva)
 "ch" = (
-/obj/item/surgical_drapes,
-/obj/item/retractor,
-/obj/item/cautery,
 /obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/medical)
 "ci" = (
@@ -1605,11 +1603,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/armory)
 "dz" = (
-/obj/item/circular_saw,
-/obj/item/surgicaldrill{
-	pixel_y = 5
-	},
-/obj/item/healthanalyzer,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/light/directional/west,
@@ -1617,6 +1610,7 @@
 	pixel_x = -32
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/healthanalyzer/advanced,
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/medical)
 "dA" = (
@@ -1835,9 +1829,6 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/medical)
 "dV" = (
-/obj/item/scalpel{
-	pixel_y = 16
-	},
 /obj/structure/table/reinforced,
 /obj/item/bodypart/arm/left/robot{
 	pixel_x = -6
@@ -1845,7 +1836,6 @@
 /obj/item/bodypart/arm/right/robot{
 	pixel_x = 6
 	},
-/obj/item/hemostat,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/medical)

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -737,11 +737,12 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/airlock)
 "nZ" = (
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
+/obj/machinery/computer/operating{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/shuttle/syndicate/medical)
 "pd" = (
@@ -860,7 +861,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/iv_drip/saline,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/iron/white/side,
 /area/shuttle/syndicate/medical)
 "zL" = (

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -314,9 +314,6 @@
 /obj/item/healthanalyzer{
 	pixel_y = 10
 	},
-/obj/item/healthanalyzer{
-	pixel_y = 10
-	},
 /turf/open/floor/iron/edge,
 /area/shuttle/syndicate/medical)
 "bu" = (
@@ -487,6 +484,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/clothing/under/syndicate/scrubs,
+/obj/item/clothing/gloves/latex/nitrile,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/iron,
 /area/shuttle/syndicate/medical)
 "ce" = (
@@ -530,7 +531,6 @@
 /area/shuttle/syndicate/hallway)
 "cp" = (
 /obj/structure/table/optable,
-/obj/item/surgical_drapes,
 /turf/open/floor/iron/white,
 /area/shuttle/syndicate/medical)
 "cr" = (
@@ -737,12 +737,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/airlock)
 "nZ" = (
-/obj/item/cautery,
-/obj/item/scalpel,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/iron/white,
 /area/shuttle/syndicate/medical)
 "pd" = (
@@ -752,10 +751,17 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/shuttle/syndicate/bridge)
 "pQ" = (
-/obj/item/retractor,
-/obj/item/hemostat,
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/table/reinforced,
+/obj/item/bodypart/arm/left/robot{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/bodypart/arm/right/robot{
+	pixel_x = -10;
+	pixel_y = 9
+	},
+/obj/item/healthanalyzer,
 /turf/open/floor/iron/white,
 /area/shuttle/syndicate/medical)
 "st" = (
@@ -850,21 +856,11 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/hallway)
 "zj" = (
-/obj/structure/table/reinforced,
 /obj/machinery/light/directional/west,
-/obj/item/bodypart/arm/left/robot{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/bodypart/arm/right/robot{
-	pixel_x = -10;
-	pixel_y = 9
-	},
-/obj/item/surgicaldrill,
-/obj/item/circular_saw,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/iv_drip/saline,
 /turf/open/floor/iron/white/side,
 /area/shuttle/syndicate/medical)
 "zL" = (

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -589,19 +589,20 @@
 	inhand_icon_state = "duffel-syndiemed"
 
 /obj/item/storage/backpack/duffelbag/syndie/surgery/PopulateContents()
-	new /obj/item/scalpel(src)
-	new /obj/item/hemostat(src)
-	new /obj/item/retractor(src)
-	new /obj/item/circular_saw(src)
-	new /obj/item/bonesetter(src)
-	new /obj/item/surgicaldrill(src)
-	new /obj/item/cautery(src)
+	new /obj/item/scalpel/advanced(src)
+	new /obj/item/retractor/advanced(src)
+	new /obj/item/cautery/advanced(src)
 	new /obj/item/surgical_drapes(src)
+	new /obj/item/reagent_containers/medigel/sterilizine(src)
+	new /obj/item/surgicaldrill(src)
+	new /obj/item/bonesetter(src)
+	new /obj/item/blood_filter(src)
+	new /obj/item/stack/medical/bone_gel(src)
+	new /obj/item/stack/sticky_tape/surgical(src)
+	new /obj/item/roller(src)
 	new /obj/item/clothing/suit/jacket/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
 	new /obj/item/mmi/syndie(src)
-	new /obj/item/blood_filter(src)
-	new /obj/item/stack/medical/bone_gel(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/ammo
 	name = "ammunition duffel bag"

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -19,7 +19,8 @@
 	desc = "The Syndicate surgery duffel bag is a toolkit containing all surgery tools, surgical drapes, \
 			a Syndicate brand MMI, a straitjacket, and a muzzle."
 	item = /obj/item/storage/backpack/duffelbag/syndie/surgery
-	cost = 3
+	cost = 4
+	surplus = 66
 
 /datum/uplink_item/device_tools/encryptionkey
 	name = "Syndicate Encryption Key"


### PR DESCRIPTION

## About The Pull Request

Changes syndicate surgery duffelbags to contain advanced tools.

In total, they contain
- All advanced surgical tools, alongside the normal ones without an advanced version
- Sterilizine gel
- Bone gel and surgical tape
- Roller bed
- Straight jacket, muzzle, and MMI

Changed the Syndicate Infiltrators' surgery areas to contain a full syndicate surgery duffelbag.

The normal infiltrator now has a operating computer and a closet of misc. surgical clothing and anesthesic tank.

## Why It's Good For The Game

> Changes syndicate surgery duffelbags to contain advanced tools.

> In total, they contain (...)

The only real reason to buy this item is for the increased storage space the duffelbag gives, and I find that a little sad. Surgical tools are plentiful, as they can either be lathed from cargo, medbay, or just taken. A surgeon, the role that *should* thematically need this the most, has absolutely no reason to take it. Now they do! A full set of advanced tools is certainly something that can be considered for purchase, especially with all the bonus items in here - which might just allow a traitor to repair their bones if they're heavily wanted and licking their wounds in maintenance. The TC cost has been increased to 4 to compensate.

> Changed the Syndicate Infiltrators' surgery areas to contain a full syndicate surgery duffelbag.

Similar to above, but instead, the reasoning is that nukies really do not have a lot of time to do surgery. A lot of the 20 minutes of prep time in War is spent figuring out what you're buying with your exorbitant amount of TC, in non-War you don't really want to delay the mission for five minutes for surgery, and its hassle means that most people do not really want to bother with things like nerve threading, etc. due to the large, annoying time cost.

> The normal infiltrator now has a operating computer and a closet of misc. surgical clothing and anesthesic tank.

The former is because, well, what the hell, why didn't it have one! Removing the loose tools gave me the space for it. The latter is just me realizing that empty closet is weird and lame and so I gave it some fluff contents to give it a reason to exist.

## Changelog

:cl:
add: Changes syndicate surgery duffelbags to contain advanced tools, sterilizine, surgical tape, and a roller bed.
add: Changed the Syndicate Infiltrators' surgery areas to contain a full syndicate surgery duffelbag.
add: The normal infiltrator now has a operating computer and a closet of misc. surgical clothing and anesthesic tank.
/:cl:

