### PR TITLE
Adjusts Test Site Materials Crates on Birdshot and Meta.

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -11755,10 +11755,6 @@
 /turf/open/floor/iron/kitchen/small,
 /area/station/security/prison/mess)
 "eHj" = (
-/obj/item/target/clown,
-/obj/item/target/clown,
-/obj/item/target/syndicate,
-/obj/item/target/alien,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
@@ -41302,6 +41298,10 @@
 	name = "Test Site Materials Crate";
 	req_access = list("ordnance")
 	},
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/item/target/syndicate,
+/obj/item/target/alien,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3741,6 +3741,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/closet/crate/secure{
+	desc = "A secure crate containing various materials for building a customised test-site.";
+	name = "Test Site Materials Crate";
+	req_access = list("ordnance")
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "brA" = (
@@ -3965,11 +3970,6 @@
 "buG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/closet/crate/secure{
-	desc = "A secure crate containing various materials for building a customised test-site.";
-	name = "Test Site Materials Crate";
-	req_access = list("ordnance")
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark,


### PR DESCRIPTION

## About The Pull Request
How it was:
![image](https://github.com/tgstation/tgstation/assets/93882977/f0af179a-9226-44ff-973d-b986d4247925)
![image](https://github.com/tgstation/tgstation/assets/93882977/9cb51684-c88e-4fa7-ae60-83605b6b018f)
How it will be:
![image](https://github.com/tgstation/tgstation/assets/93882977/49b070aa-17d3-48b3-abd1-e1fea4b7d015)
![image](https://github.com/tgstation/tgstation/assets/93882977/7b6a04c1-2042-4c3c-ab7d-066f6f48be5e)
## Why It's Good For The Game
Those crates will have some sense at least.
## Changelog
:cl:
fix: [Metastation] [Birdshot] Test Site Materials Crates now contain targets instead of existing near them purposelessly and empty.
/:cl:
