### PR TITLE
Removes misplaced unrestricted access from Lavaland Shuttle Airlocks [2]

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -4820,7 +4820,7 @@
 "Dk" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Labor Camp Shuttle Prisoner Airlock";
-	space_dir = 8
+	space_dir = null
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -7216,7 +7216,7 @@
 "SL" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Labor Camp Shuttle Prisoner Airlock";
-	space_dir = 8
+	space_dir = null
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -4818,12 +4818,11 @@
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
 "Dk" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp Shuttle Prisoner Airlock";
-	space_dir = null
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass{
+	name = "Labor Camp Shuttle Prisoner Airlock"
+	},
 /turf/open/floor/iron/smooth_large,
 /area/mine/laborcamp)
 "Dl" = (
@@ -7214,14 +7213,13 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/mine/laborcamp/security)
 "SL" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Labor Camp Shuttle Prisoner Airlock";
-	space_dir = null
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/external/glass{
+	name = "Labor Camp Shuttle Prisoner Airlock"
+	},
 /turf/open/floor/iron/smooth_large,
 /area/mine/laborcamp)
 "SO" = (


### PR DESCRIPTION
## About The Pull Request
I didn't look at gulag back in #70946 and there were unrestricted access lights shining into the wall on free-access airlocks. Whoops.

## Why It's Good For The Game
I'm pretty sure we still don't have any use for free-access placed facing into walls.
_Ever get that feeling of deja vu?_

## Changelog
:cl:
fix: fixed Lavaland Labour Camp Shuttle prisoner-side airlocks having unrestricted access from the side of a wall
/:cl:
