### PR TITLE
Morgue fix and redecoration

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7930,7 +7930,10 @@
 /area/station/maintenance/department/science/xenobiology)
 "bSI" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/mannequin/skeleton,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -10067,7 +10070,7 @@
 "cuj" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/structure/chair/office/tactical{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
@@ -16097,9 +16100,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/computer/operating{
-	dir = 4
-	},
+/obj/structure/mannequin/skeleton,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -16668,8 +16669,7 @@
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/optable,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -24288,7 +24288,7 @@
 /obj/machinery/computer/records/medical/laptop{
 	dir = 4;
 	pixel_x = 3;
-	pixel_y = -1
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
@@ -27441,6 +27441,8 @@
 /obj/item/storage/box/bodybags,
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/firealarm/directional/south,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/pushbroom,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -27640,11 +27642,12 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "gQN" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/bot,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/pushbroom,
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/table/reinforced,
+/obj/item/table_clock{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "gQV" = (
@@ -29893,7 +29896,7 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "hwa" = (
@@ -44179,7 +44182,9 @@
 "kXu" = (
 /obj/machinery/vending/wallmed/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
+/obj/machinery/computer/operating{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "kXC" = (
@@ -51510,8 +51515,7 @@
 /area/station/hallway/primary/fore)
 "mQp" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "mQt" = (
@@ -91992,8 +91996,9 @@
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/office)
 "xbk" = (
-/obj/structure/table/optable,
 /obj/machinery/newscaster/directional/north,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -137370,7 +137375,7 @@ jqJ
 dRQ
 qYL
 xbk
-cuj
+hwT
 mQp
 stB
 eLR
@@ -137627,7 +137632,7 @@ jqJ
 wIM
 qYL
 bSI
-hwT
+cuj
 kWb
 yiD
 xvC

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1262,9 +1262,8 @@
 /area/station/engineering/hallway)
 "aoN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aoO" = (
 /obj/effect/turf_decal/bot,
@@ -3665,13 +3664,8 @@
 	},
 /area/station/service/bar)
 "aRd" = (
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "aRr" = (
 /turf/open/floor/circuit/red,
@@ -6979,16 +6973,16 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bHZ" = (
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
 	dir = 4
 	},
-/obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 5
 	},
+/obj/structure/mannequin/skeleton{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "bIa" = (
 /obj/effect/turf_decal/trimline/blue/end{
@@ -7930,13 +7924,11 @@
 /area/station/maintenance/department/science/xenobiology)
 "bSI" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark/textured_half{
+/obj/machinery/computer/operating,
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "bSN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10068,13 +10060,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cuj" = (
-/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/structure/chair/office/tactical{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "cul" = (
 /obj/machinery/plate_press,
@@ -12576,9 +12565,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured_half{
+/obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 1
 	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "dbO" = (
 /obj/structure/chair/sofa/bench/right{
@@ -12772,9 +12762,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "den" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14388,10 +14376,8 @@
 "dzD" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/mapping_helpers/dead_body_placer,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "dzJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14993,10 +14979,8 @@
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "dJw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -16096,14 +16080,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dYb" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/mannequin/skeleton,
-/turf/open/floor/iron/dark/textured_half{
+/obj/machinery/smartfridge/organ,
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "dYj" = (
 /turf/closed/wall/r_wall,
@@ -16663,16 +16645,15 @@
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
 "eff" = (
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
 	dir = 4
 	},
-/obj/structure/table/optable,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 4
 	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "efg" = (
 /obj/structure/table/reinforced,
@@ -17486,9 +17467,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 2
 	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "eqH" = (
 /obj/machinery/light/directional/east,
@@ -18533,9 +18512,7 @@
 "eFy" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/bodycontainer/morgue/beeper_off,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "eFz" = (
 /obj/machinery/door/firedoor,
@@ -19075,9 +19052,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "eLR" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "eLY" = (
 /obj/machinery/door/window/right/directional/west{
@@ -24279,20 +24254,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "gbv" = (
-/obj/effect/turf_decal/trimline/neutral/warning,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/reinforced,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 4;
-	pixel_x = 3;
-	pixel_y = 3
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 4
 	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "gby" = (
 /obj/structure/table/wood,
@@ -26921,9 +26888,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "gHH" = (
 /obj/structure/cable,
@@ -27433,7 +27398,6 @@
 /area/station/security/prison)
 "gOv" = (
 /obj/structure/rack,
-/obj/effect/turf_decal/bot,
 /obj/item/storage/box/bodybags{
 	pixel_x = 3;
 	pixel_y = 3
@@ -27443,9 +27407,8 @@
 /obj/machinery/firealarm/directional/south,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/pushbroom,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "gOH" = (
 /obj/effect/landmark/blobstart,
@@ -28075,18 +28038,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"gWH" = (
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/medical/morgue)
 "gWJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_white/right,
@@ -29891,9 +29842,6 @@
 /turf/open/floor/plating,
 /area/station/medical/virology)
 "hvX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
@@ -29981,10 +29929,8 @@
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "hwK" = (
 /obj/structure/cable,
@@ -30016,11 +29962,8 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
 "hwT" = (
-/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/effect/landmark/start/coroner,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "hwX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -30576,9 +30519,7 @@
 	dir = 1
 	},
 /obj/machinery/duct,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "hFS" = (
 /obj/structure/cable,
@@ -32931,10 +32872,8 @@
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 10
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "ijm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34110,10 +34049,8 @@
 /area/station/cargo/sorting)
 "iyb" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "iyc" = (
 /obj/structure/cable,
@@ -44055,11 +43992,14 @@
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
 "kWb" = (
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	req_access = list("morgue_secure");
-	name = "Coroner's Office"
+/obj/effect/turf_decal/trimline/neutral/filled/warning,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 1;
+	pixel_y = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "kWi" = (
 /obj/effect/turf_decal/box/white/corners{
@@ -44182,10 +44122,11 @@
 "kXu" = (
 /obj/machinery/vending/wallmed/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/computer/operating{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "kXC" = (
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -51514,9 +51455,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "mQp" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	req_access = list("morgue_secure");
+	name = "Coroner's Office"
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "mQt" = (
 /obj/structure/cable,
@@ -59902,13 +59845,8 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "pdT" = (
 /obj/structure/table/wood,
@@ -62023,9 +61961,7 @@
 /area/station/maintenance/department/science)
 "pEG" = (
 /obj/structure/bodycontainer/morgue/beeper_off,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "pEH" = (
 /obj/machinery/door/poddoor/preopen{
@@ -67797,11 +67733,9 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "qYZ" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "qZb" = (
 /obj/structure/sign/warning/secure_area,
@@ -73272,18 +73206,6 @@
 	dir = 10
 	},
 /area/station/service/chapel)
-"stB" = (
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
-/area/station/medical/morgue)
 "stC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -73711,9 +73633,7 @@
 /obj/structure/bodycontainer/morgue/beeper_off{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "sxP" = (
 /obj/machinery/computer/records/security,
@@ -74415,9 +74335,7 @@
 /obj/structure/bodycontainer/morgue/beeper_off{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "sHC" = (
 /turf/open/floor/plating,
@@ -76975,9 +76893,7 @@
 /obj/effect/turf_decal/trimline/neutral/warning{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "tpg" = (
 /obj/structure/table/reinforced,
@@ -79169,9 +79085,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/duct,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "tPY" = (
 /obj/structure/cable,
@@ -81654,9 +81568,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 2
 	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "uxb" = (
 /obj/effect/turf_decal/siding/white/corner{
@@ -82081,9 +81993,7 @@
 /obj/structure/bodycontainer/morgue{
 	dir = 2
 	},
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "uBd" = (
 /obj/structure/cable,
@@ -86210,7 +86120,6 @@
 /area/station/commons/dorms)
 "vBM" = (
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -86220,9 +86129,8 @@
 	network = list("ss13","medical")
 	},
 /obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "vBO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -87625,14 +87533,13 @@
 /area/space/nearstation)
 "vVY" = (
 /obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 9
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot_white{
+	color = "#74b2d3"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "vWb" = (
 /obj/effect/turf_decal/delivery,
@@ -88761,8 +88668,8 @@
 /area/station/cargo/storage)
 "wkN" = (
 /obj/machinery/duct,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -89931,9 +89838,7 @@
 /obj/machinery/light/dim/directional/south,
 /obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "wwN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -90668,10 +90573,8 @@
 "wFK" = (
 /obj/machinery/duct,
 /obj/effect/turf_decal/trimline/neutral/warning,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "wFP" = (
 /obj/structure/table/wood,
@@ -91997,11 +91900,14 @@
 /area/station/commons/vacant_room/office)
 "xbk" = (
 /obj/machinery/newscaster/directional/north,
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/dark/textured_half{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
+	},
+/turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/morgue)
 "xbp" = (
 /obj/effect/turf_decal/tile/red{
@@ -93528,9 +93434,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "xvE" = (
 /obj/structure/disposalpipe/segment,
@@ -96595,13 +96499,8 @@
 /obj/effect/turf_decal/trimline/neutral/mid_joiner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/machinery/duct,
-/turf/open/floor/iron/dark/textured_half{
-	dir = 1
-	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "yiE" = (
 /obj/item/kirbyplants/random,
@@ -137120,7 +137019,7 @@ qYL
 dYb
 gbv
 hvX
-gWH
+hFQ
 wwI
 qYL
 bhw
@@ -137375,9 +137274,9 @@ jqJ
 dRQ
 qYL
 xbk
-hwT
+cuj
 mQp
-stB
+hFQ
 eLR
 eFy
 pEG
@@ -137632,7 +137531,7 @@ jqJ
 wIM
 qYL
 bSI
-cuj
+hwT
 kWb
 yiD
 xvC

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -620,8 +620,8 @@
 "amq" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "amt" = (
@@ -2548,6 +2548,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/dead_body_placer,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aRR" = (
@@ -6899,10 +6900,6 @@
 "cge" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/tactical{
-	dir = 1
-	},
-/obj/effect/landmark/start/coroner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "cgs" = (
@@ -7684,7 +7681,8 @@
 /obj/machinery/requests_console/auto_name/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/bodycontainer/morgue/beeper_off{
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -8843,10 +8841,11 @@
 /area/station/security/brig/upper)
 "cJa" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/computer/operating{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/table/reinforced,
+/obj/item/table_clock{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "cJb" = (
@@ -8948,10 +8947,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "cLf" = (
-/obj/effect/decal/cleanable/blood/bubblegum,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
+/obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "cLo" = (
@@ -9671,6 +9668,7 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "cWX" = (
@@ -11514,8 +11512,11 @@
 /area/station/maintenance/port/greater)
 "dzr" = (
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/smartfridge/organ,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop{
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "dzx" = (
@@ -11761,8 +11762,13 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "dDq" = (
-/obj/effect/decal/cleanable/blood/bubblegum,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/chair/office/tactical{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "dDt" = (
@@ -15617,6 +15623,7 @@
 "eQU" = (
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "eQX" = (
@@ -17885,9 +17892,8 @@
 "fDp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
-/obj/machinery/computer/records/medical/laptop{
-	dir = 8;
-	pixel_y = 1
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 4
 	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
@@ -20065,6 +20071,7 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "goi" = (
@@ -20854,8 +20861,8 @@
 /area/station/maintenance/aft/greater)
 "gCG" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table/optable,
 /obj/machinery/newscaster/directional/north,
+/obj/structure/mannequin/skeleton,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "gCK" = (
@@ -21049,9 +21056,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gEX" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "gFj" = (
@@ -22271,7 +22278,7 @@
 "hai" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/decal/cleanable/blood/bubblegum,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "han" = (
@@ -24135,6 +24142,7 @@
 	},
 /obj/item/pushbroom,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hJD" = (
@@ -24957,6 +24965,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hXk" = (
@@ -26617,6 +26627,7 @@
 "iyF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/blobstart,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iyK" = (
@@ -29112,6 +29123,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "joh" = (
@@ -30885,6 +30897,7 @@
 "jRm" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/bot_white,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -33720,7 +33733,7 @@
 /area/station/medical/storage)
 "kKa" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/bodycontainer/morgue/beeper_off{
+/obj/structure/bodycontainer/morgue{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -35823,6 +35836,13 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood/parquet,
 /area/station/commons/lounge)
+"lrU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "lsa" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
@@ -44853,9 +44873,13 @@
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
 "olO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4;
+	pixel_y = 6;
+	pixel_x = 12
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "olV" = (
@@ -46574,8 +46598,8 @@
 /area/station/command/heads_quarters/rd)
 "oNj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/structure/table/optable,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "oNp" = (
@@ -51156,6 +51180,7 @@
 "qnv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "qnC" = (
@@ -53749,7 +53774,7 @@
 /area/station/command/gateway)
 "rcU" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/mannequin/skeleton,
+/obj/effect/landmark/start/coroner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "rcY" = (
@@ -67529,7 +67554,9 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "vAO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/computer/operating{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vAP" = (
@@ -72126,6 +72153,7 @@
 /area/station/engineering/atmos)
 "wWJ" = (
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "wWL" = (
@@ -73895,6 +73923,7 @@
 "xyG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xyO" = (
@@ -179401,7 +179430,7 @@ btU
 wvL
 jnY
 cWJ
-dYX
+lrU
 wWJ
 aRQ
 ako

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1676,10 +1676,10 @@
 /turf/open/floor/iron,
 /area/mine/laborcamp/security)
 "aCl" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aCo" = (
@@ -9668,7 +9668,9 @@
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
-/obj/effect/turf_decal/bot_white,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "cWX" = (
@@ -12815,6 +12817,9 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"dVf" = (
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "dVj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13324,10 +13329,8 @@
 "eex" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "eeF" = (
@@ -14925,11 +14928,10 @@
 "eEN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "eEO" = (
@@ -19577,10 +19579,7 @@
 	dir = 9;
 	network = list("ss13","medbay")
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "gfE" = (
@@ -26628,7 +26627,9 @@
 "iyF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/bot_white,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iyK" = (
@@ -28743,9 +28744,7 @@
 /obj/machinery/light/dim/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "jhf" = (
@@ -35842,6 +35841,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_white,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "lsa" = (
@@ -36950,7 +36952,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -38051,7 +38052,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -42284,7 +42285,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron/dark,
@@ -43774,9 +43774,6 @@
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nTI" = (
@@ -47454,6 +47451,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"pch" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "pcj" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Drone Bay"
@@ -70382,10 +70386,9 @@
 "wvL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "wvN" = (
@@ -73928,6 +73931,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot_white,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xyO" = (
@@ -74808,6 +74814,10 @@
 "xMv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/decal/cleanable/blood/old,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xMx" = (
@@ -179947,7 +179957,7 @@ btU
 btU
 eex
 ofm
-nHc
+pch
 nHc
 ofm
 okf
@@ -180461,7 +180471,7 @@ fwB
 btU
 gfy
 olO
-dYr
+dVf
 xMv
 wav
 pWi

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -21598,6 +21598,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "gPn" = (
@@ -46598,8 +46599,11 @@
 /area/station/command/heads_quarters/rd)
 "oNj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "oNp" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -53170,8 +53170,11 @@
 /area/station/service/chapel)
 "teR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table/optable,
 /obj/machinery/newscaster/directional/north,
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "teY" = (
@@ -58088,6 +58091,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
+/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uOX" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4757,6 +4757,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/start/coroner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bMp" = (
@@ -5628,6 +5629,7 @@
 /area/station/commons/dorms)
 "cft" = (
 /obj/machinery/light/small/directional/north,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "cfv" = (
@@ -15916,6 +15918,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fYI" = (
@@ -20242,7 +20247,7 @@
 "hzi" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/office/tactical{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -29495,8 +29500,7 @@
 /area/station/maintenance/port/fore)
 "kHV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/table/reinforced,
-/obj/machinery/computer/records/medical/laptop,
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "kIG" = (
@@ -36255,7 +36259,9 @@
 "ndZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/small/directional/east,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "neA" = (
@@ -41642,10 +41648,11 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/aisat/exterior)
 "pap" = (
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "pav" = (
@@ -50490,7 +50497,6 @@
 /area/station/engineering/main)
 "shY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/landmark/start/coroner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -59770,6 +59776,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vvp" = (
@@ -65165,8 +65173,10 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "xsv" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
+/obj/structure/table/reinforced,
+/obj/item/table_clock{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xsy" = (
@@ -93239,7 +93249,7 @@ cSW
 hZV
 xeT
 lxT
-pYo
+kHV
 kOM
 sKG
 uWM
@@ -93494,7 +93504,7 @@ iqz
 dVN
 wrE
 hZV
-kHV
+pYo
 shY
 gdz
 pdV

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -440,11 +440,11 @@
 /area/station/maintenance/floor4/port)
 "aeS" = (
 /obj/machinery/newscaster/directional/north,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/computer/records/medical/laptop,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aeW" = (
@@ -590,14 +590,16 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port)
 "agW" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "ahd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2792,7 +2794,10 @@
 "aII" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/bodycontainer/morgue{
-	dir = 8
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
@@ -2930,13 +2935,18 @@
 	},
 /area/station/hallway/floor2/fore)
 "aKF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "aKQ" = (
 /turf/open/floor/iron/textured_half,
@@ -3750,14 +3760,14 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "aUV" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/turf/open/floor/iron/dark,
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "aVg" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
@@ -4210,14 +4220,15 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor2/starboard/aft)
 "aZs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -7292,10 +7303,10 @@
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/station/maintenance/floor2/port/fore)
 "bKs" = (
+/obj/structure/sink/kitchen/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bKv" = (
@@ -10477,19 +10488,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"cBJ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Morgue"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/turf/open/floor/iron/white,
-/area/station/medical/morgue)
 "cBP" = (
 /obj/effect/spawner/structure/window/hollow/plasma/middle{
 	dir = 4
@@ -13680,16 +13678,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard)
-"dvA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/aft)
 "dvC" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden"
@@ -15610,6 +15598,9 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "dUJ" = (
@@ -19833,7 +19824,10 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/duct,
-/obj/machinery/firealarm/directional/north,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "ffD" = (
@@ -19901,11 +19895,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/virology/isolation)
 "fgB" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fgD" = (
@@ -20674,7 +20667,10 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/random/directional/west,
-/turf/open/floor/iron/dark/textured,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fqx" = (
 /obj/structure/cable,
@@ -21139,10 +21135,10 @@
 /area/station/hallway/floor4/aft)
 "fxc" = (
 /obj/machinery/camera/autoname/directional/north,
+/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fxd" = (
@@ -22109,10 +22105,15 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "fJU" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 8
+/obj/structure/closet{
+	name = "janitorial supplies"
 	},
-/turf/open/floor/iron/dark/textured,
+/obj/item/pushbroom,
+/obj/item/storage/box/bodybags,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fJY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22611,14 +22612,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "fQH" = (
-/obj/structure/cable,
-/obj/machinery/door/window/brigdoor/left/directional/south{
-	name = "Coroner's Office";
-	req_access = list("morgue_secure")
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fQI" = (
@@ -25492,11 +25489,11 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/disposal)
 "gCw" = (
+/obj/structure/bodycontainer/morgue/beeper_off,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/bodycontainer/morgue/beeper_off,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "gCC" = (
 /obj/structure/disposalpipe/segment{
@@ -29404,14 +29401,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "hEO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/duct,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "hEQ" = (
@@ -30774,9 +30768,17 @@
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
 "hXt" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/airlock/medical{
+	name = "Morgue"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/morgue,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
 /area/station/medical/morgue)
 "hXu" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -30854,10 +30856,10 @@
 /area/station/maintenance/floor1/starboard/fore)
 "hYB" = (
 /obj/machinery/light/small/directional/north,
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hYN" = (
@@ -43840,7 +43842,10 @@
 "ltZ" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "lua" = (
 /obj/effect/turf_decal/siding/wideplating_new/corner{
@@ -45985,6 +45990,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "lVP" = (
@@ -52192,9 +52198,6 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor4/aft)
 "nuE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/structure/table/optable{
 	desc = "A cold, hard place for your final rest.";
 	name = "Morgue Slab"
@@ -52366,6 +52369,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nwL" = (
@@ -52869,13 +52873,13 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
 "nCK" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "nCL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -55574,6 +55578,9 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "omk" = (
 /obj/structure/bodycontainer/morgue,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "oml" = (
@@ -56776,13 +56783,11 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard)
 "oDi" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/dead_body_placer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "oDI" = (
 /obj/structure/table/reinforced,
@@ -58224,7 +58229,10 @@
 /obj/machinery/computer/operating{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/textured,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "oXd" = (
 /obj/structure/lattice/catwalk,
@@ -58655,10 +58663,8 @@
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
 "pfd" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "pfg" = (
@@ -60171,11 +60177,11 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server/upper)
 "pzI" = (
+/obj/structure/bodycontainer/morgue,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+	dir = 10
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "pzK" = (
 /obj/structure/chair/wood{
@@ -64124,7 +64130,10 @@
 /turf/open/floor/wood/tile,
 /area/station/service/library)
 "qAh" = (
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "qAk" = (
 /obj/effect/turf_decal/trimline/red/corner,
@@ -66997,6 +67006,7 @@
 "rlB" = (
 /obj/machinery/duct,
 /obj/effect/landmark/start/coroner,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "rlC" = (
@@ -70403,11 +70413,11 @@
 "slI" = (
 /obj/item/radio/intercom/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
 /obj/structure/bodycontainer/morgue/beeper_off,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "slP" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -72631,8 +72641,11 @@
 /area/station/command/heads_quarters/captain/private)
 "sRg" = (
 /obj/machinery/light/cold/directional/east,
-/obj/structure/bodycontainer/morgue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
@@ -73099,12 +73112,10 @@
 /area/station/hallway/floor2/fore)
 "sWW" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/structure/chair/office/tactical{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "sWZ" = (
@@ -76627,10 +76638,10 @@
 /turf/open/floor/fake_snow,
 /area/station/hallway/floor2/fore)
 "tTC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
 /obj/structure/mannequin/skeleton,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "tTI" = (
@@ -79127,13 +79138,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/service/theater)
 "uEI" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
-	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uEK" = (
@@ -79736,14 +79744,18 @@
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/rd)
 "uMK" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Coroner's Office";
+	req_access = list("morgue_secure")
 	},
-/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "uMR" = (
 /obj/effect/turf_decal/stripes/line,
@@ -80998,7 +81010,10 @@
 	pixel_y = 3
 	},
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark/textured,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "vcg" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -85702,11 +85717,13 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "wmN" = (
+/obj/item/storage/box/bodybags{
+	pixel_y = 5
+	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/structure/table/reinforced/rglass,
-/obj/item/storage/box/bodybags,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "wmQ" = (
@@ -87783,10 +87800,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/checkpoint/second)
 "wLV" = (
+/obj/structure/cable,
+/obj/machinery/duct,
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "wMr" = (
 /obj/machinery/door/airlock{
@@ -90827,7 +90846,7 @@
 "xBq" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/smartfridge/organ,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xBt" = (
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -92282,7 +92301,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "xWy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/duct,
+/obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -197590,7 +197609,7 @@ gCw
 slI
 fqu
 omk
-omk
+pzI
 vrA
 ibk
 mtV
@@ -197848,7 +197867,7 @@ uMK
 aZs
 agW
 aKF
-vrA
+hXt
 ffA
 dUF
 gaL
@@ -198105,9 +198124,9 @@ fQH
 aUV
 oDi
 fgB
-cBJ
+vrA
 hEO
-dvA
+blN
 sCp
 ecl
 lSw
@@ -198359,7 +198378,7 @@ wmN
 pUH
 rAu
 lVE
-hXt
+nCK
 qAh
 nwF
 vrA
@@ -198613,11 +198632,11 @@ aal
 aal
 lcv
 tTC
-pzI
+pUH
 nuE
 sWW
 nCK
-nCK
+qAh
 uEI
 vrA
 sxV

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -443,8 +443,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/box/bodybags,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aeW" = (
@@ -593,8 +593,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ahd" = (
@@ -2931,9 +2933,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -3755,6 +3756,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aVg" = (
@@ -4211,7 +4213,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7288,10 +7292,10 @@
 /turf/open/floor/carpet/neon/simple/pink/nodots,
 /area/station/maintenance/floor2/port/fore)
 "bKs" = (
-/obj/machinery/smartfridge/organ,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bKv" = (
@@ -21138,7 +21142,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/mannequin/skeleton,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fxd" = (
@@ -22614,6 +22618,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fQI" = (
@@ -25487,10 +25492,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/disposal)
 "gCw" = (
-/obj/machinery/vending/wardrobe/coroner_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/bodycontainer/morgue/beeper_off,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "gCC" = (
@@ -30849,11 +30854,10 @@
 /area/station/maintenance/floor1/starboard/fore)
 "hYB" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
+/obj/machinery/vending/wardrobe/coroner_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hYN" = (
@@ -41508,7 +41512,6 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/chemistry,
 /obj/item/hand_labeler,
-/obj/machinery/chem_dispenser,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
 "kPk" = (
@@ -43835,10 +43838,8 @@
 /turf/open/floor/iron/grimy,
 /area/station/science/xenobiology/hallway)
 "ltZ" = (
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
-	},
-/obj/machinery/airalarm/directional/east,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "lua" = (
@@ -45981,6 +45982,9 @@
 /area/station/maintenance/floor3/starboard/aft)
 "lVE" = (
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "lVP" = (
@@ -52188,11 +52192,14 @@
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/floor4/aft)
 "nuE" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/duct,
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
+	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nuM" = (
@@ -52356,7 +52363,9 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port/aft)
 "nwF" = (
-/obj/machinery/duct,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nwL" = (
@@ -52863,7 +52872,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/duct,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nCL" = (
@@ -56770,6 +56781,7 @@
 /obj/effect/mapping_helpers/dead_body_placer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "oDI" = (
@@ -58209,10 +58221,8 @@
 /turf/open/floor/plating/airless,
 /area/station/service/chapel)
 "oXb" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
+/obj/machinery/computer/operating{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
@@ -58646,13 +58656,9 @@
 /area/station/science/xenobiology)
 "pfd" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/table/optable{
-	desc = "A cold, hard place for your final rest.";
-	name = "Morgue Slab"
-	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "pfg" = (
@@ -60164,6 +60170,13 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server/upper)
+"pzI" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "pzK" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -61650,6 +61663,10 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/fore)
+"pUH" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "pUI" = (
 /obj/structure/chair/comfy,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -66978,9 +66995,7 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port)
 "rlB" = (
-/obj/structure/chair/office/tactical{
-	dir = 1
-	},
+/obj/machinery/duct,
 /obj/effect/landmark/start/coroner,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -68037,10 +68052,10 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "rAu" = (
-/obj/structure/cable,
-/obj/machinery/computer/operating{
-	dir = 8
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 4
 	},
+/obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "rAv" = (
@@ -70388,10 +70403,10 @@
 "slI" = (
 /obj/item/radio/intercom/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
+/obj/structure/bodycontainer/morgue/beeper_off,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "slP" = (
@@ -73087,7 +73102,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/duct,
+/obj/structure/chair/office/tactical{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "sWZ" = (
@@ -76613,7 +76630,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
-/obj/structure/sink/kitchen/directional/south,
+/obj/structure/mannequin/skeleton,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "tTI" = (
@@ -79113,8 +79130,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/duct,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uEK" = (
@@ -79721,6 +79740,9 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "uMR" = (
@@ -80971,9 +80993,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/theater)
 "vce" = (
-/obj/structure/bodycontainer/morgue/beeper_off{
-	dir = 2
+/obj/structure/table/reinforced,
+/obj/item/table_clock{
+	pixel_y = 3
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "vcg" = (
@@ -85681,7 +85705,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "wmQ" = (
@@ -87758,8 +87783,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/checkpoint/second)
 "wLV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -90801,9 +90826,7 @@
 /area/station/commons/dorms/apartment1)
 "xBq" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/bodycontainer/morgue/beeper_off{
-	dir = 1
-	},
+/obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "xBt" = (
@@ -92259,6 +92282,8 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "xWy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xWF" = (
@@ -198331,7 +198356,7 @@ cle
 bWz
 jRO
 wmN
-qAh
+pUH
 rAu
 lVE
 hXt
@@ -198588,7 +198613,7 @@ aal
 aal
 lcv
 tTC
-nCK
+pzI
 nuE
 sWW
 nCK

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -92302,7 +92302,6 @@
 "xWy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xWF" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -4220,9 +4220,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor2/starboard/aft)
 "aZs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15594,9 +15591,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -19822,7 +19816,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29406,6 +29399,7 @@
 	},
 /obj/machinery/duct,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "hEQ" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14340,7 +14340,10 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "dDZ" = (
-/obj/structure/table/optable,
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "dEc" = (
@@ -48937,10 +48940,7 @@
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/item/table_clock{
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "qtS" = (
@@ -53207,7 +53207,10 @@
 /area/station/command/meeting_room)
 "rYN" = (
 /obj/machinery/light/small/directional/south,
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/table/reinforced,
+/obj/item/table_clock{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "rYO" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -27318,6 +27318,7 @@
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iEz" = (
@@ -40032,6 +40033,19 @@
 "nim" = (
 /turf/open/floor/iron/white,
 /area/station/commons/vacant_room)
+"niw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "niF" = (
 /obj/structure/railing/corner,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -172354,7 +172368,7 @@ clT
 clT
 oIa
 dPo
-jtM
+niw
 oZq
 vrU
 std

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -10065,6 +10065,9 @@
 	req_access = list("morgue_secure");
 	name = "Secure Morgue Trays"
 	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "bZN" = (
@@ -10548,9 +10551,7 @@
 	},
 /area/station/ai_monitored/command/storage/eva)
 "cgw" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
+/obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "cgN" = (
@@ -11544,6 +11545,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
@@ -14336,7 +14340,7 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "dDZ" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/table/optable,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "dEc" = (
@@ -17601,6 +17605,9 @@
 /area/station/science/ordnance/burnchamber)
 "ePi" = (
 /obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "ePj" = (
@@ -24843,8 +24850,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "hHm" = (
-/obj/structure/table/optable,
 /obj/machinery/newscaster/directional/south,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hHu" = (
@@ -27315,10 +27325,9 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "iEt" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/structure/mannequin/skeleton,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "iEz" = (
@@ -29914,6 +29923,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/service/theater)
+"jzf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery/white{
+	color = "#52B4E9"
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/morgue)
 "jzo" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40033,19 +40055,6 @@
 "nim" = (
 /turf/open/floor/iron/white,
 /area/station/commons/vacant_room)
-"niw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/morgue)
 "niF" = (
 /obj/structure/railing/corner,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -48204,8 +48213,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/lockers)
 "qfS" = (
-/obj/machinery/smartfridge/organ,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/records/medical/laptop{
+	dir = 4;
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "qga" = (
@@ -48921,13 +48935,12 @@
 /area/station/hallway/primary/tram/right)
 "qtQ" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
-/obj/structure/table/reinforced,
-/obj/item/table_clock{
-	pixel_y = 8
-	},
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/item/table_clock{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "qtS" = (
@@ -53194,6 +53207,7 @@
 /area/station/command/meeting_room)
 "rYN" = (
 /obj/machinery/light/small/directional/south,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "rYO" = (
@@ -55061,7 +55075,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "sFA" = (
-/obj/structure/mannequin/skeleton,
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "sFE" = (
@@ -69093,7 +69108,9 @@
 /turf/open/floor/iron/freezer,
 /area/station/science/lower)
 "xHx" = (
-/obj/structure/chair/office/tactical,
+/obj/structure/chair/office/tactical{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "xIe" = (
@@ -70534,8 +70551,7 @@
 "yjl" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/table/reinforced,
-/obj/machinery/computer/records/medical/laptop,
+/obj/machinery/computer/operating,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "yjm" = (
@@ -172368,7 +172384,7 @@ clT
 clT
 oIa
 dPo
-niw
+jzf
 oZq
 vrU
 std

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -27329,7 +27329,6 @@
 /area/station/security/brig)
 "iEt" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
 /obj/structure/mannequin/skeleton,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)

--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -32,7 +32,7 @@
 		/obj/effect/spawner/random/medical/memeorgans = 1,
 	)
 
-	family_heirlooms = list(/obj/item/clothing/head/helmet/skull, /obj/item/table_clock)
+	family_heirlooms = list(/obj/item/clothing/head/helmet/skull)
 
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS | JOB_CAN_BE_INTERN
 


### PR DESCRIPTION
## About The Pull Request
- Tramstation's Morgue was annoyingly broken (the disposals chute was not linked to the disposals net). I fixed that! :D
- I also decided to change the Coroner's Office a bit up, because it makes no sense for the Surgery Tools and the Organ Storage to be two miles away from the Operating Table.
- I've also added a table clock to every Morgue because it's a pretty cool ambience sound (in exchange for that, I removed it from the Coroner's heirloom list).
- Changed the position of Northstar's Morgue Trays to have more without having to break down the walls.
- Changed a bit the Deltastation Morgue's colors to match the Coroner's black and white.

Deltastation:
![image](https://github.com/tgstation/tgstation/assets/42555530/89728209-d6f5-4ea7-adf7-b57c09c47c4a)
Metastation:
![image](https://github.com/tgstation/tgstation/assets/42555530/75632454-2168-49fc-ae2e-dabf31e4235f)
NorthStar:
![image](https://github.com/tgstation/tgstation/assets/42555530/ff124b8f-37e6-4dbe-b24a-ac24f4250bd1)
Tramstation:
![image](https://github.com/tgstation/tgstation/assets/42555530/517dc4d4-943f-4bcd-b81d-012a69510586)
Icebox:
![image](https://github.com/tgstation/tgstation/assets/42555530/44614c5b-10f4-4775-9a7b-b74f6c7b6e8c)
## Why It's Good For The Game
Tram's Morgue's disposals leading to nothing was miserable. The table clock gives a nice ticking sound. Surgery tools shouldn't be 2 miles away from the table. The Skeleton now looks at you while you perform autopsies (except on Meta, fuck Meta).
## Changelog
:cl:
add: The Morgue now always has a table clock
del: The Coroner can no longer have a table clock as an heirloom
qol: The Morgue now has the surgery tools, operating table, and organ storage all near each other
fix: The Tramstation's Morgue now has a functional disposals chute
/:cl:
