### PR TITLE
Unregister turf_change on openspace Destroy

### DIFF
--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -261,6 +261,12 @@
 	. = ..()
 	AddElement(/datum/element/turf_z_transparency)
 
+/turf/open/space/openspace/Destroy()
+	. = ..()
+	var/turf/below = SSmapping.get_turf_below(src)
+	if(below)
+		UnregisterSignal(below, COMSIG_TURF_CHANGE)
+
 /turf/open/space/openspace/zAirIn()
 	return TRUE
 

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -251,6 +251,7 @@
 
 /turf/open/space/openspace/Initialize(mapload) // handle plane and layer here so that they don't cover other obs/turfs in Dream Maker
 	. = ..()
+	ASSERT(SSmapping.get_turf_below(src)) // openspace is invalid without something below it
 	icon_state = "pure_white"
 	// We make the assumption that the space plane will never be blacklisted, as an optimization
 	if(SSmapping.max_plane_offset)

--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -101,6 +101,8 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 	ignore += subtypesof(/obj/machinery/airlock_controller)
 	// Always ought to have an associated escape menu. Any references it could possibly hold would need one regardless.
 	ignore += subtypesof(/atom/movable/screen/escape_menu)
+	//must have a turf below them
+	ignore += typesof(/turf/open/openspace,	/turf/open/space/openspace)
 
 	var/list/cached_contents = spawn_at.contents.Copy()
 	var/original_turf_type = spawn_at.type


### PR DESCRIPTION
## About The Pull Request
Cherrypicks one specific change out of #74356 since it might fix downstream CI issues with maploading.

Also stops Create and Destroy from spawning invalid openspace turfs.

## Why It's Good For The Game
The proper fix that supersedes #74406.
c.f. lizardqueenlexi/orbstation/pull/647 and the following CI fail for more information on the issue: https://github.com/Skyrat-SS13/Skyrat-tg/actions/runs/5173646250/jobs/9319185195?pr=21629