### PR TITLE
Fix some TTS jank cases

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -179,11 +179,11 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		else
 			log_talk(message, LOG_SAY, forced_by = forced, custom_say_emote = message_mods[MODE_CUSTOM_SAY_EMOTE])
 
-	#ifdef UNIT_TESTS
+#ifdef UNIT_TESTS
 	// Saves a ref() to our arglist specifically.
 	// We do this because we need to check that COMSIG_MOB_SAY is getting EXACTLY this list.
 	last_say_args_ref = REF(args)
-	#endif
+#endif
 
 	if(!HAS_TRAIT(src, TRAIT_SIGN_LANG)) // if using sign language skip sending the say signal
 		// Make sure the arglist is passed exactly - don't pass a copy of it. Say signal handlers will modify some of the parameters.
@@ -472,7 +472,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		var/replacement = tts_message[length_regex.index]+tts_message[length_regex.index]+tts_message[length_regex.index]
 		tts_message = replacetext(tts_message, length_regex.match, replacement, length_regex.index)
 
-	///removes repeated consonants at the start of a word: ex: sss
+	// removes repeated consonants at the start of a word: ex: sss
 	var/static/regex/word_start_regex = regex(@"\b([^aeiou\L])\1", "gi")
 	while(word_start_regex.Find(tts_message))
 		var/replacement = tts_message[word_start_regex.index]

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -179,6 +179,18 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		else
 			log_talk(message, LOG_SAY, forced_by = forced, custom_say_emote = message_mods[MODE_CUSTOM_SAY_EMOTE])
 
+	#ifdef UNIT_TESTS
+	// Saves a ref() to our arglist specifically.
+	// We do this because we need to check that COMSIG_MOB_SAY is getting EXACTLY this list.
+	last_say_args_ref = REF(args)
+	#endif
+
+	if(!HAS_TRAIT(src, TRAIT_SIGN_LANG)) // if using sign language skip sending the say signal
+		// Make sure the arglist is passed exactly - don't pass a copy of it. Say signal handlers will modify some of the parameters.
+		var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)
+		if(sigreturn & COMPONENT_UPPERCASE_SPEECH)
+			message = uppertext(message)
+
 	var/list/message_data = treat_message(message) // unfortunately we still need this
 	message = message_data["message"]
 	var/tts_message = message_data["tts_message"]
@@ -194,21 +206,6 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		var/randomnote = pick("\u2669", "\u266A", "\u266B")
 		message = "[randomnote] [message] [randomnote]"
 		spans |= SPAN_SINGING
-
-	#ifdef UNIT_TESTS
-	// Saves a ref() to our arglist specifically.
-	// We do this because we need to check that COMSIG_MOB_SAY is getting EXACTLY this list.
-	last_say_args_ref = REF(args)
-	#endif
-
-	if(!HAS_TRAIT(src, TRAIT_SIGN_LANG)) // if using sign language skip sending the say signal
-		// Make sure the arglist is passed exactly - don't pass a copy of it. Say signal handlers will modify some of the parameters.
-		var/last_message = message
-		var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)
-		if(last_message != message)
-			tts_message = message
-		if(sigreturn & COMPONENT_UPPERCASE_SPEECH)
-			message = uppertext(message)
 
 
 	if(!message)
@@ -474,6 +471,12 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	while(length_regex.Find(tts_message))
 		var/replacement = tts_message[length_regex.index]+tts_message[length_regex.index]+tts_message[length_regex.index]
 		tts_message = replacetext(tts_message, length_regex.match, replacement, length_regex.index)
+
+	///removes repeated consonants at the start of a word: ex: sss
+	var/static/regex/word_start_regex = regex(@"\b([^aeiou\L])\1", "gi")
+	while(word_start_regex.Find(tts_message))
+		var/replacement = tts_message[word_start_regex.index]
+		tts_message = replacetext(tts_message, word_start_regex.match, replacement, word_start_regex.index)
 
 	return list("message" = message, "tts_message" = tts_message, "tts_filter" = tts_filter)
 


### PR DESCRIPTION

## About The Pull Request
Fixes two cases TTS trips over:
1. `COMSIG_MOB_SAY` handlers such as tongues and clothing overwrite the TTS message, causing stuttered text to pass through to TTS, which pronounces each stuttered letter individually. **Note:** This fix is to simply swap the order of `COMSIG_MOB_SAY` and `COMSIG_LIVING_TREAT_MESSAGE`, I couldn't determine any adverse effects from this and it actually fixes other stuff (like properly stuttering added speech from italian mustache).
2. Trims off repeated, consecutive consonants at the start of words in all cases. This not only fixes lizard "ess-ess-speech" but also flymen and snails speech. (though snails are still extremely broken)
## Why It's Good For The Game
lizards can ess-ess-speak properly
## Changelog
:cl:
fix: fixed TTS tripping over stuttered text when other speech modifiers are in effect
fix: fixed tedious TTS "ess-ess-speech" for lizards and other species with repeated consonants
/:cl:
