### PR TITLE
Blacklist modular maps from Create and Destroy

### DIFF
--- a/code/modules/unit_tests/create_and_destroy.dm
+++ b/code/modules/unit_tests/create_and_destroy.dm
@@ -101,6 +101,8 @@ GLOBAL_VAR_INIT(running_create_and_destroy, FALSE)
 	ignore += subtypesof(/obj/machinery/airlock_controller)
 	// Always ought to have an associated escape menu. Any references it could possibly hold would need one regardless.
 	ignore += subtypesof(/atom/movable/screen/escape_menu)
+	// This will load a map on top of the testing room, which we really don't want.
+	ignore += typesof(/obj/modular_map_root)
 
 	var/list/cached_contents = spawn_at.contents.Copy()
 	var/original_turf_type = spawn_at.type


### PR DESCRIPTION
## About The Pull Request
Blacklists modular map loaders from Create and Destroy.

## Why It's Good For The Game
Lowered CI time dramatically on downstream due to subtypes defined with a non-null `key`. Either way it probably shouldn't be spawned during CI at all since it's either a no-op or spawns a whole map.