### PR TITLE
Fixes admin setting job slot number to custom amount

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -866,14 +866,13 @@
 
 		for(var/datum/job/job as anything in SSjob.joinable_occupations)
 			if(job.title == Add)
-				var/newtime = null
-				newtime = input(usr, "How many jebs do you want?", "Add wanted posters", "[newtime]") as num|null
-				if(!newtime)
-					to_chat(src.owner, "Setting to amount of positions filled for the job", confidential = TRUE)
-					job.total_positions = job.current_positions
-					log_job_debug("[key_name(usr)] set the job cap for [job.title] to [job.total_positions]")
+				var/newslots = null
+				newslots = input(usr, "How many job slots do you want?", "Add job slots", "[newslots]") as num|null
+				if(!isnull(newslots))
+					to_chat(src.owner, "Job slots for [job.title] set to [newslots]" , confidential = TRUE)
+					job.total_positions = newslots
+					log_job_debug("[key_name(usr)] set the job cap for [job.title] to [newslots]")
 					break
-				job.total_positions = newtime
 
 		src.manage_free_slots()
 


### PR DESCRIPTION

## About The Pull Request
Removed "jebs" typo from custom slot code.
Made cancel button not set job slots to 0.
## Why It's Good For The Game
It allows the custom slot menu to be cancelled without changing the slots to 0, this makes admin job slot management less annoying to use.
## Changelog
:cl:
fix: fixed admin custom job slot cancel button
spellcheck: fixed a typo that spelled "jobs" as "jebs"
/:cl:
