### PR TITLE
Fixes xeno resin floor layer

### DIFF
--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -135,7 +135,7 @@
 	desc = "A thick resin surface covers the floor."
 	anchored = TRUE
 	density = FALSE
-	layer = TURF_LAYER
+	layer = MID_TURF_LAYER
 	plane = FLOOR_PLANE
 	icon = 'icons/obj/smooth_structures/alien/weeds1.dmi'
 	icon_state = "weeds1-0"


### PR DESCRIPTION

## About The Pull Request

Changes resin floor to MID_TURF_LAYER (turf decals are not shown!

## Why It's Good For The Game

Fixes #75876

## Changelog
:cl:
fix: xeno resin floor layer
/:cl:
