### PR TITLE
""Fixes"" Siliconnect log UI updating

### DIFF
--- a/code/modules/modular_computers/file_system/programs/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/borg_monitor.dm
@@ -62,7 +62,6 @@
 			loglist.Insert(1,"System log of unit [DL_source.name]")
 		DL_progress = -1
 		DL_source = null
-		update_static_data_for_all_viewers()
 		return
 
 	DL_progress += 25
@@ -100,11 +99,9 @@
 		)
 		data["cyborgs"] += list(cyborg_data)
 		data["DL_progress"] = DL_progress
-	return data
-
-/datum/computer_file/program/borg_monitor/ui_static_data(mob/user)
-	var/list/data = list()
+	
 	data["borglog"] = loglist
+	
 	return data
 
 /datum/computer_file/program/borg_monitor/ui_act(action, params, datum/tgui/ui, datum/ui_state/state)


### PR DESCRIPTION

## About The Pull Request

i dont think borg logs are static why are they in static update
changes them to normal ui update

## Why It's Good For The Game

Fixes #75831

## Changelog
:cl:
fix: siliconnect log tab updates correctly
/:cl:
