### PR TITLE
Alexander now properly purges itself when you drop your shield

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -2457,7 +2457,7 @@
 /datum/reagent/consumable/ethanol/alexander/on_mob_life(mob/living/drinker, seconds_per_tick, times_fired)
 	..()
 	if(mighty_shield && !(mighty_shield in drinker.contents)) //If you had a shield and lose it, you lose the reagent as well. Otherwise this is just a normal drink.
-		holder.remove_reagent(type)
+		holder.remove_reagent(type, volume)
 
 /datum/reagent/consumable/ethanol/alexander/on_mob_end_metabolize(mob/living/drinker)
 	if(mighty_shield)


### PR DESCRIPTION

## About The Pull Request

remove_reagent() wasn't getting passed a volume, so it would just throw a stack_trace and not actually purge anything.
## Why It's Good For The Game

Closes #73365.
## Changelog
:cl:
fix: Alexander now properly purges itself when you drop your shield.
/:cl:
