### PR TITLE
Improves mob resizing (and UpdatePaths).

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/bigderelict1.dmm
@@ -609,7 +609,7 @@
 	health = 25;
 	maxHealth = 25;
 	name = "hatchling";
-	resize = 0.85
+	current_size = 0.85
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/derelictoutpost)
@@ -625,7 +625,7 @@
 	health = 25;
 	maxHealth = 25;
 	name = "hatchling";
-	resize = 0.85
+	current_size = 0.85
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/derelictoutpost)
@@ -1455,7 +1455,7 @@
 	health = 25;
 	maxHealth = 25;
 	name = "hatchling";
-	resize = 0.85
+	current_size = 0.85
 	},
 /turf/open/misc/asteroid,
 /area/ruin/space/has_grav/derelictoutpost)

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -380,16 +380,14 @@
 	if(..())
 		return
 	ADD_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
-	owner.resize = 1.25
-	owner.update_transform()
+	owner.update_transform(1.25)
 	owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
 
 /datum/mutation/human/gigantism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	REMOVE_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
-	owner.resize = 0.8
-	owner.update_transform()
+	owner.update_transform(0.8)
 	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
 
 /datum/mutation/human/spastic

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -566,17 +566,15 @@
 			robot.SetLockdown(FALSE)
 		robot.set_anchored(FALSE)
 		robot.notransform = FALSE
-		robot.resize = 2
 		robot.hasExpanded = TRUE
-		robot.update_transform()
+		robot.update_transform(2)
 
 /obj/item/borg/upgrade/expand/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
 		if (R.hasExpanded)
 			R.hasExpanded = FALSE
-			R.resize = 0.5
-			R.update_transform()
+			R.update_transform(0.5)
 
 /obj/item/borg/upgrade/rped
 	name = "engineering cyborg RPED"
@@ -750,7 +748,7 @@
 	var/obj/item/pushbroom/cyborg/BR = locate() in R.model.modules
 	if (BR)
 		R.model.remove_module(BR, TRUE)
-		
+
 /obj/item/borg/upgrade/condiment_synthesizer
 	name = "Service Cyborg Condiment Synthesiser"
 	desc = "An upgrade to the service model cyborg, allowing it to produce solid condiments."
@@ -778,7 +776,7 @@
 	var/obj/item/reagent_containers/borghypo/condiment_synthesizer/cynthesizer = locate() in install.model.modules
 	if (cynthesizer)
 		install.model.remove_module(cynthesizer, TRUE)
-			
+
 /obj/item/borg/upgrade/silicon_knife
 	name = "Service Cyborg Kitchen Toolset"
 	desc = "An upgrade to the service model cyborg, to help process foods."
@@ -786,7 +784,7 @@
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/service)
 	model_flags = BORG_MODEL_SERVICE
-			
+
 /obj/item/borg/upgrade/silicon_knife/action(mob/living/silicon/robot/install, user = usr)
 	. = ..()
 	if(!.)
@@ -806,15 +804,15 @@
 	var/obj/item/knife/kitchen/silicon/snife = locate() in install.model.modules
 	if (snife)
 		install.model.remove_module(snife, TRUE)
-			
+
 /obj/item/borg/upgrade/service_apparatus
 	name = "Service Cyborg Service Apparatus"
 	desc = "An upgrade to the service model cyborg, to help handle foods and paper."
 	icon_state = "cyborg_upgrade3"
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/service)
-	model_flags = BORG_MODEL_SERVICE			
-			
+	model_flags = BORG_MODEL_SERVICE
+
 /obj/item/borg/upgrade/service_apparatus/action(mob/living/silicon/robot/install, user = usr)
 	. = ..()
 	if(!.)
@@ -834,15 +832,15 @@
 	var/obj/item/borg/apparatus/service/saparatus = locate() in install.model.modules
 	if (saparatus)
 		install.model.remove_module(saparatus, TRUE)
-			
+
 /obj/item/borg/upgrade/rolling_table
 	name = "Service Cyborg Rolling Table Dock"
 	desc = "An upgrade to the service model cyborg, to help provide mobile service."
 	icon_state = "cyborg_upgrade3"
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/service)
-	model_flags = BORG_MODEL_SERVICE			
-			
+	model_flags = BORG_MODEL_SERVICE
+
 /obj/item/borg/upgrade/rolling_table/action(mob/living/silicon/robot/install, user = usr)
 	. = ..()
 	if(!.)
@@ -861,7 +859,7 @@
 		return FALSE
 	var/obj/item/rolling_table_dock/rtable = locate() in install.model.modules
 	if (rtable)
-		install.model.remove_module(rtable, TRUE)			
+		install.model.remove_module(rtable, TRUE)
 
 ///This isn't an upgrade or part of the same path, but I'm gonna just stick it here because it's a tool used on cyborgs.
 //A reusable tool that can bring borgs back to life. They gotta be repaired first, though.

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -68,26 +68,26 @@
 			update_held_items()
 
 //IMPORTANT: Multiple animate() calls do not stack well, so try to do them all at once if you can.
-/mob/living/carbon/perform_update_transform()
+/mob/living/carbon/perform_update_transform(resize = RESIZE_DEFAULT_SIZE)
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/final_pixel_y = pixel_y
 	var/final_dir = dir
 	var/changed = 0
+
 	if(lying_angle != lying_prev && rotate_on_lying)
 		changed++
 		ntransform.TurnTo(lying_prev , lying_angle)
-		if(!lying_angle) //Lying to standing
-			final_pixel_y = base_pixel_y
-		else //if(lying != 0)
-			if(lying_prev == 0) //Standing to lying
-				pixel_y = base_pixel_y
-				final_pixel_y = base_pixel_y + PIXEL_Y_OFFSET_LYING
-				if(dir & (EAST|WEST)) //Facing east or west
-					final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
-	if(resize != RESIZE_DEFAULT_SIZE)
+		if(lying_angle && lying_prev == 0 && dir & (EAST|WEST)) //Standing to lying and facing east or west
+			final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
+		final_pixel_y = base_pixel_y + body_position_pixel_y_offset //animate and animate the pixel offset too.
+
+	if(resize)
 		changed++
 		ntransform.Scale(resize)
-		resize = RESIZE_DEFAULT_SIZE
+		//Update final_pixel_y so our mob doesn't go out of the southern bounds of the tile when standing
+		if(!lying_angle || !rotate_on_lying) //But not if the mob is lying, its sprite rotated.
+			final_pixel_y += (current_size * resize - current_size) * world.icon_size/2
+		current_size *= resize
 
 	if(changed)
 		SEND_SIGNAL(src, COMSIG_PAUSE_FLOATING_ANIM, 0.3 SECONDS)

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -81,7 +81,7 @@
 			final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
 		final_pixel_y = base_pixel_y + body_position_pixel_y_offset
 
-	if(resize)
+	if(resize != RESIZE_DEFAULT_SIZE)
 		changed++
 		ntransform.Scale(resize)
 		//Update final_pixel_y so our mob doesn't go out of the southern bounds of the tile when standing

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -79,7 +79,7 @@
 		ntransform.TurnTo(lying_prev , lying_angle)
 		if(lying_angle && lying_prev == 0 && dir & (EAST|WEST)) //Standing to lying and facing east or west
 			final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
-		final_pixel_y = base_pixel_y + body_position_pixel_y_offset //animate and animate the pixel offset too.
+		final_pixel_y = base_pixel_y + body_position_pixel_y_offset
 
 	if(resize)
 		changed++

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1793,7 +1793,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 			set_body_position(var_value)
 			. = TRUE
 		if(NAMEOF(src, current_size))
-			if(var_value == 0) //prevents divisions by zero.
+			if(var_value == 0) //prevents divisions of and by zero.
 				return FALSE
 			update_transform(var_value/current_size)
 			. = TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,5 +1,7 @@
 /mob/living/Initialize(mapload)
 	. = ..()
+	if(current_size != RESIZE_DEFAULT_SIZE)
+		update_transform(current_size)
 	AddElement(/datum/element/movetype_handler)
 	register_init_signals()
 	if(unique_name)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1794,6 +1794,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 			if(var_value == 0) //prevents divisions by zero.
 				return FALSE
 			update_transform(var_value/current_size)
+			. = TRUE
 
 	if(!isnull(.))
 		datum_flags |= DF_VAR_EDITED

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -379,24 +379,26 @@
 		if(GRAB_KILL)
 			offset = GRAB_PIXEL_SHIFT_NECK
 	M.setDir(get_dir(M, src))
+	var/target_pixel_x = M.base_pixel_x + M.body_position_pixel_x_offset
+	var/target_pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset
 	switch(M.dir)
 		if(NORTH)
-			animate(M, pixel_x = M.base_pixel_x, pixel_y = M.base_pixel_y + offset, 3)
+			animate(M, pixel_x = target_pixel_x, pixel_y = target_pixel_y + offset, 3)
 		if(SOUTH)
-			animate(M, pixel_x = M.base_pixel_x, pixel_y = M.base_pixel_y - offset, 3)
+			animate(M, pixel_x = target_pixel_x, pixel_y = target_pixel_y - offset, 3)
 		if(EAST)
 			if(M.lying_angle == 270) //update the dragged dude's direction if we've turned
 				M.set_lying_angle(90)
-			animate(M, pixel_x = M.base_pixel_x + offset, pixel_y = M.base_pixel_y, 3)
+			animate(M, pixel_x = target_pixel_x + offset, pixel_y = target_pixel_y, 3)
 		if(WEST)
 			if(M.lying_angle == 90)
 				M.set_lying_angle(270)
-			animate(M, pixel_x = M.base_pixel_x - offset, pixel_y = M.base_pixel_y, 3)
+			animate(M, pixel_x = target_pixel_x - offset, pixel_y = target_pixel_y, 3)
 
 /mob/living/proc/reset_pull_offsets(mob/living/M, override)
 	if(!override && M.buckled)
 		return
-	animate(M, pixel_x = M.base_pixel_x, pixel_y = M.base_pixel_y, 1)
+	animate(M, pixel_x = M.base_pixel_x + M.body_position_pixel_x_offset , pixel_y = M.base_pixel_y + M.body_position_pixel_y_offset, 1)
 
 //mob verbs are a lot faster than object verbs
 //for more info on why this is not atom/pull, see examinate() in mob.dm
@@ -605,8 +607,8 @@
 		return
 	if(resting || body_position == STANDING_UP || HAS_TRAIT(src, TRAIT_FLOORED))
 		return
-	set_lying_angle(0)
 	set_body_position(STANDING_UP)
+	set_lying_angle(0)
 
 
 /mob/living/proc/rest_checks_callback()
@@ -636,7 +638,8 @@
 		layer = initial(layer)
 	set_density(initial(density)) // We were prone before, so we become dense and things can bump into us again.
 	remove_traits(list(TRAIT_UI_BLOCKED, TRAIT_PULL_BLOCKED), LYING_DOWN_TRAIT)
-	body_position_pixel_y_offset = 0
+	// Make sure it doesn't go out of the southern bounds of the tile when standing.
+	body_position_pixel_y_offset = (current_size-1) * world.icon_size/2
 
 //Recursive function to find everything a mob is holding. Really shitty proc tbh.
 /mob/living/get_contents()
@@ -1787,6 +1790,10 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		if(NAMEOF(src, body_position))
 			set_body_position(var_value)
 			. = TRUE
+		if(NAMEOF(src, current_size))
+			if(var_value == 0) //prevents divisions by zero.
+				return FALSE
+			update_transform(var_value/current_size)
 
 	if(!isnull(.))
 		datum_flags |= DF_VAR_EDITED
@@ -1797,8 +1804,6 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	switch(var_name)
 		if(NAMEOF(src, maxHealth))
 			updatehealth()
-		if(NAMEOF(src, resize))
-			update_transform()
 		if(NAMEOF(src, lighting_cutoff))
 			sync_lighting_plane_cutoff()
 
@@ -2243,7 +2248,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	overeatduration = 0
 
 
-/// Changes the value of the [living/body_position] variable.
+/// Changes the value of the [living/body_position] variable. Call this before set_lying_angle()
 /mob/living/proc/set_body_position(new_value)
 	if(body_position == new_value)
 		return
@@ -2261,8 +2266,8 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 /// Proc to append behavior to the condition of being floored. Called when the condition starts.
 /mob/living/proc/on_floored_start()
 	if(body_position == STANDING_UP) //force them on the ground
-		set_lying_angle(pick(90, 270))
 		set_body_position(LYING_DOWN)
+		set_lying_angle(pick(90, 270))
 		on_fall()
 
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -6,7 +6,7 @@
 	hud_type = /datum/hud/living
 
 	///Tracks the current size of the mob in relation to its original size. Use update_transform(resize) to change it.
-	var/current_size = 1
+	var/current_size = RESIZE_DEFAULT_SIZE
 	var/lastattacker = null
 	var/lastattackerckey = null
 

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -5,8 +5,8 @@
 
 	hud_type = /datum/hud/living
 
-	///Badminnery resize
-	var/resize = 1
+	///Tracks the current size of the mob in relation to its original size. Use update_transform(resize) to change it.
+	var/current_size = 1
 	var/lastattacker = null
 	var/lastattackerckey = null
 

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -5,16 +5,13 @@
 	SEND_SIGNAL(src, COMSIG_LIVING_POST_UPDATE_TRANSFORM) // ...and we want the signal to be sent last.
 
 /mob/living/proc/perform_update_transform(resize = RESIZE_DEFAULT_SIZE)
+	if(resize == RESIZE_DEFAULT_SIZE)
+		return
+
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
-	var/final_pixel_y = pixel_y
-	var/changed = FALSE
+	ntransform.Scale(resize)
+	//Update final_pixel_y so our mob doesn't go out of the southern bounds of the tile when standing
+	var/final_pixel_y = pixel_y + (current_size * resize - current_size) * world.icon_size/2
+	current_size *= resize
 
-	if(resize != RESIZE_DEFAULT_SIZE)
-		changed = TRUE
-		ntransform.Scale(resize)
-		//Update final_pixel_y so our mob doesn't go out of the southern bounds of the tile when standing
-		final_pixel_y += (current_size * resize - current_size) * world.icon_size/2
-		current_size *= resize
-
-	if(changed)
-		animate(src, transform = ntransform, time = 2, pixel_y = final_pixel_y, easing = EASE_IN|EASE_OUT)
+	animate(src, transform = ntransform, time = 2, pixel_y = final_pixel_y, easing = EASE_IN|EASE_OUT)

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -1,17 +1,20 @@
 
 /// Called whenever the mob is to be resized or when lying/standing up for carbons.
-/mob/living/update_transform()
-	perform_update_transform() // carbon mobs do it differently than silicons and simple animals.
+/mob/living/update_transform(resize = RESIZE_DEFAULT_SIZE)
+	perform_update_transform(resize) // carbon mobs do it differently than silicons and simple animals.
 	SEND_SIGNAL(src, COMSIG_LIVING_POST_UPDATE_TRANSFORM) // ...and we want the signal to be sent last.
 
-/mob/living/proc/perform_update_transform()
+/mob/living/proc/perform_update_transform(resize = RESIZE_DEFAULT_SIZE)
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
+	var/final_pixel_y = pixel_y
 	var/changed = FALSE
 
 	if(resize != RESIZE_DEFAULT_SIZE)
 		changed = TRUE
 		ntransform.Scale(resize)
-		resize = RESIZE_DEFAULT_SIZE
+		//Update final_pixel_y so our mob doesn't go out of the southern bounds of the tile when standing
+		final_pixel_y += (current_size * resize - current_size) * world.icon_size/2
+		current_size *= resize
 
 	if(changed)
-		animate(src, transform = ntransform, time = 2, easing = EASE_IN|EASE_OUT)
+		animate(src, transform = ntransform, time = 2, pixel_y = final_pixel_y, easing = EASE_IN|EASE_OUT)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -723,9 +723,8 @@
 		hud_used.update_robot_modules_display()
 
 	if (hasExpanded)
-		resize = 0.5
 		hasExpanded = FALSE
-		update_transform()
+		update_transform(0.5)
 	logevent("Chassis model has been reset.")
 	log_silicon("CYBORG: [key_name(src)] has reset their cyborg model.")
 	model.transform_to(/obj/item/robot_model)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -80,8 +80,7 @@
 
 /mob/living/simple_animal/bot/secbot/beepsky/jr/Initialize(mapload)
 	. = ..()
-	resize = 0.8
-	update_transform()
+	update_transform(0.8)
 
 /mob/living/simple_animal/bot/secbot/pingsky
 	name = "Officer Pingsky"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/gutlunch.dm
@@ -89,8 +89,7 @@
 /mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck/Initialize(mapload)
 	. = ..()
 	add_atom_colour(pick("#E39FBB", "#D97D64", "#CF8C4A"), FIXED_COLOUR_PRIORITY)
-	resize = 0.85
-	update_transform()
+	update_transform(0.85)
 
 //Lady gutlunch. They make the babby.
 /mob/living/simple_animal/hostile/asteroid/gutlunch/guthen
@@ -107,8 +106,7 @@
 /mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch/Initialize(mapload)
 	. = ..()
 	add_atom_colour("#9E9E9E", FIXED_COLOUR_PRIORITY) //Somewhat hidden
-	resize = 0.45
-	update_transform()
+	update_transform(0.45)
 
 /mob/living/simple_animal/hostile/asteroid/gutlunch/grublunch/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	..()

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -1401,15 +1401,15 @@
 
 	var/newsize = pick(0.5, 0.75, 1, 1.50, 2)
 	newsize *= RESIZE_DEFAULT_SIZE
-	current_size = newsize
 	affected_mob.update_transform(newsize/current_size)
+	current_size = newsize
 	if(SPT_PROB(23, seconds_per_tick))
 		affected_mob.emote("sneeze")
 	..()
 
 /datum/reagent/consumable/red_queen/on_mob_end_metabolize(mob/living/affected_mob)
-	current_size = RESIZE_DEFAULT_SIZE
 	affected_mob.update_transform(RESIZE_DEFAULT_SIZE/current_size)
+	current_size = RESIZE_DEFAULT_SIZE
 	..()
 
 /datum/reagent/consumable/bungojuice

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -1401,17 +1401,15 @@
 
 	var/newsize = pick(0.5, 0.75, 1, 1.50, 2)
 	newsize *= RESIZE_DEFAULT_SIZE
-	affected_mob.resize = newsize/current_size
 	current_size = newsize
-	affected_mob.update_transform()
+	affected_mob.update_transform(newsize/current_size)
 	if(SPT_PROB(23, seconds_per_tick))
 		affected_mob.emote("sneeze")
 	..()
 
 /datum/reagent/consumable/red_queen/on_mob_end_metabolize(mob/living/affected_mob)
-	affected_mob.resize = RESIZE_DEFAULT_SIZE/current_size
 	current_size = RESIZE_DEFAULT_SIZE
-	affected_mob.update_transform()
+	affected_mob.update_transform(RESIZE_DEFAULT_SIZE/current_size)
 	..()
 
 /datum/reagent/consumable/bungojuice

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2319,13 +2319,13 @@
 		if(200 to INFINITY)
 			newsize = 3.5*RESIZE_DEFAULT_SIZE
 
-	current_size = newsize
 	affected_mob.update_transform(newsize/current_size)
+	current_size = newsize
 	..()
 
 /datum/reagent/growthserum/on_mob_end_metabolize(mob/living/affected_mob)
-	current_size = RESIZE_DEFAULT_SIZE
 	affected_mob.update_transform(RESIZE_DEFAULT_SIZE/current_size)
+	current_size = RESIZE_DEFAULT_SIZE
 	..()
 
 /datum/reagent/plastic_polymers

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2319,15 +2319,13 @@
 		if(200 to INFINITY)
 			newsize = 3.5*RESIZE_DEFAULT_SIZE
 
-	affected_mob.resize = newsize/current_size
 	current_size = newsize
-	affected_mob.update_transform()
+	affected_mob.update_transform(newsize/current_size)
 	..()
 
 /datum/reagent/growthserum/on_mob_end_metabolize(mob/living/affected_mob)
-	affected_mob.resize = RESIZE_DEFAULT_SIZE/current_size
 	current_size = RESIZE_DEFAULT_SIZE
-	affected_mob.update_transform()
+	affected_mob.update_transform(RESIZE_DEFAULT_SIZE/current_size)
 	..()
 
 /datum/reagent/plastic_polymers

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -657,9 +657,8 @@
 
 /datum/reagent/toxin/venom/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	var/newsize = 1.1 * RESIZE_DEFAULT_SIZE
-	affected_mob.resize = newsize/current_size
 	current_size = newsize
-	affected_mob.update_transform()
+	affected_mob.update_transform(newsize/current_size)
 
 	toxpwr = 0.1 * volume
 	affected_mob.adjustBruteLoss((0.3 * volume) * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
@@ -671,9 +670,8 @@
 		..()
 
 /datum/reagent/toxin/venom/on_mob_end_metabolize(mob/living/affected_mob)
-	affected_mob.resize = RESIZE_DEFAULT_SIZE/current_size
 	current_size = RESIZE_DEFAULT_SIZE
-	affected_mob.update_transform()
+	affected_mob.update_transform(RESIZE_DEFAULT_SIZE/current_size)
 	..()
 
 /datum/reagent/toxin/fentanyl

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -657,8 +657,8 @@
 
 /datum/reagent/toxin/venom/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	var/newsize = 1.1 * RESIZE_DEFAULT_SIZE
-	current_size = newsize
 	affected_mob.update_transform(newsize/current_size)
+	current_size = newsize
 
 	toxpwr = 0.1 * volume
 	affected_mob.adjustBruteLoss((0.3 * volume) * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
@@ -670,8 +670,8 @@
 		..()
 
 /datum/reagent/toxin/venom/on_mob_end_metabolize(mob/living/affected_mob)
-	current_size = RESIZE_DEFAULT_SIZE
 	affected_mob.update_transform(RESIZE_DEFAULT_SIZE/current_size)
+	current_size = RESIZE_DEFAULT_SIZE
 	..()
 
 /datum/reagent/toxin/fentanyl

--- a/tools/UpdatePaths/Scripts/75892_resize_to_current_size.txt
+++ b/tools/UpdatePaths/Scripts/75892_resize_to_current_size.txt
@@ -1,0 +1,3 @@
+# In this PR, the resize variable was renamed to current_size.
+
+/mob/living/@SUBTYPES{resize = @ANY} : /mob/living/@SUBTYPES{@OLD;resize=@SKIP;current_size=@OLD:resize}

--- a/tools/UpdatePaths/__main__.py
+++ b/tools/UpdatePaths/__main__.py
@@ -13,7 +13,7 @@ Replacement syntax example:
     /turf/open/floor/iron/warningline : /obj/effect/turf_decal {@OLD} , /obj/thing {icon_state = @OLD:name; name = "meme"}
     /turf/open/floor/iron/warningline{dir=2} : /obj/thing
     /obj/effect/landmark/start/virologist : @DELETE
-    /mob/living{resize = @ANY} : /mob/living{@OLD; resize = @SKIP, current_size = @OLD:resize}
+    /mob/living{resize = @ANY} : /mob/living{@OLD; resize = @SKIP}
 Syntax for subtypes also exist, to update a path's type but maintain subtypes:
     /obj/structure/closet/crate/@SUBTYPES : /obj/structure/new_box/@SUBTYPES {@OLD}
 New paths properties:
@@ -26,6 +26,7 @@ New paths properties:
 Old paths properties:
     Will be used as a filter.
     property = @UNSET - will apply the rule only if the property is not mapedited
+    property = @ANY - will apply the rule when the property is mapedited, regardless of its value.
 """
 
 default_map_directory = "../../_maps"

--- a/tools/UpdatePaths/__main__.py
+++ b/tools/UpdatePaths/__main__.py
@@ -13,7 +13,7 @@ Replacement syntax example:
     /turf/open/floor/iron/warningline : /obj/effect/turf_decal {@OLD} , /obj/thing {icon_state = @OLD:name; name = "meme"}
     /turf/open/floor/iron/warningline{dir=2} : /obj/thing
     /obj/effect/landmark/start/virologist : @DELETE
-    /mob/living{resize:@ANY} : /mob/living{@OLD; resize = @SKIP, current_size = @OLD:resize}
+    /mob/living{resize = @ANY} : /mob/living{@OLD; resize = @SKIP, current_size = @OLD:resize}
 Syntax for subtypes also exist, to update a path's type but maintain subtypes:
     /obj/structure/closet/crate/@SUBTYPES : /obj/structure/new_box/@SUBTYPES {@OLD}
 New paths properties:

--- a/tools/UpdatePaths/__main__.py
+++ b/tools/UpdatePaths/__main__.py
@@ -13,6 +13,7 @@ Replacement syntax example:
     /turf/open/floor/iron/warningline : /obj/effect/turf_decal {@OLD} , /obj/thing {icon_state = @OLD:name; name = "meme"}
     /turf/open/floor/iron/warningline{dir=2} : /obj/thing
     /obj/effect/landmark/start/virologist : @DELETE
+    /mob/living{resize:@ANY} : /mob/living{@OLD; resize = @SKIP, current_size = @OLD:resize}
 Syntax for subtypes also exist, to update a path's type but maintain subtypes:
     /obj/structure/closet/crate/@SUBTYPES : /obj/structure/new_box/@SUBTYPES {@OLD}
 New paths properties:
@@ -91,7 +92,9 @@ def update_path(dmm_data, replacement_string, verbose=False):
                 else:
                     return [match.group(0)]
             else:
-                if old_props[filter_prop] != old_path_props[filter_prop] or old_path_props[filter_prop] == "@UNSET":
+                if old_path_props[filter_prop] == "@ANY":
+                   continue
+                elif old_props[filter_prop] != old_path_props[filter_prop] or old_path_props[filter_prop] == "@UNSET":
                     return [match.group(0)] #does not match current filter, skip the change.
         if verbose:
             print("Found match : {0}".format(match.group(0)))
@@ -110,7 +113,8 @@ def update_path(dmm_data, replacement_string, verbose=False):
                 out = new_path
 
             out_props = dict()
-            for prop_name, prop_value in new_props.items():
+            for prop_name, prop_text in new_props.items():
+                prop_value = str(prop_text)
                 if prop_name == "@OLD":
                     out_props = dict(old_props)
                     continue
@@ -119,8 +123,7 @@ def update_path(dmm_data, replacement_string, verbose=False):
                     continue
                 if prop_value.startswith("@OLD"):
                     params = prop_value.split(":")
-                    if prop_name in old_props:
-                        out_props[prop_name] = old_props[params[1]] if len(params) > 1 else old_props[prop_name]
+                    out_props[prop_name] = old_props[params[1]] if len(params) > 1 else old_props[prop_name]
                     continue
                 out_props[prop_name] = prop_value
             if out_props:

--- a/tools/UpdatePaths/readme.md
+++ b/tools/UpdatePaths/readme.md
@@ -341,13 +341,13 @@ You would then get the following output:
 Note how we keep the "Money Hole" intact, while still managing to extrapolate the `dir` variable to 1 on the sink that had absolutely no variables set on it. This is useful for when you want to change a variable that is not shown in the map editor, but you want to keep the rest of the variables intact.
 
 #### Methods: Any Value Fits All and Naming Conventions
-But what if you just want to rename the variable `maxHealth` to `good_boy_points` for all instances of `/mob/living/github_user`? Using the `@ANY` parameter after a variable name, you can capture any path that has it edited in a map. Meanwhile, to set the value of the newly named `good_boy_points` we'll use `@OLD:maxHealth` after declaring the new variable name to achieve that. The result'll be something like this:
+But what if you just want to rename the variable `maxHealth` to `good_boy_points` for all instances of `/mob/living/github_user`? Using the `@ANY` parameter after a variable name, you can capture any instance that has it edited in a map. While, to set the value of the newly named `good_boy_points` to that of the old `maxHealth`, we can use `@OLD:maxHealth`, put after the name of the new variable to achieve that. The result'll be something like this:
 
 ```txt
 /mob/living/github_user{maxHealth=@ANY} : /mob/living/github_user{good_boy_points=@OLD:maxHealth}
 ```
 
-Though, If you read the previous methods, you'd know that without the `@OLD` parameter (the one without colon), every other variable edit will also be discarded, so it's important to add that BEFORE any other parament, as well as `maxHealth=@SKIP` since we're renaming that variable. So, take two:
+Though, If you read about the previous methods, you'd know that without the `@OLD` parameter (the one without colon), every other variable edit will also be discarded, so it's important to add that BEFORE any other parament, as well as `maxHealth=@SKIP` following that since we're renaming that variable. So, take two:
 
 ```txt
 /mob/living/github_user{maxHealth=@ANY} : /mob/living/github_user{@OLD; maxHealth=@SKIP; good_boy_points=@OLD:maxHealth}
@@ -391,7 +391,7 @@ You would then get the following output:
 /area/github),
 ```
 
-As addendum, you don't have to use both `@ANY` and `@OLD:prop_name` together. I'm merely providing a single example for the both of them and their most practical usage.
+As an addendum, you don't have to use both `@ANY` and `@OLD:prop_name` together. I'm merely providing a single example for the both of them and their most practical usage.
 
 ### Blend it all together
 

--- a/tools/UpdatePaths/readme.md
+++ b/tools/UpdatePaths/readme.md
@@ -365,7 +365,7 @@ Perfect, so now let's assume the following map:
 "b" = (
 /mob/living/github_user{
 	name = "ShizCalev";
-	desc= "It has more good boy points than a megafauna has health.";
+	desc= "Has more good boy points than a megafauna has health.";
 	maxHealth = 2083
 	},
 /turf/open/floor/iron,
@@ -384,7 +384,7 @@ You would then get the following output:
 "b" = (
 /mob/living/github_user{
 	name = "ShizCalev";
-	desc= "It has more good boy points than a megafauna has health.";
+	desc= "Has more good boy points than a megafauna has health.";
 	good_boy_points = 2083
 	},
 /turf/open/floor/iron,

--- a/tools/UpdatePaths/readme.md
+++ b/tools/UpdatePaths/readme.md
@@ -340,6 +340,59 @@ You would then get the following output:
 
 Note how we keep the "Money Hole" intact, while still managing to extrapolate the `dir` variable to 1 on the sink that had absolutely no variables set on it. This is useful for when you want to change a variable that is not shown in the map editor, but you want to keep the rest of the variables intact.
 
+#### Methods: Any Value Fits All and Naming Conventions
+But what if you simply want to rename the variable `maxHealth` to `good_boy_points` for `/mob/living/github_user` that have it edited, regardless of value? Since you're required to state a value in your input anyway, in this case it'll be `@ANY`. To set the value of the newly named `good_boy_points` all we need to do is set the name, followed by `@OLD:` (colon included) and the name of the old variable `maxHealth`.
+
+```txt
+/mob/living/github_user{maxHealth=@ANY} : /mob/living/github_user{good_boy_points=@OLD:maxHealth}
+```
+
+...except this is wrong. If you read the previous methods, you'd know that without the `@OLD` (the one without colon), this will discard any other variable edit, so it's important to add it BEFORE the other paraments (as well as `maxHealth` followed by `:@SKIP`) if you're renaming the variable to something else:
+
+```txt
+/mob/living/github_user{maxHealth=@ANY} : /mob/living/github_user{@OLD; maxHealth=@SKIP; good_boy_points=@OLD:maxHealth}
+```
+
+Done that, from a map like this:
+
+```dm
+"a" = (
+/mob/living/basic/mouse{
+	maxHealth = 15
+	},
+/turf/open/floor/iron,
+/area/github),
+"b" = (
+/mob/living/github_user{
+	name = "ShizCalev";
+	desc= "It has more good boy points than a megafauna has health.";
+	maxHealth = 2083
+	},
+/turf/open/floor/iron,
+/area/github),
+```
+
+You would then get the following output:
+
+```dm
+"a" = (
+/mob/living/basic/mouse{
+	maxHealth = 15
+	},
+/turf/open/floor/iron,
+/area/github),
+"b" = (
+/mob/living/github_user{
+	name = "ShizCalev";
+	desc= "It has more good boy points than a megafauna has health.";
+	good_boy_points = 2083
+	},
+/turf/open/floor/iron,
+/area/github),
+```
+
+As addendum, you don't have to use both `@ANY` and `@OLD:prop_name` together. I'm merely providing a single example for the both of them and their most practical usage.
+
 ### Blend it all together
 
 All of the examples provided within are not mutually exclusive! They can be mixed-and-matched in several ways (old scripts might have a few good examples of these), and the only limit here is your imagination. You can do some very powerful things with UpdatePaths, with your scripts lasting for years to come.

--- a/tools/UpdatePaths/readme.md
+++ b/tools/UpdatePaths/readme.md
@@ -341,19 +341,19 @@ You would then get the following output:
 Note how we keep the "Money Hole" intact, while still managing to extrapolate the `dir` variable to 1 on the sink that had absolutely no variables set on it. This is useful for when you want to change a variable that is not shown in the map editor, but you want to keep the rest of the variables intact.
 
 #### Methods: Any Value Fits All and Naming Conventions
-But what if you simply want to rename the variable `maxHealth` to `good_boy_points` for `/mob/living/github_user` that have it edited, regardless of value? Since you're required to state a value in your input anyway, in this case it'll be `@ANY`. To set the value of the newly named `good_boy_points` all we need to do is set the name, followed by `@OLD:` (colon included) and the name of the old variable `maxHealth`.
+But what if you just want to rename the variable `maxHealth` to `good_boy_points` for all instances of `/mob/living/github_user`? Using the `@ANY` parameter after a variable name, you can capture any path that has it edited in a map. Meanwhile, to set the value of the newly named `good_boy_points` we'll use `@OLD:maxHealth` after declaring the new variable name to achieve that. The result'll be something like this:
 
 ```txt
 /mob/living/github_user{maxHealth=@ANY} : /mob/living/github_user{good_boy_points=@OLD:maxHealth}
 ```
 
-...except this is wrong. If you read the previous methods, you'd know that without the `@OLD` (the one without colon), this will discard any other variable edit, so it's important to add it BEFORE the other paraments (as well as `maxHealth` followed by `:@SKIP`) if you're renaming the variable to something else:
+Though, If you read the previous methods, you'd know that without the `@OLD` parameter (the one without colon), every other variable edit will also be discarded, so it's important to add that BEFORE any other parament, as well as `maxHealth=@SKIP` since we're renaming that variable. So, take two:
 
 ```txt
 /mob/living/github_user{maxHealth=@ANY} : /mob/living/github_user{@OLD; maxHealth=@SKIP; good_boy_points=@OLD:maxHealth}
 ```
 
-Done that, from a map like this:
+Perfect, so now let's assume the following map:
 
 ```dm
 "a" = (


### PR DESCRIPTION
## About The Pull Request
So, basically, whenever an atom is scaled up or down through editing of its `transform` variable, these changes apply in all directions in a way the movable is always centered on its location. While good, this can make mobs look like they're not quite standing on the tile they are, with their legs poking onto the turf below or not quite reaching the edge of the turf they're standing on.

It's a visual peeve, and outside that, it doesn't bear any effect on the gameplay, but I need to do something about it because of something else I'm working on that deals with another visual botherance.

I had thought of just copying whatever Skyrat did for their body size pref at first, but it turned out that translating the `transform` variable resulted in rotation looking a little askew. So I had to take the longer path to better incorporate it with the body pixel offsets that mobs use. Speaking of Skyrat, they should update their body size pref code accordingly after this is merged.

I haven't done a "before" screenshot, but you can see in this one how humies of different sizes are nicely aligned with the turfs they're on now.**
![scrnshot1](https://github.com/tgstation/tgstation/assets/42542238/f0eaf719-eac2-40dc-9b3a-f36cbd6f3127)

EDIT: This has also become a PR to fix UpdatePaths after I discovered it doesn't support catching props with any set value and that it also has an undocumented (only docced in the .py script to be precise) parameter that is currently broken (prop_value isn't recognized a string type variable). Documentation for the two has been added to boot.

~~Blame me for the unatomic change but my UpdatePaths scripts needs it.~~

## Why It's Good For The Game
Aligns resized mobs to the tile they're standing on. It looks a bit better this way. This also fixes pulls ignoring body offsets and makes carbon/update_transform use the appropriate variable to calculate the new pixel_y value.

## Changelog

:cl:
fix: pixel offsets from grabbing other mobs now respect the body offset variables.
refactor: Changed some code so that resized mobs no longer look like they're poking over the below tile with their legs or not even reaching the bottom edge of the tile they're on.
/:cl:

**I was too lazy to clear the area to make enough space for two rows of spessmen so I took two screenshots and put them together in paint, then I noticed how I hadn't vertically aligned the two screenshots properly.