### PR TITLE
Added advanced magboots module to ERT engineer

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -365,7 +365,6 @@
 /obj/item/mod/control/pre_equipped/responsory/engineer
 	insignia_type = /obj/item/mod/module/insignia/engineer
 	applied_modules = list(
-		/obj/item/mod/module/insignia/engineer,
 		/obj/item/mod/module/storage/large_capacity,
 		/obj/item/mod/module/welding,
 		/obj/item/mod/module/emp_shield,

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -364,11 +364,8 @@
 
 /obj/item/mod/control/pre_equipped/responsory/engineer
 	insignia_type = /obj/item/mod/module/insignia/engineer
-	applied_modules = list(
-		/obj/item/mod/module/rad_protection,
-		/obj/item/mod/module/tether,
-		/obj/item/mod/module/magboot/advanced,
-	)
+	additional_module = /obj/item/mod/module/rad_protection
+	additional_module = /obj/item/mod/module/magboot/advanced
 	default_pins = list(
 		/obj/item/mod/module/magboot/advanced,
 	)

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -364,7 +364,14 @@
 
 /obj/item/mod/control/pre_equipped/responsory/engineer
 	insignia_type = /obj/item/mod/module/insignia/engineer
-	additional_module = /obj/item/mod/module/rad_protection
+	applied_modules = list(
+		/obj/item/mod/module/rad_protection,
+		/obj/item/mod/module/tether,
+		/obj/item/mod/module/magboot/advanced,
+	)
+	default_pins = list(
+		/obj/item/mod/module/magboot/advanced,
+	)
 
 /obj/item/mod/control/pre_equipped/responsory/medic
 	insignia_type = /obj/item/mod/module/insignia/medic

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -364,8 +364,16 @@
 
 /obj/item/mod/control/pre_equipped/responsory/engineer
 	insignia_type = /obj/item/mod/module/insignia/engineer
-	additional_module = /obj/item/mod/module/rad_protection
-	additional_module = /obj/item/mod/module/magboot/advanced
+	applied_modules = list(
+		/obj/item/mod/module/insignia/engineer,
+		/obj/item/mod/module/storage/large_capacity,
+		/obj/item/mod/module/welding,
+		/obj/item/mod/module/emp_shield,
+		/obj/item/mod/module/magnetic_harness,
+		/obj/item/mod/module/flashlight,
+		/obj/item/mod/module/magboot/advanced,
+		/obj/item/mod/module/rad_protection,
+	)
 	default_pins = list(
 		/obj/item/mod/module/magboot/advanced,
 	)


### PR DESCRIPTION
Added advanced magboots/tether to ERT engineer
## About The Pull Request
Adds advanced magboots and a tether to the ERT engineer's modsuit. 
I tested and it works.
## Why It's Good For The Game
Magboots is really important gear when working with the SM. 
These get the advanced kind since they're kind of rare and ERT modsuit gear is usually a cut above. I could downgrade if you want.
## Changelog
:cl:
add: ERT engineers now come with advanced magboot modules.

/:cl:
