### PR TITLE
added botanical belt to botanist lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -11,3 +11,4 @@
 	new /obj/item/cultivator(src)
 	new /obj/item/hatchet(src)
 	new /obj/item/secateurs(src)
+	new /obj/item/storage/belt/plant(src)


### PR DESCRIPTION

## About The Pull Request

Adds botanical belts into the hydroponics lockers at roundstart.
## Why It's Good For The Game

Botanists are shoving tools in their bags and it's not well known enough that you can create a belt early, up for debate but this was literally just one line so I made the PR
## Changelog
:cl:
qol: added a botanical belt into all hydroponics lockers
/:cl:
