### PR TITLE
Adds the Coroner vendor to the desc of its supply pack

### DIFF
--- a/code/modules/cargo/packs/vending_restock.dm
+++ b/code/modules/cargo/packs/vending_restock.dm
@@ -187,7 +187,7 @@
 /datum/supply_pack/vending/wardrobes/medical
 	name = "Medical Wardrobe Supply Crate"
 	desc = "This crate contains refills for the MediDrobe, \
-		ChemDrobe, and ViroDrobe."
+		ChemDrobe, ViroDrobe, and MortiDrobe."
 	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/vending_refill/wardrobe/medi_wardrobe,
 					/obj/item/vending_refill/wardrobe/chem_wardrobe,


### PR DESCRIPTION
## About The Pull Request

Forgot to add the MortiDrobe to the description of the pack when adding its refill canister, this is a minor fix.

## Why It's Good For The Game

Minor fix to the pack description.

## Changelog

:cl:
spellcheck: The Medical vending refill crate's description now properly displays the Coroner's vendor as being part of its contents.
/:cl: