### PR TITLE
Fixes Minor Grammar Issue in PAI Card Suicide

### DIFF
--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -69,7 +69,7 @@
 	SSpai.pai_card_list += src
 
 /obj/item/pai_card/suicide_act(mob/living/user)
-	user.visible_message(span_suicide("[user] is staring sadly at [src]! [user.p_they()] can't keep living without real human intimacy!"))
+	user.visible_message(span_suicide("[user] is staring sadly at [src]! [user.p_they(TRUE)] can't keep living without real human intimacy!"))
 	return OXYLOSS
 
 /obj/item/pai_card/update_overlays()


### PR DESCRIPTION

## About The Pull Request
Before:
<img src="https://i.ibb.co/MSXky10/PAISuicide-Before.png" alt="PAISuicide-Before" border="0">
After:
<img src="https://i.ibb.co/HhN4kp7/PAISuicide-After.png" alt="PAISuicide-After" border="0">

Exclamation mark means new sentence which needs a capital letter. This changes the pronoun helper in the 2nd sentence to be capitalised.
## Why It's Good For The Game
Minor grammar issues getting fixed is good.
## Changelog
Too small a change for a CL entry
