### PR TITLE
Multiplicative armour penetration.

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -11,7 +11,7 @@
 
 	//the if "armor" check is because this is used for everything on /living, including humans
 	if(armour_penetration)
-		our_armor = max(0, our_armor - armour_penetration)
+		our_armor = armour_penetration == 100 ? 0 : 100 * max(our_armor - armour_penetration, 0) / (100 - armour_penetration)
 		if(penetrated_text)
 			to_chat(src, span_userdanger("[penetrated_text]"))
 		else


### PR DESCRIPTION

## About The Pull Request
Basically #71396 but for armour penetration. The formula gets changed to be the inverse function of stacking armour. An example is if you had 75% armour. That is equivalent to having two sets of 50% armour stacked. If the armour wearer gets hit by a 50% armour penetrating force, it is the same as losing a piece of armour worth 50%, knocking the 75% protection down to a 50% protection, instead of 25%.
## Why It's Good For The Game
Makes it more consistent with how armour stacking works. It also lets very strong armour be less fragile to small armour penetration. Kinda silly for 90% armour value to be half as effective if it gets hit by 10% armour penetration. This also allows it to be much easier to balance lavaland armour and fauna piercing, allowing fauna to pierce through crew armour while still letting mining armour have significant protection. That isn't included in this balance change, but it allows the option for someone to do that without changing any armour values.
## Changelog
:cl:
balance: Armour penetration calculation is now the inverse function of armour stacking.
/:cl:
