### PR TITLE
Machine's correctly eject signaller's attached to it's wires

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -197,7 +197,6 @@
 	if(S && istype(S))
 		assemblies -= color
 		S.on_detach()		// Notify the assembly.  This should remove the reference to our holder
-		S.forceMove(holder.drop_location())
 		return S
 
 /// Called from [/atom/proc/emp_act]

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -188,6 +188,14 @@
 	if(S && istype(S) && S.attachable && !is_attached(color))
 		assemblies[color] = S
 		S.forceMove(holder)
+		/**
+		 * special snowflake check for machines
+		 * someone attached a signaler to the machines wires
+		 * move it to the machines component parts so it does't get moved out in dump_inventory_contents() which get's called a lot
+		 */
+		if(istype(holder, /obj/machinery))
+			var/obj/machinery/machine = holder
+			LAZYADD(machine.component_parts, S)
 		S.connected = src
 		S.on_attach() // Notify assembly that it is attached
 		return S

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -64,7 +64,12 @@
 
 /datum/wires/Destroy()
 	holder = null
-	assemblies = list()
+	//properly clear refs to avoid harddels & other problems
+	for(var/color in assemblies)
+		var/obj/item/assembly/assembly = assemblies[color]
+		assembly.holder = null
+		assembly.connected = null
+	LAZYCLEARLIST(assemblies)
 	return ..()
 
 /datum/wires/proc/add_duds(duds)

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -191,7 +191,7 @@
 		/**
 		 * special snowflake check for machines
 		 * someone attached a signaler to the machines wires
-		 * move it to the machines component parts so it does't get moved out in dump_inventory_contents() which get's called a lot
+		 * move it to the machines component parts so it doesn't get moved out in dump_inventory_contents() which gets called a lot
 		 */
 		if(istype(holder, /obj/machinery))
 			var/obj/machinery/machine = holder

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -1112,6 +1112,15 @@
 		power -= power * 0.0005
 	return ..()
 
+/obj/machinery/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	. = ..()
+	/**
+	 * someone attached a signaler to the machines wires
+	 * move it to the machines component parts so it does't get moved out in dump_inventory_contents() which get's called a lot
+	 */
+	if(istype(arrived, /obj/item/assembly))
+		component_parts += arrived
+
 /obj/machinery/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(gone == occupant)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -1112,15 +1112,6 @@
 		power -= power * 0.0005
 	return ..()
 
-/obj/machinery/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
-	. = ..()
-	/**
-	 * someone attached a signaler to the machines wires
-	 * move it to the machines component parts so it does't get moved out in dump_inventory_contents() which get's called a lot
-	 */
-	if(istype(arrived, /obj/item/assembly))
-		component_parts += arrived
-
 /obj/machinery/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(gone == occupant)


### PR DESCRIPTION
## About The Pull Request

Fixes #72053
the signaller is made part of the machine's `component_parts` now so it doesn't get moved out when `dump_inventory_contents()` is called like in the case of microwave when it has finished cooking
This fix also applies for other machine's that call this proc

Fixes #72132
Clear's out the `holder` & `connected` vars from the signaller when the wire's get destroyed allowing the signaller to be picked up

## Changelog
:cl:
fix: microwave's(after it has finished cooking) & other machine's that spit out contents don't spit out assemblies/signallers attached to it's wires.
fix: signallers can be picked up if you attached them to a machine's wire & later deconstructed that machine without detaching it first.
/:cl: