### PR TITLE
Makes sure body position y offset is updated if resized [NO GBP]

### DIFF
--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -2,6 +2,9 @@
 /// Called whenever the mob is to be resized or when lying/standing up for carbons.
 /mob/living/update_transform(resize = RESIZE_DEFAULT_SIZE)
 	perform_update_transform(resize) // carbon mobs do it differently than silicons and simple animals.
+	//Make sure the body position y offset is updated if resized.
+	if(resize != RESIZE_DEFAULT_SIZE && body_position == STANDING_UP)
+		body_position_pixel_y_offset = (current_size-1) * world.icon_size/2
 	SEND_SIGNAL(src, COMSIG_LIVING_POST_UPDATE_TRANSFORM) // ...and we want the signal to be sent last.
 
 /mob/living/proc/perform_update_transform(resize = RESIZE_DEFAULT_SIZE)


### PR DESCRIPTION
## About The Pull Request
So far, the offset is updated only when the user is lying down or standing up, woops.

## Why It's Good For The Game
See the title.

## Changelog

:cl:
fix: Fixed a small issue with mob resizing not promptly updating a body offset variable.
/:cl:
