### PR TITLE
Emit a stacktrace on the creation of zero volume gas mixtures

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -40,8 +40,10 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 
 /datum/gas_mixture/New(volume)
 	gases = new
-	if (!isnull(volume))
+	if(!isnull(volume))
 		src.volume = volume
+	if(src.volume <= 0)
+		stack_trace("Created a gas mixture with zero volume!")
 	reaction_results = new
 
 //listmos procs

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -239,9 +239,8 @@
 
 	var/total_thermal_energy = 0
 	var/total_heat_capacity = 0
-	var/datum/gas_mixture/total_gas_mixture = new(0)
 
-	var/list/total_gases = total_gas_mixture.gases
+	var/list/total_gases = list()
 
 	var/volume_sum = 0
 
@@ -270,11 +269,13 @@
 		total_heat_capacity += heat_capacity
 		total_thermal_energy += gas_mixture.temperature * heat_capacity
 
-	total_gas_mixture.temperature = total_heat_capacity ? (total_thermal_energy / total_heat_capacity) : 0
-	total_gas_mixture.volume = volume_sum
-	total_gas_mixture.garbage_collect()
+	if(volume_sum == 0)
+		return
 
-	if(total_gas_mixture.volume > 0)
-		//Update individual gas_mixtures by volume ratio
-		for(var/datum/gas_mixture/gas_mixture as anything in gas_mixture_list)
-			gas_mixture.copy_from_ratio(total_gas_mixture, gas_mixture.volume / volume_sum)
+	var/datum/gas_mixture/total_gas_mixture = new(volume_sum)
+	total_gas_mixture.temperature = total_heat_capacity ? (total_thermal_energy / total_heat_capacity) : 0
+	total_gas_mixture.gases = total_gases
+
+	//Update individual gas_mixtures by volume ratio
+	for(var/datum/gas_mixture/gas_mixture as anything in gas_mixture_list)
+		gas_mixture.copy_from_ratio(total_gas_mixture, gas_mixture.volume / volume_sum)


### PR DESCRIPTION
Almost all of the logic used for gas mixtures does not work if they have zero volume.

I don't want this to cause a breakdown in atmos so all I'm having it do it throw a stack trace, but this should make it much easier in the future to figure out where atmos problems are coming from.

I've also changed pipenet reconciliation to not use a zero volume gas mixture, and instead only create the gas mixture after calculating what the volume should be