### PR TITLE
Air Meters check for a null target

### DIFF
--- a/code/modules/atmospherics/machinery/other/meter.dm
+++ b/code/modules/atmospherics/machinery/other/meter.dm
@@ -62,8 +62,8 @@
 	return target?.return_air() || ..()
 
 /obj/machinery/meter/process_atmos()
-	var/datum/gas_mixture/pipe_air = target.return_air()
-	if(!pipe_air)
+	var/datum/gas_mixture/pipe_air = target?.return_air()
+	if(isnull(pipe_air))
 		icon_state = "meter0"
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request

Meters can have a null target if the pipe below them is destroyed or removed; or if mappers fuck up.
## Why It's Good For The Game

Prevents runtimes
## Changelog
