### PR TITLE
Removes the infinite, super cold hypernoblium from the Winter Wonderland holodeck setting

### DIFF
--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -172,7 +172,6 @@
 	icon = 'icons/turf/snow.dmi'
 	icon_state = "snow"
 	slowdown = 2
-	initial_gas_mix = SPACE_TEMP_NOBLIUM
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = null
 	tiled_dirt = FALSE


### PR DESCRIPTION
## About The Pull Request

Removes the infinite, super cold hypernoblium from the Winter Wonderland holodeck setting. How did it get there?

## Why It's Good For The Game

This is absolutely a mistake. It allows infinite harvest of a rare gas in insane quantities and can (extremely easily, mind) destroy the entire station's air by making it the minimum possible temp. (Genuinely, how did this get into the game?)

## Changelog
:cl: Licks-the-Crystal
fix: Removes the infinite hypernoblium from the holodeck's Winter Wonderland setting.
/:cl:
