### PR TITLE
Makes transparent kudzu transparent on spawn, not on vine growth

### DIFF
--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -214,7 +214,7 @@
 	quality = POSITIVE
 	severity = SEVERITY_TRIVIAL
 
-/datum/spacevine_mutation/transparency/on_grow(obj/structure/spacevine/holder)
+/datum/spacevine_mutation/transparency/on_birth(obj/structure/spacevine/holder)
 	holder.light_state = PASS_LIGHT
 	holder.alpha = 125
 


### PR DESCRIPTION
## About The Pull Request
Makes transparent kudzu transparent on spawn, not on vine growth. Currently, they only become transparent after growing in place and not after mutating, as it should. Timid allows this, as timid is low to the ground - why shouldn't transparent vines?

## Why It's Good For The Game
Transparent vines should be transparent. Transparent is currently the only mutation that can't be immediately identified by it's change in appearance; this puts it back in line with the rest. It also blocks sight until growth, which makes its viability for positive kudzu questionable when Timid does everything it can but better. Closes #72660

## Changelog
:cl: Licks-The-Crystal
qol: Makes transparent kudzu transparent (and won't block sight)
/:cl:
