### PR TITLE
removes the slowdown from the security tider pack

### DIFF
--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -181,6 +181,7 @@
 	inhand_icon_state = "pepperbackpacksec"
 	custom_price = PAYCHECK_CREW * 2
 	volume = 1000
+	slowdown = 0
 
 /obj/item/watertank/pepperspray/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

removes the slowdown from the security tider pack

## Why It's Good For The Game

the tider pack is a very funny tool made obsolete that its locked behind a high price, takes up your back slot, and has a large slowdown effect while equipped. removing the slowdown may let us see them more.

## Changelog


:cl:
balance: removed slowdown from tider pack
/:cl:
