### PR TITLE
Map adjustment to northstars Xeno Pen and treatment center. 

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -28420,8 +28420,8 @@
 	req_access = list("medical")
 	},
 /obj/machinery/light_switch/directional/west{
-	pixel_y = -10;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = -10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
@@ -35470,8 +35470,8 @@
 "jlq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/toy/plush/lizard_plushie/green{
-	name = "Bites-The-Wires";
-	desc = "A stuffed toy which resembles a wayward Ashlander. This one fills you with hope for the future."
+	desc = "A stuffed toy which resembles a wayward Ashlander. This one fills you with hope for the future.";
+	name = "Bites-The-Wires"
 	},
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 10
@@ -47268,8 +47268,8 @@
 	dir = 8
 	},
 /obj/item/toy/plush/beeplushie{
-	name = "Bee Haave";
-	desc = "A cute bee toy to calm down hysteric patients."
+	desc = "A cute bee toy to calm down hysteric patients.";
+	name = "Bee Haave"
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
@@ -59894,8 +59894,8 @@
 "pvT" = (
 /obj/structure/rack,
 /obj/item/toy/plush/plasmamanplushie{
-	name = "Nitrous II";
-	desc = "A stuffed toy that resembles your plasma coworkers. It is cute despite itself."
+	desc = "A stuffed toy that resembles your plasma coworkers. It is cute despite itself.";
+	name = "Nitrous II"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/fore)
@@ -60002,9 +60002,6 @@
 "pxz" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/railing{
 	dir = 5
 	},
@@ -71995,9 +71992,6 @@
 "sIf" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/railing{
 	dir = 6
 	},
@@ -75807,8 +75801,8 @@
 	req_access = list("medical")
 	},
 /obj/machinery/light_switch/directional/west{
-	pixel_y = -10;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = -10
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -29725,10 +29725,6 @@
 "hJy" = (
 /turf/closed/wall,
 /area/station/maintenance/floor1/port/fore)
-"hJB" = (
-/obj/machinery/light/small/directional/south,
-/turf/closed/wall,
-/area/station/medical/paramedic)
 "hJC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -196797,7 +196793,7 @@ kMN
 tEe
 fYt
 rYI
-hJB
+sRR
 qPu
 sEl
 vOo


### PR DESCRIPTION


## About The Pull Request

Uhhhh, there were a vent and scrubber in the xeno pen, I believe there was a mistake where it was believed that players would not be able to crawl into vents with blast doors being in the way. Players were able to use the alt-click menu to do so. This PR amends this by removing the vent/scrubber combo.

There was also a light bulb in the middle of a wall in the treatment center, removed it just to make things nice.

## Why It's Good For The Game

This won't happen anymore.

![drake, where does the vent go](https://github.com/tgstation/tgstation/assets/16896032/dd129465-f596-472a-94a1-84a631b038d4)

## Changelog


:cl:
fix: Fixes a stuck lightbulb in medbay treatment center. Also fixes an accidental placement of vents/scrubbers which lead to escaping xenos.
/:cl: