### PR TITLE
Light replacer & item patches

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -100,7 +100,7 @@
 			return TRUE
 
 		//insert light. display message only if adding a shard did not create a new bulb else the messages will conflict
-		var/display_msg =TRUE
+		var/display_msg = TRUE
 		if(light_to_insert.status == LIGHT_OK)
 			add_uses(1)
 		else if(add_shard(user))
@@ -145,7 +145,7 @@
 				replaced_something = TRUE
 
 		if(!replaced_something)
-			if(src.uses == max_uses)
+			if(uses == max_uses)
 				to_chat(user, span_warning("\The [src] is full!"))
 			else
 				to_chat(user, span_warning("\The [storage_to_empty] contains no lights, glass sheets or shards."))

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -70,79 +70,89 @@
 
 /obj/item/lightreplacer/attackby(obj/item/insert, mob/user, params)
 	. = ..()
+	if(uses >= max_uses)
+		to_chat(user, span_warning("[src.name] is full."))
+		return TRUE
 
 	if(istype(insert, /obj/item/stack/sheet/glass))
 		var/obj/item/stack/sheet/glass/glass_to_insert = insert
-		if(uses >= max_uses)
-			to_chat(user, span_warning("[src.name] is full."))
-			return TRUE
-		else if(glass_to_insert.use(LIGHTBULB_COST))
+		if(glass_to_insert.use(LIGHTBULB_COST))
 			add_uses(GLASS_SHEET_USES)
-			to_chat(user, span_notice("You insert a piece of glass into \the [src.name]. You have [uses] light\s remaining."))
-			return TRUE
+			to_chat(user, span_notice("You insert a glass sheet into \the [src.name]. [status_string()]"))
 		else
-			to_chat(user, span_warning("You need one sheet of glass to replace lights!"))
+			to_chat(user, span_warning("You need [LIGHTBULB_COST] glass to replace lights!"))
+		return TRUE
 
-	if(istype(insert, /obj/item/shard))
-		if(uses >= max_uses)
-			to_chat(user, span_warning("\The [src] is full."))
-			return TRUE
+	if(insert.type == /obj/item/shard) //we don't want to insert plasma, titanium or other types of shards
 		if(!user.temporarilyRemoveItemFromInventory(insert))
+			to_chat(user, span_notice("[insert] is stuck in your hand!"))
 			return TRUE
-		add_uses(round(GLASS_SHEET_USES*0.75))
-		to_chat(user, span_notice("You insert a shard of glass into \the [src]. You have [uses] light\s remaining."))
+		if(!add_shard(user)) //add_shard will display a message if it created a bulb from the shard so only display message when that does not happen
+			to_chat(user, span_notice("You insert [insert] into \the [src]. [status_string()]"))
 		qdel(insert)
 		return TRUE
 
 	if(istype(insert, /obj/item/light))
 		var/obj/item/light/light_to_insert = insert
-		if(light_to_insert.status == 0) // LIGHT OKAY
-			if(uses < max_uses)
-				if(!user.temporarilyRemoveItemFromInventory(insert))
-					return TRUE
-				add_uses(1)
-				qdel(light_to_insert)
-		else
-			if(!user.temporarilyRemoveItemFromInventory(insert))
-				return TRUE
-			to_chat(user, span_notice("You insert [light_to_insert] into \the [src]."))
-			add_shards(1, user)
-			qdel(light_to_insert)
+		//remove from player's hand
+		if(!user.temporarilyRemoveItemFromInventory(light_to_insert))
+			to_chat(user, span_notice("[insert] is stuck in your hand!"))
+			return TRUE
+
+		//insert light. display message only if adding a shard did not create a new bulb else the messages will conflict
+		var/display_msg =TRUE
+		if(light_to_insert.status == LIGHT_OK)
+			add_uses(1)
+		else if(add_shard(user))
+			display_msg = FALSE
+		if(display_msg)
+			to_chat(user, span_notice("You insert [light_to_insert] into \the [src]. [status_string()]"))
+		qdel(light_to_insert)
+
 		return TRUE
 
 	if(istype(insert, /obj/item/storage))
-		var/obj/item/storage/storage_to_empty = insert
-		var/found_lightbulbs = FALSE
-		var/replaced_something = TRUE
+		var/replaced_something = FALSE
+		var/loaded = FALSE
 
+		var/obj/item/storage/storage_to_empty = insert
 		for(var/obj/item/item_to_check in storage_to_empty.contents)
-			if(!istype(item_to_check, /obj/item/light))
-				continue
-			var/obj/item/light/found_light = item_to_check
-			found_lightbulbs = TRUE
+			//reached max capacity during insertion
 			if(src.uses >= max_uses)
 				break
-			if(found_light.status == LIGHT_OK)
-				replaced_something = TRUE
-				add_uses(1)
-				qdel(found_light)
 
-			else if(found_light.status == LIGHT_BROKEN || found_light.status == LIGHT_BURNED)
-				replaced_something = TRUE
-				add_shards(1, user)
-				qdel(found_light)
+			//consume the item only if it's an light tube,bulb or shard
+			loaded = FALSE
+			if(istype(item_to_check, /obj/item/light))
+				var/obj/item/light/found_light = item_to_check
+				if(found_light.status == LIGHT_OK)
+					add_uses(1)
+				else
+					add_shard(user)
+				loaded = TRUE
+			else if(istype(item_to_check, /obj/item/stack/sheet/glass))
+				var/obj/item/stack/sheet/glass/glass_to_insert = item_to_check
+				if(glass_to_insert.use(LIGHTBULB_COST))
+					add_uses(GLASS_SHEET_USES)
+					loaded = TRUE
+			else if(item_to_check.type == /obj/item/shard)
+				add_shard(user)
+				loaded = TRUE
 
-		if(!found_lightbulbs)
-			to_chat(user, span_warning("\The [storage_to_empty] contains no bulbs."))
+			//if item was loaded delete it
+			if(loaded)
+				qdel(item_to_check)
+				replaced_something = TRUE
+
+		if(!replaced_something)
+			if(src.uses == max_uses)
+				to_chat(user, span_warning("\The [src] is full!"))
+			else
+				to_chat(user, span_warning("\The [storage_to_empty] contains no lights, glass sheets or shards."))
 			return TRUE
 
-		if(!replaced_something && src.uses == max_uses)
-			to_chat(user, span_warning("\The [src] is full!"))
-			return TRUE
-
-		to_chat(user, span_notice("You fill \the [src] with lights from \the [storage_to_empty]. " + status_string() + ""))
+		to_chat(user, span_notice("You fill \the [src] with lights from \the [storage_to_empty]. [status_string()]"))
 		return TRUE
-
 
 /obj/item/lightreplacer/emag_act()
 	if(obj_flags & EMAGGED)
@@ -162,14 +172,27 @@
 /obj/item/lightreplacer/vv_edit_var(vname, vval)
 	if(vname == NAMEOF(src, obj_flags))
 		update_appearance()
+	else if(vname == NAMEOF(src, uses))
+		uses = clamp(vval, 0, max_uses)
+		return TRUE
+	else if(vname == NAMEOF(src, max_uses))
+		if(vval <= 0)
+			return FALSE
+		max_uses = vval
+		uses = clamp(uses, 0, max_uses)
+		return TRUE
+	else if(vname == NAMEOF(src, bulb_shards))
+		if(vval <= 0)
+			return FALSE
+		add_uses(round(vval / BULB_SHARDS_REQUIRED))
+		bulb_shards = vval % BULB_SHARDS_REQUIRED
+		return TRUE
 	return ..()
-
 
 /obj/item/lightreplacer/attack_self(mob/user)
 	for(var/obj/machinery/light/target in user.loc)
 		replace_light(target, user)
 	to_chat(user, status_string())
-
 
 /**
  * attempts to fix lights, flood lights & lights on a turf
@@ -182,7 +205,7 @@
 	// if we are attacking an light fixture then replace it directly
 	if(istype(target, /obj/machinery/light))
 		if(replace_light(target, user) && bluespace_toggle)
-			user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
+			user.Beam(target, icon_state = "rped_upgrade", time = 0.5 SECONDS)
 			playsound(src, 'sound/items/pshoom.ogg', 40, 1)
 		return TRUE
 
@@ -192,7 +215,7 @@
 		if(frame.state == FLOODLIGHT_NEEDS_LIGHTS && Use(user))
 			new /obj/machinery/power/floodlight(frame.loc)
 			if(bluespace_toggle)
-				user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
+				user.Beam(target, icon_state = "rped_upgrade", time = 0.5 SECONDS)
 				playsound(src, 'sound/items/pshoom.ogg', 40, 1)
 			to_chat(user, span_notice("You finish \the [frame] with a light tube."))
 			qdel(frame)
@@ -205,7 +228,7 @@
 			if(replace_light(target_atom, user))
 				light_replaced = TRUE
 		if(light_replaced && bluespace_toggle)
-			user.Beam(target, icon_state = "rped_upgrade", time = 1 SECONDS)
+			user.Beam(target, icon_state = "rped_upgrade", time = 0.5 SECONDS)
 			playsound(src, 'sound/items/pshoom.ogg', 40, 1)
 		return TRUE
 
@@ -245,16 +268,15 @@
 /obj/item/lightreplacer/proc/add_uses(amount = 1)
 	uses = clamp(uses + amount, 0, max_uses)
 
-/obj/item/lightreplacer/proc/add_shards(amount = 1, user)
-	bulb_shards += amount
-	var/new_bulbs = round(bulb_shards / BULB_SHARDS_REQUIRED)
-	if(new_bulbs > 0)
-		add_uses(new_bulbs)
-	bulb_shards = bulb_shards % BULB_SHARDS_REQUIRED
-	if(new_bulbs != 0)
-		to_chat(user, span_notice("\The [src] fabricates a new bulb from the broken glass it has stored. It now has [uses] uses."))
+/obj/item/lightreplacer/proc/add_shard(user)
+	bulb_shards += 1
+	if(bulb_shards >= BULB_SHARDS_REQUIRED)
+		bulb_shards = 0
+		add_uses(1)
+		to_chat(user, span_notice("\The [src] fabricates a new bulb from the broken glass it has stored. [status_string()]"))
 		playsound(src.loc, 'sound/machines/ding.ogg', 50, TRUE)
-	return new_bulbs
+		return TRUE
+	return FALSE
 
 /obj/item/lightreplacer/proc/Charge(mob/user)
 	charge += 1
@@ -277,7 +299,7 @@
 
 	//remove any broken light on the fixture & add it as a shard
 	if(target.status != LIGHT_EMPTY)
-		add_shards(1, user)
+		add_shard(user)
 		target.status = LIGHT_EMPTY
 		target.update()
 	//create a copy of the light type & copy it's params onto the target

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -51,6 +51,9 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 
 /obj/item/stack/sheet/glass/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
+	if(istype(W, /obj/item/lightreplacer))
+		var/obj/item/lightreplacer/lightreplacer = W
+		lightreplacer.attackby(src, user)
 	if(istype(W, /obj/item/stack/cable_coil))
 		var/obj/item/stack/cable_coil/CC = W
 		if (get_amount() < 1 || CC.get_amount() < 5)

--- a/code/modules/power/lighting/light_items.dm
+++ b/code/modules/power/lighting/light_items.dm
@@ -20,8 +20,22 @@
 
 /obj/item/light/Initialize(mapload)
 	. = ..()
+	create_reagents(LIGHT_REAGENT_CAPACITY, INJECTABLE | DRAINABLE | SEALED_CONTAINER | TRANSPARENT)
+	AddComponent(/datum/component/caltrop, min_damage = force)
+	update_icon_state()
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
 	AddElement(/datum/element/update_icon_updates_onmob)
 	AddComponent(/datum/component/golem_food, golem_food_key = /obj/item/light, extra_validation = CALLBACK(src, PROC_REF(is_intact)))
+
+/obj/item/light/attackby(obj/item/attacking_item, mob/user, params)
+	. = ..()
+
+	if(istype(attacking_item, /obj/item/lightreplacer))
+		var/obj/item/lightreplacer/lightreplacer = attacking_item
+		lightreplacer.attackby(src, user)
 
 /// Returns true if bulb is intact
 /obj/item/light/proc/is_intact()
@@ -96,16 +110,6 @@
 			desc = "A burnt-out [name]."
 		if(LIGHT_BROKEN)
 			desc = "A broken [name]."
-
-/obj/item/light/Initialize(mapload)
-	. = ..()
-	create_reagents(LIGHT_REAGENT_CAPACITY, INJECTABLE | DRAINABLE | SEALED_CONTAINER | TRANSPARENT)
-	AddComponent(/datum/component/caltrop, min_damage = force)
-	update_icon_state()
-	var/static/list/loc_connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
-	)
-	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/item/light/proc/on_entered(datum/source, atom/movable/moving_atom)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request
Somehow this code break's every week, hopefully this should be the last

1. Fixes #75951
It wasn't just a problem with Jani Borg light replacer but the normal one's too. Now they all accept glass sheet's & light tubes (including broken one's) when you attack them with a light replacer and not just when you pick them up with hand (which Borg's can't do obviously) and then click them on the light replacer.
2. Glass sheet's & shard can be put inside backpack's or other storage item's and now they will all be consumed from the storage and not just light tubes & bulbs
3. Make's feedback message's more informative and display them for all insert event. they weren't displayed when a broken light tube was put in the light replacer
4. Only glass shards are accepted by the light replacer and not plasma, titanium shards etc. we should not use `istype()` for this purpose
5. Removed redundant` Initialize()` proc from `obj/item/light`
6. VV editing var's works properly
7. Blue beam for bluespace light replacer last's just 0.5 seconds so it doesn't look awkward

## Changelog
:cl:
fix: light replacer accepts glass sheets & light tubes when you attack them with a light replacer
fix: only glass shards can fill the light replacer not other shard types
qol: glass sheet's & shards inside storage items like backpacks are also consumed when you attack the light replacer with it
qol: feedback messages when inserting lights, glass sheet's, shards into the light replacer are more descriptive and displayed for all insert event's
qol: blue beam for bluespace light replacer last's just 0.5 seconds so it doesn't look awkward
refactor: renamed `add_shards()` to just `add_shard()` for adding 1 shard at a time
refactor: removed redundant` Initialize()` proc from `obj/item/light`
refactor: VV editing var's works properly
/:cl:
