### PR TITLE
Nuke Detonation now handles off-station detonation correctly. Now nukes the syndie base if detonated on the syndiebase.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -569,7 +569,9 @@ GLOBAL_VAR(station_nuke_source)
 	return detonation_status
 
 /obj/machinery/nuclearbomb/proc/really_actually_explode(detonation_status)
-	play_cinematic(get_cinematic_type(detonation_status), world, CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, station_explosion_detonation), src))
+	var/cinematic = get_cinematic_type(detonation_status)
+	if(!isnull(cinematic))
+		play_cinematic(cinematic, world, CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, station_explosion_detonation), src))
 
 	var/turf/bomb_location = get_turf(src)
 	var/list/z_levels_to_blow = list()

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -573,9 +573,6 @@ GLOBAL_VAR(station_nuke_source)
 	if(!isnull(cinematic))
 		play_cinematic(cinematic, world, CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, station_explosion_detonation), src))
 
-	var/turf/bomb_location = get_turf(src)
-	var/list/z_levels_to_blow = list()
-
 	var/drop_level = TRUE
 	switch(detonation_status)
 		if(DETONATION_HIT_STATION)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -573,16 +573,36 @@ GLOBAL_VAR(station_nuke_source)
 
 	var/turf/bomb_location = get_turf(src)
 	var/list/z_levels_to_blow = list()
-	if(detonation_status == DETONATION_HIT_STATION)
-		z_levels_to_blow |= SSmapping.levels_by_trait(ZTRAIT_STATION)
 
-	// Don't kill people in the station if the nuke missed, even if we are technically on the same z-level
-	else if(detonation_status != DETONATION_NEAR_MISSED_STATION)
-		z_levels_to_blow |= bomb_location.z
+	var/drop_level = TRUE
+	switch(detonation_status)
+		if(DETONATION_HIT_STATION)
+			nuke_effects(SSmapping.levels_by_trait(ZTRAIT_STATION))
+			drop_level = FALSE
 
-	if(length(z_levels_to_blow))
-		nuke_effects(z_levels_to_blow)
+		if(DETONATION_HIT_SYNDIE_BASE)
+			priority_announce(
+				"Long Range Scanners indicate that the nuclear device has detonated on a previously unknown base, we assume \
+				the base to be of Syndicate Origin. Good work crew.",
+				"Nuclear Operations Command",
+			)
 
+			var/datum/turf_reservation/syndicate_base = SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
+			ASYNC
+				for(var/turf/turf as anything in syndicate_base.reserved_turfs)
+					for(var/mob/living/about_to_explode in turf)
+						nuke_gib(about_to_explode, src)
+					CHECK_TICK
+
+		else
+			priority_announce(
+				"Long Range Scanners indicate that the nuclear device has detonated; however seismic activity on the station \
+				is minimal. We anticipate that the device has not detonated on the station itself.",
+				"Nuclear Operations Command",
+			)
+
+	if(drop_level)
+		SSsecurity_level.set_level(SEC_LEVEL_RED)
 	return TRUE
 
 /// Cause nuke effects to the passed z-levels.


### PR DESCRIPTION

## About The Pull Request

Title.
## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/73598
## Changelog
:cl:
add: Nuclear Detonation now drops security level if it missed the station.
add: Nuclear Detonation now nukes the syndie base if its on the syndie base.
fix: Nuclear Detonation now handles not playing a cinematic correctly.
refactor: Changed z level iteration for Nuclear Detonation
/:cl:
