### PR TITLE
Hidden nodes no longer become visible when copying them to another Techweb

### DIFF
--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -146,7 +146,7 @@
 /datum/techweb/proc/copy_research_to(datum/techweb/receiver) //Adds any missing research to theirs.
 	for(var/i in receiver.hidden_nodes)
 		CHECK_TICK
-		if(available_nodes[i] || researched_nodes[i] || visible_nodes[i])
+		if(get_available_nodes()[i] || get_researched_nodes()[i] || get_visible_nodes()[i])
 			receiver.hidden_nodes -= i //We can see it so let them see it too.
 	for(var/i in researched_nodes)
 		CHECK_TICK


### PR DESCRIPTION
## About The Pull Request

Copying techwebs did not take into account whether available/researched/visible nodes were hidden in the techweb being copied from, so copying a base techweb to another would reveal all the bepis tech modules that are available but hidden.
## Why It's Good For The Game

Pretty big cheat. Although you can't print disks any more there are Technology Disks lying around in science in most stations, so this still exploitable.
## Changelog
:cl:
fix: copying nodes from a techweb to another no longer reveals hidden nodes
/:cl:
