### PR TITLE
Creamy tomato soup, soup-free chili.

### DIFF
--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -551,7 +551,10 @@
 	drink_type = VEGETABLES | FRUIT // ??
 
 /datum/chemical_reaction/food/soup/tomatosoup
-	required_reagents = list(/datum/reagent/water = 50)
+	required_reagents = list(
+		/datum/reagent/water = 50,
+		/datum/reagent/consumable/cream = 5
+	)
 	required_ingredients = list(
 		/obj/item/food/grown/tomato = 2,
 	)

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -552,7 +552,7 @@
 
 /datum/chemical_reaction/food/soup/tomatosoup
 	required_reagents = list(
-		/datum/reagent/water = 50,
+		/datum/reagent/water = 45,
 		/datum/reagent/consumable/cream = 5
 	)
 	required_ingredients = list(

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -552,7 +552,7 @@
 
 /datum/chemical_reaction/food/soup/tomatosoup
 	required_reagents = list(
-		/datum/reagent/water = 45,
+		/datum/reagent/water = 50,
 		/datum/reagent/consumable/cream = 5
 	)
 	required_ingredients = list(


### PR DESCRIPTION
i tried to make chili and it made 50% tomato soup immersion RUINED
## About The Pull Request
Adds 5u of cream to the recipe for tomato soup. This means that tomatosoup is no longer produced as an unavoidable byproduct of all soup recipes that include a tomato when making more than one serving.
## Why It's Good For The Game
Fixes #75886 , makes soup tastier
## Changelog
:cl:
fix: Nanotrasen Cookery Command has ended the plague of staff complaining that their tomato dishes are just complicated forms of soup by redefining "tomato soup" to include a dash of cream.
/:cl:
