### PR TITLE
all logs are now externally formatted

### DIFF
--- a/code/modules/logging/log_category.dm
+++ b/code/modules/logging/log_category.dm
@@ -21,7 +21,7 @@
 	var/secret = FALSE
 
 	/// Whether the readable version of the log message is formatted internally instead of by rustg
-	var/internal_formatting = TRUE
+	var/internal_formatting = FALSE
 
 	/// List of log entries for this category
 	var/list/entries = list()


### PR DESCRIPTION
Internal formatting should only be used for logs that include their own timestamp or don't want one printed.

atm internal formatting does not add the continuation market to newlines which is an issue that is causing info leak of private loglines.

two logs that always used newlines were manually moved to external formatting in the original pr, this now makes that the default. a log type must have a valid reason to format internally now and specifically request this.

(None of this impacts json logs)

:cl:
server: fix logging infoleak from the lack of continuation markets on new lines.
/:cl:

