### PR TITLE
Autopopulate bank account ID when linking

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -638,7 +638,12 @@
 	if(loc != user)
 		to_chat(user, span_warning("You must be holding the ID to continue!"))
 		return FALSE
-	var/new_bank_id = tgui_input_number(user, "Enter your account ID number", "Account Reclamation", 111111, 999999, 111111)
+	var/list/user_memories = user.mind.memories
+	var/datum/memory/key/account/user_key = user_memories[/datum/memory/key/account]
+	var/user_account = 11111
+	if(!isnull(user_key))
+		user_account = user_key.remembered_id
+	var/new_bank_id = tgui_input_number(user, "Enter the account ID to associate with this card.", "Link Bank Account", user_account, 999999, 111111)
 	if(!new_bank_id || QDELETED(user) || QDELETED(src) || issilicon(user) || !alt_click_can_use_id(user) || loc != user)
 		return FALSE
 	if(registered_account?.account_id == new_bank_id)


### PR DESCRIPTION
## About The Pull Request

I have no idea how many times I've had to open memories to link my bank account to my ID.

## Why It's Good For The Game

Your mob has a memory, use it and fill in the dialog box!

## Changelog
:cl: LT3
qol: ID card linking now preloads your bank account number
/:cl:
