### PR TITLE
Burner can be crafted from any open container

### DIFF
--- a/code/datums/components/crafting/chemistry.dm
+++ b/code/datums/components/crafting/chemistry.dm
@@ -51,7 +51,7 @@
 	result = /obj/item/burner
 	time = 5 SECONDS
 	reqs = list(
-		/obj/item/reagent_containers/cup/beaker = 1,
+		/obj/item/reagent_containers/cup = 1,
 		/datum/reagent/consumable/ethanol = 15,
 		/obj/item/paper = 1,
 	)
@@ -62,7 +62,7 @@
 	result = /obj/item/burner/oil
 	time = 5 SECONDS
 	reqs = list(
-		/obj/item/reagent_containers/cup/beaker = 1,
+		/obj/item/reagent_containers/cup = 1,
 		/datum/reagent/fuel/oil = 15,
 		/obj/item/paper = 1,
 	)
@@ -73,7 +73,7 @@
 	result = /obj/item/burner/fuel
 	time = 5 SECONDS
 	reqs = list(
-		/obj/item/reagent_containers/cup/beaker = 1,
+		/obj/item/reagent_containers/cup = 1,
 		/datum/reagent/fuel = 15,
 		/obj/item/paper = 1,
 	)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -6,7 +6,7 @@
 	reagent_flags = OPENCONTAINER | DUNKABLE
 	spillable = TRUE
 	resistance_flags = ACID_PROOF
-
+	icon_state = "bottle"
 	lefthand_file = 'icons/mob/inhands/items/drinks_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/drinks_righthand.dmi'
 

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -1,5 +1,5 @@
 /obj/item/reagent_containers/cup
-	name = "glass"
+	name = "open container"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50)
 	volume = 50

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -5,7 +5,7 @@
 	name = "drink"
 	desc = "yummy"
 	icon = 'icons/obj/drinks/drinks.dmi'
-	icon_state = null
+	icon_state = "glass_empty"
 	possible_transfer_amounts = list(5,10,15,20,25,30,50)
 	resistance_flags = NONE
 

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -9,6 +9,7 @@
 /obj/item/reagent_containers/cup/soda_cans
 	name = "soda can"
 	icon = 'icons/obj/drinks/soda.dmi'
+	icon_state = "cola"
 	icon_state_preview = "cola"
 	reagent_flags = NONE
 	spillable = FALSE


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/3625094/042ef40c-512f-40c5-8e65-a7dc842108fd)

## About The Pull Request

Expands the options for making burners (makeshift igniters) by requiring any open container (bottles, cans, cups) instead of beaker subtypes.

## Why It's Good For The Game

Makes ghetto recipe a bit more ghetto-friendly

## Changelog
:cl:
qol: Chemical burner can be crafted from any open container, not just beakers
/:cl:

