### PR TITLE
The destabilization of your eigenstate can no longer be paused by stripping naked

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -356,7 +356,7 @@
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = null
 
-#define EIGENSTASIUM_MAX_BUFFER -250
+#define EIGENSTASIUM_MAX_BUFFER -251
 #define EIGENSTASIUM_STABILISATION_RATE 5
 #define EIGENSTASIUM_PHASE_1_END 50
 #define EIGENSTASIUM_PHASE_2_END 80
@@ -417,6 +417,10 @@
 		return
 	stable_message = FALSE
 
+	
+	//Increment cycle
+	current_cycle++ //needs to be done here because phase 2 can early return
+
 	//These run on specific cycles
 	switch(current_cycle)
 		if(0)
@@ -446,12 +450,13 @@
 					continue
 				items.Add(item)
 
-			if(LAZYLEN(items))
-				var/obj/item/item = pick(items)
-				owner.dropItemToGround(item, TRUE)
-				do_sparks(5,FALSE,item)
-				do_teleport(item, get_turf(item), 3, no_effects=TRUE);
-				do_sparks(5,FALSE,item)
+			if(!LAZYLEN(items))
+				return ..()
+			var/obj/item/item = pick(items)
+			owner.dropItemToGround(item, TRUE)
+			do_sparks(5,FALSE,item)
+			do_teleport(item, get_turf(item), 3, no_effects=TRUE);
+			do_sparks(5,FALSE,item)
 
 		//phase 3 - little break to get your items
 		if(EIGENSTASIUM_PHASE_3_START to EIGENSTASIUM_PHASE_3_END)
@@ -508,9 +513,6 @@
 				human_species.randomize_active_underwear(human_mob)
 
 			owner.remove_status_effect(/datum/status_effect/eigenstasium)
-
-	//Finally increment cycle
-	current_cycle++
 
 /datum/status_effect/eigenstasium/proc/remove_clone_from_var()
 	SIGNAL_HANDLER

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -446,13 +446,12 @@
 					continue
 				items.Add(item)
 
-			if(!LAZYLEN(items))
-				return ..()
-			var/obj/item/item = pick(items)
-			owner.dropItemToGround(item, TRUE)
-			do_sparks(5,FALSE,item)
-			do_teleport(item, get_turf(item), 3, no_effects=TRUE);
-			do_sparks(5,FALSE,item)
+			if(LAZYLEN(items))
+				var/obj/item/item = pick(items)
+				owner.dropItemToGround(item, TRUE)
+				do_sparks(5,FALSE,item)
+				do_teleport(item, get_turf(item), 3, no_effects=TRUE);
+				do_sparks(5,FALSE,item)
 
 		//phase 3 - little break to get your items
 		if(EIGENSTASIUM_PHASE_3_START to EIGENSTASIUM_PHASE_3_END)


### PR DESCRIPTION
## About The Pull Request

The destabilization of your eigenstate can no longer be paused by stripping naked.

## Why It's Good For The Game

one of the stages of the eigenstasium od's status effect is causing your items to teleport off of you

this early returned out if you had no items to teleport off of yourself

and it did this before the line of code that increments the status effect's progress counter

so if you had no items to teleport, you'd never progress to the later stages of the status effect

## Changelog

:cl: ATHATH
fix: The destabilization of your eigenstate can no longer be paused by stripping naked.
/:cl: