### PR TITLE
Fixes space dragon hitting the same target multiple times in a single fire breath stream.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -273,6 +273,8 @@
 	playsound(get_turf(src),'sound/magic/fireball.ogg', 200, TRUE)
 	var/range = 20
 	var/list/turfs = list()
+	var/list/hit_list_parameter = list()
+	hit_list_parameter += src
 	turfs = line_target(0, range, at)
 	var/delayFire = -1.0
 	for(var/turf/T in turfs)
@@ -284,7 +286,7 @@
 			if(D.density)
 				return
 		delayFire += 1.0
-		addtimer(CALLBACK(src, PROC_REF(dragon_fire_line), T), delayFire)
+		addtimer(CALLBACK(src, PROC_REF(dragon_fire_line), T, hit_list_parameter), delayFire)
 
 /**
  * What occurs on each tile to actually create the fire.
@@ -294,10 +296,9 @@
  * It can only hit any given target once.
  * Arguments:
  * * turf/T - The turf to trigger the effects on.
+ * * list/hit_list - The list of targets that have already been hit in the fire_stream.
  */
-/mob/living/simple_animal/hostile/space_dragon/proc/dragon_fire_line(turf/fire_turf)
-	var/list/hit_list = list()
-	hit_list += src
+/mob/living/simple_animal/hostile/space_dragon/proc/dragon_fire_line(turf/fire_turf, list/hit_list)
 	new /obj/effect/hotspot(fire_turf)
 	fire_turf.hotspot_expose(700,50,1)
 	for(var/mob/living/living_target in fire_turf.contents)

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -273,8 +273,7 @@
 	playsound(get_turf(src),'sound/magic/fireball.ogg', 200, TRUE)
 	var/range = 20
 	var/list/turfs = list()
-	var/list/hit_list_parameter = list()
-	hit_list_parameter += src
+	var/list/hit_list_parameter = list(src)
 	turfs = line_target(0, range, at)
 	var/delayFire = -1.0
 	for(var/turf/T in turfs)


### PR DESCRIPTION
Moves the scope of the hit_list to the fire_stream proc. It gets passed as a parameter that the other proc accesses instead of creating a new list for everybturf.
## About The Pull Request
Moves the scope of the hit_list to the fire breath rather than creating a new list for every turf action.

This is an untested webedit. I'll test this later.
## Why It's Good For The Game
Closes #75930 
## Changelog
:cl:
fix: Fix space dragon fire breath hitting the same target multiple times in a single stream.
/:cl:
