### PR TITLE
Fixes hungover closet spawner?

### DIFF
--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -549,12 +549,13 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 	icon_state = "hangover_spawn_closet"
 
 /obj/effect/landmark/start/hangover/closet/JoinPlayerHere(mob/joining_mob, buckle)
-	make_hungover(joining_mob)
 	for(var/obj/structure/closet/closet in get_turf(src))
 		if(closet.opened)
 			continue
 		joining_mob.forceMove(closet)
+		make_hungover(joining_mob)
 		return
+
 	return ..() //Call parent as fallback
 
 //Landmark that creates destinations for the navigate verb to path to

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -550,7 +550,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 
 /obj/effect/landmark/start/hangover/closet/JoinPlayerHere(mob/joining_mob, buckle)
 	make_hungover(joining_mob)
-	for(var/obj/structure/closet/closet in contents)
+	for(var/obj/structure/closet/closet in get_turf(src))
 		if(closet.opened)
 			continue
 		joining_mob.forceMove(closet)


### PR DESCRIPTION
## About The Pull Request

I don't have proof this is bugged, but does anyone have any memory of this actually working?

`in contents` doesn't work? It's a landmark? There are no closets in the contents of the landmark? Surely it should be looking at the contents of the turf?

## Why It's Good For The Game

Makes this thing work? 

## Changelog

:cl: Melbert
fix: Fix hungover people never spawning stuck in closets
/:cl:
