### PR TITLE
Standardizes deleting components on Initialize()

### DIFF
--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -2,8 +2,10 @@
 /// `parent` must not be modified if this is to be returned.
 /// This will be noted in the runtime logs
 #define COMPONENT_INCOMPATIBLE 1
+/// Like COMPONENT_INCOMPATIBLE, but it deletes the component without creating a log
+#define COMPONENT_DELETE 2
 /// Returned in PostTransfer to prevent transfer, similar to `COMPONENT_INCOMPATIBLE`
-#define COMPONENT_NOTRANSFER 2
+#define COMPONENT_NOTRANSFER 3
 
 /// Return value to cancel attaching
 #define ELEMENT_INCOMPATIBLE 1

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -458,6 +458,7 @@
 			CRASH("Incompatible [c_type] transfer attempt to a [type]!")
 		if(COMPONENT_DELETE)
 			qdel(target)
+			return
 
 	if(target == AddComponent(target))
 		target._JoinParent()

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -52,10 +52,14 @@
 /datum/component/New(list/raw_args)
 	parent = raw_args[1]
 	var/list/arguments = raw_args.Copy(2)
-	if(Initialize(arglist(arguments)) == COMPONENT_INCOMPATIBLE)
-		stack_trace("Incompatible [type] assigned to a [parent.type]! args: [json_encode(arguments)]")
-		qdel(src, TRUE, TRUE)
-		return
+	switch(Initialize(arglist(arguments)))
+		if(COMPONENT_INCOMPATIBLE)
+			stack_trace("Incompatible [type] assigned to a [parent.type]! args: [json_encode(arguments)]")
+			qdel(src, TRUE, TRUE)
+			return
+		if(COMPONENT_DELETE)
+			qdel(src, TRUE, TRUE)
+			return
 
 	_JoinParent(parent)
 
@@ -452,6 +456,8 @@
 			var/c_type = target.type
 			qdel(target)
 			CRASH("Incompatible [c_type] transfer attempt to a [type]!")
+		if(COMPONENT_DELETE)
+			qdel(target)
 
 	if(target == AddComponent(target))
 		target._JoinParent()

--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -29,13 +29,15 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 /datum/component/acid/Initialize(acid_power = ACID_POWER_MELT_TURF, acid_volume = 50, acid_overlay = GLOB.acid_overlay)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
+
 	//not incompatible, but pointless
 	var/atom/atom_parent = parent
 	if((acid_power) <= 0 || (acid_volume <= 0))
 		stack_trace("Acid component added to an atom ([atom_parent.type]) with insufficient acid power ([acid_power]) or acid volume ([acid_volume]).")
-		qdel(src)
-		return
-
+		return COMPONENT_DELETE
+	if(atom_parent.resistance_flags & UNACIDABLE)
+		stack_trace("Acid component added to an atom ([atom_parent.type]) with UNACIDABLE resistance_flag.")
+		return COMPONENT_DELETE
 
 	if(isliving(parent))
 		max_volume = MOB_ACID_VOLUME_MAX
@@ -45,11 +47,6 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		process_effect = CALLBACK(src, PROC_REF(process_turf), parent)
 	//if we failed all other checks, we must be an /atom/movable that uses integrity
 	else if(atom_parent.uses_integrity)
-		// The parent object cannot have acid. Not incompatible, but should not really happen.
-		if(atom_parent.resistance_flags & UNACIDABLE)
-			qdel(src)
-			return
-
 		max_volume = MOVABLE_ACID_VOLUME_MAX
 		process_effect = CALLBACK(src, PROC_REF(process_movable), parent)
 	//or not...

--- a/code/datums/components/burning.dm
+++ b/code/datums/components/burning.dm
@@ -18,10 +18,11 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(!atom_parent.uses_integrity)
 		stack_trace("Tried to add /datum/component/burning to an atom ([atom_parent.type]) that does not use atom_integrity!")
 		return COMPONENT_INCOMPATIBLE
+
 	// only flammable atoms should have this component, but it's not really an error if we try to apply this to a non flammable one
 	if(!(atom_parent.resistance_flags & FLAMMABLE) || (atom_parent.resistance_flags & FIRE_PROOF))
-		qdel(src)
-		return
+		return COMPONENT_DELETE
+
 	src.fire_overlay = fire_overlay
 	if(fire_particles)
 		// burning particles look pretty bad when they stack on mobs, so that behavior is not wanted for items

--- a/code/datums/components/irradiated.dm
+++ b/code/datums/components/irradiated.dm
@@ -28,8 +28,7 @@
 
 	// This isn't incompatible, it's just wrong
 	if (HAS_TRAIT(parent, TRAIT_RADIMMUNE))
-		qdel(src)
-		return
+		return COMPONENT_DELETE
 
 	ADD_TRAIT(parent, TRAIT_IRRADIATED, REF(src))
 

--- a/code/datums/components/phylactery.dm
+++ b/code/datums/components/phylactery.dm
@@ -35,7 +35,7 @@
 
 	if(isnull(lich_mind))
 		stack_trace("A [type] was created with no target lich mind!")
-		return COMPONENT_INCOMPATIBLE
+		return COMPONENT_DELETE
 
 	src.lich_mind = lich_mind
 	src.base_respawn_time = base_respawn_time

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -30,7 +30,7 @@
 		var/mob/living/living_parent = parent
 		//I think this can break in cases where someone becomes a robot post death, but I uh, I don't know how to account for that
 		if(!(living_parent.mob_biotypes & (MOB_ORGANIC|MOB_UNDEAD)))
-			return COMPONENT_INCOMPATIBLE
+			return COMPONENT_DELETE
 
 	start_delay = delay
 	scaling_delay = scaling

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -36,10 +36,10 @@
 /datum/component/thermite/Initialize(amount = 50, thermite_overlay = default_thermite_overlay)
 	if(!isturf(parent))
 		return COMPONENT_INCOMPATIBLE
+
 	//not actually incompatible, but not valid
 	if(blacklist[parent.type])
-		qdel(src)
-		return
+		return COMPONENT_DELETE
 
 	if(immunelist[parent.type])
 		src.amount = 0 //Yeah the overlay can still go on it and be cleaned but you arent burning down a diamond wall


### PR DESCRIPTION
## About The Pull Request

Adds COMPONENT_DELETE return value, which is the same as COMPONENT_INCOMPATIBLE but it just deletes the component without creating the standard error log - Useful if you want to create a custom error log, or just not create any at all.
Makes all the qdel(src) cases on component Initialize() I could find use this return value.

## Why It's Good For The Game

Professionals have standards (?)

## Changelog

nah