### PR TITLE
Stops particle holders from appearing on context menu

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -182,7 +182,7 @@
 	update_particles()
 
 /datum/status_effect/fire_handler/fire_stacks/update_particles()
-	if(on_fire && (stacks > 0))
+	if(on_fire)
 		if(!particle_effect)
 			particle_effect = new(owner, /particles/embers)
 		if(stacks > MOB_BIG_FIRE_STACK_THRESHOLD)

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -91,7 +91,9 @@
 
 /**
  * Updates the particles for the status effects
+ * Should be handled by subtypes!
  */
+
 /datum/status_effect/fire_handler/proc/update_particles()
 	SHOULD_CALL_PARENT(FALSE)
 
@@ -180,7 +182,7 @@
 	update_particles()
 
 /datum/status_effect/fire_handler/fire_stacks/update_particles()
-	if(on_fire)
+	if(on_fire && (stacks > 0))
 		if(!particle_effect)
 			particle_effect = new(owner, /particles/embers)
 		if(stacks > MOB_BIG_FIRE_STACK_THRESHOLD)

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -16,7 +16,8 @@
 	var/list/override_types
 	/// For how much firestacks does one our stack count
 	var/stack_modifier = 1
-	/// A particle effect, for things like embers
+
+	/// A particle effect, for things like embers - Should be set on update_particles()
 	var/obj/effect/abstract/particle_holder/particle_effect
 
 /datum/status_effect/fire_handler/refresh(mob/living/new_owner, new_stacks, forced = FALSE)

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -80,6 +80,8 @@
 			adjust_stacks(override_effect.stacks)
 			qdel(override_effect)
 
+/datum/status_effect/fire_handler/on_apply()
+	. = ..()
 	update_particles()
 
 /datum/status_effect/fire_handler/on_remove()
@@ -279,6 +281,7 @@
 		extinguish()
 	set_stacks(0)
 	update_overlay()
+	update_particles()
 	return ..()
 
 /datum/status_effect/fire_handler/fire_stacks/update_overlay()

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -1,11 +1,13 @@
 ///objects can only have one particle on them at a time, so we use these abstract effects to hold and display the effects. You know, so multiple particle effects can exist at once.
 ///also because some objects do not display particles due to how their visuals are built
 /obj/effect/abstract/particle_holder
-	anchored = TRUE
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	name = "particle holder"
+	desc = "How are you reading this? Please make a bug report :)"
 	appearance_flags = KEEP_APART|TILE_BOUND|PIXEL_SCALE|LONG_GLIDE
-	layer = ABOVE_ALL_MOB_LAYER
 	vis_flags = VIS_INHERIT_PLANE
+	layer = ABOVE_ALL_MOB_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	anchored = TRUE
 	/// Holds info about how this particle emitter works
 	/// See \code\__DEFINES\particles.dm
 	var/particle_flags = NONE

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -3,6 +3,7 @@
 /obj/effect/abstract/particle_holder
 	anchored = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	appearance_flags = KEEP_APART|TILE_BOUND|PIXEL_SCALE|LONG_GLIDE
 	layer = ABOVE_ALL_MOB_LAYER
 	vis_flags = VIS_INHERIT_PLANE
 	/// Holds info about how this particle emitter works

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -3,7 +3,7 @@
 /obj/effect/abstract/particle_holder
 	name = "particle holder"
 	desc = "How are you reading this? Please make a bug report :)"
-	appearance_flags = KEEP_APART|TILE_BOUND|PIXEL_SCALE|LONG_GLIDE
+	appearance_flags = KEEP_APART|KEEP_TOGETHER|TILE_BOUND|PIXEL_SCALE|LONG_GLIDE //movable appearance_flags plus KEEP_APART and KEEP_TOGETHER
 	vis_flags = VIS_INHERIT_PLANE
 	layer = ABOVE_ALL_MOB_LAYER
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT


### PR DESCRIPTION
## About The Pull Request

Basically, due to carbons using KEEP_TOGETHER, particles were appearing on the context menu which is annoying. I have no idea why it behaves like this.
Buuut, giving particle holders the KEEP_APART flag does fix this.

closes https://github.com/tgstation/tgstation/issues/75641

## Why It's Good For The Game

Bugfix good

## Changelog

no