### PR TITLE
Hotfixes Some Reagent Containers' Ordering

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -4,11 +4,11 @@
 	icon = 'icons/obj/medical/chemical.dmi'
 	icon_state = null
 	w_class = WEIGHT_CLASS_TINY
-	/// The maximum amount of reagents per transfer that will be moved out of this reagent container
+	/// The maximum amount of reagents per transfer that will be moved out of this reagent container. This value's position in possible_transfer_amounts should be reflected in amount_list_position.
 	var/amount_per_transfer_from_this = 5
 	/// The different possible amounts of reagent to transfer out of the container
 	var/list/possible_transfer_amounts = list(5,10,15,20,25,30)
-	/// Where we are in the possible transfer amount list.
+	/// Where we are in the possible transfer amount list. Number should match the position in possible_transfer_amounts corresponding to amount_per_transfer_from_this.
 	var/amount_list_position = 1
 	/// The maximum amount of reagents this container can hold
 	var/volume = 30

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -2,6 +2,7 @@
 	name = "glass"
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50)
+	amount_list_position = 2
 	volume = 50
 	reagent_flags = OPENCONTAINER | DUNKABLE
 	spillable = TRUE

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -6,6 +6,7 @@
 	inhand_icon_state = "dropper"
 	worn_icon_state = "pen"
 	amount_per_transfer_from_this = 5
+	amount_list_position = 5
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
 	reagent_flags = TRANSPARENT


### PR DESCRIPTION
## About The Pull Request

Droppers will now properly go to 1u on attackself.
Beakers will now properly go to 15u on attackself.

Caused by the ordering of the volumes transferred, it thought it was starting at 1u when it should have been starting at 5.
## Why It's Good For The Game

Was a bug someone posted about in OOC
## Changelog
:cl: Cobby
fix: Droppers/Beakers will now go to 1u/15u on the FIRST leftclick.
/:cl:
