### PR TITLE
Adds the current server name from the config to the world status

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -203,6 +203,7 @@
 	.["revision"] = GLOB.revdata.commit
 	.["revision_date"] = GLOB.revdata.date
 	.["hub"] = GLOB.hub_visibility
+	.["servername"] = CONFIG_GET(string/servername)
 
 
 	var/list/adm = get_admin_counts()

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -203,7 +203,7 @@
 	.["revision"] = GLOB.revdata.commit
 	.["revision_date"] = GLOB.revdata.date
 	.["hub"] = GLOB.hub_visibility
-	.["servername"] = CONFIG_GET(string/serversqlname)
+	.["identifier"] = CONFIG_GET(string/serversqlname)
 
 
 	var/list/adm = get_admin_counts()

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -203,7 +203,7 @@
 	.["revision"] = GLOB.revdata.commit
 	.["revision_date"] = GLOB.revdata.date
 	.["hub"] = GLOB.hub_visibility
-	.["servername"] = CONFIG_GET(string/servername)
+	.["servername"] = CONFIG_GET(string/serversqlname)
 
 
 	var/list/adm = get_admin_counts()


### PR DESCRIPTION

## About The Pull Request
Adds the server name from the configuration to the world's status topic.

## Why It's Good For The Game
We don't currently expose the server's short name (e.g. `Sybil`, `Manuel`) anywhere. This fixes that. This is mostly to support external tools.

