### PR TITLE
The Throwing Arm quirk now makes you better at basketball

### DIFF
--- a/code/modules/basketball/hoop.dm
+++ b/code/modules/basketball/hoop.dm
@@ -167,6 +167,10 @@
 	if(istype(thrower) && thrower.flags_1 & IS_SPINNING_1)
 		score_chance *= 0.5
 
+	// aim bonus for having the throwing arm trait
+	if(istype(thrower) && HAS_TRAIT(thrower, TRAIT_THROWINGARM))
+		score_chance = clamp(score_chance*1.5, 0, 95) // there's always a chance for failure
+
 	if(prob(score_chance))
 		AM.forceMove(get_turf(src))
 		// is it a 3 pointer shot


### PR DESCRIPTION

## About The Pull Request

Having the throwing arm quirk now significantly increases your chance to land shots on a basketball hoop.
## Why It's Good For The Game

Gives the throwing arm quirk more fun interactions, which is neat. This quirk has a lot of potential.
~~It's frankly a crime that this wasn't the case to begin with~~
## Changelog
:cl:
add: Having the Throwing Arm quirk increases your chances to land shoots on a basketball hoop
/:cl:
