### PR TITLE
Adds runtime safety into cinematic code to stop everyone locking up

### DIFF
--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -111,8 +111,7 @@
 	// This does potentially mean some mobs could lose their notrasnform and
 	// not be locked down by cinematics, but that should be very unlikely.
 	if(!watching_mob.notransform)
-		locked += WEAKREF(watching_mob)
-		watching_mob.notransform = TRUE
+		lock_mob(watching_mob)
 
 	// Only show the actual cinematic to cliented mobs.
 	if(!watching_client || (watching_client in watching))
@@ -146,13 +145,22 @@
 		remove_watcher(viewing_client)
 
 	for(var/datum/weakref/locked_ref as anything in locked)
-		var/mob/locked_mob = locked_ref.resolve()
-		if(QDELETED(locked_mob))
-			continue
-		locked_mob.notransform = FALSE
-		UnregisterSignal(locked_mob, COMSIG_MOB_CLIENT_LOGIN)
+		unlock_mob(locked_ref)
 
 	qdel(src)
+
+/// Locks a mob, preventing them from moving, being hurt, or acting
+/datum/cinematic/proc/lock_mob(mob/living/to_lock)
+	locked += WEAKREF(to_lock)
+	to_lock.notransform = TRUE
+
+/// Unlocks a previously locked weakref
+/datum/cinematic/proc/unlock_mob(datum/weakref/mob_ref)
+	var/mob/locked_mob = mob_ref.resolve()
+	if(QDELETED(locked_mob))
+		continue
+	locked_mob.notransform = FALSE
+	UnregisterSignal(locked_mob, COMSIG_MOB_CLIENT_LOGIN)
 
 /// Removes the passed client from our watching list.
 /datum/cinematic/proc/remove_watcher(client/no_longer_watching)

--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -150,15 +150,15 @@
 	qdel(src)
 
 /// Locks a mob, preventing them from moving, being hurt, or acting
-/datum/cinematic/proc/lock_mob(mob/living/to_lock)
+/datum/cinematic/proc/lock_mob(mob/to_lock)
 	locked += WEAKREF(to_lock)
 	to_lock.notransform = TRUE
 
 /// Unlocks a previously locked weakref
 /datum/cinematic/proc/unlock_mob(datum/weakref/mob_ref)
 	var/mob/locked_mob = mob_ref.resolve()
-	if(QDELETED(locked_mob))
-		continue
+	if(isnull(locked_mob))
+		return
 	locked_mob.notransform = FALSE
 	UnregisterSignal(locked_mob, COMSIG_MOB_CLIENT_LOGIN)
 


### PR DESCRIPTION
## About The Pull Request

Separates these two sections of cinematic code out in their own procs to add some runtime protection. 

![image](https://github.com/tgstation/tgstation/assets/51863163/b664d887-1aea-45e7-85f2-aa2e6c997c83)

This keeps happening and I have really no idea why. There shouldn't be any `null`s in this list of weakrefs. I asked Lemon a while ago and they said it was a bug in some other code. So I'm just doing this instead. Because I don't know where to hunt down that issue and try-catches aren't real. 

Closes #76024 

## Why It's Good For The Game

Runtiming in these procs is really bad because it handles setting all mobs to `notransform`. Which blocks all movement and acting and stuff. 

## Changelog

:cl: Melbert
code: Adds some runtime safety to Cinematic code
/:cl:
