### PR TITLE
Rotates a morgue tray at CC Pod bay

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6287,7 +6287,9 @@
 /area/centcom/central_command_areas/control)
 "Da" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/bodycontainer/morgue,
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,


### PR DESCRIPTION

## About The Pull Request
See title
## Why It's Good For The Game
![image](https://github.com/tgstation/tgstation/assets/62606051/4972c8d5-0581-4f4a-b03f-516846079491)
Yeah I don't think that's supposed to go through the window like that chief
## Changelog
:cl:
qol: The CC pod bay now has proper morgue facilities that don't clip through a glass window
/:cl:
