### PR TITLE
Removes silicon lathe tax

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -17,8 +17,7 @@
 
 //How many credits a player is charged if they print something from a departmental lathe they shouldn't have access to.
 #define LATHE_TAX 10
-//How much POWER a borg's cell is taxed if they print something from a departmental lathe.
-#define SILICON_LATHE_TAX 2000
+
 
 #define STATION_TARGET_BUFFER 25
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -309,13 +309,7 @@
 		say("Insufficient funds to complete prototype. Please present a holochip or valid ID card.")
 		return FALSE
 
-	if(iscyborg(usr))
-		var/mob/living/silicon/robot/borg = usr
 
-		if(!borg.cell)
-			return FALSE
-
-		borg.cell.use(SILICON_LATHE_TAX)
 
 	materials.mat_container.use_materials(efficient_mats, print_quantity)
 	materials.silo_log(src, "built", -print_quantity, "[design.name]", efficient_mats)


### PR DESCRIPTION

## About The Pull Request

The PR removes silicon energy cost for printing items from techfabs. 

## Why It's Good For The Game
As I already said in an argument with Arcane over discord, silicon lathe tax is something created to solve a problem that doesn't exist, in a way that doesn't really solve it. The problem is using cyborgs to bypass lathe tax. From my experience, it's extremely rare for anyone to try doing it. Main reason being that unless you catch a borg next to you, it will take long enough for you to actually get a cyborg via PDA messages, or by ordering it on common radio, that you will either pay the tax, or get someone who actually spends time in the department to print it for you.

As for why I consider the solution to the problem lacking? If someone wants to leverage Asimov to force cyborgs to print things for free for them, they aren't very likely to care about the fact that the cyborg will need to spend next 3-10 minutes in a charger.
Energy tax punishes only the cyborg, by forcing it to go effectively AFK for a period of time if they are either forced to print something by an order, or they print something for their job (organs for medborg, parts for engiborg)


## Changelog
:cl:
del: Removes silicon lathe tax
/:cl:
