### PR TITLE
Slightly optimizes Gas Filter ui data

### DIFF
--- a/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/filter.dm
@@ -134,7 +134,7 @@
 	data["filter_types"] = list()
 	for(var/path in GLOB.meta_gas_info)
 		var/list/gas = GLOB.meta_gas_info[path]
-		data["filter_types"] += list(list("name" = gas[META_GAS_NAME], "gas_id" = gas[META_GAS_ID], "enabled" = (path in filter_type)))
+		data["filter_types"] += list(list("gas_id" = gas[META_GAS_ID], "enabled" = (path in filter_type)))
 
 	return data
 

--- a/tgui/packages/tgui/interfaces/AtmosFilter.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosFilter.tsx
@@ -15,7 +15,6 @@ type Data = {
 type Filter = {
   enabled: BooleanLike;
   gas_id: string;
-  name: string;
 };
 
 export const AtmosFilter = (props, context) => {


### PR DESCRIPTION
**About The Pull Request**

There is no need to send gas name to the Gas Filter UI because `getGasLabel()` already decodes the name from it's ID. So, let's  save some bandwidth.

## Changelog
:cl:
refactor: don't send gas name to gas filter UI as the name is already decoded there from it's ID
/:cl:

