### PR TITLE
Positronic brains now correctly reject ghosts who have used the suicide verb

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -115,7 +115,7 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	if(user.ckey in ckeys_entered)
 		to_chat(user, span_warning("You cannot re-enter [src] a second time!"))
 		return
-	if(is_occupied() || is_banned_from(user.ckey, ROLE_POSIBRAIN) || QDELETED(user))
+	if(is_occupied() || is_banned_from(user.ckey, ROLE_POSIBRAIN) || QDELETED(src) || QDELETED(user))
 		return
 	if(HAS_TRAIT(user, TRAIT_SUICIDED)) //if they suicided, they're out forever.
 		to_chat(user, span_warning("[src] fizzles slightly. Sadly it doesn't take those who suicided!"))

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -115,9 +115,9 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	if(user.ckey in ckeys_entered)
 		to_chat(user, span_warning("You cannot re-enter [src] a second time!"))
 		return
-	if(is_occupied() || is_banned_from(user.ckey, ROLE_POSIBRAIN) || QDELETED(brainmob) || QDELETED(src) || QDELETED(user))
+	if(is_occupied() || is_banned_from(user.ckey, ROLE_POSIBRAIN) || QDELETED(user))
 		return
-	if(HAS_TRAIT(src, TRAIT_SUICIDED)) //if they suicided, they're out forever.
+	if(HAS_TRAIT(user, TRAIT_SUICIDED)) //if they suicided, they're out forever.
 		to_chat(user, span_warning("[src] fizzles slightly. Sadly it doesn't take those who suicided!"))
 		return
 	var/posi_ask = tgui_alert(user, "Become a [name]? (Warning, You can no longer be revived, and all past lives will be forgotten!)", "Confirm", list("Yes","No"))


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. It was always meant to work like this, but the code checked whether the positronic brain had the suicided trait rather than the ghost trying to enter it.

Also removes a redundant check to see if the brainmob is qdeleted.
## Why It's Good For The Game

It's a bugfix.
## Changelog
:cl:
fix: positronic brains now correctly reject the ghosts of people who have used the suicide verb
/:cl:
