### PR TITLE
[NO GBP] Tube and Bottles get main reagent in their name

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -379,7 +379,9 @@ GLOBAL_LIST_INIT(chem_master_containers, list(
 
 	// Generate item name
 	var/item_name_default = initial(container_style.name)
-	if(!(initial(container_style.reagent_flags) & OPENCONTAINER)) // Closed containers get reagent name and units in the name
+	if(selected_container == default_container) // Tubes and bottles gain reagent name
+		item_name_default = "[reagents.get_master_reagent_name()] [item_name_default]"
+	if(!(initial(container_style.reagent_flags) & OPENCONTAINER)) // Closed containers get both reagent name and units in the name
 		item_name_default = "[reagents.get_master_reagent_name()] [item_name_default] ([volume_in_each]u)"
 	var/item_name = tgui_input_text(usr,
 		"Container name",


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/3625094/f361b36b-b769-4d6f-84cb-37ae402622c0)

## About The Pull Request

I made only pills and patches have reagent name by default because I thought that open containers are temporary, and if you empty them and then fill with other reagent, it will be confusing. I was wrong, they're better be named.

## Why It's Good For The Game

Less manual input for those who want their tubes and bottles named to not rely just on reagent color

## Changelog

:cl:
qol: Tubes and Bottles have the main reagent name prefix in Chem/CondiMaster
/:cl:


