### PR TITLE
Fixes pipenet gasses not being gc'd

### DIFF
--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -275,6 +275,7 @@
 	var/datum/gas_mixture/total_gas_mixture = new(volume_sum)
 	total_gas_mixture.temperature = total_heat_capacity ? (total_thermal_energy / total_heat_capacity) : 0
 	total_gas_mixture.gases = total_gases
+	total_gas_mixture.garbage_collect()
 
 	//Update individual gas_mixtures by volume ratio
 	for(var/datum/gas_mixture/gas_mixture as anything in gas_mixture_list)


### PR DESCRIPTION

## About The Pull Request
Fixes a small bug that slipped by a couple days ago that made trillionth-of-a-mole gasses stick around in pipes and canisters. This restores to behavior to what it was no more than a week ago, and gas analyzers will still show 0 moles for a decent while before a gas is fully removed.
## Why It's Good For The Game
Fixes #76034
get that plasma out of my air tank
## Changelog
:cl:
fix: VERY small amounts of a gas (<0.0001 mol) in pipenets will once again be fully removed
/:cl:
