### PR TITLE
Re-add missing categories to externally formatted log files

### DIFF
--- a/code/modules/logging/log_entry.dm
+++ b/code/modules/logging/log_entry.dm
@@ -71,7 +71,7 @@ GENERAL_PROTECT_DATUM(/datum/log_entry)
 	if(format)
 		output += "\[[timestamp]\] [uppertext(category)]: [message]"
 	else
-		output += "[message]"
+		output += "[uppertext(category)]: [message]"
 
 	if(flags & ENTRY_USE_DATA_W_READABLE)
 #if DM_VERSION >= 515


### PR DESCRIPTION

## About The Pull Request
Currently externally-formatted log files (handled by rust-g) do not include categories. This seems erroneous, and causes a discrepancy between the internal and externally formatted files as external formatting only seems to add the timestamp and some newline handling.

Currently:
![image](https://github.com/tgstation/tgstation/assets/10467687/a8979eca-833a-4c44-9d0b-82b9925ddde4)

With this PR:
![image](https://github.com/tgstation/tgstation/assets/10467687/eeeb87ee-3395-4ecc-b97c-ec35f965eac0)


## Why It's Good For The Game

Resolves a disparity between external and internal formatting made evident by #75972.
## Changelog
:cl: bobbahbrown
server: Fix log categories being erroneously excluded from log files.
/:cl:
