### PR TITLE
Deadchat Announcement Variety Pack 2 and also some fixes to other popups

### DIFF
--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -91,8 +91,18 @@
 /obj/machinery/harvester/proc/start_harvest()
 	if(!occupant || !iscarbon(occupant))
 		return
-	var/mob/living/carbon/C = occupant
-	operation_order = reverseList(C.bodyparts)   //Chest and head are first in bodyparts, so we invert it to make them suffer more
+
+	var/mob/living/carbon/carbon_occupant = occupant
+
+	if(carbon_occupant.stat < UNCONSCIOUS)
+		notify_ghosts(
+			"[occupant] is about to be ground up by a malfunctioning organ harvester!",
+			source = src,
+			header = "Gruesome!",
+			action = NOTIFY_ORBIT,
+		)
+
+	operation_order = reverseList(carbon_occupant.bodyparts)   //Chest and head are first in bodyparts, so we invert it to make them suffer more
 	warming_up = TRUE
 	harvesting = TRUE
 	visible_message(span_notice("The [name] begins warming up!"))

--- a/code/game/objects/items/hot_potato.dm
+++ b/code/game/objects/items/hot_potato.dm
@@ -149,7 +149,8 @@
 	else
 		log_bomber(null, null, src, "was primed for detonation (Timer:[delay],Explosive:[detonate_explosion],Range:[detonate_dev_range]/[detonate_heavy_range]/[detonate_light_range]/[detonate_fire_range])")
 	active = TRUE
-	notify_ghosts("[user] has primed a Hot Potato!", source = src, action = NOTIFY_ORBIT, header = "Hot Hot Hot!")
+	if(detonate_explosion) //doesn't send a notification unless it's a genuine, exploding hot potato.
+		notify_ghosts("[user] has primed a Hot Potato!", source = src, action = NOTIFY_ORBIT, header = "Hot Hot Hot!")
 
 /obj/item/hot_potato/proc/deactivate()
 	update_appearance()

--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -85,6 +85,17 @@
 
 /obj/item/implant/explosive/proc/timed_explosion()
 	imp_in.visible_message(span_warning("[imp_in] starts beeping ominously!"))
+
+	notify_ghosts(
+		"[imp_in] is about to detonate their explosive implant!",
+		source = src,
+		action = NOTIFY_ORBIT,
+		flashwindow = FALSE,
+		ghost_sound = 'sound/machines/warning-buzzer.ogg',
+		header = "Tick Tick Tick...",
+		notify_volume = 75
+	)
+
 	playsound(loc, 'sound/items/timer.ogg', 30, FALSE)
 	sleep(delay*0.25)
 	if(imp_in && !imp_in.stat)

--- a/code/modules/antagonists/blob/blob_antag.dm
+++ b/code/modules/antagonists/blob/blob_antag.dm
@@ -137,7 +137,7 @@
 		source = blob_cam.blob_core,
 		action = NOTIFY_ORBIT,
 		ghost_sound = 'sound/ambience/antag/blobalert.ogg',
-		header = "Beware of the Blob...",
+		header = "Blob Awakening!",
 		notify_volume = 75
 	)
 

--- a/code/modules/antagonists/blob/blob_antag.dm
+++ b/code/modules/antagonists/blob/blob_antag.dm
@@ -132,6 +132,15 @@
 	blob_cam.place_blob_core(placement_override, pop_override = TRUE)
 	playsound(get_turf(blob_cam), 'sound/ambience/antag/blobalert.ogg', 50, FALSE)
 
+	notify_ghosts(
+		"A Blob host has burst in [get_area_name(blob_cam.blob_core)]",
+		source = blob_cam.blob_core,
+		action = NOTIFY_ORBIT,
+		ghost_sound = 'sound/ambience/antag/blobalert.ogg',
+		header = "Beware of the Blob...",
+		notify_volume = 75
+	)
+
 /datum/antagonist/blob/antag_listing_status()
 	. = ..()
 	if(owner?.current)

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -261,6 +261,14 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 		owner_AI.doomsday_device.start()
 		for(var/obj/item/pinpointer/nuke/P in GLOB.pinpointer_list)
 			P.switch_mode_to(TRACK_MALF_AI) //Pinpointers start tracking the AI wherever it goes
+
+		notify_ghosts(
+			"A doomsday device has been activated in [get_area_name(src)]!",
+			source = src,
+			header = "DOOOOOOM",
+			action = NOTIFY_JUMP,
+		)
+
 		qdel(src)
 
 /obj/machinery/doomsday_device
@@ -314,7 +322,6 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	for(var/mob/living/silicon/robot/borg in owner.connected_robots)
 		borg.lamp_doom = TRUE
 		borg.toggle_headlamp(FALSE, TRUE) //forces borg lamp to update
-
 
 /obj/machinery/doomsday_device/proc/seconds_remaining()
 	. = max(0, (round((detonation_timer - world.time) / 10)))

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -263,10 +263,10 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 			P.switch_mode_to(TRACK_MALF_AI) //Pinpointers start tracking the AI wherever it goes
 
 		notify_ghosts(
-			"A doomsday device has been activated in [get_area_name(src)]!",
-			source = src,
-			header = "DOOOOOOM",
-			action = NOTIFY_JUMP,
+			"[owner_AI] has activated a Doomsday Device!",
+			source = owner_AI,
+			header = "DOOOOOOM!!!",
+			action = NOTIFY_ORBIT,
 		)
 
 		qdel(src)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -462,7 +462,7 @@ GLOBAL_VAR(station_nuke_source)
 	countdown.start()
 	SSsecurity_level.set_level(SEC_LEVEL_DELTA)
 	notify_ghosts(
-		"[armer] has armed a nuclear device in [get_area_name(src)]!",
+		"A nuclear device has been armed in [get_area_name(src)]!",
 		source = src,
 		header = "Nuke Armed",
 		action = NOTIFY_ORBIT,

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -461,6 +461,12 @@ GLOBAL_VAR(station_nuke_source)
 
 	countdown.start()
 	SSsecurity_level.set_level(SEC_LEVEL_DELTA)
+	notify_ghosts(
+		"[armer] has armed a nuclear device in [get_area_name(src)]!",
+		source = src,
+		header = "Nuke Armed",
+		action = NOTIFY_ORBIT,
+	)
 	update_appearance()
 
 /// Disarms the nuke, reverting all pinpointers and the security level

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -422,6 +422,8 @@
 		source = src,
 		header = "Meltdown Incoming",
 		action = NOTIFY_ORBIT,
+		ghost_sound = 'sound/machines/warning-buzzer.ogg',
+		notify_volume = 75
 	)
 
 	for(var/i in HYPERTORUS_COUNTDOWN_TIME to 0 step -10)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_procs.dm
@@ -416,6 +416,14 @@
 				Get as far away as possible from the reactor or find a way to shut it down.", "Alert")
 	var/speaking = "[emergency_alert] The Hypertorus fusion reactor has reached critical integrity failure. Emergency magnetic dampeners online."
 	radio.talk_into(src, speaking, common_channel, language = get_selected_language())
+
+	notify_ghosts(
+		"The [src] has begun melting down!",
+		source = src,
+		header = "Meltdown Incoming",
+		action = NOTIFY_ORBIT,
+	)
+
 	for(var/i in HYPERTORUS_COUNTDOWN_TIME to 0 step -10)
 		if(critical_threshold_proximity < melting_point) // Cutting it a bit close there engineers
 			radio.talk_into(src, "[safe_alert] Failsafe has been disengaged.", common_channel)

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -101,7 +101,7 @@
 		crate.locked = FALSE //Unlock secure crates
 		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
-	var/obj/effect/pod_landingzone/landing_marker = new(landing_zone, pod, crate)
+	new /obj/effect/pod_landingzone/(landing_zone, pod, crate)
 	announce_to_ghosts(landing_zone)
 
 ///Handles the creation of the pod, in case it needs to be modified beforehand

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -102,7 +102,7 @@
 		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
 	var/obj/effect/pod_landingzone/landing_marker = new(landing_zone, pod, crate)
-	announce_to_ghosts(landing_marker)
+	announce_to_ghosts(landing_zone)
 
 ///Handles the creation of the pod, in case it needs to be modified beforehand
 /datum/round_event/stray_cargo/proc/make_pod()

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -101,8 +101,14 @@
 		crate.locked = FALSE //Unlock secure crates
 		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
-	new /obj/effect/pod_landingzone/(landing_zone, pod, crate)
-	announce_to_ghosts(landing_zone)
+	var/obj/effect/pod_landingzone/landing_zone = new(landing_zone, pod, crate)
+
+	notify_ghosts(
+		"A stray cargo pod is landing in [get_area_name(src)]!",
+		source = landing_zone,
+		header = "Heads up!",
+		action = NOTIFY_JUMP,
+	)
 
 ///Handles the creation of the pod, in case it needs to be modified beforehand
 /datum/round_event/stray_cargo/proc/make_pod()

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -101,14 +101,8 @@
 		crate.locked = FALSE //Unlock secure crates
 		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
-	var/obj/effect/pod_landingzone/landing_zone = new(landing_zone, pod, crate)
-
-	notify_ghosts(
-		"A stray cargo pod is landing in [get_area_name(src)]!",
-		source = landing_zone,
-		header = "Heads up!",
-		action = NOTIFY_JUMP,
-	)
+	var/obj/effect/pod_landingzone/landing_marker = new(landing_zone, pod, crate)
+	announce_to_ghosts(landing_marker)
 
 ///Handles the creation of the pod, in case it needs to be modified beforehand
 /datum/round_event/stray_cargo/proc/make_pod()

--- a/code/modules/mob_spawn/ghost_roles/spider_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/spider_roles.dm
@@ -82,6 +82,8 @@
 		/mob/living/basic/spiderling/guard,
 		/mob/living/basic/spiderling/scout,
 	)
+	/// Do we flash the byond window when this particular egg type is available?
+	var/flash_window = FALSE
 
 /obj/effect/mob_spawn/ghost_role/spider/Initialize(mapload)
 	. = ..()
@@ -99,7 +101,7 @@
 	amount_grown += rand(5, 15) * seconds_per_tick
 	if(amount_grown >= 100 && !ready)
 		ready = TRUE
-		notify_ghosts("[src] is ready to hatch!", null, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to play)</a>", source = src, action = NOTIFY_ORBIT, ignore_key = POLL_IGNORE_SPIDER, flashwindow = FALSE)
+		notify_ghosts("[src] is ready to hatch!", null, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to play)</a>", source = src, action = NOTIFY_ORBIT, ignore_key = POLL_IGNORE_SPIDER, flashwindow = flash_window)
 		STOP_PROCESSING(SSobj, src)
 
 /obj/effect/mob_spawn/ghost_role/spider/Topic(href, href_list)
@@ -137,6 +139,7 @@
 		/mob/living/basic/spiderling/viper,
 		/mob/living/basic/spiderling/midwife,
 	)
+	flash_window = TRUE
 
 /obj/effect/mob_spawn/ghost_role/spider/bloody
 	name = "bloody egg cluster"
@@ -148,6 +151,7 @@
 	potentialspawns = list(
 		/mob/living/basic/spiderling/hunter/flesh,
 	)
+	flash_window = TRUE
 
 /obj/effect/mob_spawn/ghost_role/spider/midwife
 	name = "midwife egg cluster"
@@ -158,6 +162,7 @@
 	potentialspawns = list(
 		/mob/living/basic/spiderling/midwife,
 	)
+	flash_window = TRUE
 
 /**
  * Makes a ghost into a spider based on the type of egg cluster.

--- a/code/modules/mob_spawn/ghost_roles/spider_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/spider_roles.dm
@@ -99,7 +99,7 @@
 	amount_grown += rand(5, 15) * seconds_per_tick
 	if(amount_grown >= 100 && !ready)
 		ready = TRUE
-		notify_ghosts("[src] is ready to hatch!", null, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to play)</a>", source = src, action = NOTIFY_ORBIT, ignore_key = POLL_IGNORE_SPIDER)
+		notify_ghosts("[src] is ready to hatch!", null, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to play)</a>", source = src, action = NOTIFY_ORBIT, ignore_key = POLL_IGNORE_SPIDER, flashwindow = FALSE)
 		STOP_PROCESSING(SSobj, src)
 
 /obj/effect/mob_spawn/ghost_role/spider/Topic(href, href_list)


### PR DESCRIPTION

## About The Pull Request

This adds ghost orbit popups for the following: 
- Macrobombs (or stacked microbombs) being triggered.
- HFR Meltdowns.
- Living players about to be gored by an emagged organ harvester.
- Nuclear devices being armed.
- Doomsday devices.
- Blob hosts bursting.

This also modifies the following ghost orbit popups:
- Toy hot potatoes will no longer cause a popup when armed.
- Normal spider eggs will not flash the byond window, only special egg types.
## Why It's Good For The Game

Gives more gathering spots/information to deadchat. Let no entertaining moment in this game go unobserved.

Spider eggs flashing your window for every single egg produced makes alt-tabbing suck. I saw some guy on the forums complaining about it and thought "huh yeah I guess he's got a point that pisses me off too" so here we are.
## Changelog
:cl: Rhials
qol: Basic spider eggs no longer flash the byond window when ready to hatch.
qol: Toy hot potatoes no longer give a ghost notification.
qol: Deadchat will be notified in the event of an imminent macrobomb detonation, HFR meltdown, organ harvesting, 
qol: Deadchat will be notified when a nuclear/doomsday device is activated, as well as when a blob-infection bursts.
/:cl:
