### PR TITLE
Fix *wing runtimes

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -141,28 +141,25 @@
 
 /datum/emote/living/carbon/human/wing/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
-	if(.)
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/wings/functional/wings = H.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
-		if(wings && findtext(select_message_type(user,intentional), "open"))
-			wings.open_wings()
-		else
-			wings.close_wings()
+	if(!.)
+		return
+	var/obj/item/organ/external/wings/functional/wings = user.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
+	if(isnull(wings))
+		CRASH("[type] ran on a mob that has no wings!")
+	if(wings.wings_open)
+		wings.close_wings()
+	else
+		wings.open_wings()
 
 /datum/emote/living/carbon/human/wing/select_message_type(mob/user, intentional)
-	. = ..()
-	var/mob/living/carbon/human/H = user
-	if(H.dna.species.mutant_bodyparts["wings"])
-		. = "opens " + message
-	else
-		. = "closes " + message
+	var/obj/item/organ/external/wings/functional/wings = user.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
+	var/emote_verb = wings.wings_open ? "closes" : "opens"
+	return "[emote_verb] [message]"
 
 /datum/emote/living/carbon/human/wing/can_run_emote(mob/user, status_check = TRUE, intentional)
-	if(!..())
+	if(!istype(user.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS), /obj/item/organ/external/wings/functional))
 		return FALSE
-	var/mob/living/carbon/human/H = user
-	if(H.dna && H.dna.species && (H.dna.features["wings"] != "None"))
-		return TRUE
+	return ..()
 
 /datum/emote/living/carbon/human/clear_throat
 	key = "clear"


### PR DESCRIPTION
## About The Pull Request

Seemed like this emote never got updated to newer "wing organ" standards. 

This fixes some runtimes that are caused by humans without wings using *wing. 

## Why It's Good For The Game

Runtimes, makes the emote a bit more clear on how it's used

## Changelog

:cl: Melbert
fix: Runtimes from wingless humans using *wing
/:cl:
