### PR TITLE
Fixes chem master replace beaker runtime

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -201,7 +201,7 @@ GLOBAL_LIST_INIT(chem_master_containers, list(
 
 /// Insert new beaker and/or eject the inserted one
 /obj/machinery/chem_master/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
-	if(!user?.transferItemToLoc(new_beaker, src))
+	if(new_beaker && user && !user.transferItemToLoc(new_beaker, src))
 		return FALSE
 	if(beaker)
 		try_put_in_hand(beaker, user)


### PR DESCRIPTION
## About The Pull Request

I think it was rather silly to put this call in this proc, but I'm not about to audit it 

`new_beaker` can be `null` if this proc is being called to drop the current beaker, so this needed a sanity check

## Why It's Good For The Game

Runtime

## Changelog

:cl: Melbert
fix: Runtime from ejecting beakers from a chem-master
/:cl:
