### PR TITLE
Welding gas masks make the same sound "pwah" sound as welding hardhats

### DIFF
--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -164,7 +164,8 @@ GLOBAL_LIST_INIT(clown_mask_options, list(
 	acid = 55
 
 /obj/item/clothing/mask/gas/welding/attack_self(mob/user)
-	weldingvisortoggle(user)
+	if(weldingvisortoggle(user))
+		playsound(src, 'sound/mecha/mechmove03.ogg', 50, TRUE)
 
 /obj/item/clothing/mask/gas/welding/up
 


### PR DESCRIPTION
## About The Pull Request

Welding gas masks make the same sound effect that welding hardhats use

## Why It's Good For The Game

I could've sworn they used to but I think I'm being Mandela Effected.

Provides some nice audio feedback that's similar to existing items. 

## Changelog

:cl: Melbert
sound: Welding Gas Masks make the same sound effect as Welding Hard Hats when they toggle
/:cl:
