### PR TITLE
Fixes ghosts being unable to click gateways to teleport through

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -68,11 +68,6 @@
 // And here are some good things for free:
 // Now you can click through portals, wormholes, gateways, and teleporters while observing. -Sayu
 
-/obj/effect/gateway_portal_bumper/attack_ghost(mob/user)
-	if(gateway)
-		gateway.Transfer(user)
-	return ..()
-
 /obj/machinery/teleport/hub/attack_ghost(mob/user)
 	if(!power_station?.engaged || !power_station.teleporter_console || !power_station.teleporter_console.target_ref)
 		return ..()

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -270,6 +270,19 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 	AM.forceMove(target.get_target_turf())
 	target.post_transfer(AM)
 
+/obj/machinery/gateway/attack_ghost(mob/user)
+	. = ..()
+	if(.)
+		return
+	var/turf/tar_turf = target?.get_target_turf()
+	if(isnull(tar_turf))
+		to_chat(user, span_warning("There's no active destination for the gateway... or it's broken. Maybe try again later?"))
+		return
+	if(is_secret_level(tar_turf.z) && !user.client?.holder)
+		to_chat(user, span_warning("The gateway destination is secret."))
+		return
+	Transfer(user)
+
 /* Station's primary gateway */
 /obj/machinery/gateway/centerstation
 	destination_type = /datum/gateway_destination/gateway/home


### PR DESCRIPTION
## About The Pull Request

Ghosts can click gateways to teleport again 

## Why It's Good For The Game

I *believe* the "gateway visual" update made it so the bumper was unclickable, not sure why

Seemed easier to move it to the gateway itself rather than be on the bumper

Also made it so you cant teleport into secret gateways

## Changelog

:cl: Melbert
fix: Ghosts can click on active gateways to teleport to the destination set. Doesn't work for secret gateways. 
/:cl:
