### PR TITLE
Fixes a sneaky antag tell with RDS / adds policy support

### DIFF
--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -658,10 +658,9 @@
 	added_trama_ref = WEAKREF(added_trauma)
 
 /datum/quirk/insanity/post_add()
+	var/rds_policy = get_policy("[type]") || "Please note that your [lowertext(name)] does NOT give you any additional right to attack people or cause chaos."
 	// I don't /think/ we'll need this, but for newbies who think "roleplay as insane" = "license to kill", it's probably a good thing to have.
-	to_chat(quirk_holder, span_big(span_info( \
-		"Please note that your [lowertext(name)] does NOT give you any additional rights to cause harm or chaos to people that you wouldn't already have. \
-	)))
+	to_chat(quirk_holder, span_big(span_info(rds_policy)))
 
 /datum/quirk/insanity/remove()
 	QDEL_NULL(added_trama_ref)

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -658,12 +658,10 @@
 	added_trama_ref = WEAKREF(added_trauma)
 
 /datum/quirk/insanity/post_add()
-	if(!quirk_holder.mind || quirk_holder.mind.special_role)
-		return
-	// I don't /think/ we'll need this, but for newbies who think "roleplay as insane" = "license to kill",
-	// it's probably a good thing to have.
-	to_chat(quirk_holder, span_big(span_bold(span_info("Please note that your [lowertext(name)] does NOT give you the right to attack people or otherwise cause any interference to \
-		the round. You are not an antagonist, and the rules will treat you the same as other crewmembers."))))
+	// I don't /think/ we'll need this, but for newbies who think "roleplay as insane" = "license to kill", it's probably a good thing to have.
+	to_chat(quirk_holder, span_big(span_info( \
+		"Please note that your [lowertext(name)] does NOT give you any additional rights to cause harm or chaos to people that you wouldn't already have. \
+	)))
 
 /datum/quirk/insanity/remove()
 	QDEL_NULL(added_trama_ref)


### PR DESCRIPTION
## About The Pull Request

Fixes being able to tell you are a special role via RDS

Adds policy support to RDS

## Why It's Good For The Game

Someone informed me that RDS was a 100% accurate antag tell you rolled a delayed spawn antag (like headrev), and that's... a little bad, you can usually insinuate you may be a headrev but straight up knowing isn't ideal - doesn't keep everyone on equal playing field. 

And while I was there I was like "y'know people might want to set policy for this" so yeah

## Changelog

:cl: Melbert
fix: Fixed a cheeky way RDS revealed you were an antag before you actually got antag. Sorry, you know who you are. 
config: RDS now has policy.json support, to allow customization of the roundstart "anti-grief" message. 
/:cl:

