### PR TITLE
Makes all limb ids and species ids normally legible, no underscores or other funnies

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -111,8 +111,8 @@
 #define SPECIES_LIZARD_SILVER "silverscale"
 #define SPECIES_NIGHTMARE "nightmare"
 #define SPECIES_MONKEY "monkey"
-#define SPECIES_MONKEY_FREAK "monkey_freak"
-#define SPECIES_MONKEY_HUMAN_LEGGED "monkey_human_legged"
+#define SPECIES_MONKEY_FREAK "monkey freak"
+#define SPECIES_MONKEY_HUMAN_LEGGED "human-legged monkey"
 #define SPECIES_MOTH "moth"
 #define SPECIES_MUSHROOM "mush"
 #define SPECIES_PLASMAMAN "plasmaman"
@@ -124,7 +124,7 @@
 #define SPECIES_VAMPIRE "vampire"
 #define SPECIES_ZOMBIE "zombie"
 #define SPECIES_ZOMBIE_INFECTIOUS "memezombie"
-#define SPECIES_ZOMBIE_KROKODIL "krokodil_zombie"
+#define SPECIES_ZOMBIE_KROKODIL "krokodil zombie"
 
 // Like species IDs, but not specifically attached a species.
 #define BODYPART_ID_ALIEN "alien"

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -123,7 +123,7 @@
 #define SPECIES_TALLBOY "tallboy"
 #define SPECIES_VAMPIRE "vampire"
 #define SPECIES_ZOMBIE "zombie"
-#define SPECIES_ZOMBIE_INFECTIOUS "memezombie"
+#define SPECIES_ZOMBIE_INFECTIOUS "infectious zombie"
 #define SPECIES_ZOMBIE_KROKODIL "krokodil zombie"
 
 // Like species IDs, but not specifically attached a species.


### PR DESCRIPTION
## About The Pull Request

Title.
Necessary because limb ids are used to automatically name bodyparts. 
Seeing something like "memezombie" ingame as a player would be uh, comical.

## Why It's Good For The Game

players shouldn't see ugly coderspeak

## Changelog

:cl:
spellcheck: All bodypart ids are now human legible.
/:cl: