### PR TITLE
MOD Complexity rebalance

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -317,7 +317,7 @@
 	resistance_flags = FIRE_PROOF|LAVA_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
+	complexity_max = DEFAULT_MAX_COMPLEXITY - 3
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
 	allowed_suit_storage = list(
 		/obj/item/resonator,

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -317,7 +317,7 @@
 	resistance_flags = FIRE_PROOF|LAVA_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 3
+	complexity_max = DEFAULT_MAX_COMPLEXITY - 2
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
 	allowed_suit_storage = list(
 		/obj/item/resonator,

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -317,7 +317,7 @@
 	resistance_flags = FIRE_PROOF|LAVA_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	complexity_max = DEFAULT_MAX_COMPLEXITY
+	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
 	allowed_suit_storage = list(
 		/obj/item/resonator,
@@ -1302,8 +1302,8 @@
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
-	slowdown_inactive = 3
-	slowdown_active = 0.4
+	slowdown_inactive = 1.5
+	slowdown_active = 1
 	ui_theme = "hackerman"
 	inbuilt_modules = list(/obj/item/mod/module/anomaly_locked/kinesis/prebuilt/prototype)
 	allowed_suit_storage = list(

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -317,7 +317,7 @@
 	resistance_flags = FIRE_PROOF|LAVA_PROOF
 	max_heat_protection_temperature = FIRE_SUIT_MAX_TEMP_PROTECT
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
-	complexity_max = DEFAULT_MAX_COMPLEXITY - 5
+	complexity_max = DEFAULT_MAX_COMPLEXITY
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
 	allowed_suit_storage = list(
 		/obj/item/resonator,
@@ -1302,8 +1302,8 @@
 	siemens_coefficient = 0
 	complexity_max = DEFAULT_MAX_COMPLEXITY + 5
 	charge_drain = DEFAULT_CHARGE_DRAIN * 2
-	slowdown_inactive = 2
-	slowdown_active = 1.5
+	slowdown_inactive = 3
+	slowdown_active = 0.4
 	ui_theme = "hackerman"
 	inbuilt_modules = list(/obj/item/mod/module/anomaly_locked/kinesis/prebuilt/prototype)
 	allowed_suit_storage = list(

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -1293,7 +1293,7 @@
 		post-void war era modular suit to ever be safely utilized by an operator. This ancient clunker is still functional, \
 		though it's missing several modern-day luxuries from updated Nakamura Engineering designs. \
 		Primarily, the suit's myoelectric suit layer is entirely non-existant, and the servos do very little to \
-		help distribute the weight evenly across the wearer's body, making it slow and bulky to move in. \
+		help distribute the weight evenly across the wearer's body when the suit is deactivated, making it slow and bulky to move in. \
 		The internal heads-up display is rendered in nearly unreadable cyan, as the visor suggests, \
 		leaving the user unable to see long distances. However, the way the helmet retracts is pretty cool."
 	default_skin = "prototype"

--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -106,6 +106,7 @@
 		/obj/item/mod/module/orebag,
 		/obj/item/mod/module/clamp,
 		/obj/item/mod/module/drill,
+		/obj/item/mod/module/mouthhole,
 	)
 	default_pins = list(
 		/obj/item/mod/module/gps,

--- a/code/modules/mod/modules/module_pathfinder.dm
+++ b/code/modules/mod/modules/module_pathfinder.dm
@@ -10,7 +10,7 @@
 		The implant is stored in the module and needs to be injected in a human to function. \
 		Nakamura Engineering swears up and down there's airbrakes."
 	icon_state = "pathfinder"
-	complexity = 2
+	complexity = 1
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 10
 	incompatible_modules = list(/obj/item/mod/module/pathfinder)
 	/// The pathfinding implant.

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -85,7 +85,7 @@
 		these are only capable of working in zero-gravity environments, a blessing to some Engineers."
 	icon_state = "tether"
 	module_type = MODULE_ACTIVE
-	complexity = 3
+	complexity = 1
 	use_power_cost = DEFAULT_CHARGE_DRAIN
 	incompatible_modules = list(/obj/item/mod/module/tether)
 	cooldown_time = 1.5 SECONDS

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -85,7 +85,7 @@
 		these are only capable of working in zero-gravity environments, a blessing to some Engineers."
 	icon_state = "tether"
 	module_type = MODULE_ACTIVE
-	complexity = 1
+	complexity = 2
 	use_power_cost = DEFAULT_CHARGE_DRAIN
 	incompatible_modules = list(/obj/item/mod/module/tether)
 	cooldown_time = 1.5 SECONDS

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -358,7 +358,7 @@
 		ensuring they're comfortable; even if they're some that like it hot."
 	icon_state = "regulator"
 	module_type = MODULE_TOGGLE
-	complexity = 2
+	complexity = 1
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
 	incompatible_modules = list(/obj/item/mod/module/thermal_regulator)
 	cooldown_time = 0.5 SECONDS
@@ -389,7 +389,7 @@
 		however, this incredibly sensitive module is shorted out by EMPs. Luckily, cloning has been outlawed."
 	icon_state = "dnalock"
 	module_type = MODULE_USABLE
-	complexity = 2
+	complexity = 1
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 3
 	incompatible_modules = list(/obj/item/mod/module/dna_lock, /obj/item/mod/module/eradication_lock)
 	cooldown_time = 0.5 SECONDS

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -8,12 +8,12 @@
 /obj/item/mod/module/health_analyzer
 	name = "MOD health analyzer module"
 	desc = "A module installed into the glove of the suit. This is a high-tech biological scanning suite, \
-		allowing the user indepth information on the vitals and injuries of others even at a distance, \
+		allowing the user indepth information on the vitals and injuries of others even at a distance, including even chemical scans, \
 		all with the flick of the wrist. Data is displayed in a convenient package on HUD in the helmet, \
 		but it's up to you to do something with it."
 	icon_state = "health"
 	module_type = MODULE_ACTIVE
-	complexity = 2
+	complexity = 1
 	use_power_cost = DEFAULT_CHARGE_DRAIN
 	incompatible_modules = list(/obj/item/mod/module/health_analyzer)
 	cooldown_time = 0.5 SECONDS

--- a/code/modules/mod/modules/modules_medical.dm
+++ b/code/modules/mod/modules/modules_medical.dm
@@ -8,7 +8,7 @@
 /obj/item/mod/module/health_analyzer
 	name = "MOD health analyzer module"
 	desc = "A module installed into the glove of the suit. This is a high-tech biological scanning suite, \
-		allowing the user indepth information on the vitals and injuries of others even at a distance, including even chemical scans, \
+		allowing the user indepth information on the vitals and injuries of others even at a distance, \
 		all with the flick of the wrist. Data is displayed in a convenient package on HUD in the helmet, \
 		but it's up to you to do something with it."
 	icon_state = "health"

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -332,7 +332,7 @@
 /obj/item/mod/module/energy_net
 	name = "MOD energy net module"
 	desc = "A custom-built net-thrower. While conventional implementations of this capturing device \
-		tilize monomolecular fibers or cutting razorwire, this uses hardlight technology to deploy a \
+		utilize monomolecular fibers or cutting razorwire, this uses hardlight technology to deploy a \
 		trapping field capable of immobilizing even the strongest opponents."
 	icon_state = "energy_net"
 	removable = FALSE

--- a/code/modules/mod/modules/modules_security.dm
+++ b/code/modules/mod/modules/modules_security.dm
@@ -365,7 +365,7 @@
 	icon_state = "active_sonar"
 	module_type = MODULE_USABLE
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 4
-	complexity = 3
+	complexity = 2
 	incompatible_modules = list(/obj/item/mod/module/active_sonar)
 	cooldown_time = 15 SECONDS
 

--- a/code/modules/mod/modules/modules_service.dm
+++ b/code/modules/mod/modules/modules_service.dm
@@ -27,7 +27,7 @@
 		allowing them to cook food from a distance, with the greatest of ease. Not recommended for use against grapes."
 	icon_state = "microwave_beam"
 	module_type = MODULE_ACTIVE
-	complexity = 2
+	complexity = 1
 	use_power_cost = DEFAULT_CHARGE_DRAIN * 5
 	incompatible_modules = list(/obj/item/mod/module/microwave_beam, /obj/item/mod/module/organ_thrower)
 	cooldown_time = 10 SECONDS

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -118,7 +118,7 @@
 		your drill is surely the one that both pierces and creates the heavens."
 	icon_state = "drill"
 	module_type = MODULE_ACTIVE
-	complexity = 2
+	complexity = 1
 	use_power_cost = DEFAULT_CHARGE_DRAIN
 	incompatible_modules = list(/obj/item/mod/module/drill)
 	cooldown_time = 0.5 SECONDS

--- a/code/modules/mod/modules/modules_visor.dm
+++ b/code/modules/mod/modules/modules_visor.dm
@@ -5,7 +5,7 @@
 	name = "MOD visor module"
 	desc = "A heads-up display installed into the visor of the suit. They say these also let you see behind you."
 	module_type = MODULE_TOGGLE
-	complexity = 2
+	complexity = 1
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
 	incompatible_modules = list(/obj/item/mod/module/visor)
 	cooldown_time = 0.5 SECONDS

--- a/code/modules/wiremod/shell/module.dm
+++ b/code/modules/wiremod/shell/module.dm
@@ -2,7 +2,7 @@
 	name = "MOD circuit adapter module"
 	desc = "A module shell that allows a circuit to be inserted into, and interface with, a MODsuit."
 	module_type = MODULE_USABLE
-	complexity = 3
+	complexity = 1
 	idle_power_cost = DEFAULT_CHARGE_DRAIN * 0.5
 	incompatible_modules = list(/obj/item/mod/module/circuit)
 	cooldown_time = 0.5 SECONDS


### PR DESCRIPTION
## About The Pull Request

Reduced the cost of a lot of MODules.

Pathfinder 2 -> 1
Tether 3 -> 1
Temperature Regulator 2 -> 1
DNA lock 2 -> 1
Health analyzer 2 -> 1
Sonar 2 -> 1
Microwave beam 2 -> 1
Drill 2 -> 1
All visors (including NV and thermals) 2 -> 1
Circuit Adapter 2 -> 1

The Mining MODsuit has had its complexity increased to 15 and now starts with the eating apparatus module, with a total base complexity of 10/15 now.

The Prototype MODsuit's active slowdown has been decreased from 1.5 (!) to 1.
## Why It's Good For The Game

> Reduced the cost of a lot of MODules.

There's lots of cute little MODules here, and they are all despite their 'small' cost far too expensive for them to ever be used. The small little cost adds up, when you consider that two 2-complexity modules cost FOUR, which is more than most good modules (that are 3), especially when storage modules take up 3 complexity already. Think about it like genetics, imagine if geladikinesis cost 40 instability. It'd be pointless and just make it not used.

> Pathfinder 2 -> 1

Pathfinder is a little buggy, a bit janky, and still just a commodity, so this might let captains keep it for themselves more often when they're kitting out their MOD.

> Tether 3 -> 1

Tether costing 3 complexity is ABSURD. That's as much as the actual ion jetpacks, and that's for something which you can replace completely with a fire extinguisher, not even including the tiny 4 tiles tethering range.

> Temperature Regulator 2 -> 1

This is vital for spacewalking, I really don't know why it's this expensive. Hell it should be the norm, but whatevs.

> DNA lock 2 -> 1

Nobody's ever going to use this if it can just be EMPed and broken... especially when it costs 2 complexity, which is the same cost as defibs, surgical processor, holster, criminal capture..

> Health analyzer 2 -> 1

This is just a health analyzer. A small item that you're paying for the privilege of being able to have it in your janksuit. It really shouldn't cost 2 complexity, nobody ever takes this.

> Sonar 2 -> 1

I don't think there's much of a reason for sonar to be 2 complexity. You might think it's nuts, but sonar really isn't that useful as it's a windup with a screen-only range. Making it 1 might let it be seen ingame at some point.

> Microwave beam 2 -> 1

Despite the cool name this just fries food. I don't think that should be expensive!

> Drill 2 -> 1

The drill module is mostly redundant when by the time you get it, chances are you have a plasma cutter already which is usually better, if not as space-efficient. There's also the dumb issue with drilling into gibtonite which instantly blows it up.

> All visors (including NV and thermals) 2 -> 1

Similarly to the health analyzer, chances are if you HAVE the module you don't actually *need* it as you're already.. that job. 

Additionally, and this is also part of the reason for the NV, thermal, and even the health analyzer modules, is that traitors/nukies now have to balance MOD economy alongside TC count, and I can't tell you just how frustrating it is to buy something and be told I don't have enough complexity to put it into the MODsuit. I already spent the damn TC!

> Circuit Adapter 2 -> 1

This thing seems pretty useless. All it can really do is open and close your modsuit, which like, wow okay. No need for it to be expensive.

> The Mining MODsuit has had its complexity increased to 15 and now starts with the eating apparatus module, with a total base complexity of 10/13 now.

The complexity increase is because for some reason the MODsuit is already filled to the brim by default, which means that actually interacting with robotics in any way is thoroughly disincentivized as you'd need to take so many modules out to do so that it makes the purchase and interaction pointless. Now you CAN go and ask robotics for anything you need, though there isn't much a miner would want and value enough to trek across the station, for now.

Also, it starts with the eating apparatus because it really looked like it should! The flavor text even talks about miners, it's strange for that to be there if miners won't use it. It'll also encourage it to actually be bought more by allowing you to eat through it.

> The Prototype MODsuit's active slowdown has been decreased from 1.5 (!) to 1.

1.5 is a lot, A LOT, of slowdown. For such an incredibly rare mod, it completely kills the damn thing, even for the charlie station crew! You can't fight xenos with 1.5 slowdown! Having Kinesis isn't enough of a reason to cripple it so thoroughly and pointlessly. It's 0.4 now, which is a nice middleground between 'fast' suits like the medical and security ones, and the 'slow' ones like civilian, engineering, science.
## Changelog
:cl:
balance: Reduced the complexity cost of a lot of MODules.
balance: Pathfinder 2 -> 1
balance: Tether 3 -> 2
balance: Temperature Regulator 2 -> 1
balance: DNA lock 2 -> 1
balance: Health analyzer 2 -> 1
balance: Sonar 2 -> 1
balance: Microwave beam 2 -> 1
balance: Drill 2 -> 1
balance: All visors (including NV and thermals) 2 -> 1
balance: Circuit Adapter 2 -> 1
balance: The Mining MODsuit has had its complexity increased to 13 and now starts with the eating apparatus module, with a total base complexity of 10/13 now.
balance: The Prototype MODsuit's active slowdown has been decreased from 1.5 (!) to 1.
spellcheck: Fixed a type on the energy net module.
/:cl:
