### PR TITLE
Adds narrow exceptions to the silicon lathe tax

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -19,6 +19,19 @@
 #define LATHE_TAX 10
 //How much POWER a borg's cell is taxed if they print something from a departmental lathe.
 #define SILICON_LATHE_TAX 2000
+//The modules that grant exceptions to the silicon lathe tax, and the items for which the exception applies
+//Because some of the modules have lists of accepted item typepaths, even single typepaths have to be encased in lists
+GLOBAL_LIST_INIT(SILICON_LATHE_TAX_EXCEPTIONS, list(
+	/obj/item/borg/apparatus/organ_storage = list(/obj/item/organ),
+	/obj/item/storage/part_replacer/cyborg = list(/obj/item/stock_parts),
+	/obj/item/borg/apparatus/beaker = list(/obj/item/reagent_containers/cup/beaker),
+	/obj/item/electroadaptive_pseudocircuit = list(
+		/obj/item/electronics/firelock,
+		/obj/item/electronics/airalarm,
+		/obj/item/electronics/firealarm,
+		/obj/item/electronics/apc,
+		),
+	))
 
 #define STATION_TARGET_BUFFER 25
 

--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -31,6 +31,7 @@ GLOBAL_LIST_INIT(SILICON_LATHE_TAX_EXCEPTIONS, list(
 		/obj/item/electronics/firealarm,
 		/obj/item/electronics/apc,
 		),
+	/obj/item/borg/apparatus/service = list(/obj/item/plate/oven_tray),
 	))
 
 #define STATION_TARGET_BUFFER 25

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -312,10 +312,20 @@
 	if(iscyborg(usr))
 		var/mob/living/silicon/robot/borg = usr
 
+		var/tax = SILICON_LATHE_TAX
+		// I decided this method was better than one extremely long, extremely unreadable if statement
+		// Borgs with the organ bag can print organs for free
+		if((locate(/obj/item/borg/apparatus/organ_storage) in borg.model.modules) && ispath(design.build_path, /obj/item/organ))
+			tax = 0
+		// Borgs with an RPED can print stock parts for free
+		else if((locate(/obj/item/storage/part_replacer/cyborg) in borg.model.modules) && ispath(design.build_path, /obj/item/stock_parts))
+			tax = 0
+
 		if(!borg.cell)
 			return FALSE
 
-		borg.cell.use(SILICON_LATHE_TAX)
+		if(tax)
+			borg.cell.use(tax)
 
 	materials.mat_container.use_materials(efficient_mats, print_quantity)
 	materials.silo_log(src, "built", -print_quantity, "[design.name]", efficient_mats)

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -313,16 +313,9 @@
 		var/mob/living/silicon/robot/borg = usr
 
 		var/tax = SILICON_LATHE_TAX
-		// I decided this method was better than one extremely long, extremely unreadable if statement
-		// Borgs with the organ bag can print organs for free
-		if((locate(/obj/item/borg/apparatus/organ_storage) in borg.model.modules) && ispath(design.build_path, /obj/item/organ))
-			tax = 0
-		// Borgs with an RPED can print stock parts for free
-		else if((locate(/obj/item/storage/part_replacer/cyborg) in borg.model.modules) && ispath(design.build_path, /obj/item/stock_parts))
-			tax = 0
-		// Borgs with the beaker manipulation apparatus can print beakers for free
-		else if((locate(/obj/item/borg/apparatus/beaker) in borg.model.modules) && ispath(design.build_path, /obj/item/reagent_containers/cup/beaker))
-			tax = 0
+		for(var/T in GLOB.SILICON_LATHE_TAX_EXCEPTIONS)
+			if((locate(T) in borg.model.modules) && is_path_in_list(design.build_path, GLOB.SILICON_LATHE_TAX_EXCEPTIONS[T]))
+				tax = 0
 
 		if(!borg.cell)
 			return FALSE

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -320,6 +320,9 @@
 		// Borgs with an RPED can print stock parts for free
 		else if((locate(/obj/item/storage/part_replacer/cyborg) in borg.model.modules) && ispath(design.build_path, /obj/item/stock_parts))
 			tax = 0
+		// Borgs with the beaker manipulation apparatus can print beakers for free
+		else if((locate(/obj/item/borg/apparatus/beaker) in borg.model.modules) && ispath(design.build_path, /obj/item/reagent_containers/cup/beaker))
+			tax = 0
 
 		if(!borg.cell)
 			return FALSE


### PR DESCRIPTION
## About The Pull Request

As part of the long-term rework of the material and money economies, all carbons are required to pay a small lathe tax when printing items from protolathes outside their department. This does not apply for lathes in the department. Cyborgs are also required to pay a lathe tax. When printing any item from any protolathe, the cyborg's cell loses 2000 units of power (for context, the default borg cell has 10000 capacity, and the best printable cell has 40000). Unlike carbons, there are no departmental exceptions. All items printed from a techfab or protolathe are subject to the power tax. This PR is intended to add some very narrow exceptions to the power tax. Borgs with the organ bag module will be able to print organs without incurring the tax, and borgs with the RPED module will be able to print stock parts (but NOT circuit boards) without paying the tax.
## Why It's Good For The Game

Regardless of whether the power tax is needed, maintainers have made it clear that the tax will not be removed wholesale (#76032). However, the tax can make it more difficult for borgs to do their jobs. Mediborgs have the organ bag module, which allows them to pick up, carry, and implant organs, both natural and cybernetic, into their patients. There are doubtless situations where a mediborg has to treat a corpse with rotted and/or missing organs, and power tax will add unnecessary difficulty, especially considering that each individual type of organ will incur the power tax separately. Replacing the heart, liver, lungs, and stomach will drain 80% of a borgs cell, assuming the cell is not upgraded. Similarly, borgs with the RPED upgrade are expected to make and install stock parts, and there are 6 different kinds of stock parts that are used in machines around the station.

By adding narrow exceptions for these scenarios, borgs will be able to do their jobs more easily without the risk of unbalancing the economy. I would like to stress that these exceptions are, in fact, narrow. The discounts will only apply to borgs with the organ bag or RPED modules, and only for relevant items, as borgs are not expected to print items that they cannot use.

EDIT: Exceptions have also been added for the beaker manipulation apparatus and pseudocircuitry module.
## Changelog
:cl:
balance: Borgs with the organ bag module can print cybernetic organs without paying the silicon lathe tax.
balance: Borgs with the RPED module can print stock parts (but NOT circuit boards) without paying the silicon lathe tax.
balance: Similar exceptions made for the beaker manipulator and pseudocircuitry module.
/:cl:
