### PR TITLE
Disables the Scrubber Overflow event. Again.

### DIFF
--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/scrubber_overflow
 	name = "Scrubber Overflow: Normal"
 	typepath = /datum/round_event/scrubber_overflow
-	weight = 10
+	weight = 0
 	max_occurrences = 3
 	min_players = 10
 	category = EVENT_CATEGORY_JANITORIAL


### PR DESCRIPTION

## About The Pull Request
Prevents the Scrubber Overflow event from rolling. No hate to @dragomagol - they did a great job refactoring this event and I would like to see it return later, but for performance reasons this really should be shelved for now.

## Why It's Good For The Game
Scrubber Overflows are lasting about 5-6 minutes on a 65-70 population server with only around 10% time dilation. I can't imagine how long they last on higher values. This isn't the fault of the event itself, but a constant issue we've had with foam in general for a long time now where it sticks around for way, way too long. It's annoying to either have to wait for the game to un-fuck itself or to wade through chems that might blind or otherwise hurt you.

Totally 100% down for this to be re-enabled once foam is working as expected, but it's really bad right now, so it's gotta go.

## Changelog
:cl:
del: Disabled the Scrubber Overflow event from rolling until a time when foam doesn't take ages to go away.
/:cl:
