### PR TITLE
Glass jaw quirk minor oversight fix

### DIFF
--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -296,10 +296,12 @@
 		return
 	//blunt items are more likely to knock out, but sharp ones are still capable of doing it
 	if(prob(CEILING(actual_damage * (sharpness & (SHARP_EDGED|SHARP_POINTY) ? 0.65 : 1), 1)))
-		source.visible_message(
-			span_warning("[source] gets knocked out!"),
-			span_userdanger("You are knocked out!"),
-			vision_distance = COMBAT_MESSAGE_RANGE,
+		//don't display the message if little mac is already KO'd
+		if(!source.IsUnconscious())
+			source.visible_message(
+				span_warning("[source] gets knocked out!"),
+				span_userdanger("You get knocked out!"),
+				vision_distance = COMBAT_MESSAGE_RANGE,
 		)
 		source.Unconscious(3 SECONDS)
 


### PR DESCRIPTION
## About The Pull Request

The knock out message will no longer appear if the quirk holder is already unconscious

## Why It's Good For The Game

Less confusing combat messages!

## Changelog

:cl:
fix: Glass joes will no longer appear to get knocked out, while already knocked out.
/:cl: