### PR TITLE
Ejecting ink cartridge from airlock painter now requires proximity

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -149,7 +149,7 @@
 
 /obj/item/airlock_painter/AltClick(mob/user)
 	. = ..()
-	if(ink)
+	if(ink && user.can_perform_action(src))
 		playsound(src.loc, 'sound/machines/click.ogg', 50, TRUE)
 		ink.forceMove(user.drop_location())
 		user.put_in_hands(ink)


### PR DESCRIPTION
## About The Pull Request
Fixes #76073

## Changelog
:cl:
fix: you need to be in proximity of the airlock painter to eject its cartridge.
/:cl: