### PR TITLE
Stop hitting the windoor after it has finished opening/closing.

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -407,7 +407,8 @@
 	try_to_activate_door(user)
 
 /obj/machinery/door/window/try_to_activate_door(mob/user, access_bypass = FALSE)
-	if (..())
+	. = ..()
+	if(.)
 		autoclose = FALSE
 
 /obj/machinery/door/window/unrestricted_side(mob/opener)


### PR DESCRIPTION
## About The Pull Request
Fixes #64315

So annoying

## Changelog
:cl:
fix: you don't hit the windoor after it has finished opening/closing.
/:cl: