### PR TITLE
Build Mode Preview + better help text

### DIFF
--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -154,7 +154,7 @@
 	holder.screen += preview
 
 /datum/buildmode/proc/close_preview()
-	if(!preview)
+	if(isnull(preview))
 		return
 	holder.screen -= preview
 	qdel(preview)

--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -157,8 +157,7 @@
 	if(isnull(preview))
 		return
 	holder.screen -= preview
-	qdel(preview)
-	preview = null
+	QDEL_NULL(preview)
 
 /datum/buildmode/proc/change_mode(newmode)
 	mode.exit_mode(src)

--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -145,8 +145,6 @@
 			scale = world.icon_size / width
 		else
 			scale = world.icon_size / height
-	preview_overlay.pixel_x = 0
-	preview_overlay.pixel_y = 0
 	preview_overlay.transform = preview_overlay.transform.Scale(scale)
 	preview_overlay.appearance_flags |= TILE_BOUND
 	preview_overlay.layer = FLOAT_LAYER

--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -22,7 +22,7 @@
 	// dirswitch UI
 	var/atom/movable/screen/buildmode/bdir/dirbutton
 	var/list/dirswitch_buttons = list()
-	// item preview for selected item
+	/// item preview for selected item
 	var/atom/movable/screen/buildmode/preview_item/preview
 
 /datum/buildmode/New(client/c)

--- a/code/modules/buildmode/buildmode.dm
+++ b/code/modules/buildmode/buildmode.dm
@@ -22,6 +22,8 @@
 	// dirswitch UI
 	var/atom/movable/screen/buildmode/bdir/dirbutton
 	var/list/dirswitch_buttons = list()
+	// item preview for selected item
+	var/atom/movable/screen/buildmode/preview_item/preview
 
 /datum/buildmode/New(client/c)
 	mode = new /datum/buildmode_mode/basic(src)
@@ -44,6 +46,7 @@
 
 /datum/buildmode/Destroy()
 	close_switchstates()
+	close_preview()
 	holder.player_details.post_login_callbacks -= li_cb
 	li_cb = null
 	holder = null
@@ -126,10 +129,44 @@
 	switch_state = BM_SWITCHSTATE_NONE
 	holder.screen -= dirswitch_buttons
 
+/datum/buildmode/proc/preview_selected_item(atom/typepath)
+	close_preview()
+	preview = new /atom/movable/screen/buildmode/preview_item(src)
+	preview.name = initial(typepath.name)
+
+	// Scale the preview if it's bigger than one tile
+	var/mutable_appearance/preview_overlay = new(typepath)
+	var/icon/size_check = icon(initial(typepath.icon), icon_state = initial(typepath.icon_state))
+	var/scale = 1
+	var/width = size_check.Width()
+	var/height = size_check.Height()
+	if(width > world.icon_size || height > world.icon_size)
+		if(width >= height)
+			scale = world.icon_size / width
+		else
+			scale = world.icon_size / height
+	preview_overlay.pixel_x = 0
+	preview_overlay.pixel_y = 0
+	preview_overlay.transform = preview_overlay.transform.Scale(scale)
+	preview_overlay.appearance_flags |= TILE_BOUND
+	preview_overlay.layer = FLOAT_LAYER
+	preview_overlay.plane = FLOAT_PLANE
+	preview.add_overlay(preview_overlay)
+
+	holder.screen += preview
+
+/datum/buildmode/proc/close_preview()
+	if(!preview)
+		return
+	holder.screen -= preview
+	qdel(preview)
+	preview = null
+
 /datum/buildmode/proc/change_mode(newmode)
 	mode.exit_mode(src)
 	QDEL_NULL(mode)
 	close_switchstates()
+	close_preview()
 	mode = new newmode(src)
 	mode.enter_mode(src)
 	modebutton.update_appearance()

--- a/code/modules/buildmode/buttons.dm
+++ b/code/modules/buildmode/buttons.dm
@@ -89,3 +89,8 @@
 /atom/movable/screen/buildmode/quit/Click()
 	bd.quit()
 	return 1
+
+/atom/movable/screen/buildmode/preview_item
+	name = "Selected Item"
+	icon_state = "template"
+	screen_loc = "NORTH,WEST+4"

--- a/code/modules/buildmode/submodes/advanced.dm
+++ b/code/modules/buildmode/submodes/advanced.dm
@@ -2,9 +2,6 @@
 	key = "advanced"
 	var/atom/objholder = null
 
-// FIXME: add logic which adds a button displaying the icon
-// of the currently selected path
-
 /datum/buildmode_mode/advanced/show_help(client/builder)
 	to_chat(builder, span_purple(examine_block(
 		"[span_bold("Set object type")] -> Right Mouse Button on buildmode button\n\
@@ -27,6 +24,7 @@
 			objholder = null
 			tgui_alert(usr,"That path is not allowed.")
 			return
+	BM.preview_selected_item(objholder)
 
 /datum/buildmode_mode/advanced/handle_click(client/c, params, obj/object)
 	var/list/modifiers = params2list(params)
@@ -38,6 +36,7 @@
 		if (istype(object, /turf) || isobj(object) || istype(object, /mob))
 			objholder = object.type
 			to_chat(c, span_notice("[initial(object.name)] ([object.type]) selected."))
+			BM.preview_selected_item(objholder)
 		else
 			to_chat(c, span_notice("[initial(object.name)] is not a turf, object, or mob! Please select again."))
 	else if(left_click)

--- a/code/modules/buildmode/submodes/advanced.dm
+++ b/code/modules/buildmode/submodes/advanced.dm
@@ -5,15 +5,15 @@
 // FIXME: add logic which adds a button displaying the icon
 // of the currently selected path
 
-/datum/buildmode_mode/advanced/show_help(client/c)
-	to_chat(c, span_notice("***********************************************************"))
-	to_chat(c, span_notice("Right Mouse Button on buildmode button = Set object type"))
-	to_chat(c, span_notice("Left Mouse Button + alt on turf/obj    = Copy object type"))
-	to_chat(c, span_notice("Left Mouse Button on turf/obj          = Place objects"))
-	to_chat(c, span_notice("Right Mouse Button                     = Delete objects"))
-	to_chat(c, span_notice("\nUse the button in the upper left corner to"))
-	to_chat(c, span_notice("change the direction of built objects."))
-	to_chat(c, span_notice("***********************************************************"))
+/datum/buildmode_mode/advanced/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Set object type")] -> Right Mouse Button on buildmode button\n\
+		[span_bold("Copy object type")] -> Left Mouse Button + Alt on turf/obj\n\
+		[span_bold("Place objects")] -> Left Mouse Button on turf/obj\n\
+		[span_bold("Delete objects")] -> Right Mouse Button\n\
+		\n\
+		Use the button in the upper left corner to change the direction of built objects."))
+	)
 
 /datum/buildmode_mode/advanced/change_settings(client/c)
 	var/target_path = input(c, "Enter typepath:", "Typepath", "/obj/structure/closet")

--- a/code/modules/buildmode/submodes/area_edit.dm
+++ b/code/modules/buildmode/submodes/area_edit.dm
@@ -8,6 +8,14 @@
 	areaimage = image('icons/area/areas_misc.dmi', null, "yellow")
 	..()
 
+/datum/buildmode_mode/area_edit/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Select corner")] -> Left Mouse Button on obj/turf/mob\n\
+		[span_bold("Paint area")] -> Left Mouse Button + Alt on turf/obj/mob\n\
+		[span_bold("Select area to paint")] -> Right Mouse Button on obj/turf/mob\n\
+		[span_bold("Create new area")] -> Right Mouse Button on buildmode button"))
+	)
+
 /datum/buildmode_mode/area_edit/enter_mode(datum/buildmode/BM)
 	BM.holder.images += areaimage
 
@@ -20,14 +28,6 @@
 	QDEL_NULL(areaimage)
 	storedarea = null
 	return ..()
-
-/datum/buildmode_mode/area_edit/show_help(client/c)
-	to_chat(c, span_notice("***********************************************************"))
-	to_chat(c, span_notice("Left Mouse Button on obj/turf/mob = Select corner"))
-	to_chat(c, "<span class='notice'>Left Mouse Button + Alt on turf/obj/mob = Paint area/span>")
-	to_chat(c, span_notice("Right Mouse Button on obj/turf/mob = Select area to paint"))
-	to_chat(c, span_notice("Right Mouse Button on buildmode button = Create new area"))
-	to_chat(c, span_notice("***********************************************************"))
 
 /datum/buildmode_mode/area_edit/change_settings(client/c)
 	var/target_path = input(c, "Enter typepath:", "Typepath", "/area")

--- a/code/modules/buildmode/submodes/basic.dm
+++ b/code/modules/buildmode/submodes/basic.dm
@@ -1,15 +1,15 @@
 /datum/buildmode_mode/basic
 	key = "basic"
 
-/datum/buildmode_mode/basic/show_help(client/c)
-	to_chat(c, span_notice("***********************************************************"))
-	to_chat(c, span_notice("Left Mouse Button        = Construct / Upgrade"))
-	to_chat(c, span_notice("Right Mouse Button       = Deconstruct / Delete / Downgrade"))
-	to_chat(c, span_notice("Left Mouse Button + ctrl = R-Window"))
-	to_chat(c, span_notice("Left Mouse Button + alt  = Airlock"))
-	to_chat(c, span_notice("\nUse the button in the upper left corner to"))
-	to_chat(c, span_notice("change the direction of built objects."))
-	to_chat(c, span_notice("***********************************************************"))
+/datum/buildmode_mode/basic/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Construct / Upgrade")] -> Left Mouse Button\n\
+		[span_bold("Deconstruct / Delete / Downgrade")] -> Right Mouse Button\n\
+		[span_bold("R-Window")] -> Left Mouse Button + Ctrl\n\
+		[span_bold("Airlock")] -> Left Mouse Button + Alt \n\
+		\n\
+		Use the button in the upper left corner to change the direction of built objects."))
+	)
 
 /datum/buildmode_mode/basic/handle_click(client/c, params, obj/object)
 	var/list/modifiers = params2list(params)

--- a/code/modules/buildmode/submodes/boom.dm
+++ b/code/modules/buildmode/submodes/boom.dm
@@ -12,14 +12,15 @@
 		BOOM_HEAVY = 0,
 		BOOM_LIGHT = 0,
 		BOOM_FLASH = 0,
-		BOOM_FLAMES = 0
-		)
+		BOOM_FLAMES = 0,
+	)
 
-/datum/buildmode_mode/boom/show_help(client/c)
-	to_chat(c, span_notice("***********************************************************"))
-	to_chat(c, span_notice("Mouse Button on obj  = Kaboom"))
-	to_chat(c, span_notice("NOTE: Using the \"Config/Launch Supplypod\" verb allows you to do this in an IC way (i.e., making a cruise missile come down from the sky and explode wherever you click!)"))
-	to_chat(c, span_notice("***********************************************************"))
+/datum/buildmode_mode/boom/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Set explosion destructiveness")] -> Right Mouse Button on buildmode button\n\
+		[span_bold("Kaboom")] -> Mouse Button on obj\n\n\
+		[span_warning("NOTE:")] Using the \"Config/Launch Supplypod\" verb allows you to do this in an IC way (i.e., making a cruise missile come down from the sky and explode wherever you click!)"))
+	)
 
 /datum/buildmode_mode/boom/change_settings(client/c)
 	for (var/explosion_level in explosions)

--- a/code/modules/buildmode/submodes/copy.dm
+++ b/code/modules/buildmode/submodes/copy.dm
@@ -6,11 +6,11 @@
 	stored = null
 	return ..()
 
-/datum/buildmode_mode/copy/show_help(client/c)
-	to_chat(c, span_notice("***********************************************************"))
-	to_chat(c, span_notice("Left Mouse Button on obj/turf/mob   = Spawn a Copy of selected target"))
-	to_chat(c, span_notice("Right Mouse Button on obj/mob = Select target to copy"))
-	to_chat(c, span_notice("***********************************************************"))
+/datum/buildmode_mode/copy/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Spawn a copy of selected target")] -> Left Mouse Button on obj/turf/mob\n\
+		[span_bold("Select target to copy")] -> Right Mouse Button on obj/mob"))
+	)
 
 /datum/buildmode_mode/copy/handle_click(client/c, params, obj/object)
 	var/list/modifiers = params2list(params)

--- a/code/modules/buildmode/submodes/delete.dm
+++ b/code/modules/buildmode/submodes/delete.dm
@@ -1,11 +1,11 @@
 /datum/buildmode_mode/delete
 	key = "delete"
 
-/datum/buildmode_mode/delete/show_help(client/c)
-	to_chat(c, "<span class='notice'>***********************************************************\n\
-		Left Mouse Button on anything to delete it. If you break it, you buy it.\n\
-		Right Mouse Button on anything to delete everything of the type. Probably don\'t do this unless you know what you are doing.\n\
-		***********************************************************</span>")
+/datum/buildmode_mode/delete/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Delete an object")] -> Left Mouse Button on obj/turf/mob\n\
+		[span_bold("Delete all objects of a type")] -> Right Mouse Button on obj/turf/mob"))
+	)
 
 /datum/buildmode_mode/delete/handle_click(client/c, params, object)
 	var/list/modifiers = params2list(params)

--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -6,12 +6,12 @@
 	use_corner_selection = TRUE
 	var/atom/objholder = null
 
-/datum/buildmode_mode/fill/show_help(client/c)
-	to_chat(c, span_notice("***********************************************************"))
-	to_chat(c, span_notice("Left Mouse Button on turf/obj/mob      = Select corner"))
-	to_chat(c, span_notice("Left Mouse Button + Alt on turf/obj/mob = Delete region"))
-	to_chat(c, span_notice("Right Mouse Button on buildmode button = Select object type"))
-	to_chat(c, span_notice("***********************************************************"))
+/datum/buildmode_mode/fill/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Select corner")] -> Left Mouse Button on turf/obj/mob\n\
+		[span_bold("Delete region")] -> Left Mouse Button + Alt on turf/obj/mob\n\
+		[span_bold("Select object type")] -> Right Mouse Button on buildmode button"))
+	)
 
 /datum/buildmode_mode/fill/change_settings(client/c)
 	var/target_path = input(c, "Enter typepath:" ,"Typepath","/obj/structure/closet")

--- a/code/modules/buildmode/submodes/fill.dm
+++ b/code/modules/buildmode/submodes/fill.dm
@@ -25,6 +25,7 @@
 			objholder = null
 			tgui_alert(usr,"Area paths are not supported for this mode, use the area edit mode instead.")
 			return
+	BM.preview_selected_item(objholder)
 	deselect_region()
 
 /datum/buildmode_mode/fill/handle_click(client/c, params, obj/object)

--- a/code/modules/buildmode/submodes/mapgen.dm
+++ b/code/modules/buildmode/submodes/mapgen.dm
@@ -6,8 +6,8 @@
 
 /datum/buildmode_mode/mapgen/show_help(client/builder)
 	to_chat(builder, span_purple(examine_block(
-		"[span_bold("Select corner")] -> Left Mouse Button on turf/obj/mob"
-		"[span_bold("Select generator")] -> Right Mouse Button on buildmode button"))
+		"[span_bold("Select corner")] -> Left Mouse Button on turf/obj/mob\n\
+		[span_bold("Select generator")] -> Right Mouse Button on buildmode button"))
 	)
 
 /datum/buildmode_mode/mapgen/change_settings(client/c)

--- a/code/modules/buildmode/submodes/mapgen.dm
+++ b/code/modules/buildmode/submodes/mapgen.dm
@@ -4,11 +4,11 @@
 	use_corner_selection = TRUE
 	var/generator_path
 
-/datum/buildmode_mode/mapgen/show_help(client/c)
-	to_chat(c, span_notice("***********************************************************"))
-	to_chat(c, span_notice("Left Mouse Button on turf/obj/mob      = Select corner"))
-	to_chat(c, span_notice("Right Mouse Button on buildmode button = Select generator"))
-	to_chat(c, span_notice("***********************************************************"))
+/datum/buildmode_mode/mapgen/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Select corner")] -> Left Mouse Button on turf/obj/mob"
+		"[span_bold("Select generator")] -> Right Mouse Button on buildmode button"))
+	)
 
 /datum/buildmode_mode/mapgen/change_settings(client/c)
 	var/list/gen_paths = subtypesof(/datum/map_generator)

--- a/code/modules/buildmode/submodes/outfit.dm
+++ b/code/modules/buildmode/submodes/outfit.dm
@@ -6,12 +6,12 @@
 	dressuptime = null
 	return ..()
 
-/datum/buildmode_mode/outfit/show_help(client/c)
-	to_chat(c, "<span class='notice'>***********************************************************\n\
-		Right Mouse Button on buildmode button = Select outfit to equip.\n\
-		Left Mouse Button on mob/living/carbon/human = Equip the selected outfit.\n\
-		Right Mouse Button on mob/living/carbon/human = Strip and delete current outfit.\n\
-		***********************************************************</span>")
+/datum/buildmode_mode/outfit/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Select outfit to equip")] -> Right Mouse Button on buildmode button\n\
+		[span_bold("Equip the selected outfit")] -> Left Mouse Button on mob/living/carbon/human\n\
+		[span_bold("Strip and delete current outfit")] -> Right Mouse Button on mob/living/carbon/human"))
+	)
 
 /datum/buildmode_mode/outfit/Reset()
 	. = ..()

--- a/code/modules/buildmode/submodes/proccall.dm
+++ b/code/modules/buildmode/submodes/proccall.dm
@@ -5,11 +5,11 @@
 	///The list of arguments for the procedure. They may not be. They are selected in the same way in the game, and can be a datum, and other types.
 	var/list/proc_args = null
 
-/datum/buildmode_mode/proccall/show_help(client/target_client)
-	to_chat(target_client, span_notice("***********************************************************\n\
-		Right Mouse Button on buildmode button = Choose procedure and arguments\n\
-		Left Mouse Button on machinery = Apply procedure on object.\n\
-		***********************************************************"))
+/datum/buildmode_mode/proccall/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Choose procedure and arguments")] -> Right Mouse Button on buildmode button\n\
+		[span_bold("Apply procedure on object")] -> Left Mouse Button on machinery"))
+	)
 
 /datum/buildmode_mode/proccall/change_settings(client/target_client)
 	if(!check_rights_for(target_client, R_DEBUG))

--- a/code/modules/buildmode/submodes/smite.dm
+++ b/code/modules/buildmode/submodes/smite.dm
@@ -6,11 +6,11 @@
 	selected_smite = null
 	return ..()
 
-/datum/buildmode_mode/smite/show_help(client/user)
-	to_chat(user, "<span class='notice'>***********************************************************\n\
-		Right Mouse Button on buildmode button = Select smite to use.\n\
-		Left Mouse Button on mob/living = Smite the mob.\n\
-		***********************************************************</span>")
+/datum/buildmode_mode/smite/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Select smite to use")] -> Right Mouse Button on buildmode button\n\
+		[span_bold("Smite the mob")] -> Left Mouse Button on mob/living"))
+	)
 
 /datum/buildmode_mode/smite/change_settings(client/user)
 	var/punishment = input(user, "Choose a punishment", "DIVINE SMITING") as null|anything in GLOB.smites

--- a/code/modules/buildmode/submodes/throwing.dm
+++ b/code/modules/buildmode/submodes/throwing.dm
@@ -7,11 +7,11 @@
 	throw_atom = null
 	return ..()
 
-/datum/buildmode_mode/throwing/show_help(client/c)
-	to_chat(c, span_notice("***********************************************************"))
-	to_chat(c, span_notice("Left Mouse Button on turf/obj/mob      = Select"))
-	to_chat(c, span_notice("Right Mouse Button on turf/obj/mob     = Throw"))
-	to_chat(c, span_notice("***********************************************************"))
+/datum/buildmode_mode/throwing/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Select")] -> Left Mouse Button on turf/obj/mob\n\
+		[span_bold("Throw")] -> Right Mouse Button on turf/obj/mob"))
+	)
 
 /datum/buildmode_mode/throwing/handle_click(client/c, params, obj/object)
 	var/list/modifiers = params2list(params)

--- a/code/modules/buildmode/submodes/tweakcomps.dm
+++ b/code/modules/buildmode/submodes/tweakcomps.dm
@@ -3,11 +3,11 @@
 	/// This variable is responsible for the rating of the components themselves. Literally tiers of components, where 1 is standard, 4 is bluespace.
 	var/rating = null
 
-/datum/buildmode_mode/tweakcomps/show_help(client/target_client)
-	to_chat(target_client, span_notice("***********************************************************\n\
-		Right Mouse Button on buildmode button = Choose the rating of the components.\n\
-		Left Mouse Button on machinery = Sets the chosen rating of the components on the machinery.\n\
-		***********************************************************"))
+/datum/buildmode_mode/tweakcomps/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Choose the rating of the components")] -> Right Mouse Button on buildmode button\n\
+		[span_bold("Sets the chosen rating of the components on the machinery")] -> Left Mouse Button on machinery"))
+	)
 
 /datum/buildmode_mode/tweakcomps/change_settings(client/target_client)
 	var/rating_to_choose = input(target_client, "Enter number of rating", "Number", "1")

--- a/code/modules/buildmode/submodes/variable_edit.dm
+++ b/code/modules/buildmode/submodes/variable_edit.dm
@@ -9,12 +9,12 @@
 	valueholder = null
 	return ..()
 
-/datum/buildmode_mode/varedit/show_help(client/c)
-	to_chat(c, span_notice("***********************************************************"))
-	to_chat(c, span_notice("Right Mouse Button on buildmode button = Select var(type) & value"))
-	to_chat(c, span_notice("Left Mouse Button on turf/obj/mob      = Set var(type) & value"))
-	to_chat(c, span_notice("Right Mouse Button on turf/obj/mob     = Reset var's value"))
-	to_chat(c, span_notice("***********************************************************"))
+/datum/buildmode_mode/varedit/show_help(client/builder)
+	to_chat(builder, span_purple(examine_block(
+		"[span_bold("Select var(type) & value")] -> Right Mouse Button on buildmode button\n\
+		[span_bold("Set var(type) & value")] -> Left Mouse Button on turf/obj/mob\n\
+		[span_bold("Reset var's value")] -> Right Mouse Button on turf/obj/mob"))
+	)
 
 /datum/buildmode_mode/varedit/Reset()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Gives `Adv Build Mode` and `Fill` an item preview, and puts the help text for build mode modes into an examine block.

https://github.com/tgstation/tgstation/assets/66640614/6751c721-6ddd-4761-8311-fb002ea905ac

![image](https://github.com/tgstation/tgstation/assets/66640614/3f6fe986-1767-4639-94d3-523f1039c947)

![image](https://github.com/tgstation/tgstation/assets/66640614/a7eae938-a575-46bd-b00e-865f04e0de20)


## Why It's Good For The Game
It's good to see what you're doing. 

## Changelog
:cl: Tattle
admin: build mode help text is in an examine block
admin: adv build mode and fill now have item previews
/:cl:
