### PR TITLE
Fix Biscuit (paper) hard delete

### DIFF
--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -15,13 +15,23 @@
 
 /obj/item/folder/biscuit/Initialize(mapload)
 	. = ..()
-	if(!isnull(contained_slip))
+	if(ispath(contained_slip, /obj/item/paper/paperslip))
 		contained_slip = new contained_slip(src)
 
 /obj/item/folder/biscuit/Destroy()
-	if(contained_slip)
+	if(isdatum(contained_slip))
 		QDEL_NULL(contained_slip)
 	return ..()
+
+/obj/item/folder/biscuit/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(contained_slip == gone)
+		contained_slip = null
+
+/obj/item/folder/biscuit/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	. = ..()
+	if(isnull(contained_slip) && istype(arrived, /obj/item/paper/paperslip))
+		contained_slip == arrived
 
 /obj/item/folder/biscuit/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] tries to eat [src]! [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/paperwork/paper_biscuit.dm
+++ b/code/modules/paperwork/paper_biscuit.dm
@@ -31,7 +31,7 @@
 /obj/item/folder/biscuit/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	. = ..()
 	if(isnull(contained_slip) && istype(arrived, /obj/item/paper/paperslip))
-		contained_slip == arrived
+		contained_slip = arrived
 
 /obj/item/folder/biscuit/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] tries to eat [src]! [user.p_theyre()] trying to commit suicide!"))


### PR DESCRIPTION
## About The Pull Request

`contained_slip` is a reference to one paperslip in the "folder" contents, when said slip was removed and eventually deleted caused a hard delete. 

## Why It's Good For The Game

Hard deletes bad

## Changelog

:cl: Melbert
fix: Fix Hard Delete from the captain's spare ID code paper
/:cl:
