### PR TITLE
Fix traitor trapper tool hard delete

### DIFF
--- a/code/modules/antagonists/traitor/objectives/sabotage_machinery.dm
+++ b/code/modules/antagonists/traitor/objectives/sabotage_machinery.dm
@@ -98,8 +98,8 @@ GLOBAL_DATUM_INIT(objective_machine_handler, /datum/objective_target_machine_han
 	var/bonus_tc = 2
 	/// Bonus progression to grant if you booby trap successfully
 	var/bonus_progression = 5 MINUTES
-	/// The trap device we give out
-	var/obj/item/traitor_machine_trapper/tool
+	/// Have we given out a traitor trap item?
+	var/traitor_trapper_given = FALSE
 
 /datum/traitor_objective/sabotage_machinery/trap/generate_objective(datum/mind/generating_for, list/possible_duplicates)
 	. = ..()
@@ -122,7 +122,7 @@ GLOBAL_DATUM_INIT(objective_machine_handler, /datum/objective_target_machine_han
 
 /datum/traitor_objective/sabotage_machinery/trap/generate_ui_buttons(mob/user)
 	var/list/buttons = list()
-	if(!tool)
+	if(!traitor_trapper_given)
 		buttons += add_ui_button("", "Pressing this will materialize an explosive trap in your hand, which you can conceal within the target machine", "wifi", "summon_gear")
 	return buttons
 
@@ -130,9 +130,10 @@ GLOBAL_DATUM_INIT(objective_machine_handler, /datum/objective_target_machine_han
 	. = ..()
 	switch(action)
 		if("summon_gear")
-			if(tool)
+			if(traitor_trapper_given)
 				return
-			tool = new(user.drop_location())
+			traitor_trapper_given = TRUE
+			var/obj/item/traitor_machine_trapper/tool = new(user.drop_location())
 			user.put_in_hands(tool)
 			tool.balloon_alert(user, "a booby trap materializes in your hand")
 			tool.target_machine_path = applicable_jobs[chosen_job]


### PR DESCRIPTION
## About The Pull Request

There's no need to hold an unmanaged reference to something just to check if it's been created or not

If the intent was to be "let the traitor re-summon it if it gets deleted somehow", this should be using a weakref and resolving it, but I'm not sure if that was the intention so I'm changing it to a bool

## Why It's Good For The Game

Hard deletes bad

## Changelog

:cl: Melbert
fix: Fix hard delete in traitor trap tool objective
/:cl:

