### PR TITLE
Fix north star random failure

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -24034,10 +24034,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard/fore)
-"gjm" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/floor1/port)
 "gjn" = (
 /obj/structure/table,
 /obj/item/stock_parts/matter_bin,
@@ -127328,7 +127324,7 @@ iun
 xgH
 kzE
 kzE
-gjm
+kzE
 kzE
 kzE
 kzE


### PR DESCRIPTION
## About The Pull Request

Loot spawn located in wall, spawns ash, causes runtime?

https://github.com/tgstation/tgstation/actions/runs/5293816730/jobs/9582438906?pr=76098

## Changelog

:cl: Melbert
fix: Fixed a maint loot spawner located inside a wall in North Star Chemistry Lab Maintenance
/:cl:

