### PR TITLE
Saves about 0.2 seconds of init re:air updates

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_system.dm
+++ b/code/modules/atmospherics/environmental/LINDA_system.dm
@@ -172,6 +172,8 @@
 	return adjacent_turfs
 
 /atom/proc/air_update_turf(update = FALSE, remove = FALSE)
+	if(!SSair.initialized) // I'm sorry for polutting user code, I'll do 10 hail giacom's
+		return
 	var/turf/local_turf = get_turf(loc)
 	if(!local_turf)
 		return
@@ -187,6 +189,8 @@
  * * remove - Are you removing an active turf (Read wall), or adding one
 */
 /turf/air_update_turf(update = FALSE, remove = FALSE)
+	if(!SSair.initialized) // I'm sorry for polutting user code, I'll do 10 hail giacom's
+		return
 	if(update)
 		immediate_calculate_adjacent_turfs()
 	if(remove)


### PR DESCRIPTION
## About The Pull Request

We should be blocking the primary ssair activity updates if the subsystem hasn't started yet

## Why It's Good For The Game

https://github.com/tgstation/dev-cycles-initiative/issues/25

Total waste of time, wins maybe 0.2 seconds of init