### PR TITLE
Cannot use departmental budget cards as source of credit withdraw

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -44,6 +44,9 @@
 #define ACCOUNT_SEC "SEC"
 #define ACCOUNT_SEC_NAME "Defense Budget"
 
+#define IS_DEPARTMENTAL_CARD(card) (card in SSeconomy.dep_cards)
+#define IS_DEPARTMENTAL_ACCOUNT(account) (account in SSeconomy.departmental_accounts)
+
 #define NO_FREEBIES "commies go home"
 
 //Defines that set what kind of civilian bounties should be applied mid-round.

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -14,7 +14,7 @@ SUBSYSTEM_DEF(economy)
 										ACCOUNT_SRV = ACCOUNT_SRV_NAME,
 										ACCOUNT_CAR = ACCOUNT_CAR_NAME,
 										ACCOUNT_SEC = ACCOUNT_SEC_NAME)
-	var/list/generated_accounts = list()
+	var/list/departmental_accounts = list()
 	/**
 	 * Enables extra money charges for things that normally would be free, such as sleepers/cryo/beepsky.
 	 * Take care when enabling, as players will NOT respond well if the economy is set up for low cash flows.
@@ -82,7 +82,7 @@ SUBSYSTEM_DEF(economy)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/economy/Recover()
-	generated_accounts = SSeconomy.generated_accounts
+	departmental_accounts = SSeconomy.departmental_accounts
 	bank_accounts_by_id = SSeconomy.bank_accounts_by_id
 	dep_cards = SSeconomy.dep_cards
 
@@ -144,7 +144,7 @@ SUBSYSTEM_DEF(economy)
  * Handy proc for obtaining a department's bank account, given the department ID, AKA the define assigned for what department they're under.
  */
 /datum/controller/subsystem/economy/proc/get_dep_account(dep_id)
-	for(var/datum/bank_account/department/D in generated_accounts)
+	for(var/datum/bank_account/department/D in departmental_accounts)
 		if(D.department_id == dep_id)
 			return D
 

--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -139,7 +139,7 @@
 			return FALSE
 
 		if(my_card)
-			if(istype(player_card, /obj/item/card/id/departmental_budget)) // Are they using a department ID
+			if(IS_DEPARTMENTAL_CARD(player_card)) // Are they using a department ID
 				say("You cannot gamble with the department budget!")
 				playsound(src, 'sound/machines/buzz-two.ogg', 30, TRUE)
 				return FALSE

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -111,7 +111,7 @@
 /obj/structure/closet/crate/secure/owned/Initialize(mapload, datum/bank_account/_buyer_account)
 	. = ..()
 	buyer_account = _buyer_account
-	if(istype(buyer_account, /datum/bank_account/department))
+	if(IS_DEPARTMENTAL_ACCOUNT(buyer_account))
 		department_purchase = TRUE
 		department_account = buyer_account
 

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -205,7 +205,7 @@
 		if(!istype(id_card))
 			say("No ID card detected.")
 			return
-		if(istype(id_card, /obj/item/card/id/departmental_budget))
+		if(IS_DEPARTMENTAL_CARD(id_card))
 			say("The [src] rejects [id_card].")
 			return
 		account = id_card.registered_account

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -132,12 +132,12 @@
 		var/reason_to = "Transfer: From [from.account_holder]"
 		var/reason_from = "Transfer: To [account_holder]"
 
-		if(istype(from, /datum/bank_account/department))
+		if(IS_DEPARTMENTAL_ACCOUNT(from))
 			reason_to = "Nanotrasen: Salary"
 			reason_from = ""
 
 		if(transfer_reason)
-			reason_to = istype(src, /datum/bank_account/department) ? "" : transfer_reason
+			reason_to = IS_DEPARTMENTAL_ACCOUNT(src) ? "" : transfer_reason
 			reason_from = transfer_reason
 
 		adjust_money(amount, reason_to)
@@ -268,7 +268,7 @@
 	department_id = dep_id
 	account_balance = budget
 	account_holder = SSeconomy.department_accounts[dep_id]
-	SSeconomy.generated_accounts += src
+	SSeconomy.departmental_accounts += src
 
 /datum/bank_account/remote // Bank account not belonging to the local station
 	add_to_accounts = FALSE

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -218,7 +218,7 @@
 				if(!istype(id_card))
 					computer.say("No ID card detected.")
 					return
-				if(istype(id_card, /obj/item/card/id/departmental_budget))
+				if(IS_DEPARTMENTAL_CARD(id_card))
 					computer.say("[id_card] cannot be used to make purchases.")
 					return
 				account = id_card.registered_account

--- a/code/modules/modular_computers/file_system/programs/nt_pay.dm
+++ b/code/modules/modular_computers/file_system/programs/nt_pay.dm
@@ -20,7 +20,7 @@
 /datum/computer_file/program/nt_pay/ui_act(action, list/params, datum/tgui/ui)
 	switch(action)
 		if("Transaction")
-			if(istype(current_user, /datum/bank_account/department))
+			if(IS_DEPARTMENTAL_ACCOUNT(current_user))
 				return to_chat(usr, span_notice("The app is unable to withdraw from that card."))
 
 			token = params["token"]

--- a/code/modules/modular_computers/file_system/programs/nt_pay.dm
+++ b/code/modules/modular_computers/file_system/programs/nt_pay.dm
@@ -20,6 +20,9 @@
 /datum/computer_file/program/nt_pay/ui_act(action, list/params, datum/tgui/ui)
 	switch(action)
 		if("Transaction")
+			if(istype(current_user, /datum/bank_account/department))
+				return to_chat(usr, span_notice("The app is unable to withdraw from that card."))
+
 			token = params["token"]
 			money_to_send = params["amount"]
 			var/datum/bank_account/recipient


### PR DESCRIPTION

## About The Pull Request

Currently you can put cargo's budget card into your PDA, go into NT Pay and send over the budget to any pay token you want including yours. This just adds a check to ensure you aren't using that kind of card as withdrawal source.

## Why It's Good For The Game

The cargo budget card isn't withdrawable from outside of the loud machine in the most secure station area that yells to everyone in Common comms to come beat you up the moment you use it as evidented by the card's code comments. This fixes a cheesy way to bypass the alt+click withdrawal restriction that was just having an extra step of putting it in your PDA before doing it.

## Changelog
:cl:
fix: you cannot use departmental budget cards as withdrawal sources for NT Pay anymore
/:cl:
