### PR TITLE
Fixes exotic blood types persisting through species change

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -468,8 +468,13 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 	INVOKE_ASYNC(src, PROC_REF(worn_items_fit_body_check), C, TRUE)
 
+	//Assigns exotic blood type if the species has one
 	if(exotic_bloodtype && C.dna.blood_type != exotic_bloodtype)
 		C.dna.blood_type = exotic_bloodtype
+	//Otherwise, check if the previous species had an exotic bloodtype and we do not have one and assign a random blood type
+	//(why the fuck is blood type not tied to a fucking DNA block?)
+	else if(old_species.exotic_bloodtype && !exotic_bloodtype)
+		C.dna.blood_type = random_blood_type()
 
 	if(ishuman(C))
 		var/mob/living/carbon/human/human = C


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/75838

## Why It's Good For The Game

It's funny but it's a bad evil bug

## Changelog

:cl:
fix: Exotic blood types no longer persist through species change if the new species does not have an exotic blood type
/:cl:
