### PR TITLE
mediborg beaker apparatuses can now hold test tubes

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -164,8 +164,10 @@
 	name = "beverage storage apparatus"
 	desc = "A special apparatus for carrying drinks and condiment packets without spilling their contents. Will resynthesize any drinks (or other nutritional liquids) you pour out of glasses!"
 	icon_state = "borg_beaker_apparatus"
-	storable = list(/obj/item/reagent_containers/cup/glass,
-					/obj/item/reagent_containers/condiment)
+	storable = list(
+		/obj/item/reagent_containers/cup/glass,
+		/obj/item/reagent_containers/condiment,
+	)
 
 /obj/item/borg/apparatus/beaker/service/add_glass()
 	stored = new /obj/item/reagent_containers/cup/glass/drinkingglass(src)

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -96,8 +96,9 @@
 	desc = "A special apparatus for carrying beakers, bottles, and test tubes without spilling their contents."
 	icon_state = "borg_beaker_apparatus"
 	storable = list(/obj/item/reagent_containers/cup/beaker,
-					/obj/item/reagent_containers/cup/bottle,
-					/obj/item/reagent_containers/cup/tube)
+		/obj/item/reagent_containers/cup/bottle,
+		/obj/item/reagent_containers/cup/tube,
+	)
 
 /obj/item/borg/apparatus/beaker/Initialize(mapload)
 	add_glass()

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -95,7 +95,8 @@
 	name = "beaker storage apparatus"
 	desc = "A special apparatus for carrying beakers, bottles, and test tubes without spilling their contents."
 	icon_state = "borg_beaker_apparatus"
-	storable = list(/obj/item/reagent_containers/cup/beaker,
+	storable = list(
+		/obj/item/reagent_containers/cup/beaker,
 		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/cup/tube,
 	)

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -93,10 +93,11 @@
 
 /obj/item/borg/apparatus/beaker
 	name = "beaker storage apparatus"
-	desc = "A special apparatus for carrying beakers without spilling the contents."
+	desc = "A special apparatus for carrying beakers, bottles, and test tubes without spilling their contents."
 	icon_state = "borg_beaker_apparatus"
 	storable = list(/obj/item/reagent_containers/cup/beaker,
-					/obj/item/reagent_containers/cup/bottle)
+					/obj/item/reagent_containers/cup/bottle,
+					/obj/item/reagent_containers/cup/tube)
 
 /obj/item/borg/apparatus/beaker/Initialize(mapload)
 	add_glass()
@@ -159,7 +160,7 @@
 
 /obj/item/borg/apparatus/beaker/service
 	name = "beverage storage apparatus"
-	desc = "A special apparatus for carrying drinks without spilling the contents. Will resynthesize any drinks you pour out!"
+	desc = "A special apparatus for carrying drinks and condiment packets without spilling their contents. Will resynthesize any drinks (or other nutritional liquids) you pour out of glasses!"
 	icon_state = "borg_beaker_apparatus"
 	storable = list(/obj/item/reagent_containers/cup/glass,
 					/obj/item/reagent_containers/condiment)


### PR DESCRIPTION
## About The Pull Request

In addition to the beakers and bottles they could already hold, mediborg beaker apparatuses can now hold test tubes.

The descriptions of beaker and drink apparatuses have been updated to more accurately reflect what they can and can't hold.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/76111.

This seems to just be an oversight from the PR that added test tubes, especially since service borg drink apparatuses can hold condiment packets.

## Changelog

:cl:
fix: In addition to the beakers and bottles they could already hold, mediborg beaker apparatuses can now hold test tubes.
spellcheck: The descriptions of beaker and drink apparatuses have been updated to more accurately reflect what they can and can't hold.
/:cl: