### PR TITLE
Nerfs summon stickman spam

### DIFF
--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -220,7 +220,7 @@
 
 	usr.say("Rise, my creation! Off your page into this realm!", forced = "stickman summoning")
 	playsound(loc, 'sound/magic/summon_magic.ogg', 50, TRUE, TRUE)
-	var/mob/living/M = new /mob/living/basic/stickman(get_turf(usr))
+	var/mob/living/M = new /mob/living/basic/stickman/lesser(get_turf(usr))
 	M.faction += list("[REF(usr)]")
 	robe_charge = FALSE
 	sleep(3 SECONDS)

--- a/code/modules/mob/living/basic/ruin_defender/stickman.dm
+++ b/code/modules/mob/living/basic/ruin_defender/stickman.dm
@@ -22,6 +22,10 @@
 
 	ai_controller = /datum/ai_controller/basic_controller/stickman
 
+/mob/living/basic/stickman/lesser
+	maxHealth = 25
+	health = 25
+
 /mob/living/basic/stickman/Initialize(mapload)
 	. = ..()
 	new /obj/effect/temp_visual/paper_scatter(get_turf(src))


### PR DESCRIPTION
Weakens stickman summoned from the summon stickman spell.
Its very toxic to play against it only encourages spamming stickmen who die from 4 laser shots(even after the laser gun buff) This will lower them to be either 1 hittable or 2 hittable depending what weapon you have available as exchange of how fast they can be summoned.
Most people who do paper wizard tend to cheese it one or the other way either trough atmos or having self revives as for example a changeling.

:cl: Improvedname
balance: Weakens summoned stickmen to be 1 or 2 hit
/:cl:

