### PR TITLE
Fixes wheelchair making sounds only on conveyor belts

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -45,7 +45,7 @@
 
 /obj/vehicle/ridden/wheelchair/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
-	if(!forced && CHECK_MOVE_LOOP_FLAGS(src, MOVEMENT_LOOP_OUTSIDE_CONTROL) && has_gravity())
+	if(!forced && !CHECK_MOVE_LOOP_FLAGS(src, MOVEMENT_LOOP_OUTSIDE_CONTROL) && has_gravity())
 		playsound(src, 'sound/effects/roll.ogg', 75, TRUE)
 
 /obj/vehicle/ridden/wheelchair/post_buckle_mob(mob/living/user)


### PR DESCRIPTION
## About The Pull Request
That's all it is, really. They went quiet because the logic check was done backwards.

## Why It's Good For The Game
Wheelchairs making sounds when they're meant to is good.

## Changelog

:cl: GoldenAlpharex
fix: Wheelchairs now make noises when they're meant to again, and don't make noises on the tram nor on conveyor belts
/:cl: