### PR TITLE
Makes abductor organ surgery consistent with other surgeries

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_surgery.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_surgery.dm
@@ -4,8 +4,8 @@
 	surgery_flags = SURGERY_IGNORE_CLOTHES | SURGERY_REQUIRE_RESTING | SURGERY_REQUIRE_LIMB
 	steps = list(
 		/datum/surgery_step/incise,
-		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/incise,
 		/datum/surgery_step/extract_organ,
 		/datum/surgery_step/gland_insert,


### PR DESCRIPTION

## About The Pull Request
Just swaps the Hemo and Retractor steps to make it more in line with other surgeries
## Why It's Good For The Game
This might just be me but I always forget that the order is different and it throws off my muscle memory
## Changelog
:cl:
qol: Abductor organ surgery steps shifted around to match other surgeries
/:cl:
