### PR TITLE
Makes decals only caught on mapload & removes turf_loc_check

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/cyborg_mothership.dmm
+++ b/_maps/RandomRuins/SpaceRuins/cyborg_mothership.dmm
@@ -7,7 +7,7 @@
 /turf/open/misc/asteroid/airless,
 /area/space)
 "d" = (
-/obj/effect/decal/remains/human/grave,
+/obj/effect/decal/remains/human,
 /turf/open/misc/asteroid/airless,
 /area/space)
 "e" = (

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -6364,7 +6364,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human/grave{
+/obj/effect/decal/remains/human{
 	pixel_x = 6;
 	pixel_y = 6
 	},

--- a/code/game/objects/effects/decals/cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/cleanable/aliens.dm
@@ -51,7 +51,7 @@
 
 /obj/effect/decal/cleanable/xenoblood/xgibs/proc/spread_movement_effects(datum/move_loop/has_target/source)
 	SIGNAL_HANDLER
-	if(isclosedturf(loc) || (isgroundlessturf(loc) && !SSmapping.get_turf_below(loc)))
+	if(NeverShouldHaveComeHere(loc))
 		return
 	new /obj/effect/decal/cleanable/xenoblood/xsplatter(loc)
 

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -73,8 +73,10 @@
 	layer = ABOVE_WINDOW_LAYER
 	plane = GAME_PLANE
 	vis_flags = VIS_INHERIT_PLANE
-	turf_loc_check = FALSE
 	alpha = 180
+
+/obj/effect/decal/cleanable/blood/splatter/over_window/NeverShouldHaveComeHere(turf/here_turf)
+	return isgroundlessturf(here_turf)
 
 /obj/effect/decal/cleanable/blood/tracks
 	icon_state = "tracks"
@@ -103,7 +105,6 @@
 	plane = GAME_PLANE
 	random_icon_states = list("gib1", "gib2", "gib3", "gib4", "gib5", "gib6")
 	mergeable_decal = FALSE
-	turf_loc_check = FALSE
 
 	dryname = "rotting gibs"
 	drydesc = "They look bloody and gruesome while some terrible smell fills the air."
@@ -169,7 +170,7 @@
 
 /obj/effect/decal/cleanable/blood/gibs/proc/spread_movement_effects(datum/move_loop/has_target/source)
 	SIGNAL_HANDLER
-	if(isclosedturf(loc) || (isgroundlessturf(loc) && !SSmapping.get_turf_below(loc)))
+	if(NeverShouldHaveComeHere(loc))
 		return
 	new /obj/effect/decal/cleanable/blood/splatter(loc, streak_diseases)
 

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -20,9 +20,8 @@
 	pixel_x = base_pixel_x + rand(-5, 5)
 	pixel_y = base_pixel_y + rand(-5, 5)
 
-/obj/effect/decal/cleanable/ash/crematorium
-//crematoriums need their own ash cause default ash deletes itself if created in an obj
-	turf_loc_check = FALSE
+/obj/effect/decal/cleanable/ash/NeverShouldHaveComeHere(turf/here_turf)
+	return !istype(here_turf, /obj/structure/bodycontainer/crematorium) && ..()
 
 /obj/effect/decal/cleanable/ash/large
 	name = "large pile of ashes"

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -36,7 +36,7 @@
 
 /obj/effect/decal/cleanable/robot_debris/proc/spread_movement_effects(datum/move_loop/has_target/source)
 	SIGNAL_HANDLER
-	if(isclosedturf(loc) || (isgroundlessturf(loc) && !SSmapping.get_turf_below(loc)))
+	if(NeverShouldHaveComeHere(loc))
 		return
 	if (prob(40))
 		new /obj/effect/decal/cleanable/oil/streak(loc)

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -31,8 +31,8 @@
 	add_atom_colour(paint_colour, FIXED_COLOUR_PRIORITY)
 	RegisterSignal(src, COMSIG_OBJ_PAINTED, PROC_REF(on_painted))
 
-/obj/effect/decal/cleanable/crayon/NeverShouldHaveComeHere(turf/T)
-	return isgroundlessturf(T)
+/obj/effect/decal/cleanable/crayon/NeverShouldHaveComeHere(turf/here_turf)
+	return isgroundlessturf(here_turf)
 
 /obj/effect/decal/cleanable/crayon/proc/on_painted(datum/source, mob/user, obj/item/toy/crayon/spraycan/spraycan, is_dark_color)
 	SIGNAL_HANDLER

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -22,6 +22,7 @@
 	if(B && B.loc == loc)
 		qdel(src)
 
+///Checks if we are allowed to be in `here_turf`, and returns that result. Subtypes should override this when necessary.
 /obj/effect/decal/proc/NeverShouldHaveComeHere(turf/here_turf)
 	return isclosedturf(here_turf) || (isgroundlessturf(here_turf) && !SSmapping.get_turf_below(here_turf))
 

--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -8,12 +8,11 @@
 
 /obj/effect/decal/Initialize(mapload)
 	. = ..()
-	if(turf_loc_check && NeverShouldHaveComeHere(loc))
-#ifdef UNIT_TESTS
-		stack_trace("[name] spawned in a bad turf ([loc]) at [AREACOORD(src)] in \the [get_area(src)]. Please remove it or set turf_loc_check to FALSE on the decal if intended.")
-#else
+	if(NeverShouldHaveComeHere(loc))
+		if(mapload)
+			stack_trace("[name] spawned in a bad turf ([loc]) at [AREACOORD(src)] in \the [get_area(src)]. \
+				Please remove it or allow it to pass NeverShouldHaveComeHere if it's intended.")
 		return INITIALIZE_HINT_QDEL
-#endif
 	var/static/list/loc_connections = list(
 		COMSIG_TURF_CHANGE = PROC_REF(on_decal_move),
 	)
@@ -23,8 +22,8 @@
 	if(B && B.loc == loc)
 		qdel(src)
 
-/obj/effect/decal/proc/NeverShouldHaveComeHere(turf/T)
-	return isclosedturf(T) || (isgroundlessturf(T) && !SSmapping.get_turf_below(T))
+/obj/effect/decal/proc/NeverShouldHaveComeHere(turf/here_turf)
+	return isclosedturf(here_turf) || (isgroundlessturf(here_turf) && !SSmapping.get_turf_below(here_turf))
 
 /obj/effect/decal/ex_act(severity, target)
 	qdel(src)

--- a/code/game/objects/effects/decals/remains.dm
+++ b/code/game/objects/effects/decals/remains.dm
@@ -14,6 +14,9 @@
 	desc = "They look like human remains. They have a strange aura about them."
 	icon_state = "remains"
 
+/obj/effect/decal/remains/human/NeverShouldHaveComeHere(turf/here_turf)
+	return !istype(here_turf, /obj/structure/closet/crate/grave/filled) && ..()
+
 /obj/effect/decal/remains/human/smokey
 	desc = "They look like human remains. They have a strange, smokey aura about them..."
 	///Our proximity monitor, for detecting nearby looters.
@@ -48,7 +51,9 @@
 
 /obj/effect/decal/remains/plasma
 	icon_state = "remainsplasma"
-	turf_loc_check = FALSE
+
+/obj/effect/decal/remains/plasma/NeverShouldHaveComeHere(turf/here_turf)
+	return isclosedturf(here_turf)
 
 /obj/effect/decal/remains/xeno
 	desc = "They look like the remains of something... alien. They have a strange aura about them."

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -236,7 +236,7 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	if(!length(compiled)) // No mobs?
 		icon_state = "morgue3"
 		return ..()
-	
+
 	if(!(obj_flags & EMAGGED))
 		for(var/mob/living/occupant as anything in compiled)
 			var/mob/living/mob_occupant = get_mob_or_brainmob(occupant)
@@ -337,7 +337,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 			qdel(O)
 
 		if(!locate(/obj/effect/decal/cleanable/ash) in get_step(src, dir))//prevent pile-up
-			new/obj/effect/decal/cleanable/ash/crematorium(src)
+			new/obj/effect/decal/cleanable/ash(src)
 
 		sleep(3 SECONDS)
 

--- a/code/modules/clothing/head/mind_monkey_helmet.dm
+++ b/code/modules/clothing/head/mind_monkey_helmet.dm
@@ -94,7 +94,7 @@
 	playsound(src, SFX_SPARKS, 100, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	visible_message(span_warning("[src] fizzles and breaks apart!"))
 	magnification = null
-	new /obj/effect/decal/cleanable/ash/crematorium(drop_location()) //just in case they're in a locker or other containers it needs to use crematorium ash, see the path itself for an explanation
+	new /obj/effect/decal/cleanable/ash(drop_location()) //just in case they're in a locker or other containers it needs to use crematorium ash, see the path itself for an explanation
 
 /obj/item/clothing/head/helmet/monkey_sentience/dropped(mob/user)
 	. = ..()

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -73,7 +73,7 @@
 	if(prob(10))
 		new /obj/item/stack/ore/iron(src, 1)
 		new /obj/item/stack/ore/glass(src, 1)
-		new /obj/effect/decal/remains/human/grave(src, 1)
+		new /obj/effect/decal/remains/human(src, 1)
 	else
 		new /obj/item/stack/sheet/bone(src, 1)
 
@@ -166,7 +166,7 @@
 
 /obj/structure/closet/crate/grave/filled/PopulateContents()  //GRAVEROBBING IS NOW A FEATURE
 	..()
-	new /obj/effect/decal/remains/human/grave(src)
+	new /obj/effect/decal/remains/human(src)
 	switch(rand(1,8))
 		if(1)
 			new /obj/item/coin/gold(src)
@@ -274,9 +274,6 @@
 	..()
 	new /obj/effect/decal/cleanable/blood/gibs/old(src)
 	new /obj/item/book/granter/crafting_recipe/boneyard_notes(src)
-
-/obj/effect/decal/remains/human/grave
-	turf_loc_check = FALSE
 
 //***Fluff items for lore/intrigue
 /obj/item/paper/crumpled/muddy/fluff/elephant_graveyard


### PR DESCRIPTION
## About The Pull Request

Theres one player-facing change in this PR and it's that I removed human gibs from being valid in space turfs, making it more consistent with the other gib decals.

I've cleaned up many instances of decals spawning in bad turfs on mapload in https://github.com/tgstation/tgstation/pull/75189, but making it error anytime in-game a decal is put over an invalid turf is bad as it punishes contributors for not optimizing their decals properly.
This changes it so it only errors if it's on mapload, unit testing or not.

I've also removed ``turf_loc_check`` and replaced instances of it with overwriting ``NeverShouldHaveComeHere``, which gives us greater control of where decals can be placed.
This let me remove 2 subtypes that were made to have decals in specific places (which then got placed elsewhere, ruining it all).

Mappers are still able to set decals to be placed anywhere, they just need to add it as a valid turf for that decal.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/76109
Closes https://github.com/tgstation/tgstation/issues/76159
Closes #76234
Closes #76235
Closes #76239
Closes #76197
Closes #76185
Closes #76165
Closes #76154
Closes #76086
Closes #76278
Closes #76288
Closes #76293
Closes #76292
Closes #76300
Removes needless errors clogging up runtime logs.
Removes human gibs from floating in space, which makes no sense as space is pretty large and blood staying in one place isn't realistic.

## Changelog

🆑
fix: Human gibs can no longer hang out in space. 
/:cl: