### PR TITLE
Adds border smoothing! (Look ma I'm upstreaming)

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -5147,8 +5147,7 @@
 "chF" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/mid/directional/south,
-/obj/structure/rack,
+/obj/structure/window/reinforced/tram/directional/south/obj/structure/rack,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
 "chO" = (
@@ -8805,8 +8804,7 @@
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/mid/directional/north,
-/obj/structure/chair/sofa/bench/right,
+/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/right,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
 "dEt" = (
@@ -12528,8 +12526,7 @@
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/left/directional/north,
-/obj/structure/chair/sofa/bench/left,
+/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/left,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
@@ -15635,8 +15632,7 @@
 "gem" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/right/directional/south,
-/obj/structure/chair/sofa/bench/left{
+/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
@@ -31964,8 +31960,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced/tram/right/directional/west,
-/obj/structure/chair{
+/obj/structure/window/reinforced/tram/directional/west/obj/structure/chair{
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram,
@@ -33216,8 +33211,7 @@
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/right/directional/north,
-/obj/structure/chair/sofa/bench/right,
+/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/right,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
@@ -38134,8 +38128,7 @@
 "nXL" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/left/directional/south,
-/obj/structure/chair/sofa/bench/right{
+/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/east,
@@ -38330,8 +38323,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced/tram/mid/directional/west,
-/obj/structure/industrial_lift/tram/white,
+/obj/structure/window/reinforced/tram/directional/west/obj/structure/industrial_lift/tram/white,
 /turf/open/floor/noslip/tram_platform,
 /area/station/security/tram)
 "ocb" = (
@@ -44463,8 +44455,7 @@
 "qfQ" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/mid/directional/south,
-/obj/structure/chair/sofa/bench/left{
+/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
 /turf/open/floor/noslip/tram_platform,
@@ -46402,8 +46393,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tram/right/directional/east,
-/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced/tram/directional/east/obj/structure/chair/comfy/shuttle,
 /obj/structure/industrial_lift/tram,
 /turf/open/floor/noslip/tram_platform,
 /area/station/security/tram)
@@ -49610,8 +49600,7 @@
 "rLv" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/mid/directional/south,
-/obj/structure/chair/sofa/bench/right{
+/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
 /turf/open/floor/noslip/tram_platform,
@@ -52162,8 +52151,7 @@
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/mid/directional/north,
-/obj/structure/chair/sofa/bench/left,
+/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/left,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
 "sBp" = (
@@ -60217,8 +60205,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced/tram/left/directional/west,
-/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced/tram/directional/west/obj/structure/chair/comfy/shuttle,
 /obj/structure/industrial_lift/tram,
 /turf/open/floor/noslip/tram_platform,
 /area/station/security/tram)
@@ -67759,8 +67746,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tram/mid/directional/east,
-/obj/structure/chair{
+/obj/structure/window/reinforced/tram/directional/east/obj/structure/chair{
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram,

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -5147,7 +5147,8 @@
 "chF" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/directional/south/obj/structure/rack,
+/obj/structure/window/reinforced/tram/directional/south,
+/obj/structure/rack,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
 "chO" = (
@@ -8804,7 +8805,8 @@
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/right,
+/obj/structure/window/reinforced/tram/directional/north,
+/obj/structure/chair/sofa/bench/right,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
 "dEt" = (
@@ -12526,7 +12528,8 @@
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/left,
+/obj/structure/window/reinforced/tram/directional/north,
+/obj/structure/chair/sofa/bench/left,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
@@ -15632,7 +15635,8 @@
 "gem" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/left{
+/obj/structure/window/reinforced/tram/directional/south,
+/obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
@@ -31960,7 +31964,8 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced/tram/directional/west/obj/structure/chair{
+/obj/structure/window/reinforced/tram/directional/west,
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram,
@@ -33211,7 +33216,8 @@
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/right,
+/obj/structure/window/reinforced/tram/directional/north,
+/obj/structure/chair/sofa/bench/right,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
@@ -38128,7 +38134,8 @@
 "nXL" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/right{
+/obj/structure/window/reinforced/tram/directional/south,
+/obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/east,
@@ -38323,7 +38330,8 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced/tram/directional/west/obj/structure/industrial_lift/tram/white,
+/obj/structure/window/reinforced/tram/directional/west,
+/obj/structure/industrial_lift/tram/white,
 /turf/open/floor/noslip/tram_platform,
 /area/station/security/tram)
 "ocb" = (
@@ -44455,7 +44463,8 @@
 "qfQ" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/left{
+/obj/structure/window/reinforced/tram/directional/south,
+/obj/structure/chair/sofa/bench/left{
 	dir = 1
 	},
 /turf/open/floor/noslip/tram_platform,
@@ -46393,7 +46402,8 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tram/directional/east/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced/tram/directional/east,
+/obj/structure/chair/comfy/shuttle,
 /obj/structure/industrial_lift/tram,
 /turf/open/floor/noslip/tram_platform,
 /area/station/security/tram)
@@ -49600,7 +49610,8 @@
 "rLv" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/right{
+/obj/structure/window/reinforced/tram/directional/south,
+/obj/structure/chair/sofa/bench/right{
 	dir = 1
 	},
 /turf/open/floor/noslip/tram_platform,
@@ -52151,7 +52162,8 @@
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram/white,
-/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/left,
+/obj/structure/window/reinforced/tram/directional/north,
+/obj/structure/chair/sofa/bench/left,
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
 "sBp" = (
@@ -60205,7 +60217,8 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
-/obj/structure/window/reinforced/tram/directional/west/obj/structure/chair/comfy/shuttle,
+/obj/structure/window/reinforced/tram/directional/west,
+/obj/structure/chair/comfy/shuttle,
 /obj/structure/industrial_lift/tram,
 /turf/open/floor/noslip/tram_platform,
 /area/station/security/tram)
@@ -67746,7 +67759,8 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
 	},
-/obj/structure/window/reinforced/tram/directional/east/obj/structure/chair{
+/obj/structure/window/reinforced/tram/directional/east,
+/obj/structure/chair{
 	dir = 1
 	},
 /obj/structure/industrial_lift/tram,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -6221,7 +6221,7 @@
 /area/station/commons/fitness/recreation)
 "aMY" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/mid/directional/south,
+/obj/structure/window/reinforced/tram/directional/south,
 /turf/open/openspace,
 /area/station/hallway/primary/tram/center)
 "aNa" = (
@@ -21740,14 +21740,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"gxA" = (
-/obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/right/directional/north,
-/obj/structure/chair/sofa/bench/tram/right{
-	dir = 8
-	},
-/turf/open/openspace,
-/area/station/hallway/primary/tram/center)
 "gxO" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -33905,8 +33897,7 @@
 /area/station/science/explab)
 "kYp" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/right/directional/south,
-/obj/machinery/destination_sign/south{
+/obj/structure/window/reinforced/tram/directional/south/obj/machinery/destination_sign/south{
 	pixel_y = -11
 	},
 /obj/effect/landmark/start/hangover,
@@ -41396,8 +41387,7 @@
 /area/station/hallway/secondary/command)
 "nKp" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/left/directional/north,
-/obj/structure/chair/sofa/bench/tram/right{
+/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/tram/right{
 	dir = 8
 	},
 /turf/open/openspace,
@@ -41740,8 +41730,7 @@
 /area/station/engineering/main)
 "nQc" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/right/directional/north,
-/obj/machinery/destination_sign/north{
+/obj/structure/window/reinforced/tram/directional/north/obj/machinery/destination_sign/north{
 	pixel_y = 10
 	},
 /obj/structure/chair/sofa/bench/tram/left{
@@ -43083,8 +43072,7 @@
 /obj/machinery/destination_sign/north{
 	pixel_y = 10
 	},
-/obj/structure/window/reinforced/tram/left/directional/north,
-/obj/structure/chair/sofa/bench/tram/right{
+/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/tram/right{
 	dir = 8
 	},
 /turf/open/openspace,
@@ -53018,8 +53006,7 @@
 /area/station/security/warden)
 "rZD" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/left/directional/south,
-/obj/structure/chair/sofa/bench/tram/right{
+/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/tram/right{
 	dir = 4
 	},
 /turf/open/openspace,
@@ -53408,14 +53395,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/hallway/primary/tram/right)
-"sgt" = (
-/obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/right/directional/south,
-/obj/structure/chair/sofa/bench/tram/right{
-	dir = 4
-	},
-/turf/open/openspace,
-/area/station/hallway/primary/tram/center)
 "sgA" = (
 /obj/structure/table,
 /obj/machinery/light/small/directional/west,
@@ -60912,8 +60891,7 @@
 /obj/machinery/destination_sign/south{
 	pixel_y = -11
 	},
-/obj/structure/window/reinforced/tram/left/directional/south,
-/obj/effect/landmark/start/hangover,
+/obj/structure/window/reinforced/tram/directional/south/obj/effect/landmark/start/hangover,
 /obj/structure/chair/sofa/bench/tram/left{
 	dir = 8
 	},
@@ -69794,7 +69772,7 @@
 /area/station/engineering/supermatter)
 "xVH" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/mid/directional/north,
+/obj/structure/window/reinforced/tram/directional/north,
 /turf/open/openspace,
 /area/station/hallway/primary/tram/center)
 "xVJ" = (
@@ -168492,11 +168470,11 @@ aEk
 rOu
 umT
 ykP
-gxA
+nKp
 hio
 rPq
 aEq
-sgt
+rZD
 ykP
 lej
 pxC

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -33897,7 +33897,8 @@
 /area/station/science/explab)
 "kYp" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/directional/south/obj/machinery/destination_sign/south{
+/obj/structure/window/reinforced/tram/directional/south,
+/obj/machinery/destination_sign/south{
 	pixel_y = -11
 	},
 /obj/effect/landmark/start/hangover,
@@ -41387,7 +41388,8 @@
 /area/station/hallway/secondary/command)
 "nKp" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/tram/right{
+/obj/structure/window/reinforced/tram/directional/north,
+/obj/structure/chair/sofa/bench/tram/right{
 	dir = 8
 	},
 /turf/open/openspace,
@@ -41730,7 +41732,8 @@
 /area/station/engineering/main)
 "nQc" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/directional/north/obj/machinery/destination_sign/north{
+/obj/structure/window/reinforced/tram/directional/north,
+/obj/machinery/destination_sign/north{
 	pixel_y = 10
 	},
 /obj/structure/chair/sofa/bench/tram/left{
@@ -43072,7 +43075,8 @@
 /obj/machinery/destination_sign/north{
 	pixel_y = 10
 	},
-/obj/structure/window/reinforced/tram/directional/north/obj/structure/chair/sofa/bench/tram/right{
+/obj/structure/window/reinforced/tram/directional/north,
+/obj/structure/chair/sofa/bench/tram/right{
 	dir = 8
 	},
 /turf/open/openspace,
@@ -53006,7 +53010,8 @@
 /area/station/security/warden)
 "rZD" = (
 /obj/structure/industrial_lift/tram,
-/obj/structure/window/reinforced/tram/directional/south/obj/structure/chair/sofa/bench/tram/right{
+/obj/structure/window/reinforced/tram/directional/south,
+/obj/structure/chair/sofa/bench/tram/right{
 	dir = 4
 	},
 /turf/open/openspace,
@@ -60891,7 +60896,8 @@
 /obj/machinery/destination_sign/south{
 	pixel_y = -11
 	},
-/obj/structure/window/reinforced/tram/directional/south/obj/effect/landmark/start/hangover,
+/obj/structure/window/reinforced/tram/directional/south,
+/obj/effect/landmark/start/hangover,
 /obj/structure/chair/sofa/bench/tram/left{
 	dir = 8
 	},

--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -14,7 +14,7 @@
 /// Uses directional object smoothing, so we care not only about something being on the right turf, but also its direction
 /// Changes the meaning of smoothing_junction, instead of representing the directions we are smoothing in
 /// it represents the sides of our directional border object that have a neighbor
-/// Is incompatible with SMOOTH_CORNERS because border turfs don't have corners
+/// Is incompatible with SMOOTH_CORNERS because border objects don't have corners
 #define SMOOTH_BORDER_OBJECT (1<<6)
 
 DEFINE_BITFIELD(smoothing_flags, list(

--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -11,6 +11,11 @@
 #define SMOOTH_QUEUED (1<<4)
 /// Smooths with objects, and will thus need to scan turfs for contents.
 #define SMOOTH_OBJ (1<<5)
+/// Uses directional object smoothing, so we care not only about something being on the right turf, but also its direction
+/// Changes the meaning of smoothing_junction, instead of representing the directions we are smoothing in
+/// it represents the sides of our directional border object that have a neighbor
+/// Is incompatible with SMOOTH_CORNERS because border turfs don't have corners
+#define SMOOTH_BORDER_OBJECT (1<<6)
 
 DEFINE_BITFIELD(smoothing_flags, list(
 	"SMOOTH_CORNERS" = SMOOTH_CORNERS,
@@ -19,6 +24,7 @@ DEFINE_BITFIELD(smoothing_flags, list(
 	"SMOOTH_BORDER" = SMOOTH_BORDER,
 	"SMOOTH_QUEUED" = SMOOTH_QUEUED,
 	"SMOOTH_OBJ" = SMOOTH_OBJ,
+	"SMOOTH_BORDER_OBJECT" = SMOOTH_BORDER_OBJECT,
 ))
 
 
@@ -132,6 +138,8 @@ DEFINE_BITFIELD(smoothing_flags, list(
 #define SMOOTH_GROUP_WINDOW_FULLTILE_BRONZE S_OBJ(23) ///obj/structure/window/bronze/fulltile
 #define SMOOTH_GROUP_WINDOW_FULLTILE_PLASTITANIUM S_OBJ(24) ///turf/closed/indestructible/opsglass, /obj/structure/window/reinforced/plasma/plastitanium
 #define SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE S_OBJ(25) ///obj/structure/window/reinforced/shuttle
+
+#define SMOOTH_GROUP_WINDOW_DIRECTIONAL_TRAM S_OBJ(26) ///obj/structure/window/reinforced/tram
 
 #define SMOOTH_GROUP_LATTICE S_OBJ(31) ///obj/structure/lattice
 #define SMOOTH_GROUP_CATWALK S_OBJ(32) ///obj/structure/lattice/catwalk

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -379,33 +379,31 @@ xxx xxx xxx
 	// Did you know you can pass defines into other defines? very handy, lets take advantage of it here to allow 0 cost variation
 	#define SEARCH_ADJ_IN_DIR(direction, direction_flag, ADJ_FOUND, WORLD_BORDER) \
 		do { \
-			set_adj_in_dir: { \
-				var/turf/neighbor = get_step(src, direction); \
-				if(neighbor) { \
-					var/neighbor_smoothing_groups = neighbor.smoothing_groups; \
-					if(neighbor_smoothing_groups) { \
-						for(var/target in canSmoothWith) { \
-							if(canSmoothWith[target] & neighbor_smoothing_groups[target]) { \
-								##ADJ_FOUND(neighbor, direction, direction_flag); \
-							} \
+			var/turf/neighbor = get_step(src, direction); \
+			if(neighbor) { \
+				var/neighbor_smoothing_groups = neighbor.smoothing_groups; \
+				if(neighbor_smoothing_groups) { \
+					for(var/target in canSmoothWith) { \
+						if(canSmoothWith[target] & neighbor_smoothing_groups[target]) { \
+							##ADJ_FOUND(neighbor, direction, direction_flag); \
 						} \
 					} \
-					if(smooth_obj) { \
-						for(var/atom/movable/thing as anything in neighbor) { \
-							var/thing_smoothing_groups = thing.smoothing_groups; \
-							if(!thing.anchored || isnull(thing_smoothing_groups)) { \
-								continue; \
-							}; \
-							for(var/target in canSmoothWith) { \
-								if(canSmoothWith[target] & thing_smoothing_groups[target]) { \
-									##ADJ_FOUND(thing, direction, direction_flag); \
-								} \
-							} \
-						} \
-					} \
-				} else if (smooth_border) { \
-					##WORLD_BORDER(null, direction, direction_flag); \
 				} \
+				if(smooth_obj) { \
+					for(var/atom/movable/thing as anything in neighbor) { \
+						var/thing_smoothing_groups = thing.smoothing_groups; \
+						if(!thing.anchored || isnull(thing_smoothing_groups)) { \
+							continue; \
+						}; \
+						for(var/target in canSmoothWith) { \
+							if(canSmoothWith[target] & thing_smoothing_groups[target]) { \
+								##ADJ_FOUND(thing, direction, direction_flag); \
+							} \
+						} \
+					} \
+				} \
+			} else if (smooth_border) { \
+				##WORLD_BORDER(null, direction, direction_flag); \
 			} \
 		} while(FALSE) \
 
@@ -424,9 +422,9 @@ xxx xxx xxx
 		BORDER_FOUND(dummy, direction, direction_flag);
 
 	// We're building 2 different types of smoothing searches here
-	// One for standard bitmask smoothing
-	#define SET_ADJ_IN_DIR(direction, direction_flag) SEARCH_ADJ_IN_DIR(direction, direction_flag, BITMASK_FOUND, BITMASK_FOUND)
-	// and another for border object work
+	// One for standard bitmask smoothing (We provide a label so our macro can eary exit, as it wants to do)
+	#define SET_ADJ_IN_DIR(direction, direction_flag) do { set_adj_in_dir: { SEARCH_ADJ_IN_DIR(direction, direction_flag, BITMASK_FOUND, BITMASK_FOUND) }} while(FALSE)
+	// and another for border object work (Doesn't early exit because we can hit more then one direction by checking the same turf)
 	#define SET_BORDER_ADJ_IN_DIR(direction) SEARCH_ADJ_IN_DIR(direction, direction, BORDER_FOUND, WORLD_BORDER_FOUND)
 
 	// Let's go over all our cardinals

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -45,10 +45,86 @@ DEFINE_BITFIELD(smoothing_junction, list(
 	"NORTHWEST_JUNCTION" = NORTHWEST_JUNCTION,
 ))
 
-
 #define NO_ADJ_FOUND 0
 #define ADJ_FOUND 1
 #define NULLTURF_BORDER 2
+
+GLOBAL_LIST_INIT(adjacent_direction_lookup, generate_adjacent_directions())
+
+/* Attempting to mirror the below
+ * Each 3x3 grid is a tile, with each X representing a direction a border object could be in IN said grid
+ * Directions marked with A are acceptable smoothing targets, M is the example direction
+ * The example given here is of a northfacing border object
+xxx xxx xxx
+xxx AxA xxx
+xxx xAx xxx
+
+xAx xMx xAx
+xxx AxA xxx
+xxx xxx xxx
+
+xxx xxx xxx
+xxx xxx xxx
+xxx xxx xxx
+*/
+/// Encodes connectivity between border objects
+/// Returns a list accessable by a border object's dir, the direction between it and a target, and a target
+/// Said list will return the direction the two objects connect, if any exists (if the target isn't a border object and the direction is fine, return the inverse of the direction in use)
+/proc/generate_adjacent_directions()
+	// Have to hold all conventional dir pairs, so we size to the largest
+	// We don't HAVE diagonal border objects, so I'm gonna pretend they'll never exist
+
+	// You might be like, lemon, can't we use GLOB.cardinals/GLOB.alldirs here
+	// No, they aren't loaded yet. life is pain
+	var/list/cardinals = list(NORTH, SOUTH, EAST, WEST)
+	var/list/alldirs = cardinals + list(NORTH|EAST, SOUTH|EAST, NORTH|WEST, SOUTH|WEST)
+	var/largest_cardinal = max(cardinals)
+	var/largest_dir = max(alldirs)
+
+	var/list/direction_map = new /list(largest_cardinal)
+	for(var/dir in cardinals)
+		var/left = turn(dir, 90)
+		var/right = turn(dir, -90)
+		var/opposite = turn(dir, 180)
+		// Need to encode diagonals here because it's possible, even if it is always false
+		var/list/acceptable_adjacents = new /list(largest_dir)
+		// Alright, what directions are acceptable to us
+		for(var/connectable_dir in (cardinals + NONE))
+			// And what border objects INSIDE those directions are alright
+			var/list/smoothable_dirs = new /list(largest_cardinal + 1) // + 1 because we need to provide space for NONE to be a valid index
+			// None is fine, we want to smooth with things on our own turf
+			// We'll do the two dirs to our left and right
+			// They connect.. "below" us and on their side
+			if(connectable_dir == NONE)
+				smoothable_dirs[left] = opposite | left
+				smoothable_dirs[right] = opposite | right
+			// If it's to our right or left we'll include just the dir matching ours
+			// Left edge touches only our left side, and so on
+			else if (connectable_dir == left)
+				smoothable_dirs[dir] = left
+			else if (connectable_dir == right)
+				smoothable_dirs[dir] = right
+			// If it's straight on we'll include all cardinals but us, since all 3 bits would touch us
+			// Turf opposite gets just our dir as the connection, the other two get our dir + theirs
+			// Since they touch the edges
+			else if(connectable_dir == dir)
+				smoothable_dirs[opposite] = dir
+				smoothable_dirs[left] = dir | left
+				smoothable_dirs[right] = dir | right
+			// otherwise, go HOME, I don't want to encode anything for you
+			else
+				continue
+			acceptable_adjacents[connectable_dir + 1] = smoothable_dirs
+		direction_map[dir] = acceptable_adjacents
+	return direction_map
+
+/// Are two atoms border adjacent, takes a border object, something to compare against, and the direction between A and B
+/// Returns the way in which the first thing is adjacent to the second
+#define CAN_DIAGONAL_SMOOTH(border_obj, target, direction) (\
+	(target.smoothing_flags & SMOOTH_BORDER_OBJECT) ? \
+		GLOB.adjacent_direction_lookup[border_obj.dir][direction + 1]?[target.dir] : \
+		(GLOB.adjacent_direction_lookup[border_obj.dir][direction + 1]) ? turn(direction, 180) : NONE \
+	)
 
 #define DEFAULT_UNDERLAY_ICON 'icons/turf/floors.dmi'
 #define DEFAULT_UNDERLAY_ICON_STATE "plating"
@@ -298,21 +374,22 @@ DEFINE_BITFIELD(smoothing_junction, list(
 
 	var/smooth_border = (smoothing_flags & SMOOTH_BORDER)
 	var/smooth_obj = (smoothing_flags & SMOOTH_OBJ)
+	var/border_object_smoothing = (smoothing_flags & SMOOTH_BORDER_OBJECT)
 
-	#define SET_ADJ_IN_DIR(direction, direction_flag) \
-		set_adj_in_dir: { \
-			do { \
+	// Did you know you can pass defines into other defines? very handy, lets take advantage of it here to allow 0 cost variation
+	#define SEARCH_ADJ_IN_DIR(direction, direction_flag, ADJ_FOUND, WORLD_BORDER) \
+		do { \
+			set_adj_in_dir: { \
 				var/turf/neighbor = get_step(src, direction); \
 				if(neighbor) { \
 					var/neighbor_smoothing_groups = neighbor.smoothing_groups; \
 					if(neighbor_smoothing_groups) { \
 						for(var/target in canSmoothWith) { \
 							if(canSmoothWith[target] & neighbor_smoothing_groups[target]) { \
-								new_junction |= direction_flag; \
-								break set_adj_in_dir; \
-							}; \
-						}; \
-					}; \
+								##ADJ_FOUND(neighbor, direction, direction_flag); \
+							} \
+						} \
+					} \
 					if(smooth_obj) { \
 						for(var/atom/movable/thing as anything in neighbor) { \
 							var/thing_smoothing_groups = thing.smoothing_groups; \
@@ -321,21 +398,55 @@ DEFINE_BITFIELD(smoothing_junction, list(
 							}; \
 							for(var/target in canSmoothWith) { \
 								if(canSmoothWith[target] & thing_smoothing_groups[target]) { \
-									new_junction |= direction_flag; \
-									break set_adj_in_dir; \
-								}; \
-							}; \
-						}; \
-					}; \
+									##ADJ_FOUND(thing, direction, direction_flag); \
+								} \
+							} \
+						} \
+					} \
 				} else if (smooth_border) { \
-					new_junction |= direction_flag; \
-				}; \
-			} while(FALSE) \
-		}
+					##WORLD_BORDER(null, direction, direction_flag); \
+				} \
+			} \
+		} while(FALSE) \
 
-	for(var/direction in GLOB.cardinals) //Cardinal case first.
-		SET_ADJ_IN_DIR(direction, direction)
+	#define BITMASK_FOUND(target, direction, direction_flag) \
+		new_junction |= direction_flag; \
+		break set_adj_in_dir; \
 
+	#define BORDER_FOUND(target, direction, direction_flag) new_junction |= CAN_DIAGONAL_SMOOTH(src, target, direction)
+	// Border objects require an object as context, so we need a dummy. I'm sorry
+	#define WORLD_BORDER_FOUND(target, direction, direction_flag) \
+		var/static/atom/dummy; \
+		if(!dummy) { \
+			dummy = new(); \
+			dummy.smoothing_flags &= ~SMOOTH_BORDER_OBJECT; \
+		} \
+		BORDER_FOUND(dummy, direction, direction_flag);
+
+	// We're building 2 different types of smoothing searches here
+	// One for standard bitmask smoothing
+	#define SET_ADJ_IN_DIR(direction, direction_flag) SEARCH_ADJ_IN_DIR(direction, direction_flag, BITMASK_FOUND, BITMASK_FOUND)
+	// and another for border object work
+	#define SET_BORDER_ADJ_IN_DIR(direction) SEARCH_ADJ_IN_DIR(direction, direction, BORDER_FOUND, WORLD_BORDER_FOUND)
+
+	// Let's go over all our cardinals
+	if(border_object_smoothing)
+		SET_BORDER_ADJ_IN_DIR(NORTH)
+		SET_BORDER_ADJ_IN_DIR(SOUTH)
+		SET_BORDER_ADJ_IN_DIR(EAST)
+		SET_BORDER_ADJ_IN_DIR(WEST)
+		// We want to check against stuff in our own turf
+		SET_BORDER_ADJ_IN_DIR(NONE)
+		// Border objects don't do diagonals, so GO HOME
+		set_smoothed_icon_state(new_junction)
+		return
+
+	SET_ADJ_IN_DIR(NORTH, NORTH)
+	SET_ADJ_IN_DIR(SOUTH, SOUTH)
+	SET_ADJ_IN_DIR(EAST, EAST)
+	SET_ADJ_IN_DIR(WEST, WEST)
+
+	// If there's nothing going on already
 	if(!(new_junction & (NORTH|SOUTH)) || !(new_junction & (EAST|WEST)))
 		set_smoothed_icon_state(new_junction)
 		return
@@ -359,7 +470,7 @@ DEFINE_BITFIELD(smoothing_junction, list(
 	#undef SET_ADJ_IN_DIR
 
 
-///Changes the icon state based on the new junction bitmask. Returns the old junction value.
+///Changes the icon state based on the new junction bitmask
 /atom/proc/set_smoothed_icon_state(new_junction)
 	. = smoothing_junction
 	smoothing_junction = new_junction
@@ -368,12 +479,12 @@ DEFINE_BITFIELD(smoothing_junction, list(
 
 /turf/closed/set_smoothed_icon_state(new_junction)
 	// Avoid calling ..() here to avoid setting icon_state twice, which is expensive given how hot this proc is
-	. = smoothing_junction
+	var/old_junction = smoothing_junction
 	smoothing_junction = new_junction
 
 	if (!(smoothing_flags & SMOOTH_DIAGONAL_CORNERS))
 		icon_state = "[base_icon_state]-[smoothing_junction]"
-		return .
+		return
 
 	switch(new_junction)
 		if(
@@ -387,8 +498,8 @@ DEFINE_BITFIELD(smoothing_junction, list(
 			SOUTH_JUNCTION|EAST_JUNCTION|SOUTHEAST_JUNCTION,
 		)
 			icon_state = "[base_icon_state]-[smoothing_junction]-d"
-			if(new_junction == . || fixed_underlay) // Mutable underlays?
-				return .
+			if(new_junction == old_junction || fixed_underlay) // Mutable underlays?
+				return
 
 			var/junction_dir = reverse_ndir(smoothing_junction)
 			var/turned_adjacency = REVERSE_DIR(junction_dir)

--- a/code/__HELPERS/icon_smoothing.dm
+++ b/code/__HELPERS/icon_smoothing.dm
@@ -470,8 +470,14 @@ xxx xxx xxx
 
 	set_smoothed_icon_state(new_junction)
 
+	#undef SET_BORDER_ADJ_IN_DIR
 	#undef SET_ADJ_IN_DIR
-
+	#undef BORDER_ON_BORDER_CHECK
+	#undef WORLD_BORDER_FOUND
+	#undef BORDER_FOUND
+	#undef BITMASK_ON_BORDER_CHECK
+	#undef BITMASK_FOUND
+	#undef SEARCH_ADJ_IN_DIR
 
 ///Changes the icon state based on the new junction bitmask
 /atom/proc/set_smoothed_icon_state(new_junction)
@@ -651,3 +657,4 @@ xxx xxx xxx
 
 #undef DEFAULT_UNDERLAY_ICON
 #undef DEFAULT_UNDERLAY_ICON_STATE
+#undef CAN_DIAGONAL_SMOOTH

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1143,6 +1143,8 @@
 	SEND_SIGNAL(src, COMSIG_ATOM_DIR_CHANGE, dir, newdir)
 	dir = newdir
 	SEND_SIGNAL(src, COMSIG_ATOM_POST_DIR_CHANGE, dir, newdir)
+	if(smoothing_flags & SMOOTH_BORDER_OBJECT)
+		QUEUE_SMOOTH_NEIGHBORS(src)
 
 /**
  * Called when the atom log's in or out

--- a/code/modules/industrial_lift/tram/tram_windows.dm
+++ b/code/modules/industrial_lift/tram/tram_windows.dm
@@ -3,6 +3,9 @@
 	desc = "A window made out of a titanium-silicate alloy. It looks tough to break. Is that a challenge?"
 	icon = 'icons/obj/smooth_structures/tram_window.dmi'
 	icon_state = "tram_mid"
+	smoothing_flags = SMOOTH_BITMASK|SMOOTH_BORDER_OBJECT
+	canSmoothWith = SMOOTH_GROUP_WINDOW_DIRECTIONAL_TRAM
+	smoothing_groups = SMOOTH_GROUP_WINDOW_DIRECTIONAL_TRAM
 	reinf = TRUE
 	heat_resistance = 1600
 	armor_type = /datum/armor/window_tram
@@ -12,6 +15,38 @@
 	rad_insulation = RAD_MEDIUM_INSULATION
 	glass_material_datum = /datum/material/alloy/titaniumglass
 
+/obj/structure/window/reinforced/tram/Initialize(mapload, direct)
+	. = ..()
+	setDir(dir)
+
+/obj/structure/window/reinforced/tram/setDir(new_dir)
+	. = ..()
+	if(fulltile)
+		return
+	if(dir & NORTH)
+		layer = LOW_ITEM_LAYER
+	else
+		layer = BELOW_OBJ_LAYER
+	if(dir & SOUTH)
+		SET_PLANE_IMPLICIT(src, WALL_PLANE_UPPER)
+	else
+		SET_PLANE_IMPLICIT(src, GAME_PLANE)
+
+/obj/structure/window/reinforced/tram/set_smoothed_icon_state(new_junction)
+	if(fulltile)
+		return ..()
+	smoothing_junction = new_junction
+	var/smooth_left = (smoothing_junction & turn(dir, 90))
+	var/smooth_right = (smoothing_junction & turn(dir, -90))
+	if(smooth_left && smooth_right)
+		icon_state = "tram_mid"
+	else if (smooth_left)
+		icon_state = "tram_left"
+	else if (smooth_right)
+		icon_state = "tram_right"
+	else
+		icon_state = "tram_mid"
+
 /obj/structure/window/reinforced/tram/front
 	name = "tram wall"
 	desc = "A lightweight titanium composite structure with a windscreen installed."
@@ -19,34 +54,13 @@
 	base_icon_state = "tram_window"
 	wtype = "shuttle"
 	fulltile = TRUE
+	smoothing_flags = NONE
+	canSmoothWith = null
+	smoothing_groups = SMOOTH_GROUP_WINDOW_DIRECTIONAL_TRAM
 	flags_1 = PREVENT_CLICK_UNDER_1
 	explosion_block = 3
 	glass_amount = 2
 	receive_ricochet_chance_mod = 1.2
-
-/obj/structure/window/reinforced/tram/left/directional/north
-	icon_state = "tram_left"
-	layer = LOW_ITEM_LAYER
-
-/obj/structure/window/reinforced/tram/left/directional/south
-	icon_state = "tram_left"
-	plane = WALL_PLANE_UPPER
-
-/obj/structure/window/reinforced/tram/mid/directional/north
-	icon_state = "tram_mid"
-	layer = LOW_ITEM_LAYER
-
-/obj/structure/window/reinforced/tram/mid/directional/south
-	icon_state = "tram_mid"
-	plane = WALL_PLANE_UPPER
-
-/obj/structure/window/reinforced/tram/right/directional/north
-	icon_state = "tram_right"
-	layer = LOW_ITEM_LAYER
-
-/obj/structure/window/reinforced/tram/right/directional/south
-	icon_state = "tram_right"
-	plane = WALL_PLANE_UPPER
 
 /datum/armor/window_tram
 	melee = 80
@@ -55,6 +69,4 @@
 	fire = 99
 	acid = 100
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tram/left, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tram/mid, 0)
-MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tram/right, 0)
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tram, 0)

--- a/tools/UpdatePaths/Scripts/76134_tram_window_cleanup.txt
+++ b/tools/UpdatePaths/Scripts/76134_tram_window_cleanup.txt
@@ -1,0 +1,5 @@
+#comment Cleans up manual tram window alignment, made redundant by {} which added automatic alignment on init/dir change
+
+/obj/structure/window/reinforced/tram/left/@SUBTYPES : /obj/structure/window/reinforced/tram/@SUBTYPES
+/obj/structure/window/reinforced/tram/mid/@SUBTYPES : /obj/structure/window/reinforced/tram/@SUBTYPES
+/obj/structure/window/reinforced/tram/right/@SUBTYPES : /obj/structure/window/reinforced/tram/@SUBTYPES

--- a/tools/UpdatePaths/Scripts/tram_window_cleanup.txt
+++ b/tools/UpdatePaths/Scripts/tram_window_cleanup.txt
@@ -1,0 +1,5 @@
+#comment Cleans up manual tram window alignment, made redundant by {} which added automatic alignment on init/dir change
+
+/obj/structure/window/reinforced/tram/left/@SUBTYPES : /obj/structure/window/reinforced/tram/@SUBTYPES
+/obj/structure/window/reinforced/tram/mid/@SUBTYPES : /obj/structure/window/reinforced/tram/@SUBTYPES
+/obj/structure/window/reinforced/tram/right/@SUBTYPES : /obj/structure/window/reinforced/tram/@SUBTYPES

--- a/tools/UpdatePaths/Scripts/tram_window_cleanup.txt
+++ b/tools/UpdatePaths/Scripts/tram_window_cleanup.txt
@@ -1,5 +1,0 @@
-#comment Cleans up manual tram window alignment, made redundant by {} which added automatic alignment on init/dir change
-
-/obj/structure/window/reinforced/tram/left/@SUBTYPES : /obj/structure/window/reinforced/tram/@SUBTYPES
-/obj/structure/window/reinforced/tram/mid/@SUBTYPES : /obj/structure/window/reinforced/tram/@SUBTYPES
-/obj/structure/window/reinforced/tram/right/@SUBTYPES : /obj/structure/window/reinforced/tram/@SUBTYPES


### PR DESCRIPTION

## About The Pull Request

Ok so we currently have 1 (count em) border object that wants to smooth with other border objects. That's the tram window.

It currently does this manually, via map edits, but that's kinda crappy so lets be better.

This pr adds a new smoothing mode to handle border objects. 
Unlike other smoothing modes, it returns a bitfield of directions the border object connects in.

I do this by memorizing a calculation of which dirs "connect" at init, and reading out of a global list with border object direction, direction between objects, and if it's a border object, the other object's dir.

I'm doing this primarily because it's become useful for wallening (a spriter saw the tram thing and is doing the same thing to pod windows, and I want to support that)

I do think it's potentially useful in other applications too tho, and I like dehardcoding tram windows.

Also fun bonus (or maybe downside), it's nearly 0 cost because I pulled the bitmask smoothing define into 2 subdefines, and am swapping the handler one out to do what I want. 
Oh also I got rid of a for loop in smoothing code, redundant and costs time in list iteration

[Moves tram windows over to the new border object smoothing](https://github.com/tgstation/tgstation/commit/114873679c94d680788edee9665fa18dba8108c0)

Also replaces some typepath chicanery with a setDir override, for redundancy in future
Oh and there's a update paths script too, to be nice

## Why It's Good For The Game

More visual possibility in future, fixes a hack we have currently, and makes some spriters happy.

## Changelog
:cl:
fix: Dehardcodes some stuff with tram windows, they'll be easier to map with now
refactor: Border objects can now smooth with each other. I'm sure something cool will come of this
/:cl:
