### PR TITLE
Fix rockets embedding in people

### DIFF
--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -16,6 +16,9 @@
 	desc = "Boom."
 	icon_state= "missile"
 	damage = 50
+	sharpness = NONE
+	embedding = null
+	shrapnel_type = null
 	ricochets_max = 0
 	/// Whether we do extra damage when hitting a mech or silicon
 	var/anti_armour_damage = 0


### PR DESCRIPTION

## About The Pull Request
Rockets can't embed anymore and are now blunt objects (so they cause blunt wounds instead)
This is what could happen before:
![rocket_embed](https://github.com/tgstation/tgstation/assets/113535457/b1213460-fb87-4c28-bde9-454a271a38fc)
## Why It's Good For The Game
I've been told that the embedding is not intentional, so this PR fixes an oversight
## Changelog
:cl:
fix: Rockets can no longer embed in people and cause blunt wounds instead of piercing
/:cl:
