### PR TITLE
North Star: Virologists Disposals Route To Space + Spawner Removal

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -22261,7 +22261,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
-/turf/open/space/basic,
+/turf/open/space/openspace,
 /area/station/maintenance/floor2/starboard)
 "fLz" = (
 /obj/effect/turf_decal/stripes/end,

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -22262,7 +22262,7 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/open/space/openspace,
-/area/station/maintenance/floor2/starboard)
+/area/space/nearstation)
 "fLz" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/effect/turf_decal/stripes/white/end,

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -642,6 +642,11 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
+"ahS" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/turf/open/floor/plating,
+/area/station/maintenance/floor2/starboard)
 "ahT" = (
 /obj/machinery/camera/directional/west,
 /turf/open/floor/wood,
@@ -8613,7 +8618,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/floor2/aft)
 "cdf" = (
@@ -11821,6 +11825,7 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
 "cTV" = (
@@ -13156,6 +13161,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
 "dnM" = (
@@ -13602,7 +13608,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/floor2/aft)
 "dtM" = (
@@ -15664,6 +15669,9 @@
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
 "dUW" = (
@@ -15859,7 +15867,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "viro"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "dWZ" = (
@@ -19750,6 +19757,9 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
 "fcC" = (
@@ -20017,7 +20027,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "fhA" = (
@@ -21912,7 +21921,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/floor2/aft)
 "fHe" = (
@@ -22247,6 +22255,14 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/plating,
 /area/station/science/server)
+"fLx" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/space/basic,
+/area/station/maintenance/floor2/starboard)
 "fLz" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/effect/turf_decal/stripes/white/end,
@@ -23686,6 +23702,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/floor2/starboard)
 "gec" = (
@@ -24355,6 +24372,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard)
 "gnx" = (
@@ -30296,9 +30314,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/virology,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "viro"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -37877,10 +37892,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
-"jRb" = (
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/iron,
-/area/station/hallway/floor2/aft)
 "jRe" = (
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -40200,16 +40211,6 @@
 	name = "padded floor"
 	},
 /area/station/medical/psychology)
-"kxL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "kxM" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -43195,18 +43196,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"lli" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/floor2/aft)
 "llm" = (
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -47449,9 +47438,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "mnQ" = (
@@ -47595,6 +47581,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/floor4/port/fore)
+"mqc" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/middle,
+/obj/structure/girder/reinforced,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "viro-inner";
+	name = "Virology Inner Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/floor2/starboard)
 "mqd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -49794,10 +49791,11 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "mRQ" = (
-/obj/structure/noticeboard/directional/north,
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "mSa" = (
@@ -51929,6 +51927,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
+"nrL" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/turf/open/floor/plating,
+/area/station/maintenance/floor2/starboard)
 "nrM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -59428,6 +59430,12 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port)
+"pqo" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/floor2/starboard)
 "pqy" = (
 /obj/machinery/camera{
 	c_tag = "Power Storage";
@@ -64617,9 +64625,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/light/cold/no_nightlight/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "qGb" = (
@@ -65002,6 +65007,13 @@
 /obj/structure/displaycase/trophy,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/library)
+"qNw" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/structure/window/hollow/reinforced/directional{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/floor2/starboard)
 "qNx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -72299,9 +72311,6 @@
 	},
 /obj/effect/turf_decal/tile/green/opposingcorners,
 /obj/effect/landmark/start/virologist,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sPs" = (
@@ -73477,6 +73486,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/red/dim/directional/west,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
 "tdB" = (
@@ -73642,15 +73652,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
 /area/station/hallway/floor1/aft)
-"tgq" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/floor2/aft)
 "tgA" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -75848,9 +75849,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/start/virologist,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
@@ -78137,6 +78135,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
+/obj/structure/noticeboard/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
 "utm" = (
@@ -81087,12 +81086,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"viV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/virology)
 "viZ" = (
 /turf/open/floor/iron/dark/side{
 	dir = 10
@@ -82235,9 +82228,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/floor2/starboard/aft)
 "vwQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/floor2/aft)
 "vwW" = (
@@ -86092,6 +86082,7 @@
 /area/station/hallway/floor2/fore)
 "wvg" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
 "wvq" = (
@@ -88859,6 +88850,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard)
 "xeO" = (
@@ -91356,7 +91348,6 @@
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/opposingcorners,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "xND" = (
@@ -92073,6 +92064,13 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/vacant_room/office)
+"xXF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor2/starboard)
 "xXK" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood/large,
@@ -193850,8 +193848,8 @@ ucA
 ucA
 ucA
 ucA
-erN
-erN
+pqo
+nrL
 wJI
 vnK
 vnK
@@ -194118,9 +194116,9 @@ tdA
 dnJ
 cTJ
 wvg
-iOA
+mqc
 mRQ
-viV
+dVV
 xNy
 sPp
 mcI
@@ -194363,10 +194361,10 @@ ucA
 ucA
 ucA
 ucA
-ucA
-vnK
-vnK
-wJI
+fLx
+qNw
+ahS
+xXF
 xeM
 geb
 gns
@@ -194379,7 +194377,7 @@ iOA
 usZ
 kpx
 gHU
-kxL
+rPC
 dqm
 aBK
 wRc
@@ -194621,8 +194619,8 @@ ucA
 ucA
 ucA
 ucA
-vnK
-vnK
+pqo
+nrL
 wJI
 vnK
 vnK
@@ -194893,7 +194891,7 @@ iOA
 aAi
 eDl
 ovY
-kxL
+rPC
 tpW
 flD
 bAq
@@ -195135,8 +195133,8 @@ ucA
 ucA
 ucA
 ucA
-erN
-erN
+pqo
+nrL
 wJI
 vnK
 lCR
@@ -195407,7 +195405,7 @@ iOA
 xvK
 bIy
 riF
-kxL
+rPC
 hwQ
 bLm
 coH
@@ -195664,7 +195662,7 @@ iOA
 joT
 pCU
 pHu
-kxL
+rPC
 xyd
 aBK
 gef
@@ -196700,7 +196698,7 @@ dJx
 fRN
 wlZ
 mqx
-tgq
+wlZ
 tUx
 ttb
 sLI
@@ -196957,7 +196955,7 @@ ttb
 ttb
 pCg
 lYd
-lli
+pCg
 ttb
 ttb
 uUF
@@ -197214,7 +197212,7 @@ okr
 oyR
 bFH
 esk
-jRb
+bFH
 dUi
 hMg
 sUy

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -24051,10 +24051,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard/fore)
-"gjm" = (
-/obj/effect/spawner/random/maintenance/two,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/floor1/port)
 "gjn" = (
 /obj/structure/table,
 /obj/item/stock_parts/matter_bin,
@@ -127326,7 +127322,7 @@ iun
 xgH
 kzE
 kzE
-gjm
+kzE
 kzE
 kzE
 kzE


### PR DESCRIPTION
## About The Pull Request
Reroutes viro's waste to a space chute rather than directly to disposals.
![f4](https://github.com/tgstation/tgstation/assets/73589390/ea335204-aa16-4a94-a32f-6d4f1fe1a650)
Also removes a spawner by plumbing
## Why It's Good For The Game
Because virologists should have a safe way to dispose of their nasty tubes of blood and disease monkeys without infecting anyone sorting through trash
That spawner in the wall probably caused some issues somewhere.
## Changelog
:cl:
fix: Virology disposals now route directly to space, rather than sending their nasty tubes to cargo.
fix: A single maintenance spawner was removed from a wall by plumbing.
/:cl:
