### PR TITLE
[NO GBP] Nerfs passive carp shuttle event spawns

### DIFF
--- a/code/modules/shuttle/shuttle_events/carp.dm
+++ b/code/modules/shuttle/shuttle_events/carp.dm
@@ -35,7 +35,7 @@
 
 	spawning_list = list(/mob/living/basic/carp/passive = 1)
 	spawning_flags = SHUTTLE_EVENT_HIT_SHUTTLE | SHUTTLE_EVENT_MISS_SHUTTLE
-	spawns_per_spawn = 2
+	spawns_per_spawn = 1
 	spawn_probability_per_process = 100
 
 	remove_from_list_when_spawned = FALSE


### PR DESCRIPTION
Reduces spawns per spawns from 2 to 1 (the shuttle event)

Two is way too many, if there's any server lag they just stack up and block each other (which I got to witness on Terry)

:cl:
balance: Reduces passive carp spawns
/:cl: