### PR TITLE
replaces the weirdly placed engine in the greytide ship with a heater

### DIFF
--- a/_maps/shuttles/pirate_grey.dmm
+++ b/_maps/shuttles/pirate_grey.dmm
@@ -131,10 +131,6 @@
 /obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
-"eK" = (
-/obj/machinery/power/shuttle_engine/propulsion,
-/turf/open/floor/plating/airless,
-/area/shuttle/pirate)
 "eU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -1514,7 +1510,7 @@ zB
 Ww
 Ww
 Ww
-eK
+Ww
 Ww
 Ww
 Ww


### PR DESCRIPTION
## About The Pull Request
<img width="180" alt="image" src="https://github.com/tgstation/tgstation/assets/80979251/fb173500-0e30-4a8e-a8a3-b4d8a4c8f7d1">
the heater in the middle used to be a thruster. i saw that and hated it immediately
just because your map is meant to be scuffed does not mean it has excuse to have this abomination
<img width="171" alt="image" src="https://github.com/tgstation/tgstation/assets/80979251/a5e2d835-007d-4188-80fa-e9dd571cd3e0">


## Why It's Good For The Game
the greytide ship is meant to be shit, but like...
please god why do you have to make us suffer like that
dont do this ever with shuttle engines

## Changelog
:cl:
fix: somehow, somewhere, a ship's engine has been changed.
/:cl:
