### PR TITLE
[NO GBP] adjust mecha generator consumption values to use `SHEET_MATERIAL_AMOUNT`

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -281,11 +281,11 @@
 	///Type of fuel the generator is using. Is set in generator_init() to add the starting amount of fuel
 	var/obj/item/stack/sheet/fuel = null
 	///Fuel used per second while idle, not generating, in units
-	var/fuelrate_idle = 12.5
+	var/fuelrate_idle = 0.00625 * SHEET_MATERIAL_AMOUNT
 	///Fuel used per second while actively generating, in units
-	var/fuelrate_active = 100
+	var/fuelrate_active = 0.05 * SHEET_MATERIAL_AMOUNT
 	///Maximum fuel capacity of the generator, in units
-	var/max_fuel = 150000
+	var/max_fuel = 75 * SHEET_MATERIAL_AMOUNT
 	///Energy recharged per second
 	var/rechargerate = 10
 
@@ -312,11 +312,11 @@
 	. = ..()
 	if(action == "toggle")
 		if(activated)
-			to_chat(usr, "[icon2html(src, usr)][span_warning("Power generation enabled.")]")
+			to_chat(chassis.occupants, "[icon2html(src, chassis.occupants)][span_warning("Power generation enabled.")]")
 			START_PROCESSING(SSobj, src)
 			log_message("Activated.", LOG_MECHA)
 		else
-			to_chat(usr, "[icon2html(src, usr)][span_warning("Power generation disabled.")]")
+			to_chat(chassis.occupants, "[icon2html(src, chassis.occupants)][span_warning("Power generation disabled.")]")
 			STOP_PROCESSING(SSobj, src)
 			log_message("Deactivated.", LOG_MECHA)
 		return TRUE


### PR DESCRIPTION
i should have adjusted these in my previous PR that was touching this equipment lol thus the no gbp

also makes the `ui_act()` not use `usr`

if my calculations are correct the consumption rates per tick should be the same — 5% of a sheet when active and 0.65% when idle

## Why It's Good For The Game
fixes #76132

## Changelog
:cl:
fix: fixed mecha generators using way too much fuel due to using the old values of material units per sheet
/:cl:
