### PR TITLE
lowers the firedelay of syndicate simplemobs from 2.5 seconds to 1 second

### DIFF
--- a/code/modules/mob/living/basic/syndicate/syndicate_ai.dm
+++ b/code/modules/mob/living/basic/syndicate/syndicate_ai.dm
@@ -36,7 +36,7 @@
 	ranged_attack_behavior = /datum/ai_behavior/basic_ranged_attack/syndicate
 
 /datum/ai_behavior/basic_ranged_attack/syndicate
-	action_cooldown = 2.5 SECONDS
+	action_cooldown = 1 SECONDS
 	required_distance = 5
 
 /datum/ai_controller/basic_controller/syndicate/ranged/burst


### PR DESCRIPTION

## Why It's Good For The Game

johnfulpwillard previously edited this to 2.5 seconds because their delay of .2 seconds was ludicrously low 

however at 2.5 seconds they're basically not a threat and will barely shoot

now they fire every second, which i think is a happy medium between 'insanely slow' and 'insanely fast', so that they are still sizeably deadly, but not at _nearly the slow firerate of the syndie shotgunner_ with none of the power

## Changelog

:cl:
balance: Syndicate simplemob fire-rate raised to one shot per second.
/:cl:

