### PR TITLE
Buffs Wizarditis

### DIFF
--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -119,7 +119,7 @@
 			human_mob.equip_to_slot_or_del(new hat_type(human_mob), ITEM_SLOT_HEAD)
 
 	if(prob(chance) && !(human_mob.wear_suit?.item_flags & CASTING_CLOTHES))
-		if(human_mob.dropItemToGround(human_mob.head))
+		if(human_mob.dropItemToGround(human_mob.wear_suit))
 			human_mob.equip_to_slot_or_del(new robe_type(human_mob), ITEM_SLOT_OCLOTHING)
 
 	if(prob(chance) && !istype(human_mob.shoes, /obj/item/clothing/shoes/sandal/magic))
@@ -153,6 +153,7 @@
 	random_spells += sneeze_blink
 
 	var/datum/action/cooldown/spell/smoke/sneeze_smoke = new(src)
+	sneeze_smoke.smoke_amt = 2
 	random_spells += sneeze_smoke
 
 	var/datum/action/cooldown/spell/spacetime_dist/sneeze_spacetime = new(src)

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -9,106 +9,177 @@
 	viable_mobtypes = list(/mob/living/carbon/human)
 	disease_flags = CAN_CARRY|CAN_RESIST|CURABLE
 	spreading_modifier = 0.75
-	desc = "Some speculate that this virus is the cause of the Space Wizard Federation's existence. Subjects affected show the signs of brain damage, yelling obscure sentences or total gibberish. On late stages subjects sometime express the feelings of inner power, and, cite, 'the ability to control the forces of cosmos themselves!' A gulp of strong, manly spirits usually reverts them to normal, humanlike, condition."
+	desc = "Some speculate that this virus is the cause of the Space Wizard Federation's existence. \
+		Subjects affected show the signs of brain damage, yelling obscure sentences or total gibberish. \
+		On late stages subjects sometime express the feelings of inner power, and cite \
+		'the ability to control the forces of cosmos themselves!' \
+		A gulp of strong, manly spirits usually reverts them to normal, humanlike, condition. \
+		A form of magical grounding can help, too, but will not cure it on its own."
 	severity = DISEASE_SEVERITY_HARMFUL
 	required_organs = list(/obj/item/bodypart/head)
 
-/*
-BIRUZ BENNAR
-SCYAR NILA - teleport
-NEC CANTIO - dis techno
-EI NATH - shocking grasp
-AULIE OXIN FIERA - knock
-TARCOL MINTI ZHERI - forcewall
-STI KALY - blind
-*/
+	/// List of random non-targeted spells to pick from to cast
+	var/list/datum/action/cooldown/spell/random_spells = list()
+	/// List of random targeted spells to pick from to cast
+	var/list/datum/action/cooldown/spell/random_targeted_spells = list()
+
+	/// The hat type to give the infected
+	var/hat_type
+	/// The robe type to give the infected
+	var/robe_type
+
+/datum/disease/wizarditis/New()
+	. = ..()
+	switch(pick("blue", "red", "yellow"))
+		if("blue")
+			hat_type = /obj/item/clothing/head/wizard
+			robe_type = /obj/item/clothing/suit/wizrobe
+		if("red")
+			hat_type = /obj/item/clothing/head/wizard/red
+			robe_type = /obj/item/clothing/suit/wizrobe/red
+		if("yellow")
+			hat_type = /obj/item/clothing/head/wizard/yellow
+			robe_type = /obj/item/clothing/suit/wizrobe/yellow
+
+	init_spells()
+
+/datum/disease/wizarditis/Destroy()
+	QDEL_LIST(random_spells)
+	QDEL_LIST(random_targeted_spells)
+	return ..()
 
 /datum/disease/wizarditis/stage_act(seconds_per_tick, times_fired)
 	. = ..()
 	if(!.)
 		return
 
+	if(affected_mob.can_block_magic(charge_cost = 0))
+		update_stage(1)
+		return
+
+	if(stage >= 3 && SPT_PROB(0.1 * stage, seconds_per_tick))
+		var/datum/action/cooldown/spell/picked = pick(random_spells)
+		if(!picked.try_invoke(affected_mob, feedback = FALSE))
+			to_chat(affected_mob, span_danger("You feel something building up inside... but the feeling passes."))
+			return
+
+		picked.spell_feedback(affected_mob)
+		return
+
+	if(stage <= 3 && SPT_PROB(0.1 * stage, seconds_per_tick))
+		affected_mob.manual_emote("sniffles.")
+
 	switch(stage)
 		if(2)
 			if(SPT_PROB(0.25, seconds_per_tick))
-				affected_mob.say(pick("You shall not pass!", "Expeliarmus!", "By Merlins beard!", "Feel the power of the Dark Side!"), forced = "wizarditis")
-			if(SPT_PROB(0.25, seconds_per_tick))
 				to_chat(affected_mob, span_danger("You feel [pick("that you don't have enough mana", "that the winds of magic are gone", "an urge to summon familiar")]."))
+
 		if(3)
 			if(SPT_PROB(0.25, seconds_per_tick))
-				affected_mob.say(pick("NEC CANTIO!","AULIE OXIN FIERA!", "STI KALY!", "TARCOL MINTI ZHERI!"), forced = "wizarditis")
-			if(SPT_PROB(0.25, seconds_per_tick))
-				to_chat(affected_mob, span_danger("You feel [pick("the magic bubbling in your veins","that this location gives you a +1 to INT","an urge to summon familiar")]."))
-		if(4)
-			if(SPT_PROB(0.5, seconds_per_tick))
-				affected_mob.say(pick("NEC CANTIO!","AULIE OXIN FIERA!","STI KALY!","EI NATH!"), forced = "wizarditis")
-				return
-			if(SPT_PROB(0.25, seconds_per_tick))
-				to_chat(affected_mob, span_danger("You feel [pick("the tidal wave of raw power building inside","that this location gives you a +2 to INT and +1 to WIS","an urge to teleport")]."))
-				spawn_wizard_clothes(50)
-			if(SPT_PROB(0.005, seconds_per_tick))
-				teleport()
+				to_chat(affected_mob, span_danger("You feel [pick("the magic bubbling in your veins", "that this location gives you a +1 to INT", "an urge to summon familiar")]."))
+				spawn_wizard_clothes(10)
 
+		if(4)
+			if(SPT_PROB(0.25, seconds_per_tick))
+				to_chat(affected_mob, span_danger("You feel [pick("the tidal wave of raw power building inside", "that this location gives you a +2 to INT and +1 to WIS", "an urge to teleport")]."))
+				spawn_wizard_clothes(50)
+
+			if(SPT_PROB(0.1, seconds_per_tick))
+				if(prob(15))
+					var/list/targets = list()
+					var/datum/action/cooldown/spell/target_picked = pick(random_targeted_spells)
+					for(var/mob/living/potential_target in view(affected_mob))
+						if(potential_target == affected_mob)
+							continue
+						targets += potential_target
+
+					if(length(targets))
+						target_picked.Activate(pick(targets))
+						affected_mob.emote("cough")
+						return
+
+				var/datum/action/cooldown/spell/picked = pick(random_spells)
+				picked.Activate(affected_mob)
+				affected_mob.emote("sneeze")
+				return
 
 /datum/disease/wizarditis/proc/spawn_wizard_clothes(chance = 0)
-	if(ishuman(affected_mob))
-		var/mob/living/carbon/human/H = affected_mob
-		if(prob(chance))
-			if(!istype(H.head, /obj/item/clothing/head/wizard))
-				if(!H.dropItemToGround(H.head))
-					qdel(H.head)
-				H.equip_to_slot_or_del(new /obj/item/clothing/head/wizard(H), ITEM_SLOT_HEAD)
-			return
-		if(prob(chance))
-			if(!istype(H.wear_suit, /obj/item/clothing/suit/wizrobe))
-				if(!H.dropItemToGround(H.wear_suit))
-					qdel(H.wear_suit)
-				H.equip_to_slot_or_del(new /obj/item/clothing/suit/wizrobe(H), ITEM_SLOT_OCLOTHING)
-			return
-		if(prob(chance))
-			if(!istype(H.shoes, /obj/item/clothing/shoes/sandal/magic))
-				if(!H.dropItemToGround(H.shoes))
-					qdel(H.shoes)
-			H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal/magic(H), ITEM_SLOT_FEET)
-			return
-	else
-		var/mob/living/carbon/H = affected_mob
-		if(prob(chance))
-			var/obj/item/staff/S = new(H)
-			if(!H.put_in_hands(S))
-				qdel(S)
+	if(prob(chance) && affected_mob.usable_hands >= 1)
+		var/obj/item/staff/funny_staff = new(affected_mob)
+		if(!affected_mob.put_in_hands(funny_staff))
+			qdel(funny_staff)
 
-
-/datum/disease/wizarditis/proc/teleport()
-	var/list/theareas = get_areas_in_range(80, affected_mob)
-	for(var/area/space/S in theareas)
-		theareas -= S
-
-	if(!theareas || !theareas.len)
+	if(!ishuman(affected_mob))
 		return
 
-	var/area/thearea = pick(theareas)
 
-	var/list/L = list()
-	var/turf/mob_turf = get_turf(affected_mob)
-	for(var/turf/T in get_area_turfs(thearea.type))
-		if(!is_valid_z_level(T, mob_turf))
-			continue
-		if(T.name == "space")
-			continue
-		if(!T.density)
-			var/clear = 1
-			for(var/obj/O in T)
-				if(O.density)
-					clear = 0
-					break
-			if(clear)
-				L+=T
+	var/mob/living/carbon/human/human_mob = affected_mob
+	if(prob(chance) && !(human_mob.head?.item_flags & CASTING_CLOTHES))
+		if(human_mob.dropItemToGround(human_mob.head))
+			human_mob.equip_to_slot_or_del(new hat_type(human_mob), ITEM_SLOT_HEAD)
 
-	if(!L)
-		return
+	if(prob(chance) && !(human_mob.wear_suit?.item_flags & CASTING_CLOTHES))
+		if(human_mob.dropItemToGround(human_mob.head))
+			human_mob.equip_to_slot_or_del(new robe_type(human_mob), ITEM_SLOT_OCLOTHING)
 
-	affected_mob.say("SCYAR NILA [uppertext(thearea.name)]!", forced = "wizarditis teleport")
-	affected_mob.forceMove(pick(L))
+	if(prob(chance) && !istype(human_mob.shoes, /obj/item/clothing/shoes/sandal/magic))
+		if(human_mob.dropItemToGround(human_mob.shoes))
+			human_mob.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal/magic(human_mob), ITEM_SLOT_FEET)
 
-	return
+/datum/disease/wizarditis/proc/init_spells()
+	// Some self cast spells
+	var/datum/action/cooldown/spell/teleport/area_teleport/wizard/sneeze_teleport = new(src)
+	sneeze_teleport.randomise_selection = TRUE
+	random_spells += sneeze_teleport
+
+	var/datum/action/cooldown/spell/emp/disable_tech/sneeze_emp = new(src)
+	sneeze_emp.emp_heavy = 1
+	sneeze_emp.emp_light = 2
+	random_spells += sneeze_emp
+
+	var/datum/action/cooldown/spell/apply_mutations/mutate/sneeze_mutate = new(src)
+	sneeze_mutate.mutation_duration = 3 SECONDS
+	random_spells += sneeze_mutate
+
+	var/datum/action/cooldown/spell/aoe/knock/sneeze_knock = new(src)
+	random_spells += sneeze_knock
+
+	var/datum/action/cooldown/spell/forcewall/sneeze_forcewall = new(src)
+	random_spells += sneeze_forcewall
+
+	var/datum/action/cooldown/spell/teleport/radius_turf/blink/sneeze_blink = new(src)
+	sneeze_blink.inner_tele_radius = 1
+	sneeze_blink.outer_tele_radius = 3
+	random_spells += sneeze_blink
+
+	var/datum/action/cooldown/spell/smoke/sneeze_smoke = new(src)
+	random_spells += sneeze_smoke
+
+	var/datum/action/cooldown/spell/spacetime_dist/sneeze_spacetime = new(src)
+	sneeze_spacetime.scramble_radius = 2
+	sneeze_spacetime.duration = 5 SECONDS
+	random_spells += sneeze_spacetime
+
+	var/datum/action/cooldown/spell/timestop/sneeze_timestop = new(src)
+	sneeze_timestop.timestop_range = 1 // heh
+	sneeze_timestop.timestop_duration = 5 SECONDS
+	random_spells += sneeze_timestop
+
+	var/datum/action/cooldown/spell/aoe/repulse/sneeze_repulse = new(src)
+	sneeze_repulse.aoe_radius = 2
+	sneeze_repulse.max_throw = 3
+	random_spells += sneeze_repulse
+
+	// Some targeted spells
+	var/datum/action/cooldown/spell/pointed/blind/cough_blind = new(src)
+	cough_blind.eye_blind_duration = 2 SECONDS
+	cough_blind.eye_blur_duration = 10 SECONDS
+	random_targeted_spells += cough_blind
+
+	var/datum/action/cooldown/spell/pointed/projectile/lightningbolt/cough_zap = new(src)
+	cough_zap.bolt_range /= 3
+	cough_zap.bolt_power /= 3
+	random_targeted_spells += cough_zap
+
+	var/datum/action/cooldown/spell/pointed/swap/cough_swap = new(src)
+	random_targeted_spells += cough_swap

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -28,8 +28,7 @@
 	/// The robe type to give the infected
 	var/robe_type
 
-/datum/disease/wizarditis/New()
-	. = ..()
+/datum/disease/wizarditis/after_add()
 	switch(pick("blue", "red", "yellow"))
 		if("blue")
 			hat_type = /obj/item/clothing/head/wizard

--- a/code/datums/diseases/wizarditis.dm
+++ b/code/datums/diseases/wizarditis.dm
@@ -56,7 +56,7 @@
 		update_stage(1)
 		return
 
-	if(stage >= 3 && SPT_PROB(0.1 * stage, seconds_per_tick))
+	if(stage >= 3 && SPT_PROB(0.15 * stage, seconds_per_tick))
 		var/datum/action/cooldown/spell/picked = pick(random_spells)
 		if(!picked.try_invoke(affected_mob, feedback = FALSE))
 			to_chat(affected_mob, span_danger("You feel something building up inside... but the feeling passes."))
@@ -65,25 +65,25 @@
 		picked.spell_feedback(affected_mob)
 		return
 
-	if(stage <= 3 && SPT_PROB(0.1 * stage, seconds_per_tick))
+	if(stage <= 3 && SPT_PROB(0.33 * stage, seconds_per_tick))
 		affected_mob.manual_emote("sniffles.")
 
 	switch(stage)
 		if(2)
-			if(SPT_PROB(0.25, seconds_per_tick))
+			if(SPT_PROB(1, seconds_per_tick))
 				to_chat(affected_mob, span_danger("You feel [pick("that you don't have enough mana", "that the winds of magic are gone", "an urge to summon familiar")]."))
 
 		if(3)
-			if(SPT_PROB(0.25, seconds_per_tick))
+			if(SPT_PROB(1, seconds_per_tick))
 				to_chat(affected_mob, span_danger("You feel [pick("the magic bubbling in your veins", "that this location gives you a +1 to INT", "an urge to summon familiar")]."))
 				spawn_wizard_clothes(10)
 
 		if(4)
-			if(SPT_PROB(0.25, seconds_per_tick))
+			if(SPT_PROB(1, seconds_per_tick))
 				to_chat(affected_mob, span_danger("You feel [pick("the tidal wave of raw power building inside", "that this location gives you a +2 to INT and +1 to WIS", "an urge to teleport")]."))
 				spawn_wizard_clothes(50)
 
-			if(SPT_PROB(0.1, seconds_per_tick))
+			if(SPT_PROB(0.2, seconds_per_tick))
 				if(prob(15))
 					var/list/targets = list()
 					var/datum/action/cooldown/spell/target_picked = pick(random_targeted_spells)

--- a/code/modules/antagonists/heretic/magic/mansus_grasp.dm
+++ b/code/modules/antagonists/heretic/magic/mansus_grasp.dm
@@ -78,7 +78,7 @@
 /obj/item/melee/touch_attack/mansus_fist/proc/after_clear_rune(obj/effect/target, mob/living/user)
 	new /obj/effect/temp_visual/drawing_heretic_rune/fail(target.loc, target.greyscale_colors)
 	var/datum/action/cooldown/spell/touch/mansus_grasp/grasp = spell_which_made_us?.resolve()
-	grasp?.spell_feedback()
+	grasp?.spell_feedback(user)
 
 	remove_hand_with_no_refund(user)
 

--- a/code/modules/antagonists/heretic/magic/star_touch.dm
+++ b/code/modules/antagonists/heretic/magic/star_touch.dm
@@ -85,7 +85,7 @@
 /obj/item/melee/touch_attack/star_touch/proc/after_clear_rune(obj/effect/target, mob/living/user)
 	new /obj/effect/temp_visual/cosmic_rune_fade(get_turf(target))
 	var/datum/action/cooldown/spell/touch/star_touch/star_touch_spell = spell_which_made_us?.resolve()
-	star_touch_spell?.spell_feedback()
+	star_touch_spell?.spell_feedback(user)
 	remove_hand_with_no_refund(user)
 
 /obj/item/melee/touch_attack/star_touch/ignition_effect(atom/to_light, mob/user)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -182,7 +182,7 @@
 			to_chat(owner, span_warning("[src] cannot be cast unless you are completely manifested in the material plane!"))
 		return FALSE
 
-	if(!try_invoke(feedback = feedback))
+	if(!try_invoke(owner, feedback = feedback))
 		return FALSE
 
 	if(ishuman(owner))
@@ -242,7 +242,7 @@
 	if(!(precast_result & SPELL_NO_FEEDBACK))
 		// We do invocation and sound effects here, before actual cast
 		// That way stuff like teleports or shape-shifts can be invoked before ocurring
-		spell_feedback()
+		spell_feedback(owner)
 
 	// Actually cast the spell. Main effects go here
 	cast(cast_on)
@@ -319,20 +319,19 @@
 	SEND_SIGNAL(src, COMSIG_SPELL_AFTER_CAST, cast_on)
 
 /// Provides feedback after a spell cast occurs, in the form of a cast sound and/or invocation
-/datum/action/cooldown/spell/proc/spell_feedback()
-	if(!owner)
+/datum/action/cooldown/spell/proc/spell_feedback(mob/living/invoker)
+	if(!invoker)
 		return
 
 	///even INVOCATION_NONE should go through this because the signal might change that
-	invocation()
-	if(sound)
-		playsound(get_turf(owner), sound, 50, TRUE)
+	invocation(invoker)
+	playsound(invoker, sound, 50, vary = TRUE)
 
 /// The invocation that accompanies the spell, called from spell_feedback() before cast().
-/datum/action/cooldown/spell/proc/invocation()
+/datum/action/cooldown/spell/proc/invocation(mob/living/invoker)
 	//lists can be sent by reference, a string would be sent by value
 	var/list/invocation_list = list(invocation, invocation_type, garbled_invocation_prob)
-	SEND_SIGNAL(owner, COMSIG_MOB_PRE_INVOCATION, src, invocation_list)
+	SEND_SIGNAL(invoker, COMSIG_MOB_PRE_INVOCATION, src, invocation_list)
 	var/used_invocation_message = invocation_list[INVOCATION_MESSAGE]
 	var/used_invocation_type = invocation_list[INVOCATION_TYPE]
 	var/used_invocation_garble_prob = invocation_list[INVOCATION_GARBLE_PROB]
@@ -340,21 +339,21 @@
 	switch(used_invocation_type)
 		if(INVOCATION_SHOUT)
 			if(prob(used_invocation_garble_prob))
-				owner.say(replacetext(used_invocation_message," ","`"), forced = "spell ([src])")
+				invoker.say(replacetext(used_invocation_message," ","`"), forced = "spell ([src])")
 			else
-				owner.say(used_invocation_message, forced = "spell ([src])")
+				invoker.say(used_invocation_message, forced = "spell ([src])")
 
 		if(INVOCATION_WHISPER)
 			if(prob(used_invocation_garble_prob))
-				owner.whisper(replacetext(used_invocation_message," ","`"), forced = "spell ([src])")
+				invoker.whisper(replacetext(used_invocation_message," ","`"), forced = "spell ([src])")
 			else
-				owner.whisper(used_invocation_message, forced = "spell ([src])")
+				invoker.whisper(used_invocation_message, forced = "spell ([src])")
 
 		if(INVOCATION_EMOTE)
-			owner.visible_message(used_invocation_message, invocation_self_message)
+			invoker.visible_message(used_invocation_message, invocation_self_message)
 
 /// Checks if the current OWNER of the spell is in a valid state to say the spell's invocation
-/datum/action/cooldown/spell/proc/try_invoke(feedback = TRUE)
+/datum/action/cooldown/spell/proc/try_invoke(mob/living/invoker, feedback = TRUE)
 	if(spell_requirements & SPELL_CASTABLE_WITHOUT_INVOCATION)
 		return TRUE
 
@@ -362,26 +361,25 @@
 		return TRUE
 
 	// If you want a spell usable by ghosts for some reason, it must be INVOCATION_NONE
-	if(!isliving(owner))
+	if(!istype(invoker))
 		if(feedback)
-			to_chat(owner, span_warning("You need to be living to invoke [src]!"))
+			to_chat(invoker, span_warning("You need to be living to invoke [src]!"))
 		return FALSE
 
-	var/mob/living/living_owner = owner
-	var/invoke_sig_return = SEND_SIGNAL(owner, COMSIG_MOB_TRY_INVOKE_SPELL, src, feedback)
+	var/invoke_sig_return = SEND_SIGNAL(invoker, COMSIG_MOB_TRY_INVOKE_SPELL, src, feedback)
 	if(invoke_sig_return & SPELL_INVOCATION_ALWAYS_SUCCEED)
 		return TRUE // skips all of the following checks
 	if(invoke_sig_return & SPELL_INVOCATION_FAIL)
 		return FALSE
 
-	if(invocation_type == INVOCATION_EMOTE && HAS_TRAIT(living_owner, TRAIT_EMOTEMUTE))
+	if(invocation_type == INVOCATION_EMOTE && HAS_TRAIT(invoker, TRAIT_EMOTEMUTE))
 		if(feedback)
-			to_chat(owner, span_warning("You can't position your hands correctly to invoke [src]!"))
+			to_chat(invoker, span_warning("You can't position your hands correctly to invoke [src]!"))
 		return FALSE
 
-	if((invocation_type == INVOCATION_WHISPER || invocation_type == INVOCATION_SHOUT) && !living_owner.can_speak())
+	if((invocation_type == INVOCATION_WHISPER || invocation_type == INVOCATION_SHOUT) && !invoker.can_speak())
 		if(feedback)
-			to_chat(owner, span_warning("You can't get the words out to invoke [src]!"))
+			to_chat(invoker, span_warning("You can't get the words out to invoke [src]!"))
 		return FALSE
 
 	return TRUE

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -60,7 +60,7 @@
 	jaunter.add_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_RUNECHAT_HIDDEN), REF(src))
 	// Don't do the feedback until we have runechat hidden.
 	// Otherwise the text will follow the jaunt holder, which reveals where our caster is travelling.
-	spell_feedback()
+	spell_feedback(jaunter)
 
 	// This needs to happen at the end, after all the traits and stuff is handled
 	SEND_SIGNAL(jaunter, COMSIG_MOB_ENTER_JAUNT, src, jaunt)

--- a/code/modules/spells/spell_types/pointed/finger_guns.dm
+++ b/code/modules/spells/spell_types/pointed/finger_guns.dm
@@ -27,19 +27,19 @@
 	projectile_type = /obj/projectile/bullet/mime
 	projectile_amount = 3
 
-/datum/action/cooldown/spell/pointed/projectile/finger_guns/try_invoke(feedback = TRUE)
+/datum/action/cooldown/spell/pointed/projectile/finger_guns/try_invoke(mob/living/invoker, feedback = TRUE)
 	if(invocation_type == INVOCATION_EMOTE)
-		if(!ishuman(owner))
+		if(!ishuman(invoker))
 			return FALSE
 
-		var/mob/living/carbon/human/human_owner = owner
-		if(human_owner.incapacitated())
+		var/mob/living/carbon/human/human_invoker = invoker
+		if(human_invoker.incapacitated())
 			if(feedback)
-				to_chat(owner, span_warning("You can't properly point your fingers while incapacitated."))
+				to_chat(human_invoker, span_warning("You can't properly point your fingers while incapacitated."))
 			return FALSE
-		if(human_owner.get_active_held_item())
+		if(human_invoker.get_active_held_item())
 			if(feedback)
-				to_chat(owner, span_warning("You can't properly fire your finger guns with something in your hand."))
+				to_chat(human_invoker, span_warning("You can't properly fire your finger guns with something in your hand."))
 			return FALSE
 
 	return ..()

--- a/code/modules/spells/spell_types/self/voice_of_god.dm
+++ b/code/modules/spells/spell_types/self/voice_of_god.dm
@@ -38,7 +38,7 @@
 	cooldown_time = (command_cooldown * cooldown_mod)
 
 // "Invocation" is done by the actual voice of god proc
-/datum/action/cooldown/spell/voice_of_god/invocation()
+/datum/action/cooldown/spell/voice_of_god/invocation(mob/living/invoker)
 	return
 
 /datum/action/cooldown/spell/voice_of_god/clown

--- a/code/modules/spells/spell_types/teleport/_teleport.dm
+++ b/code/modules/spells/spell_types/teleport/_teleport.dm
@@ -132,7 +132,7 @@
 		living_cast_on.buckled?.unbuckle_mob(cast_on, force = TRUE)
 	return ..()
 
-/datum/action/cooldown/spell/teleport/area_teleport/invocation()
+/datum/action/cooldown/spell/teleport/area_teleport/invocation(mob/living/invoker)
 	var/area/last_chosen_area = GLOB.teleportlocs[last_chosen_area_name]
 
 	if(!invocation_says_area || isnull(last_chosen_area))
@@ -140,6 +140,6 @@
 
 	switch(invocation_type)
 		if(INVOCATION_SHOUT)
-			owner.say("[invocation], [uppertext(last_chosen_area.name)]!", forced = "spell ([src])")
+			invoker.say("[invocation], [uppertext(last_chosen_area.name)]!", forced = "spell ([src])")
 		if(INVOCATION_WHISPER)
-			owner.whisper("[invocation], [uppertext(last_chosen_area.name)].", forced = "spell ([src])")
+			invoker.whisper("[invocation], [uppertext(last_chosen_area.name)].", forced = "spell ([src])")

--- a/code/modules/spells/spell_types/teleport/_teleport.dm
+++ b/code/modules/spells/spell_types/teleport/_teleport.dm
@@ -119,7 +119,7 @@
 	else
 		target_area = tgui_input_list(cast_on, "Chose an area to teleport to.", "Teleport", GLOB.teleportlocs)
 
-	if(QDELETED(src) || QDELETED(cast_on) || !can_cast_spell())
+	if(QDELETED(src) || QDELETED(cast_on) || (owner && !can_cast_spell()))
 		return . | SPELL_CANCEL_CAST
 	if(!target_area || isnull(GLOB.teleportlocs[target_area]))
 		return . | SPELL_CANCEL_CAST

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -223,7 +223,7 @@
 		return
 
 	log_combat(caster, victim, "cast the touch spell [name] on", hand)
-	spell_feedback()
+	spell_feedback(caster)
 	remove_hand(caster)
 
 /**
@@ -240,7 +240,7 @@
 		// Continue will remove the hand here and stop
 		if(SECONDARY_ATTACK_CONTINUE_CHAIN)
 			log_combat(caster, victim, "cast the touch spell [name] on", hand, "(secondary / alt cast)")
-			spell_feedback()
+			spell_feedback(caster)
 			remove_hand(caster)
 
 		// Call normal will call the normal cast proc


### PR DESCRIPTION
## About The Pull Request

Basically, reworks Wizarditis so you randomly cast real (weakened) spells instead of just saying random invocations + doing a hardcoded version of teleport. 

Spells include Teleport, Disable Tech (small radius), Mutate, Knock, Forcewall, Blink, Smoke, Spacetime Distortion (much smaller radius), Timestop (radius of 1 (haha)), Repulse (small radius), Blind, Lightning Bolt (weaker bolt), and Swap

Makes anti-magic counter wizarditis, but not cure it. 

Adds some more minor tells that one may be infected. Removes some old messages in favor of newer ones. 

## Why It's Good For The Game

Wizarditis is very lackluster for how difficult it is to obtain. 

Initially this started as de-hardcoding / optimizing the in built teleport function to use the actual scyar nila, but I realized how easy it would be to expand this, so I did it. 

Because it's funny. 

## Changelog

:cl: Melbert
add: Wizarditis Improved. Those infected will now randomly cast one of the following (weakened) spells at max stage: Teleport, Disable Tech, Mutate, Knock, Forcewall, Blink, Smoke, Spacetime Distortion, Timestop, Repulse, Blind, Lightning Bolt, or Swap
add: A source of antimagic will prevent Wizarditis's ill effects, but won't cure you.
/:cl:
