### PR TITLE
reduces the Regal Condor's base spread from 10 to 0, mildly revises its desc

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -83,14 +83,13 @@
 
 /obj/item/gun/ballistic/automatic/pistol/deagle/regal
 	name = "\improper Regal Condor"
-	desc = "Unlike the Desert Eagle, this weapon seems to utilize some kind of advance internal stabilization system to significantly \
-		reduce felt recoil and substantially increases overall accuracy, though at the cost of using a smaller caliber. This modification does \
-		allow it to fire in a 2-round burst. Uses 10mm ammo."
+	desc = "Unlike the Desert Eagle, this weapon seems to utilize some kind of advanced internal stabilization system to significantly \
+		reduce felt recoil and increase overall accuracy, at the cost of using a smaller caliber. \
+		This does allow it to fire a very quick 2-round burst. Uses 10mm ammo."
 	icon_state = "reagle"
 	inhand_icon_state = "deagleg"
 	burst_size = 2
 	fire_delay = 1
-	spread = 10
 	projectile_damage_multiplier = 1.25
 	mag_type = /obj/item/ammo_box/magazine/r10mm
 	actions_types = list(/datum/action/item_action/toggle_firemode)


### PR DESCRIPTION
## About The Pull Request
uh. tin? regal condor's spread override got dropped so it should just be getting the base gun spread of 0.

## Why It's Good For The Game
So, quick review on what you have to do to make the Regal Condor:
- emag a cargo console (4 tc investment)
- drum up 20k credits (or 22k if you're private-ordering it)
- read the memoirs to unlock the recipe
and then, the recipe for the gun itself involves stealing the captain's crown and getting your grubby mitts on:
- a makarov (7 tc),
- 3 raw telecrystals (3 tc)
- a tactical toolbox (1 TC/spaceloot)
- a syndicate mask (contraband crates/spaceloot)

The gun itself does not come with a magazine; magazines are a separate recipe and, as part of the recipe, require 2 raw TC each.

If you manage to put it together, I think you should feel confident in your gun's ability to hit where you click, and not have to worry about random projectile deviation shooting a wall or a tank, instead of the security officer who probably wants to kick you in the nuts for emagging a great many things and/or gathering the components to make a really spicy handgun.

## Changelog

:cl:
balance: The Regal Condor's base spread has been reduced to 0, like damn near every other gun that exists.
/:cl:
