### PR TITLE
Fixes materials in lathes not greying out properly at `SHEET_MATERIAL_AMOUNT` units

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -550,7 +550,8 @@
 			"amount" = amount,
 			"sheets" = round(amount / SHEET_MATERIAL_AMOUNT),
 			"removable" = amount >= SHEET_MATERIAL_AMOUNT,
-			"color" = material.greyscale_colors
+			"color" = material.greyscale_colors,
+			"sheet_material_amount" = SHEET_MATERIAL_AMOUNT
 		))
 
 	return data

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
@@ -79,8 +79,6 @@ const MaterialCounter = (props: MaterialCounterProps, context) => {
     false
   );
 
-  const canEject = material.amount > 2_000;
-
   return (
     <div
       onMouseEnter={() => setHovering(true)}
@@ -88,7 +86,7 @@ const MaterialCounter = (props: MaterialCounterProps, context) => {
       className={classes([
         'MaterialDock',
         hovering && 'MaterialDock--active',
-        !canEject && 'MaterialDock--disabled',
+        !material.removable && 'MaterialDock--disabled',
       ])}>
       <Stack vertial direction={'column-reverse'}>
         <Flex
@@ -157,7 +155,7 @@ const EjectButton = (props: EjectButtonProps, context) => {
       color={'transparent'}
       className={classes([
         'Fabricator__PrintAmount',
-        amount * 2_000 > available && 'Fabricator__PrintAmount--disabled',
+        amount * material.sheet_material_amount > available && 'Fabricator__PrintAmount--disabled',
       ])}
       onClick={() => onEject(amount)}>
       &times;{amount}

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
@@ -1,5 +1,6 @@
 import { classes } from 'common/react';
 import { Icon } from '../../components';
+import { Material } from './Types';
 
 const MATERIAL_ICONS: Record<string, [number, string][]> = {
   'iron': [
@@ -72,7 +73,7 @@ export type MaterialIconProps = {
  * A 32x32 material icon. Animates between different stack sizes of the given
  * material.
  */
-export const MaterialIcon = (props: MaterialIconProps) => {
+export const MaterialIcon = (props: MaterialIconProps, material: Material) => {
   const { materialName, amount } = props;
   const icons = MATERIAL_ICONS[materialName];
 
@@ -84,7 +85,7 @@ export const MaterialIcon = (props: MaterialIconProps) => {
 
   while (
     icons[activeIdx + 1] &&
-    icons[activeIdx + 1][0] <= (amount ?? 200_000) / 2_000
+    icons[activeIdx + 1][0] <= (amount ?? 200_000) / 2_000 // todo: how does this work exactly? change to use the define
   ) {
     activeIdx += 1;
   }

--- a/tgui/packages/tgui/interfaces/Fabrication/Types.ts
+++ b/tgui/packages/tgui/interfaces/Fabrication/Types.ts
@@ -21,7 +21,7 @@ export type Material = {
   ref: string;
 
   /**
-   * The amount of material; 2,000 units is one sheet.
+   * The amount of material in units.
    */
   amount: number;
 
@@ -39,6 +39,11 @@ export type Material = {
    * The color of the material.
    */
   color: string;
+
+  /**
+   * The define of material units amount per sheet.
+   */
+  sheet_material_amount: number;
 };
 
 /**


### PR DESCRIPTION
## About The Pull Request
The lathe UI was using hardcoded values for unit material amounts per sheet and thus when the #75052 rolled out, lathes would show their materials as undispensable at less than 2000 units. It would let you dispense the material, though, as a sheet is 100 units now. 
This PR aims to make that UI code make use of the define properly to bring it in line with the material changes.

## Why It's Good For The Game
Consistency. Less lies in the UI.

## Changelog
:cl:
fix: fixed lathe UI incorrectly showing materials as undispensable at less than 2k of that material in the silo. a sheet of a material is currently a 100 units, not 2000.
/:cl: