### PR TITLE
Makes it so acid does not loop through turf contents twice

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -602,11 +602,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		return FALSE
 
 	AddComponent(/datum/component/acid, acidpwr, acid_volume, GLOB.acid_overlay)
-	for(var/atom/movable/movable_atom as anything in src)
-		if(underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(movable_atom, TRAIT_T_RAY_VISIBLE))
-			continue
-
-		movable_atom.acid_act(acidpwr, acid_volume)
 
 	return . || TRUE
 


### PR DESCRIPTION
## About The Pull Request

When applying acid_act() to a turf, it was looping through the contents of the turf twice and applying acid_act() to them, once in the turf's acid_act, and once in the acid component. This makes it so it only loops through the contents once, keeping it in the component. The acid_act in the turf had some checks to make sure acid does not affect undertile stuff, but the component does not, so I decided not too add the check to keep current functionality as much as possible.

## Why It's Good For The Game

Bug fix, makes the damage of acid less hidden

## Changelog

:cl: Seven
fix: Acid applied to turfs no longer applies acid to the contents of that turf twice
/:cl:
