### PR TITLE
Atmos MODsuits now have quick carry module pre installed.

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -66,6 +66,7 @@
 		/obj/item/mod/module/rad_protection,
 		/obj/item/mod/module/flashlight,
 		/obj/item/mod/module/t_ray,
+		/obj/item/mod/module/quick_carry,
 	)
 
 /obj/item/mod/control/pre_equipped/advanced


### PR DESCRIPTION

## About The Pull Request
#72736 added the firefighter gloves to atmos techs which lets them quick carry wounded people faster.
Firefighting RP is fun, so this PR just gives the quick carry module to the Atmos MODsuit. Now they don't miss on the best part of the job!!!
## Why It's Good For The Game
Having atmos tech be first responders to emergencies is neat IMO, this PR pushes this niche further into their MODsuits and unify this small identity then now have.
## Changelog
:cl: Guillaume Prata
balance: The Atmospheric MODsuit now comes pre equipped with the quick carry module. Go save some lives!
/:cl:
