### PR TITLE
Modular machinery computer UI opens again

### DIFF
--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -22,6 +22,7 @@
 		CRASH("A non '/obj/machinery/modular_computer' had a [src] initialized in it!")
 
 	// Obtain reference to machinery computer
+	physical = loc
 	machinery_computer = loc
 	machinery_computer.cpu = src
 	internal_cell = machinery_computer.internal_cell


### PR DESCRIPTION
## About The Pull Request

**Problem Reproduction**
1. Find/Make any instance of `/obj/machinery/modular_computer`
2. Try opening its UI
3. Doesn't work

**The Solution**
Assign the processor's `physical` var with the computer that it's inside in.

Fixes #76194
Fixes #76192 

## Changelog
:cl:
fix: Modular machinery computer UI opens again
/:cl:
