### PR TITLE
Fixes a runtime when attacking non-carbon mobs with a cuffsnapper 

### DIFF
--- a/code/datums/elements/cuffsnapping.dm
+++ b/code/datums/elements/cuffsnapping.dm
@@ -68,7 +68,7 @@
 /datum/element/cuffsnapping/proc/try_cuffsnap_target(obj/item/cutter, mob/living/carbon/target, mob/cutter_user, params)
 	SIGNAL_HANDLER
 
-	if(istype(target)) //we aren't the kind of mob that can even have cuffs, so we skip.
+	if(!istype(target)) //we aren't the kind of mob that can even have cuffs, so we skip.
 		return
 
 	if(!target.handcuffed)

--- a/code/datums/elements/cuffsnapping.dm
+++ b/code/datums/elements/cuffsnapping.dm
@@ -68,6 +68,9 @@
 /datum/element/cuffsnapping/proc/try_cuffsnap_target(obj/item/cutter, mob/living/carbon/target, mob/cutter_user, params)
 	SIGNAL_HANDLER
 
+	if(istype(target)) //we aren't the kind of mob that can even have cuffs, so we skip.
+		return
+
 	if(!target.handcuffed)
 		return
 


### PR DESCRIPTION

## About The Pull Request

The cuffsnapper component now checks to make sure the target is a carbon before running the rest of the cuffsnapping process on them.

target.handcuffed is checked (handcuffed is defined on carbon), but nowhere is it actually asserted that the target is a carbon, so a runtime would occur when attacking non-carbon mobs.
## Why It's Good For The Game

This runtime fix was brought to you by https://runtimes.moth.fans
## Changelog
:cl:
fix: attacking non-carbon mobs with a cuffsnapping object will no longer runtime.
/:cl:
