### PR TITLE
Fix bileworm runtime targeting non-living mobs

### DIFF
--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
@@ -31,8 +31,11 @@
 
 /datum/ai_planning_subtree/bileworm_execute/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 
-	var/mob/living/target = controller.blackboard[BB_BASIC_MOB_EXECUTION_TARGET]
-	if(QDELETED(target) || target.stat < UNCONSCIOUS)
+	var/atom/movable/target = controller.blackboard[BB_BASIC_MOB_EXECUTION_TARGET]
+	if(QDELETED(target) || !isliving(target))
+		return
+	var/mob/living/living_target = target
+	if(living_target.stat < UNCONSCIOUS)
 		return
 
 	controller.queue_behavior(/datum/ai_behavior/targeted_mob_ability, BB_BILEWORM_DEVOUR, BB_BASIC_MOB_EXECUTION_TARGET)


### PR DESCRIPTION
## About The Pull Request

Targeting datums will target non-living movables which have livings inside, such as mechas. 

So this casting to living as a bad assumption.

## Changelog

:cl: Melbert
fix: Fix runtimes from Bileworms targeting mechas (or other objects people are hiding in)
/:cl:
