### PR TITLE
Fix colossus finale firing like 100 fewer projectiles than it should be

### DIFF
--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -285,6 +285,7 @@
 	name = "Titan's Finale"
 	desc = "A single-use ability that shoots a large amount of projectiles around you."
 	cooldown_time = 2.5 SECONDS
+	projectile_type = /obj/projectile/colossus
 
 /datum/action/cooldown/mob_cooldown/projectile_attack/colossus_final/Activate(atom/target_atom)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/51863163/b7d831db-dd38-4a60-b8e3-9a02c0101d40)

## Changelog

:cl: Melbert
fix: The colossus's finale attack is now 100x more lethal, because it was firing 100x fewer projectiles than intended 
/:cl:
