### PR TITLE
Increases bottle max volume for pill press to 50.

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -12,7 +12,7 @@
 	///maximum size of a patch
 	var/max_patch_volume = 40
 	///maximum size of a bottle
-	var/max_bottle_volume = 30
+	var/max_bottle_volume = 50
 	///current operating product (pills or patches)
 	var/product = "pill"
 	///the minimum size a pill or patch can be


### PR DESCRIPTION

## About The Pull Request
Bottle volume was increased but not for pill press.
## Why It's Good For The Game
I mean, it should be this way?
## Changelog
:cl:
qol: pill press' max volume for bottles are 50, as the volume of bottles itself.
/:cl:
