### PR TITLE
Bubble gum crate looks correct 

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -118,6 +118,7 @@
 	desc = "Once guarded by the King of Demons, this sarcophagus contains the relics of an ancient soldier."
 	icon_state = "necro_bubblegum"
 	base_icon_state = "necro_bubblegum"
+	lid_icon_state = "necro_bubblegum_lid"
 	lid_x = -26
 	lid_y = 2
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -117,6 +117,7 @@
 	name = "\improper Ancient Sarcophagus"
 	desc = "Once guarded by the King of Demons, this sarcophagus contains the relics of an ancient soldier."
 	icon_state = "necro_bubblegum"
+	base_icon_state = "necro_bubblegum"
 	lid_x = -26
 	lid_y = 2
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -117,10 +117,8 @@
 	name = "\improper Ancient Sarcophagus"
 	desc = "Once guarded by the King of Demons, this sarcophagus contains the relics of an ancient soldier."
 	icon_state = "necro_bubblegum"
-	lid_icon_state = "necro_bubblegum_lid"
 	lid_x = -26
 	lid_y = 2
-
 
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	new /obj/item/clothing/suit/hooded/hostile_environment(src)


### PR DESCRIPTION
## About The Pull Request
Fixes #76216

Bubble gum crate now refers to the correct icon via `base_icon_state` so the crate actually looks correct

## Changelog

:cl:
fix: bubble gum crate actually looks correct
/:cl: