### PR TITLE
Allows apostrophes and quotes at start of player name

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -197,8 +197,15 @@
 					continue
 				number_of_alphanumeric++
 				last_char_group = NUMBERS_DETECTED
-			// '  -  .
-			if(39,45,46) //Common name punctuation
+
+			// "  '
+			if(34, 39) //Quotes and Apostrophes for nickname text and punctuation
+				if(last_char_group == NO_CHARS_DETECTED)
+					if(strict)
+						return
+				last_char_group = SYMBOLS_DETECTED
+			// -  .
+			if(45,46) //Common name punctuation
 				if(last_char_group == NO_CHARS_DETECTED)
 					if(strict)
 						return


### PR DESCRIPTION
Changes filter code to not remove apostrophes and quotes from the beginning of a name.
## About The Pull Request

Changes the logic in code/_HELPERS/text.dm to allow players to start their name with a quotation mark or apostrophe, this is implemented by adding an additional if block checking for these specific characters, does NOT allow for names to start with hyphens or periods.
## Why It's Good For The Game

fixes #76155
Less filtered text characters in the player name are helpful for creating more unique names.  This does not conflict with the database schema and all tested interactions still work as intended.
## Changelog
:cl:
fix: player names can start with apostrophes ' and quotes "
fix: player names no longer remove quotation marks
/:cl:
