### PR TITLE
Acid balance and fixes, Xeno's no longer instakill with their acid

### DIFF
--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -21,6 +21,8 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	var/stage = 0
 	/// Acid overlay appearance we apply
 	var/acid_overlay
+	/// Boolean for if we ignore mobs when applying acid to turf contents
+	var/turf_acid_ignores_mobs
 	/// The ambient sound of acid eating away at the parent [/atom].
 	var/datum/looping_sound/acid/sizzle
 	/// Particle holder for acid particles (sick)
@@ -28,7 +30,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	/// The proc used to handle the parent [/atom] when processing. TODO: Unify damage and resistance flags so that this doesn't need to exist!
 	var/datum/callback/process_effect
 
-/datum/component/acid/Initialize(acid_power = ACID_POWER_MELT_TURF, acid_volume = 50, acid_overlay = GLOB.acid_overlay, acid_particles = /particles/acid)
+/datum/component/acid/Initialize(acid_power = ACID_POWER_MELT_TURF, acid_volume = 50, acid_overlay = GLOB.acid_overlay, acid_particles = /particles/acid, turf_acid_ignores_mobs = FALSE)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -146,8 +148,14 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	var/acid_used = min(acid_volume * 0.05, 20) * seconds_per_tick
 	var/applied_targets = 0
 	for(var/atom/movable/target_movable as anything in target_turf)
+		// Dont apply acid to things under the turf
 		if(target_turf.underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(target_movable, TRAIT_T_RAY_VISIBLE))
 			continue
+		// Ignore mobs if turf_acid_ignores_mobs is TRUE
+		if(turf_acid_ignores_mobs)
+			if(ismob(target_movable))
+				continue
+		// Apply the acid
 		if(target_movable.acid_act(acid_power, acid_used))
 			applied_targets++
 

--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -22,7 +22,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	/// Acid overlay appearance we apply
 	var/acid_overlay
 	/// Boolean for if we ignore mobs when applying acid to turf contents
-	var/turf_acid_ignores_mobs
+	var/turf_acid_ignores_mobs = FALSE
 	/// The ambient sound of acid eating away at the parent [/atom].
 	var/datum/looping_sound/acid/sizzle
 	/// Particle holder for acid particles (sick)
@@ -50,6 +50,7 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		src.max_volume = MOB_ACID_VOLUME_MAX
 		src.process_effect = CALLBACK(src, PROC_REF(process_mob), parent)
 	else if(isturf(parent))
+		src.turf_acid_ignores_mobs = turf_acid_ignores_mobs
 		src.max_volume = TURF_ACID_VOLUME_MAX
 		src.process_effect = CALLBACK(src, PROC_REF(process_turf), parent)
 	//if we failed all other checks, we must be an /atom/movable that uses integrity
@@ -152,9 +153,8 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		if(target_turf.underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(target_movable, TRAIT_T_RAY_VISIBLE))
 			continue
 		// Ignore mobs if turf_acid_ignores_mobs is TRUE
-		if(turf_acid_ignores_mobs)
-			if(ismob(target_movable))
-				continue
+		if(turf_acid_ignores_mobs && ismob(target_movable))
+			continue
 		// Apply the acid
 		if(target_movable.acid_act(acid_power, acid_used))
 			applied_targets++
@@ -243,6 +243,8 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 /datum/component/acid/proc/on_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
 	SIGNAL_HANDLER
 
+	if(turf_acid_ignores_mobs)
+		return
 	if(!isliving(arrived))
 		return
 	var/mob/living/crosser = arrived

--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -146,6 +146,8 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 	var/acid_used = min(acid_volume * 0.05, 20) * seconds_per_tick
 	var/applied_targets = 0
 	for(var/atom/movable/target_movable as anything in target_turf)
+		if(target_turf.underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(target_movable, TRAIT_T_RAY_VISIBLE))
+			continue
 		if(target_movable.acid_act(acid_power, acid_used))
 			applied_targets++
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -602,11 +602,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		return FALSE
 
 	AddComponent(/datum/component/acid, acidpwr, acid_volume, GLOB.acid_overlay)
-	for(var/atom/movable/movable_atom as anything in src)
-		if(underfloor_accessibility < UNDERFLOOR_INTERACTABLE && HAS_TRAIT(movable_atom, TRAIT_T_RAY_VISIBLE))
-			continue
-
-		movable_atom.acid_act(acidpwr, acid_volume)
 
 	return . || TRUE
 

--- a/code/modules/mob/living/carbon/alien/adult/adult.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult.dm
@@ -151,3 +151,7 @@ GLOBAL_LIST_INIT(strippable_alien_humanoid_items, create_strippable_list(list(
 	log_combat(src, lucky_winner, "devoured")
 	melting_pot.consume_thing(lucky_winner)
 	return TRUE
+
+// Aliens can touch acid
+/mob/living/carbon/alien/can_touch_acid(atom/acided_atom, acid_power, acid_volume)
+	return TRUE

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -228,7 +228,9 @@ Doesn't work on other aliens/AI.*/
 	return ..()
 
 /datum/action/cooldown/alien/acid/corrosion/Activate(atom/target)
-	if(!target.acid_act(200, 1000))
+	if(isturf(target))
+		target.AddComponent(/datum/component/acid, 200, 1000, GLOB.acid_overlay, /particles/acid, TRUE)
+	else if(!target.acid_act(200, 1000))
 		to_chat(owner, span_noticealien("You cannot dissolve this object."))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -200,6 +200,8 @@ Doesn't work on other aliens/AI.*/
 	desc = "Drench an object in acid, destroying it over time."
 	button_icon_state = "alien_acid"
 	plasma_cost = 200
+	var/corrosion_acid_power = 200
+	var/corrosion_acid_volume = 1000
 
 /datum/action/cooldown/alien/acid/corrosion/set_click_ability(mob/on_who)
 	. = ..()
@@ -229,8 +231,8 @@ Doesn't work on other aliens/AI.*/
 
 /datum/action/cooldown/alien/acid/corrosion/Activate(atom/target)
 	if(isturf(target))
-		target.AddComponent(/datum/component/acid, 200, 1000, GLOB.acid_overlay, /particles/acid, turf_acid_ignores_mobs = TRUE)
-	else if(!target.acid_act(200, 1000))
+		target.AddComponent(/datum/component/acid, corrosion_acid_power, corrosion_acid_volume, GLOB.acid_overlay, /particles/acid, turf_acid_ignores_mobs = TRUE)
+	else if(!target.acid_act(corrosion_acid_power, corrosion_acid_volume))
 		to_chat(owner, span_noticealien("You cannot dissolve this object."))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -229,7 +229,7 @@ Doesn't work on other aliens/AI.*/
 
 /datum/action/cooldown/alien/acid/corrosion/Activate(atom/target)
 	if(isturf(target))
-		target.AddComponent(/datum/component/acid, 200, 1000, GLOB.acid_overlay, /particles/acid, TRUE)
+		target.AddComponent(/datum/component/acid, 200, 1000, GLOB.acid_overlay, /particles/acid, turf_acid_ignores_mobs = TRUE)
 	else if(!target.acid_act(200, 1000))
 		to_chat(owner, span_noticealien("You cannot dissolve this object."))
 		return FALSE

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -200,7 +200,9 @@ Doesn't work on other aliens/AI.*/
 	desc = "Drench an object in acid, destroying it over time."
 	button_icon_state = "alien_acid"
 	plasma_cost = 200
+	/// The acid power for the aliens acid corrosion, will ignore mobs
 	var/corrosion_acid_power = 200
+	/// The acid volume for the aliens acid corrosion, will ignore mobs
 	var/corrosion_acid_volume = 1000
 
 /datum/action/cooldown/alien/acid/corrosion/set_click_ability(mob/on_who)


### PR DESCRIPTION

## About The Pull Request

Acid, when applied to a turf, does not immediately apply acid to the turfs contents, instead just doing that in the acid component.
The acid component now does not destroy things under a turf, like pipes.
Alien acid no longer instakills mobs, Fixes #69577 (Acid component now has an option not to apply acid to mobs on a turf).
Aliens can now touch acid.

## Why It's Good For The Game

Fixes some bugs with aliens and acid.
I don't really like how the acid now does not damage mobs at all, but that seems to be what is intended.
I don't think that acid should be going through a turfs contents in different places, plus I like the look of it not immediately applying the acid to them better.

## Changelog

:cl: Seven
balance: Acid on a turf no longer immediately applies acid to its contents
fix: Acid applied on a tile will no longer damage pipes below that tile
fix: Xeno's corrosive acid no longer instakills mobs
fix: Xenos can now touch acid
/:cl:
