### PR TITLE
Fixes a runtime in atom init management

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -175,7 +175,9 @@ SUBSYSTEM_DEF(atoms)
 	initialized = state
 
 /datum/controller/subsystem/atoms/proc/clear_tracked_initalize(source)
-	for(var/i in length(initialized_state) to 1)
+	if(!length(initialized_state))
+		return
+	for(var/i in length(initialized_state) to 1 step -1)
 		if(initialized_state[i][1] == source)
 			initialized_state.Cut(i, i+1)
 			break

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -107,6 +107,9 @@
 	/// Pulls out model paths for DMM
 	var/static/regex/model_path = new(@'(\/[^\{]*?(?:\{.*?\})?)(?:,|$)', "g")
 
+	/// If we are currently loading this map
+	var/loading = FALSE
+
 	#ifdef TESTING
 	var/turfsSkipped = 0
 	#endif
@@ -249,9 +252,13 @@
 
 #define MAPLOADING_CHECK_TICK \
 	if(TICK_CHECK) { \
-		SSatoms.map_loader_stop(REF(src)); \
-		stoplag(); \
-		SSatoms.map_loader_begin(REF(src)); \
+		if(loading) { \
+			SSatoms.map_loader_stop(REF(src)); \
+			stoplag(); \
+			SSatoms.map_loader_begin(REF(src)); \
+		} else { \
+			stoplag(); \
+		} \
 	}
 
 // Do not call except via load() above.
@@ -259,6 +266,7 @@
 	PRIVATE_PROC(TRUE)
 	// Tell ss atoms that we're doing maploading
 	// We'll have to account for this in the following tick_checks so it doesn't overflow
+	loading = TRUE
 	SSatoms.map_loader_begin(REF(src))
 
 	// Loading used to be done in this proc
@@ -273,6 +281,7 @@
 
 	// And we are done lads, call it off
 	SSatoms.map_loader_stop(REF(src))
+	loading = FALSE
 
 	if(new_z)
 		for(var/z_index in bounds[MAP_MINZ] to bounds[MAP_MAXZ])


### PR DESCRIPTION

## About The Pull Request

The issue was map verification calling build_cache, which uses the define which enables/disables init values on sleep. We avoid this by using a var on map datums and using that to enable the init value modification only when we are actually loading stuff.

Also fixes a bug in clear_tracked_initialize() where it being called with no values lead to bad values/potentially overriding initialized on accident.

Also also I forgot how for loops worked so this would not have worked regardless

## Why It's Good For The Game

Code should like, function