### PR TITLE
Arm implants can be properly EMP'd again; Organic implants will NOT be EMP'd.

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -98,7 +98,7 @@
 
 /obj/item/organ/internal/cyberimp/arm/emp_act(severity)
 	. = ..()
-	if(. & EMP_PROTECT_SELF || status == ORGAN_ROBOTIC)
+	if(. & EMP_PROTECT_SELF || status == ORGAN_ORGANIC)
 		return
 	if(prob(15/severity) && owner)
 		to_chat(owner, span_warning("The electromagnetic pulse causes [src] to malfunction!"))


### PR DESCRIPTION

## About The Pull Request

Reverses the logic of an early return in the EMP proc of arm implants. Rather than returning if the implant is robotic, it returns if it is organic.

## Why It's Good For The Game

It appears arm implant emp act was broken for about...like 2 years? But today, I discovered that my vorpal scythe was EMP vulnerable.

I thought 'Oh someone didn't do a proper check that's an easy fix'

Turns out, robotic implants were immune to EMPs this whole time, but the very few organic arm implants were vulnerable instead!

Well, it's fixed now. I blame the penguin maint.

## Changelog
:cl:
fix: Arm implants properly handle EMPs depending on whether it is robotic or organic. No longer can you EMP an organic organ!
/:cl:
