### PR TITLE
Fix a href exploit in limbgrower

### DIFF
--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -185,7 +185,10 @@
 			use_power(power)
 			flick("limbgrower_fill", src)
 			icon_state = "limbgrower_idleon"
-			selected_category = params["active_tab"]
+			var temp_category = params["active_tab"]
+			if( ! (temp_category in categories) )
+				return FALSE //seriously come on
+			selected_category = temp_category
 			addtimer(CALLBACK(src, PROC_REF(build_item), consumed_reagents_list), production_speed * production_coefficient)
 			return TRUE
 

--- a/code/game/machinery/limbgrower.dm
+++ b/code/game/machinery/limbgrower.dm
@@ -185,7 +185,7 @@
 			use_power(power)
 			flick("limbgrower_fill", src)
 			icon_state = "limbgrower_idleon"
-			var temp_category = params["active_tab"]
+			var/temp_category = params["active_tab"]
 			if( ! (temp_category in categories) )
 				return FALSE //seriously come on
 			selected_category = temp_category


### PR DESCRIPTION
This could be used to spoof category which may then be useable to inject html into the tgui or into vv


All credit to @powerfulbacon

https://github.com/BeeStation/BeeStation-Hornet/pull/9274