### PR TITLE
You can now revive dead fishes, bees and mice with a lazarus injector

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -102,6 +102,10 @@
 /// generally called before temporary non-parallel animate()s on the atom (animation_duration)
 #define COMSIG_ATOM_TEMPORARY_ANIMATION_START "atom_temp_animate_start"
 
+/// called on [/obj/item/lazarus_injector/afterattack] : (injector, user)
+#define COMSIG_ATOM_ON_LAZARUS_INJECTOR "atom_on_lazarus_injector"
+	#define LAZARUS_INJECTOR_USED (1<<0) //Early return.
+
 /// from internal loop in /atom/proc/propagate_radiation_pulse: (atom/pulse_source)
 #define COMSIG_ATOM_PROPAGATE_RAD_PULSE "atom_propagate_radiation_pulse"
 /// from cosmetic items to restyle certain mobs, objects or organs: (atom/source, mob/living/trimmer, atom/movable/original_target, body_zone, restyle_type, style_speed)

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -105,6 +105,7 @@
 		AddElement(/datum/element/processable, TOOL_KNIFE, fillet_type, 1, 5, screentip_verb = "Cut")
 	AddComponent(/datum/component/aquarium_content, PROC_REF(get_aquarium_animation), list(COMSIG_FISH_STATUS_CHANGED,COMSIG_FISH_STIRRED))
 	RegisterSignal(src, COMSIG_ATOM_TEMPORARY_ANIMATION_START, PROC_REF(on_temp_animation))
+	RegisterSignal(src, COMSIG_ATOM_ON_LAZARUS_INJECTOR, PROC_REF(use_lazarus))
 
 	check_environment_after_movement()
 	if(status != FISH_DEAD)
@@ -206,7 +207,8 @@
 	switch(new_status)
 		if(FISH_ALIVE)
 			status = FISH_ALIVE
-			health = initial(health) // this is admin option anyway
+			health = initial(health) // since the fishe has been revived
+			start_flopping()
 			START_PROCESSING(SSobj, src)
 		if(FISH_DEAD)
 			status = FISH_DEAD
@@ -218,6 +220,18 @@
 			else
 				visible_message(message)
 	SEND_SIGNAL(src, COMSIG_FISH_STATUS_CHANGED)
+
+/obj/item/fish/proc/use_lazarus(datum/source, obj/item/lazarus_injector/injector, mob/user)
+	SIGNAL_HANDLER
+	if(injector.revive_type != SENTIENCE_ORGANIC)
+		balloon_alert(user, "invalid creature!")
+		return
+	if(status != FISH_DEAD)
+		balloon_alert(user, "it's not dead!")
+		return
+	set_status(FISH_ALIVE)
+	injector.expende(src, user)
+	return LAZARUS_INJECTOR_USED
 
 /obj/item/fish/proc/get_aquarium_animation()
 	var/obj/structure/aquarium/aquarium = loc

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -230,7 +230,7 @@
 		balloon_alert(user, "it's not dead!")
 		return
 	set_status(FISH_ALIVE)
-	injector.expende(src, user)
+	injector.expend(src, user)
 	return LAZARUS_INJECTOR_USED
 
 /obj/item/fish/proc/get_aquarium_animation()

--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -27,7 +27,13 @@
 
 /obj/item/lazarus_injector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
-	if(!loaded || !(isliving(target) && proximity_flag) )
+	if(!loaded || !proximity_flag)
+		return
+
+	if(SEND_SIGNAL(target, COMSIG_ATOM_ON_LAZARUS_INJECTOR, src, user) & LAZARUS_INJECTOR_USED)
+		return
+
+	if(!isliving(target))
 		return
 
 	var/mob/living/target_animal = target
@@ -39,9 +45,12 @@
 		return
 
 	target_animal.lazarus_revive(user, malfunctioning)
+	expende(target_animal, user)
+
+/obj/item/lazarus_injector/proc/expende(atom/revived_target, mob/user)
+	user.visible_message(span_notice("[user] injects [revived_target] with [src], reviving it."))
+	SSblackbox.record_feedback("tally", "lazarus_injector", 1, revived_target.type)
 	loaded = FALSE
-	user.visible_message(span_notice("[user] injects [target_animal] with [src], reviving it."))
-	SSblackbox.record_feedback("tally", "lazarus_injector", 1, target_animal.type)
 	playsound(src,'sound/effects/refill.ogg',50,TRUE)
 	icon_state = "lazarus_empty"
 

--- a/code/modules/mining/equipment/lazarus_injector.dm
+++ b/code/modules/mining/equipment/lazarus_injector.dm
@@ -45,9 +45,9 @@
 		return
 
 	target_animal.lazarus_revive(user, malfunctioning)
-	expende(target_animal, user)
+	expend(target_animal, user)
 
-/obj/item/lazarus_injector/proc/expende(atom/revived_target, mob/user)
+/obj/item/lazarus_injector/proc/expend(atom/revived_target, mob/user)
 	user.visible_message(span_notice("[user] injects [revived_target] with [src], reviving it."))
 	SSblackbox.record_feedback("tally", "lazarus_injector", 1, revived_target.type)
 	loaded = FALSE

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -325,6 +325,7 @@
 	revived_critter.name = name
 	revived_critter.lazarus_revive(user, injector.malfunctioning)
 	injector.expende(revived_critter, user)
+	qdel(src)
 	return LAZARUS_INJECTOR_USED
 
 /obj/item/food/deadmouse/attackby(obj/item/attacking_item, mob/user, params)

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -37,13 +37,14 @@
 	/// Probability that, if we successfully bite a shocked cable, that we will die to it.
 	var/cable_zap_prob = 85
 
-/mob/living/basic/mouse/Initialize(mapload, tame = FALSE)
+/mob/living/basic/mouse/Initialize(mapload, tame = FALSE, new_body_color)
 	. = ..()
 	if(contributes_to_ratcap)
 		SSmobs.cheeserats |= src
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 	src.tame = tame
+	body_color = new_body_color
 	if(isnull(body_color))
 		body_color = pick("brown", "gray", "white")
 	held_state = "mouse_[body_color]" // not handled by variety element
@@ -114,9 +115,7 @@
 	. = ..(TRUE)
 	// Now if we were't ACTUALLY gibbed, spawn the dead mouse
 	if(!gibbed)
-		var/obj/item/food/deadmouse/mouse = new(loc)
-		mouse.name = name
-		mouse.icon_state = icon_dead
+		var/obj/item/food/deadmouse/mouse = new(loc, src)
 		if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
 			mouse.desc = "They're toast."
 			mouse.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)
@@ -250,6 +249,7 @@
 	response_harm_continuous = "splats"
 	response_harm_simple = "splat"
 	gold_core_spawnable = NO_SPAWN
+	contributes_to_ratcap = FALSE
 
 /mob/living/basic/mouse/brown/tom/make_tameable()
 	tame = TRUE
@@ -296,16 +296,36 @@
 	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/consumable/liquidgibs = 5)
 	decomp_req_handle = TRUE
 	ant_attracting = FALSE
+	var/body_color = "gray"
+	var/critter_type = /mob/living/basic/mouse
 	decomp_type = /obj/item/food/deadmouse/moldy
 
-/obj/item/food/deadmouse/Initialize(mapload)
+/obj/item/food/deadmouse/Initialize(mapload, mob/living/basic/mouse/dead_critter)
 	. = ..()
+	if(dead_critter)
+		body_color = dead_critter.body_color
+		critter_type = dead_critter.type
+		name = dead_critter.name
+		icon_state = dead_critter.icon_dead
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOUSE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 10)
+	RegisterSignal(src, COMSIG_ATOM_ON_LAZARUS_INJECTOR, PROC_REF(use_lazarus))
 
 /obj/item/food/deadmouse/examine(mob/user)
 	. = ..()
 	if (reagents?.has_reagent(/datum/reagent/yuck) || reagents?.has_reagent(/datum/reagent/fuel))
 		. += span_warning("[p_theyre(TRUE)] dripping with fuel and smells terrible.")
+
+///Spawn a new mouse from this dead mouse item when hit by a lazarus injector and conditions are met.
+/obj/item/food/deadmouse/proc/use_lazarus(datum/source, obj/item/lazarus_injector/injector, mob/user)
+	SIGNAL_HANDLER
+	if(injector.revive_type != SENTIENCE_ORGANIC)
+		balloon_alert(user, "invalid creature!")
+		return
+	var/mob/living/basic/mouse/revived_critter = new critter_type (drop_location(), FALSE, body_color)
+	revived_critter.name = name
+	revived_critter.lazarus_revive(user, injector.malfunctioning)
+	injector.expende(revived_critter, user)
+	return LAZARUS_INJECTOR_USED
 
 /obj/item/food/deadmouse/attackby(obj/item/attacking_item, mob/user, params)
 	var/mob/living/living_user = user

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -296,9 +296,9 @@
 	grind_results = list(/datum/reagent/blood = 20, /datum/reagent/consumable/liquidgibs = 5)
 	decomp_req_handle = TRUE
 	ant_attracting = FALSE
+	decomp_type = /obj/item/food/deadmouse/moldy
 	var/body_color = "gray"
 	var/critter_type = /mob/living/basic/mouse
-	decomp_type = /obj/item/food/deadmouse/moldy
 
 /obj/item/food/deadmouse/Initialize(mapload, mob/living/basic/mouse/dead_critter)
 	. = ..()
@@ -324,7 +324,7 @@
 	var/mob/living/basic/mouse/revived_critter = new critter_type (drop_location(), FALSE, body_color)
 	revived_critter.name = name
 	revived_critter.lazarus_revive(user, injector.malfunctioning)
-	injector.expende(revived_critter, user)
+	injector.expend(revived_critter, user)
 	qdel(src)
 	return LAZARUS_INJECTOR_USED
 

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -182,8 +182,8 @@
 /mob/living/simple_animal/hostile/bee/proc/assign_reagent(datum/reagent/R)
 	if(istype(R))
 		var/static/list/injection_range = list(1, 5)
-		//clear the old since this one is going to have some new value
-		RemoveElement(/datum/element/venomous, beegent.type, injection_range)
+		if(beegent) //clear the old since this one is going to have some new value
+			RemoveElement(/datum/element/venomous, beegent.type, injection_range)
 		beegent = R
 		name = "[initial(name)] ([R.name])"
 		real_name = name

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -181,12 +181,12 @@
 
 /mob/living/simple_animal/hostile/bee/proc/assign_reagent(datum/reagent/R)
 	if(istype(R))
+		var/static/list/injection_range = list(1, 5)
 		//clear the old since this one is going to have some new value
 		RemoveElement(/datum/element/venomous, beegent.type, injection_range)
 		beegent = R
 		name = "[initial(name)] ([R.name])"
 		real_name = name
-		var/static/list/injection_range = list(1, 5)
 		AddElement(/datum/element/venomous, beegent.type, injection_range)
 		generate_bee_visuals()
 

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -94,13 +94,7 @@
 		beehome = null
 	if((flags_1 & HOLOGRAM_1))
 		return ..()
-	var/obj/item/trash/bee/bee_to_eat = new(loc)
-	bee_to_eat.pixel_x = pixel_x
-	bee_to_eat.pixel_y = pixel_y
-	if(beegent)
-		bee_to_eat.beegent = beegent
-		bee_to_eat.reagents.add_reagent(beegent.type, 5)
-	bee_to_eat.update_appearance()
+	var/obj/item/trash/bee/bee_to_eat = new(loc, src)
 	beegent = null
 	return ..()
 
@@ -377,17 +371,46 @@
 	icon = 'icons/mob/simple/bees.dmi'
 	icon_state = "bee_item"
 	var/datum/reagent/beegent
+	var/bee_type = /mob/living/simple_animal/hostile/bee
 
-/obj/item/trash/bee/Initialize(mapload)
+/obj/item/trash/bee/Initialize(mapload, mob/living/simple_animal/hostile/bee/dead_bee)
 	. = ..()
+	if(dead_bee)
+		pixel_x = dead_bee.pixel_x
+		pixel_y = dead_bee.pixel_y
+		bee_type = dead_bee.type
+		if(dead_bee.beegent)
+			beegent = dead_bee.beegent
+			reagents.add_reagent(beegent.type, 5)
+		update_appearance()
 	AddComponent(/datum/component/edible, list(/datum/reagent/consumable/nutriment/vitamin = 5), null, BEE_FOODGROUPS, 10, 0, list("bee"), null, 10)
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_QUEEN_BEE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
+	RegisterSignal(src, COMSIG_ATOM_ON_LAZARUS_INJECTOR, PROC_REF(use_lazarus))
+
+/obj/item/trash/bee/Destroy()
+	beegent = null
+	return ..()
 
 /obj/item/trash/bee/update_overlays()
 	. = ..()
 	var/mutable_appearance/body_overlay = mutable_appearance(icon = icon, icon_state = "bee_item_overlay")
 	body_overlay.color = beegent ? beegent.color : BEE_DEFAULT_COLOUR
 	. += body_overlay
+
+///Spawn a new bee from this trash item when hit by a lazarus injector and conditions are met.
+/obj/item/trash/bee/proc/use_lazarus(datum/source, obj/item/lazarus_injector/injector, mob/user)
+	SIGNAL_HANDLER
+	if(injector.revive_type != SENTIENCE_ORGANIC)
+		balloon_alert(user, "invalid creature!")
+		return
+	var/mob/living/simple_animal/hostile/bee/revived_bee = new bee_type (drop_location())
+	if(beegent)
+		revived_bee.assign_reagent(beegent)
+	revived_bee.lazarus_revive(user, injector.malfunctioning)
+	injector.expende(revived_bee, user)
+	qdel(src)
+	return LAZARUS_INJECTOR_USED
+
 
 #undef BEE_DEFAULT_COLOUR
 #undef BEE_FOODGROUPS

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -94,7 +94,7 @@
 		beehome = null
 	if((flags_1 & HOLOGRAM_1))
 		return ..()
-	var/obj/item/trash/bee/bee_to_eat = new(loc, src)
+	new /obj/item/trash/bee(loc, src)
 	beegent = null
 	return ..()
 
@@ -181,11 +181,11 @@
 
 /mob/living/simple_animal/hostile/bee/proc/assign_reagent(datum/reagent/R)
 	if(istype(R))
+		//clear the old since this one is going to have some new value
+		RemoveElement(/datum/element/venomous, beegent.type, injection_range)
 		beegent = R
 		name = "[initial(name)] ([R.name])"
 		real_name = name
-		//clear the old since this one is going to have some new value
-		RemoveElement(/datum/element/venomous)
 		var/static/list/injection_range = list(1, 5)
 		AddElement(/datum/element/venomous, beegent.type, injection_range)
 		generate_bee_visuals()

--- a/code/modules/mob/living/simple_animal/hostile/bees.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bees.dm
@@ -407,7 +407,7 @@
 	if(beegent)
 		revived_bee.assign_reagent(beegent)
 	revived_bee.lazarus_revive(user, injector.malfunctioning)
-	injector.expende(revived_bee, user)
+	injector.expend(revived_bee, user)
 	qdel(src)
 	return LAZARUS_INJECTOR_USED
 


### PR DESCRIPTION
## About The Pull Request
This PR introduces a signal sent to the target when a lazarus injector is being used on them, hence read the title.
EDIT: I've forgotten to add that Tom no longer counts toward the mice population cap now, being unique.

## Why It's Good For The Game
Being items rather than simple/basic mobs, dead mice (without a mind datum), bees and fishes cannot be revived by the lazarus injector. While I agree that spending one for this may be an egregious waste of mining points, it's still fleshing out the feature a bit.

## Changelog

:cl:
add: You can now revive dead fishes, bees and (mindless) mice with a lazarus injector.
balance: Tom, the mouse, no longer counts toward the mice population cap.
/:cl:
