### PR TITLE
Glass bottles with reagents can be used for crafting, empty ones will be used as tools if possible

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -124,7 +124,7 @@
 				.["other"][item.type] += stack.amount
 			else if(is_reagent_container(item) && item.is_drainable() && length(item.reagents.reagent_list)) //some container that has some reagents inside it that can be drained
 				var/obj/item/reagent_containers/container = item
-				for(var/datum/reagent/reagent in container.reagents.reagent_list)
+				for(var/datum/reagent/reagent as anything in container.reagents.reagent_list)
 					.["other"][reagent.type] += reagent.volume
 			else //a reagent container that is empty can also be used as a tool. e.g. glass bottle can be used as a rolling pin
 				if(item.tool_behaviour)

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -122,22 +122,18 @@
 			if(isstack(item))
 				var/obj/item/stack/stack = item
 				.["other"][item.type] += stack.amount
-			else if(item.tool_behaviour)
-				.["tool_behaviour"] += item.tool_behaviour
-				.["other"][item.type] += 1
-			else
-				if(is_reagent_container(item))
-					var/obj/item/reagent_containers/container = item
-					if(container.is_drainable())
-						for(var/datum/reagent/reagent in container.reagents.reagent_list)
-							.["other"][reagent.type] += reagent.volume
+			else if(is_reagent_container(item) && item.is_drainable() && length(item.reagents.reagent_list)) //some container that has some reagents inside it that can be drained
+				var/obj/item/reagent_containers/container = item
+				for(var/datum/reagent/reagent in container.reagents.reagent_list)
+					.["other"][reagent.type] += reagent.volume
+			else //a reagent container that is empty can also be used as a tool. e.g. glass bottle can be used as a rolling pin
+				if(item.tool_behaviour)
+					.["tool_behaviour"] += item.tool_behaviour
 				.["other"][item.type] += 1
 		else if (ismachinery(object))
 			LAZYADDASSOCLIST(.["machinery"], object.type, object)
 		else if (isstructure(object))
 			LAZYADDASSOCLIST(.["structures"], object.type, object)
-
-
 
 /// Returns a boolean on whether the tool requirements of the input recipe are satisfied by the input source and surroundings.
 /datum/component/personal_crafting/proc/check_tools(atom/source, datum/crafting_recipe/recipe, list/surroundings)


### PR DESCRIPTION
## About The Pull Request
Fixes #76250

The problem was a glass bottle has `tool_behaviour = rollingpin` and so it took priority in this if condition
https://github.com/tgstation/tgstation/blob/93d4b6d6cd3b160989960f9f88c27640ab06ba2d/code/datums/components/crafting/crafting.dm#L125-L134
before it could check if its a reagent container

Now the priority is inverted, if the glass bottle has reagents inside it then it is used as a reagent container else if it is empty then it used as a rolling pin(i.e. checks for its tool behaviours)

## Changelog
:cl:
fix: glass bottles with reagents can be used for crafting, empty glass bottles will be used as tools(e.g. empty glass bottle as rolling pin)
fix: glass bottle with welding fuel can be used for crafting improvised shotgun shells
/:cl:
