### PR TITLE
The Debug and Admin MODsuits now take a lot less time to (de)activate.

### DIFF
--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -102,6 +102,7 @@
 	extended_desc = theme.extended_desc
 	slowdown_inactive = theme.slowdown_inactive
 	slowdown_active = theme.slowdown_active
+	activation_step_time = theme.activation_step_time
 	complexity_max = theme.complexity_max
 	ui_theme = theme.ui_theme
 	charge_drain = theme.charge_drain

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -41,6 +41,8 @@
 	var/slowdown_inactive = 1.25
 	/// Slowdown of the MOD when active.
 	var/slowdown_active = 0.75
+	/// How long this MOD takes each part to seal.
+	var/activation_step_time= MOD_ACTIVATION_STEP_TIME
 	/// Theme used by the MOD TGUI.
 	var/ui_theme = "ntos"
 	/// List of inbuilt modules. These are different from the pre-equipped suits, you should mainly use these for unremovable modules with 0 complexity.
@@ -1633,6 +1635,7 @@
 	siemens_coefficient = 0
 	slowdown_inactive = 0.5
 	slowdown_active = 0
+	activation_step_time = 0.4 SECONDS
 	allowed_suit_storage = list(
 		/obj/item/gun,
 	)
@@ -1692,6 +1695,7 @@
 	siemens_coefficient = 0
 	slowdown_inactive = 0
 	slowdown_active = 0
+	activation_step_time = 0.1 SECONDS
 	allowed_suit_storage = list(
 		/obj/item/gun,
 	)

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -42,7 +42,7 @@
 	/// Slowdown of the MOD when active.
 	var/slowdown_active = 0.75
 	/// How long this MOD takes each part to seal.
-	var/activation_step_time= MOD_ACTIVATION_STEP_TIME
+	var/activation_step_time = MOD_ACTIVATION_STEP_TIME
 	/// Theme used by the MOD TGUI.
 	var/ui_theme = "ntos"
 	/// List of inbuilt modules. These are different from the pre-equipped suits, you should mainly use these for unremovable modules with 0 complexity.


### PR DESCRIPTION
## About The Pull Request
Read the title. An equivalent 'activation_step_time' variable has been added to the mod theme datum to accomplish that.

## Why It's Good For The Game
Why do we have to wait over 10 seconds for a debug suit to activate or deactivate on top of everything else that comes with coding, programming, bugfixing etc? It now takes about 2 seconds to do so, which should be enough to notice the effects of modules such as the springlock anyway. The admin one takes 0.5 seconds, as it's by all means a better debug suit.

## Changelog

:cl:
admin: The Debug and Admin MODsuits now take a lot less time to (de)activate. 2 and 0.5 seconds respectively, compared to the default of 10s.
/:cl:
