### PR TITLE
Changes brand intelligence to check onstation var instead of station z level. Well, kind of both.

### DIFF
--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -35,7 +35,7 @@
 /datum/round_event/brand_intelligence/setup()
 	//select our origin machine (which will also be the type of vending machine affected.)
 	for(var/obj/machinery/vending/vendor in GLOB.machines)
-		if(!is_station_level(vendor.z))
+		if(!vendor.onstation)
 			continue
 		if(!vendor.density)
 			continue

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -165,10 +165,11 @@
 	  * Is this item on station or not
 	  *
 	  * if it doesn't originate from off-station during mapload, everything is free
+	  * if it's off-station during mapload, it's also safe from the brand intelligence event
 	  */
-	var/onstation = TRUE //if it doesn't originate from off-station during mapload, everything is free
-	///A variable to change on a per instance basis on the map that allows the instance to force cost and ID requirements
-	var/onstation_override = FALSE //change this on the object on the map to override the onstation check. DO NOT APPLY THIS GLOBALLY.
+	var/onstation = TRUE
+	///A variable to change on a per instance basis on the map that allows the instance to force cost and ID requirements. DO NOT APPLY THIS GLOBALLY.
+	var/onstation_override = FALSE
 
 	var/list/vending_machine_input = list()
 	///Display header on the input view


### PR DESCRIPTION
## About The Pull Request

Checks the `.onstation` var on `/obj/machinery/vending` instead of checking the z-level directly.

The z-level check is already run in init to set this var in the first place, but this way it allows the var to be set manually to secure vendors that are on the station z-level but are not wanted as candidates for brand intelligence.
This scenario doesn't currently exist here, but it affects things like https://github.com/Skyrat-SS13/Skyrat-tg/issues/21918 and future-proofing is always nice.

I did consider doing this as another var, but that felt a bit excessive. Can change if wanted.

(also removes some duplicate comments because I was there)

## Why It's Good For The Game

Wasted events uhh bad

## Changelog
:cl:
fix: Brand intelligence can no longer affect off-station vendors in some specific circumstances.
/:cl: