### PR TITLE
adds a version of the external organ manipulation surgery for robotic body parts, crowbars aren't penalized for robotic organ manip

### DIFF
--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -23,6 +23,24 @@
 		/datum/surgery_step/close,
 	)
 
+/datum/surgery/organ_manipulation/external
+	name = "Feature manipulation"
+	possible_locs = list(
+		BODY_ZONE_CHEST,
+		BODY_ZONE_HEAD,
+		BODY_ZONE_PRECISE_GROIN,
+		BODY_ZONE_L_ARM,
+		BODY_ZONE_R_ARM,
+		BODY_ZONE_L_LEG,
+		BODY_ZONE_R_LEG,
+	)
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/manipulate_organs/external,
+		/datum/surgery_step/close,
+	)
+
 /datum/surgery/organ_manipulation/alien
 	name = "Alien organ manipulation"
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
@@ -46,7 +64,7 @@
 		/datum/surgery_step/open_hatch,
 		/datum/surgery_step/mechanic_unwrench,
 		/datum/surgery_step/prepare_electronics,
-		/datum/surgery_step/manipulate_organs/internal,
+		/datum/surgery_step/manipulate_organs/internal/mechanic,
 		/datum/surgery_step/mechanic_wrench,
 		/datum/surgery_step/mechanic_close,
 	)
@@ -87,12 +105,12 @@
 		/datum/surgery_step/mechanic_open,
 		/datum/surgery_step/open_hatch,
 		/datum/surgery_step/prepare_electronics,
-		/datum/surgery_step/manipulate_organs/internal,
+		/datum/surgery_step/manipulate_organs/internal/mechanic,
 		/datum/surgery_step/mechanic_close,
 	)
 
-/datum/surgery/organ_manipulation/external
-	name = "Feature manipulation"
+/datum/surgery/organ_manipulation/mechanic/external
+	name = "Prosthetic feature manipulation"
 	possible_locs = list(
 		BODY_ZONE_CHEST,
 		BODY_ZONE_HEAD,
@@ -102,11 +120,12 @@
 		BODY_ZONE_L_LEG,
 		BODY_ZONE_R_LEG,
 	)
-	steps = list(
-		/datum/surgery_step/incise,
-		/datum/surgery_step/retract_skin,
-		/datum/surgery_step/manipulate_organs/external,
-		/datum/surgery_step/close,
+	steps = list( //not shorter than soft prosthetic manip because I dunno what steps could be cut here
+		/datum/surgery_step/mechanic_open,
+		/datum/surgery_step/open_hatch,
+		/datum/surgery_step/prepare_electronics,
+		/datum/surgery_step/manipulate_organs/external/mechanic,
+		/datum/surgery_step/mechanic_close,
 	)
 
 ///Organ manipulation base class. Do not use, it wont work. Use it's subtypes
@@ -272,6 +291,11 @@
 /datum/surgery_step/manipulate_organs/internal/can_use_organ(mob/user, obj/item/organ/organ)
 	return isinternalorgan(organ)
 
+///prosthetic surgery gives full effectiveness to crowbars (and hemostats)
+/datum/surgery_step/manipulate_organs/internal/mechanic
+	implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 100, /obj/item/kitchen/fork = 35)
+	name = "manipulate prosthetic organs (hemostat or crowbar/organ)"
+
 ///Surgery step for external organs/features, like tails, frills, wings etc
 /datum/surgery_step/manipulate_organs/external
 	time = 3.2 SECONDS
@@ -280,3 +304,8 @@
 ///Only operate on external organs
 /datum/surgery_step/manipulate_organs/external/can_use_organ(mob/user, obj/item/organ/organ)
 	return isexternalorgan(organ)
+
+///prosthetic surgery gives full effectiveness to crowbars (and hemostats)
+/datum/surgery_step/manipulate_organs/external/mechanic
+	implements_extract = list(TOOL_HEMOSTAT = 100, TOOL_CROWBAR = 100, /obj/item/kitchen/fork = 35)
+	name = "manipulate prosthetic features (hemostat or crowbar/feature)"


### PR DESCRIPTION
## About The Pull Request

Adds a variant of the external organ manipulation surgery for robotic body parts, similar to the robotic version of the internal organ manipulation surgery. It uses the same procedure as non-head/torso prosthetic organ manipulation.

The suitability of crowbars in the "manipulate organs" and "manipulate features" steps has been boosted from 55% to 100%, but only for the robotic versions of those steps. Their suitability remains 55% for organic organ manipulation.

In other words, augged people can get frills, antennae, wings, tails, etc. attached to them now.

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/42606352/621501c0-5de4-4f9c-942b-d89eef7b207d)

Previously, augged and robotic characters had no way of adjusting their external organs, as the external organ manipulation surgery defaults to being organic-only. Lizards couldn't reattach their tails, moths couldn't reattach their wings, etc. Now they can!

Mechanical organ manipulation being a series of engineering tool steps followed by one surgical tool step (with the engineering tool equivalent, the crowbar, being the ghetto option that the surgical console doesn't mention) always felt odd to me. I'm not as attached to this part of the PR, and can undo it if maintainers request it.

## Proof of testing

(moth's head is augged)
![image](https://github.com/tgstation/tgstation/assets/42606352/f3c40ed9-337b-4a59-9acb-89292d4c5791)
![image](https://github.com/tgstation/tgstation/assets/42606352/2e56f20c-bbc1-4cd7-9c58-02359535c97f)
![image](https://github.com/tgstation/tgstation/assets/42606352/52f97284-6569-4539-bc93-e1a846347d62)
(I then put the antennae back in)
![image](https://github.com/tgstation/tgstation/assets/42606352/5f886490-d12b-4cc1-9f12-b7e7cfce11b7)

## Changelog

:cl: ATHATH
add: Adds a variant of the external organ manipulation surgery for robotic body parts, similar to the robotic version of the internal organ manipulation surgery. It uses the same procedure as non-head/torso prosthetic organ manipulation.
add: In layman's terms, augged people can get frills, antennae, wings, tails, etc. attached to them now.
qol: The suitability of crowbars in the "manipulate organs" and "manipulate features" steps has been boosted from 55% to 100%, but only for the robotic versions of those steps. Their suitability remains 55% for organic organ manipulation.
/:cl: