### PR TITLE
jetpack unit tests 

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -139,6 +139,7 @@
 #include "hydroponics_self_mutations.dm"
 #include "hydroponics_validate_genes.dm"
 #include "inhands.dm"
+#include "jetpack_on_off.dm"
 #include "json_savefile_importing.dm"
 #include "keybinding_init.dm"
 #include "knockoff_component.dm"

--- a/code/modules/unit_tests/jetpack_on_off.dm
+++ b/code/modules/unit_tests/jetpack_on_off.dm
@@ -1,0 +1,23 @@
+/// Test if jetpacks properly turn on and off!
+
+/datum/unit_test/jetpacks_on_off
+
+// test
+/datum/unit_test/jetpacks_on_off/Run()
+	// Fun fact, I broke ion jetpacks for like a week because I didn't think to test modsuit ion jetpacks when fixing
+	// a bug related to gas jetpacks -stonetear
+	// Modsuits.  Is there a better way to do this?
+	var/list/paths = typesof(/obj/item/mod/module/jetpack)
+	for(var/obj/item/mod/module/jetpack/jetpack in paths)
+		var/obj/item/mod/control/pre_equipped/mod = allocate(/obj/item/mod/control/pre_equipped) // create modsuit
+		var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human) // create human
+		mod.modules += jetpack // add this to the modsuit
+		mod.activation_step_time = 0 // Instant?  Unit tests run faster?
+		human.equip_to_slot_if_possible(mod, ITEM_SLOT_BACK) // Put modsuit on back
+		mod.quick_deploy(human) // deploy modsuit
+		mod.toggle_activate(human) // activate modsuit
+		jetpack.on_activation() // activate the module
+		var/list/sigprocs = jetpack.GetComponent(/datum/component/jetpack)._signal_procs // get the signal procs list
+		var/list/sighuman = locate(/mob/living/carbon/human) in sigprocs
+		TEST_ASSERT(locate(/datum/component/jetpack/proc/spacemove_react) in sighuman, "There was no spacemove_react proc inside [jetpack], this probably means you broke jetpacks.")
+


### PR DESCRIPTION
## About The Pull Request

This pull request adds unit tests to ensure jetpacks work.  I'm just putting this up for now so I can get some help with some of the issues I'm having trouble with.

- [ ]  Spawn modsuit jetpacks and test that they apply `_signal_procs`.
- [ ]  Spawn gas jetpacks and test that they apply `_signal_procs`.
- [ ]  (?) Devise a clever way to check if jetpacks properly propel you in zero gravity.

## Why It's Good For The Game

unit test
## Changelog
:cl:
code: Added some unit tests for jetpacks to avoid issues with testing.
/:cl:
