### PR TITLE
Make the server not shit the bed under default compile time settings

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -98,7 +98,7 @@
 #endif
 
 #ifndef PRELOAD_RSC //set to:
-#define PRELOAD_RSC 2 // 0 to allow using external resources or on-demand behaviour;
+#define PRELOAD_RSC 1 // 0 to allow using external resources or on-demand behaviour;
 #endif // 1 to use the default behaviour;
 								// 2 for preloading absolutely everything;
 


### PR DESCRIPTION
This being 2 is causing all connected clients to get all generated or runtime created assets (like tts), but it is not set to 2 on prod because the rsc cdn requires setting this to 0 via `server_side_modifications.dm`

also causes spritesheet to send resources out to all connected clients every insert mid generation, massively slowing it down as it will FUCKING BLOCK during this.