### PR TITLE
Fix Too Slowing people with high fives 

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -427,7 +427,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/give/highfive/proc/check_fake_out(mob/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	var/mob/living/offerer = offer.owner
 	if(QDELETED(offer.offered_item))
 		examine_list += "[span_warning("[source]'s arm appears tensed up, as if [source.p_they()] plan on pulling it back suddenly...")]\n"
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -304,14 +304,13 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/give // information set when the give alert is made
 	icon_state = "default"
-	var/mob/living/carbon/offerer
-	var/obj/item/receiving
+	/// The offer we're linked to, yes this is suspiciously like a status effect alert
+	var/datum/status_effect/offering/offer
 	/// Additional text displayed in the description of the alert.
 	var/additional_desc_text = "Click this alert to take it."
 
 /atom/movable/screen/alert/give/Destroy()
-	offerer = null
-	receiving = null
+	offer = null
 	return ..()
 
 /**
@@ -324,16 +323,16 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
  * * offerer - The person giving the alert and item
  * * receiving - The item being given by the offerer
  */
-/atom/movable/screen/alert/give/proc/setup(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
+/atom/movable/screen/alert/give/proc/setup(mob/living/carbon/taker, datum/status_effect/offering/offer)
+	var/mob/living/offerer = offer.owner
+	var/obj/item/receiving = offer.offered_item
 	var/receiving_name = get_receiving_name(taker, offerer, receiving)
 	name = "[offerer] is offering [receiving_name]"
 	desc = "[offerer] is offering [receiving_name]. [additional_desc_text]"
 	icon_state = "template"
 	cut_overlays()
 	add_overlay(receiving)
-	src.receiving = receiving
-	src.offerer = offerer
-
+	src.offer = offer
 
 /**
  * Called right before `setup()`, to do any sort of logic to change the name of
@@ -353,7 +352,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/give/proc/get_receiving_name(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	return receiving.name
 
-
 /atom/movable/screen/alert/give/Click(location, control, params)
 	. = ..()
 	if(!.)
@@ -367,26 +365,26 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /// An overrideable proc used simply to hand over the item when claimed, this is a proc so that high-fives can override them since nothing is actually transferred
 /atom/movable/screen/alert/give/proc/handle_transfer()
 	var/mob/living/carbon/taker = owner
+	var/mob/living/offerer = offer.owner
+	var/obj/item/receiving = offer.offered_item
 	taker.take(offerer, receiving)
 	SEND_SIGNAL(offerer, COMSIG_CARBON_ITEM_GIVEN, taker, receiving)
-
 
 /atom/movable/screen/alert/give/highfive
 	additional_desc_text = "Click this alert to slap it."
 
-
 /atom/movable/screen/alert/give/highfive/get_receiving_name(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	return "a high-five"
 
-
-/atom/movable/screen/alert/give/highfive/setup(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
+/atom/movable/screen/alert/give/highfive/setup(mob/living/carbon/taker, datum/status_effect/offering/offer)
 	. = ..()
-	RegisterSignal(offerer, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(check_fake_out))
-
+	RegisterSignal(offer.owner, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(check_fake_out))
 
 /atom/movable/screen/alert/give/highfive/handle_transfer()
 	var/mob/living/carbon/taker = owner
-	if(receiving && (receiving in offerer.held_items))
+	var/mob/living/offerer = offer.owner
+	var/obj/item/receiving = offer.offered_item
+	if(!QDELETED(receiving) && offerer.is_holding(receiving))
 		receiving.on_offer_taken(offerer, taker)
 		return
 
@@ -395,7 +393,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /// If the person who offered the high five no longer has it when we try to accept it, we get pranked hard
 /atom/movable/screen/alert/give/highfive/proc/too_slow_p1()
 	var/mob/living/carbon/rube = owner
-	if(!rube || !offerer)
+	var/mob/living/offerer = offer?.owner
+	if(QDELETED(rube) || QDELETED(offerer))
 		qdel(src)
 		return
 
@@ -406,48 +405,35 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /// Part two of the ultimate prank
 /atom/movable/screen/alert/give/highfive/proc/too_slow_p2()
 	var/mob/living/carbon/rube = owner
-	if(!rube || !offerer)
-		qdel(src)
-		return
+	var/mob/living/offerer = offer?.owner
+	if(!QDELETED(rube) && !QDELETED(offerer))
+		offerer.visible_message(span_danger("[offerer] pulls away from [rube]'s slap at the last second, dodging the high-five entirely!"), span_nicegreen("[rube] fails to make contact with your hand, making an utter fool of [rube.p_them()]self!"), span_hear("You hear a disappointing sound of flesh not hitting flesh!"), ignored_mobs=rube)
+		to_chat(rube, span_userdanger("[uppertext("NO! [offerer] PULLS [offerer.p_their()] HAND AWAY FROM YOURS! YOU'RE TOO SLOW!")]"))
+		playsound(offerer, 'sound/weapons/thudswoosh.ogg', 100, TRUE, 1)
+		rube.Knockdown(1 SECONDS)
+		offerer.add_mood_event("high_five", /datum/mood_event/down_low)
+		rube.add_mood_event("high_five", /datum/mood_event/too_slow)
+		offerer.remove_status_effect(/datum/status_effect/offering/no_item_received/high_five)
 
-	offerer.visible_message(span_danger("[offerer] pulls away from [rube]'s slap at the last second, dodging the high-five entirely!"), span_nicegreen("[rube] fails to make contact with your hand, making an utter fool of [rube.p_them()]self!"), span_hear("You hear a disappointing sound of flesh not hitting flesh!"), ignored_mobs=rube)
-	var/all_caps_for_emphasis = uppertext("NO! [offerer] PULLS [offerer.p_their()] HAND AWAY FROM YOURS! YOU'RE TOO SLOW!")
-	to_chat(rube, span_userdanger("[all_caps_for_emphasis]"))
-	playsound(offerer, 'sound/weapons/thudswoosh.ogg', 100, TRUE, 1)
-	rube.Knockdown(1 SECONDS)
-	offerer.add_mood_event("high_five", /datum/mood_event/down_low)
-	rube.add_mood_event("high_five", /datum/mood_event/too_slow)
 	qdel(src)
 
 /// If someone examine_more's the offerer while they're trying to pull a too-slow, it'll tip them off to the offerer's trickster ways
-/atom/movable/screen/alert/give/highfive/proc/check_fake_out(datum/source, mob/user, list/examine_list)
+/atom/movable/screen/alert/give/highfive/proc/check_fake_out(mob/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
-	if(!receiving)
-		examine_list += "[span_warning("[offerer]'s arm appears tensed up, as if [offerer.p_they()] plan on pulling it back suddenly...")]\n"
-
+	var/mob/living/offerer = offer.owner
+	if(QDELETED(offer.offered_item))
+		examine_list += "[span_warning("[source]'s arm appears tensed up, as if [source.p_they()] plan on pulling it back suddenly...")]\n"
 
 /atom/movable/screen/alert/give/hand/get_receiving_name(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	additional_desc_text = "Click this alert to take it and let [offerer.p_them()] pull you around!"
 	return "[offerer.p_their()] [receiving.name]"
 
+/atom/movable/screen/alert/give/hand/helping
 
 /atom/movable/screen/alert/give/hand/helping/get_receiving_name(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	. = ..()
 	additional_desc_text = "Click this alert to let them help you up!"
-
-
-/atom/movable/screen/alert/give/secret_handshake
-	icon_state = "default"
-
-/atom/movable/screen/alert/give/secret_handshake/setup(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
-	name = "[offerer] is offering a Handshake"
-	desc = "[offerer] wants to teach you the Secret Handshake for their Family and induct you! Click on this alert to accept."
-	icon_state = "template"
-	cut_overlays()
-	add_overlay(receiving)
-	src.receiving = receiving
-	src.offerer = offerer
 
 /// Gives the player the option to succumb while in critical condition
 /atom/movable/screen/alert/succumb

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -324,6 +324,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
  * * receiving - The item being given by the offerer
  */
 /atom/movable/screen/alert/give/proc/setup(mob/living/carbon/taker, datum/status_effect/offering/offer)
+	src.offer = offer
+
 	var/mob/living/offerer = offer.owner
 	var/obj/item/receiving = offer.offered_item
 	var/receiving_name = get_receiving_name(taker, offerer, receiving)
@@ -332,7 +334,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	icon_state = "template"
 	cut_overlays()
 	add_overlay(receiving)
-	src.offer = offer
 
 /**
  * Called right before `setup()`, to do any sort of logic to change the name of
@@ -428,7 +429,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	SIGNAL_HANDLER
 
 	if(QDELETED(offer.offered_item))
-		examine_list += "[span_warning("[source]'s arm appears tensed up, as if [source.p_they()] plan on pulling it back suddenly...")]\n"
+		examine_list += span_warning("[source]'s arm appears tensed up, as if [source.p_they()] plan on pulling it back suddenly...")
 
 /atom/movable/screen/alert/give/hand/get_receiving_name(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	additional_desc_text = "Click this alert to take it and let [offerer.p_them()] pull you around!"

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -372,6 +372,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/give/highfive
 	additional_desc_text = "Click this alert to slap it."
+	/// Tracks active "to slow"ing so we can't spam click
+	var/too_slowing_this_guy = FALSE
 
 /atom/movable/screen/alert/give/highfive/get_receiving_name(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	return "a high-five"
@@ -381,6 +383,9 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	RegisterSignal(offer.owner, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(check_fake_out))
 
 /atom/movable/screen/alert/give/highfive/handle_transfer()
+	if(too_slowing_this_guy)
+		return
+
 	var/mob/living/carbon/taker = owner
 	var/mob/living/offerer = offer.owner
 	var/obj/item/receiving = offer.offered_item
@@ -398,6 +403,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		qdel(src)
 		return
 
+	too_slowing_this_guy = TRUE
 	offerer.visible_message(span_notice("[rube] rushes in to high-five [offerer], but-"), span_nicegreen("[rube] falls for your trick just as planned, lunging for a high-five that no longer exists! Classic!"), ignored_mobs=rube)
 	to_chat(rube, span_nicegreen("You go in for [offerer]'s high-five, but-"))
 	addtimer(CALLBACK(src, PROC_REF(too_slow_p2), offerer, rube), 0.5 SECONDS)

--- a/code/datums/elements/high_fiver.dm
+++ b/code/datums/elements/high_fiver.dm
@@ -21,20 +21,12 @@
 /datum/element/high_fiver/proc/on_offer(obj/item/source, mob/living/carbon/offerer)
 	SIGNAL_HANDLER
 
-	if(locate(/mob/living/carbon) in orange(1, offerer))
-		offerer.visible_message(
-			span_notice("[offerer] raises [offerer.p_their()] arm, looking for a high-five!"),
-			span_notice("You post up, looking for a high-five!"),
-			vision_distance = 2,
-		)
-		offerer.apply_status_effect(/datum/status_effect/offering, source, /atom/movable/screen/alert/give/highfive)
-
-	else
-		offerer.visible_message(
-			span_danger("[offerer] raises [offerer.p_their()] arm, looking around for a high-five, but there's no one around!"),
-			span_warning("You post up, looking for a high-five, but find no one to accept it..."),
-			vision_distance = 4,
-		)
+	offerer.visible_message(
+		span_notice("[offerer] raises [offerer.p_their()] arm, looking for a high-five!"),
+		span_notice("You post up, looking for a high-five!"),
+		vision_distance = 2,
+	)
+	offerer.apply_status_effect(/datum/status_effect/offering/no_item_received/high_five, source, /atom/movable/screen/alert/give/highfive)
 
 	return COMPONENT_OFFER_INTERRUPT
 
@@ -89,4 +81,5 @@
 		offerer.add_mood_event(descriptor, /datum/mood_event/high_five)
 		taker.add_mood_event(descriptor, /datum/mood_event/high_five)
 
+	offerer.remove_status_effect(/datum/status_effect/offering/no_item_received/high_five)
 	return COMPONENT_OFFER_INTERRUPT

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -186,13 +186,12 @@
 
 	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(check_owner_in_range))
 	RegisterSignals(offered_item, list(COMSIG_QDELETING, COMSIG_ITEM_DROPPED), PROC_REF(dropped_item))
-	//RegisterSignal(owner, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(check_fake_out))
 
 /datum/status_effect/offering/Destroy()
-	for(var/i in possible_takers)
-		var/mob/living/carbon/removed_taker = i
+	for(var/mob/living/carbon/removed_taker as anything in possible_takers)
 		remove_candidate(removed_taker)
 	LAZYCLEARLIST(possible_takers)
+	offered_item = null
 	return ..()
 
 /// Hook up the specified carbon mob to be offered the item in question, give them the alert and signals and all
@@ -202,7 +201,7 @@
 		return
 	LAZYADD(possible_takers, possible_candidate)
 	RegisterSignal(possible_candidate, COMSIG_MOVABLE_MOVED, PROC_REF(check_taker_in_range))
-	G.setup(possible_candidate, owner, offered_item)
+	G.setup(possible_candidate, src)
 
 /// Remove the alert and signals for the specified carbon mob. Automatically removes the status effect when we lost the last taker
 /datum/status_effect/offering/proc/remove_candidate(mob/living/carbon/removed_candidate)
@@ -225,8 +224,7 @@
 /datum/status_effect/offering/proc/check_owner_in_range(mob/living/carbon/source)
 	SIGNAL_HANDLER
 
-	for(var/i in possible_takers)
-		var/mob/living/carbon/checking_taker = i
+	for(var/mob/living/carbon/checking_taker as anything in possible_takers)
 		if(!istype(checking_taker) || !owner.CanReach(checking_taker) || IS_DEAD_OR_INCAP(checking_taker))
 			remove_candidate(checking_taker)
 
@@ -244,7 +242,6 @@
 /datum/status_effect/offering/proc/is_taker_elligible(mob/living/carbon/taker)
 	return owner.CanReach(taker) && !IS_DEAD_OR_INCAP(taker) && additional_taker_check(taker)
 
-
 /**
  * Additional checks added to `CanReach()` and `IS_DEAD_OR_INCAP()` in `is_taker_elligible()`.
  * Should be what you override instead of `is_taker_elligible()`. By default, checks if the
@@ -256,17 +253,14 @@
 /datum/status_effect/offering/proc/additional_taker_check(mob/living/carbon/taker)
 	return taker.can_hold_items()
 
-
 /**
  * This status effect is meant only for items that you don't actually receive
  * when offered, mostly useful for `/obj/item/hand_item` subtypes.
  */
 /datum/status_effect/offering/no_item_received
 
-
 /datum/status_effect/offering/no_item_received/additional_taker_check(mob/living/carbon/taker)
-	return TRUE
-
+	return taker.usable_hands > 0
 
 /**
  * This status effect is meant only to be used for offerings that require the target to
@@ -276,25 +270,20 @@
  */
 /datum/status_effect/offering/no_item_received/needs_resting
 
-
 /datum/status_effect/offering/no_item_received/needs_resting/additional_taker_check(mob/living/carbon/taker)
 	return taker.body_position == LYING_DOWN
-
 
 /datum/status_effect/offering/no_item_received/needs_resting/on_creation(mob/living/new_owner, obj/item/offer, give_alert_override, mob/living/carbon/offered)
 	. = ..()
 	RegisterSignal(owner, COMSIG_LIVING_SET_BODY_POSITION, PROC_REF(check_owner_standing))
 
-
 /datum/status_effect/offering/no_item_received/needs_resting/register_candidate(mob/living/carbon/possible_candidate)
 	. = ..()
 	RegisterSignal(possible_candidate, COMSIG_LIVING_SET_BODY_POSITION, PROC_REF(check_candidate_resting))
 
-
 /datum/status_effect/offering/no_item_received/needs_resting/remove_candidate(mob/living/carbon/removed_candidate)
 	UnregisterSignal(removed_candidate, COMSIG_LIVING_SET_BODY_POSITION)
 	return ..()
-
 
 /// Simple signal handler that ensures that, if the owner stops standing, the offer no longer stands either!
 /datum/status_effect/offering/no_item_received/needs_resting/proc/check_owner_standing(mob/living/carbon/owner)
@@ -303,7 +292,6 @@
 
 	// This doesn't work anymore if the owner is no longer standing up, sorry!
 	qdel(src)
-
 
 /// Simple signal handler that ensures that, should a candidate now be standing up, the offer won't be standing for them anymore!
 /datum/status_effect/offering/no_item_received/needs_resting/proc/check_candidate_resting(mob/living/carbon/candidate)
@@ -315,10 +303,13 @@
 	// No longer lying down? You're no longer eligible to take the offer, sorry!
 	remove_candidate(candidate)
 
+/// Subtype for high fives, so we can fake out people
+/datum/status_effect/offering/no_item_received/high_five
+	id = "offer_high_five"
 
-/datum/status_effect/offering/secret_handshake
-	id = "secret_handshake"
-	give_alert_type = /atom/movable/screen/alert/give/secret_handshake
+/datum/status_effect/offering/no_item_received/high_five/dropped_item(obj/item/source)
+	// Lets us "too slow" people, instead of qdeling we just handle the ref
+	offered_item = null
 
 //this effect gives the user an alert they can use to surrender quickly
 /datum/status_effect/grouped/surrender
@@ -417,7 +408,7 @@
 		return
 	stable_message = FALSE
 
-	
+
 	//Increment cycle
 	current_cycle++ //needs to be done here because phase 2 can early return
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -131,6 +131,7 @@
 #include "hallucination_icons.dm"
 #include "heretic_knowledge.dm"
 #include "heretic_rituals.dm"
+#include "high_five.dm"
 #include "holidays.dm"
 #include "human_through_recycler.dm"
 #include "hunger_curse.dm"

--- a/code/modules/unit_tests/high_five.dm
+++ b/code/modules/unit_tests/high_five.dm
@@ -1,0 +1,57 @@
+// Test a high five through and through, with multiple people nearby
+/datum/unit_test/high_five
+
+/datum/unit_test/high_five/Run()
+	var/mob/living/carbon/human/offer_guy = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/take_guy = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/random_bystander = allocate(/mob/living/carbon/human/consistent) // this guy's just here for another valid taker
+
+	offer_guy.emote("slap")
+	offer_guy.give()
+
+	TEST_ASSERT_NOTNULL(offer_guy.has_status_effect(/datum/status_effect/offering/no_item_received/high_five), \
+		"Offerer doesn't have the high five offer status effect after offering (giving) to takers nearby")
+
+	var/atom/movable/screen/alert/give/highfive/alert_to_click = locate() in flatten_list(take_guy.alerts)
+	var/atom/movable/screen/alert/give/highfive/bystander_alert_we_dont_click = locate() in flatten_list(random_bystander.alerts)
+	TEST_ASSERT_NOTNULL(alert_to_click, "Taker had no alert to click to accept the high five offer")
+	TEST_ASSERT_NOTNULL(bystander_alert_we_dont_click, "Bystander had no alert from the high fiver offer")
+
+	alert_to_click.handle_transfer() // high five happens here with the taker only. Can't call click but this is close
+
+	TEST_ASSERT_NULL(offer_guy.has_status_effect(/datum/status_effect/offering/no_item_received/high_five), \
+		"Offerer still has the high five offer status effect after a high five was completed")
+	TEST_ASSERT(QDELETED(bystander_alert_we_dont_click), \
+		"Bystander still has the alert from the high fiver offer after the high five was completed")
+
+// Test a too slow setup
+/datum/unit_test/high_five_too_slow
+
+/datum/unit_test/high_five_too_slow/Run()
+	var/mob/living/carbon/human/offer_guy = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/take_guy = allocate(/mob/living/carbon/human/consistent)
+
+	// Just testing a too slow setup - so long as the setup works, we're good.
+	offer_guy.emote("slap")
+	offer_guy.give()
+	offer_guy.dropItemToGround(offer_guy.get_active_held_item())
+	TEST_ASSERT_NOTNULL(offer_guy.has_status_effect(/datum/status_effect/offering/no_item_received/high_five), \
+		"Offerer lost the high five offer status effect from dropping the slapper, even though this is valid, as it is used to too-slow")
+
+/// Tests someone offering a high five correctly stops offering when all takers walks away
+/datum/unit_test/high_five_walk_away
+
+/datum/unit_test/high_five_walk_away/Run()
+	var/mob/living/carbon/human/offer_guy = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/take_guy_A = allocate(/mob/living/carbon/human/consistent)
+	var/mob/living/carbon/human/take_guy_B = allocate(/mob/living/carbon/human/consistent)
+
+	offer_guy.emote("slap")
+	offer_guy.give()
+	take_guy_A.forceMove(run_loc_floor_top_right)
+	TEST_ASSERT_NOTNULL(offer_guy.has_status_effect(/datum/status_effect/offering/no_item_received/high_five), \
+		"Offerer lost the high fiver offer status effect from taker A moving away, which is invalid because taker B is still nearby")
+
+	take_guy_B.forceMove(run_loc_floor_top_right)
+	TEST_ASSERT_NULL(offer_guy.has_status_effect(/datum/status_effect/offering/no_item_received/high_five), \
+		"Offerer still has the high fiver offer status effect from taker B moving away, which is invalid because there are no takers are nearby")


### PR DESCRIPTION
## About The Pull Request

At some point with the refactors to offering it was made so that dropping the item stops the offer, unfortunately too slowing people with high fives relied on this behavior (dropping not stopping the offer). 

Restores that behavior with a bit more code tweaking. 

## Why It's Good For The Game

How can I be too slow?

## Changelog

:cl: Melbert
fix: You can once again "too slow" someone with a high five
/:cl:

