### PR TITLE
Fixes SS13.register_signal on parent_qdeleting signal in lua causing an error

### DIFF
--- a/lua/SS13.lua
+++ b/lua/SS13.lua
@@ -80,7 +80,7 @@ function SS13.register_signal(datum, signal, func, make_easy_clear_function)
 		}
 	end
 	if signal == "parent_qdeleting" then --We want to make sure that the cleanup function is the very last signal handler called.
-		local comp_lookup = datum.vars.comp_lookup
+		local comp_lookup = datum.vars._listen_lookup
 		if comp_lookup then
 			local lookup_for_signal = comp_lookup.entries.parent_qdeleting
 			if lookup_for_signal and not SS13.istype(lookup_for_signal, "/datum") then


### PR DESCRIPTION
## About The Pull Request
Potato renamed comp_lookup to _listen_lookup, which wasn't updated in the lua script. This PR changes the SS13 lua script to properly access the correct variable

## Why It's Good For The Game
Bugfix

## Changelog
