### PR TITLE
Wizard's wound spell costs 2 points

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
@@ -95,7 +95,6 @@
 	name = "Scream For Me"
 	desc = "Sadistic sanguine spell that inflicts numerous severe blood wounds all over the victim's body."
 	spell_type =  /datum/action/cooldown/spell/touch/scream_for_me
-	cost = 1
 	category = "Offensive"
 
 /datum/spellbook_entry/item/staffchaos

--- a/code/modules/spells/spell_types/touch/scream_for_me.dm
+++ b/code/modules/spells/spell_types/touch/scream_for_me.dm
@@ -10,6 +10,7 @@
 	invocation_type = INVOCATION_SHOUT
 	cooldown_time = 40 SECONDS
 	cooldown_reduction_per_rank = 10 SECONDS
+	spell_max_level = 3 //max is 10 seconds.
 
 	invocation = "SCREAM FOR ME!!"
 

--- a/code/modules/spells/spell_types/touch/scream_for_me.dm
+++ b/code/modules/spells/spell_types/touch/scream_for_me.dm
@@ -8,7 +8,7 @@
 
 	school = SCHOOL_SANGUINE
 	invocation_type = INVOCATION_SHOUT
-	cooldown_time = 60 SECONDS
+	cooldown_time = 40 SECONDS
 	cooldown_reduction_per_rank = 10 SECONDS
 
 	invocation = "SCREAM FOR ME!!"


### PR DESCRIPTION
## About The Pull Request

Increases the wound spell by 1 to the default offensive spell cost of 2.

## Why It's Good For The Game

This spell causes you to die in about a minute from blood loss alone, I don't think it should be worth as little as it does now, considering other spells don't mess you up as much as this one does (the other offensive spells is blind and shock, the latter doesnt even stun).

I also lowered its timer by 20 seconds to make up from it, so it isn't running the same stats as Smite.

## Changelog

:cl:
balance: Wizard's wounding spell now costs 2 spellbook points, and its cooldown has been decreased from 1 minute to 40 seconds.
/:cl: