### PR TITLE
Incident counter and digital clock placement [NO GBP]

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -30451,6 +30451,7 @@
 "ljp" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/digital_clock/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "lju" = (
@@ -31828,6 +31829,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/machinery/digital_clock/directional/south,
 /turf/open/floor/iron,
 /area/station/security/tram)
 "lJA" = (
@@ -35067,6 +35069,7 @@
 /area/station/hallway/secondary/entry)
 "mPv" = (
 /obj/item/kirbyplants/random/fullysynthetic,
+/obj/machinery/digital_clock/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
 "mPx" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -69959,6 +69959,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
+"rBw" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/digital_clock/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/command/bridge)
 "rBB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70254,6 +70259,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/incident_display/delam/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "rGU" = (
@@ -137259,7 +137265,7 @@ diL
 hFx
 drj
 bog
-nkU
+rBw
 gOU
 gOU
 vDo

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13538,13 +13538,6 @@
 /obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron/white,
 /area/station/security/prison/mess)
-"fdu" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/digital_clock/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/command/bridge)
 "fdH" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -21563,7 +21556,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
 "hXK" = (
-/obj/item/radio/intercom/directional/south,
 /obj/structure/rack,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
@@ -21571,6 +21563,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/digital_clock/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "hXQ" = (
@@ -96209,7 +96202,7 @@ tqI
 gkD
 nXm
 wNh
-fdu
+veO
 duI
 duI
 duI

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -21044,6 +21044,10 @@
 	},
 /turf/open/openspace,
 /area/station/hallway/primary/tram/center)
+"gjO" = (
+/obj/machinery/digital_clock,
+/turf/closed/wall,
+/area/station/medical/treatment_center)
 "gjP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/left/directional/east{
@@ -22229,6 +22233,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/digital_clock/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "gGb" = (
@@ -27497,6 +27502,7 @@
 "iLD" = (
 /obj/machinery/chem_mass_spec,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/machinery/digital_clock/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "iLP" = (
@@ -44466,6 +44472,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"oTk" = (
+/obj/machinery/digital_clock,
+/turf/closed/wall/r_wall,
+/area/station/command/bridge)
 "oTl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50670,6 +50680,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/digital_clock/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "rfQ" = (
@@ -155886,7 +155897,7 @@ aQO
 aQO
 aQO
 aQO
-aQO
+oTk
 aQO
 aQO
 aQO
@@ -169535,7 +169546,7 @@ iTt
 itk
 jtr
 jtr
-jtr
+gjO
 xSZ
 xqB
 xSZ


### PR DESCRIPTION
## About The Pull Request

The incident counters and digital clocks merged at roughly the same time, causing some overlap. Moves a few around and adds where missing.

## Changelog

:cl: LT3
fix: MetaStation's bridge incident counter and clock no longer overlap
fix: Deltastation's missing incident counter has been found. Does that count as an incident?
qol: Tramstation bridge and medbay now have a clock where the tram hit counter used to be
/:cl: