### PR TITLE
Mind link speech displays symbols correctly

### DIFF
--- a/code/datums/components/mind_linker.dm
+++ b/code/datums/components/mind_linker.dm
@@ -243,7 +243,7 @@
 	var/datum/component/mind_linker/linker = target
 	var/mob/living/linker_parent = linker.parent
 
-	var/message = sanitize(tgui_input_text(owner, "Enter a message to transmit.", "[linker.network_name] Telepathy"))
+	var/message = tgui_input_text(owner, "Enter a message to transmit.", "[linker.network_name] Telepathy")
 	if(!message || QDELETED(src) || QDELETED(owner) || owner.stat == DEAD)
 		return
 


### PR DESCRIPTION
## About The Pull Request
Closes #71991 
Removes a call to sanitize() in mind linker code because tgui_input_text() already sanitizes input by default, symbols now display correctly
Before:
![sym](https://github.com/tgstation/tgstation/assets/113535457/103335d5-2fc5-4a45-95d3-39fb41224f10)
After:
![sym_fixed](https://github.com/tgstation/tgstation/assets/113535457/78208a62-8e59-410c-b52c-7ebd80a012c8)

## Why It's Good For The Game
It's a bugfix

## Changelog
:cl:
fix: Symbols display correctly when sending messages via mind link
/:cl: