### PR TITLE
Makes HMS (and uncurable severity diseases) actually uncurable.

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -133,6 +133,8 @@
 
 
 /datum/disease/proc/cure(add_resistance = TRUE)
+	if(severity == DISEASE_SEVERITY_UNCURABLE) //aw man :(
+		return
 	if(affected_mob)
 		if(add_resistance && (disease_flags & CAN_RESIST))
 			LAZYOR(affected_mob.disease_resistances, GetDiseaseID())

--- a/code/modules/surgery/advanced/viral_bonding.dm
+++ b/code/modules/surgery/advanced/viral_bonding.dm
@@ -54,5 +54,6 @@
 	)
 	display_pain(target, "You feel a faint throbbing in your chest.")
 	for(var/datum/disease/infected_disease as anything in target.diseases)
-		infected_disease.carrier = TRUE
+		if(infected_disease.severity != DISEASE_SEVERITY_UNCURABLE) //no curing quirks, sweaty
+			infected_disease.carrier = TRUE
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

This PR makes HMS and any other diseases set to uncurable severity (only HMS counts right now) actually uncurable through either aheal or viral bonding.

## Why It's Good For The Game

Well, simply put, you shouldn't be able to cure quirks. Viral bonding doesn't technically "cure" the disease but makes you into a carrier for something that doesn't spread, which has been fixed.

## Changelog

:cl:
fix: Hereditary Manifold Sickness, and other uncurable diseases, have been found to no longer disappear upon miraculous acts of divine restoration. In addition, viral bonding no longer makes you into a carrier for those aswell.
/:cl:
