### PR TITLE
Centers the TGUI-Say window when the client is open

### DIFF
--- a/code/modules/tgui_input/say_modal/modal.dm
+++ b/code/modules/tgui_input/say_modal/modal.dm
@@ -55,6 +55,11 @@
 	);
 
 
+/**
+ * Centers the tgui-say window on the main window.
+ * Arguments: id - the id of the window to set the position of
+ * This code borrowed lovingly from itsmeow on Bee
+ */
 /client/proc/center_window(id, window_width, window_height)
 	//Center the window on the main window
 	var/mainwindow_data = params2list(winget(src, "mainwindow", "pos;outer-size;size;inner-size;is-maximized"))
@@ -91,6 +96,7 @@
  * as soon as the window sends the "ready" message.
  */
 /datum/tgui_say/proc/load()
+	set waitfor = FALSE
 	window_open = FALSE
 	client.center_window("tgui_say", 231, 30)
 	winshow(client, "tgui_say", FALSE)


### PR DESCRIPTION

## About The Pull Request
Prevents the TGUI-Say box from fucking off into the top left corner on higher resolution monitors.

Ported from https://github.com/BeeStation/BeeStation-Hornet/commit/917ab3e53df52b6961e1cf43ad9691b88d6b6a82

## Why It's Good For The Game
Fixes #74541
## Changelog
:cl:
fix: The TGUI-Say box will now always start in the center of the screen when the client is opened, as opposed to off in a corner somewhere for higher resolution users.
/:cl:
