### PR TITLE
[s] Knocks the lights out of Tinea Luxor

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -417,7 +417,7 @@
 		return
 	stable_message = FALSE
 
-	
+
 	//Increment cycle
 	current_cycle++ //needs to be done here because phase 2 can early return
 
@@ -531,3 +531,21 @@
 #undef EIGENSTASIUM_PHASE_2_END
 #undef EIGENSTASIUM_PHASE_3_START
 #undef EIGENSTASIUM_PHASE_3_END
+
+///Makes the mob luminescent for the duration of the effect.
+/datum/status_effect/tinlux_light
+	id = "tinea_luxor_light"
+	processing_speed = STATUS_EFFECT_NORMAL_PROCESS
+	remove_on_fullheal = TRUE
+	var/obj/effect/dummy/lighting_obj/moblight/mob_light_obj
+
+/datum/status_effect/tinlux_light/on_creation(mob/living/new_owner, duration = 2 SECONDS)
+	src.duration = duration
+	return ..()
+
+/datum/status_effect/tinlux_light/on_apply()
+	mob_light_obj = owner.mob_light(2)
+	return TRUE
+
+/datum/status_effect/tinlux_light/on_remove()
+	QDEL_NULL(mob_light_obj)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -787,14 +787,13 @@
 	ph = 11.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	//Lazy list of mobs affected by the luminosity of this reagent.
-	var/list/mobs_affected
+	var/static/list/mobs_affected
 
-/datum/reagent/consumable/tinlux/expose_mob(mob/living/exposed_mob)
-	. = ..()
-	add_reagent_light(exposed_mob)
+/datum/reagent/consumable/tinlux/on_mob_metabolize(mob/living/metabolizer)
+	add_reagent_light(metabolizer)
 
-/datum/reagent/consumable/tinlux/on_mob_end_metabolize(mob/living/M)
-	remove_reagent_light(M)
+/datum/reagent/consumable/tinlux/on_mob_end_metabolize(mob/living/metabolizer)
+	remove_reagent_light(metabolizer)
 
 /datum/reagent/consumable/tinlux/proc/on_living_holder_deletion(mob/living/source)
 	SIGNAL_HANDLER

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -55,7 +55,7 @@
 	reagent_state = SOLID
 	nutriment_factor = 15 * REAGENTS_METABOLISM
 	color = "#664330" // rgb: 102, 67, 48
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_DEAD_PROCESS
 
 	var/brute_heal = 1
 	var/burn_heal = 0
@@ -785,9 +785,8 @@
 	color = "#b5a213"
 	taste_description = "tingling mushroom"
 	ph = 11.2
-	metabolization_rate = REAGENTS_METABOLISM/2 //doubled when the mob starts to metabolize it.
 	self_consuming = TRUE
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_DEAD_PROCESS
 
 /datum/reagent/consumable/tinlux/expose_mob(mob/living/exposed_mob, methods = TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()
@@ -800,14 +799,6 @@
 /datum/reagent/consumable/tinlux/on_mob_add(mob/living/living_mob)
 	. = ..()
 	living_mob.apply_status_effect(/datum/status_effect/tinlux_light) //infinite duration
-
-/datum/reagent/consumable/tinlux/on_mob_metabolize(mob/living/living_mob)
-	nutriment_factor = initial(nutriment_factor)
-	metabolization_rate *= 2
-
-/datum/reagent/consumable/tinlux/on_mob_end_metabolize(mob/living/living_mob)
-	nutriment_factor = 0
-	metabolization_rate /= 2
 
 /datum/reagent/consumable/tinlux/on_mob_delete(mob/living/living_mob)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -786,6 +786,7 @@
 	taste_description = "tingling mushroom"
 	ph = 11.2
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	penetrates_skin = ALL
 	//Lazy list of mobs affected by the luminosity of this reagent.
 	var/static/list/mobs_affected
 


### PR DESCRIPTION
## About The Pull Request
So, we've a problem where the lights from Tinea Luxor can be staked up indefinitely, because someone thought it was a brilliant idea to use expose_mob rather than on_mob_metabolize.

## Why It's Good For The Game
This will close #76263. Aaaand yes, this is a webedit PR.

## Changelog

:cl:
fix: Fixes the lights from Tinea Luxor being stackable to the point of crashing the game for others.
/:cl:
