### PR TITLE
Doctors surgical caps hides hair

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -395,6 +395,7 @@
 	name = "blue surgery cap"
 	icon_state = "surgicalcap"
 	desc = "A blue medical surgery cap to prevent the surgeon's hair from entering the insides of the patient!"
+	flags_inv = HIDEHAIR //Cover your head doctor!
 
 /obj/item/clothing/head/utility/surgerycap/purple
 	name = "burgundy surgery cap"


### PR DESCRIPTION

## About The Pull Request

Simple pr that makes the doctors surgical cap hide your hair.

## Why It's Good For The Game

Less hair in patients insides.
But actually, I think this looks better, and it opens some more possibilities to go incognito as a doctor.
Plus, that's what a surgical cap is supposed to do!

## Changelog

:cl: Seven
add: Surgical caps now actually hide your hair
/:cl:
