### PR TITLE
Removes silicon's knowledge of non human languages

### DIFF
--- a/code/modules/language/beachbum.dm
+++ b/code/modules/language/beachbum.dm
@@ -4,16 +4,18 @@
 	key = "u"
 	space_chance = 85
 	default_priority = 90
-	syllables = list("cowabunga", "rad", "radical", "dudes", "bogus", "weeed", "every",
-					"dee", "dah", "woah", "surf", "blazed", "high", "heinous", "day",
-					"brah", "bro", "blown", "catch", "body", "beach", "oooo", "twenty",
-					"shiz", "phiz", "wizz", "pop", "chill", "awesome", "dude", "it",
-					"wax", "stoked", "yes", "ding", "way", "no", "wicked", "aaaa",
-					"cool", "hoo", "wah", "wee", "man", "maaaaaan", "mate", "wick",
-					"oh", "ocean", "up", "out", "rip", "slide", "big", "stomp",
-					"weed", "pot", "smoke", "four-twenty", "shove", "wacky", "hah",
-					"sick", "slash", "spit", "stoked", "shallow", "gun", "party",
-					"heavy", "stellar", "excellent", "triumphant", "babe", "four",
-					"tail", "trim", "tube", "wobble", "roll", "gnarly", "epic")
+	syllables = list(
+		"cowabunga", "rad", "radical", "dudes", "bogus", "weeed", "every",
+		"dee", "dah", "woah", "surf", "blazed", "high", "heinous", "day",
+		"brah", "bro", "blown", "catch", "body", "beach", "oooo", "twenty",
+		"shiz", "phiz", "wizz", "pop", "chill", "awesome", "dude", "it",
+		"wax", "stoked", "yes", "ding", "way", "no", "wicked", "aaaa",
+		"cool", "hoo", "wah", "wee", "man", "maaaaaan", "mate", "wick",
+		"oh", "ocean", "up", "out", "rip", "slide", "big", "stomp",
+		"weed", "pot", "smoke", "four-twenty", "shove", "wacky", "hah",
+		"sick", "slash", "spit", "stoked", "shallow", "gun", "party",
+		"heavy", "stellar", "excellent", "triumphant", "babe", "four",
+		"tail", "trim", "tube", "wobble", "roll", "gnarly", "epic",
+	)
 
 	icon_state = "beach"

--- a/code/modules/language/calcic.dm
+++ b/code/modules/language/calcic.dm
@@ -6,8 +6,8 @@
 	syllables = list(
 		"k", "ck", "ack", "ick", "cl", "tk", "sk", "isk", "tak",
 		"kl", "hs", "ss", "ks", "lk", "dk", "gk", "ka", "ska", "la", "pk",
-	"wk", "ak", "ik", "ip", "ski", "bk", "kb", "ta", "is", "it", "li", "di",
-	"ds", "ya", "sck", "crk", "hs", "ws", "mk", "aaa", "skraa", "skee", "hss",
+		"wk", "ak", "ik", "ip", "ski", "bk", "kb", "ta", "is", "it", "li", "di",
+		"ds", "ya", "sck", "crk", "hs", "ws", "mk", "aaa", "skraa", "skee", "hss",
 		"raa", "klk", "tk", "stk", "clk"
 	)
 	icon_state = "calcic"

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -321,22 +321,16 @@ Key procs
 	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/synthetic
-	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-								/datum/language/uncommon = list(LANGUAGE_ATOM),
-								/datum/language/machine = list(LANGUAGE_ATOM),
-								/datum/language/draconic = list(LANGUAGE_ATOM),
-								/datum/language/moffic = list(LANGUAGE_ATOM),
-								/datum/language/calcic = list(LANGUAGE_ATOM),
-								/datum/language/voltaic = list(LANGUAGE_ATOM),
-								/datum/language/nekomimetic = list(LANGUAGE_ATOM))
-	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
-							/datum/language/uncommon = list(LANGUAGE_ATOM),
-							/datum/language/machine = list(LANGUAGE_ATOM),
-							/datum/language/draconic = list(LANGUAGE_ATOM),
-							/datum/language/moffic = list(LANGUAGE_ATOM),
-							/datum/language/calcic = list(LANGUAGE_ATOM),
-							/datum/language/voltaic = list(LANGUAGE_ATOM),
-							/datum/language/nekomimetic = list(LANGUAGE_ATOM))
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
+		/datum/language/machine = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
+		/datum/language/machine = list(LANGUAGE_ATOM),
+	)
 
 /datum/language_holder/moth
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),

--- a/code/modules/language/machine.dm
+++ b/code/modules/language/machine.dm
@@ -4,7 +4,11 @@
 	spans = list(SPAN_ROBOT)
 	key = "6"
 	flags = NO_STUTTER
-	syllables = list("beep","beep","beep","beep","beep","boop","boop","boop","bop","bop","dee","dee","doo","doo","hiss","hss","buzz","buzz","bzz","ksssh","keey","wurr","wahh","tzzz")
+	syllables = list(
+		"beep", "beep", "beep", "beep", "beep", "boop", "boop", "boop",
+		"bop", "bop", "dee", "dee", "doo", "doo", "hiss", "hss", "buzz",
+		"buzz", "bzz", "ksssh", "keey", "wurr", "wahh", "tzzz",
+	)
 	space_chance = 10
 	default_priority = 90
 

--- a/code/modules/language/piratespeak.dm
+++ b/code/modules/language/piratespeak.dm
@@ -5,8 +5,8 @@
 	space_chance = 100
 	default_priority = 90
 	syllables = list(
-	"arr","ahoy","rum","aye","blimey","booty","bucko","grog","treasure",
-	"me","scallywag","landlubber","poopdeck","ye","avast",
-	"shiver","timbers","matey","swashbuckler"
+		"arr", "ahoy", "rum", "aye", "blimey", "booty", "bucko", "grog", "treasure",
+		"me", "scallywag", "landlubber", "poopdeck", "ye", "avast",
+		"shiver", "timbers", "matey", "swashbuckler"
 	)
 	icon_state = "pirate"

--- a/code/modules/language/uncommon.dm
+++ b/code/modules/language/uncommon.dm
@@ -5,12 +5,12 @@
 	flags = TONGUELESS_SPEECH
 	space_chance = 50
 	syllables = list(
-"ba", "be", "bo", "ca", "ce", "co", "da", "de", "do",
-"fa", "fe", "fo", "ga", "ge", "go", "ha", "he", "ho",
-"ja", "je", "jo", "ka", "ke", "ko", "la", "le", "lo",
-"ma", "me", "mo", "na", "ne", "no", "ra", "re", "ro",
-"sa", "se", "so", "ta", "te", "to", "va", "ve", "vo",
-"xa", "xe", "xo", "ya", "ye", "yo", "za", "ze", "zo"
+		"ba", "be", "bo", "ca", "ce", "co", "da", "de", "do",
+		"fa", "fe", "fo", "ga", "ge", "go", "ha", "he", "ho",
+		"ja", "je", "jo", "ka", "ke", "ko", "la", "le", "lo",
+		"ma", "me", "mo", "na", "ne", "no", "ra", "re", "ro",
+		"sa", "se", "so", "ta", "te", "to", "va", "ve", "vo",
+		"xa", "xe", "xo", "ya", "ye", "yo", "za", "ze", "zo"
 	)
 	icon_state = "galuncom"
 	default_priority = 90


### PR DESCRIPTION
## About The Pull Request

Silicon now only know Common, Uncommon (Humans with Foreigner quirk) and Robotic.
I also made the indentation in languages consistent because it bugged me lol.

## Why It's Good For The Game

1. There are currently many ways of learning languages, which devalues the language system as a whole. There's no real reason to use a language when anyone potentially understands what you're saying anyways.
2. Players of these non-human Species should be able to use their language to have hidden discussions in the open (you know, what languages were meant for), and Silicons should be included in this, especially since Silicon are generally on Asimov where they do not care for non-human life, giving non-humans SOMETHING over Silicon would be nice.

## Changelog

:cl:
balance: Silicon now only know Common, Uncommon and Robotic languages.
/:cl: