### PR TITLE
Fixes hardcore random not getting species names

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -255,6 +255,7 @@
 		if (preference.is_randomizable())
 			preference.apply_to_human(src, preference.create_random_value(preferences))
 
+	fully_replace_character_name(real_name, dna.species.random_name())
 /**
  * Setter for mob height
  *


### PR DESCRIPTION
It always just grabs a human name, this makes it grab a proper species name
This also fixes other stuff that uses the randomize_human_appearance proc

:cl:
fix: hardcore random now gives you a species specific name
/:cl:

I tested it, my gits just being ass