### PR TITLE
Adds missing medical laptop to morgue on Northstar

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -444,7 +444,7 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced/rglass,
-/obj/item/storage/box/bodybags,
+/obj/machinery/computer/records/medical/laptop,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "aeW" = (
@@ -21184,7 +21184,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/mannequin/skeleton,
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "fxd" = (
@@ -30880,11 +30881,11 @@
 "hYB" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /obj/machinery/digital_clock/directional/north,
+/obj/item/storage/box/bodybags,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "hYN" = (
@@ -85452,6 +85453,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/mannequin/skeleton,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "wmQ" = (


### PR DESCRIPTION
## About The Pull Request
![image](https://github.com/tgstation/tgstation/assets/7019927/98947f87-bd84-4f53-981c-57f3e185d22b)
Hence
![image](https://github.com/tgstation/tgstation/assets/7019927/8f85e6b4-e526-42e6-ae60-4ea2d63f7d48)


## Why It's Good For The Game
Coroner already doesn't have a ton to do so let's make sure he doesn't have to also walk all the way to the paramedic checkpoint just to do his job.

## Changelog
:cl:
fix: Added the missing medical laptop to the morgue on Northstar.
/:cl:
