### PR TITLE
Fixes empty casings being incorrectly replaced by a casing in guns with internal magazines

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -369,6 +369,7 @@
 		if (bolt_type == BOLT_TYPE_NO_BOLT || internal_magazine)
 			if (chambered && !chambered.loaded_projectile)
 				chambered.forceMove(drop_location())
+				magazine?.stored_ammo -= chambered
 				chambered = null
 			var/num_loaded = magazine?.attackby(A, user, params, TRUE)
 			if (num_loaded)


### PR DESCRIPTION
## About The Pull Request
<details><summary>What?</summary>

### e.g. double-barrel shotgun
spent shell inserted -> no chambered shell,  all is fine -> spent shell goes into the shotgun's mag -> spent shell gets added to the mag -> gun chambers a round from the mag - it's the newly added spent shell

2nd spent shell inserted -> chambered shell present, dump it out (but forget to remove it from the mag) -> 2nd spent shell goes into the shotgun's mag -> gun chambers a round from the mag - it's the last shell to be added to the mag - it's the 2nd shell

dump the gun's mag -> mag still has the 1st shell -> dumps the 2nd shell and the 1st one gets moved to the dump tile

relevant code:
https://github.com/tgstation/tgstation/blob/b832e2f47765ea321457221cc4e2a8ea64137555/code/modules/projectiles/guns/ballistic.dm#L369-L380

https://github.com/tgstation/tgstation/blob/b832e2f47765ea321457221cc4e2a8ea64137555/code/modules/projectiles/boxes_magazines/_box_magazine.dm#L128-L156

https://github.com/tgstation/tgstation/blob/b832e2f47765ea321457221cc4e2a8ea64137555/code/modules/projectiles/boxes_magazines/_box_magazine.dm#L101-L110
</details> 

so we just remove the dumped shell from the mag as well? it works but i think i'm maybe missing something?

## Why It's Good For The Game
Fixes #54771

## Changelog
:cl:
fix: fixed shotguns not clearing their "mag" correctly
/:cl:
