### PR TITLE
Fixes cult communication not working while buckled or cuffed

### DIFF
--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -7,7 +7,20 @@
 
 	buttontooltipstyle = "cult"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
+	/// If the cult action does not require hands to be performed
+	var/does_not_need_hands = FALSE
+	/// If the cult action can be performed while immobile
+	var/does_not_need_mobility = FALSE
 	ranged_mousepointer = 'icons/effects/mouse_pointers/cult_target.dmi'
+
+/datum/action/innate/cult/New()
+	..()
+	// If we dont need hands, remove the check from check_flags
+	if(does_not_need_hands == TRUE)
+		check_flags = check_flags & ~AB_CHECK_HANDS_BLOCKED
+	// If we dont need to be mobile, remove the check from check_flags
+	if(does_not_need_mobility == TRUE)
+		check_flags = check_flags & ~AB_CHECK_IMMOBILE
 
 /datum/action/innate/cult/IsAvailable(feedback = FALSE)
 	if(!IS_CULTIST(owner))
@@ -18,6 +31,9 @@
 	name = "Communion"
 	desc = "Whispered words that all cultists can hear.<br><b>Warning:</b>Nearby non-cultists can still hear you."
 	button_icon_state = "cult_comms"
+	// Unholy words dont require hands
+	does_not_need_hands = TRUE
+	does_not_need_mobility = TRUE
 
 /datum/action/innate/cult/comm/IsAvailable(feedback = FALSE)
 	if(isshade(owner) && IS_CULTIST(owner))
@@ -90,6 +106,9 @@
 /datum/action/innate/cult/mastervote
 	name = "Assert Leadership"
 	button_icon_state = "cultvote"
+	// If you want to assert your leadership while handcuffed to a chair, be my guest
+	does_not_need_hands = TRUE
+	does_not_need_mobility = TRUE
 
 /datum/action/innate/cult/mastervote/IsAvailable(feedback = FALSE)
 	var/datum/antagonist/cult/C = owner.mind.has_antag_datum(/datum/antagonist/cult,TRUE)

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -92,6 +92,7 @@
 /datum/action/innate/cult/mastervote
 	name = "Assert Leadership"
 	button_icon_state = "cultvote"
+	// So you can use it while your hands are cuffed or you are bucked
 	// If you want to assert your leadership while handcuffed to a chair, be my guest
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -94,7 +94,7 @@
 	button_icon_state = "cultvote"
 	// So you can use it while your hands are cuffed or you are bucked
 	// If you want to assert your leadership while handcuffed to a chair, be my guest
-	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED
 
 /datum/action/innate/cult/mastervote/IsAvailable(feedback = FALSE)
 	var/datum/antagonist/cult/C = owner.mind.has_antag_datum(/datum/antagonist/cult,TRUE)

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -7,20 +7,7 @@
 
 	buttontooltipstyle = "cult"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
-	/// If the cult action does not require hands to be performed
-	var/does_not_need_hands = FALSE
-	/// If the cult action can be performed while immobile
-	var/does_not_need_mobility = FALSE
 	ranged_mousepointer = 'icons/effects/mouse_pointers/cult_target.dmi'
-
-/datum/action/innate/cult/New()
-	..()
-	// If we dont need hands, remove the check from check_flags
-	if(does_not_need_hands == TRUE)
-		check_flags = check_flags & ~AB_CHECK_HANDS_BLOCKED
-	// If we dont need to be mobile, remove the check from check_flags
-	if(does_not_need_mobility == TRUE)
-		check_flags = check_flags & ~AB_CHECK_IMMOBILE
 
 /datum/action/innate/cult/IsAvailable(feedback = FALSE)
 	if(!IS_CULTIST(owner))
@@ -31,9 +18,8 @@
 	name = "Communion"
 	desc = "Whispered words that all cultists can hear.<br><b>Warning:</b>Nearby non-cultists can still hear you."
 	button_icon_state = "cult_comms"
-	// Unholy words dont require hands
-	does_not_need_hands = TRUE
-	does_not_need_mobility = TRUE
+	// Unholy words dont require hands or mobility
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 
 /datum/action/innate/cult/comm/IsAvailable(feedback = FALSE)
 	if(isshade(owner) && IS_CULTIST(owner))
@@ -107,8 +93,7 @@
 	name = "Assert Leadership"
 	button_icon_state = "cultvote"
 	// If you want to assert your leadership while handcuffed to a chair, be my guest
-	does_not_need_hands = TRUE
-	does_not_need_mobility = TRUE
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS
 
 /datum/action/innate/cult/mastervote/IsAvailable(feedback = FALSE)
 	var/datum/antagonist/cult/C = owner.mind.has_antag_datum(/datum/antagonist/cult,TRUE)


### PR DESCRIPTION

## About The Pull Request

Fixes #73701
Lets cult communion and assert leadership (lol) be usable while your hands are blocked or you are immobile.

## Why It's Good For The Game

Fixes a bug, and these are supposed to be whispers or whatever so it does not make much sense that being cuffed would stop that. Plus the ability makes you whisper, so its not without risks if you do call for help while cuffed in brig.
Also assert leadership makes sense I guess?

## Changelog

:cl: Seven
fix: Cult communion and assert leadership can be used while your hands are blocked or you are immobile
/:cl:
