### PR TITLE
Sends AI VOX messages over announcement instead of radio

### DIFF
--- a/code/controllers/subsystem/communications.dm
+++ b/code/controllers/subsystem/communications.dm
@@ -33,7 +33,7 @@ SUBSYSTEM_DEF(communications)
 	if(!can_announce(user, is_silicon))
 		return FALSE
 	if(is_silicon)
-		minor_announce(html_decode(input),"[user.name] Announces:", players = players)
+		minor_announce(html_decode(input),"[user.name] announces:", players = players)
 		COOLDOWN_START(src, silicon_message_cooldown, COMMUNICATION_COOLDOWN_AI)
 	else
 		var/list/message_data = user.treat_message(input)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -129,7 +129,7 @@
 
 	log_message("made a vocal announcement with the following message: [message].", LOG_GAME)
 	log_talk(message, LOG_SAY, tag="VOX Announcement")
-	minor_announce(capitalize(message), "[name] VOX Announces:", sound_override = TRUE)
+	minor_announce(capitalize(message), "[name] announces:", sound_override = TRUE)
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -129,7 +129,7 @@
 
 	log_message("made a vocal announcement with the following message: [message].", LOG_GAME)
 	log_talk(message, LOG_SAY, tag="VOX Announcement")
-	minor_announce(message, "[name] VOX Announces:", sound_override = TRUE)
+	minor_announce(capitalize(message), "[name] VOX Announces:", sound_override = TRUE)
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -133,7 +133,7 @@
 	var/list/players = list()
 	for(var/mob/player_mob in GLOB.player_list)
 		var/turf/T = get_turf(player_mob)
-		if(T.z == z_level)
+		if(T.z == src.z)
 			players += player_mob
 	minor_announce(capitalize(message), "[name] announces:", players = players, sound_override = TRUE)
 

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -131,17 +131,18 @@
 	log_talk(message, LOG_SAY, tag="VOX Announcement")
 
 	var/list/players = list()
-	for(var/mob/player_mob in GLOB.player_list)
-		var/turf/T = get_turf(player_mob)
-		if(T.z == src.z)
+	var/turf/ai_turf = get_turf(src)
+	for(var/mob/player_mob as anything in GLOB.player_list)
+		var/turf/player_turf = get_turf(player_mob)
+		if(is_valid_z_level(ai_turf, player_turf))
 			players += player_mob
 	minor_announce(capitalize(message), "[name] announces:", players = players, sound_override = TRUE)
 
 	for(var/word in words)
-		play_vox_word(word, src.z, null)
+		play_vox_word(word, ai_turf, null)
 
 
-/proc/play_vox_word(word, z_level, mob/only_listener)
+/proc/play_vox_word(word, ai_turf, mob/only_listener)
 
 	word = lowertext(word)
 
@@ -154,15 +155,19 @@
 	// If there is no single listener, broadcast to everyone in the same z level
 		if(!only_listener)
 			// Play voice for all mobs in the z level
-			for(var/mob/player_mob in GLOB.player_list)
+			for(var/mob/player_mob as anything in GLOB.player_list)
 				if(player_mob.client && !player_mob.client?.prefs)
 					stack_trace("[player_mob] ([player_mob.ckey]) has null prefs, which shouldn't be possible!")
 					continue
 
-				if(player_mob.can_hear() && (player_mob.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements)))
-					var/turf/T = get_turf(player_mob)
-					if(T.z == z_level)
-						SEND_SOUND(player_mob, voice)
+				if(!player_mob.can_hear() || !(player_mob.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements)))
+					continue
+
+				var/turf/player_turf = get_turf(player_mob)
+				if(!is_valid_z_level(ai_turf, player_turf))
+					continue
+
+				SEND_SOUND(player_mob, voice)
 		else
 			SEND_SOUND(only_listener, voice)
 		return TRUE

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -129,7 +129,13 @@
 
 	log_message("made a vocal announcement with the following message: [message].", LOG_GAME)
 	log_talk(message, LOG_SAY, tag="VOX Announcement")
-	minor_announce(capitalize(message), "[name] announces:", sound_override = TRUE)
+
+	var/list/players = list()
+	for(var/mob/player_mob in GLOB.player_list)
+		var/turf/T = get_turf(player_mob)
+		if(T.z == z_level)
+			players += player_mob
+	minor_announce(capitalize(message), "[name] announces:", players = players, sound_override = TRUE)
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -129,7 +129,7 @@
 
 	log_message("made a vocal announcement with the following message: [message].", LOG_GAME)
 	log_talk(message, LOG_SAY, tag="VOX Announcement")
-	say(";[message]", forced = "VOX Announcement")
+	radio.talk_into(src, "[message]")
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -129,7 +129,7 @@
 
 	log_message("made a vocal announcement with the following message: [message].", LOG_GAME)
 	log_talk(message, LOG_SAY, tag="VOX Announcement")
-	radio.talk_into(src, "[message]")
+	minor_announce(message, "[name] VOX Announces:", sound_override = TRUE)
 
 	for(var/word in words)
 		play_vox_word(word, src.z, null)


### PR DESCRIPTION
## About The Pull Request
Fixes #76310

`sound_override = TRUE` makes it so that no sound is played for the announcement since "TRUE" isn't a sound file, but that might be bad code let me know

## Why It's Good For The Game

Sending the message over the radio makes the AI "speak" it, so TTS plays from AI at the same time as the VOX sounds, which makes the announcement sound bad for the AI and anyone around them. This turns it from being sent over the radio to an announcement so that TTS doesn't apply. It also just makes more sense having the VOX announcement sent as an announcement rather than just a normal radio message. 
## Changelog
:cl:
qol: AI VOX messages are sent over announcement instead of radio
fix: AI VOX messages work properly on multi-Z stations
/:cl:
