### PR TITLE
[NO GBP] I flunked a commit just a hour ago and now Tinea Luxor's effect only lasts two seconds when added to mobs with a reagent holder. That was idiotic of me.

### DIFF
--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -539,8 +539,9 @@
 	remove_on_fullheal = TRUE
 	var/obj/effect/dummy/lighting_obj/moblight/mob_light_obj
 
-/datum/status_effect/tinlux_light/on_creation(mob/living/new_owner, duration = 2 SECONDS)
-	src.duration = duration
+/datum/status_effect/tinlux_light/on_creation(mob/living/new_owner, duration)
+	if(duration)
+		src.duration = duration
 	return ..()
 
 /datum/status_effect/tinlux_light/on_apply()


### PR DESCRIPTION
## About The Pull Request
So, I was going to use `-1` as second arg for that apply_status_effect() call, which is the duration of all status effects that don't expire with time, except that looks like a magic number that could use a define, though I was groaning at the idea of doing that, so I rolled back the change. Turns out I had forgotten the default value of that duration argument was `2 SECONDS` and only noticed it a few minutes after the PR was merged. @ZephyrTFA 

## Why It's Good For The Game
Do I have to explain again?

## Changelog
If this gets merged before the change goes live, I won't have to.