### PR TITLE
Updates the ports for the TTS docker compose file

### DIFF
--- a/tools/tts/docker-compose.yml
+++ b/tools/tts/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
     build: ./tts-api
     ports:
-      - "5002:5002"
+      - "127.0.0.1:5002:5002"
     restart: always
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:5002/health-check"]

--- a/tools/tts/tts/Dockerfile
+++ b/tools/tts/tts/Dockerfile
@@ -26,7 +26,7 @@ RUN pip install Flask &&\
 	pip install waitress &&\
 	pip install llvmlite --ignore-installed &&\
 	pip install torch torchaudio --extra-index-url https://download.pytorch.org/whl/cu118 &&\
-    pip install pydub &&\
+	pip install pydub &&\
 	pip install TTS &&\
 	pip cache purge
 

--- a/tools/tts/tts/Dockerfile
+++ b/tools/tts/tts/Dockerfile
@@ -26,6 +26,7 @@ RUN pip install Flask &&\
 	pip install waitress &&\
 	pip install llvmlite --ignore-installed &&\
 	pip install torch torchaudio --extra-index-url https://download.pytorch.org/whl/cu118 &&\
+    pip install pydub &&\
 	pip install TTS &&\
 	pip cache purge
 


### PR DESCRIPTION

## About The Pull Request
Current setup will bind to every interface which makes it publically available. Also skips past most of the firewalling on linux.
This improves the security for anyone who tries running TTS on their server directly out of the docker-compose file.
