### PR TITLE
Makes puzzle elements unable to have their icons messed with

### DIFF
--- a/code/modules/mapfluff/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/puzzle.dm
@@ -223,6 +223,9 @@
 		puzzle_small.pixel_y = 7
 		add_overlay(puzzle_small)
 
+/obj/structure/puzzle_element/update_icon(updates=ALL) // to prevent update_appearance calls from cutting the overlays
+	return
+
 /obj/structure/puzzle_element/Destroy()
 	if(source)
 		source.elements -= src

--- a/code/modules/mapfluff/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/puzzle.dm
@@ -223,8 +223,9 @@
 		puzzle_small.pixel_y = 7
 		add_overlay(puzzle_small)
 
-/obj/structure/puzzle_element/update_icon(updates=ALL) // to prevent update_appearance calls from cutting the overlays
-	return
+/obj/structure/puzzle_element/update_icon(updates=ALL) // to prevent update_appearance calls from cutting the overlays and not adding them back
+	. = ..()
+	set_puzzle_icon()
 
 /obj/structure/puzzle_element/Destroy()
 	if(source)


### PR DESCRIPTION
## About The Pull Request

The hand labeler (and any other item that is capable of calling `update_appearance` on an atom) was erasing the overlay icon when used on a sliding puzzle piece. This just stops that from being able to happen. 

There should never be a case when the puzzle icon or overlays get changed outside of during `set_puzzle_icon()`.

The puzzle is still able to be completed if any of the pieces get labeled, by the way.

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/22065

## Why It's Good For The Game

Fixes a bug/oversight

## Changelog

:cl:
fix: sliding puzzles can no longer have their icons erased by the hand labeler
/:cl:
