### PR TITLE
Plasmamen can now get HMS

### DIFF
--- a/code/datums/diseases/chronic_illness.dm
+++ b/code/datums/diseases/chronic_illness.dm
@@ -4,6 +4,7 @@
 	spread_text = "Unspread Illness"
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	disease_flags = CHRONIC
+	infectable_biotypes = MOB_ORGANIC | MOB_MINERAL | MOB_ROBOTIC
 	process_dead = TRUE
 	stage_prob = 0.25
 	cure_text = "Sansufentanyl"


### PR DESCRIPTION

## About The Pull Request
As plasmaman it is not currently possible to get HMS, despite being able to pick it as a trait roundstart and being able to get infected by traitors with the objective, this will fix two issues in one, removing yet another free points, this time 12, AND making them suffer the consequences of the syndicate.
## Why It's Good For The Game
Plasmamen now too can exit reality, by choice or infection.
## Changelog
:cl:
fix: Plasmamen can now get HMS
/:cl:
