### PR TITLE
Changeling hallucination sting now mentions it costs 10 chemicals

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -215,8 +215,9 @@
 
 /datum/action/changeling/sting/lsd
 	name = "Hallucination Sting"
-	desc = "We cause mass terror to our victim."
-	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs after 30 to 60 seconds."
+	desc = "We cause mass terror to our victim. Costs 10 chemicals."
+	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. \
+			The target does not notice they have been stung, and the effect occurs after 30 to 60 seconds."
 	button_icon_state = "sting_lsd"
 	chemical_cost = 10
 	dna_cost = 1


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Informing players that an ability has some sort of "power consumption" in a description would be very nice to know!

Also for the description text in code, I just did whatever its called to make it slightly more legible, as it was just a long line that got slightly cut off.

## Changelog

:cl: Jolly
spellcheck: Changeling hallucination sting will now tell you it costs 10 chemicals. It always did, but now its there. Cheers?
/:cl:

