### PR TITLE
Add hotkeys to APC settings

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -205,7 +205,7 @@
 
 /// Toggle APC lighting settings
 /obj/machinery/power/apc/AIShiftClick(mob/living/silicon/ai/user)
-	if(!can_use(user, 1))
+	if(!can_use(user, loud = TRUE))
 		return
 
 	if(!is_operational || failure_timer)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -184,7 +184,7 @@
 
 /// Toggle APC power settings
 /obj/machinery/power/apc/AICtrlClick(mob/living/silicon/ai/user)
-	if(!can_use(user, 1))
+	if(!can_use(user, loud = TRUE))
 		return
 
 	toggle_breaker(user)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -134,61 +134,64 @@
 /* Questions: Instead of an Emag check on every function, can we not add to airlocks onclick if emag return? */
 
 /* Atom Procs */
-/atom/proc/AICtrlClick()
+/atom/proc/AICtrlClick(mob/living/silicon/ai/user)
 	return
+
 /atom/proc/AIAltClick(mob/living/silicon/ai/user)
 	AltClick(user)
 	return
-/atom/proc/AIShiftClick()
+
+/atom/proc/AIShiftClick(mob/living/silicon/ai/user)
 	return
-/atom/proc/AICtrlShiftClick()
+
+/atom/proc/AICtrlShiftClick(mob/living/silicon/ai/user)
 	return
 
 /* Airlocks */
-/obj/machinery/door/airlock/AICtrlClick() // Bolts doors
+/obj/machinery/door/airlock/AICtrlClick(mob/living/silicon/ai/user) // Bolts doors
 	if(obj_flags & EMAGGED)
 		return
 
-	toggle_bolt(usr)
-	add_hiddenprint(usr)
+	toggle_bolt(user)
+	add_hiddenprint(user)
 
-/obj/machinery/door/airlock/AIAltClick() // Eletrifies doors.
+/obj/machinery/door/airlock/AIAltClick(mob/living/silicon/ai/user) // Eletrifies doors.
 	if(obj_flags & EMAGGED)
 		return
 
 	if(!secondsElectrified)
-		shock_perm(usr)
+		shock_perm(user)
 	else
-		shock_restore(usr)
+		shock_restore(user)
 
-/obj/machinery/door/airlock/AIShiftClick()  // Opens and closes doors!
+/obj/machinery/door/airlock/AIShiftClick(mob/living/silicon/ai/user)  // Opens and closes doors!
 	if(obj_flags & EMAGGED)
 		return
 
-	user_toggle_open(usr)
-	add_hiddenprint(usr)
+	user_toggle_open(user)
+	add_hiddenprint(user)
 
-/obj/machinery/door/airlock/AICtrlShiftClick()  // Sets/Unsets Emergency Access Override
+/obj/machinery/door/airlock/AICtrlShiftClick(mob/living/silicon/ai/user)  // Sets/Unsets Emergency Access Override
 	if(obj_flags & EMAGGED)
 		return
 
-	toggle_emergency(usr)
-	add_hiddenprint(usr)
+	toggle_emergency(user)
+	add_hiddenprint(user)
 
 /////////////
 /*   APC   */
 /////////////
 
 /// Toggle APC power settings
-/obj/machinery/power/apc/AICtrlClick()
-	if(!can_use(usr, 1))
+/obj/machinery/power/apc/AICtrlClick(mob/living/silicon/ai/user)
+	if(!can_use(user, 1))
 		return
 
-	toggle_breaker(usr)
+	toggle_breaker(user)
 
 /// Toggle APC environment settings (atmos)
-/obj/machinery/power/apc/AICtrlShiftClick()
-	if(!can_use(usr, 1))
+/obj/machinery/power/apc/AICtrlShiftClick(mob/living/silicon/ai/user)
+	if(!can_use(user, 1))
 		return
 
 	if(!is_operational || failure_timer)
@@ -208,8 +211,8 @@
 	update()
 
 /// Toggle APC lighting settings
-/obj/machinery/power/apc/AIShiftClick()
-	if(!can_use(usr, 1))
+/obj/machinery/power/apc/AIShiftClick(mob/living/silicon/ai/user)
+	if(!can_use(user, 1))
 		return
 
 	if(!is_operational || failure_timer)
@@ -222,8 +225,8 @@
 	update()
 
 /// Toggle APC equipment settings
-/obj/machinery/power/apc/AIAltClick()
-	if(!can_use(usr, 1))
+/obj/machinery/power/apc/AIAltClick(mob/living/silicon/ai/user)
+	if(!can_use(user, 1))
 		return
 
 	if(!is_operational || failure_timer)
@@ -236,31 +239,31 @@
 	update()
 
 /obj/machinery/power/apc/attack_ai_secondary(mob/living/silicon/user, list/modifiers)
-	if(!can_use(usr, 1))
+	if(!can_use(user, 1))
 		return
 
 	togglelock(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /* AI Turrets */
-/obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
+/obj/machinery/turretid/AIAltClick(mob/living/silicon/ai/user) //toggles lethal on turrets
 	if(ailock)
 		return
-	toggle_lethal(usr)
+	toggle_lethal(user)
 
-/obj/machinery/turretid/AICtrlClick() //turns off/on Turrets
+/obj/machinery/turretid/AICtrlClick(mob/living/silicon/ai/user) //turns off/on Turrets
 	if(ailock)
 		return
-	toggle_on(usr)
+	toggle_on(user)
 
 /* Holopads */
 /obj/machinery/holopad/AIAltClick(mob/living/silicon/ai/user)
 	hangup_all_calls()
-	add_hiddenprint(usr)
+	add_hiddenprint(user)
 
 //
 // Override TurfAdjacent for AltClicking
 //
 
-/mob/living/silicon/ai/TurfAdjacent(turf/T)
-	return (GLOB.cameranet && GLOB.cameranet.checkTurfVis(T))
+/mob/living/silicon/ai/TurfAdjacent(turf/target_turf)
+	return (GLOB.cameranet && GLOB.cameranet.checkTurfVis(target_turf))

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -115,14 +115,17 @@
 	for AI shift, ctrl, and alt clicking.
 */
 
-/mob/living/silicon/ai/CtrlShiftClickOn(atom/A)
-	A.AICtrlShiftClick(src)
-/mob/living/silicon/ai/ShiftClickOn(atom/A)
-	A.AIShiftClick(src)
-/mob/living/silicon/ai/CtrlClickOn(atom/A)
-	A.AICtrlClick(src)
-/mob/living/silicon/ai/AltClickOn(atom/A)
-	A.AIAltClick(src)
+/mob/living/silicon/ai/CtrlShiftClickOn(atom/target)
+	target.AICtrlShiftClick(src)
+
+/mob/living/silicon/ai/ShiftClickOn(atom/target)
+	target.AIShiftClick(src)
+
+/mob/living/silicon/ai/CtrlClickOn(atom/target)
+	target.AICtrlClick(src)
+
+/mob/living/silicon/ai/AltClickOn(atom/target)
+	target.AIAltClick(src)
 
 /*
 	The following criminally helpful code is just the previous code cleaned up;
@@ -176,6 +179,8 @@
 /obj/machinery/power/apc/AICtrlClick() // turns off/on APCs.
 	if(can_use(usr, 1))
 		toggle_breaker(usr)
+
+
 
 /* AI Turrets */
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -203,13 +203,6 @@
 	update_appearance()
 	update()
 
-
-	lighting = APC_CHANNEL_OFF
-	equipment = APC_CHANNEL_OFF
-	environ = APC_CHANNEL_OFF
-	update_appearance()
-	update()
-
 /// Toggle APC lighting settings
 /obj/machinery/power/apc/AIShiftClick(mob/living/silicon/ai/user)
 	if(!can_use(user, 1))

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -175,12 +175,72 @@
 	toggle_emergency(usr)
 	add_hiddenprint(usr)
 
-/* APC */
-/obj/machinery/power/apc/AICtrlClick() // turns off/on APCs.
-	if(can_use(usr, 1))
-		toggle_breaker(usr)
+/////////////
+/*   APC   */
+/////////////
+
+/// Toggle APC power settings
+/obj/machinery/power/apc/AICtrlClick()
+	if(!can_use(usr, 1))
+		return
+
+	toggle_breaker(usr)
+
+/// Toggle APC environment settings (atmos)
+/obj/machinery/power/apc/AICtrlShiftClick()
+	if(!can_use(usr, 1))
+		return
+
+	if(!is_operational || failure_timer)
+		return
+
+	add_hiddenprint(user)
+	environ = environ ? APC_CHANNEL_OFF : APC_CHANNEL_ON
+	user.log_message("turned [environ ? "on" : "off"] the [src] environment settings", LOG_GAME)
+	update_appearance()
+	update()
 
 
+	lighting = APC_CHANNEL_OFF
+	equipment = APC_CHANNEL_OFF
+	environ = APC_CHANNEL_OFF
+	update_appearance()
+	update()
+
+/// Toggle APC lighting settings
+/obj/machinery/power/apc/AIShiftClick()
+	if(!can_use(usr, 1))
+		return
+
+	if(!is_operational || failure_timer)
+		return
+
+	add_hiddenprint(user)
+	lighting = lighting ? APC_CHANNEL_OFF : APC_CHANNEL_ON
+	user.log_message("turned [lighting ? "on" : "off"] the [src] lighting settings", LOG_GAME)
+	update_appearance()
+	update()
+
+/// Toggle APC equipment settings
+/obj/machinery/power/apc/AIAltClick()
+	if(!can_use(usr, 1))
+		return
+
+	if(!is_operational || failure_timer)
+		return
+
+	add_hiddenprint(user)
+	equipment = equipment ? APC_CHANNEL_OFF : APC_CHANNEL_ON
+	user.log_message("turned [equipment ? "on" : "off"] the [src] equipment settings", LOG_GAME)
+	update_appearance()
+	update()
+
+/obj/machinery/power/apc/attack_ai_secondary(mob/living/silicon/user, list/modifiers)
+	if(!can_use(usr, 1))
+		return
+
+	togglelock(user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /* AI Turrets */
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -232,7 +232,7 @@
 	update()
 
 /obj/machinery/power/apc/attack_ai_secondary(mob/living/silicon/user, list/modifiers)
-	if(!can_use(user, 1))
+	if(!can_use(user, loud = TRUE))
 		return
 
 	togglelock(user)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -219,7 +219,7 @@
 
 /// Toggle APC equipment settings
 /obj/machinery/power/apc/AIAltClick(mob/living/silicon/ai/user)
-	if(!can_use(user, 1))
+	if(!can_use(user, loud = TRUE))
 		return
 
 	if(!is_operational || failure_timer)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -191,7 +191,7 @@
 
 /// Toggle APC environment settings (atmos)
 /obj/machinery/power/apc/AICtrlShiftClick(mob/living/silicon/ai/user)
-	if(!can_use(user, 1))
+	if(!can_use(user, loud = TRUE))
 		return
 
 	if(!is_operational || failure_timer)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -111,8 +111,8 @@
 	CtrlShiftClick(user)
 
 /obj/machinery/door/airlock/BorgCtrlShiftClick(mob/living/silicon/robot/user) // Sets/Unsets Emergency Access Override Forwards to AI code.
-	if(get_dist(src,user) <= user.interaction_range)
-		AICtrlShiftClick()
+	if(get_dist(src, user) <= user.interaction_range)
+		AICtrlShiftClick(user)
 	else
 		..()
 
@@ -120,8 +120,8 @@
 	ShiftClick(user)
 
 /obj/machinery/door/airlock/BorgShiftClick(mob/living/silicon/robot/user)  // Opens and closes doors! Forwards to AI code.
-	if(get_dist(src,user) <= user.interaction_range)
-		AIShiftClick()
+	if(get_dist(src, user) <= user.interaction_range)
+		AIShiftClick(user)
 	else
 		..()
 
@@ -131,31 +131,31 @@
 
 /obj/machinery/door/airlock/BorgCtrlClick(mob/living/silicon/robot/user) // Bolts doors. Forwards to AI code.
 	if(get_dist(src, user) <= user.interaction_range)
-		AICtrlClick()
+		AICtrlClick(user)
 	else
 		..()
 
 /obj/machinery/power/apc/BorgCtrlClick(mob/living/silicon/robot/user) // turns off/on APCs. Forwards to AI code.
 	if(get_dist(src, user) <= user.interaction_range)
-		AICtrlClick()
+		AICtrlClick(user)
 	else
 		..()
 
 /obj/machinery/power/apc/BorgCtrlShiftClick(mob/living/silicon/robot/user)
 	if(get_dist(src, user) <= user.interaction_range)
-		AICtrlShiftClick()
+		AICtrlShiftClick(user)
 	else
 		..()
 
 /obj/machinery/power/apc/BorgShiftClick(mob/living/silicon/robot/user)
 	if(get_dist(src, user) <= user.interaction_range)
-		AIShiftClick()
+		AIShiftClick(user)
 	else
 		..()
 
 /obj/machinery/power/apc/BorgAltClick(mob/living/silicon/robot/user)
 	if(get_dist(src, user) <= user.interaction_range)
-		AIAltClick()
+		AIAltClick(user)
 	else
 		..()
 
@@ -167,8 +167,8 @@
 		..()
 
 /obj/machinery/turretid/BorgCtrlClick(mob/living/silicon/robot/user) //turret control on/off. Forwards to AI code.
-	if(get_dist(src,user) <= user.interaction_range)
-		AICtrlClick()
+	if(get_dist(src, user) <= user.interaction_range)
+		AICtrlClick(user)
 	else
 		..()
 
@@ -177,14 +177,14 @@
 	return
 
 /obj/machinery/door/airlock/BorgAltClick(mob/living/silicon/robot/user) // Eletrifies doors. Forwards to AI code.
-	if(get_dist(src,user) <= user.interaction_range)
-		AIAltClick()
+	if(get_dist(src, user) <= user.interaction_range)
+		AIAltClick(user)
 	else
 		..()
 
 /obj/machinery/turretid/BorgAltClick(mob/living/silicon/robot/user) //turret lethal on/off. Forwards to AI code.
-	if(get_dist(src,user) <= user.interaction_range)
-		AIAltClick()
+	if(get_dist(src, user) <= user.interaction_range)
+		AIAltClick(user)
 	else
 		..()
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -130,14 +130,39 @@
 	CtrlClick(user)
 
 /obj/machinery/door/airlock/BorgCtrlClick(mob/living/silicon/robot/user) // Bolts doors. Forwards to AI code.
-	if(get_dist(src,user) <= user.interaction_range)
+	if(get_dist(src, user) <= user.interaction_range)
 		AICtrlClick()
 	else
 		..()
 
 /obj/machinery/power/apc/BorgCtrlClick(mob/living/silicon/robot/user) // turns off/on APCs. Forwards to AI code.
-	if(get_dist(src,user) <= user.interaction_range)
+	if(get_dist(src, user) <= user.interaction_range)
 		AICtrlClick()
+	else
+		..()
+
+/obj/machinery/power/apc/BorgCtrlShiftClick(mob/living/silicon/robot/user)
+	if(get_dist(src, user) <= user.interaction_range)
+		AICtrlShiftClick()
+	else
+		..()
+
+/obj/machinery/power/apc/BorgShiftClick(mob/living/silicon/robot/user)
+	if(get_dist(src, user) <= user.interaction_range)
+		AIShiftClick()
+	else
+		..()
+
+/obj/machinery/power/apc/BorgAltClick(mob/living/silicon/robot/user)
+	if(get_dist(src, user) <= user.interaction_range)
+		AIAltClick()
+	else
+		..()
+
+
+/obj/machinery/power/apc/attack_robot_secondary(mob/living/silicon/user, list/modifiers)
+	if(get_dist(src, user) <= user.interaction_range)
+		return attack_ai_secondary(user, modifiers)
 	else
 		..()
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -95,14 +95,17 @@
 
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
-/mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
-	A.BorgCtrlShiftClick(src)
-/mob/living/silicon/robot/ShiftClickOn(atom/A)
-	A.BorgShiftClick(src)
-/mob/living/silicon/robot/CtrlClickOn(atom/A)
-	A.BorgCtrlClick(src)
-/mob/living/silicon/robot/AltClickOn(atom/A)
-	A.BorgAltClick(src)
+/mob/living/silicon/robot/CtrlShiftClickOn(atom/target)
+	target.BorgCtrlShiftClick(src)
+
+/mob/living/silicon/robot/ShiftClickOn(atom/target)
+	target.BorgShiftClick(src)
+
+/mob/living/silicon/robot/CtrlClickOn(atom/target)
+	target.BorgCtrlClick(src)
+
+/mob/living/silicon/robot/AltClickOn(atom/target)
+	target.BorgAltClick(src)
 
 /atom/proc/BorgCtrlShiftClick(mob/living/silicon/robot/user) //forward to human click if not overridden
 	CtrlShiftClick(user)

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -116,7 +116,6 @@
 	else
 		..()
 
-
 /atom/proc/BorgShiftClick(mob/living/silicon/robot/user) //forward to human click if not overridden
 	ShiftClick(user)
 

--- a/code/modules/power/apc/apc_contextual_tips.dm
+++ b/code/modules/power/apc/apc_contextual_tips.dm
@@ -1,7 +1,15 @@
 /obj/machinery/power/apc/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 
-	if (isnull(held_item))
+	if(isAI(user) || iscyborg(user))
+		context[SCREENTIP_CONTEXT_LMB] = "Open UI"
+		context[SCREENTIP_CONTEXT_RMB] = locked ? "Unlock" : "Lock"
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = operating ? "Disable power" : "Enable power"
+		context[SCREENTIP_CONTEXT_SHIFT_LMB] = lighting ? "Disable lights" : "Enable lights"
+		context[SCREENTIP_CONTEXT_ALT_LMB] = equipment ? "Disable equipment" : "Enable equipment"
+		context[SCREENTIP_CONTEXT_CTRL_SHIFT_LMB] = environ ? "Disable environment" : "Enable environment"
+
+	else if (isnull(held_item))
 		if (opened == APC_COVER_CLOSED)
 			context[SCREENTIP_CONTEXT_RMB] = locked ? "Unlock" : "Lock"
 		else if (opened == APC_COVER_OPENED && cell)

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -251,7 +251,5 @@
 			locked = !locked
 			balloon_alert(user, locked ? "locked" : "unlocked")
 			update_appearance()
-			if(!locked)
-				ui_interact(user)
 		else
 			balloon_alert(user, "access denied!")


### PR DESCRIPTION

## About The Pull Request
This adds a few hotkeys to APCs for AIs and borgs.

- Toggle environmental (ctrl + shift)
- Toggle lighting (shift)
- Toggle equipment (alt) 
- Toggle breaker (ctrl)

These are included as contextual screentips.  Also removed the UI popup when using RMB to toggle the lock as well since it was annoying.  Went and cleaned up quite a bit of one letter var names and `usr` arguments.

## Why It's Good For The Game
Easier controls for equipment.

## Changelog
:cl:
qol: Add hotkeys to APCs for AIs and borgs. Toggle environmental (ctrl + shift), toggle lighting (shift), toggle equipment (alt), and toggle breaker (ctrl).
qol: Remove APC UI popup when using RMB to toggle the lock.
/:cl:
