### PR TITLE
Removes per z level station relays, allows tcomms to reach across interconnected zs

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12309,13 +12309,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"dMu" = (
-/obj/machinery/door/airlock/research{
-	name = "Communications Server"
-	},
-/obj/effect/turf_decal/tile/purple/fourcorners,
-/turf/open/floor/iron,
-/area/mine/living_quarters)
 "dMv" = (
 /obj/item/clothing/gloves/color/rainbow,
 /obj/item/clothing/head/soft/rainbow,
@@ -24995,10 +24988,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/security/prison/rec)
-"hYA" = (
-/obj/machinery/telecomms/relay/preset/mining,
-/turf/open/floor/circuit,
-/area/mine/living_quarters)
 "hYC" = (
 /obj/structure/closet/athletic_mixed,
 /obj/effect/landmark/start/hangover/closet,
@@ -28235,10 +28224,9 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "iYA" = (
-/obj/machinery/telecomms/relay/preset/mining,
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/circuit/green,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/mine/mechbay)
 "iYG" = (
 /obj/structure/cable,
@@ -34636,9 +34624,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"kYA" = (
-/turf/open/floor/circuit,
-/area/mine/living_quarters)
 "kYF" = (
 /obj/structure/light_construct/directional/west,
 /mob/living/simple_animal/hostile/retaliate/goose/vomit,
@@ -34906,12 +34891,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "lcY" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Station Communications Relay"
-	},
 /obj/structure/sign/poster/official/random/directional/west,
-/turf/open/floor/circuit/green,
+/turf/open/floor/iron/dark,
 /area/mine/mechbay)
 "ldi" = (
 /obj/structure/table,
@@ -153195,10 +153176,10 @@ iDt
 lwR
 tUK
 tUK
-lwR
+igm
 scw
-scw
-scw
+iDt
+iDt
 scw
 scw
 gjq
@@ -153453,9 +153434,9 @@ sJH
 ngj
 orS
 igm
-lwR
-lwR
-lwR
+scw
+iDt
+iDt
 scw
 gjq
 gjq
@@ -153709,10 +153690,10 @@ gpU
 oaG
 nSs
 xuB
-dMu
-kYA
-hYA
-lwR
+igm
+scw
+scw
+scw
 gjq
 gjq
 gjq
@@ -153970,8 +153951,8 @@ sJH
 riL
 riL
 sJH
-lwR
-lwR
+sJH
+sJH
 scw
 scw
 scw

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -1390,11 +1390,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port/aft)
-"aqU" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "aqW" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw{
 	dir = 1
@@ -9002,15 +8997,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
-"chA" = (
-/obj/effect/turf_decal/trimline/blue/corner,
-/obj/item/wrench,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "chF" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/red/opposingcorners{
@@ -12653,12 +12639,6 @@
 /obj/machinery/duct,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
-"dfd" = (
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "dff" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -15930,17 +15910,6 @@
 	dir = 4
 	},
 /area/station/hallway/floor2/fore)
-"dXR" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4
-	},
-/obj/machinery/light/small/blacklight/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "dXX" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/rnd/production/techfab/department/security,
@@ -20782,14 +20751,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"frE" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/obj/machinery/light/small/blacklight/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "frL" = (
 /turf/closed/wall,
 /area/station/engineering/gravity_generator)
@@ -21137,14 +21098,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/security/range)
-"fwF" = (
-/obj/effect/turf_decal/trimline/blue/corner,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "fwJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/trash/graffiti{
@@ -22673,11 +22626,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/fore)
-"fQJ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "fQQ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -24509,7 +24457,6 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor3/port/aft)
 "gpt" = (
-/obj/structure/cable,
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -25030,11 +24977,6 @@
 	dir = 6
 	},
 /area/station/hallway/floor2/aft)
-"gwD" = (
-/obj/structure/frame/machine,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "gwH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -26260,13 +26202,6 @@
 	dir = 1
 	},
 /area/station/hallway/floor2/fore)
-"gMd" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "gMe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -30356,12 +30291,6 @@
 /obj/effect/spawner/random/entertainment/money_small,
 /turf/open/floor/wood,
 /area/station/hallway/floor3/fore)
-"hRc" = (
-/obj/structure/table/glass,
-/obj/item/stack/sheet/mineral/plasma/five,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "hRd" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
@@ -31732,15 +31661,6 @@
 /obj/structure/sign/poster/random/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/toilet)
-"ikF" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1
-	},
-/obj/item/stack/cable_coil/five,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "ikG" = (
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 8
@@ -31963,10 +31883,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/locker)
 "inK" = (
-/obj/structure/ladder,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "inM" = (
 /obj/structure/sign/poster/official/random/directional/west,
 /obj/machinery/camera/autoname/directional/west,
@@ -35486,16 +35405,6 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/station/service/chapel)
-"jkv" = (
-/obj/effect/turf_decal/trimline/blue/corner,
-/obj/structure/cable,
-/obj/machinery/light/small/blacklight/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "jkH" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white,
@@ -35811,16 +35720,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/chemistry)
-"jps" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "jpy" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
@@ -40886,11 +40785,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/library/printer)
-"kGy" = (
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "kGz" = (
 /obj/effect/decal/cleanable/glitter,
 /obj/effect/turf_decal/siding/blue{
@@ -42004,7 +41898,6 @@
 /area/station/medical/abandoned)
 "kVT" = (
 /obj/machinery/light/small/directional/north,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port/aft)
 "kVY" = (
@@ -42980,14 +42873,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"lhP" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "lhT" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -45144,7 +45029,6 @@
 /obj/machinery/door/airlock/external{
 	name = "External Airlock"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -52629,12 +52513,6 @@
 	dir = 4
 	},
 /area/station/commons/storage/primary)
-"nAv" = (
-/obj/item/storage/toolbox/electrical,
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "nAC" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -53626,16 +53504,6 @@
 /obj/structure/disposalpipe/trunk/multiz/down,
 /turf/open/openspace,
 /area/station/maintenance/floor4/starboard/fore)
-"nMV" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "nMX" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -54639,12 +54507,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
-"nZJ" = (
-/obj/structure/table/glass,
-/obj/item/multitool,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "nZR" = (
 /obj/machinery/light_switch/directional/north,
 /obj/effect/landmark/start/assistant,
@@ -56921,14 +56783,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/shower)
-"oFN" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "oFS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/side{
@@ -57551,14 +57405,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"oOr" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "oOA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
 	dir = 1
@@ -59063,14 +58909,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/fore)
-"plE" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/obj/machinery/light/small/blacklight/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "plI" = (
 /obj/structure/table,
 /obj/item/food/pizzaslice/moldy,
@@ -60157,14 +59995,6 @@
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plating,
 /area/station/construction)
-"pzH" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "pzK" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -61438,15 +61268,6 @@
 /obj/item/knife/shiv,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
-"pRO" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "pRS" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark/side,
@@ -61555,14 +61376,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"pTW" = (
-/obj/machinery/door/airlock/external{
-	name = "External Airlock"
-	},
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "pUa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -65443,9 +65256,11 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor4/fore)
 "qRS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/space/openspace,
+/area/space)
 "qRW" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -66854,9 +66669,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"rlN" = (
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "rlP" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 1
@@ -67547,11 +67359,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
-"rvE" = (
-/obj/machinery/telecomms/relay/preset/station,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "rvL" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/floor2/port/fore)
@@ -70472,17 +70279,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"srq" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "srz" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics"
@@ -76530,8 +76326,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "tUT" = (
-/turf/closed/wall/r_wall,
-/area/station/tcommsat/server/upper)
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/engine/hull/reinforced,
+/area/space/nearstation)
 "tVa" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -80682,16 +80481,6 @@
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"vba" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "vbg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83233,12 +83022,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"vKH" = (
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "vKY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83834,14 +83617,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port)
-"vSS" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "vSW" = (
 /obj/structure/sign/poster/official/moth_hardhat/directional/east,
 /obj/structure/rack,
@@ -87419,7 +87194,6 @@
 	name = "External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -88403,14 +88177,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"wYl" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "wYs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet,
@@ -91318,12 +91084,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"xMG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/circuit/telecomms,
-/area/station/tcommsat/server/upper)
 "xMH" = (
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/machinery/door/airlock/hatch{
@@ -92504,13 +92264,6 @@
 /obj/effect/landmark/navigate_destination/chapel,
 /turf/open/floor/iron/chapel,
 /area/station/service/chapel)
-"ydj" = (
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server/upper)
 "ydm" = (
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
@@ -209076,7 +208829,7 @@ oyh
 oyh
 oyh
 oyh
-fQJ
+gpt
 oyh
 oyh
 oyh
@@ -209333,7 +209086,7 @@ oyh
 oyh
 oyh
 oyh
-fQJ
+gpt
 hQT
 oyh
 oyh
@@ -209590,7 +209343,7 @@ oyh
 oyh
 oyh
 edA
-fQJ
+gpt
 fPW
 eYj
 eYj
@@ -209844,12 +209597,12 @@ oyh
 oyh
 oyh
 oyh
-tUT
-tUT
-tUT
-pTW
-tUT
-tUT
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
 tUT
 eYj
 fPW
@@ -210100,15 +209853,15 @@ oyh
 oyh
 oyh
 oyh
-tUT
-tUT
-nAv
-jkv
-wYl
-dXR
-hRc
-tUT
-tUT
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
 eYj
 oyh
 oyh
@@ -210357,15 +210110,15 @@ oyh
 oyh
 oyh
 oyh
-tUT
-rlN
-rvE
-dfd
+oyh
+oyh
+oyh
+oyh
 inK
-oOr
-oFN
-xMG
-tUT
+oyh
+oyh
+oyh
+oyh
 fPW
 eYj
 eYj
@@ -210614,15 +210367,15 @@ oyh
 oyh
 oyh
 oyh
-tUT
-tUT
-aqU
-srq
-pRO
-nMV
-vSS
-tUT
-tUT
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
 itT
 oyh
 oyh
@@ -210872,13 +210625,13 @@ oyh
 oyh
 oyh
 oyh
-tUT
-tUT
-tUT
-tUT
-tUT
-tUT
-tUT
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
+oyh
 oyh
 oyh
 oyh
@@ -275380,13 +275133,13 @@ ucA
 ucA
 ucA
 ucA
-tUT
-tUT
-tUT
-tUT
-tUT
-tUT
-oyh
+ucA
+ujI
+pRs
+pRs
+pRs
+wbT
+ucA
 ucA
 ucA
 ucA
@@ -275636,15 +275389,15 @@ ucA
 ucA
 ucA
 ucA
-tUT
-tUT
+ucA
+ucA
 qRS
-fwF
-frE
-vba
-tUT
-oyh
-oyh
+acl
+pRs
+acl
+xUk
+ucA
+ucA
 ucA
 ucA
 ucA
@@ -275893,15 +275646,15 @@ ucA
 ucA
 ucA
 ucA
-tUT
-rlN
-rvE
-kGy
-inK
-oOr
-tUT
-oyh
-oyh
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
 ucA
 ucA
 ucA
@@ -276150,15 +275903,15 @@ ucA
 ucA
 ucA
 ucA
-tUT
-tUT
-nZJ
-jps
-ydj
-pzH
-tUT
-oyh
-oyh
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
 ucA
 ucA
 ucA
@@ -276408,13 +276161,13 @@ ucA
 ucA
 ucA
 ucA
-tUT
-tUT
-tUT
-tUT
-tUT
-tUT
-oyh
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
 ucA
 ucA
 ucA
@@ -340916,12 +340669,12 @@ ucA
 ucA
 ucA
 ucA
-tUT
-tUT
-tUT
-tUT
-tUT
-tUT
+ucA
+ujI
+pRs
+pRs
+ucA
+ucA
 ucA
 ucA
 ucA
@@ -341172,13 +340925,13 @@ ucA
 ucA
 ucA
 ucA
-tUT
-tUT
-gwD
-chA
-lhP
-vba
-tUT
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
 ucA
 ucA
 ucA
@@ -341429,13 +341182,13 @@ ucA
 ucA
 ucA
 ucA
-tUT
-rlN
-rvE
-vKH
-inK
-gMd
-tUT
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
 ucA
 ucA
 ucA
@@ -341686,13 +341439,13 @@ ucA
 ucA
 ucA
 ucA
-tUT
-tUT
-qRS
-jps
-plE
-ikF
-tUT
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
 ucA
 ucA
 ucA
@@ -341944,12 +341697,12 @@ ucA
 ucA
 ucA
 ucA
-tUT
-tUT
-tUT
-tUT
-tUT
-tUT
+ucA
+ucA
+ucA
+ucA
+ucA
+ucA
 ucA
 ucA
 ucA

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7629,15 +7629,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"bkh" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "blg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/tram/filled/line{
@@ -8582,12 +8573,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"bDj" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "bDk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -9412,15 +9397,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"bPZ" = (
-/obj/machinery/camera/motion{
-	c_tag = "Secure - AI Upper External South";
-	dir = 9;
-	network = list("aicore")
-	},
-/obj/structure/lattice,
-/turf/open/space/openspace,
-/area/space/nearstation)
 "bQt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -22863,12 +22839,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/glass,
 /area/station/cargo/sorting)
-"gSr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "gSF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33438,11 +33408,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/arrivals)
-"kRi" = (
-/obj/machinery/telecomms/relay/preset/station,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "kRm" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters"
@@ -39931,14 +39896,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
-"njt" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north{
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "njv" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -43837,19 +43794,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"oFJ" = (
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Telecomms Relay Access"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "oGj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -45435,12 +45379,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/hallway/primary/tram/left)
-"pmn" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "pmq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
@@ -48307,16 +48245,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
-"qmq" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "qmH" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -66451,6 +66379,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
+"wBR" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "wBV" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
@@ -67610,15 +67542,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/station/medical/virology)
-"xbk" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "xbp" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -68610,16 +68533,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
-"xxD" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/obj/machinery/camera/motion/directional/north{
-	c_tag = "Secure - Upper Station Comms Relay";
-	network = list("aicore")
-	},
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/turret_protected/aisat/hallway)
 "xxW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -184006,11 +183919,11 @@ jhd
 jhd
 jhd
 rxw
-rxw
-rxw
-rxw
-rxw
-rxw
+wBR
+jhd
+jhd
+jhd
+jhd
 jhd
 jhd
 jhd
@@ -184263,11 +184176,11 @@ gFf
 gFf
 jhd
 jhd
-avE
-jhd
-jhd
-jhd
 rxw
+jhd
+jhd
+jhd
+jhd
 jhd
 jhd
 jhd
@@ -184519,12 +184432,12 @@ eXb
 uqS
 gFf
 gFf
-gFf
-gFf
-gFf
-gFf
 jhd
 rxw
+jhd
+jhd
+jhd
+jhd
 jhd
 jhd
 jhd
@@ -184776,12 +184689,12 @@ pnT
 uqS
 uqS
 gFf
-bDj
-xbk
-gSr
-gFf
 jhd
 rxw
+jhd
+jhd
+jhd
+jhd
 jhd
 jhd
 jhd
@@ -185032,13 +184945,13 @@ rsZ
 vOD
 cmo
 uqS
-oFJ
-qmq
-kRi
-njt
 gFf
-bPZ
+jhd
 rxw
+jhd
+jhd
+jhd
+jhd
 jhd
 jhd
 jhd
@@ -185290,12 +185203,12 @@ dNi
 uqS
 uqS
 gFf
-xxD
-bkh
-pmn
-gFf
 jhd
 rxw
+jhd
+jhd
+jhd
+jhd
 jhd
 jhd
 jhd
@@ -185547,12 +185460,12 @@ cSe
 uqS
 gFf
 gFf
-gFf
-gFf
-gFf
-gFf
 jhd
 rxw
+jhd
+jhd
+jhd
+jhd
 jhd
 jhd
 jhd
@@ -185805,11 +185718,11 @@ gFf
 gFf
 jhd
 jhd
-avE
-jhd
-jhd
-jhd
 rxw
+jhd
+jhd
+jhd
+jhd
 jhd
 jhd
 jhd
@@ -186063,10 +185976,10 @@ jhd
 jhd
 rxw
 rxw
-rxw
-rxw
-rxw
-rxw
+jhd
+jhd
+jhd
+jhd
 jhd
 jhd
 jhd

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -776,8 +776,11 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	// We are guarenteed that we'll always grow bottom up
 	// Suck it jannies
 	z_level_to_plane_offset.len += 1
-	z_level_to_lowest_plane_offset += 1
+	z_level_to_lowest_plane_offset.len += 1
 	gravity_by_z_level.len += 1
+	z_level_to_stack.len += 1
+	// Bare minimum we have ourselves
+	z_level_to_stack[z_value] = list(z_value)
 	// 0's the default value, we'll update it later if required
 	z_level_to_plane_offset[z_value] = 0
 	z_level_to_lowest_plane_offset[z_value] = 0

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -896,7 +896,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	var/z_level = connected
 	if(isturf(z_level))
 		z_level = connected.z
-	return z_level_to_stack[connected.z]
+	return z_level_to_stack[connected]
 
 /datum/controller/subsystem/mapping/proc/lazy_load_template(template_key, force = FALSE)
 	RETURN_TYPE(/datum/turf_reservation)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -33,6 +33,9 @@ SUBSYSTEM_DEF(mapping)
 	/// List of z level (as number) -> plane offset of that z level
 	/// Used to maintain the plane cube
 	var/list/z_level_to_plane_offset = list()
+	/// List of z level (as number) -> list of all z levels vertically connected to ours
+	/// Useful for fast grouping lookups and such
+	var/list/z_level_to_stack = list()
 	/// List of z level (as number) -> The lowest plane offset in that z stack
 	var/list/z_level_to_lowest_plane_offset = list()
 	// This pair allows for easy conversion between an offset plane, and its true representation
@@ -812,9 +815,11 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	var/current_level = -1
 	var/current_z = update_with.z_value
 	var/list/datum/space_level/levels_checked = list()
+	var/list/new_stack = list()
 	do
 		current_level += 1
 		current_z += below_offset
+		new_stack += current_z
 		z_level_to_plane_offset[current_z] = current_level
 		var/datum/space_level/next_level = z_list[current_z]
 		below_offset = next_level.traits[ZTRAIT_DOWN]
@@ -824,6 +829,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	/// Updates the lowest offset value
 	for(var/datum/space_level/level_to_update in levels_checked)
 		z_level_to_lowest_plane_offset[level_to_update.z_value] = current_level
+		z_level_to_stack[level_to_update.z_value] = new_stack
 
 	// This can be affected by offsets, so we need to update it
 	// PAIN
@@ -881,6 +887,13 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 				true_to_offset_planes[string_real] = list()
 
 			true_to_offset_planes[string_real] |= offset_plane
+
+/// Takes a turf or a z level, and returns a list of all the z levels that are connected to it
+/datum/controller/subsystem/mapping/proc/get_connected_levels(turf/connected)
+	var/z_level = connected
+	if(isturf(z_level))
+		z_level = connected.z
+	return z_level_to_stack[connected.z]
 
 /datum/controller/subsystem/mapping/proc/lazy_load_template(template_key, force = FALSE)
 	RETURN_TYPE(/datum/turf_reservation)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -896,7 +896,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 	var/z_level = connected
 	if(isturf(z_level))
 		z_level = connected.z
-	return z_level_to_stack[connected]
+	return z_level_to_stack[z_level]
 
 /datum/controller/subsystem/mapping/proc/lazy_load_template(template_key, force = FALSE)
 	RETURN_TYPE(/datum/turf_reservation)

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -118,8 +118,7 @@
 		"spans" = spans,
 		"mods" = message_mods
 	)
-	var/turf/T = get_turf(source)
-	levels = list(T.z)
+	levels = SSmapping.get_connected_levels(get_turf(source))
 
 /datum/signal/subspace/vocal/copy()
 	var/datum/signal/subspace/vocal/copy = new(source, frequency, virt, language)

--- a/code/game/machinery/telecomms/machines/broadcaster.dm
+++ b/code/game/machinery/telecomms/machines/broadcaster.dm
@@ -34,7 +34,7 @@ GLOBAL_VAR_INIT(message_delay, 0) // To make sure restarting the recentmessages 
 
 	var/turf/T = get_turf(src)
 	if (T)
-		signal.levels |= T.z
+		signal.levels |= SSmapping.get_connected_levels(T)
 
 	var/signal_message = "[signal.frequency]:[signal.data["message"]]:[signal.data["name"]]"
 	if(signal_message in GLOB.recentmessages)

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -164,7 +164,7 @@
 	source = init_source
 	data = init_data
 	var/turf/T = get_turf(source)
-	levels = list(T.z)
+	levels = SSmapping.get_connected_levels(T)
 	if(!("reject" in data))
 		data["reject"] = TRUE
 

--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -26,9 +26,9 @@
 		// Relays send signals to all ZTRAIT_STATION z-levels
 		if(SSmapping.level_trait(relay_turf.z, ZTRAIT_STATION))
 			for(var/z in SSmapping.levels_by_trait(ZTRAIT_STATION))
-				signal.levels |= z
+				signal.levels |= SSmapping.get_connected_levels(z)
 		else
-			signal.levels |= relay_turf.z
+			signal.levels |= SSmapping.get_connected_levels(relay_turf)
 
 	use_power(idle_power_usage)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -342,7 +342,7 @@
 	// Okay, the signal was never processed, send a mundane broadcast.
 	signal.data["compression"] = 0
 	signal.transmission_method = TRANSMISSION_RADIO
-	signal.levels = list(T.z)
+	signal.levels = SSmapping.get_connected_levels(T)
 	signal.broadcast()
 
 /obj/item/radio/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), message_range)


### PR DESCRIPTION

## About The Pull Request

The second layer of tram does not need its own relay, it is like 10 feet max above the first. 
Feels wrong in game, mappers tend to just sneak these off in corners, it sucks. 
Shouldn't need to do it.

Instead, tcomms z levels will be filled based off the z stack, rather then just the layer itself.

Adds a list/helper to make this more efficient/more easily duplicable

## Why It's Good For The Game

Matches what people expect better, removes redundant map bits, better vibes.

## Changelog
:cl:
balance: Tcomms now works across connected (vertically) zlevels. No more hunting in maint for the relay.
/:cl:
