### PR TITLE
Fix limb DNA check

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -326,6 +326,8 @@
 	SEND_SIGNAL(src, COMSIG_BODYPART_ATTACHED, new_limb_owner, special)
 	moveToNullspace()
 	set_owner(new_limb_owner)
+	if(check_for_frankenstein(new_limb_owner))
+		bodypart_flags |= BODYPART_IMPLANTED
 	new_limb_owner.add_bodypart(src)
 	if(held_index)
 		new_limb_owner.on_added_hand(src, held_index)

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -96,8 +96,6 @@
 	if(isbodypart(tool) && user.temporarilyRemoveItemFromInventory(tool))
 		var/obj/item/bodypart/bodypart_to_attach = tool
 		bodypart_to_attach.try_attach_limb(target)
-		if(bodypart_to_attach.check_for_frankenstein(target))
-			bodypart_to_attach.bodypart_flags |= BODYPART_IMPLANTED
 		if(organ_rejection_dam)
 			target.adjustToxLoss(organ_rejection_dam)
 		display_results(


### PR DESCRIPTION
## About The Pull Request

Currently the DNA check when performing prosthetic replacement surgery occurs after the surgery is complete, after the COMSIG_CARBON_POST_ATTACH_LIMB signal has fired.

Trying to check bodypart_flags on COMSIG_CARBON_POST_ATTACH_LIMB will thus give you the incorrect status of the bodypart.

This moves the check to happen between COMSIG_CARBON_ATTACH_LIMB (starting the limb attachment) and COMSIG_CARBON_POST_ATTACH_LIMB (success,) after the new owner is assigned.

## Why It's Good For The Game

Registering to a signal for limb addition/loss should provide the correct information

## Changelog

:cl: LT3
fix: DNA check on prosthetic replacement surgery now happens during the surgery, not after
/:cl:
