### PR TITLE
Prevent ashwalkers using the shuttle console

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -142,6 +142,7 @@ Lizard subspecies: ASHWALKERS
 	inherent_traits = list(
 		//TRAIT_LITERATE,
 		TRAIT_VIRUSIMMUNE,
+		TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION,
 	)
 	species_language_holder = /datum/language_holder/lizard/ash
 	digitigrade_customization = DIGITIGRADE_FORCED


### PR DESCRIPTION
Once again seth is arguing he can murderbone on station as an ashlizard, and since this is totally against what I want for this ghost role I have added a prevention for them using the shuttle console.

## Changelog


:cl: oranges
balance: Ashlizards can no longer use the shuttle console to go on station
/:cl:
