### PR TITLE
adds chilis, bananas, korta nuts and berries to the produce order console. renames and makes categories slightly more consistent.

### DIFF
--- a/code/__DEFINES/computers.dm
+++ b/code/__DEFINES/computers.dm
@@ -1,6 +1,6 @@
 //Categories used for the order console
-#define CATEGORY_FRUITS_VEGGIES "Veggies"
-#define CATEGORY_MILK_EGGS "Milk & Eggs"
+#define CATEGORY_FRUITS_VEGGIES "Fruits & Veggies"
+#define CATEGORY_MILK_EGGS "Miscellaneous & Imports"
 #define CATEGORY_SAUCES_REAGENTS "Reagents"
 
 #define CATEGORY_GOLEM "Golem"

--- a/code/game/machinery/computer/orders/order_items/cook/order_milk_eggs.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_milk_eggs.dm
@@ -1,26 +1,6 @@
 /datum/orderable_item/milk_eggs
 	category_index = CATEGORY_MILK_EGGS
 
-/datum/orderable_item/milk_eggs/milk
-	name = "Milk"
-	item_path = /obj/item/reagent_containers/condiment/milk
-	cost_per_order = 30
-
-/datum/orderable_item/milk_eggs/soymilk
-	name = "Soy Milk"
-	item_path = /obj/item/reagent_containers/condiment/soymilk
-	cost_per_order = 30
-
-/datum/orderable_item/milk_eggs/cream
-	name = "Cream"
-	item_path = /obj/item/reagent_containers/cup/glass/bottle/juice/cream
-	cost_per_order = 40
-
-/datum/orderable_item/milk_eggs/yoghurt
-	name = "Yoghurt"
-	item_path = /obj/item/reagent_containers/condiment/yoghurt
-	cost_per_order = 40
-
 /datum/orderable_item/milk_eggs/eggs
 	name = "Egg Carton"
 	item_path = /obj/item/storage/fancy/egg_box

--- a/code/game/machinery/computer/orders/order_items/cook/order_reagents.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_reagents.dm
@@ -21,6 +21,26 @@
 	item_path = /obj/item/reagent_containers/condiment/cornmeal
 	cost_per_order = 30
 
+/datum/orderable_item/reagents/milk
+	name = "Milk"
+	item_path = /obj/item/reagent_containers/condiment/milk
+	cost_per_order = 30
+
+/datum/orderable_item/reagents/soymilk
+	name = "Soy Milk"
+	item_path = /obj/item/reagent_containers/condiment/soymilk
+	cost_per_order = 30
+
+/datum/orderable_item/reagents/cream
+	name = "Cream"
+	item_path = /obj/item/reagent_containers/cup/glass/bottle/juice/cream
+	cost_per_order = 40
+
+/datum/orderable_item/reagents/yoghurt
+	name = "Yoghurt"
+	item_path = /obj/item/reagent_containers/condiment/yoghurt
+	cost_per_order = 40
+
 /datum/orderable_item/reagents/enzyme
 	name = "Universal Enzyme"
 	item_path = /obj/item/reagent_containers/condiment/enzyme

--- a/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
@@ -24,7 +24,7 @@
 // cringe
 /datum/orderable_item/veggies/mushroom
 	name = "Plump Helmet"
-	desc = "Plumus Hellmus: Plump, soft and s-so inviting~" 
+	desc = "Plumus Hellmus: Plump, soft and s-so inviting~"
 	item_path = /obj/item/food/grown/mushroom/plumphelmet
 
 /datum/orderable_item/veggies/cabbage

--- a/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
@@ -75,6 +75,10 @@
 	name = "Cocoa"
 	item_path = /obj/item/food/grown/cocoapod
 
+/datum/orderable_item/veggies/korta_nut
+	name = "Korta Nut"
+	item_path = /obj/item/seeds/korta_nut
+
 /datum/orderable_item/veggies/herbs
 	name = "Bundle of Herbs"
 	item_path = /obj/item/food/grown/herbs

--- a/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
@@ -13,13 +13,18 @@
 	name = "Carrot"
 	item_path = /obj/item/food/grown/carrot
 
+/datum/orderable_item/veggies/chili
+	name = "Chili"
+	item_path = /obj/item/food/grown/chili	
+
 /datum/orderable_item/veggies/eggplant
 	name = "Eggplant"
 	item_path = /obj/item/food/grown/eggplant
 
+// cringe
 /datum/orderable_item/veggies/mushroom
 	name = "Plump Helmet"
-	desc = "Plumus Hellmus: Plump, soft and s-so inviting~"
+	desc = "Plumus Hellmus: Plump, soft and s-so inviting~" 
 	item_path = /obj/item/food/grown/mushroom/plumphelmet
 
 /datum/orderable_item/veggies/cabbage
@@ -41,6 +46,10 @@
 /datum/orderable_item/veggies/watermelon
 	name = "Watermelon"
 	item_path = /obj/item/food/grown/watermelon
+
+/datum/orderable_item/veggies/banana
+	name = "Banana"
+	item_path = /obj/item/food/grown/banana	
 
 /datum/orderable_item/veggies/corn
 	name = "Corn"
@@ -71,6 +80,10 @@
 	item_path = /obj/item/food/grown/herbs
 	cost_per_order = 5
 
+/datum/orderable_item/veggies/berries
+	name = "Bunch of Berries"
+	item_path = /obj/item/food/grown/berries
+
 /datum/orderable_item/veggies/bell_pepper
 	name = "Bell Pepper"
 	item_path = /obj/item/food/grown/bell_pepper
@@ -78,7 +91,6 @@
 /datum/orderable_item/veggies/cucumbers
 	name = "Cucumber"
 	item_path = /obj/item/food/grown/cucumber
-	cost_per_order = 10
 
 /datum/orderable_item/veggies/pickles
 	name = "Jar of pickles"


### PR DESCRIPTION
## About The Pull Request

adds chilis, bananas and berries to the produce order console. renames and makes categories slightly more consistent.

## Why It's Good For The Game

The produce order console is, as an emergency use case for when botany is slacking, unusually inconsistent. Chilis are one of the most commonly used ingredients and aren't present, while berries and bananas are flavorful options that open up a fair few more avenues. Bananas are especially fun if the clown is looking to supply himself with more banana cream pies or if he loses his prize roundstart banana.
Intended to make cooking/bartending a little more interesting if botany is absent. Only adding these plants as they feel especially fun/useful. Categories revised as they are hilariously inaccurate.
Next is hacking the console? Will see if this passes

## Changelog

:cl: Licks-The-Crystal
add: Adds Chilis, Bananas, Korta Nuts and Berries to the produce order console.
qol: Made the produce order console categories slightly more consistent
/:cl: