### PR TITLE
Adds file cycling for icon2base64

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1133,6 +1133,23 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 /proc/generate_asset_name(file)
 	return "asset.[md5(fcopy_rsc(file))]"
 
+/// Gets a dummy savefile for usage in icon generation.
+/// Savefiles generated from this proc will be empty.
+/proc/get_dummy_savefile(from_failure = FALSE)
+	var/static/next_id = 0
+	if(next_id++ > 9)
+		next_id = 0
+	var/savefile_path = "tmp/dummy-save-[next_id].sav"
+	try
+		if(fexists(savefile_path))
+			fdel(savefile_path)
+		return new /savefile(savefile_path)
+	catch(exception/error)
+		// if we failed to create a dummy once, try again; maybe someone slept somewhere they shouldnt have
+		if(from_failure) // this *is* the retry, something fucked up
+			CRASH("get_dummy_savefile failed to create a dummy savefile: '[error]'")
+		return get_dummy_savefile(from_failure = TRUE)
+
 /**
  * Converts an icon to base64. Operates by putting the icon in the iconCache savefile,
  * exporting it as text, and then parsing the base64 from that.
@@ -1141,14 +1158,11 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 /proc/icon2base64(icon/icon)
 	if (!isicon(icon))
 		return FALSE
-	var/savefile/dummySave = new("tmp/dummySave.sav")
+	var/savefile/dummySave = get_dummy_savefile()
 	WRITE_FILE(dummySave["dummy"], icon)
 	var/iconData = dummySave.ExportText("dummy")
 	var/list/partial = splittext(iconData, "{")
-	. = replacetext(copytext_char(partial[2], 3, -5), "\n", "") //if cleanup fails we want to still return the correct base64
-	dummySave.Unlock()
-	dummySave = null
-	fdel("tmp/dummySave.sav") //if you get the idea to try and make this more optimized, make sure to still call unlock on the savefile after every write to unlock it.
+	return replacetext(copytext_char(partial[2], 3, -5), "\n", "") //if cleanup fails we want to still return the correct base64
 
 ///given a text string, returns whether it is a valid dmi icons folder path
 /proc/is_valid_dmi_file(icon_path)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1144,7 +1144,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 		if(fexists(savefile_path))
 			fdel(savefile_path)
 		return new /savefile(savefile_path)
-	catch(exception/error)
+	catch(var/exception/error)
 		// if we failed to create a dummy once, try again; maybe someone slept somewhere they shouldnt have
 		if(from_failure) // this *is* the retry, something fucked up
 			CRASH("get_dummy_savefile failed to create a dummy savefile: '[error]'")


### PR DESCRIPTION
## About The Pull Request

I was going through condensed runtime stastics earlier today and noticed that we're getting thousands of runtimes from icon2base64 trying to write into a read only savefile; which can only happen if that savefile is opened more than once, (or is Locked)

This is likely due to some logic somewhere holding onto a reference it really shouldn't; but also is almost certainly a byond issue since the proc also clears the reference immediately after doing its work.

In order to combat this I've added a simple file cycling setup for icon2base64 so that it can hopefully not run into that issue again and by the time it gets back to a previous savefile byond has cleaned up its lock.

## Why It's Good For The Game

See the top of https://tgstation13.download/parsed-logs/manuel/data/logs/2023/06/28/round-209229/runtime.condensed.txt
