### PR TITLE
Fixes a compiler warning when compiling unit tests (that I caused)

### DIFF
--- a/code/modules/unit_tests/high_five.dm
+++ b/code/modules/unit_tests/high_five.dm
@@ -30,6 +30,7 @@
 /datum/unit_test/high_five_too_slow/Run()
 	var/mob/living/carbon/human/offer_guy = allocate(/mob/living/carbon/human/consistent)
 	var/mob/living/carbon/human/take_guy = allocate(/mob/living/carbon/human/consistent)
+	pass(take_guy) // This guy just needs to stand around
 
 	// Just testing a too slow setup - so long as the setup works, we're good.
 	offer_guy.emote("slap")


### PR DESCRIPTION
Fixes this 

![image](https://github.com/tgstation/tgstation/assets/51863163/6cde5634-4b83-4c9a-8336-f234345bbcce)
