### PR TITLE
Makes dissections dissect with a scalpel

### DIFF
--- a/code/modules/surgery/dissection.dm
+++ b/code/modules/surgery/dissection.dm
@@ -30,10 +30,10 @@
 	return TRUE
 
 /datum/surgery_step/dissection
-	name = "dissect (autopsy scanner)"
+	name = "dissect (scalpel)"
 	time = 16 SECONDS
 	implements = list(
-		/obj/item/autopsy_scanner = 100,
+		TOOL_SCALPEL = 100,
 	)
 
 /datum/surgery_step/dissection/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
## About The Pull Request

Makes dissections (the surgery for that research) use a scalpel to dissect (as it was previously)
Autopsy is not touched

## Why It's Good For The Game

Sci does not get autopsy scanners nor can they print them and theyre locked behind advanced biotech which needs dissections (which you need to get an autopsy scanner to dissect) and have to break into coroner office which is often pretty secured on rounds with no coroner
MDs with minimal access have to also break into coroner office to get an autopsy scanner
## Changelog
:cl:
qol: dissections use scalpels instead of autopsy scanner
/:cl:
