### PR TITLE
Adds 50 armor penetration to neurotoxin spit

### DIFF
--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -5,6 +5,7 @@
 	damage_type = STAMINA
 	armor_flag = BIO
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/neurotoxin
+	armour_penetration = 50
 
 /obj/projectile/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))


### PR DESCRIPTION

## About The Pull Request
Someone noted in an issue report that virologists could tank like 7 of these without breaking a sweat, that's a little goofy. This knocks it down to 4. You're still getting some protection by having extra gear on, but you're not immune to it.

Fixes #76389

## Why It's Good For The Game
Xenos should be dangerous to most of the crew without significant protection. I argue that, while a labcoat is meant to protect from nasty fluids, it shouldn't completely negate them, especially if a Sentinel has saved up a good chunk of plasma to throw at you.

## Changelog
:cl: Vekter
balance: Increased armor penetration on xenos' neurotoxin spit. Well-protected crew members should still take more than a few hits to down but shouldn't be immune to it.
/:cl:
