### PR TITLE
Command and Centcom plasmamen envirosuit helmets get armor.

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -390,23 +390,36 @@
 	desc = "A special containment helmet designed for the Head of Personnel. Embarrassingly enough, it looks way too much like the captain's design save for the red stripes."
 	icon_state = "hop_envirohelm"
 	inhand_icon_state = null
+	armor_type = /datum/armor/hats_hopcap/plasmaman
+
+/datum/armor/hats_hopcap/plasmaman
+	bio = 100
+	fire = 100
+	acid = 75
 
 /obj/item/clothing/head/helmet/space/plasmaman/captain
 	name = "captain's plasma envirosuit helmet"
 	desc = "A special containment helmet designed for the Captain. Embarrassingly enough, it looks way too much like the Head of Personnel's design save for the gold stripes. I mean, come on. Gold stripes can fix anything."
 	icon_state = "captain_envirohelm"
 	inhand_icon_state = null
-	armor_type = /datum/armor/space_plasmaman/captain
+	armor_type = /datum/armor/hats_caphat/plasmaman
 
-/datum/armor/space_plasmaman/captain
-	acid = 95
-	wound = 15
+/datum/armor/hats_caphat/plasmaman
+	bio = 100
+	fire = 100
+	acid = 75
 
 /obj/item/clothing/head/helmet/space/plasmaman/centcom_commander
 	name = "CentCom commander plasma envirosuit helmet"
 	desc = "A special containment helmet designed for the Higher Central Command Staff. Not many of these exist, as CentCom does not usually employ plasmamen to higher staff positions due to their complications."
 	icon_state = "commander_envirohelm"
 	inhand_icon_state = null
+	armor_type = /datum/armor/hats_centhat/plasmaman
+
+/datum/armor/hats_centhat/plasmaman
+	bio = 100
+	fire = 100
+	acid = 75
 
 /obj/item/clothing/head/helmet/space/plasmaman/centcom_official
 	name = "CentCom official plasma envirosuit helmet"


### PR DESCRIPTION

## About The Pull Request
This will mostly only affect downstreams where plasmamen can be command but this adds the armor values of the Captains, HoPs, and Centcom Commanders hats to their plasmaman envirosuit helmet equivalent.
## Why It's Good For The Game
The HoS gets armor values for their envirosuit helm, it would only be fitting if the rest of command had their envirosuit helmets have armor as well.
## Changelog
:cl:
qol: Matches command envirosuit helms' armor value with their hat counterparts.
/:cl:
