### PR TITLE
Fixes Duffelbags Storing Less than They Should

### DIFF
--- a/code/datums/storage/subtypes/duffel_bag.dm
+++ b/code/datums/storage/subtypes/duffel_bag.dm
@@ -1,5 +1,6 @@
 /datum/storage/duffel
 	max_total_storage = 30
+	max_slots = 21
 
 // Syndi bags get some FUN extras
 // You can fit any 3 bulky objects (assuming they're in the whitelist)


### PR DESCRIPTION
## About The Pull Request
Fixes oversight made in this PR:
- tgstation/tgstation#76313

Fixes #76429
After moving duffel bags to their own storage datum, the original PR author forgot to ensure that duffel bags had a correct slot limit to use their 30 total storage capacity to its fullest. More is detailed below.
## Why It's Good For The Game
This was an oversight that lead to duffel bags being nothing more than a box that can store normal-sized items. This was obviously not intended by the original author, and was simply an oversight. Code snippets can be seen below:

Originally, duffelbags inherited their basic /datum/storage variables from backpacks, that being `max_slots = 21`, as the most important variable relevant to this change.
https://github.com/tgstation/tgstation/blob/7c0fb221626e88c669c9d3e83e0db473595cbe3e/code/game/objects/items/storage/backpack.dm#L26-L29

Duffel bags, inheriting their Initialize() proc from their parent, backpacks, too had `max_slots = 21`), but simply just had 9 more `max_total_storage` than backpacks.
https://github.com/tgstation/tgstation/blob/7c0fb221626e88c669c9d3e83e0db473595cbe3e/code/game/objects/items/storage/backpack.dm#L403-L405

In #76313, however, backpacks were made to have their own /datum/storage/.
https://github.com/tgstation/tgstation/blob/03c964ac45e727543aac85ad817df89a7555fb31/code/datums/storage/subtypes/backpack.dm#L1-L3

Following so, so did duffel bags.
https://github.com/tgstation/tgstation/blob/03c964ac45e727543aac85ad817df89a7555fb31/code/datums/storage/subtypes/duffel_bag.dm#L1-L3

However, this fails to remember the important variable of `max_slots`. As such, this PR aims to rectify this erroneous oversight.
## Changelog
:cl:
fix: Fixes duffelbag slot limits to be what they were prior to the zipper PR.
/:cl:
