### PR TITLE
Refactors Silverscale tongue action into cooldown action, buffs it slightly

### DIFF
--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -203,81 +203,147 @@
 	name = "silver tongue"
 	desc = "A genetic branch of the high society Silver Scales that gives them their silverizing properties. To them, it is everything, and society traitors have their tongue forcibly revoked. Oddly enough, it itself is just blue."
 	icon_state = "silvertongue"
-	actions_types = list(/datum/action/item_action/organ_action/statue)
+	actions_types = list(/datum/action/cooldown/turn_to_statue)
 
-/datum/action/item_action/organ_action/statue
+/datum/action/cooldown/turn_to_statue
 	name = "Become Statue"
 	desc = "Become an elegant silver statue. Its durability and yours are directly tied together, so make sure you're careful."
-	COOLDOWN_DECLARE(ability_cooldown)
+	button_icon = 'icons/obj/medical/organs/organs.dmi'
+	button_icon_state = "silvertongue"
+	cooldown_time = 10 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_LYING
 
+	/// The statue we turn into.
+	/// We only ever make one (in New) and simply move it into nullspace or back.
 	var/obj/structure/statue/custom/statue
 
-/datum/action/item_action/organ_action/statue/New(Target)
+/datum/action/cooldown/turn_to_statue/New(Target)
 	. = ..()
-	statue = new
-	RegisterSignal(statue, COMSIG_QDELETING, PROC_REF(statue_destroyed))
+	if(!istype(Target, /obj/item/organ/internal/tongue/lizard/silver))
+		stack_trace("Non-silverscale tongue initialized a turn to statue action.")
+		qdel(src)
+		return
 
-/datum/action/item_action/organ_action/statue/Destroy()
-	UnregisterSignal(statue, COMSIG_QDELETING)
-	QDEL_NULL(statue)
+	init_statue()
+
+/datum/action/cooldown/turn_to_statue/Destroy()
+	clean_up_statue()
+	return ..()
+
+/datum/action/cooldown/turn_to_statue/IsAvailable(feedback)
 	. = ..()
+	if(!.)
+		return FALSE
 
-/datum/action/item_action/organ_action/statue/Trigger(trigger_flags)
-	. = ..()
-	if(!iscarbon(owner))
-		to_chat(owner, span_warning("Your body rejects the powers of the tongue!"))
-		return
-	var/mob/living/carbon/becoming_statue = owner
-	if(becoming_statue.health < 1)
-		to_chat(becoming_statue, span_danger("You are too weak to become a statue!"))
-		return
-	if(!COOLDOWN_FINISHED(src, ability_cooldown))
-		to_chat(becoming_statue, span_warning("You just used the ability, wait a little bit!"))
-		return
-	var/is_statue = becoming_statue.loc == statue
-	to_chat(becoming_statue, span_notice("You begin to [is_statue ? "break free from the statue" : "make a glorious pose as you become a statue"]!"))
-	if(!do_after(becoming_statue, (is_statue ? 5 : 30), target = get_turf(becoming_statue)))
-		to_chat(becoming_statue, span_warning("Your transformation is interrupted!"))
-		COOLDOWN_START(src, ability_cooldown, 3 SECONDS)
-		return
-	COOLDOWN_START(src, ability_cooldown, 10 SECONDS)
+	if(!isliving(owner))
+		return FALSE
+	var/obj/item/organ/internal/tongue/lizard/silver/tongue_target = target
+	if(tongue_target.owner != owner)
+		return FALSE
 
-	if(statue.name == initial(statue.name)) //statue has not been set up
-		statue.name = "statue of [becoming_statue.real_name]"
-		statue.desc = "statue depicting [becoming_statue.real_name]"
-		statue.set_custom_materials(list(/datum/material/silver=SHEET_MATERIAL_AMOUNT*5))
+	if(isnull(statue))
+		if(feedback)
+			owner.balloon_alert(owner, "you can't seem to statue-ize!")
+		return FALSE // permanently bricked
+	if(owner.stat != CONSCIOUS)
+		if(feedback)
+			owner.balloon_alert(owner, "you're too weak!")
+		return FALSE
+
+	return TRUE
+
+/datum/action/cooldown/turn_to_statue/Activate(atom/target)
+	StartCooldown(3 SECONDS)
+
+	var/is_statue = owner.loc == statue
+	if(!is_statue)
+		owner.visible_message(
+			span_notice("[owner] strikes a glorious pose."),
+			span_notice("You strike a glorious pose as you become a statue!"),
+		)
+
+	owner.balloon_alert(owner, is_statue ? "breaking free..." : "striking a pose...")
+	if(!do_after(owner, (is_statue ? 0.5 SECONDS : 3 SECONDS), target = get_turf(owner)))
+		owner.balloon_alert(owner, "interrupted!")
+		return
+
+	StartCooldown()
+
+	statue.name = "statue of [owner.real_name]"
+	statue.desc = "statue depicting [owner.real_name]"
 
 	if(is_statue)
 		statue.visible_message(span_danger("[statue] becomes animated!"))
-		becoming_statue.forceMove(get_turf(statue))
+		owner.forceMove(get_turf(statue))
 		statue.moveToNullspace()
-		UnregisterSignal(becoming_statue, COMSIG_MOVABLE_MOVED)
-	else
-		becoming_statue.visible_message(span_notice("[becoming_statue] hardens into a silver statue."), span_notice("You have become a silver statue!"))
-		statue.set_visuals(becoming_statue.appearance)
-		statue.forceMove(get_turf(becoming_statue))
-		becoming_statue.forceMove(statue)
-		statue.update_integrity(becoming_statue.health)
-		RegisterSignal(becoming_statue, COMSIG_MOVABLE_MOVED, PROC_REF(human_left_statue))
+		UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
 
-	//somehow they used an exploit/teleportation to leave statue, lets clean up
-/datum/action/item_action/organ_action/statue/proc/human_left_statue(atom/movable/mover, atom/oldloc, direction)
+	else
+		owner.visible_message(
+			span_notice("[owner] hardens into a silver statue."),
+			span_notice("You have become a silver statue!"),
+		)
+		statue.set_visuals(owner.appearance)
+		statue.forceMove(get_turf(owner))
+		owner.forceMove(statue)
+		RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(human_left_statue))
+
+		var/mob/living/living_owner = owner
+		statue.update_integrity(living_owner.health) // Statue has 100 health, humans have 100 health
+
+/// Somehow they used an exploit/teleportation to leave statue, lets clean up
+/datum/action/cooldown/turn_to_statue/proc/human_left_statue(atom/movable/mover, atom/oldloc, direction)
 	SIGNAL_HANDLER
 
 	statue.moveToNullspace()
 	UnregisterSignal(mover, COMSIG_MOVABLE_MOVED)
 
-/datum/action/item_action/organ_action/statue/proc/statue_destroyed(datum/source)
+/// Statue was destroyed via IC means (destruction / deconstruction), dust the owner and drop their stuff
+/datum/action/cooldown/turn_to_statue/proc/statue_destroyed(datum/source)
 	SIGNAL_HANDLER
 
-	to_chat(owner, span_userdanger("Your existence as a living creature snaps as your statue form crumbles!"))
-	if(iscarbon(owner))
-		//drop everything, just in case
-		var/mob/living/carbon/dying_carbon = owner
-		for(var/obj/item/dropped in dying_carbon)
-			if(!dying_carbon.dropItemToGround(dropped))
-				qdel(dropped)
-	qdel(owner)
+	if(isnull(statue.loc))
+		return // the statue ended up getting destroyed while in nullspace?
+
+	var/mob/living/carbon/carbon_owner = owner
+	to_chat(carbon_owner, span_userdanger("Your existence as a living creature snaps as your statue form crumbles!"))
+	carbon_owner.forceMove(get_turf(statue))
+	carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
+	carbon_owner.investigate_log("has been dusted from having their Silverscale Statue deconstructed / destroyed.", INVESTIGATE_DEATHS)
+
+	clean_up_statue() // unregister signal before we can do further side effects.
+
+/// Statue was qdeleted outright, do nothing but clear refs.
+/datum/action/cooldown/turn_to_statue/proc/statue_deleted(datum/source)
+	SIGNAL_HANDLER
+
+	clean_up_statue() // Note that if the lizard is in the statue when they're raw deleted, they too will be raw deleted. This is fine
+
+/// Initializes the statue we're going to hang around inside
+/datum/action/cooldown/turn_to_statue/proc/init_statue()
+	statue = new()
+	statue.set_custom_materials(list(/datum/material/silver = SHEET_MATERIAL_AMOUNT * 5))
+	statue.max_integrity = 100 // statues already have 100 max integrity, so this is a safety net
+	statue.set_armor(/datum/armor/obj_structure/silverscale_statue_armor)
+	statue.flags_ricochet |= RICOCHET_SHINY
+	RegisterSignal(statue, list(COMSIG_OBJ_DECONSTRUCT, COMSIG_ATOM_DESTRUCTION), PROC_REF(statue_destroyed))
+	RegisterSignal(statue, COMSIG_QDELETING, PROC_REF(statue_deleted))
+
+/// Cleans up the reference to the statue and unregisters signals
+/datum/action/cooldown/turn_to_statue/proc/clean_up_statue()
+	UnregisterSignal(statue, list(COMSIG_OBJ_DECONSTRUCT, COMSIG_ATOM_DESTRUCTION, COMSIG_QDELETING))
+	if(QDELETED(statue))
+		statue = null
+	else
+		QDEL_NULL(statue)
+
+/datum/armor/obj_structure/silverscale_statue_armor
+	melee = 50
+	bullet = 50
+	laser = 70
+	energy = 70
+	bomb = 50
+	fire = 100
 
 /obj/item/organ/internal/tongue/abductor
 	name = "superlingual matrix"

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -306,6 +306,8 @@
 		return // the statue ended up getting destroyed while in nullspace?
 
 	var/mob/living/carbon/carbon_owner = owner
+	RegisterSignal(carbon_owner, COMSIG_MOVABLE_MOVED)
+
 	to_chat(carbon_owner, span_userdanger("Your existence as a living creature snaps as your statue form crumbles!"))
 	carbon_owner.forceMove(get_turf(statue))
 	carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
@@ -326,16 +328,17 @@
 	statue.max_integrity = 100 // statues already have 100 max integrity, so this is a safety net
 	statue.set_armor(/datum/armor/obj_structure/silverscale_statue_armor)
 	statue.flags_ricochet |= RICOCHET_SHINY
-	RegisterSignal(statue, list(COMSIG_OBJ_DECONSTRUCT, COMSIG_ATOM_DESTRUCTION), PROC_REF(statue_destroyed))
+	RegisterSignals(statue, list(COMSIG_OBJ_DECONSTRUCT, COMSIG_ATOM_DESTRUCTION), PROC_REF(statue_destroyed))
 	RegisterSignal(statue, COMSIG_QDELETING, PROC_REF(statue_deleted))
 
 /// Cleans up the reference to the statue and unregisters signals
 /datum/action/cooldown/turn_to_statue/proc/clean_up_statue()
-	UnregisterSignal(statue, list(COMSIG_OBJ_DECONSTRUCT, COMSIG_ATOM_DESTRUCTION, COMSIG_QDELETING))
 	if(QDELETED(statue))
 		statue = null
-	else
-		QDEL_NULL(statue)
+		return
+
+	UnregisterSignal(statue, list(COMSIG_OBJ_DECONSTRUCT, COMSIG_ATOM_DESTRUCTION, COMSIG_QDELETING))
+	QDEL_NULL(statue)
 
 /datum/armor/obj_structure/silverscale_statue_armor
 	melee = 50


### PR DESCRIPTION
## About The Pull Request

Action? With a cooldown? That isn't a cooldown action? 

- Refactors Silverscale tongue action into a cooldown action

- Removes side effects on destroy, replaces it with destruction / deconstruction signals

- Buffs the statue itself slightly, since I'm here
  - Gives it some pretty decent innate armor (it didn't have any prior)
  - Makes it reflect lasers
 
- Also just for consistency: 
  - Also makes it require you not be lying down

## Why It's Good For The Game

- The previous method was very clunky, by making it a cooldown action it is much easier to use. 

- The statue was very weak before, so weak it was actually a downside if you tried to use it. This might help a bit. ~~Do not say "I'll still never use it" in the comments~~

## Changelog
:cl: Melbert
qol: Sivlerscale Tongue action is now a cooldown action, making it significantly easier to use
balance: Buffed the silverscale statue every so slightly, it now has innate armor and can reflect lasers shot at it. But it also requires you not by lying down to activate. 
/:cl:

