### PR TITLE
splits out tgui from the debug master category

### DIFF
--- a/code/__DEFINES/logging.dm
+++ b/code/__DEFINES/logging.dm
@@ -105,7 +105,6 @@
 #define LOG_CATEGORY_SUSPICIOUS_LOGIN "supicious-login"
 #define LOG_CATEGORY_TARGET_ZONE_SWITCH "target-zone-switch"
 #define LOG_CATEGORY_TELECOMMS "telecomms"
-#define LOG_CATEGORY_TGUI "tgui"
 #define LOG_CATEGORY_TOOL "tool"
 #define LOG_CATEGORY_VIRUS "virus"
 
@@ -121,7 +120,6 @@
 // Debug categories
 #define LOG_CATEGORY_DEBUG "debug"
 #define LOG_CATEGORY_DEBUG_ASSET "debug-asset"
-#define LOG_CATEGORY_DEBUG_HREF "debug-href"
 #define LOG_CATEGORY_DEBUG_JOB "debug-job"
 #define LOG_CATEGORY_DEBUG_LUA "debug-lua"
 #define LOG_CATEGORY_DEBUG_MAPPING "debug-mapping"
@@ -144,6 +142,10 @@
 #define LOG_CATEGORY_GAME_TRAITOR "game-traitor"
 #define LOG_CATEGORY_GAME_VOTE "game-vote"
 #define LOG_CATEGORY_GAME_WHISPER "game-whisper"
+
+// HREF categories
+#define LOG_CATEGORY_HREF "href"
+#define LOG_CATEGORY_HREF_TGUI "href-tgui"
 
 // Uplink categories
 #define LOG_CATEGORY_UPLINK "uplink"

--- a/code/__DEFINES/logging.dm
+++ b/code/__DEFINES/logging.dm
@@ -95,6 +95,7 @@
 #define LOG_CATEGORY_MANIFEST "manifest"
 #define LOG_CATEGORY_MECHA "mecha"
 #define LOG_CATEGORY_PAPER "paper"
+#define LOG_CATEGORY_QDEL "qdel"
 #define LOG_CATEGORY_RUNTIME "runtime"
 #define LOG_CATEGORY_SHUTTLE "shuttle"
 #define LOG_CATEGORY_SILICON "silicon"
@@ -104,9 +105,9 @@
 #define LOG_CATEGORY_SUSPICIOUS_LOGIN "supicious-login"
 #define LOG_CATEGORY_TARGET_ZONE_SWITCH "target-zone-switch"
 #define LOG_CATEGORY_TELECOMMS "telecomms"
+#define LOG_CATEGORY_TGUI "tgui"
 #define LOG_CATEGORY_TOOL "tool"
 #define LOG_CATEGORY_VIRUS "virus"
-#define LOG_CATEGORY_QDEL "qdel"
 
 // Admin categories
 #define LOG_CATEGORY_ADMIN "admin"
@@ -126,7 +127,6 @@
 #define LOG_CATEGORY_DEBUG_MAPPING "debug-mapping"
 #define LOG_CATEGORY_DEBUG_MOBTAG "debug-mobtag"
 #define LOG_CATEGORY_DEBUG_SQL "debug-sql"
-#define LOG_CATEGORY_DEBUG_TGUI "debug-tgui"
 
 // Compatibility categories, for when stuff is changed and you need existing functionality to work
 #define LOG_CATEGORY_COMPAT_GAME "game-compat"

--- a/code/__HELPERS/logging/ui.dm
+++ b/code/__HELPERS/logging/ui.dm
@@ -1,5 +1,5 @@
 /proc/log_href(text, list/data)
-	logger.Log(LOG_CATEGORY_DEBUG_HREF, text, data)
+	logger.Log(LOG_CATEGORY_HREF, text, data)
 
 /**
  * Appends a tgui-related log entry. All arguments are optional.
@@ -36,4 +36,4 @@
 	// Insert message
 	if(message)
 		entry += "\n[message]"
-	logger.Log(LOG_CATEGORY_TGUI, entry)
+	logger.Log(LOG_CATEGORY_HREF_TGUI, entry)

--- a/code/__HELPERS/logging/ui.dm
+++ b/code/__HELPERS/logging/ui.dm
@@ -9,7 +9,7 @@
 	message,
 	context,
 	datum/tgui_window/window,
-	datum/src_object
+	datum/src_object,
 )
 
 	var/entry = ""

--- a/code/__HELPERS/logging/ui.dm
+++ b/code/__HELPERS/logging/ui.dm
@@ -4,9 +4,14 @@
 /**
  * Appends a tgui-related log entry. All arguments are optional.
  */
-/proc/log_tgui(user, message, context,
-		datum/tgui_window/window,
-		datum/src_object)
+/proc/log_tgui(
+	user,
+	message,
+	context,
+	datum/tgui_window/window,
+	datum/src_object
+)
+
 	var/entry = ""
 	// Insert user info
 	if(!user)
@@ -31,4 +36,4 @@
 	// Insert message
 	if(message)
 		entry += "\n[message]"
-	logger.Log(LOG_CATEGORY_DEBUG_TGUI, entry)
+	logger.Log(LOG_CATEGORY_TGUI, entry)

--- a/code/modules/logging/categories/log_category_debug.dm
+++ b/code/modules/logging/categories/log_category_debug.dm
@@ -1,10 +1,6 @@
 /datum/log_category/debug
 	category = LOG_CATEGORY_DEBUG
 
-/datum/log_category/debug_tgui
-	category = LOG_CATEGORY_DEBUG_TGUI
-	master_category = /datum/log_category/debug
-
 /datum/log_category/debug_sql
 	category = LOG_CATEGORY_DEBUG_SQL
 	master_category = /datum/log_category/debug
@@ -20,7 +16,6 @@
 // This is not in the debug master category on purpose, do not add it
 /datum/log_category/debug_runtime
 	category = LOG_CATEGORY_RUNTIME
-	internal_formatting = FALSE
 
 /datum/log_category/debug_mapping
 	category = LOG_CATEGORY_DEBUG_MAPPING

--- a/code/modules/logging/categories/log_category_debug.dm
+++ b/code/modules/logging/categories/log_category_debug.dm
@@ -9,10 +9,6 @@
 	category = LOG_CATEGORY_DEBUG_LUA
 	master_category = /datum/log_category/debug
 
-/datum/log_category/debug_href
-	category = LOG_CATEGORY_DEBUG_HREF
-	master_category = /datum/log_category/debug
-
 // This is not in the debug master category on purpose, do not add it
 /datum/log_category/debug_runtime
 	category = LOG_CATEGORY_RUNTIME

--- a/code/modules/logging/categories/log_category_href.dm
+++ b/code/modules/logging/categories/log_category_href.dm
@@ -1,0 +1,6 @@
+/datum/log_category/href
+	category = LOG_CATEGORY_HREF
+
+/datum/log_category/href_tgui
+	category = LOG_CATEGORY_HREF_TGUI
+	master_category = /datum/log_category/href

--- a/code/modules/logging/categories/log_category_misc.dm
+++ b/code/modules/logging/categories/log_category_misc.dm
@@ -58,8 +58,11 @@
 	config_flag = /datum/config_entry/flag/log_speech_indicators
 
 // Logs seperately, printed into on server shutdown to store hard deletes and such
-/datum/log_category/debug_qdel
+/datum/log_category/qdel
 	category = LOG_CATEGORY_QDEL
 	// We want this human readable so it's easy to see at a glance
 	entry_flags = ENTRY_USE_DATA_W_READABLE
-	internal_formatting = FALSE
+
+/datum/log_category/tgui
+	category = LOG_CATEGORY_TGUI
+	master_category = /datum/log_category/debug

--- a/code/modules/logging/categories/log_category_misc.dm
+++ b/code/modules/logging/categories/log_category_misc.dm
@@ -62,7 +62,3 @@
 	category = LOG_CATEGORY_QDEL
 	// We want this human readable so it's easy to see at a glance
 	entry_flags = ENTRY_USE_DATA_W_READABLE
-
-/datum/log_category/tgui
-	category = LOG_CATEGORY_TGUI
-	master_category = /datum/log_category/debug

--- a/code/modules/logging/log_category.dm
+++ b/code/modules/logging/log_category.dm
@@ -21,6 +21,7 @@
 	var/secret = FALSE
 
 	/// Whether the readable version of the log message is formatted internally instead of by rustg
+	/// IF YOU CHANGE THIS VERIFY LOGS ARE STILL PARSED CORRECTLY
 	var/internal_formatting = FALSE
 
 	/// List of log entries for this category

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3790,6 +3790,7 @@
 #include "code\modules\logging\categories\log_category_compats.dm"
 #include "code\modules\logging\categories\log_category_debug.dm"
 #include "code\modules\logging\categories\log_category_game.dm"
+#include "code\modules\logging\categories\log_category_href.dm"
 #include "code\modules\logging\categories\log_category_misc.dm"
 #include "code\modules\logging\categories\log_category_pda.dm"
 #include "code\modules\logging\categories\log_category_silo.dm"


### PR DESCRIPTION
## About The Pull Request

Splits out tgui from the debug master category at the request of @Fikou 
Removes pointless overrides of internal_format since the default is now FALSE and also adds an additional comment about ensuring the shit works if you change the default.

## Why It's Good For The Game

I believe the original reason was that fikou didnt want to sort through the entire debug log for tgui stuff.

## Changelog
