### PR TITLE
Adds secure morgue access to lowpop roboticist extra access

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -904,6 +904,7 @@
 	extra_access = list(
 		ACCESS_GENETICS,
 		ACCESS_XENOBIOLOGY,
+		ACCESS_MORGUE_SECURE,
 		)
 	template_access = list(
 		ACCESS_CAPTAIN,


### PR DESCRIPTION
## About The Pull Request

In case of a skeleton crew (sybil 90% of the time/Campbell/lowpop), jobs get extra access to their id
Roboticists now also get secure morgue access to that extra access

## Why It's Good For The Game

Allows roboticists to conveniently walk to the secure part of morgue to buy an autopsy scanner to actually unlock 90% of their tech whenever its lowpop and a coroner is likely not present alongside most roles with said access

## Changelog
:cl:
balance: roboticists now have secure morgue access in their extra access
/:cl:
