### PR TITLE
Fix organ damage being uncapped

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -116,7 +116,7 @@
  * * maximum - currently an arbitrarily large number, can be set so as to limit damage
  * * required_organ_flag - targets only a specific organ type if set to ORGAN_ORGANIC or ORGAN_ROBOTIC
  */
-/mob/living/carbon/adjustOrganLoss(slot, amount, maximum = INFINITY, required_organ_flag = NONE)
+/mob/living/carbon/adjustOrganLoss(slot, amount, maximum, required_organ_flag = NONE)
 	var/obj/item/organ/affected_organ = get_organ_slot(slot)
 	if(!affected_organ || (status_flags & GODMODE))
 		return

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -240,6 +240,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 /obj/item/organ/proc/apply_organ_damage(damage_amount, maximum = maxHealth, required_organ_flag = NONE) //use for damaging effects
 	if(!damage_amount) //Micro-optimization.
 		return
+	maximum = clamp(maximum, 0, maxHealth) // the logical max is, our max
 	if(maximum < damage)
 		return
 	if(required_organ_flag && !(organ_flags & required_organ_flag))


### PR DESCRIPTION
## About The Pull Request

`maximum` being null caused it to default to `maxHealth` which was a sensible value

instead it was passing infinite to apply organ damage which then clamped damage to infinity instead of max health

unit test pending in a follow up pr

Fixes #76435

## Changelog

:cl: Melbert
fix: Fix organ damage being uncapped
/:cl:
