### PR TITLE
Fixes the ORM not correcty granting mining points if adding ore by hand

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -210,7 +210,8 @@
 		if(isnull(O.refined_type))
 			to_chat(user, span_warning("[O] has already been refined!"))
 			return
-
+		smelt_ore(O)
+		return TRUE
 	return ..()
 
 /obj/machinery/mineral/ore_redemption/AltClick(mob/living/user)


### PR DESCRIPTION

## About The Pull Request
This was an oversight from back when material datums were redone. Ideally you should still be dumping your ore on the floor so the ORM can slurp it up, but if for some reason you just want to add it by hand, this works fine.

## Why It's Good For The Game
Consistency good.

Fixes #76409

## Changelog
:cl: Vekter
fix: Fixed the ORM not granting mining points if you added ore by hand instead of dumping it on the floor.
/:cl:
