### PR TITLE
Removes excess ID boxes from the HoP's office and adds silver IDs to their locker.

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -22555,14 +22555,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/item/storage/box/pdas{
-	pixel_x = 7;
-	pixel_y = 12
-	},
-/obj/item/storage/box/ids{
-	pixel_x = 7;
-	pixel_y = 3
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/diagonal,
 /area/station/command/heads_quarters/hop)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -47711,7 +47711,6 @@
 	req_access = list("hop")
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/papercutter,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "lQV" = (
@@ -62697,7 +62696,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/item/paper/fluff/ids_for_dummies,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
@@ -63828,11 +63826,8 @@
 /area/station/command/heads_quarters/captain)
 "pXM" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/ids{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/silver_ids,
+/obj/item/papercutter,
+/obj/item/paper/fluff/ids_for_dummies,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "pXW" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10412,15 +10412,6 @@
 "dho" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/briefcase,
-/obj/item/storage/box/pdas{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/silver_ids{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/item/storage/box/ids,
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -39674,6 +39665,10 @@
 	dir = 4
 	},
 /area/station/service/chapel)
+"mJv" = (
+/obj/item/paper/fluff/ids_for_dummies,
+/turf/open/genturf,
+/area/icemoon/underground/unexplored/rivers/deep)
 "mJD" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -79227,7 +79222,7 @@ oSU
 oSU
 oSU
 oSU
-oSU
+mJv
 oSU
 oSU
 oSU

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4992,7 +4992,6 @@
 /obj/machinery/modular_computer/preset/id{
 	dir = 4
 	},
-/obj/item/paper/fluff/ids_for_dummies,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "bSm" = (
@@ -48915,16 +48914,11 @@
 	c_tag = "Head of Personnel's Office"
 	},
 /obj/structure/table/wood,
-/obj/item/storage/box/pdas{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/silver_ids,
-/obj/item/storage/box/ids,
 /obj/machinery/light/directional/south,
 /obj/item/papercutter{
 	pixel_x = -4
 	},
+/obj/item/paper/fluff/ids_for_dummies,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "rJz" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -109,9 +109,6 @@
 	},
 /obj/item/folder/blue,
 /obj/machinery/light/small/directional/west,
-/obj/item/hand_labeler{
-	pixel_y = 8
-	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "aba" = (
@@ -10856,15 +10853,7 @@
 "cGI" = (
 /obj/structure/table,
 /obj/item/paper_bin/construction,
-/obj/item/pen/fountain{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/item/pen/fountain,
-/obj/item/pen/fountain{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/hop)
 "cGQ" = (
@@ -31162,13 +31151,7 @@
 "idM" = (
 /obj/structure/table,
 /obj/machinery/status_display/evac/directional/north,
-/obj/item/paper_bin/construction{
-	pixel_x = -6
-	},
-/obj/item/paper_bin,
-/obj/item/storage/box/pdas{
-	pixel_x = 10
-	},
+/obj/item/papercutter,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "iea" = (
@@ -66699,11 +66682,6 @@
 /area/station/medical/paramedic)
 "rmm" = (
 /obj/structure/table,
-/obj/item/storage/box/ids{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/silver_ids,
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/requests_console/directional/north{
 	department = "Head of Personnel's Desk";
@@ -66712,6 +66690,9 @@
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
+/obj/item/hand_labeler{
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "rmu" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -36187,14 +36187,10 @@
 /area/station/security/courtroom/holding)
 "lPd" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/pdas{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/pdas,
 /obj/item/papercutter{
 	pixel_x = -4
 	},
+/obj/item/paper/fluff/ids_for_dummies,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "lPl" = (
@@ -50369,6 +50365,10 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"raH" = (
+/obj/item/paper/fluff/ids_for_dummies,
+/turf/open/misc/asteroid/airless,
+/area/station/asteroid)
 "raP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54349,13 +54349,6 @@
 /obj/item/storage/secure/briefcase{
 	pixel_x = -2;
 	pixel_y = 6
-	},
-/obj/item/storage/box/silver_ids{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/assembly/flash/handheld{
-	pixel_x = -8
 	},
 /obj/structure/cable,
 /turf/open/floor/wood,
@@ -74951,7 +74944,7 @@ aaa
 gcp
 gcp
 gcp
-aac
+raH
 aac
 aaa
 aaa

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -13,7 +13,6 @@
 	new /obj/item/pet_carrier(src)
 	new /obj/item/storage/bag/garment/captain(src)
 	new /obj/item/computer_disk/command/captain(src)
-	new /obj/item/storage/box/silver_ids(src)
 	new /obj/item/radio/headset/heads/captain/alt(src)
 	new /obj/item/radio/headset/heads/captain(src)
 	new /obj/item/storage/belt/sabre(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -34,7 +34,7 @@
 	new /obj/item/computer_disk/command/hop(src)
 	new /obj/item/radio/headset/heads/hop(src)
 	new /obj/item/storage/box/ids(src)
-	new /obj/item/storage/box/ids(src)
+	new /obj/item/storage/box/silver_ids(src)
 	new /obj/item/megaphone/command(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/gun/energy/e_gun(src)


### PR DESCRIPTION

## About The Pull Request

Every ID, silver ID, and PDA box has been removed from the maps. You can now only find ID boxes on the HoP's locker and PDAs must be bought from the tech vendor. Said locker also had two instances of ID boxes, so i've swapped one of them for the silver ID box
## Why It's Good For The Game

tram had, in total, 5 ID boxes. That's *35 IDs in total.* No one is ever gonna lose that much, and having 7 is more than enough. If a situation happens where you somehow need more, you can still buy it on the tech vendor AND on cargo. I realized how many boxes the HoP had on the other PR
## Changelog
:cl:
del: Removed excess ID boxes on HoP's office
/:cl:
