### PR TITLE
Frontier Militia ERT Fix [NO GBP]

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -118,7 +118,7 @@
 	ert_template = /datum/map_template/shuttle/ert/bounty
 
 /datum/ert/militia
-	roles = list(/datum/antagonist/ert/militia, /datum/antagonist/ert/militia/general)
+	roles = list(/datum/antagonist/ert/militia)
 	leader_role = /datum/antagonist/ert/militia/general
 	teamsize = 4
 	opendoors = FALSE

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -279,9 +279,9 @@
 /datum/antagonist/ert/militia
 	name = "Frontier Militia"
 	outfit = /datum/outfit/centcom/militia
-	role = "Minuteman"
+	role = "Volunteer"
 
 /datum/antagonist/ert/militia/general
 	name = "Frontier Militia General"
 	outfit = /datum/outfit/centcom/militia/general
-	role = "Minuteman Leader"
+	role = "General"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -551,7 +551,7 @@
 	back = /obj/item/storage/backpack/satchel/leather
 	l_pocket = /obj/item/switchblade
 	r_pocket = /obj/item/reagent_containers/hypospray/medipen/salacid
-	belt = /obj/item/storage/belt/holster/energy/thermal
+	ears = /obj/item/radio/headset
 	backpack_contents = list(
 			/obj/item/storage/box/survival = 1,
 			/obj/item/storage/medkit/emergency = 1,


### PR DESCRIPTION
## About The Pull Request
Makes sure only ONE LEADER SPAWNS instead of like 3
Also they have headsets
And I removed their energy pistols
Renames the ERT roles to shorten the names, I totally didn't get how that worked
## Why It's Good For The Game
TOO MANY LEADERS WERE SPAWNING
Headsets good
The energy pistols detracted from the musket, which is what makes em unique and fun.
The ERT names were too direct a reference.
## Changelog
:cl:
fix: Frontier Militia only have one general now, and have headsets.
balance: Frontier Militia no longer have energy pistols.
/:cl:
