### PR TITLE
Fix mouse colour subtypes

### DIFF
--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -44,7 +44,8 @@
 	ADD_TRAIT(src, TRAIT_VENTCRAWLER_ALWAYS, INNATE_TRAIT)
 
 	src.tame = tame
-	body_color = new_body_color
+	if(!isnull(new_body_color))
+		body_color = new_body_color
 	if(isnull(body_color))
 		body_color = pick("brown", "gray", "white")
 	held_state = "mouse_[body_color]" // not handled by variety element


### PR DESCRIPTION
## About The Pull Request

Allows the specifically coloured mouse subtypes to work. If you want a brown mouse then by god you are going to get one.

## Why It's Good For The Game

I will be honest that I don't know if anyone even cares about this but I guess it restore's Tom's consistent colour, which was presumably broken.

## Changelog

:cl:
fix: Tom will now always be a brown rat, instead of a random colour, as intended.
/:cl:
