### PR TITLE
Emergency Relief Capsule

### DIFF
--- a/_maps/templates/shelter_t.dmm
+++ b/_maps/templates/shelter_t.dmm
@@ -1,0 +1,46 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/misc/survivalpod)
+"e" = (
+/obj/structure/sign/warning/biohazard,
+/turf/closed/wall/mineral/titanium/survival/pod,
+/area/misc/survivalpod)
+"C" = (
+/obj/machinery/door/airlock/survival_pod/glass,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "podtoilet";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/pod,
+/area/misc/survivalpod)
+"H" = (
+/obj/structure/toilet,
+/obj/item/paper{
+	pixel_x = 7;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/trimline/red,
+/obj/machinery/button/door/directional/east{
+	id = "podtoilet";
+	name = "Privacy Shutters";
+	pixel_y = 6
+	},
+/turf/open/floor/pod,
+/area/misc/survivalpod)
+
+(1,1,1) = {"
+a
+e
+a
+"}
+(2,1,1) = {"
+a
+H
+C
+"}
+(3,1,1) = {"
+a
+a
+a
+"}

--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -79,6 +79,10 @@
 	item_path = /obj/item/survivalcapsule
 	cost_per_order = 400
 
+/datum/orderable_item/mining/capsule/bathroom
+	item_path = /obj/item/survivalcapsule/bathroom
+	cost_per_order = 375
+
 /datum/orderable_item/mining/capsule_luxury
 	item_path = /obj/item/survivalcapsule/luxury
 	cost_per_order = 3000

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -79,6 +79,11 @@
 	desc = "A luxury bar in a capsule. Bartender required and not included."
 	template_id = "shelter_charlie"
 
+/obj/item/survivalcapsule/bathroom
+	name = "emergency relief capsule"
+	desc = "Provides vital emergency support to employees who are caught short in the field."
+	template_id = "shelter_toilet"
+
 //Pod objects
 
 //Window

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -63,7 +63,10 @@
 	new /obj/item/t_scanner/adv_mining_scanner/lesser(src)
 	new /obj/item/gun/energy/recharge/kinetic_accelerator(src)
 	new /obj/item/clothing/glasses/meson(src)
-	new /obj/item/survivalcapsule(src)
+	if (HAS_TRAIT(SSstation, STATION_TRAIT_SMALLER_PODS))
+		new /obj/item/survivalcapsule/bathroom(src)
+	else
+		new /obj/item/survivalcapsule(src)
 	new /obj/item/assault_pod/mining(src)
 
 

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -85,3 +85,16 @@
 	. = ..()
 	whitelisted_turfs = typecacheof(/turf/closed/mineral)
 	banned_objects = typecacheof(/obj/structure/stone_tile)
+
+/datum/map_template/shelter/toilet
+	name = "Emergency Relief Shelter"
+	shelter_id = "shelter_toilet"
+	description = "A stripped-down emergency shelter focused on providing \
+		only the most essential amenities to unfortunate employees who find \
+		themselves in need far from home."
+	mappath = "_maps/templates/shelter_t.dmm"
+
+/datum/map_template/shelter/toilet/New()
+	. = ..()
+	whitelisted_turfs = typecacheof(/turf/closed/mineral)
+	banned_objects = typecacheof(/obj/structure/stone_tile)


### PR DESCRIPTION
## About The Pull Request

Getting back into coding by making some soul PRs.
Adds a new kind of bluespace capsule which replaces the default one when the "budget pods" station trait runs, and is available from the vendor for a (marginal) discount.

![image](https://github.com/tgstation/tgstation/assets/7483112/3fdf30e4-56c3-4181-9f8f-d11b6ec7a5e5)
![image](https://github.com/tgstation/tgstation/assets/7483112/a47581aa-ee2b-47c4-bd91-5a71391c2dd9)

The Nanotrasen Emergency Relief Capsule provides a port in the storm for people with an urgent need, and very little else.

## Why It's Good For The Game

This one is mostly just kind of funny I'll be honest.
I guess it uuuuuuuh provides a kind of pod with no GPS signal if you really want to go off the grid? But anything I write here is secondary to the point of "someone suggested it on the forums and I liked it".

## Changelog

:cl:
add: Budget cuts can sometimes effect the station's supply of Emergency Bluespace Shelters.
/:cl:
