### PR TITLE
Monkeyize() now gives you an anonymous monkey name.

### DIFF
--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -28,6 +28,8 @@
 	icon = initial(icon)
 	invisibility = 0
 	set_species(/datum/species/monkey)
+	name = "monkey"
+	set_name()
 	SEND_SIGNAL(src, COMSIG_HUMAN_MONKEYIZE)
 	uncuff()
 	regenerate_icons()

--- a/code/modules/unit_tests/lesserform.dm
+++ b/code/modules/unit_tests/lesserform.dm
@@ -3,6 +3,7 @@
 
 /datum/unit_test/lesserform/Run()
 	var/mob/living/carbon/human/changeling = allocate(/mob/living/carbon/human/consistent)
+	var/name = changeling.name
 	changeling.mind_initialize()
 	var/datum/mind/mind = changeling.mind
 	var/datum/antagonist/changeling/changeling_datum = mind.add_antag_datum(/datum/antagonist/changeling)
@@ -13,11 +14,13 @@
 
 	transform_ability.Trigger()
 	TEST_ASSERT(ismonkey(changeling), "Changeling failed to turn into a monkey after voluntarily transforming using lesser form.")
+	TEST_ASSERT_NOTEQUAL(name, changeling.name, "Monkeyisation failed to anonymise changeling's name.")
 	changeling.humanize(instant = TRUE)
 	transform_ability.Trigger()
 	TEST_ASSERT(ismonkey(changeling), "Changeling failed to turn into a monkey after involuntarily being made into a human.")
 	transform_ability.Trigger()
 	TEST_ASSERT(!ismonkey(changeling), "Changeling failed to stop being a monkey after voluntarily transforming using lesser form.")
+	TEST_ASSERT_EQUAL(name, changeling.name, "Returning from monkey form failed to restore original name.")
 	changeling.monkeyize(instant = TRUE)
 	transform_ability.Trigger()
 	TEST_ASSERT(!ismonkey(changeling), "Changeling failed to stop being a monkey after being involuntarily turned into one.")


### PR DESCRIPTION
## About The Pull Request

Previously Lesser Form would transform you into a monkey with the same name as you had before transforming.
Nobody has complained about this because nobody uses Lesser Form for its intended purpose, but it should probably work for that anyway.

Now when you use Lesser Form it will call you "monkey (420)" or something instead, so it's less obvious that you're just larping as a monkey.
I checked and you still get your name back if you're a normal human who gets turned into one and back via DNA machine don't worry.

Also I unit test it.

## Why It's Good For The Game

Allows ability to be used for its presumed intended purpose.

## Changelog

:cl:
fix: Lesser Form monkeys no longer maintain the name of the form you had prior to transformation.
/:cl:
