### PR TITLE
Fixes a typo on the Interdyne shuttle

### DIFF
--- a/_maps/shuttles/pirate_Interdyne.dmm
+++ b/_maps/shuttles/pirate_Interdyne.dmm
@@ -213,7 +213,7 @@
 	pixel_x = -8
 	},
 /obj/item/disk/surgery/sleeper_protocol{
-	name = "Interdyne Sleeper Protocal Surgery Disk";
+	name = "Interdyne Sleeper Protocol Surgery Disk";
 	pixel_x = 1
 	},
 /obj/item/disk/surgery/forgottenship{
@@ -723,7 +723,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/light/small/blacklight/directional/south,
 /obj/item/reagent_containers/cup/beaker/meta/salbutamol{
-	list_reagents = list(/datum/reagent/medicine/c2/convermol = 180)
+	list_reagents = list(/datum/reagent/medicine/c2/convermol=180)
 	},
 /obj/item/wrench/medical,
 /turf/open/floor/iron/dark,


### PR DESCRIPTION
## About The Pull Request
Fixes #76463

## Why It's Good For The Game
Critical that everything is spelled correctly or I might pop a blood vessel

## Changelog
:cl: Vekter
spellcheck: Fixed a typo on the Interdyne shuttle.
/:cl:
