### PR TITLE
Increases throwing weapons box storage to fit reinforced bolas and stuff it spawns with.

### DIFF
--- a/code/game/objects/items/storage/boxes/engineering_boxes.dm
+++ b/code/game/objects/items/storage/boxes/engineering_boxes.dm
@@ -22,6 +22,13 @@
 	name = "box of materials"
 	illustration = "implant"
 
+/obj/item/storage/box/material/Initialize(mapload)
+	. = ..()
+	atom_storage.allow_big_nesting = TRUE
+	atom_storage.max_slots = 99
+	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC
+	atom_storage.max_total_storage = 99
+
 /obj/item/storage/box/material/PopulateContents() //less uranium because radioactive
 	var/static/items_inside = list(
 		/obj/item/stack/sheet/iron/fifty=1,
@@ -49,6 +56,13 @@
 /obj/item/storage/box/debugtools
 	name = "box of debug tools"
 	icon_state = "syndiebox"
+
+/obj/item/storage/box/debugtools/Initialize(mapload)
+	. = ..()
+	atom_storage.allow_big_nesting = TRUE
+	atom_storage.max_slots = 99
+	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC
+	atom_storage.max_total_storage = 99
 
 /obj/item/storage/box/debugtools/PopulateContents()
 	var/static/items_inside = list(

--- a/code/game/objects/items/storage/boxes/science_boxes.dm
+++ b/code/game/objects/items/storage/boxes/science_boxes.dm
@@ -112,6 +112,13 @@
 	name = "box of stabilized extracts"
 	icon_state = "syndiebox"
 
+/obj/item/storage/box/stabilized/Initialize(mapload)
+	. = ..()
+	atom_storage.allow_big_nesting = TRUE
+	atom_storage.max_slots = 99
+	atom_storage.max_specific_storage = WEIGHT_CLASS_GIGANTIC
+	atom_storage.max_total_storage = 99
+
 /obj/item/storage/box/stabilized/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/slimecross/stabilized/adamantine=1,

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -515,6 +515,17 @@
 	new /obj/item/restraints/legcuffs/bola/tactical(src)
 	new /obj/item/restraints/legcuffs/bola/tactical(src)
 
+/obj/item/storage/box/syndie_kit/throwing_weapons/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 9 // 5 + 2 + 2
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.max_total_storage = 18 // 5*2 + 2*1 + 3*2
+	atom_storage.set_holdable(list(
+		/obj/item/restraints/legcuffs/bola/tactical,
+		/obj/item/paperplane/syndicate,
+		/obj/item/throwing_star,
+	))
+
 /obj/item/storage/box/syndie_kit/cutouts/PopulateContents()
 	for(var/i in 1 to 3)
 		new/obj/item/cardboard_cutout/adaptive(src)


### PR DESCRIPTION

## About The Pull Request

- Increased box with throwing weapons storage to fit the things it spawns with, such as reinforced bolas.
- Increased debug boxes to fit other boxes and the items it spawns with too.
## Why It's Good For The Game
Less bluespace magic.
## Changelog
:cl:
qol: Box with throwing weapons now can hold the items it spawns with. Incredible!
admin: Boxex of materials, debugtools and stabilized extracts now 99 of total storage because they are meant to be debug.
/:cl:
