### PR TITLE
Applies the IC word filters to emotes.

### DIFF
--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -654,7 +654,12 @@
 		return FALSE
 
 	if(!params)
-		emote_type = get_custom_emote_type_from_user()
+		var/user_emote_type = get_custom_emote_type_from_user()
+
+		if(!user_emote_type)
+			return FALSE
+
+		emote_type = user_emote_type
 	else if(type_override)
 		emote_type = type_override
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -584,6 +584,11 @@
 	. = ..() && intentional
 
 /datum/emote/living/custom/proc/emote_is_valid(mob/user, input)
+	// We're assuming clientless mobs custom emoting is something codebase-driven and not player-driven.
+	// If players ever get the ability to force clientless mobs to emote, we'd need to reconsider this.
+	if(!user.client)
+		return TRUE
+
 	if(CAN_BYPASS_FILTER(user))
 		return TRUE
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -583,45 +583,83 @@
 /datum/emote/living/custom/can_run_emote(mob/user, status_check, intentional)
 	. = ..() && intentional
 
-/datum/emote/living/custom/proc/check_invalid(mob/user, input)
+/datum/emote/living/custom/proc/emote_is_valid(mob/user, input)
+	if(CAN_BYPASS_FILTER(user))
+		return TRUE
+
 	var/static/regex/stop_bad_mime = regex(@"says|exclaims|yells|asks")
 	if(stop_bad_mime.Find(input, 1, 1))
 		to_chat(user, span_danger("Invalid emote."))
-		return TRUE
-	return FALSE
+		return FALSE
+
+	var/list/filter_result = is_ic_filtered(input)
+
+	if(filter_result)
+		to_chat(user, span_warning("That emote contained a word prohibited in IC emotes! Consider reviewing the server rules."))
+		to_chat(user, span_warning("\"[input]\""))
+		REPORT_CHAT_FILTER_TO_USER(user, filter_result)
+		log_filter("IC Emote", input, filter_result)
+		SSblackbox.record_feedback("tally", "ic_blocked_words", 1, lowertext(config.ic_filter_regex.match))
+		return FALSE
+
+	filter_result = is_soft_ic_filtered(input)
+
+	if(filter_result)
+		if(tgui_alert(user,"Your emote contains \"[filter_result[CHAT_FILTER_INDEX_WORD]]\". \"[filter_result[CHAT_FILTER_INDEX_REASON]]\", Are you sure you want to emote it?", "Soft Blocked Word", list("Yes", "No")) != "Yes")
+			SSblackbox.record_feedback("tally", "soft_ic_blocked_words", 1, lowertext(config.soft_ic_filter_regex.match))
+			log_filter("Soft IC Emote", input, filter_result)
+			return FALSE
+
+		message_admins("[ADMIN_LOOKUPFLW(user)] has passed the soft filter for emote \"[filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term. Emote: \"[input]\"")
+		log_admin_private("[key_name(user)] has passed the soft filter for emote \"[filter_result[CHAT_FILTER_INDEX_WORD]]\" they may be using a disallowed term. Emote: \"[input]\"")
+		SSblackbox.record_feedback("tally", "passed_soft_ic_blocked_words", 1, lowertext(config.soft_ic_filter_regex.match))
+		log_filter("Soft IC Emote (Passed)", input, filter_result)
+
+	return TRUE
+
+/datum/emote/living/custom/proc/get_custom_emote_from_user()
+	return copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
+
+/datum/emote/living/custom/proc/get_custom_emote_type_from_user()
+	var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
+
+	switch(type)
+		if("Visible")
+			return EMOTE_VISIBLE
+		if("Hearable")
+			return EMOTE_AUDIBLE
+		else
+			tgui_alert(usr,"Unable to use this emote, must be either hearable or visible.")
+			return FALSE
 
 /datum/emote/living/custom/run_emote(mob/user, params, type_override = null, intentional = FALSE)
-	var/custom_emote
-	var/custom_emote_type
 	if(!can_run_emote(user, TRUE, intentional))
 		return FALSE
+
 	if(is_banned_from(user.ckey, "Emote"))
 		to_chat(user, span_boldwarning("You cannot send custom emotes (banned)."))
 		return FALSE
-	else if(QDELETED(user))
+
+	if(QDELETED(user))
 		return FALSE
-	else if(user.client && user.client.prefs.muted & MUTE_IC)
+
+	if(user.client && user.client.prefs.muted & MUTE_IC)
 		to_chat(user, span_boldwarning("You cannot send IC messages (muted)."))
 		return FALSE
-	else if(!params)
-		custom_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
-		if(custom_emote && !check_invalid(user, custom_emote))
-			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
-			switch(type)
-				if("Visible")
-					custom_emote_type = EMOTE_VISIBLE
-				if("Hearable")
-					custom_emote_type = EMOTE_AUDIBLE
-				else
-					tgui_alert(usr,"Unable to use this emote, must be either hearable or visible.")
-					return
-	else
-		custom_emote = params
-		if(type_override)
-			custom_emote_type = type_override
-	message = custom_emote
-	emote_type = custom_emote_type
+
+	message = params ? params : get_custom_emote_from_user()
+
+	if(!emote_is_valid(user, message))
+		message = null
+		return FALSE
+
+	if(!params)
+		emote_type = get_custom_emote_type_from_user()
+	else if(type_override)
+		emote_type = type_override
+
 	. = ..()
+
 	message = null
 	emote_type = EMOTE_VISIBLE
 


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/71570

Since I was digging around in the proc, this does a very minor refactor of custom run_emote code, removing unnecessary if/else statements and pulling behaviour into procs for improved code readability.

Applies IC filters to emotes, which were otherwise completely unfiltered except for the "bad mime" checks.
## Why It's Good For The Game

Users shouldn't be able to bypass the filters via emotes. The hard filters contain netspeak, smileys, acronyms and other OOC in IC content. The soft filters contain potentially rule breaking content that players may wish to think twice about before putting in emotes.
## Changelog
:cl:
fix: Emotes now respect word filters.
/:cl:
