### PR TITLE
Removes a random nondescript item from near Meta Xenobiology 

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -13172,10 +13172,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
-"eWG" = (
-/obj/item,
-/turf/open/space/basic,
-/area/space)
 "eWO" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -118602,7 +118598,7 @@ aaa
 aaa
 aaa
 aaa
-eWG
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Random ass /obj/item floating in space. Don't know how it got there, don't know when.

## Changelog

:cl: Jolly
fix: [MetaStation] There is no longer a random nondescript "item" outside Xenobiology. No, it was NOT a Xenomorph.
/:cl:


