### PR TITLE
Fixes oversight with the voice disable config not working right for situations in which a player re-enters their mob.

### DIFF
--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -4,7 +4,8 @@
 	dna?.species?.on_owner_login(src)
 
 	if(SStts.tts_enabled && !voice)
-		voice = pick(SStts.available_speakers)
+		if(!CONFIG_GET(flag/tts_allow_player_voice_disabling) || !client?.prefs.read_preference(/datum/preference/toggle/tts_voice_disable))
+			voice = pick(SStts.available_speakers)
 
 	if(!LAZYLEN(afk_thefts))
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes oversight with the voice disable config not working right for situations in which a player re-enters their mob.

## Why It's Good For The Game

Bugfix good.

## Changelog
:cl:
fix: Fixes oversight with the voice disable config not working right for situations in which a player re-enters their mob.
/:cl: