### PR TITLE
Fixes nebula vomiting being in the normal symptom pool

### DIFF
--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -63,3 +63,4 @@ and your disease can spread via people walking on vomit.
 	desc = "The condition irritates the stomach, causing occasional vomit with stars that does not stun."
 	illness = "Nebula Nausea"
 	vomit_nebula = TRUE
+	naturally_occuring = FALSE


### PR DESCRIPTION

## About The Pull Request
Fixes #76488.

To my knowledge, these are supposed to be bespoke to the floor contamination PR, not actual symptoms you can roll in a normal virus. If @MTandi corrects me then I'll close this.

## Why It's Good For The Game
Thing not meant to happen happened, this make not happen.

## Changelog
:cl: Vekter
fix: Removed nebula vomiting from the normal symptom pool. It should no longer appear on regular viruses.
/:cl:
