### PR TITLE
Plasma objects no longer violently explode when ignited

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -149,8 +149,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	. = ..()
 	if(ismovable(source))
 		source.AddElement(/datum/element/firestacker, amount=1)
-		// Ideally exploding plasma objects should delete themselves but we still have the flooder and SSexplosions to rely on deleting it asynchronously so it's not that bad.
-		//source.AddComponent(/datum/component/explodable, 0, 0, amount / 2500, 0, amount / 1250, delete_after = EXPLODABLE_NO_DELETE)
 	source.AddComponent(/datum/component/combustible_flooder, "plasma", amount*0.05) //Empty temp arg, fully dependent on whatever ignited it.
 
 /datum/material/plasma/on_removed(atom/source, amount, material_flags)

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -150,7 +150,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	if(ismovable(source))
 		source.AddElement(/datum/element/firestacker, amount=1)
 		// Ideally exploding plasma objects should delete themselves but we still have the flooder and SSexplosions to rely on deleting it asynchronously so it's not that bad.
-		source.AddComponent(/datum/component/explodable, 0, 0, amount / 2500, 0, amount / 1250, delete_after = EXPLODABLE_NO_DELETE)
+		//source.AddComponent(/datum/component/explodable, 0, 0, amount / 2500, 0, amount / 1250, delete_after = EXPLODABLE_NO_DELETE)
 	source.AddComponent(/datum/component/combustible_flooder, "plasma", amount*0.05) //Empty temp arg, fully dependent on whatever ignited it.
 
 /datum/material/plasma/on_removed(atom/source, amount, material_flags)


### PR DESCRIPTION
## About The Pull Request
This is one of those "can I get away with making a change I want" PRs.

I actually didn't know this had been changed before as it's not exactly something I mess with often, but I really think it sucks. Plasma stuff is supposed to ignite and cause fires, not explode (unless in a TTV). I noticed this when I was poking around and found out that apparently Disco Inferno just explodes now instead of setting on fire which also sucks.

I figure there's a few fixes for this problem:

1) Nerf how hard plasma stuff explodes. This is an option, but I kind of dislike that it does it at all more than anything. The biggest issue is that just the regular statues explode with 20 LIGHT, which is pretty fucking massive and basically just delimbs everyone around. I'd have to nerf it HARD for it to get anywhere near what I think is acceptable.
2) Make a snowflake version of the statue that just ignites on hit with a torch. I also don't like this because it'll make people think the regular statues don't explode.
3) This option, which I think is cleaner and just makes sense compared to the others.

I don't know if @vincentiusvin still codes, but as far as I can tell this was their doing, so it's only fair they get to speak up.

Fixes #71894

## Why It's Good For The Game
I don't like it, I think it goes against what we're used to for plasma stuff (that it starts fires, not makes explosions) and it makes one of my favorite shuttles boring and stupid. That being said, I'm honestly not going to fight for this too hard if a lot of people like it, but I am - as always - open to alternatives.

## Changelog
:cl: Vekter
del: Plasma objects (statues, toilets, etc.) no longer explode when ignited. They just release plasma like everything else plasma. (This doesn't impact injecting plasma into cells or dipping cigars in plasma, those still explode.)
/:cl:
