### PR TITLE
Add a heretics sacrifice targets to the end of round report

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -761,5 +761,6 @@
 	r_hand = /obj/item/melee/touch_attack/mansus_fist
 
 /datum/antagonist/heretic/roundend_report_footer()
-	var/message = "<br><b>This heretics sacrifice targets were:</b> [sac_targets]<br>"
+	var/roundend_targets = jointext(sac_targets, ", ")
+	var/message = "<br><b>This heretics sacrifice targets were:</b> [roundend_targets]<br>"
 	return message

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -447,7 +447,9 @@
 
 	parts += printplayer(owner)
 	parts += "<b>Sacrifices Made:</b> [total_sacrifices]"
-
+	var/roundend_targets = jointext(sac_targets, ", ")
+	var/targets = "The heretics targets were [sac_targets]"
+	parts += targets
 	if(length(objectives))
 		var/count = 1
 		for(var/datum/objective/objective as anything in objectives)

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -762,3 +762,4 @@
 
 /datum/antagonist/heretic/roundend_report_footer()
 	var/message = "<br><b>This heretics sacrifice targets were:</b> [sac_targets]<br>"
+	return message

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -762,5 +762,5 @@
 
 /datum/antagonist/heretic/roundend_report_footer()
 	var/roundend_targets = jointext(sac_targets, ", ")
-	var/message = "<br><b>This heretics sacrifice targets were:</b> [roundend_targets]<br>"
+	var/message = "<br><b>The heretics sacrifice targets were:</b> [roundend_targets]<br>"
 	return message

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -448,7 +448,7 @@
 	parts += printplayer(owner)
 	parts += "<b>Sacrifices Made:</b> [total_sacrifices]"
 	var/roundend_targets = jointext(sac_targets, ", ")
-	var/targets = "The heretics targets were [sac_targets]"
+	var/targets = "The heretics targets were [roundend_targets]"
 	parts += targets
 	if(length(objectives))
 		var/count = 1

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -759,3 +759,6 @@
 
 	suit = /obj/item/clothing/suit/hooded/cultrobes/eldritch
 	r_hand = /obj/item/melee/touch_attack/mansus_fist
+
+/datum/antagonist/heretic/roundend_report_footer()
+	var/message = "<br><b>This heretics sacrifice targets were:</b> [sac_targets]<br>"

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -760,7 +760,3 @@
 	suit = /obj/item/clothing/suit/hooded/cultrobes/eldritch
 	r_hand = /obj/item/melee/touch_attack/mansus_fist
 
-/datum/antagonist/heretic/roundend_report_footer()
-	var/roundend_targets = jointext(sac_targets, ", ")
-	var/message = "<br><b>The heretics sacrifice targets were:</b> [roundend_targets]<br>"
-	return message

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -409,7 +409,7 @@
 
 	LAZYSET(sac_targets, target, target_image)
 	RegisterSignal(target, COMSIG_QDELETING, PROC_REF(on_target_deleted))
-	all_sac_targets.add(target.real_name)
+	all_sac_targets.Add(target.real_name)
 
 /**
  * Removes [target] from the heretic's sacrifice list.

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -449,8 +449,7 @@
 
 	parts += printplayer(owner)
 	parts += "<b>Sacrifices Made:</b> [total_sacrifices]"
-	var/roundend_targets = jointext(all_sac_targets, ", ")
-	var/targets = "The heretics targets were [roundend_targets]"
+	var/targets = "The heretic's targets were: [english_list(all_sac_targets, nothing_text = "No one")]."
 	parts += targets
 	if(length(objectives))
 		var/count = 1

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -23,7 +23,7 @@
 	hijack_speed = 0.5
 	suicide_cry = "THE MANSUS SMILES UPON ME!!"
 	preview_outfit = /datum/outfit/heretic
-	var/list/all_sac_targets()
+	var/list/all_sac_targets = list()
 	/// Whether we give this antagonist objectives on gain.
 	var/give_objectives = TRUE
 	/// Whether we've ascended! (Completed one of the final rituals)
@@ -409,7 +409,7 @@
 
 	LAZYSET(sac_targets, target, target_image)
 	RegisterSignal(target, COMSIG_QDELETING, PROC_REF(on_target_deleted))
-	add_sac_target.add(target)
+	all_sac_targets.add(target.real_name)
 
 /**
  * Removes [target] from the heretic's sacrifice list.

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -23,7 +23,6 @@
 	hijack_speed = 0.5
 	suicide_cry = "THE MANSUS SMILES UPON ME!!"
 	preview_outfit = /datum/outfit/heretic
-	var/list/all_sac_targets = list()
 	/// Whether we give this antagonist objectives on gain.
 	var/give_objectives = TRUE
 	/// Whether we've ascended! (Completed one of the final rituals)
@@ -44,6 +43,8 @@
 	var/high_value_sacrifices = 0
 	/// Lazy assoc list of [refs to humans] to [image previews of the human]. Humans that we have as sacrifice targets.
 	var/list/mob/living/carbon/human/sac_targets
+	// list of all targets used for end of round report
+	var/list/all_sac_targets = list()
 	/// Whether we're drawing a rune or not
 	var/drawing_rune = FALSE
 	/// A static typecache of all tools we can scribe with.

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -23,6 +23,7 @@
 	hijack_speed = 0.5
 	suicide_cry = "THE MANSUS SMILES UPON ME!!"
 	preview_outfit = /datum/outfit/heretic
+	var/list/all_sac_targets()
 	/// Whether we give this antagonist objectives on gain.
 	var/give_objectives = TRUE
 	/// Whether we've ascended! (Completed one of the final rituals)
@@ -408,6 +409,7 @@
 
 	LAZYSET(sac_targets, target, target_image)
 	RegisterSignal(target, COMSIG_QDELETING, PROC_REF(on_target_deleted))
+	add_sac_target.add(target)
 
 /**
  * Removes [target] from the heretic's sacrifice list.
@@ -447,7 +449,7 @@
 
 	parts += printplayer(owner)
 	parts += "<b>Sacrifices Made:</b> [total_sacrifices]"
-	var/roundend_targets = jointext(sac_targets, ", ")
+	var/roundend_targets = jointext(all_sac_targets, ", ")
 	var/targets = "The heretics targets were [roundend_targets]"
 	parts += targets
 	if(length(objectives))

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -409,7 +409,7 @@
 
 	LAZYSET(sac_targets, target, target_image)
 	RegisterSignal(target, COMSIG_QDELETING, PROC_REF(on_target_deleted))
-	all_sac_targets.Add(target.real_name)
+	all_sac_targets += target.real_name
 
 /**
  * Removes [target] from the heretic's sacrifice list.

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -43,7 +43,7 @@
 	var/high_value_sacrifices = 0
 	/// Lazy assoc list of [refs to humans] to [image previews of the human]. Humans that we have as sacrifice targets.
 	var/list/mob/living/carbon/human/sac_targets
-	// list of all targets used for end of round report
+	/// List of all sacrifice target's names, used for end of round report
 	var/list/all_sac_targets = list()
 	/// Whether we're drawing a rune or not
 	var/drawing_rune = FALSE
@@ -450,8 +450,7 @@
 
 	parts += printplayer(owner)
 	parts += "<b>Sacrifices Made:</b> [total_sacrifices]"
-	var/targets = "The heretic's targets were: [english_list(all_sac_targets, nothing_text = "No one")]."
-	parts += targets
+	parts += "The heretic's sacrifice targets were: [english_list(all_sac_targets, nothing_text = "No one")]."
 	if(length(objectives))
 		var/count = 1
 		for(var/datum/objective/objective as anything in objectives)


### PR DESCRIPTION
## About The Pull Request
adds a heretics sac targets to the end of round report
## Why It's Good For The Game
lets others know who heretics needed to sac
![image](https://github.com/tgstation/tgstation/assets/61211748/6bed4e3e-4e37-4c2a-b1a9-e24354fd5786)

## Changelog
:cl:
qol: heretic sac targets now appear on the end of round report
/:cl:
