### PR TITLE
Increases morbidity factor (fix morbid surgery boost)

### DIFF
--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -231,7 +231,7 @@
 		return FALSE
 	if(tool && !(tool.item_flags & CRUEL_IMPLEMENT))
 		return FALSE
-	if(surgery.surgery_flags != SURGERY_MORBID_CURIOSITY)
+	if(!(surgery.surgery_flags & SURGERY_MORBID_CURIOSITY))
 		return FALSE
 	return TRUE
 

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -229,7 +229,7 @@
 /datum/surgery_step/proc/check_morbid_curiosity(mob/user, obj/item/tool, datum/surgery/surgery)
 	if(!(user.mind && HAS_TRAIT(user.mind, TRAIT_MORBID)))
 		return FALSE
-	if(!tool || tool && !(tool.item_flags & CRUEL_IMPLEMENT))
+	if(tool && !(tool.item_flags & CRUEL_IMPLEMENT))
 		return FALSE
 	if(surgery.surgery_flags != SURGERY_MORBID_CURIOSITY)
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
Fixes a bug that prevents morbid surgical implements from receiving their 30% speed boost. Also removes a small redundant check in the same area 
## Why It's Good For The Game
Fix bugs!
## Changelog
:cl:

fix: Morbid (coroner's) tools now properly receive their speed boost in appropriate conditions

/:cl:
