### PR TITLE
Makes cargo orders and req forms easier to differentiate

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -323,6 +323,7 @@
 							requisition_text += "- Reason Given: [reason]</br>"
 						requisition_text += "</br></br>"
 					requisition_paper.add_raw_text(requisition_text)
+					requisition_paper.color = "#9ef5ff"
 					requisition_paper.update_appearance()
 
 				ui.user.investigate_log("called the supply shuttle.", INVESTIGATE_CARGO)

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -304,7 +304,7 @@
 				//create the paper from the SSshuttle.shopping_list
 				if(length(SSshuttle.shopping_list))
 					var/obj/item/paper/requisition_paper = new(get_turf(src))
-					requisition_paper.name = "requisition form [station_time_timestamp()]"
+					requisition_paper.name = "requisition form - [station_time_timestamp()]"
 					var/requisition_text = "<h2>[station_name()] Supply Requisition</h2>"
 					requisition_text += "<hr/>"
 					requisition_text += "Time of Order: [station_time_timestamp()]<br/><br/>"

--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -304,7 +304,7 @@
 				//create the paper from the SSshuttle.shopping_list
 				if(length(SSshuttle.shopping_list))
 					var/obj/item/paper/requisition_paper = new(get_turf(src))
-					requisition_paper.name = "requisition form"
+					requisition_paper.name = "requisition form [station_time_timestamp()]"
 					var/requisition_text = "<h2>[station_name()] Supply Requisition</h2>"
 					requisition_text += "<hr/>"
 					requisition_text += "Time of Order: [station_time_timestamp()]<br/><br/>"

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -161,7 +161,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 		if(!spawning_order.pack.goody) //we handle goody crates below
 			var/obj/structure/closet/crate = spawning_order.generate(pick_n_take(empty_turfs))
-			crate.name = crate.name += " - #[spawning_order.id]"
+			crate.name += " - #[spawning_order.id]"
 
 		SSblackbox.record_feedback("nested tally", "cargo_imports", 1, list("[spawning_order.pack.get_cost()]", "[spawning_order.pack.name]"))
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -160,7 +160,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		QDEL_NULL(spawning_order.applied_coupon)
 
 		if(!spawning_order.pack.goody) //we handle goody crates below
-			spawning_order.generate(pick_n_take(empty_turfs))
+			var/obj/structure/closet/crate = spawning_order.generate(pick_n_take(empty_turfs))
+			crate.name = crate.name += " - #[spawning_order.id]"
 
 		SSblackbox.record_feedback("nested tally", "cargo_imports", 1, list("[spawning_order.pack.get_cost()]", "[spawning_order.pack.name]"))
 


### PR DESCRIPTION
## About The Pull Request
This PR makes two very simple changes. First, requisition forms printed off by the order consoles in cargo now print with a timestamp on the name, so that it's a bit easier to differentiate between forms when there's a bunch of them. Second, crates that come on the cargo shuttle now have the order ID they are associated with appended to their name.
The req forms:
![image](https://github.com/tgstation/tgstation/assets/42454181/233777d9-79ed-4bf7-9d62-4d4b65ce88c7)

As well as two crates that would normally be impossible to differentiate
![image](https://github.com/tgstation/tgstation/assets/42454181/340ffc7a-ac2e-4668-9eac-73ce5e9975b7)
![image](https://github.com/tgstation/tgstation/assets/42454181/105d1b34-edac-4e16-8fe6-641b344fc2fc)

## Why It's Good For The Game
When there are lots of requisition forms laying on the ground and you need to refer back to one of them (to see who ordered what or something like that), it can be a pain to find the right one since they all have the same name. This is even worse if someone has tried to be helpful and put them all in a folder, since you now have to take them out and look at each one. Adding the timestamp helps to remedy this.

For the crates, when someone orders something that doesn't come with a named crate (for example, some medical orders just have the name "medical crate"), or when multiples of the same things are ordered, it can be hard to match up the shipping manifest with the crate again, leading to unwanted fines, especially when people don't return all their crates at once. Adding the order ID to the name of the crate lets you easily identify which manifest goes where.
## Changelog
:cl:
qol: Crates that come in the cargo shuttle now have the order ID in their name
qol: Requisition forms are now blue, and named with the timestamp they were created on
/:cl:
