### PR TITLE
You can now imitate people from photos using plastic surgery!

### DIFF
--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -5,6 +5,7 @@
 	var/list/mobs_seen = list()
 	/// List of weakrefs pointing at dead mobs that appear in this photo
 	var/list/dead_seen = list()
+	var/list/real_names_seen = list()
 	var/caption
 	var/icon/picture_image
 	var/icon/picture_icon
@@ -16,7 +17,7 @@
 	///Was this image capable of seeing ghosts?
 	var/see_ghosts = CAMERA_NO_GHOSTS
 
-/datum/picture/New(name, desc, mobs_spotted, dead_spotted, image, icon, size_x, size_y, bp, caption_, autogenerate_icon, can_see_ghosts)
+/datum/picture/New(name, desc, mobs_spotted, dead_spotted, real_names, image, icon, size_x, size_y, bp, caption_, autogenerate_icon, can_see_ghosts)
 	if(!isnull(name))
 		picture_name = name
 	if(!isnull(desc))
@@ -27,6 +28,9 @@
 	if(!isnull(dead_spotted))
 		for(var/mob/seen as anything in dead_spotted)
 			dead_seen += WEAKREF(seen)
+	if(!isnull(real_names))
+		for(var/mob/seen as anything in real_names)
+			real_names_seen += seen
 	if(!isnull(image))
 		picture_image = image
 	if(!isnull(icon))

--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -29,7 +29,7 @@
 		for(var/mob/seen as anything in dead_spotted)
 			dead_seen += WEAKREF(seen)
 	if(!isnull(real_names))
-		for(var/mob/seen as anything in real_names)
+		for(var/seen in real_names)
 			real_names_seen += seen
 	if(!isnull(image))
 		picture_image = image

--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -5,7 +5,8 @@
 	var/list/mobs_seen = list()
 	/// List of weakrefs pointing at dead mobs that appear in this photo
 	var/list/dead_seen = list()
-	var/list/real_names_seen = list()
+	/// List of strings of face-visible humans in this photo
+	var/list/names_seen = list()
 	var/caption
 	var/icon/picture_image
 	var/icon/picture_icon
@@ -17,7 +18,7 @@
 	///Was this image capable of seeing ghosts?
 	var/see_ghosts = CAMERA_NO_GHOSTS
 
-/datum/picture/New(name, desc, mobs_spotted, dead_spotted, real_names, image, icon, size_x, size_y, bp, caption_, autogenerate_icon, can_see_ghosts)
+/datum/picture/New(name, desc, mobs_spotted, dead_spotted, names, image, icon, size_x, size_y, bp, caption_, autogenerate_icon, can_see_ghosts)
 	if(!isnull(name))
 		picture_name = name
 	if(!isnull(desc))
@@ -28,9 +29,9 @@
 	if(!isnull(dead_spotted))
 		for(var/mob/seen as anything in dead_spotted)
 			dead_seen += WEAKREF(seen)
-	if(!isnull(real_names))
-		for(var/seen in real_names)
-			real_names_seen += seen
+	if(!isnull(names))
+		for(var/seen in names)
+			names_seen += seen
 	if(!isnull(image))
 		picture_image = image
 	if(!isnull(icon))

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -188,6 +188,7 @@
 	var/list/mobs = list()
 	var/blueprints = FALSE
 	var/clone_area = SSmapping.RequestBlockReservation(size_x * 2 + 1, size_y * 2 + 1)
+	var/list/real_names = list() //list of human names taken on picture
 
 	var/width = size_x * 2 + 1
 	var/height = size_y * 2 + 1
@@ -218,8 +219,11 @@
 	var/icon/get_icon = camera_get_icon(turfs, target_turf, psize_x, psize_y, clone_area, size_x, size_y, (size_x * 2 + 1), (size_y * 2 + 1))
 	qdel(clone_area)
 	get_icon.Blend("#000", ICON_UNDERLAY)
+	for(var/mob/living/carbon/human/person as anything in mobs)
+		if(person.is_face_visible())
+			real_names.Add("[person.real_name]")
 
-	var/datum/picture/picture = new("picture", desc.Join(" "), mobs_spotted, dead_spotted, get_icon, null, psize_x, psize_y, blueprints, can_see_ghosts = see_ghosts)
+	var/datum/picture/picture = new("picture", desc.Join(" "), mobs_spotted, dead_spotted, real_names, get_icon, null, psize_x, psize_y, blueprints, can_see_ghosts = see_ghosts)
 	after_picture(user, picture)
 	SEND_SIGNAL(src, COMSIG_CAMERA_IMAGE_CAPTURED, target, user)
 	blending = FALSE

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -188,7 +188,8 @@
 	var/list/mobs = list()
 	var/blueprints = FALSE
 	var/clone_area = SSmapping.RequestBlockReservation(size_x * 2 + 1, size_y * 2 + 1)
-	var/list/real_names = list() //list of human names taken on picture
+	///list of human names taken on picture
+	var/list/names = list()
 
 	var/width = size_x * 2 + 1
 	var/height = size_y * 2 + 1
@@ -221,9 +222,9 @@
 	get_icon.Blend("#000", ICON_UNDERLAY)
 	for(var/mob/living/carbon/human/person in mobs)
 		if(person.is_face_visible())
-			real_names.Add("[person.real_name]")
+			names += "[person.name]"
 
-	var/datum/picture/picture = new("picture", desc.Join(" "), mobs_spotted, dead_spotted, real_names, get_icon, null, psize_x, psize_y, blueprints, can_see_ghosts = see_ghosts)
+	var/datum/picture/picture = new("picture", desc.Join(" "), mobs_spotted, dead_spotted, names, get_icon, null, psize_x, psize_y, blueprints, can_see_ghosts = see_ghosts)
 	after_picture(user, picture)
 	SEND_SIGNAL(src, COMSIG_CAMERA_IMAGE_CAPTURED, target, user)
 	blending = FALSE

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -219,7 +219,7 @@
 	var/icon/get_icon = camera_get_icon(turfs, target_turf, psize_x, psize_y, clone_area, size_x, size_y, (size_x * 2 + 1), (size_y * 2 + 1))
 	qdel(clone_area)
 	get_icon.Blend("#000", ICON_UNDERLAY)
-	for(var/mob/living/carbon/human/person as anything in mobs)
+	for(var/mob/living/carbon/human/person in mobs)
 		if(person.is_face_visible())
 			real_names.Add("[person.real_name]")
 

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -4,9 +4,31 @@
 	steps = list(
 		/datum/surgery_step/incise,
 		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/insert_plastic,
 		/datum/surgery_step/reshape_face,
 		/datum/surgery_step/close,
 	)
+
+//insert plastic
+/datum/surgery_step/insert_plastic
+	name = "insert plastic (plastic)"
+	implements = list(
+		/obj/item/stack/sheet/plastic = 100,
+		/obj/item/food/meat/slab = 100)
+	time = 32
+	preop_sound = 'sound/effects/blobattack.ogg'
+	success_sound = 'sound/effects/attackblob.ogg'
+	failure_sound = 'sound/effects/blobattack.ogg'
+
+/datum/surgery_step/insert_plastic/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(
+		user,
+		target,
+		span_notice("You begin to insert [tool] into the incision in [target]'s [parse_zone(target_zone)]..."),
+		span_notice("[user] begins to insert [tool] into the incision in [target]'s [parse_zone(target_zone)]."),
+		span_notice("[user] begins to insert [tool] into the incision in [target]'s [parse_zone(target_zone)]."),
+	)
+	display_pain(target, "You feel a something inserting just below the skin in your [parse_zone(target_zone)].")
 
 //reshape_face
 /datum/surgery_step/reshape_face
@@ -42,8 +64,14 @@
 	else
 		var/list/names = list()
 		if(!isabductor(user))
-			for(var/i in 1 to 10)
-				names += target.dna.species.random_name(target.gender, TRUE)
+			var/obj/item/offhand = user.get_inactive_held_item()
+			if(istype(offhand, /obj/item/photo))
+				var/obj/item/photo/disguises = offhand
+				for(var/mob/namelist as anything in disguises.picture.real_names_seen)
+					names += namelist
+			else
+				for(var/i in 1 to 10)
+					names += target.dna.species.random_name(target.gender, TRUE)
 		else
 			for(var/_i in 1 to 9)
 				names += "Subject [target.gender == MALE ? "i" : "o"]-[pick("a", "b", "c", "d", "e")]-[rand(10000, 99999)]"

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -14,14 +14,13 @@
 	name = "insert plastic (plastic)"
 	implements = list(
 		/obj/item/stack/sheet/plastic = 100,
-		/obj/item/food/meat/slab = 100,
 		/obj/item/stack/sheet/meat = 100)
 	time = 3.2 SECONDS
 	preop_sound = 'sound/effects/blobattack.ogg'
 	success_sound = 'sound/effects/attackblob.ogg'
 	failure_sound = 'sound/effects/blobattack.ogg'
 
-/datum/surgery_step/insert_plastic/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/insert_plastic/preop(mob/user, mob/living/target, target_zone, obj/item/stack/tool, datum/surgery/surgery)
 	display_results(
 		user,
 		target,
@@ -31,9 +30,9 @@
 	)
 	display_pain(target, "You feel something inserting just below the skin in your [parse_zone(target_zone)].")
 
-/datum/surgery_step/insert_plastic/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
+/datum/surgery_step/insert_plastic/success(mob/user, mob/living/target, target_zone, obj/item/stack/tool, datum/surgery/surgery, default_display_results)
 	. = ..()
-	tool.Destroy()
+	tool.use(1)
 
 //reshape_face
 /datum/surgery_step/reshape_face
@@ -72,7 +71,7 @@
 			var/obj/item/offhand = user.get_inactive_held_item()
 			if(istype(offhand, /obj/item/photo))
 				var/obj/item/photo/disguises = offhand
-				for(var/namelist in disguises.picture?.real_names_seen)
+				for(var/namelist as anything in disguises.picture?.names_seen)
 					names += namelist
 			else
 				for(var/i in 1 to 10)

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -28,7 +28,7 @@
 		span_notice("[user] begins to insert [tool] into the incision in [target]'s [parse_zone(target_zone)]."),
 		span_notice("[user] begins to insert [tool] into the incision in [target]'s [parse_zone(target_zone)]."),
 	)
-	display_pain(target, "You feel a something inserting just below the skin in your [parse_zone(target_zone)].")
+	display_pain(target, "You feel something inserting just below the skin in your [parse_zone(target_zone)].")
 
 //reshape_face
 /datum/surgery_step/reshape_face

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -14,7 +14,8 @@
 	name = "insert plastic (plastic)"
 	implements = list(
 		/obj/item/stack/sheet/plastic = 100,
-		/obj/item/food/meat/slab = 100)
+		/obj/item/food/meat/slab = 100,
+		/obj/item/stack/sheet/meat = 100)
 	time = 32
 	preop_sound = 'sound/effects/blobattack.ogg'
 	success_sound = 'sound/effects/attackblob.ogg'
@@ -29,6 +30,10 @@
 		span_notice("[user] begins to insert [tool] into the incision in [target]'s [parse_zone(target_zone)]."),
 	)
 	display_pain(target, "You feel something inserting just below the skin in your [parse_zone(target_zone)].")
+
+/datum/surgery_step/insert_plastic/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
+	. = ..()
+	tool.Destroy()
 
 //reshape_face
 /datum/surgery_step/reshape_face

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -16,7 +16,7 @@
 		/obj/item/stack/sheet/plastic = 100,
 		/obj/item/food/meat/slab = 100,
 		/obj/item/stack/sheet/meat = 100)
-	time = 32
+	time = 3.2 SECONDS
 	preop_sound = 'sound/effects/blobattack.ogg'
 	success_sound = 'sound/effects/attackblob.ogg'
 	failure_sound = 'sound/effects/blobattack.ogg'
@@ -72,7 +72,7 @@
 			var/obj/item/offhand = user.get_inactive_held_item()
 			if(istype(offhand, /obj/item/photo))
 				var/obj/item/photo/disguises = offhand
-				for(var/mob/namelist as anything in disguises.picture.real_names_seen)
+				for(var/namelist in disguises.picture?.real_names_seen)
 					names += namelist
 			else
 				for(var/i in 1 to 10)


### PR DESCRIPTION
## About The Pull Request
This PR allows you to imitate someone from a photo so long as their face aren't covered. this only works with photos after this PR is merged though. To do simply hold the photo in your offhand while you make the incision to alter appearance

https://www.youtube.com/watch?v=0zYREwD9e6U

Also adds a new step, you need to insert plastic before altering their appearance. I find it funny, it ain't called plastic surgery for nothing! a meat sheet will do as a subtitute however
## Why It's Good For The Game
Opportunity for more fun gimmicks, ammo for BB's and paranoia is never too much for SS13!
This also retroactively buffs forensic scanners and records since it really only changes your name and voice. You can change your hair all you want but anything more than that is a trip to genetics. overall allows for more engaging gameplay
## Changelog
:cl:
add: You can now imitate someone from a photograph during plastic surgery! Simply hold a picture in your offhand of the person you wish to imitate as while conducting the surgery! Remember, it's not foolproof! it only changes your name and voice
add: It requires plastic to conduct plastic surgery. it's not called plastic surgery for no raisins!
/:cl:
