### PR TITLE
Alcoholic quirk

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -698,6 +698,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 
 //quirk traits
 #define TRAIT_ALCOHOL_TOLERANCE "alcohol_tolerance"
+#define TRAIT_HEAVY_DRINKER "heavy_drinker"
 #define TRAIT_AGEUSIA "ageusia"
 #define TRAIT_HEAVY_SLEEPER "heavy_sleeper"
 #define TRAIT_NIGHT_VISION "night_vision"

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -65,3 +65,6 @@ GLOBAL_LIST_EMPTY(alert_consoles) // Station alert consoles, /obj/machinery/comp
 
 GLOBAL_LIST_EMPTY(roundstart_station_borgcharger_areas) // List of area names of roundstart station cyborg rechargers, for the low charge/no charge cyborg screen alert tooltips.
 GLOBAL_LIST_EMPTY(roundstart_station_mechcharger_areas) // List of area names of roundstart station mech rechargers, for the low charge/no charge mech screen alert tooltips.
+
+/// Associative list of alcoholic container typepath to instances, currently used by the alcoholic quirk
+GLOBAL_LIST_INIT(alcohol_containers, init_alcohol_containers())

--- a/code/datums/memory/key_memories.dm
+++ b/code/datums/memory/key_memories.dm
@@ -127,6 +127,34 @@
 /datum/memory/key/quirk_smoker/get_moods()
 	return list("[memorizer] [mood_verb] as they light another up.")
 
+/// Tracks what beverage an alcoholic quirk user likes
+/datum/memory/key/quirk_alcoholic
+	memory_flags = MEMORY_FLAG_NOLOCATION|MEMORY_FLAG_NOPERSISTENCE|MEMORY_SKIP_UNCONSCIOUS // Does not have nomood
+	var/preferred_brandy //haha, get it because brandy is a type of alcohol wow!
+
+/datum/memory/key/quirk_alcoholic/New(
+	datum/mind/memorizer_mind,
+	atom/protagonist,
+	atom/deuteragonist,
+	atom/antagonist,
+	preferred_brandy,
+)
+	src.preferred_brandy = preferred_brandy
+	return ..()
+
+/datum/memory/key/quirk_alcoholic/get_names()
+	return list("[protagonist_name]'s drinking problem.")
+
+/datum/memory/key/quirk_alcoholic/get_starts()
+	return list(
+		"[preferred_brandy] being downed by [protagonist_name].",
+		"[protagonist_name] buying a box of [preferred_brandy] bottles.",
+		"[protagonist_name] fiending for some [preferred_brandy].",
+	)
+
+/datum/memory/key/quirk_alcoholic/get_moods()
+	return list("[memorizer] [mood_verb] as they drink some [preferred_brandy].")
+
 /// Where our traitor uplink is, and what is its code
 /datum/memory/key/traitor_uplink
 	var/uplink_loc

--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -13,6 +13,11 @@
 /datum/mood_event/drunk/remove_effects()
 	QDEL_NULL(blush_overlay)
 
+/datum/mood_event/wrong_brandy
+	description = "I hate that type of drink."
+	mood_change = -2
+	timeout = 6 MINUTES
+
 /datum/mood_event/quality_nice
 	description = "That drink wasn't bad at all."
 	mood_change = 2

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -942,6 +942,7 @@
 	medical_record_text = "Patient is an alcoholic."
 	reagent_type = /datum/reagent/consumable/ethanol
 	drug_container_type = /obj/item/reagent_containers/cup/glass/bottle/whiskey
+	mob_trait = TRAIT_HEAVY_DRINKER
 	hardcore_value = 1
 	drug_flavour_text = "Make sure you get your favorite type of drink when you run out."
 	mail_goodies = list(

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -953,13 +953,15 @@
 	var/datum/reagent/consumable/ethanol/favorite_alcohol
 
 /datum/quirk/item_quirk/junkie/alcoholic/New()
-	drug_container_type = pick(/obj/item/reagent_containers/cup/glass/bottle/whiskey,
+	drug_container_type = pick(
+		/obj/item/reagent_containers/cup/glass/bottle/whiskey,
 		/obj/item/reagent_containers/cup/glass/bottle/vodka,
 		/obj/item/reagent_containers/cup/glass/bottle/ale,
 		/obj/item/reagent_containers/cup/glass/bottle/beer,
 		/obj/item/reagent_containers/cup/glass/bottle/hcider,
 		/obj/item/reagent_containers/cup/glass/bottle/wine,
-		/obj/item/reagent_containers/cup/glass/bottle/sake)
+		/obj/item/reagent_containers/cup/glass/bottle/sake,
+	)
 
 	return ..()
 

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -938,7 +938,7 @@
 	icon = FA_ICON_WINE_BOTTLE
 	value = -4
 	gain_text = span_danger("You really need a drink.")
-	lose_text = span_notice("Alcohol doesn't seem too enticing anymore.")
+	lose_text = span_notice("Alcohol doesn't seem nearly as enticing anymore.")
 	medical_record_text = "Patient is an alcoholic."
 	reagent_type = /datum/reagent/consumable/ethanol
 	drug_container_type = /obj/item/reagent_containers/cup/glass/bottle/whiskey

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -983,7 +983,7 @@
 	var/obj/item/organ/internal/liver/alcohol_liver = quirk_holder.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(alcohol_liver && IS_ORGANIC_ORGAN(alcohol_liver)) // robotic livers aren't affected
 		alcohol_liver.maxHealth = alcohol_liver.maxHealth * 0.75
-		alcohol_liver.healing_factor = alcohol_liver.healing_factor * 0.7)
+		alcohol_liver.healing_factor = alcohol_liver.healing_factor * 0.75
 
 /datum/quirk/item_quirk/junkie/alcoholic/remove()
 	UnregisterSignal(quirk_holder, COMSIG_MOB_REAGENT_CHECK)

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -909,7 +909,6 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_robust,
 		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 		/obj/item/storage/fancy/cigarettes/cigpack_carp)
-	mail_goodies += drug_container_type
 
 	return ..()
 

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -968,7 +968,7 @@
 	var/obj/item/reagent_containers/brandy_container = GLOB.alcohol_containers[drug_container_type]
 	if(isnull(brandy_container))
 		stack_trace("Alcoholic quirk added while the GLOB.alcohol_containers is (somehow) not initialized!")
-		brandy_container = new drug_container_type()
+		brandy_container = new drug_container_type
 		favorite_alcohol = brandy_container.list_reagents[1]
 		qdel(brandy_container)
 	else

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -909,6 +909,7 @@
 		/obj/item/storage/fancy/cigarettes/cigpack_robust,
 		/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 		/obj/item/storage/fancy/cigarettes/cigpack_carp)
+	mail_goodies += drug_container_type
 
 	return ..()
 

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -888,7 +888,7 @@
 	icon = FA_ICON_SMOKING
 	value = -4
 	gain_text = span_danger("You could really go for a smoke right about now.")
-	gain_text = span_notice("You don't feel hooked to nicotine anymore.")
+	lose_text = span_notice("You don't feel hooked to nicotine anymore.")
 	medical_record_text = "Patient is a current smoker."
 	reagent_type = /datum/reagent/drug/nicotine
 	accessory_type = /obj/item/lighter/greyscale

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -888,7 +888,7 @@
 	icon = FA_ICON_SMOKING
 	value = -4
 	gain_text = span_danger("You could really go for a smoke right about now.")
-	lose_text = span_notice("You don't feel hooked to nicotine anymore.")
+	lose_text = span_notice("You don't feel nearly as hooked to nicotine anymore.")
 	medical_record_text = "Patient is a current smoker."
 	reagent_type = /datum/reagent/drug/nicotine
 	accessory_type = /obj/item/lighter/greyscale

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -935,7 +935,7 @@
 /datum/quirk/item_quirk/junkie/alcoholic
 	name = "Alcoholic"
 	desc = "You just can't live without alcohol. Your liver is a machine that turns ethanol into acetaldehyde."
-	icon = FA_ICON_WINE_BOTTLE
+	icon = FA_ICON_WINE_GLASS
 	value = -4
 	gain_text = span_danger("You really need a drink.")
 	lose_text = span_notice("Alcohol doesn't seem nearly as enticing anymore.")

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -948,6 +948,7 @@
 		/obj/effect/spawner/random/food_or_drink/booze,
 		/obj/item/book/bible/booze,
 	)
+	/// Cached typepath of the owner's favorite alcohol reagent
 	var/datum/reagent/consumable/ethanol/favorite_alcohol
 
 /datum/quirk/item_quirk/junkie/alcoholic/New()

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -888,6 +888,7 @@
 	icon = FA_ICON_SMOKING
 	value = -4
 	gain_text = span_danger("You could really go for a smoke right about now.")
+	gain_text = span_notice("You don't feel hooked to nicotine anymore.")
 	medical_record_text = "Patient is a current smoker."
 	reagent_type = /datum/reagent/drug/nicotine
 	accessory_type = /obj/item/lighter/greyscale
@@ -924,12 +925,71 @@
 	. = ..()
 	var/mob/living/carbon/human/human_holder = quirk_holder
 	var/obj/item/mask_item = human_holder.get_item_by_slot(ITEM_SLOT_MASK)
-	if (istype(mask_item, /obj/item/clothing/mask/cigarette))
+	if(istype(mask_item, /obj/item/clothing/mask/cigarette))
 		var/obj/item/storage/fancy/cigarettes/cigarettes = drug_container_type
 		if(istype(mask_item, initial(cigarettes.spawn_type)))
 			quirk_holder.clear_mood_event("wrong_cigs")
-			return
-		quirk_holder.add_mood_event("wrong_cigs", /datum/mood_event/wrong_brand)
+		else
+			quirk_holder.add_mood_event("wrong_cigs", /datum/mood_event/wrong_brand)
+
+/datum/quirk/item_quirk/junkie/alcoholic
+	name = "Alcoholic"
+	desc = "You just can't live without alcohol. Your liver is a machine that turns ethanol into acetaldehyde."
+	icon = FA_ICON_WINE_BOTTLE
+	value = -4
+	gain_text = span_danger("You really need a drink.")
+	lose_text = span_notice("Alcohol doesn't seem too enticing anymore.")
+	medical_record_text = "Patient is an alcoholic."
+	reagent_type = /datum/reagent/consumable/ethanol
+	drug_container_type = /obj/item/reagent_containers/cup/glass/bottle/whiskey
+	hardcore_value = 1
+	drug_flavour_text = "Make sure you get your favorite type of drink when you run out."
+	mail_goodies = list(
+		/obj/effect/spawner/random/food_or_drink/booze,
+		/obj/item/book/bible/booze,
+	)
+	var/datum/reagent/consumable/ethanol/favorite_alcohol
+
+/datum/quirk/item_quirk/junkie/alcoholic/New()
+	drug_container_type = pick(/obj/item/reagent_containers/cup/glass/bottle/whiskey,
+		/obj/item/reagent_containers/cup/glass/bottle/vodka,
+		/obj/item/reagent_containers/cup/glass/bottle/ale,
+		/obj/item/reagent_containers/cup/glass/bottle/beer,
+		/obj/item/reagent_containers/cup/glass/bottle/hcider,
+		/obj/item/reagent_containers/cup/glass/bottle/wine,
+		/obj/item/reagent_containers/cup/glass/bottle/sake)
+
+	return ..()
+
+/datum/quirk/item_quirk/junkie/alcoholic/post_add()
+	. = ..()
+	//ugh this sucks but cant use initial on lists
+	var/obj/item/reagent_containers/brandy_container = new drug_container_type()
+	favorite_alcohol = brandy_container.list_reagents[1]
+	qdel(brandy_container)
+
+	quirk_holder.add_mob_memory(/datum/memory/key/quirk_alcoholic, protagonist = quirk_holder, preferred_brandy = initial(favorite_alcohol.name))
+	// alcoholic livers have 25% less health and healing
+	var/obj/item/organ/internal/liver/alcohol_liver = quirk_holder.get_organ_slot(ORGAN_SLOT_LIVER)
+	if(alcohol_liver && IS_ORGANIC_ORGAN(alcohol_liver)) // robotic livers aren't affected
+		alcohol_liver.maxHealth = alcohol_liver.maxHealth * 0.75
+		alcohol_liver.healing_factor = alcohol_liver.healing_factor * 0.75
+	RegisterSignal(quirk_holder, COMSIG_MOB_REAGENT_CHECK, PROC_REF(check_brandy))
+
+/datum/quirk/item_quirk/junkie/alcoholic/remove()
+	UnregisterSignal(quirk_holder, COMSIG_MOB_REAGENT_CHECK)
+
+/datum/quirk/item_quirk/junkie/alcoholic/proc/check_brandy(mob/source, datum/reagent/booze)
+	SIGNAL_HANDLER
+
+	//we don't care if it is not alcohol
+	if(!istype(booze, /datum/reagent/consumable/ethanol))
+		return
+
+	if(istype(booze, favorite_alcohol))
+		quirk_holder.clear_mood_event("wrong_alcohol")
+	else
+		quirk_holder.add_mood_event("wrong_alcohol", /datum/mood_event/wrong_brandy)
 
 /datum/quirk/item_quirk/chronic_illness
 	name = "Chronic Illness"

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -964,10 +964,14 @@
 
 /datum/quirk/item_quirk/junkie/alcoholic/post_add()
 	. = ..()
-	//ugh this sucks but cant use initial on lists
-	var/obj/item/reagent_containers/brandy_container = new drug_container_type()
-	favorite_alcohol = brandy_container.list_reagents[1]
-	qdel(brandy_container)
+	var/obj/item/reagent_containers/brandy_container = GLOB.alcohol_containers[drug_container_type]
+	if(!brandy_container)
+		stack_trace("Alcoholic quirk added while the GLOB.alcohol_containers is (somehow) not initialized!")
+		brandy_container = new drug_container_type()
+		favorite_alcohol = brandy_container.list_reagents[1]
+		qdel(brandy_container)
+	else
+		favorite_alcohol = brandy_container.list_reagents[1]
 
 	quirk_holder.add_mob_memory(/datum/memory/key/quirk_alcoholic, protagonist = quirk_holder, preferred_brandy = initial(favorite_alcohol.name))
 	// alcoholic livers have 25% less health and healing

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -967,6 +967,8 @@
 
 /datum/quirk/item_quirk/junkie/alcoholic/post_add()
 	. = ..()
+	RegisterSignal(quirk_holder, COMSIG_MOB_REAGENT_CHECK, PROC_REF(check_brandy))
+
 	var/obj/item/reagent_containers/brandy_container = GLOB.alcohol_containers[drug_container_type]
 	if(isnull(brandy_container))
 		stack_trace("Alcoholic quirk added while the GLOB.alcohol_containers is (somehow) not initialized!")
@@ -981,8 +983,7 @@
 	var/obj/item/organ/internal/liver/alcohol_liver = quirk_holder.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(alcohol_liver && IS_ORGANIC_ORGAN(alcohol_liver)) // robotic livers aren't affected
 		alcohol_liver.maxHealth = alcohol_liver.maxHealth * 0.75
-		alcohol_liver.healing_factor = alcohol_liver.healing_factor * 0.75
-	RegisterSignal(quirk_holder, COMSIG_MOB_REAGENT_CHECK, PROC_REF(check_brandy))
+		alcohol_liver.healing_factor = alcohol_liver.healing_factor * 0.7)
 
 /datum/quirk/item_quirk/junkie/alcoholic/remove()
 	UnregisterSignal(quirk_holder, COMSIG_MOB_REAGENT_CHECK)

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -966,7 +966,7 @@
 /datum/quirk/item_quirk/junkie/alcoholic/post_add()
 	. = ..()
 	var/obj/item/reagent_containers/brandy_container = GLOB.alcohol_containers[drug_container_type]
-	if(!brandy_container)
+	if(isnull(brandy_container))
 		stack_trace("Alcoholic quirk added while the GLOB.alcohol_containers is (somehow) not initialized!")
 		brandy_container = new drug_container_type()
 		favorite_alcohol = brandy_container.list_reagents[1]

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -329,7 +329,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	var/obj/item/organ/internal/lungs/lungs = smoker.get_organ_slot(ORGAN_SLOT_LUNGS)
 	if(lungs && IS_ORGANIC_ORGAN(lungs))
 		var/smoker_resistance = HAS_TRAIT(smoker, TRAIT_SMOKER) ? 0.5 : 1
-		smoker.adjustOrganLoss(ORGAN_SLOT_LUNGS, lung_harm*smoker_resistance)
+		smoker.adjustOrganLoss(ORGAN_SLOT_LUNGS, lung_harm * smoker_resistance)
 	if(!reagents.trans_to(smoker, to_smoke, methods = INGEST, ignore_stomach = TRUE))
 		reagents.remove_any(to_smoke)
 

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -60,8 +60,9 @@
 		drinker.adjust_drunk_effect(sqrt(volume) * booze_power * ALCOHOL_RATE * REM * seconds_per_tick)
 		if(boozepwr > 0)
 			var/obj/item/organ/internal/liver/liver = drinker.get_organ_slot(ORGAN_SLOT_LIVER)
+			var/heavy_drinker_multiplier = (HAS_TRAIT(drinker, TRAIT_HEAVY_DRINKER) ? 0.5 : 1)
 			if (istype(liver))
-				liver.apply_organ_damage(((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * liver.alcohol_tolerance * seconds_per_tick, 0))/150))
+				liver.apply_organ_damage(((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * liver.alcohol_tolerance * heavy_drinker_multiplier * seconds_per_tick, 0))/150))
 	return ..()
 
 /datum/reagent/consumable/ethanol/expose_obj(obj/exposed_obj, reac_volume)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -4,6 +4,18 @@
 //Functionally identical to regular drinks. The only difference is that the default bottle size is 100. - Darem
 //Bottles now knockdown and break when smashed on people's heads. - Giacom
 
+/// Initializes GLOB.alcohol_containers, only containers that actually have reagents are added to the list.
+/proc/init_alcohol_containers()
+	var/list/containers = subtypesof(/obj/item/reagent_containers/cup/glass/bottle)
+	for(var/typepath in containers)
+		containers -= typepath
+		var/obj/item/reagent_containers/cup/glass/bottle/instance = new typepath()
+		if(!length(instance.list_reagents))
+			qdel(instance)
+			continue
+		containers[typepath] = instance
+	return containers
+
 /obj/item/reagent_containers/cup/glass/bottle
 	name = "glass bottle"
 	desc = "This blank bottle is unyieldingly anonymous, offering no clues to its contents."

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -9,7 +9,7 @@
 	var/list/containers = subtypesof(/obj/item/reagent_containers/cup/glass/bottle)
 	for(var/typepath in containers)
 		containers -= typepath
-		var/obj/item/reagent_containers/cup/glass/bottle/instance = new typepath()
+		var/obj/item/reagent_containers/cup/glass/bottle/instance = new typepath
 		if(!length(instance.list_reagents))
 			qdel(instance)
 			continue


### PR DESCRIPTION
## About The Pull Request

So you're telling me we have a smoker quirk and we DON'T have an alcoholic quirk?
What a travesty! Time to fix that.

This quirk is essentially equivalent to smoker, but instead of a favorite brand you get a favorite *brandy* (as in, favorite type of booze).
![image](https://github.com/tgstation/tgstation/assets/82850673/f3883f76-414a-48a8-8f69-76f1bc01d020)

## Why It's Good For The Game

More quirk variety with decent roleplay value.
What will we do with a drunken sailor?

## Changelog

:cl:
add: Added Alcoholic as a negative quirk.
/:cl: