### PR TITLE
Improves spacepol jumpsuit wound armor from 5 to 10

### DIFF
--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -225,6 +225,7 @@
 	fire = 10
 	acid = 10
 	melee = 10
+	wound = 10
 
 /obj/item/clothing/under/rank/prisoner
 	name = "prison jumpsuit"


### PR DESCRIPTION


## About The Pull Request

I was looking at uniform code and noticed that spacepol jumpsuits didn't have 10 wound armor like the rest of the security jumpsuits in the file it's in.

## Why It's Good For The Game

Improving the wound armor of spacepol jumpsuits makes it more consistent with the other security uniforms and slightly increases spacepol survivability considering they don't have any medicine.

## Changelog
:cl:

balance: Improved spacepol jumpsuit wound armor from 5 to 10

/:cl:

