### PR TITLE
Mini Fridges now have a grimy subtype, can go over tables, and start off anchored.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/crashedship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/crashedship.dmm
@@ -130,7 +130,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav/crashedship/fore)
 "fI" = (
-/obj/structure/closet/mini_fridge,
+/obj/structure/closet/mini_fridge/grimy,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/crashedship/fore)

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -1664,7 +1664,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/table/reinforced,
-/obj/structure/closet/mini_fridge{
+/obj/structure/closet/mini_fridge/grimy{
 	anchored = 1;
 	pixel_y = 6
 	},

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -6905,7 +6905,7 @@
 /area/ruin/space/ancientstation/beta/supermatter)
 "Nt" = (
 /obj/structure/table/glass,
-/obj/structure/closet/mini_fridge{
+/obj/structure/closet/mini_fridge/grimy{
 	pixel_y = 8;
 	pixel_x = 2
 	},

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -3399,7 +3399,7 @@
 /turf/closed/wall/r_wall,
 /area/awaymission/moonoutpost19/research)
 "vI" = (
-/obj/structure/closet/mini_fridge,
+/obj/structure/closet/mini_fridge/grimy,
 /obj/item/food/pizzaslice/margherita,
 /obj/item/food/pizzaslice/margherita{
 	pixel_x = 5;

--- a/_maps/map_files/Basketball/greytide_worldwide.dmm
+++ b/_maps/map_files/Basketball/greytide_worldwide.dmm
@@ -628,7 +628,7 @@
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "Tc" = (
-/obj/structure/closet/mini_fridge,
+/obj/structure/closet/mini_fridge/grimy,
 /turf/open/floor/plating,
 /area/centcom/basketball)
 "Tl" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -28054,8 +28054,6 @@
 /area/station/service/hydroponics)
 "hlG" = (
 /obj/structure/closet/mini_fridge{
-	desc = "A small contraption designed to imbue a few drinks with a pleasant chill.";
-	name = "mini-fridge";
 	pixel_x = 6;
 	pixel_y = 5
 	},
@@ -76176,8 +76174,6 @@
 /area/station/cargo/sorting)
 "tSD" = (
 /obj/structure/closet/mini_fridge{
-	desc = "A small contraption designed to imbue a few drinks with a pleasant chill.";
-	name = "mini-fridge";
 	pixel_x = 6;
 	pixel_y = 5
 	},

--- a/_maps/map_files/tramstation/maintenance_modules/cargoscilower_attachment_b_1.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/cargoscilower_attachment_b_1.dmm
@@ -26,7 +26,7 @@
 /area/station/maintenance/starboard/central)
 "v" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/mini_fridge,
+/obj/structure/closet/mini_fridge/grimy,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/central)
 "z" = (

--- a/_maps/map_files/tramstation/maintenance_modules/dormmedupper_attachment_b_3.dmm
+++ b/_maps/map_files/tramstation/maintenance_modules/dormmedupper_attachment_b_3.dmm
@@ -70,7 +70,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/dorms)
 "w" = (
-/obj/structure/closet/mini_fridge,
+/obj/structure/closet/mini_fridge/grimy,
 /turf/open/misc/asteroid,
 /area/station/asteroid)
 "y" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -62118,10 +62118,7 @@
 /area/station/commons/storage/art)
 "vbb" = (
 /obj/structure/table,
-/obj/structure/closet/mini_fridge{
-	name = "mini-fridge";
-	anchored = 1
-	},
+/obj/structure/closet/mini_fridge,
 /obj/item/reagent_containers/condiment/milk,
 /obj/item/reagent_containers/cup/soda_cans/cola,
 /turf/open/floor/iron/white,

--- a/code/game/objects/effects/spawners/random/structure.dm
+++ b/code/game/objects/effects/spawners/random/structure.dm
@@ -142,7 +142,7 @@
 		/obj/structure/closet/l3closet = 1,
 		/obj/structure/closet/radiation = 1,
 		/obj/structure/closet/bombcloset = 1,
-		/obj/structure/closet/mini_fridge = 1,
+		/obj/structure/closet/mini_fridge/grimy = 1,
 	)
 
 /obj/effect/spawner/random/structure/chair_flipped

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -118,6 +118,7 @@
 	icon_welded = "welded_small"
 	max_mob_size = MOB_SIZE_SMALL
 	pass_flags = PASSTABLE
+	anchored_tabletop_offset = 3
 	anchored = 1
 	storage_capacity = 10
 

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -113,13 +113,28 @@
 
 /obj/structure/closet/mini_fridge
 	name = "grimy mini-fridge"
-	desc = "A small contraption designed to imbue a few drinks with a pleasant chill. This antiquated unit however seems to serve no purpose other than keeping the roaches company."
+	desc = "A small contraption designed to imbue a few drinks with a pleasant chill."
 	icon_state = "mini_fridge"
 	icon_welded = "welded_small"
 	max_mob_size = MOB_SIZE_SMALL
+	pass_flags = PASSTABLE
+	anchored = 1
 	storage_capacity = 10
 
 /obj/structure/closet/mini_fridge/PopulateContents()
+	. = ..()
+	new /obj/effect/spawner/random/food_or_drink/refreshing_beverage(src)
+	new /obj/effect/spawner/random/food_or_drink/refreshing_beverage(src)
+	if(prob(50))
+		new /obj/effect/spawner/random/food_or_drink/refreshing_beverage(src)
+	if(prob(40))
+		new /obj/item/reagent_containers/cup/glass/bottle/beer(src)
+
+/obj/structure/closet/mini_fridge/grimy
+	name = "grimy mini_fridge"
+	desc = "A small contraption designed to imbue a few drinks with a pleasant chill. This antiquated unit however seems to serve no purpose other than keeping the roaches company."
+
+/obj/structure/closet/mini_fridge/grimy/PopulateContents()
 	. = ..()
 	new /obj/effect/spawner/random/food_or_drink/refreshing_beverage(src)
 	new /obj/effect/spawner/random/food_or_drink/refreshing_beverage(src)
@@ -130,5 +145,8 @@
 			new /obj/item/food/pizzaslice/moldy/bacteria(src)
 		else
 			new /obj/item/food/breadslice/moldy/bacteria(src)
-	else if(prob(30))
-		new /obj/item/food/syndicake(src)
+	else if(prob(40))
+		if(prob(50))
+			new /obj/item/food/syndicake(src)
+		else
+			new /mob/living/basic/cockroach(src)

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -137,10 +137,6 @@
 
 /obj/structure/closet/mini_fridge/grimy/PopulateContents()
 	. = ..()
-	new /obj/effect/spawner/random/food_or_drink/refreshing_beverage(src)
-	new /obj/effect/spawner/random/food_or_drink/refreshing_beverage(src)
-	if(prob(50))
-		new /obj/effect/spawner/random/food_or_drink/refreshing_beverage(src)
 	if(prob(40))
 		if(prob(50))
 			new /obj/item/food/pizzaslice/moldy/bacteria(src)


### PR DESCRIPTION

## About The Pull Request

/obj/structure/closet/mini_fridge is now a clean nice one, which only spawns beverages and does not have that cockroach reference in the description, and starts off anchored. now /obj/structure/closet/mini_fridge/grimy works like the old mini-fridge, with syndicake, moldy bread, and now the chance of an ACTUAL cockroach. I've replaced them on maps according to each one's needs, So, as an example, Northstar gets a regular one (it var edited it before) while tram maints get the grimy subtype.
mini-fridges now can properly go over tables, so you don't have to deconstruct said table to put it on top again.
## Why It's Good For The Game

I've found the need for a nice subtype while doing a ruin, and so has a few other mappers apparently, as northstar had a var edited variant. The fact that it couldn't go over tables and started off unanchored was annoying on tram and icebox, where it is present on the kitchen and you could easily push it to the ground and suffer.
## Changelog
:cl:
qol: It has been issued brand new mini-fridges for our active stations, Featuring more booze and less moldy pizza!
/:cl:
