### PR TITLE
Slimes don't skip sending on-death signals

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -21,7 +21,6 @@
 	if(buckled)
 		Feedstop(silent = TRUE) //releases ourselves from the mob we fed on.
 
-	set_stat(DEAD)
 	cut_overlays()
 
 	return ..(gibbed)


### PR DESCRIPTION
## About The Pull Request

I noticed that if you let a slime hold the nuclear disk it didn't drop it upon death.
This turns out to be because `slime/death()` calls `set_stat(DEAD)` which means that by the time it calls `..()` it fails the "are we dead already" check.
As the superproc of `death` also calls `set_stat(DEAD)` I just removed the redundant call from slime, it does not appear that anything in the superproc was being skipped on purpose.

## Why It's Good For The Game

It fixes a handful of extremely niche bugs which nobody has ever encountered or reported because they only happen if an admin is fucking around with components.
Now slimes no longer irretrievably consume the nuke discs or crates upon death if made into bomb operators or crate carriers, and they can correctly be made into pinatas.

## Changelog

:cl:
fix: A nuclear operative who is a slime will now correctly drop the disk upon death.
/:cl:
