### PR TITLE
Adds colorblindness as a mild brain trauma

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -268,7 +268,7 @@
 
 /datum/brain_trauma/mild/color_blindness
 	name = "Achromatopsia"
-	desc = "Patient's occipital lobe is unable to interpret information from cone cells, rendering the patient completely colorblind."
+	desc = "Patient's occipital lobe is unable to recognize and interpret color, rendering the patient completely colorblind."
 	scan_desc = "colorblindness"
 	gain_text = span_warning("The world around you seems to lose its color.")
 	lose_text = span_notice("The world feels bright and colorful again.")

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -268,7 +268,7 @@
 
 /datum/brain_trauma/mild/color_blindness
 	name = "Achromatopsia"
-	desc = "Patient's occipital lobe receives no color information from cone cells, rendering the patient colorblind."
+	desc = "Patient's occipital lobe receives no information from cone cells, rendering the patient completely colorblind."
 	scan_desc = "colorblindness"
 	gain_text = span_warning("The world around you seems to lose its color.")
 	lose_text = span_notice("The world feels bright and colorful again.")

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -265,3 +265,18 @@
 			speak_dejavu += speech_args[SPEECH_MESSAGE]
 	else
 		speak_dejavu += speech_args[SPEECH_MESSAGE]
+
+/datum/brain_trauma/mild/color_blindness
+	name = "Achromatopsia"
+	desc = "Patient's occipital lobe receives no color information from cone cells, rendering the patient colorblind."
+	scan_desc = "colorblindness"
+	gain_text = span_warning("The world around you seems to lose its color.")
+	lose_text = span_notice("The world feels bright and colorful again.")
+
+/datum/brain_trauma/mild/color_blindness/on_gain()
+	owner.add_client_colour(/datum/client_colour/monochrome/colorblind)
+	return ..()
+
+/datum/brain_trauma/mild/color_blindness/on_lose(silent)
+	owner.remove_client_colour(/datum/client_colour/monochrome/colorblind)
+	return ..()

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -268,7 +268,7 @@
 
 /datum/brain_trauma/mild/color_blindness
 	name = "Achromatopsia"
-	desc = "Patient's occipital lobe receives no information from cone cells, rendering the patient completely colorblind."
+	desc = "Patient's occipital lobe is unable to interpret information from cone cells, rendering the patient completely colorblind."
 	scan_desc = "colorblindness"
 	gain_text = span_warning("The world around you seems to lose its color.")
 	lose_text = span_notice("The world feels bright and colorful again.")

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -198,6 +198,9 @@
 	fade_in = 20
 	fade_out = 20
 
+/datum/client_colour/monochrome/colorblind
+	priority = PRIORITY_HIGH
+
 /datum/client_colour/monochrome/trance
 	priority = PRIORITY_NORMAL
 


### PR DESCRIPTION
## About The Pull Request

What the title says. 
The brain trauma makes the whole screen monochrome until cured.
![image](https://github.com/tgstation/tgstation/assets/82850673/442d24a8-6625-454c-bc28-64b786b03f49)

## Why It's Good For The Game

I feel like the current pool for mild brain traumas is quite lame, this helps spice it up a bit with something that is quite annoying and distracting but not game breaking (as mild brain traumas should generally be).

## Changelog

:cl:
add: Added colorblindness as a mild brain trauma.
/:cl: