### PR TITLE
Removes TTS voice disable option

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -427,6 +427,4 @@
 
 /datum/config_entry/str_list/tts_voice_blacklist
 
-/datum/config_entry/flag/tts_allow_player_voice_disabling
-
 /datum/config_entry/flag/give_tutorials_without_db

--- a/code/modules/client/preferences/voice.dm
+++ b/code/modules/client/preferences/voice.dm
@@ -23,8 +23,7 @@
 /datum/preference/choiced/voice/apply_to_human(mob/living/carbon/human/target, value)
 	if(SStts.tts_enabled && !(value in SStts.available_speakers))
 		value = pick(SStts.available_speakers) // As a failsafe
-	if(!CONFIG_GET(flag/tts_allow_player_voice_disabling) || !target.client?.prefs.read_preference(/datum/preference/toggle/tts_voice_disable))
-		target.voice = value
+	target.voice = value
 
 /datum/preference/numeric/tts_voice_pitch
 	savefile_identifier = PREFERENCE_CHARACTER
@@ -44,17 +43,3 @@
 /datum/preference/numeric/tts_voice_pitch/apply_to_human(mob/living/carbon/human/target, value)
 	if(SStts.tts_enabled && SStts.pitch_enabled)
 		target.pitch = value
-
-/datum/preference/toggle/tts_voice_disable
-	savefile_identifier = PREFERENCE_CHARACTER
-	savefile_key = "tts_voice_disable"
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	default_value = FALSE
-
-/datum/preference/toggle/tts_voice_disable/apply_to_human(mob/living/carbon/human/target, value)
-	return TRUE
-
-/datum/preference/toggle/tts_voice_disable/is_accessible(datum/preferences/preferences)
-	if(!SStts.tts_enabled || !CONFIG_GET(flag/tts_allow_player_voice_disabling))
-		return FALSE
-	return ..()

--- a/code/modules/mob/living/carbon/human/login.dm
+++ b/code/modules/mob/living/carbon/human/login.dm
@@ -4,8 +4,7 @@
 	dna?.species?.on_owner_login(src)
 
 	if(SStts.tts_enabled && !voice)
-		if(!CONFIG_GET(flag/tts_allow_player_voice_disabling) || !client?.prefs.read_preference(/datum/preference/toggle/tts_voice_disable))
-			voice = pick(SStts.available_speakers)
+		voice = pick(SStts.available_speakers)
 
 	if(!LAZYLEN(afk_thefts))
 		return

--- a/config/config.txt
+++ b/config/config.txt
@@ -575,9 +575,6 @@ PR_ANNOUNCEMENTS_PER_ROUND 5
 #TTS_VOICE_BLACKLIST Sans Undertale
 #TTS_VOICE_BLACKLIST Papyrus Undertale
 
-## Uncomment this to allow players to disable having a voice on their character for TTS.
-#TTS_ALLOW_PLAYER_VOICE_DISABLING
-
 ## Comment to disable sending a toast notification on the host server when initializations complete.
 ## Even if this is enabled, a notification will only be sent if there are no clients connected.
 TOAST_NOTIFICATION_ON_INIT

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/tts_voice.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/tts_voice.tsx
@@ -1,4 +1,4 @@
-import { FeatureChoiced, FeatureChoicedServerData, FeatureDropdownInput, FeatureValueProps, FeatureNumeric, FeatureNumberInput, FeatureToggle, CheckboxInput } from '../base';
+import { FeatureChoiced, FeatureChoicedServerData, FeatureDropdownInput, FeatureValueProps, FeatureNumeric, FeatureNumberInput } from '../base';
 import { Stack, Button } from '../../../../../components';
 
 const FeatureTTSDropdownInput = (

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/tts_voice.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/tts_voice.tsx
@@ -42,10 +42,3 @@ export const tts_voice_pitch: FeatureNumeric = {
   name: 'Voice Pitch Adjustment',
   component: FeatureNumberInput,
 };
-
-export const tts_voice_disable: FeatureToggle = {
-  name: 'Voice Disable Toggle',
-  description:
-    'Disables the TTS voice for this specific character when enabled.',
-  component: CheckboxInput,
-};


### PR DESCRIPTION
## About The Pull Request
Removes the TTS voice disable option, which was already unavailable on TG as it was set to off by default. The reason this was added was so that downstreams could toggle the config on or off.

## Why It's Good For The Game
I think this option fundamentally undermines the TTS system because it allows individual players to disable their voice globally, meaning that players who have TTS enabled will not be able to hear them. 

This worsens the experience for players who have TTS enabled and it's not something I want to include as an option. If players don't like their voice, they can turn TTS off for themselves so that they don't hear the voices. If players don't want to customize their voice, they can quickly choose a random voice, and we can take directions in the future to make voice randomization consistent with gender so that a male does not get randomly assigned a female voice and vice versa.

This option is already unavailable on TG servers because it was primarily added for downstreams, but I don't think giving downstreams the option to undermine the TTS system is the right direction to take. Downstreams are still completely free to code this option on their own codebase.
