### PR TITLE
Fix Tongues Displaying Food Preferences Incorrectly

### DIFF
--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -56,11 +56,11 @@
 	. = ..()
 	if(HAS_TRAIT(user, TRAIT_ENTRAILS_READER) || (user.mind && HAS_TRAIT(user.mind, TRAIT_ENTRAILS_READER)) || isobserver(user))
 		if(liked_foodtypes)
-			. += span_info("This tongue has an affinity the taste of [english_list(bitfield_to_list(liked_foodtypes), FOOD_FLAGS_IC)].")
+			. += span_info("This tongue has an affinity for the taste of [english_list(bitfield_to_list(liked_foodtypes, FOOD_FLAGS_IC))].")
 		if(disliked_foodtypes)
-			. += span_info("This tongue has an aversion for taste of [english_list(bitfield_to_list(disliked_foodtypes), FOOD_FLAGS_IC)].")
+			. += span_info("This tongue has an aversion for the taste of [english_list(bitfield_to_list(disliked_foodtypes, FOOD_FLAGS_IC))].")
 		if(toxic_foodtypes)
-			. += span_info("This tongue's physiology makes [english_list(bitfield_to_list(toxic_foodtypes), FOOD_FLAGS_IC)] toxic.")
+			. += span_info("This tongue's physiology makes [english_list(bitfield_to_list(toxic_foodtypes, FOOD_FLAGS_IC))] toxic.")
 
 /**
  * Used in setting up the "languages possible" list.


### PR DESCRIPTION

## About The Pull Request
It fixes food preferences displaying incorrectly when examining tongues. 
## Why It's Good For The Game
It's unreadable currently.

**Before**
![image](https://github.com/tgstation/tgstation/assets/22015544/b2c49426-f173-4d65-b71b-6b6e71c7928a)

**After**
![image](https://github.com/tgstation/tgstation/assets/22015544/babe07bc-94ea-4232-b6d6-524e0c281b21)
## Changelog
:cl:
fix: fixed food preferences displaying incorrectly when examining tongues
/:cl:
