### PR TITLE
Removes metalgen from randomspawns

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2561,7 +2561,7 @@
 	description = "A purple metal morphic liquid, said to impose it's metallic properties on whatever it touches."
 	color = "#b000aa"
 	taste_mult = 0 // oderless and tasteless
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_NO_RANDOM_RECIPE
+	chemical_flags = REAGENT_NO_RANDOM_RECIPE
 	/// The material flags used to apply the transmuted materials
 	var/applied_material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR
 	/// The amount of materials to apply to the transmuted objects if they don't contain materials


### PR DESCRIPTION
## About The Pull Request
Metalgen can't spawn in strange seeds, maintpills, random geysers, egg gland etc anymore

## Why It's Good For The Game

Metalgen is an extremely strong chem, intentionally gated behind both a a rare geyser chem and a randomized recipe. A botanist being able to mass-produce it randomly roundstart throws off the entire balance systems and takes away from the novelty of metalgen synthesis

The randomized recipe system is meant to reward players for putting in extraordinary effort to get an extraordinary reagent. Secret sauce (the only other secret chem) can also not be randomly generated for this reason, I made an oversight by not doing the same for metalgen. 

## Changelog
:cl:
balance: Metalgen cannot spawn as a random chem anymore (strange seeds, maintpills etc)
/:cl:
