### PR TITLE
[TramStation] Fixes Barber shop doors having the `commissarydoor` ID tag

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -36417,7 +36417,6 @@
 /area/station/medical/treatment_center)
 "lTf" = (
 /obj/machinery/door/airlock{
-	id_tag = "commissarydoor";
 	name = "Barber Storage"
 	},
 /turf/open/floor/plating,
@@ -66336,7 +66335,6 @@
 /area/station/maintenance/disposal/incinerator)
 "wAY" = (
 /obj/machinery/door/airlock{
-	id_tag = "commissarydoor";
 	name = "Barber Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Door var which is primarily used in the.. commissary.
Now the doors won't be locked and fucked up if someone decides to close the commissary.
~~Actually tram doesn't use this var, I think, but my point still stands.~~

## Changelog

:cl: Jolly
fix: [TramStation] - Removed a (possibly) unused var on the barber shop doors. Hopefully those taking refuge in the commissary wasn't causing too many issues.
/:cl:


