### PR TITLE
Stop stack tracing if ezdb daemon is already running

### DIFF
--- a/code/controllers/subsystem/dbcore.dm
+++ b/code/controllers/subsystem/dbcore.dm
@@ -460,11 +460,11 @@ Delayed insert mode was removed in mysql 7 and only works with MyISAM type table
 	ASSERT(fexists(daemon), "Configured db_daemon doesn't exist")
 
 	var/list/result = world.shelleo("echo \"Starting ezdb daemon, do not close this window\" && [daemon]")
-	var/error_code = result[1]
-	if (!error_code)
+	var/result_code = result[1]
+	if (!result_code || result_code == 1)
 		return
 
-	stack_trace("Failed to start DB daemon: [error_code]\n[result[3]]")
+	stack_trace("Failed to start DB daemon: [result_code]\n[result[3]]")
 
 /datum/controller/subsystem/dbcore/proc/stop_db_daemon()
 	set waitfor = FALSE


### PR DESCRIPTION

## About The Pull Request

This is an annoyance for me because I often kill the game but not the EZDB daemon (leaving the cmd window open), and it just triggers this stack trace while I have a debugger running. It's still able to connect to the daemon in-game and functions perfectly fine, just hate dealing with a completely needless stack_trace() every single time.

![image](https://github.com/tgstation/tgstation/assets/34697715/f8ae3cec-1cf6-4e70-b9bc-c7088121b85c)

![image](https://github.com/tgstation/tgstation/assets/34697715/a13774b8-addf-43fd-82f0-3d0e644d2dc1)
## Why It's Good For The Game

LET ME WORK!!! PLEASE!!!
## Changelog
Nothing that players should care about.
