### PR TITLE
[NO GBP] Fixes the venomous element for projectiles, invisible arrows and something off with envenomable casings.

### DIFF
--- a/code/datums/components/on_hit_effect.dm
+++ b/code/datums/components/on_hit_effect.dm
@@ -59,18 +59,18 @@
 			return
 	on_hit_callback.Invoke(attacker, attacker, target, attacker.zone_selected)
 
-/datum/component/on_hit_effect/proc/on_projectile_hit(datum/fired_from, atom/movable/firer, atom/target, angle, obj/item/bodypart/hit_limb)
+/datum/component/on_hit_effect/proc/on_projectile_hit(datum/fired_from, atom/movable/firer, atom/target, angle, body_zone)
 	SIGNAL_HANDLER
 
 	if(extra_check_callback)
 		if(!extra_check_callback.Invoke(firer, target))
 			return
-	on_hit_callback.Invoke(fired_from, firer, target, hit_limb.body_zone)
+	on_hit_callback.Invoke(fired_from, firer, target, body_zone)
 
-/datum/component/on_hit_effect/proc/on_projectile_self_hit(datum/source, mob/firer, atom/target, angle, obj/item/bodypart/hit_limb)
+/datum/component/on_hit_effect/proc/on_projectile_self_hit(datum/source, mob/firer, atom/target, angle, body_zone)
 	SIGNAL_HANDLER
 
 	if(extra_check_callback)
 		if(!extra_check_callback.Invoke(firer, target))
 			return
-	on_hit_callback.Invoke(source, firer, target, hit_limb.body_zone)
+	on_hit_callback.Invoke(source, firer, target, body_zone)

--- a/code/datums/elements/envenomable_casing.dm
+++ b/code/datums/elements/envenomable_casing.dm
@@ -44,7 +44,7 @@
 	venom_container.reagents.remove_reagent(venom_applied.type, amount_applied)
 	///stops further poison application
 	UnregisterSignal(casing, COMSIG_ITEM_AFTERATTACK)
-	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine_after_dip), override = TRUE)
+	RegisterSignal(casing, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine_after_dip), override = TRUE)
 
 ///signal called on parent being examined while not coated
 /datum/element/envenomable_casing/proc/on_examine_before_dip(obj/item/ammo_casing/casing, mob/user, list/examine_list)

--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -4,6 +4,7 @@
 	desc = "Stabby Stabman!"
 	icon = 'icons/obj/weapons/guns/bows/arrows.dmi'
 	icon_state = "arrow"
+	base_icon_state = "arrow"
 	inhand_icon_state = "arrow"
 	projectile_type = /obj/projectile/bullet/arrow
 	flags_1 = NONE
@@ -18,17 +19,11 @@
 	AddElement(/datum/element/envenomable_casing)
 	AddElement(/datum/element/caseless, reusable)
 
-///base arrow projectile
-/obj/projectile/bullet/arrow
-	name = "arrow"
-	desc = "Ow! Get it out of me!"
-	icon = 'icons/obj/weapons/guns/bows/arrows.dmi'
-	icon_state = "arrow_projectile"
-	damage = 50
-	speed = 1
-	range = 25
+/obj/item/ammo_casing/arrow/update_icon_state()
+	. = ..()
+	icon_state = "[base_icon_state]"
 
-///*sigh* NON-REUSABLE base arrow projectile. In the future: let's componentize the reusable subtype, jesus
+///base arrow projectile
 /obj/projectile/bullet/arrow
 	name = "arrow"
 	desc = "Ow! Get it out of me!"


### PR DESCRIPTION
## About The Pull Request
See #76551. The on hit effect component was treating the `hit_limb` arg of the projectile on_hit signals as if it were a bodypart item rather than a string. This wasn't my fault.
Also, invisible arrows because I forgot to set up their definition of update_icon_state() and base icon state var.
Lastly, the envenomable casing registering a signal on the wrong atom, and the arrow bullet subtype being defined twice.

## Why It's Good For The Game
This will close #76551.

## Changelog

:cl:
fix: Fixes venomous projectiles for real, and invisible arrow sprites.
/:cl:
