### PR TITLE
Genetic Sequencers now can scan genetic makeup, not just mutations

### DIFF
--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -43,7 +43,7 @@
 	//no scanning if its a husk or DNA-less Species
 	if (!HAS_TRAIT(target, TRAIT_GENELESS) && !HAS_TRAIT(target, TRAIT_BADDNA))
 		user.visible_message(span_bolddanger("[user] is scanning [target]'s genetic makeup."))
-		if(!do_after(user, 6 SECONDS))
+		if(!do_after(user, 3 SECONDS))
 			balloon_alert(user, "scan failed!")
 			user.visible_message(span_alert("[user] fails to scan [target]'s genetic makeup."))
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN

--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -42,10 +42,10 @@
 	add_fingerprint(user)
 	//no scanning if its a husk or DNA-less Species
 	if (!HAS_TRAIT(target, TRAIT_GENELESS) && !HAS_TRAIT(target, TRAIT_BADDNA))
-		user.visible_message(span_warning("[user] is scanning [target]'s genetic makeup."))
+		user.visible_message(span_bolddanger("[user] is scanning [target]'s genetic makeup."))
 		if(!do_after(user, 3 SECONDS))
 			balloon_alert(user, "scan failed!")
-			user.visible_message(span_warning("[user] fails to scan [target]'s genetic makeup."))
+			user.visible_message(span_alert("[user] fails to scan [target]'s genetic makeup."))
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 		makeup_scan(target, user)
 		balloon_alert(user, "makeup scanned")

--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -42,10 +42,10 @@
 	add_fingerprint(user)
 	//no scanning if its a husk or DNA-less Species
 	if (!HAS_TRAIT(target, TRAIT_GENELESS) && !HAS_TRAIT(target, TRAIT_BADDNA))
-		user.visible_message(span_bolddanger("[user] is scanning [target]'s genetic makeup."))
+		user.visible_message(span_warning("[user] is scanning [target]'s genetic makeup."))
 		if(!do_after(user, 3 SECONDS))
 			balloon_alert(user, "scan failed!")
-			user.visible_message(span_alert("[user] fails to scan [target]'s genetic makeup."))
+			user.visible_message(span_warning("[user] fails to scan [target]'s genetic makeup."))
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 		makeup_scan(target, user)
 		balloon_alert(user, "makeup scanned")

--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -20,6 +20,13 @@
 	var/list/buffer
 	var/ready = TRUE
 	var/cooldown = 200
+	var/list/genetic_makeup_buffer = list()
+
+/obj/item/sequence_scanner/examine(mob/user)
+	. = ..()
+	. += span_notice("Use primary attack to scan mutations, Secondary attack to scan genetic makeup")
+	if(LAZYLEN(genetic_makeup_buffer) > 0)
+		. += span_notice("It has the genetic makeup of \"[genetic_makeup_buffer["name"]]\" stored inside its buffer")
 
 /obj/item/sequence_scanner/attack(mob/living/target, mob/living/carbon/human/user)
 	add_fingerprint(user)
@@ -30,6 +37,31 @@
 		gene_scan(target, user)
 	else
 		user.visible_message(span_notice("[user] fails to analyze [target]'s genetic sequence."), span_warning("[target] has no readable genetic sequence!"))
+
+/obj/item/sequence_scanner/attack_secondary(mob/living/target, mob/living/carbon/human/user, max_interact_count=1)
+	add_fingerprint(user)
+	//no scanning if its a husk or DNA-less Species
+	if (!HAS_TRAIT(target, TRAIT_GENELESS) && !HAS_TRAIT(target, TRAIT_BADDNA))
+		user.visible_message(span_bolddanger("[user] is scanning [target]'s genetic makeup."))
+		if(!do_after(user, 6 SECONDS))
+			balloon_alert(user, "scan failed!")
+			user.visible_message(span_alert("[user] fails to scan [target]'s genetic makeup."))
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		makeup_scan(target, user)
+		balloon_alert(user, "makeup scanned")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	else
+		user.visible_message(span_notice("[user] fails to analyze [target]'s genetic makeup."), span_warning("[target] has no readable genetic makeup!"))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
+/obj/item/sequence_scanner/afterattack_secondary(obj/object, mob/user, proximity)
+	. = ..()
+	if(!istype(object) || !proximity)
+		return
+	if(istype(object, /obj/machinery/computer/scan_consolenew))
+		var/obj/machinery/computer/scan_consolenew/console = object
+		var/buffer_index = tgui_input_number(user, "Slot:", "Which slot to export:", 1, LAZYLEN(console.genetic_makeup_buffer), 1)
+		console.genetic_makeup_buffer[buffer_index] = genetic_makeup_buffer
 
 /obj/item/sequence_scanner/attack_self(mob/user)
 	display_sequence(user)
@@ -69,6 +101,18 @@
 			to_chat(user, span_boldnotice("[get_display_name(mutation)]"))
 		else
 			to_chat(user, span_notice("[get_display_name(mutation)]"))
+
+/obj/item/sequence_scanner/proc/makeup_scan(mob/living/carbon/target, mob/living/user)
+	if(!iscarbon(target) || !target.has_dna())
+		return
+
+	genetic_makeup_buffer = list(
+	"label"="Analyzer Slot:[target.real_name]",
+	"UI"=target.dna.unique_identity,
+	"UE"=target.dna.unique_enzymes,
+	"UF"=target.dna.unique_features,
+	"name"=target.real_name,
+	"blood_type"=target.dna.blood_type)
 
 /obj/item/sequence_scanner/proc/display_sequence(mob/living/user)
 	if(!LAZYLEN(buffer) || !ready)

--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -41,7 +41,7 @@
 
 /obj/item/sequence_scanner/attack_secondary(mob/living/target, mob/living/carbon/human/user, max_interact_count = 1)
 	add_fingerprint(user)
-	//no scanning if its a husk, DNA-less Species or DNA from a changeling/disease
+	//no scanning if its a husk, DNA-less Species or DNA that isn't able to be copied by a changeling/disease
 	if (!HAS_TRAIT(target, TRAIT_GENELESS) && !HAS_TRAIT(target, TRAIT_BADDNA) && !HAS_TRAIT(target, TRAIT_NO_DNA_COPY))
 		user.visible_message(span_warning("[user] is scanning [target]'s genetic makeup."))
 		if(!do_after(user, 3 SECONDS))

--- a/code/game/objects/items/devices/scanners/sequence_scanner.dm
+++ b/code/game/objects/items/devices/scanners/sequence_scanner.dm
@@ -20,6 +20,7 @@
 	var/list/buffer
 	var/ready = TRUE
 	var/cooldown = 200
+	/// genetic makeup data that's scanned
 	var/list/genetic_makeup_buffer = list()
 
 /obj/item/sequence_scanner/examine(mob/user)
@@ -38,10 +39,10 @@
 	else
 		user.visible_message(span_notice("[user] fails to analyze [target]'s genetic sequence."), span_warning("[target] has no readable genetic sequence!"))
 
-/obj/item/sequence_scanner/attack_secondary(mob/living/target, mob/living/carbon/human/user, max_interact_count=1)
+/obj/item/sequence_scanner/attack_secondary(mob/living/target, mob/living/carbon/human/user, max_interact_count = 1)
 	add_fingerprint(user)
-	//no scanning if its a husk or DNA-less Species
-	if (!HAS_TRAIT(target, TRAIT_GENELESS) && !HAS_TRAIT(target, TRAIT_BADDNA))
+	//no scanning if its a husk, DNA-less Species or DNA from a changeling/disease
+	if (!HAS_TRAIT(target, TRAIT_GENELESS) && !HAS_TRAIT(target, TRAIT_BADDNA) && !HAS_TRAIT(target, TRAIT_NO_DNA_COPY))
 		user.visible_message(span_warning("[user] is scanning [target]'s genetic makeup."))
 		if(!do_after(user, 3 SECONDS))
 			balloon_alert(user, "scan failed!")
@@ -82,6 +83,7 @@
 		else
 			to_chat(user,span_warning("No database to update from."))
 
+///proc for scanning someone's mutations
 /obj/item/sequence_scanner/proc/gene_scan(mob/living/carbon/target, mob/living/user)
 	if(!iscarbon(target) || !target.has_dna())
 		return
@@ -102,6 +104,7 @@
 		else
 			to_chat(user, span_notice("[get_display_name(mutation)]"))
 
+///proc for scanning someone's genetic makeup
 /obj/item/sequence_scanner/proc/makeup_scan(mob/living/carbon/target, mob/living/user)
 	if(!iscarbon(target) || !target.has_dna())
 		return


### PR DESCRIPTION
## About The Pull Request
Adds a feature to the genetic sequencer geneticists has, you can now right click someone to copy their genetic makeup and export it to the DNA scanner console.
## Why It's Good For The Game
QOL but mostly more ammo for antagonist geneticists, the enzyme feature of genetics is seldom used since you need someone to willingly (if they are alive) step inside the machine which is close to impossible. Not to mention the esoteric way you can change them.

I feel like the art disguising and deception has been dying and tried to make it easier in #76508 which got closed for stealing genetics neesh. this fixes that problem while still serving the same end goal in an albeit less soulful way
## Changelog
:cl:
add: You can now use the genetic sequencer secondary click (RMB) to scan someone 
/:cl:
