### PR TITLE
If you keybind "moan" and "resist" at the same time, then use your "moan" keybind, you get gibbed.

### DIFF
--- a/code/__DEFINES/emotes.dm
+++ b/code/__DEFINES/emotes.dm
@@ -1,4 +1,4 @@
-// Bitflag defines used to ascertain the _why_ this emote is being executed to determine how intentional it was (either user-initiated or game-initiated)
+// Bitflag defines used to ascertain the _why_ this emote is being executed to determine what path we took if it was intentional (either user-initiated or game-initiated)
 /// This emote was forced by the game, default to this if it's not a user actually executing this emote.
 #define EMOTE_EXECUTION_FORCED NONE
 /// This emote was executed by the user via keybindings.

--- a/code/__DEFINES/emotes.dm
+++ b/code/__DEFINES/emotes.dm
@@ -1,0 +1,7 @@
+// Bitflag defines used to ascertain the _why_ this emote is being executed to determine how intentional it was (either user-initiated or game-initiated)
+/// This emote was forced by the game, default to this if it's not a user actually executing this emote.
+#define EMOTE_EXECUTION_FORCED NONE
+/// This emote was executed by the user via keybindings.
+#define EMOTE_EXECUTION_USER_KEYBINDING (1 << 0)
+/// This emote was executed by the user typing it out manually (e.g. writing out "*moan" in chat).
+#define EMOTE_EXECUTION_USER_CHAT (1 << 1)

--- a/code/datums/ai/basic_mobs/pet_commands/play_dead.dm
+++ b/code/datums/ai/basic_mobs/pet_commands/play_dead.dm
@@ -6,7 +6,7 @@
 	var/mob/living/basic/basic_pawn = controller.pawn
 	if(!istype(basic_pawn) || basic_pawn.stat) // Can't act dead if you're dead
 		return
-	basic_pawn.emote("deathgasp", intentional=FALSE)
+	basic_pawn.emote("deathgasp", intentional = EMOTE_EXECUTION_FORCED)
 	basic_pawn.look_dead()
 
 /datum/ai_behavior/play_dead/perform(seconds_per_tick, datum/ai_controller/controller)

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -334,7 +334,10 @@
 	message = null
 
 /datum/emote/imaginary_friend/custom/can_run_emote(mob/user, status_check, intentional)
-	return ..() && intentional
+	if(intentional == EMOTE_EXECUTION_FORCED)
+		return FALSE
+
+	return ..()
 
 /datum/emote/imaginary_friend/custom/run_emote(mob/user, params, type_override = null, intentional = EMOTE_EXECUTION_FORCED)
 	if(!can_run_emote(user, TRUE, intentional))

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -286,7 +286,7 @@
 	mob_type_allowed_typecache = /mob/camera/imaginary_friend
 
 // We have to create our own since we can only show emotes to ourselves and our owner
-/datum/emote/imaginary_friend/run_emote(mob/user, params, type_override, intentional = FALSE)
+/datum/emote/imaginary_friend/run_emote(mob/user, params, type_override, intentional = EMOTE_EXECUTION_FORCED)
 	user.log_talk(message, LOG_EMOTE)
 	if(!can_run_emote(user, FALSE, intentional))
 		return FALSE
@@ -336,7 +336,7 @@
 /datum/emote/imaginary_friend/custom/can_run_emote(mob/user, status_check, intentional)
 	return ..() && intentional
 
-/datum/emote/imaginary_friend/custom/run_emote(mob/user, params, type_override = null, intentional = FALSE)
+/datum/emote/imaginary_friend/custom/run_emote(mob/user, params, type_override = null, intentional = EMOTE_EXECUTION_FORCED)
 	if(!can_run_emote(user, TRUE, intentional))
 		return FALSE
 	if(is_banned_from(user.ckey, "Emote"))

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -161,7 +161,7 @@
 	to_chat(src, span_warning("You cannot speak, your other self is controlling your body!"))
 	return FALSE
 
-/mob/living/split_personality/emote(act, m_type = null, message = null, intentional = FALSE, force_silence = FALSE)
+/mob/living/split_personality/emote(act, m_type = null, message = null, intentional = EMOTE_EXECUTION_FORCED, force_silence = FALSE)
 	return FALSE
 
 ///////////////BRAINWASHING////////////////////

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -49,7 +49,7 @@
 	shooter.Immobilize(0.75 SECONDS / distance)
 	if(!HAS_TRAIT(target, TRAIT_NOFEAR_HOLDUPS))
 		target.Immobilize(0.75 SECONDS / distance)
-		target.emote("gaspshock", intentional = FALSE)
+		target.emote("gaspshock", intentional = EMOTE_EXECUTION_FORCED)
 		add_memory_in_range(target, 7, /datum/memory/held_at_gunpoint, protagonist = target, deuteragonist = shooter, antagonist = weapon)
 
 	shooter.apply_status_effect(/datum/status_effect/holdup, shooter)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -133,7 +133,7 @@
  * Returns FALSE if the cooldown is not over, TRUE if the cooldown is over.
  */
 /datum/emote/proc/check_cooldown(mob/user, intentional)
-	if(!intentional)
+	if(intentional == EMOTE_EXECUTION_FORCED)
 		return TRUE
 	if(user.emotes_used && user.emotes_used[src] + cooldown > world.time)
 		var/datum/emote/default_emote = /datum/emote

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -78,11 +78,11 @@
  * * user - Person that is trying to send the emote.
  * * params - Parameters added after the emote.
  * * type_override - Override to the current emote_type.
- * * intentional - Bool that says whether the emote was forced (FALSE) or not (TRUE).
+ * * intentional - Bitflag that ascertains if the emote was intentional by the user or forced by the game, see __DEFINES/emotes.dm. Defaults to the value that says "forced by the game"
  *
  * Returns TRUE if it was able to run the emote, FALSE otherwise.
  */
-/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = FALSE)
+/datum/emote/proc/run_emote(mob/user, params, type_override, intentional = EMOTE_EXECUTION_FORCED)
 	. = TRUE
 	if(!can_run_emote(user, TRUE, intentional))
 		return FALSE
@@ -128,7 +128,7 @@
  *
  * Arguments:
  * * user - Person that is trying to send the emote.
- * * intentional - Bool that says whether the emote was forced (FALSE) or not (TRUE).
+ * * intentional - Bitflag that ascertains if the emote was intentional by the user or forced by the game, see __DEFINES/emotes.dm. Defaults to the value that says "forced by the game"
  *
  * Returns FALSE if the cooldown is not over, TRUE if the cooldown is over.
  */
@@ -182,7 +182,7 @@
  * Arguments:
  * * user - Person that is trying to send the emote.
  * * msg - The string to modify.
- * * intentional - Bool that says whether the emote was forced (FALSE) or not (TRUE).
+ * * intentional - Bitflag that ascertains if the emote was intentional by the user or forced by the game, see __DEFINES/emotes.dm. Defaults to the value that says "forced by the game"
  *
  * Returns the new message, or msg directly, if no change was needed.
  */
@@ -224,18 +224,18 @@
  * Arguments:
  * * user - Person that is trying to send the emote.
  * * status_check - Bool that says whether we should check their stat or not.
- * * intentional - Bool that says whether the emote was forced (FALSE) or not (TRUE).
+ * * intentional - Bitflag that ascertains if the emote was intentional by the user or forced by the game, see __DEFINES/emotes.dm. Defaults to the value that says "forced by the game"
  *
  * Returns a bool about whether or not the user can run the emote.
  */
-/datum/emote/proc/can_run_emote(mob/user, status_check = TRUE, intentional = FALSE)
+/datum/emote/proc/can_run_emote(mob/user, status_check = TRUE, intentional = EMOTE_EXECUTION_FORCED)
 	if(!is_type_in_typecache(user, mob_type_allowed_typecache))
 		return FALSE
 	if(is_type_in_typecache(user, mob_type_blacklist_typecache))
 		return FALSE
 	if(status_check && !is_type_in_typecache(user, mob_type_ignore_stat_typecache))
 		if(user.stat > stat_allowed)
-			if(!intentional)
+			if(intentional == EMOTE_EXECUTION_FORCED)
 				return FALSE
 			switch(user.stat)
 				if(SOFT_CRIT)
@@ -246,7 +246,7 @@
 					to_chat(user, span_warning("You cannot [key] while dead!"))
 			return FALSE
 		if(hands_use_check && HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
-			if(!intentional)
+			if(intentional == EMOTE_EXECUTION_FORCED)
 				return FALSE
 			to_chat(user, span_warning("You cannot use your hands to [key] right now!"))
 			return FALSE
@@ -261,11 +261,11 @@
  *
  * Arguments:
  * * user - Person that is doing the emote.
- * * intentional - Bool that says whether the emote was forced (FALSE) or not (TRUE).
+ * * intentional - Bitflag that ascertains if the emote was intentional by the user or forced by the game, see __DEFINES/emotes.dm. Defaults to the value that says "forced by the game"
  *
  * Returns a bool about whether or not the user should play a sound when performing the emote.
  */
-/datum/emote/proc/should_play_sound(mob/user, intentional = FALSE)
+/datum/emote/proc/should_play_sound(mob/user, intentional = EMOTE_EXECUTION_FORCED)
 	if(emote_type & EMOTE_AUDIBLE && !muzzle_ignore)
 		if(user.is_muzzled())
 			return FALSE
@@ -278,7 +278,7 @@
 			if(!loud_mouth.get_organ_slot(ORGAN_SLOT_TONGUE))
 				return FALSE
 
-	if(only_forced_audio && intentional)
+	if(only_forced_audio && (intentional == EMOTE_EXECUTION_FORCED))
 		return FALSE
 	return TRUE
 

--- a/code/datums/keybinding/emote.dm
+++ b/code/datums/keybinding/emote.dm
@@ -15,4 +15,4 @@
 	. = ..()
 	if(.)
 		return
-	return user.mob.emote(emote_key, intentional=TRUE)
+	return user.mob.emote(emote_key, intentional = EMOTE_EXECUTION_USER_KEYBINDING)

--- a/code/modules/mob/camera/camera.dm
+++ b/code/modules/mob/camera/camera.dm
@@ -40,7 +40,7 @@
 	z_move_flags |= ZMOVE_IGNORE_OBSTACLES  //cameras do not respect these FLOORS you speak so much of
 	return ..()
 
-/mob/camera/emote(act, m_type=1, message = null, intentional = FALSE, force_silence = FALSE)
+/mob/camera/emote(act, m_type=1, message = null, intentional = EMOTE_EXECUTION_FORCED, force_silence = FALSE)
 	if(has_emotes)
 		return ..()
 	return FALSE

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -1,5 +1,8 @@
 /mob/dead/observer/check_emote(message, forced)
-	return emote(copytext(message, length(message[1]) + 1), intentional = !forced, force_silence = TRUE)
+	if(forced)
+		return emote(copytext(message, length(message[1]) + 1), intentional = EMOTE_EXECUTION_FORCED, force_silence = TRUE)
+	else
+		return emote(copytext(message, length(message[1]) + 1), intentional = EMOTE_EXECUTION_USER_CHAT, force_silence = TRUE)
 
 //Modified version of get_message_mods, removes the trimming, the only thing we care about here is admin channels
 /mob/dead/observer/get_message_mods(message, list/mods)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -23,7 +23,7 @@
 	var/list/key_emotes = GLOB.emote_list[act]
 
 	if(!length(key_emotes))
-		if(intentional && !force_silence)
+		if((intentional != EMOTE_EXECUTION_FORCED) && !force_silence)
 			to_chat(src, span_notice("'[act]' emote does not exist. Say *help for a list."))
 		return FALSE
 	var/silenced = FALSE
@@ -35,7 +35,7 @@
 			SEND_SIGNAL(src, COMSIG_MOB_EMOTE, P, act, m_type, message, intentional)
 			SEND_SIGNAL(src, COMSIG_MOB_EMOTED(P.key))
 			return TRUE
-	if(intentional && !silenced && !force_silence)
+	if((intentional != EMOTE_EXECUTION_FORCED) && !silenced && !force_silence)
 		to_chat(src, span_notice("Unusable emote '[act]'. Say *help for a list."))
 	return FALSE
 

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -12,7 +12,7 @@
 #define BEYBLADE_CONFUSION_LIMIT (40 SECONDS)
 
 //The code execution of the emote datum is located at code/datums/emotes.dm
-/mob/proc/emote(act, m_type = null, message = null, intentional = FALSE, force_silence = FALSE)
+/mob/proc/emote(act, m_type = null, message = null, intentional = EMOTE_EXECUTION_FORCED, force_silence = FALSE)
 	var/param = message
 	var/custom_param = findchar(act, " ")
 	if(custom_param)
@@ -52,7 +52,7 @@
 		for(var/datum/emote/P in GLOB.emote_list[key])
 			if(P.key in keys)
 				continue
-			if(P.can_run_emote(user, status_check = FALSE , intentional = TRUE))
+			if(P.can_run_emote(user, status_check = FALSE , intentional = EMOTE_EXECUTION_USER_CHAT))
 				keys += P.key
 
 	keys = sort_list(keys)
@@ -77,7 +77,7 @@
 	. = ..()
 	if(.)
 		return
-	if(!can_run_emote(user, intentional=intentional))
+	if(!can_run_emote(user, intentional = intentional))
 		return
 	if(isliving(user))
 		var/mob/living/flippy_mcgee = user
@@ -111,7 +111,7 @@
 	. = ..()
 	if(.)
 		return
-	if(!can_run_emote(user, intentional=intentional))
+	if(!can_run_emote(user, intentional = intentional))
 		return
 	if(!iscarbon(user))
 		return

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -67,33 +67,37 @@
 	message = "moans!"
 	message_mime = "appears to moan!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
-	can_message_change = TRUE
 
-/datum/emote/living/carbon/moan/run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/carbon/moan/can_run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	if(!.)
+		return FALSE
+
 	if(!intentional || !iscarbon(user) || isnull(user.client) || isnull(user.client.prefs))
-		return ..()
+		return TRUE
 
 	var/datum/preferences/cached_prefs = user.client.prefs
 	var/list/moan_keys = cached_prefs.key_bindings[key]
 	if(!length(moan_keys))
-		return ..()
+		return TRUE
 
 	var/list/resist_hotkeys = cached_prefs.key_bindings["resist"]
 	if(!length(resist_hotkeys))
-		return ..()
+		return TRUE
 
 	var/hotkey_matched = FALSE
 	for(var/moan_hotkey in moan_keys)
-		if(resist_hotkeys[moan_hotkey])
+		if(moan_hotkey in resist_hotkeys)
 			hotkey_matched = TRUE
 			break
 
 	if(!hotkey_matched)
-		return ..()
+		return TRUE
 
 	var/mob/living/carbon/carbon_user = user
-	to_chat(user, span_bolddanger("As you try to let out a moan while you resist, all that comes out of your mouth is blood! Your throat starts to implode in on itself, and then you feel a big rushing sensation of air..."))
+	to_chat(user, span_bolddanger("As you try to let out a moan while you resist, all that comes out of your mouth is blood! You feel extremely woozy, and then comes a rushing sensation of air..."))
 	carbon_user.gib(safe_gib = TRUE)
+	return FALSE
 
 /datum/emote/living/carbon/noogie
 	key = "noogie"

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -95,7 +95,7 @@
 		return TRUE
 
 	var/mob/living/carbon/carbon_user = user
-	to_chat(user, span_suicide("As you try to let out a moan while you resist, all that comes out of your mouth is blood! You feel extremely woozy, and then comes a rushing sensation of air..."))
+	to_chat(user, span_userdanger("As you try to let out a moan while you resist, all that comes out of your mouth is blood! You feel extremely woozy, and then comes a rushing sensation of air..."))
 	carbon_user.gib(safe_gib = TRUE)
 	return FALSE
 

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -73,7 +73,7 @@
 	if(!.)
 		return FALSE
 
-	if(!intentional || !iscarbon(user) || isnull(user.client) || isnull(user.client.prefs))
+	if(!(intentional & EMOTE_EXECUTION_USER_KEYBINDING) || !iscarbon(user) || isnull(user.client) || isnull(user.client.prefs))
 		return TRUE
 
 	var/datum/preferences/cached_prefs = user.client.prefs

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -67,6 +67,33 @@
 	message = "moans!"
 	message_mime = "appears to moan!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
+	can_message_change = TRUE
+
+/datum/emote/living/carbon/moan/run_emote(mob/user, params, type_override, intentional)
+	if(!intentional || !iscarbon(user) || isnull(user.client) || isnull(user.client.prefs))
+		return ..()
+
+	var/datum/preferences/cached_prefs = user.client.prefs
+	var/list/moan_keys = cached_prefs.key_bindings[key]
+	if(!length(moan_keys))
+		return ..()
+
+	var/list/resist_hotkeys = cached_prefs.key_bindings["resist"]
+	if(!length(resist_hotkeys))
+		return ..()
+
+	var/hotkey_matched = FALSE
+	for(var/moan_hotkey in moan_keys)
+		if(resist_hotkeys[moan_hotkey])
+			hotkey_matched = TRUE
+			break
+
+	if(!hotkey_matched)
+		return ..()
+
+	var/mob/living/carbon/carbon_user = user
+	to_chat(user, span_bolddanger("As you try to let out a moan while you resist, all that comes out of your mouth is blood! Your throat starts to implode in on itself, and then you feel a big rushing sensation of air..."))
+	carbon_user.gib(safe_gib = TRUE)
 
 /datum/emote/living/carbon/noogie
 	key = "noogie"

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -68,7 +68,7 @@
 	message_mime = "appears to moan!"
 	emote_type = EMOTE_AUDIBLE | EMOTE_VISIBLE
 
-/datum/emote/living/carbon/moan/can_run_emote(mob/user, params, type_override, intentional)
+/datum/emote/living/carbon/moan/can_run_emote(mob/user, status_check, intentional)
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -95,7 +95,7 @@
 		return TRUE
 
 	var/mob/living/carbon/carbon_user = user
-	to_chat(user, span_bolddanger("As you try to let out a moan while you resist, all that comes out of your mouth is blood! You feel extremely woozy, and then comes a rushing sensation of air..."))
+	to_chat(user, span_suicide("As you try to let out a moan while you resist, all that comes out of your mouth is blood! You feel extremely woozy, and then comes a rushing sensation of air..."))
 	carbon_user.gib(safe_gib = TRUE)
 	return FALSE
 

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -331,7 +331,7 @@
 
 /datum/emote/living/scream/select_message_type(mob/user, message, intentional)
 	. = ..()
-	if(!intentional && isanimal_or_basicmob(user))
+	if((intentional == EMOTE_EXECUTION_FORCED) && isanimal_or_basicmob(user))
 		return "makes a loud and pained whimper."
 
 /datum/emote/living/scowl

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -590,7 +590,7 @@
 		return TRUE
 	return FALSE
 
-/datum/emote/living/custom/run_emote(mob/user, params, type_override = null, intentional = FALSE)
+/datum/emote/living/custom/run_emote(mob/user, params, type_override = null, intentional = EMOTE_EXECUTION_FORCED)
 	var/custom_emote
 	var/custom_emote_type
 	if(!can_run_emote(user, TRUE, intentional))

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -147,7 +147,11 @@
 ///Check if this message is an emote
 /mob/proc/check_emote(message, forced)
 	if(message[1] == "*")
-		emote(copytext(message, length(message[1]) + 1), intentional = !forced)
+		if(forced)
+			emote(copytext(message, length(message[1]) + 1), intentional = EMOTE_EXECUTION_FORCED)
+		else
+			emote(copytext(message, length(message[1]) + 1), intentional = EMOTE_EXECUTION_USER_CHAT)
+
 		return TRUE
 
 ///Check if the mob has a hivemind channel

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -88,6 +88,7 @@
 #include "code\__DEFINES\dynamic.dm"
 #include "code\__DEFINES\economy.dm"
 #include "code\__DEFINES\electrified_buckle.dm"
+#include "code\__DEFINES\emotes.dm"
 #include "code\__DEFINES\events.dm"
 #include "code\__DEFINES\exosuit_fab.dm"
 #include "code\__DEFINES\experisci.dm"


### PR DESCRIPTION

## About The Pull Request

On the tin. Features a new bitflag system to ascertain an "intentional" emote's source, if it was typed out in chat (e.g. `*moan`) the behavioral strategy would fall completely flat. So, we just track the source via the bitflag. If this PR gets closed or reverted, I would greatly appreciate it if you were to keep the framework of intentionality in as it might be useful in the future, simply removing the interaction on the `/datum/emote/moan/can_run_emote()` proc. thanks.
## Why It's Good For The Game

You're being weird buddy. You should fix those binds. Positive Punishment is a powerful tool (or would it be negative punishment since we're removing your life? unsure). Powergamer. Neener neener.
## Changelog
:cl:
add: For some reason, spacemen everywhere who both moan and resist something at the same time have been getting gibbed. Would be worthwhile to change up those habits.
/:cl:
The system should be foolproof enough to where you don't get gibbed if you don't stringently meet the following criteria:
- The emote was not forced by the game, but must have been forced via you doing a keybind.
- The keybind is the same for resisting (which means that you _will_ be resisting since you did the keybind aforementioned)
- You're capable of doing the emote on your own volition otherwise.