### PR TITLE
Fixes multiz gas not displaying properly

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_helpers.dm
+++ b/code/__DEFINES/atmospherics/atmos_helpers.dm
@@ -53,13 +53,13 @@ GLOBAL_LIST_INIT(nonoverlaying_gases, typecache_of_gases_with_no_overlays())
 #define GAS_OVERLAYS(gases, out_var, z_layer_turf)\
 	do { \
 		out_var = list();\
-		var/offset = GET_TURF_PLANE_OFFSET(z_layer_turf);\
+		var/offset = GET_TURF_PLANE_OFFSET(z_layer_turf) + 1;\
 		for(var/_ID in gases){\
 			if(GLOB.nonoverlaying_gases[_ID]) continue;\
 			var/_GAS = gases[_ID];\
 			var/_GAS_META = _GAS[GAS_META];\
 			if(_GAS[MOLES] <= _GAS_META[META_GAS_MOLES_VISIBLE]) continue;\
-			var/_GAS_OVERLAY = _GAS_META[META_GAS_OVERLAY][offset + 1];\
+			var/_GAS_OVERLAY = _GAS_META[META_GAS_OVERLAY][offset];\
 			out_var += _GAS_OVERLAY[min(TOTAL_VISIBLE_STATES, CEILING(_GAS[MOLES] / MOLES_GAS_VISIBLE_STEP, 1))];\
 		} \
 	}\

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -301,7 +301,7 @@
 	alpha = alph
 	plane_offset = offset
 
-/obj/effect/overlay/gas/Initialize(mapload, icon_state, alpha, offset)
+/obj/effect/overlay/gas/Initialize(mapload)
 	. = ..()
 	SET_PLANE_W_SCALAR(src, initial(plane), plane_offset)
 

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -23,8 +23,7 @@
 		var/fill = list()
 		to_return += list(fill)
 		for(var/j in 1 to TOTAL_VISIBLE_STATES)
-			var/obj/effect/overlay/gas/gas =  new (initial(gas_type.gas_overlay), log(4, (j+0.4*TOTAL_VISIBLE_STATES) / (0.35*TOTAL_VISIBLE_STATES)) * 255)
-			SET_PLANE_W_SCALAR(gas, gas.plane, i)
+			var/obj/effect/overlay/gas/gas = new (initial(gas_type.gas_overlay), log(4, (j+0.4*TOTAL_VISIBLE_STATES) / (0.35*TOTAL_VISIBLE_STATES)) * 255, i)
 			fill += gas
 	return to_return
 
@@ -292,8 +291,17 @@
 	plane = ABOVE_GAME_PLANE
 	appearance_flags = TILE_BOUND
 	vis_flags = NONE
+	// The visual offset we are "on".
+	// Can't use the tradtional loc because we are stored in nullspace, and we can't set plane before init because of the helping that SET_PLANE_EXPLICIT does IN init
+	var/plane_offset = 0
 
-/obj/effect/overlay/gas/New(state, alph)
+/obj/effect/overlay/gas/New(state, alph, offset)
 	. = ..()
 	icon_state = state
 	alpha = alph
+	plane_offset = offset
+
+/obj/effect/overlay/gas/Initialize(mapload, icon_state, alpha, offset)
+	. = ..()
+	SET_PLANE_W_SCALAR(src, initial(plane), plane_offset)
+


### PR DESCRIPTION

## About The Pull Request

Broken by 51f02b5acc0ee3d042734b8fd4fd2b58ac41f9ab I introduced logic that would use SET_PLANE_EXPLICIT's context arg's PLANE (if it had no turf) as a source.
Since we use SET_PLANE_IMPLICIT in atom Initialize, if we set a plane before Init, it'll end up double offsetting. This was effecting gas.

Solution, because this case is so rare, is just to set the plane on init and store the offset on the object until then.

## Why It's Good For The Game

Closes #75709 
Closes #73642
## Changelog
:cl:
fix: Gas, like plasma, will now properly display on multiz stations
/:cl:
