### PR TITLE
Teslium Reactions now charge tesla coils

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -538,7 +538,7 @@
 	modifier = -100
 	mix_message = "<span class='boldannounce'>The teslium starts to spark as electricity arcs away from it!</span>"
 	mix_sound = 'sound/machines/defib_zap.ogg'
-	var/zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_MOB_STUN | ZAP_LOW_POWER_GEN
+	var/zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_MOB_STUN | ZAP_GENERATES_POWER | ZAP_LOW_POWER_GEN
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_EXPLOSIVE | REACTION_TAG_DANGEROUS
 
 /datum/chemical_reaction/reagent_explosion/teslium_lightning/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)


### PR DESCRIPTION
## About The Pull Request

Fixes #74151

Teslium reaction did not have the `ZAP_GENERATES_POWER` flag
https://github.com/tgstation/tgstation/blob/95298fb99d3d55a555667e4c9def3112ac2593a8/code/modules/reagents/chemistry/recipes/pyrotechnics.dm#L541

So tesla coil early returned when it checked for it
https://github.com/tgstation/tgstation/blob/95298fb99d3d55a555667e4c9def3112ac2593a8/code/modules/power/tesla/coil.dm#L104-L105

So let's add that flag

## Why it's good for the game

Because it gives players a reason to even do the Teslium reaction as now it can generate power & more power means more FUN.

## Changelog
:cl:
add: teslium Reactions now charge tesla coils.
/:cl:
