### PR TITLE
Emagged organ harvesters can now harvest people who aren't naked

### DIFF
--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -189,7 +189,8 @@
 		return
 	obj_flags |= EMAGGED
 	allow_living = TRUE
-	to_chat(user, span_warning("You overload [src]'s lifesign scanners."))
+	allow_clothing = TRUE
+	to_chat(user, span_warning("You overload [src]'s lifesign and abiotic material scanners."))
 
 /obj/machinery/harvester/container_resist_act(mob/living/user)
 	if(!harvesting)


### PR DESCRIPTION
## About The Pull Request

Emagged organ harvesters will no longer refuse a victim that has items on their person, such as the handcuffs they've been bound with.

To be clear, this PR affects the organ harvester, which should not be confused with the chef's gibber or cargo's recycler.

## Why It's Good For The Game

Emagging an organ harvester disables its checks to make sure that the "patient" is dead, but doesn't disable its checks to make sure that the patient is naked. This makes grinding people alive with an organ harvester very awkward, as the machine will detect the cuffs you've bound them with and refuse to grind them.

A demonstration of the jank involved in the current organ harvester experience, courtesy of Livrah: https://youtube.com/clip/UgkxC8OmO90nEhAonO0PIhRmQtcA-0urZoZ3

For the record, grinding conscious victims (but not critted or unconscious ones) notifies ghosts. Furthermore, the variable for disabling the item check actually already existed in the code for the organ harvester, but was unused. I believe that tying someone up and killing them slowly and painfully by shoving them into an organ harvester is supposed to be intentional.

## Changelog
:cl: ATHATH
qol: Emagged organ harvesters will no longer refuse a victim that has items on their person, such as the handcuffs they've been bound with.
/:cl:
