### PR TITLE
Fixes invisible arrow sprite & some code cleanup

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -37,9 +37,10 @@
 	if(isturf(loc))
 		qdel(src)
 
+// We don't want to have '-live' appended to the end of the icon_state for arrows
 /obj/item/ammo_casing/arrow/update_icon_state()
+	. = ..()
 	icon_state = "[initial(icon_state)]
-	return ..()
 
 /// holy arrows
 /obj/item/ammo_casing/arrow/holy

--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -28,16 +28,6 @@
 	speed = 1
 	range = 25
 
-///*sigh* NON-REUSABLE base arrow projectile. In the future: let's componentize the reusable subtype, jesus
-/obj/projectile/bullet/arrow
-	name = "arrow"
-	desc = "Ow! Get it out of me!"
-	icon = 'icons/obj/weapons/guns/bows/arrows.dmi'
-	icon_state = "arrow_projectile"
-	damage = 50
-	speed = 1
-	range = 25
-
 /// despawning arrow type
 /obj/item/ammo_casing/arrow/despawning/dropped()
 	. = ..()
@@ -46,6 +36,10 @@
 /obj/item/ammo_casing/arrow/despawning/proc/floor_vanish()
 	if(isturf(loc))
 		qdel(src)
+
+/obj/item/ammo_casing/arrow/update_icon_state()
+	icon_state = "[initial(icon_state)]
+	return ..()
 
 /// holy arrows
 /obj/item/ammo_casing/arrow/holy


### PR DESCRIPTION
## About The Pull Request

Fixes invisible arrow sprites (https://github.com/Skyrat-SS13/Skyrat-tg/issues/22267)

Caused by https://github.com/tgstation/tgstation/pull/76335 which appended '-live' to the icon_state of arrow ammo casings, causing a discrepancy between the code and the .dmi file icon_states for arrows.

Also removes an subtype of projectile that is no longer necessary after their changes.

Edit nevermind, see https://github.com/tgstation/tgstation/pull/76565

## Why It's Good For The Game

Fixes invisible arrow sprites, code cleanup.

## Changelog

:cl:
fix: arrows will no longer have invisible sprites
/:cl:

