### PR TITLE
nightmare vision goggles give you night vision

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -679,6 +679,7 @@
 	inhand_icon_state = "glasses"
 	glass_colour_type = /datum/client_colour/glass_colour/nightmare
 	forced_glass_color = TRUE
+	lighting_cutoff = LIGHTING_CUTOFF_FULLBRIGHT
 
 /obj/item/clothing/glasses/osi
 	name = "O.S.I. Sunglasses"


### PR DESCRIPTION
## About The Pull Request
what the title says, it gives you fullbright

## Why It's Good For The Game
it'd be really funny to see people use it in dark areas for the night vision while trying to work with the full red/black screen

## Changelog
:cl:
balance: nightmare vision goggles give you night vision
/:cl:
