### PR TITLE
Fixes organ/implant manipulator creating implants in the void when failing to insert

### DIFF
--- a/code/modules/admin/verbs/manipulate_organs.dm
+++ b/code/modules/admin/verbs/manipulate_organs.dm
@@ -1,4 +1,4 @@
-/client/proc/manipulate_organs(mob/living/carbon/C in world)
+/client/proc/manipulate_organs(mob/living/carbon/carbon_victim in world)
 	set name = "Manipulate Organs"
 	set category = "Debug"
 	var/operation = tgui_input_list(usr, "Select organ operation", "Organ Manipulation", list("add organ", "add implant", "drop organ/implant", "remove organ/implant"))
@@ -12,65 +12,72 @@
 				var/dat = replacetext("[path]", "/obj/item/organ/", ":")
 				organs[dat] = path
 
-			var/obj/item/organ/organ = tgui_input_list(usr, "Select organ type", "Organ Manipulation", organs)
-			if(isnull(organ))
+			var/obj/item/organ/organ_to_grant = tgui_input_list(usr, "Select organ type", "Organ Manipulation", organs)
+			if(isnull(organ_to_grant))
 				return
-			if(isnull(organs[organ]))
+			if(isnull(organs[organ_to_grant]))
 				return
-			organ = organs[organ]
-			organ = new organ
-			organ.Insert(C)
-			log_admin("[key_name(usr)] has added organ [organ.type] to [key_name(C)]")
-			message_admins("[key_name_admin(usr)] has added organ [organ.type] to [ADMIN_LOOKUPFLW(C)]")
+			organ_to_grant = organs[organ_to_grant]
+			organ_to_grant = new organ_to_grant
+			if(!organ_to_grant.Insert(carbon_victim))
+				to_chat(usr, span_notice("[carbon_victim] is unable to carry this organ!"))
+				qdel(organ_to_grant)
+				return
+			log_admin("[key_name(usr)] has added organ [organ_to_grant.type] to [key_name(carbon_victim)]")
+			message_admins("[key_name_admin(usr)] has added organ [organ_to_grant.type] to [ADMIN_LOOKUPFLW(carbon_victim)]")
 
 		if("add implant")
 			for(var/path in subtypesof(/obj/item/implant))
 				var/dat = replacetext("[path]", "/obj/item/implant/", ":")
 				organs[dat] = path
 
-			var/obj/item/implant/organ = tgui_input_list(usr, "Select implant type", "Organ Manipulation", organs)
-			if(isnull(organ))
+			var/obj/item/implant/implant_to_grant = tgui_input_list(usr, "Select implant type", "Organ Manipulation", organs)
+			if(isnull(implant_to_grant))
 				return
-			if(isnull(organs[organ]))
+			if(isnull(organs[implant_to_grant]))
 				return
-			organ = organs[organ]
-			organ = new organ
-			organ.implant(C)
-			log_admin("[key_name(usr)] has added implant [organ.type] to [key_name(C)]")
-			message_admins("[key_name_admin(usr)] has added implant [organ.type] to [ADMIN_LOOKUPFLW(C)]")
+			implant_to_grant = organs[implant_to_grant]
+			implant_to_grant = new implant_to_grant
+			if(!implant_to_grant.implant(carbon_victim))
+				to_chat(usr, span_notice("[carbon_victim] is unable to hold this implant!"))
+				qdel(implant_to_grant)
+				return
+			log_admin("[key_name(usr)] has added implant [implant_to_grant.type] to [key_name(carbon_victim)]")
+			message_admins("[key_name_admin(usr)] has added implant [implant_to_grant.type] to [ADMIN_LOOKUPFLW(carbon_victim)]")
 
 		if("drop organ/implant", "remove organ/implant")
-			for(var/obj/item/organ/user_organs as anything in C.organs)
+			for(var/obj/item/organ/user_organs as anything in carbon_victim.organs)
 				organs["[user_organs.name] ([user_organs.type])"] = user_organs
 
-			for(var/obj/item/implant/user_implants as anything in C.implants)
+			for(var/obj/item/implant/user_implants as anything in carbon_victim.implants)
 				organs["[user_implants.name] ([user_implants.type])"] = user_implants
 
-			var/obj/item/organ = tgui_input_list(usr, "Select organ/implant", "Organ Manipulation", organs)
-			if(isnull(organ))
+			var/obj/item/organ_to_modify = tgui_input_list(usr, "Select organ/implant", "Organ Manipulation", organs)
+			if(isnull(organ_to_modify))
 				return
-			if(isnull(organs[organ]))
+			if(isnull(organs[organ_to_modify]))
 				return
-			organ = organs[organ]
-			var/obj/item/organ/O
-			var/obj/item/implant/I
+			organ_to_modify = organs[organ_to_modify]
 
-			log_admin("[key_name(usr)] has removed [organ.type] from [key_name(C)]")
-			message_admins("[key_name_admin(usr)] has removed [organ.type] from [ADMIN_LOOKUPFLW(C)]")
+			log_admin("[key_name(usr)] has removed [organ_to_modify.type] from [key_name(carbon_victim)]")
+			message_admins("[key_name_admin(usr)] has removed [organ_to_modify.type] from [ADMIN_LOOKUPFLW(carbon_victim)]")
 
-			if(isorgan(organ))
-				O = organ
-				O.Remove(C)
+			var/obj/item/organ/organ_holder
+			var/obj/item/implant/implant_holder
+
+			if(isorgan(organ_to_modify))
+				organ_holder = organ_to_modify
+				organ_holder.Remove(carbon_victim)
 			else
-				I = organ
-				I.removed(C)
+				implant_holder = organ_to_modify
+				implant_holder.removed(carbon_victim)
 
-			organ.forceMove(get_turf(C))
+			organ_to_modify.forceMove(get_turf(carbon_victim))
 
 			if(operation == "remove organ/implant")
-				qdel(organ)
-			else if(I) // Put the implant in case.
-				var/obj/item/implantcase/case = new(get_turf(C))
-				case.imp = I
-				I.forceMove(case)
+				qdel(organ_to_modify)
+			else if(implant_holder) // Put the implant in case.
+				var/obj/item/implantcase/case = new(get_turf(carbon_victim))
+				case.imp = implant_holder
+				implant_holder.forceMove(case)
 				case.update_appearance()


### PR DESCRIPTION

## About The Pull Request

When using the organ manipulator, implants that fail implant() would still be created and be left out of the implantee.

Now, implants that fail insertion will self-delete and notify the menu operator. This functionality has been extended to organs as well, although I don't know of any cases where they could fail insertion.

I also touched up on the variable names while I was here, because they needed a face-lift.
## Why It's Good For The Game

Prevents edge cases that could lead to orphaned implants or organs.

More readable code is neat too.
## Changelog
:cl: Rhials
fix: The organ manipulator menu will now delete implants or organs that fail to properly insert.
code: The organ manipulator menu code now looks nicer :)
/:cl:
