### PR TITLE
cursed katana shard no longer called "dark spoon shard"

### DIFF
--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -915,6 +915,8 @@
 	return
 
 /obj/item/organ/internal/cyberimp/arm/shard/katana
+	name = "dark shard"
+	desc = "An eerie metal shard surrounded by dark energies."
 	items_to_create = list(/obj/item/cursed_katana)
 
 /obj/item/organ/internal/cyberimp/arm/shard/katana/Retract()


### PR DESCRIPTION

## About The Pull Request
https://github.com/tgstation/tgstation/pull/75948 changed the name of the cursed shard and made the katana version a subtype...without changing the name or desc of the shard
## Why It's Good For The Game
the dark shard from tendril loot will no longer have a stupid name and tell you you're not supposed to have it
## Changelog
:cl:
fix: The cursed katana shard you can get from tendril loot no longer falsely tells you you're not supposed to have it
/:cl:
