### PR TITLE
Fix double signal send of `COMSIG_MOB_EMOTED`

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -121,8 +121,6 @@
 			if(viewer.is_blind() && !viewer.can_hear())
 				to_chat(viewer, msg)
 
-	SEND_SIGNAL(user, COMSIG_MOB_EMOTED(key))
-
 /**
  * For handling emote cooldown, return true to allow the emote to happen.
  *


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/blob/75af2bed854c6426f46ed2797714c45446d92303/code/datums/emotes.dm#L124

https://github.com/tgstation/tgstation/blob/75af2bed854c6426f46ed2797714c45446d92303/code/modules/mob/emote.dm#L34-L36

I opted to keep the latter because it's always sent when the former is only sent under certain conditions. 

## Why It's Good For The Game

Fixes some strangeness involving this signal

## Changelog

:cl: Melbert
fix: Fix certain emote interactions happening twice at the same time
/:cl:


