### PR TITLE
fixes changelog linters

### DIFF
--- a/tools/ss13_genchangelog.py
+++ b/tools/ss13_genchangelog.py
@@ -60,7 +60,9 @@ validPrefixes = [
     'refactor',
     'config',
     'admin',
-    'server'
+    'server',
+    'sound',
+    'image',
 ]
 
 def dictToTuples(inp):
@@ -127,6 +129,7 @@ for fileName in glob.glob(os.path.join(args.ymlDir, "*.yml")):
                 (change_type, _) = dictToTuples(change)[0]
                 if change_type not in validPrefixes:
                     print('  {0}: Invalid prefix {1}'.format(fileName, change_type), file=sys.stderr)
+                    sys.exit(1)
                 author_entries += [change]
                 new += 1
         currentEntries[today][cl['author']] = author_entries


### PR DESCRIPTION
## About The Pull Request

This portion of the script wasn't updated post-#74865 (aeed75d72f82b4d6631391e67680f6a3733120d8), so we always got an error on linters. This never threw a `sys.exit` error so this list hasn't been updated for a solid while now...

Let's both add the prefix and make sure we throw so we don't forget about this script in the future. Quite important to make sure this stuff works!

![image](https://github.com/tgstation/tgstation/assets/34697715/0a3ff732-116c-4d1e-8fe7-f199d1222f4c)
