### PR TITLE
pAIs copy their master's languages, loses universal translator

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -24,3 +24,4 @@
 #define LANGUAGE_VOICECHANGE "voicechange"
 #define LANGUAGE_RADIOKEY "radiokey"
 #define LANGUAGE_BABEL "babel"
+#define LANGUAGE_PAI "pai"

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -51,8 +51,6 @@
 	var/holoform = FALSE
 	/// Installed software on the pAI
 	var/list/installed_software = list()
-	/// Toggles whether universal translator has been activated. Cannot be reversed
-	var/languages_granted = FALSE
 	/// Reference of the bound master
 	var/datum/weakref/master_ref
 	/// The master's name string
@@ -101,7 +99,6 @@
 		"Crew Monitor" = 35,
 		"Door Jack" = 35,
 		"Internal GPS" = 35,
-		"Universal Translator" = 35,
 	)
 	/// List of all possible chasises. TRUE means the pAI can be picked up in this chasis.
 	var/static/list/possible_chassis = list(
@@ -359,6 +356,7 @@
 	master_ref = WEAKREF(master)
 	master_name = master.real_name
 	master_dna = master.dna.unique_enzymes
+	copy_languages(master, source_override = LANGUAGE_PAI)
 	to_chat(src, span_boldannounce("You have been bound to a new master: [user.real_name]!"))
 	holochassis_ready = TRUE
 	return TRUE

--- a/code/modules/pai/software.dm
+++ b/code/modules/pai/software.dm
@@ -164,7 +164,10 @@
 		balloon_alert(src, "no dna detected!")
 		return FALSE
 	to_chat(src, span_boldannounce(("[holder]'s UE string: [holder.dna.unique_enzymes]")))
-	to_chat(src, span_notice("DNA [holder.dna.unique_enzymes == master_dna ? "matches" : "does not match"] our stored Master's DNA."))
+	var/dna_matches = (holder.dna.unique_enzymes == master_dna)
+	to_chat(src, span_notice("DNA [dna_matches ? "matches" : "does not match"] our stored Master's DNA."))
+	if(dna_matches)
+		copy_languages(dna_matches, source_override = LANGUAGE_PAI)
 	return TRUE
 
 /**

--- a/code/modules/pai/software.dm
+++ b/code/modules/pai/software.dm
@@ -18,7 +18,6 @@
 	data["available"] = available_software
 	data["directives"] = laws.supplied
 	data["emagged"] = emagged
-	data["languages"] = languages_granted
 	data["master_name"] = master_name
 	data["master_dna"] = master_dna
 	return data
@@ -86,10 +85,6 @@
 			return TRUE
 		if("Security HUD")
 			toggle_hud(PAI_TOGGLE_SECURITY_HUD)
-			return TRUE
-		if("Universal Translator")
-			grant_languages()
-			ui.send_full_update()
 			return TRUE
 	return FALSE
 
@@ -170,18 +165,6 @@
 		return FALSE
 	to_chat(src, span_boldannounce(("[holder]'s UE string: [holder.dna.unique_enzymes]")))
 	to_chat(src, span_notice("DNA [holder.dna.unique_enzymes == master_dna ? "matches" : "does not match"] our stored Master's DNA."))
-	return TRUE
-
-/**
- * Grant all languages to the current pAI.
- *
- * @returns {boolean} - TRUE if the languages were granted, FALSE otherwise.
- */
-/mob/living/silicon/pai/proc/grant_languages()
-	if(languages_granted)
-		return FALSE
-	grant_all_languages(TRUE, TRUE, TRUE, LANGUAGE_SOFTWARE)
-	languages_granted = TRUE
 	return TRUE
 
 /**

--- a/tgui/packages/tgui/interfaces/PaiInterface/Installed.tsx
+++ b/tgui/packages/tgui/interfaces/PaiInterface/Installed.tsx
@@ -144,15 +144,6 @@ const SoftwareButtons = (props, context) => {
           </Button>
         </>
       );
-    case 'Universal Translator':
-      return (
-        <Button
-          icon="download"
-          onClick={() => act(currentSelection)}
-          disabled={!!languages}>
-          {!languages ? 'Install' : 'Installed'}
-        </Button>
-      );
     default:
       return (
         <Button

--- a/tgui/packages/tgui/interfaces/PaiInterface/constants.ts
+++ b/tgui/packages/tgui/interfaces/PaiInterface/constants.ts
@@ -67,7 +67,6 @@ export const SOFTWARE_DESC = {
   'Remote Signaler': `A remote signalling device to transmit and receive
     codes.`,
   'Security HUD': `Allows you to view security records using an overlay HUD.`,
-  'Universal Translator': `Translation module for non-common languages.`,
 } as const;
 
 export enum PAI_TAB {


### PR DESCRIPTION
## About The Pull Request

This PR removes pAI's universal translator app. Instead they copy the languages of whoever imprints them, on top of their default languages (silicon ones, so Common, Uncommon and Robotic).

## Why It's Good For The Game

Universal Translator is seen as a necessity for pAIs to translate things for Foreigners, and I don't want to take that away, so instead pAIs will always know their base languages, and any languages their master knows.
The app itself essentially turns a pAI into a Curator, which kinda sucks as it takes away one of the main points of the Curator, being a translator for people who have no other option.
It also means pAIs can listen and talk in the native languages their master can, without having to buy the most expensive program in their shop. 

This is also the last agreed upon removal for language knowledge from the coderbus meeting, as far as I'm aware.

## Changelog

:cl:
balance: pAIs can no longer purchase the Universal Translator app.
balance: pAIs now copy the languages of their master upon imprint.
/:cl: