### PR TITLE
[NO GBP] Crayon fixes

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -231,9 +231,9 @@
 	update_appearance()
 
 /**
- *	Refills charges_left in infinite crayons on use.
- *	Sets charges_left in infinite crayons to 100 for spawning reagents.
- *	Spawns reagents in crayons based on the amount of charges_left if not spawned yet.
+ * Refills charges_left in infinite crayons on use.
+ * Sets charges_left in infinite crayons to 100 for spawning reagents.
+ * Spawns reagents in crayons based on the amount of charges_left if not spawned yet.
  */
 /obj/item/toy/crayon/proc/refill()
 	if(charges == INFINITE_CHARGES)
@@ -274,7 +274,7 @@
 	return TRUE
 
 /**
- *	When eating a crayon, check_empty() can be called twice producing two messages unless we check for being deleted first.
+ * When eating a crayon, check_empty() can be called twice producing two messages unless we check for being deleted first.
  *
  * Arguments:
  * * user - the user.

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -218,16 +218,23 @@
 	if(edible)
 		AddComponent(/datum/component/edible, bite_consumption = reagents.total_volume / (charges_left / 5), after_eat = CALLBACK(src, PROC_REF(after_eat)))
 
+/// Used for edible component to reduce charges_left on bite.
 /obj/item/toy/crayon/proc/after_eat(mob/user)
-	use_charges(user, amount = 5, requires_full = FALSE, override_infinity = TRUE)
+	use_charges(user, 5, FALSE, TRUE)
 	if(check_empty(user, override_infinity = TRUE)) //Prevents division by zero
 		return
 
+/// Sets painting color and updates appearance.
 /obj/item/toy/crayon/set_painting_tool_color(chosen_color)
 	. = ..()
 	paint_color = chosen_color
 	update_appearance()
 
+/**
+ *	Refills charges_left in infinite crayons on use.
+ *	Sets charges_left in infinite crayons to 100 for spawning reagents.
+ *	Spawns reagents in crayons based on the amount of charges_left if not spawned yet.
+ */
 /obj/item/toy/crayon/proc/refill()
 	if(charges == INFINITE_CHARGES)
 		charges_left = 100
@@ -248,8 +255,16 @@
 		var/amount = weight * units_per_weight
 		reagents.add_reagent(reagent, amount)
 
+/**
+ * Returns number of charges actually used.
+ *
+ * Arguments:
+ * * user - the user.
+ * * amount - how much charges do we reduce.
+ * * requires_full - Seems to transfer its data to the same argument on check_empty(). I'm not sure tho.
+ * * override_infinity - if TRUE stops infinite crayons from refilling.
+ */
 /obj/item/toy/crayon/proc/use_charges(mob/user, amount = 1, requires_full = TRUE, override_infinity = FALSE)
-	// Returns number of charges actually used
 	if(charges == INFINITE_CHARGES && !override_infinity)
 		refill()
 		return TRUE
@@ -258,9 +273,19 @@
 	charges_left -= min(charges_left, amount)
 	return TRUE
 
+/**
+ *	When eating a crayon, check_empty() can be called twice producing two messages unless we check for being deleted first.
+ *
+ *	Either qdells or calls balloon_alerts if crayon or spraycan is empty.
+ *	Also balloon_alerts you if don't have enought charges_left for big painting.
+ *
+ * Arguments:
+ * * user - the user.
+ * * amount - used for use_on() and when requires_full is TRUE
+ * * requires_full - if TRUE and charges_left < amount it will balloon_alert you. Used just for borgs spraycan it seems.
+ * * override_infinity - if TRUE it will override checks for infinite crayons.
+ */
 /obj/item/toy/crayon/proc/check_empty(mob/user, amount = 1, requires_full = TRUE, override_infinity = FALSE)
-	// When eating a crayon, check_empty() can be called twice producing
-	// two messages unless we check for being deleted first
 	if(QDELETED(src))
 		return TRUE
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -276,9 +276,6 @@
 /**
  *	When eating a crayon, check_empty() can be called twice producing two messages unless we check for being deleted first.
  *
- *	Either qdells or calls balloon_alerts if crayon or spraycan is empty.
- *	Also balloon_alerts you if don't have enought charges_left for big painting.
- *
  * Arguments:
  * * user - the user.
  * * amount - used for use_on() and when requires_full is TRUE
@@ -752,7 +749,6 @@
 
 /obj/item/toy/crayon/spraycan/isValidSurface(surface)
 	return (isfloorturf(surface) || iswallturf(surface))
-
 
 /obj/item/toy/crayon/spraycan/suicide_act(mob/living/user)
 	var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -219,7 +219,7 @@
 		AddComponent(/datum/component/edible, bite_consumption = reagents.total_volume / (charges_left / 5), after_eat = CALLBACK(src, PROC_REF(after_eat)))
 
 /obj/item/toy/crayon/proc/after_eat(mob/user)
-	use_charges(user, 5, FALSE, TRUE)
+	use_charges(user, amount = 5, requires_full = FALSE, override_infinity = TRUE)
 	if(check_empty(user, override_infinity = TRUE)) //Prevents division by zero
 		return
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -220,7 +220,7 @@
 
 /// Used for edible component to reduce charges_left on bite.
 /obj/item/toy/crayon/proc/after_eat(mob/user)
-	use_charges(user, 5, FALSE, TRUE)
+	use_charges(user, amount = 5, requires_full = FALSE, override_infinity = TRUE)
 	if(check_empty(user, override_infinity = TRUE)) //Prevents division by zero
 		return
 
@@ -924,7 +924,7 @@
 	desc = "A metallic container containing shiny synthesised paint."
 	charges = INFINITE_CHARGES
 
-/obj/item/toy/crayon/spraycan/borg/use_charges(mob/user, amount = 1, requires_full = TRUE)
+/obj/item/toy/crayon/spraycan/borg/use_charges(mob/user, amount = 1, requires_full = TRUE, override_infinity = FALSE)
 	if(!iscyborg(user))
 		to_chat(user, span_notice("How did you get this?"))
 		qdel(src)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -211,15 +211,12 @@
 	drawtype = pick(all_drawables)
 
 	AddElement(/datum/element/venue_price, FOOD_PRICE_EXOTIC)
-	if(edible)
-		if(charges == INFINITE_CHARGES)
-			AddComponent(/datum/component/edible, bite_consumption = 50 / (100 / 5), after_eat = CALLBACK(src, PROC_REF(after_eat)))
-		else
-			AddComponent(/datum/component/edible, bite_consumption = 45 / (charges / 5), after_eat = CALLBACK(src, PROC_REF(after_eat)))
 	if(can_change_colour)
 		AddComponent(/datum/component/palette, AVAILABLE_SPRAYCAN_SPACE, paint_color)
 
 	refill()
+	if(edible)
+		AddComponent(/datum/component/edible, bite_consumption = reagents.total_volume / (charges_left / 5), after_eat = CALLBACK(src, PROC_REF(after_eat)))
 
 /obj/item/toy/crayon/proc/after_eat(mob/user)
 	use_charges(user, 5, FALSE, TRUE)

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -27,7 +27,7 @@
 	name = "orange gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "orange"
-	greyscale_colors = FF9300
+	greyscale_colors = COLOR_CRAYON_ORANGE
 
 /obj/item/clothing/gloves/color/red
 	name = "red gloves"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -27,14 +27,13 @@
 	name = "orange gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "orange"
-	greyscale_colors = "#ff9300"
+	greyscale_colors = FF9300
 
 /obj/item/clothing/gloves/color/red
 	name = "red gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "red"
-	greyscale_colors = "#da0000"
-
+	greyscale_colors = COLOR_CRAYON_RED
 
 /obj/item/clothing/gloves/color/red/insulated
 	name = "insulated gloves"
@@ -57,7 +56,7 @@
 	name = "blue gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "blue"
-	greyscale_colors = "#00b7ef"
+	greyscale_colors = COLOR_CRAYON_BLUE
 
 /obj/item/clothing/gloves/color/purple
 	name = "purple gloves"
@@ -69,7 +68,7 @@
 	name = "green gloves"
 	desc = "A pair of gloves, they don't look special in any way."
 	icon_state = "green"
-	greyscale_colors = "#a8e61d"
+	greyscale_colors = COLOR_CRAYON_GREEN
 
 /obj/item/clothing/gloves/color/grey
 	name = "grey gloves"
@@ -103,5 +102,5 @@
 	name = "white gloves"
 	desc = "These look pretty fancy."
 	icon_state = "white"
-	greyscale_colors = "#ffffff"
+	greyscale_colors = COLOR_WHITE
 	custom_price = PAYCHECK_CREW

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -129,7 +129,7 @@
 /datum/reagent/consumable/ethanol/beer/green
 	name = "Green Beer"
 	description = "An alcoholic beverage brewed since ancient times on Old Earth. This variety is dyed a festive green."
-	color = "#A8E61D"
+	color = COLOR_CRAYON_GREEN
 	taste_description = "green piss water"
 	ph = 6
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1466,7 +1466,7 @@
 	var/colorname = "none"
 	description = "A powder that is used for coloring things."
 	reagent_state = SOLID
-	color = "#FFFFFF" // rgb: 207, 54, 0
+	color = COLOR_WHITE
 	taste_description = "the back of class"
 
 /datum/reagent/colorful_reagent/powder/New()
@@ -1481,7 +1481,7 @@
 /datum/reagent/colorful_reagent/powder/red
 	name = "Red Powder"
 	colorname = "red"
-	color = "#DA0000" // red
+	color = COLOR_CRAYON_RED
 	random_color_list = list("#FC7474")
 	ph = 0.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -1489,29 +1489,29 @@
 /datum/reagent/colorful_reagent/powder/orange
 	name = "Orange Powder"
 	colorname = "orange"
-	color = "#FF9300" // orange
-	random_color_list = list("#FF9300")
+	color = COLOR_CRAYON_ORANGE
+	random_color_list = list(COLOR_CRAYON_ORANGE)
 	ph = 2
 
 /datum/reagent/colorful_reagent/powder/yellow
 	name = "Yellow Powder"
 	colorname = "yellow"
-	color = "#FFF200" // yellow
-	random_color_list = list("#FFF200")
+	color = COLOR_CRAYON_YELLOW
+	random_color_list = list(COLOR_CRAYON_YELLOW)
 	ph = 5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/colorful_reagent/powder/green
 	name = "Green Powder"
 	colorname = "green"
-	color = "#A8E61D" // green
-	random_color_list = list("#A8E61D")
+	color = COLOR_CRAYON_GREEN
+	random_color_list = list(COLOR_CRAYON_GREEN)
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/colorful_reagent/powder/blue
 	name = "Blue Powder"
 	colorname = "blue"
-	color = "#00B7EF" // blue
+	color = COLOR_CRAYON_BLUE
 	random_color_list = list("#71CAE5")
 	ph = 10
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -1519,7 +1519,7 @@
 /datum/reagent/colorful_reagent/powder/purple
 	name = "Purple Powder"
 	colorname = "purple"
-	color = "#DA00FF" // purple
+	color = COLOR_CRAYON_PURPLE
 	random_color_list = list("#BD8FC4")
 	ph = 13
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -1528,21 +1528,21 @@
 	name = "Invisible Powder"
 	colorname = "invisible"
 	color = "#FFFFFF00" // white + no alpha
-	random_color_list = list("#FFFFFF") //because using the powder color turns things invisible
+	random_color_list = list(COLOR_WHITE) //because using the powder color turns things invisible
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/colorful_reagent/powder/black
 	name = "Black Powder"
 	colorname = "black"
-	color = "#1C1C1C" // not quite black
+	color = COLOR_CRAYON_BLACK
 	random_color_list = list("#8D8D8D") //more grey than black, not enough to hide your true colors
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/colorful_reagent/powder/white
 	name = "White Powder"
 	colorname = "white"
-	color = "#FFFFFF" // white
-	random_color_list = list("#FFFFFF") //doesn't actually change appearance at all
+	color = COLOR_WHITE
+	random_color_list = list(COLOR_WHITE) //doesn't actually change appearance at all
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /* used by crayons, can't color living things but still used for stuff like food recipes */
@@ -1754,7 +1754,7 @@
 /datum/reagent/carpet/green
 	name = "Green Carpet"
 	description = "For those that need the perfect flourish for green eggs and ham."
-	color = "#A8E61D"
+	color = COLOR_CRAYON_GREEN
 	taste_description = "Green" //the caps is intentional
 	carpet_type = /turf/open/floor/carpet/green
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED


### PR DESCRIPTION

## About The Pull Request
I left `bite_consumption` be `charges / 5` which led to -1 being depleted on 5 and not giving any reagents on bite.
Also i somehow managed to change the total volume of crayons from 50 to 30 for usual ones and 100 for infinite. I'm a bit confused if number 50 was intended even. I tested it on the older branch and it was 30 and 100, so i dunno.
`override_infinity` is used just so you can't infinitely chew infinite crayons.
## Why It's Good For The Game
Stuff should work like intended.
## Changelog
:cl:
fix: eating mime's and rainbow crayons now properly transfers reagents.
fix: I somehow fixed the amount of reagents in crayons to what it was before.
/:cl:
