### PR TITLE
Golems can dig up the floor with their bare hands

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -405,7 +405,7 @@
 	if(ispath(component_type))
 		component_type = GetExactComponent(component_type)
 	if(!component_type)
-		CRASH("Attempted to remove a null or non-existent component '[component_type]' from '[type]'")
+		return
 	component_type.on_source_remove(source)
 
 /**

--- a/code/datums/components/shovel_hands.dm
+++ b/code/datums/components/shovel_hands.dm
@@ -1,0 +1,42 @@
+/// This component lets mobs dig up the floor with their bare hands
+/datum/component/shovel_hands
+	dupe_mode = COMPONENT_DUPE_SOURCES
+	/// It's a lie, they're actually just using a shovel
+	var/obj/item/shovel/internal_shovel
+
+/datum/component/shovel_hands/Initialize()
+	. = ..()
+	if (!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	internal_shovel = new(null)
+	RegisterSignal(internal_shovel, COMSIG_QDELETING, PROC_REF(shovel_destroyed))
+
+/datum/component/shovel_hands/RegisterWithParent()
+	. = ..()
+	RegisterSignals(parent, list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, COMSIG_HOSTILE_PRE_ATTACKINGTARGET), PROC_REF(dig))
+
+/datum/component/shovel_hands/UnregisterFromParent()
+	UnregisterSignal(parent, list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_HUMAN_MELEE_UNARMED_ATTACK, COMSIG_HOSTILE_PRE_ATTACKINGTARGET))
+	return ..()
+
+/datum/component/shovel_hands/Destroy(force, silent)
+	if (internal_shovel)
+		UnregisterSignal(internal_shovel, COMSIG_QDELETING)
+	QDEL_NULL(internal_shovel)
+	return ..()
+
+/// Called when you click on literally anything with your hands
+/datum/component/shovel_hands/proc/dig(mob/living/mole, atom/target)
+	SIGNAL_HANDLER
+	if (!isopenturf(target))
+		return
+
+	INVOKE_ASYNC(target, TYPE_PROC_REF(/atom, attackby), internal_shovel, mole)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/// Don't know how the fuck this happened but I guess you can't dig any more
+/datum/component/shovel_hands/proc/shovel_destroyed(atom/shovel)
+	SIGNAL_HANDLER
+	UnregisterSignal(shovel, COMSIG_QDELETING)
+	qdel(src)

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -487,7 +487,6 @@
 		return
 	if (owner)
 		owner.AddComponentFrom(REF(src), /datum/component/shovel_hands)
-		return
 	if (isnull(.))
 		return
 	var/mob/living/carbon/old_owner = .
@@ -522,7 +521,6 @@
 		return
 	if (owner)
 		owner.AddComponentFrom(REF(src), /datum/component/shovel_hands)
-		return
 	if (isnull(.))
 		return
 	var/mob/living/carbon/old_owner = .

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -481,6 +481,18 @@
 	)
 	return ..()
 
+/obj/item/bodypart/arm/left/golem/set_owner(new_owner)
+	. = ..()
+	if (. == FALSE)
+		return
+	if (owner)
+		owner.AddComponentFrom(REF(src), /datum/component/shovel_hands)
+		return
+	if (isnull(.))
+		return
+	var/mob/living/carbon/old_owner = .
+	old_owner.RemoveComponentSource(REF(src), /datum/component/shovel_hands)
+
 /obj/item/bodypart/arm/right/golem
 	icon = 'icons/mob/species/golems.dmi'
 	icon_static = 'icons/mob/species/golems.dmi'
@@ -503,6 +515,18 @@
 		offset_y = list("south" = -2),
 	)
 	return ..()
+
+/obj/item/bodypart/arm/right/golem/set_owner(new_owner)
+	. = ..()
+	if (. == FALSE)
+		return
+	if (owner)
+		owner.AddComponentFrom(REF(src), /datum/component/shovel_hands)
+		return
+	if (isnull(.))
+		return
+	var/mob/living/carbon/old_owner = .
+	old_owner.RemoveComponentSource(REF(src), /datum/component/shovel_hands)
 
 /obj/item/bodypart/leg/left/golem
 	icon = 'icons/mob/species/golems.dmi'

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -995,6 +995,7 @@
 #include "code\datums\components\seethrough.dm"
 #include "code\datums\components\shell.dm"
 #include "code\datums\components\shielded.dm"
+#include "code\datums\components\shovel_hands.dm"
 #include "code\datums\components\shrink.dm"
 #include "code\datums\components\shuttle_cling.dm"
 #include "code\datums\components\shy.dm"


### PR DESCRIPTION
## About The Pull Request

I'm atomising a different branch I'm working on so here comes a bunch of goofy components.
This one lets mobs dig up floor by clicking on them. 

![image](https://github.com/tgstation/tgstation/assets/7483112/723b712b-1d3d-4154-a116-7a0379e4e522)
I have justified the existence both of this component and of this system by attaching it to golem arms.

## Why It's Good For The Game

If you can mine solid rock with your fists you should probably be able to get sand too

## Changelog

:cl:
add: Golems can scoop sand (or snow) off the floor by clicking on it.
/:cl:
