### PR TITLE
Elementises mining mob resistance to being attacked from off screen

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -91,6 +91,9 @@
 #define COMSIG_ATOM_ORBIT_STOP "atom_orbit_stop"
 ///from base of atom/set_opacity(): (new_opacity)
 #define COMSIG_ATOM_SET_OPACITY "atom_set_opacity"
+///from base of atom/throw_impact, sent by the target hit by a thrown object. (hit_atom, thrown_atom, datum/thrownthing/throwingdatum)
+#define COMSIG_ATOM_PREHITBY "atom_pre_hitby"
+	#define COMSIG_HIT_PREVENTED (1<<0)
 ///from base of atom/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 #define COMSIG_ATOM_HITBY "atom_hitby"
 ///when an atom starts playing a song datum (datum/song)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -937,3 +937,6 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define NO_OBSERVED_ACTIONS (1<<1)
 /// Flag which stops you from attacking while observed
 #define NO_OBSERVED_ATTACKS (1<<2)
+
+/// Types of bullets that mining mobs take full damage from
+#define MINING_MOB_PROJECTILE_VULNERABILITY list(BRUTE)

--- a/code/datums/elements/ranged_armour.dm
+++ b/code/datums/elements/ranged_armour.dm
@@ -19,7 +19,7 @@
 	below_projectile_multiplier = 0,
 	list/vulnerable_projectile_types = list(),
 	minimum_thrown_force = 0,
-	throw_blocked_message = "bounces off"
+	throw_blocked_message = "bounces off",
 )
 	. = ..()
 	if (!isatom(target))

--- a/code/datums/elements/ranged_armour.dm
+++ b/code/datums/elements/ranged_armour.dm
@@ -1,0 +1,61 @@
+/// Reduces or nullifies damage from ranged weaponry with force below a certain value
+/datum/element/ranged_armour
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	/// The minimum force a projectile must have to ignore our armour
+	var/minimum_projectile_force
+	/// Projectile damage below the minimum is multiplied by this value
+	var/below_projectile_multiplier
+	/// Projectile damage types which work regardless of force
+	var/list/vulnerable_projectile_types
+	/// The minimum force a thrown object must have to ignore our armour
+	var/minimum_thrown_force
+	/// Message to output if throwing damage is absorbed
+	var/throw_blocked_message
+
+/datum/element/ranged_armour/Attach(
+	atom/target,
+	minimum_projectile_force = 0,
+	below_projectile_multiplier = 0,
+	list/vulnerable_projectile_types = list(),
+	minimum_thrown_force = 0,
+	throw_blocked_message = "bounces off"
+)
+	. = ..()
+	if (!isatom(target))
+		return ELEMENT_INCOMPATIBLE
+	src.minimum_projectile_force = minimum_projectile_force
+	src.below_projectile_multiplier = below_projectile_multiplier
+	src.vulnerable_projectile_types = vulnerable_projectile_types
+	src.minimum_thrown_force = minimum_thrown_force
+	src.throw_blocked_message = throw_blocked_message
+
+	if (minimum_projectile_force > 0)
+		RegisterSignal(target, COMSIG_PROJECTILE_PREHIT, PROC_REF(pre_bullet_impact))
+	if (minimum_thrown_force > 0)
+		RegisterSignal(target, COMSIG_ATOM_PREHITBY, PROC_REF(pre_thrown_impact))
+
+/datum/element/ranged_armour/Detach(datum/target)
+	UnregisterSignal(target, list(COMSIG_PROJECTILE_PREHIT, COMSIG_ATOM_PREHITBY))
+	return ..()
+
+/// Modify or ignore bullet damage based on projectile properties
+/datum/element/ranged_armour/proc/pre_bullet_impact(atom/parent, list/signal_args, obj/projectile/bullet)
+	SIGNAL_HANDLER
+	if (bullet.damage >= minimum_projectile_force || (bullet.damage_type in vulnerable_projectile_types))
+		return
+	if (below_projectile_multiplier == 0)
+		parent.visible_message(span_danger("[parent] seems unharmed by [bullet]!"))
+		return PROJECTILE_INTERRUPT_HIT
+	bullet.damage *= below_projectile_multiplier
+	parent.visible_message(span_danger("[parent] seems resistant to [bullet]!"))
+
+/// Ignore thrown damage based on projectile properties. There's no elegant way to multiply the damage because throwforce is persistent.
+/datum/element/ranged_armour/proc/pre_thrown_impact(atom/parent, obj/item/hit_atom, datum/thrownthing/throwingdatum)
+	SIGNAL_HANDLER
+	if (!isitem(hit_atom))
+		return
+	if (hit_atom.throwforce >= minimum_thrown_force)
+		return
+	parent.visible_message(span_danger("[hit_atom] [throw_blocked_message] [parent]!"))
+	return COMSIG_HIT_PREVENTED

--- a/code/datums/elements/relay_attackers.dm
+++ b/code/datums/elements/relay_attackers.dm
@@ -11,8 +11,8 @@
 	RegisterSignal(target, COMSIG_ATOM_AFTER_ATTACKEDBY, PROC_REF(after_attackby))
 	RegisterSignals(target, list(COMSIG_ATOM_ATTACK_HAND, COMSIG_ATOM_ATTACK_PAW, COMSIG_MOB_ATTACK_ALIEN), PROC_REF(on_attack_generic))
 	RegisterSignals(target, list(COMSIG_ATOM_ATTACK_BASIC_MOB, COMSIG_ATOM_ATTACK_ANIMAL), PROC_REF(on_attack_npc))
-	RegisterSignal(target, COMSIG_ATOM_BULLET_ACT, PROC_REF(on_bullet_act))
-	RegisterSignal(target, COMSIG_ATOM_HITBY, PROC_REF(on_hitby))
+	RegisterSignal(target, COMSIG_PROJECTILE_PREHIT, PROC_REF(on_bullet_act))
+	RegisterSignal(target, COMSIG_ATOM_PREHITBY, PROC_REF(on_hitby))
 	RegisterSignal(target, COMSIG_ATOM_HULK_ATTACK, PROC_REF(on_attack_hulk))
 	RegisterSignal(target, COMSIG_ATOM_ATTACK_MECH, PROC_REF(on_attack_mech))
 
@@ -25,8 +25,8 @@
 		COMSIG_ATOM_ATTACK_BASIC_MOB,
 		COMSIG_ATOM_ATTACK_ANIMAL,
 		COMSIG_MOB_ATTACK_ALIEN,
-		COMSIG_ATOM_BULLET_ACT,
-		COMSIG_ATOM_HITBY,
+		COMSIG_PROJECTILE_PREHIT,
+		COMSIG_ATOM_PREHITBY,
 		COMSIG_ATOM_HULK_ATTACK,
 		COMSIG_ATOM_ATTACK_MECH,
 	))
@@ -47,7 +47,8 @@
 	if(attacker.melee_damage_upper > 0)
 		relay_attacker(target, attacker)
 
-/datum/element/relay_attackers/proc/on_bullet_act(atom/target, obj/projectile/hit_projectile)
+/// Even if another component blocked this hit, someone still shot at us
+/datum/element/relay_attackers/proc/on_bullet_act(atom/target, list/bullet_args, obj/projectile/hit_projectile)
 	SIGNAL_HANDLER
 	if(!hit_projectile.is_hostile_projectile())
 		return
@@ -55,7 +56,8 @@
 		return
 	relay_attacker(target, hit_projectile.firer, hit_projectile.damage_type == STAMINA ? ATTACKER_STAMINA_ATTACK : NONE)
 
-/datum/element/relay_attackers/proc/on_hitby(atom/target, atom/movable/hit_atom, skipcatch = FALSE, hitpush = TRUE, blocked = FALSE, datum/thrownthing/throwingdatum)
+/// Even if another component blocked this hit, someone still threw something
+/datum/element/relay_attackers/proc/on_hitby(atom/target, atom/movable/hit_atom, datum/thrownthing/throwingdatum)
 	SIGNAL_HANDLER
 	if(!isitem(hit_atom))
 		return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1240,7 +1240,7 @@
 	if(impact_signal & COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH)
 		hitpush = FALSE // hacky, tie this to something else or a proper workaround later
 
-	if((impact_signal && (impact_signal & COMPONENT_MOVABLE_IMPACT_NEVERMIND)))
+	if(impact_signal && (impact_signal & COMPONENT_MOVABLE_IMPACT_NEVERMIND))
 		return // in case a signal interceptor broke or deleted the thing before we could process our hit
 	if(SEND_SIGNAL(hit_atom, COMSIG_ATOM_PREHITBY, src, throwingdatum) & COMSIG_HIT_PREVENTED)
 		return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1240,8 +1240,11 @@
 	if(impact_signal & COMPONENT_MOVABLE_IMPACT_FLIP_HITPUSH)
 		hitpush = FALSE // hacky, tie this to something else or a proper workaround later
 
-	if(!(impact_signal && (impact_signal & COMPONENT_MOVABLE_IMPACT_NEVERMIND))) // in case a signal interceptor broke or deleted the thing before we could process our hit
-		return hit_atom.hitby(src, throwingdatum=throwingdatum, hitpush=hitpush)
+	if((impact_signal && (impact_signal & COMPONENT_MOVABLE_IMPACT_NEVERMIND)))
+		return // in case a signal interceptor broke or deleted the thing before we could process our hit
+	if(SEND_SIGNAL(hit_atom, COMSIG_ATOM_PREHITBY, src, throwingdatum) & COMSIG_HIT_PREVENTED)
+		return
+	return hit_atom.hitby(src, throwingdatum=throwingdatum, hitpush=hitpush)
 
 /atom/movable/hitby(atom/movable/hitting_atom, skipcatch, hitpush = TRUE, blocked, datum/thrownthing/throwingdatum)
 	if(!anchored && hitpush && (!throwingdatum || (throwingdatum.force >= (move_resist * MOVE_FORCE_PUSH_RATIO))))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -761,6 +761,8 @@
 		return
 	if(SEND_SIGNAL(src, COMSIG_MOVABLE_IMPACT, hit_atom, throwingdatum) & COMPONENT_MOVABLE_IMPACT_NEVERMIND)
 		return
+	if(SEND_SIGNAL(hit_atom, COMSIG_ATOM_PREHITBY, src, throwingdatum) & COMSIG_HIT_PREVENTED)
+		return
 	if(get_temperature() && isliving(hit_atom))
 		var/mob/living/L = hit_atom
 		L.ignite_mob()

--- a/code/modules/mob/living/basic/lavaland/bileworm/_bileworm.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/_bileworm.dm
@@ -13,6 +13,8 @@
 	verb_ask = "spittles questioningly"
 	verb_exclaim = "splutters and gurgles"
 	verb_yell = "splutters and gurgles"
+	crusher_loot = /obj/item/crusher_trophy/bileworm_spewlet
+	crusher_drop_chance = 15
 	butcher_results = list(/obj/item/food/meat/slab/bugmeat = 4)
 	guaranteed_butcher_results = list(
 		/obj/effect/gibspawner/generic = 1,
@@ -42,7 +44,6 @@
 
 	if(ispath(evolve_path))
 		AddComponent(/datum/component/evolutionary_leap, 30 MINUTES, evolve_path)
-	AddElement(/datum/element/crusher_loot, /obj/item/crusher_trophy/bileworm_spewlet, 15)
 	AddElement(/datum/element/content_barfer)
 
 	//setup mob abilities

--- a/code/modules/mob/living/basic/lavaland/bileworm/_bileworm.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/_bileworm.dm
@@ -20,6 +20,7 @@
 		/obj/item/stack/ore/gold = 2,
 	)
 	death_message = "seizes up and falls limp, slowly receeding into its burrow with a dying gurgle..."
+	throw_blocked_message = "is absorbed by the spongy hide of"
 
 	//it can't be dragged, just butcher it
 	move_resist = INFINITY

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -1,13 +1,22 @@
 ///prototype for mining mobs
 /mob/living/basic/mining
-
 	combat_mode = TRUE
 	faction = list(FACTION_MINING)
 	unsuitable_atmos_damage = 0
 	minimum_survivable_temperature = 0
 	maximum_survivable_temperature = INFINITY
+	/// Message to output if throwing damage is absorbed
+	var/throw_blocked_message = "bounces off"
 
 /mob/living/basic/mining/Initialize(mapload)
 	. = ..()
 	add_traits(list(TRAIT_LAVA_IMMUNE, TRAIT_ASHSTORM_IMMUNE), INNATE_TRAIT)
 	AddElement(/datum/element/mob_killed_tally, "mobs_killed_mining")
+	AddElement(\
+		/datum/element/ranged_armour,\
+		minimum_projectile_force = 30,\
+		below_projectile_multiplier = 0.3,\
+		vulnerable_projectile_types = MINING_MOB_PROJECTILE_VULNERABILITY,\
+		minimum_thrown_force = 20,\
+		throw_blocked_message = throw_blocked_message,\
+	)

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -29,5 +29,5 @@
 			/datum/element/crusher_loot,\
 			trophy_type = crusher_loot,\
 			drop_mod = crusher_drop_chance,\
-			drop_immediately = basic_mob_flags & DEL_ON_DEATH\
+			drop_immediately = basic_mob_flags & DEL_ON_DEATH,\
 		)

--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -7,6 +7,10 @@
 	maximum_survivable_temperature = INFINITY
 	/// Message to output if throwing damage is absorbed
 	var/throw_blocked_message = "bounces off"
+	/// What crusher trophy this mob drops, if any
+	var/crusher_loot
+	/// What is the chance the mob drops it if all their health was taken by crusher attacks
+	var/crusher_drop_chance = 25
 
 /mob/living/basic/mining/Initialize(mapload)
 	. = ..()
@@ -20,3 +24,10 @@
 		minimum_thrown_force = 20,\
 		throw_blocked_message = throw_blocked_message,\
 	)
+	if(crusher_loot)
+		AddElement(\
+			/datum/element/crusher_loot,\
+			trophy_type = crusher_loot,\
+			drop_mod = crusher_drop_chance,\
+			drop_immediately = basic_mob_flags & DEL_ON_DEATH\
+		)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -33,6 +33,16 @@
 	if(crusher_loot)
 		AddElement(/datum/element/crusher_loot, crusher_loot, crusher_drop_mod, del_on_death)
 	AddElement(/datum/element/mob_killed_tally, "mobs_killed_mining")
+	AddElement(\
+		/datum/element/ranged_armour,\
+		minimum_projectile_force = 30,\
+		below_projectile_multiplier = 0.3,\
+		vulnerable_projectile_types = MINING_MOB_PROJECTILE_VULNERABILITY,\
+		minimum_thrown_force = 20,\
+		throw_blocked_message = throw_message,\
+	)
+
+	RegisterSignals(src, list(COMSIG_PROJECTILE_PREHIT, COMSIG_ATOM_PREHITBY), PROC_REF(Aggro))
 
 /mob/living/simple_animal/hostile/asteroid/Aggro()
 	..()
@@ -44,21 +54,3 @@
 	if(stat == DEAD)
 		return
 	icon_state = icon_living
-
-/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/projectile/shot)//Reduces damage from most projectiles to curb off-screen kills
-	if(!stat)
-		Aggro()
-	if(shot.damage < 30 && shot.damage_type != BRUTE)
-		shot.damage = (shot.damage / 3)
-		visible_message(span_danger("[shot] has a reduced effect on [src]!"))
-	..()
-
-/mob/living/simple_animal/hostile/asteroid/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum) //No floor tiling them to death, wiseguy
-	if(isitem(AM))
-		var/obj/item/T = AM
-		if(!stat)
-			Aggro()
-		if(T.throwforce <= 20)
-			visible_message(span_notice("The [T.name] [throw_message] [src.name]!"))
-			return
-	..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1250,6 +1250,7 @@
 #include "code\datums\elements\projectile_shield.dm"
 #include "code\datums\elements\radiation_protected_clothing.dm"
 #include "code\datums\elements\radioactive.dm"
+#include "code\datums\elements\ranged_armour.dm"
 #include "code\datums\elements\ranged_attacks.dm"
 #include "code\datums\elements\relay_attackers.dm"
 #include "code\datums\elements\ridable.dm"


### PR DESCRIPTION
## About The Pull Request

Converts the `bullet_act`/`hitby` overrides on `simple_animal/hostile/asteroid` into an element,
This is currently "reused" in that it's also applied to its equivalent on `basic/mining` although some day hopefully the `hostile/asteroid` subtype will stop existing.

This is a specific-ass component but it's not totally impossible something else will want it some day.

## Why It's Good For The Game

I'm a little mixed on this one honestly, I did this because I am adapting some old code but I would be open to the idea that this should just be left where it is (`bullet_act`/`hitby` overrides) and just copied/pasted onto `basic/mining`. 
I am also open to the idea that we don't need this at all and should just delete it, it seems unecessarily protective to me but I wasn't around at the time and maybe people really _were_ chucking hundreds of floor tiles at goliaths and that was a problem.

If it _is_ a problem then I guess this extends those protections to Bileworms now, because they need to be more durable and less possible to take down using non-mining tools, obviously.

## Changelog

:cl:
fix: Bile/Vileworms now have the same projectile and thrown weapon resistances of other mining mobs.
/:cl:
