### PR TITLE
Makes /datum/client_colour use the game plane master controller

### DIFF
--- a/code/__DEFINES/hud.dm
+++ b/code/__DEFINES/hud.dm
@@ -11,9 +11,9 @@
 
 // Consider these images/atoms as part of the UI/HUD (apart of the appearance_flags)
 /// Used for progress bars and chat messages
-#define APPEARANCE_UI_IGNORE_ALPHA (RESET_COLOR|RESET_TRANSFORM|NO_CLIENT_COLOR|RESET_ALPHA|PIXEL_SCALE)
+#define APPEARANCE_UI_IGNORE_ALPHA (RESET_COLOR|RESET_TRANSFORM|RESET_ALPHA|PIXEL_SCALE)
 /// Used for HUD objects
-#define APPEARANCE_UI (RESET_COLOR|RESET_TRANSFORM|NO_CLIENT_COLOR|PIXEL_SCALE)
+#define APPEARANCE_UI (RESET_COLOR|RESET_TRANSFORM|PIXEL_SCALE)
 
 /*
 	These defines specificy screen locations.  For more information, see the byond documentation on the screen_loc var.

--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -54,7 +54,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 		. += pm_iterator.get_filter(name)
 
 ///Transitions all filters owned by this plane master controller
-/atom/movable/plane_master_controller/transition_filter(name, time, list/new_params, easing, loop)
+/atom/movable/plane_master_controller/transition_filter(name, list/new_params, time, easing, loop)
 	. = ..()
 	for(var/atom/movable/screen/plane_master/pm_iterator as anything in get_planes())
 		pm_iterator.transition_filter(name, new_params, time, easing, loop)

--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -95,7 +95,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 		RENDER_PLANE_NON_GAME,
 	)
 
-/// Exists for convienience when referencing all game render plates
+/// Exists for convienience when testing colorblindness
 /atom/movable/plane_master_controller/colorblind
 	name = PLANE_MASTERS_COLORBLIND
 	controlled_planes = list(

--- a/code/_onclick/hud/rendering/plane_master_controller.dm
+++ b/code/_onclick/hud/rendering/plane_master_controller.dm
@@ -75,9 +75,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/plane_master_controller)
 
 ///Resets the atom's color to null, and then sets it to the highest priority colour available
 /atom/movable/plane_master_controller/update_atom_colour()
+	. = ..()
 	for(var/atom/movable/screen/plane_master/pm_iterator as anything in get_planes())
 		pm_iterator.update_atom_colour()
-
 
 /// Exists for convienience when referencing all game render plates
 /atom/movable/plane_master_controller/game

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1102,7 +1102,6 @@
 		M.client.screen -= src
 	layer = initial(layer)
 	SET_PLANE_IMPLICIT(src, initial(plane))
-	appearance_flags &= ~NO_CLIENT_COLOR
 	dropped(M, FALSE)
 	return ..()
 

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -144,13 +144,13 @@
 		return
 	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	if(!client_colours.len)
-		game_plane_master_controller.transition_filter("client_colour", anim_time, color_matrix_filter(), anim_easing)
-		addtimer(CALLBACK(src, PROC_REF(clear_client_colour)), anim_time)
+		game_plane_master_controller.transition_filter("client_colour", color_matrix_filter(), anim_time, anim_easing)
+		addtimer(CALLBACK(src, PROC_REF(clear_client_colour)))
 		return
 	MIX_CLIENT_COLOUR(var/anim_colour)
 	if(!length(game_plane_master_controller.get_filters("client_colour")))
 		game_plane_master_controller.add_filter("client_colour", 5, color_matrix_filter())
-	game_plane_master_controller.transition_filter("client_colour", anim_time, color_matrix_filter(anim_colour), anim_easing)
+	game_plane_master_controller.transition_filter("client_colour", color_matrix_filter(anim_colour), anim_time, anim_easing)
 
 ///Used to clear the client colour once the fade animation is done
 /mob/proc/clear_client_colour()

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -13,6 +13,9 @@
  * (e.g. wearing blue glasses under a yellow visor, even though the result is a little unsatured.)
  * As well as some support for animated colour transitions.
  *
+ * Refactored yet again to use hud render plates instead of the client's color.
+ * Using client.color is effectively retired and unsupported.
+ *
  * Define subtypes of this datum
  */
 /datum/client_colour

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -145,11 +145,22 @@
 	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	if(!client_colours.len)
 		game_plane_master_controller.transition_filter("client_colour", anim_time, color_matrix_filter(), anim_easing)
+		addtimer(CALLBACK(src, PROC_REF(clear_client_colour)), anim_time)
 		return
 	MIX_CLIENT_COLOUR(var/anim_colour)
 	if(!length(game_plane_master_controller.get_filters("client_colour")))
 		game_plane_master_controller.add_filter("client_colour", 5, color_matrix_filter())
 	game_plane_master_controller.transition_filter("client_colour", anim_time, color_matrix_filter(anim_colour), anim_easing)
+
+///Used to clear the client colour once the fade animation is done
+/mob/proc/clear_client_colour()
+	if(!hud_used)
+		return
+	//we don't actually need to be cleared anymore, for whatever reason
+	if(client_colours.len)
+		return
+	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	game_plane_master_controller.remove_filter("client_colour")
 
 #undef MIX_CLIENT_COLOUR
 

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -129,22 +129,27 @@
  * on the client_colour datums it currently has.
  */
 /mob/proc/update_client_colour()
-	if(!client)
+	if(!hud_used)
 		return
-	client.color = ""
+	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	if(!client_colours.len)
+		game_plane_master_controller.remove_filter("client_colour")
 		return
-	MIX_CLIENT_COLOUR(client.color)
+	MIX_CLIENT_COLOUR(var/final_colour)
+	game_plane_master_controller.add_filter("client_colour", 5, color_matrix_filter(final_colour))
 
 ///Works similarly to 'update_client_colour', but animated.
-/mob/proc/animate_client_colour(anim_time = 20, anim_easing = 0)
-	if(!client)
+/mob/proc/animate_client_colour(anim_time = 20, anim_easing = NONE)
+	if(!hud_used)
 		return
+	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	if(!client_colours.len)
-		animate(client, color = "", time = anim_time, easing = anim_easing)
+		game_plane_master_controller.transition_filter("client_colour", anim_time, color_matrix_filter(), anim_easing)
 		return
 	MIX_CLIENT_COLOUR(var/anim_colour)
-	animate(client, color = anim_colour, time = anim_time, easing = anim_easing)
+	if(!length(game_plane_master_controller.get_filters("client_colour")))
+		game_plane_master_controller.add_filter("client_colour", 5, color_matrix_filter())
+	game_plane_master_controller.transition_filter("client_colour", anim_time, color_matrix_filter(anim_colour), anim_easing)
 
 #undef MIX_CLIENT_COLOUR
 
@@ -209,11 +214,11 @@
 
 /datum/client_colour/bloodlust
 	priority = PRIORITY_ABSOLUTE // Only anger.
-	colour = list(0,0,0,0,0,0,0,0,0,1,0,0) //pure red.
+	colour = list(0,0,0, 0,0,0, 0,0,0, 1,0,0) //pure red.
 	fade_out = 10
 
 /datum/client_colour/bloodlust/New(mob/_owner)
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(update_colour), list(1,0,0,0.8,0.2,0, 0.8,0,0.2,0.1,0,0), 10, SINE_EASING|EASE_OUT), 1)
 
 /datum/client_colour/rave

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -368,7 +368,6 @@
 			client.screen -= I
 		I.layer = initial(I.layer)
 		SET_PLANE_EXPLICIT(I, initial(I.plane), newloc)
-		I.appearance_flags &= ~NO_CLIENT_COLOR
 		if(!no_move && !(I.item_flags & DROPDEL)) //item may be moved/qdel'd immedietely, don't bother moving it
 			if (isnull(newloc))
 				I.moveToNullspace()

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -80,7 +80,6 @@
 				observe.client.screen -= equipping
 	equipping.forceMove(src)
 	SET_PLANE_EXPLICIT(equipping, ABOVE_HUD_PLANE, src)
-	equipping.appearance_flags |= NO_CLIENT_COLOR
 	var/not_handled = FALSE
 
 	switch(slot)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -97,7 +97,6 @@
 		var/datum/atom_hud/alternate_appearance/AA = v
 		AA.onNewMob(src)
 
-	update_client_colour()
 	update_mouse_pointer()
 	if(client)
 		if(client.view_size)


### PR DESCRIPTION
## About The Pull Request

What the title says.
Retires NO_CLIENT_COLOR use from the codebase (for hud atoms).

Fixes https://github.com/tgstation/tgstation/issues/76606

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/82850673/30460f29-9f03-4bb3-95ae-01f9414f58d1)
Client colours will no longer affect the hud, which is annoying and impacts usability.
![image](https://github.com/tgstation/tgstation/assets/82850673/e9454308-a660-4f45-8078-150fd5c27696)

## Changelog

:cl:
fix: Client colors no longer affect hud elements.
/:cl:
