### PR TITLE
Block adminhelp input of escaped html chars

### DIFF
--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -211,8 +211,12 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
  */
 /datum/admin_help/New(msg_raw, client/C, is_bwoink, urgent = FALSE)
 	//clean the input msg
-	var/msg = sanitize(copytext_char(msg_raw, 1, MAX_MESSAGE_LEN))
-	if(!msg || !C || !C.mob)
+	var/msg = reject_bad_text(trim(msg_raw, MAX_MESSAGE_LEN), ascii_only = FALSE)
+	if(!C || !C.mob)
+		qdel(src)
+		return
+	if(!msg)
+		to_chat(C, type = MESSAGE_TYPE_SYSTEM, html = span_warning("Your adminhelp message contained invalid characters and was not sent. Please try again."))
 		qdel(src)
 		return
 


### PR DESCRIPTION
## About The Pull Request

Uses reject_bad_text to prevent initial adminhelp messages with any potentially dangerous HTML characters, escaped or not. Provides feedback if the message is rejected for this reason.

HTML is still allowed in system generated interactions as links are used for various functions once a ticket is open.

https://github.com/tgstation/tgstation/assets/83487515/8d264962-cabb-4a62-9f45-7171138f540a

## Why It's Good For The Game

We shouldn't allow player input of the first adminhelp message to contain HTML elements, as even escaped it may be able to be unescaped later down the line such as form URL-encoded text.

## Changelog

:cl: LT3
admin: Players will receive a message if their adminhelp is blocked due to invalid characters
/:cl:
