### PR TITLE
Vision in engi scanner goggles is green-tinted and not yellow while in meson mode

### DIFF
--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -46,8 +46,8 @@
 	switch(mode)
 		if(MODE_MESON)
 			vision_flags = SEE_TURFS
-			color_cutoffs = list(15, 12, 0)
-			change_glass_color(user, /datum/client_colour/glass_colour/yellow)
+			color_cutoffs = list(5, 15, 5)
+			change_glass_color(user, /datum/client_colour/glass_colour/lightgreen)
 
 		if(MODE_TRAY) //undoes the last mode, meson
 			vision_flags = NONE


### PR DESCRIPTION

## About The Pull Request
https://github.com/tgstation/tgstation/pull/76596 changed engineering scanner goggles, now the sprite is green when in meson mode, but the vision is still yellow-tinted. This PR makes them apply light-green tint like meson goggles, to match their new sprite
## Why It's Good For The Game
The tint matches the new sprite's colors
## Changelog
:cl:
fix: Engineering scanner goggles now apply a green tint while in meson mode, to match their new sprite
/:cl:
