### PR TITLE
Added the supermatter (shard) to the list of things simplemobs can't easily pull

### DIFF
--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -36,4 +36,5 @@ GLOBAL_LIST_INIT(typecache_general_bad_hostile_attack_targets, typecacheof(list(
 GLOBAL_LIST_INIT(typecache_general_bad_things_to_easily_move, typecacheof(list(
 	/obj/machinery/portable_atmospherics/canister,
 	/obj/structure/reagent_dispensers,
+	/obj/machinery/power/supermatter_crystal,
 )))


### PR DESCRIPTION

## About The Pull Request

Added the supermatter (shard) to the list of things simplemobs can't easily pull

## Why It's Good For The Game

Probably not good for spiders to pull a loose SM shard around, hm?

However in the interest of honesty, this is a malding ided PR because I was moving an SM shard around the spider tunnels and some frickin' spider just walked in and zoomed away with it, never to be seen again. Do with this PR as you will, though note I have a positive GBP and am a very good boy.

## Changelog

:cl:
bal: Added the supermatter (shard) to the list of things some mobs can't easily pull.
/:cl:

