### PR TITLE
Fix WIzard Ritual hard delete

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -77,6 +77,10 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	if(allow_rename)
 		rename_wizard()
 
+/datum/antagonist/wizard/Destroy()
+	QDEL_NULL(ritual)
+	return ..()
+
 /datum/antagonist/wizard/create_team(datum/team/wizard/new_team)
 	if(!new_team)
 		return
@@ -98,7 +102,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 
 /// Initialises the grand ritual action for this mob
 /datum/antagonist/wizard/proc/assign_ritual()
-	ritual = new(owner.current)
+	ritual = new(src)
 	RegisterSignal(ritual, COMSIG_GRAND_RITUAL_FINAL_COMPLETE, PROC_REF(on_ritual_complete))
 
 /datum/antagonist/wizard/proc/send_to_lair()


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/51863163/c59c619a-34cc-4adb-ab75-ffdc345a1e9a)

So this action was created with the target = the wizard's body
Wizard body gets deleted -> action gets deleted -> hard delete, bad

## Why It's Good For The Game

Stop bricking wizards

## Changelog

:cl: Melbert
fix: Fix hard deletes that brick all of a wizards spell when their body is delted
/:cl:

