### PR TITLE
Re-adds placing patients on surgical tables

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -104,9 +104,12 @@
 
 /obj/structure/table/attack_hand(mob/living/user, list/modifiers)
 	if(Adjacent(user) && user.pulling)
-		if(isliving(user.pulling) && climbable)
+		if(isliving(user.pulling))
 			var/mob/living/pushed_mob = user.pulling
 			if(pushed_mob.buckled)
+				if(pushed_mob.buckled == src)
+					//Already buckled to the table, you probably meant to unbuckle them
+					return ..()
 				to_chat(user, span_warning("[pushed_mob] is buckled to [pushed_mob.buckled]!"))
 				return
 			if(user.combat_mode)


### PR DESCRIPTION
## About The Pull Request
This was removed by #75840, as it had a conflict that made it so that trying to unbuckle someone that was buckled to a table would try to place them again instead. This redoes that, unbuckling if the person you're pulling is already buckled to said table.
## Why It's Good For The Game
It feels a bit less friendly that your only options are being buckled to a table or shoved onto a table. Also, buckling requires both mobs to be beside the table, where placing only requires the placer to be, which makes things a lot less awkward in cramped operating rooms.
## Changelog
:cl:
fix: You can once again directly place patients on operating tables
/:cl:
