### PR TITLE
Fixes water-resistant creampies

### DIFF
--- a/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
+++ b/code/datums/bodypart_overlays/simple_bodypart_overlay.dm
@@ -27,5 +27,5 @@
 
 ///A creampie drawn on the head
 /datum/bodypart_overlay/simple/creampie
-	icon_state = "creampie"
+	icon_state = "creampie_human"
 	layers = EXTERNAL_FRONT

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -73,7 +73,9 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 			my_head.remove_bodypart_overlay(bodypart_overlay)
 			if(!my_head.owner)
 				my_head.update_icon_dropped()
+			QDEL_NULL(bodypart_overlay)
 		UnregisterSignal(my_head, list(COMSIG_BODYPART_REMOVED, COMSIG_QDELETING))
+		my_head = null
 	if(iscarbon(parent))
 		var/mob/living/carbon/carbon_parent = parent
 		carbon_parent.clear_mood_event("creampie")
@@ -82,6 +84,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 		var/atom/atom_parent = parent
 		UnregisterSignal(atom_parent, COMSIG_ATOM_UPDATE_OVERLAYS)
 		atom_parent.update_appearance()
+		normal_overlay = null
 
 ///Callback to remove pieface
 /datum/component/creamed/proc/clean_up(datum/source, clean_types)

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -11,7 +11,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 /datum/component/creamed
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 	/// Creampie overlay we use for non-carbon mobs
-	var/mutable_appearance/creamface
+	var/mutable_appearance/normal_overlay
 	/// Creampie bodypart overlay we use for carbon mobs
 	var/datum/bodypart_overlay/simple/creampie/bodypart_overlay
 	/// Cached head for carbons, to ensure proper removal of the creampie overlay
@@ -27,7 +27,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 
 /datum/component/creamed/Destroy(force)
 	. = ..()
-	creamface = null
+	normal_overlay = null
 	my_head = null
 	QDEL_NULL(bodypart_overlay)
 
@@ -50,16 +50,16 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 		carbon_parent.add_mood_event("creampie", /datum/mood_event/creampie)
 		carbon_parent.update_body_parts()
 	else if(iscorgi(parent))
-		creamface = mutable_appearance('icons/effects/creampie.dmi', "creampie_corgi")
+		normal_overlay = mutable_appearance('icons/effects/creampie.dmi', "creampie_corgi")
 	else if(isAI(parent))
-		creamface = mutable_appearance('icons/effects/creampie.dmi', "creampie_ai")
+		normal_overlay = mutable_appearance('icons/effects/creampie.dmi', "creampie_ai")
 
 	RegisterSignals(parent, list(
 		COMSIG_COMPONENT_CLEAN_ACT,
 		COMSIG_COMPONENT_CLEAN_FACE_ACT),
 		PROC_REF(clean_up)
 	)
-	if(creamface)
+	if(normal_overlay)
 		var/atom/atom_parent = parent
 		RegisterSignal(atom_parent, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(update_overlays))
 		atom_parent.update_appearance()
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 		var/mob/living/carbon/carbon_parent = parent
 		carbon_parent.clear_mood_event("creampie")
 		carbon_parent.update_body_parts()
-	if(creamface)
+	if(normal_overlay)
 		var/atom/atom_parent = parent
 		UnregisterSignal(atom_parent, COMSIG_ATOM_UPDATE_OVERLAYS)
 		atom_parent.update_appearance()
@@ -91,12 +91,12 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	qdel(src)
 	return COMPONENT_CLEANED
 
-/// Ensures creamface overlay in case the mob is not a carbon
+/// Ensures normal_overlay overlay in case the mob is not a carbon
 /datum/component/creamed/proc/update_overlays(atom/parent_atom, list/overlays)
 	SIGNAL_HANDLER
 
-	if(creamface)
-		overlays += creamface
+	if(normal_overlay)
+		overlays += normal_overlay
 
 /// Removes creampie when the head gets dismembered
 /datum/component/creamed/proc/lost_head(obj/item/bodypart/source, mob/living/carbon/owner, dismembered)

--- a/code/datums/components/creamed.dm
+++ b/code/datums/components/creamed.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 			qdel(src)
 			return
 		bodypart_overlay = new()
-		if(my_head.bodytype & BODYTYPE_SNOUTED)
+		if(carbon_parent.bodytype & BODYTYPE_SNOUTED) //stupid, but external organ bodytypes are not stored on the limb
 			bodypart_overlay.icon_state = "creampie_lizard"
 		else if(my_head.bodytype & BODYTYPE_MONKEY)
 			bodypart_overlay.icon_state = "creampie_monkey"
@@ -71,6 +71,8 @@ GLOBAL_LIST_INIT(creamable, typecacheof(list(
 	if(my_head)
 		if(bodypart_overlay)
 			my_head.remove_bodypart_overlay(bodypart_overlay)
+			if(!my_head.owner)
+				my_head.update_icon_dropped()
 		UnregisterSignal(my_head, list(COMSIG_BODYPART_REMOVED, COMSIG_QDELETING))
 	if(iscarbon(parent))
 		var/mob/living/carbon/carbon_parent = parent


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/76641
Caused by the bodypart overlay being deleted before it got properly removed on UnregisterFromParent()

## Why It's Good For The Game

One less hard delete and one less bug caused by said hard delete

## Changelog

:cl:
fix: Creampies will no longer irreparably stain your face
/:cl: