### PR TITLE
SPECIES NUKING 2023: Makes underwear get handled by the chest

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -680,7 +680,7 @@ GLOBAL_LIST_INIT(human_heights_to_offsets, list(
 #define BODYPARTS_LOW_LAYER 32
 /// Layer for most bodyparts, appears above BODYPARTS_LOW_LAYER and below BODYPARTS_HIGH_LAYER
 #define BODYPARTS_LAYER 31
-/// Mutantrace features (snout, body markings) that must appear above the body parts
+/// Mutantrace features (snout, body markings) that must appear above the body parts, but below underwear
 #define BODY_ADJ_LAYER 30
 /// Underwear, undershirts, socks, eyes, lips(makeup)
 #define BODY_LAYER 29

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -5,18 +5,19 @@
 /// The priority at which species runs, needed for external organs to apply properly.
 #define PREFERENCE_PRIORITY_SPECIES 2
 
-/**
- * Some preferences get applied directly to bodyparts (anything head_flags related right now).
- * These must apply after species, as species gaining might replace the bodyparts of the human.
- */
-#define PREFERENCE_PRIORITY_BODYPARTS 3
-
 /// The priority at which gender is determined, needed for proper randomization.
-#define PREFERENCE_PRIORITY_GENDER 4
+#define PREFERENCE_PRIORITY_GENDER 3
 
 /// The priority at which body type is decided, applied after gender so we can
 /// support the "use gender" option.
-#define PREFERENCE_PRIORITY_BODY_TYPE 5
+#define PREFERENCE_PRIORITY_BODY_TYPE 4
+
+/**
+ * Some preferences get applied directly to bodyparts (anything head_flags related right now).
+ * These must apply after species, as species gaining might replace the bodyparts of the human.
+ * These also should apply after gender and body type, as those might change the bodyparts.
+ */
+#define PREFERENCE_PRIORITY_BODYPARTS 5
 
 /// The priority at which names are decided, needed for proper randomization.
 #define PREFERENCE_PRIORITY_NAMES 6

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -631,6 +631,32 @@
 
 	return .
 
+/obj/item/bodypart/chest/generate_icon_key()
+	. = ..()
+	if(!(bodytype & BODYTYPE_HUMANOID) || !ishuman(owner) || HAS_TRAIT(owner, TRAIT_NO_UNDERWEAR))
+		return .
+
+	var/mob/living/carbon/human/human_owner = owner
+	. += "-[human_owner.underwear]"
+	. += "-[human_owner.underwear_color]"
+	. += "-[human_owner.undershirt]"
+	. += "-[human_owner.socks]"
+
+	return .
+
+/obj/item/bodypart/chest/generate_husk_key()
+	. = ..()
+	if(!(bodytype & BODYTYPE_HUMANOID) || !ishuman(owner) || HAS_TRAIT(owner, TRAIT_NO_UNDERWEAR))
+		return .
+
+	var/mob/living/carbon/human/human_owner = owner
+	. += "-[human_owner.underwear]"
+	. += "-[human_owner.underwear_color]"
+	. += "-[human_owner.undershirt]"
+	. += "-[human_owner.socks]"
+
+	return .
+
 GLOBAL_LIST_EMPTY(masked_leg_icons_cache)
 
 /**

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -644,19 +644,6 @@
 
 	return .
 
-/obj/item/bodypart/chest/generate_husk_key()
-	. = ..()
-	if(!(bodytype & BODYTYPE_HUMANOID) || !ishuman(owner) || HAS_TRAIT(owner, TRAIT_NO_UNDERWEAR))
-		return .
-
-	var/mob/living/carbon/human/human_owner = owner
-	. += "-[human_owner.underwear]"
-	. += "-[human_owner.underwear_color]"
-	. += "-[human_owner.undershirt]"
-	. += "-[human_owner.socks]"
-
-	return .
-
 GLOBAL_LIST_EMPTY(masked_leg_icons_cache)
 
 /**

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -585,8 +585,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/height_offset = species_human.get_top_offset() // From high changed by varying limb height
 	if(HAS_TRAIT(species_human, TRAIT_INVISIBLE_MAN))
 		return handle_mutant_bodyparts(species_human)
-	var/list/standing = list()
 
+	var/list/standing = list()
 	if(!HAS_TRAIT(species_human, TRAIT_HUSK))
 		var/obj/item/bodypart/head/noggin = species_human.get_bodypart(BODY_ZONE_HEAD)
 		if(noggin?.head_flags & HEAD_EYESPRITES)
@@ -634,37 +634,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				var/mutable_appearance/markings_l_leg_overlay = mutable_appearance(markings.icon, "[markings.icon_state]_l_leg", -BODY_LAYER)
 				standing += markings_l_leg_overlay
 
-	//Underwear, Undershirts & Socks
-	if(!HAS_TRAIT(species_human, TRAIT_NO_UNDERWEAR))
-		if(species_human.underwear)
-			var/datum/sprite_accessory/underwear/underwear = GLOB.underwear_list[species_human.underwear]
-			var/mutable_appearance/underwear_overlay
-			if(underwear)
-				if(species_human.dna.species.sexes && species_human.physique == FEMALE && (underwear.gender == MALE))
-					underwear_overlay = wear_female_version(underwear.icon_state, underwear.icon, BODY_LAYER, FEMALE_UNIFORM_FULL)
-				else
-					underwear_overlay = mutable_appearance(underwear.icon, underwear.icon_state, -BODY_LAYER)
-				if(!underwear.use_static)
-					underwear_overlay.color = species_human.underwear_color
-				underwear_overlay.pixel_y += height_offset
-				standing += underwear_overlay
-
-		if(species_human.undershirt)
-			var/datum/sprite_accessory/undershirt/undershirt = GLOB.undershirt_list[species_human.undershirt]
-			if(undershirt)
-				var/mutable_appearance/working_shirt
-				if(species_human.dna.species.sexes && species_human.physique == FEMALE)
-					working_shirt = wear_female_version(undershirt.icon_state, undershirt.icon, BODY_LAYER)
-				else
-					working_shirt = mutable_appearance(undershirt.icon, undershirt.icon_state, -BODY_LAYER)
-				working_shirt.pixel_y += height_offset
-				standing += working_shirt
-
-		if(species_human.socks && species_human.num_legs >= 2 && !(species_human.bodytype & BODYTYPE_DIGITIGRADE))
-			var/datum/sprite_accessory/socks/socks = GLOB.socks_list[species_human.socks]
-			if(socks)
-				standing += mutable_appearance(socks.icon, socks.icon_state, -BODY_LAYER)
-
 	if(standing.len)
 		species_human.overlays_standing[BODY_LAYER] = standing
 
@@ -703,7 +672,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		return
 
 	var/g = (source.physique == FEMALE) ? "f" : "m"
-
 	for(var/layer in relevent_layers)
 		var/layertext = mutant_bodyparts_layertext(layer)
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -810,7 +810,7 @@
 	// No, xenos don't actually use bodyparts. Don't ask.
 	var/mob/living/carbon/human/human_owner = owner
 
-	limb_gender = (human_owner.physique == MALE) ? "m" : "f"
+	limb_gender = (human_owner.physique == FEMALE) ? "f" : "m"
 	if(HAS_TRAIT(human_owner, TRAIT_USES_SKINTONES))
 		skin_tone = human_owner.skin_tone
 	else if(HAS_TRAIT(human_owner, TRAIT_MUTANT_COLORS))

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -188,7 +188,7 @@
 	var/list/bodypart_traits = list()
 	/// The name of the trait source that the organ gives. Should not be altered during the events of gameplay, and will cause problems if it is.
 	var/bodypart_trait_source = BODYPART_TRAIT
-	/// List of the above datums which have actually been instantiated, managed automatically
+	/// List of feature offset datums which have actually been instantiated, managed automatically
 	var/list/feature_offsets = list()
 
 /obj/item/bodypart/Initialize(mapload)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -912,21 +912,21 @@
 			if(aux_zone)
 				aux.color = "[draw_color]"
 
-		//EMISSIVE CODE START
-		// For some reason this was applied as an overlay on the aux image and limb image before.
-		// I am very sure that this is unnecessary, and i need to treat it as part of the return list
-		// to be able to mask it proper in case this limb is a leg.
-		if(blocks_emissive)
-			var/atom/location = loc || owner || src
-			var/mutable_appearance/limb_em_block = emissive_blocker(limb.icon, limb.icon_state, location, layer = limb.layer, alpha = limb.alpha)
-			limb_em_block.dir = image_dir
-			. += limb_em_block
+	//EMISSIVE CODE START
+	// For some reason this was applied as an overlay on the aux image and limb image before.
+	// I am very sure that this is unnecessary, and i need to treat it as part of the return list
+	// to be able to mask it proper in case this limb is a leg.
+	if(blocks_emissive)
+		var/atom/location = loc || owner || src
+		var/mutable_appearance/limb_em_block = emissive_blocker(limb.icon, limb.icon_state, location, layer = limb.layer, alpha = limb.alpha)
+		limb_em_block.dir = image_dir
+		. += limb_em_block
 
-			if(aux_zone)
-				var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, layer = aux.layer, alpha = aux.alpha)
-				aux_em_block.dir = image_dir
-				. += aux_em_block
-		//EMISSIVE CODE END
+		if(aux_zone)
+			var/mutable_appearance/aux_em_block = emissive_blocker(aux.icon, aux.icon_state, location, layer = aux.layer, alpha = aux.alpha)
+			aux_em_block.dir = image_dir
+			. += aux_em_block
+	//EMISSIVE CODE END
 
 	//No need to handle leg layering if dropped, we only face south anyways
 	if(!dropped && ((body_zone == BODY_ZONE_R_LEG) || (body_zone == BODY_ZONE_L_LEG)))

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -191,16 +191,19 @@
 
 /obj/item/bodypart/head/update_limb(dropping_limb, is_creating)
 	. = ..()
-	real_name = owner.real_name
-	if(HAS_TRAIT(owner, TRAIT_HUSK))
-		real_name = "Unknown"
+	if(owner)
+		real_name = owner.real_name
+		if(HAS_TRAIT(owner, TRAIT_HUSK))
+			real_name = "Unknown"
 	update_hair_and_lips(dropping_limb, is_creating)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /obj/item/bodypart/head/get_limb_icon(dropped)
 	. = ..()
-
+	// husks don't get any of the fancy stuff
+	if(is_husked)
+		return .
 	. += get_hair_and_lips_icon(dropped)
 	// We need to get the eyes if we are dropped (ugh)
 	if(dropped)
@@ -230,7 +233,7 @@
 			worn_face_offset?.apply_offset(no_eyes)
 			. += no_eyes
 
-	return
+	return .
 
 /obj/item/bodypart/head/talk_into(mob/holder, message, channel, spans, datum/language/language, list/message_mods)
 	var/mob/headholder = holder

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -202,7 +202,7 @@
 /obj/item/bodypart/head/get_limb_icon(dropped)
 	. = ..()
 	// husks don't get any of the fancy stuff
-	if(is_husked)
+	if(is_invisible || is_husked)
 		return .
 	. += get_hair_and_lips_icon(dropped)
 	// We need to get the eyes if we are dropped (ugh)

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -8,32 +8,32 @@
 	//HIDDEN CHECKS START
 	hair_hidden = FALSE
 	facial_hair_hidden = FALSE
-	if(human_head_owner)
-		if(human_head_owner.head)
-			var/obj/item/hat = human_head_owner.head
-			if(hat.flags_inv & HIDEHAIR)
-				hair_hidden = TRUE
-			if(hat.flags_inv & HIDEFACIALHAIR)
-				facial_hair_hidden = TRUE
-
-		if(human_head_owner.wear_mask)
-			var/obj/item/mask = human_head_owner.wear_mask
-			if(mask.flags_inv & HIDEHAIR)
-				hair_hidden = TRUE
-			if(mask.flags_inv & HIDEFACIALHAIR)
-				facial_hair_hidden = TRUE
-
-		if(human_head_owner.w_uniform)
-			var/obj/item/item_uniform = human_head_owner.w_uniform
-			if(item_uniform.flags_inv & HIDEHAIR)
-				hair_hidden = TRUE
-			if(item_uniform.flags_inv & HIDEFACIALHAIR)
-				facial_hair_hidden = TRUE
-		//invisibility and husk stuff
+	if(owner)
 		if(HAS_TRAIT(human_head_owner, TRAIT_INVISIBLE_MAN) || HAS_TRAIT(human_head_owner, TRAIT_HUSK))
 			hair_hidden = TRUE
 			facial_hair_hidden = TRUE
-	if(is_husked)
+		if(istype(human_head_owner))
+			if(human_head_owner.head)
+				var/obj/item/hat = human_head_owner.head
+				if(hat.flags_inv & HIDEHAIR)
+					hair_hidden = TRUE
+				if(hat.flags_inv & HIDEFACIALHAIR)
+					facial_hair_hidden = TRUE
+
+			if(human_head_owner.wear_mask)
+				var/obj/item/mask = human_head_owner.wear_mask
+				if(mask.flags_inv & HIDEHAIR)
+					hair_hidden = TRUE
+				if(mask.flags_inv & HIDEFACIALHAIR)
+					facial_hair_hidden = TRUE
+
+			if(human_head_owner.w_uniform)
+				var/obj/item/item_uniform = human_head_owner.w_uniform
+				if(item_uniform.flags_inv & HIDEHAIR)
+					hair_hidden = TRUE
+				if(item_uniform.flags_inv & HIDEFACIALHAIR)
+					facial_hair_hidden = TRUE
+	if(is_husked || is_invisible)
 		hair_hidden = TRUE
 		facial_hair_hidden = TRUE
 	//HIDDEN CHECKS END
@@ -59,7 +59,7 @@
 		else
 			show_eyeless = FALSE
 
-	if(!is_creating || !owner)
+	if(!is_creating || !istype(human_head_owner))
 		return
 
 	lip_style = human_head_owner.lip_style
@@ -78,12 +78,14 @@
 	SHOULD_CALL_PARENT(TRUE)
 	RETURN_TYPE(/list)
 	. = list()
+	if(!(bodytype & BODYTYPE_HUMANOID) || is_invisible || is_husked)
+		return .
 
 	var/atom/location = loc || owner || src
 	var/image_dir = (dropped ? SOUTH : NONE)
 
 	var/datum/sprite_accessory/sprite_accessory
-	if(!facial_hair_hidden && lip_style && (head_flags & HEAD_LIPS))
+	if(lip_style && (head_flags & HEAD_LIPS))
 		//not a sprite accessory, don't ask
 		//Overlay
 		var/image/lip_overlay = image('icons/mob/species/human/human_face.dmi', "lips_[lip_style]", -BODY_LAYER, image_dir)

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -90,7 +90,7 @@
 		lip_overlay.color = lip_color
 		//Emissive blocker
 		if(blocks_emissive)
-			lip_overlay.overlays += emissive_blocker(lip_overlay.icon, lip_overlay.icon_state, location, alpha = facial_hair_alpha)
+			lip_overlay.overlays += emissive_blocker(lip_overlay.icon, lip_overlay.icon_state, location)
 		//Offsets
 		worn_face_offset?.apply_offset(lip_overlay)
 		. += lip_overlay

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -113,6 +113,7 @@
 			if(facial_hair_gradient_style)
 				var/facial_hair_gradient_color = LAZYACCESS(gradient_colors, GRADIENT_FACIAL_HAIR_KEY)
 				var/image/facial_hair_gradient_overlay = get_gradient_overlay(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER, GLOB.facial_hair_gradients_list[facial_hair_gradient_style], facial_hair_gradient_color)
+				worn_face_offset?.apply_offset(facial_hair_gradient_overlay)
 				. += facial_hair_gradient_overlay
 
 	var/image/hair_overlay
@@ -133,6 +134,7 @@
 			if(hair_gradient_style)
 				var/hair_gradient_color = LAZYACCESS(gradient_colors, GRADIENT_HAIR_KEY)
 				var/image/hair_gradient_overlay = get_gradient_overlay(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER, GLOB.hair_gradients_list[hair_gradient_style], hair_gradient_color)
+				worn_face_offset?.apply_offset(hair_gradient_overlay)
 				. += hair_gradient_overlay
 
 	if(show_debrained && (head_flags & HEAD_DEBRAIN))

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -80,9 +80,7 @@
 	. = list()
 
 	var/atom/location = loc || owner || src
-	var/image_dir = NONE
-	if(dropped)
-		image_dir = SOUTH
+	var/image_dir = (dropped ? SOUTH : NONE)
 
 	var/datum/sprite_accessory/sprite_accessory
 	if(!facial_hair_hidden && lip_style && (head_flags & HEAD_LIPS))

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -68,6 +68,7 @@
 		return .
 
 	var/mob/living/carbon/human/human_owner = owner
+
 	var/atom/location = loc || owner || src
 	var/image_dir = (dropped ? SOUTH : NONE)
 
@@ -82,6 +83,10 @@
 			if(!underwear.use_static)
 				underwear_overlay.color = human_owner.underwear_color
 			underwear_overlay.dir = image_dir
+			//Emissive blocker
+			if(blocks_emissive)
+				underwear_overlay.overlays += emissive_blocker(underwear_overlay.icon, underwear_overlay.icon_state, location)
+			worn_uniform_offset?.apply_offset(underwear_overlay)
 			. += underwear_overlay
 
 	if(human_owner.undershirt)
@@ -93,14 +98,22 @@
 			else
 				shirt_overlay = mutable_appearance(undershirt.icon, undershirt.icon_state, -BODY_LAYER)
 			shirt_overlay.dir = image_dir
+			//Emissive blocker
+			if(blocks_emissive)
+				underwear_overlay.overlays += emissive_blocker(shirt_overlay.icon, shirt_overlay.icon_state, location)
+			worn_uniform_offset?.apply_offset(shirt_overlay)
 			. += shirt_overlay
 
 	//handling socks here is not ideal and this should be moved to be handled by legs somehow, but that's for later i guess
 	if(human_owner.socks && (human_owner.num_legs >= 2) && !(human_owner.bodytype & BODYTYPE_DIGITIGRADE))
 		var/datum/sprite_accessory/socks/socks = GLOB.socks_list[human_owner.socks]
 		if(socks)
-			var/mutable_appearance/socks_overlay =mutable_appearance(socks.icon, socks.icon_state, -BODY_LAYER)
+			var/mutable_appearance/socks_overlay = mutable_appearance(socks.icon, socks.icon_state, -BODY_LAYER)
 			socks_overlay.dir = image_dir
+			//Emissive blocker
+			if(blocks_emissive)
+				underwear_overlay.overlays += emissive_blocker(socks_overlay.icon, socks_overlay.icon_state, location)
+			worn_uniform_offset?.apply_offset(socks_overlay)
 			. += socks_overlay
 
 	return .

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -12,9 +12,10 @@
 	grind_results = null
 	wound_resistance = 10
 	bodypart_trait_source = CHEST_TRAIT
-	///The bodytype(s) allowed to attach to this chest.
+	/// The bodytype(s) allowed to attach to this chest.
 	var/acceptable_bodytype = BODYTYPE_HUMANOID
 
+	/// Current item inserted in the chest's cavity, if any
 	var/obj/item/cavity_item
 
 	/// Offset to apply to equipment worn as a uniform

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -66,7 +66,7 @@
 	if(!(bodytype & BODYTYPE_HUMANOID) || !ishuman(owner) || HAS_TRAIT(owner, TRAIT_NO_UNDERWEAR))
 		return .
 
-	var/mob/living/carbon/human/human_owner
+	var/mob/living/carbon/human/human_owner = owner
 	var/atom/location = loc || owner || src
 	var/image_dir = (dropped ? SOUTH : NONE)
 

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -57,6 +57,9 @@
 
 /obj/item/bodypart/chest/get_limb_icon(dropped)
 	. = ..()
+	// husks don't get any of the fancy stuff
+	if(is_invisible || is_husked)
+		return .
 	. += get_underwear_icon(dropped)
 	return .
 

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -103,7 +103,7 @@
 			shirt_overlay.dir = image_dir
 			//Emissive blocker
 			if(blocks_emissive)
-				underwear_overlay.overlays += emissive_blocker(shirt_overlay.icon, shirt_overlay.icon_state, location)
+				shirt_overlay.overlays += emissive_blocker(shirt_overlay.icon, shirt_overlay.icon_state, location)
 			worn_uniform_offset?.apply_offset(shirt_overlay)
 			. += shirt_overlay
 
@@ -115,7 +115,7 @@
 			socks_overlay.dir = image_dir
 			//Emissive blocker
 			if(blocks_emissive)
-				underwear_overlay.overlays += emissive_blocker(socks_overlay.icon, socks_overlay.icon_state, location)
+				socks_overlay.overlays += emissive_blocker(socks_overlay.icon, socks_overlay.icon_state, location)
 			worn_uniform_offset?.apply_offset(socks_overlay)
 			. += socks_overlay
 

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -80,23 +80,27 @@
 				underwear_overlay = mutable_appearance(underwear.icon, underwear.icon_state, -BODY_LAYER)
 			if(!underwear.use_static)
 				underwear_overlay.color = human_owner.underwear_color
+			underwear_overlay.dir = image_dir
 			. += underwear_overlay
 
 	if(human_owner.undershirt)
 		var/datum/sprite_accessory/undershirt/undershirt = GLOB.undershirt_list[human_owner.undershirt]
 		if(undershirt)
-			var/mutable_appearance/working_shirt
+			var/mutable_appearance/shirt_overlay
 			if(is_dimorphic && limb_gender == "f")
-				working_shirt = wear_female_version(undershirt.icon_state, undershirt.icon, BODY_LAYER)
+				shirt_overlay = wear_female_version(undershirt.icon_state, undershirt.icon, BODY_LAYER)
 			else
-				working_shirt = mutable_appearance(undershirt.icon, undershirt.icon_state, -BODY_LAYER)
-			. += working_shirt
+				shirt_overlay = mutable_appearance(undershirt.icon, undershirt.icon_state, -BODY_LAYER)
+			shirt_overlay.dir = image_dir
+			. += shirt_overlay
 
 	//handling socks here is not ideal and this should be moved to be handled by legs somehow, but that's for later i guess
 	if(human_owner.socks && (human_owner.num_legs >= 2) && !(human_owner.bodytype & BODYTYPE_DIGITIGRADE))
 		var/datum/sprite_accessory/socks/socks = GLOB.socks_list[human_owner.socks]
 		if(socks)
-			. += mutable_appearance(socks.icon, socks.icon_state, -BODY_LAYER)
+			var/mutable_appearance/socks_overlay =mutable_appearance(socks.icon, socks.icon_state, -BODY_LAYER)
+			socks_overlay.dir = image_dir
+			. += socks_overlay
 
 	return .
 

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -64,7 +64,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	RETURN_TYPE(/list)
 	. = list()
-	if(!(bodytype & BODYTYPE_HUMANOID) || !ishuman(owner) || HAS_TRAIT(owner, TRAIT_NO_UNDERWEAR))
+	if(!(bodytype & BODYTYPE_HUMANOID) || is_invisible || is_husked || !ishuman(owner) || HAS_TRAIT(owner, TRAIT_NO_UNDERWEAR))
 		return .
 
 	var/mob/living/carbon/human/human_owner = owner

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -1,4 +1,3 @@
-
 /obj/item/bodypart/chest
 	name = BODY_ZONE_CHEST
 	desc = "It's impolite to stare at a person's chest."
@@ -54,6 +53,52 @@
 		cavity_item.forceMove(drop_location())
 		cavity_item = null
 	..()
+
+/obj/item/bodypart/chest/get_limb_icon(dropped)
+	. = ..()
+	. += get_underwear_icon(dropped)
+	return .
+
+/obj/item/bodypart/chest/proc/get_underwear_icon(dropped)
+	SHOULD_CALL_PARENT(TRUE)
+	RETURN_TYPE(/list)
+	. = list()
+	if(!(bodytype & BODYTYPE_HUMANOID) || !ishuman(owner) || HAS_TRAIT(owner, TRAIT_NO_UNDERWEAR))
+		return .
+
+	var/mob/living/carbon/human/human_owner
+	var/atom/location = loc || owner || src
+	var/image_dir = (dropped ? SOUTH : NONE)
+
+	if(human_owner.underwear)
+		var/datum/sprite_accessory/underwear/underwear = GLOB.underwear_list[human_owner.underwear]
+		var/mutable_appearance/underwear_overlay
+		if(underwear)
+			if(is_dimorphic && limb_gender == "f" && (underwear.gender == MALE))
+				underwear_overlay = wear_female_version(underwear.icon_state, underwear.icon, BODY_LAYER, FEMALE_UNIFORM_FULL)
+			else
+				underwear_overlay = mutable_appearance(underwear.icon, underwear.icon_state, -BODY_LAYER)
+			if(!underwear.use_static)
+				underwear_overlay.color = human_owner.underwear_color
+			. += underwear_overlay
+
+	if(human_owner.undershirt)
+		var/datum/sprite_accessory/undershirt/undershirt = GLOB.undershirt_list[human_owner.undershirt]
+		if(undershirt)
+			var/mutable_appearance/working_shirt
+			if(is_dimorphic && limb_gender == "f")
+				working_shirt = wear_female_version(undershirt.icon_state, undershirt.icon, BODY_LAYER)
+			else
+				working_shirt = mutable_appearance(undershirt.icon, undershirt.icon_state, -BODY_LAYER)
+			. += working_shirt
+
+	//handling socks here is not ideal and this should be moved to be handled by legs somehow, but that's for later i guess
+	if(human_owner.socks && (human_owner.num_legs >= 2) && !(human_owner.bodytype & BODYTYPE_DIGITIGRADE))
+		var/datum/sprite_accessory/socks/socks = GLOB.socks_list[human_owner.socks]
+		if(socks)
+			. += mutable_appearance(socks.icon, socks.icon_state, -BODY_LAYER)
+
+	return .
 
 /obj/item/bodypart/chest/monkey
 	icon = 'icons/mob/species/monkey/bodyparts.dmi'


### PR DESCRIPTION
## About The Pull Request

As we march ever closer to obliterating species/handle_body() and species/handle_mutant_bodyparts(), it's time to nuke this which bothers me in a similar fashion to hair and lips.

## Why It's Good For The Game

Simplifying the human icon generation pipeline is always good.

## Changelog

:cl:
refactor: Underwear icons are handled by the chest bodypart now. Please report any bugs you encounter with underwear.
/:cl:
