### PR TITLE
Gives androids proper robotic organs.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -28,9 +28,12 @@
 	meat = null
 	mutanttongue = /obj/item/organ/internal/tongue/robot
 	mutantstomach = null
+	mutantappendix = null
 	mutantheart = null
 	mutantliver = null
 	mutantlungs = null
+	mutanteyes = /obj/item/organ/internal/eyes/robotic
+	mutantears = /obj/item/organ/internal/ears/cybernetic
 	species_language_holder = /datum/language_holder/synthetic
 	wing_types = list(/obj/item/organ/external/wings/functional/robotic)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/76644
appendix to null
ears to simple cybernetic
eyes to tier 2 cybernetic eyes because i don't want android wizards to cosplay moths, they are weak enough already.
## Why It's Good For The Game
Androids are now blind when emp'd.
## Changelog
:cl:
fix: androids now have proper robotic organs and no appendix.
/:cl:
