### PR TITLE
Lets you enter fakedeath when dead

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -384,9 +384,10 @@
 
 
 /datum/symptom/heal/coma/proc/coma(mob/living/M)
+	if(QDELETED(M) || M.stat == DEAD)
+		return
 	M.fakedeath("regenerative_coma", !deathgasp)
 	addtimer(CALLBACK(src, PROC_REF(uncoma), M), 300)
-
 
 /datum/symptom/heal/coma/proc/uncoma(mob/living/M)
 	if(QDELETED(M) || !active_coma)

--- a/code/modules/antagonists/changeling/powers/defib_grasp.dm
+++ b/code/modules/antagonists/changeling/powers/defib_grasp.dm
@@ -33,7 +33,6 @@
 	else
 		changeling.fully_heal(heal_flags)
 
-	changeling.cure_fakedeath(CHANGELING_TRAIT) // rips us out of revival stasis (if we're in it)
 	changeling.buckled?.unbuckle_mob(changeling) // get us off of stasis beds please
 	changeling.set_resting(FALSE)
 	changeling.adjust_jitter(20 SECONDS)

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -42,13 +42,13 @@
 	return TRUE
 
 /// Sets [revive_ready] to FALSE and updates the button icons.
+/// Can be called mid-revival if the process is being cancelled
 /datum/action/changeling/fakedeath/proc/disable_revive(mob/living/changeling)
-	if(!revive_ready)
-		return
+	if(revive_ready)
+		chemical_cost = 15
+		revive_ready = FALSE
+		build_all_button_icons(UPDATE_BUTTON_NAME|UPDATE_BUTTON_ICON)
 
-	chemical_cost = 15
-	revive_ready = FALSE
-	build_all_button_icons(UPDATE_BUTTON_NAME|UPDATE_BUTTON_ICON)
 	UnregisterSignal(changeling, SIGNAL_REMOVETRAIT(TRAIT_DEATHCOMA))
 	UnregisterSignal(changeling, COMSIG_MOB_STATCHANGE)
 

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -517,12 +517,12 @@
 
 /// Induces fake death on a living mob.
 /mob/living/proc/fakedeath(source, silent = FALSE)
-	if(stat == DEAD)
-		return
-	if(!silent)
-		emote("deathgasp")
+	if(stat != DEAD)
+		if(!silent)
+			emote("deathgasp")
+		tod = station_time_timestamp()
+
 	add_traits(list(TRAIT_FAKEDEATH, TRAIT_DEATHCOMA), source)
-	tod = station_time_timestamp()
 
 ///Unignores all slowdowns that lack the IGNORE_NOSLOW flag.
 /mob/living/proc/unignore_slowdown(source)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -247,7 +247,7 @@
 /datum/reagent/toxin/zombiepowder/on_mob_metabolize(mob/living/holder_mob)
 	. = ..()
 	holder_mob.adjustOxyLoss(0.5*REM, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	if(data?["method"] & INGEST)
+	if((data?["method"] & INGEST) && holder_mob.stat != DEAD)
 		holder_mob.fakedeath(type)
 
 /datum/reagent/toxin/zombiepowder/on_mob_end_metabolize(mob/living/holder_mob)
@@ -274,7 +274,8 @@
 		if(5 to 8)
 			affected_mob.adjustStaminaLoss(40 * REM * seconds_per_tick, 0)
 		if(9 to INFINITY)
-			affected_mob.fakedeath(type)
+			if(affected_mob.stat != STAT_DEAD)
+				affected_mob.fakedeath(type)
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -274,7 +274,7 @@
 		if(5 to 8)
 			affected_mob.adjustStaminaLoss(40 * REM * seconds_per_tick, 0)
 		if(9 to INFINITY)
-			if(affected_mob.stat != STAT_DEAD)
+			if(affected_mob.stat != DEAD)
 				affected_mob.fakedeath(type)
 	..()
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes #76665

`fakedeath` early returned if the mob was dead, I guess it assumed if you were dead dead you wouldn't want to become fake dead as well

I removed that because it's definitely a valid use case, in my eyes, that you would be able to apply the fakedeath traits to a mob who is dead, for the event they are revived at some point (to still appear dead)

## Why It's Good For The Game

Lings rely on this

## Changelog

:cl: Melbert
fix: Fix ling revival for full-dead lings
/:cl:
