### PR TITLE
Failed MOD auto-storage attempts now tell you that it failed

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -38,9 +38,12 @@
 /obj/item/mod/module/storage/proc/on_chestplate_unequip(obj/item/source, force, atom/newloc, no_move, invdrop, silent)
 	if(QDELETED(source) || !mod.wearer || newloc == mod.wearer || !mod.wearer.s_store)
 		return
-	to_chat(mod.wearer, span_notice("[src] tries to store [mod.wearer.s_store] inside itself."))
-	if(atom_storage?.attempt_insert(mod.wearer.s_store, mod.wearer, override = TRUE))
-		mod.wearer.temporarilyRemoveItemFromInventory(mod.wearer.s_store)
+	if(!atom_storage?.attempt_insert(mod.wearer.s_store, mod.wearer, override = TRUE))
+		balloon_alert(mod.wearer, "storage failed!")
+		to_chat(mod.wearer, span_warning("[src] fails to store [mod.wearer.s_store] inside itself!"))
+		return
+	to_chat(mod.wearer, span_notice("[src] stores [mod.wearer.s_store] inside itself."))
+	mod.wearer.temporarilyRemoveItemFromInventory(mod.wearer.s_store)
 
 /obj/item/mod/module/storage/large_capacity
 	name = "MOD expanded storage module"
@@ -214,7 +217,7 @@
 		virus_data["cure"] = virus.cure_text
 		viruses += list(virus_data)
 	.["statusviruses"] = viruses
-	
+
 	return .
 
 /obj/item/mod/module/status_readout/on_suit_activation()


### PR DESCRIPTION
## About The Pull Request
title; if you try to retract your suit and it fails to store your suit slot item (tank/gun/etc) into storage, now it tells you with both a balloon alert and chat that you dropped something

![image](https://github.com/tgstation/tgstation/assets/31829017/318b3d19-ba74-46ea-a85b-6f620bcb2e19)
![image](https://github.com/tgstation/tgstation/assets/31829017/602ca3bf-ccb0-4f48-a8a6-9faa0b1c1f6c)

## Why It's Good For The Game
"oh shit where'd i put my oxygen tank" (you left it behind 3 Zs ago or something)

## Changelog

:cl:
qol: When a MOD fails to store something in itself when retracting, you're now notified in both the chat and by a balloon alert.
/:cl: