### PR TITLE
Clear PDA now has all themes

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -425,3 +425,10 @@
 	greyscale_config = null
 	greyscale_colors = null
 	long_ranged = TRUE
+
+/obj/item/modular_computer/pda/clear/Initialize(mapload)
+	. = ..()
+	var/datum/computer_file/program/themeify/theme_app = locate() in stored_files
+	if(theme_app)
+		for(var/theme_key in GLOB.pda_name_to_theme - GLOB.default_pda_themes)
+			theme_app.imported_themes += theme_key

--- a/code/modules/modular_computers/file_system/programs/theme_selector.dm
+++ b/code/modules/modular_computers/file_system/programs/theme_selector.dm
@@ -28,7 +28,11 @@
 	switch(action)
 		if("PRG_change_theme")
 			var/selected_theme = params["selected_theme"]
-			if(!GLOB.default_pda_themes.Find(selected_theme) && !imported_themes.Find(selected_theme) && !(computer.obj_flags & EMAGGED))
+			if( \
+				!GLOB.default_pda_themes.Find(selected_theme) && \
+				!imported_themes.Find(selected_theme) && \
+				!(computer.obj_flags & EMAGGED) \
+			)
 				return FALSE
 			computer.device_theme = GLOB.pda_name_to_theme[selected_theme]
 			return TRUE


### PR DESCRIPTION
## About The Pull Request

Gives all themes to clear PDAs

## Why It's Good For The Game

Clear PDAs are found/purchased late into a round and theme apps would generally already be found and installed in PDAs. This means there's nothing left to install in the crystal PDA, so instead I thought why shouldn't they just get all themes?

## Changelog

:cl:
qol: Clear PDAs now has all themes in their themify app by default.
/:cl: