### PR TITLE
(no gbp change) Adds a blacklist to spidereggs.

### DIFF
--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -97,6 +97,7 @@
 
 /datum/food_processor_process/spidereggs
 	input = /obj/item/food/spidereggs
+	blacklist = list(/obj/item/food/spidereggs/processed)
 	output = /obj/item/food/spidereggs/processed
 
 /datum/food_processor_process/potato


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/16896032/f75ed7da-a208-49ed-8dc2-da37d70149a0)


## Why It's Good For The Game

Fewer crashes due to infinite spider eggs. 

## Changelog


:cl:
fix:  Infinite spider eggs are no more. 
/:cl:
