### PR TITLE
Add healing boost to organs while mob is sleeping

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -202,10 +202,20 @@
 		if(locate(/obj/item/pillow) in owner.loc)
 			healing += 0.1
 
-		if(healing > 0 && health_ratio > 0.8)
-			owner.adjustBruteLoss(-1 * healing, required_bodytype = BODYTYPE_ORGANIC)
-			owner.adjustFireLoss(-1 * healing, required_bodytype = BODYTYPE_ORGANIC)
-			owner.adjustToxLoss(-1 * healing * 0.5, TRUE, TRUE, required_biotype = MOB_ORGANIC)
+		if(healing > 0)
+			// gives a boost to internal organs healing
+			for(var/obj/item/bodypart/target_bodypart in owner.bodyparts)
+				for(var/obj/item/organ/internal/target_organ in target_bodypart.contents)
+					if(!target_organ.damage || target_organ.organ_flags & ORGAN_FAILING)
+						continue
+
+					var/healing_bonus = target_organ.healing_factor * healing
+					target_organ.apply_organ_damage(-healing_bonus * target_organ.maxHealth)
+
+			if(health_ratio > 0.8) // only heals minor physical damage
+				owner.adjustBruteLoss(-1 * healing, required_bodytype = BODYTYPE_ORGANIC)
+				owner.adjustFireLoss(-1 * healing, required_bodytype = BODYTYPE_ORGANIC)
+				owner.adjustToxLoss(-1 * healing * 0.5, TRUE, TRUE, required_biotype = MOB_ORGANIC)
 		owner.adjustStaminaLoss(min(-1 * healing, -1 * HEALING_SLEEP_DEFAULT))
 	// Drunkenness gets reduced by 0.3% per tick (6% per 2 seconds)
 	owner.set_drunk_effect(owner.get_drunk_amount() * 0.997)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -204,13 +204,13 @@
 
 		if(healing > 0)
 			// gives a boost to internal organs healing
-			for(var/obj/item/bodypart/target_bodypart in owner.bodyparts)
-				for(var/obj/item/organ/internal/target_organ in target_bodypart.contents)
-					if(!target_organ.damage || target_organ.organ_flags & ORGAN_FAILING)
-						continue
+			for(var/obj/item/organ/target_organ as anything in owner.organs)
+				// no healing boost for robotic or dying organs
+				if(IS_ROBOTIC_ORGAN(target_organ) || !target_organ.damage || target_organ.organ_flags & ORGAN_FAILING)
+					continue
 
-					var/healing_bonus = target_organ.healing_factor * healing
-					target_organ.apply_organ_damage(-healing_bonus * target_organ.maxHealth)
+				var/healing_bonus = target_organ.healing_factor * healing
+				target_organ.apply_organ_damage(-healing_bonus * target_organ.maxHealth)
 
 			if(health_ratio > 0.8) // only heals minor physical damage
 				owner.adjustBruteLoss(-1 * healing, required_bodytype = BODYTYPE_ORGANIC)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -215,7 +215,6 @@
 					// organ regeneration is very low so we crank up the healing rate to give a good bonus
 					var/healing_bonus = target_organ.healing_factor * healing * HEALING_SLEEP_ORGAN_MULTIPLIER
 					target_organ.apply_organ_damage(-healing_bonus * target_organ.maxHealth)
-					to_chat(carbon_owner, span_notice("[healing_bonus] is applied to [target_organ], the damage is now [target_organ.damage]"))
 
 			if(health_ratio > 0.8) // only heals minor physical damage
 				owner.adjustBruteLoss(-1 * healing, required_bodytype = BODYTYPE_ORGANIC)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -206,7 +206,6 @@
 		if(healing > 0)
 			if(iscarbon(owner))
 				var/mob/living/carbon/carbon_owner = owner
-				// gives a boost to internal organs healing
 				for(var/obj/item/organ/target_organ as anything in carbon_owner.organs)
 					// no healing boost for robotic or dying organs
 					if(IS_ROBOTIC_ORGAN(target_organ) || !target_organ.damage || target_organ.organ_flags & ORGAN_FAILING)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1,4 +1,6 @@
+/// The damage healed per tick while sleeping without any modifiers
 #define HEALING_SLEEP_DEFAULT 0.2
+/// The sleep healing multipler for organ passive healing (since organs heal slowly)
 #define HEALING_SLEEP_ORGAN_MULTIPLIER 5
 
 //Largely negative status effects go here, even if they have small benificial effects

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -597,7 +597,10 @@
 		repair_rate = max(0, STANDARD_ORGAN_HEALING * (matter_bin.tier - 1) * 0.5)
 
 /obj/machinery/smartfridge/organ/process(seconds_per_tick)
-	for(var/obj/item/organ/organ in contents)
+	for(var/obj/item/organ/target_organ in contents)
+		if(IS_ROBOTIC_ORGAN(target_organ) || !target_organ.damage)
+			continue
+
 		organ.apply_organ_damage(-repair_rate * organ.maxHealth * seconds_per_tick)
 
 /obj/machinery/smartfridge/organ/Exited(atom/movable/gone, direction)

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -597,10 +597,7 @@
 		repair_rate = max(0, STANDARD_ORGAN_HEALING * (matter_bin.tier - 1) * 0.5)
 
 /obj/machinery/smartfridge/organ/process(seconds_per_tick)
-	for(var/obj/item/organ/target_organ in contents)
-		if(IS_ROBOTIC_ORGAN(target_organ) || !target_organ.damage)
-			continue
-
+	for(var/obj/item/organ/organ in contents)
 		organ.apply_organ_damage(-repair_rate * organ.maxHealth * seconds_per_tick)
 
 /obj/machinery/smartfridge/organ/Exited(atom/movable/gone, direction)

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -229,7 +229,7 @@ Most job-related exosuit clothing can fit job-related items into it, such as the
 Most things have special interactions with right, alt, shift, and control click. Experiment!
 On most clothing items that go in the exosuit slot, you can put certain small items into your suit storage, such as a spraycan, your emergency oxygen tank, or a flashlight.
 Remote devices will work when used through cameras. For example: Bluespace RPEDs and door remotes.
-Sleeping can be used to recover from minor injuries. Sanity, darkness, blindfolds, earmuffs, tables, beds, and bedsheets affect the healing rate.
+Sleeping can be used to recover from minor injuries and organ damage. Sanity, darkness, blindfolds, earmuffs, tables, beds, and bedsheets affect the healing rate.
 Some roles cannot be antagonists by default, but antag selection is decided first. For instance, you can set Security Officer to High without affecting your chances of becoming an antag -- the game will just select a different role.
 Some weapons are better at taking down robots and structures than others. Don't try to break a window with a scalpel, try a toolbox.
 Standard epipens contain a potent coagulant that not only slow bloodloss, but also help clot whichever of your wounds is bleeding the most! If you're suffering multiple bad bleeding wounds, make sure to seek out additional treatment ASAP!


### PR DESCRIPTION
## About The Pull Request
This adds the healing bonuses from sleeping effects (mood, pillow, sleeping in darkness, etc.) and applies it to organs natural healing regeneration.  The regen rate is very low, so I added a heavy x5 multiplication rate to all the sleep bonuses for organs specifically.

If an organ is dying or robotic then the effects don't apply.

## Why It's Good For The Game
More benefits to sleeping after injuries.  This encourages patients to rest properly after revival or major surgery.

## Changelog
:cl:
add: Add healing boost to organs while mob is sleeping (does not apply to robotic or dying organs)
/:cl:
