### PR TITLE
Fixes regenerate_organs not respecting TRAIT_NOBREATH and giving lungs to someone that shouldn't have them

### DIFF
--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -320,7 +320,7 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 	// Default organ fixing handling
 	// May result in kinda cursed stuff for mobs which don't need these organs
 	var/obj/item/organ/internal/lungs/lungs = get_organ_slot(ORGAN_SLOT_LUNGS)
-	if(!lungs)
+	if(!lungs && !HAS_TRAIT(src, TRAIT_NOBREATH))
 		lungs = new()
 		lungs.Insert(src)
 	lungs.set_organ_damage(0)


### PR DESCRIPTION
## About The Pull Request
If the checks were somehow to fail, there would be lungs given to the mob, even if it had TRAIT_NOBREATH, which should be preventing it from getting lungs in the first place.

## Why It's Good For The Game
Not having lungs when you're not meant to is a good thing, methinks.

## Changelog

:cl: GoldenAlpharex
fix: Regenerating organs should no longer give lungs to those that have TRAIT_NOBREATH
/:cl: