### PR TITLE
makes morgue units not hold ghosts

### DIFF
--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -156,6 +156,8 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 					continue
 			else if(istype(AM, /obj/effect/dummy/phased_mob))
 				continue
+			else if(isdead(AM))
+				continue
 			AM.forceMove(src)
 	toggle_organ_decay(src)
 	update_appearance()


### PR DESCRIPTION

## About The Pull Request

makes them unable to hold any /mob/dead

## Why It's Good For The Game

Fixes #76632

## Changelog
:cl:
fix: morgue units can no longer hold ghosts
/:cl:
