### PR TITLE
cake cats/butter bear now grab ghost of whoever was used to make it

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -303,7 +303,9 @@
 	var/obj/item/organ/internal/brain/candidate = locate(/obj/item/organ/internal/brain) in contents
 	if(!candidate || !candidate.brainmob || !candidate.brainmob.mind)
 		return
-	candidate.brainmob.mind.transfer_to(src)
+	var/datum/mind/candidate_mind = candidate.brainmob.mind
+	candidate_mind.transfer_to(src)
+	candidate_mind.grab_ghost()
 	to_chat(src, "[span_boldbig("You are a cak!")]<b> You're a harmless cat/cake hybrid that everyone loves. People can take bites out of you if they're hungry, but you regenerate health \
 	so quickly that it generally doesn't matter. You're remarkably resilient to any damage besides this and it's hard for you to really die at all. You should go around and bring happiness and \
 	free cake to the station!</b>")

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -167,7 +167,9 @@
 	var/obj/item/organ/internal/brain/candidate = locate(/obj/item/organ/internal/brain) in contents
 	if(!candidate || !candidate.brainmob || !candidate.brainmob.mind)
 		return
-	candidate.brainmob.mind.transfer_to(src)
+	var/datum/mind/candidate_mind = candidate.brainmob.mind
+	candidate_mind.transfer_to(src)
+	candidate_mind.grab_ghost()
 	to_chat(src, "[span_boldbig("You are a butter bear!")]<b> You're a mostly harmless bear/butter hybrid that everyone loves. People can take bites out of you if they're hungry, but you regenerate health \
 	so quickly that it generally doesn't matter. You're remarkably resilient to any damage besides this and it's hard for you to really die at all. You should go around and bring happiness and \
 	free butter to the station!</b>")


### PR DESCRIPTION
## About The Pull Request

If a chef crafts a cake cat/bear from someones brain, grabs their ghost into the new cat so they dont have to press "Reenter body"

## Why It's Good For The Game

Fixes #75994

## Changelog
:cl:
fix: Cake cats/butter bear now grab the ghost of the brain used in their making
/:cl:
