### PR TITLE
Fixes a runtime where deployable turrets were spawning projectiles with no source

### DIFF
--- a/code/game/objects/structures/deployable_turret.dm
+++ b/code/game/objects/structures/deployable_turret.dm
@@ -202,7 +202,7 @@
 	var/turf/targets_from = get_turf(src)
 	if(QDELETED(target))
 		target = target_turf
-	var/obj/projectile/projectile_to_fire = new projectile_type
+	var/obj/projectile/projectile_to_fire = new projectile_type(targets_from)
 	playsound(src, firesound, 75, TRUE)
 	projectile_to_fire.preparePixelProjectile(target, targets_from)
 	projectile_to_fire.firer = user


### PR DESCRIPTION

## About The Pull Request

Title.
## Why It's Good For The Game

Runtimes bad.
## Changelog
:cl:
fix: Deployable turrets no longer runtime when firing
/:cl:
