### PR TITLE
Fixes explorer drone trader asking for "suit"

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1,4 +1,5 @@
 /obj/item/clothing/suit/armor
+	name = "armor"
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
 	allowed = null


### PR DESCRIPTION

## About The Pull Request

There was an oversight with one of the explorer drone trader events who wants /obj/item/clothing/suit/armor (base armor path) which currently doesn't have its own name so it gets referred to by the inherited name from /obj/item/clothing/suit in game. I've given it the proper generic name "armor" so this sort of thing won't happen in the future.
## Why It's Good For The Game

Ran into a player doing explorer drone who tried using different types of clothing because the trader asked for "suit" and not even the admins online knew what it meant. This will clear things up and stop similar confusion in the event any code needs to refer to the base armor path by name.
## Changelog

:cl:
fix: The military surplus trader encountered by explorer drones will now correctly ask for armor rather than "suit"
/:cl:

