### PR TITLE
Fix invisible superscript characters in runechat [NO GBP]

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -239,7 +239,7 @@
 	message.pixel_y = target.maptext_height
 	message.pixel_x = -target.base_pixel_x
 	message.maptext_width = CHAT_MESSAGE_WIDTH
-	message.maptext_height = mheight
+	message.maptext_height = mheight * 1.25 // We add extra because some characters are superscript, like actions
 	message.maptext_x = (CHAT_MESSAGE_WIDTH - owner.bound_width) * -0.5
 	message.maptext = MAPTEXT(complete_text)
 


### PR DESCRIPTION
## About The Pull Request

Fixes superscript characters from being invisible (like the asterisk when you perform actions)

![image](https://github.com/tgstation/tgstation/assets/83487515/ea863d0d-69ab-4791-820a-717ce3a2dbd1)

## Changelog
:cl: LT3
fix: Maptext should now properly show superscript characters when performing actions
/:cl: