### PR TITLE
[no gbp] Restores cooldown to spider guard ability

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/web.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/web.dm
@@ -161,3 +161,4 @@
 
 /datum/action/cooldown/web_effigy/Activate()
 	new /obj/structure/spider/effigy(get_turf(owner))
+	return ..()


### PR DESCRIPTION
## About The Pull Request

I guess in some commit I accidentally dropped the super call in this proc, meaning the cooldown was never set

## Why It's Good For The Game

You should get one (1) instant statue per minute, not several hundred

## Changelog

:cl:
fix: Guard spiders can now only make one scary duplicate of themselves at a time, rather than as many as they can click on the button.
/:cl: