### PR TITLE
pAIs and AIs are no longer arbitrarily restricted from casting spells

### DIFF
--- a/code/datums/mutations/cold.dm
+++ b/code/datums/mutations/cold.dm
@@ -18,6 +18,8 @@
 
 	item_type = /obj/item/stack/sheet/mineral/snow
 	delete_old = FALSE
+	delete_on_failure = FALSE
+	drop_inhand = FALSE
 
 /datum/mutation/human/cryokinesis
 	name = "Cryokinesis"

--- a/code/modules/antagonists/heretic/magic/aggressive_spread.dm
+++ b/code/modules/antagonists/heretic/magic/aggressive_spread.dm
@@ -16,6 +16,8 @@
 
 	aoe_radius = 3
 
+	coward_casting = TRUE
+
 /datum/action/cooldown/spell/aoe/rust_conversion/get_things_to_cast_on(atom/center)
 	var/list/things = list()
 	for(var/turf/nearby_turf in range(aoe_radius, center))
@@ -25,7 +27,7 @@
 
 /datum/action/cooldown/spell/aoe/rust_conversion/cast_on_thing_in_aoe(turf/victim, atom/caster)
 	// We have less chance of rusting stuff that's further
-	var/distance_to_caster = get_dist(victim, caster)
+	var/distance_to_caster = get_dist(victim, get_caster_from_cast_on(caster))
 	var/chance_of_not_rusting = (max(distance_to_caster, 1) - 1) * 100 / (aoe_radius + 1)
 
 	if(prob(chance_of_not_rusting))

--- a/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
+++ b/code/modules/antagonists/heretic/magic/nightwatcher_rebirth.dm
@@ -37,7 +37,7 @@
 
 /datum/action/cooldown/spell/aoe/fiery_rebirth/cast_on_thing_in_aoe(mob/living/carbon/victim, mob/living/carbon/human/caster)
 	new /obj/effect/temp_visual/eldritch_smoke(get_turf(victim))
-	victim.Beam(caster, icon_state = "r_beam", time = 2 SECONDS)
+	victim.Beam(get_caster_from_cast_on(caster), icon_state = "r_beam", time = 2 SECONDS)
 
 	//This is essentially a death mark, use this to finish your opponent quicker.
 	if(CAN_SUCCUMB(victim))

--- a/code/modules/antagonists/heretic/magic/void_pull.dm
+++ b/code/modules/antagonists/heretic/magic/void_pull.dm
@@ -53,10 +53,10 @@
 // For the actual cast, we microstun people nearby and pull them in
 /datum/action/cooldown/spell/aoe/void_pull/cast_on_thing_in_aoe(mob/living/victim, atom/caster)
 	// If the victim's within the stun radius, they're stunned / knocked down
-	if(get_dist(victim, caster) < stun_radius)
+	if(get_dist(victim, get_caster_from_cast_on(caster)) < stun_radius)
 		victim.AdjustKnockdown(3 SECONDS)
 		victim.AdjustParalyzed(0.5 SECONDS)
 
 	// Otherwise, they take a few steps closer
 	for(var/i in 1 to 3)
-		victim.forceMove(get_step_towards(victim, caster))
+		victim.forceMove(get_step_towards(victim, get_caster_from_cast_on(caster)))

--- a/code/modules/antagonists/wizard/equipment/enchanted_clown_suit.dm
+++ b/code/modules/antagonists/wizard/equipment/enchanted_clown_suit.dm
@@ -9,6 +9,8 @@
 	cooldown_time = 30 SECONDS
 	cooldown_reduction_per_rank = 2 SECONDS
 	delete_old = FALSE
+	delete_on_failure = FALSE
+	drop_inhand = FALSE
 	/// Amount of time it takes you to rummage around in there
 	var/cast_time = 3 SECONDS
 	/// True while currently casting the spell

--- a/code/modules/mob/living/basic/space_fauna/statue/statue.dm
+++ b/code/modules/mob/living/basic/space_fauna/statue/statue.dm
@@ -102,6 +102,7 @@
 	cooldown_time = 30 SECONDS
 	spell_requirements = NONE
 	aoe_radius = 14
+	coward_casting = TRUE
 
 /datum/action/cooldown/spell/aoe/flicker_lights/get_things_to_cast_on(atom/center)
 	var/list/things = list()

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -209,10 +209,6 @@
 				to_chat(owner, span_warning("[src] can't be cast in this state!"))
 			return FALSE
 
-		// Being put into a card form breaks a lot of spells, so we'll just forbid them in these states
-		if(ispAI(owner) || (isAI(owner) && istype(owner.loc, /obj/item/aicard)))
-			return FALSE
-
 	return TRUE
 
 /**

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -146,6 +146,22 @@
 
 	return Activate(target)
 
+/**
+ * Returns the 'actual caster', allowing spells to work while the caster is in a locker, a mecha, or 'is' a container, such as pAIs.
+ * Some spells should probably still cancel if the 'true caster' isn't compatible. (such as Smite as a p/AI/posibrain)
+ */
+/datum/action/cooldown/spell/proc/get_caster_from_cast_on(atom/cast_on)
+	var/cast_loc = cast_on.loc
+	if(isturf(cast_loc))
+		return cast_on
+	if(ismecha(cast_loc) && isbrain(cast_on))
+		return cast_loc
+	if(ispAI(cast_on))
+		return istype(cast_loc, /obj/item/pai_card) ? cast_loc : cast_on
+	if(isAI(cast_on))
+		return istype(cast_loc, /obj/item/aicard) ? cast_loc : cast_on
+	return cast_on
+
 /// Checks if the owner of the spell can currently cast it.
 /// Does not check anything involving potential targets.
 /datum/action/cooldown/spell/proc/can_cast_spell(feedback = TRUE)

--- a/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
+++ b/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
@@ -17,7 +17,8 @@
 /datum/action/cooldown/spell/aoe/cast(atom/cast_on)
 	. = ..()
 	// Get every atom around us to our aoe cast on
-	var/list/atom/things_to_cast_on = get_things_to_cast_on(cast_on)
+	var/cast_turf = get_turf(cast_on)
+	var/list/atom/things_to_cast_on = get_things_to_cast_on(cast_turf)
 	// If set, shuffle the list of things we're going to cast on to remove any existing order
 	if(shuffle_targets_list)
 		shuffle_inplace(things_to_cast_on)

--- a/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
+++ b/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
@@ -11,13 +11,23 @@
 	var/shuffle_targets_list = FALSE
 	/// The radius of the aoe.
 	var/aoe_radius = 7
+	/// Allows one to cast while hiding inside something.
+	var/coward_casting = FALSE
+
+/datum/action/cooldown/spell/aoe/can_cast_spell(feedback = TRUE)
+	..()
+	var/mob/truecaster = get_caster_from_cast_on(owner)
+	if(!coward_casting && (istype(truecaster.loc, /obj/structure)))
+		to_chat(owner, span_warning("You cannot cast this spell inside something!"))
+		return FALSE
+	return TRUE
 
 // At this point, cast_on == owner. Either works.
 // Don't extend this for your spell! Look at cast_on_thing_in_aoe.
 /datum/action/cooldown/spell/aoe/cast(atom/cast_on)
 	. = ..()
 	// Get every atom around us to our aoe cast on
-	var/cast_turf = get_turf(cast_on)
+	var/cast_turf = get_turf(get_caster_from_cast_on(cast_on))
 	var/list/atom/things_to_cast_on = get_things_to_cast_on(cast_turf)
 	// If set, shuffle the list of things we're going to cast on to remove any existing order
 	if(shuffle_targets_list)

--- a/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
+++ b/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
@@ -15,10 +15,13 @@
 	var/coward_casting = FALSE
 
 /datum/action/cooldown/spell/aoe/can_cast_spell(feedback = TRUE)
-	..()
+	. = ..()
+	if(!.)
+		return
 	var/mob/truecaster = get_caster_from_cast_on(owner)
 	if(!coward_casting && isstructure(truecaster.loc))
-		to_chat(owner, span_warning("You cannot cast this spell inside something!"))
+		if(feedback)
+			to_chat(owner, span_warning("You cannot cast this spell inside something!"))
 		return FALSE
 	return TRUE
 

--- a/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
+++ b/code/modules/spells/spell_types/aoe_spell/_aoe_spell.dm
@@ -17,7 +17,7 @@
 /datum/action/cooldown/spell/aoe/can_cast_spell(feedback = TRUE)
 	..()
 	var/mob/truecaster = get_caster_from_cast_on(owner)
-	if(!coward_casting && (istype(truecaster.loc, /obj/structure)))
+	if(!coward_casting && isstructure(truecaster.loc))
 		to_chat(owner, span_warning("You cannot cast this spell inside something!"))
 		return FALSE
 	return TRUE

--- a/code/modules/spells/spell_types/aoe_spell/area_conversion.dm
+++ b/code/modules/spells/spell_types/aoe_spell/area_conversion.dm
@@ -13,6 +13,8 @@
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 
+	coward_casting = TRUE
+
 	aoe_radius = 2
 
 /datum/action/cooldown/spell/aoe/area_conversion/get_things_to_cast_on(atom/center)
@@ -24,4 +26,4 @@
 
 /datum/action/cooldown/spell/aoe/area_conversion/cast_on_thing_in_aoe(turf/victim, atom/caster)
 	playsound(victim, 'sound/items/welder.ogg', 75, TRUE)
-	victim.narsie_act(FALSE, TRUE, 100 - (get_dist(victim, caster) * 25))
+	victim.narsie_act(FALSE, TRUE, 100 - (get_dist(victim, get_caster_from_cast_on(caster)) * 25))

--- a/code/modules/spells/spell_types/aoe_spell/knock.dm
+++ b/code/modules/spells/spell_types/aoe_spell/knock.dm
@@ -13,6 +13,8 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 	aoe_radius = 3
 
+	coward_casting = TRUE
+
 /datum/action/cooldown/spell/aoe/knock/get_things_to_cast_on(atom/center)
 	return RANGE_TURFS(aoe_radius, center)
 

--- a/code/modules/spells/spell_types/aoe_spell/magic_missile.dm
+++ b/code/modules/spells/spell_types/aoe_spell/magic_missile.dm
@@ -27,7 +27,7 @@
 	return things
 
 /datum/action/cooldown/spell/aoe/magic_missile/cast_on_thing_in_aoe(mob/living/victim, atom/caster)
-	fire_projectile(victim, caster)
+	fire_projectile(victim, get_caster_from_cast_on(caster))
 
 /datum/action/cooldown/spell/aoe/magic_missile/proc/fire_projectile(atom/victim, mob/caster)
 	var/obj/projectile/to_fire = new projectile_type()

--- a/code/modules/spells/spell_types/aoe_spell/repulse.dm
+++ b/code/modules/spells/spell_types/aoe_spell/repulse.dm
@@ -1,4 +1,6 @@
 /datum/action/cooldown/spell/aoe/repulse
+	// I find the concept of blowing a locker open with repulse, knocking everything back, amusing
+	coward_casting = TRUE
 	/// The max throw range of the repulsioon.
 	var/max_throw = 5
 	/// A visual effect to be spawned on people who are thrown away.
@@ -24,8 +26,10 @@
 		if(victim_mob.can_block_magic(antimagic_flags))
 			return
 
-	var/turf/throwtarget = get_edge_target_turf(caster, get_dir(caster, get_step_away(victim, caster)))
-	var/dist_from_caster = get_dist(victim, caster)
+	var/atom/truecaster = get_caster_from_cast_on(caster)
+
+	var/turf/throwtarget = get_edge_target_turf(truecaster, get_dir(truecaster, get_step_away(victim, truecaster)))
+	var/dist_from_caster = get_dist(victim, truecaster)
 
 	if(dist_from_caster == 0)
 		if(isliving(victim))
@@ -36,12 +40,16 @@
 	else
 		if(sparkle_path)
 			// Created sparkles will disappear on their own
-			new sparkle_path(get_turf(victim), get_dir(caster, victim))
+			new sparkle_path(get_turf(victim), get_dir(truecaster, victim))
 
 		if(isliving(victim))
 			var/mob/living/victim_living = victim
 			victim_living.Paralyze(4 SECONDS)
 			to_chat(victim, span_userdanger("You're thrown back by [caster]!"))
+
+		if(istype(victim, /obj/structure/closet))
+			var/obj/structure/closet/flying_closet = victim
+			flying_closet.open(force = FALSE)
 
 		// So stuff gets tossed around at the same time.
 		victim.safe_throw_at(throwtarget, ((clamp((max_throw - (clamp(dist_from_caster - 2, 0, dist_from_caster))), 3, max_throw))), 1, caster, force = repulse_force)

--- a/code/modules/spells/spell_types/charged/_charged.dm
+++ b/code/modules/spells/spell_types/charged/_charged.dm
@@ -144,7 +144,11 @@
 
 /datum/action/cooldown/spell/charged/beam/cast(atom/cast_on)
 	. = ..()
-	send_beam(cast_on, initial_target, max_beam_bounces)
+	var/castloc = cast_on
+	if(!isturf(cast_on.loc)) // If inside a locker or something
+		castloc = cast_on.loc
+
+	send_beam(castloc, initial_target, max_beam_bounces)
 	initial_target = null
 
 /datum/action/cooldown/spell/charged/beam/proc/send_beam(atom/origin, atom/to_beam, bounces)

--- a/code/modules/spells/spell_types/charged/_charged.dm
+++ b/code/modules/spells/spell_types/charged/_charged.dm
@@ -144,9 +144,7 @@
 
 /datum/action/cooldown/spell/charged/beam/cast(atom/cast_on)
 	. = ..()
-	var/castloc = get_caster_from_cast_on(cast_on)
-
-	send_beam(castloc, initial_target, max_beam_bounces)
+	send_beam(get_caster_from_cast_on(cast_on), initial_target, max_beam_bounces)
 	initial_target = null
 
 /datum/action/cooldown/spell/charged/beam/proc/send_beam(atom/origin, atom/to_beam, bounces)

--- a/code/modules/spells/spell_types/charged/_charged.dm
+++ b/code/modules/spells/spell_types/charged/_charged.dm
@@ -144,9 +144,7 @@
 
 /datum/action/cooldown/spell/charged/beam/cast(atom/cast_on)
 	. = ..()
-	var/castloc = cast_on
-	if(!isturf(cast_on.loc)) // If inside a locker or something
-		castloc = cast_on.loc
+	var/castloc = get_caster_from_cast_on(cast_on)
 
 	send_beam(castloc, initial_target, max_beam_bounces)
 	initial_target = null

--- a/code/modules/spells/spell_types/conjure/_conjure.dm
+++ b/code/modules/spells/spell_types/conjure/_conjure.dm
@@ -19,7 +19,8 @@
 /datum/action/cooldown/spell/conjure/cast(atom/cast_on)
 	. = ..()
 	var/list/to_summon_in = list()
-	for(var/turf/summon_turf in range(summon_radius, cast_on))
+	var/turf/cast_turf = get_turf(cast_on)
+	for(var/turf/summon_turf in range(summon_radius, cast_turf))
 		if(summon_respects_density && summon_turf.density)
 			continue
 		to_summon_in += summon_turf

--- a/code/modules/spells/spell_types/conjure/_conjure.dm
+++ b/code/modules/spells/spell_types/conjure/_conjure.dm
@@ -21,7 +21,7 @@
 /datum/action/cooldown/spell/conjure/can_cast_spell(feedback = TRUE)
 	..()
 	var/mob/truecaster = get_caster_from_cast_on(owner)
-	if(!coward_casting && (istype(truecaster.loc, /obj/structure)))
+	if(!coward_casting && isstructure(truecaster.loc)
 		to_chat(owner, span_warning("You cannot cast this spell inside something!"))
 		return FALSE
 	return TRUE

--- a/code/modules/spells/spell_types/conjure/_conjure.dm
+++ b/code/modules/spells/spell_types/conjure/_conjure.dm
@@ -15,12 +15,21 @@
 	var/summon_respects_density = FALSE
 	/// If TRUE, no two summons can be spawned in the same turf.
 	var/summon_respects_prev_spawn_points = TRUE
+	/// Allows one to cast while hiding inside something.
+	var/coward_casting = FALSE
+
+/datum/action/cooldown/spell/conjure/can_cast_spell(feedback = TRUE)
+	..()
+	var/mob/truecaster = get_caster_from_cast_on(owner)
+	if(!coward_casting && (istype(truecaster.loc, /obj/structure)))
+		to_chat(owner, span_warning("You cannot cast this spell inside something!"))
+		return FALSE
+	return TRUE
 
 /datum/action/cooldown/spell/conjure/cast(atom/cast_on)
 	. = ..()
 	var/list/to_summon_in = list()
-	var/turf/cast_turf = get_turf(cast_on)
-	for(var/turf/summon_turf in range(summon_radius, cast_turf))
+	for(var/turf/summon_turf in range(summon_radius, get_turf(get_caster_from_cast_on(cast_on))))
 		if(summon_respects_density && summon_turf.density)
 			continue
 		to_summon_in += summon_turf

--- a/code/modules/spells/spell_types/conjure/_conjure.dm
+++ b/code/modules/spells/spell_types/conjure/_conjure.dm
@@ -19,10 +19,13 @@
 	var/coward_casting = FALSE
 
 /datum/action/cooldown/spell/conjure/can_cast_spell(feedback = TRUE)
-	..()
+	. = ..()
+	if(!.)
+		return
 	var/mob/truecaster = get_caster_from_cast_on(owner)
-	if(!coward_casting && isstructure(truecaster.loc)
-		to_chat(owner, span_warning("You cannot cast this spell inside something!"))
+	if(!coward_casting && (isstructure(truecaster.loc)) || iseffect(truecaster.loc))
+		if(feedback)
+			to_chat(owner, span_warning("You cannot cast this spell inside something!"))
 		return FALSE
 	return TRUE
 

--- a/code/modules/spells/spell_types/conjure_item/_conjure_item.dm
+++ b/code/modules/spells/spell_types/conjure_item/_conjure_item.dm
@@ -24,8 +24,6 @@
 
 	return ..()
 
-//datum/action/cooldown/spell/conjure_item/is_valid_target(atom/cast_on)
-//	return iscarbon(cast_on)
 
 /datum/action/cooldown/spell/conjure_item/cast(mob/living/carbon/cast_on)
 	if(delete_old && LAZYLEN(item_refs))
@@ -43,7 +41,7 @@
 	return ..()
 
 /// Instantiates the item we're conjuring and returns it.
-/// Item is made in nullspace and moved out in cast().
+/// Item is made on the owner's turf and moved into the owner's hand if the spell and mob type allows it.
 /datum/action/cooldown/spell/conjure_item/proc/make_item()
 	var/obj/item/made_item = new item_type(get_turf(owner))
 	LAZYADD(item_refs, WEAKREF(made_item))

--- a/code/modules/spells/spell_types/conjure_item/infinite_guns.dm
+++ b/code/modules/spells/spell_types/conjure_item/infinite_guns.dm
@@ -19,7 +19,7 @@
 // Because enchanted guns self-delete and regenerate themselves,
 // override make_item here and let's not bother with tracking their weakrefs.
 /datum/action/cooldown/spell/conjure_item/infinite_guns/make_item()
-	return new item_type()
+	return new item_type(get_turf(owner))
 
 /datum/action/cooldown/spell/conjure_item/infinite_guns/gun
 	name = "Lesser Summon Guns"

--- a/code/modules/spells/spell_types/conjure_item/infinite_guns.dm
+++ b/code/modules/spells/spell_types/conjure_item/infinite_guns.dm
@@ -28,7 +28,8 @@
 		but will knock targets down. Requires both hands free to use. \
 		Learning this spell makes you unable to learn Arcane Barrage."
 	button_icon_state = "bolt_action"
-
+	delete_on_failure = FALSE
+	drop_inhand = TRUE
 	item_type = /obj/item/gun/ballistic/rifle/enchanted
 
 /datum/action/cooldown/spell/conjure_item/infinite_guns/arcane_barrage
@@ -37,5 +38,7 @@
 		Deals much more damage than Lesser Summon Guns, but won't knock targets down. Requires both hands free to use. \
 		Learning this spell makes you unable to learn Lesser Summon Gun."
 	button_icon_state = "arcane_barrage"
+	delete_on_failure = TRUE
+	drop_inhand = TRUE
 
 	item_type = /obj/item/gun/ballistic/rifle/enchanted/arcane_barrage

--- a/code/modules/spells/spell_types/conjure_item/invisible_box.dm
+++ b/code/modules/spells/spell_types/conjure_item/invisible_box.dm
@@ -22,6 +22,8 @@
 	spell_max_level = 1
 
 	delete_old = FALSE
+	delete_on_failure = FALSE
+	drop_inhand = FALSE
 	item_type = /obj/item/storage/box/mime
 	/// How long boxes last before going away
 	var/box_lifespan = 50 SECONDS

--- a/code/modules/spells/spell_types/conjure_item/lighting_packet.dm
+++ b/code/modules/spells/spell_types/conjure_item/lighting_packet.dm
@@ -7,6 +7,8 @@
 
 	cooldown_time = 1 SECONDS
 	spell_max_level = 1
+	delete_on_failure = TRUE
+	drop_inhand = TRUE
 
 	item_type = /obj/item/spellpacket/lightningbolt
 

--- a/code/modules/spells/spell_types/conjure_item/snowball.dm
+++ b/code/modules/spells/spell_types/conjure_item/snowball.dm
@@ -7,4 +7,6 @@
 	spell_requirements = NONE
 	antimagic_flags = NONE
 	cooldown_time = 1.5 SECONDS
+	delete_on_failure = FALSE
+	drop_inhand = TRUE
 	item_type = /obj/item/toy/snowball

--- a/code/modules/spells/spell_types/pointed/_pointed.dm
+++ b/code/modules/spells/spell_types/pointed/_pointed.dm
@@ -133,10 +133,10 @@
 // cast_on is a turf, or atom target, that we clicked on to fire at.
 /datum/action/cooldown/spell/pointed/projectile/cast(atom/cast_on)
 	. = ..()
-	if(!isturf(owner.loc))
-		return FALSE
 
 	var/turf/caster_turf = get_turf(owner)
+	if(!caster_turf)
+		return FALSE
 	// Get the tile infront of the caster, based on their direction
 	var/turf/caster_front_turf = get_step(owner, owner.dir)
 

--- a/code/modules/spells/spell_types/pointed/_pointed.dm
+++ b/code/modules/spells/spell_types/pointed/_pointed.dm
@@ -135,7 +135,7 @@
 	. = ..()
 
 	var/turf/caster_turf = get_turf(owner)
-	if(!caster_turf)
+	if(isnull(caster_turf))
 		return FALSE
 	// Get the tile infront of the caster, based on their direction
 	var/turf/caster_front_turf = get_step(owner, owner.dir)


### PR DESCRIPTION
## About The Pull Request

pAIs and carded AIs are no longer arbitrarily restricted from casting spells

Slightly improved some spell code to recognize when the caster's location is not a turf. For example, Rust Aggressive Spread works inside lockers now.

fixes #76684

## Why It's Good For The Game

It makes sense on the face of it to disable spellcasting for them, but in practice, the only time this is going to happen is when an admin gives them spells, and thus are right there ready to help out and debug any issues, so all this does is hinder funny events in a strange and unintuitive manner. Especially when normal actions work already, this isn't a good solution.

## Changelog

:cl:
add: pAIs and carded AIs are no longer arbitrarily restricted from casting spells, though that doesn't mean the spells will be compatible.
add: Slightly improved some spell code to recognize when the caster's location is not a turf. For example, Rust Aggressive Spread works inside lockers now.
/:cl:

