### PR TITLE
Rocket launcher's backblast now doesn't ignore armor.

### DIFF
--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -84,7 +84,7 @@
 			LAZYADD(launched_items, iter_item)
 		else if(isliving(iter))
 			var/mob/living/incineratee = iter
-			incineratee.take_bodypart_damage(0, damage, wound_bonus=wound_bonus, bare_wound_bonus=bare_wound_bonus)
+			incineratee.take_bodypart_damage(0, damage, check_armor = TRUE, wound_bonus=wound_bonus, bare_wound_bonus=bare_wound_bonus)
 			incineratee.adjust_fire_stacks(fire_stacks)
 
 #undef BACKBLAST_MAX_ITEM_KNOCKBACK


### PR DESCRIPTION
## About The Pull Request
Seeing nukie in elite mod-suit die from this stacking shit is just sad.
## Why It's Good For The Game
Gun is a bit more usable for nukies now.
## Changelog
:cl:
balance: Rocket launcher's backblast doesnt ignore armor now.
/:cl:
