### PR TITLE
Autorifle magazines are no longer hidden from printing

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -108,7 +108,9 @@
 	build_type = PROTOLATHE | AWAY_LATHE
 	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2)
 	build_path = /obj/item/ammo_box/magazine/wt550m9
-	category = list("Ammo")
+	category = list(
+		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
+	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/mag_autorifle/ap_mag


### PR DESCRIPTION

## About The Pull Request

Fixes the design category for autorifle magazines to not be broken, so they now appear in the ammo category instead of having to search all designs to find them.

## Why It's Good For The Game

I HATE BUGS I HATE BUGS

## Changelog
:cl:
fix: Autorifle magazines are now visible in the security techfab's ammunition category.
/:cl:
