### PR TITLE
Makes gravity generator proximity field signal suppress the signal override warning

### DIFF
--- a/code/datums/elements/forced_gravity.dm
+++ b/code/datums/elements/forced_gravity.dm
@@ -14,7 +14,7 @@
 	src.gravity = gravity
 	src.ignore_turf_gravity = ignore_turf_gravity
 
-	RegisterSignal(target, COMSIG_ATOM_HAS_GRAVITY, PROC_REF(gravity_check), override = override_sig)
+	RegisterSignal(target, COMSIG_ATOM_HAS_GRAVITY, PROC_REF(gravity_check), override = overrides_sig)
 	if(isturf(target))
 		RegisterSignal(target, COMSIG_TURF_HAS_GRAVITY, PROC_REF(turf_gravity_check), override = overrides_sig)
 

--- a/code/datums/elements/forced_gravity.dm
+++ b/code/datums/elements/forced_gravity.dm
@@ -6,7 +6,7 @@
 	///whether we will override the turf if it forces no gravity
 	var/ignore_turf_gravity
 
-/datum/element/forced_gravity/Attach(datum/target, gravity = 1, ignore_turf_gravity = FALSE)
+/datum/element/forced_gravity/Attach(datum/target, gravity = 1, ignore_turf_gravity = FALSE, overrides_sig = FALSE)
 	. = ..()
 	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
@@ -14,9 +14,9 @@
 	src.gravity = gravity
 	src.ignore_turf_gravity = ignore_turf_gravity
 
-	RegisterSignal(target, COMSIG_ATOM_HAS_GRAVITY, PROC_REF(gravity_check))
+	RegisterSignal(target, COMSIG_ATOM_HAS_GRAVITY, PROC_REF(gravity_check), override = override_sig)
 	if(isturf(target))
-		RegisterSignal(target, COMSIG_TURF_HAS_GRAVITY, PROC_REF(turf_gravity_check))
+		RegisterSignal(target, COMSIG_TURF_HAS_GRAVITY, PROC_REF(turf_gravity_check), override = overrides_sig)
 
 	ADD_TRAIT(target, TRAIT_FORCED_GRAVITY, REF(src))
 

--- a/code/datums/proximity_monitor/fields/gravity.dm
+++ b/code/datums/proximity_monitor/fields/gravity.dm
@@ -15,7 +15,7 @@
 		return
 	if(HAS_TRAIT(target, TRAIT_FORCED_GRAVITY))
 		return
-	target.AddElement(/datum/element/forced_gravity, gravity_value)
+	target.AddElement(/datum/element/forced_gravity, gravity_value, overrides_sig = TRUE)
 	modified_turfs[target] = gravity_value
 
 /datum/proximity_monitor/advanced/gravity/cleanup_field_turf(turf/target)


### PR DESCRIPTION
## About The Pull Request

During init, when the gravity generator is being set up and creating its proximity field, a turf can get the `COMSIG_ATOM_HAS_GRAVITY` signal registered to it multiple times. It seems like it shouldn't be possible for this to happen due to the `HAS_TRAIT(TRAIT_FORCED_GRAVITY)` check, but it can.

I was not able to discern the exact cause or reproduce it while the server was running.

As seen below, causing CI failures. The problem turf is directly below the `gravity_generator/main` object.

![firefox_D4BgPpRbW6](https://github.com/tgstation/tgstation/assets/13398309/d41355de-d05b-4f9d-8305-524408c93022)

It shouldn't even matter if this signal gets overriden here because it's being registered by the same proximity field each time. The warning is unneeded. So this seems like as good a solution as any in this case.

## Why It's Good For The Game

Less CI failures for something trivial.

## Changelog

:cl:
code: suppresses signal override warning for gravity generators
/:cl: