### PR TITLE
Buffs the Syndicate Tome

### DIFF
--- a/code/modules/library/bibles.dm
+++ b/code/modules/library/bibles.dm
@@ -360,6 +360,17 @@ GLOBAL_LIST_INIT(bibleitemstates, list(
 	var/uses = 1
 	var/owner_name
 
+/obj/item/book/bible/syndicate/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
+	AddComponent(/datum/component/effect_remover, \
+		success_feedback = "You disrupt the magic of %THEEFFECT with %THEWEAPON.", \
+		success_forcesay = "BEGONE FOUL MAGIKS!!", \
+		tip_text = "Clear rune", \
+		effects_we_clear = list(/obj/effect/rune, /obj/effect/heretic_rune, /obj/effect/cosmic_rune), \
+	)
+	AddElement(/datum/element/bane, target_type = /mob/living/simple_animal/revenant, damage_multiplier = 0, added_damage = 25, requires_combat_mode = FALSE)
+
 /obj/item/book/bible/syndicate/attack_self(mob/living/carbon/human/user, modifiers)
 	if(!uses || !istype(user))
 		return


### PR DESCRIPTION

## About The Pull Request
Betcha forgot this item even existed huh?
Well the wiki page about it is wrong, and its been pretty much untouched since its implementation so i'll tell you what it does do before I tell you about the buff.
So, the syndicate tome is a 5tc traitor item that functions as a bible. It also has a very high force of 18 burn, and you hurt people with it instead of healing them with in on harm intent. Because normally only chaps can use the bible, the first person to use the bible inhand can "bind" to it which deals 5 damage, gives them the priest trait, and adds their true name to the item's description.

Now, it also functions like a nullrod, granting anti-magic and allowing the clearing of heretic/cult runes.
## Why It's Good For The Game
When this thing was introduced magic could hardly even exist in the same round as a traitor. But in the world of dynamic, we have antag on antag interactions all the time. This gives traitors the opportunity to go anti-cultist/anti-wizard/anti-heretic if they wish, and at a cost.
## Changelog
:cl: itseasytosee
balance: the Syndicate Tome traitor item now grants anti-magic while held and can be used to clear cult runes.
/:cl:
