### PR TITLE
Mulebots no longer have their speed reset by rods of asclepius

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -94,6 +94,9 @@
 		diag_hud_set_mulebotcell()
 	return ..()
 
+/mob/living/simple_animal/bot/mulebot/update_stamina() //we override this so that the speed changes from our motor wires won't be reset every time our health is updated
+	return
+
 /mob/living/simple_animal/bot/mulebot/examine(mob/user)
 	. = ..()
 	if(bot_cover_flags & BOT_COVER_OPEN)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -94,9 +94,6 @@
 		diag_hud_set_mulebotcell()
 	return ..()
 
-/mob/living/simple_animal/bot/mulebot/update_stamina() //we override this so that the speed changes from our motor wires won't be reset every time our health is updated
-	return
-
 /mob/living/simple_animal/bot/mulebot/examine(mob/user)
 	. = ..()
 	if(bot_cover_flags & BOT_COVER_OPEN)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -251,6 +251,8 @@
  * Reduces the stamina loss by stamina_recovery
  */
 /mob/living/simple_animal/update_stamina()
+	if(damage_coeff[STAMINA] <= 0) //we shouldn't reset our speed to its initial value if we don't need to, as that can mess with things like mulebot motor wires
+		return
 	set_varspeed(initial(speed) + (staminaloss * 0.06))
 
 /mob/living/simple_animal/proc/handle_automated_action()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/76614.

Simplemobs that can't take stamina damage, including mulebots, will no longer be reset to their default speed whenever they take damage or are healed.

## Why It's Good For The Game

See https://github.com/tgstation/tgstation/issues/76614.

## Changelog

:cl: ATHATH
fix: Simplemobs that can't take stamina damage, including mulebots, will no longer be reset to their default speed whenever they take damage or are healed.
/:cl: