### PR TITLE
Adds a few things to drobes

### DIFF
--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -34,6 +34,8 @@
 				/obj/item/clothing/head/cowboy/white = 1,
 				/obj/item/clothing/head/cowboy/grey = 1,
 				/obj/item/clothing/head/costume/sombrero/green = 1,
+				/obj/item/clothing/head/costume/nightcap/blue = 2,
+				/obj/item/clothing/head/costume/nightcap/red = 2,
 			),
 		),
 
@@ -79,6 +81,8 @@
 				/obj/item/clothing/under/dress/sailor = 1,
 				/obj/item/clothing/under/dress/redeveninggown = 1,
 				/obj/item/clothing/suit/apron/purple_bartender = 2,
+				/obj/item/clothing/under/misc/pj/blue = 2,
+				/obj/item/clothing/under/misc/pj/red = 2,
 			),
 		),
 
@@ -118,6 +122,7 @@
 			"icon" = "socks",
 			"products" = list(
 				/obj/item/clothing/shoes/sneakers/black = 4,
+				/obj/item/clothing/shoes/sneakers/white = 4,
 				/obj/item/clothing/shoes/sandal = 2,
 				/obj/item/clothing/shoes/laceup = 2,
 				/obj/item/clothing/shoes/winterboots = 2,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -187,6 +187,9 @@
 		/obj/item/clothing/suit/hooded/wintercoat/science/robotics = 2,
 		/obj/item/clothing/gloves/fingerless = 2,
 		/obj/item/clothing/shoes/sneakers/black = 2,
+		/obj/item/storage/backpack/science = 3,
+		/obj/item/storage/backpack/satchel/science = 3,
+		/obj/item/storage/backpack/duffelbag/science = 3,
 		/obj/item/radio/headset/headset_sci = 2,
 	)
 	contraband = list(

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -75,9 +75,11 @@
 		/obj/item/clothing/shoes/sneakers/white = 4,
 		/obj/item/clothing/shoes/sneakers/blue = 4,
 		/obj/item/clothing/gloves/latex/nitrile = 4,
+		/obj/item/clothing/gloves/latex,
 		/obj/item/storage/backpack/duffelbag/med = 4,
 		/obj/item/storage/backpack/medic = 4,
 		/obj/item/storage/backpack/satchel/med = 4,
+		/obj/item/radio/headset/headset_med = 4,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/medi_wardrobe
 	payment_department = ACCOUNT_MED

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -75,7 +75,7 @@
 		/obj/item/clothing/shoes/sneakers/white = 4,
 		/obj/item/clothing/shoes/sneakers/blue = 4,
 		/obj/item/clothing/gloves/latex/nitrile = 4,
-		/obj/item/clothing/gloves/latex,
+		/obj/item/clothing/gloves/latex = 4,
 		/obj/item/storage/backpack/duffelbag/med = 4,
 		/obj/item/storage/backpack/medic = 4,
 		/obj/item/storage/backpack/satchel/med = 4,


### PR DESCRIPTION
## About The Pull Request
Adds latex gloves and medical headsets to the MediDrobe.
Adds pyjamas and white shoes to the ClothesMate.
Adds science backpack, duffel bag and satchel to the RoboDrobe.
## Why It's Good For The Game
It is nice be able to replace your medical headset on Metastation where there is no lockers with medical headsets in.
More clothes in the ClothesMate allows people to have more fun dressing up their spaceman in the locker room.
RoboDrobe currently lacks backpacks which is a bit annoying and this PR fixes that.
## Changelog
:cl:
add: Adds latex gloves and medical headsets to the MediDrobe.
add: Adds pyjamas, nightcaps and white shoes to the ClothesMate.
add: Adds science backpack, duffel bag and satchel to the RoboDrobe.
/:cl:
