### PR TITLE
Crusader armor and forgotten armor block shove knockdown like other chaplain armor sets

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_costumes.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_costumes.dm
@@ -143,7 +143,6 @@
 	icon_state = "clockwork_cuirass"
 	inhand_icon_state = null
 	slowdown = 0
-	clothing_flags = NONE
 
 /obj/item/clothing/head/helmet/chaplain
 	name = "crusader helmet"
@@ -172,7 +171,6 @@
 	icon_state = "knight_templar"
 	inhand_icon_state = null
 	slowdown = 0
-	clothing_flags = NONE
 
 /obj/item/clothing/head/helmet/chaplain/cage
 	name = "cage"


### PR DESCRIPTION
## About The Pull Request
The chaplain's crusader armor and clockwork armor had their clothing flags set to 'NONE', making them the only chaplain armor sets that don't block shove knockdown, this PR makes them block shove knockdown like other sets.
## Why It's Good For The Game
Makes the 2 pieces of armor consistent with the chaplain's other sets
## Changelog
:cl:
balance: Crusader armor and forgotten armor block shove knockdown like other sets of chaplain armor
/:cl:
