### PR TITLE
Attempts to fix an issue with gravity generators triggering CI failures

### DIFF
--- a/code/datums/elements/forced_gravity.dm
+++ b/code/datums/elements/forced_gravity.dm
@@ -6,7 +6,7 @@
 	///whether we will override the turf if it forces no gravity
 	var/ignore_turf_gravity
 
-/datum/element/forced_gravity/Attach(datum/target, gravity = 1, ignore_turf_gravity = FALSE)
+/datum/element/forced_gravity/Attach(datum/target, gravity = 1, ignore_turf_gravity = FALSE, can_override = FALSE)
 	. = ..()
 	if(!isatom(target))
 		return ELEMENT_INCOMPATIBLE
@@ -14,9 +14,9 @@
 	src.gravity = gravity
 	src.ignore_turf_gravity = ignore_turf_gravity
 
-	RegisterSignal(target, COMSIG_ATOM_HAS_GRAVITY, PROC_REF(gravity_check))
+	RegisterSignal(target, COMSIG_ATOM_HAS_GRAVITY, PROC_REF(gravity_check), override = can_override)
 	if(isturf(target))
-		RegisterSignal(target, COMSIG_TURF_HAS_GRAVITY, PROC_REF(turf_gravity_check))
+		RegisterSignal(target, COMSIG_TURF_HAS_GRAVITY, PROC_REF(turf_gravity_check), override = can_override)
 
 	ADD_TRAIT(target, TRAIT_FORCED_GRAVITY, REF(src))
 

--- a/code/datums/proximity_monitor/field.dm
+++ b/code/datums/proximity_monitor/field.dm
@@ -38,8 +38,7 @@
 	var/list/new_edge_turfs = new_turfs[EDGE_TURFS_KEY]
 
 	for(var/turf/old_turf as anything in field_turfs)
-		if(!(old_turf in new_field_turfs))
-			cleanup_field_turf(old_turf)
+		cleanup_field_turf(old_turf)
 	for(var/turf/old_turf as anything in edge_turfs)
 		cleanup_edge_turf(old_turf)
 

--- a/code/datums/proximity_monitor/field.dm
+++ b/code/datums/proximity_monitor/field.dm
@@ -38,7 +38,8 @@
 	var/list/new_edge_turfs = new_turfs[EDGE_TURFS_KEY]
 
 	for(var/turf/old_turf as anything in field_turfs)
-		cleanup_field_turf(old_turf)
+		if(!(old_turf in new_field_turfs))
+			cleanup_field_turf(old_turf)
 	for(var/turf/old_turf as anything in edge_turfs)
 		cleanup_edge_turf(old_turf)
 

--- a/code/datums/proximity_monitor/fields/gravity.dm
+++ b/code/datums/proximity_monitor/fields/gravity.dm
@@ -15,7 +15,7 @@
 		return
 	if(HAS_TRAIT(target, TRAIT_FORCED_GRAVITY))
 		return
-	target.AddElement(/datum/element/forced_gravity, gravity_value)
+	target.AddElement(/datum/element/forced_gravity, gravity_value, can_override = TRUE)
 	modified_turfs[target] = gravity_value
 
 /datum/proximity_monitor/advanced/gravity/cleanup_field_turf(turf/target)


### PR DESCRIPTION
## About The Pull Request

#76730 continuation, but I think I have found the actual source of the bug. EDIT: Just kidding, that turned out to not be it either.

The issue:

During init, when the gravity generator is being set up and creating its proximity field, a turf can get the `COMSIG_ATOM_HAS_GRAVITY` signal registered to it multiple times. It seems like it shouldn't be possible for this to happen due to the `HAS_TRAIT(TRAIT_FORCED_GRAVITY)` check, but it can.

I've only seen this happen during CI and have not been able to reproduce it during runtime, but it comes up often enough to be a nuisance when testing PRs.

As seen below, causing CI failures. The problem turf is directly below the `gravity_generator/main` object.

![firefox_D4BgPpRbW6](https://github.com/tgstation/tgstation/assets/13398309/d41355de-d05b-4f9d-8305-524408c93022)

I spent too much time trying to figure out the cause of this duped signal when it really does not matter if this signal gets overridden here, since it's always going to be from the same proximity field. Suppressing the warning will stop the CI failures without any ill effects in this case.

So let's just do that.

## Why It's Good For The Game

Less CI failures for something trivial.

## Changelog

:cl:
fix: fixes gravity generators causing CI failures from overriding a signal
/:cl: