### PR TITLE
Remove initial 500 balance on mining point cards to fix infinite mining points exploit 

### DIFF
--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -149,7 +149,7 @@
 	icon_state = "data_1"
 
 	///Amount of points this card contains.
-	var/points = 500
+	var/points = 0
 
 /obj/item/card/mining_point_card/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -28,7 +28,7 @@
 
 /datum/orderable_item/mining/point_card
 	item_path = /obj/item/card/mining_point_card
-	cost_per_order = 500
+	cost_per_order = 50
 
 /datum/orderable_item/mining/jaunter
 	item_path = /obj/item/wormhole_jaunter

--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -26,10 +26,6 @@
 	item_path = /obj/item/storage/belt/mining
 	cost_per_order = 500
 
-/datum/orderable_item/mining/point_card
-	item_path = /obj/item/card/mining_point_card
-	cost_per_order = 50
-
 /datum/orderable_item/mining/jaunter
 	item_path = /obj/item/wormhole_jaunter
 	cost_per_order = 750

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -54,6 +54,7 @@
 	..()
 	new /obj/item/stack/sheet/mineral/sandbags(src, 5)
 	new /obj/item/storage/box/emptysandbags(src)
+	new /obj/item/card/mining_point_card(src)
 	new /obj/item/shovel(src)
 	new /obj/item/pickaxe/mini(src)
 	new /obj/item/radio/headset/headset_cargo/mining(src)


### PR DESCRIPTION
## About The Pull Request

Fixes #76768
## Why It's Good For The Game

The idea is you put the amount of points of cards you want on the card after buying it. This has the added benefit of making it easier to transfer smaller amounts of points, since you don't need 500 points to buy the card. 

## Changelog
:cl:
fix: Removed initial 500 point balance on mining point transfer cards. Load them up with points instead. 
add: Added mining point transfer cards to mining lockers.
del: Removed mining point transfer cards from mining equipment vendor.
/:cl:
