### PR TITLE
Replace dorm lights with lamp random spawners

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -8735,7 +8735,6 @@
 "dBA" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet/royalblack,
 /area/station/commons/dorms)
 "dBH" = (
@@ -10367,7 +10366,6 @@
 /obj/item/bedsheet/dorms{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
 "eip" = (
@@ -34887,12 +34885,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security)
-"mMZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "mNh" = (
 /obj/machinery/computer/cargo{
 	dir = 1
@@ -38591,7 +38583,6 @@
 "ohO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "ohQ" = (
@@ -39671,6 +39662,7 @@
 "oDm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oDs" = (
@@ -40756,11 +40748,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
-"oXI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
 "oXM" = (
 /obj/machinery/light/cold/directional/south,
 /obj/item/kirbyplants/random,
@@ -68901,7 +68888,6 @@
 /obj/item/bedsheet/dorms{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/west,
 /turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
 "xGl" = (
@@ -101567,7 +101553,7 @@ aVV
 qZq
 qIv
 oEi
-mMZ
+oGv
 qUt
 qUt
 qUt
@@ -104137,7 +104123,7 @@ qIv
 nOf
 rsv
 oGv
-oXI
+nhs
 qUt
 tnO
 uYp

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -26971,7 +26971,7 @@
 /obj/structure/sign/calendar/directional/north,
 /obj/structure/table/wood,
 /obj/effect/landmark/start/hangover,
-/obj/item/flashlight/lamp,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "gIk" = (
@@ -74718,8 +74718,8 @@
 /area/station/commons/dorms)
 "sKM" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /obj/machinery/newscaster/directional/south,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "sKP" = (
@@ -79776,7 +79776,7 @@
 /area/station/security/prison/garden)
 "tYs" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "tYu" = (
@@ -80094,9 +80094,9 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 8;
-	pixel_y = 6
+/obj/effect/spawner/random/decoration/ornament{
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
@@ -88392,8 +88392,8 @@
 /area/station/engineering/supermatter)
 "wgE" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /obj/machinery/newscaster/directional/north,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "wgF" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10780,6 +10780,9 @@
 /area/station/command/heads_quarters/rd)
 "dnk" = (
 /obj/structure/dresser,
+/obj/effect/spawner/random/decoration/ornament{
+	pixel_y = 13
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "dnq" = (
@@ -11354,7 +11357,6 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "dxh" = (
-/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
@@ -34835,8 +34837,8 @@
 /turf/closed/wall/ice,
 /area/icemoon/underground/explored)
 "lcB" = (
-/obj/machinery/light/small/directional/west,
 /obj/structure/table/wood,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "lcG" = (
@@ -37152,7 +37154,6 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "lQr" = (
-/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
@@ -54155,6 +54156,7 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "rlV" = (
 /obj/structure/table/wood,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "rlX" = (
@@ -57899,8 +57901,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
 "svH" = (
-/obj/machinery/light/small/directional/west,
 /obj/structure/dresser,
+/obj/effect/spawner/random/decoration/ornament{
+	pixel_y = 13
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "svL" = (
@@ -71067,9 +71071,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "wIz" = (
-/obj/machinery/light/small/directional/west,
 /obj/structure/table/wood,
 /obj/effect/landmark/start/hangover,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "wIF" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1575,7 +1575,14 @@
 "aFv" = (
 /obj/machinery/newscaster/directional/north,
 /obj/structure/table/wood,
-/obj/effect/spawner/random/bureaucracy/paper,
+/obj/effect/spawner/random/bureaucracy/paper{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/effect/spawner/random/decoration/ornament{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "aFW" = (
@@ -3411,7 +3418,6 @@
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "bmz" = (
-/obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -4182,6 +4188,9 @@
 "bAD" = (
 /obj/structure/dresser,
 /obj/machinery/newscaster/directional/north,
+/obj/effect/spawner/random/decoration/ornament{
+	pixel_y = 13
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "bAR" = (
@@ -8403,7 +8412,6 @@
 "dis" = (
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -14543,7 +14551,6 @@
 /area/station/engineering/atmos)
 "fyo" = (
 /obj/effect/landmark/generic_maintenance_landmark,
-/obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -33544,7 +33551,14 @@
 "mil" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/east,
-/obj/effect/spawner/random/bureaucracy/paper,
+/obj/effect/spawner/random/bureaucracy/paper{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/effect/spawner/random/decoration/ornament{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "min" = (
@@ -41884,10 +41898,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "pgI" = (
-/obj/machinery/light/small/directional/north,
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/north,
-/obj/effect/spawner/random/entertainment/lighter,
+/obj/effect/spawner/random/entertainment/lighter{
+	pixel_x = -8
+	},
+/obj/effect/spawner/random/decoration/ornament{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "pgJ" = (
@@ -67132,9 +67151,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "yft" = (
-/obj/machinery/light/small/directional/north,
 /obj/machinery/newscaster/directional/north,
 /obj/structure/dresser,
+/obj/effect/spawner/random/decoration/ornament{
+	pixel_y = 13
+	},
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "yfx" = (
@@ -67305,10 +67326,6 @@
 /obj/effect/spawner/random/bureaucracy/stamp,
 /turf/open/floor/wood,
 /area/station/commons/vacant_room/office)
-"yjN" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/carpet,
-/area/station/commons/dorms)
 "yjW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -105075,7 +105092,7 @@ qXB
 cgL
 qXB
 bAD
-yjN
+xpo
 lnc
 cUP
 mil

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -160,10 +160,10 @@
 /area/mine/laborcamp)
 "bh" = (
 /obj/structure/table/wood/fancy/blue,
-/obj/machinery/light/small/directional/south,
 /obj/item/paper,
 /obj/item/pen,
 /obj/effect/turf_decal/siding/yellow,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/carpet/royalblue,
 /area/mine/living_quarters)
 "bt" = (
@@ -996,7 +996,6 @@
 /turf/open/floor/plating,
 /area/mine/hydroponics)
 "gz" = (
-/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
@@ -3951,6 +3950,7 @@
 /obj/structure/table,
 /obj/item/paper,
 /obj/item/pen,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/carpet,
 /area/mine/living_quarters)
 "xn" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -20047,10 +20047,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"fiu" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/carpet/red,
-/area/station/commons/dorms/room1)
 "fiz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/tile/light,
@@ -24365,10 +24361,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port)
-"got" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet/royalblue,
-/area/station/commons/dorms/room4)
 "goy" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/item/wallframe/light_fixture{
@@ -51884,6 +51876,7 @@
 /area/station/science/lobby)
 "nsM" = (
 /obj/structure/table,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/eighties,
 /area/station/commons/dorms/room2)
 "nsO" = (
@@ -52475,6 +52468,7 @@
 /area/station/maintenance/floor4/port/fore)
 "nAF" = (
 /obj/structure/table/reinforced/rglass,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room3)
 "nAH" = (
@@ -52819,8 +52813,8 @@
 /area/station/maintenance/floor2/starboard/fore)
 "nEO" = (
 /obj/structure/table,
-/obj/item/screwdriver,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
 "nET" = (
@@ -53002,6 +52996,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/random/directional/north,
+/obj/item/screwdriver,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
 "nHr" = (
@@ -55259,10 +55254,6 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/chemistry)
-"olg" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/parquet,
-/area/station/commons/dorms/room2)
 "olt" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -56284,10 +56275,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
-"ozK" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/carpet/neon/simple/white,
-/area/station/commons/dorms/room3)
 "ozL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -82914,6 +82901,7 @@
 /area/station/maintenance/disposal/incinerator)
 "vLb" = (
 /obj/structure/table,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room1)
 "vLd" = (
@@ -254966,7 +254954,7 @@ isU
 isU
 qrd
 nZR
-fiu
+nWo
 bvR
 qNF
 bxl
@@ -256508,7 +256496,7 @@ aOt
 oQN
 nWe
 niM
-olg
+lof
 pUI
 qQN
 dCU
@@ -260363,7 +260351,7 @@ qrd
 qrd
 qrd
 aiS
-ozK
+ovK
 qov
 dhs
 rfU
@@ -261905,7 +261893,7 @@ pIu
 cmu
 qrd
 nIt
-got
+ryx
 qAI
 uLH
 kDB

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -20047,6 +20047,10 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/service/library)
+"fiu" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/red,
+/area/station/commons/dorms/room1)
 "fiz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/tile/light,
@@ -24361,6 +24365,10 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port)
+"got" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/royalblue,
+/area/station/commons/dorms/room4)
 "goy" = (
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/item/wallframe/light_fixture{
@@ -51876,7 +51884,6 @@
 /area/station/science/lobby)
 "nsM" = (
 /obj/structure/table,
-/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/eighties,
 /area/station/commons/dorms/room2)
 "nsO" = (
@@ -52468,7 +52475,6 @@
 /area/station/maintenance/floor4/port/fore)
 "nAF" = (
 /obj/structure/table/reinforced/rglass,
-/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room3)
 "nAH" = (
@@ -52813,8 +52819,8 @@
 /area/station/maintenance/floor2/starboard/fore)
 "nEO" = (
 /obj/structure/table,
+/obj/item/screwdriver,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
 "nET" = (
@@ -52996,7 +53002,6 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/random/directional/north,
-/obj/item/screwdriver,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/room4)
 "nHr" = (
@@ -55254,6 +55259,10 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/station/medical/chemistry)
+"olg" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/parquet,
+/area/station/commons/dorms/room2)
 "olt" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -56275,6 +56284,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor2/aft)
+"ozK" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/neon/simple/white,
+/area/station/commons/dorms/room3)
 "ozL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -82901,7 +82914,6 @@
 /area/station/maintenance/disposal/incinerator)
 "vLb" = (
 /obj/structure/table,
-/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/iron,
 /area/station/commons/dorms/room1)
 "vLd" = (
@@ -254954,7 +254966,7 @@ isU
 isU
 qrd
 nZR
-nWo
+fiu
 bvR
 qNF
 bxl
@@ -256496,7 +256508,7 @@ aOt
 oQN
 nWe
 niM
-lof
+olg
 pUI
 qQN
 dCU
@@ -260351,7 +260363,7 @@ qrd
 qrd
 qrd
 aiS
-ovK
+ozK
 qov
 dhs
 rfU
@@ -261893,7 +261905,7 @@ pIu
 cmu
 qrd
 nIt
-ryx
+got
 qAI
 uLH
 kDB

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -20060,7 +20060,7 @@
 /area/station/maintenance/tram/mid)
 "fOs" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "fOv" = (
@@ -28742,10 +28742,10 @@
 /area/station/security/prison/safe)
 "jiz" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "jiF" = (
@@ -46809,7 +46809,7 @@
 /area/station/solars/starboard/fore)
 "pKZ" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp,
+/obj/effect/spawner/random/decoration/ornament,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "pLf" = (

--- a/code/game/objects/effects/spawners/random/decoration.dm
+++ b/code/game/objects/effects/spawners/random/decoration.dm
@@ -31,11 +31,11 @@
 /obj/effect/spawner/random/decoration/ornament
 	name = "ornament spawner"
 	icon_state = "lamp"
+	spawn_loot_chance = 95 // station light bulbs have a 5% chance to break
 	loot = list(
-		/obj/item/flashlight/lamp = 35,
-		/obj/item/flashlight/lamp/green = 35,
+		/obj/item/flashlight/lamp = 40,
+		/obj/item/flashlight/lamp/green = 40,
 		/obj/item/flashlight/lantern = 10,
-		/obj/item/phone = 10,
 		/obj/item/flashlight/lantern/jade = 5,
 		/obj/item/flashlight/lamp/bananalamp = 5,
 	)


### PR DESCRIPTION
## About The Pull Request

This removes the default light from dorm private area and replaces it with a lamp random spawner.  This gives the crew the ability to toggle the lights without outside help.

The chance for light bulbs to spawn broken is 5% so the lamp spawner reflects that.

## Why It's Good For The Game

Now you can sleep in peace.

## Changelog

:cl:
qol: Replace dorm lights with lamp random spawners
qol: Remove non-lamp item from lamp random spawner and give it a 95% chance to spawn (light bulbs have a 5% to spawn broken)
/:cl:

