### PR TITLE
Allows players to rename the skeleton model

### DIFF
--- a/code/game/objects/structures/mannequin.dm
+++ b/code/game/objects/structures/mannequin.dm
@@ -191,6 +191,7 @@
 	desc = "Not to knock over."
 	material = MANNEQUIN_SKELETON
 	anchored = TRUE
+	obj_flags = UNIQUE_RENAME
 	starting_items = list(
 		/obj/item/clothing/glasses/eyepatch,
 		/obj/item/clothing/suit/costume/hawaiian,


### PR DESCRIPTION

## About The Pull Request
Allows players to change the name and description of the skeleton model using a pen.
![noBonesAboutIt](https://github.com/tgstation/tgstation/assets/44104681/8c7955c2-c63e-4682-af1b-ae9229261f4e)

<!-- Describe The Pull
 Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Anyone who owns a skeleton and/or skeleton model fits into one of two categories:
 - Named their skeleton/model
 - Person no one likes

It's just a fun little detail for people to be silly with. I'm sure at least a few people can do better than "guys look its sans", though I also fully expect that to happen. 
## Changelog
:cl:
qol: You can now rename the coroner's skeleton model with a pen!
/:cl:
