### PR TITLE
balloon alerts for storage failures

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -386,7 +386,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		var/datum/storage/item_storage = to_insert.atom_storage
 		if((to_insert.w_class >= resolve_parent.w_class) && item_storage && !allow_big_nesting)
 			if(messages && user)
-				user.balloon_alert("too big!")
+				user.balloon_alert(user, "too big!")
 			return FALSE
 
 	return TRUE

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -328,6 +328,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return FALSE
 
 	if(locked > force)
+		user.balloon_alert(user, "closed!")
 		return FALSE
 
 	if((to_insert == resolve_parent) || (to_insert == real_location))
@@ -756,6 +757,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	var/obj/item/resolve_location = real_location.resolve()
 
 	if(locked)
+		user.balloon_alert(user, "closed!")
 		return
 	if(!user.CanReach(resolve_parent) || !user.CanReach(dest_object))
 		return
@@ -987,7 +989,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(locked)
 		if(!silent)
-			resolve_parent.balloon_alert(to_show, "locked!")
+			resolve_parent.balloon_alert(to_show, "closed!")
 		return FALSE
 
 	// If we're quickdrawing boys

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -386,7 +386,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(biggerfish && biggerfish.max_specific_storage < max_specific_storage)
 		if(messages && user)
 			//to_chat(user, span_warning("[to_insert] can't fit in [resolve_parent] while [resolve_parent.loc] is in the way!"))
-			user.balloon_alert(user, "\the [resolve_parent.loc] in the way!")
+			user.balloon_alert(user, "[resolve_parent.loc] in the way!")
 		return FALSE
 
 	if(istype(resolve_parent))
@@ -775,7 +775,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	// Storage to storage transfer is instant
 	if(dest_object.atom_storage)
 		//to_chat(user, span_notice("You dump the contents of [resolve_parent] into [dest_object]."))
-		user.balloon_alert(user, "dumped into \the [dest_object]")
+		user.balloon_alert(user, "dumped into [dest_object]")
 
 		if(rustle_sound)
 			playsound(resolve_parent, SFX_RUSTLE, 50, TRUE, -5)

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -378,7 +378,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(biggerfish && biggerfish.max_specific_storage < max_specific_storage)
 		if(messages && user)
-			user.balloon_alert(user, "[resolve_parent.loc] is in the way!")
+			user.balloon_alert(user, "[lowertext(resolve_parent.loc.name)] is in the way!")
 		return FALSE
 
 	if(istype(resolve_parent))

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -336,18 +336,15 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(to_insert.w_class > max_specific_storage)
 		if(!is_type_in_typecache(to_insert, exception_hold))
 			if(messages && user)
-				//to_chat(user, span_warning("\The [to_insert] is too big for \the [resolve_parent]!"))
 				user.balloon_alert(user, "too big!")
 			return FALSE
 		if(exception_max != INFINITE && exception_max <= exception_count())
 			if(messages && user)
-				//to_chat(user, span_warning("Too many large items already in \the [resolve_parent], can't fit \the [to_insert]!"))
 				user.balloon_alert(user, "no room!")
 			return FALSE
 
 	if(resolve_location.contents.len >= max_slots)
 		if(messages && user && !silent_for_user)
-			///to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
 			user.balloon_alert(user, "no room!")
 		return FALSE
 
@@ -358,26 +355,22 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(total_weight > max_total_storage)
 		if(messages && user && !silent_for_user)
-			///to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
 			user.balloon_alert(user, "no room!")
 		return FALSE
 
 	if(length(can_hold))
 		if(!is_type_in_typecache(to_insert, can_hold))
 			if(messages && user)
-				//to_chat(user, span_warning("\The [resolve_parent] cannot hold \the [to_insert]!"))
 				user.balloon_alert(user, "can't hold!")
 			return FALSE
 
 	if(is_type_in_typecache(to_insert, cant_hold) || HAS_TRAIT(to_insert, TRAIT_NO_STORAGE_INSERT) || (can_hold_trait && !HAS_TRAIT(to_insert, can_hold_trait)))
 		if(messages && user)
-			//to_chat(user, span_warning("\The [resolve_parent] cannot hold \the [to_insert]!"))
 			user.balloon_alert(user, "can't hold!")
 		return FALSE
 
 	if(HAS_TRAIT(to_insert, TRAIT_NODROP))
 		if(messages)
-			//to_chat(user, span_warning("\The [to_insert] is stuck on your hand!"))
 			user.balloon_alert(user, "stuck on your hand!")
 		return FALSE
 
@@ -385,15 +378,13 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(biggerfish && biggerfish.max_specific_storage < max_specific_storage)
 		if(messages && user)
-			//to_chat(user, span_warning("[to_insert] can't fit in [resolve_parent] while [resolve_parent.loc] is in the way!"))
-			user.balloon_alert(user, "[resolve_parent.loc] in the way!")
+			user.balloon_alert(user, "[resolve_parent.loc] is in the way!")
 		return FALSE
 
 	if(istype(resolve_parent))
 		var/datum/storage/item_storage = to_insert.atom_storage
 		if((to_insert.w_class >= resolve_parent.w_class) && item_storage && !allow_big_nesting)
 			if(messages && user)
-				//to_chat(user, span_warning("[resolve_parent] cannot hold [to_insert] as it's a storage item of the same size!"))
 				user.balloon_alert("too big!")
 			return FALSE
 
@@ -774,8 +765,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	// Storage to storage transfer is instant
 	if(dest_object.atom_storage)
-		//to_chat(user, span_notice("You dump the contents of [resolve_parent] into [dest_object]."))
-		user.balloon_alert(user, "dumped into [dest_object]")
+		to_chat(user, span_notice("You dump the contents of [resolve_parent] into [dest_object]."))
 
 		if(rustle_sound)
 			playsound(resolve_parent, SFX_RUSTLE, 50, TRUE, -5)
@@ -793,8 +783,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return
 
 	// Storage to loc transfer requires a do_after
-	//to_chat(user, span_notice("You start dumping out the contents of [resolve_parent] onto [dest_object]..."))
-	user.balloon_alert(user, "dumping onto [dest_object]...")
+	to_chat(user, span_notice("You start dumping out the contents of [resolve_parent] onto [dest_object]..."))
 	if(!do_after(user, 2 SECONDS, target = dest_object))
 		return
 

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -336,16 +336,19 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(to_insert.w_class > max_specific_storage)
 		if(!is_type_in_typecache(to_insert, exception_hold))
 			if(messages && user)
-				to_chat(user, span_warning("\The [to_insert] is too big for \the [resolve_parent]!"))
+				//to_chat(user, span_warning("\The [to_insert] is too big for \the [resolve_parent]!"))
+				user.balloon_alert(user, "too big!")
 			return FALSE
 		if(exception_max != INFINITE && exception_max <= exception_count())
 			if(messages && user)
-				to_chat(user, span_warning("Too many large items already in \the [resolve_parent], can't fit \the [to_insert]!"))
+				//to_chat(user, span_warning("Too many large items already in \the [resolve_parent], can't fit \the [to_insert]!"))
+				user.balloon_alert(user, "no room!")
 			return FALSE
 
 	if(resolve_location.contents.len >= max_slots)
 		if(messages && user && !silent_for_user)
-			to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
+			///to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
+			user.balloon_alert(user, "no room!")
 		return FALSE
 
 	var/total_weight = to_insert.w_class
@@ -355,37 +358,43 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	if(total_weight > max_total_storage)
 		if(messages && user && !silent_for_user)
-			to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
+			///to_chat(user, span_warning("\The [to_insert] can't fit into \the [resolve_parent]! Make some space!"))
+			user.balloon_alert(user, "no room!")
 		return FALSE
 
 	if(length(can_hold))
 		if(!is_type_in_typecache(to_insert, can_hold))
 			if(messages && user)
-				to_chat(user, span_warning("\The [resolve_parent] cannot hold \the [to_insert]!"))
+				//to_chat(user, span_warning("\The [resolve_parent] cannot hold \the [to_insert]!"))
+				user.balloon_alert(user, "can't hold!")
 			return FALSE
 
 	if(is_type_in_typecache(to_insert, cant_hold) || HAS_TRAIT(to_insert, TRAIT_NO_STORAGE_INSERT) || (can_hold_trait && !HAS_TRAIT(to_insert, can_hold_trait)))
 		if(messages && user)
-			to_chat(user, span_warning("\The [resolve_parent] cannot hold \the [to_insert]!"))
+			//to_chat(user, span_warning("\The [resolve_parent] cannot hold \the [to_insert]!"))
+			user.balloon_alert(user, "can't hold!")
 		return FALSE
 
 	if(HAS_TRAIT(to_insert, TRAIT_NODROP))
 		if(messages)
-			to_chat(user, span_warning("\The [to_insert] is stuck on your hand!"))
+			//to_chat(user, span_warning("\The [to_insert] is stuck on your hand!"))
+			user.balloon_alert(user, "stuck on your hand!")
 		return FALSE
 
 	var/datum/storage/biggerfish = resolve_parent.loc.atom_storage // this is valid if the container our resolve_parent is being held in is a storage item
 
 	if(biggerfish && biggerfish.max_specific_storage < max_specific_storage)
 		if(messages && user)
-			to_chat(user, span_warning("[to_insert] can't fit in [resolve_parent] while [resolve_parent.loc] is in the way!"))
+			//to_chat(user, span_warning("[to_insert] can't fit in [resolve_parent] while [resolve_parent.loc] is in the way!"))
+			user.balloon_alert(user, "\the [resolve_parent.loc] in the way!")
 		return FALSE
 
 	if(istype(resolve_parent))
 		var/datum/storage/item_storage = to_insert.atom_storage
 		if((to_insert.w_class >= resolve_parent.w_class) && item_storage && !allow_big_nesting)
 			if(messages && user)
-				to_chat(user, span_warning("[resolve_parent] cannot hold [to_insert] as it's a storage item of the same size!"))
+				//to_chat(user, span_warning("[resolve_parent] cannot hold [to_insert] as it's a storage item of the same size!"))
+				user.balloon_alert("too big!")
 			return FALSE
 
 	return TRUE
@@ -765,7 +774,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	// Storage to storage transfer is instant
 	if(dest_object.atom_storage)
-		to_chat(user, span_notice("You dump the contents of [resolve_parent] into [dest_object]."))
+		//to_chat(user, span_notice("You dump the contents of [resolve_parent] into [dest_object]."))
+		user.balloon_alert(user, "dumped into \the [dest_object]")
 
 		if(rustle_sound)
 			playsound(resolve_parent, SFX_RUSTLE, 50, TRUE, -5)
@@ -783,7 +793,8 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		return
 
 	// Storage to loc transfer requires a do_after
-	to_chat(user, span_notice("You start dumping out the contents of [resolve_parent] onto [dest_object]..."))
+	//to_chat(user, span_notice("You start dumping out the contents of [resolve_parent] onto [dest_object]..."))
+	user.balloon_alert(user, "dumping onto [dest_object]...")
 	if(!do_after(user, 2 SECONDS, target = dest_object))
 		return
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -432,6 +432,7 @@
 	playsound(src, 'sound/items/un_zip.ogg', 100, FALSE)
 	var/datum/callback/can_unzip = CALLBACK(src, PROC_REF(zipper_matches), TRUE)
 	if(!do_after(user, 2.1 SECONDS, src, extra_checks = can_unzip))
+		user.balloon_alert(user, "unzip failed!")
 		return
 	balloon_alert(user, "unzipped")
 	set_zipper(FALSE)
@@ -448,6 +449,7 @@
 	playsound(src, 'sound/items/zip_up.ogg', 100, FALSE)
 	var/datum/callback/can_zip = CALLBACK(src, PROC_REF(zipper_matches), FALSE)
 	if(!do_after(user, 0.5 SECONDS, src, extra_checks = can_zip))
+		user.balloon_alert(user, "zip failed!")
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	balloon_alert(user, "zipped")
 	set_zipper(TRUE)


### PR DESCRIPTION
## About The Pull Request

Adds some balloon alerts for when you fail to put something in storage items (when there is not enough room, item is too big, etc.)
Also adds some balloon alerts for when you fail with a duffelbag (if it's zipped it will say "closed!", and failure alerts if you move when zipping/unzipping)

## Why It's Good For The Game

Balloon alerts are immediately obvious and leave no residue, which is good for failing to put something into a bag, as you probably don't really care to look back on it in the future, and want to immediately know why you cant put it in. I chose not to add balloon alerts for putting things in storage successfully for a couple reasons. For balloon alerts, they would be too long, but they hold fairly useful information so I don't want to cut down the messages. Also just having something like "placed" looked really bad in my opinion. I also can see what you or others put in their bag theoretically being useful to look back on. I think the compromise of storage failures and successes being held in different places (balloon alerts vs in chat) is fine, but if others disagree I can change it or just close this.

## Changelog

:cl: Seven
qol: Added some balloon alerts for failing to place items in storage containers
/:cl:

