### PR TITLE
Blood information will now always show in autopsy reports

### DIFF
--- a/code/game/objects/items/devices/scanners/autopsy_scanner.dm
+++ b/code/game/objects/items/devices/scanners/autopsy_scanner.dm
@@ -91,8 +91,8 @@
 			if(blood_id != /datum/reagent/blood)
 				var/datum/reagent/reagents = GLOB.chemical_reagents_list[blood_id]
 				blood_type = reagents ? reagents.name : blood_id
-				autopsy_information += "Blood Type: [blood_type]<br>"
-				autopsy_information += "Blood Volume: [scanned.blood_volume] cl ([blood_percent]) %<br>"
+			autopsy_information += "Blood Type: [blood_type]<br>"
+			autopsy_information += "Blood Volume: [scanned.blood_volume] cl ([blood_percent]%) <br>"
 
 	for(var/datum/disease/diseases as anything in scanned.diseases)
 		autopsy_information += "Name: [diseases.name] | Type: [diseases.spread_text]<br>"


### PR DESCRIPTION

## About The Pull Request

Some (presumably) misplaced tabs in the autopsy report code resulted in blood type and blood levels only showing if your blood was something other than blood. So any blood-blooded corpse that didn't happen to have any diseases would produce a completely empty "Blood" section in their autopsy report. Such is no longer the case. I also moved the percent sign inside the parentheses where it belongs.

![whatIfBloodWasReal](https://github.com/tgstation/tgstation/assets/44104681/3d6fc853-00df-4e1e-9fce-54b012eae71e)
## Why It's Good For The Game
autopsy report now does thing it is supposed to do 👍 
## Changelog
:cl:
fix: Autopsy reports will now correctly report blood type and level for corpses who happen to have blood for blood.
/:cl:
