### PR TITLE
Terminals will be on the same layer as their APC/SMES by default & Selecting a layer when constructing an APC terminal now works.

### DIFF
--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -61,7 +61,7 @@
 			balloon_alert(user, "need ten lengths of cable!")
 			return
 
-		var/terminal_cable_layer = CABLE_LAYER_1
+		var/terminal_cable_layer
 		if(LAZYACCESS(params2list(params), RIGHT_CLICK))
 			var/choice = tgui_input_list(user, "Select Power Input Cable Layer", "Select Cable Layer", GLOB.cable_name_to_layer)
 			if(isnull(choice))

--- a/code/modules/power/apc/apc_power_proc.dm
+++ b/code/modules/power/apc/apc_power_proc.dm
@@ -7,11 +7,11 @@
 	if(terminal)
 		terminal.connect_to_network()
 
-/obj/machinery/power/apc/proc/make_terminal(terminal_cable_layer)
+/obj/machinery/power/apc/proc/make_terminal(terminal_cable_layer = cable_layer)
 	// create a terminal object at the same position as original turf loc
 	// wires will attach to this
 	terminal = new/obj/machinery/power/terminal(loc)
-	terminal.cable_layer = cable_layer
+	terminal.cable_layer = terminal_cable_layer
 	terminal.setDir(dir)
 	terminal.master = src
 

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -134,7 +134,7 @@
 			to_chat(user, span_warning("You need more wires!"))
 			return
 
-		var/terminal_cable_layer = CABLE_LAYER_1
+		var/terminal_cable_layer
 		if(LAZYACCESS(params2list(params), RIGHT_CLICK))
 			var/choice = tgui_input_list(user, "Select Power Input Cable Layer", "Select Cable Layer", GLOB.cable_name_to_layer)
 			if(isnull(choice))
@@ -205,7 +205,7 @@
 
 // create a terminal object pointing towards the SMES
 // wires will attach to this
-/obj/machinery/power/smes/proc/make_terminal(turf/T, terminal_cable_layer)
+/obj/machinery/power/smes/proc/make_terminal(turf/T, terminal_cable_layer = cable_layer)
 	terminal = new/obj/machinery/power/terminal(T)
 	terminal.cable_layer = terminal_cable_layer
 	terminal.setDir(get_dir(T,src))


### PR DESCRIPTION

## About The Pull Request

Terminals built on APCs and SMES units using left click will now be on the same layer as the machine they're being built for, instead of the first layer.

They can still be built on other layers using right click and that feature will now work for APCs, not just SMES units (it was seemingly forgotten to actually use the argument of the make_terminal() function.)
## Why It's Good For The Game

It is far more intuitive this way, and makes building terminals generally more convenient.
The fix in the case of APCs is good simply by virtue of being a fix.
## Changelog
:cl:
qol: terminals built by left-clicking on SMES and APC units will now be on the same layer as the machine.
fix: constructing a terminal on a specific layer with right-click now works for APCs, not just SMES units
/:cl:
