### PR TITLE
Some iron floor fixes.

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -16,7 +16,7 @@
 	source = /datum/robot_energy_storage/material/iron
 	merge_type = /obj/item/stack/tile/iron
 	tile_reskin_types = list(
-		/obj/item/stack/tile/iron/base,
+		/obj/item/stack/tile/iron,
 		/obj/item/stack/tile/iron/edge,
 		/obj/item/stack/tile/iron/half,
 		/obj/item/stack/tile/iron/corner,

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -136,7 +136,6 @@
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/tile/iron/base //this subtype should be used for most stuff
-	turf_type = /turf/open/floor/iron/base
 	merge_type = /obj/item/stack/tile/iron/base
 
 /obj/item/stack/tile/iron/base/cyborg //cant reskin these, fucks with borg code

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -12,11 +12,11 @@
 	armor_type = /datum/armor/tile_iron
 	resistance_flags = FIRE_PROOF
 	matter_amount = 1
-	cost = SMALL_MATERIAL_AMOUNT * 5
+	cost = HALF_SHEET_MATERIAL_AMOUNT / 2
 	source = /datum/robot_energy_storage/material/iron
 	merge_type = /obj/item/stack/tile/iron
 	tile_reskin_types = list(
-		/obj/item/stack/tile/iron,
+		/obj/item/stack/tile/iron/base,
 		/obj/item/stack/tile/iron/edge,
 		/obj/item/stack/tile/iron/half,
 		/obj/item/stack/tile/iron/corner,
@@ -136,10 +136,10 @@
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/tile/iron/base //this subtype should be used for most stuff
+	turf_type = /turf/open/floor/iron/base
 	merge_type = /obj/item/stack/tile/iron/base
 
 /obj/item/stack/tile/iron/base/cyborg //cant reskin these, fucks with borg code
-	merge_type = /obj/item/stack/tile/iron/base/cyborg
 	tile_reskin_types = null
 
 /obj/item/stack/tile/iron/edge

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -12,7 +12,7 @@
 	armor_type = /datum/armor/tile_iron
 	resistance_flags = FIRE_PROOF
 	matter_amount = 1
-	cost = HALF_SHEET_MATERIAL_AMOUNT / 2
+	cost = HALF_SHEET_MATERIAL_AMOUNT * 0.5
 	source = /datum/robot_energy_storage/material/iron
 	merge_type = /obj/item/stack/tile/iron
 	tile_reskin_types = list(


### PR DESCRIPTION
fixed that borgs cant merge their floor with other iron floor fixed power amount floor tiles use
## About The Pull Request
- Changed energy cost for borgs so its not the same as for rods.
- Made cyborg's floor tiles merge with base floor tiles and not the cyborg base ones, so you can pickup floortiles.
## Why It's Good For The Game
Things work like intended.
## Changelog
:cl:
fix: fixed energy cost on floor tiles for engi borgs.
fix: engi borgs can now properly merge base floor tiles with other base floor tiles.
/:cl:
