### PR TITLE
Gets rid of an unneeded second arrow definition

### DIFF
--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -33,16 +33,6 @@
 	speed = 1
 	range = 25
 
-///*sigh* NON-REUSABLE base arrow projectile. In the future: let's componentize the reusable subtype, jesus
-/obj/projectile/bullet/arrow
-	name = "arrow"
-	desc = "Ow! Get it out of me!"
-	icon = 'icons/obj/weapons/bows/arrows.dmi'
-	icon_state = "arrow_projectile"
-	damage = 50
-	speed = 1
-	range = 25
-
 /// despawning arrow type
 /obj/item/ammo_casing/arrow/despawning/dropped()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

When they were merging during https://github.com/tgstation/tgstation/pull/76703 this must have gotten accidentally put back into the code. This should have been removed by the recent caseless refactor PR.

## Why It's Good For The Game

Keep the code clean.

## Changelog

Not player facing
