### PR TITLE
Changes the Xenomorph Infestation orbit tab to a nice shade of violet, again

### DIFF
--- a/tgui/packages/tgui/interfaces/Orbit/constants.ts
+++ b/tgui/packages/tgui/interfaces/Orbit/constants.ts
@@ -6,6 +6,7 @@ export const ANTAG2COLOR = {
   'Emergency Response Team': 'teal',
   'Escaped Fugitives': 'orange',
   'Bounty Hunters': 'yellow',
+  'Xenomorph Infestation': 'violet',
 } as const;
 
 export const THREAT = {


### PR DESCRIPTION

## About The Pull Request

Original PR: #76745.

I made the branch name way too long, and github desktop threw a fit. In the process of trying to rename it, I deleted the old branch. 

Before:
![image](https://user-images.githubusercontent.com/28870487/252534925-dfd32641-56d5-4133-9084-3ee95565932e.png)

After:
![image](https://github.com/tgstation/tgstation/assets/28870487/1f3d68f7-6fff-4c10-8053-467af458a6f4)
## Why It's Good For The Game

Pretty purpleish colors :)
## Changelog
:cl: Rhials
qol: The Xenomorph Infestation orbit menu tab is now violet instead of red!
/:cl:
