### PR TITLE
Fixes issue with blood deficient jellypeople not receiving bloodpacks in the mail

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -582,8 +582,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		quirk.mail_goodies = mail_goodies
 		return
 	if(istype(quirk, /datum/quirk/blooddeficiency))
-		if(HAS_TRAIT(recipient, TRAIT_NOBLOOD)) // no blood packs should be sent in this case (like if a mob transforms into a plasmaman)
-			quirk.mail_goodies = list()
+		if(HAS_TRAIT(recipient, TRAIT_NOBLOOD) && isnull(recipient.dna.species.exotic_blood)  // TRAIT_NOBLOOD and no exotic blood (yes we have to check for both, jellypeople exist)
+			quirk.mail_goodies = list() // means no blood pack gets sent to them.
 			return
 
 

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -582,7 +582,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		quirk.mail_goodies = mail_goodies
 		return
 	if(istype(quirk, /datum/quirk/blooddeficiency))
-		if(HAS_TRAIT(recipient, TRAIT_NOBLOOD) && isnull(recipient.dna.species.exotic_blood)  // TRAIT_NOBLOOD and no exotic blood (yes we have to check for both, jellypeople exist)
+		if(HAS_TRAIT(recipient, TRAIT_NOBLOOD) && isnull(recipient.dna.species.exotic_blood))  // TRAIT_NOBLOOD and no exotic blood (yes we have to check for both, jellypeople exist)
 			quirk.mail_goodies = list() // means no blood pack gets sent to them.
 			return
 


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/76209 removes this line with no explanation as to why. It was/is needed there. I have adjusted comment to explain why.

(The reason being, Jellypeople are an edge case where they have special exotic blood and the `TRAIT_NOBLOOD` trait simultaneously).

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
fix: transformed jellypeople with the blood deficiency quirk will now receive the right bloodpacks as mail goodies
/:cl:

