### PR TITLE
Buffs Lionhunter Damage and Range

### DIFF
--- a/code/modules/antagonists/heretic/items/hunter_rifle.dm
+++ b/code/modules/antagonists/heretic/items/hunter_rifle.dm
@@ -1,5 +1,5 @@
 /// The max range we can zoom in on people from.
-#define MAX_LIONHUNTER_RANGE 16
+#define MAX_LIONHUNTER_RANGE 30
 
 // The Lionhunter, a gun for heretics
 // The ammo it uses takes time to "charge" before firing,
@@ -16,7 +16,7 @@
 
 /obj/item/gun/ballistic/rifle/lionhunter/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/scope, range_modifier = 1.25)
+	AddComponent(/datum/component/scope, range_modifier = 3.2)
 
 /obj/item/ammo_box/magazine/internal/boltaction/lionhunter
 	name = "lionhunter rifle internal magazine"
@@ -113,7 +113,7 @@
 	// BUT, if we're at a decent range and the target's a living mob,
 	// the projectile's been channel fired. It has full effects and homes in.
 	if(distance > min_distance && isliving(target) && iscarbon(user))
-		loaded_projectile.damage *= 1.33
+		loaded_projectile.damage *= 2
 		loaded_projectile.stamina *= 2
 		loaded_projectile.knockdown = 0.5 SECONDS
 		loaded_projectile.stutter = 6 SECONDS


### PR DESCRIPTION

## About The Pull Request

- Increases damage modifier to 2 from 1.33, bringing up the Lionhunter's charged shot from 40 to 60 (closer to a mosin)
- Increases max range to do a charged shot from 16 to 30
- Increases how far you can use the scope component so you make use of the new max range
- Uncharged Lionhunter shots are unchanged (still 30)

## Why It's Good For The Game

The Lionhunter is originally described in the blade heretic PR as being able to charge to deal "massively increased damage" but in practice it doesn't seem very potent. The damage increase for charging goes from 30 to 40, which is just barely enough to crit unarmoured targets if you hit someone in the chest or head with every shot, and can't crit armoured targets at all, assuming you even land all chest / head shots and not limb shots at the current max range of 16

Which is also being increased because it has a scope component that is fairly unhelpful because it only gives you an extra 2 tiles of range and was much longer before scopes were changed

With the damage increase you should be able to fairly reliably crit armoured targets like sec officers with 3 shots and regular crew in 2, but with the ammo capacity its not enough to kill a target outright. So blade heretics will have a more potent weapon this far up the tree, but from testing shouldn't be too SILLY

If @MrMelbert wants some things to be adjusted I will happily oblige

on a separate note ive never opened a pr or touched github in my life please dont hurt me

## Changelog

:cl:
balance: Lionhunter on charge now has a damage modifier of 2 instead of 1.33
balance: Increased max range of charged shot from 16 to 30
balance: Increased scope modifier so you can use the new max range
/:cl:
