### PR TITLE
Removes shove knockdown protection from all chaplain clothes

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -318,10 +318,10 @@
 //called in /obj/item/tank/jetpack/proc/turn_off() : ()
 #define COMSIG_JETPACK_DEACTIVATED "jetpack_deactivated"
 
-//called in /obj/item/organ/cyberimp/chest/thrusters/proc/toggle() : ()
+//called in /obj/item/organ/internal/cyberimp/chest/thrusters/proc/toggle() : ()
 #define COMSIG_THRUSTER_ACTIVATED "jetmodule_activated"
 	#define THRUSTER_ACTIVATION_FAILED (1<<0)
-//called in /obj/item/organ/cyberimp/chest/thrusters/proc/toggle() : ()
+//called in /obj/item/organ/internal/cyberimp/chest/thrusters/proc/toggle() : ()
 #define COMSIG_THRUSTER_DEACTIVATED "jetmodule_deactivated"
 
 // /obj/item/camera signals

--- a/code/modules/jobs/job_types/chaplain/chaplain_costumes.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_costumes.dm
@@ -14,7 +14,6 @@
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	armor_type = /datum/armor/chaplainsuit_armor
-	clothing_flags = BLOCKS_SHOVE_KNOCKDOWN
 	strip_delay = 80
 	equip_delay_other = 60
 
@@ -143,7 +142,6 @@
 	icon_state = "clockwork_cuirass"
 	inhand_icon_state = null
 	slowdown = 0
-	clothing_flags = NONE
 
 /obj/item/clothing/head/helmet/chaplain
 	name = "crusader helmet"
@@ -172,7 +170,6 @@
 	icon_state = "knight_templar"
 	inhand_icon_state = null
 	slowdown = 0
-	clothing_flags = NONE
 
 /obj/item/clothing/head/helmet/chaplain/cage
 	name = "cage"

--- a/code/modules/jobs/job_types/chaplain/chaplain_divine_archer.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_divine_archer.dm
@@ -20,7 +20,6 @@
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	armor_type = /datum/armor/chaplainsuit_armor_weaker
-	clothing_flags = BLOCKS_SHOVE_KNOCKDOWN
 	strip_delay = 80
 	equip_delay_other = 60
 	hoodtype = /obj/item/clothing/head/hooded/chaplain_hood/divine_archer


### PR DESCRIPTION
## About The Pull Request

Alternative to https://github.com/tgstation/tgstation/pull/76759

Removes all shove protection from Chaplain clothes.

## Why It's Good For The Game

This was accidentally added when Chaplain suits were refactored away from being subtypes of riot suits (the TYPE was checked in tackling, which is the only thing the clothes gained from being a subtype previously) in https://github.com/tgstation/tgstation/pull/68417
People sorta just forgot that Chaplain gear never had this functionality, or assumed it was intentional because it's been like that for some time now.

Chaplains already have enough gear (Null rod, better armor than Security, Bible healing, sects) as a ROLEPLAY-focused job that I do not think they need more combat-focused buffs.

Also fixes an accidental bug.

## Changelog

:cl:
fix: Chaplain armor no longer blocks being shoved down.
/:cl: