### PR TITLE
Removes the ID box from the HoP's starting equipment.

### DIFF
--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -56,7 +56,6 @@
 	uniform = /obj/item/clothing/under/rank/civilian/head_of_personnel
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic = 1,
-		/obj/item/storage/box/ids = 1,
 		)
 	belt = /obj/item/modular_computer/pda/heads/hop
 	ears = /obj/item/radio/headset/heads/hop


### PR DESCRIPTION
## About The Pull Request

I forgot this one in #76448. oops
## Why It's Good For The Game

As before, the goal is to remove redundancy with these boxes, as you're never gonna use all 7 of them anyways outside of a freak accident, and they only create clutter. This does NOT remove the ID box and silver ID box from their locker, mind you, only the one they start with.
## Changelog
:cl:
del: The Head of Personnel no longer spawns with an ID box.
/:cl:
