### PR TITLE
Changes the damage reduction for robotic limbs to be multiplicative instead of additive.

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/_reagent.dm
+++ b/code/modules/antagonists/blob/blobstrains/_reagent.dm
@@ -25,7 +25,7 @@
 	color = "#FFFFFF"
 	taste_description = "bad code and slime"
 	chemical_flags = NONE
-	penetrates_skin = VAPOR
+	penetrates_skin = NONE
 
 /// Used by blob reagents to calculate the reaction volume they should use when exposing mobs.
 /datum/reagent/blob/proc/return_mob_expose_reac_volume(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/overmind)

--- a/code/modules/antagonists/blob/blobstrains/_reagent.dm
+++ b/code/modules/antagonists/blob/blobstrains/_reagent.dm
@@ -25,7 +25,7 @@
 	color = "#FFFFFF"
 	taste_description = "bad code and slime"
 	chemical_flags = NONE
-	penetrates_skin = NONE
+	penetrates_skin = VAPOR
 
 /// Used by blob reagents to calculate the reaction volume they should use when exposing mobs.
 /datum/reagent/blob/proc/return_mob_expose_reac_volume(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/overmind)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -95,11 +95,6 @@
 	var/brute_modifier = 1
 	/// Burn damage gets multiplied by this on receive_damage()
 	var/burn_modifier = 1
-	// Damage reduction variables for damage handled on the limb level. Handled after worn armor.
-	/// Amount subtracted from brute damage inflicted on the limb.
-	var/brute_reduction = 0
-	/// Amount subtracted from burn damage inflicted on the limb.
-	var/burn_reduction = 0
 
 	//Coloring and proper item icon update
 	var/skin_tone = ""
@@ -445,8 +440,6 @@
 	var/dmg_multi = CONFIG_GET(number/damage_multiplier) * hit_percent
 	brute = round(max(brute * dmg_multi * brute_modifier, 0), DAMAGE_PRECISION)
 	burn = round(max(burn * dmg_multi * burn_modifier, 0), DAMAGE_PRECISION)
-	brute = max(0, brute - brute_reduction)
-	burn = max(0, burn - burn_reduction)
 
 	if(!brute && !burn)
 		return FALSE

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -395,8 +395,8 @@
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon_static = 'icons/mob/augmentation/surplus_augments.dmi'
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	burn_modifier = 0
-	brute_modifier = 0
+	burn_modifier = 1
+	brute_modifier = 1
 	max_damage = 20
 
 /obj/item/bodypart/leg/left/robot/surplus
@@ -404,8 +404,8 @@
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon_static = 'icons/mob/augmentation/surplus_augments.dmi'
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_modifier = 0
-	burn_modifier = 0
+	brute_modifier = 1
+	burn_modifier = 1
 	max_damage = 20
 
 /obj/item/bodypart/leg/right/robot/surplus
@@ -413,8 +413,8 @@
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon_static = 'icons/mob/augmentation/surplus_augments.dmi'
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_modifier = 0
-	burn_modifier = 0
+	brute_modifier = 1
+	burn_modifier = 1
 	max_damage = 20
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -26,8 +26,8 @@
 	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_modifier = 0.8
+	burn_modifier = 0.8
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -56,8 +56,8 @@
 	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_modifier = 0.8
+	burn_modifier = 0.8
 	disabling_threshold_percentage = 1
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
@@ -86,8 +86,8 @@
 	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_modifier = 0.8
+	burn_modifier = 0.8
 	disabling_threshold_percentage = 1
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
@@ -125,8 +125,8 @@
 	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_modifier = 0.8
+	burn_modifier = 0.8
 	disabling_threshold_percentage = 1
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
@@ -163,8 +163,8 @@
 	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_modifier = 0.8
+	burn_modifier = 0.8
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -283,8 +283,8 @@
 	change_exempt_flags = BP_BLOCK_CHANGE_SPECIES
 	dmg_overlay_type = "robotic"
 
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_modifier = 0.8
+	burn_modifier = 0.8
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -386,8 +386,8 @@
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon_static = 'icons/mob/augmentation/surplus_augments.dmi'
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 0
-	burn_reduction = 0
+	burn_modifier = 1
+	brute_modifier = 1
 	max_damage = 20
 
 /obj/item/bodypart/arm/right/robot/surplus
@@ -395,8 +395,8 @@
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon_static = 'icons/mob/augmentation/surplus_augments.dmi'
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 0
-	burn_reduction = 0
+	burn_modifier = 0
+	brute_modifier = 0
 	max_damage = 20
 
 /obj/item/bodypart/leg/left/robot/surplus
@@ -404,8 +404,8 @@
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon_static = 'icons/mob/augmentation/surplus_augments.dmi'
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 0
-	burn_reduction = 0
+	brute_modifier = 0
+	burn_modifier = 0
 	max_damage = 20
 
 /obj/item/bodypart/leg/right/robot/surplus
@@ -413,8 +413,8 @@
 	desc = "A skeletal, robotic limb. Outdated and fragile, but it's still better than nothing."
 	icon_static = 'icons/mob/augmentation/surplus_augments.dmi'
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 0
-	burn_reduction = 0
+	brute_modifier = 0
+	burn_modifier = 0
 	max_damage = 20
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG


### PR DESCRIPTION
## About The Pull Request
Robotic limbs currently use additive damage reduction to reduce the damage received, which allows for damage to be completely negated if the damage applied is low enough.
As you can imagine, this can create silly situations where androids are completely immune to anything that applies a low and consistent amount of damage.

## Why It's Good For The Game
Complete damage reduction feels very unfair if you're an antagonist 
For example, there was a blob round on Manuel where an android was completely able to negate 100% of the damage from a blob and their blobbernauts because they were on a strain that dealt low amounts of damage. They were able to singlehandedly kill the blob and the blob was unable to do much about it.

Considering that borgs and silicons still take damage to the strain that the android did not take any damage to, this also fixes a consistency problem.

## Changelog
:cl:
balance: Changed damage reduction for robotic limbs to be multiplicative instead of additive
/:cl:
