### PR TITLE
Fixes ventilation clog spawning mobs in impassable objects

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -145,7 +145,7 @@
 	var/list/potential_locations = list()
 
 	for(var/turf/nearby_turf in view(1, get_turf(vent)))
-		if(!nearby_turf.is_blocked_turf_ignore_climbable()) // not perfect, but the worst that happens here is they ignore directional windows
+		if(!nearby_turf.is_blocked_turf_ignore_climbable()) // not perfect, but the worst that happens here is they ignore windows
 			potential_locations += nearby_turf
 
 	var/turf/spawn_location = pick(potential_locations)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -139,20 +139,27 @@
  */
 
 /datum/round_event/vent_clog/proc/produce_mob()
-	if(vent.welded)
+	var/turf/vent_loc = get_turf(vent)
+	if (isnull(vent_loc))
+		CRASH("[vent] has no loc, aborting mobspawn")
+
+	if(vent.welded || vent_loc.is_blocked_turf_ignore_climbable()) // vents under tables can still spawn stuff
 		return
 
-	var/list/potential_locations = list()
+	var/mob/new_mob = new spawned_mob(vent_loc) // we spawn it early so we can actually use is_blocked_turf
+	living_mobs += WEAKREF(new_mob)
+	vent.visible_message(span_warning("[new_mob] crawls out of [vent]!"))
 
-	for(var/turf/nearby_turf in view(1, get_turf(vent)))
-		if(!nearby_turf.is_blocked_turf_ignore_climbable()) // not perfect, but the worst that happens here is they ignore windows
+	var/list/potential_locations = list(vent_loc) // already confirmed to be accessable via the 2nd if check of the proc
+
+	// exists to prevent mobs from trying to move onto turfs they physically cannot
+	for(var/turf/nearby_turf in oview(1, get_turf(vent))) // oview, since we always add our loc to the list
+		if(!nearby_turf.is_blocked_turf(source_atom = new_mob))
 			potential_locations += nearby_turf
 
 	var/turf/spawn_location = pick(potential_locations)
+	new_mob.Move(spawn_location)
 
-	var/mob/new_mob = new spawned_mob(spawn_location)
-	living_mobs += WEAKREF(new_mob)
-	vent.visible_message(span_warning("[new_mob] crawls out of [vent]!"))
 	var/filth_to_spawn = pick(filth_spawn_types)
 	new filth_to_spawn(spawn_location)
 	playsound(spawn_location, 'sound/effects/splat.ogg', 30, TRUE)

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -83,7 +83,7 @@
 /**
  * Finds a valid vent to spawn mobs from.
  *
- * Randomly selects a vent that is on-station and unwelded. If no vents are found, the event
+ * Randomly selects a vent that is on-station, unwelded, and hosted by a passable turf. If no vents are found, the event
  * is immediately killed.
  */
 
@@ -91,7 +91,7 @@
 	var/list/vent_list = list()
 	for(var/obj/machinery/atmospherics/components/unary/vent_pump/vent in GLOB.machines)
 		var/turf/vent_turf = get_turf(vent)
-		if(vent_turf && is_station_level(vent_turf.z) && !vent.welded)
+		if(vent_turf && is_station_level(vent_turf.z) && !vent.welded && !vent_turf.is_blocked_turf_ignore_climbable())
 			vent_list += vent
 
 	if(!length(vent_list))
@@ -145,7 +145,7 @@
 	var/list/potential_locations = list()
 
 	for(var/turf/nearby_turf in view(1, get_turf(vent)))
-		if(!nearby_turf.density)
+		if(!nearby_turf.is_blocked_turf_ignore_climbable()) // not perfect, but the worst that happens here is they ignore directional windows
 			potential_locations += nearby_turf
 
 	var/turf/spawn_location = pick(potential_locations)


### PR DESCRIPTION

## About The Pull Request

Title.

Also changes how they spawn - they now always spawn on the turf of the vent and move onto the tile they pick. 

Closes https://github.com/tgstation/tgstation/issues/76707
## Why It's Good For The Game

Bugs are bad.
## Changelog
:cl:
fix: Ventilation clog no longer spawns mobs in inappropriate places
/:cl:
