### PR TITLE
Fixes AIs being able to untilt vendors remotely

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -859,15 +859,16 @@
 	to_chat(user, span_notice("You short out the product lock on [src]."))
 
 /obj/machinery/vending/interact(mob/user)
-	if(seconds_electrified && !(machine_stat & NOPOWER))
-		if(shock(user, 100))
-			return
+	if (!isAI(user))
+		if(seconds_electrified && !(machine_stat & NOPOWER))
+			if(shock(user, 100))
+				return
 
-	if(tilted && !user.buckled && !isAdminGhostAI(user))
-		to_chat(user, span_notice("You begin righting [src]."))
-		if(do_after(user, 50, target=src))
-			untilt(user)
-		return
+		if(tilted && !user.buckled && !isAdminGhostAI(user))
+			to_chat(user, span_notice("You begin righting [src]."))
+			if(do_after(user, 50, target=src))
+				untilt(user)
+			return
 
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

Title. Also prevents AIs from making shocked vendors repeatedly do sparks as failed shock() procs happen on each click.
## Why It's Good For The Game

Bugs... bad?
## Changelog
:cl:
fix: The AI can no longer untip vendors remotely/spam sparks from shocked vendors
/:cl:
