### PR TITLE
Adds already existing circuits to exodrone consoles.

### DIFF
--- a/code/modules/explorer_drone/control_console.dm
+++ b/code/modules/explorer_drone/control_console.dm
@@ -1,6 +1,7 @@
 /obj/machinery/computer/exodrone_control_console
 	name = "exploration drone control console"
 	desc = "control eploration drones from intersteller distances. Communication lag not included."
+	circuit = /obj/item/circuitboard/computer/exodrone_console
 	//Currently controlled drone
 	var/obj/item/exodrone/controlled_drone
 	/// Have we lost contact with the drone without disconnecting. Unset on user confirmation.

--- a/code/modules/explorer_drone/scanner_array.dm
+++ b/code/modules/explorer_drone/scanner_array.dm
@@ -77,6 +77,7 @@ GLOBAL_LIST_INIT(scan_conditions,init_scan_conditions())
 
 /obj/machinery/computer/exoscanner_control
 	name = "Scanner Array Control Console"
+	circuit = /obj/item/circuitboard/computer/exoscanner_console
 	/// If scan was interrupted show a popup until dismissed.
 	var/failed_popup = FALSE
 	/// Site we're configuring targeted scans for.


### PR DESCRIPTION
## About The Pull Request
Consoles for exodronning didn't have circuits so you couldn't unscrew and move them or similar.
## Why It's Good For The Game
Consistency?
## Changelog
:cl:
fix: roundstart exodrone consoles are now unscrewable.
/:cl:
