### PR TITLE
Fixes some synthetic language oversights

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -36,6 +36,7 @@
 #define LANGUAGE_VOICECHANGE "voicechange"
 #define LANGUAGE_RADIOKEY "radiokey"
 #define LANGUAGE_BABEL "babel"
+#define LANGUAGE_EMP "emp"
 
 // Language flags. Used in granting and removing languages.
 /// This language can be spoken.

--- a/code/datums/quirks/positive_quirks.dm
+++ b/code/datums/quirks/positive_quirks.dm
@@ -221,7 +221,7 @@
 	var/wanted_language = client_source?.prefs.read_preference(/datum/preference/choiced/language)
 	var/datum/language/language_type
 	if(wanted_language == "Random")
-		language_type = pick(GLOB.roundstart_languages)
+		language_type = pick(GLOB.uncommon_roundstart_languages)
 	else
 		language_type = GLOB.language_types_by_name[wanted_language]
 	if(quirk_holder.has_language(language_type))

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1544,10 +1544,16 @@
 		// Why snowflake check for escape shuttle? Well, a lot of shuttles spawn with machines
 		// but docked at centcom, and I wanted those machines to also speak funny languages
 		return FALSE
+	grant_random_uncommon_language()
+	return TRUE
 
-	/// The atom's language holder - so we can randomize and change their language
-	var/datum/language_holder/atom_languages = get_language_holder()
-	atom_languages.selected_language = atom_languages.get_random_spoken_uncommon_language()
+/// Teaches a random non-common language and sets it as the active language
+/atom/movable/proc/grant_random_uncommon_language(source)
+	if (!length(GLOB.uncommon_roundstart_languages))
+		return FALSE
+	var/picked = pick(GLOB.uncommon_roundstart_languages)
+	grant_language(picked, source = source)
+	set_active_language(picked)
 	return TRUE
 
 /* End language procs */

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -311,12 +311,17 @@
 
 /obj/machinery/emp_act(severity)
 	. = ..()
-	if(use_power && !machine_stat && !(. & EMP_PROTECT_SELF))
-		use_power(7500/severity)
-		new /obj/effect/temp_visual/emp(loc)
+	if(!use_power || machine_stat || (. & EMP_PROTECT_SELF))
+		return
+	use_power(7500/severity)
+	new /obj/effect/temp_visual/emp(loc)
 
-		if(prob(70/severity))
-			set_active_language(get_random_spoken_language())
+	if(!prob(70/severity))
+		return
+	if (!length(GLOB.uncommon_roundstart_languages))
+		return
+	remove_all_languages(source = LANGUAGE_EMP)
+	grant_random_uncommon_language(source = LANGUAGE_EMP)
 
 /**
  * Opens the machine.

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -100,7 +100,7 @@
 	anchored = TRUE
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
-	initial_language_holder = /datum/language_holder/synthetic
+	initial_language_holder = /datum/language_holder/speaking_machine
 
 	var/machine_stat = NONE
 	var/use_power = IDLE_POWER_USE

--- a/code/modules/client/preferences/language.dm
+++ b/code/modules/client/preferences/language.dm
@@ -12,7 +12,7 @@
 /datum/preference/choiced/language/init_possible_values()
 	var/list/values = list()
 
-	if(!GLOB.roundstart_languages.len)
+	if(!GLOB.uncommon_roundstart_languages.len)
 		generate_selectable_species_and_languages()
 
 	values += "Random"
@@ -21,9 +21,7 @@
 	var/datum/language/uncommon/uncommon_language = /datum/language/uncommon
 	values += initial(uncommon_language.name)
 
-	for(var/datum/language/language_type as anything in GLOB.roundstart_languages)
-		if(ispath(language_type, /datum/language/common))
-			continue
+	for(var/datum/language/language_type as anything in GLOB.uncommon_roundstart_languages)
 		if(initial(language_type.name) in values)
 			continue
 		values += initial(language_type.name)

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -480,6 +480,29 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 	)
 	selected_language = /datum/language/beachbum
 
+// Vending machines are extremely well-educated
+/datum/language_holder/speaking_machine
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
+		/datum/language/machine = list(LANGUAGE_ATOM),
+		/datum/language/draconic = list(LANGUAGE_ATOM),
+		/datum/language/moffic = list(LANGUAGE_ATOM),
+		/datum/language/calcic = list(LANGUAGE_ATOM),
+		/datum/language/voltaic = list(LANGUAGE_ATOM),
+		/datum/language/nekomimetic = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/uncommon = list(LANGUAGE_ATOM),
+		/datum/language/machine = list(LANGUAGE_ATOM),
+		/datum/language/draconic = list(LANGUAGE_ATOM),
+		/datum/language/moffic = list(LANGUAGE_ATOM),
+		/datum/language/calcic = list(LANGUAGE_ATOM),
+		/datum/language/voltaic = list(LANGUAGE_ATOM),
+		/datum/language/nekomimetic = list(LANGUAGE_ATOM),
+	)
+
 /datum/language_holder/empty
 	understood_languages = null
 	spoken_languages = null

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -65,7 +65,7 @@
 
 /obj/item/language_manual/roundstart_species/Initialize(mapload)
 	. = ..()
-	var/list/available_languages = length(GLOB.uncommon_roundstart_languages) ? GLOB.uncommon_roundstart_languages : list(datum/language/common)
+	var/list/available_languages = length(GLOB.uncommon_roundstart_languages) ? GLOB.uncommon_roundstart_languages : list(/datum/language/common)
 	language = pick(available_languages)
 	name = "[initial(language.name)] manual"
 	desc = "The book's cover reads: \"[initial(language.name)] for Xenos - Learn common galactic tongues in seconds.\""

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -65,7 +65,8 @@
 
 /obj/item/language_manual/roundstart_species/Initialize(mapload)
 	. = ..()
-	language = pick(GLOB.uncommon_roundstart_languages)
+	var/list/available_languages = length(GLOB.uncommon_roundstart_languages) ? GLOB.uncommon_roundstart_languages : list(datum/language/common)
+	language = pick(available_languages)
 	name = "[initial(language.name)] manual"
 	desc = "The book's cover reads: \"[initial(language.name)] for Xenos - Learn common galactic tongues in seconds.\""
 	flavour_text = "you feel empowered with a mastery over [initial(language.name)]"

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -65,13 +65,7 @@
 
 /obj/item/language_manual/roundstart_species/Initialize(mapload)
 	. = ..()
-	language = pick( \
-		/datum/language/voltaic, \
-		/datum/language/nekomimetic, \
-		/datum/language/draconic, \
-		/datum/language/moffic, \
-		/datum/language/calcic \
-	)
+	language = pick(GLOB.uncommon_roundstart_languages)
 	name = "[initial(language.name)] manual"
 	desc = "The book's cover reads: \"[initial(language.name)] for Xenos - Learn common galactic tongues in seconds.\""
 	flavour_text = "you feel empowered with a mastery over [initial(language.name)]"

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1,6 +1,8 @@
 GLOBAL_LIST_EMPTY(roundstart_races)
 ///List of all roundstart languages by path
 GLOBAL_LIST_EMPTY(roundstart_languages)
+///List of all roundstart languages by path except common
+GLOBAL_LIST_EMPTY(uncommon_roundstart_languages)
 
 /// An assoc list of species types to their features (from get_features())
 GLOBAL_LIST_EMPTY(features_by_species)
@@ -235,6 +237,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			qdel(temp_holder)
 			qdel(species)
 
+	GLOB.uncommon_roundstart_languages = GLOB.roundstart_languages - /datum/language/common
 	if(!selectable_species.len)
 		selectable_species += SPECIES_HUMAN
 

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1,6 +1,4 @@
 GLOBAL_LIST_EMPTY(roundstart_races)
-///List of all roundstart languages by path
-GLOBAL_LIST_EMPTY(roundstart_languages)
 ///List of all roundstart languages by path except common
 GLOBAL_LIST_EMPTY(uncommon_roundstart_languages)
 
@@ -230,14 +228,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if(species.check_roundstart_eligible())
 			selectable_species += species.id
 			var/datum/language_holder/temp_holder = new species.species_language_holder
-			for(var/datum/language/spoken_languages as anything in temp_holder.understood_languages)
-				if(spoken_languages in GLOB.roundstart_languages)
-					continue
-				GLOB.roundstart_languages += spoken_languages
+			for(var/datum/language/spoken_language as anything in temp_holder.understood_languages)
+				GLOB.uncommon_roundstart_languages |= spoken_language
 			qdel(temp_holder)
 			qdel(species)
 
-	GLOB.uncommon_roundstart_languages = GLOB.roundstart_languages - /datum/language/common
+	GLOB.uncommon_roundstart_languages -= /datum/language/common
 	if(!selectable_species.len)
 		selectable_species += SPECIES_HUMAN
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -227,7 +227,7 @@
 		to_chat(src, span_warning("You feel yourself fade as your personality matrix is reset!"))
 		ghostize(can_reenter_corpse = FALSE)
 		playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
-		say("Personally matrix reset!", forced = "bot")
+		speak("Personality matrix reset!")
 		key = null
 
 /// Returns true if this mob can be controlled
@@ -239,7 +239,7 @@
 /// Fired after something takes control of this mob
 /mob/living/simple_animal/bot/proc/post_possession()
 	playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
-	say("New personality installed successfully!", forced = "bot")
+	speak("New personality installed successfully!")
 	rename(src)
 
 /// Allows renaming the bot to something else
@@ -475,12 +475,18 @@
 	stat |= EMPED
 	new /obj/effect/temp_visual/emp(loc)
 
-	if(prob(70/severity))
-		set_active_language(get_random_spoken_language())
+	if (QDELETED(src))
+		return
 
 	if(bot_mode_flags & BOT_MODE_ON)
 		turn_off()
 	addtimer(CALLBACK(src, PROC_REF(emp_reset), was_on), severity * 30 SECONDS)
+	if(!prob(70/severity))
+		return
+	if (!length(GLOB.uncommon_roundstart_languages))
+		return
+	remove_all_languages(source = LANGUAGE_EMP)
+	grant_random_uncommon_language(source = LANGUAGE_EMP)
 
 /mob/living/simple_animal/bot/proc/emp_reset(was_on)
 	stat &= ~EMPED


### PR DESCRIPTION

## About The Pull Request

#76305 removed the knowledge of every language from silicons, but this had a couple of oversights.
This language set was not only used by cyborgs but also bots and vending machines.

A couple of effects relied on them knowing all of those languages, specifically their emp_act and also the station trait which rerolled their languages.
Now they actually _learn_ a random language and start speaking it instead.

Also I fixed a related runtime which I noticed in testing where a bot would die as a result of being EMPed, delete itself, and then try and do a bunch more shit after it stopped existing. Annoying. 

Why was I looking at bot languages? Haha don't worry about it 😇 

## Why It's Good For The Game

Restores function of a funny feature.

## Changelog

:cl:
fix: Station traits can once again allow vending machines and bots to speak a random language
fix: EMPed bots and vending machines once again speak a random language
/:cl:
