### PR TITLE
Arcane/Blood Barrage fixes, cleans up cult spell code, autofire barrage, more responsive/sane blood collection

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -751,7 +751,7 @@
 					uses = 0
 				playsound(get_turf(construct_thing), 'sound/magic/staff_healing.ogg', 25)
 				user.Beam(construct_thing, icon_state="sendbeam", time = 1 SECONDS)
-		if(istype(target, /obj/effect/decal/cleanable/blood) || istype(target, /obj/effect/decal/cleanable/trail_holder))
+		if(istype(target, /obj/effect/decal/cleanable/blood) || istype(target, /obj/effect/decal/cleanable/trail_holder) || isturf(target))
 			blood_draw(target, user)
 		..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -81,8 +81,8 @@
 		return
 	if(do_after(owner, 100 - rune*60, target = owner))
 		if(ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			H.bleed(40 - rune*32)
+			var/mob/living/carbon/human/human_owner = owner
+			human_owner.bleed(40 - rune*32)
 		var/datum/action/innate/cult/blood_spell/new_spell = new BS(owner)
 		new_spell.Grant(owner, src)
 		spells += new_spell
@@ -322,7 +322,6 @@
 	charges = 5
 	magic_path = "/obj/item/melee/blood_magic/manipulator"
 
-
 // The "magic hand" items
 /obj/item/melee/blood_magic
 	name = "\improper magical aura"
@@ -333,7 +332,6 @@
 	icon_state = "disintegrate"
 	inhand_icon_state = "disintegrate"
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL
-
 	w_class = WEIGHT_CLASS_HUGE
 	throwforce = 0
 	throw_range = 0
@@ -677,106 +675,109 @@
 /obj/item/melee/blood_magic/manipulator/afterattack(atom/target, mob/living/carbon/human/user, proximity)
 	if(proximity)
 		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			if(HAS_TRAIT(H, TRAIT_NOBLOOD))
+			var/mob/living/carbon/human/human_bloodbag = target
+			if(HAS_TRAIT(human_bloodbag, TRAIT_NOBLOOD))
 				to_chat(user,span_warning("Blood rites do not work on people with no blood!"))
 				return
-			if(IS_CULTIST(H))
-				if(H.stat == DEAD)
+			if(IS_CULTIST(human_bloodbag))
+				if(human_bloodbag.stat == DEAD)
 					to_chat(user,span_warning("Only a revive rune can bring back the dead!"))
 					return
-				if(H.blood_volume < BLOOD_VOLUME_SAFE)
-					var/restore_blood = BLOOD_VOLUME_SAFE - H.blood_volume
+				if(human_bloodbag.blood_volume < BLOOD_VOLUME_SAFE)
+					var/restore_blood = BLOOD_VOLUME_SAFE - human_bloodbag.blood_volume
 					if(uses*2 < restore_blood)
-						H.blood_volume += uses*2
+						human_bloodbag.blood_volume += uses*2
 						to_chat(user,span_danger("You use the last of your blood rites to restore what blood you could!"))
 						uses = 0
 						return ..()
 					else
-						H.blood_volume = BLOOD_VOLUME_SAFE
+						human_bloodbag.blood_volume = BLOOD_VOLUME_SAFE
 						uses -= round(restore_blood/2)
-						to_chat(user,span_warning("Your blood rites have restored [H == user ? "your" : "[H.p_their()]"] blood to safe levels!"))
-				var/overall_damage = H.getBruteLoss() + H.getFireLoss() + H.getToxLoss() + H.getOxyLoss()
+						to_chat(user,span_warning("Your blood rites have restored [human_bloodbag == user ? "your" : "[human_bloodbag.p_their()]"] blood to safe levels!"))
+				var/overall_damage = human_bloodbag.getBruteLoss() + human_bloodbag.getFireLoss() + human_bloodbag.getToxLoss() + human_bloodbag.getOxyLoss()
 				if(overall_damage == 0)
 					to_chat(user,span_cult("That cultist doesn't require healing!"))
 				else
 					var/ratio = uses/overall_damage
-					if(H == user)
+					if(human_bloodbag == user)
 						to_chat(user,span_cult("<b>Your blood healing is far less efficient when used on yourself!</b>"))
 						ratio *= 0.35 // Healing is half as effective if you can't perform a full heal
 						uses -= round(overall_damage) // Healing is 65% more "expensive" even if you can still perform the full heal
 					if(ratio>1)
 						ratio = 1
 						uses -= round(overall_damage)
-						H.visible_message(span_warning("[H] is fully healed by [H == user ? "[H.p_their()]":"[H]'s"] blood magic!"))
+						human_bloodbag.visible_message(span_warning("[human_bloodbag] is fully healed by [human_bloodbag == user ? "[human_bloodbag.p_their()]":"[human_bloodbag]'s"] blood magic!"))
 					else
-						H.visible_message(span_warning("[H] is partially healed by [H == user ? "[H.p_their()]":"[H]'s"] blood magic."))
+						human_bloodbag.visible_message(span_warning("[human_bloodbag] is partially healed by [human_bloodbag == user ? "[human_bloodbag.p_their()]":"[human_bloodbag]'s"] blood magic."))
 						uses = 0
 					ratio *= -1
-					H.adjustOxyLoss((overall_damage*ratio) * (H.getOxyLoss() / overall_damage), 0)
-					H.adjustToxLoss((overall_damage*ratio) * (H.getToxLoss() / overall_damage), 0)
-					H.adjustFireLoss((overall_damage*ratio) * (H.getFireLoss() / overall_damage), 0)
-					H.adjustBruteLoss((overall_damage*ratio) * (H.getBruteLoss() / overall_damage), 0)
-					H.updatehealth()
-					playsound(get_turf(H), 'sound/magic/staff_healing.ogg', 25)
-					new /obj/effect/temp_visual/cult/sparks(get_turf(H))
-					user.Beam(H, icon_state="sendbeam", time = 15)
+					human_bloodbag.adjustOxyLoss((overall_damage*ratio) * (human_bloodbag.getOxyLoss() / overall_damage), 0)
+					human_bloodbag.adjustToxLoss((overall_damage*ratio) * (human_bloodbag.getToxLoss() / overall_damage), 0)
+					human_bloodbag.adjustFireLoss((overall_damage*ratio) * (human_bloodbag.getFireLoss() / overall_damage), 0)
+					human_bloodbag.adjustBruteLoss((overall_damage*ratio) * (human_bloodbag.getBruteLoss() / overall_damage), 0)
+					human_bloodbag.updatehealth()
+					playsound(get_turf(human_bloodbag), 'sound/magic/staff_healing.ogg', 25)
+					new /obj/effect/temp_visual/cult/sparks(get_turf(human_bloodbag))
+					user.Beam(human_bloodbag, icon_state="sendbeam", time = 15)
 			else
-				if(H.stat == DEAD)
-					to_chat(user,span_warning("[H.p_their(TRUE)] blood has stopped flowing, you'll have to find another way to extract it."))
+				if(human_bloodbag.stat == DEAD)
+					to_chat(user,span_warning("[human_bloodbag.p_their(TRUE)] blood has stopped flowing, you'll have to find another way to extract it."))
 					return
-				if(H.has_status_effect(/datum/status_effect/speech/slurring/cult))
-					to_chat(user,span_danger("[H.p_their(TRUE)] blood has been tainted by an even stronger form of blood magic, it's no use to us like this!"))
+				if(human_bloodbag.has_status_effect(/datum/status_effect/speech/slurring/cult))
+					to_chat(user,span_danger("[human_bloodbag.p_their(TRUE)] blood has been tainted by an even stronger form of blood magic, it's no use to us like this!"))
 					return
-				if(H.blood_volume > BLOOD_VOLUME_SAFE)
-					H.blood_volume -= 100
+				if(human_bloodbag.blood_volume > BLOOD_VOLUME_SAFE)
+					human_bloodbag.blood_volume -= 100
 					uses += 50
-					user.Beam(H, icon_state="drainbeam", time = 1 SECONDS)
-					playsound(get_turf(H), 'sound/magic/enter_blood.ogg', 50)
-					H.visible_message(span_danger("[user] drains some of [H]'s blood!"))
-					to_chat(user,span_cultitalic("Your blood rite gains 50 charges from draining [H]'s blood."))
-					new /obj/effect/temp_visual/cult/sparks(get_turf(H))
+					user.Beam(human_bloodbag, icon_state="drainbeam", time = 1 SECONDS)
+					playsound(get_turf(human_bloodbag), 'sound/magic/enter_blood.ogg', 50)
+					human_bloodbag.visible_message(span_danger("[user] drains some of [human_bloodbag]'s blood!"))
+					to_chat(user,span_cultitalic("Your blood rite gains 50 charges from draining [human_bloodbag]'s blood."))
+					new /obj/effect/temp_visual/cult/sparks(get_turf(human_bloodbag))
 				else
-					to_chat(user,span_warning("[H.p_theyre(TRUE)] missing too much blood - you cannot drain [H.p_them()] further!"))
+					to_chat(user,span_warning("[human_bloodbag.p_theyre(TRUE)] missing too much blood - you cannot drain [human_bloodbag.p_them()] further!"))
 					return
 		if(isconstruct(target))
-			var/mob/living/simple_animal/M = target
-			var/missing = M.maxHealth - M.health
-			if(missing)
-				if(uses > missing)
-					M.adjustHealth(-missing)
-					M.visible_message(span_warning("[M] is fully healed by [user]'s blood magic!"))
-					uses -= missing
+			var/mob/living/simple_animal/construct_thing = target
+			var/missing_health = construct_thing.maxHealth - construct_thing.health
+			if(missing_health)
+				if(uses > missing_health)
+					construct_thing.adjustHealth(-missing_health)
+					construct_thing.visible_message(span_warning("[construct_thing] is fully healed by [user]'s blood magic!"))
+					uses -= missing_health
 				else
-					M.adjustHealth(-uses)
-					M.visible_message(span_warning("[M] is partially healed by [user]'s blood magic!"))
+					construct_thing.adjustHealth(-uses)
+					construct_thing.visible_message(span_warning("[construct_thing] is partially healed by [user]'s blood magic!"))
 					uses = 0
-				playsound(get_turf(M), 'sound/magic/staff_healing.ogg', 25)
-				user.Beam(M, icon_state="sendbeam", time = 1 SECONDS)
-		if(istype(target, /obj/effect/decal/cleanable/blood))
+				playsound(get_turf(construct_thing), 'sound/magic/staff_healing.ogg', 25)
+				user.Beam(construct_thing, icon_state="sendbeam", time = 1 SECONDS)
+		if(istype(target, /obj/effect/decal/cleanable/blood) || istype(target, /obj/effect/decal/cleanable/trail_holder))
 			blood_draw(target, user)
 		..()
 
 /obj/item/melee/blood_magic/manipulator/proc/blood_draw(atom/target, mob/living/carbon/human/user)
-	var/temp = 0
-	var/turf/T = get_turf(target)
-	if(T)
-		for(var/obj/effect/decal/cleanable/blood/B in view(T, 2))
-			if(B.blood_state == BLOOD_STATE_HUMAN)
-				if(B.bloodiness == 100) //Bonus for "pristine" bloodpools, also to prevent cheese with footprint spam
-					temp += 30
+	var/blood_to_gain = 0
+	var/turf/our_turf = get_turf(target)
+	if(our_turf)
+		for(var/obj/effect/decal/cleanable/blood/blood_around_us in range(our_turf,2))
+			if(blood_around_us.blood_state == BLOOD_STATE_HUMAN)
+				if(blood_around_us.bloodiness == 100) //Bonus for "pristine" bloodpools, also to prevent cheese with footprint spam
+					blood_to_gain += 30
 				else
-					temp += max((B.bloodiness**2)/800,1)
-				new /obj/effect/temp_visual/cult/turf/floor(get_turf(B))
-				qdel(B)
-		for(var/obj/effect/decal/cleanable/trail_holder/TH in view(T, 2))
-			qdel(TH)
-		if(temp)
-			user.Beam(T,icon_state="drainbeam", time = 15)
+					blood_to_gain += max((blood_around_us.bloodiness**2)/800,1)
+				new /obj/effect/temp_visual/cult/turf/floor(get_turf(blood_around_us))
+				qdel(blood_around_us)
+		for(var/obj/effect/decal/cleanable/trail_holder/trail_around_us in range(our_turf, 2))
+			if(trail_around_us.blood_state == BLOOD_STATE_HUMAN)
+				blood_to_gain += 5 //These don't get bloodiness, so we'll just increase this by a fixed value
+				new /obj/effect/temp_visual/cult/turf/floor(get_turf(trail_around_us))
+			qdel(trail_around_us)
+		if(blood_to_gain)
+			user.Beam(our_turf,icon_state="drainbeam", time = 15)
 			new /obj/effect/temp_visual/cult/sparks(get_turf(user))
-			playsound(T, 'sound/magic/enter_blood.ogg', 50)
-			to_chat(user, span_cultitalic("Your blood rite has gained [round(temp)] charge\s from blood sources around you!"))
-			uses += max(1, round(temp))
+			playsound(our_turf, 'sound/magic/enter_blood.ogg', 50)
+			to_chat(user, span_cultitalic("Your blood rite has gained [round(blood_to_gain)] charge\s from blood sources around you!"))
+			uses += max(1, round(blood_to_gain))
 
 /obj/item/melee/blood_magic/manipulator/attack_self(mob/living/user)
 	if(IS_CULTIST(user))
@@ -810,7 +811,7 @@
 				if(uses < BLOOD_BARRAGE_COST)
 					to_chat(user, span_cultitalic("You need [BLOOD_BARRAGE_COST] charges to perform this rite."))
 				else
-					var/obj/rite = new /obj/item/gun/ballistic/rifle/enchanted/arcane_barrage/blood()
+					var/obj/rite = new /obj/item/gun/magic/wand/arcane_barrage/blood()
 					uses -= BLOOD_BARRAGE_COST
 					qdel(src)
 					if(user.put_in_hands(rite))

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -788,32 +788,12 @@ Striking a noncultist, however, will tear their flesh."}
 		halberd.throw_at(owner, 10, 2, owner)
 
 
-/obj/item/gun/ballistic/rifle/enchanted/arcane_barrage/blood
+/obj/item/gun/magic/wand/arcane_barrage/blood
 	name = "blood bolt barrage"
 	desc = "Blood for blood."
 	color = "#ff0000"
-	guns_left = 24
-	mag_type = /obj/item/ammo_box/magazine/internal/blood
+	ammo_type =  /obj/item/ammo_casing/magic/arcane_barrage/blood
 	fire_sound = 'sound/magic/wand_teleport.ogg'
-
-/obj/item/gun/ballistic/rifle/enchanted/arcane_barrage/blood/can_trigger_gun(mob/living/user, akimbo_usage)
-	if(akimbo_usage)
-		return FALSE //no akimbo wielding magic lol.
-	. = ..()
-	if(!IS_CULTIST(user))
-		to_chat(user, span_cultlarge("\"Did you truly think that you could channel MY blood without my approval? Amusing, but futile.\""))
-		if(iscarbon(user))
-			var/mob/living/carbon/C = user
-			if(C.active_hand_index == 1)
-				C.apply_damage(20, BRUTE, BODY_ZONE_L_ARM, wound_bonus = 20, sharpness = SHARP_EDGED) //oof ouch
-			else
-				C.apply_damage(20, BRUTE, BODY_ZONE_R_ARM, wound_bonus = 20, sharpness = SHARP_EDGED)
-		qdel(src)
-		return FALSE
-
-/obj/item/ammo_box/magazine/internal/blood
-	caliber = CALIBER_A762
-	ammo_type = /obj/item/ammo_casing/magic/arcane_barrage/blood
 
 /obj/item/ammo_casing/magic/arcane_barrage/blood
 	projectile_type = /obj/projectile/magic/arcane_barrage/blood
@@ -827,23 +807,24 @@ Striking a noncultist, however, will tear their flesh."}
 	impact_effect_type = /obj/effect/temp_visual/dir_setting/bloodsplatter
 
 /obj/projectile/magic/arcane_barrage/blood/Bump(atom/target)
-	var/turf/T = get_turf(target)
-	playsound(T, 'sound/effects/splat.ogg', 50, TRUE)
-	var/mob/mob_target = target
+	. = ..()
+	var/turf/our_turf = get_turf(target)
+	playsound(our_turf , 'sound/effects/splat.ogg', 50, TRUE)
+	new /obj/effect/temp_visual/cult/sparks(our_turf)
 
-	if(ismob(mob_target) && IS_CULTIST(mob_target))
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			if(H.stat != DEAD)
-				H.reagents.add_reagent(/datum/reagent/fuel/unholywater, 4)
-		if(isshade(target) || isconstruct(target))
-			var/mob/living/simple_animal/M = target
-			if(M.health+5 < M.maxHealth)
-				M.adjustHealth(-5)
-		new /obj/effect/temp_visual/cult/sparks(T)
-		qdel(src)
-	else
-		..()
+/obj/projectile/magic/arcane_barrage/blood/prehit_pierce(atom/target)
+	. = ..()
+	if(ismob(target))
+		var/mob/living/our_target = target
+		if(IS_CULTIST(our_target))
+			if(iscarbon(our_target) && our_target.stat != DEAD)
+				var/mob/living/carbon/carbon_cultist = our_target
+				carbon_cultist.reagents.add_reagent(/datum/reagent/fuel/unholywater, 4)
+			if(isshade(our_target) || isconstruct(our_target))
+				var/mob/living/simple_animal/undead_abomination = our_target
+				if(undead_abomination.health+5 < undead_abomination.maxHealth)
+					undead_abomination.adjustHealth(-5)
+			return PROJECTILE_DELETE_WITHOUT_HITTING
 
 /obj/item/blood_beam
 	name = "\improper magical aura"

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -814,17 +814,21 @@ Striking a noncultist, however, will tear their flesh."}
 
 /obj/projectile/magic/arcane_barrage/blood/prehit_pierce(atom/target)
 	. = ..()
-	if(ismob(target))
-		var/mob/living/our_target = target
-		if(IS_CULTIST(our_target))
-			if(iscarbon(our_target) && our_target.stat != DEAD)
-				var/mob/living/carbon/carbon_cultist = our_target
-				carbon_cultist.reagents.add_reagent(/datum/reagent/fuel/unholywater, 4)
-			if(isshade(our_target) || isconstruct(our_target))
-				var/mob/living/simple_animal/undead_abomination = our_target
-				if(undead_abomination.health+5 < undead_abomination.maxHealth)
-					undead_abomination.adjustHealth(-5)
-			return PROJECTILE_DELETE_WITHOUT_HITTING
+	if(!ismob(target))
+		return PROJECTILE_PIERCE_NONE
+
+	var/mob/living/our_target = target
+	if(!IS_CULTIST(our_target))
+		return PROJECTILE_PIERCE_NONE
+
+	if(iscarbon(our_target) && our_target.stat != DEAD)
+		var/mob/living/carbon/carbon_cultist = our_target
+		carbon_cultist.reagents.add_reagent(/datum/reagent/fuel/unholywater, 4)
+	if(isshade(our_target) || isconstruct(our_target))
+		var/mob/living/simple_animal/undead_abomination = our_target
+		if(undead_abomination.health+5 < undead_abomination.maxHealth)
+			undead_abomination.adjustHealth(-5)
+	return PROJECTILE_DELETE_WITHOUT_HITTING
 
 /obj/item/blood_beam
 	name = "\improper magical aura"

--- a/code/modules/projectiles/boxes_magazines/internal/rifle.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/rifle.dm
@@ -24,10 +24,6 @@
 	caliber = CALIBER_A762
 	ammo_type = /obj/item/ammo_casing/a762/enchanted
 
-/obj/item/ammo_box/magazine/internal/arcane_barrage
-	caliber = CALIBER_A762
-	ammo_type = /obj/item/ammo_casing/magic/arcane_barrage
-
 /obj/item/ammo_box/magazine/internal/boltaction/harpoon
 	max_ammo = 1
 	caliber = CALIBER_HARPOON

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -211,22 +211,6 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/enchanted
 	can_be_sawn_off = FALSE
 
-/obj/item/gun/ballistic/rifle/enchanted/arcane_barrage
-	name = "arcane barrage"
-	desc = "Pew Pew Pew."
-	fire_sound = 'sound/weapons/emitter.ogg'
-	pin = /obj/item/firing_pin/magic
-	icon_state = "arcane_barrage"
-	inhand_icon_state = "arcane_barrage"
-	slot_flags = null
-	can_bayonet = FALSE
-	item_flags = NEEDS_PERMIT | DROPDEL | ABSTRACT | NOBLUDGEON
-	flags_1 = NONE
-	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
-	show_bolt_icon = FALSE //It's a magic hand, not a rifle
-
-	mag_type = /obj/item/ammo_box/magazine/internal/arcane_barrage
-
 /obj/item/gun/ballistic/rifle/enchanted/dropped()
 	. = ..()
 	guns_left = 0
@@ -235,9 +219,6 @@
 
 /obj/item/gun/ballistic/rifle/enchanted/proc/discard_gun(mob/living/user)
 	user.throw_item(pick(oview(7,get_turf(user))))
-
-/obj/item/gun/ballistic/rifle/enchanted/arcane_barrage/discard_gun(mob/living/user)
-	qdel(src)
 
 /obj/item/gun/ballistic/rifle/enchanted/attack_self()
 	return

--- a/code/modules/projectiles/guns/magic/arcane_barrage.dm
+++ b/code/modules/projectiles/guns/magic/arcane_barrage.dm
@@ -1,0 +1,27 @@
+/obj/item/gun/magic/wand/arcane_barrage
+	name = "arcane barrage"
+	desc = "Pew Pew Pew."
+	fire_sound = 'sound/weapons/emitter.ogg'
+	icon = 'icons/obj/weapons/guns/ballistic.dmi'
+	icon_state = "arcane_barrage"
+	inhand_icon_state = "arcane_barrage"
+	base_icon_state = "arcane_barrage"
+	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
+	slot_flags = null
+	item_flags = NEEDS_PERMIT | DROPDEL | ABSTRACT | NOBLUDGEON
+	flags_1 = NONE
+	weapon_weight = WEAPON_HEAVY
+	max_charges = 30
+	ammo_type = /obj/item/ammo_casing/magic/arcane_barrage
+
+/obj/item/gun/magic/wand/arcane_barrage/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS)
+
+/obj/item/gun/magic/wand/arcane_barrage/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
+	. = ..()
+	if(!.)
+		return
+	if(!charges)
+		user.dropItemToGround(src, TRUE)

--- a/code/modules/spells/spell_types/conjure_item/infinite_guns.dm
+++ b/code/modules/spells/spell_types/conjure_item/infinite_guns.dm
@@ -38,4 +38,4 @@
 		Learning this spell makes you unable to learn Lesser Summon Gun."
 	button_icon_state = "arcane_barrage"
 
-	item_type = /obj/item/gun/ballistic/rifle/enchanted/arcane_barrage
+	item_type = /obj/item/gun/magic/wand/arcane_barrage

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4677,6 +4677,7 @@
 #include "code\modules\projectiles\guns\energy\recharge.dm"
 #include "code\modules\projectiles\guns\energy\special.dm"
 #include "code\modules\projectiles\guns\energy\stun.dm"
+#include "code\modules\projectiles\guns\magic\arcane_barrage.dm"
 #include "code\modules\projectiles\guns\magic\staff.dm"
 #include "code\modules\projectiles\guns\magic\wand.dm"
 #include "code\modules\projectiles\guns\special\blastcannon.dm"


### PR DESCRIPTION

## About The Pull Request

Refactors arcane barrage (the wizard spell) and blood barrage (the weird version of the same spell that cultists get) into the magic subtype. No longer are they rifles...for some reason. Also they have sprites once again! Yay. Fixes https://github.com/tgstation/tgstation/issues/76561

So as to not replicate a really crappy system used to get the hand swapping working, I've just opted to take this opportunity to make arcane barrage an automatic fire weapon. Yes, this is kind of a feature, but it's...it's appropriate, don't you think? And I don't think meaningfully changes its fire rate?

Blood Barrage no longer harms cultists/constructs shot by it and now properly just heals them/injects them with unholy water. Why all this was shoved into the Bump() proc is beyond me, but it works now. Fixes https://github.com/tgstation/tgstation/issues/76560

I've improved the variables for some of the cult spells, and I've also fixed what I think is one the most pesky parts of how drawing blood works. So, rather than using range(), it uses view(), which seems to cause the spell to be a bit funky with lighting? So if you're in darkness (gosh cultists in dim light, how unheard of), this spell struggles to gather up blood. Not anymore it doesn't!

Lastly, it only worked on blood pools or droplets, not blood trails. So, you could bleed a character out by dragging them around, but not sap up the blood they're dropping from doing so. Only the intermittent blood splatters or your own bloody footprints count.

Here is the funny thing with that. It still cleans up the blood trail. You just couldn't activate the blood draw from the trail or treat it as blood. Now you can. Blood trails now give you +5 charges, and you can activate the blood draw using blood trails.

## Why It's Good For The Game

Arcane Barrage/Blood Barrage:

This was some really old code and I'm still not sure why they were made as a separate spell to the madoka reference, which at this stage is still better than this spell. But at least it is using a sensible subtype with a reasonable, more modern component to facilitate the 'rapid firing barrage of magical bullet' image this spell is meant to invoke. As a result of all this nonsense, this spell had its sprites broken because it kept being attached to stuff in the rifles folder. Let's put a stop to that here and now and break it independently instead.

Oh also cultists getting shot by healing bullets that still killed them is both funny and dumb and the way it worked was bonkers.

Blood Draw:
A cultist trying to determine, on the fly, what blood is a valid for the blood draw is nearly impossible from visual alone. You'd be convinced this part of the spell is broken just because having a splatter and a trail on the same tile massively obfuscates whether you're looking at valid sources of blood. I've struggled to understand as a player what was going on and why it was so selective about what was acceptable. Now I see that the problem was one of visual accuracy, bad type checking, and really, really outdated code that should have been improved with better procs.

Blood trails are also actually made from dragging out a creature's bloody corpse. For humans, the most common source of blood trails, this does actually mean they're losing blood to produce these trails. It stands to reason this should be a valid source (bloody footprints are, after all). I gave them a...somewhat minor amount of charge contribution just to keep it moderately sane for how much blood it generates.

## Changelog
:cl:
refactor: Arcane Barrage and Blood Barrage are magic gun subtypes and not rifle subtypes. Also they have sprites again.
qol: The barrage spells now use the automatic component to do its thing.
fix: Blood Barrage once again heals cultists and constructs without hurting them.
code: Cleans up how Blood Rites finds blood to draw in. You can now just click turfs as well as blood, and it should now be much more accurate about it.
qol: Blood trails contribute to charges gained using Blood Rites. You can also activate Blood Rite's blood draw using blood trails.
/:cl:
