### PR TITLE
You can opt out of heretic rolls for the rest of the round

### DIFF
--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -1,76 +1,76 @@
 //Each lists stores ckeys for "Never for this round" option category
 
-#define POLL_IGNORE_SENTIENCE_POTION "sentience_potion"
-#define POLL_IGNORE_POSSESSED_BLADE "possessed_blade"
-#define POLL_IGNORE_ALIEN_LARVA "alien_larva"
-#define POLL_IGNORE_SYNDICATE "syndicate"
-#define POLL_IGNORE_HOLOPARASITE "holoparasite"
-#define POLL_IGNORE_POSIBRAIN "posibrain"
-#define POLL_IGNORE_SPECTRAL_BLADE "spectral_blade"
-#define POLL_IGNORE_CONSTRUCT "construct"
-#define POLL_IGNORE_SPIDER "spider"
-#define POLL_IGNORE_ASHWALKER "ashwalker"
-#define POLL_IGNORE_GOLEM "golem"
-#define POLL_IGNORE_DRONE "drone"
-#define POLL_IGNORE_FUGITIVE "fugitive"
-#define POLL_IGNORE_PYROSLIME "slime"
-#define POLL_IGNORE_SHADE "shade"
-#define POLL_IGNORE_IMAGINARYFRIEND "imaginary_friend"
-#define POLL_IGNORE_SPLITPERSONALITY "split_personality"
-#define POLL_IGNORE_CONTRACTOR_SUPPORT "contractor_support"
 #define POLL_IGNORE_ACADEMY_WIZARD "academy_wizard"
-#define POLL_IGNORE_PAI "pai"
-#define POLL_IGNORE_VENUSHUMANTRAP "venus_human_trap"
-#define POLL_IGNORE_REGAL_RAT "regal_rat"
-#define POLL_IGNORE_CARGORILLA "cargorilla"
-#define POLL_IGNORE_MONKEY_HELMET "mind_magnified_monkey"
-#define POLL_IGNORE_LAVALAND_ELITE "lavaland_elite"
-#define POLL_IGNORE_SHUTTLE_DENIZENS "shuttle_denizens"
-#define POLL_IGNORE_BOTS "bots"
-#define POLL_IGNORE_HERETIC_MONSTER "heretic_monster"
-#define POLL_IGNORE_RAW_PROPHET "raw_prophet"
-#define POLL_IGNORE_STALKER "stalker"
-#define POLL_IGNORE_FIRE_SHARK "fire_shark"
+#define POLL_IGNORE_ALIEN_LARVA "alien_larva"
 #define POLL_IGNORE_ASH_SPIRIT "ash_spirit"
-#define POLL_IGNORE_RUST_SPIRIT "rust_spirit"
+#define POLL_IGNORE_ASHWALKER "ashwalker"
+#define POLL_IGNORE_BOTS "bots"
+#define POLL_IGNORE_CARGORILLA "cargorilla"
+#define POLL_IGNORE_CONTRACTOR_SUPPORT "contractor_support"
+#define POLL_IGNORE_CONSTRUCT "construct"
+#define POLL_IGNORE_DRONE "drone"
+#define POLL_IGNORE_FIRE_SHARK "fire_shark"
+#define POLL_IGNORE_FUGITIVE "fugitive"
+#define POLL_IGNORE_GOLEM "golem"
+#define POLL_IGNORE_HERETIC_MONSTER "heretic_monster"
+#define POLL_IGNORE_HOLOPARASITE "holoparasite"
+#define POLL_IGNORE_IMAGINARYFRIEND "imaginary_friend"
+#define POLL_IGNORE_LAVALAND_ELITE "lavaland_elite"
 #define POLL_IGNORE_MAID_IN_MIRROR "maid_in_mirror"
+#define POLL_IGNORE_MONKEY_HELMET "mind_magnified_monkey"
+#define POLL_IGNORE_PAI "pai"
+#define POLL_IGNORE_POSIBRAIN "posibrain"
+#define POLL_IGNORE_POSSESSED_BLADE "possessed_blade"
+#define POLL_IGNORE_PYROSLIME "slime"
+#define POLL_IGNORE_RAW_PROPHET "raw_prophet"
+#define POLL_IGNORE_REGAL_RAT "regal_rat"
+#define POLL_IGNORE_RUST_SPIRIT "rust_spirit"
+#define POLL_IGNORE_SENTIENCE_POTION "sentience_potion"
+#define POLL_IGNORE_SHADE "shade"
+#define POLL_IGNORE_SHUTTLE_DENIZENS "shuttle_denizens"
+#define POLL_IGNORE_SPECTRAL_BLADE "spectral_blade"
+#define POLL_IGNORE_SPIDER "spider"
+#define POLL_IGNORE_SPLITPERSONALITY "split_personality"
+#define POLL_IGNORE_STALKER "stalker"
+#define POLL_IGNORE_SYNDICATE "syndicate"
+#define POLL_IGNORE_VENUSHUMANTRAP "venus_human_trap"
 
 
 GLOBAL_LIST_INIT(poll_ignore_desc, list(
-	POLL_IGNORE_SENTIENCE_POTION = "Sentience potion",
-	POLL_IGNORE_POSSESSED_BLADE = "Possessed blade",
-	POLL_IGNORE_ALIEN_LARVA = "Xenomorph larva",
-	POLL_IGNORE_SYNDICATE = "Syndicate",
-	POLL_IGNORE_HOLOPARASITE = "Holoparasite",
-	POLL_IGNORE_POSIBRAIN = "Positronic brain",
-	POLL_IGNORE_SPECTRAL_BLADE = "Spectral blade",
-	POLL_IGNORE_CONSTRUCT = "Construct",
-	POLL_IGNORE_SPIDER = "Spiders",
-	POLL_IGNORE_ASHWALKER = "Ashwalker eggs",
-	POLL_IGNORE_GOLEM = "Golems",
-	POLL_IGNORE_DRONE = "Drone shells",
-	POLL_IGNORE_FUGITIVE = "Fugitive Hunter",
-	POLL_IGNORE_PYROSLIME = "Slime",
-	POLL_IGNORE_SHADE = "Shade",
-	POLL_IGNORE_IMAGINARYFRIEND = "Imaginary Friend",
-	POLL_IGNORE_SPLITPERSONALITY = "Split Personality",
-	POLL_IGNORE_CONTRACTOR_SUPPORT = "Contractor Support Unit",
 	POLL_IGNORE_ACADEMY_WIZARD = "Academy Wizard Defender",
-	POLL_IGNORE_PAI = JOB_PERSONAL_AI,
-	POLL_IGNORE_VENUSHUMANTRAP = "Venus Human Traps",
-	POLL_IGNORE_REGAL_RAT = "Regal rat",
-	POLL_IGNORE_CARGORILLA = "Cargorilla",
-	POLL_IGNORE_MONKEY_HELMET = "Mind magnified monkey",
-	POLL_IGNORE_LAVALAND_ELITE = "Lavaland elite",
-	POLL_IGNORE_SHUTTLE_DENIZENS = "Shuttle denizens",
-	POLL_IGNORE_BOTS = "Bots",
-	POLL_IGNORE_HERETIC_MONSTER = "Heretic Monster",
-	POLL_IGNORE_RAW_PROPHET = "Raw Prophet",
-	POLL_IGNORE_STALKER = "Stalker",
-	POLL_IGNORE_FIRE_SHARK = "Fire Shark",
+	POLL_IGNORE_ALIEN_LARVA = "Xenomorph larva",
 	POLL_IGNORE_ASH_SPIRIT = "Ash Spirit",
-	POLL_IGNORE_RUST_SPIRIT = "Rust Spirit",
+	POLL_IGNORE_ASHWALKER = "Ashwalker eggs",
+	POLL_IGNORE_BOTS = "Bots",
+	POLL_IGNORE_CARGORILLA = "Cargorilla",
+	POLL_IGNORE_CONTRACTOR_SUPPORT = "Contractor Support Unit",
+	POLL_IGNORE_CONSTRUCT = "Construct",
+	POLL_IGNORE_DRONE = "Drone shells",
+	POLL_IGNORE_FIRE_SHARK = "Fire Shark",
+	POLL_IGNORE_FUGITIVE = "Fugitive Hunter",
+	POLL_IGNORE_GOLEM = "Golems",
+	POLL_IGNORE_HERETIC_MONSTER = "Heretic Monster",
+	POLL_IGNORE_HOLOPARASITE = "Holoparasite",
+	POLL_IGNORE_IMAGINARYFRIEND = "Imaginary Friend",
+	POLL_IGNORE_LAVALAND_ELITE = "Lavaland elite",
 	POLL_IGNORE_MAID_IN_MIRROR = "Maid in the Mirror",
+	POLL_IGNORE_MONKEY_HELMET = "Mind magnified monkey",
+	POLL_IGNORE_PAI = JOB_PERSONAL_AI,
+	POLL_IGNORE_POSIBRAIN = "Positronic brain",
+	POLL_IGNORE_POSSESSED_BLADE = "Possessed blade",
+	POLL_IGNORE_PYROSLIME = "Slime",
+	POLL_IGNORE_RAW_PROPHET = "Raw Prophet",
+	POLL_IGNORE_RUST_SPIRIT = "Rust Spirit",
+	POLL_IGNORE_REGAL_RAT = "Regal rat",
+	POLL_IGNORE_SENTIENCE_POTION = "Sentience potion",
+	POLL_IGNORE_SHADE = "Shade",
+	POLL_IGNORE_SHUTTLE_DENIZENS = "Shuttle denizens",
+	POLL_IGNORE_SPECTRAL_BLADE = "Spectral blade",
+	POLL_IGNORE_SPIDER = "Spiders",
+	POLL_IGNORE_SPLITPERSONALITY = "Split Personality",
+	POLL_IGNORE_STALKER = "Stalker",
+	POLL_IGNORE_SYNDICATE = "Syndicate",
+	POLL_IGNORE_VENUSHUMANTRAP = "Venus Human Traps",
 ))
 GLOBAL_LIST_INIT(poll_ignore, init_poll_ignore())
 

--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -27,6 +27,13 @@
 #define POLL_IGNORE_LAVALAND_ELITE "lavaland_elite"
 #define POLL_IGNORE_SHUTTLE_DENIZENS "shuttle_denizens"
 #define POLL_IGNORE_BOTS "bots"
+#define POLL_IGNORE_HERETIC_MONSTER "heretic_monster"
+#define POLL_IGNORE_RAW_PROPHET "raw_prophet"
+#define POLL_IGNORE_STALKER "stalker"
+#define POLL_IGNORE_FIRE_SHARK "fire_shark"
+#define POLL_IGNORE_ASH_SPIRIT "ash_spirit"
+#define POLL_IGNORE_RUST_SPIRIT "rust_spirit"
+#define POLL_IGNORE_MAID_IN_MIRROR "maid_in_mirror"
 
 
 GLOBAL_LIST_INIT(poll_ignore_desc, list(
@@ -57,6 +64,13 @@ GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_LAVALAND_ELITE = "Lavaland elite",
 	POLL_IGNORE_SHUTTLE_DENIZENS = "Shuttle denizens",
 	POLL_IGNORE_BOTS = "Bots",
+	POLL_IGNORE_HERETIC_MONSTER = "Heretic Monster",
+	POLL_IGNORE_RAW_PROPHET = "Raw Prophet",
+	POLL_IGNORE_STALKER = "Stalker",
+	POLL_IGNORE_FIRE_SHARK = "Fire Shark",
+	POLL_IGNORE_ASH_SPIRIT = "Ash Spirit",
+	POLL_IGNORE_RUST_SPIRIT = "Rust Spirit",
+	POLL_IGNORE_MAID_IN_MIRROR = "Maid in the Mirror",
 ))
 GLOBAL_LIST_INIT(poll_ignore, init_poll_ignore())
 

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -503,6 +503,8 @@
 	abstract_parent_type = /datum/heretic_knowledge/summon
 	/// Typepath of a mob to summon when we finish the recipe.
 	var/mob/living/mob_to_summon
+	///Determines what kind of monster ghosts will ignore from here on out. Defaults to POLL_IGNORE_HERETIC_MONSTER, but we define other types of monsters for more granularity.
+	var/poll_ignore_define = POLL_IGNORE_HERETIC_MONSTER
 
 /datum/heretic_knowledge/summon/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/mob/living/summoned = new mob_to_summon(loc)
@@ -514,7 +516,7 @@
 	animate(summoned, 10 SECONDS, alpha = 155)
 
 	message_admins("A [summoned.name] is being summoned by [ADMIN_LOOKUPFLW(user)] in [ADMIN_COORDJMP(summoned)].")
-	var/list/mob/dead/observer/candidates = poll_candidates_for_mob("Do you want to play as a [summoned.real_name]?", ROLE_HERETIC, FALSE, 10 SECONDS, summoned)
+	var/list/mob/dead/observer/candidates = poll_candidates_for_mob("Do you want to play as a [summoned.real_name]?", ROLE_HERETIC, FALSE, 10 SECONDS, summoned, poll_ignore_define)
 	if(!LAZYLEN(candidates))
 		loc.balloon_alert(user, "ritual failed, no ghosts!")
 		animate(summoned, 0.5 SECONDS, alpha = 0)

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -253,6 +253,7 @@
 	mob_to_summon = /mob/living/simple_animal/hostile/heretic_summon/raw_prophet
 	cost = 1
 	route = PATH_FLESH
+	poll_ignore_define = POLL_IGNORE_RAW_PROPHET
 
 /datum/heretic_knowledge/blade_upgrade/flesh
 	name = "Bleeding Steel"
@@ -292,6 +293,7 @@
 	mob_to_summon = /mob/living/simple_animal/hostile/heretic_summon/stalker
 	cost = 1
 	route = PATH_FLESH
+	poll_ignore_define = POLL_IGNORE_STALKER
 
 /datum/heretic_knowledge/ultimate/flesh_final
 	name = "Priest's Final Hymn"

--- a/code/modules/antagonists/heretic/knowledge/side_ash_flesh.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_ash_flesh.dm
@@ -74,6 +74,7 @@
 	mob_to_summon = /mob/living/simple_animal/hostile/heretic_summon/ash_spirit
 	cost = 1
 	route = PATH_SIDE
+	poll_ignore_define = POLL_IGNORE_ASH_SPIRIT
 
 /datum/heretic_knowledge/summon/ashy/cleanup_atoms(list/selected_atoms)
 	var/obj/item/bodypart/head/ritual_head = locate() in selected_atoms

--- a/code/modules/antagonists/heretic/knowledge/side_cosmos_ash.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_cosmos_ash.dm
@@ -18,6 +18,7 @@
 	mob_to_summon = /mob/living/basic/fire_shark
 	cost = 1
 	route = PATH_SIDE
+	poll_ignore_define = POLL_IGNORE_FIRE_SHARK
 
 /datum/heretic_knowledge/spell/space_phase
 	name = "Space Phase"

--- a/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_rust_cosmos.dm
@@ -69,6 +69,7 @@
 	mob_to_summon = /mob/living/simple_animal/hostile/heretic_summon/rust_spirit
 	cost = 1
 	route = PATH_SIDE
+	poll_ignore_define = POLL_IGNORE_RUST_SPIRIT
 
 /datum/heretic_knowledge/summon/rusty/cleanup_atoms(list/selected_atoms)
 	var/obj/item/bodypart/head/ritual_head = locate() in selected_atoms

--- a/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
@@ -160,3 +160,4 @@
 	cost = 1
 	route = PATH_SIDE
 	mob_to_summon = /mob/living/simple_animal/hostile/heretic_summon/maid_in_the_mirror
+	poll_ignore_define = POLL_IGNORE_MAID_IN_MIRROR


### PR DESCRIPTION
## About The Pull Request

Adds some poll defines for opting out of heretic roles. Includes a generic role define so there is a degree of futureproofing. Fixes https://github.com/tgstation/tgstation/issues/76808

## Why It's Good For The Game

Players don't often like getting spammed for summons. This helps.

## Changelog
:cl:
code: Adds an opt out for the rest of the round for the various heretic summons.
/:cl:
