### PR TITLE
fixes icebox genetics having a science headset instead of a medisci headset

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4308,12 +4308,12 @@
 	pixel_x = 11;
 	pixel_y = 7
 	},
-/obj/item/radio/headset/headset_sci{
-	pixel_x = -7;
-	pixel_y = 6
-	},
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 2
+	},
+/obj/item/radio/headset/headset_medsci{
+	pixel_x = -7;
+	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)


### PR DESCRIPTION

## About The Pull Request

currently of all the maps in rotation other than birdshot icebox is the only map wherein the genetics office is lacking a medisci headset for reasons unknown, unlike birdshot however icebox is meant to be a full station that was properly put together whereas the theme for birdshot would lend it some credibility to NOT having the medisci headset.

## Why It's Good For The Game

consistency issues are annoying, and as a genetics player myself this is one i know has probably irked some other people as well. 

## Changelog



:cl:
fix: replaces icebox genetics' regular science headset with a medisci headset, making it more in line with other genetics offices
/:cl:


