### PR TITLE
Fix anti-breach shields being dragged away

### DIFF
--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -42,7 +42,7 @@
 /turf/open/space/transit/proc/initialize_drifting_but_from_initialize(atom/movable/location, atom/movable/enterer, mapload)
 	SIGNAL_HANDLER
 
-	if(!mapload && !istype(enterer, /obj/docking_port))
+	if(!mapload && !istype(enterer, /obj/docking_port) && !enterer.anchored)
 		INVOKE_ASYNC(src, PROC_REF(initialize_drifting), src, enterer)
 
 /turf/open/space/transit/Exited(atom/movable/gone, direction)


### PR DESCRIPTION
closes #76172

Logic never checked for anchoring

:cl:
fix: anti-breach shields wont be dragged away during shuttle flight anymore
/:cl: