### PR TITLE
Fixes triple carp shuttle event failing

### DIFF
--- a/code/modules/shuttle/shuttle_events/player_controlled.dm
+++ b/code/modules/shuttle/shuttle_events/player_controlled.dm
@@ -65,4 +65,4 @@
 	var/list/spawning_list_copy = spawning_list.Copy()
 	spawning_list.Cut()
 	for(var/i in 1 to max_carp_spawns)
-		spawning_list.Add(pick_weight(spawning_list_copy))
+		spawning_list[pick_weight(spawning_list_copy)] = 1

--- a/code/modules/shuttle/shuttle_events/player_controlled.dm
+++ b/code/modules/shuttle/shuttle_events/player_controlled.dm
@@ -65,4 +65,4 @@
 	var/list/spawning_list_copy = spawning_list.Copy()
 	spawning_list.Cut()
 	for(var/i in 1 to max_carp_spawns)
-		spawning_list[pick_weight(spawning_list_copy)] = 1
+		spawning_list[pick_weight(spawning_list_copy)] += 1


### PR DESCRIPTION
It got pickweighted but I never assigned a value to the index, so every carpweight was 0 and would thus return null

:cl:
fix: Triple carp player controlled shuttle event works again
/:cl: