### PR TITLE
Adds circuit for bank machine.

### DIFF
--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -34,6 +34,7 @@
 	radio.set_listening(FALSE)
 	radio.recalculateChannels()
 	synced_bank_account = SSeconomy.get_dep_account(account_department)
+	AddComponent(/datum/component/gps, "Forbidden Cash Signal")
 
 /obj/machinery/computer/bank_machine/Destroy()
 	QDEL_NULL(radio)

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -117,11 +117,9 @@
 	syphoning_credits = 0
 
 /obj/machinery/computer/bank_machine/proc/start_siphon(mob/living/carbon/user)
-	siphoning = TRUE
-	unauthorized = FALSE
 	var/obj/item/card/id/card = user.get_idcard(hand_first = TRUE)
-	if(!istype(card))
-		return
-	if(!check_access(card))
-		return
-	unauthorized = TRUE
+	if(!istype(card) || !check_access(card))
+		unauthorized = TRUE
+	else
+		unauthorized = FALSE
+	siphoning = TRUE

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -1,6 +1,7 @@
 /obj/machinery/computer/bank_machine
 	name = "bank machine"
 	desc = "A machine used to deposit and withdraw station funds."
+	circuit = /obj/item/circuitboard/computer/bankmachine
 	icon_screen = "vault"
 	icon_keyboard = "security_key"
 	req_access = list(ACCESS_VAULT)

--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -34,7 +34,9 @@
 	radio.set_listening(FALSE)
 	radio.recalculateChannels()
 	synced_bank_account = SSeconomy.get_dep_account(account_department)
-	AddComponent(/datum/component/gps, "Forbidden Cash Signal")
+
+	if(!mapload)
+		AddComponent(/datum/component/gps, "Forbidden Cash Signal")
 
 /obj/machinery/computer/bank_machine/Destroy()
 	QDEL_NULL(radio)

--- a/code/game/objects/effects/spawners/random/techstorage.dm
+++ b/code/game/objects/effects/spawners/random/techstorage.dm
@@ -113,6 +113,7 @@
 	loot = list(
 		/obj/item/circuitboard/computer/crew,
 		/obj/item/circuitboard/computer/communications,
+		/obj/item/circuitboard/computer/bankmachine,
 	)
 
 /obj/effect/spawner/random/techstorage/rnd_secure_all

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -23,6 +23,11 @@
 	greyscale_colors = CIRCUIT_COLOR_COMMAND
 	build_path = /obj/machinery/computer/accounting
 
+/obj/item/circuitboard/computer/bankmachine
+	name = "Bank Machine Console"
+	greyscale_colors = CIRCUIT_COLOR_COMMAND
+	build_path = /obj/machinery/computer/bank_machine
+
 //Engineering
 
 /obj/item/circuitboard/computer/apc_control

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -126,7 +126,7 @@
 	category = list(
 		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_COMMAND
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SECURITY
+	departmental_flags = DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/board/crewconsole
 	name = "Crew Monitoring Computer Board"

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -118,6 +118,16 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SECURITY //Honestly should have a bridge techfab for this sometime.
 
+/datum/design/board/bankmachine
+	name = "Bank Machine Board"
+	desc = "All0ws for the construction of circuit boards used to build a Bank Machine."
+	id = "bankmachine"
+	build_path = /obj/item/circuitboard/computer/bankmachine
+	category = list(
+		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_COMMAND
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SECURITY
+
 /datum/design/board/crewconsole
 	name = "Crew Monitoring Computer Board"
 	desc = "Allows for the construction of circuit boards used to build a Crew monitoring computer."

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -120,7 +120,7 @@
 
 /datum/design/board/bankmachine
 	name = "Bank Machine Board"
-	desc = "All0ws for the construction of circuit boards used to build a Bank Machine."
+	desc = "Allows for the construction of circuit boards used to build a Bank Machine."
 	id = "bankmachine"
 	build_path = /obj/item/circuitboard/computer/bankmachine
 	category = list(

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1141,6 +1141,7 @@
 		"cargo",
 		"cargorequest",
 		"comconsole",
+		"bankmachine",
 		"crewconsole",
 		"idcard",
 		"libraryconsole",


### PR DESCRIPTION
## About The Pull Request
Bank machine now has a circuit so you can repair it.
You can steal it from the secure tech storage.
You can research it and print in the same node as comms console.
Also i messed around with start_siphon proc by making check for unauthorized before siphoning sets to TRUE so supposedly that should prevent incorrect messages when someone starts to siphon.
Added gps signal to it because of possibility of creating custom area and building machine there.
## Why It's Good For The Game
You can distract people with it, you can rob cargo with it, you can repair it when someone breaks it.
## Changelog
:cl:
add: Bank machine now has a circuit for it. Spawns in secure tech storage and researchable in the same nod as comms console.
balance: Due to possibility of creating area and making there bank machines that aren't roundstart will have gps signals.
fix: Bank machine now doesn't yell about unauthorized credit withdrawal when its authorized.
/:cl:
