### PR TITLE
Fixes some ha ha funny issues with the preferences spritesheet

### DIFF
--- a/code/modules/mob/living/silicon/ai/_preferences.dm
+++ b/code/modules/mob/living/silicon/ai/_preferences.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(ai_hologram_icons, list(
 	AI_HOLOGRAM_CAT_2 = 'icons/mob/simple/pets.dmi',
 	AI_HOLOGRAM_CHICKEN = 'icons/mob/simple/animal.dmi',
 	AI_HOLOGRAM_CORGI = 'icons/mob/simple/pets.dmi',
-	AI_HOLOGRAM_COW = 'icons/mob/simple/animal.dmi',
+	AI_HOLOGRAM_COW = 'icons/mob/simple/cows.dmi',
 	AI_HOLOGRAM_CRAB = 'icons/mob/simple/animal.dmi',
 	AI_HOLOGRAM_DEFAULT = 'icons/mob/silicon/ai.dmi',
 	AI_HOLOGRAM_FACE = 'icons/mob/silicon/ai.dmi',

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -720,7 +720,7 @@
 			"carp" = 'icons/mob/simple/carp.dmi',
 			"chicken" = 'icons/mob/simple/animal.dmi',
 			"corgi" = 'icons/mob/simple/pets.dmi',
-			"cow" = 'icons/mob/simple/animal.dmi',
+			"cow" = 'icons/mob/simple/cows.dmi',
 			"crab" = 'icons/mob/simple/animal.dmi',
 			"fox" = 'icons/mob/simple/pets.dmi',
 			"goat" = 'icons/mob/simple/animal.dmi',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

We had some icon cleanup recently, it removed what I think was a redundant cow sprite in animals.dmi. 
The trouble is hologram code referenced that icon+state as the cow hologram in an obscure untested list.

So when preferences went to load it and failed it defaulted to the first sprite in the folder, the chicken.

For some strange reason it dumped all 4 directionals, which, because the css file can't mindread, caused our preference css stuff to "mis index" the actual png asset.

![image](https://github.com/tgstation/tgstation/assets/58055496/c7ea1c23-28b7-44ab-bcdf-1eb5a0ea900b)

This meant all icons "below" ais in the sheet were offset. So you'd get the xeno ai form in the backpack slot, glasses in your hair, etc.

This pr resolves the cow thing. 
We however need a better way of preventing this class of error in future (Devs should not need to dig in the cache folder to figure out why they broke backpack preferences) 
I think preventing whatever that "all 4 icons" thing was + maybe screenshot testing assets would help? unsure.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The preference menu has had its weird index lowered (Assets are no longer semi garbled)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
