### PR TITLE
Protolathe UI QoL tweaks + mechfab UI fix

### DIFF
--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialCostSequence.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialCostSequence.tsx
@@ -74,7 +74,7 @@ export const MaterialCostSequence = (
             <Flex.Item>
               <MaterialIcon
                 materialName={material}
-                amount={(amount || 1) * quantity}
+                sheets={((amount || 1) * quantity) / 100}
               />
             </Flex.Item>
             <Flex.Item
@@ -88,7 +88,7 @@ export const MaterialCostSequence = (
                         : '#db2828',
                 }
               }>
-              {formatSiUnit((amount || 1) * quantity, 0)}
+              {formatSiUnit(((amount || 1) * quantity) / 100, 0)}
             </Flex.Item>
           </Flex>
         </Flex.Item>

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
@@ -1,7 +1,5 @@
 import { classes } from 'common/react';
 import { Icon } from '../../components';
-import { Material } from './Types';
-import { useBackend } from '../../backend';
 
 const MATERIAL_ICONS: Record<string, [number, string][]> = {
   'iron': [
@@ -64,10 +62,9 @@ export type MaterialIconProps = {
   materialName: string;
 
   /**
-   * The amount of material. One sheet is 100 units. By default, the icon
-   * attempts to render a full stack (5,000 units).
+   * The number of sheets of the material.
    */
-  amount?: number;
+  sheets?: number;
 };
 
 /**
@@ -75,10 +72,8 @@ export type MaterialIconProps = {
  * material.
  */
 export const MaterialIcon = (props: MaterialIconProps, context) => {
-  const { materialName, amount } = props;
+  const { materialName, sheets = 0 } = props;
   const icons = MATERIAL_ICONS[materialName];
-  const { data } = useBackend<Material>(context);
-  const { SHEET_MATERIAL_AMOUNT } = data;
 
   if (!icons) {
     return <Icon name="question-circle" />;
@@ -86,11 +81,7 @@ export const MaterialIcon = (props: MaterialIconProps, context) => {
 
   let activeIdx = 0;
 
-  while (
-    icons[activeIdx + 1] &&
-    icons[activeIdx + 1][0] <=
-      (amount ?? 50 * SHEET_MATERIAL_AMOUNT) / SHEET_MATERIAL_AMOUNT
-  ) {
+  while (icons[activeIdx + 1] && icons[activeIdx + 1][0] <= sheets) {
     activeIdx += 1;
   }
 

--- a/tgui/packages/tgui/interfaces/Fabrication/Types.ts
+++ b/tgui/packages/tgui/interfaces/Fabrication/Types.ts
@@ -26,11 +26,6 @@ export type Material = {
   amount: number;
 
   /**
-   * Definition of how much units 1 sheet has.
-   */
-  SHEET_MATERIAL_AMOUNT: number;
-
-  /**
    * The number of sheets.
    */
   sheets: number;


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/12202230/54bbb7ef-4ff0-4a4b-bc57-ecfacbd49761)

- All quantities are now in *sheets of material.*
- Fixes mechfab quantities always being inactive
## Why It's Good For The Game

you can stop dividing by fifty
## Changelog
:cl:
qol: techfabs now use sheets(TM) as the default unit of measurement
fix: mechfab icons aren't perpetually gray
/:cl:
