### PR TITLE
Fixes the AI vox announcement abruptly interrupting every other sound playing.

### DIFF
--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -122,6 +122,6 @@
 			continue
 
 		to_chat(target, "[span_minorannounce("<font color = red>[title]</font color><BR>[message]")]<BR>")
-		if(target.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements))
+		if(should_play_sound && target.client?.prefs.read_preference(/datum/preference/toggle/sound_announcements))
 			var/sound_to_play = sound_override || (alert ? 'sound/misc/notice1.ogg' : 'sound/misc/notice2.ogg')
 			SEND_SOUND(target, sound(sound_to_play))

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -102,8 +102,9 @@
  * html_encode - if TRUE, we will html encode our title and message before sending it, to prevent player input abuse.
  * players - optional, a list mobs to send the announcement to. If unset, sends to all palyers.
  * sound_override - optional, use the passed sound file instead of the default notice sounds.
+ * should_play_sound - Whether the notice sound should be played or not.
  */
-/proc/minor_announce(message, title = "Attention:", alert, html_encode = TRUE, list/players, sound_override)
+/proc/minor_announce(message, title = "Attention:", alert, html_encode = TRUE, list/players = null, sound_override = null, should_play_sound = TRUE)
 	if(!message)
 		return
 

--- a/code/modules/mob/living/silicon/ai/ai_say.dm
+++ b/code/modules/mob/living/silicon/ai/ai_say.dm
@@ -136,7 +136,7 @@
 		var/turf/player_turf = get_turf(player_mob)
 		if(is_valid_z_level(ai_turf, player_turf))
 			players += player_mob
-	minor_announce(capitalize(message), "[name] announces:", players = players, sound_override = TRUE)
+	minor_announce(capitalize(message), "[name] announces:", players = players, should_play_sound = FALSE)
 
 	for(var/word in words)
 		play_vox_word(word, ai_turf, null)


### PR DESCRIPTION

## About The Pull Request
The AI minor announcement is supposed to suppress only its sound, but there's a bug where it interrupts every playing sound because it's passing in the equivalent of sound(null) to every player. This fixes that by making it only disable the minor announcement sound instead of stopping every sound.

## Why It's Good For The Game
Bugfix

## Changelog
:cl:
fix: Fixed the AI vox announcement interrupting every other sound being played.
/:cl:
