### PR TITLE
Alien acid no longer eats through reinforced walls and floors

### DIFF
--- a/code/datums/components/acid.dm
+++ b/code/datums/components/acid.dm
@@ -167,6 +167,13 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 
 	// Snowflake code for handling acid melting walls.
 	// We really should consider making turfs use atom_integrity, but for now this is just for acids.
+
+	//Strong walls will never get melted
+	if(target_turf.get_explosive_block() >= 2)
+		return
+	//Reinforced floors never get melted
+	if(istype(target_turf, /turf/open/floor/engine))
+		return
 	if(acid_power < ACID_POWER_MELT_TURF)
 		return
 

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -264,11 +264,6 @@
 /turf/closed/wall/get_dumping_location()
 	return null
 
-/turf/closed/wall/acid_act(acidpwr, acid_volume)
-	if(get_explosive_block() >= 2)
-		acidpwr = min(acidpwr, 50) //we reduce the power so strong walls never get melted.
-	return ..()
-
 /turf/closed/wall/acid_melt()
 	dismantle_wall(1)
 

--- a/code/game/turfs/open/floor/reinforced_floor.dm
+++ b/code/game/turfs/open/floor/reinforced_floor.dm
@@ -50,10 +50,6 @@
 		ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 	return TRUE
 
-/turf/open/floor/engine/acid_act(acidpwr, acid_volume)
-	acidpwr = min(acidpwr, 50) //we reduce the power so reinf floor never get melted.
-	return ..()
-
 /turf/open/floor/engine/ex_act(severity, target)
 	if(target == src)
 		ScrapeAway(flags = CHANGETURF_INHERIT_AIR)


### PR DESCRIPTION

## About The Pull Request

Fixes #76473 
Title, This was broken cause I made xenos directly apply the acid component
Makes the acid component a bit safer to directly add to something

## Why It's Good For The Game

Bug fixes good, cleaning my own mess. Surely now we can safely contain xenos, right?

## Changelog

:cl: Seven
fix: Xeno's corrosion ability no longer breaks reinforced walls and floors
/:cl:

