### PR TITLE
Fixes punctuation on the flux anomaly announcement

### DIFF
--- a/code/modules/events/anomaly/anomaly_flux.dm
+++ b/code/modules/events/anomaly/anomaly_flux.dm
@@ -15,4 +15,4 @@
 	anomaly_path = /obj/effect/anomaly/flux
 
 /datum/round_event/anomaly/anomaly_flux/announce(fake)
-	priority_announce("Hyper-energetic flux wave detected on [ANOMALY_ANNOUNCE_DANGEROUS_TEXT]. [impact_area.name].", "Anomaly Alert")
+	priority_announce("Hyper-energetic flux wave detected on [ANOMALY_ANNOUNCE_DANGEROUS_TEXT] [impact_area.name].", "Anomaly Alert")


### PR DESCRIPTION

## About The Pull Request

Fixes an errant period between two text defines.

ANOMALY_ANNOUNCE_DANGEROUS_TEXT ends with "Detected location:" and is expected to be followed up with by the impact area, not a period.
## Why It's Good For The Game

Makes one sentence slightly more readable.
## Changelog
:cl: Rhials
spellcheck: removes an errant period from the flux anomaly announcement.
/:cl:
