### PR TITLE
Blacklist abductor posters from spawning

### DIFF
--- a/code/game/objects/effects/posters/poster.dm
+++ b/code/game/objects/effects/posters/poster.dm
@@ -289,7 +289,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/ripped, 32)
 	icon_state = "random_anything"
 	never_random = TRUE
 	random_basetype = /obj/structure/sign/poster
-	blacklisted_types = list(/obj/structure/sign/poster/traitor)
+	blacklisted_types = list(
+		/obj/structure/sign/poster/traitor,
+		/obj/structure/sign/poster/abductor,
+	)
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sign/poster/random, 32)
 


### PR DESCRIPTION

## About The Pull Request

Fixes #76868
## Why It's Good For The Game

alien posters should be exclusive to aliens i guess
## Changelog
:cl:
fix: Abductor posters can no longer randomly spawn
/:cl:
