### PR TITLE
There is no longer a 50% chance of catching a heretic out when examining them drawing influences

### DIFF
--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -254,16 +254,13 @@
 
 	being_drained = TRUE
 	balloon_alert(user, "draining influence...")
-	RegisterSignal(user, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 
 	if(!do_after(user, 10 SECONDS, src))
 		being_drained = FALSE
 		balloon_alert(user, "interrupted!")
-		UnregisterSignal(user, COMSIG_ATOM_EXAMINE)
 		return
 
 	// We don't need to set being_drained back since we delete after anyways
-	UnregisterSignal(user, COMSIG_ATOM_EXAMINE)
 	balloon_alert(user, "influence drained")
 
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
@@ -285,19 +282,6 @@
 
 	GLOB.reality_smash_track.num_drained++
 	qdel(src)
-
-/*
- * Signal proc for [COMSIG_ATOM_EXAMINE], registered on the user draining the influence.
- *
- * Gives a chance for examiners to see that the heretic is interacting with an infuence.
- */
-/obj/effect/heretic_influence/proc/on_examine(atom/source, mob/user, list/examine_list)
-	SIGNAL_HANDLER
-
-	if(prob(50))
-		return
-
-	examine_list += span_warning("[source]'s hand seems to be glowing a [span_hypnophrase("strange purple")]...")
 
 /*
  * Add a mind to the list of tracked minds,


### PR DESCRIPTION

## About The Pull Request

There is no longer a 50% chance of catching a heretic out when examining them drawing influences.

## Why It's Good For The Game

> There is no longer a 50% chance of catching a heretic out when examining them drawing influences

This is a bad thing for several reasons.

1. It means the heretic will most often be caught out at the very start of the shift, when they are weakest and most vulnerable.
Heretics already have it hard enough, adding yet another source of stress is undue.

2. It has no effective counter.
What are you going to do? Not draw any influences? That shouldn't be the 'counter'. The influence drawing period is meant to parallel the crew prepping period, the traitor rep-collecting period, etc.

3. In a way, it's more blatant than Codex Cicatrix drawing.
Codexi show up as a normal item in your hand. This instead shows a huge flashing glowing neon rainbow text that says THIS IS A HERETIC. SHRIEK IN RADIO AND VALID.

4. It's badly designed, and can be manipulated way too easily to always show.
Examine a target thrice and you're pretty much guaranteed to see if they are indeed drawing or not. You can just keep rolling the 50% chance.

5. It feels random and unfair for the heretic to die to it.
I've seen this happen and it sucks. There's no sign for heretics that they have a risk of being found out when examined, which means that this is just an extremely rare occurrence that you try to ignore *could* happen 99% of the time, and feel like shit the 1% of the time it backfires.

## Changelog

:cl:
del: There is no longer a 50% chance of catching a heretic out when examining them drawing influences.
/:cl:

