### PR TITLE
Fixes a spelling error in the name of the Tiziran fish case.

### DIFF
--- a/code/modules/cargo/packs/general.dm
+++ b/code/modules/cargo/packs/general.dm
@@ -62,7 +62,7 @@
 	crate_name = "saltwater fish crate"
 
 /datum/supply_pack/misc/tiziran_fish
-	name = "Tirizan Fish Case"
+	name = "Tiziran Fish Case"
 	desc = "Tiziran saltwater fish imported from the Zagos Sea."
 	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/storage/fish_case/tiziran = 2)


### PR DESCRIPTION

## About The Pull Request

This, as the title suggests, fixes a spelling error in the name of the Tiziran fish case.

Namely, it corrects "Ti**riz**an Fish Case" to "Ti**zir**an Fish Case".

## Why It's Good For The Game

Spelling errors are bad, and we should fix them.

## Changelog
:cl:
spellcheck: A spelling error in the name of the Tiziran fish case has been corrected.
/:cl:
