### PR TITLE
Megafauna can be destroyed by the singularity

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -102,6 +102,10 @@
 	else
 		..()
 
+/mob/living/simple_animal/hostile/megafauna/singularity_act()
+	set_health(0)
+	return ..()
+
 /mob/living/simple_animal/hostile/megafauna/dust(just_ash, drop_items, force)
 	if(!force && health > 0)
 		return


### PR DESCRIPTION
## About The Pull Request

Who would win in a fight; A miniature black hole or an unusually ornery miner? The answer may surprise you.
Previously the singularity would attempt to gib megafauna but fail because they can only be gibbed at 0 health, presumably to prevent things like plasma fist cheese?
This would lead to the singularity actually repeatedly "eating" the boss and gaining energy, but not killing or deleting it.

Fixes #76831

I fix this the easy way: set the health to 0 before we try to gib it.
If we alternately wanted to codify them being immune to the singularity I could modify this to not energise it instead, but this makes more sense to me.

## Why It's Good For The Game

You can kill them with the supermatter, seems reasonable to kill them with an event horizon.
It'll eat the dropped items anyway.

## Changelog

:cl:
fix: Megafauna can be consumed by the singularity.
/:cl:
