### PR TITLE
ports Kapu's optimization of get_hearers_in_view()

### DIFF
--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -79,7 +79,8 @@
 /**
  * returns every hearaing movable in view to the turf of source not taking into account lighting
  * useful when you need to maintain always being able to hear something if a sound is emitted from it and you can see it (and youre in range).
- * otherwise this is just a more expensive version of get_hearers_in_LOS()
+ * otherwise this is just a more expensive version of get_hearers_in_LOS().
+ * uses hearers() instead of view() now as a slight optimization.
  *
  * * view_radius - what radius search circle we are using, worse performance as this increases
  * * source - object at the center of our search area. everything in get_turf(source) is guaranteed to be part of the search area
@@ -105,25 +106,22 @@
 
 	var/list/assigned_oranges_ears = SSspatial_grid.assign_oranges_ears(hearables_from_grid)
 
-	var/old_luminosity = center_turf.luminosity
-	center_turf.luminosity = 6 //man if only we had an inbuilt dview()
-
-	//this is the ENTIRE reason all this shit is worth it due to how view() and the contents list works and can be optimized
+	//this is the ENTIRE reason all this shit is worth it due to how view()-like procs and the contents list works and can be optimized
 	//internally, the contents list is secretly two linked lists, one for /obj's and one for /mob's (/atom/movable counts as /obj here)
 	//by default, for(var/atom/name in view()) iterates through both the /obj linked list then the /mob linked list of each turf
 	//but because what we want are only a tiny proportion of all movables, most of the things in the /obj contents list are not what we're looking for
-	//while every mob can hear. for this case view() has an optimization to only look through 1 of these lists if it can (eg youre only looking for mobs)
+	//while every mob can hear. for this case view() and similar procs have an optimization to only look through 1 of these lists if it can (eg youre only looking for mobs)
 	//so by representing every hearing contents on a turf with a single /mob/oranges_ear containing references to all of them, we are:
 	//1. making view() only go through the smallest of the two linked lists per turf, which contains the type we're looking for at the end
 	//2. typechecking all mobs in the output to only actually return mobs of type /mob/oranges_ear
 	//on a whole this can outperform iterating through all movables in view() by ~2x especially when hearables are a tiny percentage of movables in view
-	for(var/mob/oranges_ear/ear in view(view_radius, center_turf))
+	//using hearers is a further optimization of that because for our purposes its the same as view except we dont have to set center's luminosity to 6 and then unset it
+	for(var/mob/oranges_ear/ear in hearers(view_radius, center_turf))
 		. += ear.references
 
 	for(var/mob/oranges_ear/remaining_ear as anything in assigned_oranges_ears)//we need to clean up our mess
 		remaining_ear.unassign()
 
-	center_turf.luminosity = old_luminosity
 	return .
 
 /**

--- a/code/__HELPERS/spatial_info.dm
+++ b/code/__HELPERS/spatial_info.dm
@@ -80,7 +80,6 @@
  * returns every hearaing movable in view to the turf of source not taking into account lighting
  * useful when you need to maintain always being able to hear something if a sound is emitted from it and you can see it (and youre in range).
  * otherwise this is just a more expensive version of get_hearers_in_LOS().
- * uses hearers() instead of view() now as a slight optimization.
  *
  * * view_radius - what radius search circle we are using, worse performance as this increases
  * * source - object at the center of our search area. everything in get_turf(source) is guaranteed to be part of the search area


### PR DESCRIPTION

## About The Pull Request
ports https://github.com/DaedalusDock/daedalusdock/pull/421
@Kapu1178 pointed out that get_hearers_in_view() could be improved by replacing view() with hearers() since 1. hearers only looks for mobs (this is the same as what view() was already doing in this case since it used the for(var/primitive_type/name in view(...)) optimization) and 2. unlike view(), hearers() doesnt need to set and unset the center turf's luminosity 
## Why It's Good For The Game
profiled it for a bit and the results are:
![Figure_3_no_mega](https://github.com/tgstation/tgstation/assets/15794172/00d23458-d8ef-478b-9e37-d20fa6254970)
about a microsecond per call across all ranges for the area i tested. so not much but its a hot proc
