### PR TITLE
Fixes a likely copy paste error in the APC update_icon_state() proc

### DIFF
--- a/code/modules/power/apc/apc_appearance.dm
+++ b/code/modules/power/apc/apc_appearance.dm
@@ -27,7 +27,6 @@
 
 /obj/machinery/power/apc/update_icon_state()
 	if(!update_state)
-		icon = 'icons/obj/machines/wallmounts.dmi'
 		icon_state = "apc0"
 		return ..()
 	if(update_state & (UPSTATE_OPENED1|UPSTATE_OPENED2))


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/76788 introduced this.

I don't think it was intentional. Probably a copy paste error, which is bound to happen when you clean so many files! My goodness.

Keep up the good work though @YesterdaysPromise!!

## Why It's Good For The Game

Downstreams can have different filepaths for sprites, and this would override them.

## Changelog

:cl:
code: apc's update_icon_state proc will no longer set the icon file path
/:cl:

