### PR TITLE
allows surgery caps to toggle hair visibility

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -456,7 +456,7 @@
 		return
 	flags_inv ^= HIDEHAIR
 	balloon_alert(user, "[flags_inv & HIDEHAIR ? "tightened" : "loosened "] strings")
-
+	return TRUE
 /obj/item/clothing/head/utility/surgerycap/examine(mob/user)
 	. = ..()
 	. += span_notice("Use in hand to [flags_inv ? "loosen" : "tighten"] the strings.")

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -451,7 +451,7 @@
 	. = ..()
 	if(.)
 		return
-	to_chat(user, span_notice("You begin to [flags_inv ? "loosen" : "tighten"] the strings on \the [src]..."))
+	balloon_alert(user, "[flags_inv & HIDEHAIR ? "loosening" : "tightening"] strings...")
 	if(!do_after(user, 3 SECONDS, src))
 		return
 	if(!flags_inv)

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -447,6 +447,21 @@
 	desc = "A blue medical surgery cap to prevent the surgeon's hair from entering the insides of the patient!"
 	flags_inv = HIDEHAIR //Cover your head doctor!
 
+/obj/item/clothing/head/utility/surgerycap/attack_self(mob/user)
+	to_chat(user, span_notice("You begin to [flags_inv ? "loosen" : "tighten"] the strings on \the [src]..."))
+	if(!do_after(user, 3 SECONDS, src))
+		return
+	if(!flags_inv)
+		flags_inv = HIDEHAIR
+		to_chat(user, span_notice("You tighten the strings on \the [src]."))
+	else
+		flags_inv = NONE
+		to_chat(user, span_notice("You loosen the strings on \the [src]."))
+
+/obj/item/clothing/head/utility/surgerycap/examine(mob/user)
+	. = ..()
+	. += span_notice("Use in hand to [flags_inv ? "loosen" : "tighten"] the strings.")
+
 /obj/item/clothing/head/utility/surgerycap/purple
 	name = "burgundy surgery cap"
 	icon_state = "surgicalcapwine"

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -454,12 +454,8 @@
 	balloon_alert(user, "[flags_inv & HIDEHAIR ? "loosening" : "tightening"] strings...")
 	if(!do_after(user, 3 SECONDS, src))
 		return
-	if(!flags_inv)
-		flags_inv = HIDEHAIR
-		to_chat(user, span_notice("You tighten the strings on \the [src]."))
-	else
-		flags_inv = NONE
-		to_chat(user, span_notice("You loosen the strings on \the [src]."))
+	flags_inv ^= HIDEHAIR
+	balloon_alert(user, "[flags_inv & HIDEHAIR ? "tightened" : "loosened "] strings")
 
 /obj/item/clothing/head/utility/surgerycap/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -457,9 +457,10 @@
 	flags_inv ^= HIDEHAIR
 	balloon_alert(user, "[flags_inv & HIDEHAIR ? "tightened" : "loosened "] strings")
 	return TRUE
+	
 /obj/item/clothing/head/utility/surgerycap/examine(mob/user)
 	. = ..()
-	. += span_notice("Use in hand to [flags_inv ? "loosen" : "tighten"] the strings.")
+	. += span_notice("Use in hand to [flags_inv & HIDEHAIR ? "loosen" : "tighten"] the strings.")
 
 /obj/item/clothing/head/utility/surgerycap/purple
 	name = "burgundy surgery cap"

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -448,6 +448,9 @@
 	flags_inv = HIDEHAIR //Cover your head doctor!
 
 /obj/item/clothing/head/utility/surgerycap/attack_self(mob/user)
+	. = ..()
+	if(.)
+		return
 	to_chat(user, span_notice("You begin to [flags_inv ? "loosen" : "tighten"] the strings on \the [src]..."))
 	if(!do_after(user, 3 SECONDS, src))
 		return


### PR DESCRIPTION
## About The Pull Request
Allows doctors to choose between looking like a baldie and letting their hair peek out.

![dreamseeker_habQTXtLxo](https://github.com/tgstation/tgstation/assets/6972764/25ee7931-c3a4-437c-bbd9-c08c8ce8e4b7)

**By default** the original behaviour of hiding all hair remains. Using the cap in your hands you can "loosen" the strings which toggles the visibility of the hair.

![dreamseeker_wRz9kTLe4i](https://github.com/tgstation/tgstation/assets/6972764/d42d0066-2dc6-4694-827c-0b494ba03752)
(Outdated image, now uses a balloon alert instead of a to_chat)

It's also on a short do_after so you can't just spam flip it back and forth, plus you have to actually take it off to fiddle with it.
## Why It's Good For The Game
We can already wear uniforms "casually" by alt clicking them, this is just something similar but for caps.
Creates opportunities for CMO's to yell at their doctors for not keeping their uniforms up to scratch.

Also fashion idk.

## Changelog
:cl:
add: You can now toggle the visibility for hair on your noggin when wearing surgery caps.
/:cl:
