### PR TITLE
Unfucks interactions between hypnoflashes and conversion antags.

### DIFF
--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -564,13 +564,20 @@
 		return
 
 	var/mob/hearing_speaker = hearing_args[HEARING_SPEAKER]
-	var/mob/living/carbon/C = owner
-	C.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
+	var/mob/living/carbon/carbon_owner = owner
+	carbon_owner.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
 	// The brain trauma itself does its own set of logging, but this is the only place the source of the hypnosis phrase can be found.
-	hearing_speaker.log_message("hypnotised [key_name(C)] with the phrase '[hearing_args[HEARING_RAW_MESSAGE]]'", LOG_ATTACK, color="red")
-	C.log_message("has been hypnotised by the phrase '[hearing_args[HEARING_RAW_MESSAGE]]' spoken by [key_name(hearing_speaker)]", LOG_VICTIM, color="orange", log_globally = FALSE)
-	addtimer(CALLBACK(C, TYPE_PROC_REF(/mob/living/carbon, gain_trauma), /datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, hearing_args[HEARING_RAW_MESSAGE]), 10)
-	addtimer(CALLBACK(C, TYPE_PROC_REF(/mob/living, Stun), 60, TRUE, TRUE), 15) //Take some time to think about it
+	hearing_speaker.log_message("hypnotised [key_name(carbon_owner)] with the phrase '[hearing_args[HEARING_RAW_MESSAGE]]'", LOG_ATTACK, color="red")
+	carbon_owner.log_message("has been hypnotised by the phrase '[hearing_args[HEARING_RAW_MESSAGE]]' spoken by [key_name(hearing_speaker)]", LOG_VICTIM, color="orange", log_globally = FALSE)
+	if(IS_REVOLUTIONARY(carbon_owner))
+		carbon_owner.log_message("has been deconverted from the revolution by [hearing_speaker] via hypnosis!", LOG_ATTACK, color="#960000")
+		carbon_owner.mind.special_role = null
+		carbon_owner.mind.remove_antag_datum(/datum/antagonist/rev)
+	if(IS_CULTIST(carbon_owner))
+		carbon_owner.log_message("has been deconverted from the cult by [hearing_speaker] via hypnosis!", LOG_ATTACK, color="#960000")
+		carbon_owner.mind.remove_antag_datum(/datum/antagonist/cult)
+	addtimer(CALLBACK(carbon_owner, TYPE_PROC_REF(/mob/living/carbon, gain_trauma), /datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, hearing_args[HEARING_RAW_MESSAGE]), 10)
+	addtimer(CALLBACK(carbon_owner, TYPE_PROC_REF(/mob/living, Stun), 60, TRUE, TRUE), 15) //Take some time to think about it
 	qdel(src)
 
 /datum/status_effect/spasms

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -294,6 +294,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	new /obj/item/melee/cultblade/dagger(get_turf(src))
 	if(istype(human_convertee))
 		human_convertee.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY)
+	convertee.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 	convertee.mind.special_role = ROLE_CULTIST
 	convertee.mind.add_antag_datum(/datum/antagonist/cult, cult_team)
 

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -292,6 +292,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 		convertee.Unconscious(10 SECONDS)
 
 	new /obj/item/melee/cultblade/dagger(get_turf(src))
+	if(istype(human_convertee))
+		human_convertee.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY)
 	convertee.mind.special_role = ROLE_CULTIST
 	convertee.mind.add_antag_datum(/datum/antagonist/cult, cult_team)
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -305,6 +305,7 @@
 	if(iscarbon(convertee))
 		var/mob/living/carbon/carbon_convertee = convertee
 		carbon_convertee.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY)
+	owner.remove_antag_datum(/datum/antagonist/brainwashed)
 
 	rev_mind.add_memory(/datum/memory/recruited_by_headrev, protagonist = rev_mind.current, antagonist = owner.current)
 	rev_mind.add_antag_datum(/datum/antagonist/rev,rev_team)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -292,14 +292,19 @@
  * * mute - If TRUE, we will apply a mute when we're applied
  */
 /datum/antagonist/rev/proc/add_revolutionary(datum/mind/rev_mind, stun = TRUE, mute = TRUE)
-	if(!can_be_converted(rev_mind.current))
+	var/mob/living/convertee = rev_mind.current
+	if(!can_be_converted(convertee))
 		return FALSE
 
 	if(mute)
-		rev_mind.current.set_silence_if_lower(10 SECONDS)
+		convertee.set_silence_if_lower(10 SECONDS)
 	if(stun)
-		rev_mind.current.flash_act(1, 1)
-		rev_mind.current.Stun(10 SECONDS)
+		convertee.flash_act(1, 1)
+		convertee.Stun(10 SECONDS)
+
+	if(iscarbon(convertee))
+		var/mob/living/carbon/carbon_convertee = convertee
+		carbon_convertee.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY)
 
 	rev_mind.add_memory(/datum/memory/recruited_by_headrev, protagonist = rev_mind.current, antagonist = owner.current)
 	rev_mind.add_antag_datum(/datum/antagonist/rev,rev_team)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -343,42 +343,48 @@
 /obj/item/assembly/flash/hypnotic/burn_out()
 	return
 
-/obj/item/assembly/flash/hypnotic/flash_carbon(mob/living/carbon/M, mob/user, confusion_duration = 15, targeted = TRUE, generic_message = FALSE)
-	if(!istype(M))
+/obj/item/assembly/flash/hypnotic/flash_carbon(mob/living/carbon/hypnotize_target, mob/user, confusion_duration = 15, targeted = TRUE, generic_message = FALSE)
+	if(!istype(hypnotize_target))
 		return
 	if(user)
-		log_combat(user, M, "[targeted? "hypno-flashed(targeted)" : "hypno-flashed(AOE)"]", src)
+		log_combat(user, hypnotize_target, "[targeted? "hypno-flashed(targeted)" : "hypno-flashed(AOE)"]", src)
 	else //caused by emp/remote signal
-		M.log_message("was [targeted? "hypno-flashed(targeted)" : "hypno-flashed(AOE)"]", LOG_ATTACK)
-	if(generic_message && M != user)
-		to_chat(M, span_notice("[src] emits a soothing light..."))
+		hypnotize_target.log_message("was [targeted? "hypno-flashed(targeted)" : "hypno-flashed(AOE)"]", LOG_ATTACK)
+	if(generic_message && hypnotize_target != user)
+		to_chat(hypnotize_target, span_notice("[src] emits a soothing light..."))
 	if(targeted)
-		if(M.flash_act(1, 1))
+		if(hypnotize_target.flash_act(1, 1))
 			var/hypnosis = FALSE
-			if(M.hypnosis_vulnerable())
+			if(hypnotize_target.hypnosis_vulnerable())
 				hypnosis = TRUE
+			if(IS_REVOLUTIONARY(user) && IS_REVOLUTIONARY(hypnotize_target))
+				to_chat(user, span_danger("[hypnotize_target] is already on your team!"))
+				hypnosis = FALSE
+			if(IS_CULTIST(hypnotize_target) && IS_REVOLUTIONARY(hypnotize_target))
+				to_chat(user, span_danger("[hypnotize_target] is already on your team!"))
+				hypnosis = FALSE
 			if(user)
-				user.visible_message(span_danger("[user] blinds [M] with the flash!"), span_danger("You hypno-flash [M]!"))
+				user.visible_message(span_danger("[user] blinds [hypnotize_target] with the flash!"), span_danger("You hypno-flash [hypnotize_target]!"))
 
 			if(!hypnosis)
-				to_chat(M, span_hypnophrase("The light makes you feel oddly relaxed..."))
-				M.adjust_confusion_up_to(10 SECONDS, 20 SECONDS)
-				M.adjust_dizzy_up_to(20 SECONDS, 40 SECONDS)
-				M.adjust_drowsiness_up_to(20 SECONDS, 40 SECONDS)
-				M.adjust_pacifism(10 SECONDS)
+				to_chat(hypnotize_target, span_hypnophrase("The light makes you feel oddly relaxed..."))
+				hypnotize_target.adjust_confusion_up_to(10 SECONDS, 20 SECONDS)
+				hypnotize_target.adjust_dizzy_up_to(20 SECONDS, 40 SECONDS)
+				hypnotize_target.adjust_drowsiness_up_to(20 SECONDS, 40 SECONDS)
+				hypnotize_target.adjust_pacifism(10 SECONDS)
 			else
-				M.apply_status_effect(/datum/status_effect/trance, 200, TRUE)
+				hypnotize_target.apply_status_effect(/datum/status_effect/trance, 200, TRUE)
 
 		else if(user)
-			user.visible_message(span_warning("[user] fails to blind [M] with the flash!"), span_warning("You fail to hypno-flash [M]!"))
+			user.visible_message(span_warning("[user] fails to blind [hypnotize_target] with the flash!"), span_warning("You fail to hypno-flash [hypnotize_target]!"))
 		else
-			to_chat(M, span_danger("[src] fails to blind you!"))
+			to_chat(hypnotize_target, span_danger("[src] fails to blind you!"))
 
-	else if(M.flash_act())
-		to_chat(M, span_notice("Such a pretty light..."))
-		M.adjust_confusion_up_to(4 SECONDS, 20 SECONDS)
-		M.adjust_dizzy_up_to(8 SECONDS, 40 SECONDS)
-		M.adjust_drowsiness_up_to(8 SECONDS, 40 SECONDS)
-		M.adjust_pacifism(4 SECONDS)
+	else if(hypnotize_target.flash_act())
+		to_chat(hypnotize_target, span_notice("Such a pretty light..."))
+		hypnotize_target.adjust_confusion_up_to(4 SECONDS, 20 SECONDS)
+		hypnotize_target.adjust_dizzy_up_to(8 SECONDS, 40 SECONDS)
+		hypnotize_target.adjust_drowsiness_up_to(8 SECONDS, 40 SECONDS)
+		hypnotize_target.adjust_pacifism(4 SECONDS)
 
 #undef CONFUSION_STACK_MAX_MULTIPLIER

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -360,7 +360,7 @@
 			if(IS_REVOLUTIONARY(user) && IS_REVOLUTIONARY(hypnotize_target))
 				to_chat(user, span_danger("[hypnotize_target] is already on your team!"))
 				hypnosis = FALSE
-			if(IS_CULTIST(hypnotize_target) && IS_REVOLUTIONARY(hypnotize_target))
+			if(IS_CULTIST(user) && IS_REVOLUTIONARY(hypnotize_target))
 				to_chat(user, span_danger("[hypnotize_target] is already on your team!"))
 				hypnosis = FALSE
 			if(user)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1150,6 +1150,10 @@
 /mob/living/carbon/proc/hypnosis_vulnerable()
 	if(HAS_TRAIT(src, TRAIT_MINDSHIELD))
 		return FALSE
+	if(IS_HEAD_REVOLUTIONARY(src))
+		return FALSE
+	if(mind.unconvertable)
+		return FALSE
 	if(has_status_effect(/datum/status_effect/hallucination))
 		return TRUE
 	if(IsSleeping() || IsUnconscious())

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -51,12 +51,20 @@
 	display_pain(target, "Your head pounds with unimaginable pain!") // Same message as other brain surgeries
 
 /datum/surgery_step/brainwash/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
-	if(!target.mind)
+	if(!target.mind || target.mind.unconvertable)
 		to_chat(user, span_warning("[target] doesn't respond to the brainwashing, as if [target.p_they()] lacked a mind..."))
 		return FALSE
 	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 		to_chat(user, span_warning("You hear a faint buzzing from a device inside [target]'s brain, and the brainwashing is erased."))
 		return FALSE
+
+	if(IS_REVOLUTIONARY(user) && IS_REVOLUTIONARY(target))
+		to_chat(user, span_danger("[target] is already on your team!"))
+		return FALSE
+	if(IS_CULTIST(user) && IS_REVOLUTIONARY(target))
+		to_chat(user, span_danger("[target] is already on your team!"))
+		return FALSE
+
 	display_results(
 		user,
 		target,
@@ -64,6 +72,15 @@
 		span_notice("[user] successfully fixes [target]'s brain!"),
 		span_notice("[user] completes the surgery on [target]'s brain."),
 	)
+
+	if(IS_REVOLUTIONARY(target))
+		target.log_message("has been deconverted from the revolution by [user] via brainwashing!", LOG_ATTACK, color="#960000")
+		target.mind.special_role = null
+		target.mind.remove_antag_datum(/datum/antagonist/rev)
+	if(IS_CULTIST(target))
+		target.log_message("has been deconverted from the cult by [user] via brainwashing!", LOG_ATTACK, color="#960000")
+		target.mind.remove_antag_datum(/datum/antagonist/cult)
+
 	to_chat(target, span_userdanger("A new compulsion fills your mind... you feel forced to obey it!"))
 	brainwash(target, objective)
 	message_admins("[ADMIN_LOOKUPFLW(user)] surgically brainwashed [ADMIN_LOOKUPFLW(target)] with the objective '[objective]'.")


### PR DESCRIPTION

## About The Pull Request
The following interactions now occur:

Traitor cultists are no longer able to brainwash their fellow cultists with hypno-flashes or brainwashing surgery
Traitor revolutionary are no longer able to brainwash their fellow revolutionaries with brainwashing surgery

Traitors who are NOT cultists will now deconvert cultists when they brainwash or hypnoflash them
Traitors who are NOT revolutionaries will now deconvert revolutionaries when they brainwash or hypnoflash them
Head revs are immune to hypnoflashes (as would be typical of their training)

Being converted to a cultist removes brainwashing and hypnosis
Being converted to a revolutionary removes brainwashing and hypnosis (alternative to this is to make brainwashed individuals immune to being converted to the revolution)

Admins still have the power to do whatever.
## Why It's Good For The Game
Adds a point of tension between traitor and conversion antags, which is something that dynamic excels with. Unmudies waters when players are dealing with both a syndicate brainwasher and a conversion antag. Split loyalties lead to alot of confusion, and generally aren't very fun for the converted or the converter.
This maintains the ability for traitors to still brainwash whoever they want as long as they aren't on the same conversion team, which they shouldn't be doing anyways.
## Changelog
:cl: itseasytosee
balance: Hypnoflash/brainwashing now deconverts conversion antags
balance: You can not Hypnoflash/brainwash your fellow conversion antags.
balance: Being converted by a conversion antag now undoes hypnosis or brainwashing.
/:cl:
