### PR TITLE
[GBP: NO UPDATE] Fixes a runtime from inserting the vorpal scythe

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -13,7 +13,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 /obj/item/organ/internal/cyberimp/arm/shard/scythe/Insert(mob/living/carbon/receiver, special, drop_if_replaced)
 	. = ..()
 	if(receiver.mind)
-		receiver.mind.add_traits(TRAIT_MORBID, ORGAN_TRAIT)
+		ADD_TRAIT(receiver.mind, TRAIT_MORBID, ORGAN_TRAIT)
 
 /obj/item/organ/internal/cyberimp/arm/shard/scythe/Retract()
 	var/obj/item/vorpalscythe/scythe = active_item


### PR DESCRIPTION

## About The Pull Request

Uses the correct proc to add the Morbid trait to chaplains who use the scythe.

## Why It's Good For The Game

Nyoops.

## Changelog
:cl:
fix: Fixes a runtime on inserting the vorpal scythe into your arm. You should now gain the Morbid trait, as expected.
/:cl:
