### PR TITLE
Fixes Linters by Bumping PyYAML To Latest

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,7 +3,7 @@ bidict==0.22.0
 Pillow==9.3.0
 
 # changelogs
-PyYaml==5.4
+PyYaml==6.0.1
 beautifulsoup4==4.9.3
 
 # ezdb


### PR DESCRIPTION

## About The Pull Request

This was broken because we weren't on the latest PyYAML, they released a minor version today which presumably fixes this bug https://pypi.org/project/PyYAML/6.0.1/#history . Can't find any release notes but it works on my repo:tm: - https://github.com/san7890/bruhstation/actions/runs/5582227521/jobs/10201285675?pr=29

