### PR TITLE
Fixes cryo cells being on at roundstart

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -240,7 +240,7 @@
 	if(on && is_operational)
 		. += mutable_appearance('icons/obj/medical/cryogenics.dmi', "cover-on", ABOVE_ALL_MOB_LAYER, src, plane = ABOVE_GAME_PLANE)
 	else
-		. += mutable_appearance('icons/obj/medical/cryogenics.dmi', "cover-on", ABOVE_ALL_MOB_LAYER, src, plane = ABOVE_GAME_PLANE)
+		. += mutable_appearance('icons/obj/medical/cryogenics.dmi', "cover-off", ABOVE_ALL_MOB_LAYER, src, plane = ABOVE_GAME_PLANE)
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/nap_violation(mob/violator)
 	open_machine()


### PR DESCRIPTION
## About The Pull Request

Fixes a minor oversight in cryo cell's update overlays which gave the exact same overlay regardless of being on/operational, now they have the proper 'off' overlay when necessary.

## Why It's Good For The Game

Fixes a minor visual bug with cryo cells.

## Changelog

:cl:
fix: Cryo cells no longer appear on when off.
/:cl: