### PR TITLE
[NO-GBP] Changing shuttle events now alerts admins

### DIFF
--- a/code/modules/admin/verbs/change_shuttle_events.dm
+++ b/code/modules/admin/verbs/change_shuttle_events.dm
@@ -31,12 +31,12 @@
 
 	if(result == "Clear")
 		port.event_list.Cut()
-		log_admin("[key_name_admin(usr)] has cleared the shuttle events on: [port]")
+		message_admins("[key_name_admin(usr)] has cleared the shuttle events on: [port]")
 	else if(options[result])
 		var/typepath = options[result]
 		if(typepath in active)
 			port.event_list.Remove(active[options[result]])
-			log_admin("[key_name_admin(usr)] has removed '[active[result]]' from [port].")
+			message_admins("[key_name_admin(usr)] has removed '[active[result]]' from [port].")
 		else
 			port.event_list.Add(new typepath (port))
-			log_admin("[key_name_admin(usr)] has added '[typepath]' to [port].")
+			message_admins("[key_name_admin(usr)] has added '[typepath]' to [port].")


### PR DESCRIPTION
If an admin forces 10 alien queen shuttle events, you'd probably want to alert the other admins. Previously this just put it in the admin log without telling anyone, but it's probably more fitting to just pop it in asay for how infrequent it is and considering forcing other events does it too

:cl:
admin: Changing shuttle events now alerts admins
/:cl:

Thanks to @Rex9001 for calling it out