### PR TITLE
Fixes a bug where borgs effectively break IDs when removing them from modular consoles

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -280,11 +280,10 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	if(crew_manifest_update)
 		GLOB.manifest.modify(computer_id_slot.registered_name, computer_id_slot.assignment, computer_id_slot.get_trim_assignment())
 
-	if(user)
-		if(!issilicon(user) && in_range(src, user))
-			user.put_in_hands(computer_id_slot)
-		balloon_alert(user, "removed ID")
-		to_chat(user, span_notice("You remove the card from the card slot."))
+    if(user && !issilicon(user) && in_range(src, user))
+        user.put_in_hands(computer_id_slot)
+        balloon_alert(user, "removed ID")
+        to_chat(user, span_notice("You remove the card from the card slot."))
 	else
 		computer_id_slot.forceMove(drop_location())
 

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -282,13 +282,13 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 
 	if(user && !issilicon(user) && in_range(src, user))
 		user.put_in_hands(computer_id_slot)
-		balloon_alert(user, "removed ID")
-		to_chat(user, span_notice("You remove the card from the card slot."))
 	else
 		computer_id_slot.forceMove(drop_location())
 
 	computer_id_slot = null
 	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 50, FALSE)
+	balloon_alert(user, "removed ID")
+	to_chat(user, span_notice("You remove the card from the card slot."))
 
 	if(ishuman(loc))
 		var/mob/living/carbon/human/human_wearer = loc

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -280,10 +280,10 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 	if(crew_manifest_update)
 		GLOB.manifest.modify(computer_id_slot.registered_name, computer_id_slot.assignment, computer_id_slot.get_trim_assignment())
 
-    if(user && !issilicon(user) && in_range(src, user))
-        user.put_in_hands(computer_id_slot)
-        balloon_alert(user, "removed ID")
-        to_chat(user, span_notice("You remove the card from the card slot."))
+	if(user && !issilicon(user) && in_range(src, user))
+		user.put_in_hands(computer_id_slot)
+		balloon_alert(user, "removed ID")
+		to_chat(user, span_notice("You remove the card from the card slot."))
 	else
 		computer_id_slot.forceMove(drop_location())
 


### PR DESCRIPTION

## About The Pull Request
Fixes a bug where borgs effectively break IDs when removing them from modular consoles. Previously when they did this it would cause the ID to be unretrievable.
## Why It's Good For The Game
Fixes a stinky bug!!
## Changelog
:cl:Sapphoqueer
fix: fixes a bug where borgs and TK users could effectively break ID's by removing them from modular computers.
/:cl:
