### PR TITLE
Adds a new severe trauma, Trauma Savant

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -287,8 +287,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_TOXINLOVER "toxinlover"
 /// Doesn't get overlays from being in critical.
 #define TRAIT_NOCRITOVERLAY "no_crit_overlay"
-/// Gets a mood boost from being in the hideout.
-#define TRAIT_VAL_CORRIN_MEMBER "val_corrin_member"
 /// reduces the use time of syringes, pills, patches and medigels but only when using on someone
 #define TRAIT_FASTMED "fast_med_use"
 /// The mob is holy and resistance to cult magic

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -330,3 +330,24 @@
 /datum/brain_trauma/severe/dyslexia/on_lose()
 	REMOVE_TRAIT(owner, TRAIT_ILLITERATE, TRAUMA_TRAIT)
 	..()
+
+// Can't speak or even gesticulate, but you are now a master at sleight of hand! Inspired by Rimworld and real-life savant syndrome.
+// Also, it's pretty mimey, so you become basically a super mime, in case that somehow applies in anything you do now.
+/datum/brain_trauma/severe/trauma_savant
+	name = "Trauma Savant"
+	desc = "Patient displays enhanced, mime-like dexterity, but is unable to speak or gesticulate intelligibly."
+	scan_desc = "damaged, monochrome speech center and swollen primary motor cortex"
+	gain_text = span_warning("You feel unable to express yourself at all! And yet, things you found complex once you seem to find extremely simple now.")
+	lose_text = span_warning("You remember how to express yourself, but start having familiar trouble with complex topics.")
+
+/datum/brain_trauma/severe/trauma_savant/on_gain()
+	ADD_TRAIT(owner, list(TRAIT_EMOTEMUTE, TRAIT_MUTE, TRAIT_MIMING), TRAUMA_TRAIT)
+	owner.add_actionspeed_modifier(/datum/actionspeed_modifier/trauma_savant)
+	owner.sound_environment_override = SOUND_ENVIRONMENT_HANGAR
+	..()
+
+/datum/brain_trauma/severe/trauma_savant/on_lose()
+	REMOVE_TRAIT(owner, list(TRAIT_EMOTEMUTE, TRAIT_MUTE, TRAIT_MIMING), TRAUMA_TRAIT)
+	owner.remove_actionspeed_modifier(/datum/actionspeed_modifier/trauma_savant)
+	owner.sound_environment_override = NONE
+	..()

--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -337,17 +337,27 @@
 	name = "Trauma Savant"
 	desc = "Patient displays enhanced, mime-like dexterity, but is unable to speak or gesticulate intelligibly."
 	scan_desc = "damaged, monochrome speech center and swollen primary motor cortex"
-	gain_text = span_warning("You feel unable to express yourself at all! And yet, things you found complex once you seem to find extremely simple now.")
-	lose_text = span_warning("You remember how to express yourself, but start having familiar trouble with complex topics.")
+	gain_text = span_warning("You feel unable to express yourself at all! And yet, you feel a newfound dexterity and ability to quickly put things together.")
+	lose_text = span_warning("You remember how to express yourself, but start having familiar trouble with complex problems and actions.")
 
 /datum/brain_trauma/severe/trauma_savant/on_gain()
 	ADD_TRAIT(owner, list(TRAIT_EMOTEMUTE, TRAIT_MUTE, TRAIT_MIMING), TRAUMA_TRAIT)
+
 	owner.add_actionspeed_modifier(/datum/actionspeed_modifier/trauma_savant)
 	owner.sound_environment_override = SOUND_ENVIRONMENT_HANGAR
+
+	owner.add_blocked_language(subtypesof(/datum/language) - /datum/language/aphasia, LANGUAGE_APHASIA)
+	// they can *hear* it, but they can't *speak* it
+	owner.grant_language(/datum/language/aphasia, source = LANGUAGE_APHASIA)
 	..()
 
 /datum/brain_trauma/severe/trauma_savant/on_lose()
 	REMOVE_TRAIT(owner, list(TRAIT_EMOTEMUTE, TRAIT_MUTE, TRAIT_MIMING), TRAUMA_TRAIT)
+
 	owner.remove_actionspeed_modifier(/datum/actionspeed_modifier/trauma_savant)
 	owner.sound_environment_override = NONE
+
+	if(!QDELING(owner))
+		owner.remove_blocked_language(subtypesof(/datum/language), LANGUAGE_APHASIA)
+		owner.remove_language(/datum/language/aphasia, source = LANGUAGE_APHASIA)
 	..()

--- a/code/modules/actionspeed/modifiers/status_effects.dm
+++ b/code/modules/actionspeed/modifiers/status_effects.dm
@@ -14,4 +14,4 @@
 	multiplicative_slowdown = 4
 
 /datum/actionspeed_modifier/trauma_savant
-	multiplicative_slowdown = 0.5
+	multiplicative_slowdown = -0.8

--- a/code/modules/actionspeed/modifiers/status_effects.dm
+++ b/code/modules/actionspeed/modifiers/status_effects.dm
@@ -12,3 +12,6 @@
 
 /datum/actionspeed_modifier/status_effect/hazard_area
 	multiplicative_slowdown = 4
+
+/datum/actionspeed_modifier/trauma_savant
+	multiplicative_slowdown = 0.5


### PR DESCRIPTION

## About The Pull Request

Adds a new severe trauma, Trauma Savant! Kronkaine tier sped up action speed, but the recipient is unable to talk or gesticulate. As a byproduct, they also seem to be pretty decent at imitating mimes in ways both natural and not.

Removes an unused trait

## Why It's Good For The Game

> Adds a new severe trauma, Trauma Savant! Kronkaine tier sped up action speed, but the recipient is unable to talk or gesticulate. As a byproduct, they also seem to be pretty decent at imitating mimes in ways both natural and not.

I think this would be a fun little thing to have appear in game. You'd be this super competent worker that can do things nigh instantly, BUT you can't really communicate with others in most ways. Muteness is already a severe trait, this is just taking it to a higher level. If there's worry about them being unable to express their illness to doctors... just PDA. Or write on paper. Or hand them a health analyzer and point at yourself.

It'd be nice if this could be a roundstart trait somehow but it would need some heavy tuning to not make it a troll trait, so that's not on the table here.

Untested, its 3 am gimme a break

## Changelog

:cl:
add: Adds a new severe trauma, Trauma Savant! Kronkaine tier sped up action speed, but the recipient is unable to talk or gesticulate. As a byproduct, they also seem to be pretty decent at imitating mimes in ways both natural and not.
code: Removes an unused trait
/:cl:

