### PR TITLE
Ice Cream Vat QoL: Elevated surface, placing in hands, not using usr

### DIFF
--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -32,6 +32,7 @@ GLOBAL_LIST_INIT(typecache_elevated_structures, typecacheof(list(
 	/obj/machinery/oven,
 	/obj/machinery/stove,
 	/obj/machinery/gibber,
+	/obj/machinery/icecream_vat,
 	//Botany
 	/obj/machinery/hydroponics, // So that harvest doesn't catch germs or decompose (includes dirt piles)
 	//Medbay

--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -41,6 +41,13 @@ GLOBAL_LIST_INIT(typecache_elevated_structures, typecacheof(list(
 	/obj/machinery/plumbing/pill_press,
 )))
 
+/// A typecache listing elevated structures that can cook things, and thus should probably not be prioritized for putting things on.
+GLOBAL_LIST_INIT(typecache_hot_elevated_structures, typecacheof(list(
+	/obj/structure/bonfire,
+	/obj/machinery/grill,
+	/obj/machinery/griddle,
+)))
+
 /// A typecache of objects that player controlled, easily accessible, hostile mobs should not be able to attack
 GLOBAL_LIST_INIT(typecache_general_bad_hostile_attack_targets, typecacheof(list(
 	/obj/machinery/airalarm,

--- a/code/_globalvars/lists/typecache.dm
+++ b/code/_globalvars/lists/typecache.dm
@@ -41,13 +41,6 @@ GLOBAL_LIST_INIT(typecache_elevated_structures, typecacheof(list(
 	/obj/machinery/plumbing/pill_press,
 )))
 
-/// A typecache listing elevated structures that can cook things, and thus should probably not be prioritized for putting things on.
-GLOBAL_LIST_INIT(typecache_hot_elevated_structures, typecacheof(list(
-	/obj/structure/bonfire,
-	/obj/machinery/grill,
-	/obj/machinery/griddle,
-)))
-
 /// A typecache of objects that player controlled, easily accessible, hostile mobs should not be able to attack
 GLOBAL_LIST_INIT(typecache_general_bad_hostile_attack_targets, typecacheof(list(
 	/obj/machinery/airalarm,

--- a/code/modules/food_and_drinks/machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/machinery/icecream_vat.dm
@@ -126,11 +126,12 @@
 /obj/machinery/icecream_vat/Topic(href, href_list)
 	if(..())
 		return
+	var/mob/user = usr
 	if(href_list["select"])
 		var/datum/ice_cream_flavour/flavour = GLOB.ice_cream_flavours[href_list["select"]]
 		if(!flavour || flavour.hidden) //Nice try, tex.
 			return
-		visible_message(span_notice("[usr] sets [src] to dispense [href_list["select"]] flavoured ice cream."))
+		visible_message(span_notice("[user] sets [src] to dispense [href_list["select"]] flavoured ice cream."))
 		selected_flavour = flavour.name
 
 	if(href_list["cone"])
@@ -139,17 +140,18 @@
 			return
 		if(product_types[cone_path] >= 1)
 			product_types[cone_path]--
-			var/obj/item/food/icecream/cone = new cone_path(loc)
-			visible_message(span_info("[usr] dispenses a crunchy [cone.name] from [src]."))
+			var/obj/item/food/icecream/cone = new cone_path
+			try_put_in_hand(cone, user)
+			visible_message(span_info("[user] dispenses a crunchy [cone.name] from [src]."))
 		else
-			to_chat(usr, span_warning("There are no [initial(cone_path.name)]s left!"))
+			to_chat(user, span_warning("There are no [initial(cone_path.name)]s left!"))
 
 	if(href_list["make"])
 		var/datum/ice_cream_flavour/flavour = GLOB.ice_cream_flavours[href_list["make"]]
 		if(!flavour || flavour.hidden) //Nice try, tex.
 			return
 		var/amount = (text2num(href_list["amount"]))
-		make(usr, href_list["make"], amount, flavour.ingredients)
+		make(user, href_list["make"], amount, flavour.ingredients)
 
 	if(href_list["make_cone"])
 		var/path = text2path(href_list["make_cone"])
@@ -157,7 +159,7 @@
 		if(!cone) //Nice try, tex.
 			return
 		var/amount = (text2num(href_list["amount"]))
-		make(usr, path, amount, cone.ingredients)
+		make(user, path, amount, cone.ingredients)
 
 	if(href_list["disposeI"])
 		reagents.del_reagent(text2path(href_list["disposeI"]))
@@ -171,8 +173,8 @@
 		updateDialog()
 
 	if(href_list["close"])
-		usr.unset_machine()
-		usr << browse(null,"window=icecreamvat")
+		user.unset_machine()
+		user << browse(null,"window=icecreamvat")
 	return
 
 /obj/machinery/icecream_vat/deconstruct(disassembled = TRUE)

--- a/code/modules/food_and_drinks/machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/machinery/icecream_vat.dm
@@ -140,8 +140,9 @@
 			return
 		if(product_types[cone_path] >= 1)
 			product_types[cone_path]--
-			var/obj/item/food/icecream/cone = new cone_path
-			try_put_in_hand(cone, user)
+			var/obj/item/food/icecream/cone = new cone_path(get_turf(src))
+			if(!user.put_in_hands(cone))
+				cone.forceMove(drop_location())
 			visible_message(span_info("[user] dispenses a crunchy [cone.name] from [src]."))
 		else
 			to_chat(user, span_warning("There are no [initial(cone_path.name)]s left!"))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -273,11 +273,12 @@
 				ccw_index = dir_count
 			turfs_ordered += get_step(src, dirs[ccw_index])	// Add next tile on your left
 
-		// Check tables on these turfs
-		for(var/turf in turfs_ordered)
-			if(locate(/obj/structure/table) in turf)
-				location = turf
-				break
+		// Check for elevated structures (incl. tables) on these turfs
+		for(var/turf/our_turf in turfs_ordered)
+			for(var/atom/movable/content as anything in our_turf.contents)
+				if(GLOB.typecache_elevated_structures[content.type])
+					location = our_turf
+					break
 
 	I.forceMove(location)
 	I.layer = initial(I.layer)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -261,6 +261,7 @@
 		var/cw_index = facing_dir_index
 		var/ccw_index = facing_dir_index
 		var/list/turfs_ordered = list(get_step(src, dir))
+		var/elevated_found = FALSE
 
 		// Build ordered list of turfs starting from the front facing
 		for(var/i in 1 to ROUND_UP(dir_count/2) - 1)
@@ -273,12 +274,22 @@
 				ccw_index = dir_count
 			turfs_ordered += get_step(src, dirs[ccw_index])	// Add next tile on your left
 
-		// Check for elevated structures (incl. tables) on these turfs
+		// Check for not-hot elevated structures (incl. tables) on these turfs
 		for(var/turf/our_turf in turfs_ordered)
 			for(var/atom/movable/content as anything in our_turf.contents)
-				if(GLOB.typecache_elevated_structures[content.type])
+				if(GLOB.typecache_elevated_structures[content.type]) // if it's an elevated structure,
+					if(GLOB.typecache_hot_elevated_structures[content.type]) // but it's a hot one,
+						break // don't put it there
+					elevated_found = TRUE
 					location = our_turf
 					break
+		if(!elevated_found) // if we didn't find a suitable not-hot elevated structure, do everything again
+			for(var/turf/our_turf in turfs_ordered)
+				for(var/atom/movable/content as anything in our_turf.contents) // but without the not-hot check
+					if(GLOB.typecache_elevated_structures[content.type])
+						elevated_found = TRUE
+						location = our_turf
+						break
 
 	I.forceMove(location)
 	I.layer = initial(I.layer)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -261,7 +261,6 @@
 		var/cw_index = facing_dir_index
 		var/ccw_index = facing_dir_index
 		var/list/turfs_ordered = list(get_step(src, dir))
-		var/elevated_found = FALSE
 
 		// Build ordered list of turfs starting from the front facing
 		for(var/i in 1 to ROUND_UP(dir_count/2) - 1)
@@ -274,22 +273,11 @@
 				ccw_index = dir_count
 			turfs_ordered += get_step(src, dirs[ccw_index])	// Add next tile on your left
 
-		// Check for not-hot elevated structures (incl. tables) on these turfs
-		for(var/turf/our_turf in turfs_ordered)
-			for(var/atom/movable/content as anything in our_turf.contents)
-				if(GLOB.typecache_elevated_structures[content.type]) // if it's an elevated structure,
-					if(GLOB.typecache_hot_elevated_structures[content.type]) // but it's a hot one,
-						break // don't put it there
-					elevated_found = TRUE
-					location = our_turf
-					break
-		if(!elevated_found) // if we didn't find a suitable not-hot elevated structure, do everything again
-			for(var/turf/our_turf in turfs_ordered)
-				for(var/atom/movable/content as anything in our_turf.contents) // but without the not-hot check
-					if(GLOB.typecache_elevated_structures[content.type])
-						elevated_found = TRUE
-						location = our_turf
-						break
+		// Check tables on these turfs
+		for(var/turf in turfs_ordered)
+			if(locate(/obj/structure/table) in turf || locate(/obj/structure/rack) in turf || locate(/obj/machinery/icecream_vat) in turf)
+				location = turf
+				break
 
 	I.forceMove(location)
 	I.layer = initial(I.layer)


### PR DESCRIPTION
## About The Pull Request
- Ice cream vats now count as elevated surfaces for preventing germs from getting on your ice cream cones.
- Ice cream vats now try to dispense cones into your hands first, and defaulting to regular placement afterwards.
- Put-in-hands behavior for germ-sensitive items has been changed; instead of looking solely for tables, it checks for any suitably elevated surface to put things on, which now includes icecream vats.
- Ice cream vats' HTML no longer uses usr. Not player-facing, simple find-replace. Probably doesn't qualify as code improvement.

Anyways, shoutout to ice cream vats' HTML still using usr. Not sure if what I did to the put-in-hand code is too expensive or not, but it should be fine.

## Why It's Good For The Game
It's probably a good thing for ice cream to not fall onto the floor and become dirty upon being dispensed.
## Changelog

:cl:
qol: Ice cream vats now count as elevated surfaces for preventing germs from getting onto germ-sensitive items (food).
qol: Ice cream vats now dispense cones into your hands first, if possible.
fix: Germ-sensitive items that fail to be placed in-hand now check for all elevated surfaces, not just tables.
/:cl:
