### PR TITLE
Fixes silicon alarm reports displaying power alarms as `ALARM_ALARM_POWER`

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -25,8 +25,8 @@
 
 	var/obj/item/radio/borg/radio = null  ///If this is a path, this gets created as an object in Initialize.
 
-	var/list/alarm_types_show = list(ALARM_ATMOS = 0, ALARM_ALARM_POWER = 0, ALARM_CAMERA = 0, ALARM_MOTION = 0)
-	var/list/alarm_types_clear = list(ALARM_ATMOS = 0, ALARM_ALARM_POWER = 0, ALARM_CAMERA = 0, ALARM_MOTION = 0)
+	var/list/alarm_types_show = list(ALARM_ATMOS = 0, ALARM_POWER = 0, ALARM_CAMERA = 0, ALARM_MOTION = 0)
+	var/list/alarm_types_clear = list(ALARM_ATMOS = 0, ALARM_POWER = 0, ALARM_CAMERA = 0, ALARM_MOTION = 0)
 
 	//These lists will contain each law that should be announced / set to yes in the state laws menu.
 	///List keeping track of which laws to announce


### PR DESCRIPTION
## About The Pull Request
Removes an excessive `ALARM_` from silicon's alarm list entry
fucked by and never reported after apparently: #71986

## Why It's Good For The Game
there is no `ALARM_ALARM_POWER` define what are you doing
lmao

## Changelog
:cl:
fix: fixed silicon alarm reports displaying power alarms as ALARM_ALARM_POWER
/:cl:
