### PR TITLE
Removes the word "chemical" from "chemical patch"

### DIFF
--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -1,5 +1,5 @@
 /obj/item/reagent_containers/pill/patch
-	name = "chemical patch"
+	name = "patch"
 	desc = "A chemical patch for touch based applications."
 	icon = 'icons/obj/medical/chemical.dmi'
 	icon_state = "bandaid_blank"


### PR DESCRIPTION

## About The Pull Request
In #76011, I bitched and moaned about how the ChemMaster gives patches a huge ass name. I've talked to other Medical Doctor mains and I also heard bitching about the word "chemical", which is just a pain in the ass. It seems many of us just end up removing it because it's so repetitive and makes the patch's name long fnr. I don't think the word "chemical" is really needed in there since you can clearly tell it's a chemical patch just by looking at the word "patch" and the sprite.

I don't think this should affect anything else in the game in a negative way. In that same issue, it was suggested that the cap for names was increased instead, but this also solves the issue of the word "chemical" taking up so much space in the patch's name without touching unknown lands.
## Why It's Good For The Game
Less words, more healing!
## Changelog
:cl:
qol: The word "chemical" has been removed from "chemical patch" when printing patches
/:cl:
