### PR TITLE
Splits ballistic firearms "mag_type" into "accepted_magazine_type" and "spawn_magazine_type", fixing a few funny magazine bugs

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -1109,7 +1109,7 @@ DEFINE_BITFIELD(turret_flags, list(
 
 /obj/item/gun/ballistic/get_turret_properties()
 	. = ..()
-	var/obj/item/ammo_box/mag = mag_type
+	var/obj/item/ammo_box/mag = spawn_magazine_type
 	var/obj/item/ammo_casing/primary_ammo = initial(mag.ammo_type)
 
 	.["base_icon_state"] = "syndie"

--- a/code/game/objects/structures/mystery_box.dm
+++ b/code/game/objects/structures/mystery_box.dm
@@ -187,7 +187,7 @@ GLOBAL_LIST_INIT(mystery_box_extended, list(
 		if(grant_extra_mag && istype(instantiated_gun, /obj/item/gun/ballistic))
 			var/obj/item/gun/ballistic/instantiated_ballistic = instantiated_gun
 			if(!instantiated_ballistic.internal_magazine)
-				var/obj/item/ammo_box/magazine/extra_mag = new instantiated_ballistic.mag_type(loc)
+				var/obj/item/ammo_box/magazine/extra_mag = new instantiated_ballistic.spawn_magazine_type(loc)
 				user.put_in_hands(extra_mag)
 
 	user.visible_message(span_notice("[user] takes [presented_item] from [src]."), span_notice("You take [presented_item] from [src]."), vision_distance = COMBAT_MESSAGE_RANGE)

--- a/code/modules/antagonists/heretic/items/hunter_rifle.dm
+++ b/code/modules/antagonists/heretic/items/hunter_rifle.dm
@@ -11,7 +11,7 @@
 	icon_state = "moistprime"
 	inhand_icon_state = "moistprime"
 	worn_icon_state = "moistprime"
-	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/lionhunter
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/lionhunter
 	fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
 
 /obj/item/gun/ballistic/rifle/lionhunter/Initialize(mapload)

--- a/code/modules/capture_the_flag/ctf_equipment.dm
+++ b/code/modules/capture_the_flag/ctf_equipment.dm
@@ -37,7 +37,7 @@
 // LASER RIFLE
 
 /obj/item/gun/ballistic/automatic/laser/ctf
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle
 	desc = "This looks like it could really hurt in melee."
 	force = 50
 	weapon_weight = WEAPON_HEAVY
@@ -70,7 +70,7 @@
 	inhand_icon_state = "shotgun_combat"
 	worn_icon_state = "gun"
 	slot_flags = null
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun
 	empty_indicator = TRUE
 	fire_sound = 'sound/weapons/gun/shotgun/shot_alt.ogg'
 	semi_auto = TRUE
@@ -103,7 +103,7 @@
 	name = "designated marksman rifle"
 	icon_state = "ctfmarksman"
 	inhand_icon_state = "ctfmarksman"
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman
 	fire_delay = 1 SECONDS
 
 /obj/item/ammo_box/magazine/recharge/ctf/marksman
@@ -125,7 +125,7 @@
 /obj/item/gun/ballistic/automatic/pistol/deagle/ctf
 	desc = "This looks like it could really hurt in melee."
 	force = 75
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/deagle
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/deagle
 
 /obj/item/gun/ballistic/automatic/pistol/deagle/ctf/Initialize(mapload)
 	. = ..()
@@ -236,7 +236,7 @@
 
 // Rifle
 /obj/item/gun/ballistic/automatic/laser/ctf/red
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle/red
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle/red
 
 /obj/item/ammo_box/magazine/recharge/ctf/rifle/red
 	ammo_type = /obj/item/ammo_casing/laser/ctf/rifle/red
@@ -252,7 +252,7 @@
 
 // Shotgun
 /obj/item/gun/ballistic/shotgun/ctf/red
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun/red
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun/red
 
 /obj/item/ammo_box/magazine/recharge/ctf/shotgun/red
 	ammo_type = /obj/item/ammo_casing/laser/ctf/shotgun/red
@@ -268,7 +268,7 @@
 
 // DMR
 /obj/item/gun/ballistic/automatic/laser/ctf/marksman/red
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman/red
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman/red
 
 /obj/item/ammo_box/magazine/recharge/ctf/marksman/red
 	ammo_type = /obj/item/ammo_casing/laser/ctf/marksman/red
@@ -302,7 +302,7 @@
 
 // Rifle
 /obj/item/gun/ballistic/automatic/laser/ctf/blue
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle/blue
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle/blue
 
 /obj/item/ammo_box/magazine/recharge/ctf/rifle/blue
 	ammo_type = /obj/item/ammo_casing/laser/ctf/rifle/blue
@@ -316,7 +316,7 @@
 
 // Shotgun
 /obj/item/gun/ballistic/shotgun/ctf/blue
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun/blue
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun/blue
 
 /obj/item/ammo_box/magazine/recharge/ctf/shotgun/blue
 	ammo_type = /obj/item/ammo_casing/laser/ctf/shotgun/blue
@@ -331,7 +331,7 @@
 
 // DMR
 /obj/item/gun/ballistic/automatic/laser/ctf/marksman/blue
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman/blue
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman/blue
 
 /obj/item/ammo_box/magazine/recharge/ctf/marksman/blue
 	ammo_type = /obj/item/ammo_casing/laser/ctf/marksman/blue
@@ -361,7 +361,7 @@
 
 // Rifle
 /obj/item/gun/ballistic/automatic/laser/ctf/green
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle/green
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle/green
 
 /obj/item/ammo_box/magazine/recharge/ctf/rifle/green
 	ammo_type = /obj/item/ammo_casing/laser/ctf/rifle/green
@@ -377,7 +377,7 @@
 
 // Shotgun
 /obj/item/gun/ballistic/shotgun/ctf/green
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun/green
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun/green
 
 /obj/item/ammo_box/magazine/recharge/ctf/shotgun/green
 	ammo_type = /obj/item/ammo_casing/laser/ctf/shotgun/green
@@ -393,7 +393,7 @@
 
 // DMR
 /obj/item/gun/ballistic/automatic/laser/ctf/marksman/green
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman/green
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman/green
 
 /obj/item/ammo_box/magazine/recharge/ctf/marksman/green
 	ammo_type = /obj/item/ammo_casing/laser/ctf/marksman/green
@@ -427,7 +427,7 @@
 
 // Rifle
 /obj/item/gun/ballistic/automatic/laser/ctf/yellow
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle/yellow
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/rifle/yellow
 
 /obj/item/ammo_box/magazine/recharge/ctf/rifle/yellow
 	ammo_type = /obj/item/ammo_casing/laser/ctf/rifle/yellow
@@ -443,7 +443,7 @@
 
 // Shotgun
 /obj/item/gun/ballistic/shotgun/ctf/yellow
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun/yellow
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/shotgun/yellow
 
 /obj/item/ammo_box/magazine/recharge/ctf/shotgun/yellow
 	ammo_type = /obj/item/ammo_casing/laser/ctf/shotgun/yellow
@@ -459,7 +459,7 @@
 
 // DMR
 /obj/item/gun/ballistic/automatic/laser/ctf/marksman/yellow
-	mag_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman/yellow
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge/ctf/marksman/yellow
 
 /obj/item/ammo_box/magazine/recharge/ctf/marksman/yellow
 	ammo_type = /obj/item/ammo_casing/laser/ctf/marksman/yellow

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -955,7 +955,7 @@
 
 	if(istype(gun_to_set, /obj/item/gun/ballistic))
 		var/obj/item/gun/ballistic/ball_gun = gun_to_set
-		var/obj/item/ammo_box/ball_ammo = new ball_gun.mag_type(gun_to_set)
+		var/obj/item/ammo_box/ball_ammo = new ball_gun.spawn_magazine_type(gun_to_set)
 		qdel(ball_gun)
 
 		if(!istype(ball_ammo) || !ball_ammo.ammo_type)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_INIT(animatable_blacklist, list(/obj/structure/table, /obj/structure
 			projectiletype = initial(M.projectile_type)
 		if(istype(G, /obj/item/gun/ballistic))
 			Pewgun = G
-			var/obj/item/ammo_box/magazine/M = Pewgun.mag_type
+			var/obj/item/ammo_box/magazine/M = Pewgun.spawn_magazine_type
 			casingtype = initial(M.ammo_type)
 		if(istype(G, /obj/item/gun/energy))
 			Zapgun = G

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -47,10 +47,12 @@
 	///Whether our gun clicks when it approaches an empty magazine/chamber
 	var/click_on_low_ammo = TRUE
 
-	///Whether the gun will spawn loaded with a magazine
+	/// What type (includes subtypes) of magazine will this gun accept being put into it
+	var/obj/item/ammo_box/magazine/accepted_magazine_type = /obj/item/ammo_box/magazine/m10mm
+	/// Whether the gun will spawn loaded with a magazine
 	var/spawnwithmagazine = TRUE
-	///Compatible magazines with the gun
-	var/obj/item/ammo_box/magazine/mag_type = /obj/item/ammo_box/magazine/m10mm //Removes the need for max_ammo and caliber info
+	/// Change this if the gun should spawn with a different magazine type to what accepted_magazine_type defines. Will create errors if not a type or subtype of accepted magazine.
+	var/obj/item/ammo_box/magazine/spawn_magazine_type
 	///Whether the sprite has a visible magazine or not
 	var/mag_display = TRUE
 	///Whether the sprite has a visible ammo display or not
@@ -130,12 +132,16 @@
 
 /obj/item/gun/ballistic/Initialize(mapload)
 	. = ..()
+	if(!spawn_magazine_type)
+		spawn_magazine_type = accepted_magazine_type
 	if (!spawnwithmagazine)
 		bolt_locked = TRUE
 		update_appearance()
 		return
 	if (!magazine)
-		magazine = new mag_type(src)
+		magazine = new spawn_magazine_type(src)
+		if(!istype(magazine, accepted_magazine_type))
+			CRASH("[src] spawned with a magazine type that isn't allowed by its accepted_magazine_type!")
 	if(bolt_type == BOLT_TYPE_STANDARD || internal_magazine) //Internal magazines shouldn't get magazine + 1.
 		chamber_round()
 	else
@@ -151,7 +157,7 @@
 	AddElement(/datum/element/weapon_description, attached_proc = PROC_REF(add_notes_ballistic))
 
 /obj/item/gun/ballistic/fire_sounds()
-	var/max_ammo = magazine?.max_ammo || initial(mag_type.max_ammo)
+	var/max_ammo = magazine?.max_ammo || initial(spawn_magazine_type.max_ammo)
 	var/current_ammo = get_ammo()
 	var/frequency_to_use = sin((90 / max_ammo) * current_ammo)
 	var/click_frequency_to_use = 1 - frequency_to_use * 0.75
@@ -303,7 +309,7 @@
 
 ///Handles all the logic needed for magazine insertion
 /obj/item/gun/ballistic/proc/insert_magazine(mob/user, obj/item/ammo_box/magazine/AM, display_message = TRUE)
-	if(!istype(AM, mag_type))
+	if(!istype(AM, accepted_magazine_type))
 		balloon_alert(user, "[AM.name] doesn't fit!")
 		return FALSE
 	if(user.transferItemToLoc(AM, src))
@@ -698,9 +704,9 @@ GLOBAL_LIST_INIT(gun_saw_types, typecacheof(list(
 	if(magazine)
 		magazine.top_off()
 	else
-		if(!mag_type)
+		if(!spawn_magazine_type)
 			return
-		magazine = new mag_type(src)
+		magazine = new spawn_magazine_type(src)
 	chamber_round()
 	update_appearance()
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -53,7 +53,7 @@
 	actions_types = list()
 	mag_display = TRUE
 	empty_indicator = TRUE
-	mag_type = /obj/item/ammo_box/magazine/smgm9mm
+	accepted_magazine_type = /obj/item/ammo_box/magazine/smgm9mm
 	pin = null
 	bolt_type = BOLT_TYPE_LOCKING
 	show_bolt_icon = FALSE
@@ -71,7 +71,7 @@
 	icon_state = "c20r"
 	inhand_icon_state = "c20r"
 	selector_switch_icon = TRUE
-	mag_type = /obj/item/ammo_box/magazine/smgm45
+	accepted_magazine_type = /obj/item/ammo_box/magazine/smgm45
 	fire_delay = 2
 	burst_size = 3
 	pin = /obj/item/firing_pin/implant/pindicate
@@ -104,7 +104,7 @@
 	icon_state = "wt550"
 	w_class = WEIGHT_CLASS_BULKY
 	inhand_icon_state = "arg"
-	mag_type = /obj/item/ammo_box/magazine/wt550m9
+	accepted_magazine_type = /obj/item/ammo_box/magazine/wt550m9
 	fire_delay = 2
 	can_suppress = FALSE
 	burst_size = 1
@@ -125,7 +125,7 @@
 	desc = "An ancient 9mm submachine gun pattern updated and simplified to lower costs, though perhaps simplified too much."
 	icon_state = "plastikov"
 	inhand_icon_state = "plastikov"
-	mag_type = /obj/item/ammo_box/magazine/plastikov9mm
+	accepted_magazine_type = /obj/item/ammo_box/magazine/plastikov9mm
 	burst_size = 5
 	spread = 25
 	can_suppress = FALSE
@@ -139,7 +139,7 @@
 	name = "\improper Type U3 Uzi"
 	desc = "A lightweight, burst-fire submachine gun, for when you really want someone dead. Uses 9mm rounds."
 	icon_state = "miniuzi"
-	mag_type = /obj/item/ammo_box/magazine/uzim9mm
+	accepted_magazine_type = /obj/item/ammo_box/magazine/uzim9mm
 	burst_size = 2
 	bolt_type = BOLT_TYPE_OPEN
 	show_bolt_icon = FALSE
@@ -154,7 +154,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	inhand_icon_state = "m90"
 	selector_switch_icon = TRUE
-	mag_type = /obj/item/ammo_box/magazine/m556
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m556
 	can_suppress = FALSE
 	var/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel
 	burst_size = 3
@@ -210,7 +210,7 @@
 	selector_switch_icon = TRUE
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = 0
-	mag_type = /obj/item/ammo_box/magazine/tommygunm45
+	accepted_magazine_type = /obj/item/ammo_box/magazine/tommygunm45
 	can_suppress = FALSE
 	burst_size = 1
 	actions_types = list()
@@ -229,7 +229,7 @@
 	icon_state = "arg"
 	inhand_icon_state = "arg"
 	slot_flags = 0
-	mag_type = /obj/item/ammo_box/magazine/m556
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m556
 	can_suppress = FALSE
 	burst_size = 3
 	fire_delay = 1
@@ -244,7 +244,7 @@
 	base_icon_state = "l6"
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = 0
-	mag_type = /obj/item/ammo_box/magazine/mm712x82
+	accepted_magazine_type = /obj/item/ammo_box/magazine/mm712x82
 	weapon_weight = WEAPON_HEAVY
 	burst_size = 1
 	actions_types = list()
@@ -314,7 +314,7 @@
 	..()
 
 /obj/item/gun/ballistic/automatic/l6_saw/attackby(obj/item/A, mob/user, params)
-	if(!cover_open && istype(A, mag_type))
+	if(!cover_open && istype(A, accepted_magazine_type))
 		balloon_alert(user, "open the cover!")
 		return
 	..()
@@ -332,7 +332,7 @@
 	inhand_y_dimension = 64
 	worn_icon_state = null
 	weapon_weight = WEAPON_HEAVY
-	mag_type = /obj/item/ammo_box/magazine/m10mm/rifle
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m10mm/rifle
 	fire_delay = 30
 	burst_size = 1
 	can_unsuppress = TRUE
@@ -350,7 +350,7 @@
 	icon_state = "oldrifle"
 	w_class = WEIGHT_CLASS_BULKY
 	inhand_icon_state = "arg"
-	mag_type = /obj/item/ammo_box/magazine/recharge
+	accepted_magazine_type = /obj/item/ammo_box/magazine/recharge
 	empty_indicator = TRUE
 	fire_delay = 2
 	can_suppress = FALSE

--- a/code/modules/projectiles/guns/ballistic/bows/_bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/_bow.dm
@@ -10,7 +10,7 @@
 	base_icon_state = "bow"
 	load_sound = 'sound/weapons/gun/general/ballistic_click.ogg'
 	fire_sound = 'sound/weapons/gun/bow/bow_fire.ogg'
-	mag_type = /obj/item/ammo_box/magazine/internal/bow
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/bow
 	force = 15
 	pinless = TRUE
 	attack_verb_continuous = list("whipped", "cracked")

--- a/code/modules/projectiles/guns/ballistic/bows/bow_types.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_types.dm
@@ -14,7 +14,7 @@
 	worn_icon_state = "holybow"
 	slot_flags = ITEM_SLOT_BACK
 	obj_flags = UNIQUE_RENAME
-	mag_type = /obj/item/ammo_box/magazine/internal/bow/holy
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/bow/holy
 
 /obj/item/ammo_box/magazine/internal/bow/holy
 	name = "divine bowstring"

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -6,7 +6,7 @@
 	name = "grenade launcher"
 	icon_state = "dshotgun_sawn"
 	inhand_icon_state = "gun"
-	mag_type = /obj/item/ammo_box/magazine/internal/grenadelauncher
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/grenadelauncher
 	fire_sound = 'sound/weapons/gun/general/grenade_launch.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 	pin = /obj/item/firing_pin/implant/pindicate
@@ -25,7 +25,7 @@
 	name = "multi grenade launcher"
 	icon = 'icons/mob/mecha_equipment.dmi'
 	icon_state = "mecha_grenadelnchr"
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/grenademulti
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/grenademulti
 	pin = /obj/item/firing_pin
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/cyborg/attack_self()
@@ -36,7 +36,7 @@
 	desc = "A prototype pistol designed to fire self propelled rockets."
 	icon_state = "gyropistol"
 	fire_sound = 'sound/weapons/gun/general/grenade_launch.ogg'
-	mag_type = /obj/item/ammo_box/magazine/m75
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m75
 	burst_size = 1
 	fire_delay = 0
 	actions_types = list()
@@ -48,7 +48,7 @@
 	A sticker near the cheek rest reads, \"ENSURE AREA BEHIND IS CLEAR BEFORE FIRING\""
 	icon_state = "rocketlauncher"
 	inhand_icon_state = "rocketlauncher"
-	mag_type = /obj/item/ammo_box/magazine/internal/rocketlauncher
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/rocketlauncher
 	fire_sound = 'sound/weapons/gun/general/rocket_launch.ogg'
 	w_class = WEIGHT_CLASS_BULKY
 	can_suppress = FALSE

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -3,7 +3,7 @@
 	desc = "A small, easily concealable 9mm handgun. Has a threaded barrel for suppressors."
 	icon_state = "pistol"
 	w_class = WEIGHT_CLASS_SMALL
-	mag_type = /obj/item/ammo_box/magazine/m9mm
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m9mm
 	can_suppress = TRUE
 	burst_size = 1
 	fire_delay = 0
@@ -28,7 +28,7 @@
 	spawnwithmagazine = FALSE
 
 /obj/item/gun/ballistic/automatic/pistol/fire_mag
-	mag_type = /obj/item/ammo_box/magazine/m9mm/fire
+	spawn_magazine_type = /obj/item/ammo_box/magazine/m9mm/fire
 
 /obj/item/gun/ballistic/automatic/pistol/suppressed/Initialize(mapload)
 	. = ..()
@@ -39,7 +39,7 @@
 	name = "\improper Ansem pistol"
 	desc = "The spiritual successor of the Makarov, or maybe someone just dropped their gun in a bucket of paint. The gun is chambered in 10mm."
 	icon_state = "pistol_evil"
-	mag_type = /obj/item/ammo_box/magazine/m10mm
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m10mm
 	empty_indicator = TRUE
 	suppressor_x_offset = 12
 
@@ -48,7 +48,7 @@
 	desc = "A classic .45 handgun with a small magazine capacity."
 	icon_state = "m1911"
 	w_class = WEIGHT_CLASS_NORMAL
-	mag_type = /obj/item/ammo_box/magazine/m45
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m45
 	can_suppress = FALSE
 	fire_sound = 'sound/weapons/gun/pistol/shot_alt.ogg'
 	rack_sound = 'sound/weapons/gun/pistol/rack.ogg'
@@ -63,7 +63,7 @@
 	desc = "A robust .50 AE handgun."
 	icon_state = "deagle"
 	force = 14
-	mag_type = /obj/item/ammo_box/magazine/m50
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m50
 	can_suppress = FALSE
 	mag_display = TRUE
 	fire_sound = 'sound/weapons/gun/rifle/shot.ogg'
@@ -91,7 +91,7 @@
 	burst_size = 2
 	fire_delay = 1
 	projectile_damage_multiplier = 1.25
-	mag_type = /obj/item/ammo_box/magazine/r10mm
+	accepted_magazine_type = /obj/item/ammo_box/magazine/r10mm
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	obj_flags = UNIQUE_RENAME // if you did the sidequest, you get the customization
 
@@ -103,7 +103,7 @@
 	desc = "An old Soviet machine pistol. It fires quickly, but kicks like a mule. Uses 9mm ammo. Has a threaded barrel for suppressors."
 	icon_state = "aps"
 	w_class = WEIGHT_CLASS_NORMAL
-	mag_type = /obj/item/ammo_box/magazine/m9mm_aps
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m9mm_aps
 	can_suppress = TRUE
 	burst_size = 3
 	fire_delay = 1

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -2,7 +2,7 @@
 	name = "\improper .357 revolver"
 	desc = "A suspicious revolver. Uses .357 ammo."
 	icon_state = "revolver"
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder
 	fire_sound = 'sound/weapons/gun/revolver/shot_alt.ogg'
 	load_sound = 'sound/weapons/gun/revolver/load_bullet.ogg'
 	eject_sound = 'sound/weapons/gun/revolver/empty.ogg'
@@ -100,7 +100,7 @@
 /obj/item/gun/ballistic/revolver/c38
 	name = "\improper .38 revolver"
 	desc = "A classic, if not outdated, lethal firearm. Uses .38 Special rounds."
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
 	icon_state = "c38"
 	fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
 
@@ -154,7 +154,7 @@
 	icon_state = "nagant"
 	can_suppress = TRUE
 
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev762
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/rev762
 
 
 // A gun to play Russian Roulette!
@@ -164,7 +164,7 @@
 	name = "\improper Russian revolver"
 	desc = "A Russian-made revolver for drinking games. Uses .357 ammo, and has a mechanism requiring you to spin the chamber before each trigger pull."
 	icon_state = "russianrevolver"
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rus357
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/rus357
 	var/spun = FALSE
 	hidden_chambered = TRUE //Cheater.
 	gun_flags = NOT_A_REAL_GUN

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -10,7 +10,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	inhand_icon_state = "moistnugget"
 	worn_icon_state = "moistnugget"
-	mag_type = /obj/item/ammo_box/magazine/internal/boltaction
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction
 	bolt_wording = "bolt"
 	bolt_type = BOLT_TYPE_LOCKING
 	semi_auto = FALSE
@@ -58,7 +58,7 @@
 	icon_state = "moistnugget"
 	inhand_icon_state = "moistnugget"
 	slot_flags = ITEM_SLOT_BACK
-	mag_type = /obj/item/ammo_box/magazine/internal/boltaction
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction
 	can_bayonet = TRUE
 	knife_x_offset = 37
 	knife_y_offset = 14
@@ -131,7 +131,7 @@
 	inhand_y_dimension = 32
 	inhand_icon_state = "speargun"
 	worn_icon_state = "speargun"
-	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/harpoon
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/harpoon
 	fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
 	can_be_sawn_off = FALSE
 
@@ -147,7 +147,7 @@
 		Tiger Co-op assassins, cryo-frozen Space Russians, and security personnel with \
 		little care for professional conduct while making 'arrests' point blank in the back of the head \
 		until the gun clicks. EXTREMELY moist."
-	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/surplus
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/surplus
 	can_jam = TRUE
 
 /obj/item/gun/ballistic/rifle/boltaction/prime
@@ -178,7 +178,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
-	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun
 	initial_caliber = CALIBER_SHOTGUN
 	alternative_caliber = CALIBER_A762
 	initial_fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
@@ -199,7 +199,7 @@
 	icon_state = "musket_prime"
 	inhand_icon_state = "musket_prime"
 	worn_icon_state = "musket_prime"
-	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime
 	projectile_damage_multiplier = 1
 
 /// MAGICAL BOLT ACTIONS + ARCANE BARRAGE? ///
@@ -208,7 +208,7 @@
 	name = "enchanted bolt action rifle"
 	desc = "Careful not to lose your head."
 	var/guns_left = 30
-	mag_type = /obj/item/ammo_box/magazine/internal/enchanted
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/enchanted
 	can_be_sawn_off = FALSE
 
 /obj/item/gun/ballistic/rifle/enchanted/dropped()
@@ -258,7 +258,7 @@
 	rack_sound = 'sound/weapons/gun/sniper/rack.ogg'
 	suppressed_sound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg'
 	recoil = 2
-	mag_type = /obj/item/ammo_box/magazine/sniper_rounds
+	accepted_magazine_type = /obj/item/ammo_box/magazine/sniper_rounds
 	internal_magazine = FALSE
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BACK

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -16,7 +16,7 @@
 	force = 10
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
-	mag_type = /obj/item/ammo_box/magazine/internal/shot
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot
 	semi_auto = FALSE
 	internal_magazine = TRUE
 	casing_ejector = FALSE
@@ -34,7 +34,7 @@
 		. = 1
 
 /obj/item/gun/ballistic/shotgun/lethal
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/lethal
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/lethal
 
 // RIOT SHOTGUN //
 
@@ -44,7 +44,7 @@
 	icon_state = "riotshotgun"
 	inhand_icon_state = "shotgun"
 	fire_delay = 8
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	can_be_sawn_off = TRUE
 
@@ -60,7 +60,7 @@
 	icon_state = "cshotgun"
 	inhand_icon_state = "shotgun_combat"
 	fire_delay = 5
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
 
 //Dual Feed Shotgun
@@ -77,7 +77,7 @@
 	worn_icon_state = "cshotgun"
 	w_class = WEIGHT_CLASS_HUGE
 	semi_auto = TRUE
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/tube
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/tube
 	/// If defined, the secondary tube is this type, if you want different shell loads
 	var/alt_mag_type
 	/// If TRUE, we're drawing from the alternate_magazine
@@ -96,7 +96,7 @@
 
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube/Initialize(mapload)
 	. = ..()
-	alt_mag_type = alt_mag_type || mag_type
+	alt_mag_type = alt_mag_type || spawn_magazine_type
 	alternate_magazine = new alt_mag_type(src)
 
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube/Destroy()
@@ -139,7 +139,7 @@
 	inhand_y_dimension = 32
 	projectile_damage_multiplier = 1.2
 	weapon_weight = WEAPON_MEDIUM
-	mag_type = /obj/item/ammo_box/magazine/m12g
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m12g
 	can_suppress = FALSE
 	burst_size = 1
 	fire_delay = 0
@@ -161,7 +161,7 @@
 
 /obj/item/gun/ballistic/shotgun/bulldog/Initialize(mapload)
 	. = ..()
-	secondary_magazine_type = secondary_magazine_type || mag_type
+	secondary_magazine_type = secondary_magazine_type || spawn_magazine_type
 	secondary_magazine = new secondary_magazine_type(src)
 	update_appearance()
 
@@ -260,7 +260,7 @@
 	force = 10
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	sawn_desc = "Omar's coming!"
 	obj_flags = UNIQUE_RENAME
 	rack_sound_volume = 0
@@ -290,13 +290,13 @@
 	name = "hunting shotgun"
 	desc = "A hunting shotgun used by the wealthy to hunt \"game\"."
 	sawn_desc = "A sawn-off hunting shotgun. In its new state, it's remarkably less effective at hunting... anything."
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual/slugs
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/dual/slugs
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/breacherslug
 	name = "breaching shotgun"
 	desc = "A normal double-barrel shotgun that has been rechambered to fit breaching shells. Useful in breaching airlocks and windows, not much else."
 	sawn_desc = "A sawn-off breaching shotgun, making for a more compact configuration while still having the same capability as before."
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual/breacherslug
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/dual/breacherslug
 
 /obj/item/gun/ballistic/shotgun/hook
 	name = "hook modified sawn-off shotgun"
@@ -307,7 +307,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/bounty
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/bounty
 	weapon_weight = WEAPON_MEDIUM
 	semi_auto = TRUE
 	flags_1 = CONDUCT_1

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -4,7 +4,7 @@
 	icon_state = "saber"
 	selector_switch_icon = TRUE
 	inhand_icon_state = "gun"
-	mag_type = /obj/item/ammo_box/magazine/toy/smg
+	accepted_magazine_type = /obj/item/ammo_box/magazine/toy/smg
 	fire_sound = 'sound/items/syringeproj.ogg'
 	force = 0
 	throwforce = 0
@@ -21,12 +21,12 @@
 /obj/item/gun/ballistic/automatic/pistol/toy
 	name = "foam force pistol"
 	desc = "A small, easily concealable toy handgun. Ages 8 and up."
-	mag_type = /obj/item/ammo_box/magazine/toy/pistol
+	accepted_magazine_type = /obj/item/ammo_box/magazine/toy/pistol
 	fire_sound = 'sound/items/syringeproj.ogg'
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 
 /obj/item/gun/ballistic/automatic/pistol/toy/riot
-	mag_type = /obj/item/ammo_box/magazine/toy/pistol/riot
+	spawn_magazine_type = /obj/item/ammo_box/magazine/toy/pistol/riot
 
 /obj/item/gun/ballistic/automatic/pistol/riot/Initialize(mapload)
 	magazine = new /obj/item/ammo_box/magazine/toy/pistol/riot(src)
@@ -37,7 +37,7 @@
 	desc = "A toy shotgun with wood furniture and a four-shell capacity underneath. Ages 8 and up."
 	force = 0
 	throwforce = 0
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/toy
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/toy
 	fire_sound = 'sound/items/syringeproj.ogg'
 	clumsy_check = FALSE
 	item_flags = NONE
@@ -67,7 +67,7 @@
 	inhand_y_dimension = 32
 	worn_icon_state = "gun"
 	worn_icon = null
-	mag_type = /obj/item/ammo_box/magazine/internal/shot/toy/crossbow
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/toy/crossbow
 	fire_sound = 'sound/items/syringeproj.ogg'
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
@@ -78,17 +78,18 @@
 	desc = "A bullpup three-round burst toy SMG, designated 'C-20r'. Ages 8 and up."
 	can_suppress = TRUE
 	item_flags = NONE
-	mag_type = /obj/item/ammo_box/magazine/toy/smgm45/riot
+	accepted_magazine_type = /obj/item/ammo_box/magazine/toy/smgm45
+	spawn_magazine_type = /obj/item/ammo_box/magazine/toy/smgm45/riot
 	casing_ejector = FALSE
 	clumsy_check = FALSE
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted //Use this for actual toys
 	pin = /obj/item/firing_pin
-	mag_type = /obj/item/ammo_box/magazine/toy/smgm45
+	spawn_magazine_type = /obj/item/ammo_box/magazine/toy/smgm45
 
 /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted/riot
-	mag_type = /obj/item/ammo_box/magazine/toy/smgm45/riot
+	spawn_magazine_type = /obj/item/ammo_box/magazine/toy/smgm45/riot
 
 /obj/item/gun/ballistic/automatic/l6_saw/toy //This is the syndicate variant with syndicate firing pin and riot darts.
 	name = "donksoft LMG"
@@ -96,14 +97,15 @@
 	fire_sound = 'sound/items/syringeproj.ogg'
 	can_suppress = FALSE
 	item_flags = NONE
-	mag_type = /obj/item/ammo_box/magazine/toy/m762/riot
+	accepted_magazine_type = /obj/item/ammo_box/magazine/toy/m762
+	spawn_magazine_type = /obj/item/ammo_box/magazine/toy/m762/riot
 	casing_ejector = FALSE
 	clumsy_check = FALSE
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 
 /obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted //Use this for actual toys
 	pin = /obj/item/firing_pin
-	mag_type = /obj/item/ammo_box/magazine/toy/m762
+	spawn_magazine_type = /obj/item/ammo_box/magazine/toy/m762
 
 /obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted/riot
-	mag_type = /obj/item/ammo_box/magazine/toy/m762/riot
+	spawn_magazine_type = /obj/item/ammo_box/magazine/toy/m762/riot

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -129,7 +129,7 @@
 	icon_state = "lucky"
 	force = 10
 	fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
-	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/revchap
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/cylinder/revchap
 	obj_flags = UNIQUE_RENAME
 	custom_materials = null
 	actions_types = list(/datum/action/item_action/pray_refill)


### PR DESCRIPTION

## About The Pull Request

As the title says, mag type has been split into two variable that do different things:

Accepted magazine type handles what magazines that gun will accept, type and any subtypes. If spawn magazine type isnt defined, then it will be made equal to accepted magazine type to prevent having to double define magazines on every gun ever.

Spawn magazine type is separate from accepted magazine type, spawn magazine type is what magazine the gun will actually spawn with. This exists because there are a few weapons which are made to spawn with special magazines, that can't use normal magazines anymore. For example, the riot dart pre-loaded donk soft pistol can only ever be reloaded with the riot subtype of donk soft magazines at the moment. This isn't typically something people notice because new magazines are usually not a thing people come by with these specific weapons, but its a problem I noticed while coding some weapons.
## Why It's Good For The Game

In short, certain weapons (mostly donksoft weapons, but there's a single traitor pistol subtype that spawns with fire ammo) will no longer be limited to the exact subtype of magazine they spawned with, allowing them to use the normal versions of those magazines as well.
## Changelog
:cl:
refactor: The mag_type variable on guns has been split between accepted_magazine_type and spawn_magazine_type, allowing weapons to safely spawn with subtypes of their normal magazines without breaking the weapon
fix: Several weapons that spawned with special magazines, the riot dart pre-loaded donk pistol for example, will now be able to accept normal donksoft magazines that don't spawn loaded with riot darts.
/:cl:
