### PR TITLE
Outpost-45-update

### DIFF
--- a/_maps/RandomZLevels/undergroundoutpost45 (1).dmm
+++ b/_maps/RandomZLevels/undergroundoutpost45 (1).dmm
@@ -20,42 +20,46 @@
 "ah" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"ai" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
 "aj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/central)
 "ak" = (
 /obj/machinery/light/small/broken/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "al" = (
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "an" = (
 /turf/closed/wall/r_wall/rust,
 /area/awaymission/undergroundoutpost45/central)
 "ao" = (
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ap" = (
 /obj/machinery/light/small/broken/directional/east,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/central)
 "aq" = (
@@ -80,13 +84,15 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/central)
 "ar" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/central)
 "as" = (
@@ -94,29 +100,39 @@
 	id = "UO45_Elevator"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "at" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "au" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ax" = (
 /obj/effect/landmark/awaystart,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ay" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
 	},
 /obj/effect/landmark/awaystart,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "az" = (
 /obj/structure/sign/warning/vacuum{
@@ -129,15 +145,19 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/landmark/awaystart,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aC" = (
 /turf/closed/wall,
@@ -145,9 +165,20 @@
 "aD" = (
 /turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/central)
+"aE" = (
+/obj/item/organ/internal/body_egg,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "aF" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aG" = (
 /obj/machinery/button/door/directional/north{
@@ -162,126 +193,169 @@
 	name = "Call Elevator";
 	pixel_x = -6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aH" = (
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aJ" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aK" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
 /obj/structure/sign/poster/official/safety_internals/directional/west,
-/turf/open/floor/iron/dark,
-/area/awaymission/undergroundoutpost45/central)
-"aL" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/research)
+/area/awaymission/undergroundoutpost45/central)
 "aM" = (
 /obj/machinery/vending/cola,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aN" = (
 /obj/machinery/light/blacklight/directional/west,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aO" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aP" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aR" = (
 /obj/machinery/light/blacklight/directional/east,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aS" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aT" = (
 /obj/effect/landmark/awaystart,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
 	req_access = list("away_maintenance")
 	},
 /obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aV" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aW" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/soda_cans/cola,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aX" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aY" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "aZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 8
+	},
 /obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
 	req_access = list("away_maintenance")
 	},
 /obj/item/clothing/under/suit/black/skirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ba" = (
 /obj/structure/table/wood,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bb" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/ripley_build_and_repair,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bc" = (
 /obj/structure/chair/comfy/beige{
 	dir = 8
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/space,
 /area/awaymission/undergroundoutpost45/central)
 "bf" = (
 /obj/item/storage/belt/security,
@@ -295,37 +369,60 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bg" = (
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bi" = (
 /obj/structure/sink/directional/south,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bj" = (
 /obj/structure/sink/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bk" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bm" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bn" = (
 /obj/structure/table/wood,
@@ -333,7 +430,9 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bo" = (
 /obj/structure/table/wood,
@@ -344,29 +443,51 @@
 	pixel_x = 4;
 	pixel_y = 2
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bq" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "br" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bs" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bu" = (
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bv" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/camera/directional/east{
 	c_tag = "Arrivals";
 	network = list("uo45")
@@ -374,53 +495,118 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bx" = (
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "by" = (
 /obj/machinery/door/airlock{
 	name = "Unit 2"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bz" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bA" = (
 /obj/machinery/light/blacklight/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 5
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bH" = (
 /obj/machinery/light/blacklight/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bI" = (
 /obj/structure/toilet{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bJ" = (
 /obj/structure/toilet{
@@ -428,92 +614,322 @@
 	},
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bK" = (
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "bN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/nanotrasen_logo/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
-"bY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+"bO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall,
 /area/awaymission/undergroundoutpost45/central)
-"bZ" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+"bP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/awaymission/undergroundoutpost45/central)
-"ci" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
+"bQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/rust,
+/area/awaymission/undergroundoutpost45/central)
+"bR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/awaymission/undergroundoutpost45/central)
+"bT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
+/turf/closed/wall/rust,
+/area/awaymission/undergroundoutpost45/central)
+"bV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall,
+/area/awaymission/undergroundoutpost45/central)
+"bW" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/larva,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"cm" = (
+"bY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/gateway)
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"bZ" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"ca" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"ce" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"ch" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"ci" = (
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"cj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"ck" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
 "cn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 10
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"co" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/rust,
+/area/awaymission/undergroundoutpost45/central)
+"cp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall,
+/area/awaymission/undergroundoutpost45/central)
+"cq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/central)
 "cs" = (
 /obj/machinery/light/small/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"ct" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cu" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cv" = (
 /obj/structure/closet,
 /obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 8
+	},
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
-"cA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/gateway)
+"cz" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 10
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "cB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/east,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cD" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cE" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/grille,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/structure/chair/wood{
@@ -525,27 +941,39 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cJ" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/awaymission/undergroundoutpost45/central)
-"cK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /obj/machinery/button/door/directional/south{
 	id = "awaydorm1";
@@ -553,67 +981,228 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/spawner/directional/west,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/reagent_dispensers/fueltank,
 /obj/structure/window/spawner/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/central)
 "cW" = (
 /obj/structure/grille,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cX" = (
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"cY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/grille,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "cZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm2";
 	name = "Dorm 2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "da" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "db" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm1";
 	name = "Dorm 1"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
 /obj/structure/closet,
 /obj/item/poster/random_contraband,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"dd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"de" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/awaymission/undergroundoutpost45/central)
+"df" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/rust,
+/area/awaymission/undergroundoutpost45/central)
+"dg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"dh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"di" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"dk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"dl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dm" = (
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dn" = (
 /obj/machinery/light/blacklight/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "do" = (
 /obj/item/kirbyplants{
@@ -621,20 +1210,82 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
-"du" = (
-/obj/effect/turf_decal/tile/purple{
+"dp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall,
+/area/awaymission/undergroundoutpost45/central)
+"dq" = (
+/obj/effect/decal/cleanable/xenoblood,
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"dv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/central)
+"dw" = (
+/obj/machinery/power/shuttle_engine/heater{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/gateway)
+/obj/structure/window/reinforced/unanchored/spawner/directional,
+/obj/structure/window/reinforced/unanchored/spawner/directional,
+/obj/structure/window/reinforced/unanchored/spawner/directional{
+	dir = 8
+	},
+/obj/structure/window/reinforced/unanchored/spawner/directional{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/awaymission/undergroundoutpost45/caves)
+"dx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"dy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"dz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"dA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
 "dB" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dC" = (
 /obj/structure/disposalpipe/segment{
@@ -645,19 +1296,22 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/sink/directional/south,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dF" = (
 /obj/structure/disposalpipe/segment{
@@ -667,9 +1321,9 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dG" = (
 /obj/structure/disposalpipe/segment{
@@ -678,9 +1332,9 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dH" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -689,9 +1343,9 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dI" = (
 /obj/structure/disposalpipe/segment{
@@ -702,9 +1356,9 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dJ" = (
 /obj/machinery/light/blacklight/directional/north,
@@ -715,27 +1369,30 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/sink/directional/south,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dL" = (
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dM" = (
 /obj/item/food/meat/slab/monkey,
@@ -747,12 +1404,17 @@
 	name = "meat fridge";
 	req_access = list("away_maintenance")
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "dN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dO" = (
 /obj/item/reagent_containers/condiment/milk,
@@ -765,68 +1427,84 @@
 	name = "refrigerator";
 	req_access = list("away_maintenance")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "dP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 8
+	},
 /obj/structure/chair,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dR" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dT" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dX" = (
 /obj/structure/disposalpipe/segment{
@@ -835,9 +1513,9 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dY" = (
 /obj/machinery/door/firedoor,
@@ -848,36 +1526,40 @@
 	name = "Hydroponics"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "dZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ea" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eb" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ec" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ed" = (
 /obj/machinery/door/firedoor,
@@ -886,59 +1568,95 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"ee" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
 "ef" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Checkpoint Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"eg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ei" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ej" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ek" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "el" = (
 /obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "em" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "en" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eo" = (
 /obj/machinery/door/firedoor,
@@ -946,55 +1664,94 @@
 	name = "Hydroponics"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ep" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"er" = (
+/obj/item/flamethrower,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"es" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/wall,
 /area/awaymission/undergroundoutpost45/central)
 "et" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eu" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/awaymission/undergroundoutpost45)
 "ev" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
 	req_access = list("away_maintenance")
 	},
 /obj/item/clothing/under/misc/pj/red,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ew" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"ex" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/down,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "ey" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ez" = (
 /obj/structure/chair{
@@ -1003,15 +1760,21 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eA" = (
 /obj/structure/flora/bush/flowers_pp/style_random,
-/turf/open/floor/grass,
+/turf/open/floor/grass{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eB" = (
 /obj/structure/flora/bush/flowers_br/style_random,
-/turf/open/floor/grass,
+/turf/open/floor/grass{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eC" = (
 /obj/structure/chair{
@@ -1020,23 +1783,48 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eD" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
-"eH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+"eF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"eG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external/ruin,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"eH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eI" = (
 /obj/machinery/door/airlock/external/ruin,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eL" = (
 /obj/structure/chair/office{
@@ -1045,7 +1833,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eN" = (
 /obj/structure/chair{
@@ -1055,59 +1845,77 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eO" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
-/turf/open/floor/grass,
+/turf/open/floor/grass{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eP" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eR" = (
 /obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eV" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
 /obj/structure/sign/warning/vacuum/external/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eW" = (
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eX" = (
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/item/radio/off,
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
 /obj/structure/sign/poster/official/safety_report/directional/south,
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eY" = (
 /obj/machinery/computer/security{
@@ -1115,39 +1923,52 @@
 	network = list("uo45")
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "eZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fb" = (
 /obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ff" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fg" = (
 /obj/machinery/camera/directional/south{
@@ -1160,57 +1981,81 @@
 /obj/effect/mapping_helpers/apc/cell_10k,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fh" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fj" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fl" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"fm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/awaymission/undergroundoutpost45/central)
+"fo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/central)
 "fp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fq" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ft" = (
 /obj/structure/closet/crate/hydroponics,
@@ -1218,24 +2063,24 @@
 /obj/item/wrench,
 /obj/item/screwdriver,
 /obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fu" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
-"fv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/closed/wall/r_wall,
-/area/awaymission/undergroundoutpost45/engineering)
 "fw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fx" = (
 /obj/structure/disposalpipe/segment{
@@ -1246,68 +2091,105 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /obj/structure/chair/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/button/door/directional/north{
 	id = "awaydorm3";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm3";
 	name = "Dorm 3"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"fE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"fF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"fG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fI" = (
 /obj/structure/disposalpipe/segment{
@@ -1318,33 +2200,46 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fK" = (
 /turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"fL" = (
+/obj/structure/chair/sofa/corp{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"fM" = (
+/obj/structure/table/glass,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "fN" = (
 /turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "fO" = (
 /turf/closed/wall,
 /area/awaymission/undergroundoutpost45/crew_quarters)
-"fP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/mining)
 "fQ" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/south,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fS" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fT" = (
 /obj/item/kirbyplants{
@@ -1352,7 +2247,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fU" = (
 /obj/machinery/firealarm/directional/south,
@@ -1360,20 +2257,28 @@
 	c_tag = "Central Hallway";
 	network = list("uo45")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fV" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fW" = (
 /obj/machinery/vending/snack,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fX" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fY" = (
 /obj/machinery/disposal/bin,
@@ -1384,47 +2289,90 @@
 	desc = "A warning sign which reads 'DISPOSAL: LEADS TO EXTERIOR'";
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "fZ" = (
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ga" = (
 /obj/structure/sink/kitchen/directional/south,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gb" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "gc" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/research)
-"gf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/central)
+"gd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/central)
+"ge" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"gf" = (
+/obj/item/restraints/legcuffs/bola/energy,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "gg" = (
 /turf/closed/wall/r_wall/rust,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gh" = (
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gi" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"gj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"gl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gm" = (
 /obj/structure/closet/crate{
@@ -1434,19 +2382,25 @@
 /obj/item/storage/box/mousetraps,
 /obj/item/clothing/under/suit/waiter,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gn" = (
 /obj/item/tank/internals/oxygen,
 /obj/item/clothing/mask/gas,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "go" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "gp" = (
 /obj/structure/disposalpipe/segment{
@@ -1454,38 +2408,47 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "gq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "gr" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gs" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gu" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Cold Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/showroomfloor{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gv" = (
 /turf/closed/wall/r_wall,
@@ -1504,24 +2467,29 @@
 /area/awaymission/undergroundoutpost45/research)
 "gA" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gC" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gE" = (
 /obj/structure/sink/kitchen/directional/south,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gF" = (
@@ -1535,30 +2503,37 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gG" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gH" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "gI" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "gJ" = (
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "gK" = (
 /turf/closed/wall,
@@ -1576,16 +2551,21 @@
 /obj/item/stack/sheet/iron{
 	amount = 23
 	},
-/turf/open/floor/iron/white/side,
+/turf/open/floor/iron/white/side{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "gN" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
-/turf/open/floor/iron/white/side,
+/turf/open/floor/iron/white/side{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "gO" = (
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "gP" = (
@@ -1595,17 +2575,31 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"gQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
 "gU" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "gV" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "gW" = (
 /obj/structure/table,
@@ -1614,18 +2608,26 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "gX" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "gZ" = (
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "ha" = (
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "hb" = (
 /obj/machinery/light/small/directional/east,
@@ -1640,7 +2642,8 @@
 	},
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/iron/white/side{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "hc" = (
@@ -1649,7 +2652,9 @@
 "hf" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hh" = (
 /obj/structure/table/reinforced,
@@ -1660,52 +2665,69 @@
 	name = "Security Checkpoint";
 	req_access = list("away_maintenance")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "hi" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hj" = (
 /obj/machinery/vending/snack,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hk" = (
 /obj/machinery/vending/cola,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hl" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hm" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hn" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap,
 /obj/item/reagent_containers/cup/rag,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ho" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hp" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hq" = (
@@ -1715,114 +2737,173 @@
 	layer = 5
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hr" = (
 /obj/structure/table,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"ht" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
 "hu" = (
 /obj/machinery/gateway/away{
 	calibrated = 0
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "hw" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "hx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "hy" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "hz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /obj/item/storage/box/lights/mixed,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "hA" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/plating,
+/obj/item/flashlight/lantern,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "hB" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "hC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "hD" = (
 /obj/machinery/rnd/production/protolathe/offstation,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "hE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "hF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"hG" = (
+/obj/structure/closet/crate,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "hH" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "hI" = (
 /obj/structure/table,
 /obj/item/trash/chips,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hJ" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hK" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hL" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hM" = (
 /obj/structure/table/reinforced,
 /obj/item/lighter,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1830,14 +2911,18 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hP" = (
 /obj/machinery/door/firedoor,
@@ -1849,14 +2934,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hR" = (
@@ -1868,7 +2956,8 @@
 	pixel_x = 3
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hS" = (
@@ -1876,24 +2965,56 @@
 /obj/item/food/mint,
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "hU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"hV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"hW" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"hX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
 "hZ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -1904,39 +3025,55 @@
 	name = "Hydroponics Desk";
 	req_access = list("away_maintenance")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ib" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "id" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "ie" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "if" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "ig" = (
 /obj/machinery/computer/rdconsole{
 	dir = 4;
 	req_access = null
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "ih" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "ii" = (
 /obj/machinery/rnd/production/circuit_imprinter/offstation,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "ik" = (
 /obj/structure/table/glass,
@@ -1946,14 +3083,17 @@
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/matter_bin,
 /turf/open/floor/iron/white/side{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "il" = (
 /obj/structure/table,
 /obj/item/plate,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "im" = (
 /obj/structure/chair{
@@ -1961,49 +3101,62 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "in" = (
 /obj/structure/chair/stool/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "io" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/barman_recipes,
 /obj/item/reagent_containers/cup/glass/shaker,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ip" = (
 /obj/machinery/firealarm/directional/west,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "iq" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ir" = (
 /obj/machinery/light/blacklight/directional/east,
 /obj/machinery/processor,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "is" = (
 /obj/machinery/light/blacklight/directional/west,
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "it" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iu" = (
 /obj/machinery/door/window{
@@ -2011,54 +3164,87 @@
 	req_access = list("away_maintenance")
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iv" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"iw" = (
+/obj/effect/decal/cleanable/xenoblood,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "ix" = (
 /obj/machinery/door/airlock{
 	name = "Emergency Supplies"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "iA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "iB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "iC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "iD" = (
 /obj/machinery/disposal/bin,
@@ -2066,120 +3252,208 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/side{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "iE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "iF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "iG" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/drinkingglass,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "iH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "iI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "iJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "iK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "iL" = (
 /obj/machinery/light/small/directional/north,
 /obj/item/clothing/gloves/latex,
 /obj/structure/closet/emcloset,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "iM" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"iN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/tgmcemblem/center{
+	dir = 8
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "iO" = (
 /obj/structure/table,
 /obj/item/radio/off,
 /obj/item/radio/off,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iP" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iQ" = (
 /obj/structure/table,
 /obj/machinery/recharger,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /obj/structure/table,
 /obj/item/paper/pamphlet/gateway,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"iS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"iU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"iV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/awaymission/undergroundoutpost45/gateway)
 "iW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"iX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "iY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "iZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"ja" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
 "jc" = (
 /obj/machinery/light/blacklight/directional/east,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jd" = (
 /obj/machinery/disposal/bin,
@@ -2191,15 +3465,16 @@
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR"
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "je" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/disposalpipe/junction,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jf" = (
@@ -2213,73 +3488,158 @@
 /obj/item/reagent_containers/condiment/sugar,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"ji" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"jj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/chair/stool/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"jl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"jm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"jn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	name = "Gateway Observation"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"jp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"js" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"jt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
 "ju" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jv" = (
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jw" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jx" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/bottle/beer,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jy" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/awaymission/undergroundoutpost45/gateway)
+/obj/structure/table/glass,
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
 "jz" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Bar";
@@ -2287,68 +3647,121 @@
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 8
+	},
 /obj/machinery/door/airlock{
 	name = "Kitchen"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"jB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"jC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jD" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
+"jE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/central)
 "jF" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jG" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "jJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"jM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
 "jN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock/research{
 	name = "Research Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "jO" = (
 /obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"jQ" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
 /area/awaymission/undergroundoutpost45/research)
 "jR" = (
 /obj/structure/closet/emcloset,
@@ -2356,7 +3769,8 @@
 /obj/structure/sign/poster/official/safety_internals/directional/north,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jS" = (
@@ -2364,18 +3778,24 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jT" = (
 /obj/structure/table,
 /obj/item/kitchen/fork,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jV" = (
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -2384,64 +3804,99 @@
 /obj/effect/mapping_helpers/apc/cell_10k,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jW" = (
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jX" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "jY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"jZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
 "ka" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "kb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "kc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "kd" = (
 /obj/item/storage/backpack/satchel/science,
@@ -2454,42 +3909,66 @@
 	req_access = list("away_maintenance")
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
+"kf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
 "kh" = (
 /obj/item/kirbyplants{
 	layer = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"ki" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kj" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kl" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command{
 	name = "Gateway EVA"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "km" = (
 /obj/item/clothing/under/suit/navy,
@@ -2497,48 +3976,88 @@
 	locked = 0;
 	req_access = list("away_maintenance")
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "kn" = (
 /obj/machinery/light/blacklight/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "kp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Diner"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"kq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "kr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"ks" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"kt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ku" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/firealarm/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "kv" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "kw" = (
 /obj/structure/closet/l3closet,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "kx" = (
 /obj/structure/closet/crate,
@@ -2548,7 +4067,9 @@
 	pixel_y = -1
 	},
 /obj/item/multitool,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "ky" = (
 /obj/structure/table,
@@ -2560,7 +4081,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "kA" = (
 /obj/structure/tank_dispenser/oxygen,
@@ -2568,55 +4091,103 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "kB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "kC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"kE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "kF" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "kG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "kH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "kI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"kK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "kL" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
 	},
@@ -2624,50 +4195,113 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"kM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"kN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
 "kO" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"kP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kQ" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"kR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"kS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kW" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kX" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kY" = (
 /obj/machinery/door/firedoor,
@@ -2676,92 +4310,165 @@
 	name = "Biohazard Containment Door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "kZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/research)
+/obj/structure/alien/weeds,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/structure/glowshroom/single,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "la" = (
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lb" = (
 /obj/structure/sink/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 8
+	},
 /obj/structure/sign/departments/science/directional/west,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"ld" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "le" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lf" = (
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lg" = (
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"li" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"ll" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lm" = (
 /obj/structure/disposalpipe/junction,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ln" = (
 /turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/engineering)
+"lp" = (
+/obj/machinery/computer/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "lq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
 /obj/item/reagent_containers/spray/pepper,
@@ -2771,93 +4478,136 @@
 	req_access = list("away_maintenance")
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/research)
 "lv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"lw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lx" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "ly" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"lz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lA" = (
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/camera/directional/south{
 	c_tag = "Research Division West";
 	network = list("uo45","uo45r")
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lD" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "lE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lG" = (
 /obj/machinery/light/blacklight/directional/south,
@@ -2865,11 +4615,12 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lH" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -2878,43 +4629,63 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"lK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lM" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lN" = (
 /obj/machinery/firealarm/directional/south,
@@ -2923,37 +4694,42 @@
 	network = list("uo45","uo45r")
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lO" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "lP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lR" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lS" = (
 /obj/structure/chair{
@@ -2961,7 +4737,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lT" = (
 /obj/structure/table,
@@ -2972,7 +4750,9 @@
 	pixel_x = 3
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lU" = (
 /obj/machinery/disposal/bin,
@@ -2984,16 +4764,31 @@
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR"
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"lV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/door/airlock/public/glass{
+	name = "Diner"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Diner"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "lX" = (
 /obj/structure/closet/crate,
@@ -3003,7 +4798,10 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/item/crowbar/large/old,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "lY" = (
 /obj/machinery/light/small/directional/north,
@@ -3011,14 +4809,18 @@
 	c_tag = "Engineering Secure Storage";
 	network = list("uo45")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "lZ" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "ma" = (
 /obj/structure/table,
@@ -3031,51 +4833,74 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mb" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mc" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/gateway)
 "md" = (
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "me" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/spawner/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "mg" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "mh" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"mi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "UO45_rdprivacy";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "mj" = (
@@ -3084,58 +4909,94 @@
 	id = "UO45_rdprivacy";
 	name = "Privacy Shutters"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "mk" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "ml" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"mm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/mineral/titanium/survival,
+/area/awaymission/undergroundoutpost45)
 "mn" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "mp" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "mq" = (
 /obj/structure/table,
 /obj/item/newspaper,
 /obj/machinery/newscaster/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "mr" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "mt" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "mu" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"mv" = (
+/obj/structure/showcase/machinery/tv/broken,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "mw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
+	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/storage/backpack/satchel/eng,
 /obj/item/clothing/suit/hazardvest,
@@ -3148,28 +5009,41 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "mx" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "my" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "mz" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/rods/fifty,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "mA" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "mB" = (
 /obj/structure/table,
@@ -3180,13 +5054,17 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
@@ -3195,7 +5073,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mE" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -3209,7 +5089,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mF" = (
 /obj/machinery/firealarm/directional/south,
@@ -3218,60 +5100,80 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mG" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "mH" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"mJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/awaymission/undergroundoutpost45/research)
 "mK" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "mL" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "mM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "mN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"mO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron/cafeteria{
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "mP" = (
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "mQ" = (
@@ -3280,7 +5182,8 @@
 	layer = 5
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "mR" = (
@@ -3294,7 +5197,9 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "mS" = (
 /obj/structure/table,
@@ -3302,7 +5207,9 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "mT" = (
 /obj/structure/table,
@@ -3312,24 +5219,41 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "mU" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "mV" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"mW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/door/airlock/public/glass{
+	name = "Dormitories"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "mX" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/chair/wood{
 	dir = 1
 	},
@@ -3339,16 +5263,26 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/carpet,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "mY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"mZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Air to Distro"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
 "nb" = (
 /obj/machinery/button/door/directional/south{
 	id = "awaydorm7";
@@ -3356,10 +5290,9 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/carpet,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nc" = (
 /obj/machinery/vending/cola,
@@ -3367,7 +5300,9 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nd" = (
 /obj/structure/chair/comfy/black{
@@ -3376,14 +5311,18 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ne" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nf" = (
 /obj/structure/chair/comfy/black{
@@ -3393,46 +5332,69 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"ng" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nh" = (
 /obj/machinery/door/poddoor{
 	id = "UO45_Secure Storage";
 	name = "Secure Storage"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "ni" = (
 /turf/closed/wall/r_wall/rust,
 /area/awaymission/undergroundoutpost45/engineering)
 "nj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
+/area/awaymission/undergroundoutpost45/research)
+"nk" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/torso,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "nl" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "nm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "nn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/chair,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "no" = (
@@ -3443,13 +5405,17 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "np" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "nq" = (
 /obj/structure/table,
@@ -3463,124 +5429,248 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "nr" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"ns" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "nt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"nu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "nv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "nw" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ny" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nz" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/sign/poster/contraband/smoke/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"nA" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/item/shard/plastitanium,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "nB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm5";
 	name = "Dorm 5"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm7";
 	name = "Dorm 7"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nD" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"nE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nG" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"nH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"nI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "nJ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "nK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "nL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"nM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/research)
+"nN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"nO" = (
+/obj/machinery/vending/sustenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "nQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
 	pixel_x = 1;
@@ -3588,7 +5678,8 @@
 	},
 /obj/item/pen,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "nR" = (
@@ -3600,7 +5691,8 @@
 	network = list("uo45r")
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "nS" = (
@@ -3614,33 +5706,70 @@
 	pixel_x = 4
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
+"nT" = (
+/turf/closed/indestructible/fakedoor/maintenance,
+/area/awaymission/undergroundoutpost45)
 "nU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "nV" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"nW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/research)
+"nX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/research)
+"nY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/awaymission/undergroundoutpost45/research)
+"nZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
 "oa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ob" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3648,39 +5777,46 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oc" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "od" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/camera/directional/north{
 	c_tag = "Dormitories";
 	network = list("uo45")
@@ -3689,47 +5825,58 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "of" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "og" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oj" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -3737,72 +5884,129 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ok" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"ol" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "om" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"on" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oo" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "op" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"oq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "or" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "os" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "ot" = (
 /obj/machinery/power/smes{
@@ -3812,7 +6016,9 @@
 	output_level = 7000
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "ou" = (
 /obj/machinery/power/smes{
@@ -3822,19 +6028,33 @@
 	output_level = 7000
 	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "ov" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"ow" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
 "ox" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "oy" = (
@@ -3855,7 +6075,8 @@
 	req_access = list("away_maintenance")
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "oz" = (
@@ -3863,14 +6084,17 @@
 	dir = 1;
 	pixel_y = 3
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "oA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "oB" = (
@@ -3878,7 +6102,8 @@
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "oC" = (
@@ -3887,61 +6112,163 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"oD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "oE" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"oF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
 "oG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oH" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"oI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"oM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"oO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"oP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oQ" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oR" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"oS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "oU" = (
 /obj/machinery/light/small/directional/west,
@@ -3950,7 +6277,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "oV" = (
 /obj/machinery/power/terminal{
@@ -3959,7 +6288,9 @@
 /obj/machinery/power/port_gen/pacman{
 	name = "P.A.C.M.A.N.-type portable generator"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "oW" = (
 /obj/machinery/power/terminal{
@@ -3969,7 +6300,9 @@
 	name = "S.U.P.E.R.P.A.C.M.A.N.-type portable generator"
 	},
 /obj/item/wrench,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "oY" = (
 /obj/machinery/light/small/directional/east,
@@ -3977,7 +6310,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "oZ" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -3993,21 +6328,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "pc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "pd" = (
 /obj/machinery/disposal/bin,
@@ -4019,7 +6356,8 @@
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR"
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "pe" = (
@@ -4027,18 +6365,18 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "pf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "pg" = (
@@ -4047,7 +6385,8 @@
 	pixel_y = -27
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "ph" = (
@@ -4055,9 +6394,12 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "pi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door/directional/south{
 	desc = "A remote control switch which locks the research division down in the event of a biohazard leak or contamination.";
@@ -4066,8 +6408,18 @@
 	req_access = list("away_maintenance")
 	},
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"pj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
+	dir = 6
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
 "pl" = (
 /obj/item/kirbyplants{
 	layer = 5
@@ -4076,13 +6428,17 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pn" = (
 /obj/machinery/light/small/directional/east,
@@ -4090,65 +6446,140 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "po" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm4";
 	name = "Dorm 4"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"pp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm6";
 	name = "Dorm 6"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pr" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ps" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"pu" = (
+/obj/effect/gibspawner/xeno,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/molten_object,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"pv" = (
+/obj/machinery/computer/pod/old{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"px" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/rust,
+/area/awaymission/undergroundoutpost45/engineering)
+"py" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/engineering)
 "pz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"pA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"pB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "pC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "pD" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "pE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
@@ -4164,32 +6595,50 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "pG" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"pH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/research)
 "pI" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "pJ" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"pK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall,
+/area/awaymission/undergroundoutpost45/research)
+"pL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/research)
 "pM" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "pN" = (
 /obj/structure/chair/comfy/black,
@@ -4197,21 +6646,27 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pO" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pP" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/button/door/directional/west{
@@ -4220,14 +6675,24 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pR" = (
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"pS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall,
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/button/door/directional/east{
@@ -4236,8 +6701,9 @@
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pV" = (
 /obj/machinery/light/small/directional/north,
@@ -4245,59 +6711,91 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pW" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pX" = (
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pY" = (
 /obj/structure/mirror/directional/east,
 /obj/structure/sink/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "pZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "qb" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "SMES Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qd" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/meter{
 	layer = 3.3;
 	name = "Mixed Air Tank Out"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/meter{
 	layer = 3.3;
 	name = "Mixed Air Tank In"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"qf" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"qg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall/rust,
+/area/awaymission/undergroundoutpost45/research)
 "qh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -4310,79 +6808,107 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/telecomms,
 /area/awaymission/undergroundoutpost45/research)
 "qk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "ql" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "qm" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/sink/directional/east,
 /obj/structure/mirror/directional/west,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "qn" = (
 /obj/structure/toilet{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "qo" = (
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/clothing/glasses/hud/health,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/corner,
+/turf/open/floor/iron/white/corner{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"qp" = (
+/obj/machinery/power/shuttle_engine/large{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/awaymission/undergroundoutpost45/caves)
 "qq" = (
 /obj/machinery/vending/medical{
 	req_access = list("away_maintenance")
 	},
 /turf/open/floor/iron/white/side{
-	dir = 6
+	dir = 6;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "qr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "qs" = (
 /obj/structure/chair/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "qu" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/dresser,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "qx" = (
 /obj/structure/sink/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "qy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "qC" = (
 /obj/machinery/vending/cola,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qD" = (
 /obj/structure/chair,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4390,20 +6916,33 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/valve/on/layer2{
-	dir = 4
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/iron,
+/area/awaymission/undergroundoutpost45/engineering)
+"qG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
+	},
 /obj/structure/window/reinforced/spawner/directional/east{
 	layer = 2.9
 	},
@@ -4414,10 +6953,15 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qJ" = (
 /obj/machinery/light/blacklight/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 10
+	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics";
 	network = list("uo45")
@@ -4432,18 +6976,21 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/computer/atmos_control/noreconnect{
 	atmos_chambers = list("uo45air"="Air Supply")
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/corner{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qL" = (
@@ -4453,13 +7000,35 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/cafeteria,
+/turf/open/floor/iron/cafeteria{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"qM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
+	dir = 10
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "qN" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"qO" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
 "qQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general,
 /turf/open/floor/iron/dark/telecomms,
@@ -4472,13 +7041,17 @@
 	name = "Server Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "qS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "qT" = (
 /obj/machinery/light/small/directional/east,
@@ -4487,102 +7060,140 @@
 	},
 /obj/structure/chair/office/light,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "qU" = (
 /obj/machinery/light/small/directional/west,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
-/area/awaymission/undergroundoutpost45/research)
-"qV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/side{
+	dir = 4;
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"qV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "qW" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "qX" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "qY" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/south,
 /obj/item/pen,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "qZ" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ra" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rb" = (
 /obj/machinery/door/airlock{
 	name = "Unit 2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rc" = (
 /obj/structure/mirror/directional/east,
 /obj/structure/sink/directional/west,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rd" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "re" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rf" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"rg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rh" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "ri" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rj" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rk" = (
 /obj/item/kirbyplants{
@@ -4591,7 +7202,9 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rl" = (
 /obj/machinery/firealarm/directional/north,
@@ -4601,7 +7214,9 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rm" = (
 /obj/machinery/light/small/directional/north,
@@ -4623,9 +7238,14 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
 /obj/structure/table,
 /obj/item/storage/box,
 /obj/item/storage/box,
@@ -4633,18 +7253,40 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"ro" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/engineering)
 "rp" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/effect/mapping_helpers/apc/cell_10k,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"rq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/machinery/meter/monitored{
+	chamber_id = "uo45distro"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /obj/item/clothing/suit/armor/vest,
 /obj/item/clothing/head/helmet,
@@ -4660,7 +7302,9 @@
 	req_access = list("away_maintenance")
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rs" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
@@ -4668,32 +7312,62 @@
 	req_access = list("away_maintenance")
 	},
 /obj/item/clothing/under/misc/pj/blue,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"rt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"ru" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Mix to Exterior"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
 "rv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
+	dir = 9
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rw" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "ry" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "rz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general{
@@ -4705,13 +7379,17 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/pen,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "rC" = (
 /obj/machinery/computer/rdservercontrol{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "rD" = (
 /obj/structure/closet/crate,
@@ -4719,114 +7397,171 @@
 /obj/item/poster/random_contraband,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "rE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "rF" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Research Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "rG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
 /turf/open/floor/iron/white/side{
-	dir = 4
+	dir = 4;
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"rH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "rI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "rJ" = (
 /obj/structure/table,
 /obj/item/storage/box/gloves,
 /turf/open/floor/iron/white/side{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "rK" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "rL" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rM" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 8
+	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering Hallway";
 	network = list("uo45")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rQ" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"rR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rS" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -4834,45 +7569,63 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rV" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rW" = (
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "rX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/door/airlock/engineering/glass{
@@ -4880,36 +7633,77 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "rZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/awaymission/undergroundoutpost45/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
 "sb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"se" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -4918,22 +7712,44 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "UO45_Engineering";
+	name = "Engineering Security Door"
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "si" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/personal/cabinet{
 	locked = 0;
 	req_access = list("away_maintenance")
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "sj" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -4941,6 +7757,9 @@
 /obj/effect/mapping_helpers/apc/unlocked,
 /obj/effect/mapping_helpers/apc/cell_10k,
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/closet/secure_closet/engineering_personal{
 	icon_state = "mining";
 	locked = 0;
@@ -4951,19 +7770,54 @@
 /obj/item/clothing/gloves/fingerless,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"sk" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Distro"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
 "sn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "so" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/atmos_control/noreconnect{
 	atmos_chambers = list("uo45mix"="Mix Chamber");
@@ -4972,16 +7826,21 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible{
+	dir = 4
+	},
 /obj/machinery/meter{
 	layer = 3.3
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored{
@@ -4996,14 +7855,17 @@
 /area/awaymission/undergroundoutpost45/engineering)
 "st" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "su" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "sv" = (
 /obj/machinery/disposal/bin,
@@ -5015,146 +7877,321 @@
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR"
 	},
 /turf/open/floor/iron/white/corner{
-	dir = 4
+	dir = 4;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "sw" = (
 /obj/structure/closet/l3closet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/white/side{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "sx" = (
 /obj/structure/closet/l3closet,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
+"sz" = (
+/obj/item/paper{
+	default_raw_text = Gary,ifyoueverreadthis,knowthatilovedyou,andthatnomatterwhatyouneedtocontinueonandliveoninthisworld,evenwithoutme.
+	},
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "sA" = (
 /obj/machinery/shower/directional/east,
 /obj/item/soap/nanotrasen,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sB" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sC" = (
 /obj/machinery/shower/directional/west,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sE" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sH" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"sI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "sL" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Reception"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/chair/office{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "sT" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/preopen{
 	id = "UO45_Engineering";
 	name = "Engineering Security Door"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sU" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Waste In"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 10
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sY" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Mix to Filter"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"sZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
+	dir = 6
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"ta" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 6
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
-/obj/machinery/atmospherics/components/trinary/filter/on/layer2{
-	dir = 1
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
 "td" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
+	},
 /obj/machinery/meter{
 	layer = 3.3
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/orange{
-	dir = 4
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/awaymission/undergroundoutpost45/engineering)
 "te" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
@@ -5173,69 +8210,148 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"th" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"ti" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "tj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"tk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "tl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "tm" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"tn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/research)
+"to" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/research)
+"tp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/rust,
+/area/awaymission/undergroundoutpost45/research)
+"tq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
+/turf/closed/wall/r_wall/rust,
 /area/awaymission/undergroundoutpost45/research)
 "tr" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "ts" = (
 /obj/machinery/shower/directional/east,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "tt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "tu" = (
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "tv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
-	dir = 1
-	},
 /turf/open/floor/iron/white/corner{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tw" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/structure/window/reinforced/spawner/directional/east{
 	layer = 2.9
 	},
@@ -5243,21 +8359,31 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/white/corner{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tx" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"ty" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/mob/living/simple_animal/hostile/alien/sentinel,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "tz" = (
 /obj/machinery/computer/security{
 	dir = 1;
@@ -5272,9 +8398,20 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"tA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 8
+	},
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
@@ -5282,150 +8419,270 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"tD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 8
+	},
 /obj/machinery/meter/monitored{
 	chamber_id = "uo45waste"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 9
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"tH" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "N2 Outlet Pump"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "tI" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "O2 Outlet Pump"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"tK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/rust,
+/area/awaymission/undergroundoutpost45/research)
 "tL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"tM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/awaymission/undergroundoutpost45/research)
+"tN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/research)
 "tO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "tP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "tQ" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "tR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "tS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "tT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"tU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "tV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
 /obj/item/stack/rods,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"tW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/research)
 "tX" = (
 /obj/machinery/shower/directional/north,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "tY" = (
 /obj/machinery/shower/directional/north,
 /obj/item/bikehorn/rubberducky,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "tZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "ua" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"uc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/engineering)
+"ud" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/awaymission/undergroundoutpost45/engineering)
 "ue" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Foyer"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uf" = (
 /obj/structure/filingcabinet,
@@ -5433,107 +8690,188 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "ug" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/red/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"uh" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/down,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"ui" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uj" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "External to Filter"
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uk" = (
-/obj/machinery/atmospherics/components/binary/pump/on/supply/visible/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Air to External"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "um" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/on/layer2{
-	dir = 4
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
 "un" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/computer/atmos_control/noreconnect{
 	atmos_chambers = list("uo45n2"="Nitrogen Supply");
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
+	},
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "up" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/on/layer2{
-	dir = 4
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
 "uq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/computer/atmos_control/noreconnect{
 	atmos_chambers = list("uo45o2"="Oxygen Supply");
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "ur" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 9
+	},
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "us" = (
+/obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "ut" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "uu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden{
+	dir = 10
+	},
 /obj/structure/table/reinforced,
 /obj/item/wrench,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"uv" = (
+/turf/closed/mineral/random/labormineral,
+/area/awaymission/undergroundoutpost45/research)
+"uw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/door/airlock/external/ruin,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"ux" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall,
 /area/awaymission/undergroundoutpost45/research)
 "uy" = (
 /obj/structure/closet,
 /obj/item/storage/belt/utility,
 /obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "uz" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "uA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/computer/atmos_control/fixed{
 	atmos_chambers = list("uo45air"="Air Supply","uo45mix"="Mix Chamber","uo45n2"="Nitrogen Supply","uo45o2"="Oxygen Supply");
 	dir = 4;
@@ -5543,23 +8881,35 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/corner{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"uB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uC" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 8
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uE" = (
 /turf/closed/wall,
@@ -5569,38 +8919,47 @@
 	name = "Security Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/closed/wall/r_wall,
 /area/awaymission/undergroundoutpost45/engineering)
 "uI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 1
+	},
 /obj/machinery/meter{
 	layer = 3.3
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/orange,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uJ" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/meter{
 	layer = 3.3
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uK" = (
 /obj/machinery/light/small/directional/west,
@@ -5608,60 +8967,87 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "uL" = (
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"uM" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "uN" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
 /obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/obj/item/flashlight/lantern/heirloom_moth,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "uO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "uP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "uQ" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "uR" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "uS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "uT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "uU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/computer/atmos_control/fixed{
 	atmos_chambers = list("uo45waste","uo45distro");
 	dir = 4;
@@ -5671,14 +9057,35 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/corner{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "uV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 5
+	},
 /obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"uW" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"uZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/awaymission/undergroundoutpost45/engineering)
 "va" = (
 /obj/machinery/door/firedoor,
@@ -5686,8 +9093,13 @@
 	id = "UO45_Engineering";
 	name = "Engineering Security Door"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vb" = (
 /obj/machinery/door/firedoor,
@@ -5695,10 +9107,14 @@
 	id = "UO45_Engineering";
 	name = "Engineering Security Door"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 9
+	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vd" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored{
@@ -5729,61 +9145,96 @@
 /turf/open/floor/engine/o2,
 /area/awaymission/undergroundoutpost45/engineering)
 "vh" = (
+/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/components/tank/air,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "vi" = (
-/obj/machinery/atmospherics/components/tank/air,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/research)
+"vj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "vk" = (
 /obj/machinery/door/airlock/external/ruin,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "vm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "vn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/item/stack/rods,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "vo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "vp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "vq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "vr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "vs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/computer/atmos_alert{
 	dir = 4
 	},
@@ -5791,56 +9242,71 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/corner{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 1
+	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vw" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
 "vx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vz" = (
 /obj/machinery/door/airlock/engineering{
@@ -5848,15 +9314,26 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"vB" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "vC" = (
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vD" = (
 /obj/machinery/light/small/directional/south,
@@ -5897,275 +9374,561 @@
 	name = "Mining Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "vN" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Foyer"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "vO" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Foyer"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "vP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 5
+	},
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron/checker,
+/turf/open/floor/iron/checker{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/noticeboard{
 	dir = 1;
 	pixel_y = -27
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"vS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vT" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"vU" = (
+/obj/machinery/camera/xray/directional/north,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "vV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/vending/tool,
 /obj/structure/sign/poster/official/build/directional/south,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"vX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/awaymission/undergroundoutpost45/engineering)
 "vY" = (
 /obj/structure/closet/emcloset,
 /obj/item/clothing/mask/breath,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "vZ" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"wa" = (
+/obj/structure/closet/firecloset,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "wb" = (
 /obj/structure/table/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "wc" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "wd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /obj/structure/bed,
 /obj/item/bedsheet,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"we" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
 /area/awaymission/undergroundoutpost45/mining)
 "wf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "wg" = (
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/item/kirbyplants{
 	layer = 5
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"wh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"wi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"wk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
 "wl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"wm" = (
+/obj/item/organ/internal/lungs,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "wn" = (
 /turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/engineering)
 "wp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "wq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/button/door/directional/south{
 	id = "awaydorm8";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "wr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm8";
 	name = "Mining Dorm 1"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/mining)
-"wt" = (
-/obj/machinery/atmospherics/components/tank/air,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/research)
+/area/awaymission/undergroundoutpost45/mining)
+"ws" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"wu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
 "wv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "ww" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"wA" = (
+/obj/effect/mob_spawn/corpse/human/assistant,
+/obj/structure/alien/egg,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "wB" = (
 /obj/structure/toilet{
 	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"wC" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "wD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"wE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"wF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"wJ" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/obj/item/ammo_box/magazine/wt550m9,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "wK" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "wL" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/light/small/directional/south,
 /obj/structure/mirror/directional/east,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "wM" = (
 /obj/structure/chair/wood,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "wN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/button/door/directional/north{
 	id = "awaydorm9";
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "wO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	id_tag = "awaydorm9";
 	name = "Mining Dorm 2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"wP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"wQ" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"wS" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"wT" = (
+/turf/closed/indestructible/reinforced,
+/area/awaymission/undergroundoutpost45)
+"wU" = (
+/obj/machinery/suit_storage_unit,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "wX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/firealarm/directional/south,
 /obj/structure/closet/secure_closet/miner{
 	req_access = list("away_maintenance")
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "wZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
-"xd" = (
-/obj/machinery/meter{
-	layer = 3.3
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/engineering)
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"xe" = (
+/obj/item/chair/wood,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "xg" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock/mining{
 	name = "Processing Area"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xh" = (
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/door/airlock/mining{
 	name = "Processing Area"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xl" = (
 /obj/machinery/conveyor{
@@ -6174,7 +9937,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xm" = (
 /obj/machinery/mineral/unloading_machine{
@@ -6186,36 +9951,54 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xn" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"xo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xr" = (
 /obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xs" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "UO45_mining";
 	name = "mining conveyor"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xu" = (
 /obj/machinery/suit_storage_unit/mining,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xv" = (
 /obj/structure/table,
 /obj/item/pickaxe,
 /obj/item/radio/off,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xw" = (
 /obj/machinery/mineral/processing_unit{
@@ -6224,14 +10007,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xx" = (
 /obj/machinery/mineral/processing_unit_console,
 /turf/closed/wall/rust,
 /area/awaymission/undergroundoutpost45/mining)
 "xy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /obj/machinery/light/blacklight/directional/west,
@@ -6240,18 +10025,42 @@
 	network = list("uo45")
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"xz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"xA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 2
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xC" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xD" = (
 /obj/machinery/light/small/directional/east,
@@ -6262,7 +10071,8 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "xE" = (
@@ -6273,48 +10083,88 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xF" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"xG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining EVA"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"xJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xL" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xM" = (
 /obj/machinery/mineral/stacking_unit_console,
 /turf/closed/wall,
 /area/awaymission/undergroundoutpost45/mining)
 "xN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/iron{
 	amount = 26
@@ -6323,14 +10173,18 @@
 	amount = 19
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xQ" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xR" = (
 /obj/structure/cable,
@@ -6352,15 +10206,27 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xU" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"xV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "xW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/mineral/plasma{
@@ -6368,52 +10234,80 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "xX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/door/airlock/external/ruin{
 	name = "Mining External Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"xY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"xZ" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "ya" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "yb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/mining)
 "yc" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "yd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "ye" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "yf" = (
 /obj/machinery/door/airlock/external/ruin{
@@ -6424,53 +10318,173 @@
 /turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/mining)
 "yh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/no_smoking/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
-"yj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/mining)
-"yq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+"yp" = (
+/obj/machinery/camera/xray/directional/south,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"yr" = (
+/obj/structure/chair/office{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/gateway)
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
+"ys" = (
+/obj/effect/decal/cleanable/ash/large,
+/obj/item/clothing/shoes/combat,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"yx" = (
+/obj/machinery/computer/crew{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"yy" = (
+/obj/structure/table/wood,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"yz" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/limb,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"yC" = (
+/obj/item/clothing/mask/gas/sechailer/swat/spacepol,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"yE" = (
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"yF" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"yH" = (
+/turf/closed/wall/r_wall/rust,
+/area/awaymission/undergroundoutpost45)
+"yL" = (
+/obj/effect/mob_spawn/corpse/human/engineer/mod,
+/obj/item/paperwork/engineering,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "yN" = (
 /obj/structure/chair/office/light{
 	dir = 1;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"yQ" = (
+/obj/item/clothing/suit/hazardvest,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "yR" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"yV" = (
+/obj/effect/gibspawner/human,
+/obj/item/gun/ballistic/automatic/wt550,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"yX" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"za" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
 "zb" = (
 /obj/structure/alien/weeds,
 /obj/structure/alien/resin/wall,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "ze" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 6
+	},
 /obj/structure/table,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil{
@@ -6486,38 +10500,48 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"zi" = (
+/obj/vehicle/sealed/mecha/durand,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"zj" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "zn" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "zq" = (
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"zr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
 "zA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
 "zG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -6529,16 +10553,15 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
-"zJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "zK" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
@@ -6547,6 +10570,16 @@
 "zO" = (
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"zT" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
@@ -6564,39 +10597,121 @@
 /obj/item/clothing/mask/bandana/striped/botany,
 /obj/item/hatchet,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"Aa" = (
+/obj/effect/decal/cleanable/ash,
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "Ac" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"Ad" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
 "Ae" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "Ai" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Ak" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Ap" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/item/hand_labeler,
 /obj/item/clothing/neck/stethoscope,
-/turf/open/floor/iron/white/side,
+/turf/open/floor/iron/white/side{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"Aq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Ar" = (
 /obj/machinery/oven/range,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"Au" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Ax" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Ay" = (
+/obj/structure/barricade/sandbags,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"AA" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
 "AN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/sign/warning/electric_shock/directional/south,
 /obj/machinery/vending/engivend,
 /obj/machinery/camera/directional/south{
@@ -6604,75 +10719,193 @@
 	network = list("uo45")
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "AQ" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"AR" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen,
+/obj/item/shard/plastitanium,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"AS" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/structure/chair/comfy/shuttle/tactical,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname/directional/south,
+/obj/item/paperwork/security,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "AT" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"AW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/closed/indestructible/reinforced,
+/area/awaymission/undergroundoutpost45)
+"AX" = (
+/mob/living/simple_animal/hostile/alien/queen/large,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "AZ" = (
 /obj/machinery/light/blacklight/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
+	dir = 5
+	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "Ba" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"Bc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/small,
+/area/awaymission/undergroundoutpost45)
+"Be" = (
+/obj/item/chair/wood,
+/obj/structure/alien/weeds/node,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Bh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"Bk" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Bo" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Bq" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 10
+	},
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
-"Bz" = (
+"Bs" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"BB" = (
+/obj/effect/decal/cleanable/xenoblood,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/mining)
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"BF" = (
+/obj/structure/alien/weeds/node,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "BI" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"BJ" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced/unanchored/spawner/directional,
+/obj/structure/window/reinforced/unanchored/spawner/directional{
+	dir = 1
+	},
+/obj/structure/window/reinforced/unanchored/spawner/directional{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/awaymission/undergroundoutpost45/caves)
 "BL" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs/down,
 /obj/effect/mob_spawn/corpse/human,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
@@ -6685,26 +10918,79 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "BQ" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
+/area/awaymission/undergroundoutpost45/caves)
+"BS" = (
+/obj/effect/decal/cleanable/xenoblood,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"BU" = (
+/obj/effect/gibspawner/xeno,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Ca" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
 /area/awaymission/undergroundoutpost45/caves)
 "Cd" = (
 /obj/structure/alien/weeds,
 /obj/structure/glowshroom/single,
 /obj/effect/decal/cleanable/blood/gibs/down,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
+"Ce" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/research)
+"Cg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Ci" = (
+/obj/effect/gibspawner/human,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
 "Cj" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -6715,14 +11001,28 @@
 	pixel_y = -2
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "Cr" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"Cv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Cw" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
@@ -6730,18 +11030,24 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/white/corner{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "Cy" = (
 /obj/structure/sign/warning/secure_area/directional/north,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
-"CD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
+"Cz" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "CH" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -6751,17 +11057,61 @@
 /obj/item/pen,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
-"CT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
+"CM" = (
+/obj/machinery/shower/directional/west,
+/obj/structure/fans/tiny,
+/obj/structure/curtain,
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/iron/small,
+/area/awaymission/undergroundoutpost45)
+"CQ" = (
+/obj/item/pipe{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/awaymission/undergroundoutpost45/caves)
+"CS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"CV" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/obj/item/clothing/head/helmet/marine/sulaco,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"CX" = (
+/mob/living/simple_animal/bot/cleanbot,
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
+"CY" = (
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/airlock/command,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"CZ" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/closed/wall/mineral/titanium/survival,
+/area/awaymission/undergroundoutpost45)
+"Da" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/mask/gas/sechailer/swat/spacepol,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "De" = (
 /obj/machinery/computer/monitor{
 	name = "primary power monitoring console"
@@ -6771,31 +11121,77 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"Dg" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office"
+	},
+/obj/machinery/door/firedoor/heavy,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
 "Dm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/iron,
 /area/awaymission/undergroundoutpost45/engineering)
-"Dt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/gateway)
+"Dp" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/effect/decal/cleanable/xenoblood,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Dq" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"Ds" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Dw" = (
+/obj/machinery/door/poddoor/ert,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Dz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "DB" = (
 /obj/machinery/light/small/directional/west,
@@ -6809,26 +11205,67 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"DC" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/structure/fluff/oldturret,
+/turf/closed/wall/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45/caves)
+"DD" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/core,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"DF" = (
+/obj/structure/sign/poster/contraband/syndiemoth,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 351.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "DJ" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 6
 	},
 /turf/open/floor/plating{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"DL" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+"DM" = (
+/mob/living/carbon/alien/adult/drone,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
+/area/awaymission/undergroundoutpost45/caves)
+"DQ" = (
+/obj/structure/dresser,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"DT" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "DU" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes{
@@ -6838,7 +11275,9 @@
 	pixel_x = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "Ea" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6846,12 +11285,18 @@
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "Ec" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/research)
+/obj/machinery/door/poddoor{
+	id = "UO45_Elevator"
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Ed" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -6860,14 +11305,112 @@
 	name = "Hydroponics Desk";
 	req_access = list("away_maintenance")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"Ef" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Em" = (
+/obj/effect/spawner/random/trash/bin,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"En" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"Eo" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Eu" = (
+/obj/machinery/door/poddoor/preopen,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Ex" = (
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
+"EA" = (
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"EE" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"EI" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "EJ" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"EL" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"EM" = (
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
+/obj/item/restraints/legcuffs/bola/energy,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"EN" = (
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/obj/structure/alien/gelpod,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"EO" = (
+/obj/machinery/power/shuttle_engine/large{
+	dir = 4
+	},
+/obj/structure/window/reinforced/unanchored/spawner/directional,
+/turf/open/floor/engine,
+/area/awaymission/undergroundoutpost45/caves)
 "EP" = (
 /obj/structure/closet/secure_closet{
 	icon_state = "hydro";
@@ -6880,7 +11423,9 @@
 /obj/item/clothing/mask/bandana/striped/botany,
 /obj/item/cultivator,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "EQ" = (
 /obj/machinery/airalarm/directional/east,
@@ -6895,65 +11440,213 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"EX" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/small,
+/area/awaymission/undergroundoutpost45)
+"Fb" = (
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "Fd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"Fq" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 4
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Fr" = (
+/obj/structure/glowshroom/single,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Fu" = (
+/obj/machinery/camera/xray/directional/east,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Fw" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"Fx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Fy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "FA" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/light/small/directional/east,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"FB" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"FC" = (
+/obj/item/bedsheet/captain/double{
+	dir = 8
+	},
+/obj/structure/bed/double,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"FG" = (
+/obj/structure/alien/weeds,
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "FS" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"FY" = (
+/obj/structure/closet/bombcloset/security,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"Ga" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 4
+	},
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Gc" = (
 /obj/machinery/light/blacklight/directional/west,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/iron{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/central)
 "Ge" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/filingcabinet,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"Gj" = (
+/obj/effect/gibspawner/human,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Gl" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "Gn" = (
 /obj/structure/alien/weeds,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Go" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/effect/decal/cleanable/glass/plastitanium,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
@@ -6963,7 +11656,9 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "Gq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6971,32 +11666,180 @@
 	desc = "A warning sign which reads 'SERVER ROOM'.";
 	name = "SERVER ROOM"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"Gz" = (
+/obj/item/paper{
+	default_raw_text = Heythere,theminingoperationsaregoingswell,howeveriswearifeelsmallvibrationseverynowandthen.
+	},
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"GC" = (
+/obj/structure/closet/crate,
+/obj/item/a_gift/anything,
+/obj/item/a_gift/anything,
+/obj/item/a_gift/anything,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"GH" = (
+/obj/machinery/camera/xray/directional/south,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
 "GI" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
-"Hp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/central)
-"HA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
+"GJ" = (
+/obj/item/clothing/head/helmet/marine/sulaco,
+/obj/machinery/suit_storage_unit,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"GN" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"GO" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/structure/chair/comfy/shuttle/tactical,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paperwork/security,
+/obj/item/paperwork/security,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Hb" = (
+/obj/machinery/door/airlock/security/glass,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Hd" = (
+/obj/machinery/camera/xray/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Hg" = (
+/obj/item/flashlight/flare,
+/obj/structure/alien/weeds/node,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Hh" = (
+/obj/item/clothing/suit/armor/vest/marine/sulaco,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Hm" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Hr" = (
+/obj/item/banner/security/mundane,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"HE" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced/unanchored/spawner/directional{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/awaymission/undergroundoutpost45/caves)
+"HH" = (
+/obj/effect/mine/explosive,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"HI" = (
+/obj/item/banner/security,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"HK" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/obj/item/storage/box/lethalshot,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"HL" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/grass/fairy,
+/area/awaymission/undergroundoutpost45)
 "HM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/bed{
 	dir = 4
 	},
 /obj/item/bedsheet{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"HN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/light/bulb/broken,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "HR" = (
 /obj/machinery/light/blacklight/directional/east,
 /obj/machinery/airalarm/directional/east,
@@ -7004,53 +11847,96 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"HT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/mineral/random/labormineral,
+/area/awaymission/undergroundoutpost45/caves)
+"HU" = (
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "HW" = (
 /obj/structure/alien/weeds,
 /obj/structure/glowshroom/single,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
+"Ia" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/bedsheet,
+/obj/item/bedsheet/black,
+/obj/structure/bed/pod,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Ic" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "Ie" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/carpet,
 /area/awaymission/undergroundoutpost45/crew_quarters)
-"Ij" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
+"Il" = (
+/obj/item/paper{
+	default_raw_text = Comeongarywearealmostthere!Ibelieveinus!
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
-"Iw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/gateway)
-"IH" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/central)
+/area/awaymission/undergroundoutpost45/caves)
+"Iv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Ix" = (
+/obj/effect/mob_spawn/corpse/human/scientist,
+/obj/item/paperwork/research,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"IG" = (
+/obj/item/flashlight/flare,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "IK" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -7059,84 +11945,176 @@
 	name = "\improper DISPOSAL: LEADS TO EXTERIOR"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"IO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "IT" = (
 /obj/structure/alien/weeds,
 /obj/effect/mob_spawn/corpse/human,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"IV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
 "IX" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"IY" = (
+/obj/machinery/camera/xray/directional/south,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"Jd" = (
+/turf/open/space/basic,
+/area/space)
+"Jg" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"Jh" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Ji" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Gateway Ready Room";
 	network = list("uo45","uo45r")
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
-"Jm" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+"Ju" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"Jw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
-"Jo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/area/awaymission/undergroundoutpost45)
+"Jx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/paper{
+	default_raw_text = imnotfeelingtocompetantinourdriversability,iswearhesdrinkingsomething
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/research)
-"Jv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/cafeteria{
-	dir = 5
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Jy" = (
+/obj/item/beacon,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
 	},
-/area/awaymission/undergroundoutpost45/crew_quarters)
+/area/awaymission/undergroundoutpost45/caves)
+"Jz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/closed/mineral/random/labormineral,
+/area/awaymission/undergroundoutpost45/caves)
 "JD" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "JJ" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"JL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/indestructible/reinforced,
+/area/awaymission/undergroundoutpost45)
 "JO" = (
+/obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/research)
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"JP" = (
+/turf/open/floor/engine,
+/area/awaymission/undergroundoutpost45/caves)
+"JX" = (
+/obj/machinery/computer/mech_bay_power_console,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"JY" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Kk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
 "Km" = (
 /obj/structure/table,
 /obj/item/storage/medkit/toxin{
@@ -7149,48 +12127,74 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
-	dir = 1
+	dir = 1;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
+"Ko" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45/caves)
+"Kt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/engineering)
 "KE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/awaymission/undergroundoutpost45/research)
+"KL" = (
+/obj/structure/sign/flag/nanotrasen,
+/turf/closed/indestructible/reinforced,
+/area/awaymission/undergroundoutpost45)
 "KN" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"KO" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "UO45_biohazard";
-	name = "Biohazard Containment Door"
+"KP" = (
+/obj/structure/chair/sofa/corp{
+	dir = 1
 	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/research)
-"KT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"KR" = (
+/obj/structure/alien/egg,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "KU" = (
 /obj/structure/closet/crate,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
+"KV" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "KW" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
@@ -7201,19 +12205,22 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "KY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "Lb" = (
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/mob_spawn/corpse/human,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
@@ -7223,23 +12230,91 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/mob_spawn/corpse/human,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
 "Lo" = (
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 4
-	},
+/obj/effect/gibspawner/human,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Lq" = (
+/obj/structure/alien/weeds/node,
+/mob/living/carbon/alien/adult/hunter,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
+"Lv" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
 "Lz" = (
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 351.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"LA" = (
+/obj/structure/safe,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/ammo_box/magazine/m50,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/book/bible,
+/obj/effect/spawner/random/exotic/languagebook,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"LI" = (
+/mob/living/carbon/alien/adult/drone,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"LJ" = (
+/obj/item/mecha_parts/camera_kit,
+/obj/structure/glowshroom/single,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"LK" = (
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45/caves)
+"LR" = (
+/obj/item/gun/ballistic/automatic/pistol/m1911/no_mag,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"LS" = (
+/obj/structure/closet/crate/cardboard/mothic,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 351.9
@@ -7253,35 +12328,88 @@
 	},
 /obj/item/stamp/head/ce,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"LV" = (
+/obj/structure/closet/crate,
+/obj/item/book,
+/obj/item/book,
+/obj/item/book,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "LW" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/awaymission/undergroundoutpost45/gateway)
-"LX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/awaymission/undergroundoutpost45/gateway)
-"LZ" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 8
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
-"Mg" = (
-/obj/effect/turf_decal/tile/purple{
+/area/awaymission/undergroundoutpost45/gateway)
+"Ma" = (
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Mf" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/gibspawner/human,
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Mk" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"Mm" = (
+/obj/structure/sign/poster/official/moth_hardhat,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 351.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Mn" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"Mr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/research)
-"Mo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/research)
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Ms" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/limb,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Mu" = (
 /obj/machinery/door/window/right/directional/south{
 	name = "Bar Door";
@@ -7289,11 +12417,23 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "Mx" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"MA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
@@ -7302,30 +12442,137 @@
 "MC" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"MF" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"MH" = (
+/obj/item/food/canned/peaches,
+/obj/item/food/canned/peaches,
+/obj/item/food/canned/desert_snails,
+/obj/item/food/canned/pine_nuts,
+/obj/item/food/canned/pine_nuts,
+/obj/item/food/canned/beans,
+/obj/structure/closet/crate,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"MJ" = (
-/obj/machinery/light/blacklight/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+"MI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
+"MK" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/mob_spawn/corpse/human/damaged,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"MN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"MQ" = (
+/obj/item/organ/internal/heart,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"MR" = (
+/obj/structure/window/reinforced/unanchored/spawner/directional{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/awaymission/undergroundoutpost45/caves)
+"MV" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"MW" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
 /area/awaymission/undergroundoutpost45/central)
+"MX" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"MY" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Nb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron/small,
+/area/awaymission/undergroundoutpost45)
 "Nd" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"Nf" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/awaymission/undergroundoutpost45)
+"Nh" = (
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
 "Ni" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "Nl" = (
 /obj/machinery/airalarm/directional/north,
@@ -7335,8 +12582,15 @@
 	c_tag = "Research Lab";
 	network = list("uo45","uo45r")
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"Nm" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
 "No" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -7344,19 +12598,12 @@
 	id = "UO45_Engineering";
 	name = "Engineering Security Door"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
-"Nr" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Diner"
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
+/area/awaymission/undergroundoutpost45/engineering)
 "NA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -7372,20 +12619,37 @@
 	name = "Security Checkpoint";
 	req_access = list("away_maintenance")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "NK" = (
 /obj/structure/bookcase/manuals/engineering,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"NL" = (
+/obj/item/mecha_parts/mecha_equipment/repair_droid,
+/obj/item/megaphone/sec,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "NQ" = (
 /obj/structure/table,
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "NR" = (
 /obj/structure/sink/directional/south,
@@ -7394,8 +12658,95 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"NS" = (
+/obj/structure/sign/poster/official/moth_meth,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 351.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"NT" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/central)
+"NU" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"NW" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/gibspawner/human,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"NX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/tgmcemblem,
+/area/awaymission/undergroundoutpost45/caves)
+"Oa" = (
+/obj/machinery/door/poddoor/shutters/preopen,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/door_assembly/door_assembly_highsecurity,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Ob" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/robot_debris,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"Oh" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/gateway)
+"Oj" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/resin/membrane,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Ok" = (
+/turf/closed/wall/mineral/titanium,
+/area/awaymission/undergroundoutpost45)
+"On" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "Oq" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/bed{
@@ -7404,7 +12755,9 @@
 /obj/item/bedsheet{
 	dir = 4
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
 "Os" = (
 /obj/machinery/light/small/directional/west,
@@ -7421,26 +12774,54 @@
 	},
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"OB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
 "OF" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plating{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"OL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
+"OG" = (
+/obj/item/toy/plush/moth,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 351.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"OH" = (
+/obj/item/paper{
+	default_raw_text = MISSIONFAILUREWEAREOVERUNEBYXENOS,ACTIVATETHEBEACONTELLTHEMTHISAREAISLOST.
+	},
+/mob/living/carbon/alien/larva,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "ON" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/research)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
 "OO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -7452,40 +12833,162 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
-"Pi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/research)
-"Pw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/research)
-"PB" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
-"Qb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/gateway)
+/area/awaymission/undergroundoutpost45/engineering)
+"OW" = (
+/obj/machinery/door/poddoor/ert,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Pd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Pf" = (
+/obj/structure/fluff/oldturret,
+/turf/closed/wall/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45/caves)
+"Ph" = (
+/obj/effect/gibspawner/xeno,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Pw" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/core,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Px" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds/node,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"PE" = (
+/obj/effect/decal/cleanable/ash,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"PO" = (
+/obj/machinery/vending/security,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"PR" = (
+/obj/effect/decal/cleanable/shreds,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"PS" = (
+/obj/item/clothing/gloves/color/black,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"PT" = (
+/obj/structure/alien/weeds/node,
+/obj/structure/alien/resin/membrane,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"PX" = (
+/obj/structure/barricade/sandbags,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"Qa" = (
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
 "Qe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"Qf" = (
+/obj/structure/closet/cabinet,
+/obj/item/disk/nuclear/fake/obvious,
+/obj/item/megaphone/command,
+/obj/item/clothing/neck/cloak/cap,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Qh" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/up,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Qj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/closed/indestructible/reinforced,
+/area/awaymission/undergroundoutpost45)
+"Qk" = (
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Qm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "UO45_EngineeringOffice";
 	name = "Privacy Shutters"
@@ -7500,24 +13003,57 @@
 	pixel_y = 9
 	},
 /obj/item/pen,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"Qn" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/item/clothing/shoes/combat,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Qo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"Qp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 8
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Qq" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Qs" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 "Qu" = (
 /obj/structure/disposaloutlet{
@@ -7527,76 +13063,161 @@
 	dir = 4
 	},
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"Qw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"Qv" = (
+/obj/item/paper{
+	default_raw_text = Larry,wemustpushontotheextractionpoint,thexenomorphsbreachedtheminesandnowwemustgothroughtheminesifwewanttomakeittothemarines,bestofwishes.
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "QC" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"QF" = (
+/obj/item/storage/secure/safe/directional,
+/turf/closed/wall/mineral/titanium/survival,
+/area/awaymission/undergroundoutpost45)
 "QG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/structure/sign/warning/secure_area/directional/west,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
-"QL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/research)
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"QI" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"QJ" = (
+/obj/structure/alien/egg/burst,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"QK" = (
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"QN" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"QT" = (
+/obj/effect/decal/cleanable/ash,
+/turf/closed/wall/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45/caves)
 "QX" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular,
 /obj/structure/sign/warning/biohazard/directional/west,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"Ra" = (
+/obj/structure/sign/poster/official/moth_delam,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 351.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Rb" = (
 /obj/machinery/seed_extractor,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
-"Rn" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
-"Ro" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
+"Rf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 5
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Rh" = (
+/obj/item/restraints/legcuffs/beartrap/energy,
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"Ri" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Ru" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Rx" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
-"RA" = (
-/obj/machinery/light/small/directional/south,
+"Ry" = (
+/obj/structure/alien/weeds,
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
+"RA" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
 "RC" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
@@ -7608,25 +13229,45 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
 "RF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/sign/warning/secure_area/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"RG" = (
+/obj/structure/closet/secure_closet/security,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"RJ" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "RN" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"RP" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
 "RX" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 1
@@ -7644,18 +13285,18 @@
 	req_access = list("away_maintenance")
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "Sa" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/research)
-"Sb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/gateway)
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Sd" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
@@ -7664,13 +13305,96 @@
 	network = list("uo45","uo45r")
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"Se" = (
+/turf/closed/wall/mineral/titanium/survival,
+/area/awaymission/undergroundoutpost45)
+"Sf" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/research)
+"Sh" = (
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/engineering)
+"Sn" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/down,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Sq" = (
+/obj/structure/closet/crate,
+/obj/item/gun/energy/laser/captain/scattershot,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Su" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
+"SA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"SC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"SE" = (
+/obj/vehicle/sealed/mecha/gygax/dark,
+/mob/living/basic/syndicate/ranged/smg/pilot,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"SG" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/structure/chair/comfy/shuttle/tactical,
+/obj/effect/mob_spawn/corpse/human/waystation/quartermaster,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/cup/glass/bottle/whiskey,
+/obj/item/reagent_containers/cup/glass/bottle/whiskey,
+/obj/item/reagent_containers/cup/glass/bottle/whiskey,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"SJ" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"SN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
 "SO" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
@@ -7679,55 +13403,130 @@
 /obj/item/radio/off,
 /obj/item/laser_pointer,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
+"SP" = (
+/obj/structure/window/reinforced/unanchored/spawner/directional,
+/turf/open/floor/engine,
+/area/awaymission/undergroundoutpost45/caves)
+"SR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"SS" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/mob_spawn/corpse/human/damaged,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "SZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/light/small/directional/west,
 /obj/structure/sign/warning/secure_area/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/gateway)
-"Ta" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/gateway)
-"Tf" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
-"Tr" = (
-/obj/structure/alien/resin/membrane,
+/area/awaymission/undergroundoutpost45/gateway)
+"Tc" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Te" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	id_tag = 182;
+	id = 182
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Tf" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds/node,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
+"Tl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 6
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Tr" = (
+/obj/structure/alien/resin/membrane,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Ts" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "Tu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /obj/structure/sign/warning/secure_area/directional/south,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "TC" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
-"TE" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
+"TD" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"TF" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"TI" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
 "TP" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/north,
@@ -7735,35 +13534,133 @@
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
+"TQ" = (
+/obj/machinery/computer/camera_advanced{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
+"TT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall/rust,
+/area/awaymission/undergroundoutpost45)
 "Ud" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
-"Ug" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
-"Ul" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
-"Us" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/research)
-"UH" = (
-/obj/structure/alien/weeds,
-/obj/effect/decal/cleanable/blood/gibs/down,
+/mob/living/carbon/alien/adult/hunter,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
+/area/awaymission/undergroundoutpost45/caves)
+"Uf" = (
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Ul" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/mob_spawn/corpse/human/damaged,
+/obj/item/clothing/head/helmet/marine/sulaco,
+/obj/item/clothing/suit/armor/vest/marine/sulaco,
+/obj/item/gun/ballistic/shotgun/doublebarrel,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Up" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Uq" = (
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
+"Us" = (
+/obj/structure/table,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"Ut" = (
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Uu" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"UD" = (
+/mob/living/carbon/alien/adult/royal/praetorian,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"UG" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/crew_quarters)
+"UH" = (
+/obj/structure/alien/weeds,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"UJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"UK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
+"UL" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/vault,
 /area/awaymission/undergroundoutpost45/caves)
 "UM" = (
 /obj/effect/turf_decal/sand/plating,
@@ -7771,40 +13668,105 @@
 	dir = 10
 	},
 /turf/open/floor/plating{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
+"UO" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"UR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "UU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/awaymission/undergroundoutpost45/gateway)
-"Vo" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
-"VF" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
+/obj/structure/sign/poster/official/moth_epi,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 351.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Va" = (
+/obj/structure/glowshroom/single,
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Vb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Vn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/research)
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"Vv" = (
+/obj/structure/alien/weeds,
+/turf/closed/mineral/random/labormineral,
+/area/awaymission/undergroundoutpost45/caves)
+"Vx" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"VA" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "VH" = (
 /obj/machinery/light/blacklight/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
 "VM" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "VR" = (
 /obj/machinery/airalarm/directional/north,
@@ -7812,49 +13774,71 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "VX" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Unfiltered to Mix"
+	},
 /obj/structure/sign/warning/no_smoking/directional/east,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
-"Wa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general,
-/turf/open/floor/plating,
-/area/awaymission/undergroundoutpost45/research)
-"Wd" = (
-/obj/structure/alien/resin/wall,
+/area/awaymission/undergroundoutpost45/engineering)
+"VY" = (
+/obj/machinery/door_buttons/access_button,
+/turf/closed/indestructible/reinforced,
+/area/awaymission/undergroundoutpost45)
+"Wb" = (
+/obj/effect/decal/cleanable/plasma,
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"Wc" = (
+/obj/effect/mob_spawn/corpse/human/engineer/mod,
 /obj/structure/alien/weeds,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"Wk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/mining)
-"Wn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+"Wd" = (
+/obj/structure/alien/resin/wall,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
 	},
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
+/area/awaymission/undergroundoutpost45/caves)
+"We" = (
+/obj/effect/mob_spawn/corpse/human/charredskeleton,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Wo" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -7863,46 +13847,80 @@
 	name = "Hydroponics Desk";
 	req_access = list("away_maintenance")
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
-"WD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/crew_quarters)
+"Ws" = (
+/obj/machinery/door/poddoor/preopen,
+/obj/effect/decal/cleanable/plasma,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Wt" = (
+/obj/structure/barricade/sandbags,
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"Wv" = (
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
+/turf/closed/indestructible/reinforced,
+/area/awaymission/undergroundoutpost45)
+"WB" = (
+/obj/item/clothing/shoes/workboots,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "WE" = (
 /obj/structure/glowshroom/single,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 351.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"WG" = (
-/obj/effect/turf_decal/tile/red/half/contrasted{
-	dir = 4
+"WI" = (
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/research)
+/area/awaymission/undergroundoutpost45/caves)
+"WK" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/ladder/unbreakable{
+	id_tag = 182;
+	id = 182
+	},
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45/central)
 "WQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /obj/structure/bed{
 	dir = 4
 	},
 /obj/item/bedsheet{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/carpet,
 /area/awaymission/undergroundoutpost45/crew_quarters)
-"WR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
 "WT" = (
 /obj/structure/table/glass,
 /obj/item/stock_parts/servo,
@@ -7913,34 +13931,98 @@
 /obj/item/stock_parts/micro_laser,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/side{
-	dir = 8
+	dir = 8;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "WU" = (
-/obj/effect/turf_decal/tile/green/anticorner/contrasted{
-	dir = 4
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"WZ" = (
+/obj/structure/alien/weeds/node,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
+/area/awaymission/undergroundoutpost45/caves)
 "Xd" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
+/obj/effect/mob_spawn/corpse/human/waystation/nanotrasenofficer,
+/obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"Xj" = (
+/obj/machinery/door/poddoor/shutters,
+/obj/machinery/door/airlock/command,
+/turf/open/floor/carpet/royalblue,
+/area/awaymission/undergroundoutpost45)
+"Xl" = (
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Xq" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light/small/directional/south,
 /obj/structure/sign/warning/secure_area/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/research)
+"Xr" = (
+/obj/structure/alien/resin,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Xy" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"XC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"XE" = (
+/obj/structure/table/wood,
+/obj/item/kirbyplants/random,
+/obj/machinery/camera/xray/directional/east,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "XF" = (
 /obj/structure/ore_box,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"XH" = (
+/obj/structure/alien/weeds,
+/mob/living/carbon/alien/adult/drone,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
@@ -7949,6 +14031,9 @@
 "XJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "UO45_EngineeringOffice";
 	name = "Privacy Shutters"
@@ -7961,42 +14046,69 @@
 	req_access = list("away_maintenance")
 	},
 /obj/item/folder/red,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
-"XQ" = (
-/obj/structure/glowshroom/single,
+"XK" = (
+/obj/structure/alien/egg,
+/obj/structure/alien/weeds/node,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"XU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/gateway)
+"XQ" = (
+/obj/structure/glowshroom/single,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"XT" = (
+/obj/item/light/bulb/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"XX" = (
+/obj/effect/decal/cleanable/glass/plastitanium,
+/obj/machinery/door/poddoor/shutters/preopen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/vault,
+/area/awaymission/undergroundoutpost45/caves)
+"XZ" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron{
+	dir = 8;
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "Yb" = (
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /obj/effect/mob_spawn/corpse/human,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
 	},
 /area/awaymission/undergroundoutpost45/caves)
-"Yf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
 "Yk" = (
 /obj/structure/table,
 /obj/item/computer_disk/ordnance,
 /obj/item/computer_disk/ordnance,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria{
-	dir = 5
+	dir = 5;
+	heat_capacity = 1e+006
 	},
 /area/awaymission/undergroundoutpost45/research)
 "Yn" = (
@@ -8004,20 +14116,46 @@
 	slogan_delay = 700
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
-"YD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
-/turf/open/floor/iron,
-/area/awaymission/undergroundoutpost45/engineering)
-"YF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/awaymission/undergroundoutpost45/research)
+"Yp" = (
+/obj/structure/sink/kitchen/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/iron/small,
+/area/awaymission/undergroundoutpost45)
+"Yq" = (
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
+/obj/effect/decal/cleanable/blood/footprints,
+/mob/living/carbon/alien/adult/hunter,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"YH" = (
+/obj/effect/gibspawner/xeno,
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "YK" = (
 /obj/structure/chair/stool/directional/west,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/crew_quarters)
 "YM" = (
 /obj/machinery/conveyor{
@@ -8027,21 +14165,114 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/mining)
+"YN" = (
+/obj/item/paper{
+	default_raw_text = Theheadofsecurityhasgonemad!thexenosjumpingoutoftheventshasmadehimparanoidenoughtoturnonhismen!Heclimbedinthestolenmechandisshootinganybodyheseesnow!WHATEVERWILLWEDO?
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/awaymission/undergroundoutpost45)
+"YO" = (
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
+"YP" = (
+/obj/structure/sign/poster/official/moth_piping,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 351.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"YT" = (
+/obj/structure/window/reinforced/spawner{
+	dir = 4
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
 "YV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/engineering)
+"YY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"YZ" = (
+/obj/effect/decal/cleanable/xenoblood,
+/obj/effect/decal/cleanable/xenoblood/xgibs/core,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Zd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 1
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"Zr" = (
+/obj/item/mod/module/flamethrower,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
 "Zs" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/mining)
+"ZA" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/plasma,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"ZB" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/alien/weeds/node,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
@@ -8051,6 +14282,7 @@
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
 	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
 	name = "Cave Floor";
 	temperature = 363.9
@@ -8059,22 +14291,57 @@
 "ZH" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/all_access,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/gateway)
 "ZM" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/structure/dresser,
-/turf/open/floor/carpet,
+/turf/open/floor/carpet{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
+"ZS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/turf/open/floor/iron{
+	heat_capacity = 1e+006
+	},
+/area/awaymission/undergroundoutpost45)
+"ZU" = (
+/obj/item/food/canned/beans,
+/obj/item/food/canned/beans,
+/obj/item/food/canned/beans,
+/obj/item/food/canned/peaches,
+/obj/item/food/canned/peaches,
+/obj/item/food/canned/desert_snails,
+/obj/item/food/canned/desert_snails,
+/obj/structure/closet/crate,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid{
+	heat_capacity = 1e+006;
+	initial_gas_mix = "co2=173.4;n2=135.1;plasma=229.8;TEMP=351.9";
+	name = "Cave Floor";
+	temperature = 363.9
+	},
+/area/awaymission/undergroundoutpost45/caves)
+"ZV" = (
+/obj/item/storage/toolbox/maint_kit,
+/obj/structure/closet/secure_closet/contraband/heads,
+/turf/open/floor/mineral/plastitanium,
+/area/awaymission/undergroundoutpost45)
 "ZZ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/plantbgone{
@@ -8090,7 +14357,9 @@
 	},
 /obj/item/watertank,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark{
+	heat_capacity = 1e+006
+	},
 /area/awaymission/undergroundoutpost45/central)
 
 (1,1,1) = {"
@@ -19732,7 +26001,7 @@ aa
 aa
 aa
 aa
-aa
+Jd
 aa
 aa
 aa
@@ -26245,8 +32514,8 @@ ad
 ad
 ad
 ad
-ad
-ad
+zq
+zq
 ad
 ad
 ad
@@ -26475,6 +32744,12 @@ ad
 ad
 ad
 ad
+Gn
+Gn
+Gn
+Gn
+Gn
+Gn
 ad
 ad
 ad
@@ -26496,6 +32771,9 @@ ad
 ad
 ad
 ad
+zq
+zq
+zq
 ad
 ad
 ad
@@ -26508,18 +32786,9 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Gn
+Gn
+Vv
 ad
 ad
 Yb
@@ -26731,6 +33000,14 @@ ad
 ad
 ad
 ad
+Gn
+Gn
+Gn
+Oj
+Fr
+BF
+Gn
+Gn
 ad
 ad
 ad
@@ -26745,6 +33022,19 @@ ad
 ad
 ad
 ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+ad
+zq
+zq
 ad
 ad
 ad
@@ -26752,36 +33042,15 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+Ry
+HW
+Gn
+Ry
+Gn
 zK
 KN
-Gn
+Px
 ad
 ad
 ad
@@ -26988,6 +33257,13 @@ ad
 ad
 ad
 ad
+Gn
+Gn
+wA
+Gn
+Gn
+Gn
+Gn
 ad
 ad
 ad
@@ -27003,39 +33279,32 @@ ad
 ad
 ad
 ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+BU
+iw
+Dp
+yF
+Tf
+HW
+Gn
 HW
 Gn
 zq
@@ -27245,56 +33514,56 @@ gK
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Gn
+Fr
+Gn
+Oj
+Gn
+Gn
+Fr
+Gn
+Gn
 ad
 Gn
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+Qq
+zq
+EE
+zq
+ad
+ad
+Au
+Ay
+Au
+XQ
+Ay
+FG
+Px
+Gn
+ad
+ad
+ad
+XH
 zq
 ci
 ad
@@ -27450,17 +33719,17 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+wT
+yH
+VY
+wT
+wT
+wT
+yH
+yH
+wT
+wT
+yH
 ad
 ad
 ad
@@ -27502,49 +33771,49 @@ gK
 ad
 ad
 ad
+Gn
+Be
+Gn
+Fr
+LI
+Gn
+Fr
+Gn
+Gn
+Gn
+Gn
+BF
+ad
+ad
+zq
 ad
 ad
 ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+DD
+Ms
+Ay
+BS
+zq
+Ay
 ad
 ad
 ad
@@ -27553,7 +33822,7 @@ ad
 ad
 ad
 zq
-zq
+WZ
 zO
 ad
 UH
@@ -27707,6 +33976,17 @@ ad
 ad
 ad
 ad
+yH
+fM
+jy
+TQ
+Ex
+Ex
+Ex
+Ex
+jy
+fM
+wT
 ad
 ad
 ad
@@ -27714,27 +33994,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+Se
+Se
+Se
+Se
+Se
+Se
+Se
+Se
+Se
 ad
 ad
 ad
@@ -27748,58 +34017,58 @@ hu
 Su
 iu
 iP
-cA
-Qb
+ji
+iP
 ed
-Qb
-Qb
-cm
+iP
+iP
+jI
 mC
 gL
 ad
 ad
 ad
+Vv
+Gn
+Gn
+Gn
+Gn
+Gn
+Gn
+QJ
+Fr
+Gn
+Gn
+Gn
+Xr
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+er
+Il
+BU
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+Uf
+zT
+zT
+zT
+zT
+Yq
+zT
+uh
+zT
+YZ
+zT
+VA
+zT
+ZA
+Qh
 ad
 ad
 ad
@@ -27964,6 +34233,17 @@ ad
 ad
 ad
 ad
+wT
+QK
+Uq
+yr
+yr
+yr
+yr
+yr
+Uq
+QK
+wT
 ad
 ad
 ad
@@ -27971,27 +34251,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+JX
+Ju
+JX
+YO
+Bs
+YO
+YO
+Ju
+Se
 ad
 ad
 ad
@@ -28005,57 +34274,57 @@ LW
 LW
 iv
 iQ
-mb
+jj
 jI
 gv
 Cy
 lq
-cm
+jI
 mD
 gL
 ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Gn
+Gn
+IG
+Gn
+Jy
+Gn
+Gn
+Wc
+Gn
+WZ
+Gn
+Xr
+Xr
+Ph
+Gn
+zq
+zq
+zq
+BU
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+Bk
+zq
+PS
+BU
+zq
+zq
+zq
+YH
+Pw
+nk
+yz
 ad
 ad
 ad
@@ -28221,6 +34490,17 @@ ad
 ad
 ad
 ad
+wT
+LA
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+Uq
+QK
+wT
 ad
 ad
 ad
@@ -28228,27 +34508,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+Xy
+YO
+Xy
+YO
+Se
+RP
+OB
+Ju
+Se
 ad
 ad
 ad
@@ -28263,11 +34532,11 @@ gJ
 it
 iR
 jk
-yq
+jI
 gv
 gK
 Ji
-Qb
+iP
 mE
 gK
 ad
@@ -28275,6 +34544,15 @@ ad
 ad
 ad
 ad
+Gn
+Gn
+Fr
+EN
+Gn
+Oj
+Fr
+WZ
+Gn
 ad
 ad
 ad
@@ -28284,32 +34562,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+BU
+zq
+zq
+Bk
+zq
+zq
+zq
+Qq
+EE
+zq
+zq
+DD
+zq
+zq
+zq
 ad
 ad
 ad
@@ -28319,7 +34588,7 @@ ad
 ad
 Yb
 zK
-Gn
+HW
 IT
 zb
 ad
@@ -28327,7 +34596,7 @@ ad
 ad
 XQ
 zq
-BQ
+ZB
 ad
 ad
 ad
@@ -28478,6 +34747,17 @@ ad
 ad
 ad
 ad
+yH
+QK
+ON
+SN
+SN
+MI
+nZ
+UK
+Uq
+QK
+yH
 ad
 ad
 ad
@@ -28485,27 +34765,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+zi
+YO
+Ju
+IY
+Se
+Jg
+za
+YO
+Se
 ad
 ad
 ad
@@ -28518,13 +34787,13 @@ gU
 gU
 gU
 gU
-gU
-gU
+iS
+jl
 gv
 gv
 kA
-cA
-XU
+ji
+mb
 mF
 gv
 ad
@@ -28532,6 +34801,15 @@ ad
 ad
 ad
 ad
+Gn
+XK
+Ix
+Gn
+Gn
+AX
+Oj
+Gn
+Gn
 ad
 ad
 ad
@@ -28541,31 +34819,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+Bk
+Go
+nA
+zq
+BS
+zq
+zq
+bW
+We
 ad
 ad
 ad
@@ -28733,6 +35002,19 @@ ad
 ad
 ad
 ad
+Jz
+ad
+wT
+KV
+mv
+Ru
+QK
+CX
+Uq
+Qj
+wT
+wT
+wT
 ad
 ad
 ad
@@ -28740,29 +35022,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+Ju
+Ju
+Mn
+Ci
+Se
+Jg
+wS
+YO
+Se
 ad
 ad
 ad
@@ -28776,12 +35045,12 @@ hw
 ib
 ib
 iT
-LX
+jm
 gK
 Rx
 kB
 lt
-XU
+mb
 mG
 gw
 zq
@@ -28789,6 +35058,14 @@ ad
 ad
 ad
 ad
+Gn
+Gn
+Gn
+Fr
+Gn
+Gn
+Gn
+Fr
 ad
 ad
 ad
@@ -28798,31 +35075,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+WI
+DC
+AR
+EL
+XX
+DC
+zq
+BS
+zq
+zq
+Sn
+zq
 ad
 ad
 ad
@@ -28839,7 +35108,7 @@ zq
 Gn
 ad
 Lb
-zq
+DM
 zq
 ad
 ad
@@ -28986,6 +35255,23 @@ ab
 ad
 ad
 ad
+wT
+wT
+yH
+wT
+Qj
+Qj
+TT
+Iv
+Cg
+Iv
+Hd
+UK
+UK
+Qj
+QK
+Ia
+wT
 ad
 ad
 ad
@@ -28993,33 +35279,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+Se
+Se
+Se
+Se
+Se
+Jg
+En
+YO
+Se
 ad
 ad
 ad
@@ -29032,12 +35301,12 @@ gW
 hx
 ZH
 yh
-jy
-UU
+iU
+jn
 gL
 Rx
 kC
-Qb
+ji
 mc
 mH
 gw
@@ -29046,6 +35315,14 @@ zq
 ad
 ad
 ad
+Gn
+Gn
+OH
+Gn
+WZ
+Gn
+Gn
+Gn
 ad
 ad
 ad
@@ -29055,30 +35332,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+XQ
+Bk
+Au
+Ko
+yx
+pv
+lp
+Ko
+zq
+zq
+ex
+zq
+aE
 ad
 ad
 ad
@@ -29093,10 +35362,10 @@ ad
 ad
 zO
 Gn
+Px
 Gn
 Gn
-Gn
-zq
+WZ
 zq
 ad
 ad
@@ -29104,7 +35373,7 @@ ad
 ad
 IT
 ZD
-UH
+kZ
 ad
 ad
 ad
@@ -29243,6 +35512,23 @@ ab
 ad
 ad
 ad
+wT
+Nf
+Ok
+Ok
+Ok
+Nf
+yH
+wT
+AW
+wT
+wT
+Uq
+Uq
+CY
+QK
+Up
+yH
 ad
 ad
 ad
@@ -29250,33 +35536,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+FY
+YO
+SJ
+ZV
+Se
+Jg
+En
+SE
+Se
 ad
 ad
 ad
@@ -29289,11 +35558,11 @@ gK
 gL
 gL
 gK
-gK
+iV
 jo
 gL
 gL
-gK
+iV
 kl
 gK
 gw
@@ -29303,6 +35572,14 @@ XQ
 ad
 ad
 ad
+Gn
+Gn
+Fr
+Gn
+Gn
+EN
+Gn
+yQ
 ad
 ad
 ad
@@ -29312,30 +35589,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+Ko
+GO
+SG
+AS
+Ko
+zq
+YY
+YY
+EE
+YY
 ad
 ad
 ad
@@ -29353,14 +35622,14 @@ ad
 Gn
 zq
 zq
-zq
+WZ
 zq
 Lk
 Tr
 zO
 XQ
 BQ
-zq
+WZ
 zb
 ad
 ad
@@ -29500,6 +35769,23 @@ ab
 ad
 ad
 ad
+wT
+Ok
+Pd
+Sa
+MV
+Ok
+wT
+Tc
+nO
+HU
+wT
+Uq
+Uq
+wT
+wT
+wT
+yH
 ad
 ad
 ad
@@ -29507,33 +35793,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+RG
+YO
+YO
+YO
+Se
+OB
+ht
+YO
+Se
 ad
 ad
 ad
@@ -29547,9 +35816,9 @@ hy
 id
 gK
 iW
-Sb
+jp
 jJ
-Ta
+kf
 SZ
 lv
 md
@@ -29560,6 +35829,14 @@ zq
 zq
 ad
 ad
+Gn
+yL
+NL
+QJ
+Gn
+Gn
+Fr
+LI
 ad
 ad
 ad
@@ -29569,30 +35846,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+Au
+Ko
+Ko
+Ko
+Ko
+Oa
+Ko
+Ko
+Ko
+Ko
+EE
+WI
+zq
 ad
 ad
 ad
@@ -29609,13 +35878,13 @@ ad
 ad
 Tr
 zq
-zq
+XQ
 zq
 Gn
 zq
 zq
 zq
-zq
+Lq
 zq
 zb
 Wd
@@ -29757,6 +36026,23 @@ ab
 ad
 ad
 ad
+yH
+Ok
+Sa
+Vb
+Ax
+Ec
+CS
+QK
+Cg
+IO
+wT
+Uq
+Uq
+CY
+IO
+JO
+wT
 ad
 ad
 ad
@@ -29764,33 +36050,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+RG
+YO
+Ju
+Ju
+Dg
+Jg
+ht
+YO
+Se
 ad
 ad
 ad
@@ -29803,12 +36072,12 @@ gK
 hz
 ie
 ix
-md
+iX
 jq
 QC
-Dt
-Dt
-lv
+kE
+kE
+lw
 me
 gU
 zq
@@ -29817,6 +36086,14 @@ zq
 zq
 ad
 ad
+Gn
+Fr
+Gn
+Fr
+Gn
+KR
+Gn
+KR
 ad
 ad
 ad
@@ -29826,30 +36103,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+Pf
+Ul
+HN
+NU
+SA
+BB
+On
+UL
+Pf
+Ay
+Ay
+Ay
 ad
 ad
 ad
@@ -29868,7 +36137,7 @@ IT
 BQ
 zq
 Gn
-Gn
+Px
 ZD
 zq
 Gn
@@ -30014,6 +36283,23 @@ ab
 ad
 ad
 ad
+yH
+Ok
+Vb
+XZ
+yX
+Ec
+CS
+QK
+Cg
+QK
+KL
+Uq
+Uq
+wT
+QK
+Qf
+wT
 ad
 ad
 ad
@@ -30021,33 +36307,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+RG
+YO
+YO
+YO
+Dg
+Jg
+En
+YO
+Se
 ad
 ad
 ad
@@ -30068,13 +36337,20 @@ kF
 lx
 gw
 gv
-Zs
+Oh
 zq
 zq
 zq
 ad
 ad
 ad
+Gn
+Oj
+Oj
+Gn
+sz
+Fr
+Gn
 ad
 ad
 ad
@@ -30084,29 +36360,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+EE
+zq
+LK
+EI
+Lo
+MN
+Jx
+wQ
+ys
+UL
+LK
+Ma
+ty
+zq
 ad
 ad
 ad
@@ -30123,7 +36392,7 @@ ad
 ad
 UH
 Gn
-zq
+Ud
 Gn
 ad
 ad
@@ -30271,6 +36540,23 @@ ab
 ad
 ad
 ad
+wT
+Ok
+Te
+Ax
+Cz
+Ok
+yH
+QK
+Cg
+QK
+Jw
+Uq
+Uq
+wT
+IO
+FC
+yH
 ad
 ad
 ad
@@ -30278,33 +36564,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Se
+Nm
+Ju
+YO
+yp
+QF
+Jg
+Ob
+GH
+Se
 ad
 ad
 ad
@@ -30332,6 +36601,13 @@ XQ
 ad
 ad
 ad
+Gn
+Gn
+PT
+Gn
+Hg
+Gn
+Gn
 ad
 ad
 ad
@@ -30340,30 +36616,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+PS
+zq
+LK
+JY
+wQ
+GN
+Ko
+MY
+Ca
+SS
+LK
+Ma
+yV
+MQ
 ad
 ad
 ad
@@ -30528,6 +36797,23 @@ ab
 ad
 ad
 ad
+wT
+Nf
+Ok
+Ok
+Ok
+Nf
+wT
+QK
+Cg
+IO
+Jw
+Uq
+Uq
+wT
+QK
+DQ
+wT
 ad
 ad
 ad
@@ -30535,33 +36821,16 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+CZ
+PO
+YO
+EM
+Us
+Se
+Jg
+Xd
+YO
+Se
 ad
 ad
 ad
@@ -30590,6 +36859,12 @@ ad
 ad
 ad
 ad
+MH
+Gn
+Gn
+xe
+Gn
+Gn
 ad
 ad
 ad
@@ -30598,29 +36873,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+Au
+Ko
+EI
+zq
+UL
+Ko
+EI
+XC
+vB
+Ko
+zq
+zq
+Mf
 ad
 ad
 ad
@@ -30785,40 +37054,40 @@ ab
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+wT
+wT
+wT
+yH
+JL
+JL
+eu
+Mr
+Cg
+Mr
+Aq
+SN
+SN
+JL
+Bc
+JL
+JL
+JL
+eu
+JL
+JL
+JL
+eu
+JL
+mm
+mm
+mm
+mm
+mm
+mm
+AA
+Kk
+zA
+Se
 ad
 ad
 ad
@@ -30836,7 +37105,7 @@ zq
 zq
 gU
 kI
-ly
+lz
 gU
 zq
 zq
@@ -30847,6 +37116,12 @@ XQ
 ad
 ad
 ad
+ZU
+Gn
+LJ
+xe
+Zr
+Gn
 ad
 ad
 ad
@@ -30855,29 +37130,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+BS
+BS
+zq
+wm
+zq
+zq
+Au
+zq
+Fb
+Ut
+ci
+zq
+Ud
 ad
 ad
 ad
@@ -30894,7 +37163,7 @@ ad
 ad
 ad
 ad
-zq
+XQ
 ad
 ad
 ad
@@ -31046,36 +37315,36 @@ ad
 ad
 ad
 ad
+HT
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+yH
+QK
+Cg
+Iv
+Qj
+UK
+UK
+Qj
+Nb
+Yp
+Qj
+Bo
+Iv
+PR
+Uu
+Iv
+Iv
+UR
+Iv
+Iv
+Hb
+YN
+PX
+SR
+SR
+SR
+YO
+Se
 ad
 ad
 ad
@@ -31105,6 +37374,11 @@ zq
 ad
 ad
 ad
+GC
+Gn
+Gn
+Fr
+Sq
 ad
 ad
 ad
@@ -31113,28 +37387,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+NW
+Qq
+zq
+zq
+zq
+zq
+zq
+wC
+zq
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -31305,34 +37574,34 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+yH
+QK
+RN
+QK
+wT
+Uq
+Uq
+Qj
+CM
+EX
+wT
+QK
+QK
+pu
+QK
+Hm
+Hm
+Hm
+Hm
+Hm
+Eo
+Nh
+Wt
+Jg
+Wt
+Rh
+Ju
+Se
 ad
 ad
 ad
@@ -31347,12 +37616,12 @@ zq
 zq
 zq
 zq
-RA
+Mk
 gw
 yR
 lA
 gw
-Zs
+Oh
 zq
 zq
 zq
@@ -31362,6 +37631,11 @@ zq
 ad
 ad
 ad
+LV
+Gn
+WB
+Gn
+hG
 ad
 ad
 ad
@@ -31369,29 +37643,24 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+Qq
+UD
+zq
+zq
+zq
+zq
+zq
+Ma
+MX
+zq
+Gj
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -31562,34 +37831,34 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+yH
+QK
+Vn
+IO
+wT
+Xj
+Xj
+Qj
+wT
+wT
+wT
+QK
+MF
+HH
+TD
+QK
+QK
+QK
+QK
+HI
+Se
+Mn
+Lv
+YO
+Lv
+YO
+YO
+Se
 ad
 ad
 ad
@@ -31606,7 +37875,7 @@ zq
 zq
 zq
 gU
-du
+kH
 ly
 gU
 zq
@@ -31620,6 +37889,8 @@ ad
 ad
 ad
 ad
+Gn
+Gn
 ad
 ad
 ad
@@ -31629,26 +37900,24 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+Vx
+zq
+zq
+zq
+Qn
+zq
+On
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -31819,34 +38088,34 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Wv
+vU
+Mr
+QK
+QK
+QK
+QK
+Iv
+QK
+QK
+QK
+QK
+IO
+QK
+IO
+IO
+QK
+QK
+QK
+QK
+Se
+YO
+Qa
+Ad
+Lv
+YO
+YO
+Se
 ad
 ad
 ad
@@ -31863,7 +38132,7 @@ zq
 zq
 zq
 gU
-du
+kK
 lB
 gU
 zq
@@ -31888,24 +38157,24 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+We
+Au
+zq
+Au
+zq
+EE
+zq
+zq
+Qq
+zq
+zq
+Au
+Ud
+zq
 ad
 ad
 ad
@@ -32076,34 +38345,34 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+wT
+QK
+Mr
+YT
+YT
+YT
+YT
+Iv
+QK
+IO
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+IO
+QK
+IO
+Se
+Se
+Se
+Se
+Se
+Se
+Se
+Se
 ad
 ad
 ad
@@ -32120,7 +38389,7 @@ zq
 zq
 zq
 gU
-Iw
+kG
 ly
 gU
 zq
@@ -32145,25 +38414,25 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+Au
+zq
+zq
+zq
+Ko
+XC
+Da
+zq
+zq
+RJ
+SA
+PE
+zq
+Qq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -32175,7 +38444,7 @@ ad
 ad
 zq
 zq
-ad
+zq
 zq
 zq
 ad
@@ -32333,27 +38602,27 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+wT
+QK
+Qk
+HL
+HL
+HL
+HL
+Jh
+QK
+QK
+QK
+gf
+QK
+QK
+QK
+QK
+Fu
+IO
+QK
+Em
+wT
 ad
 ad
 ad
@@ -32402,25 +38671,25 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+Qq
+zq
+Pf
+EI
+XC
+UL
+QT
+EI
+Lo
+Wb
+Pf
+zq
+zq
+Gj
+zq
 ad
 ad
 ad
@@ -32590,27 +38859,27 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+wT
+IO
+QK
+Ds
+Ds
+Ds
+ZS
+QK
+QK
+QN
+wT
+wT
+wT
+yH
+nT
+wT
+wT
+yH
+yH
+wT
+wT
 ad
 ad
 ad
@@ -32653,31 +38922,31 @@ gx
 gy
 gy
 gy
-gy
 ad
 ad
 ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+Au
+zq
+Qq
+zq
+XC
+UL
+Ko
+MK
+XC
+zq
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -32847,17 +39116,17 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+wT
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+QK
+KP
+yH
 ad
 ad
 ad
@@ -32891,24 +39160,23 @@ hc
 gz
 gz
 kh
-ha
+kM
 lE
 mf
-hc
-hc
-gz
-gz
+mJ
+mJ
+nM
+nM
 pb
 pG
-qX
-tr
+qf
+qO
 ry
-tr
+qO
 tg
-gx
+tK
 us
 uK
-wt
 vh
 gy
 ad
@@ -32916,24 +39184,25 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+Ud
+zq
+zq
+zq
+XC
+Au
+Ud
+zq
+zq
+zq
+zq
+dq
+zq
 ad
 ad
 ad
@@ -33104,17 +39373,17 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+yH
+HU
+yy
+Xl
+Xl
+Xl
+XE
+DT
+fL
+zj
+wT
 ad
 ad
 ad
@@ -33146,51 +39415,51 @@ ig
 ze
 iY
 jr
-jO
-mU
-ha
+jM
+ki
+kN
 lF
 mg
 mK
-pG
-tr
-ry
+nj
+nN
+ow
 pc
-gz
-hc
-gz
-hc
-hc
-tP
+pH
+qg
+pH
+qg
+qg
+th
 tL
 ut
-Pi
+uL
 vi
-Ec
-gy
+gx
 ad
 ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+PE
+zq
+zq
+Ma
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -33203,7 +39472,7 @@ ad
 ad
 ad
 zq
-zq
+Ud
 ad
 ad
 ad
@@ -33361,17 +39630,17 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+wT
+wT
+yH
+wT
+wT
+wT
+yH
+wT
+wT
+wT
+wT
 ad
 ad
 ad
@@ -33402,7 +39671,7 @@ hC
 ih
 iz
 iZ
-kO
+js
 jN
 kj
 kO
@@ -33419,35 +39688,35 @@ Os
 qh
 gz
 nt
-gy
+tM
 uu
-Pi
-vi
-Sa
-gy
+uM
+vj
+gx
 ad
 ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+Qq
+zq
+Au
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+yE
+zq
 ad
 ad
 ad
@@ -33658,11 +39927,11 @@ gZ
 hD
 ii
 iA
-YF
-JO
+ha
+gX
 jO
 kk
-ha
+kP
 lH
 gy
 kd
@@ -33675,35 +39944,35 @@ qi
 qQ
 rz
 gz
-tS
+ti
+tN
+gy
+gy
 gx
-QL
-Wa
-Wa
-Pw
 gy
 ad
 ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+BS
+zq
+PS
+zq
+xZ
+EE
+Au
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -33932,13 +40201,9 @@ Gq
 qR
 Ea
 gz
-tP
-gx
-gy
-gy
-gy
-gy
-gy
+nu
+tN
+uv
 ad
 ad
 ad
@@ -33948,19 +40213,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+yE
+Gj
+zq
+zq
+zq
+zq
+PE
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -34170,28 +40439,28 @@ gy
 gN
 gX
 hF
-YF
+kN
 iC
 hc
 zq
 zq
 gz
-mU
+kR
 lJ
 mh
 mN
 nm
 Cj
 oy
-rZ
+mP
 pI
 qk
 qS
 rB
 hc
-tP
+nu
+tM
 gy
-gy
 ad
 ad
 ad
@@ -34201,23 +40470,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+SC
+BS
+zq
+zq
+zq
+zq
+XQ
 ad
 ad
 ad
@@ -34433,10 +40702,10 @@ hc
 zq
 zq
 hH
-Jo
-lM
-mj
-mP
+kS
+lK
+mi
+mO
 nn
 nQ
 oz
@@ -34458,23 +40727,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+Dw
+XC
+Ud
+Au
+zq
+WU
+UJ
+On
+zq
+Hh
+EE
+zq
 ad
 ad
 ad
@@ -34690,7 +40959,7 @@ gz
 zq
 zq
 hH
-Jo
+kR
 lL
 mj
 mP
@@ -34703,7 +40972,7 @@ gx
 gz
 gz
 gz
-uL
+tk
 tP
 gy
 ad
@@ -34715,23 +40984,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+Ud
+zq
+MQ
+Eu
+Ef
+SC
+zq
+Ko
+QI
+UJ
+wQ
+Ws
+zq
+zq
+zq
 ad
 ad
 ad
@@ -34939,7 +41208,7 @@ ad
 ad
 ad
 zq
-MC
+jQ
 zq
 zq
 zq
@@ -34947,8 +41216,8 @@ zq
 zq
 zq
 hH
-Jo
-ON
+kR
+lM
 mj
 mQ
 mP
@@ -34972,23 +41241,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+Ma
+zq
+zq
+Ko
+Aa
+EA
+XC
+Ko
+EI
+On
+UL
+Ko
+zq
+zq
+zq
 ad
 ad
 ad
@@ -35202,7 +41471,7 @@ zq
 zq
 zq
 zq
-RA
+Sf
 gz
 IX
 lN
@@ -35229,23 +41498,23 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+Ko
+EI
+SA
+FB
+Ko
+Ri
+On
+CV
+Ko
+zq
+yE
+zq
 ad
 ad
 ad
@@ -35461,7 +41730,7 @@ zq
 zq
 zq
 hH
-Mg
+kR
 lM
 hH
 mR
@@ -35474,7 +41743,7 @@ gy
 gz
 rF
 gz
-gz
+tn
 tP
 gx
 ad
@@ -35486,22 +41755,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+Va
+EE
+zq
+Pf
+TF
+XC
+wJ
+Lo
+HK
+Lo
+TI
+Pf
+zq
+zq
 ad
 ad
 ad
@@ -35724,14 +41993,14 @@ hH
 mS
 np
 nU
-Mo
+oD
 pi
-gy
+pK
 qo
 qU
 rG
 sv
-gz
+tn
 tP
 gz
 ad
@@ -35743,22 +42012,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+Ko
+Ko
+Gl
+XT
+Qp
+cz
+UO
+Ko
+Ko
+Qq
+zq
 ad
 ad
 ad
@@ -35981,14 +42250,14 @@ hH
 mT
 nq
 nV
-WG
+nV
 lu
-gx
+pL
 Ap
 qV
-YF
+rH
 sw
-gz
+to
 tR
 gz
 zq
@@ -36000,22 +42269,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+Au
+CQ
+Ko
+EI
+Zd
+iN
+NX
+UL
+Ko
+CQ
+Gj
+zq
 ad
 ad
 ad
@@ -36243,9 +42512,9 @@ hH
 gx
 qq
 ha
-YF
+kP
 sx
-gz
+tn
 tP
 hc
 zq
@@ -36257,22 +42526,22 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+BJ
+HE
+Ko
+Ts
+Rf
+Fq
+Tl
+Wb
+Ko
+HE
+dw
+zq
 ad
 ad
 ad
@@ -36466,10 +42735,10 @@ aC
 cu
 cD
 cW
-bZ
-bY
-bY
-bq
+di
+cq
+cq
+ee
 aC
 ad
 ad
@@ -36490,24 +42759,24 @@ zq
 gz
 gn
 kV
-kZ
-aL
-aL
-aL
-aL
-aL
+ha
+mk
+mk
+mk
+mk
+mk
 mk
 pM
 ha
 ha
 rI
 Km
-gz
+tn
 tS
 hc
 hc
 hc
-Zs
+Ce
 zq
 ad
 ad
@@ -36515,21 +42784,21 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+MR
+qp
+Ko
+GJ
+XC
+SA
+SA
+wU
+Ko
+JP
+EO
+zq
 ad
 ad
 ad
@@ -36723,7 +42992,7 @@ aC
 al
 bY
 cX
-bY
+cm
 ae
 ae
 ef
@@ -36747,7 +43016,7 @@ zq
 gz
 iL
 kX
-VF
+kX
 kX
 mU
 nr
@@ -36759,7 +43028,7 @@ qr
 qW
 rJ
 Cw
-hc
+tp
 tT
 gy
 uN
@@ -36772,21 +43041,21 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+MR
+JP
+Ko
+Ko
+OW
+OW
+OW
+Ko
+Ko
+JP
+SP
+zq
 ad
 ad
 ad
@@ -36980,14 +43249,14 @@ aC
 cv
 cE
 cW
-al
+ce
 ae
 bf
-ey
+eg
 Ge
 zG
 eW
-ae
+fo
 fA
 fQ
 aC
@@ -37004,7 +43273,7 @@ ad
 gz
 gz
 kY
-KO
+kY
 kY
 gz
 hc
@@ -37016,9 +43285,9 @@ gz
 gz
 gz
 gz
-hc
-tP
-gc
+tq
+tU
+uw
 uO
 vk
 ah
@@ -37029,21 +43298,21 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+Au
+Au
+zq
+Ko
+XC
+XC
+XC
+Ko
+zq
+Au
+zq
+zq
 ad
 ad
 ad
@@ -37231,20 +43500,20 @@ bi
 bs
 by
 bI
-aC
-bq
-aC
-aC
+bO
+ca
+cp
+cp
 cF
-cW
-bq
-ae
+cY
+cf
+dv
 dP
 eh
-Ai
-Wn
+bL
+bL
 eX
-an
+fm
 fB
 ZM
 aC
@@ -37264,18 +43533,18 @@ gz
 lO
 gz
 gz
-pb
-tr
-pG
+ns
+nN
+nj
 rK
-tr
-tr
+nN
+nN
 qX
 rK
-tr
+nN
 tr
 tV
-gy
+ux
 uP
 hH
 ah
@@ -37287,20 +43556,20 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+Au
+LR
+Ko
+Ko
+XC
+XC
+XC
+Ko
+Ko
+zq
+Au
+Au
 ad
 ad
 ad
@@ -37488,13 +43757,13 @@ bj
 AT
 aC
 aC
-aC
-bq
-bY
-bq
-al
-bY
-bq
+bP
+cb
+cq
+ct
+cG
+cq
+dk
 an
 dQ
 ei
@@ -37518,20 +43787,20 @@ zq
 ad
 gy
 NR
-Us
+ha
 ml
 gx
 nt
-gz
-hc
-hc
-gz
-hc
-hc
-hc
-hc
-gz
-gz
+nW
+mJ
+mJ
+nM
+mJ
+mJ
+mJ
+mJ
+nM
+tW
 hc
 hc
 hc
@@ -37544,20 +43813,20 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+yE
+Hh
+zq
+zq
+zq
+zq
+Hr
+zq
+Au
+zq
+zq
 ad
 ad
 ad
@@ -37745,8 +44014,8 @@ bi
 bu
 bz
 bJ
-aD
-bq
+bQ
+cc
 aC
 aC
 aC
@@ -37775,11 +44044,11 @@ zq
 ad
 gx
 la
-Us
+ha
 Xq
 gy
-tP
-gz
+nu
+nX
 zq
 zq
 XQ
@@ -37801,20 +44070,20 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+Gj
+zq
+yC
+zq
+zq
+zq
+zq
+Ud
 ad
 ad
 ad
@@ -38002,21 +44271,21 @@ aC
 bv
 aC
 aC
-aD
-bY
-aD
+bQ
+cd
+cr
 cw
 cH
 ae
 aF
 Gc
-IV
+aS
 ej
-LZ
-LZ
+ey
+ey
 eZ
-MJ
-IV
+bA
+fE
 fT
 aC
 ad
@@ -38032,11 +44301,11 @@ XQ
 ad
 gy
 lb
-Us
+ha
 mn
 gy
-tP
-hc
+nu
+nY
 zq
 zq
 zq
@@ -38059,19 +44328,19 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+Ud
+zq
+zq
+PS
+zq
+zq
+zq
+zq
+zq
+zq
+Ak
+zq
+zq
 ad
 ad
 ad
@@ -38259,21 +44528,21 @@ bk
 aS
 bA
 aF
-aC
-al
+bP
+ce
 aC
 Qs
-fB
+cI
 cZ
-gf
-gf
-zJ
-zJ
-zJ
-zJ
-zJ
-zJ
-Ai
+dl
+dx
+aS
+aS
+aS
+aS
+aS
+aS
+fE
 aS
 aC
 fO
@@ -38293,7 +44562,7 @@ lO
 gy
 gx
 nv
-hc
+nY
 gr
 gr
 gr
@@ -38316,19 +44585,19 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -38351,7 +44620,7 @@ zq
 zq
 ad
 zq
-zq
+Qv
 zq
 ad
 ad
@@ -38512,25 +44781,25 @@ aO
 ax
 az
 aB
-Xd
+bl
 bw
 bB
 bK
-aC
-bq
-aC
+bR
+cf
+cp
 aU
 cJ
 ae
 aF
-IV
+dy
 dS
 ek
 ez
 eN
 fa
 fp
-Ai
+bL
 aS
 da
 gA
@@ -38541,9 +44810,9 @@ hf
 gs
 gs
 iE
-Ug
-ju
-Ud
+ja
+jt
+ng
 kn
 lc
 lP
@@ -38551,7 +44820,7 @@ QG
 mV
 nw
 JD
-nD
+oF
 pl
 gr
 gr
@@ -38573,18 +44842,18 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -38771,44 +45040,44 @@ ay
 aT
 bm
 aC
-fq
-Ai
-aD
-br
+bC
+aS
+bQ
+cg
 ae
 ae
 ae
 ae
 aS
-IV
+aS
 dT
 el
 el
 el
 el
 fq
-Ai
-aS
-da
-gs
+fF
+bL
+ge
+gl
 gt
-WD
-HA
-JJ
-WD
-WD
-WD
-WD
-Ij
-HA
-HA
-Ug
-lQ
+gA
 gs
-nG
+JJ
+gA
+gA
+gA
+gA
+ju
+gs
+gs
+ld
+lQ
+gl
+mW
 nx
 oa
-gs
+ld
 pm
 pN
 gr
@@ -38830,17 +45099,17 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+Ud
+zq
+zq
+zq
 ad
 ad
 ad
@@ -39028,23 +45297,23 @@ ba
 bg
 bn
 aC
-fq
-Ai
-Ai
-Ai
+bD
+bL
+bL
+ch
 cs
-Ul
-Ai
-nj
-Ai
-IV
+aI
+aS
+da
+aS
+aS
 dT
 el
 eA
 eB
 el
 fq
-Ai
+fE
 fU
 ae
 fK
@@ -39058,14 +45327,14 @@ gr
 gg
 gg
 jR
-Ro
-Ug
+gs
+ld
 gA
 mp
 fN
 ny
 ob
-gs
+ld
 gs
 pO
 gr
@@ -39087,17 +45356,17 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -39285,30 +45554,30 @@ bb
 bg
 bo
 aC
-fq
-zJ
-zJ
-zJ
-zJ
-zJ
-zJ
-zr
-zJ
-IV
+bE
+bM
+bT
+bM
+aS
+aS
+aS
+da
+aS
+aS
 dT
 el
 eB
 eO
 el
 fq
-Ai
+fE
 fV
 ae
 zq
 zq
 zq
 zq
-MC
+Dq
 zq
 zq
 zq
@@ -39345,15 +45614,15 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -39529,7 +45798,7 @@ ad
 ad
 ae
 ag
-al
+WK
 ap
 fu
 ag
@@ -39542,23 +45811,23 @@ bc
 bg
 bm
 aC
-fq
-WR
-aC
-br
+bF
+aF
+bP
+cg
 aC
 aC
 aC
 aC
 dm
-IV
+aS
 dU
 el
 el
 el
 el
 fq
-Ai
+fE
 aF
 aP
 zq
@@ -39572,7 +45841,7 @@ zq
 zq
 zq
 fK
-Ro
+gs
 lf
 fO
 fO
@@ -39602,14 +45871,14 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+Gj
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -39797,25 +46066,25 @@ aQ
 aY
 aY
 bh
-vw
-vw
+bp
+bp
 bG
 bN
-aC
-bq
-aD
+bP
+cj
+cr
 aZ
 cK
 aC
 dn
-IV
+dz
 dV
 em
 eC
 eC
 aY
 fr
-Ai
+fG
 fW
 aP
 zq
@@ -39829,14 +46098,14 @@ zq
 zq
 zq
 gr
-KT
+gA
 gs
 fN
 mr
 mX
-fO
+pS
 oe
-zA
+oI
 po
 pQ
 qs
@@ -39860,13 +46129,13 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
-ad
-ad
-ad
-ad
+zq
+zq
+zq
+zq
+zq
+zq
+zq
 ad
 ad
 ad
@@ -40058,20 +46327,20 @@ aS
 bx
 bH
 aS
-aD
-bZ
+bQ
+ck
 aC
 Bq
-fB
+cI
 db
-IV
-IV
+bM
+dA
 dW
-PB
-PB
-PB
-PB
-PB
+en
+en
+en
+en
+en
 fH
 fX
 aP
@@ -40086,7 +46355,7 @@ zq
 zq
 zq
 gr
-Ro
+gs
 gs
 fO
 EJ
@@ -40315,9 +46584,9 @@ aP
 aC
 aC
 aD
-aD
-al
-aD
+bU
+cl
+co
 cB
 cL
 aC
@@ -40343,7 +46612,7 @@ zq
 zq
 zq
 gg
-Ro
+gs
 lg
 fO
 mt
@@ -40351,8 +46620,8 @@ km
 fO
 og
 oK
-fN
-fO
+pp
+pS
 fO
 fO
 gg
@@ -40572,8 +46841,8 @@ ad
 ad
 ad
 ad
-aC
-bY
+bP
+cm
 aC
 aC
 aC
@@ -40600,7 +46869,7 @@ gr
 fK
 gg
 gg
-Nr
+kp
 kp
 fN
 fN
@@ -40829,14 +47098,14 @@ ad
 ad
 ad
 ad
-aC
+bP
 cn
-bq
-al
-bq
+ct
+cG
+ct
 dc
 aD
-aP
+bd
 dZ
 aS
 aP
@@ -40857,14 +47126,14 @@ iF
 Nd
 jv
 jS
-TE
+hK
 hK
 fN
 mu
 HM
-fO
+pS
 oi
-zA
+oI
 pq
 pU
 Fw
@@ -41086,12 +47355,12 @@ ad
 ad
 ad
 ad
-aC
-aD
-aC
-aC
-bq
-bY
+bV
+co
+cp
+cp
+cM
+cm
 aD
 dC
 ea
@@ -41114,14 +47383,14 @@ hJ
 hK
 jw
 jT
-TE
+hK
 iH
 fO
 TP
 mY
 nC
 of
-oG
+oM
 fO
 fN
 fO
@@ -41347,11 +47616,11 @@ ad
 ad
 ad
 ae
-bq
-bZ
-aC
+cN
+dd
+dp
 dD
-IV
+bM
 ep
 aS
 aS
@@ -41371,7 +47640,7 @@ hK
 iH
 hK
 hJ
-TE
+hK
 hK
 fO
 ev
@@ -41604,8 +47873,8 @@ ad
 ad
 ad
 ae
-bq
-aC
+cN
+de
 aC
 KW
 eb
@@ -41628,14 +47897,14 @@ in
 YK
 iH
 jU
-TE
+kq
 lh
 fO
 fN
 fN
 fO
 ok
-pm
+oO
 fN
 pW
 fO
@@ -41861,8 +48130,8 @@ ad
 ad
 ad
 ae
-bq
-aC
+cN
+de
 Cr
 dF
 aF
@@ -41886,13 +48155,13 @@ hl
 hl
 hL
 iH
-TE
+li
 lS
 fN
 nc
 nD
-oi
-gA
+ol
+oP
 pr
 pX
 Ac
@@ -42118,8 +48387,8 @@ ad
 ad
 Lz
 an
-bq
-aC
+cN
+de
 Yn
 dG
 eb
@@ -42143,11 +48412,11 @@ hK
 jx
 hL
 hK
-TE
+li
 lT
 fO
 nd
-ai
+gA
 om
 oJ
 fO
@@ -42375,8 +48644,8 @@ ad
 Lz
 WE
 ae
-bq
-aD
+cN
+df
 IK
 dH
 aS
@@ -42385,7 +48654,7 @@ aS
 aS
 fg
 an
-Zs
+NT
 zq
 zq
 zq
@@ -42400,12 +48669,12 @@ hK
 Mu
 hK
 kr
-TE
+li
 hJ
 fO
 ne
-gs
-of
+nE
+on
 oQ
 fO
 fN
@@ -42419,11 +48688,11 @@ uy
 uR
 vo
 vL
-vK
+we
 wr
 vL
 wO
-vK
+we
 vK
 xl
 YM
@@ -42632,8 +48901,8 @@ WE
 Lz
 Lz
 an
-bq
-aC
+cN
+de
 Rb
 dG
 eb
@@ -42656,7 +48925,7 @@ iH
 jc
 jz
 hK
-Vo
+ks
 lj
 lU
 fN
@@ -42677,9 +48946,9 @@ uS
 vp
 vM
 wf
-Bz
+ws
 Ba
-wv
+wu
 wX
 vK
 xm
@@ -42889,8 +49158,8 @@ Lz
 Lz
 Lz
 an
-al
-aD
+cO
+df
 FS
 dI
 aS
@@ -42913,7 +49182,7 @@ iI
 fO
 fO
 jV
-hK
+ks
 xc
 fO
 fO
@@ -42934,9 +49203,9 @@ fO
 fN
 vK
 wg
-wv
+wu
 wD
-Wk
+wP
 sj
 vL
 xn
@@ -43146,8 +49415,8 @@ Lz
 Lz
 Lz
 aP
-bY
-aD
+cP
+df
 aC
 dJ
 eb
@@ -43170,38 +49439,38 @@ iJ
 jd
 fO
 jW
-hK
-RN
-kp
+kt
+ll
+lV
 mx
-gA
-gs
-of
-KT
+ng
+nH
+oq
+oS
 pt
-Ro
-Ro
+ja
+ja
 re
 rN
-Ud
+ng
 tt
 tZ
 tZ
 uT
 vq
 vN
-Bz
-wv
-Wk
-wv
+wh
+wu
+wE
+wu
 wZ
 xg
-wv
-wv
-wv
-wv
-Bz
-Bz
+xo
+xo
+wu
+xG
+wh
+xV
 xX
 ya
 yd
@@ -43211,7 +49480,7 @@ zq
 zq
 zq
 zq
-zq
+Gz
 zq
 zq
 zq
@@ -43403,9 +49672,9 @@ ad
 WE
 Lz
 aP
-bq
-cX
-aD
+cQ
+dg
+co
 dK
 ec
 eq
@@ -43432,7 +49701,7 @@ lm
 lW
 my
 my
-my
+nI
 or
 FA
 my
@@ -43442,24 +49711,24 @@ rf
 rO
 sD
 tu
-Jm
+ua
 ua
 ua
 vr
 vO
-xH
-xH
-wD
-wD
+wi
+wv
+wF
+wF
 xa
 xh
 Qe
+wv
+xz
 xH
-xH
-Wk
 xP
 xW
-yj
+xY
 yb
 ye
 ww
@@ -43660,13 +49929,13 @@ ad
 Lz
 Lz
 an
-bZ
-bq
+cR
+cc
 aC
-WU
-DL
-DL
-DL
+dL
+dB
+dB
+dB
 eT
 fl
 fw
@@ -43681,8 +49950,8 @@ hr
 hS
 iq
 gO
-Jv
-fO
+gO
+jB
 jY
 fO
 fK
@@ -43712,7 +49981,7 @@ vI
 vI
 vJ
 ww
-ww
+xA
 xI
 ww
 vI
@@ -43918,7 +50187,7 @@ Lz
 Lz
 an
 cS
-al
+ce
 aC
 zX
 EP
@@ -43936,11 +50205,11 @@ gF
 gO
 gO
 hT
-Jv
-Jv
+gO
+gO
 dO
-fO
-fy
+jB
+jZ
 kv
 ae
 zq
@@ -43948,7 +50217,7 @@ zq
 zq
 zq
 zq
-MC
+Dq
 zq
 zq
 zq
@@ -43970,7 +50239,7 @@ ad
 vJ
 xu
 xB
-fP
+xJ
 xQ
 vI
 zq
@@ -44175,7 +50444,7 @@ WE
 Lz
 an
 cT
-bq
+cc
 aC
 aC
 aC
@@ -44196,7 +50465,7 @@ hU
 ir
 Ar
 jf
-fN
+jC
 ka
 kw
 an
@@ -44210,7 +50479,7 @@ zq
 zq
 zq
 gr
-rQ
+rR
 sG
 gr
 zq
@@ -44432,28 +50701,28 @@ Lz
 Lz
 ae
 cU
-bq
-bY
+dh
+cq
 dN
-al
-bq
-Hp
-Hp
-Hp
+cG
+ct
+eF
+ct
+ct
 fz
-jD
+gQ
 gb
-gb
+gj
 gp
 fO
 fN
 fN
 fN
-gr
+hV
 fO
 fN
 fO
-fN
+jC
 kb
 kx
 an
@@ -44688,25 +50957,25 @@ ad
 ad
 ad
 ae
-aD
-aC
-aD
-aD
-aC
-aC
-IH
-aC
-an
-an
-an
-ae
-bq
+cV
+cp
+co
+co
+cp
+es
+eG
+cp
+fm
+fm
+fm
+gc
+dh
 gq
 gb
 gH
-jD
+gQ
 gb
-gb
+hW
 gH
 iM
 gb
@@ -44727,7 +50996,7 @@ gg
 BI
 sH
 gg
-Zs
+UG
 zq
 zq
 zq
@@ -44956,18 +51225,18 @@ eV
 an
 zq
 zq
-ae
-an
-an
-an
-ae
-ae
-an
-aP
-an
-an
-an
-ae
+gd
+fm
+fm
+fm
+dv
+dv
+fm
+hX
+fm
+fm
+fm
+jE
 an
 ae
 zq
@@ -44982,7 +51251,7 @@ zq
 zq
 gr
 rQ
-Tf
+sF
 gr
 zq
 zq
@@ -45221,7 +51490,7 @@ zq
 zq
 zq
 zq
-MC
+MW
 zq
 zq
 zq
@@ -45236,12 +51505,12 @@ zq
 zq
 zq
 zq
-zq
+Ga
 gr
 rU
-Tf
+sI
 gr
-zq
+Ga
 zq
 zq
 zq
@@ -45467,7 +51736,7 @@ ad
 ah
 ah
 ah
-MC
+MW
 zq
 zq
 zq
@@ -45493,12 +51762,12 @@ zq
 zq
 zq
 zq
-zq
-gr
+Fx
+rg
 rV
 sJ
-gr
-zq
+rg
+Cv
 zq
 zq
 zq
@@ -45748,9 +52017,9 @@ zq
 zq
 zq
 zq
-zq
-zq
-zq
+Fy
+MA
+Cv
 fK
 rW
 sK
@@ -46005,7 +52274,7 @@ zq
 zq
 zq
 zq
-zq
+Ai
 ni
 ni
 ln
@@ -46262,14 +52531,14 @@ zq
 zq
 zq
 zq
-zq
+Ai
 ni
 qC
 rh
 rY
-Yf
+sM
 tv
-ln
+uc
 uA
 uU
 vs
@@ -46519,15 +52788,15 @@ zq
 zq
 zq
 zq
-zq
+Ai
 qb
 qD
 ri
-Qw
-Yf
+rZ
+sM
 tw
-ln
-rj
+ud
+uB
 uV
 rj
 vQ
@@ -46776,19 +53045,19 @@ zq
 zq
 zq
 zq
-zq
+Ai
 qb
 qD
 rj
-vv
-uC
+sa
+sN
 tx
 ue
 uC
-vT
+uW
 vt
 vR
-wl
+wk
 Dm
 Ae
 Gp
@@ -47033,7 +53302,7 @@ zq
 zq
 zq
 zq
-RA
+Sh
 ni
 ln
 rk
@@ -47042,9 +53311,9 @@ sO
 Tu
 ln
 uD
-rj
+sM
 vu
-rj
+vS
 wl
 Dz
 KY
@@ -47290,7 +53559,7 @@ zq
 zq
 zq
 zq
-zq
+Ai
 zq
 ni
 ni
@@ -47300,11 +53569,11 @@ ln
 ln
 uE
 VH
-CT
+vv
 vT
 Fd
 Qo
-eu
+Kt
 zn
 YV
 ln
@@ -47547,7 +53816,7 @@ ad
 ad
 zq
 zq
-zq
+Ai
 zq
 ni
 rl
@@ -47556,8 +53825,8 @@ sQ
 tz
 uf
 qb
-rj
-Rn
+sM
+vw
 AN
 wn
 uE
@@ -47804,16 +54073,16 @@ ad
 ad
 ad
 ad
-zq
+Ai
 zq
 ni
 rm
-rj
-CD
-CD
+se
+sR
+tA
 ug
 uF
-Yf
+sR
 vx
 vV
 uE
@@ -48061,8 +54330,8 @@ ad
 ad
 ad
 ad
-wn
-Lo
+px
+ad
 ln
 rn
 sf
@@ -48318,18 +54587,18 @@ ln
 ni
 ni
 ln
+py
 ln
-fv
-fv
 ln
+ro
+sg
 sT
 sT
-sT
 ln
 ln
-uE
+uZ
 vz
-uE
+vX
 ni
 ad
 ad
@@ -48580,12 +54849,12 @@ qb
 De
 rp
 sh
-tG
+sU
 tC
-qN
+ui
 ln
 va
-Rn
+mL
 vY
 ln
 ad
@@ -48832,17 +55101,17 @@ ln
 nK
 ot
 oV
-pC
+pA
 qb
 qF
 mL
 qH
-mL
-uj
+sV
+tD
 uj
 uG
 vb
-Rn
+mL
 vZ
 ln
 ad
@@ -49089,18 +55358,18 @@ nh
 nK
 ou
 oW
-pC
+pB
 qc
-uj
-so
-tE
-CD
+qG
+pj
+rq
+sW
 tE
 uk
 uH
 No
 vC
-vZ
+wa
 ni
 ad
 ad
@@ -49349,9 +55618,9 @@ oV
 pC
 qb
 mw
-tG
-tE
-rj
+mZ
+sk
+sX
 tF
 AZ
 ln
@@ -49606,9 +55875,9 @@ oY
 pD
 qb
 qI
-rj
-tE
-rj
+rt
+sl
+sY
 tG
 um
 uI
@@ -49863,10 +56132,10 @@ ln
 ni
 ln
 qJ
-rj
-tE
-rj
-tb
+ru
+sm
+sZ
+tH
 un
 uJ
 ve
@@ -50065,9 +56334,9 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
+NS
+Ra
+LS
 ad
 ad
 ad
@@ -50122,8 +56391,8 @@ qd
 qK
 rv
 sn
-tb
-tb
+rt
+rj
 uo
 ni
 ln
@@ -50322,9 +56591,9 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
+YP
+OG
+DF
 ad
 ad
 ad
@@ -50379,7 +56648,7 @@ qe
 qL
 rw
 so
-rj
+ta
 rj
 up
 uI
@@ -50579,9 +56848,9 @@ ad
 ad
 ad
 ad
-ad
-ad
-ad
+Mm
+UU
+LS
 ad
 ad
 ad
@@ -50633,13 +56902,13 @@ ln
 ln
 ln
 ln
+qM
 rx
-rx
-OL
-YD
+so
+tb
 tI
 uq
-xd
+uJ
 vg
 vG
 ln


### PR DESCRIPTION

## About The Pull Request

Outpost45 is as of now, over eight years old, and after so much time it has gotten very, very little attention, this fixes that and completely changes the gateway destination to have much more than it currently does both in terms of area to explore, story to learn, and stuff to grab.
## Why It's Good For The Game

As of right now outpost45 sat at a spot where people would wait to see what the gateway destination is, see its outpost45 by the ominous purple glow, and then immediately back away knowing that outpost45, in a casual conversation in a ticket I was talking with an admin and they said "Well then if you don't like it anybody can contribute" and so I did. (Extreme thank you to pumpkin0, vekkter, and jolly for helping me learn how to PR, how to github, and how to map.)
## Changelog

Adds two new areas complete with their own threats and rewards,
Adds an old crowbar to the engineering storage
Generally makes the gateway have a much more engaging story
:cl:
add: Added more content to outpost 45
/:cl:
