### PR TITLE
Prevents possessed blade spirits and similar entities from being created in a destroyed parent item

### DIFF
--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -67,6 +67,9 @@
 	UnregisterSignal(parent, COMSIG_ITEM_ATTACK_SELF)
 
 	var/mob/dead/observer/chosen_spirit = pick(candidates)
+	if(QDELETED(parent)) //if the thing that we're conjuring a spirit in has been destroyed, don't create a spirit
+		to_chat(chosen_spirit, span_userdanger("The new vessel for your spirit has been destroyed! You remain an unbound ghost."))
+		return
 	bound_spirit = new(parent)
 	bound_spirit.ckey = chosen_spirit.ckey
 	bound_spirit.fully_replace_character_name(null, "The spirit of [parent]")


### PR DESCRIPTION
## About The Pull Request
Activating any item with a `spirit_holder` component to poll for a new spirit, then destroying the item before the poll process is completed would create the spirit in nullspace, which would then dump them to the error room. These spirits are in GODMODE by default, but are usually contained within an item. See the issue?

This PR makes the spirit creation process check for whether the parent item was deleted or not before actually creating the spirit. If the summoning item was destroyed, the would-be spirit will get a message about it so they can brag about it in deadchat

## Why It's Good For The Game
Fixes #61935

## Changelog

:cl:
fix: fixed possessed sword spirits summoned during destruction of the sword spawning in the error room. those fellas are in godmode, and y'all don't need an immortal spirit haunting your station, m'kay?
/:cl:
