### PR TITLE
Wizard Spell Cooldown Changes

### DIFF
--- a/code/modules/spells/spell_types/pointed/spell_cards.dm
+++ b/code/modules/spells/spell_types/pointed/spell_cards.dm
@@ -7,7 +7,8 @@
 
 	school = SCHOOL_EVOCATION
 	cooldown_time = 5 SECONDS
-	cooldown_reduction_per_rank = 1 SECONDS
+	cooldown_reduction_per_rank = 2 SECONDS
+	spell_max_level = 3
 
 	invocation = "Sigi'lu M'Fan 'Tasia!"
 	invocation_type = INVOCATION_SHOUT

--- a/code/modules/spells/spell_types/pointed/swap.dm
+++ b/code/modules/spells/spell_types/pointed/swap.dm
@@ -8,11 +8,11 @@
 	active_overlay_icon_state = "bg_spell_border_active_blue"
 
 	school = SCHOOL_TRANSLOCATION
-	cooldown_time = 30 SECONDS
-	cooldown_reduction_per_rank = 6 SECONDS
+	cooldown_time = 25 SECONDS
+	cooldown_reduction_per_rank = 10 SECONDS
+	spell_max_level = 3
 	cast_range = 9
-	invocation = "FRO' BRT'TRO, DA!"
-	invocation_type = INVOCATION_SHOUT
+	invocation_type = INVOCATION_NONE
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC|SPELL_REQUIRES_STATION
 	active_msg = "You prepare to swap locations with a target..."
 

--- a/code/modules/spells/spell_types/self/mutate.dm
+++ b/code/modules/spells/spell_types/self/mutate.dm
@@ -40,7 +40,8 @@
 	name = "Mutate"
 	desc = "This spell causes you to turn into a hulk and gain laser vision for a short while."
 	cooldown_time = 40 SECONDS
-	cooldown_reduction_per_rank = 2.5 SECONDS
+	cooldown_reduction_per_rank = 5 SECONDS
+	spell_max_level = 3
 
 	invocation = "BIRUZ BENNAR"
 	invocation_type = INVOCATION_SHOUT

--- a/code/modules/spells/spell_types/shapeshift/shapechange.dm
+++ b/code/modules/spells/spell_types/shapeshift/shapechange.dm
@@ -4,7 +4,8 @@
 		Once you've made your choice, it cannot be changed."
 
 	cooldown_time = 20 SECONDS
-	cooldown_reduction_per_rank = 3.75 SECONDS
+	cooldown_reduction_per_rank = 8 SECONDS
+	spell_max_level = 3
 
 	invocation = "RAC'WA NO!"
 	invocation_type = INVOCATION_SHOUT

--- a/code/modules/spells/spell_types/teleport/teleport.dm
+++ b/code/modules/spells/spell_types/teleport/teleport.dm
@@ -7,7 +7,8 @@
 
 	school = SCHOOL_TRANSLOCATION
 	cooldown_time = 1 MINUTES
-	cooldown_reduction_per_rank = 10 SECONDS
+	cooldown_reduction_per_rank = 20 SECONDS
+	spell_max_level = 3
 
 	invocation = "SCYAR NILA"
 	invocation_type = INVOCATION_SHOUT


### PR DESCRIPTION

## About The Pull Request
Mutate prev = 40 / 37.5 / 35 / 32.5 / 30
Mutate now = 40 / 35 / 30

Spell cards prev = 6 / 5 / 4 / 3 / 2
Spell cards now = 6 / 4 / 2

Teleport prev = 60 / 50 / 40 / 30 / 20
Teleport now = 60 / 40 / 20

Shape change prev = 20 / 16.75 / 12.5 / 8.75 / 5 
Shape change now = 20 / 12 / 4

Swap prev = 30 / 24 / 18 / 12 / 6
Swap now = 25 / 15 / 5

I also deleted the invocation for swap to make it more usable. When I added the spell I thought it would be used more but I have never seen it been used.
## Why It's Good For The Game
For a lot of spells it seems like it is useless to upgrade them, since it costs a lot but does little in a lot of cases. Maybe this goes for more spells than my pr changes but I wanted how this comes over first. I rather do not do balance changes since it ruins my gbp even though I am trying to improve the game but I still thought this was worth it since it might also make the swap spell more relevant.
## Changelog
:cl:
balance: Changes some cooldowns and upgrades of spells.
/:cl:
