### PR TITLE
Various tweaks to cargo/bounties

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -138,7 +138,7 @@
 	sending = FALSE
 
 ///Here is where cargo bounties are added to the player's bank accounts, then adjusted and scaled into a civilian bounty.
-/obj/machinery/computer/piratepad_control/civilian/proc/add_bounties(var/cooldown_reduction = 0)
+/obj/machinery/computer/piratepad_control/civilian/proc/add_bounties(cooldown_reduction = 0)
 	if(!inserted_scan_id || !inserted_scan_id.registered_account)
 		return
 	var/datum/bank_account/pot_acc = inserted_scan_id.registered_account

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -8,6 +8,7 @@
 	layer = TABLE_LAYER
 	resistance_flags = FIRE_PROOF
 	circuit = /obj/item/circuitboard/machine/bountypad
+	var/cooldown_reduction = 0
 
 /obj/machinery/piratepad/civilian/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()
@@ -18,6 +19,20 @@
 	. = ..()
 	if(!.)
 		return default_deconstruction_crowbar(tool)
+
+/obj/machinery/piratepad/civilian/RefreshParts()
+	. = ..()
+	var/T = -2
+	for(var/datum/stock_part/micro_laser/micro_laser in component_parts)
+		T += micro_laser.tier
+
+	for(var/datum/stock_part/scanning_module/scanning_module in component_parts)
+		T += scanning_module.tier
+
+	cooldown_reduction = T * (30 SECONDS)
+
+/obj/machinery/piratepad/civilian/proc/get_cooldown_reduction()
+	return cooldown_reduction
 
 ///Computer for assigning new civilian bounties, and sending bounties for collection.
 /obj/machinery/computer/piratepad_control/civilian
@@ -68,7 +83,7 @@
 		playsound(loc, 'sound/machines/synth_no.ogg', 30 , TRUE)
 		return FALSE
 	status_report = "Civilian Bounty: "
-	var/obj/machinery/piratepad/pad = pad_ref?.resolve()
+	var/obj/machinery/piratepad/civilian/pad = pad_ref?.resolve()
 	for(var/atom/movable/AM in get_turf(pad))
 		if(AM == pad)
 			continue
@@ -94,7 +109,7 @@
 		return FALSE
 	var/datum/bounty/curr_bounty = inserted_scan_id.registered_account.civilian_bounty
 	var/active_stack = 0
-	var/obj/machinery/piratepad/pad = pad_ref?.resolve()
+	var/obj/machinery/piratepad/civilian/pad = pad_ref?.resolve()
 	for(var/atom/movable/AM in get_turf(pad))
 		if(AM == pad)
 			continue
@@ -123,7 +138,7 @@
 	sending = FALSE
 
 ///Here is where cargo bounties are added to the player's bank accounts, then adjusted and scaled into a civilian bounty.
-/obj/machinery/computer/piratepad_control/civilian/proc/add_bounties()
+/obj/machinery/computer/piratepad_control/civilian/proc/add_bounties(var/cooldown_reduction = 0)
 	if(!inserted_scan_id || !inserted_scan_id.registered_account)
 		return
 	var/datum/bank_account/pot_acc = inserted_scan_id.registered_account
@@ -137,7 +152,7 @@
 	var/list/datum/bounty/crumbs = list(random_bounty(pot_acc.account_job.bounty_types), // We want to offer 2 bounties from their appropriate job catagories
 										random_bounty(pot_acc.account_job.bounty_types), // and 1 guarenteed assistant bounty if the other 2 suck.
 										random_bounty(CIV_JOB_BASIC))
-	COOLDOWN_START(pot_acc, bounty_timer, 5 MINUTES)
+	COOLDOWN_START(pot_acc, bounty_timer, (5 MINUTES) - cooldown_reduction)
 	pot_acc.bounties = crumbs
 
 /obj/machinery/computer/piratepad_control/civilian/proc/pick_bounty(choice)
@@ -183,7 +198,8 @@
 	. = ..()
 	if(.)
 		return
-	if(!pad_ref?.resolve())
+	var/obj/machinery/piratepad/civilian/pad = pad_ref?.resolve()
+	if(!pad)
 		return
 	if(!usr.can_perform_action(src) || (machine_stat & (NOPOWER|BROKEN)))
 		return
@@ -197,7 +213,7 @@
 		if("pick")
 			pick_bounty(params["value"])
 		if("bounty")
-			add_bounties()
+			add_bounties(pad.get_cooldown_reduction())
 		if("eject")
 			id_eject(usr, inserted_scan_id)
 			inserted_scan_id = null

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -9,6 +9,16 @@
 	resistance_flags = FIRE_PROOF
 	circuit = /obj/item/circuitboard/machine/bountypad
 
+/obj/machinery/piratepad/civilian/screwdriver_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(!.)
+		return default_deconstruction_screwdriver(user, "lpad-idle-open", "lpad-idle-off", screw)
+
+/obj/machinery/piratepad/civilian/crowbar_act(mob/living/user, obj/item/tool)
+	. = ..()
+	default_deconstruction_crowbar(tool)
+	return TRUE
+
 ///Computer for assigning new civilian bounties, and sending bounties for collection.
 /obj/machinery/computer/piratepad_control/civilian
 	name = "civilian bounty control terminal"

--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -12,12 +12,12 @@
 /obj/machinery/piratepad/civilian/screwdriver_act(mob/living/user, obj/item/tool)
 	. = ..()
 	if(!.)
-		return default_deconstruction_screwdriver(user, "lpad-idle-open", "lpad-idle-off", screw)
+		return default_deconstruction_screwdriver(user, "lpad-idle-open", "lpad-idle-off", tool)
 
 /obj/machinery/piratepad/civilian/crowbar_act(mob/living/user, obj/item/tool)
 	. = ..()
-	default_deconstruction_crowbar(tool)
-	return TRUE
+	if(!.)
+		return default_deconstruction_crowbar(tool)
 
 ///Computer for assigning new civilian bounties, and sending bounties for collection.
 /obj/machinery/computer/piratepad_control/civilian

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -129,12 +129,6 @@
 	wanted_types = list(/obj/item/food/grown/poppy = TRUE)
 	include_subtypes = FALSE
 
-/datum/bounty/item/assistant/shadyjims
-	name = "Shady Jim's"
-	description = "There's an irate officer at CentCom demanding that he receive a box of Shady Jim's cigarettes. Please ship one. He's starting to make threats."
-	reward = CARGO_CRATE_VALUE
-	wanted_types = list(/obj/item/storage/fancy/cigarettes/cigpack_shadyjims = TRUE)
-
 /datum/bounty/item/assistant/potted_plants
 	name = "Potted Plants"
 	description = "Central Command is looking to commission a new BirdBoat-class station. You've been ordered to supply the potted plants."

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -265,9 +265,3 @@
 	desc = "A standard-sized coffeepot, for use with a coffeemaker."
 	cost = PAYCHECK_CREW
 	contains = list(/obj/item/reagent_containers/cup/coffeepot)
-
-/datum/supply_pack/goody/sunglasses
-	name = "Sunglasses Single-Pack"
-	desc = "A single pair of sunglasses. Very convenient for welding."
-	cost = PAYCHECK_CREW * 8
-	contains = list(/obj/item/clothing/glasses/sunglasses)

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -93,7 +93,7 @@
 	cost = PAYCHECK_CREW * 8
 	contains = list(/obj/item/clothing/gloves/color/yellow)
 
-/datum/supply_pack/goody/gorrilla_single
+/datum/supply_pack/goody/gorilla_single
 	name = "Gorilla Gloves Single-Pack"
 	desc = "A spare pair of gorilla gloves. Better for tackles than grippers from the security vendor."
 	cost = PAYCHECK_COMMAND * 6

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -93,11 +93,11 @@
 	cost = PAYCHECK_CREW * 8
 	contains = list(/obj/item/clothing/gloves/color/yellow)
 
-/datum/supply_pack/goody/gripper_single
-	name = "Gripper Gloves Single-Pack"
+/datum/supply_pack/goody/gorrilla_single
+	name = "Gorilla Gloves Single-Pack"
 	desc = "A spare pair of gripper gloves. Perfect for when the security vendor is empty (or when you're not actually a security officer)."
 	cost = PAYCHECK_COMMAND * 6
-	contains = list(/obj/item/clothing/gloves/tackler)
+	contains = list(/obj/item/clothing/gloves/tackler/combat)
 
 /datum/supply_pack/goody/firstaidbruises_single
 	name = "Bruise Treatment Kit Single-Pack"

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -95,7 +95,7 @@
 
 /datum/supply_pack/goody/gorrilla_single
 	name = "Gorilla Gloves Single-Pack"
-	desc = "A spare pair of gripper gloves. Perfect for when the security vendor is empty (or when you're not actually a security officer)."
+	desc = "A spare pair of gorilla gloves. Better for tackles than grippers from the security vendor."
 	cost = PAYCHECK_COMMAND * 6
 	contains = list(/obj/item/clothing/gloves/tackler/combat)
 
@@ -266,4 +266,8 @@
 	cost = PAYCHECK_CREW
 	contains = list(/obj/item/reagent_containers/cup/coffeepot)
 
-
+/datum/supply_pack/goody/sunglasses
+	name = "Sunglasses Single-Pack"
+	desc = "A single pair of sunglasses. Very convenient for welding."
+	cost = PAYCHECK_CREW * 8
+	contains = list(/obj/item/clothing/glasses/sunglasses)

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -316,3 +316,11 @@
 	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/storage/belt/holster/energy/thermal = 2)
 	crate_name = "thermal pistol crate"
+
+/datum/supply_pack/security/sunglasses
+	name = "Sunglasses Crate"
+	desc = "Three pairs of flash-proof sunglasses."
+	cost = CARGO_CRATE_VALUE * 8
+	access_view = ACCESS_SECURITY
+	contains = list(/obj/item/clothing/glasses/sunglasses = 3)
+	crate_name = "disabler crate"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -319,8 +319,8 @@
 
 /datum/supply_pack/security/sunglasses
 	name = "Sunglasses Crate"
-	desc = "Three pairs of flash-proof sunglasses."
-	cost = CARGO_CRATE_VALUE * 8
+	desc = "A single pair of flash-proof sunglasses."
+	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
-	contains = list(/obj/item/clothing/glasses/sunglasses = 3)
-	crate_name = "disabler crate"
+	contains = list(/obj/item/clothing/glasses/sunglasses = 1)
+	crate_name = "sunglasses crate"


### PR DESCRIPTION
## About The Pull Request
- Bounty pads now benefit from upgraded parts (microlaser and scanning module). When you pick a bounty that you can't complete, you normally have to wait 5 minutes to pick another. Each upgrade will reduce this time by 30 seconds, down to a minimum of 2 minutes.
- Sunglasses can now be bought from cargo. They can be bought as a crate with one pair for 400 credits. Security access is needed to purchase it.
- The gripper gloves single-pack has been changed into the gorilla-gloves single-pack.
- Removed the shady jims bounty.
- Previously, you could only screwdriver/crowbar bounty pads with right click, not left click. Most machines use left click, and the bounty pad does too now.

## Why It's Good For The Game
- This now gives a reason to actually upgrade the bounty pad. It also mitigates situations where you are only offered bounties that are infeasible to complete; This happens a lot to cargo techs, as they can get most if not all bounties offered to them.
- Much like insulated gloves, sunglasses are limited in supply and are desirable for both antags (flash protection) and nonantags (convenient welding protection, revolution protection). This allows sunglasses to be ordered from cargo. Ideally, this will lead to more interaction with cargo.
- The gripper gloves single-pack costs 600 credits. Gripper gloves can already be bought from the sectech vendor, usually for less than that, and the vendor has 5 of them in stock so they almost never run out. There is very little reason to go to the hassle of ordering something from cargo when you could just buy from the sectech instead. By replacing the gripper gloves with gorilla gloves, there is now a reason to order from cargo instead.
- The shady jims bounty has always been a bit of a noob trap, being an item that sounds common but is in reality rare contraband. However, the nerf of smuggler satchel spawns from 10 to 2 (#76621) was the final nail in the coffin. This bounty is just infeasibly hard to complete, and should be removed.
- There is no reason for the bounty pad to use right click instead of left click, and consistency is generally good.

## Changelog
:cl:
add: Bounty pads can now be upgraded, to reduce the time until you can pick a new bounty
add: Sunglasses can now be bought from cargo if you have security access.
balance: Gripper gloves single-pack is now gorilla gloves singlepack
del: Removed shady jims bounty
qol: Bounty pads can now be screwdrivered/crowbarred with left click like every other machine
/:cl:
