### PR TITLE
Fixes inconsistency in security hat armor berets/softcaps

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -567,4 +567,4 @@
 	greyscale_config = /datum/greyscale_config/beret_badge
 	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
 	greyscale_colors = "#43523d#a2abb0"
-	armor_type = /datum/armor/beret_sec
+	armor_type = /datum/armor/cosmetic_sec

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -391,10 +391,10 @@
 	flags_1 = NONE
 
 /datum/armor/beret_sec
-	melee = 35
-	bullet = 30
-	laser = 30
-	energy = 40
+	melee = 30
+	bullet = 25
+	laser = 25
+	energy = 35
 	bomb = 25
 	fire = 20
 	acid = 50
@@ -457,7 +457,7 @@
 	flags_inv ^= HIDEHAIR
 	balloon_alert(user, "[flags_inv & HIDEHAIR ? "tightened" : "loosened "] strings")
 	return TRUE
-	
+
 /obj/item/clothing/head/utility/surgerycap/examine(mob/user)
 	. = ..()
 	. += span_notice("Use in hand to [flags_inv & HIDEHAIR ? "loosen" : "tighten"] the strings.")

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -385,12 +385,12 @@
 	greyscale_config = /datum/greyscale_config/beret_badge
 	greyscale_config_worn = /datum/greyscale_config/beret_badge/worn
 	greyscale_colors = "#a52f29#F2F2F2"
-	armor_type = /datum/armor/beret_sec
+	armor_type = /datum/armor/cosmetic_sec
 	strip_delay = 60
 	dog_fashion = null
 	flags_1 = NONE
 
-/datum/armor/beret_sec
+/datum/armor/cosmetic_sec
 	melee = 30
 	bullet = 25
 	laser = 25

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -129,19 +129,9 @@
 	desc = "It's a robust baseball hat in tasteful red colour."
 	icon_state = "secsoft"
 	soft_type = "sec"
-	armor_type = /datum/armor/soft_sec
+	armor_type = /datum/armor/cosmetic_sec
 	strip_delay = 60
 	dog_fashion = null
-
-/datum/armor/soft_sec
-	melee = 30
-	bullet = 25
-	laser = 25
-	energy = 35
-	bomb = 25
-	fire = 20
-	acid = 50
-	wound = 4
 
 /obj/item/clothing/head/soft/paramedic
 	name = "paramedic cap"

--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -141,6 +141,7 @@
 	bomb = 25
 	fire = 20
 	acid = 50
+	wound = 4
 
 /obj/item/clothing/head/soft/paramedic
 	name = "paramedic cap"


### PR DESCRIPTION

## About The Pull Request

Brings soft sec headgear softcaps/berets more in line with eachother in armor

## Why It's Good For The Game

More consistent armor values for "cosmetic" security gear instead one cosmetic hat being better then the other(even though they should serve the same values)

## Changelog

:cl: Improvedname
fix: Brings security berets down to softcap armor values also softcaps get wound armor
/:cl:
