### PR TITLE
Re-adds medal code I accidentally removed

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -181,11 +181,6 @@
 /obj/item/clothing/under/proc/attach_accessory(obj/item/clothing/accessory/accessory, mob/living/user, attach_message = TRUE)
 	if(!istype(accessory))
 		return
-	if(length(attached_accessories) >= max_number_of_accessories)
-		if(user)
-			balloon_alert(user, "too many accessories!")
-		return
-
 	if(!accessory.can_attach_accessory(src, user))
 		return
 	if(user && !user.temporarilyRemoveItemFromInventory(accessory))

--- a/code/modules/clothing/under/accessories/_accessories.dm
+++ b/code/modules/clothing/under/accessories/_accessories.dm
@@ -17,6 +17,7 @@
 	inhand_icon_state = "" //no inhands
 	slot_flags = NONE
 	w_class = WEIGHT_CLASS_SMALL
+	item_flags = NOBLUDGEON
 	/// Whether or not the accessory displays through suits and the like.
 	var/above_suit = TRUE
 	/// TRUE if shown as a small icon in corner, FALSE if overlayed
@@ -44,6 +45,11 @@
 	if(attachment_slot && !(attach_to.body_parts_covered & attachment_slot))
 		if(user)
 			attach_to.balloon_alert(user, "can't attach there!")
+		return FALSE
+
+	if(length(attach_to.attached_accessories) >= attach_to.max_number_of_accessories)
+		if(user)
+			attach_to.balloon_alert(user, "too many accessories!")
 		return FALSE
 
 	return TRUE

--- a/code/modules/clothing/under/accessories/medals.dm
+++ b/code/modules/clothing/under/accessories/medals.dm
@@ -43,7 +43,7 @@
 		return .
 
 	user.visible_message(
-		span_notice("[user] tries pin [src] on [distinguished]'s chest."),
+		span_notice("[user] tries to pin [src] on [distinguished]'s chest."),
 		span_notice("You try to pin [src] on [distinguished]'s chest."),
 	)
 
@@ -69,18 +69,18 @@
 /obj/item/clothing/accessory/medal/attach(obj/item/clothing/under/attach_to, mob/living/attacher)
 	var/mob/living/distinguished = attach_to.loc
 	if(isnull(attacher) || !istype(distinguished) || distinguished == attacher || awarded_to)
-		// You can't be awarded by nothing, you can't award yourseld, and you can't be awarded someone else's medal
+		// You can't be awarded by nothing, you can't award yourself, and you can't be awarded someone else's medal
 		return ..()
 
 	awarder = attacher.real_name
 	awarded_to = distinguished.real_name
 
 	update_appearance(UPDATE_DESC)
-	SSblackbox.record_feedback("associative", "commendation", 1, list("commender" = "[awarder]", "commendee" = "[awarded_to]", "medal" = "[src]", "reason" = commendation_message))
-	GLOB.commendations += "[awarder] awarded <b>[awarded_to]</b> the <span class='medaltext'>[name]</span>! \n- [commendation_message]"
+	add_memory_in_range(distinguished, 7, /datum/memory/received_medal, protagonist = distinguished, deuteragonist = attacher, medal_type = src, medal_text = commendation_message)
 	distinguished.log_message("was given the following commendation by <b>[key_name(attacher)]</b>: [commendation_message]", LOG_GAME, color = "green")
 	message_admins("<b>[key_name_admin(distinguished)]</b> was given the following commendation by <b>[key_name_admin(attacher)]</b>: [commendation_message]")
-	add_memory_in_range(distinguished, 7, /datum/memory/received_medal, protagonist = distinguished, deuteragonist = attacher, medal_type = src, medal_text = commendation_message)
+	GLOB.commendations += "[awarder] awarded <b>[awarded_to]</b> the <span class='medaltext'>[name]</span>! \n- [commendation_message]"
+	SSblackbox.record_feedback("associative", "commendation", 1, list("commender" = "[awarder]", "commendee" = "[awarded_to]", "medal" = "[src]", "reason" = commendation_message))
 
 	return ..()
 

--- a/code/modules/clothing/under/accessories/medals.dm
+++ b/code/modules/clothing/under/accessories/medals.dm
@@ -7,47 +7,87 @@
 	/// Sprite used for medalbox
 	var/medaltype = "medal"
 	/// Has this been use for a commendation?
-	var/commended = FALSE
+	var/commendation_message
+	/// Who was first given this medal
+	var/awarded_to
+	/// Who gave out this medal
+	var/awarder
 
-// If someone adds SHOULD_NOT_SLEEP anywhere up the chain, this will need to be reworked
-/obj/item/clothing/accessory/medal/attach(obj/item/clothing/under/attach_to, mob/living/attacher)
-	if(isnull(attacher))
-		// Do normal attach
-		return ..()
+/// Callback for do_after to check if we can still be pinned
+/obj/item/clothing/accessory/medal/proc/pin_checks(mob/living/pinner, mob/living/carbon/human/pinning_on)
+	if(QDELETED(src) || QDELETED(pinner) || QDELETED(pinning_on))
+		return FALSE
+	if(!pinner.is_holding(src) || !pinner.Adjacent(pinning_on))
+		return FALSE
+	var/obj/item/clothing/under/pinning_on_uniform = pinning_on.w_uniform
+	if(!istype(pinning_on_uniform) || !can_attach_accessory(pinning_on_uniform, pinner))
+		return FALSE
+	return TRUE
 
-	var/mob/living/distinguished = attach_to.loc
-	if(!istype(distinguished) || distinguished == attacher)
-		// Do normal attach
-		return ..()
+/obj/item/clothing/accessory/medal/pre_attack(atom/target, mob/living/user, params)
+	. = ..()
+	if(.)
+		return
+	if(!ishuman(target) || target == user)
+		return
 
-	// Do a do_after before we attach, and allow us to include a commendation message.
-	attacher.visible_message(
-		span_notice("[attacher] is trying to pin [src] on [distinguished]'s chest."),
+	. = TRUE // no attack chain please
+
+	var/mob/living/carbon/human/distinguished = target
+	var/obj/item/clothing/under/distinguished_uniform = distinguished.w_uniform
+	if(!istype(distinguished_uniform))
+		distinguished.balloon_alert(user, "no uniform to pin on!")
+		return .
+	if(!can_attach_accessory(distinguished_uniform, user))
+		// Check handles feedback messages and etc
+		return .
+
+	user.visible_message(
+		span_notice("[user] tries pin [src] on [distinguished]'s chest."),
 		span_notice("You try to pin [src] on [distinguished]'s chest."),
 	)
 
-	var/input
-	if(!commended)
-		input = tgui_input_text(attacher, "Reason for this commendation? It will be recorded by Nanotrasen.", "Commendation", max_length = 140)
+	commendation_message = tgui_input_text(user, "Reason for this commendation? It will be recorded by Nanotrasen.", "Commendation", max_length = 140)
+	if(!commendation_message || !pin_checks(user, distinguished))
+		return .
+	if(!do_after(user, 2 SECONDS, distinguished, extra_checks = CALLBACK(src, PROC_REF(pin_checks), user, distinguished)))
+		return .
 
-	if(!do_after(attacher, 2 SECONDS, distinguished))
-		return FALSE
+	if(distinguished_uniform.attach_accessory(src, user))
+		user.visible_message(
+			span_notice("[user] pins [src] on [distinguished]'s chest."),
+			span_notice("You pin [src] on [distinguished]'s chest."),
+		)
+	else
+		user.visible_message(
+			span_warning("[user] fails to pin [src] on [distinguished]'s chest, seemingly unable to part with it."),
+			span_warning("You fail to pin [src] on [distinguished]'s chest."),
+		)
 
-	attacher.visible_message(
-		span_notice("[attacher] pins [src] on [distinguished]'s chest."),
-		span_notice("You pin [src] on [distinguished]'s chest."),
-	)
-	if(!input)
-		return FALSE
+	return .
 
-	commended = TRUE
-	SSblackbox.record_feedback("associative", "commendation", 1, list("commender" = "[attacher.real_name]", "commendee" = "[distinguished.real_name]", "medal" = "[src]", "reason" = input))
-	GLOB.commendations += "[attacher.real_name] awarded <b>[distinguished.real_name]</b> the <span class='medaltext'>[name]</span>! \n- [input]"
-	desc += "<br>The inscription reads: [input] - [attacher.real_name]"
-	distinguished.log_message("was given the following commendation by <b>[key_name(attacher)]</b>: [input]", LOG_GAME, color = "green")
-	message_admins("<b>[key_name_admin(distinguished)]</b> was given the following commendation by <b>[key_name_admin(attacher)]</b>: [input]")
-	add_memory_in_range(distinguished, 7, /datum/memory/received_medal, protagonist = distinguished, deuteragonist = attacher, medal_type = src, medal_text = input)
+/obj/item/clothing/accessory/medal/attach(obj/item/clothing/under/attach_to, mob/living/attacher)
+	var/mob/living/distinguished = attach_to.loc
+	if(isnull(attacher) || !istype(distinguished) || distinguished == attacher || awarded_to)
+		// You can't be awarded by nothing, you can't award yourseld, and you can't be awarded someone else's medal
+		return ..()
+
+	awarder = attacher.real_name
+	awarded_to = distinguished.real_name
+
+	update_appearance(UPDATE_DESC)
+	SSblackbox.record_feedback("associative", "commendation", 1, list("commender" = "[awarder]", "commendee" = "[awarded_to]", "medal" = "[src]", "reason" = commendation_message))
+	GLOB.commendations += "[awarder] awarded <b>[awarded_to]</b> the <span class='medaltext'>[name]</span>! \n- [commendation_message]"
+	distinguished.log_message("was given the following commendation by <b>[key_name(attacher)]</b>: [commendation_message]", LOG_GAME, color = "green")
+	message_admins("<b>[key_name_admin(distinguished)]</b> was given the following commendation by <b>[key_name_admin(attacher)]</b>: [commendation_message]")
+	add_memory_in_range(distinguished, 7, /datum/memory/received_medal, protagonist = distinguished, deuteragonist = attacher, medal_type = src, medal_text = commendation_message)
+
 	return ..()
+
+/obj/item/clothing/accessory/medal/update_desc(updates)
+	. = ..()
+	if(commendation_message && awarded_to && awarder)
+		desc += span_info("<br>The inscription reads: [commendation_message] - Awarded to [awarded_to] by [awarder]")
 
 /obj/item/clothing/accessory/medal/conduct
 	name = "distinguished conduct medal"


### PR DESCRIPTION
## About The Pull Request

In https://github.com/tgstation/tgstation/pull/76629/commits/79c57e3d147cb7d287d3f87220e56c819c5bfc27 , I snapped all of the medal awarding code out of existence, as I thought I moved it all over to attach, which I did

But I forgot to move the... rest of it over. The attacking part. Very foolish of me. 

I re-added it into pre-attack, gave accessories `nobludgeon`, and generally cleaned it up a bit.

## Why It's Good For The Game

Accidentally removing code is bad

## Changelog

:cl: Melbert
fix: Once again you can award people medals. 
/:cl:
