### PR TITLE
Weight Machines - Silicon messages and removes screentips

### DIFF
--- a/code/game/objects/structures/gym/weight_machine.dm
+++ b/code/game/objects/structures/gym/weight_machine.dm
@@ -31,17 +31,18 @@
 		"You feel robust!",
 		"You feel indestructible!",
 	)
+	var/static/list/finished_silicon_message = list(
+		"You feel nothing!",
+		"No pain, no gain!",
+		"Your shell is hardened... not!",
+		"You feels the exact same. Nothing.",
+	)
 
 /obj/structure/weightmachine/Initialize(mapload)
 	. = ..()
 
 	weight_action = new(src)
 	weight_action.weightpress = src
-
-	AddElement( \
-		/datum/element/contextual_screentip_bare_hands, \
-		lmb_text = "Work out", \
-	)
 
 	var/static/list/tool_behaviors = list(
 		TOOL_CROWBAR = list(
@@ -91,7 +92,10 @@
 	START_PROCESSING(SSobj, src)
 	if(do_after(user, 8 SECONDS, src) && user.has_gravity())
 		user.Stun(2 SECONDS)
-		user.balloon_alert(user, pick(finished_message))
+		if(issilicon(user))
+			user.balloon_alert(user, pick(finished_silicon_message))
+		else
+			user.balloon_alert(user, pick(finished_message))
 		user.add_mood_event("exercise", /datum/mood_event/exercise)
 		user.apply_status_effect(/datum/status_effect/exercised)
 	end_workout()

--- a/code/game/objects/structures/gym/weight_machine.dm
+++ b/code/game/objects/structures/gym/weight_machine.dm
@@ -35,7 +35,7 @@
 		"You feel nothing!",
 		"No pain, no gain!",
 		"Chassis hardness rating... Unchanged.",
-		"You feels the exact same. Nothing.",
+		"You feel the exact same. Nothing.",
 	)
 
 /obj/structure/weightmachine/Initialize(mapload)

--- a/code/game/objects/structures/gym/weight_machine.dm
+++ b/code/game/objects/structures/gym/weight_machine.dm
@@ -34,7 +34,7 @@
 	var/static/list/finished_silicon_message = list(
 		"You feel nothing!",
 		"No pain, no gain!",
-		"Your shell is hardened... not!",
+		"Chassis hardness rating... Unchanged.",
 		"You feels the exact same. Nothing.",
 	)
 


### PR DESCRIPTION
## About The Pull Request

Removes the hand screentips for weight machines, as it requires you to buckle yourself now, making it misinformation. There's no click+drag tooltip and I dunno if I should add one to something that is obviously a chair.

Adds messages for Silicons using the weight machine, because I accidentally added this and thought it was funny enough to keep around.

## Why It's Good For The Game

Less misinformation to players.
Closes https://github.com/tgstation/tgstation/issues/76980

## Changelog

:cl:
spellcheck: Silicons using weight machines are now told how pointless the task was.
spellcheck: Weight machine tooltips no longer lie about using LMB to use the machine.
/:cl: