### PR TITLE
Removes a untrue sillytip about blob

### DIFF
--- a/strings/sillytips.txt
+++ b/strings/sillytips.txt
@@ -17,6 +17,7 @@ Just the tip?
 Killing the entire station isn't fun except when it is.
 Make sure you put the fresh corpse on a Nanotrasen-Brand Stasis Bed! (Patent Pending)
 Most items have names longer than "soap".
+Nanotrasen doesn't want you to know, you can print Tinfoil Hats by hacking the Autolathe at cargo, It will protect you from ...aliens, and a... plethora of mind-based magic.
 Occasionally the tip of the round might lie to you. Don't panic, this is normal.
 Plenty of things that aren't traditionally considered weapons can still be used to slowly brutalize someone to death, get creative!
 Some people are unable to read text on a game where half of it is based on text.

--- a/strings/sillytips.txt
+++ b/strings/sillytips.txt
@@ -17,7 +17,7 @@ Just the tip?
 Killing the entire station isn't fun except when it is.
 Make sure you put the fresh corpse on a Nanotrasen-Brand Stasis Bed! (Patent Pending)
 Most items have names longer than "soap".
-Nanotrasen doesn't want you to know, you can print Tinfoil Hats by hacking the Autolathe at cargo, It will protect you from ...aliens, and a... plethora of mind-based magic.
+Nanotrasen doesn't want you to know, you can print Tinfoil Hats by hacking the Autolathe at cargo. It will protect you from... aliens, and a... plethora of mind-based magic.
 Occasionally the tip of the round might lie to you. Don't panic, this is normal.
 Plenty of things that aren't traditionally considered weapons can still be used to slowly brutalize someone to death, get creative!
 Some people are unable to read text on a game where half of it is based on text.

--- a/strings/sillytips.txt
+++ b/strings/sillytips.txt
@@ -11,7 +11,6 @@ Did you know that tossing the clown into a singularity will either increase or d
 Did you know that tossing the clown into the Supermatter engine can destabilize or fix it massively?
 Do not go gentle into that good night.
 FEED ME A STRAY CAT
-Flashbangs can weaken blob tiles, allowing for you and the crew to easily destroy them.
 It's fun to try and predict the round type from the tip of the round message.
 Just like real life the entropy of the game can only increase with time. If things aren't on fire yet, just wait.
 Just the tip?


### PR DESCRIPTION
## About The Pull Request

Removes a sillytip flashbangs no longer do damage to blob since
https://github.com/tgstation/tgstation/pull/30862 

## Why It's Good For The Game

So people will no longer think flashbangs can kill blob(i died due to this)

## Changelog

:cl:
fix: removed a false silly tip about blob taking damage from flashbangs
/:cl:


