### PR TITLE
ID card screentips now show you how to assign an account to an ID.

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -436,7 +436,7 @@
 
 	context[SCREENTIP_CONTEXT_LMB] = "Show ID"
 	context[SCREENTIP_CONTEXT_RMB] = "Project pay stand"
-	context[SCREENTIP_CONTEXT_ALT_LMB] = "Withdraw credits"
+	context[SCREENTIP_CONTEXT_ALT_LMB] = "Withdraw credits / Assign account"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/card/id/proc/try_project_paystand(mob/user, turf/target)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -436,7 +436,7 @@
 
 	context[SCREENTIP_CONTEXT_LMB] = "Show ID"
 	context[SCREENTIP_CONTEXT_RMB] = "Project pay stand"
-	if(!registered_account || registered_account.replaceable) //Same check we use when we check if we can assign an account
+	if(isnull(registered_account) || registered_account.replaceable) //Same check we use when we check if we can assign an account
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Assign account"
 	else
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Withdraw credits"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -436,7 +436,10 @@
 
 	context[SCREENTIP_CONTEXT_LMB] = "Show ID"
 	context[SCREENTIP_CONTEXT_RMB] = "Project pay stand"
-	context[SCREENTIP_CONTEXT_ALT_LMB] = "Withdraw credits / Assign account"
+	if(!registered_account || registered_account.replaceable) //Same check we use when we check if we can assign an account
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Assign account"
+	else
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Withdraw credits"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/card/id/proc/try_project_paystand(mob/user, turf/target)


### PR DESCRIPTION

## About The Pull Request

Based on discussion regarding player bank accounts and prisoners, I was sure that Id cards had screentips, and it turns out I was right. However, the screentips are inaccurate. Alt Click serves a dual purpose. In an ID card with only a default storage account, alt-click will ask you to assign a new account to it. After, you can remove credits from it after it's been assigned. Apparently players have been confused about assigning their account to an ID card, due to not having a proper screentip telling them how.

This updates the screentip to show both functions.

## Why It's Good For The Game
![image](https://github.com/tgstation/tgstation/assets/41715314/346269d2-0224-4bf6-8d6a-fef7e52e1926)

Improves visual clarity and better teaches the mechanics related to economy.

## Changelog

:cl:
qol: ID cards tooltips now show how to assign a new account.
/:cl:
