### PR TITLE
Fixes getting stuck in the leaning condition when you try to lean facing the wrong direction

### DIFF
--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -44,7 +44,6 @@
 		return
 	if(!carbon_mob.density)
 		return
-	carbon_mob.is_leaning = TRUE
 	var/turf/checked_turf = get_step(carbon_mob, turn(carbon_mob.dir, 180))
 	if(checked_turf == src)
 		carbon_mob.start_leaning(src)
@@ -67,6 +66,7 @@
 						span_notice("You lean against \the [wall]!"))
 	RegisterSignals(src, list(COMSIG_MOB_CLIENT_PRE_MOVE, COMSIG_HUMAN_DISARM_HIT, COMSIG_LIVING_GET_PULLED, COMSIG_MOVABLE_TELEPORTING, COMSIG_ATOM_DIR_CHANGE), PROC_REF(stop_leaning))
 	update_fov()
+	is_leaning = TRUE
 
 /mob/living/carbon/proc/stop_leaning()
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. Was just testing out https://github.com/tgstation/tgstation/pull/76704 and noticed that if you try to lean while facing the wrong direction, you get stuck in the `is_leaning` state and are unable to lean again.

For the best chance of this not happening, I just moved it to the very end of the `start_leaning()` proc.

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
fix: fixed a bug that would cause you to be unable to lean again if you tried leaning while facing the wrong direction
/:cl:
