### PR TITLE
Make electrified grilles, APCs, SMES and buckled stuff shock as expected again

### DIFF
--- a/code/__DEFINES/power.dm
+++ b/code/__DEFINES/power.dm
@@ -1,3 +1,4 @@
+#define CABLE_LAYER_ALL (~0)
 #define CABLE_LAYER_1 (1<<0)
 	#define CABLE_LAYER_1_NAME "Red Power Line"
 #define CABLE_LAYER_2 (1<<1)

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -61,7 +61,7 @@
 			balloon_alert(user, "need ten lengths of cable!")
 			return
 
-		var/terminal_cable_layer
+		var/terminal_cable_layer = cable_layer // Default to machine's cable layer
 		if(LAZYACCESS(params2list(params), RIGHT_CLICK))
 			var/choice = tgui_input_list(user, "Select Power Input Cable Layer", "Select Cable Layer", GLOB.cable_name_to_layer)
 			if(isnull(choice))
@@ -79,7 +79,7 @@
 		if(terminal || !opened || !has_electronics)
 			return
 		var/turf/our_turf = get_turf(src)
-		var/obj/structure/cable/cable_node = our_turf.get_cable_node()
+		var/obj/structure/cable/cable_node = our_turf.get_cable_node(terminal_cable_layer)
 		if(prob(50) && electrocute_mob(usr, cable_node, cable_node, 1, TRUE))
 			do_sparks(5, TRUE, src)
 			return

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -459,7 +459,7 @@
 ///////////////////////////////////////////////
 
 // return a cable able connect to machinery on layer if there's one on the turf, null if there isn't one
-/turf/proc/get_cable_node(cable_layer = CABLE_LAYER_1)
+/turf/proc/get_cable_node(cable_layer = CABLE_LAYER_ALL)
 	if(!can_have_cabling())
 		return null
 	for(var/obj/structure/cable/C in src)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -147,7 +147,7 @@
 		if(do_after(user, 20, target = src))
 			if(C.get_amount() < 10 || !C)
 				return
-			var/obj/structure/cable/N = T.get_cable_node() //get the connecting node cable, if there's one
+			var/obj/structure/cable/N = T.get_cable_node(terminal_cable_layer) //get the connecting node cable, if there's one
 			if (prob(50) && electrocute_mob(usr, N, N, 1, TRUE)) //animate the electrocution if uncautious and unlucky
 				do_sparks(5, TRUE, src)
 				return


### PR DESCRIPTION

## About The Pull Request

Fixes some issues form the #76075 rework.

1. Grilles didn't shock anymore unless placed on red (layer 1) wire. Now it looks for any of the three layers.
2. APCs also didn't get the correct cable layer for shocking as you build a terminal. So they wouldn't shock you if there wasn't a layer 1 cable that carried power. And no one ever uses layer 1 cables sadly. Now they look for the cable layer you're building the terminal on.
3. SMES, like APCs, didn't check for the correct cable layer when building a terminal. Now they do.
4. As far as I can tell, gas miners would also only have worked on cable layer 1, now they work on all layers.

This is because before the #76075 rework, all machinery connected to a "machinery" cable layer instead of an actual cable layer.
The reworks' `get_cable_node` assumes `CABLE_LAYER_1` as a default parameter, causing only red cables to connect when no parameter is passed, unlike before where all cables would connect.

The rework adjusted some machines to be able to connect to a specific layer. But I think other "machines" such as grilles should just us all layers available. So I adjusted the `get_cable_node` to look for all layers unless a specific layer is specified in the call

## Why It's Good For The Game

Rage cages good
Maint shocking grilles good
No one knows to use red cable to shock stuff

:cl:
fix: Cable connections on various structures including electrified grilles, APC terminals, and SMES terminals have been rectified and will shock as expected again.
fix: Gas miners draw power properly again.
/:cl:
