### PR TITLE
Assorted changes to mafia map closet contents

### DIFF
--- a/_maps/map_files/Mafia/mafia_ayylmao.dmm
+++ b/_maps/map_files/Mafia/mafia_ayylmao.dmm
@@ -28,6 +28,7 @@
 /area/centcom/mafia)
 "l" = (
 /obj/structure/closet/abductor,
+/obj/item/abductor/gizmo,
 /turf/open/floor/plating/abductor,
 /area/centcom/mafia)
 "m" = (
@@ -42,6 +43,7 @@
 /area/centcom/mafia)
 "o" = (
 /obj/structure/closet/abductor,
+/obj/item/abductor/gizmo,
 /turf/open/floor/plating/abductor2,
 /area/centcom/mafia)
 "p" = (

--- a/_maps/map_files/Mafia/mafia_lavaland.dmm
+++ b/_maps/map_files/Mafia/mafia_lavaland.dmm
@@ -50,13 +50,9 @@
 /turf/open/floor/plating,
 /area/centcom/mafia)
 "al" = (
-/obj/structure/closet{
-	desc = "It's a storage unit. For mining stuff. Y'know.";
-	icon_state = "mining";
-	name = "miner equipment locker"
-	},
 /obj/item/shovel,
 /obj/item/pickaxe,
+/obj/structure/closet/secure_closet/miner/unlocked,
 /turf/open/floor/fakebasalt,
 /area/centcom/mafia)
 "am" = (
@@ -75,13 +71,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 4
 	},
-/obj/structure/closet{
-	desc = "It's a storage unit. For mining stuff. Y'know.";
-	icon_state = "mining";
-	name = "miner equipment locker"
-	},
 /obj/item/shovel,
 /obj/item/pickaxe,
+/obj/structure/closet/secure_closet/miner/unlocked,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "ap" = (
@@ -100,13 +92,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
-/obj/structure/closet{
-	desc = "It's a storage unit. For mining stuff. Y'know.";
-	icon_state = "mining";
-	name = "miner equipment locker"
-	},
 /obj/item/shovel,
 /obj/item/pickaxe,
+/obj/structure/closet/secure_closet/miner/unlocked,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "as" = (
@@ -144,13 +132,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
-/obj/structure/closet{
-	desc = "It's a storage unit. For mining stuff. Y'know.";
-	icon_state = "mining";
-	name = "miner equipment locker"
-	},
 /obj/item/shovel,
 /obj/item/pickaxe,
+/obj/structure/closet/secure_closet/miner/unlocked,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "aA" = (
@@ -210,26 +194,18 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
-/obj/structure/closet{
-	desc = "It's a storage unit. For mining stuff. Y'know.";
-	icon_state = "mining";
-	name = "miner equipment locker"
-	},
 /obj/item/shovel,
 /obj/item/pickaxe,
+/obj/structure/closet/secure_closet/miner/unlocked,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "aI" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/structure/closet{
-	desc = "It's a storage unit. For mining stuff. Y'know.";
-	icon_state = "mining";
-	name = "miner equipment locker"
-	},
 /obj/item/shovel,
 /obj/item/pickaxe,
+/obj/structure/closet/secure_closet/miner/unlocked,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "aJ" = (
@@ -246,13 +222,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 8
 	},
-/obj/structure/closet{
-	desc = "It's a storage unit. For mining stuff. Y'know.";
-	icon_state = "mining";
-	name = "miner equipment locker"
-	},
 /obj/item/shovel,
 /obj/item/pickaxe,
+/obj/structure/closet/secure_closet/miner/unlocked,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "aL" = (

--- a/_maps/map_files/Mafia/mafia_lavaland.dmm
+++ b/_maps/map_files/Mafia/mafia_lavaland.dmm
@@ -55,7 +55,8 @@
 	icon_state = "mining";
 	name = "miner equipment locker"
 	},
-/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/shovel,
+/obj/item/pickaxe,
 /turf/open/floor/fakebasalt,
 /area/centcom/mafia)
 "am" = (
@@ -79,7 +80,8 @@
 	icon_state = "mining";
 	name = "miner equipment locker"
 	},
-/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/shovel,
+/obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "ap" = (
@@ -103,7 +105,8 @@
 	icon_state = "mining";
 	name = "miner equipment locker"
 	},
-/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/shovel,
+/obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "as" = (
@@ -111,20 +114,6 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/centcom/mafia)
-"at" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/mafia)
-"au" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron/dark,
 /area/centcom/mafia)
 "av" = (
 /obj/mafia_game_board,
@@ -160,7 +149,8 @@
 	icon_state = "mining";
 	name = "miner equipment locker"
 	},
-/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/shovel,
+/obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "aA" = (
@@ -225,7 +215,8 @@
 	icon_state = "mining";
 	name = "miner equipment locker"
 	},
-/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/shovel,
+/obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "aI" = (
@@ -237,7 +228,8 @@
 	icon_state = "mining";
 	name = "miner equipment locker"
 	},
-/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/shovel,
+/obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "aJ" = (
@@ -259,7 +251,8 @@
 	icon_state = "mining";
 	name = "miner equipment locker"
 	},
-/obj/item/clothing/under/rank/cargo/miner/lavaland,
+/obj/item/shovel,
+/obj/item/pickaxe,
 /turf/open/floor/iron,
 /area/centcom/mafia)
 "aL" = (
@@ -333,24 +326,6 @@
 	dir = 6
 	},
 /turf/open/floor/iron,
-/area/centcom/mafia)
-"aW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/mafia)
-"aX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
 /area/centcom/mafia)
 "aY" = (
 /turf/closed/indestructible/reinforced,

--- a/_maps/map_files/Mafia/mafia_snow.dmm
+++ b/_maps/map_files/Mafia/mafia_snow.dmm
@@ -144,15 +144,13 @@
 /area/centcom/mafia)
 "D" = (
 /obj/structure/closet/crate/science,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat/miner,
 /turf/open/floor/holofloor/snow,
 /area/centcom/mafia)
 "E" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/closet/crate/critter,
 /obj/item/clothing/suit/hooded/wintercoat/miner,
-/obj/item/clothing/shoes/winterboots,
 /turf/open/lava/plasma/mafia,
 /area/centcom/mafia)
 "F" = (

--- a/_maps/map_files/Mafia/mafia_syndie.dmm
+++ b/_maps/map_files/Mafia/mafia_syndie.dmm
@@ -7,8 +7,7 @@
 	desc = "A storage closet for syndicate conflict resolution operatives.";
 	name = "red closet"
 	},
-/obj/item/clothing/under/syndicate/tacticool,
-/obj/item/clothing/under/syndicate/tacticool/skirt,
+/obj/effect/spawner/random/clothing/syndie,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/mafia)
 "c" = (
@@ -46,16 +45,6 @@
 /obj/mafia_game_board,
 /turf/open/floor/plating,
 /area/centcom/mafia)
-"m" = (
-/obj/structure/closet/syndicate{
-	desc = "A storage closet for syndicate conflict resolution operatives.";
-	name = "red closet"
-	},
-/obj/item/clothing/under/syndicate/tacticool,
-/obj/item/clothing/under/syndicate/tacticool/skirt,
-/obj/effect/turf_decal/tile/red/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/mafia)
 "n" = (
 /obj/effect/landmark/mafia,
 /turf/open/floor/mineral/plastitanium,
@@ -85,15 +74,18 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/mafia)
 "s" = (
+/obj/effect/turf_decal/syndicateemblem/top/left,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/mafia)
 "t" = (
+/obj/effect/turf_decal/syndicateemblem/top/middle,
 /turf/open/floor/circuit/red,
 /area/centcom/mafia)
 "u" = (
 /obj/effect/baseturf_helper/asteroid,
 /obj/effect/landmark/mafia/town_center,
 /obj/structure/chair,
+/obj/effect/turf_decal/syndicateemblem/middle/middle,
 /turf/open/floor/circuit/red,
 /area/centcom/mafia)
 "v" = (
@@ -155,19 +147,42 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/mafia)
 "G" = (
-/obj/item/clothing/under/syndicate/tacticool,
 /obj/structure/closet/syndicate{
 	desc = "A storage closet for syndicate conflict resolution operatives.";
 	name = "red closet"
 	},
-/obj/item/clothing/under/syndicate/tacticool/skirt,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/effect/spawner/random/clothing/syndie,
 /turf/open/floor/iron/dark,
 /area/centcom/mafia)
 "H" = (
 /obj/effect/landmark/mafia,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
+/area/centcom/mafia)
+"O" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/right,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/mafia)
+"Q" = (
+/obj/effect/turf_decal/syndicateemblem/middle/left,
+/turf/open/floor/circuit/red,
+/area/centcom/mafia)
+"S" = (
+/obj/effect/turf_decal/syndicateemblem/top/right,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/mafia)
+"T" = (
+/obj/effect/turf_decal/syndicateemblem/middle/right,
+/turf/open/floor/circuit/red,
+/area/centcom/mafia)
+"W" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/left,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/mafia)
+"Y" = (
+/obj/effect/turf_decal/syndicateemblem/bottom/middle,
+/turf/open/floor/circuit/red,
 /area/centcom/mafia)
 
 (1,1,1) = {"
@@ -309,7 +324,7 @@ b
 r
 w
 o
-m
+G
 w
 j
 w
@@ -327,7 +342,7 @@ c
 c
 d
 w
-m
+G
 o
 p
 n
@@ -413,7 +428,7 @@ p
 p
 w
 p
-m
+G
 w
 d
 c
@@ -432,8 +447,8 @@ r
 y
 p
 s
-t
-s
+Q
+W
 p
 q
 o
@@ -458,7 +473,7 @@ p
 p
 t
 u
-t
+Y
 p
 p
 w
@@ -481,9 +496,9 @@ o
 o
 z
 p
-s
-t
-s
+S
+T
+O
 p
 E
 r
@@ -501,7 +516,7 @@ w
 c
 d
 w
-m
+G
 p
 w
 p
@@ -605,7 +620,7 @@ w
 w
 j
 w
-m
+G
 o
 w
 r

--- a/_maps/map_files/Mafia/mafia_syndie.dmm
+++ b/_maps/map_files/Mafia/mafia_syndie.dmm
@@ -73,19 +73,10 @@
 "r" = (
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/mafia)
-"s" = (
-/obj/effect/turf_decal/syndicateemblem/top/left,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/mafia)
-"t" = (
-/obj/effect/turf_decal/syndicateemblem/top/middle,
-/turf/open/floor/circuit/red,
-/area/centcom/mafia)
 "u" = (
 /obj/effect/baseturf_helper/asteroid,
 /obj/effect/landmark/mafia/town_center,
 /obj/structure/chair,
-/obj/effect/turf_decal/syndicateemblem/middle/middle,
 /turf/open/floor/circuit/red,
 /area/centcom/mafia)
 "v" = (
@@ -160,29 +151,11 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/mafia)
-"O" = (
-/obj/effect/turf_decal/syndicateemblem/bottom/right,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/mafia)
 "Q" = (
-/obj/effect/turf_decal/syndicateemblem/middle/left,
 /turf/open/floor/circuit/red,
 /area/centcom/mafia)
 "S" = (
-/obj/effect/turf_decal/syndicateemblem/top/right,
 /turf/open/floor/mineral/plastitanium/red,
-/area/centcom/mafia)
-"T" = (
-/obj/effect/turf_decal/syndicateemblem/middle/right,
-/turf/open/floor/circuit/red,
-/area/centcom/mafia)
-"W" = (
-/obj/effect/turf_decal/syndicateemblem/bottom/left,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/mafia)
-"Y" = (
-/obj/effect/turf_decal/syndicateemblem/bottom/middle,
-/turf/open/floor/circuit/red,
 /area/centcom/mafia)
 
 (1,1,1) = {"
@@ -446,9 +419,9 @@ r
 r
 y
 p
-s
+S
 Q
-W
+S
 p
 q
 o
@@ -471,9 +444,9 @@ p
 w
 p
 p
-t
+Q
 u
-Y
+Q
 p
 p
 w
@@ -497,8 +470,8 @@ o
 z
 p
 S
-T
-O
+Q
+S
 p
 E
 r


### PR DESCRIPTION

## About The Pull Request

This changes the contents of some lockers on various mafia maps.

**Lavaland Excursion:** The spare mining uniforms in each locker have been replaced with a pickaxe and shovel.

**Snowdin:** The rooms containing closets now have alternate (mining) winter coats instead of the standard ones you already spawn with. 

**Mothership Zeta:** All closets now contain a gizmo. Wow!

**Syndicate Megastation:** The closets now contain one random piece of syndie clothing, instead of another tacticool turtleneck.
## Why It's Good For The Game

Some of the gear in the closets kind of became redundant when the map outfits were added and I just forgot to remove them.

Gives some more stuff for people to fidget with during mafia downtime. For the maps not touched, they either already had closet contents or were intentionally left empty.

I'm all but certain the items provided in the closets have no way of endangering the controlled environment of a mafia game, so that shouldn't be an issue.
## Changelog
:cl: Rhials
qol: Modifies the contents of some Mafia lockers. Go check 'em out!
/:cl:
