### PR TITLE
Dish drive no longer spams with empty messages

### DIFF
--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -138,5 +138,7 @@
 		bin.update_appearance()
 		flick("synthesizer_beam", src)
 	else
+		if(manual)
+			visible_message(span_notice("There are no disposable items in [src]!"))
 		return
 	time_since_dishes = world.time + 600

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -138,5 +138,5 @@
 		bin.update_appearance()
 		flick("synthesizer_beam", src)
 	else
-		visible_message(span_notice("There are no disposable items in [src]!"))
+		return
 	time_since_dishes = world.time + 600


### PR DESCRIPTION
## About The Pull Request
Removes the annoying message that the dish drive constantly spams for no reason.

## Why It's Good For The Game

I don't need to know the machine hasn't processed anything new every 6 seconds, thanks.

## Changelog

:cl:
fix: Dish drive no longer spams the bar/kitchen/etc when its idle with empty messages.
/:cl:
