### PR TITLE
Rename digital clock subsystem

### DIFF
--- a/code/controllers/subsystem/processing/digital_clock.dm
+++ b/code/controllers/subsystem/processing/digital_clock.dm
@@ -1,5 +1,5 @@
 /// The subsystem used to tick digital clocks
 PROCESSING_SUBSYSTEM_DEF(digital_clock)
-	name = "digital_clock"
+	name = "Digital Clocks"
 	flags = SS_NO_INIT|SS_BACKGROUND|SS_KEEP_TIMING
 	wait = 1 SECONDS


### PR DESCRIPTION
Renames digital clock subsystem to be better alongside other player facing names
