### PR TITLE
Adds a new way to track note age using playtime.

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -375,12 +375,15 @@
 
 /datum/config_entry/flag/see_own_notes //Can players see their own admin notes
 
-/datum/config_entry/number/note_fresh_days
+/datum/config_entry/string/note_fade_type
+	default = null
+
+/datum/config_entry/number/note_fresh_time
 	default = null
 	min_val = 0
 	integer = FALSE
 
-/datum/config_entry/number/note_stale_days
+/datum/config_entry/number/note_stale_time
 	default = null
 	min_val = 0
 	integer = FALSE

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -468,7 +468,7 @@
 				expire_timestamp,
 				severity,
 				playtime,
-				round_id
+				round_id,
 			FROM [format_table_name("messages")]
 			WHERE type <> 'memo' AND targetckey = :targetckey AND deleted = 0 AND (expire_timestamp > NOW() OR expire_timestamp IS NULL)
 			ORDER BY timestamp DESC
@@ -501,11 +501,23 @@
 			var/severity = query_get_messages.item[12]
 			var/playtime = query_get_messages.item[13]
 			var/round_id = query_get_messages.item[14]
+			var/playage = usr.client.get_exp_living(pure_numeric = TRUE) - query_get_messages.item[15]
 			var/alphatext = ""
-			var/nsd = CONFIG_GET(number/note_stale_days)
-			var/nfd = CONFIG_GET(number/note_fresh_days)
-			if (agegate && type == "note" && isnum(nsd) && isnum(nfd) && nsd > nfd)
-				var/alpha = clamp(100 - (age - nfd) * (85 / (nsd - nfd)), 15, 100)
+			var/notestale = CONFIG_GET(number/note_stale_time)
+			var/notefresh = CONFIG_GET(number/note_fresh_time)
+			var/notetype = CONFIG_GET(string/note_fade_type)
+			if(notetype == "time" && agegate && type == "note" && isnum(notestale) && isnum(notefresh) && notestale > notefresh)
+				var/alpha = clamp(100 - (age - notefresh) * (85 / (notestale - notefresh)), 15, 100)
+				if (alpha < 100)
+					if (alpha <= 15)
+						if (skipped)
+							skipped++
+							continue
+						alpha = 10
+						skipped = TRUE
+					alphatext = "filter: alpha(opacity=[alpha]); opacity: [alpha/100];"
+			if(notetype == "playtime" && agegate && type == "note" && isnum(notestale) && isnum(notefresh) && notestale > notefresh)
+				var/alpha = clamp(100 - (playage - notefresh * 60) * (85 / (notestale * 60 - notefresh * 60)), 15, 100)
 				if (alpha < 100)
 					if (alpha <= 15)
 						if (skipped)

--- a/code/modules/admin/sql_message_system.dm
+++ b/code/modules/admin/sql_message_system.dm
@@ -468,7 +468,7 @@
 				expire_timestamp,
 				severity,
 				playtime,
-				round_id,
+				round_id
 			FROM [format_table_name("messages")]
 			WHERE type <> 'memo' AND targetckey = :targetckey AND deleted = 0 AND (expire_timestamp > NOW() OR expire_timestamp IS NULL)
 			ORDER BY timestamp DESC

--- a/config/config.txt
+++ b/config/config.txt
@@ -252,11 +252,11 @@ TICKLAG 0.5
 
 ### Comment these three out to prevent notes fading out over time for admins.
 ## Sets how admin notes are faded, either by time elapsed (calculated in days), or playtime (calculated in hours). ('time' for time elapsed, 'playtime' for playtime elapsed)
-NOTE_FADE_TYPE playtime
+NOTE_FADE_TYPE time
 ## Notes older then this will start fading out.
 NOTE_FRESH_TIME 91.31055
 ## Notes older then this will be completely faded out.
-NOTE_STALE_TIME 365.2422
+NOTE_STALE_TIMES 365.2422
 
 ## Uncomment to allow drastic performence enhancemet measures to turn on automatically once there are equal or more clients than the configured amount (will also prompt admin for veto)
 #AUTO_LAG_SWITCH_POP 75

--- a/config/config.txt
+++ b/config/config.txt
@@ -250,11 +250,13 @@ TICKLAG 0.5
 ## Uncomment this to let players see their own notes (they can still be set by admins only)
 #SEE_OWN_NOTES
 
-### Comment these two out to prevent notes fading out over time for admins.
+### Comment these three out to prevent notes fading out over time for admins.
+## Sets how admin notes are faded, either by time elapsed (calculated in days), or playtime (calculated in hours). ('time' for time elapsed, 'playtime' for playtime elapsed)
+NOTE_FADE_TYPE playtime
 ## Notes older then this will start fading out.
-NOTE_FRESH_DAYS 91.31055
+NOTE_FRESH_TIME 91.31055
 ## Notes older then this will be completely faded out.
-NOTE_STALE_DAYS 365.2422
+NOTE_STALE_TIME 365.2422
 
 ## Uncomment to allow drastic performence enhancemet measures to turn on automatically once there are equal or more clients than the configured amount (will also prompt admin for veto)
 #AUTO_LAG_SWITCH_POP 75
@@ -355,7 +357,6 @@ AUTOADMIN_RANK Game Master
 #AUTO_DEADMIN_HEADS
 #AUTO_DEADMIN_SECURITY
 #AUTO_DEADMIN_SILICONS
-
 
 ## CLIENT VERSION CONTROL
 ## This allows you to configure the minimum required client version, as well as a warning version, and message for both.


### PR DESCRIPTION

## About The Pull Request

Attempts to add a way for note fresh/stale times to be tracked based of a player's game time rather than overall time elapsed. This should hopefully empower both players and admins as if utilized, will mean faded notes are truly representative of time has elapsed and overall improvement in player conduct.

## Why It's Good For The Game

Using time elapsed for notes isn't telling of the full picture, with bans putting people out of commission, or simply dropping the game, notes can get swept under the fade when in reality they're a dead-ringer for player conduct. This makes it sticky for admins since it somewhat forces their hand to open pandora's box to a player's history of sin, and doesn't allow the player to vindicate themselves through repeated good paly.

## Changelog
:cl:
config: Adds a new way for notes to be tracked in the config
admin: admins will have a new way to gauge player's development based on playtime rather than time elapsed.
/:cl:
