### PR TITLE
A collection of food tweaks

### DIFF
--- a/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_veggies.dm
@@ -26,7 +26,7 @@
 	name = "Cabbage"
 	item_path = /obj/item/food/grown/cabbage
 
-/datum/orderable_item/veggies/beets
+/datum/orderable_item/veggies/onion
 	name = "Onion"
 	item_path = /obj/item/food/grown/onion
 

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -661,6 +661,7 @@
 
 /obj/item/food/nugget
 	name = "chicken nugget"
+	desc = "A \"chicken\" nugget vaguely shaped like something."
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment = 2,
 		/datum/reagent/consumable/nutriment/protein = 2,
@@ -817,6 +818,7 @@
 
 /obj/item/food/kebab/fiesta
 	name = "fiesta skewer"
+	desc = "Variety of meats and vegetables on a stick."
 	icon_state = "fiestaskewer"
 	food_reagents = list(
 		/datum/reagent/consumable/nutriment/protein = 12,

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -1470,10 +1470,10 @@
 /datum/chemical_reaction/food/soup/cheese
 	required_reagents = list(
 		/datum/reagent/water = 30,
-		/datum/reagent/consumable/flour = 10,
 		/datum/reagent/consumable/milk = 10,
 	)
 	required_ingredients = list(
+		/obj/item/food/doughslice = 2,
 		/obj/item/food/cheese/wedge = 2,
 		/obj/item/food/butterslice = 1,
 		/obj/item/food/grown/potato/sweet = 1,

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
@@ -612,10 +612,6 @@
 	reqs = list(/obj/item/food/tempehstarter = 1)
 	result = /obj/item/food/tempeh
 
-/datum/crafting_recipe/food/processor/yakiimo
-	reqs = list(/obj/item/food/grown/potato/sweet = 1)
-	result = /obj/item/food/yakiimo
-
 /datum/crafting_recipe/food/processor/popsicle_stick
 	reqs = list(/obj/item/grown/log = 1)
 	result = /obj/item/popsicle_stick
@@ -768,7 +764,7 @@
 /datum/crafting_recipe/food/oven/yakiimo
 	reqs = list(/obj/item/food/grown/potato/sweet = 1)
 	result = /obj/item/food/yakiimo
-	category = CAT_SALAD
+	category = CAT_MISCFOOD
 
 // Machinery: Drying rack
 /datum/crafting_recipe/food/drying


### PR DESCRIPTION
## About The Pull Request

- Chicken nuggets had no description in the recipe book, due to gaining their real description on initialize. I have placed a default description for them, so they will not appear as "You eat this".
- Fiesta Skewer lacked description, so I have added one for the same reason.
- Yaki Imo had an incorrect duplicate recipe, asking you to process sweet potatoes to make them.
- The onion order in the produce console was called beet in its typepath, now its properly onion
- Ælosterrmæsch now requires dough slices. This prevents dough from popping out of the pot if you add these ingredients while its not on the oven, and also prevents most of the soup's ingredients turning into gravy, when the nutriment is released from the ingredients. Amount of water unchanged, as there is plenty of it.

## Why It's Good For The Game
- It's good for items to have descriptions in recipe books
- It's good for items to have descriptions in general!
- It's good to not have incorrect recipes
- The produce order thing is just a minor nitpick I finally got around to do. Not player facing.
- Adding dough slices instead of pouring flour into soup (as one would normally do to make it thicker) might break immersion, but I think, if you want to make a delicious cheese soup, it shouldn't transform into 90% gravy, and this is a small sacrifice i am willing to make.

## Changelog

:cl:
fix: Removed duplicate and incorrect Yaki Imo recipe 
qol: Swapped out the flour in Ælosterrmæsch with two dough slices, to avoid competing reactions while preparing or cooking
spellcheck: Chicken nugget will have a description in the craft menu, and fiesta skewers will have a description in general
/:cl:
