### PR TITLE
Fixes lightning on Northstar's HoP's office, and moves the stamp to somewhere visible

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -6111,7 +6111,7 @@
 /obj/effect/turf_decal/trimline/blue/arrow_cw{
 	dir = 8
 	},
-/obj/machinery/light/small/directional/west,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "bwx" = (
@@ -14536,7 +14536,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
 "dJC" = (
-/obj/machinery/light/small/directional/east,
+/obj/machinery/light/small/dim/directional/east,
 /turf/open/openspace,
 /area/station/command/heads_quarters/hop)
 "dJF" = (
@@ -20082,8 +20082,7 @@
 	pixel_y = 4
 	},
 /obj/item/stamp/head/hop{
-	pixel_x = -4;
-	pixel_y = 4
+	pixel_y = 7
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
@@ -30831,6 +30830,7 @@
 /obj/structure/table,
 /obj/machinery/status_display/evac/directional/north,
 /obj/item/papercutter,
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "iea" = (
@@ -82226,7 +82226,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/east,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "vzS" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -20081,9 +20081,6 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
-/obj/item/stamp/head/hop{
-	pixel_y = 7
-	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "fmE" = (
@@ -28426,7 +28423,14 @@
 /obj/machinery/button/ticket_machine{
 	pixel_x = -32
 	},
-/obj/item/flashlight/lamp,
+/obj/item/stamp/head/hop{
+	pixel_y = 5;
+	pixel_x = 8
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -4;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "hxy" = (


### PR DESCRIPTION

## About The Pull Request

There was nothing to illuminate the main area of the hop's office, this PR fixes that
Also takes the stamp out from under the carbon bin. Nothing i did was able to make it spawn on top, so i just moved it near the lamp.
## Why It's Good For The Game

Seeing is good, be it your own office or stamp
## Changelog
:cl:
fix: New lights have been issued to the Head of Personnel's office.
fix: We've instructed our intern to no longer place the HoP's stamps UNDER the carbon paper bin, making many think there was no stamp at all.
/:cl:
