### PR TITLE
removes floating light fixture from the deltastation security hallway

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -70312,12 +70312,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
-"rHO" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "rHQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -146189,7 +146183,7 @@ qRu
 lYY
 nJP
 lYY
-rHO
+lYY
 lYY
 lYY
 lYY


### PR DESCRIPTION

## About The Pull Request
before:
![THIS LAMP AGAIN](https://github.com/tgstation/tgstation/assets/94711066/a42a90db-e876-4436-b3d0-7767c40f51e5)

after: (sharks not included)
![THIS LAMP IS NOW GONE](https://github.com/tgstation/tgstation/assets/94711066/2db697e6-96a0-4dd4-945c-b5856e93891c)
## Why It's Good For The Game
I don't think it was supposed to be there
## Changelog
:cl:
del: removed floating light fixture from the Deltastation security hallway
/:cl:
