### PR TITLE
[NO GBP] Fixes a rare runtime that might occur with request internet sound

### DIFF
--- a/code/modules/admin/verbs/request_internet_sound.dm
+++ b/code/modules/admin/verbs/request_internet_sound.dm
@@ -38,7 +38,7 @@
 			return
 
 	if(usr?.client == null)
-		to_chat(src, span_boldwarning("An error occured, please try again."), confidential = TRUE)
+		to_chat(src, span_boldwarning("An error occurred, please try again."), confidential = TRUE)
 		return
 
 	GLOB.requests.music_request(usr.client, request_url, credit)

--- a/code/modules/admin/verbs/request_internet_sound.dm
+++ b/code/modules/admin/verbs/request_internet_sound.dm
@@ -3,7 +3,7 @@
 	set name = "Request Internet Sound"
 
 	if(usr == null)
-		to_chat(src, "An Error Occured, this might be because round just started. If so try again.", confidential = TRUE)
+		to_chat(src, span_boldwarning("An Error Occured, this might be because round just started. If so try again."), confidential = TRUE)
 		return
 
 	if(GLOB.say_disabled) //This is here to try to identify lag problems

--- a/code/modules/admin/verbs/request_internet_sound.dm
+++ b/code/modules/admin/verbs/request_internet_sound.dm
@@ -2,6 +2,10 @@
 	set category = "OOC"
 	set name = "Request Internet Sound"
 
+	if(usr == null)
+		to_chat(src, "An Error Occured, this might be because round just started. If so try again.", confidential = TRUE)
+		return
+
 	if(GLOB.say_disabled) //This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."), confidential = TRUE)
 		return

--- a/code/modules/admin/verbs/request_internet_sound.dm
+++ b/code/modules/admin/verbs/request_internet_sound.dm
@@ -2,10 +2,6 @@
 	set category = "OOC"
 	set name = "Request Internet Sound"
 
-	if(usr == null)
-		to_chat(src, span_boldwarning("An Error Occured, this might be because round just started. If so try again."), confidential = TRUE)
-		return
-
 	if(GLOB.say_disabled) //This is here to try to identify lag problems
 		to_chat(usr, span_danger("Speech is currently admin-disabled."), confidential = TRUE)
 		return
@@ -40,6 +36,10 @@
 			return
 		if(src.client.handle_spam_prevention(request_url,MUTE_INTERNET_REQUEST))
 			return
+
+	if(usr?.client == null)
+		to_chat(src, span_boldwarning("An error occured, please try again."), confidential = TRUE)
+		return
 
 	GLOB.requests.music_request(usr.client, request_url, credit)
 	to_chat(usr, span_info("You requested: \"[request_url]\" to be played."), confidential = TRUE)


### PR DESCRIPTION
## About The Pull Request

i just notice  this runtime happen as someone attempted to request a sound JUST as round started so their usr was null thus creating this tiny runtime in `request_manager.dm`

`Runtime in code/modules/requests/request_manager.dm, line 133: Cannot read null.ckey`

This small PR just makes request internet sound check if usr is null and to throw a error to the user simply telling them to try again.

This error is very unlikely to occur as it requires someone to request a sound as the round starts.

## Why It's Good For The Game

Less bugs? Unless you like having bugs in your game.

## Changelog

:cl:
fix: fixed a rare runtime with request internet sound.
/:cl:

