### PR TITLE
Arconomy: Balance Update 2023

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -213,8 +213,8 @@ SUBSYSTEM_DEF(economy)
  */
 /datum/controller/subsystem/economy/proc/update_vending_prices()
 	var/list/obj/machinery/vending/prices_to_update = list()
-		// Assoc list of "z level" -> if it's on the station
-		// Hack, is station z level is too expensive to do for each machine, I hate this place
+	// Assoc list of "z level" -> if it's on the station
+	// Hack, is station z level is too expensive to do for each machine, I hate this place
 	var/list/station_z_status = list()
 	for(var/obj/machinery/vending/vending_lad as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/vending))
 		if(istype(vending_lad, /obj/machinery/vending/custom))

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -113,24 +113,6 @@ SUBSYSTEM_DEF(economy)
 			return
 
 		processing_part = ECON_PRICE_UPDATE_STEP
-		var/list/obj/machinery/vending/prices_to_update = list()
-		// Assoc list of "z level" -> if it's on the station
-		// Hack, is station z level is too expensive to do for each machine, I hate this place
-		var/list/station_z_status = list()
-		for(var/obj/machinery/vending/vending_lad as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/vending))
-			if(istype(vending_lad, /obj/machinery/vending/custom))
-				continue
-			var/vending_level = vending_lad.z
-			var/station_status = station_z_status["[vending_level]"]
-			if(station_status == null)
-				station_status = is_station_level(vending_level)
-				station_z_status["[vending_level]"] = station_status
-			if(!station_status)
-				continue
-
-			prices_to_update += vending_lad
-
-		cached_processing = prices_to_update
 		station_target = max(round(temporary_total / max(bank_accounts_by_id.len * 2, 1)) + station_target_buffer, 1)
 
 	if(processing_part == ECON_PRICE_UPDATE_STEP)
@@ -182,19 +164,15 @@ SUBSYSTEM_DEF(economy)
 	return TRUE
 
 /**
- * Updates the prices of all station vendors with the inflation_value, increasing/decreasing costs across the station, and alerts the crew.
- *
- * Iterates over the machines list for vending machines, resets their regular and premium product prices (Not contraband), and sends a message to the newscaster network.
+ * Updates the the inflation_value, effecting newscaster alerts and the mail system.
  **/
 /datum/controller/subsystem/economy/proc/price_update()
-	var/list/cached_processing = src.cached_processing
-	for(var/i in 1 to length(cached_processing))
-		var/obj/machinery/vending/V = cached_processing[i]
-		V.reset_prices(V.product_records, V.coin_records)
-		if(MC_TICK_CHECK)
-			cached_processing.Cut(1, i + 1)
-			return FALSE
-	earning_report = "<b>Sector Economic Report</b><br><br> Sector vendor prices is currently at <b>[SSeconomy.inflation_value()*100]%</b>.<br><br> The station spending power is currently <b>[station_total] Credits</b>, and the crew's targeted allowance is at <b>[station_target] Credits</b>.<br><br> That's all from the <i>Nanotrasen Economist Division</i>."
+	var/fluff_string = ""
+	if(!HAS_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING))
+		fluff_string = ", but company countermeasures protect <b>YOU</b> from being affected!"
+	else
+		fluff_string = ", and company countermeasures are failing to protect <b>YOU</b> from being affected. We're all doomed!"
+	earning_report = "<b>Sector Economic Report</b><br><br> Sector vendor prices is currently at <b>[SSeconomy.inflation_value()*100]%</b>[fluff_string]<br><br> The station spending power is currently <b>[station_total] Credits</b>, and the crew's targeted allowance is at <b>[station_target] Credits</b>.<br><br> That's all from the <i>Nanotrasen Economist Division</i>."
 	GLOB.news_network.submit_article(earning_report, "Station Earnings Report", "Station Announcements", null, update_alert = FALSE)
 	return TRUE
 
@@ -208,6 +186,8 @@ SUBSYSTEM_DEF(economy)
 /datum/controller/subsystem/economy/proc/inflation_value()
 	if(!bank_accounts_by_id.len)
 		return 1
+	if(HAS_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING))
+		return inflation_value //early return instead of the actual check
 	inflation_value = max(round(((station_total / bank_accounts_by_id.len) / station_target), 0.1), 1.0)
 	return inflation_value
 
@@ -227,6 +207,29 @@ SUBSYSTEM_DEF(economy)
 		"cost" = price_to_use,
 		"vendor" = vendor,
 	))
+
+/**
+ * Iterates over the machines list for vending machines, resets their regular and premium product prices (Not contraband), and sends a message to the newscaster network.
+ */
+/datum/controller/subsystem/economy/proc/update_vending_prices()
+	var/list/obj/machinery/vending/prices_to_update = list()
+		// Assoc list of "z level" -> if it's on the station
+		// Hack, is station z level is too expensive to do for each machine, I hate this place
+	var/list/station_z_status = list()
+	for(var/obj/machinery/vending/vending_lad as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/vending))
+		if(istype(vending_lad, /obj/machinery/vending/custom))
+			continue
+		var/vending_level = vending_lad.z
+		var/station_status = station_z_status["[vending_level]"]
+		if(station_status == null)
+			station_status = is_station_level(vending_level)
+			station_z_status["[vending_level]"] = station_status
+		if(!station_status)
+			continue
+		prices_to_update += vending_lad
+	for(var/i in 1 to length(prices_to_update))
+		var/obj/machinery/vending/V = prices_to_update[i]
+		V.reset_prices(V.product_records, V.coin_records)
 
 #undef ECON_DEPARTMENT_STEP
 #undef ECON_ACCOUNT_STEP

--- a/code/game/machinery/computer/accounting.dm
+++ b/code/game/machinery/computer/accounting.dm
@@ -24,8 +24,8 @@
 		player_accounts += list(list(
 			"name" = current_bank_account.account_holder,
 			"job" = current_bank_account.account_job.title,
-			"balance" = current_bank_account.account_balance,
-			"modifier" = current_bank_account.payday_modifier,
+			"balance" = round(current_bank_account.account_balance),
+			"modifier" = round((current_bank_account.payday_modifier * 0.9), 0.1),
 		))
 	data["PlayerAccounts"] = player_accounts
 	data["AuditLog"] = audit_list

--- a/code/modules/events/market_crash.dm
+++ b/code/modules/events/market_crash.dm
@@ -11,7 +11,8 @@
 	description = "Temporarily increases the prices of vending machines."
 
 /datum/round_event/market_crash
-	var/every_fifth = 1
+	/// This counts the number of ticks that the market crash event has been processing, so that we don't call vendor price updates every tick, but we still iterate for other mechanics that use inflation.
+	var/tick_counter = 1
 
 /datum/round_event/market_crash/setup()
 	start_when = 1
@@ -49,8 +50,8 @@
 
 /datum/round_event/market_crash/tick()
 	. = ..()
-	every_fifth = every_fifth + 1
+	tick_counter = tick_counter++
 	SSeconomy.inflation_value = 5.5*(log(activeFor+1))
-	if(every_fifth == 5)
-		every_fifth = 1
+	if(tick_counter == 5)
+		tick_counter = 1
 		SSeconomy.update_vending_prices()

--- a/code/modules/events/market_crash.dm
+++ b/code/modules/events/market_crash.dm
@@ -11,33 +11,46 @@
 	description = "Temporarily increases the prices of vending machines."
 
 /datum/round_event/market_crash
-	var/market_dip = 0
+	var/every_fifth = 1
 
 /datum/round_event/market_crash/setup()
 	start_when = 1
-	end_when = rand(25, 50)
+	end_when = rand(100, 50)
 	announce_when = 2
 
 /datum/round_event/market_crash/announce(fake)
 	var/list/poss_reasons = list("the alignment of the moon and the sun",\
 		"some risky housing market outcomes",\
-		"The B.E.P.I.S. team's untimely downfall",\
+		"the B.E.P.I.S. team's untimely downfall",\
 		"speculative Terragov grants backfiring",\
-		"greatly exaggerated reports of Nanotrasen accountancy personnel committing mass suicide")
+		"greatly exaggerated reports of Nanotrasen accountancy personnel being \"laid off\"",\
+		"a \"great investment\" into \"non-fungible tokens\" by a \"moron\"",\
+		"a number of raids from Tiger Cooperative agents",\
+		"supply chain shortages",\
+		"the \"Nanotrasen+\" social media network's untimely downfall",\
+		"the \"Nanotrasen+\" social media network's unfortunate success",\
+		"uhh, bad luck, we guess"
+	)
 	var/reason = pick(poss_reasons)
 	priority_announce("Due to [reason], prices for on-station vendors will be increased for a short period.", "Nanotrasen Accounting Division")
 
 /datum/round_event/market_crash/start()
 	. = ..()
-	market_dip = rand(1000,10000) * length(SSeconomy.bank_accounts_by_id)
-	SSeconomy.station_target = max(SSeconomy.station_target - market_dip, 1)
+	SSeconomy.update_vending_prices()
 	SSeconomy.price_update()
 	ADD_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING, MARKET_CRASH_EVENT_TRAIT)
 
 /datum/round_event/market_crash/end()
 	. = ..()
-	SSeconomy.station_target += market_dip
 	REMOVE_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING, MARKET_CRASH_EVENT_TRAIT)
 	SSeconomy.price_update()
+	SSeconomy.update_vending_prices()
 	priority_announce("Prices for on-station vendors have now stabilized.", "Nanotrasen Accounting Division")
 
+/datum/round_event/market_crash/tick()
+	. = ..()
+	every_fifth = every_fifth + 1
+	SSeconomy.inflation_value = 5.5*(log(activeFor+1))
+	if(every_fifth == 5)
+		every_fifth = 1
+		SSeconomy.update_vending_prices()

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -111,7 +111,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///multiplier for stun durations
 	var/stunmod = 1
 	///multiplier for money paid at payday
-	var/payday_modifier = 1
+	var/payday_modifier = 1.0
 	///Base electrocution coefficient.  Basically a multiplier for damage from electrocutions.
 	var/siemens_coeff = 1
 	///To use MUTCOLOR with a fixed color that's independent of the mcolor feature in DNA.

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -9,7 +9,7 @@
 	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
 	exotic_bloodtype = "LE"
 	siemens_coeff = 0.5 //They thrive on energy
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	inherent_traits = list(
 		TRAIT_NO_UNDERWEAR,
 		TRAIT_MUTANT_COLORS,

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -16,7 +16,7 @@
 	)
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/felinid
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	ass_image = 'icons/ass/asscat.png'
 	family_heirlooms = list(/obj/item/toy/cattoy)
 	/// When false, this is a felinid created by mass-purrbation

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -13,7 +13,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/fly
 	wing_types = list(/obj/item/organ/external/wings/functional/fly)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 
 	mutanttongue = /obj/item/organ/internal/tongue/fly
 	mutantheart = /obj/item/organ/internal/heart/fly

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -20,7 +20,7 @@
 	mutantlungs = null
 	inherent_biotypes = MOB_HUMANOID|MOB_MINERAL
 	damage_modifier = 10 //golem is stronk
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	siemens_coeff = 0
 	no_equip_flags = ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING | ITEM_SLOT_SUITSTORE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -8,7 +8,7 @@
 	mutant_bodyparts = list("wings" = "None")
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
-	payday_modifier = 1
+	payday_modifier = 1.1
 
 /datum/species/human/prepare_human_for_preview(mob/living/carbon/human/human)
 	human.set_haircolor("#bb9966", update = FALSE) // brown

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -25,7 +25,7 @@
 	blood_deficiency_drain_rate = JELLY_REGEN_RATE + BLOOD_DEFICIENCY_MODIFIER
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_factions = list(FACTION_SLIME)
 	species_language_holder = /datum/language_holder/jelly

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -20,7 +20,7 @@
 	mutanttongue = /obj/item/organ/internal/tongue/lizard
 	coldmod = 1.5
 	heatmod = 0.67
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_cookie = /obj/item/food/meat/slab
 	meat = /obj/item/food/meat/slab/human/mutant/lizard

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -17,7 +17,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/moth
 	wing_types = list(/obj/item/organ/external/wings/functional/moth/megamoth, /obj/item/organ/external/wings/functional/moth/mothra)
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	family_heirlooms = list(/obj/item/flashlight/lantern/heirloom_moth)
 
 	bodypart_overrides = list(

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -23,7 +23,7 @@
 	mutantappendix = null
 	mutantheart = null
 	heatmod = 1.5
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	breathid = GAS_PLASMA
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC
 	species_cookie = /obj/item/reagent_containers/condiment/milk

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -14,7 +14,7 @@
 	inherent_factions = list(FACTION_PLANTS, FACTION_VINES)
 
 	heatmod = 1.5
-	payday_modifier = 0.75
+	payday_modifier = 1.0
 	meat = /obj/item/food/meat/slab/human/mutant/plant
 	exotic_blood = /datum/reagent/water
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -348,8 +348,11 @@
  * * startempty - should we set vending_product record amount from the product list (so it's prefilled at roundstart)
  */
 /obj/machinery/vending/proc/build_inventory(list/productlist, list/recordlist, list/categories, start_empty = FALSE)
-	default_price = round(initial(default_price) * SSeconomy.inflation_value())
-	extra_price = round(initial(extra_price) * SSeconomy.inflation_value())
+	default_price = round(initial(default_price))
+	extra_price = round(initial(extra_price))
+	if(HAS_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING))
+		default_price *= SSeconomy.inflation_value()
+		extra_price *= SSeconomy.inflation_value()
 
 	var/list/product_to_category = list()
 	for (var/list/category as anything in categories)
@@ -370,8 +373,11 @@
 			R.amount = amount
 		R.max_amount = amount
 		///Prices of vending machines are all increased uniformly.
-		R.custom_price = round(initial(temp.custom_price) * SSeconomy.inflation_value())
-		R.custom_premium_price = round(initial(temp.custom_premium_price) * SSeconomy.inflation_value())
+		R.custom_price = round(initial(temp.custom_price))
+		R.custom_premium_price = round(initial(temp.custom_premium_price))
+		if(HAS_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING))
+			R.custom_price = round(initial(temp.custom_price) * SSeconomy.inflation_value())
+			R.custom_premium_price = round(initial(temp.custom_premium_price) * SSeconomy.inflation_value())
 		R.age_restricted = initial(temp.age_restricted)
 		R.colorable = !!(initial(temp.greyscale_config) && initial(temp.greyscale_colors) && (initial(temp.flags_1) & IS_PLAYER_COLORABLE_1))
 		R.category = product_to_category[typepath]
@@ -409,21 +415,32 @@
  * * premiumlist - the list of premium product datums in the vendor to refresh their prices.
  */
 /obj/machinery/vending/proc/reset_prices(list/recordlist, list/premiumlist)
-	default_price = round(initial(default_price) * SSeconomy.inflation_value())
-	extra_price = round(initial(extra_price) * SSeconomy.inflation_value())
+	var/crash_status = HAS_TRAIT(SSeconomy, TRAIT_MARKET_CRASHING)
+	default_price = round(initial(default_price))
+	extra_price = round(initial(extra_price))
+	if(crash_status)
+		default_price *= SSeconomy.inflation_value()
+		extra_price *= SSeconomy.inflation_value()
+
 	for(var/R in recordlist)
 		var/datum/data/vending_product/record = R
 		var/obj/item/potential_product = record.product_path
-		record.custom_price = round(initial(potential_product.custom_price) * SSeconomy.inflation_value())
+		record.custom_price = round(initial(potential_product.custom_price))
+		if(crash_status)
+			record.custom_price = round(initial(potential_product.custom_price) * SSeconomy.inflation_value())
 	for(var/R in premiumlist)
 		var/datum/data/vending_product/record = R
 		var/obj/item/potential_product = record.product_path
 		var/premium_sanity = round(initial(potential_product.custom_premium_price))
 		if(premium_sanity)
-			record.custom_premium_price = round(premium_sanity * SSeconomy.inflation_value())
+			record.custom_premium_price = round(premium_sanity)
+			if(crash_status)
+				record.custom_premium_price = round(premium_sanity * SSeconomy.inflation_value())
 			continue
 		//For some ungodly reason, some premium only items only have a custom_price
-		record.custom_premium_price = round(extra_price + (initial(potential_product.custom_price) * (SSeconomy.inflation_value() - 1)))
+		record.custom_premium_price = round(extra_price + (initial(potential_product.custom_price)))
+		if(crash_status)
+			record.custom_premium_price = round(extra_price + (initial(potential_product.custom_price) * (SSeconomy.inflation_value() - 1)))
 
 /**
  * Refill a vending machine from a refill canister

--- a/tgui/packages/tgui/interfaces/AccountingConsole.tsx
+++ b/tgui/packages/tgui/interfaces/AccountingConsole.tsx
@@ -1,4 +1,4 @@
-import { BlockQuote, Collapsible, LabeledList, Modal, Section, Stack, Tabs } from '../components';
+import { BlockQuote, Collapsible, Modal, Section, Stack, Tabs } from '../components';
 import { useBackend } from '../backend';
 import { useLocalState } from '../backend';
 import { Window } from '../layouts';
@@ -73,18 +73,20 @@ const UsersScreen = (props, context) => {
   return (
     <Section fill scrollable title="Crew Account Summary">
       {PlayerAccounts.map((account) => (
-        <Collapsible fill key={account.index} title={account.name}>
-          <LabeledList>
-            <LabeledList.Item label="Occupation">
-              {account.job}
-            </LabeledList.Item>
-            <LabeledList.Item label="Balance">
-              {account.balance}
-            </LabeledList.Item>
-            <LabeledList.Item label="Pay Modifier">
-              {account.modifier * 100}%
-            </LabeledList.Item>
-          </LabeledList>
+        <Collapsible
+          fill
+          key={account.index}
+          title={account.name + ' the ' + account.job}>
+          <Stack vertical>
+            <BlockQuote>
+              <Stack.Item textColor={'green'}>
+                {account.balance} credit balance
+              </Stack.Item>
+              <Stack.Item>
+                Employee has {account.modifier * 100}% pay modifier
+              </Stack.Item>
+            </BlockQuote>
+          </Stack>
         </Collapsible>
       ))}
     </Section>


### PR DESCRIPTION

## About The Pull Request
Hey everyone I've been dead and tired and distracted and wage cage'd and hopefully you'll see why in the coming weeks but this isn't that PR this is something slightly different

So! Changes in this Pull Request:

- I've implemented the changes in #76999 but with the commented suggestion so that now, mechanically, the foreign species modifier is now considered to be the floor payment amount. This means a functional buff to human paychecks, but in game it's still represented as a non-human nerf.

- The inflation mechanic on vending machines has been removed. This means that vending machines will keep a consistent cost at all times. Inflation as a mechanic is still utilized for mail, as well as kept on the SS level in order to ensure that the market crash events still works properly.
- Market Crash event has been improved, with some new flavor messages added, as well as using a new formula where inflation increases for the period of the event along a 5.5*log(time) scale.

- Tweaks have been made to the accounting computer TGUI to better follow standard conventions and not use a labeledList. It also properly shows the player facing paycheck modifier as well. It also looks a bit better now!

## Why It's Good For The Game

Justification for the change on the 90% paycheck modifier change has been discussed in #76999 already, but going with the more positive spin angle.

The inflation mechanic in general has rather unintuitive for a number of reasons, but the biggest one being that the mechanic doesn't really have any bearing that players in-game can really effect. Especially with passive paychecks, the only way to work around inflation is to make... other players spend their money. That's hardly an easy task with a 10 player crew, let alone a 90 player crew. Plus, the outcome is that it... punishes players for engaging with the economy if done correctly? Point being it was a decent idea but it doesn't mash with the desired outcomes of the player economy in it's current state.

Improvements to the accounting TGUI showcase were necessary as a result, and just look a bit nicer (I will get a screenshot in a moment). There is still room to potentially look into command staff being able to give raises/pay-cuts to crew but I'd want to treat that similar to opening up crew slots, so I'm putting that off for now.

## Changelog

:cl:
qol: Improvements to the accounting console in the HOP office.
balance: Non-human species now receive a 90% racial paycut, up from 75%.
balance: The inflation mechanic affecting vending machines has been removed, except during the market crash event.
balance: The market crash event now stands as it's own separate event, and ramps up the cost of vendor items until finally popping and returning to normal. Market crash now lasts longer to have more impact while it scales with time.
/:cl:

