### PR TITLE
Flypeople can now eat food and pills that have been left on the floor longer than five seconds without getting sick.

### DIFF
--- a/code/datums/components/infective.dm
+++ b/code/datums/components/infective.dm
@@ -58,7 +58,8 @@
 
 /datum/component/infective/proc/try_infect_eat(datum/source, mob/living/eater, mob/living/feeder)
 	SIGNAL_HANDLER
-
+	if(isflyperson(eater))
+		return // flies can eat food off the floor just fine
 	if(!eater.has_quirk(/datum/quirk/deviant_tastes))
 		eater.add_mood_event("disgust", /datum/mood_event/disgust/dirty_food)
 


### PR DESCRIPTION
## About The Pull Request

Flypeople can now eat food and pills that have been left on the floor longer than five seconds without getting sick.

## Why It's Good For The Game

I mean, they're fly people. It just makes sense.

## Changelog
:cl:
fix: Flypeople can now eat food and pills that have been left on the floor longer than five seconds without getting sick.
/:cl: