### PR TITLE
Bite sized radical progtot rebalance (Or: How I PR'd progtot powercreep)

### DIFF
--- a/code/modules/antagonists/traitor/objectives/destroy_item.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_item.dm
@@ -27,7 +27,7 @@
 	progression_minimum = 20 MINUTES
 	progression_maximum = 35 MINUTES
 	progression_reward = list(5 MINUTES, 10 MINUTES)
-	telecrystal_reward = list(3, 4)
+	telecrystal_reward = list(4,5)
 
 	possible_items = list(
 		/datum/objective_item/steal/traitor/bartender_shotgun,
@@ -63,7 +63,7 @@
 	if(target_item.exists_on_map)
 		var/list/items = GLOB.steal_item_handler.objectives_by_path[target_item.targetitem]
 		for(var/obj/item/item as anything in items)
-			AddComponent(/datum/component/traitor_objective_register, item, succeed_signals = list(COMSIG_QDELETING))
+			AddComponent(/datum/component/traitor_objective_register, item, succeed_signals = list(COMSIG_PARENT_QDELETING))
 			tracked_items += item
 	if(length(target_item.special_equipment))
 		special_equipment = target_item.special_equipment
@@ -93,7 +93,7 @@
 /datum/traitor_objective/destroy_item/proc/on_item_pickup(datum/source, obj/item/item, slot)
 	SIGNAL_HANDLER
 	if(istype(item, target_item.targetitem) && !(item in tracked_items))
-		AddComponent(/datum/component/traitor_objective_register, item, succeed_signals = list(COMSIG_QDELETING))
+		AddComponent(/datum/component/traitor_objective_register, item, succeed_signals = list(COMSIG_PARENT_QDELETING))
 		tracked_items += item
 
 /datum/traitor_objective/destroy_item/ungenerate_objective()

--- a/code/modules/antagonists/traitor/objectives/destroy_item.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_item.dm
@@ -21,6 +21,10 @@
 	possible_items = list(
 		/datum/objective_item/steal/traitor/cargo_budget,
 		/datum/objective_item/steal/traitor/clown_shoes,
+		/datum/objective_item/steal/traitor/bartender_shotgun,
+		/datum/objective_item/steal/traitor/fireaxe,
+		/datum/objective_item/steal/traitor/nullrod,
+		/datum/objective_item/steal/traitor/big_crowbar,
 	)
 
 /datum/traitor_objective/destroy_item/high_risk
@@ -30,10 +34,6 @@
 	telecrystal_reward = list(4,5)
 
 	possible_items = list(
-		/datum/objective_item/steal/traitor/bartender_shotgun,
-		/datum/objective_item/steal/traitor/fireaxe,
-		/datum/objective_item/steal/traitor/nullrod,
-		/datum/objective_item/steal/traitor/big_crowbar,
 		/datum/objective_item/steal/blackbox,
 	)
 

--- a/code/modules/antagonists/traitor/objectives/destroy_item.dm
+++ b/code/modules/antagonists/traitor/objectives/destroy_item.dm
@@ -13,16 +13,28 @@
 	abstract_type = /datum/traitor_objective/destroy_item
 
 /datum/traitor_objective/destroy_item/low_risk
-	progression_minimum = 10 MINUTES
+	progression_minimum = 5 MINUTES
+	progression_maximum = 25 MINUTES
+	progression_reward = list(5 MINUTES, 10 MINUTES)
+	telecrystal_reward = list(1, 2)
+
+	possible_items = list(
+		/datum/objective_item/steal/traitor/cargo_budget,
+		/datum/objective_item/steal/traitor/clown_shoes,
+	)
+
+/datum/traitor_objective/destroy_item/high_risk
+	progression_minimum = 20 MINUTES
 	progression_maximum = 35 MINUTES
 	progression_reward = list(5 MINUTES, 10 MINUTES)
-	telecrystal_reward = 1
+	telecrystal_reward = list(3, 4)
 
 	possible_items = list(
 		/datum/objective_item/steal/traitor/bartender_shotgun,
 		/datum/objective_item/steal/traitor/fireaxe,
 		/datum/objective_item/steal/traitor/nullrod,
 		/datum/objective_item/steal/traitor/big_crowbar,
+		/datum/objective_item/steal/blackbox,
 	)
 
 /datum/traitor_objective/destroy_item/very_risky
@@ -31,7 +43,8 @@
 	telecrystal_reward = list(6, 9)
 
 	possible_items = list(
-		/datum/objective_item/steal/blackbox,
+		/datum/objective_item/steal/traitor/captain_spare,
+		/datum/objective_item/steal/caplaser
 	)
 
 /datum/traitor_objective/destroy_item/generate_objective(datum/mind/generating_for, list/possible_duplicates)
@@ -50,7 +63,7 @@
 	if(target_item.exists_on_map)
 		var/list/items = GLOB.steal_item_handler.objectives_by_path[target_item.targetitem]
 		for(var/obj/item/item as anything in items)
-			AddComponent(/datum/component/traitor_objective_register, item, succeed_signals = list(COMSIG_PARENT_QDELETING))
+			AddComponent(/datum/component/traitor_objective_register, item, succeed_signals = list(COMSIG_QDELETING))
 			tracked_items += item
 	if(length(target_item.special_equipment))
 		special_equipment = target_item.special_equipment
@@ -80,7 +93,7 @@
 /datum/traitor_objective/destroy_item/proc/on_item_pickup(datum/source, obj/item/item, slot)
 	SIGNAL_HANDLER
 	if(istype(item, target_item.targetitem) && !(item in tracked_items))
-		AddComponent(/datum/component/traitor_objective_register, item, succeed_signals = list(COMSIG_PARENT_QDELETING))
+		AddComponent(/datum/component/traitor_objective_register, item, succeed_signals = list(COMSIG_QDELETING))
 		tracked_items += item
 
 /datum/traitor_objective/destroy_item/ungenerate_objective()

--- a/code/modules/antagonists/traitor/objectives/infect.dm
+++ b/code/modules/antagonists/traitor/objectives/infect.dm
@@ -13,7 +13,7 @@
 	maximum_objectives_in_period = 1
 	progression_minimum = 30 MINUTES
 
-	progression_reward = list(8 MINUTES, 14 MINUTES)
+	progression_reward = list(4 MINUTES, 7 MINUTES)
 	telecrystal_reward = 1
 
 

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -35,7 +35,7 @@
 	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
 	progression_reward = list(4 MINUTES, 8 MINUTES)
-	telecrystal_reward = list(2)
+	telecrystal_reward = 2
 	target_jobs = list(
 		// Cargo
 		/datum/job/cargo_technician,
@@ -90,7 +90,7 @@
 	progression_minimum = 15 MINUTES
 	progression_maximum = 60 MINUTES
 	progression_reward = list(8 MINUTES, 12 MINUTES)
-	telecrystal_reward = list(4)
+	telecrystal_reward = list(2, 3)
 	target_jobs = list(
 		// Heads of staff
 		/datum/job/chief_engineer,
@@ -108,7 +108,7 @@
 /datum/traitor_objective/target_player/kidnapping/captain
 	progression_minimum = 30 MINUTES
 	progression_reward = list(12 MINUTES, 16 MINUTES)
-	telecrystal_reward = list(5)
+	telecrystal_reward = list(2, 3)
 	target_jobs = list(
 		/datum/job/captain,
 		/datum/job/head_of_security,

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -35,7 +35,7 @@
 	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
 	progression_reward = list(4 MINUTES, 8 MINUTES)
-	telecrystal_reward = list(2, 3)
+	telecrystal_reward = list(2)
 	target_jobs = list(
 		// Cargo
 		/datum/job/cargo_technician,
@@ -74,7 +74,7 @@
 	progression_minimum = 0 MINUTES
 	progression_maximum = 45 MINUTES
 	progression_reward = list(4 MINUTES, 8 MINUTES)
-	telecrystal_reward = list(3, 4)
+	telecrystal_reward = list(3)
 
 	target_jobs = list(
 		// Cargo
@@ -90,7 +90,7 @@
 	progression_minimum = 15 MINUTES
 	progression_maximum = 60 MINUTES
 	progression_reward = list(8 MINUTES, 12 MINUTES)
-	telecrystal_reward = list(4, 5)
+	telecrystal_reward = list(4)
 	target_jobs = list(
 		// Heads of staff
 		/datum/job/chief_engineer,
@@ -108,7 +108,7 @@
 /datum/traitor_objective/target_player/kidnapping/captain
 	progression_minimum = 30 MINUTES
 	progression_reward = list(12 MINUTES, 16 MINUTES)
-	telecrystal_reward = list(5, 6)
+	telecrystal_reward = list(5)
 	target_jobs = list(
 		/datum/job/captain,
 		/datum/job/head_of_security,

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -1,7 +1,7 @@
 /datum/traitor_objective/target_player/kidnapping
 	name = "Kidnap %TARGET% the %JOB TITLE% and deliver them to %AREA%"
 	description = "%TARGET% holds extremely important information regarding secret NT projects - and you'll need to kidnap and deliver them to %AREA%, where our transport pod will be waiting. \
-		You'll get additional reward if %TARGET% is delivered alive."
+	If %TARGET% is delivered alive, you will be rewarded with an additional %TC% telecrystals."
 
 	abstract_type = /datum/traitor_objective/target_player/kidnapping
 
@@ -34,8 +34,8 @@
 /datum/traitor_objective/target_player/kidnapping/common
 	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
-	progression_reward = list(2 MINUTES, 4 MINUTES)
-	telecrystal_reward = list(1, 2)
+	progression_reward = list(4 MINUTES, 8 MINUTES)
+	telecrystal_reward = list(2, 3)
 	target_jobs = list(
 		// Cargo
 		/datum/job/cargo_technician,
@@ -74,7 +74,7 @@
 	progression_minimum = 0 MINUTES
 	progression_maximum = 45 MINUTES
 	progression_reward = list(4 MINUTES, 8 MINUTES)
-	telecrystal_reward = list(1, 2)
+	telecrystal_reward = list(3, 4)
 
 	target_jobs = list(
 		// Cargo
@@ -90,7 +90,7 @@
 	progression_minimum = 15 MINUTES
 	progression_maximum = 60 MINUTES
 	progression_reward = list(8 MINUTES, 12 MINUTES)
-	telecrystal_reward = list(2, 3)
+	telecrystal_reward = list(4, 5)
 	target_jobs = list(
 		// Heads of staff
 		/datum/job/chief_engineer,
@@ -108,7 +108,7 @@
 /datum/traitor_objective/target_player/kidnapping/captain
 	progression_minimum = 30 MINUTES
 	progression_reward = list(12 MINUTES, 16 MINUTES)
-	telecrystal_reward = list(2, 3)
+	telecrystal_reward = list(5, 6)
 	target_jobs = list(
 		/datum/job/captain,
 		/datum/job/head_of_security,
@@ -158,7 +158,7 @@
 
 	var/datum/mind/target_mind = pick(possible_targets)
 	target = target_mind.current
-	AddComponent(/datum/component/traitor_objective_register, target, fail_signals = list(COMSIG_PARENT_QDELETING))
+	AddComponent(/datum/component/traitor_objective_register, target, fail_signals = list(COMSIG_QDELETING))
 	var/list/possible_areas = GLOB.the_station_areas.Copy()
 	for(var/area/possible_area as anything in possible_areas)
 		if(ispath(possible_area, /area/station/hallway) || ispath(possible_area, /area/station/security) || initial(possible_area.outdoors))
@@ -168,6 +168,7 @@
 	replace_in_name("%TARGET%", target_mind.name)
 	replace_in_name("%JOB TITLE%", target_mind.assigned_role.title)
 	replace_in_name("%AREA%", initial(dropoff_area.name))
+	replace_in_name("%TC%", alive_bonus)
 	return TRUE
 
 /datum/traitor_objective/target_player/kidnapping/ungenerate_objective()
@@ -309,8 +310,9 @@
 	sent_mob.flash_act()
 	sent_mob.adjust_confusion(10 SECONDS)
 	sent_mob.adjust_dizzy(10 SECONDS)
-	sent_mob.set_eye_blur_if_lower(100 SECONDS)
+	sent_mob.set_eye_blur_if_lower(50 SECONDS)
 	sent_mob.dna.species.give_important_for_life(sent_mob) // so plasmamen do not get left for dead
+	to_chat(sent_mob, span_hypnophrase(span_reallybig("You can't remember a thing leading up to the kidnapping, and your head hurts like hell...")))
 
 	new /obj/effect/pod_landingzone(pick(possible_turfs), return_pod)
 


### PR DESCRIPTION
## About The Pull Request
The "low risk" Destroy objective items have been changed to "high risk" and now offer more TC. Conversely, they are only available 20 minutes into the round. The black box has been downgraded to high risk. A new "low risk" category has been created, sharing low risk "Steal" objective items; the Clown's shoes and the Cargo Departmental Budget card. The "very risky" category has had the Captain's Spare ID and the Captain's Antique Lasergun added.
Low risk rewards for the destruction of the Cargo Departmental Budget Card or the Clown's Shoes are 1-2 telecrystals.
High risk rewards for the destruction of the Bartender's Shotgun, Chaplain's Nullrod, Fireaxe, Blackbox or Mech Crowbar are 4-5 telecrystals.
Very risky rewards for the destruction of the Captain's Spare ID or the Captain's Antique Lasergun are 6-9 telecrystals.

The Infect objective's reputation gain has been halved.

Kidnapping now rewards more TC across the board, offering incentive for a difficult objective and placing it further above just outright killing them and dumping the body. It will now display the telecrystals you will be awarded if they are kidnapped alive.

## Why It's Good For The Game

Destruction objectives are often overlooked in the case of the original four low risk items, as there's too little reward for stealing a weapon carried on someone's body or a useful, dangerous tool kept inside someone's workplace. The fireaxe or the nullrod are multipurpose and have great use outside of being destroyed; offering more TC is intended to make people weigh the pros and cons of if its destruction is warranted and to encourage more aggressive, forward behaviur as the round progresses. 
The Black Box has been downgraded as it serves zero function outside of being a destruction objective, and is incredibly easy to take without getting in people's way. People really don't seem to care if it's stolen, but due to it's high security placement and the inability to conceal it, it feels warranted at roughly half the reward. 
New low risk items, siblings with the steal objectives with similar rewards, are intended to help the traitor warm up while still being aggressive. Assaulting the Clown like one would for an heirloom, or breaking into the Quartermaster's office to steal their beloved Departmental Budget Card (or assaulting whoever possesses it) to permanently destroy it are low stakes, low reward objectives to offer a sidegrade to holding onto the items for a few minutes.
The addition of the Captain's Spare ID and the Antique Lasergun at the original "very risky" TC reward of 6-9 both require investment in going loud, either to break into the Captain's office and destroy the display case or to assault the (acting) Captain. Further, they both offer significant advantages - either all access, or a concealable, convenient and deadly weapon. This aims to ask the player whether they'd prefer the advantages or the TC reward with *actually* desirable items.

The Infect objective's reputation gain has been halved, as compared to objectives of the same timeslot and reward, it takes far less effort nor planning. 

Nobody kidnaps, and people should. This is likely because the rewards are low and the alive bonus is poorly communicated, concealing one's identity is expensive/difficult/borderline impossible for lizards, moths and plasmamen, and without voice changing gear, it all has to be done silently. Kidnapping someone perfectly and having them rat you out 3 minutes later is a poor enough experience to warrant never wanting to interact with the system again. By offering a higher TC payout upfront, this offers a reward higher than outright murder, as the objective will always require the victim being taken to a certain place for a drop pod - and as it's unweighted, it can be in very disadvantageous conditions. The alive bonus is now communicated clearly, which is quality of life.

The biggest change is offering metaprotections on kidnapping, similar to a heretic sacrifice. Because of the issues listed above, as well as people validhunting with a name and face to go after, this gives traitors more breathing room when kidnapping and doesn't require outright murder for what should be a more stealthy, strategy focused objective. 

## Changelog

:cl: Licks-The-Crystal
qol: Kidnapping objectives now display how many bonus telecrystals you will receive for a live victim.
balance: Destruction objectives have been moved around, with new options now available. 
add: Amnestics are now administered to kidnapping victims, preventing them from remembering the events leading up to the kidnapping.
/:cl: