### PR TITLE
Syndicate Duffelbag Rerework

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -140,6 +140,7 @@
 	RegisterSignal(resolve_parent, COMSIG_TOPIC, PROC_REF(topic_handle))
 
 	RegisterSignal(resolve_parent, COMSIG_ATOM_EXAMINE, PROC_REF(handle_examination))
+	RegisterSignal(resolve_parent, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(handle_extra_examination))
 
 	orient_to_hud()
 
@@ -236,11 +237,17 @@
 	if(href_list["show_valid_pocket_items"])
 		handle_show_valid_items(source, user)
 
-/datum/storage/proc/handle_examination(datum/source, user)
+/datum/storage/proc/handle_examination(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER
 
 	if(!isnull(can_hold_description))
-		handle_show_valid_items(source, user)
+		examine_list += span_notice("You can examine this further to check what kind of extra items it can hold.")
+
+/datum/storage/proc/handle_extra_examination(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	if(!isnull(can_hold_description))
+		examine_list += handle_show_valid_items(source, user)
 
 /datum/storage/proc/handle_show_valid_items(datum/source, user)
 	to_chat(user, span_notice("[source] can hold: [can_hold_description]"))

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -139,6 +139,8 @@
 
 	RegisterSignal(resolve_parent, COMSIG_TOPIC, PROC_REF(topic_handle))
 
+	RegisterSignal(resolve_parent, COMSIG_ATOM_EXAMINE, PROC_REF(handle_examination))
+
 	orient_to_hud()
 
 /datum/storage/Destroy()
@@ -232,6 +234,12 @@
 	SIGNAL_HANDLER
 
 	if(href_list["show_valid_pocket_items"])
+		handle_show_valid_items(source, user)
+
+/datum/storage/proc/handle_examination(datum/source, user)
+	SIGNAL_HANDLER
+
+	if(!isnull(can_hold_description))
 		handle_show_valid_items(source, user)
 
 /datum/storage/proc/handle_show_valid_items(datum/source, user)

--- a/code/datums/storage/subtypes/duffel_bag.dm
+++ b/code/datums/storage/subtypes/duffel_bag.dm
@@ -3,42 +3,61 @@
 	max_slots = 21
 
 // Syndi bags get some FUN extras
-// You can fit any 3 bulky objects (assuming they're in the whitelist)
+// You can fit any 2 bulky objects (assuming they're in the whitelist)
 // Should have traitorus stuff in here, not just useful big things
 // Idea is to allow for things we typically restrict in exchange for going loud
 /datum/storage/duffel/syndicate
 	silent = TRUE
-	exception_max = 3
+	exception_max = 2
 
 /datum/storage/duffel/syndicate/New()
 	. = ..()
 
 	var/static/list/exception_cache = typecacheof(list(
+		// Most Important Item On List
+		/obj/item/greentext,
+		// Gun and gun-related accessories
 		/obj/item/gun,
+		/obj/item/pneumatic_cannon,
+		// Melee
+		/obj/item/kinetic_crusher, //mostly
+		/obj/item/dualsaber,
 		/obj/item/staff/bostaff,
+		/obj/item/fireaxe,
+		/obj/item/crowbar/mechremoval,
+		/obj/item/spear,
+		/obj/item/nullrod,
+		/obj/item/melee/cleric_mace,
+		/obj/item/melee/ghost_sword,
+		/obj/item/melee/cleaving_saw,
+		// Deployables
+		/obj/item/transfer_valve,
+		/obj/item/powersink,
 		/obj/item/deployable_turret_folded,
 		/obj/item/cardboard_cutout,
-		/obj/item/dualsaber,
-		/obj/item/fireaxe,
-		/obj/item/pneumatic_cannon,
-		/obj/item/spear,
-		/obj/item/powersink,
-		/obj/item/transfer_valve,
+		/obj/item/gibtonite,
+		// Sustenance
 		/obj/item/food/cheese/royal,
 		/obj/item/food/powercrepe,
-		/obj/item/melee/cleric_mace,
+		// Back Items
 		/obj/item/tank/jetpack,
 		/obj/item/watertank,
+		// Skub
+		/obj/item/skub,
+		// Bulky Supplies
+		/obj/item/mecha_ammo,
+		/obj/item/golem_shell,
+		// Clothing
 		/obj/item/clothing/shoes/winterboots/ice_boots/eva,
 		/obj/item/clothing/suit/space,
 		/obj/item/clothing/suit/armor/heavy,
 		/obj/item/clothing/suit/bio_suit,
 		/obj/item/clothing/suit/utility,
-		/obj/item/nullrod,
+		// Storage
 		/obj/item/storage/bag/money,
-		/obj/item/kinetic_crusher,
-		/obj/item/melee/ghost_sword,
-		/obj/item/melee/cleaving_saw,
+		// Heads!
 		/obj/item/bodypart/head,
 	))
 	exception_hold = exception_cache
+
+	generate_hold_desc(exception_cache)

--- a/code/datums/storage/subtypes/duffel_bag.dm
+++ b/code/datums/storage/subtypes/duffel_bag.dm
@@ -13,7 +13,7 @@
 /datum/storage/duffel/syndicate/New()
 	. = ..()
 
-	var/static/list/exception_cache = typecacheof(list(
+	var/static/list/exception_type_list = list(
 		// Most Important Item On List
 		/obj/item/greentext,
 		// Gun and gun-related accessories
@@ -57,7 +57,11 @@
 		/obj/item/storage/bag/money,
 		// Heads!
 		/obj/item/bodypart/head,
-	))
+	)
+
+	// We keep the type list and the typecache list separate...
+	var/static/list/exception_cache = typecacheof(exception_type_list)
 	exception_hold = exception_cache
 
-	generate_hold_desc(exception_cache)
+	//...So we can run this without it generating a line for every subtype.
+	can_hold_description = generate_hold_desc(exception_type_list)

--- a/code/datums/storage/subtypes/duffel_bag.dm
+++ b/code/datums/storage/subtypes/duffel_bag.dm
@@ -14,8 +14,6 @@
 	. = ..()
 
 	var/static/list/exception_type_list = list(
-		// Most Important Item On List
-		/obj/item/greentext,
 		// Gun and gun-related accessories
 		/obj/item/gun,
 		/obj/item/pneumatic_cannon,

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -21,7 +21,7 @@
  */
 
 /obj/item/toy/crayon
-	name = "red crayon"
+	name = "crayon"
 	desc = "A colourful crayon. Looks tasty. Mmmm..."
 	icon = 'icons/obj/art/crayons.dmi'
 	icon_state = "crayonred"

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -72,12 +72,7 @@
 	user.suicide_log()
 	qdel(user)
 
-/obj/item/storage/backpack/santabag
-	name = "Santa's Gift Bag"
-	desc = "Space Santa uses this to deliver presents to all the nice children in space in Christmas! Wow, it's pretty big!"
-	icon_state = "giftbag0"
-	inhand_icon_state = "giftbag"
-	w_class = WEIGHT_CLASS_BULKY
+
 	storage_type = /datum/storage/backpack/santabag
 
 /obj/item/storage/backpack/santabag/Initialize(mapload)
@@ -392,6 +387,14 @@
 	/// If this bag is zipped (contents hidden) up or not
 	/// Starts enabled so you're forced to interact with it to "get" it
 	var/zipped_up = TRUE
+	// How much time it takes to zip up (close) the duffelbag
+	var/zip_up_duration = 0.5 SECONDS
+	// Audio played during zipup
+	var/zip_up_sfx = 'sound/items/zip_up.ogg'
+	// How much time it takes to unzip the duffel
+	var/unzip_duration = 2.1 SECONDS
+	// Audio played during unzip
+	var/unzip_sfx = 'sound/items/un_zip.ogg'
 
 /obj/item/storage/backpack/duffelbag/Initialize(mapload)
 	. = ..()
@@ -425,9 +428,9 @@
 		return ..()
 
 	balloon_alert(user, "unzipping...")
-	playsound(src, 'sound/items/un_zip.ogg', 100, FALSE)
+	playsound(src, unzip_sfx, 100, FALSE)
 	var/datum/callback/can_unzip = CALLBACK(src, PROC_REF(zipper_matches), TRUE)
-	if(!do_after(user, 2.1 SECONDS, src, extra_checks = can_unzip))
+	if(!do_after(user, unzip_duration, src, extra_checks = can_unzip))
 		user.balloon_alert(user, "unzip failed!")
 		return
 	balloon_alert(user, "unzipped")
@@ -442,9 +445,9 @@
 		return SECONDARY_ATTACK_CALL_NORMAL
 
 	balloon_alert(user, "zipping...")
-	playsound(src, 'sound/items/zip_up.ogg', 100, FALSE)
+	playsound(src, zip_up_sfx, 100, FALSE)
 	var/datum/callback/can_zip = CALLBACK(src, PROC_REF(zipper_matches), FALSE)
-	if(!do_after(user, 0.5 SECONDS, src, extra_checks = can_zip))
+	if(!do_after(user, zip_up_duration, src, extra_checks = can_zip))
 		user.balloon_alert(user, "zip failed!")
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	balloon_alert(user, "zipped")
@@ -621,11 +624,16 @@
 
 /obj/item/storage/backpack/duffelbag/syndie
 	name = "suspicious looking duffel bag"
-	desc = "A large duffel bag for holding extra tactical supplies."
+	desc = "A large duffel bag for holding extra tactical supplies. It contains an oiled plastitanium zipper for maximum speed tactical zipping, and is better balanced on your back than an average duffelbag. Can hold two bulky items!"
 	icon_state = "duffel-syndie"
 	inhand_icon_state = "duffel-syndieammo"
 	storage_type = /datum/storage/duffel/syndicate
 	resistance_flags = FIRE_PROOF
+	// Less slowdown while unzipped. Still bulky, but it won't halve your movement speed in an active combat situation.
+	zip_slowdown = 0.3
+	// Faster unzipping. Utilizes the same noise as zipping up to fit the unzip duration.
+	unzip_duration = 0.5 SECONDS
+	unzip_sfx = 'sound/items/zip_up.ogg'
 
 /obj/item/storage/backpack/duffelbag/syndie/hitman
 	desc = "A large duffel bag for holding extra things. There is a Nanotrasen logo on the back."
@@ -660,7 +668,6 @@
 	new /obj/item/cautery/advanced(src)
 	new /obj/item/surgical_drapes(src)
 	new /obj/item/reagent_containers/medigel/sterilizine(src)
-	new /obj/item/surgicaldrill(src)
 	new /obj/item/bonesetter(src)
 	new /obj/item/blood_filter(src)
 	new /obj/item/stack/medical/bone_gel(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -73,8 +73,6 @@
 	qdel(user)
 
 
-	storage_type = /datum/storage/backpack/santabag
-
 /obj/item/storage/backpack/santabag
 	name = "Santa's Gift Bag"
 	desc = "Space Santa uses this to deliver presents to all the nice children in space in Christmas! Wow, it's pretty big!"

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -75,6 +75,13 @@
 
 	storage_type = /datum/storage/backpack/santabag
 
+/obj/item/storage/backpack/santabag
+	name = "Santa's Gift Bag"
+	desc = "Space Santa uses this to deliver presents to all the nice children in space in Christmas! Wow, it's pretty big!"
+	icon_state = "giftbag0"
+	inhand_icon_state = "giftbag"
+	w_class = WEIGHT_CLASS_BULKY
+
 /obj/item/storage/backpack/santabag/Initialize(mapload)
 	. = ..()
 	regenerate_presents()

--- a/code/modules/unit_tests/crayons.dm
+++ b/code/modules/unit_tests/crayons.dm
@@ -3,7 +3,7 @@
 
 /datum/unit_test/crayon_naming/Run()
 	for(var/obj/item/toy/crayon/crayon_path as anything in typesof(/obj/item/toy/crayon))
-		if(ispath(crayon_path, /obj/item/toy/crayon/spraycan))
+		if(is_path_in_list(crayon_path, list(/obj/item/toy/crayon/spraycan, /obj/item/toy/crayon)))
 			continue
 		var/obj/item/toy/crayon/real_crayon = new crayon_path
 		if(!findtext(initial(real_crayon.name),real_crayon.crayon_color))


### PR DESCRIPTION
## About The Pull Request

Syndicate duffelbags can fit 2 extra bulky items, down from three.

Reduced syndicate duffelbag's unzipped slowdown from '1' to '0.3', and set its zipping-up sped to 0.5, same as unzipping.

Added the following items to the Syndicate Duffelbag bulky exception list: Greentext, mech removal tool, gibtonite, skub, golem shells, mech ammo. Roughly sorted the list by item category.

Fixed the syndie surgery duffelbag having more items than it can hold by removing the redundant surgical drill (Upgraded cauteries can turn into one anyways)

Any storage item with a can_hold description can be examined twice to see what it can hold now.

## Why It's Good For The Game

> Syndicate duffelbags can fit 2 extra bulky items, down from three.

> Reduced syndicate duffelbag's unzipped slowdown from '1' to '0.3', and set its zipping-up sped to 0.5, same as unzipping.

For most intents and purposes, it seems the syndicate duffelbag has gone from 'bland upgrade to backpack', to 'useless'. This is especially made apparent because it isn't exactly shown to the player that these duffelbags can carry bulky items (I didn't even know about it until I was making this PR!)

The extra bulky item hold concept is great, but I have my issues with the item as-is that I seek to fix with this PR. There are TONS of issues with being unable to access your bag quickly, which is twice as relevant when your bag is an incredibly conspicious traitor item. Sure, you can have it in your hand, but then why even have it in the first place?

That's why I want to reduce the slowdown significantly. '1' slowdowns are thrown around the whole game like they're reasonable (galoshes, water back-tanks, biosuits) - they aren't. '1' slowdown is CRIPPLING. It makes you frustratingly slow and effectively destroys any combat maneuvering you can do. This is very relevant for a traitorious item.

The zip speed helps one use the duffelbag as a storage item dynamically, letting the item be an actual trade-off rather than mostly a downside. Gives you a reason to use it rather than just buying a smuggler satchel for more storage.

Of course these are some hefty buffs, so I lowered the bulky storage to make up for it. I can bring it back up to 3 if wanted.

> Added the following items to the Syndicate Duffelbag bulky exception list: Greentext, mech removal tool, gibtonite, skub, golem shells, mech ammo. Roughly sorted the list by item category.

Some traitorious items that felt like they should be allowed in. Honestly, I think this shouldn't even be an exception hold except for blacklisting clearly bonkers things like backpacks, but whatevs.

> Any storage item with a can_hold description can be examined twice to see what it can hold now.

Generalization is awesome. Hardcoding is cringe!

## Changelog

:cl:
balance: Syndicate duffelbags can fit 2 extra bulky items, down from three.
balance: Reduced syndicate duffelbag's unzipped slowdown from '1' to '0.3', and set its zipping-up sped to 0.5, same as unzipping.
add: Added the following items to the Syndicate Duffelbag bulky exception list: Greentext, mech removal tool, gibtonite, skub, golem shells, mech ammo. Roughly sorted the list by item category.
fix: Fixed the syndie surgery duffelbag having more items than it can hold by removing the redundant surgical drill (Upgraded cauteries can turn into one anyways)
qol: Any storage item with a can_hold description can be examined twice to see what it can hold now.
fix: The parent crayon's name is 'crayon' to prevent any weirdness with things that show the parent type's name.
/:cl:

