### PR TITLE
Resizing mobs also affects their maptext height

### DIFF
--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -206,10 +206,12 @@
 	/// Is this mob allowed to be buckled/unbuckled to/from things?
 	var/can_buckle_to = TRUE
 
-	///The y amount a mob's sprite should be offset due to the current position they're in (e.g. lying down moves your sprite down)
-	var/body_position_pixel_x_offset = 0
 	///The x amount a mob's sprite should be offset due to the current position they're in
+	var/body_position_pixel_x_offset = 0
+	///The y amount a mob's sprite should be offset due to the current position they're in or size (e.g. lying down moves your sprite down)
 	var/body_position_pixel_y_offset = 0
+	///The height offset of a mob's maptext due to their current size.
+	var/body_maptext_height_offset = 0
 
 	/// FOV view that is applied from either nativeness or traits
 	var/fov_view

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -18,6 +18,10 @@
 		changed = TRUE
 		ntransform.Scale(resize)
 		current_size *= resize
+		//Update the height of the maptext according to the size of the mob so they don't overlap.
+		var/old_maptext_offset = body_maptext_height_offset
+		body_maptext_height_offset = initial(maptext_height) * (current_size - 1)
+		maptext_height += body_maptext_height_offset - old_maptext_offset
 		//Update final_pixel_y so our mob doesn't go out of the southern bounds of the tile when standing
 		if(!lying_angle || !rotate_on_lying) //But not if the mob has been rotated.
 			//Make sure the body position y offset is also updated


### PR DESCRIPTION
## About The Pull Request
I'll make this brief: the maptext height isn't currently being affected by mob resizing unlike pixel y, which means text may overlap with an upsized mob's sprite. However, it's a mild issue to be frank. 

## Why It's Good For The Game
Making runechat look nicer I guess.

## Changelog

:cl:
fix: the height of runechat messages should now scale correctly with the current size variable of living mob.
/:cl:
