### PR TITLE
Phobia warnings have the same glowy text now as they would in say messages

### DIFF
--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -109,9 +109,9 @@
 		return
 	var/message = pick("spooks you to the bone", "shakes you up", "terrifies you", "sends you into a panic", "sends chills down your spine")
 	if(reason)
-		to_chat(owner, span_userdanger("Seeing [reason] [message]!"))
+		to_chat(owner, span_userdanger("Seeing [span_phobia(reason)] [message]!"))
 	else if(trigger_word)
-		to_chat(owner, span_userdanger("Hearing \"[trigger_word]\" [message]!"))
+		to_chat(owner, span_userdanger("Hearing \"[span_phobia(trigger_word)]\" [message]!"))
 	else
 		to_chat(owner, span_userdanger("Something [message]!"))
 	var/reaction = rand(1,4)


### PR DESCRIPTION

## About The Pull Request

Title.
## Why It's Good For The Game

Fixes #48028
## Changelog
:cl:
spellcheck: Phobia warnings have the same glowy text now as they would in messages.
/:cl:
