### PR TITLE
Fixes bluespace bodybag duping

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -20,6 +20,12 @@
 		if(isopenturf(target))
 			deploy_bodybag(user, target)
 
+/obj/item/bodybag/attempt_pickup(mob/user)
+	// can't pick ourselves up if we are inside of the bodybag, else very weird things may happen
+	if(contains(user))
+		return TRUE
+	return ..()
+
 /**
  * Creates a new body bag item when unfolded, at the provided location, replacing the body bag item.
  * * mob/user: User opening the body bag.


### PR DESCRIPTION

## About The Pull Request

Folded bluespace bodybags had no prior checks to see if the person picking the item up was the one inside of the bag. This naturally broke things, because BYOND doesn't like it when you have an infinite cycle of locs, so it refuses to move the folded bluespace item onto your mob. This then leads to the bluespace bodybag duping bug, as the item is still in your hand even though it really isn't.
## Why It's Good For The Game

Fixes #44902 
## Changelog
:cl:
fix: Fixed a rare bug that let you spam bluespace bodybags everywhere.
/:cl:
