### PR TITLE
HoP's policy now states that they should answer to the captain instead of themselves

### DIFF
--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -8,7 +8,7 @@
 	faction = FACTION_STATION
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = SUPERVISOR_HOP
+	supervisors = SUPERVISOR_CAPTAIN
 	req_admin_notify = 1
 	minimal_player_age = 10
 	exp_requirements = 180


### PR DESCRIPTION

## About The Pull Request

Title
## Why It's Good For The Game

Silly oversight
## Changelog
:cl:
spellcheck: Head of Personnel's roundstart text now says that they should answer to the captain now instead of themselves.
/:cl:
