### PR TITLE
Prisoner slots can no longer be controlled by HR Core

### DIFF
--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -26,6 +26,7 @@ GLOBAL_VAR_INIT(time_last_changed_position, 0)
 		JOB_AI,
 		JOB_CYBORG,
 		JOB_ASSISTANT,
+		JOB_PRISONER,
 	)
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %


### PR DESCRIPTION

## About The Pull Request

This just adds the prisoner role to the blacklist of controllable jobs in the job management app.
## Why It's Good For The Game

It doesn't seem like a good idea that prisoners should be controllable by the job management app, because prisoner is not really supported as a latejoin role here.

Fixes #77047
## Changelog
:cl:
fix: Prisoner slots can no longer be controlled by Plexagon HR Core.
/:cl:
