### PR TITLE
Mafia chaplain seance can no longer be used on living people

### DIFF
--- a/code/modules/mafia/_defines.dm
+++ b/code/modules/mafia/_defines.dm
@@ -68,7 +68,7 @@
 #define CAN_USE_ON_OTHERS (1<<0)
 ///Flag that decides whether the Mafia ability can be used on themselves.
 #define CAN_USE_ON_SELF (1<<1)
-///Flag that decides whether the Mafia ability can be used on dead players. This overwrites the first two, and only allows for dead.
+///Flag that decides whether the Mafia ability can be used on dead players.
 #define CAN_USE_ON_DEAD (1<<2)
 
 #define MAFIA_PHASE_SETUP "No Game"

--- a/code/modules/mafia/abilities/abilities.dm
+++ b/code/modules/mafia/abilities/abilities.dm
@@ -56,7 +56,7 @@
 		return FALSE
 
 	if(potential_target)
-		if(!(use_flags & CAN_USE_ON_DEAD) && (potential_target.game_status == MAFIA_DEAD))
+		if((use_flags & CAN_USE_ON_DEAD) && (potential_target.game_status != MAFIA_DEAD))
 			if(!silent)
 				to_chat(host_role.body, span_notice("This can only be used on dead players."))
 			return FALSE


### PR DESCRIPTION

## About The Pull Request

Small oversight in how the use flag was checked. Also there was a misleading code comment that I removed.
## Why It's Good For The Game

Fixes #77042
## Changelog
:cl:
fix: Mafia chaplains can now only use their seances on dead people now.
/:cl:
