### PR TITLE
Adds a sanity check to /mob/living/brain/Life() to make sure it's actually in an MMI

### DIFF
--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -4,10 +4,7 @@
 		return
 	if(!loc)
 		return
-	// this is a sanity check to make sure that our MMI reference is still valid
-	// there used to be a bug where container still held a reference to an MMI that the brain wasn't
-	// inside of which caused the brain mob to be permanently stuck in nullspace even with a client,
-	// so this code exists as a failsafe in case everything goes wrong
+
 	if(!isnull(container))
 		if(!istype(container))
 			stack_trace("/mob/living/brain with container set, but container was not an MMI!")

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -4,6 +4,17 @@
 		return
 	if(!loc)
 		return
+	// this is a sanity check to make sure that our MMI reference is still valid
+	// there used to be a bug where container still held a reference to an MMI that the brain wasn't
+	// inside of which caused the brain mob to be permanently stuck in nullspace even with a client,
+	// so this code exists as a failsafe in case everything goes wrong
+	if(!isnull(container))
+		if(!istype(container))
+			stack_trace("/mob/living/brain with container set, but container was not an MMI!")
+			container = null
+		if(!container.contains(src))
+			stack_trace("/mob/living/brain with container set, but we weren't inside of it!")
+			container = null
 	. = ..()
 	handle_emp_damage(seconds_per_tick, times_fired)
 


### PR DESCRIPTION

## About The Pull Request

This PR adds a sanity check to /mob/living/brain in the offchance that the reference to container is no longer valid. This has only happened once before as far as I know, but it was catastrophical enough to warrant a failsafe system. I'm not even sure if this is something that's player-facing because there's no set of circumstances in the game that would cause this bug to happen, outside of adminbus.
## Why It's Good For The Game

Fixes #68497
## Changelog
:cl:
fix: Fixes an extremely rare bug where a /mob/living/brain with a client would not be moved out of nullspace correctly, causing admin log spam.
/:cl:
