### PR TITLE
Add "Hall of Fame" emergency shuttle

### DIFF
--- a/_maps/shuttles/emergency_fame.dmm
+++ b/_maps/shuttles/emergency_fame.dmm
@@ -2,9 +2,15 @@
 "aj" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_scatter_radius = 1;
-	spawn_loot_count = 2
+	spawn_loot_count = 2;
+	spawn_loot_chance = 50
 	},
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"as" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/storage/photo_album/hall_of_fame,
+/turf/open/floor/mineral/silver,
 /area/shuttle/escape)
 "aI" = (
 /obj/machinery/power/shuttle_engine/heater{
@@ -33,7 +39,9 @@
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
 "bT" = (
-/obj/item/reagent_containers/cup/glass/trophy/silver_cup,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "cb" = (
@@ -41,7 +49,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
 "ct" = (
-/obj/effect/spawner/random/trash/hobo_squat,
+/obj/effect/spawner/random/trash/hobo_squat{
+	spawn_loot_chance = 50
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "cu" = (
@@ -62,7 +72,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
 "dh" = (
-/obj/effect/spawner/random/trash/graffiti,
+/obj/effect/spawner/random/trash/graffiti{
+	spawn_loot_chance = 50
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "dp" = (
@@ -121,9 +133,7 @@
 /area/shuttle/escape)
 "gE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 6
-	},
+/obj/effect/gibspawner/human/bodypartless,
 /turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "gI" = (
@@ -187,6 +197,13 @@
 "kM" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
+/area/shuttle/escape)
+"kR" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow/corner,
+/turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "la" = (
 /obj/item/reagent_containers/cup/bottle/epinephrine{
@@ -369,6 +386,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
+"pJ" = (
+/obj/effect/turf_decal/siding,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
 "qd" = (
 /obj/effect/turf_decal/siding{
 	dir = 9
@@ -386,11 +410,15 @@
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
 "qr" = (
-/obj/item/reagent_containers/cup/glass/trophy/bronze_cup,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "qx" = (
-/obj/structure/curtain/cloth/fancy,
+/obj/structure/curtain/cloth/fancy{
+	name = "Hall of Fame"
+	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "qG" = (
@@ -422,14 +450,28 @@
 /turf/closed/wall/mineral/gold,
 /area/shuttle/escape)
 "si" = (
-/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external,
 /turf/open/floor/catwalk_floor,
 /area/shuttle/escape)
 "so" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
+"ss" = (
+/obj/effect/turf_decal/siding,
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"th" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
 "vi" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/sink/directional/south,
@@ -482,14 +524,8 @@
 "wv" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table/wood/fancy/royalblue,
-/obj/item/camera_film{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/camera{
-	pixel_x = 4
-	},
-/turf/open/floor/mineral/silver,
+/obj/effect/spawner/random/decoration/statue,
+/turf/open/floor/carpet/black,
 /area/shuttle/escape)
 "wK" = (
 /obj/machinery/vending/boozeomat,
@@ -536,8 +572,8 @@
 /turf/template_noop,
 /area/shuttle/escape)
 "ye" = (
-/obj/item/reagent_containers/cup/glass/trophy/gold_cup,
-/turf/open/floor/carpet/red,
+/obj/structure/fluff/arc,
+/turf/open/floor/mineral/gold,
 /area/shuttle/escape)
 "yo" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -547,8 +583,8 @@
 "yy" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table/wood/fancy/royalblue,
-/obj/item/storage/photo_album/hall_of_fame,
-/turf/open/floor/mineral/silver,
+/obj/effect/spawner/random/decoration/statue,
+/turf/open/floor/carpet/black,
 /area/shuttle/escape)
 "yH" = (
 /obj/structure/table,
@@ -576,6 +612,13 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"zy" = (
+/obj/effect/turf_decal/siding,
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
 "zG" = (
 /obj/effect/turf_decal/siding{
 	dir = 6
@@ -596,7 +639,7 @@
 /area/shuttle/escape)
 "AA" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/glass/reinforced,
 /area/shuttle/escape)
 "AS" = (
 /obj/effect/turf_decal/siding,
@@ -625,10 +668,10 @@
 	},
 /area/shuttle/escape)
 "Cz" = (
-/obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/machinery/door/airlock/external,
 /turf/open/floor/catwalk_floor,
 /area/shuttle/escape)
 "Dv" = (
@@ -637,7 +680,6 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "DA" = (
-/obj/effect/gibspawner/human/bodypartless,
 /turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "DO" = (
@@ -652,7 +694,7 @@
 /area/shuttle/escape)
 "Ei" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass/reinforced,
 /area/shuttle/escape)
 "EF" = (
 /obj/item/kirbyplants/organic/plant16,
@@ -719,7 +761,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "HZ" = (
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass/reinforced,
 /area/shuttle/escape)
 "Ih" = (
 /obj/machinery/power/shuttle_engine/propulsion{
@@ -765,6 +807,11 @@
 /area/shuttle/escape)
 "Mb" = (
 /turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"Mj" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/hourglass,
+/turf/open/floor/carpet/black,
 /area/shuttle/escape)
 "MO" = (
 /obj/effect/turf_decal/siding/wood{
@@ -878,6 +925,15 @@
 	pixel_y = 2
 	},
 /turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"PM" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "PP" = (
 /obj/structure/chair/comfy/shuttle,
@@ -1327,9 +1383,9 @@ Bj
 Bj
 Bj
 mx
-Yp
-Yp
-Yp
+HZ
+HZ
+HZ
 mx
 Bj
 Bj
@@ -1352,9 +1408,9 @@ YF
 aj
 yc
 mx
-Yp
-Yp
-Yp
+HZ
+HZ
+HZ
 mx
 yc
 aj
@@ -1377,9 +1433,9 @@ YF
 YF
 yc
 mx
-Yp
+HZ
 AA
-Yp
+HZ
 mx
 yc
 YF
@@ -1426,11 +1482,11 @@ Bj
 Bj
 mz
 mz
-Xr
+mZ
 vD
 Sl
 lr
-Xr
+mZ
 mz
 mz
 Bj
@@ -1450,13 +1506,13 @@ mz
 Bj
 mz
 mz
-Xr
-mZ
+aS
+it
 jS
 Xv
 AS
-mZ
-Xr
+Bb
+rH
 mz
 mz
 Bj
@@ -1475,13 +1531,13 @@ mz
 yc
 mz
 Xr
-aS
-it
-jS
+bR
+YN
+kR
 qr
-AS
-Bb
-rH
+ss
+YN
+qG
 Xr
 mz
 yc
@@ -1501,11 +1557,11 @@ yc
 FZ
 yy
 bR
-YN
-jS
+as
+th
 ye
-AS
-YN
+pJ
+Mj
 qG
 wv
 Ab
@@ -1525,13 +1581,13 @@ mz
 yc
 mz
 Xr
-qn
-MS
-jS
+bR
+YN
+PM
 bT
-AS
-kz
-LL
+zy
+YN
+qG
 Xr
 mz
 yc
@@ -1550,13 +1606,13 @@ mz
 Bj
 mz
 mz
-Xr
-mZ
+qn
+MS
 jS
 Xv
 AS
-mZ
-Xr
+kz
+LL
 mz
 mz
 Bj
@@ -1576,11 +1632,11 @@ Bj
 Bj
 mz
 mz
-Xr
+mZ
 vZ
 dr
 Pj
-Xr
+mZ
 mz
 mz
 Bj

--- a/_maps/shuttles/emergency_fame.dmm
+++ b/_maps/shuttles/emergency_fame.dmm
@@ -1,0 +1,1997 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aj" = (
+/obj/effect/spawner/random/trash/garbage{
+	spawn_scatter_radius = 1;
+	spawn_loot_count = 2
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"aI" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"aS" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"aX" = (
+/obj/machinery/door/airlock/engineering,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"bG" = (
+/obj/machinery/space_heater,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"bR" = (
+/obj/structure/chair/sofa/corp,
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"bT" = (
+/obj/item/reagent_containers/cup/glass/trophy/silver_cup,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"cb" = (
+/obj/effect/turf_decal/siding,
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"ct" = (
+/obj/effect/spawner/random/trash/hobo_squat,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"cu" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"cV" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"dd" = (
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"dh" = (
+/obj/effect/spawner/random/trash/graffiti,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"dp" = (
+/obj/item/kirbyplants/organic/plant16,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"dr" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"dy" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"el" = (
+/obj/machinery/stasis,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ep" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"et" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"eW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"fi" = (
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"fm" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"fS" = (
+/obj/structure/mineral_door/silver,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"ga" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"gm" = (
+/obj/structure/sign/departments/medbay/alt,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"gE" = (
+/obj/machinery/computer/pod/old/mass_driver_controller{
+	id = "shuttle_trash";
+	pixel_x = 26
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"gI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"hg" = (
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"it" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"iz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum/external/directional/north,
+/obj/machinery/mass_driver{
+	dir = 4;
+	id = "shuttle_trash"
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape/brig)
+"iN" = (
+/turf/open/floor/catwalk_floor,
+/area/shuttle/escape)
+"jH" = (
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/machinery/door/airlock/command/glass{
+	name = "Cockpit"
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"jQ" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"jS" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"kz" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"kA" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"kM" = (
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"la" = (
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/syringe/epinephrine{
+	pixel_x = 2;
+	pixel_y = 8
+	},
+/obj/structure/table/glass,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"lr" = (
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"ly" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"lA" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/cigarettes/cigars/havana{
+	pixel_y = 3
+	},
+/obj/item/storage/fancy/cigarettes/cigars/cohiba{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/lighter,
+/obj/item/lighter,
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"lB" = (
+/obj/item/kirbyplants/organic/plant16,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"lV" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"mc" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/turf/open/floor/catwalk_floor,
+/area/shuttle/escape)
+"mm" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/toolcloset,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"mn" = (
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"mr" = (
+/obj/item/defibrillator/loaded,
+/obj/structure/table/glass,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"mt" = (
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"mx" = (
+/obj/item/storage/toolbox/emergency,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/flashlight/flare{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/flashlight/flare{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/radio,
+/obj/item/radio,
+/obj/structure/closet,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"mz" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"mT" = (
+/obj/structure/sign/painting/large/library,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"mZ" = (
+/obj/item/kirbyplants/organic/plant1,
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"ni" = (
+/obj/item/scalpel{
+	pixel_y = 12
+	},
+/obj/item/circular_saw,
+/obj/item/retractor{
+	pixel_x = 4
+	},
+/obj/item/hemostat{
+	pixel_x = -4
+	},
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
+/obj/structure/table/glass,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"nx" = (
+/obj/machinery/power/shuttle_engine/huge{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"oc" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"ok" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"oz" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"oB" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"pg" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"px" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"qd" = (
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"qj" = (
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"qn" = (
+/obj/structure/chair/sofa/corp/corner,
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"qr" = (
+/obj/item/reagent_containers/cup/glass/trophy/bronze_cup,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"qx" = (
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"qG" = (
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"qM" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"qW" = (
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"rH" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1;
+	name = "couch";
+	desc = "Looks like someone threw it out. Covered in donut crumbs."
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"rV" = (
+/obj/structure/sign/picture_frame/showroom/one,
+/turf/closed/wall/mineral/gold,
+/area/shuttle/escape)
+"si" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/catwalk_floor,
+/area/shuttle/escape)
+"so" = (
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"vi" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/sink/directional/south,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"vD" = (
+/obj/effect/turf_decal/siding{
+	dir = 9
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"vK" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"vL" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"vP" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"vT" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"vZ" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"we" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"wu" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"wv" = (
+/obj/machinery/light/directional/south,
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/camera_film{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/camera{
+	pixel_x = 4
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"wI" = (
+/obj/structure/kitchenspike,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"wK" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"xc" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/structure/plaque/static_plaque/golden/captain{
+	pixel_y = 29
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"xg" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"xl" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"xt" = (
+/obj/effect/spawner/random/entertainment/plushie,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"xI" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/docking_port/mobile/emergency{
+	dir = 2;
+	name = "Hall of fame emergency shuttle"
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"yc" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/shuttle/escape)
+"ye" = (
+/obj/item/reagent_containers/cup/glass/trophy/gold_cup,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"yo" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/massdriver_trash{
+	id = "shuttle_trash"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape/brig)
+"yy" = (
+/obj/machinery/light/directional/north,
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/storage/photo_album/hall_of_fame,
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"yH" = (
+/obj/structure/table,
+/obj/item/clothing/mask/whistle,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"yJ" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"zc" = (
+/obj/structure/tank_dispenser/oxygen{
+	layer = 2.7;
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"zG" = (
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"Ab" = (
+/obj/structure/sign/picture_frame/showroom/four,
+/turf/closed/wall/mineral/gold,
+/area/shuttle/escape)
+"Aw" = (
+/obj/effect/spawner/random/entertainment/arcade,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"AA" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"AS" = (
+/obj/effect/turf_decal/siding,
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Bb" = (
+/obj/structure/chair/sofa/corp/left{
+	desc = "Looks like someone threw it out. Covered in donut crumbs.";
+	name = "couch";
+	dir = 4
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"Bf" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/closet/toolcloset,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Bj" = (
+/turf/template_noop,
+/area/template_noop)
+"BY" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Cg" = (
+/turf/open/floor/iron/stairs/right{
+	dir = 8
+	},
+/area/shuttle/escape)
+"Cz" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor,
+/area/shuttle/escape)
+"Dv" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/entertainment/deck,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"DA" = (
+/obj/machinery/door/window{
+	dir = 4;
+	name = "Trash Disposal"
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"DO" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Ec" = (
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/clothing/suit/hazardvest{
+	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
+	name = "emergency lifejacket"
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/emergency_oxygen{
+	pixel_x = 3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/mask/breath{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/item/clothing/head/utility/hardhat/orange{
+	name = "protective hat";
+	pixel_y = 9
+	},
+/obj/structure/closet/crate{
+	name = "lifejackets"
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Ei" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"EF" = (
+/obj/item/kirbyplants/organic/plant16,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Fi" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Fl" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/structure/sign/flag/nanotrasen/directional/south,
+/obj/item/megaphone/command{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"FJ" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"FZ" = (
+/obj/structure/sign/picture_frame/showroom/two,
+/turf/closed/wall/mineral/gold,
+/area/shuttle/escape)
+"Gf" = (
+/turf/open/floor/iron/stairs/left{
+	dir = 8
+	},
+/area/shuttle/escape)
+"Gs" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	pixel_y = 4;
+	use_power = 0
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"GU" = (
+/obj/machinery/computer/crew{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Hy" = (
+/obj/structure/table,
+/obj/item/storage/box/handcuffs,
+/obj/machinery/light/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"HS" = (
+/obj/structure/table/optable,
+/obj/item/surgical_drapes,
+/obj/machinery/light/directional/west,
+/obj/machinery/defibrillator_mount/directional/west,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"HZ" = (
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Ih" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"JZ" = (
+/obj/machinery/computer/communications{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Km" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"KG" = (
+/obj/machinery/shower/directional/south,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Ll" = (
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"Lv" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"LL" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"LR" = (
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Mb" = (
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"MO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"MS" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"MT" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/bottle/rum{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/bottle/amaretto{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_y = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"MX" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	use_power = 0
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"Nw" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Ny" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/wall/peppertank/directional/south,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"NN" = (
+/obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"NU" = (
+/obj/structure/sign/picture_frame/showroom/three,
+/turf/closed/wall/mineral/gold,
+/area/shuttle/escape)
+"NV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Oa" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Or" = (
+/obj/structure/sign/painting/library{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Ow" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"OA" = (
+/obj/effect/turf_decal/siding{
+	dir = 5
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"Pb" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Pf" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Pj" = (
+/obj/effect/turf_decal/siding{
+	dir = 6
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Pu" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_x = 3;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"PP" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"PQ" = (
+/obj/structure/displaycase/trophy,
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Qk" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"Ru" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"RZ" = (
+/turf/open/floor/wood,
+/area/shuttle/escape)
+"Sl" = (
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"Ty" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Uu" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"UA" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Vl" = (
+/obj/structure/sign/painting/library{
+	pixel_y = -32
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"VQ" = (
+/obj/machinery/computer/security{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Wp" = (
+/obj/machinery/door/window/left/directional/west{
+	dir = 4;
+	name = "Infirmary"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Ws" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Xg" = (
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/shuttle/escape)
+"Xl" = (
+/obj/item/kirbyplants/organic/plant16,
+/obj/machinery/light/directional/west,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Xr" = (
+/obj/effect/spawner/random/decoration/statue,
+/obj/structure/table/wood/fancy/royalblue,
+/turf/open/floor/carpet/black,
+/area/shuttle/escape)
+"Xv" = (
+/turf/open/floor/carpet/red,
+/area/shuttle/escape)
+"XW" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Yp" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Yt" = (
+/obj/structure/table,
+/obj/item/clothing/head/fedora/beige,
+/obj/machinery/recharger{
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	use_power = 0
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
+"YF" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"YN" = (
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"YS" = (
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"YX" = (
+/obj/item/kirbyplants/organic/plant21,
+/turf/open/floor/iron/dark,
+/area/shuttle/escape)
+"Zj" = (
+/obj/item/storage/medkit/regular{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/toxin{
+	pixel_x = -3
+	},
+/obj/item/storage/medkit/o2{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/table/glass,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+YF
+YF
+nx
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(2,1,1) = {"
+Bj
+YF
+YF
+nx
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+YF
+YF
+YF
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+YF
+YF
+nx
+Bj
+"}
+(3,1,1) = {"
+Bj
+YF
+YF
+YF
+Bj
+Bj
+Bj
+Bj
+Bj
+Ih
+YF
+YF
+YF
+Ih
+Bj
+Bj
+Bj
+Bj
+Bj
+YF
+YF
+YF
+Bj
+"}
+(4,1,1) = {"
+Bj
+YF
+YF
+YF
+Ih
+Ih
+Bj
+Bj
+Bj
+aI
+aI
+aI
+aI
+aI
+Bj
+Bj
+Bj
+Ih
+Ih
+YF
+YF
+YF
+Bj
+"}
+(5,1,1) = {"
+Ih
+aI
+aI
+aI
+aI
+aI
+Bj
+Bj
+Bj
+Uu
+Oa
+Oa
+Oa
+Uu
+Bj
+Bj
+Bj
+aI
+aI
+aI
+aI
+aI
+Ih
+"}
+(6,1,1) = {"
+aI
+Oa
+Oa
+Oa
+Oa
+Oa
+Uu
+dh
+Uu
+Oa
+mr
+HS
+ni
+Oa
+Uu
+ct
+Uu
+Oa
+Oa
+Oa
+Oa
+Oa
+aI
+"}
+(7,1,1) = {"
+Oa
+Oa
+mx
+Bf
+mm
+Ec
+Oa
+Uu
+gm
+el
+Fi
+Fi
+Fi
+DO
+gm
+Uu
+Oa
+UA
+bG
+vL
+Oa
+pg
+Oa
+"}
+(8,1,1) = {"
+Oa
+zc
+LR
+Km
+LR
+LR
+cV
+Oa
+KG
+Fi
+Fi
+xt
+Fi
+Fi
+la
+Oa
+we
+iN
+iN
+iN
+si
+iN
+Cz
+"}
+(9,1,1) = {"
+qM
+Oa
+aX
+Uu
+BY
+BY
+ly
+Oa
+vi
+ok
+Wp
+Oa
+Wp
+ok
+Zj
+Oa
+Oa
+Oa
+Oa
+mc
+Oa
+Oa
+qM
+"}
+(10,1,1) = {"
+mz
+fm
+MO
+NV
+xl
+xl
+xl
+mz
+cu
+cu
+Yp
+Xl
+Yp
+cu
+cu
+mz
+cu
+cu
+cu
+Yp
+Ty
+PP
+mz
+"}
+(11,1,1) = {"
+mz
+fi
+eW
+RZ
+RZ
+RZ
+RZ
+fS
+Yp
+Pb
+Yp
+Yp
+Yp
+Nw
+Yp
+fS
+Yp
+Yp
+Yp
+Yp
+Yp
+PP
+mz
+"}
+(12,1,1) = {"
+mz
+NN
+eW
+RZ
+qM
+mz
+mz
+Ws
+Oa
+Oa
+qx
+Oa
+qx
+Oa
+Oa
+Ws
+mz
+mz
+qM
+Yp
+Yp
+PP
+mz
+"}
+(13,1,1) = {"
+qM
+Oa
+FJ
+RZ
+Oa
+Bj
+Bj
+Bj
+Bj
+Oa
+YS
+Yp
+Or
+Oa
+Bj
+Bj
+Bj
+Bj
+mz
+Yp
+Yp
+oc
+qM
+"}
+(14,1,1) = {"
+Oa
+EF
+RZ
+lV
+mz
+yc
+YF
+aj
+yc
+Ws
+Yp
+Yp
+Yp
+Ws
+yc
+aj
+YF
+yc
+mz
+lB
+Yp
+px
+Oa
+"}
+(15,1,1) = {"
+ga
+RZ
+RZ
+lV
+mz
+yc
+YF
+YF
+yc
+Oa
+YS
+AA
+Or
+Oa
+yc
+YF
+YF
+yc
+Oa
+Oa
+vK
+mz
+Oa
+"}
+(16,1,1) = {"
+Oa
+Oa
+Pf
+RZ
+Ws
+Bj
+Bj
+Bj
+mz
+mz
+Cg
+rV
+Cg
+mz
+mz
+Bj
+Bj
+Bj
+Oa
+MX
+dy
+Yt
+Oa
+"}
+(17,1,1) = {"
+ga
+RZ
+RZ
+RZ
+Oa
+Bj
+Bj
+mz
+mz
+Xr
+vD
+Sl
+lr
+Xr
+mz
+mz
+Bj
+Bj
+Oa
+wu
+dy
+Lv
+Oa
+"}
+(18,1,1) = {"
+mT
+lV
+RZ
+PQ
+mz
+Bj
+mz
+mz
+Xr
+mZ
+jS
+Xv
+AS
+mZ
+Xr
+mz
+mz
+Bj
+mz
+Ru
+oz
+Lv
+mz
+"}
+(19,1,1) = {"
+Oa
+lV
+RZ
+PQ
+mz
+yc
+mz
+Xr
+aS
+it
+jS
+qr
+AS
+Bb
+rH
+Xr
+mz
+yc
+mz
+Ru
+dy
+Lv
+mz
+"}
+(20,1,1) = {"
+Ws
+vP
+RZ
+Dv
+mz
+yc
+FZ
+yy
+bR
+YN
+jS
+ye
+AS
+YN
+qG
+wv
+Ab
+yc
+Ws
+ep
+dy
+Hy
+Ws
+"}
+(21,1,1) = {"
+mT
+lV
+RZ
+PQ
+mz
+yc
+mz
+Xr
+qn
+MS
+jS
+bT
+AS
+kz
+LL
+Xr
+mz
+yc
+mz
+Ru
+dy
+Lv
+mz
+"}
+(22,1,1) = {"
+Oa
+lV
+RZ
+PQ
+mz
+Bj
+mz
+mz
+Xr
+mZ
+jS
+Xv
+AS
+mZ
+Xr
+mz
+mz
+Bj
+mz
+Ru
+dy
+Lv
+mz
+"}
+(23,1,1) = {"
+xI
+RZ
+RZ
+RZ
+Oa
+Bj
+Bj
+mz
+mz
+Xr
+vZ
+dr
+Pj
+Xr
+mz
+mz
+Bj
+Bj
+Oa
+so
+dy
+Ny
+Oa
+"}
+(24,1,1) = {"
+Oa
+Oa
+kM
+RZ
+Ws
+Bj
+Bj
+Bj
+mz
+mz
+Gf
+NU
+Gf
+mz
+mz
+Bj
+Bj
+Bj
+Oa
+wI
+dy
+xg
+Oa
+"}
+(25,1,1) = {"
+ga
+RZ
+RZ
+lV
+mz
+yc
+YF
+YF
+yc
+Oa
+Ow
+Ei
+Vl
+Oa
+yc
+YF
+YF
+yc
+mz
+dy
+dy
+yH
+Oa
+"}
+(26,1,1) = {"
+Oa
+dp
+gI
+kA
+mz
+yc
+aj
+YF
+yc
+Ws
+HZ
+HZ
+HZ
+Ws
+yc
+YF
+aj
+yc
+mz
+DA
+gE
+yJ
+Oa
+"}
+(27,1,1) = {"
+Uu
+Oa
+oc
+XW
+Oa
+Bj
+Bj
+Bj
+Bj
+Oa
+Ow
+HZ
+Vl
+Oa
+Bj
+Bj
+Bj
+Bj
+Oa
+iz
+Oa
+Oa
+Uu
+"}
+(28,1,1) = {"
+Bj
+Uu
+Oa
+Oa
+Uu
+Bj
+Bj
+Uu
+Oa
+Oa
+Oa
+jH
+Oa
+Oa
+Oa
+Uu
+Bj
+Bj
+Uu
+yo
+Uu
+Uu
+Bj
+"}
+(29,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Oa
+YX
+qd
+mt
+mn
+Ll
+qW
+YX
+Oa
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(30,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Oa
+Aw
+Xg
+et
+et
+et
+cb
+wK
+Oa
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(31,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Oa
+hg
+Xg
+MT
+Pu
+lA
+cb
+Gs
+Oa
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(32,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Oa
+xc
+jQ
+Mb
+Mb
+Mb
+dd
+Fl
+Oa
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(33,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Uu
+Oa
+GU
+OA
+Qk
+zG
+VQ
+Oa
+Uu
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(34,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Uu
+Oa
+JZ
+vT
+qj
+Oa
+Uu
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+"}
+(35,1,1) = {"
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Uu
+oB
+oB
+oB
+Uu
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+Bj
+"}

--- a/_maps/shuttles/emergency_fame.dmm
+++ b/_maps/shuttles/emergency_fame.dmm
@@ -83,10 +83,6 @@
 /obj/machinery/stasis,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"ep" = (
-/obj/effect/mapping_helpers/engraving,
-/turf/closed/wall/mineral/iron,
-/area/shuttle/escape)
 "et" = (
 /obj/structure/chair{
 	dir = 4
@@ -495,10 +491,6 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
-"wI" = (
-/obj/effect/mapping_helpers/engraving,
-/turf/closed/wall/mineral/bronze,
-/area/shuttle/escape)
 "wK" = (
 /obj/machinery/vending/boozeomat,
 /obj/machinery/status_display/evac/directional/south,
@@ -627,10 +619,6 @@
 "Bj" = (
 /turf/template_noop,
 /area/template_noop)
-"BY" = (
-/obj/effect/mapping_helpers/engraving,
-/turf/closed/wall/mineral/sandstone,
-/area/shuttle/escape)
 "Cg" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -1342,7 +1330,7 @@ mx
 Yp
 Yp
 Yp
-wI
+mx
 Bj
 Bj
 Bj
@@ -1367,7 +1355,7 @@ mx
 Yp
 Yp
 Yp
-wI
+mx
 yc
 aj
 YF
@@ -1392,7 +1380,7 @@ mx
 Yp
 AA
 Yp
-wI
+mx
 yc
 YF
 YF
@@ -1638,11 +1626,11 @@ yc
 YF
 YF
 yc
-BY
+mx
 HZ
 Ei
 HZ
-ep
+mx
 yc
 YF
 YF
@@ -1663,11 +1651,11 @@ yc
 aj
 YF
 yc
-BY
+mx
 HZ
 HZ
 HZ
-ep
+mx
 yc
 YF
 aj
@@ -1688,11 +1676,11 @@ Bj
 Bj
 Bj
 Bj
-BY
+mx
 HZ
 HZ
 HZ
-ep
+mx
 Bj
 Bj
 Bj

--- a/_maps/shuttles/emergency_fame.dmm
+++ b/_maps/shuttles/emergency_fame.dmm
@@ -84,9 +84,9 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ep" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/fakebasalt,
-/area/shuttle/escape/brig)
+/obj/effect/mapping_helpers/engraving,
+/turf/closed/wall/mineral/iron,
+/area/shuttle/escape)
 "et" = (
 /obj/structure/chair{
 	dir = 4
@@ -232,6 +232,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
+"ly" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
 "lA" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigars/havana{
@@ -296,11 +302,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
 "mx" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/escape/brig)
+/obj/effect/mapping_helpers/engraving,
+/turf/closed/wall/mineral/silver,
+/area/shuttle/escape)
 "mz" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
@@ -351,10 +355,8 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "oz" = (
-/obj/machinery/door/window/brigdoor/security/holding/left/directional/west,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood,
 /turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "oB" = (
@@ -420,7 +422,7 @@
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
 "rV" = (
-/obj/structure/sign/picture_frame/showroom/one,
+/obj/structure/sign/picture_frame/hall_of_fame/one,
 /turf/closed/wall/mineral/gold,
 /area/shuttle/escape)
 "si" = (
@@ -494,11 +496,12 @@
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
 "wI" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/mineral/plastitanium/red,
-/area/shuttle/escape/brig)
+/obj/effect/mapping_helpers/engraving,
+/turf/closed/wall/mineral/bronze,
+/area/shuttle/escape)
 "wK" = (
 /obj/machinery/vending/boozeomat,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "xc" = (
@@ -510,9 +513,9 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "xg" = (
-/mob/living/basic/cockroach,
-/turf/open/floor/fakebasalt,
-/area/shuttle/escape/brig)
+/obj/structure/sign/painting/library,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
 "xl" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -546,7 +549,7 @@
 /area/shuttle/escape)
 "yo" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
 /turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "yy" = (
@@ -591,11 +594,12 @@
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
 "Ab" = (
-/obj/structure/sign/picture_frame/showroom/four,
+/obj/structure/sign/picture_frame/hall_of_fame/four,
 /turf/closed/wall/mineral/gold,
 /area/shuttle/escape)
 "Aw" = (
 /obj/effect/spawner/random/entertainment/arcade,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "AA" = (
@@ -624,10 +628,9 @@
 /turf/template_noop,
 /area/template_noop)
 "BY" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/fakebasalt,
-/area/shuttle/escape/brig)
+/obj/effect/mapping_helpers/engraving,
+/turf/closed/wall/mineral/sandstone,
+/area/shuttle/escape)
 "Cg" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -646,9 +649,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "DA" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/gibspawner/human/bodypartless,
 /turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "DO" = (
@@ -691,7 +692,7 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "FZ" = (
-/obj/structure/sign/picture_frame/showroom/two,
+/obj/structure/sign/picture_frame/hall_of_fame/two,
 /turf/closed/wall/mineral/gold,
 /area/shuttle/escape)
 "Gf" = (
@@ -830,7 +831,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "NU" = (
-/obj/structure/sign/picture_frame/showroom/three,
+/obj/structure/sign/picture_frame/hall_of_fame/three,
 /turf/closed/wall/mineral/gold,
 /area/shuttle/escape)
 "NV" = (
@@ -844,17 +845,13 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "Or" = (
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
+/mob/living/basic/cockroach,
+/turf/open/floor/fakebasalt,
+/area/shuttle/escape/brig)
 "Ow" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
 "OA" = (
 /obj/effect/turf_decal/siding{
 	dir = 5
@@ -937,11 +934,10 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Vl" = (
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
-/turf/open/floor/iron/dark,
-/area/shuttle/escape)
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/fakebasalt,
+/area/shuttle/escape/brig)
 "VQ" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -1004,11 +1000,12 @@
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
 "YS" = (
-/obj/structure/sign/painting/library{
-	pixel_y = 32
+/obj/machinery/door/window/brigdoor/security/holding/left/directional/west,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
+/turf/open/floor/fakebasalt,
+/area/shuttle/escape/brig)
 "YX" = (
 /obj/item/kirbyplants/organic/plant21,
 /turf/open/floor/iron/dark,
@@ -1336,16 +1333,16 @@ qM
 Oa
 FJ
 RZ
-Oa
+Ws
 Bj
 Bj
 Bj
 Bj
-Oa
-YS
+mx
 Yp
-Or
-Oa
+Yp
+Yp
+wI
 Bj
 Bj
 Bj
@@ -1366,11 +1363,11 @@ yc
 YF
 aj
 yc
-Ws
+mx
 Yp
 Yp
 Yp
-Ws
+wI
 yc
 aj
 YF
@@ -1391,11 +1388,11 @@ yc
 YF
 YF
 yc
-Oa
-YS
+mx
+Yp
 AA
-Or
-Oa
+Yp
+wI
 yc
 YF
 YF
@@ -1411,7 +1408,7 @@ Oa
 Oa
 Pf
 RZ
-Ws
+xg
 Bj
 Bj
 Bj
@@ -1436,7 +1433,7 @@ ga
 RZ
 RZ
 RZ
-Oa
+xg
 Bj
 Bj
 mz
@@ -1577,7 +1574,7 @@ mz
 Bj
 mz
 Ru
-wI
+Ow
 Lv
 mz
 "}
@@ -1586,7 +1583,7 @@ xI
 RZ
 RZ
 RZ
-Oa
+xg
 Bj
 Bj
 mz
@@ -1602,7 +1599,7 @@ Bj
 Bj
 Oa
 so
-mx
+ly
 Ny
 Oa
 "}
@@ -1611,7 +1608,7 @@ Oa
 Oa
 kM
 RZ
-Ws
+xg
 Bj
 Bj
 Bj
@@ -1627,7 +1624,7 @@ Bj
 Bj
 Oa
 yJ
-mx
+ly
 yH
 Oa
 "}
@@ -1641,19 +1638,19 @@ yc
 YF
 YF
 yc
-Oa
-Ow
+BY
+HZ
 Ei
-Vl
-Oa
+HZ
+ep
 yc
 YF
 YF
 yc
 mz
+Vl
+YS
 yo
-oz
-ep
 Oa
 "}
 (26,1,1) = {"
@@ -1666,11 +1663,11 @@ yc
 aj
 YF
 yc
-Ws
+BY
 HZ
 HZ
 HZ
-Ws
+ep
 yc
 YF
 aj
@@ -1678,7 +1675,7 @@ yc
 mz
 DA
 gE
-xg
+Or
 Oa
 "}
 (27,1,1) = {"
@@ -1686,23 +1683,23 @@ Uu
 Oa
 oc
 XW
-Oa
+Ws
 Bj
 Bj
 Bj
 Bj
-Oa
-Ow
+BY
 HZ
-Vl
-Oa
+HZ
+HZ
+ep
 Bj
 Bj
 Bj
 Bj
 Oa
 iz
-BY
+oz
 Oa
 Uu
 "}

--- a/_maps/shuttles/emergency_fame.dmm
+++ b/_maps/shuttles/emergency_fame.dmm
@@ -84,9 +84,8 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ep" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "et" = (
 /obj/structure/chair{
@@ -125,12 +124,11 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "gE" = (
-/obj/machinery/computer/pod/old/mass_driver_controller{
-	id = "shuttle_trash";
-	pixel_x = 26
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "gI" = (
 /obj/effect/turf_decal/siding/wood{
@@ -151,15 +149,9 @@
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
 "iz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/sign/warning/vacuum/external/directional/north,
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "shuttle_trash"
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "iN" = (
 /turf/open/floor/catwalk_floor,
@@ -240,12 +232,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
-"ly" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/east,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/delivery/white,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
 "lA" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigars/havana{
@@ -272,8 +258,21 @@
 /turf/open/floor/catwalk_floor,
 /area/shuttle/escape)
 "mm" = (
+/obj/item/storage/toolbox/emergency,
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/flashlight/flare{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/flashlight/flare{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/radio,
+/obj/item/radio,
+/obj/structure/closet,
 /obj/effect/turf_decal/bot_white,
-/obj/structure/closet/toolcloset,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
@@ -297,23 +296,11 @@
 /turf/open/floor/carpet/royalblue,
 /area/shuttle/escape)
 "mx" = (
-/obj/item/storage/toolbox/emergency,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/flashlight/flare{
-	pixel_x = -6;
-	pixel_y = -2
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
 	},
-/obj/item/flashlight/flare{
-	pixel_x = -6;
-	pixel_y = -2
-	},
-/obj/item/radio,
-/obj/item/radio,
-/obj/structure/closet,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
+/turf/open/floor/mineral/plastitanium/red,
+/area/shuttle/escape/brig)
 "mz" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
@@ -364,8 +351,11 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "oz" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/machinery/door/window/brigdoor/security/holding/left/directional/west,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "oB" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
@@ -504,7 +494,7 @@
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
 "wI" = (
-/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "wK" = (
@@ -520,8 +510,8 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "xg" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/mineral/plastitanium/red,
+/mob/living/basic/cockroach,
+/turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "xl" = (
 /obj/structure/chair/comfy/shuttle{
@@ -555,11 +545,9 @@
 /turf/open/floor/carpet/red,
 /area/shuttle/escape)
 "yo" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/massdriver_trash{
-	id = "shuttle_trash"
-	},
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "yy" = (
 /obj/machinery/light/directional/north,
@@ -636,9 +624,10 @@
 /turf/template_noop,
 /area/template_noop)
 "BY" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/east,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
+/obj/structure/kitchenspike,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/fakebasalt,
+/area/shuttle/escape/brig)
 "Cg" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -657,11 +646,10 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "DA" = (
-/obj/machinery/door/window{
-	dir = 4;
-	name = "Trash Disposal"
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/fakebasalt,
 /area/shuttle/escape/brig)
 "DO" = (
 /obj/structure/bed,
@@ -669,84 +657,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Ec" = (
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/clothing/suit/hazardvest{
-	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
-	name = "emergency lifejacket"
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/emergency_oxygen{
-	pixel_x = 3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/breath{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/item/clothing/head/utility/hardhat/orange{
-	name = "protective hat";
-	pixel_y = 9
-	},
-/obj/structure/closet/crate{
-	name = "lifejackets"
-	},
+/obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
@@ -1273,7 +1184,7 @@ aI
 (7,1,1) = {"
 Oa
 Oa
-mx
+LR
 Bf
 mm
 Ec
@@ -1325,9 +1236,9 @@ qM
 Oa
 aX
 Uu
-BY
-BY
-ly
+Uu
+Uu
+Uu
 Oa
 vi
 ok
@@ -1353,7 +1264,7 @@ NV
 xl
 xl
 xl
-mz
+Oa
 cu
 cu
 Yp
@@ -1361,7 +1272,7 @@ Xl
 Yp
 cu
 cu
-mz
+Oa
 cu
 cu
 cu
@@ -1566,7 +1477,7 @@ mz
 Bj
 mz
 Ru
-oz
+dy
 Lv
 mz
 "}
@@ -1615,7 +1526,7 @@ wv
 Ab
 yc
 Ws
-ep
+dy
 dy
 Hy
 Ws
@@ -1666,7 +1577,7 @@ mz
 Bj
 mz
 Ru
-dy
+wI
 Lv
 mz
 "}
@@ -1691,7 +1602,7 @@ Bj
 Bj
 Oa
 so
-dy
+mx
 Ny
 Oa
 "}
@@ -1715,9 +1626,9 @@ Bj
 Bj
 Bj
 Oa
-wI
-dy
-xg
+yJ
+mx
+yH
 Oa
 "}
 (25,1,1) = {"
@@ -1740,9 +1651,9 @@ YF
 YF
 yc
 mz
-dy
-dy
-yH
+yo
+oz
+ep
 Oa
 "}
 (26,1,1) = {"
@@ -1767,7 +1678,7 @@ yc
 mz
 DA
 gE
-yJ
+xg
 Oa
 "}
 (27,1,1) = {"
@@ -1791,7 +1702,7 @@ Bj
 Bj
 Oa
 iz
-Oa
+BY
 Oa
 Uu
 "}
@@ -1815,8 +1726,8 @@ Uu
 Bj
 Bj
 Uu
-yo
-Uu
+Oa
+Oa
 Uu
 Bj
 "}

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -9,6 +9,8 @@ SUBSYSTEM_DEF(persistence)
 
 	///instantiated wall engraving components
 	var/list/wall_engravings = list()
+	///all saved persistent engravings loaded from JSON
+	var/list/saved_engravings = list()
 	///tattoo stories that we're saving.
 	var/list/prison_tattoos_to_save = list()
 	///tattoo stories that have been selected for this round.
@@ -65,6 +67,7 @@ SUBSYSTEM_DEF(persistence)
 	var/json_file = file(ENGRAVING_SAVE_FILE)
 	if(!fexists(json_file))
 		return
+
 	var/list/json = json_decode(file2text(json_file))
 	if(!json)
 		return
@@ -72,7 +75,11 @@ SUBSYSTEM_DEF(persistence)
 	if(json["version"] < ENGRAVING_PERSISTENCE_VERSION)
 		update_wall_engravings(json)
 
-	var/successfully_loaded_engravings = 0
+	saved_engravings = json["entries"]
+
+	if(!saved_engravings.len)
+		log_world("Failed to load engraved messages on map [SSmapping.config.map_name]")
+		return
 
 	var/list/viable_turfs = get_area_turfs(/area/station/maintenance, subtypes = TRUE) + get_area_turfs(/area/station/security/prison, subtypes = TRUE)
 	var/list/turfs_to_pick_from = list()
@@ -82,23 +89,22 @@ SUBSYSTEM_DEF(persistence)
 			continue
 		turfs_to_pick_from += T
 
-	var/list/engraving_entries = json["entries"]
+	var/successfully_loaded_engravings = 0
 
-	if(engraving_entries.len)
-		for(var/iteration in 1 to rand(MIN_PERSISTENT_ENGRAVINGS, MAX_PERSISTENT_ENGRAVINGS))
-			var/engraving = engraving_entries[rand(1, engraving_entries.len)] //This means repeats will happen for now, but its something I can live with. Just make more engravings!
-			if(!islist(engraving))
-				stack_trace("something's wrong with the engraving data! one of the saved engravings wasn't a list!")
-				continue
+	for(var/iteration in 1 to rand(MIN_PERSISTENT_ENGRAVINGS, MAX_PERSISTENT_ENGRAVINGS))
+		var/engraving = saved_engravings[rand(1, saved_engravings.len)] //This means repeats will happen for now, but its something I can live with. Just make more engravings!
+		if(!islist(engraving))
+			stack_trace("something's wrong with the engraving data! one of the saved engravings wasn't a list!")
+			continue
 
-			var/turf/closed/engraved_wall = pick(turfs_to_pick_from)
+		var/turf/closed/engraved_wall = pick(turfs_to_pick_from)
 
-			if(HAS_TRAIT(engraved_wall, TRAIT_NOT_ENGRAVABLE))
-				continue
+		if(HAS_TRAIT(engraved_wall, TRAIT_NOT_ENGRAVABLE))
+			continue
 
-			engraved_wall.AddComponent(/datum/component/engraved, engraving["story"], FALSE, engraving["story_value"])
-			successfully_loaded_engravings++
-			turfs_to_pick_from -= engraved_wall
+		engraved_wall.AddComponent(/datum/component/engraved, engraving["story"], FALSE, engraving["story_value"])
+		successfully_loaded_engravings++
+		turfs_to_pick_from -= engraved_wall
 
 	log_world("Loaded [successfully_loaded_engravings] engraved messages on map [SSmapping.config.map_name]")
 
@@ -130,8 +136,6 @@ SUBSYSTEM_DEF(persistence)
 
 ///This proc can update entries if the format has changed at some point.
 /datum/controller/subsystem/persistence/proc/update_wall_engravings(json)
-
-
 	for(var/engraving_entry in json["entries"])
 		continue //no versioning yet
 
@@ -187,7 +191,6 @@ SUBSYSTEM_DEF(persistence)
 
 ///This proc can update entries if the format has changed at some point.
 /datum/controller/subsystem/persistence/proc/update_prisoner_tattoos(json)
-
 	for(var/tattoo_entry in json["entries"])
 		continue //no versioning yet
 

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -92,7 +92,7 @@ SUBSYSTEM_DEF(persistence)
 	var/successfully_loaded_engravings = 0
 
 	for(var/iteration in 1 to rand(MIN_PERSISTENT_ENGRAVINGS, MAX_PERSISTENT_ENGRAVINGS))
-		var/engraving = saved_engravings[rand(1, saved_engravings.len)] //This means repeats will happen for now, but its something I can live with. Just make more engravings!
+		var/engraving = pick_n_take(saved_engravings)
 		if(!islist(engraving))
 			stack_trace("something's wrong with the engraving data! one of the saved engravings wasn't a list!")
 			continue

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -493,6 +493,13 @@
 	admin_notes = "Has a sentience fun balloon for pets."
 	credit_cost = CARGO_CRATE_VALUE * 16
 
+/datum/map_template/shuttle/emergency/fame
+	suffix = "fame"
+	name = "Hall of Fame Shuttle"
+	description = "A grandiose shuttle that has a red carpet leading to the hall of fame. Are you worthy to stand among the best spessmen in existence?"
+	admin_notes = "Uses persistence from memories, photos, and statues."
+	credit_cost = CARGO_CRATE_VALUE * 5
+
 /datum/map_template/shuttle/ferry/base
 	suffix = "base"
 	name = "transport ferry"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -497,8 +497,8 @@
 	suffix = "fame"
 	name = "Hall of Fame Shuttle"
 	description = "A grandiose shuttle that has a red carpet leading to the hall of fame. Are you worthy to stand among the best spessmen in existence?"
-	admin_notes = "Uses persistence from memories, photos, and statues."
-	credit_cost = CARGO_CRATE_VALUE * 5
+	admin_notes = "Designed around persistence from memories, trophies, photos, and statues."
+	credit_cost = CARGO_CRATE_VALUE * 25
 
 /datum/map_template/shuttle/ferry/base
 	suffix = "base"

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1323,3 +1323,30 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 
 /obj/effect/mapping_helpers/requests_console/ore_update/payload(obj/machinery/requests_console/console)
 	console.receive_ore_updates = TRUE
+
+/obj/effect/mapping_helpers/engraving
+	name = "engraving helper"
+	icon = 'icons/turf/wall_overlays.dmi'
+	icon_state = "engraving2"
+	late = TRUE
+	layer = ABOVE_NORMAL_TURF_LAYER
+
+/obj/effect/mapping_helpers/engraving/Initialize(mapload)
+	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/effect/mapping_helpers/engraving/LateInitialize()
+	var/turf/closed/engraved_wall = get_turf(src)
+
+	if(!isclosedturf(engraved_wall) || !SSpersistence.saved_engravings.len || HAS_TRAIT(engraved_wall, TRAIT_NOT_ENGRAVABLE))
+		qdel(src)
+		return
+
+	var/engraving = SSpersistence.saved_engravings[rand(1, SSpersistence.saved_engravings.len)] //This means repeats will happen for now, but its something I can live with. Just make more engravings!
+	if(!islist(engraving))
+		stack_trace("something's wrong with the engraving data! one of the saved engravings wasn't a list!")
+		qdel(src)
+		return
+
+	engraved_wall.AddComponent(/datum/component/engraved, engraving["story"], FALSE, engraving["story_value"])
+	qdel(src)

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -1342,7 +1342,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 		qdel(src)
 		return
 
-	var/engraving = SSpersistence.saved_engravings[rand(1, SSpersistence.saved_engravings.len)] //This means repeats will happen for now, but its something I can live with. Just make more engravings!
+	var/engraving = pick_n_take(SSpersistence.saved_engravings)
 	if(!islist(engraving))
 		stack_trace("something's wrong with the engraving data! one of the saved engravings wasn't a list!")
 		qdel(src)

--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -122,3 +122,8 @@
 
 /obj/item/storage/photo_album/personal
 	icon_state = "album_green"
+
+/obj/item/storage/photo_album/hall_of_fame
+	name = "photo album (Hall of Fame)"
+	icon_state = "album_red"
+	persistence_id = "hall_of_fame"

--- a/code/modules/photography/photos/frame.dm
+++ b/code/modules/photography/photos/frame.dm
@@ -262,6 +262,19 @@
 /obj/structure/sign/picture_frame/showroom/four
 	persistence_id = "frame_showroom4"
 
+// for the hall of fame escape shuttle
+/obj/structure/sign/picture_frame/hall_of_fame/one
+	persistence_id = "frame_hall_of_fame_1"
+
+/obj/structure/sign/picture_frame/hall_of_fame/two
+	persistence_id = "frame_hall_of_fame_2"
+
+/obj/structure/sign/picture_frame/hall_of_fame/three
+	persistence_id = "frame_hall_of_fame_3"
+
+/obj/structure/sign/picture_frame/hall_of_fame/four
+	persistence_id = "frame_hall_of_fame_4"
+
 /obj/structure/sign/picture_frame/portrait/bar
 	persistence_id = "frame_bar"
 	del_id_on_destroy = TRUE


### PR DESCRIPTION
## About The Pull Request
This adds a new emergency shuttle called the **Hall of Fame**.

![2023-07-28 06 49 58](https://github.com/tgstation/tgstation/assets/5195984/d818058c-f031-472a-8314-8e4c9054c807)

It's designed around persistence.  The goal is to have the shuttle store memories, photos, and trophies for the crew to see!

## Why It's Good For The Game
Cool way for the crew to store and share memories.

## Changelog
:cl:
add: Add a new 'Hall of Fame' emergency shuttle.  It even comes with it's own nifty photo album.
/:cl:
