### PR TITLE
Fixes bloody soles making jumpsuits that cover your feet bloody when you're wearing shoes

### DIFF
--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -7,7 +7,7 @@
 	var/last_blood_state = BLOOD_STATE_NOT_BLOODY
 
 	/// How much of each grubby type we have on our feet
-	var/list/bloody_shoes = list(BLOOD_STATE_HUMAN = 0,BLOOD_STATE_XENO = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
+	var/list/bloody_shoes = list(BLOOD_STATE_HUMAN = 0, BLOOD_STATE_XENO = 0, BLOOD_STATE_OIL = 0, BLOOD_STATE_NOT_BLOODY = 0)
 
 	/// The ITEM_SLOT_* slot the item is equipped on, if it is.
 	var/equipped_slot
@@ -44,7 +44,20 @@
  * Returns true if the parent item is obscured by something else that the wielder is wearing
  */
 /datum/component/bloodysoles/proc/is_obscured()
-	return wielder.check_obscured_slots(TRUE) & equipped_slot
+	return wielder.check_obscured_slots(TRUE) & equipped_slot || is_under_feet_covered()
+
+/**
+ * Returns true if the parent item is worn in the ITEM_SLOT_ICLOTHING slot and the
+ * wielder is wearing something on their shoes.
+ *
+ * Allows for jumpsuits to cover feet without getting all bloodied when their wearer
+ * is wearing shoes.
+ */
+/datum/component/bloodysoles/proc/is_under_feet_covered()
+	if(equipped_slot != ITEM_SLOT_ICLOTHING)
+		return FALSE
+
+	return wielder.shoes != null
 
 /**
  * Run to update the icon of the parent

--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -57,7 +57,7 @@
 	if(equipped_slot != ITEM_SLOT_ICLOTHING)
 		return FALSE
 
-	return wielder.shoes != null
+	return !isnull(wielder.shoes)
 
 /**
  * Run to update the icon of the parent

--- a/code/datums/components/bloodysoles.dm
+++ b/code/datums/components/bloodysoles.dm
@@ -54,7 +54,7 @@
  * is wearing shoes.
  */
 /datum/component/bloodysoles/proc/is_under_feet_covered()
-	if(equipped_slot != ITEM_SLOT_ICLOTHING)
+	if(!(equipped_slot & ITEM_SLOT_ICLOTHING))
 		return FALSE
 
 	return !isnull(wielder.shoes)


### PR DESCRIPTION
## About The Pull Request
Title says it all.

It basically made it so wearing something like a kilt would result in the kilt getting all bloody as soon as you walked over blood, even when you were wearing shoes, unless you wore something else that obscured shoes.

Here's some pictures of my testing proving that it works:
_No blood, before walking over blood_
![image](https://github.com/tgstation/tgstation/assets/58045821/55d6a4c6-bf46-49ca-8b1d-e505d4966be9)

_Walked over blood with shoes, only shoes are bloody_
![image](https://github.com/tgstation/tgstation/assets/58045821/00da9a76-2f01-4550-99ce-36be8bf3a3cf)

_Walked over blood without shoes, kilt is bloody_
![image](https://github.com/tgstation/tgstation/assets/58045821/c7427679-5058-4a3f-8851-c343451c38c2)

I debated with myself a lot over the implementation for this, I was thinking of adding some way to obscure feet in particular, but it's honestly so niche that it could only have caused more issues elsewhere if I tried to fix this issue that way.

## Why It's Good For The Game
It just makes sense, and it allows more consistency within the bloodysoles usage as a whole.

## Changelog

:cl: GoldenAlpharex
fix: Clothes equipped in the jumpsuit slot that happen to cover your feet will no longer get bloody when you walk over blood if you are also wearing shoes. Your kilt won't be getting bloody instantly anymore, it only will if you take your shoes off!
/:cl: