### PR TITLE
Hologram banners no longer give inspiration effects

### DIFF
--- a/code/game/objects/items/religion.dm
+++ b/code/game/objects/items/religion.dm
@@ -24,7 +24,7 @@
 		. += span_notice("Activate it in your hand to inspire nearby allies of this banner's allegiance!")
 
 /obj/item/banner/attack_self(mob/living/carbon/human/user)
-	if(!inspiration_available)
+	if(!inspiration_available || flags_1 & HOLOGRAM_1)
 		return
 	if(morale_time > world.time)
 		to_chat(user, span_warning("You aren't feeling inspired enough to flourish [src] again yet."))


### PR DESCRIPTION

## About The Pull Request

Banners spawned via the holodeck are no longer eligible to give healing effects

## Why It's Good For The Game
This makes it too easy to source the banners and gives you another healing option that isn't technically supposed to be possible.

## Changelog

:cl: oranges
balance: holodeck spawned banners no longer give the inspiration effects
/:cl:
