### PR TITLE
Emagged bots can no longer be player controlled

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -210,6 +210,8 @@
 	if (paicard)
 		balloon_alert(user, "already sapient!")
 		return
+	if (bot_cover_flags & BOT_COVER_EMAGGED)
+		return
 	can_be_possessed = TRUE
 	var/can_announce = !mapload && COOLDOWN_FINISHED(src, offer_ghosts_cooldown)
 	personality_download = AddComponent(\
@@ -225,7 +227,7 @@
 		COOLDOWN_START(src, offer_ghosts_cooldown, 30 SECONDS)
 
 /// Disables this bot from being possessed by ghosts
-/mob/living/simple_animal/bot/proc/disable_possession(mob/user)
+/mob/living/simple_animal/bot/proc/disable_possession(mob/user, silent = FALSE)
 	can_be_possessed = FALSE
 	QDEL_NULL(personality_download)
 	if (isnull(key))
@@ -234,8 +236,9 @@
 		log_combat(user, src, "ejected from [initial(src.name)] control.")
 	to_chat(src, span_warning("You feel yourself fade as your personality matrix is reset!"))
 	ghostize(can_reenter_corpse = FALSE)
-	playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
-	speak("Personality matrix reset!")
+	if (!silent)
+		playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
+		speak("Personality matrix reset!")
 	key = null
 
 /// Returns true if this mob can be controlled
@@ -323,6 +326,7 @@
 		bot_reset()
 		turn_on() //The bot automatically turns on when emagged, unless recently hit with EMP.
 		to_chat(src, span_userdanger("(#$*#$^^( OVERRIDE DETECTED"))
+		disable_possession(user = user, silent = TRUE)
 		if(user)
 			log_combat(user, src, "emagged")
 		return TRUE

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -973,6 +973,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 		data["settings"]["pai_inserted"] = !!paicard
 		data["settings"]["allow_possession"] = bot_mode_flags & BOT_MODE_CAN_BE_SAPIENT
 		data["settings"]["possession_enabled"] = can_be_possessed
+		data["settings"]["possession_locked"] = bot_cover_flags & BOT_COVER_EMAGGED
 		data["settings"]["airplane_mode"] = !(bot_mode_flags & BOT_MODE_REMOTE_ENABLED)
 		data["settings"]["maintenance_lock"] = !(bot_cover_flags & BOT_COVER_OPEN)
 		data["settings"]["power"] = bot_mode_flags & BOT_MODE_ON

--- a/tgui/packages/tgui/interfaces/SimpleBot.tsx
+++ b/tgui/packages/tgui/interfaces/SimpleBot.tsx
@@ -19,6 +19,7 @@ type Settings = {
   patrol_station: number;
   allow_possession: number;
   possession_enabled: number;
+  possession_locked: number;
   has_personality: number;
   pai_inserted: boolean;
 };
@@ -144,6 +145,7 @@ const SettingsDisplay = (props, context) => {
     maintenance_lock,
     allow_possession,
     possession_enabled,
+    possession_locked,
   } = settings;
 
   return (
@@ -203,14 +205,18 @@ const SettingsDisplay = (props, context) => {
         <LabeledControls.Item label="Personality">
           <Tooltip
             content={
-              possession_enabled
-                ? 'Resets personality to factory default.'
-                : 'Enables download of a unique personality.'
+              possession_locked
+                ? 'Error.'
+                : possession_enabled
+                  ? 'Resets personality to factory default.'
+                  : 'Enables download of a unique personality.'
             }>
             <Icon
               size={2}
               name="robot"
-              color={possession_enabled ? 'good' : 'gray'}
+              color={
+                possession_locked ? 'red' : possession_enabled ? 'good' : 'gray'
+              }
               onClick={() => act('toggle_personality')}
             />
           </Tooltip>


### PR DESCRIPTION
## About The Pull Request

Emagged bots can no longer be player controlled
## Why It's Good For The Game

https://tgstation13.org/phpBB/viewtopic.php?p=695556#p695556

Admins have ruled that bots must follow their flavor text, which means that emagged bots would be required by admins to not use their abilities and do nothing. This would mess with antags that probably want the bots to do antagonist stuff and not just do nothing. That's why it's better to just disable them being controlled entirely so the AI that can do antag stuff takes over.

An alternative option to this PR is making it so that they get emag flavor text that lets them do antag stuff

## Changelog
:cl:
del: Emagged bots can no longer be player controlled
/:cl:
