### PR TITLE
Fixes emissives blockers being broken on mobs

### DIFF
--- a/code/modules/mob/living/carbon/alien/adult/adult_update_icons.dm
+++ b/code/modules/mob/living/carbon/alien/adult/adult_update_icons.dm
@@ -67,7 +67,7 @@
 
 	if(handcuffed)
 		var/mutable_appearance/handcuff_overlay = mutable_appearance(dmi_file, cuff_icon, -HANDCUFF_LAYER)
-		if(handcuffed.blocks_emissive)
+		if(handcuffed.blocks_emissive != EMISSIVE_BLOCK_NONE)
 			handcuff_overlay += emissive_blocker(handcuff_overlay.icon, handcuff_overlay.icon_state, src, alpha = handcuff_overlay.alpha)
 
 		overlays_standing[HANDCUFF_LAYER] = handcuff_overlay
@@ -86,7 +86,7 @@
 		if(!itm_state)
 			itm_state = l_hand.icon_state
 		var/mutable_appearance/l_hand_item = mutable_appearance(alt_inhands_file, "[itm_state][caste]_l", -HANDS_LAYER)
-		if(l_hand.blocks_emissive)
+		if(l_hand.blocks_emissive != EMISSIVE_BLOCK_NONE)
 			l_hand_item.overlays += emissive_blocker(l_hand_item.icon, l_hand_item.icon_state, src, alpha = l_hand_item.alpha)
 		hands += l_hand_item
 
@@ -96,7 +96,7 @@
 		if(!itm_state)
 			itm_state = r_hand.icon_state
 		var/mutable_appearance/r_hand_item = mutable_appearance(alt_inhands_file, "[itm_state][caste]_r", -HANDS_LAYER)
-		if(r_hand.blocks_emissive)
+		if(r_hand.blocks_emissive != EMISSIVE_BLOCK_NONE)
 			r_hand_item.overlays += emissive_blocker(r_hand_item.icon, r_hand_item.icon_state, src, alpha = r_hand_item.alpha)
 		hands += r_hand_item
 

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -447,7 +447,7 @@
 	remove_overlay(HANDCUFF_LAYER)
 	if(handcuffed)
 		var/mutable_appearance/handcuff_overlay = mutable_appearance('icons/mob/simple/mob.dmi', "handcuff1", -HANDCUFF_LAYER)
-		if(handcuffed.blocks_emissive)
+		if(handcuffed.blocks_emissive != EMISSIVE_BLOCK_NONE)
 			handcuff_overlay.overlays += emissive_blocker(handcuff_overlay.icon, handcuff_overlay.icon_state, src, alpha = handcuff_overlay.alpha)
 
 		overlays_standing[HANDCUFF_LAYER] = handcuff_overlay
@@ -488,7 +488,7 @@
 	RETURN_TYPE(/list)
 
 	. = list()
-	if(blocks_emissive)
+	if(blocks_emissive != EMISSIVE_BLOCK_NONE)
 		. += emissive_blocker(standing.icon, standing.icon_state, src, alpha = standing.alpha)
 	SEND_SIGNAL(src, COMSIG_ITEM_GET_WORN_OVERLAYS, ., standing, isinhands, icon_file)
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -909,7 +909,7 @@
 		// For some reason this was applied as an overlay on the aux image and limb image before.
 		// I am very sure that this is unnecessary, and i need to treat it as part of the return list
 		// to be able to mask it proper in case this limb is a leg.
-		if(blocks_emissive)
+		if(blocks_emissive != EMISSIVE_BLOCK_NONE)
 			var/atom/location = loc || owner || src
 			var/mutable_appearance/limb_em_block = emissive_blocker(limb.icon, limb.icon_state, location, layer = limb.layer, alpha = limb.alpha)
 			limb_em_block.dir = image_dir

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -216,7 +216,7 @@
 			if(eyes.overlay_ignore_lighting)
 				eye_left.overlays += emissive_appearance(eye_left.icon, eye_left.icon_state, src, alpha = eye_left.alpha)
 				eye_right.overlays += emissive_appearance(eye_right.icon, eye_right.icon_state, src, alpha = eye_right.alpha)
-			else if(blocks_emissive)
+			else if(blocks_emissive != EMISSIVE_BLOCK_NONE)
 				var/atom/location = loc || owner || src
 				eye_left.overlays += emissive_blocker(eye_left.icon, eye_left.icon_state, location, alpha = eye_left.alpha)
 				eye_right.overlays += emissive_blocker(eye_right.icon, eye_right.icon_state, location, alpha = eye_right.alpha)

--- a/code/modules/surgery/bodyparts/head_hair_and_lips.dm
+++ b/code/modules/surgery/bodyparts/head_hair_and_lips.dm
@@ -91,7 +91,7 @@
 		var/image/lip_overlay = image('icons/mob/species/human/human_face.dmi', "lips_[lip_style]", -BODY_LAYER, image_dir)
 		lip_overlay.color = lip_color
 		//Emissive blocker
-		if(blocks_emissive)
+		if(blocks_emissive != EMISSIVE_BLOCK_NONE)
 			lip_overlay.overlays += emissive_blocker(lip_overlay.icon, lip_overlay.icon_state, location, alpha = facial_hair_alpha)
 		//Offsets
 		worn_face_offset?.apply_offset(lip_overlay)
@@ -105,7 +105,7 @@
 			facial_hair_overlay = image(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER, image_dir)
 			facial_hair_overlay.alpha = facial_hair_alpha
 			//Emissive blocker
-			if(blocks_emissive)
+			if(blocks_emissive != EMISSIVE_BLOCK_NONE)
 				facial_hair_overlay.overlays += emissive_blocker(facial_hair_overlay.icon, facial_hair_overlay.icon_state, location, alpha = facial_hair_alpha)
 			//Offsets
 			worn_face_offset?.apply_offset(facial_hair_overlay)
@@ -125,7 +125,7 @@
 			hair_overlay = image(sprite_accessory.icon, sprite_accessory.icon_state, -HAIR_LAYER, image_dir)
 			hair_overlay.alpha = hair_alpha
 			//Emissive blocker
-			if(blocks_emissive)
+			if(blocks_emissive != EMISSIVE_BLOCK_NONE)
 				hair_overlay.overlays += emissive_blocker(hair_overlay.icon, hair_overlay.icon_state, location, alpha = hair_alpha)
 			//Offsets
 			worn_face_offset?.apply_offset(hair_overlay)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/76065
Fixes https://github.com/tgstation/tgstation/issues/73860

![firefox_woFR1lmIQq](https://github.com/tgstation/tgstation/assets/13398309/e9b48e8d-4c0d-484f-b57e-94f06a456934)

https://github.com/tgstation/tgstation/pull/74453 _cough_

So it turned out that no emissive blocker overlays were being added to mobs because `blocks_emissive` being `FALSE` no longer means that it doesn't block emissives.

We have to check for `EMISSIVE_BLOCK_NONE` instead after the optimization from the linked PR.

## Why It's Good For The Game

![dreamseeker_I9MuQEUjcC](https://github.com/tgstation/tgstation/assets/13398309/3a507c28-59e3-4276-b4f1-0babdcf952f1)

<details><summary>Fixes the window mesh prisons</summary>

![dreamseeker_wkCElt1Znp](https://github.com/tgstation/tgstation/assets/13398309/b9bb22a0-99f2-4ffa-ae32-6bc734be8353)

![dreamseeker_vhqFYt5X11](https://github.com/tgstation/tgstation/assets/13398309/b7364472-71c9-43e0-9ba8-bbb4bd5b489d)

</details>

<details><summary>No more of the weird partial transparency with buttons and the like</summary>

![dreamseeker_IweBhZRpa3](https://github.com/tgstation/tgstation/assets/13398309/04938001-6201-45b0-9caa-5a305b40e116)

![dreamseeker_PK06VGj28o](https://github.com/tgstation/tgstation/assets/13398309/c482228b-988a-4861-8037-204471f2408e)

</details>

## Changelog

:cl:
fix: fixes mobs missing most of their emissive blockers
/:cl:
