### PR TITLE
[NO GBP]Mat container Final clean-up & patches

### DIFF
--- a/code/__HELPERS/construction.dm
+++ b/code/__HELPERS/construction.dm
@@ -45,4 +45,3 @@
 		return null
 
 	. = new target.type(target.drop_location(), amount, FALSE, target.mats_per_unit)
-

--- a/code/__HELPERS/construction.dm
+++ b/code/__HELPERS/construction.dm
@@ -37,7 +37,7 @@
  * Has special internal uses for e.g. by the material container
  *
  * Arguments:
- * - [target][obj/item]: the stack to splot
+ * - [target][obj/item/stack]: the stack to split
  * - [amount]: amount to split by
  */
 /proc/fast_split_stack(obj/item/stack/target, amount)

--- a/code/__HELPERS/construction.dm
+++ b/code/__HELPERS/construction.dm
@@ -40,7 +40,7 @@
  * - [target][obj/item]: the stack to splot
  * - [amount]: amount to split by
  */
-/datum/component/material_container/proc/fast_split_stack(obj/item/stack/target, amount)
+/proc/fast_split_stack(obj/item/stack/target, amount)
 	if(!target.use(amount, TRUE, FALSE))
 		return null
 

--- a/code/__HELPERS/construction.dm
+++ b/code/__HELPERS/construction.dm
@@ -45,7 +45,4 @@
 		return null
 
 	. = new target.type(target.drop_location(), amount, FALSE, target.mats_per_unit)
-	target.loc.atom_storage?.refresh_views()
-
-	target.is_zero_amount(delete_if_zero = TRUE)
 

--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -286,16 +286,12 @@
 
 		//not a solid subtype or an hologram
 		if((target.item_flags & ABSTRACT) || (target.flags_1 & HOLOGRAM_1))
-			if(target == active_held) //was this the original item in the players hand? put it back because we coudn't salvage it
-				user.put_in_active_hand(target)
 			continue
 
 		//item is either not allowed for redemption, not in the allowed types
 		if((target.item_flags & NO_MAT_REDEMPTION) || (allowed_item_typecache && !is_type_in_typecache(target, allowed_item_typecache)))
 			if(!(mat_container_flags & MATCONTAINER_SILENT))
 				to_chat(user, span_warning("[parent] won't accept [target]!"))
-			if(target == active_held) //was this the original item in the players hand? put it back because we coudn't salvage it
-				user.put_in_active_hand(target)
 			continue
 
 		//untouchable, move it out the way, code copied from recycler

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -13,11 +13,11 @@ handles linking back and forth.
 
 	///The silo machine this container is connected to
 	var/obj/machinery/ore_silo/silo
-	//Material container. the value is either the silo or local
+	///Material container. the value is either the silo or local
 	var/datum/component/material_container/mat_container
-	//Should we create a local storage if we can't connect to silo
+	///Should we create a local storage if we can't connect to silo
 	var/allow_standalone
-	//Local size of container when silo = null
+	///Local size of container when silo = null
 	var/local_size = INFINITY
 	///Flags used when converting inserted materials into their component materials.
 	var/mat_container_flags = NONE

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -36,9 +36,13 @@ handles linking back and forth.
 	var/connect_to_silo = FALSE
 	if(force_connect || (mapload && is_station_level(T.z)))
 		connect_to_silo = TRUE
-	addtimer(CALLBACK(src, PROC_REF(LateInitialize), connect_to_silo))
 
-/datum/component/remote_materials/proc/LateInitialize(connect_to_silo)
+	if(mapload) // wait for silo to initialize during mapload
+		addtimer(CALLBACK(src, PROC_REF(_PrepareStorage), connect_to_silo))
+	else // directly call in round
+		_PrepareStorage(connect_to_silo)
+
+/datum/component/remote_materials/proc/_PrepareStorage(connect_to_silo)
 	if (connect_to_silo)
 		silo = GLOB.ore_silo_default
 		if (silo)

--- a/code/datums/components/material/remote_materials.dm
+++ b/code/datums/components/material/remote_materials.dm
@@ -11,19 +11,22 @@ handles linking back and forth.
 	// 2. silo is null, materials is parented to parent
 	// 3. silo is null, materials is null
 
-	/// The silo machine this container is connected to
+	///The silo machine this container is connected to
 	var/obj/machinery/ore_silo/silo
-	//material container. the value is either the silo or local
+	//Material container. the value is either the silo or local
 	var/datum/component/material_container/mat_container
-	//should we create a local storage if we can't connect to silo
+	//Should we create a local storage if we can't connect to silo
 	var/allow_standalone
-	//local size of container when silo = null
+	//Local size of container when silo = null
 	var/local_size = INFINITY
 	///Flags used when converting inserted materials into their component materials.
 	var/mat_container_flags = NONE
 
 	//Internal vars
+
+	///Prepare storage when component is registered to parent. This allows local material container(if created) to be first in the component list so it gets GC'd properly
 	var/_prepare_on_register = FALSE
+	///Are we trying to to connect to remote ore silo or not
 	var/_connect_to_silo = FALSE
 
 /datum/component/remote_materials/Initialize(mapload, allow_standalone = TRUE, force_connect = FALSE, mat_container_flags = NONE)

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -48,14 +48,18 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 	if(upgrade & RCD_UPGRADE_SILO_LINK)
-		silo_mats = AddComponent(/datum/component/remote_materials, mapload, FALSE)
+		silo_mats = AddComponent( \
+			/datum/component/remote_materials, \
+			mapload, \
+			FALSE \
+		)
 	update_appearance()
 
 ///used for examining the RCD and for its UI
 /obj/item/construction/proc/get_silo_iron()
 	if(silo_link && silo_mats.mat_container && !silo_mats.on_hold())
 		return silo_mats.mat_container.get_material_amount(/datum/material/iron) / SILO_USE_AMOUNT
-	return FALSE
+	return 0
 
 ///returns local matter units available. overriden by rcd borg to return power units available
 /obj/item/construction/proc/get_matter(mob/user)
@@ -101,7 +105,11 @@
 		return
 	upgrade |= design_disk.upgrade
 	if((design_disk.upgrade & RCD_UPGRADE_SILO_LINK) && !silo_mats)
-		silo_mats = AddComponent(/datum/component/remote_materials, FALSE, FALSE)
+		silo_mats = AddComponent(
+			/datum/component/remote_materials, \
+			FALSE, \
+			FALSE \
+		)
 	playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
 	qdel(design_disk)
 
@@ -176,15 +184,15 @@
 			if(user)
 				balloon_alert(user, "no silo detected!")
 			return FALSE
-		if(!silo_mats.mat_container.has_materials(list(/datum/material/iron = SILO_USE_AMOUNT), multiplier = amount))
+
+		if(!silo_mats.mat_container.has_enough_of_material(/datum/material/iron, amount * SILO_USE_AMOUNT))
 			if(user)
 				balloon_alert(user, "not enough silo material!")
 			return FALSE
 
-		var/list/materials = list()
-		materials[GET_MATERIAL_REF(/datum/material/iron)] = SILO_USE_AMOUNT
-		silo_mats.mat_container.use_materials(materials, multiplier = amount)
-		silo_mats.silo_log(src, "consume", -amount, "build", materials)
+		silo_mats.mat_container.use_amount_mat(amount * SILO_USE_AMOUNT, /datum/material/iron)
+		var/static/list/mats = list(GET_MATERIAL_REF(/datum/material/iron) = SILO_USE_AMOUNT)
+		silo_mats.silo_log(src, "consume", -amount, "build", mats)
 		return TRUE
 
 ///shared data for rcd,rld & plumbing
@@ -238,7 +246,7 @@
 			if(user)
 				balloon_alert(user, "silo on hold!")
 			return FALSE
-		. = silo_mats.mat_container.has_materials(list(/datum/material/iron = SILO_USE_AMOUNT), multiplier = amount)
+		. = silo_mats.mat_container.has_enough_of_material(/datum/material/iron, amount * SILO_USE_AMOUNT)
 	if(!. && user)
 		balloon_alert(user, "low ammo!")
 		if(has_ammobar)

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -48,11 +48,7 @@
 	spark_system.set_up(5, 0, src)
 	spark_system.attach(src)
 	if(upgrade & RCD_UPGRADE_SILO_LINK)
-		silo_mats = AddComponent( \
-			/datum/component/remote_materials, \
-			mapload, \
-			FALSE \
-		)
+		silo_mats = AddComponent(/datum/component/remote_materials, mapload, FALSE)
 	update_appearance()
 
 ///used for examining the RCD and for its UI
@@ -105,11 +101,7 @@
 		return
 	upgrade |= design_disk.upgrade
 	if((design_disk.upgrade & RCD_UPGRADE_SILO_LINK) && !silo_mats)
-		silo_mats = AddComponent(
-			/datum/component/remote_materials, \
-			FALSE, \
-			FALSE \
-		)
+		silo_mats = AddComponent(/datum/component/remote_materials, FALSE, FALSE)
 	playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
 	qdel(design_disk)
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -174,13 +174,9 @@
 	switch (action)
 		if("remove_mat")
 			var/datum/material/material = locate(params["ref"])
-
-			if(!materials.mat_container.can_hold_material(material))
-				// I don't know who you are or what you want, but whatever it is,
-				// we don't have it.
-				return
-
-			eject_sheets(material, params["amount"])
+			var/amount = text2num(params["amount"])
+			// SAFETY: eject_sheets checks for valid mats
+			materials.eject_sheets(material, amount)
 
 		if("build")
 			user_try_print_id(params["ref"], params["amount"])
@@ -322,26 +318,6 @@
 	update_static_data_for_all_viewers()
 
 	return TRUE
-
-/obj/machinery/rnd/production/proc/eject_sheets(eject_sheet, eject_amt)
-	var/datum/component/material_container/mat_container = materials.mat_container
-
-	if(!mat_container)
-		say("No access to material storage, please contact the quartermaster.")
-		return 0
-
-	if(materials.on_hold())
-		say("Mineral access is on hold, please contact the quartermaster.")
-		return 0
-
-	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location())
-
-	var/list/matlist = list()
-	matlist[eject_sheet] = SHEET_MATERIAL_AMOUNT * count
-
-	materials.silo_log(src, "ejected", -count, "sheets", matlist)
-
-	return count
 
 // Stuff for the stripe on the department machines
 /obj/machinery/rnd/production/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/screwdriver)

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -469,10 +469,6 @@
 		if("remove_mat")
 			var/datum/material/material = locate(params["ref"])
 			var/amount = text2num(params["amount"])
-
-			if (!amount)
-				return
-
 			// SAFETY: eject_sheets checks for valid mats
 			rmat.eject_sheets(material, amount)
 			return

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -148,10 +148,6 @@
 		if ("remove_mat")
 			var/datum/material/material = locate(params["ref"])
 			var/amount = text2num(params["amount"])
-
-			if (!amount)
-				return TRUE
-
 			// SAFETY: eject_sheets checks for valid mats
 			materials.eject_sheets(material, amount)
 
@@ -393,10 +389,6 @@
 		if ("remove_mat")
 			var/datum/material/material = locate(params["ref"])
 			var/amount = text2num(params["amount"])
-
-			if (!amount)
-				return TRUE
-
 			// SAFETY: eject_sheets checks for valid mats
 			materials.eject_sheets(material, amount)
 


### PR DESCRIPTION
## About The Pull Request
1. Fixes #77177 
Some things were not connecting to the ore silo round start because the silo was not initialized yet so it went to local storage. Now it connects with the ore silo again
3. Removed some unused code in remote materials
4. Protolathe uses `eject_sheets()` defined in remote materials and not it's own version because that's redundant
5. Don't put the item back in the players hand when inserting it in the material container cause we haven't even removed it yet
6. `fast_split()` is now even faster & robust and is a global proc
7. Some code cleanup for RHD silo link

## Changelog
:cl:
fix: some things not connecting to the ore silo round start
/:cl:
