### PR TITLE
Emagged player-controlled bots now get antagonistic flavor text

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -60,6 +60,7 @@
 #define ROLE_MIND_TRANSFER "Mind Transfer Potion"
 #define ROLE_POSIBRAIN "Posibrain"
 #define ROLE_DRONE "Drone"
+#define ROLE_EMAGGED_BOT "Malfunctioning Bot"
 #define ROLE_DEATHSQUAD "Deathsquad"
 #define ROLE_LAVALAND "Lavaland"
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -323,7 +323,7 @@
 		bot_reset()
 		turn_on() //The bot automatically turns on when emagged, unless recently hit with EMP.
 		to_chat(src, span_userdanger("(#$*#$^^( OVERRIDE DETECTED"))
-		possessed_message = 'You are a malfunctioning bot! Disrupt everyone and cause chaos!'
+		possessed_message = "You are a malfunctioning bot! Disrupt everyone and cause chaos!"
 		to_chat(src, span_boldnotice(possessed_message))
 		if(user)
 			log_combat(user, src, "emagged")

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -134,11 +134,7 @@
  * Returns a string of flavor text for emagged bots as defined by policy.
  */
 /mob/living/simple_animal/bot/proc/get_emagged_message()
-	var/emagged_message = "You are a malfunctioning bot! Disrupt everyone and cause chaos!"
-	var/policy = get_policy(ROLE_EMAGGED_BOT)
-	if (policy)
-		emagged_message = policy
-	return emagged_message
+	return get_policy(ROLE_EMAGGED_BOT) || "You are a malfunctioning bot! Disrupt everyone and cause chaos!"
 
 /mob/living/simple_animal/bot/proc/turn_on()
 	if(stat)

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -323,6 +323,8 @@
 		bot_reset()
 		turn_on() //The bot automatically turns on when emagged, unless recently hit with EMP.
 		to_chat(src, span_userdanger("(#$*#$^^( OVERRIDE DETECTED"))
+		possessed_message = 'You are a malfunctioning bot! Disrupt everyone and cause chaos!'
+		to_chat(src, span_boldnotice(possessed_message))
 		if(user)
 			log_combat(user, src, "emagged")
 		return TRUE

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -130,6 +130,16 @@
 		return "Inactive"
 	return "[mode]"
 
+/**
+ * Returns a string of flavor text for emagged bots as defined by policy.
+ */
+/mob/living/simple_animal/bot/proc/get_emagged_message()
+	var/emagged_message = "You are a malfunctioning bot! Disrupt everyone and cause chaos!"
+	var/policy = get_policy(ROLE_EMAGGED_BOT)
+	if (policy)
+		emagged_message = policy
+	return emagged_message
+
 /mob/living/simple_animal/bot/proc/turn_on()
 	if(stat)
 		return FALSE
@@ -217,7 +227,7 @@
 		ban_type = ROLE_BOT,\
 		poll_candidates = can_announce,\
 		poll_ignore_key = POLL_IGNORE_BOTS,\
-		assumed_control_message = possessed_message,\
+		assumed_control_message = (bot_cover_flags & BOT_COVER_EMAGGED) ? get_emagged_message() : possessed_message,\
 		extra_control_checks = CALLBACK(src, PROC_REF(check_possession)),\
 		after_assumed_control = CALLBACK(src, PROC_REF(post_possession)),\
 	)
@@ -323,8 +333,7 @@
 		bot_reset()
 		turn_on() //The bot automatically turns on when emagged, unless recently hit with EMP.
 		to_chat(src, span_userdanger("(#$*#$^^( OVERRIDE DETECTED"))
-		possessed_message = "You are a malfunctioning bot! Disrupt everyone and cause chaos!"
-		to_chat(src, span_boldnotice(possessed_message))
+		to_chat(src, span_boldnotice(get_emagged_message()))
 		if(user)
 			log_combat(user, src, "emagged")
 		return TRUE
@@ -1011,6 +1020,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 				message_admins("Safety lock of [ADMIN_LOOKUPFLW(src)] was disabled by [ADMIN_LOOKUPFLW(usr)] in [ADMIN_VERBOSEJMP(src)]")
 				usr.log_message("disabled safety lock of [src]", LOG_GAME)
 				bot_reset()
+				to_chat(src, span_userdanger("(#$*#$^^( OVERRIDE DETECTED"))
+				to_chat(src, span_boldnotice(get_emagged_message()))
 				return
 			if(!(bot_cover_flags & BOT_COVER_HACKED))
 				to_chat(usr, span_boldannounce("You fail to repair [src]'s [hackables]."))
@@ -1019,6 +1030,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 			to_chat(usr, span_notice("You reset the [src]'s [hackables]."))
 			usr.log_message("re-enabled safety lock of [src]", LOG_GAME)
 			bot_reset()
+			to_chat(src, span_userdanger("Software restored to standard."))
+			to_chat(src, span_boldnotice(possessed_message))
 		if("eject_pai")
 			if(!paicard)
 				return


### PR DESCRIPTION
## About The Pull Request

The default flavor text is 'You are a malfunctioning bot! Disrupt everyone and cause chaos!'
## Why It's Good For The Game

Bots are required to follow their flavor text, so meant emagged bots couldn't use any of their new dangerous abilities since that would go against their initial helping the station flavor text. This wouldn't be fun for both the bot themselves and the person who emagged them. Now that they get antagonistic flavor text after being emagged, they actually can go out and use their abilities and act antagonistically. 

It also makes it more clear what has happened to you, especially when an AI emags you as there was no message for that before. 

## Changelog
:cl:
add: Emagged player-controlled bots now get different flavor text (depends on policy)
add: Bots are now notified when a silicon toggles them malfunctioning
/:cl:
