### PR TITLE
Fixes tgui_open_uis tracking

### DIFF
--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -285,6 +285,7 @@ SUBSYSTEM_DEF(tgui)
  * required ui datum/tgui The UI to be added.
  */
 /datum/controller/subsystem/tgui/proc/on_open(datum/tgui/ui)
+	ui.user?.tgui_open_uis |= ui
 	LAZYOR(ui.src_object.open_uis, ui)
 	all_uis |= ui
 


### PR DESCRIPTION
Fixes https://github.com/tgstation/tgstation/issues/77097

This breaks uis for everyone with fancy-tgui off and in cases where the window is closed by external action (byond closing it) which is pretty bad.