### PR TITLE
Fixes undeleted SQL queries in `IsBanned()`

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -43,12 +43,14 @@
 
 		var/client_is_in_db = query_client_in_db.NextRow()
 		if(!client_is_in_db)
-			
 			var/reject_message = "Failed Login: [ckey] [address]-[computer_id] - New Account attempting to connect during panic bunker, but was rejected due to no prior connections to game servers (no database entry)"
 			log_access(reject_message)
 			if (message)
 				message_admins(span_adminnotice("[reject_message]"))
+			qdel(query_client_in_db)
 			return list("reason"="panicbunker", "desc" = "Sorry but the server is currently not accepting connections from never before seen players")
+
+		qdel(query_client_in_db)
 
 	//Whitelist
 	if(!real_bans_only && !C && CONFIG_GET(flag/usewhitelist))


### PR DESCRIPTION
Discovered while working on #76663

## About The Pull Request

We were getting undeleted SQL stack traces with the following: `[2023-07-25 19:27:33.832] DEBUG-SQL: Undeleted query: "SELECT 1 FROM player WHERE ckey = :ckey" LA: NextRow LAT: 39397`

There's only one spot in the code (which happens to be the newest, introduced in #74496 / 8fc56cbda075f7355ac084a71ac398048f937db8) where we don't always qdel the query regardless of the path the proc takes (and that seems to match the error per the `LA` field), so let's make sure we always clean that up since it's a drather silly runtime. It's also rather spontaneous, as this code is only executed when servers are bunkered up (which Sybil presently is)

This is my first time dealing with SQL Query code, so let me know if I'm missing something critical here. 