### PR TITLE
Adds a runtime protection check to play_tts

### DIFF
--- a/code/controllers/subsystem/tts.dm
+++ b/code/controllers/subsystem/tts.dm
@@ -107,6 +107,9 @@ SUBSYSTEM_DEF(tts)
 
 	var/channel = SSsounds.random_available_channel()
 	for(var/mob/listening_mob in listeners | SSmobs.dead_players_by_zlevel[turf_source.z])//observers always hear through walls
+		if(QDELING(listening_mob))
+			stack_trace("TTS tried to play a sound to a deleted mob.")
+			continue
 		var/volume_to_play_at = listening_mob.client?.prefs.read_preference(/datum/preference/numeric/sound_tts_volume)
 		var/use_blips = listening_mob.client?.prefs.read_preference(/datum/preference/toggle/sound_tts_blips)
 		if(volume_to_play_at == 0 || !listening_mob.client?.prefs.read_preference(/datum/preference/toggle/sound_tts))


### PR DESCRIPTION
## About The Pull Request
I see this stack trace on occasion
```
[2023-07-25 19:04:56.970] RUNTIME: runtime error: get_language_holder() called on a QDELing atom, this will try to re-instantiate the language holder that's about to be deleted, which is bad.
 - proc name: get language holder (/atom/movable/proc/get_language_holder)
 -   source file: code/game/atoms_movable.dm,1458
 -   usr: null
 -   src: AdipemDragon (/mob/dead/new_player)
 -   src.loc: null
 -   call stack:
 - AdipemDragon (/mob/dead/new_player): get language holder()
 - Text To Speech (/datum/controller/subsystem/tts): play tts(L.E.M.O.N. (/mob/living/silicon/robot), /list (/list), /sound (/sound), /sound (/sound), /datum/language/common (/datum/language/common), 7, 0)
 - Text To Speech (/datum/controller/subsystem/tts): fire(0)
 - Text To Speech (/datum/controller/subsystem/tts): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```

Evidently, the list of listeners is *somehow* getting new players or observers that are being qdeleted (maybe hard deleting?) 

That might be a little hard to track down so until then I figure it's fine to throw in a stack trace and continue so it doesn't brick the message for everyone else

## Why It's Good For The Game

Prevents the proc from runtiming and cancelling execution, ergo not playing to everyone else

## Changelog

:cl: Melbert
fix: Fixes some occasions which result in TTS messages not playing
/:cl:

