### PR TITLE
Improves text readability in some parts of the PDA retro theme

### DIFF
--- a/tgui/packages/tgui/styles/themes/ntOS95.scss
+++ b/tgui/packages/tgui/styles/themes/ntOS95.scss
@@ -32,7 +32,7 @@ $scrollbar-color-multiplier: 1;
     '../components/Button.scss',
     $with: (
       'color-default': #e8e4c9,
-      'color-disabled': #363636,
+      'color-disabled': #707070,
       'color-selected': #007c11,
       'color-caution': #be6209,
       'color-danger': #9d0808
@@ -71,12 +71,24 @@ $scrollbar-color-multiplier: 1;
   }
 
   .Section {
+    &__titleText {
+      color: black;
+    }
     color: black;
     background-color: #c0c0c0;
     outline: base.em(2px) outset #c3c3c3;
   }
 
   .Input {
+    background-color: white;
+    outline: base.em(2px) inset #c3c3c3;
+    color: black;
+    &__input:-ms-input-placeholder {
+      color: black;
+    }
+  }
+
+  .TextArea {
     background-color: white;
     outline: base.em(2px) inset #c3c3c3;
   }


### PR DESCRIPTION

## About The Pull Request

Fixes a few issues in the retro theme where text blended in with the background or was otherwise hard to read
This was originally in the improved messenger PR but that got too big, so I am splitting features from it off into smaller PRs
## Why It's Good For The Game

Fixes #76968
## Changelog
:cl: distributivgesetz
qol: Made reading text with the PDA retro theme a bit more accessible.
/:cl:
