### PR TITLE
Removed unnecessary/incorrectly placed space tiles on multiple ruins maps

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_3.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/kitchen_3.dmm
@@ -51,11 +51,6 @@
 /obj/modular_map_connector,
 /turf/template_noop,
 /area/ruin/space/djstation)
-"O" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
 "P" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage{
@@ -94,7 +89,7 @@ e
 e
 e
 e
-O
+e
 j
 e
 a

--- a/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
+++ b/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
@@ -2,7 +2,7 @@
 "aa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/teal,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "aA" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
@@ -270,7 +270,7 @@
 /area/ruin/space/has_grav/allamericandiner)
 "nv" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "ny" = (
 /obj/machinery/oven,
@@ -1050,7 +1050,7 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/allamericandiner)
 "SU" = (
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "SZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1221,7 +1221,7 @@
 "Yd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/fuchsia,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space)
 "Yo" = (
 /obj/structure/table/wood,

--- a/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
@@ -93,18 +93,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/misc/anomaly_research)
-"dz" = (
-/turf/open/space/basic,
-/area/misc/anomaly_research)
 "dD" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/spawner/random/environmentally_safe_anomaly,
 /turf/open/lava/plasma/ice_moon,
-/area/misc/anomaly_research)
-"ek" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/purple/opposingcorners,
-/turf/open/floor/iron/white,
 /area/misc/anomaly_research)
 "eq" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -3287,7 +3279,7 @@ Iw
 Iw
 iq
 Iw
-ek
+Bc
 xQ
 AV
 nA
@@ -3467,7 +3459,7 @@ Ya
 RT
 RT
 Ya
-dz
+Ya
 Ya
 AV
 hq
@@ -3504,8 +3496,8 @@ Ya
 (43,1,1) = {"
 RT
 RT
-dz
-dz
+Ya
+Ya
 Ya
 AV
 uN
@@ -3542,7 +3534,7 @@ Ya
 (44,1,1) = {"
 RT
 Ya
-dz
+Ya
 Ya
 Ya
 AV
@@ -3580,7 +3572,7 @@ RT
 (45,1,1) = {"
 RT
 Ya
-dz
+Ya
 Ya
 Ya
 AV

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -34,7 +34,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "aB" = (
 /obj/item/shard,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "aV" = (
 /obj/machinery/light/small/red/dim/directional/north,
@@ -83,7 +83,7 @@
 /obj/structure/broken_flooring/plating/directional/east,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "bD" = (
 /obj/effect/decal/cleanable/blood/gibs{
@@ -421,7 +421,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/infested_frigate)
 "fl" = (
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "fr" = (
 /obj/effect/turf_decal/tile/bar{
@@ -453,7 +453,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "fM" = (
 /obj/structure/door_assembly/door_assembly_ext,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "fX" = (
 /obj/structure/toilet{
@@ -466,7 +466,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "gG" = (
 /obj/effect/spawner/random/trash/food_packaging,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "gW" = (
 /obj/effect/turf_decal{
@@ -954,7 +954,7 @@
 	pixel_y = 2;
 	pixel_x = 15
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "qb" = (
 /obj/effect/turf_decal{
@@ -1024,14 +1024,14 @@
 /area/ruin/space/has_grav/infested_frigate)
 "qF" = (
 /obj/item/ammo_casing/spent,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "qJ" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/clothing/mask/facehugger/toy,
 /obj/item/storage/fancy/cigarettes/cigpack_cannabis,
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "qR" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -1113,7 +1113,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "rO" = (
 /obj/structure/broken_flooring/pile/directional/south,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "so" = (
 /obj/effect/mapping_helpers/broken_floor,
@@ -1160,7 +1160,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "sT" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "sZ" = (
 /obj/structure/cable,
@@ -1379,7 +1379,7 @@
 /obj/item/stack/rods{
 	amount = 25
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "wt" = (
 /obj/effect/turf_decal{
@@ -1671,7 +1671,7 @@
 /area/template_noop)
 "zU" = (
 /obj/structure/broken_flooring/pile/directional/east,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "zV" = (
 /obj/machinery/suit_storage_unit/open,
@@ -1855,7 +1855,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "Eg" = (
 /obj/item/stack/rods,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Er" = (
 /obj/effect/turf_decal{
@@ -1895,7 +1895,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "EB" = (
 /obj/structure/girder/displaced,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "EL" = (
 /obj/effect/turf_decal{
@@ -2106,12 +2106,12 @@
 /area/ruin/space/has_grav/infested_frigate)
 "HD" = (
 /obj/structure/broken_flooring/singular/directional/south,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "HP" = (
 /obj/structure/broken_flooring/plating/directional/north,
 /obj/structure/broken_flooring/pile/directional/west,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Im" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -2538,7 +2538,7 @@
 /obj/item/stack/rods{
 	amount = 23
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Ou" = (
 /obj/structure/cable,
@@ -2644,7 +2644,7 @@
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Qm" = (
 /obj/effect/turf_decal/tile/red{
@@ -2669,7 +2669,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "QL" = (
 /obj/structure/broken_flooring/singular/directional/east,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Ru" = (
 /obj/effect/turf_decal/delivery,
@@ -2748,7 +2748,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "RY" = (
 /obj/effect/spawner/random/trash,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Sr" = (
 /obj/effect/turf_decal{
@@ -2958,7 +2958,7 @@
 /area/ruin/space/has_grav/infested_frigate)
 "VR" = (
 /obj/item/tank/internals/oxygen/empty,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "VU" = (
 /obj/structure/cable,
@@ -3025,7 +3025,7 @@
 /obj/item/stack/rods{
 	amount = 50
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Xc" = (
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/RandomRuins/SpaceRuins/mimesvsclowns.dmm
+++ b/_maps/RandomRuins/SpaceRuins/mimesvsclowns.dmm
@@ -271,7 +271,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/effect/mapping_helpers/damaged_window,
 /obj/effect/decal/cleanable/blood/splatter/over_window,
-/turf/template_noop,
+/turf/open/floor/plating/airless,
 /area/ruin)
 "XA" = (
 /obj/machinery/computer/old{

--- a/_maps/RandomRuins/SpaceRuins/phonebooth.dmm
+++ b/_maps/RandomRuins/SpaceRuins/phonebooth.dmm
@@ -11,7 +11,7 @@
 /turf/open/floor/iron/dark/smooth_edge,
 /area/ruin/space/has_grav/powered/space_phone_booth)
 "e" = (
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space/has_grav/powered/space_phone_booth)
 "k" = (
 /obj/machinery/vending/snack/green{
@@ -35,7 +35,7 @@
 "v" = (
 /obj/structure/lattice,
 /obj/structure/billboard/Phone_booth,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space/has_grav/powered/space_phone_booth)
 "z" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -65,7 +65,7 @@
 /area/ruin/space/has_grav/powered/space_phone_booth)
 "V" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/ruin/space/has_grav/powered/space_phone_booth)
 "W" = (
 /obj/machinery/vending/cigarette{

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2202,11 +2202,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/blue,
 /area/ruin/space/has_grav/hotel)
-"wT" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/ruin/space/has_grav/hotel)
 "wW" = (
 /obj/structure/chair/plastic,
 /obj/structure/cable,
@@ -4023,7 +4018,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/power)
 "UD" = (
 /obj/effect/turf_decal/stripes/end,
@@ -8175,11 +8170,11 @@ Qy
 ak
 ak
 ak
-wT
 ak
-wT
 ak
-wT
+ak
+ak
+ak
 ak
 yV
 ak

--- a/_maps/RandomRuins/SpaceRuins/the_faceoff.dmm
+++ b/_maps/RandomRuins/SpaceRuins/the_faceoff.dmm
@@ -42,8 +42,8 @@
 /turf/open/floor/iron/dark/smooth_large/airless,
 /area/ruin/space)
 "bz" = (
-/turf/open/space/basic,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "bM" = (
 /obj/item/ammo_casing/a357/spent{
 	dir = 1;
@@ -335,9 +335,6 @@
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron/dark/airless,
 /area/ruin/space)
-"ka" = (
-/turf/open/space/basic,
-/area/template_noop)
 "kC" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/airless,
@@ -1408,11 +1405,11 @@ bz
 bz
 bz
 bz
-ka
-ka
-ka
-ka
-ka
+bz
+bz
+bz
+bz
+bz
 bz
 bz
 bz
@@ -1438,18 +1435,18 @@ bz
 bz
 bz
 bz
-ka
-ka
-ka
-ka
-ka
 bz
-ka
-ka
+bz
+bz
+bz
+bz
+bz
+bz
+bz
 Er
 Er
 Er
-ka
+bz
 bz
 bz
 bz
@@ -1474,23 +1471,23 @@ bz
 bz
 bz
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 Er
-ka
-ka
-ka
+bz
+bz
+bz
 Er
 Er
 Er
 Er
-ka
-ka
-ka
-ka
-ka
+bz
+bz
+bz
+bz
+bz
 bz
 bz
 bz
@@ -1510,14 +1507,14 @@ bz
 bz
 bz
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 Er
 Er
 Er
-ka
+bz
 Er
 Er
 Er
@@ -1527,8 +1524,8 @@ Er
 Er
 Er
 Er
-ka
-ka
+bz
+bz
 bz
 bz
 bz
@@ -1546,8 +1543,8 @@ bz
 bz
 bz
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 Er
@@ -1565,7 +1562,7 @@ ED
 ED
 Er
 Er
-ka
+bz
 bz
 bz
 bz
@@ -1582,8 +1579,8 @@ bz
 bz
 bz
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 Er
@@ -1602,7 +1599,7 @@ so
 ED
 ED
 Er
-ka
+bz
 bz
 bz
 bz
@@ -1617,9 +1614,9 @@ bz
 bz
 bz
 bz
-ka
-ka
-ka
+bz
+bz
+bz
 Er
 ED
 Er
@@ -1639,7 +1636,7 @@ Ck
 fR
 xT
 Er
-ka
+bz
 bz
 bz
 bz
@@ -1653,8 +1650,8 @@ bz
 bz
 bz
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 Er
@@ -1676,7 +1673,7 @@ yx
 Dm
 Er
 Er
-ka
+bz
 bz
 bz
 bz
@@ -1688,9 +1685,9 @@ bz
 (12,1,1) = {"
 bz
 bz
-ka
-ka
-ka
+bz
+bz
+bz
 Er
 Er
 ED
@@ -1713,7 +1710,7 @@ rG
 ED
 ED
 Er
-ka
+bz
 bz
 bz
 bz
@@ -1724,8 +1721,8 @@ bz
 "}
 (13,1,1) = {"
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 Er
@@ -1750,7 +1747,7 @@ Er
 Er
 Er
 Er
-ka
+bz
 bz
 bz
 bz
@@ -1761,7 +1758,7 @@ bz
 "}
 (14,1,1) = {"
 bz
-ka
+bz
 Er
 Er
 Er
@@ -1785,9 +1782,9 @@ vZ
 xT
 Er
 Er
-ka
-ka
-ka
+bz
+bz
+bz
 bz
 bz
 bz
@@ -1798,7 +1795,7 @@ bz
 "}
 (15,1,1) = {"
 bz
-ka
+bz
 Er
 Er
 Er
@@ -1821,9 +1818,9 @@ je
 ZC
 ED
 Er
-ka
-ka
-ka
+bz
+bz
+bz
 bz
 bz
 bz
@@ -1835,8 +1832,8 @@ bz
 "}
 (16,1,1) = {"
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 AV
@@ -1860,8 +1857,8 @@ ij
 Er
 Er
 Er
-ka
-ka
+bz
+bz
 bz
 bz
 bz
@@ -1873,7 +1870,7 @@ bz
 (17,1,1) = {"
 bz
 bz
-ka
+bz
 Er
 ED
 wW
@@ -1898,8 +1895,8 @@ ED
 ED
 ED
 Er
-ka
-ka
+bz
+bz
 bz
 bz
 bz
@@ -1910,7 +1907,7 @@ bz
 (18,1,1) = {"
 bz
 bz
-ka
+bz
 Er
 ED
 fa
@@ -1936,7 +1933,7 @@ ch
 ED
 Er
 Er
-ka
+bz
 bz
 bz
 bz
@@ -1947,8 +1944,8 @@ bz
 (19,1,1) = {"
 bz
 bz
-ka
-ka
+bz
+bz
 Er
 ED
 ou
@@ -1973,9 +1970,9 @@ ZC
 HG
 ED
 Er
-ka
-ka
-ka
+bz
+bz
+bz
 bz
 bz
 bz
@@ -1985,7 +1982,7 @@ bz
 bz
 bz
 bz
-ka
+bz
 Er
 ED
 ED
@@ -2011,8 +2008,8 @@ ZC
 ED
 ED
 Er
-ka
-ka
+bz
+bz
 bz
 bz
 bz
@@ -2022,8 +2019,8 @@ bz
 bz
 bz
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 Er
@@ -2049,7 +2046,7 @@ ZC
 ED
 ED
 Er
-ka
+bz
 bz
 bz
 bz
@@ -2060,8 +2057,8 @@ bz
 bz
 bz
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 ED
@@ -2086,7 +2083,7 @@ ZO
 aC
 ED
 Er
-ka
+bz
 bz
 bz
 bz
@@ -2098,9 +2095,9 @@ bz
 bz
 bz
 bz
-ka
-ka
-ka
+bz
+bz
+bz
 Er
 Er
 Er
@@ -2123,7 +2120,7 @@ Ef
 Ef
 ED
 Er
-ka
+bz
 bz
 bz
 bz
@@ -2137,9 +2134,9 @@ bz
 bz
 bz
 bz
-ka
-ka
-ka
+bz
+bz
+bz
 Er
 ED
 LX
@@ -2160,7 +2157,7 @@ Ef
 GX
 eA
 Er
-ka
+bz
 bz
 bz
 bz
@@ -2176,7 +2173,7 @@ bz
 bz
 bz
 bz
-ka
+bz
 Er
 ED
 mG
@@ -2197,7 +2194,7 @@ YI
 YI
 Qx
 Er
-ka
+bz
 bz
 bz
 bz
@@ -2213,7 +2210,7 @@ bz
 bz
 bz
 bz
-ka
+bz
 Er
 Er
 Er
@@ -2233,8 +2230,8 @@ xI
 sa
 Ds
 eA
-ka
-ka
+bz
+bz
 bz
 bz
 bz
@@ -2250,11 +2247,11 @@ bz
 bz
 bz
 bz
-ka
-ka
-ka
-ka
-ka
+bz
+bz
+bz
+bz
+bz
 Er
 ED
 ED
@@ -2270,7 +2267,7 @@ YI
 eA
 Ds
 eA
-ka
+bz
 bz
 bz
 bz
@@ -2291,7 +2288,7 @@ bz
 bz
 bz
 bz
-ka
+bz
 Er
 Er
 Er
@@ -2307,7 +2304,7 @@ Ts
 nl
 cq
 nl
-ka
+bz
 bz
 bz
 bz
@@ -2328,10 +2325,10 @@ bz
 bz
 bz
 bz
-ka
-ka
-ka
-ka
+bz
+bz
+bz
+bz
 Er
 Er
 ED
@@ -2339,12 +2336,12 @@ ED
 sZ
 ED
 Er
-ka
-ka
-ka
-ka
-ka
-ka
+bz
+bz
+bz
+bz
+bz
+bz
 bz
 bz
 bz
@@ -2368,15 +2365,15 @@ bz
 bz
 bz
 bz
-ka
-ka
-ka
+bz
+bz
+bz
 Er
 ED
 ED
 ED
 Er
-ka
+bz
 bz
 bz
 bz
@@ -2407,13 +2404,13 @@ bz
 bz
 bz
 bz
-ka
-ka
+bz
+bz
 Er
 Er
 Er
 Er
-ka
+bz
 bz
 bz
 bz
@@ -2445,12 +2442,12 @@ bz
 bz
 bz
 bz
-ka
-ka
-ka
-ka
-ka
-ka
+bz
+bz
+bz
+bz
+bz
+bz
 bz
 bz
 bz

--- a/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
+++ b/_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
@@ -397,7 +397,7 @@
 	id = "oldship_ruin_gun";
 	name = "Pod Bay Door"
 	},
-/turf/open/space/basic,
+/turf/open/floor/iron/textured,
 /area/ruin/space/has_grav/whiteship/box)
 "lO" = (
 /obj/effect/turf_decal/siding/wideplating{

--- a/_maps/shuttles/emergency_fish.dmm
+++ b/_maps/shuttles/emergency_fish.dmm
@@ -144,7 +144,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/dark_red/opposingcorners,
-/turf/open/space/basic,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "iA" = (
 /obj/structure/chair/pew/right{


### PR DESCRIPTION

## About The Pull Request

This fixes all failing instances of `/datum/unit_test/mapload_space_verification` on local machines.
These never popped up on Github CI actions because the space budget is set to 0, but running unit tests on local machine will cause some ruins maps to fail the test on other z levels.  This fixes all instances of the failed test and also adjusts the space ruin space tile placement to be more consistent across all maps.

Space tiles should be placed whenever necessary for a map, otherwise usage of template_noop is more appropriate.  This consistency is improved by removing surrounding space tiles and replacing them with template_noop on several maps.

Also fixes a loose space turf inside one of the shuttles.
## Why It's Good For The Game

Consistency is key also failing tests bad.  Only integral changes are the 5 space tiles on one of the ruins and the singular space tile inside another, the mass space replacements with template_noop can be argued, however it mostly seems to be because of how long those templates have existed that they have the surrounding space tiles in the first place.
## Changelog
:cl:Senefi
fix: Replaced 5 space tiles in the wall of the anomaly research ruin with rocks.
fix: Replaced the tile under the window in the mimes vs clowns ruin with plating.
fix: Replaced space tile in the emergency fish shuttle with plastitanium flooring.
fix: Removed space tiles from the exterior of some ruins templates.
/:cl:
