### PR TITLE
Fix adrenal crisis being incurable (Fixes #77086)

### DIFF
--- a/code/datums/diseases/adrenal_crisis.dm
+++ b/code/datums/diseases/adrenal_crisis.dm
@@ -10,7 +10,6 @@
 	spreading_modifier = 1
 	desc = "If left untreated the subject will suffer from lethargy, dizziness and periodic loss of conciousness."
 	severity = DISEASE_SEVERITY_MEDIUM
-	disease_flags = CAN_CARRY|CAN_RESIST
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	spread_text = "Organ failure"
 	visibility_flags = HIDDEN_PANDEMIC


### PR DESCRIPTION

## About The Pull Request

Fixes #77086 

Adrenal Crisis lacks the CURABLE flag, meaning it will never be cured, even if the cure is present.
I opted to remove the `var/disease_flags` from it, since it has `CAN_CARRY|CAN_RESIST`, if I add `CURABLE` to that it's the same flags as the base `/datum/disease` datum has, and I think it's cleaner to not list them again if they don't change from the base.

Not sure if it was ever curable? Seemed to have these flags since it was added. And the `has_cure` proc seemed to check for that flag even back then.
## Why It's Good For The Game

Disease that's supposed to be curable is now curable.

## Changelog
:cl:
fix: Determination can now actually overcome your adrenal glands, making adrenal crisis a curable condition!
/:cl:
