### PR TITLE
[NO-GBP] Warns viro of radioactive resonance absence

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -572,6 +572,8 @@
 		//if engineering isnt valid, just send it to the bridge
 		send_supply_pod_to_area(supply_pack_shielding.generate(null), /area/station/command/bridge, /obj/structure/closet/supplypod/centcompod)
 
+	send_supply_pod_to_area(new /obj/item/paper/fluff/radiation_nebula_virologist(), /area/station/medical/virology, /obj/structure/closet/supplypod/centcompod)
+
 	//Disables radstorms, they don't really make sense since we already have the nebula causing storms
 	var/datum/round_event_control/modified_event = locate(/datum/round_event_control/radiation_storm) in SSevents.control
 	modified_event.weight = 0

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -527,6 +527,7 @@
 	blacklist = list(/datum/station_trait/random_event_weight_modifier/rad_storms)
 	threat_reduction = 30
 	dynamic_threat_id = "Radioactive Nebula"
+	force = TRUE
 
 	intensity_increment_time = 5 MINUTES
 	maximum_nebula_intensity = 1 HOURS + 40 MINUTES
@@ -572,7 +573,9 @@
 		//if engineering isnt valid, just send it to the bridge
 		send_supply_pod_to_area(supply_pack_shielding.generate(null), /area/station/command/bridge, /obj/structure/closet/supplypod/centcompod)
 
-	send_supply_pod_to_area(new /obj/item/paper/fluff/radiation_nebula_virologist(), /area/station/medical/virology, /obj/structure/closet/supplypod/centcompod)
+	// Let the viro know resistence is futile
+	send_fax_to_area(new /obj/item/paper/fluff/radiation_nebula_virologist(), /area/station/medical/virology, "NT Virology Department", \
+	force = TRUE, force_pod_type = /obj/structure/closet/supplypod/centcompod)
 
 	//Disables radstorms, they don't really make sense since we already have the nebula causing storms
 	var/datum/round_event_control/modified_event = locate(/datum/round_event_control/radiation_storm) in SSevents.control

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -527,7 +527,6 @@
 	blacklist = list(/datum/station_trait/random_event_weight_modifier/rad_storms)
 	threat_reduction = 30
 	dynamic_threat_id = "Radioactive Nebula"
-	force = TRUE
 
 	intensity_increment_time = 5 MINUTES
 	maximum_nebula_intensity = 1 HOURS + 40 MINUTES

--- a/code/game/machinery/nebula_shielding.dm
+++ b/code/game/machinery/nebula_shielding.dm
@@ -119,11 +119,19 @@
 
 	..()
 
-///Small explanation for engineering on how to set-up the radioactive nebula shielding
+/// Small explanation for engineering on how to set-up the radioactive nebula shielding
 /obj/item/paper/fluff/radiation_nebula
 	name = "radioactive nebula shielding"
 	default_raw_text = {"EXTREME IMPORTANCE!!!! <br>
 		Set up these radioactive nebula shielding units before the gravity generators native shielding is overwhelmed! <br>
 		Shielding units passively generate tritium, so make sure to properly ventilate/isolate the area before setting up a shielding unit!
 		More circuit boards can be ordered through cargo. Consider setting up auxillary shielding units in-case of destruction, power loss or sabotage.
+	"}
+
+/// Warns the viro that they can't use radioactive resonance
+/obj/item/paper/fluff/radiation_nebula_virologist
+	name = "radioactive resonance"
+	default_raw_text = {"EXTREME IMPORTANCE!!!! <br>
+		During routine bloodscreening on employees working in the nebula, we found no traces of the sympton called 'Radioactive Resonance'. <br>
+		Something inside the nebula is interfering with it, be wary of a more shallow viral genepool.
 	"}


### PR DESCRIPTION
There was no in-game way for the viro to know the radioactive resonance sympton couldn't be rolled (during rad nebula)

Now it sends a fax to the virologist, or if there's no fax it sends a supplypod straight at the virologist with a fax machine and then sends the fax

:cl:
qol: The virologist is warned when radioactive resonance cannot be obtained
/:cl: