### PR TITLE
Adds a negative station trait: Vending products shortage.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1114,6 +1114,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_SPIDER_INFESTATION "station_trait_spider_infestation"
 #define STATION_TRAIT_REVOLUTIONARY_TRASHING "station_trait_revolutionary_trashing"
 #define STATION_TRAIT_RADIOACTIVE_NEBULA "station_trait_radioactive_nebula"
+#define STATION_TRAIT_VENDING_SHORTAGE "station_trait_vending_shortage"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -20,7 +20,7 @@
 /datum/station_trait/vending_shortage
 	name = "Vending products shortage"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 1
+	weight = 2
 	show_in_report = TRUE
 	can_revert = FALSE //Because it touches every maploaded vending machine on the station.
 	report_message = "We haven't had the time to properly resupply the station's vending machines. Some items may be unavailable."

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -17,13 +17,14 @@
 /datum/station_trait/distant_supply_lines/on_round_start()
 	SSeconomy.pack_price_modifier *= 1.2
 
+///A negative trait that reduces the amount of products available from vending machines throughout the station.
 /datum/station_trait/vending_shortage
 	name = "Vending products shortage"
 	trait_type = STATION_TRAIT_NEGATIVE
-	weight = 2
+	weight = 3
 	show_in_report = TRUE
 	can_revert = FALSE //Because it touches every maploaded vending machine on the station.
-	report_message = "We haven't had the time to properly resupply the station's vending machines. Some items may be unavailable."
+	report_message = "We haven't had the time to take care of the station's vending machines. Some may be tilted, and some products may be unavailable."
 	trait_to_give = STATION_TRAIT_VENDING_SHORTAGE
 
 /datum/station_trait/late_arrivals

--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -17,6 +17,15 @@
 /datum/station_trait/distant_supply_lines/on_round_start()
 	SSeconomy.pack_price_modifier *= 1.2
 
+/datum/station_trait/vending_shortage
+	name = "Vending products shortage"
+	trait_type = STATION_TRAIT_NEGATIVE
+	weight = 1
+	show_in_report = TRUE
+	can_revert = FALSE //Because it touches every maploaded vending machine on the station.
+	report_message = "We haven't had the time to properly resupply the station's vending machines. Some items may be unavailable."
+	trait_to_give = STATION_TRAIT_VENDING_SHORTAGE
+
 /datum/station_trait/late_arrivals
 	name = "Late Arrivals"
 	trait_type = STATION_TRAIT_NEGATIVE

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -168,7 +168,11 @@
 	  * if it's off-station during mapload, it's also safe from the brand intelligence event
 	  */
 	var/onstation = TRUE
-	///A variable to change on a per instance basis on the map that allows the instance to force cost and ID requirements. DO NOT APPLY THIS GLOBALLY.
+	/**
+	 * A variable to change on a per instance basis on the map that allows the instance
+	 * to ignore whether it's on the station or not.
+	 * Useful to force cost and ID requirements. DO NOT APPLY THIS GLOBALLY.
+	 */
 	var/onstation_override = FALSE
 
 	var/list/vending_machine_input = list()
@@ -225,14 +229,20 @@
 	last_slogan = world.time + rand(0, slogan_delay)
 	power_change()
 
-	if(onstation_override) //overrides the checks if true.
-		onstation = TRUE
-		return
 	if(mapload) //check if it was initially created off station during mapload.
 		if(!is_station_level(z))
-			onstation = FALSE
+			if(!onstation_override)
+				onstation = FALSE
 			if(circuit)
 				circuit.onstation = onstation //sync up the circuit so the pricing schema is carried over if it's reconstructed.
+		else if(HAS_TRAIT(SSstation, STATION_TRAIT_VENDING_SHORTAGE))
+			for (var/datum/data/vending_product/product_record as anything in product_records + coin_records + hidden_records)
+				/**
+				 * in average, it should be 37.5% of the max amount, rounded up to the nearest int,
+				 * tho the max boundary can be as low/high as 50%/100%
+				 */
+				var/max_amount = CEILING(product_record.amount/2, product_record.amount)
+				product_record.amount = rand(0, max_amount)
 	else if(circuit && (circuit.onstation != onstation)) //check if they're not the same to minimize the amount of edited values.
 		onstation = circuit.onstation //if it was constructed outside mapload, sync the vendor up with the circuit's var so you can't bypass price requirements by moving / reconstructing it off station.
 
@@ -957,7 +967,7 @@
 			.["user"]["department"] = DEPARTMENT_UNASSIGNED
 	.["stock"] = list()
 
-	for (var/datum/data/vending_product/product_record in product_records + coin_records + hidden_records)
+	for (var/datum/data/vending_product/product_record as anything in product_records + coin_records + hidden_records)
 		var/list/product_data = list(
 			name = product_record.name,
 			amount = product_record.amount,

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -241,8 +241,10 @@
 				 * in average, it should be 37.5% of the max amount, rounded up to the nearest int,
 				 * tho the max boundary can be as low/high as 50%/100%
 				 */
-				var/max_amount = CEILING(product_record.amount/2, product_record.amount)
+				var/max_amount = rand(CEILING(product_record.amount * 0.5, 1), product_record.amount)
 				product_record.amount = rand(0, max_amount)
+			if(tiltable && prob(6)) // 1 in 17 chance to start tilted (as an additional hint to the station trait behind it)
+				tilt(loc)
 	else if(circuit && (circuit.onstation != onstation)) //check if they're not the same to minimize the amount of edited values.
 		onstation = circuit.onstation //if it was constructed outside mapload, sync the vendor up with the circuit's var so you can't bypass price requirements by moving / reconstructing it off station.
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -244,7 +244,7 @@
 				var/max_amount = rand(CEILING(product_record.amount * 0.5, 1), product_record.amount)
 				product_record.amount = rand(0, max_amount)
 			if(tiltable && prob(6)) // 1 in 17 chance to start tilted (as an additional hint to the station trait behind it)
-				tilt(loc)
+				INVOKE_ASYNC(src, PROC_REF(tilt), loc)
 	else if(circuit && (circuit.onstation != onstation)) //check if they're not the same to minimize the amount of edited values.
 		onstation = circuit.onstation //if it was constructed outside mapload, sync the vendor up with the circuit's var so you can't bypass price requirements by moving / reconstructing it off station.
 


### PR DESCRIPTION
## About The Pull Request
Adds in a mean station trait that randomly lowers the availability of all vending products from vending machines on the station.

## Why It's Good For The Game
Kicking aside the simple concept of "The more the merrier (until it's a feature creep)" for a moment, vending (re)supplies are scarcely needed on a generic round basis. The addition of this new trait could lead to situations where more vending supplies are wanted/ordered once in a while.

Beside, this is a pretty evil negative trait notwithstanding its simplicity, unlike many other relatively innocuous ones.

## Changelog

:cl:
add: Added a 'Vending products shortage' station trait, that randomly lowers the availability of all vending products from vending machines on the station, with a 1/20 chance of the vending machine itself being tilted.
/:cl:
