### PR TITLE
fixes SM crystals dusting themselves after falling

### DIFF
--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -213,6 +213,8 @@
 /datum/component/supermatter_crystal/proc/intercept_z_fall(datum/source, list/falling_movables, levels)
 	SIGNAL_HANDLER
 	for(var/atom/movable/hit_object as anything in falling_movables)
+		if(hit_object == source)
+			continue
 		bumped_hit(parent, hit_object)
 	return FALL_INTERCEPTED | FALL_NO_MESSAGE
 


### PR DESCRIPTION

## About The Pull Request

get_z_move_affected always returns src which is something that wasnt exactly accounted in this case

## Why It's Good For The Game

fixes #76811

## Changelog
:cl:
fix: shoving a crystal down a hole no longer makes it dust itself
/:cl:
