### PR TITLE
fixes a guillotine logging runtime

### DIFF
--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -130,7 +130,7 @@
 			else
 				blade_status = GUILLOTINE_BLADE_MOVING
 				icon_state = "guillotine_drop"
-				addtimer(CALLBACK(src, PROC_REF(drop_blade)), GUILLOTINE_ANIMATION_LENGTH)
+				addtimer(CALLBACK(src, PROC_REF(drop_blade), user), GUILLOTINE_ANIMATION_LENGTH)
 
 /// Sets the guillotine blade in a raised position
 /obj/structure/guillotine/proc/raise_blade()


### PR DESCRIPTION

## About The Pull Request

passes user

## Why It's Good For The Game

fixes #77082

## Changelog
:cl:
fix: guillotines no longer runtime when logging after decapping someone if they buckle AFTER the blade starts to drop
/:cl:
