### PR TITLE
makes puzzle doors not open if you just walk into them while fireman carrying someone

### DIFF
--- a/code/game/objects/items/puzzle_pieces.dm
+++ b/code/game/objects/items/puzzle_pieces.dm
@@ -44,6 +44,7 @@
 	resistance_flags = INDESTRUCTIBLE | FIRE_PROOF | ACID_PROOF | LAVA_PROOF
 	move_resist = MOVE_FORCE_OVERPOWERING
 	damage_deflection = 70
+	can_open_with_hands = FALSE
 	/// Make sure that the puzzle has the same puzzle_id as the keycard door!
 	var/puzzle_id = null
 	/// Message that occurs when the door is opened


### PR DESCRIPTION

## About The Pull Request

i dont know how this happens but this fixes it so

## Why It's Good For The Game

fixes #77112

## Changelog
:cl:
fix: you can no longer fireman carry to bypass puzzle doors
/:cl:
