### PR TITLE
[no gbp] Goliaths make less mess

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_area.dm
+++ b/code/__DEFINES/dcs/signals/signals_area.dm
@@ -32,3 +32,8 @@
 // Area fire signals
 /// Sent when an area's fire var changes: (fire_value)
 #define COMSIG_AREA_FIRE_CHANGED "area_fire_set"
+
+/// Called when some weather starts in this area
+#define COMSIG_WEATHER_BEGAN_IN_AREA(event_type) "weather_began_in_area_[event_type]"
+/// Called when some weather ends in this area
+#define COMSIG_WEATHER_ENDED_IN_AREA(event_type) "weather_ended_in_area_[event_type]"

--- a/code/datums/components/storm_hating.dm
+++ b/code/datums/components/storm_hating.dm
@@ -1,0 +1,47 @@
+/**
+ * The parent of this component will be destroyed if it's on the ground during a storm
+ */
+/datum/component/storm_hating
+	/// Types of weather which trigger the effect
+	var/static/list/stormy_weather = list(
+		/datum/weather/ash_storm,
+		/datum/weather/snow_storm,
+		/datum/weather/void_storm,
+	)
+
+/datum/component/storm_hating/Initialize()
+	. = ..()
+	if (!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	on_area_entered(parent, get_area(parent))
+
+/datum/component/storm_hating/RegisterWithParent()
+	. = ..()
+	RegisterSignal(parent, COMSIG_ENTER_AREA, PROC_REF(on_area_entered))
+	RegisterSignal(parent, COMSIG_EXIT_AREA, PROC_REF(on_area_exited))
+
+/datum/component/storm_hating/UnregisterFromParent()
+	. = ..()
+	on_area_exited(parent, get_area(parent))
+	UnregisterSignal(parent, COMSIG_ENTER_AREA)
+	RegisterSignal(parent, COMSIG_EXIT_AREA)
+
+/datum/component/storm_hating/proc/on_area_entered(atom/source, area/new_area)
+	SIGNAL_HANDLER
+	for (var/weather in stormy_weather)
+		RegisterSignal(new_area, COMSIG_WEATHER_BEGAN_IN_AREA(weather), PROC_REF(on_storm_event))
+		RegisterSignal(new_area, COMSIG_WEATHER_ENDED_IN_AREA(weather), PROC_REF(on_storm_event))
+
+/datum/component/storm_hating/proc/on_area_exited(atom/source, area/old_area)
+	SIGNAL_HANDLER
+	for (var/weather in stormy_weather)
+		UnregisterSignal(old_area, COMSIG_WEATHER_BEGAN_IN_AREA(weather))
+		UnregisterSignal(old_area, COMSIG_WEATHER_ENDED_IN_AREA(weather))
+
+/datum/component/storm_hating/proc/on_storm_event()
+	SIGNAL_HANDLER
+	var/atom/parent_atom = parent
+	if (!isturf(parent_atom.loc))
+		return
+	parent.AddElement(/datum/element/temporary_atom, life_time = 3 SECONDS, fade_time = 2 SECONDS)
+	qdel(src)

--- a/code/datums/weather/weather.dm
+++ b/code/datums/weather/weather.dm
@@ -134,6 +134,8 @@
 	send_alert(weather_message, weather_sound)
 	if(!perpetual)
 		addtimer(CALLBACK(src, PROC_REF(wind_down)), weather_duration)
+	for(var/area/impacted_area as anything in impacted_areas)
+		SEND_SIGNAL(impacted_area, COMSIG_WEATHER_BEGAN_IN_AREA(type))
 
 /**
  * Weather enters the winding down phase, stops effects
@@ -165,6 +167,8 @@
 	stage = END_STAGE
 	SSweather.processing -= src
 	update_areas()
+	for(var/area/impacted_area as anything in impacted_areas)
+		SEND_SIGNAL(impacted_area, COMSIG_WEATHER_ENDED_IN_AREA(type))
 
 // handles sending all alerts
 /datum/weather/proc/send_alert(alert_msg, alert_sfx)

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -347,6 +347,10 @@ GLOBAL_LIST_INIT(snow_recipes, list ( \
 	new/datum/stack_recipe("snow tile", /obj/item/stack/tile/mineral/snow, 1, 4, 20, check_density = FALSE, category = CAT_TILES), \
 ))
 
+/obj/item/stack/sheet/mineral/snow/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
+	. = ..()
+	AddComponent(/datum/component/storm_hating)
+
 /obj/item/stack/sheet/mineral/snow/get_main_recipes()
 	. = ..()
 	. += GLOB.snow_recipes

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -112,6 +112,10 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		new /datum/stack_recipe("aesthetic volcanic floor tile", /obj/item/stack/tile/basalt, 2, 1, 50, check_density = FALSE, category = CAT_TILES)\
 ))
 
+/obj/item/stack/ore/glass/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
+	. = ..()
+	AddComponent(/datum/component/storm_hating)
+
 /obj/item/stack/ore/glass/get_main_recipes()
 	. = ..()
 	. += GLOB.sand_recipes

--- a/code/modules/mob/living/basic/lavaland/goliath/goliath_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/goliath_ai.dm
@@ -93,7 +93,7 @@
 
 /// If we got nothing better to do, dig a little hole
 /datum/ai_behavior/goliath_dig
-	action_cooldown = 1 MINUTES
+	action_cooldown = 3 MINUTES
 	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_CAN_PLAN_DURING_EXECUTION
 
 /datum/ai_behavior/goliath_dig/setup(datum/ai_controller/controller, target_key)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1034,6 +1034,7 @@
 #include "code\datums\components\squeak.dm"
 #include "code\datums\components\stationloving.dm"
 #include "code\datums\components\stationstuck.dm"
+#include "code\datums\components\storm_hating.dm"
 #include "code\datums\components\strong_pull.dm"
 #include "code\datums\components\subtype_picker.dm"
 #include "code\datums\components\summoning.dm"


### PR DESCRIPTION
## About The Pull Request

In an earlier PR I made Goliaths dig when they are bored. I still like this behaviour as an ambient thing for them to do, but the consequence is that after 30 minutes there were huge piles of sand all over lavaland.
While convenient for actually having miners bring glass back to the station, it was an eyesore and too much.

To resolve this I have made two changes:
- Goliaths dig 1/3 as often as they did before.
- Sand (and snow) which are left outside during a storm gets blown away if it's not inside someone's inventory.

Together these prevent the accumulation of hundreds of piles of sand.

## Why It's Good For The Game

Fixes an unintended consequence of my actions.

## Changelog

:cl:
add: Uncollected sand and snow will be blown away by the wind when storms happen (but don't worry, storms also allow those turfs to be freshly dug up again).
/:cl: