### PR TITLE
removes mayhem in a bottle as a bubblegum drop

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -124,12 +124,7 @@
 
 /obj/structure/closet/crate/necropolis/bubblegum/PopulateContents()
 	new /obj/item/clothing/suit/hooded/hostile_environment(src)
-	var/loot = rand(1,2)
-	switch(loot)
-		if(1)
-			new /obj/item/mayhem(src)
-		if(2)
-			new /obj/item/soulscythe(src)
+	new /obj/item/soulscythe(src)
 
 /obj/structure/closet/crate/necropolis/bubblegum/crusher
 	name = "bloody bubblegum chest"


### PR DESCRIPTION

## About The Pull Request
This pr will remove mayhem in a bottle as a drop from bubblegum.
## Why It's Good For The Game
Mayhem in a bottle as it stands is a fairly useless drop in its current form. Considering that it's dropped by arguably the most difficult lavaland boss, this shouldn't be the case. As well as the H.E.C.K. armor being worse then it's counterpart the drake armor, you should at least be guaranteed a useful drop.
## Changelog
:cl:
del: removed mayhem in a bottle from bubblegum's loot pool
/:cl:
