### PR TITLE
Makes transparent curtains not block emissives

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -741,6 +741,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink/kitchen, (-16))
 	/// if it can be seen through when closed
 	var/opaque_closed = FALSE
 
+/obj/structure/curtain/Initialize(mapload)
+	// see-through curtains should let emissives shine through
+	if(!opaque_closed)
+		blocks_emissive = EMISSIVE_BLOCK_NONE
+
 /obj/structure/curtain/proc/toggle()
 	open = !open
 	if(open)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -745,7 +745,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink/kitchen, (-16))
 	// see-through curtains should let emissives shine through
 	if(!opaque_closed)
 		blocks_emissive = EMISSIVE_BLOCK_NONE
-	
 	return ..()
 
 /obj/structure/curtain/proc/toggle()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -745,6 +745,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink/kitchen, (-16))
 	// see-through curtains should let emissives shine through
 	if(!opaque_closed)
 		blocks_emissive = EMISSIVE_BLOCK_NONE
+	
+	return ..()
 
 /obj/structure/curtain/proc/toggle()
 	open = !open


### PR DESCRIPTION
## About The Pull Request

What is says on the tin. The base curtain type is partially transparent and should let light through. It's a small detail but I think it makes a difference.

## Why It's Good For The Game

What it looks like (seen with a character wearing a safety vest behind the curtains):

![dreamseeker_5j2folwK0s](https://github.com/tgstation/tgstation/assets/13398309/53c07344-ef35-4d56-acac-c4371ebd0888)

## Changelog

:cl:
fix: non-opaque curtains will no longer block emissives
/:cl:
