### PR TITLE
Gives `flick_visual` `MOUSE_OPACITY_TRANSPARENT`

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -179,6 +179,7 @@
 	// This is faster then pooling. I promise
 	var/atom/movable/flick_visual/visual = new()
 	visual.appearance = passed_appearance
+	visual.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	// I hate /area
 	var/atom/movable/lies_to_children = src
 	lies_to_children.vis_contents += visual


### PR DESCRIPTION
## About The Pull Request

#76937 introduced a temporary movable `flick_visual` to act as an image for overlays and whatnot.
this used to be handled by images and i'm not sure whether images were mouse transparent or were just inheriting parent ID but i'm assuming since images are kinda virtual (from what i know anyway) they don't interrupt clicks.
since flick_visual is an atom, it intercepts mouse clicks, which caused #77142
this PR gives flick_visual `MOUSE_OPACITY_TRANSPARENT` during `flick_overlay_view()`, which makes it no longer intercept clicks

## Why It's Good For The Game

Fixes #77142 and possibly some other things that use that proc to show animations or overlays

## Changelog

:cl:
fix: fixed gibtonite countdown animation interrupting clicks with the mining scanner
/:cl: