### PR TITLE
fixes revolvers losing ammo capacity when you load in ammo

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -375,7 +375,8 @@
 		if (bolt_type == BOLT_TYPE_NO_BOLT || internal_magazine)
 			if (chambered && !chambered.loaded_projectile)
 				chambered.forceMove(drop_location())
-				magazine?.stored_ammo -= chambered
+				if(chambered != magazine?.stored_ammo[1])
+					magazine.stored_ammo -= chambered
 				chambered = null
 			var/num_loaded = magazine?.attackby(A, user, params, TRUE)
 			if (num_loaded)


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/76681

Unfortunately, for revolvers, chambered is whatever is first on the list of stored_ammo rather than that ammo being removed from the magazine. If something works like a revolver does, we don't remove chambered from stored_ammo.

## Why It's Good For The Game

The way revolvers work is literally so that we can have russian roulette, just so you know.

## Changelog
:cl:
fix: Fixes revolvers losing ammo capacity when you reload them.
/:cl:
