### PR TITLE
Puts a cap to the amount of stickers that can be sticked to an atom.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -763,6 +763,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_POSTERBOY "poster_boy"
 #define TRAIT_THROWINGARM "throwing_arm"
 
+///if the atom has a sticker attached to it
+#define TRAIT_STICKERED "stickered"
+
 // Debug traits
 /// This object has light debugging tools attached to it
 #define TRAIT_LIGHTING_DEBUGGED "lighting_debugged"

--- a/code/datums/components/attached_sticker.dm
+++ b/code/datums/components/attached_sticker.dm
@@ -45,6 +45,7 @@
 /datum/component/attached_sticker/proc/peel(atom/source)
 	SIGNAL_HANDLER
 	if(!QDELETED(sticker))
+		var/atom/as_atom = parent
 		sticker.forceMove(isturf(as_atom) ? as_atom : as_atom.drop_location())
 		sticker.pixel_y = rand(-4,1)
 		sticker.pixel_x = rand(-3,3)

--- a/code/datums/components/attached_sticker.dm
+++ b/code/datums/components/attached_sticker.dm
@@ -31,54 +31,46 @@
 		signal_turf = (user && isclosedturf(parent)) ? get_turf(user) : parent
 		RegisterSignal(signal_turf, COMSIG_TURF_EXPOSE, PROC_REF(on_turf_expose))
 	sticker.moveToNullspace()
+	RegisterSignal(sticker, COMSIG_QDELETING, PROC_REF(peel))
 
-///Move sticker item from nullspace, delete this component, cut overlay
-/datum/component/attached_sticker/proc/peel(atom/source)
-	SIGNAL_HANDLER
-	if(!parent) // just in case
-		return
+/datum/component/attached_sticker/Destroy()
 	var/atom/as_atom = parent
 	as_atom.cut_overlay(sticker_overlay)
 	sticker_overlay = null
 	if(sticker)
-		sticker.forceMove(isturf(parent) ? parent : as_atom.drop_location())
+		QDEL_NULL(sticker)
+	return ..()
+
+///Move sticker item from nullspace, delete this component, cut overlay
+/datum/component/attached_sticker/proc/peel(atom/source)
+	SIGNAL_HANDLER
+	if(!QDELETED(sticker))
+		sticker.forceMove(isturf(as_atom) ? as_atom : as_atom.drop_location())
 		sticker.pixel_y = rand(-4,1)
 		sticker.pixel_x = rand(-3,3)
-		sticker = null
+	sticker = null
 	qdel(src)
 
 /datum/component/attached_sticker/RegisterWithParent()
 	if(sticker.resistance_flags & FLAMMABLE)
-		RegisterSignal(parent, COMSIG_LIVING_IGNITED, PROC_REF(on_ignite))
+		RegisterSignal(parent, COMSIG_LIVING_IGNITED, PROC_REF(peel))
 	if(washable)
 		RegisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT, PROC_REF(peel))
-	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(on_attached_qdel))
+	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(peel))
+	ADD_TRAIT(parent, TRAIT_STICKERED, REF(sticker))
 
 /datum/component/attached_sticker/UnregisterFromParent()
-	if(sticker.resistance_flags & FLAMMABLE)
-		UnregisterSignal(parent, list(COMSIG_LIVING_IGNITED, COMSIG_QDELETING))
-		if(signal_turf)
-			UnregisterSignal(signal_turf, COMSIG_TURF_EXPOSE)
-			signal_turf = null
+	UnregisterSignal(parent, list(COMSIG_LIVING_IGNITED, COMSIG_QDELETING))
+	if(signal_turf)
+		UnregisterSignal(signal_turf, COMSIG_TURF_EXPOSE)
+		signal_turf = null
 	if(washable)
 		UnregisterSignal(parent, COMSIG_COMPONENT_CLEAN_ACT)
+	REMOVE_TRAIT(parent, TRAIT_STICKERED, REF(sticker))
 
 ///Signal handler for COMSIG_TURF_EXPOSE, deletes this sticker if the temperature is above 100C and it is flammable
 /datum/component/attached_sticker/proc/on_turf_expose(datum/source, datum/gas_mixture/air, exposed_temperature)
 	SIGNAL_HANDLER
 	if(exposed_temperature <= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		return
-	qdel(sticker)
-	peel()
-
-///Signal handler for COMSIG_LIVING_IGNITED, deletes this sticker
-/datum/component/attached_sticker/proc/on_ignite(datum/source)
-	SIGNAL_HANDLER
-	qdel(sticker)
-	peel()
-
-/// Signal handler for COMSIG_QDELETING, deletes this sticker if the attached object is deleted
-/datum/component/attached_sticker/proc/on_attached_qdel(datum/source)
-	SIGNAL_HANDLER
-	qdel(sticker)
 	peel()

--- a/code/datums/components/attached_sticker.dm
+++ b/code/datums/components/attached_sticker.dm
@@ -50,7 +50,8 @@
 		sticker.pixel_y = rand(-4,1)
 		sticker.pixel_x = rand(-3,3)
 	sticker = null
-	qdel(src)
+	if(!QDELETED(src))
+		qdel(src)
 
 /datum/component/attached_sticker/RegisterWithParent()
 	if(sticker.resistance_flags & FLAMMABLE)

--- a/code/datums/elements/sticker.dm
+++ b/code/datums/elements/sticker.dm
@@ -40,6 +40,7 @@
 ///Add our stick_type to the target with px and py as pixel x and pixel y respectively
 /datum/element/sticker/proc/do_stick(obj/item/source, atom/target, mob/living/user, px, py)
 	if(length(GET_TRAIT_SOURCES(target, TRAIT_STICKERED)) >= MAX_ALLOWED_STICKERS)
+		source.balloon_alert_to_viewers("sticker won't stick")
 		return FALSE
 	target.AddComponent(stick_type, px, py, source, user, washable)
 	return TRUE

--- a/code/datums/elements/sticker.dm
+++ b/code/datums/elements/sticker.dm
@@ -1,3 +1,5 @@
+#define MAX_ALLOWED_STICKERS 12
+
 /datum/element/sticker
 	///The typepath for our attached sticker component
 	var/stick_type = /datum/component/attached_sticker
@@ -9,7 +11,7 @@
 	if(!isitem(target))
 		return ELEMENT_INCOMPATIBLE
 	RegisterSignal(target, COMSIG_ITEM_AFTERATTACK, PROC_REF(on_afterattack))
-	RegisterSignal(target, COMSIG_MOVABLE_IMPACT, PROC_REF(on_throw_impact))	
+	RegisterSignal(target, COMSIG_MOVABLE_IMPACT, PROC_REF(on_throw_impact))
 	if(sticker_type)
 		stick_type = sticker_type
 	washable = cleanable
@@ -32,14 +34,19 @@
 	var/py = text2num(LAZYACCESS(parameters, ICON_Y)) - divided_size
 
 	user.do_attack_animation(target)
-	do_stick(source, target, user, px, py)
+	if(do_stick(source, target, user, px, py))
+		target.balloon_alert_to_viewers("sticker sticked")
 
 ///Add our stick_type to the target with px and py as pixel x and pixel y respectively
 /datum/element/sticker/proc/do_stick(obj/item/source, atom/target, mob/living/user, px, py)
+	if(length(GET_TRAIT_SOURCES(target, TRAIT_STICKERED)) >= MAX_ALLOWED_STICKERS)
+		return FALSE
 	target.AddComponent(stick_type, px, py, source, user, washable)
+	return TRUE
 
 /datum/element/sticker/proc/on_throw_impact(obj/item/source, atom/hit_atom, datum/thrownthing/throwingdatum)
 	SIGNAL_HANDLER
-	if(prob(50))
-		do_stick(source, hit_atom, null, rand(-7,7), rand(-7,7))
-		source.balloon_alert_to_viewers("the sticker lands on its sticky side!")
+	if(prob(50) && do_stick(source, hit_atom, null, rand(-7,7), rand(-7,7)))
+		hit_atom.balloon_alert_to_viewers("sticker landed on sticky side!")
+
+#undef MAX_ALLOWED_STICKERS

--- a/code/datums/elements/sticker.dm
+++ b/code/datums/elements/sticker.dm
@@ -40,7 +40,7 @@
 ///Add our stick_type to the target with px and py as pixel x and pixel y respectively
 /datum/element/sticker/proc/do_stick(obj/item/source, atom/target, mob/living/user, px, py)
 	if(length(GET_TRAIT_SOURCES(target, TRAIT_STICKERED)) >= MAX_ALLOWED_STICKERS)
-		source.balloon_alert_to_viewers("sticker won't stick")
+		source.balloon_alert_to_viewers("sticker won't stick!")
 		return FALSE
 	target.AddComponent(stick_type, px, py, source, user, washable)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
The lack of a limit to the amount of stickers that can be attached on an atom can lead overlays-related issues, as shown in #76987, likely by going past the maximum number of overlays an atom can safely have. 

The cap will be of 12 stickers per atom, an honest amount if you ask me.

Oh yeah, I've also taken the opportunity to improve the code a smidge I guess.

## Why It's Good For The Game
This will fix #76987.

## Changelog

:cl:
fix: Put a cap to the amount of stickers that can be sticked to an atom (12) to prevent icon-related issues.
/:cl:
