### PR TITLE
Fixing the greyscale modify menu not sanitizing inputs.

### DIFF
--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -140,7 +140,7 @@
 	if(href_list[VV_HK_MODIFY_GREYSCALE])
 		if(!check_rights(NONE))
 			return
-		var/datum/greyscale_modify_menu/menu = new(target, usr, SSgreyscale.configurations)
+		var/datum/greyscale_modify_menu/menu = new(target, usr, SSgreyscale.configurations, specific_ui_state = GLOB.always_state)
 		menu.Unlock()
 		menu.ui_interact(usr)
 	if(href_list[VV_HK_CALLPROC])


### PR DESCRIPTION
## About The Pull Request
exactly what it reads on the tin. Also the ui is now anchored to the target and uses their state unless a specific one is set, so that it'll correctly close or be unusable if the mob user is incapacitated or too far.

## Why It's Good For The Game
this will fix #70444.

## Changelog

:cl:
fix: Fixing some jank with the a greyscale modify menu, like inputs not being sanitized.
/:cl:
