### PR TITLE
[no gbp] Hoods will unequip on hoodie removal.

### DIFF
--- a/code/datums/components/toggle_attached_clothing.dm
+++ b/code/datums/components/toggle_attached_clothing.dm
@@ -67,6 +67,7 @@
 	RegisterSignal(parent, COMSIG_ITEM_UI_ACTION_CLICK, PROC_REF(on_toggle_pressed))
 	RegisterSignal(parent, COMSIG_ITEM_UI_ACTION_SLOT_CHECKED, PROC_REF(on_action_slot_checked))
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_parent_equipped))
+	RegisterSignal(parent, COMSIG_ITEM_POST_UNEQUIP, PROC_REF(remove_deployable))
 	RegisterSignal(parent, COMSIG_ITEM_EQUIPPED_AS_OUTFIT, PROC_REF(on_parent_equipped_outfit))
 	if (down_overlay_state_suffix)
 		var/overlay_state = "[initial(clothing_parent.icon_state)][down_overlay_state_suffix]"
@@ -187,6 +188,7 @@
 
 /// Removes our deployed equipment from the wearer
 /datum/component/toggle_attached_clothing/proc/remove_deployable()
+	SIGNAL_HANDLER
 	unequip_deployable()
 	if (!currently_deployed)
 		return


### PR DESCRIPTION
## About The Pull Request

Fixes #77010
Adds a missing event registration to "toggled items", as I apparently didn't consider all means that equipment can be removed from your person (I was mostly testing unequipping it from _myself_).

## Why It's Good For The Game

If someone snatches your jacket they should get the hood too.

## Changelog

:cl:
fix: Losing your hooded suit (whether to theft, or because you were turned into an ape) will also cause you to lose the hood.
/:cl: