### PR TITLE
Piggyback rides no longer permanently remove your density

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -210,7 +210,7 @@
 	unequip_buckle_inhands(parent)
 	var/mob/living/carbon/human/H = parent
 	H.remove_movespeed_modifier(/datum/movespeed_modifier/human_carry)
-	REMOVE_TRAIT(H, TRAIT_UNDENSE, VEHICLE_TRAIT)
+	REMOVE_TRAIT(former_rider, TRAIT_UNDENSE, VEHICLE_TRAIT)
 	return ..()
 
 /// If the carrier shoves the person they're carrying, force the carried mob off


### PR DESCRIPTION
## About The Pull Request

Fixes #77041
Getting onto someone's back would give you "TRAIT_UNDENSE" to stop you from colliding with things your mount could cross.
Getting off someone's back would remove "TRAIT_UNDENSE" from the person being ridden.
They didn't have the trait, so removing it from them wasn't very useful.

## Why It's Good For The Game

This is silly

## Changelog

:cl:
fix: Dismounting from a piggyback no longer allows you to phase through other players.
/:cl:
