### PR TITLE
Removed tails inherit their color

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/cat_surgeon.dm
+++ b/code/modules/mob/living/basic/space_fauna/cat_surgeon.dm
@@ -61,7 +61,6 @@
 	)
 	tail.Remove(attacked)
 	tail.forceMove(drop_location())
-	tail.color = attacked.hair_color
 
 /datum/ai_controller/basic_controller/cat_butcherer
 	blackboard = list(

--- a/code/modules/surgery/organs/external/_external_organ.dm
+++ b/code/modules/surgery/organs/external/_external_organ.dm
@@ -101,6 +101,11 @@
 	if(organ_owner)
 		organ_owner.update_body_parts()
 
+
+/obj/item/organ/external/on_remove(mob/living/carbon/organ_owner, special)
+	. = ..()
+	color = bodypart_overlay.draw_color // so a pink felinid doesn't drop a gray tail
+
 ///Transfers the organ to the limb, and to the limb's owner, if it has one.
 /obj/item/organ/external/transfer_to_limb(obj/item/bodypart/bodypart, mob/living/carbon/bodypart_owner)
 	if(owner)

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -34,12 +34,22 @@
 /obj/item/organ/external/tail/Remove(mob/living/carbon/organ_owner, special, moving)
 	if(wag_flags & WAG_WAGGING)
 		wag(FALSE)
+
+	return ..()
+
+/obj/item/organ/external/tail/on_remove(mob/living/carbon/organ_owner, special)
 	. = ..()
+
 	UnregisterSignal(organ_owner, COMSIG_ORGAN_WAG_TAIL)
 
 	if(type in organ_owner.dna.species.external_organs)
 		organ_owner.add_mood_event("tail_lost", /datum/mood_event/tail_lost)
 		organ_owner.add_mood_event("tail_balance_lost", /datum/mood_event/tail_balance_lost)
+
+	if(bodypart_overlay.color_source == NONE)
+		return
+
+	color = bodypart_overlay.draw_color // so a pink felinid doesn't drop a gray tail
 
 /obj/item/organ/external/tail/proc/wag(mob/user, start = TRUE, stop_after = 0)
 	if(!(wag_flags & WAG_ABLE))

--- a/code/modules/surgery/organs/external/tails.dm
+++ b/code/modules/surgery/organs/external/tails.dm
@@ -46,10 +46,6 @@
 		organ_owner.add_mood_event("tail_lost", /datum/mood_event/tail_lost)
 		organ_owner.add_mood_event("tail_balance_lost", /datum/mood_event/tail_balance_lost)
 
-	if(bodypart_overlay.color_source == NONE)
-		return
-
-	color = bodypart_overlay.draw_color // so a pink felinid doesn't drop a gray tail
 
 /obj/item/organ/external/tail/proc/wag(mob/user, start = TRUE, stop_after = 0)
 	if(!(wag_flags & WAG_ABLE))


### PR DESCRIPTION

## About The Pull Request

Hey there,

![image](https://github.com/tgstation/tgstation/assets/34697715/5fe5d71a-de67-463c-8381-b094d09d21a3)

Something that was pissing me off was that tails weren't inheriting the color when they were removed from a carbon. I actually did a bit of chicanery in cat surgeon code so I wouldn't be so pissed off about it, but I think now is the time to fix it for real.
## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/34697715/53b1fb5a-3487-4649-866a-f5d83736d951)

Much better. I also got rid of one of my pet peeves since I decided to do this in `on_remove()` (nothing should break as a consequence, though let me know if anything looks cringe) and was able to remove the fugly override of parent on `Remove()` which didn't need to be like that at all
## Changelog
:cl:
fix: Carbons with tails (felinids, lizards) who have that tail removed will now have that tail actually look like it came from the person in question, rather than just be a grey thing of sadness.
/:cl:
