### PR TITLE
[NO GBP] fixes the logic for mob size-related maptext height.

### DIFF
--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -20,7 +20,7 @@
 		current_size *= resize
 		//Update the height of the maptext according to the size of the mob so they don't overlap.
 		var/old_maptext_offset = body_maptext_height_offset
-		body_maptext_height_offset = initial(maptext_height) * (current_size - 1)
+		body_maptext_height_offset = initial(maptext_height) * (current_size - 1) * 0.5
 		maptext_height += body_maptext_height_offset - old_maptext_offset
 		//Update final_pixel_y so our mob doesn't go out of the southern bounds of the tile when standing
 		if(!lying_angle || !rotate_on_lying) //But not if the mob has been rotated.


### PR DESCRIPTION
## About The Pull Request
I've made a hiccup in the logic at the last moment and forgot that the offset should be half of the size difference from trom the default identity, not its entirety,  this is because scaling is equally distributed vertically and horizontally, we only have to deal with the upper half of it.

## Why It's Good For The Game
Fixing a human error.

## Changelog
N/A, it's a barely noticeable whoopsie all in all.