### PR TITLE
Fixes anomaly research ruin failing compile maps

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
@@ -1456,8 +1456,6 @@
 "MJ" = (
 /turf/closed/wall/r_wall,
 /area/misc/anomaly_research)
-"MM" = (
-)
 "MN" = (
 /obj/structure/flora/grass/green/style_random,
 /obj/machinery/light/floor,
@@ -3281,7 +3279,7 @@ Iw
 Iw
 iq
 Iw
-MM
+tG
 xQ
 AV
 nA
@@ -3355,7 +3353,7 @@ kY
 oK
 ip
 ii
-MM
+tG
 Iw
 fe
 YA
@@ -3393,7 +3391,7 @@ Gr
 mC
 nh
 cA
-MM
+tG
 ZL
 Ng
 Ox
@@ -3509,7 +3507,7 @@ ut
 cA
 Cf
 sE
-MM
+tG
 xQ
 AV
 jN

--- a/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/anomaly_research.dmm
@@ -731,6 +731,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
 /area/misc/anomaly_research)
+"tG" = (
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white,
+/area/misc/anomaly_research)
 "tK" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -1451,6 +1456,8 @@
 "MJ" = (
 /turf/closed/wall/r_wall,
 /area/misc/anomaly_research)
+"MM" = (
+)
 "MN" = (
 /obj/structure/flora/grass/green/style_random,
 /obj/machinery/light/floor,
@@ -2967,7 +2974,7 @@ rX
 xo
 xo
 aX
-ek
+tG
 Cl
 xE
 xE
@@ -3005,7 +3012,7 @@ Ew
 AV
 lL
 QP
-ek
+tG
 Cl
 xE
 xE
@@ -3043,7 +3050,7 @@ QI
 AV
 SQ
 Iw
-ek
+tG
 Cl
 Cl
 AV
@@ -3082,8 +3089,8 @@ AV
 wz
 Iw
 Ov
-ek
-ek
+tG
+tG
 AV
 Ya
 xE
@@ -3121,7 +3128,7 @@ GI
 Iw
 iK
 wg
-ek
+tG
 AV
 Ya
 xE
@@ -3159,7 +3166,7 @@ ok
 Iw
 uB
 oq
-ek
+tG
 AV
 Ya
 xE
@@ -3197,7 +3204,7 @@ sg
 Iw
 hU
 Ia
-ek
+tG
 AV
 Ya
 Ya
@@ -3274,7 +3281,7 @@ Iw
 Iw
 iq
 Iw
-Bc
+MM
 xQ
 AV
 nA
@@ -3348,7 +3355,7 @@ kY
 oK
 ip
 ii
-ek
+MM
 Iw
 fe
 YA
@@ -3386,7 +3393,7 @@ Gr
 mC
 nh
 cA
-ek
+MM
 ZL
 Ng
 Ox
@@ -3502,7 +3509,7 @@ ut
 cA
 Cf
 sE
-ek
+MM
 xQ
 AV
 jN


### PR DESCRIPTION

## About The Pull Request

There was a group of invalid keys which resulted in blank tiles, this was easy enough to fix.
## Why It's Good For The Game

I'd imagine prs passing linters and compile maps is a little important.
## Changelog
:cl:
fix: The anomaly research ruin is no longer missing several tiles on the inside to the void
/:cl:
