### PR TITLE
Module duplicator has cheaper costs for circuit duplication

### DIFF
--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -312,9 +312,9 @@
 
 	///The internal material bus
 	var/datum/component/remote_materials/materials
-	//List of designs scanned and saved
+	///List of designs scanned and saved
 	var/list/scanned_designs = list()
-	//Constant material cost per component
+	///Constant material cost per component
 	var/cost_per_component = HALF_SHEET_MATERIAL_AMOUNT
 	///Cost efficiency of this machine
 	var/efficiency_coeff = 1

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -308,16 +308,15 @@
 	icon = 'icons/obj/machines/wiremod_fab.dmi'
 	icon_state = "module-fab-idle"
 	circuit = /obj/item/circuitboard/machine/module_duplicator
-
-	/// The internal material bus
-	var/datum/component/remote_materials/materials
-
 	density = TRUE
 
+	///The internal material bus
+	var/datum/component/remote_materials/materials
+	//List of designs scanned and saved
 	var/list/scanned_designs = list()
-
-	var/cost_per_component = 1000
-
+	//Constant material cost per component
+	var/cost_per_component = HALF_SHEET_MATERIAL_AMOUNT
+	///Cost efficiency of this machine
 	var/efficiency_coeff = 1
 
 /obj/machinery/module_duplicator/Initialize(mapload)

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -315,7 +315,7 @@
 	///List of designs scanned and saved
 	var/list/scanned_designs = list()
 	///Constant material cost per component
-	var/cost_per_component = HALF_SHEET_MATERIAL_AMOUNT
+	var/cost_per_component = SHEET_MATERIAL_AMOUNT / 10
 	///Cost efficiency of this machine
 	var/efficiency_coeff = 1
 


### PR DESCRIPTION
## About The Pull Request
Fixes #77158

> this is pretty clearly a relic of the resource cost rebalance.

Yes it is. `cost_per_component` var had a fixed value of 1000. Now it's value is 1 /10th of `SHEET_MATERIAL_AMOUNT `

Also added some autodocs for vars

## Changelog
:cl:
fix: Module duplicator has cheaper costs for circuit duplication
/:cl: