### PR TITLE
Fix timeline jumper MOD module not updating stamina on jaunt

### DIFF
--- a/code/modules/mod/modules/modules_timeline.dm
+++ b/code/modules/mod/modules/modules_timeline.dm
@@ -173,7 +173,7 @@
 		//phasing out
 		mod.visible_message(span_warning("[mod.wearer] leaps out of the timeline!"))
 		mod.wearer.SetAllImmobility(0)
-		mod.wearer.setStaminaLoss(0, 0)
+		mod.wearer.setStaminaLoss(0)
 		phased_mob = new(get_turf(mod.wearer.loc), mod.wearer)
 		RegisterSignal(mod, COMSIG_MOD_ACTIVATE, PROC_REF(on_activate_block))
 	else


### PR DESCRIPTION

## About The Pull Request
Fixes #77152 
updating_stamina was set to 0 in the jaunt's setStaminaLoss for some reason, this PR fixes that
## Why It's Good For The Game
It's a bugfix
## Changelog
:cl:
fix: Using the timeline jumper MOD module updates stamina after resetting it, no more infinite stamcrits
/:cl:
