### PR TITLE
Adds advanced insulated gloves to cargo

### DIFF
--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -314,3 +314,11 @@
 	)
 	crate_name = "radioactive nebula shielding (IMPORTANT)"
 	crate_type = /obj/structure/closet/crate/engineering
+
+/datum/supply_pack/engineering/Advanced_Insulated_Gloves	
+	name = "Advanced Insulated Gloves Crate"
+	desc = "Contains 2 pairs of advanced insulated gloves. Shockproof, fireproof and does not encumber your fingers to boot! Unlike regular gloves"
+	cost = CARGO_CRATE_VALUE * 20
+	contains = list(/obj/item/clothing/gloves/chief_engineer = 2)
+	crate_name = "advanced insulated gloves crate"
+	crate_type = /obj/structure/closet/crate/engineering


### PR DESCRIPTION


## About The Pull Request

This Pr adds the ability to buy advanced insulated gloves from cargo, Please be patient with me, this is my first pull request and im new to coding. (And i have no idea what price i gave the gloves crate)

## Why It's Good For The Game

Advanced insuls are currently a very poor example of head of staff equipment as stated by john Willard in #59381 where people play CE mostly for the gamer insulated gloves.

By adding the ability to obtain advanced insulated gloves through cargo, there'll hopefully be less people playing CE just for the gloves. This also contributes to desirable items obtainable at cargo, hopefully increasing foot traffic and getting cargo visited more often for purchases

Advanced insuls are also quite scarce, leading to potentially theft and fights over it, hopefully the addition of it to cargo decentralizes it from being CE exclusive gear while also maintain it's rarity and highly coveted status


I can tweak with the prices and quantity, be patient im new.
## Changelog



:cl:
add: You can buy advanced insulated gloves from cargo.

/:cl:
