### PR TITLE
Fixes a bug with pAI leashing

### DIFF
--- a/code/datums/components/leash.dm
+++ b/code/datums/components/leash.dm
@@ -138,6 +138,7 @@
 
 		if (!movable_parent.Move(to_move))
 			force_teleport_back("bad path step")
+			performing_path_move = FALSE
 			return
 
 	if (get_dist(parent, owner) > distance)


### PR DESCRIPTION
## About The Pull Request

If a path can't be found to move back to, the pAI can get stuck in the `performing_path_move` state permanently--which lets them bypass all movement checks, essentially making them unleashed. This makes sure that this does not happen.

## Why It's Good For The Game

Fixes a bug

## Changelog

:cl:
fix: fixed a bug that would cause pAIs to be able to break their leash
/:cl:
