### PR TITLE
Bluespace MOD Storage can now hold bulky storage items.

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -14,6 +14,8 @@
 	var/max_combined_w_class = 15
 	/// Max amount of items in the storage.
 	var/max_items = 7
+	/// Is nesting same-size items allowed?
+	var/big_nesting = FALSE
 
 /obj/item/mod/module/storage/Initialize(mapload)
 	. = ..()
@@ -24,6 +26,7 @@
 /obj/item/mod/module/storage/on_install()
 	var/datum/storage/modstorage = mod.create_storage(max_specific_storage = max_w_class, max_total_storage = max_combined_w_class, max_slots = max_items)
 	modstorage.set_real_location(src)
+	modstorage.allow_big_nesting = big_nesting
 	atom_storage.locked = STORAGE_NOT_LOCKED
 	RegisterSignal(mod.chestplate, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(on_chestplate_unequip))
 
@@ -83,6 +86,7 @@
 	max_w_class = WEIGHT_CLASS_GIGANTIC
 	max_combined_w_class = 60
 	max_items = 21
+	big_nesting = TRUE
 
 ///Ion Jetpack - Lets the user fly freely through space using battery charge.
 /obj/item/mod/module/jetpack

--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -14,7 +14,7 @@
 	var/max_combined_w_class = 15
 	/// Max amount of items in the storage.
 	var/max_items = 7
-	/// Is nesting same-size items allowed?
+	/// Is nesting same-size storage items allowed?
 	var/big_nesting = FALSE
 
 /obj/item/mod/module/storage/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

The admin-only bluespace MOD storage can now hold bulky storage items (backpacks, belts) without needing a varedit to do so, kinda like the bag of holding can do.

Is this even a rebalance if it's very likely an oversight on an admin-only item?

## Why It's Good For The Game

The bluespace MOD storage is pretty much just a super snowflakey bag of holding for modsuits, so this brings it more in line.

## Changelog

:cl:
balance: The bluespace MOD storage can now hold bulky storage items (backpacks, toolbelts) just like the bag of holding.
/:cl: