### PR TITLE
pAIs can be inserted into a MODsuit

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -362,7 +362,8 @@
 		being = card.AI // why is this one capitalized and the other one not? i wish i knew.
 	else if(istype(potential_storage, /obj/item/mod/control))
 		var/obj/item/mod/control/suit = potential_storage
-		being = suit.ai
+		if(isAI(suit.ai_assistant))
+			being = suit.ai_assistant
 	else
 		stack_trace("check_special_completion() called on [src] with [potential_storage] ([potential_storage.type])! That's not supposed to happen!")
 		return FALSE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -296,13 +296,15 @@
 
 	LAZYADD(actions, action)
 	RegisterSignal(action, COMSIG_QDELETING, PROC_REF(on_action_deleted))
-	if(ismob(loc))
-		// We're being held or are equipped by someone while adding an action?
-		// Then they should also probably be granted the action, given it's in a correct slot
-		var/mob/holder = loc
-		give_item_action(action, holder, holder.get_slot_by_item(src))
-
+	grant_action_to_bearer(action)
 	return action
+
+/// Grant the action to anyone who has this item equipped to an appropriate slot
+/obj/item/proc/grant_action_to_bearer(datum/action/action)
+	if(!ismob(loc))
+		return
+	var/mob/holder = loc
+	give_item_action(action, holder, holder.get_slot_by_item(src))
 
 /// Removes an instance of an action from our list of item actions.
 /obj/item/proc/remove_item_action(datum/action/action)

--- a/code/modules/mod/mod_activation.dm
+++ b/code/modules/mod/mod_activation.dm
@@ -70,6 +70,9 @@
 
 /// Deploys a part of the suit onto the user.
 /obj/item/mod/control/proc/deploy(mob/user, obj/item/part)
+	if(!wearer)
+		playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
+		return FALSE // pAI is trying to deploy it from your hands
 	if(part.loc != src)
 		if(!user)
 			return FALSE
@@ -157,6 +160,8 @@
 		module.on_deactivation(display_message = FALSE)
 	activating = TRUE
 	to_chat(wearer, span_notice("MODsuit [active ? "shutting down" : "starting up"]."))
+	if (ai_assistant)
+		to_chat(ai_assistant, span_notice("MODsuit [active ? "shutting down" : "starting up"]."))
 	if(do_after(wearer, activation_step_time, wearer, MOD_ACTIVATION_STEP_FLAGS, extra_checks = CALLBACK(src, PROC_REF(has_wearer))))
 		to_chat(wearer, span_notice("[boots] [active ? "relax their grip on your legs" : "seal around your feet"]."))
 		playsound(src, 'sound/mecha/mechmove03.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
@@ -175,8 +180,8 @@
 		seal_part(helmet, seal = !active)
 	if(do_after(wearer, activation_step_time, wearer, MOD_ACTIVATION_STEP_FLAGS, extra_checks = CALLBACK(src, PROC_REF(has_wearer))))
 		to_chat(wearer, span_notice("Systems [active ? "shut down. Parts unsealed. Goodbye" : "started up. Parts sealed. Welcome"], [wearer]."))
-		if(ai)
-			to_chat(ai, span_notice("<b>SYSTEMS [active ? "DEACTIVATED. GOODBYE" : "ACTIVATED. WELCOME"]: \"[ai]\"</b>"))
+		if(ai_assistant)
+			to_chat(ai_assistant, span_notice("<b>SYSTEMS [active ? "DEACTIVATED. GOODBYE" : "ACTIVATED. WELCOME"]: \"[ai_assistant]\"</b>"))
 		finish_activation(on = !active)
 		if(active)
 			playsound(src, 'sound/machines/synth_yes.ogg', 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, frequency = 6000)

--- a/code/modules/mod/mod_ai.dm
+++ b/code/modules/mod/mod_ai.dm
@@ -88,6 +88,7 @@
 	pai_assistant.can_holo = FALSE
 	if (pai_assistant.holoform)
 		pai_assistant.fold_in()
+	SStgui.close_uis(card)
 	on_gained_assistant(card.pai)
 	return TRUE
 

--- a/code/modules/mod/mod_ai.dm
+++ b/code/modules/mod/mod_ai.dm
@@ -7,36 +7,25 @@
 		return
 	switch(interaction)
 		if(AI_TRANS_TO_CARD)
-			if(!ai)
+			if(!ai_assistant)
 				balloon_alert(user, "no ai in suit!")
 				return
 			balloon_alert(user, "transferring to card...")
 			if(!do_after(user, 5 SECONDS, target = src))
 				balloon_alert(user, "interrupted!")
 				return
-			if(!ai)
+			if(!ai_assistant)
+				balloon_alert(user, "no ai in suit!")
 				return
-			intAI = ai
-			intAI.ai_restore_power()//So the AI initially has power.
-			intAI.control_disabled = TRUE
-			intAI.radio_enabled = FALSE
-			intAI.disconnect_shell()
-			intAI.forceMove(card)
-			card.AI = intAI
-			for(var/datum/action/action as anything in actions)
-				action.Remove(intAI)
-			intAI.controlled_equipment = null
-			intAI.remote_control = null
-			balloon_alert(intAI, "transferred to a card")
 			balloon_alert(user, "ai transferred to card")
-			ai = null
+			ai_exit_mod(card)
 
 		if(AI_TRANS_FROM_CARD) //Using an AI card to upload to the suit.
 			intAI = card.AI
 			if(!intAI)
 				balloon_alert(user, "no ai in card!")
 				return
-			if(ai)
+			if(ai_assistant)
 				balloon_alert(user, "already has ai!")
 				return
 			if(intAI.deployed_shell) //Recall AI if shelled so it can be checked for a client
@@ -48,12 +37,13 @@
 			if(!do_after(user, 5 SECONDS, target = src))
 				balloon_alert(user, "interrupted!")
 				return
-			if(ai)
+			if(ai_assistant)
 				return
 			balloon_alert(user, "ai transferred to suit")
 			ai_enter_mod(intAI)
 			card.AI = null
 
+/// Place an AI in control of your suit functions
 /obj/item/mod/control/proc/ai_enter_mod(mob/living/silicon/ai/new_ai)
 	new_ai.control_disabled = FALSE
 	new_ai.radio_enabled = TRUE
@@ -62,10 +52,79 @@
 	new_ai.controlled_equipment = src
 	new_ai.remote_control = src
 	new_ai.forceMove(src)
-	ai = new_ai
-	balloon_alert(new_ai, "transferred to a suit")
+	on_gained_assistant(new_ai)
+
+/// Remove an AI's control of your suit functions
+/obj/item/mod/control/proc/ai_exit_mod(obj/item/aicard/card)
+	var/mob/living/silicon/ai/old_ai = ai_assistant
+	old_ai.ai_restore_power()//So the AI initially has power.
+	old_ai.control_disabled = TRUE
+	old_ai.radio_enabled = FALSE
+	old_ai.disconnect_shell()
+	old_ai.forceMove(card)
+	card.AI = old_ai
+	old_ai.controlled_equipment = null
+	on_removed_assistant(old_ai)
+
+/// Place a pAI in control of your suit functions
+/obj/item/mod/control/proc/insert_pai(mob/user, obj/item/pai_card/card)
+	if (!isnull(ai_assistant))
+		balloon_alert(user, "slot occupied!")
+		return FALSE
+	if (isnull(card.pai?.mind))
+		balloon_alert(user, "pAI unresponsive!")
+		return FALSE
+	balloon_alert(user, "transferring to suit...")
+	if (!do_after(user, 5 SECONDS, target = src))
+		balloon_alert(user, "interrupted!")
+		return FALSE
+	if (!user.transferItemToLoc(card, src))
+		balloon_alert(user, "transfer failed!")
+		return FALSE
+	balloon_alert(user, "pAI transferred to suit")
+	var/mob/living/silicon/pai/pai_assistant = card.pai
+	pai_assistant.can_transmit = TRUE
+	pai_assistant.can_receive = TRUE
+	pai_assistant.can_holo = FALSE
+	if (pai_assistant.holoform)
+		pai_assistant.fold_in()
+	on_gained_assistant(card.pai)
+	return TRUE
+
+/// Removes pAI control from a modsuit
+/obj/item/mod/control/proc/remove_pai(mob/user, forced = FALSE)
+	if (isnull(ai_assistant))
+		balloon_alert(user, "no pAI!")
+		return FALSE
+	if (!forced)
+		if (!open)
+			balloon_alert(user, "suit panel closed!")
+			return FALSE
+		balloon_alert(user, "uninstalling card...")
+		if (!do_after(user, 5 SECONDS, target = src))
+			balloon_alert(user, "interrupted!")
+			return FALSE
+
+	balloon_alert(user, "pAI removed from suit")
+	var/mob/living/silicon/pai/pai_helper = ai_assistant
+	pai_helper.can_holo = TRUE
+	pai_helper.card.forceMove(get_turf(src))
+	on_removed_assistant()
+
+/// Called when a new ai assistant is inserted
+/obj/item/mod/control/proc/on_gained_assistant(mob/living/silicon/new_helper)
+	ai_assistant = new_helper
+	balloon_alert(new_helper, "transferred to a suit")
 	for(var/datum/action/action as anything in actions)
-		action.Grant(new_ai)
+		action.Grant(new_helper)
+
+/// Called when an existing ai assistant is removed
+/obj/item/mod/control/proc/on_removed_assistant()
+	for(var/datum/action/action as anything in actions)
+		action.Remove(ai_assistant)
+	ai_assistant.remote_control = null
+	balloon_alert(ai_assistant, "transferred to a card")
+	ai_assistant = null
 
 #define MOVE_DELAY 2
 #define WEARER_DELAY 1
@@ -74,7 +133,7 @@
 #define AI_FALL_TIME (1 SECONDS)
 
 /obj/item/mod/control/relaymove(mob/user, direction)
-	if((!active && wearer) || get_charge() < CHARGE_PER_STEP  || user != ai || !COOLDOWN_FINISHED(src, cooldown_mod_move) || (wearer?.pulledby?.grab_state > GRAB_PASSIVE))
+	if((!active && wearer) || get_charge() < CHARGE_PER_STEP  || user != ai_assistant || !COOLDOWN_FINISHED(src, cooldown_mod_move) || (wearer?.pulledby?.grab_state > GRAB_PASSIVE))
 		return FALSE
 	var/timemodifier = MOVE_DELAY * (ISDIAGONALDIR(direction) ? sqrt(2) : 1) * (wearer ? WEARER_DELAY : LONE_DELAY)
 	if(wearer && !wearer.Process_Spacemove(direction))
@@ -111,8 +170,10 @@
 
 /obj/item/mod/ai_minicard/Initialize(mapload, mob/living/silicon/ai/ai)
 	. = ..()
-	if(!ai)
+	if(isnull(ai))
 		return
+	ai.controlled_equipment = null
+	ai.remote_control = null
 	ai.apply_damage(150, BURN)
 	INVOKE_ASYNC(ai, TYPE_PROC_REF(/mob/living/silicon/ai, death))
 	ai.forceMove(src)

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -82,8 +82,8 @@
 	var/list/modules = list()
 	/// Currently used module.
 	var/obj/item/mod/module/selected_module
-	/// AI mob inhabiting the MOD.
-	var/mob/living/silicon/ai/ai
+	/// AI or pAI mob inhabiting the MOD.
+	var/mob/living/silicon/ai_assistant
 	/// Delay between moves as AI.
 	var/static/movedelay = 0
 	/// Cooldown for AI moves.
@@ -184,13 +184,14 @@
 		var/obj/item/overslot = overslotting_parts[part]
 		overslot.forceMove(drop_location())
 		overslotting_parts[part] = null
-	if(ai)
-		ai.controlled_equipment = null
-		ai.remote_control = null
-		for(var/datum/action/action as anything in actions)
-			if(action.owner == ai)
-				action.Remove(ai)
-		new /obj/item/mod/ai_minicard(drop_location(), ai)
+	if(ai_assistant)
+		if(ispAI(ai_assistant))
+			INVOKE_ASYNC(src, PROC_REF(remove_pai), /* user = */ null, /* forced = */ TRUE) // async to appease spaceman DMM because the branch we don't run has a do_after
+		else
+			for(var/datum/action/action as anything in actions)
+				if(action.owner == ai_assistant)
+					action.Remove(ai_assistant)
+			new /obj/item/mod/ai_minicard(drop_location(), ai_assistant)
 	return ..()
 
 /obj/item/mod/control/examine(mob/user)
@@ -212,10 +213,10 @@
 			. += span_notice("You could remove [core] with a <b>wrench</b>.")
 		else
 			. += span_notice("You could use a <b>MOD core</b> on it to install one.")
-		if(ai)
-			. += span_notice("You could remove [ai] with an <b>intellicard</b>.")
-		else
-			. += span_notice("You could install an AI with an <b>intellicard</b>.")
+		if(isnull(ai_assistant))
+			. += span_notice("You could install an AI or pAI using their <b>storage card</b>.")
+		else if(isAI(ai_assistant))
+			. += span_notice("You could remove [ai_assistant] with an <b>intellicard</b>.")
 	. += span_notice("<i>You could examine it more thoroughly...</i>")
 
 /obj/item/mod/control/examine_more(mob/user)
@@ -254,6 +255,13 @@
 /obj/item/mod/control/item_action_slot_check(slot)
 	if(slot & slot_flags)
 		return TRUE
+
+// Grant pinned actions to pin owners, gives AI pinned actions to the AI and not the wearer
+/obj/item/mod/control/grant_action_to_bearer(datum/action/action)
+	if (!istype(action, /datum/action/item_action/mod/pinned_module))
+		return ..()
+	var/datum/action/item_action/mod/pinned_module/pinned = action
+	give_item_action(action, pinned.pinner, slot_flags)
 
 /obj/item/mod/control/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
 	. = ..()
@@ -306,7 +314,8 @@
 	return ..()
 
 /obj/item/mod/control/screwdriver_act(mob/living/user, obj/item/screwdriver)
-	if(..())
+	. = ..()
+	if(.)
 		return TRUE
 	if(active || activating || ai_controller)
 		balloon_alert(user, "deactivate suit first!")
@@ -356,6 +365,12 @@
 	return FALSE
 
 /obj/item/mod/control/attackby(obj/item/attacking_item, mob/living/user, params)
+	if(istype(attacking_item, /obj/item/pai_card))
+		if(!open)
+			balloon_alert(user, "open the cover first!")
+			return FALSE
+		insert_pai(user, attacking_item)
+		return TRUE
 	if(istype(attacking_item, /obj/item/mod/module))
 		if(!open)
 			balloon_alert(user, "open the cover first!")

--- a/code/modules/mod/mod_ui.dm
+++ b/code/modules/mod/mod_ui.dm
@@ -12,7 +12,9 @@
 		"cell_charge_current" = get_charge(),
 		"cell_charge_max" = get_max_charge(),
 		"active" = active,
-		"ai_name" = ai?.name,
+		"ai_name" = ai_assistant?.name,
+		"has_pai" = ispAI(ai_assistant),
+		"is_ai" = ai_assistant && ai_assistant == user,
 		// Wires
 		"open" = open,
 		"seconds_electrified" = seconds_electrified,
@@ -65,11 +67,16 @@
 	data["boots"] = boots?.name
 	return data
 
+/obj/item/mod/control/ui_state(mob/user)
+	if(user == ai_assistant)
+		return GLOB.contained_state
+	return ..()
+
 /obj/item/mod/control/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
 	if(.)
 		return
-	if(locked && !allowed(usr))
+	if(locked && (!allowed(usr) || !ispAI(usr))) // pAIs automatically fail out of allowed()
 		balloon_alert(usr, "insufficient access!")
 		playsound(src, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
 		return
@@ -97,4 +104,8 @@
 			if(!module)
 				return
 			module.pin(usr)
+		if("eject_pai")
+			if (!ishuman(usr))
+				return
+			remove_pai(usr)
 	return TRUE

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -257,8 +257,8 @@
 	. = ..()
 	if(. != MOD_CANCEL_ACTIVATE || !isliving(user))
 		return
-	if(mod.ai == user)
-		to_chat(mod.ai, span_danger("<B>fATaL EERRoR</B>: 381200-*#00CODE <B>BLUE</B>\nAI INTErFERenCE DEtECted\nACTi0N DISrEGArdED"))
+	if(mod.ai_assistant == user)
+		to_chat(mod.ai_assistant, span_danger("<B>fATaL EERRoR</B>: 381200-*#00CODE <B>BLUE</B>\nAI INTErFERenCE DEtECted\nACTi0N DISrEGArdED"))
 		return
 	var/mob/living/living_user = user
 	to_chat(living_user, span_danger("<B>fATaL EERRoR</B>: 382200-*#00CODE <B>RED</B>\nUNAUTHORIZED USE DETECteD\nCoMMENCING SUB-R0UTIN3 13...\nTERMInATING U-U-USER..."))

--- a/tgui/packages/tgui/interfaces/MODsuit.tsx
+++ b/tgui/packages/tgui/interfaces/MODsuit.tsx
@@ -33,6 +33,8 @@ type SuitStatus = {
   complexity: number;
   selected_module: string;
   ai_name: string;
+  has_pai: boolean;
+  is_ai: boolean;
 };
 
 type UserStatus = {
@@ -313,6 +315,8 @@ const SuitStatusSection = (props, context) => {
     malfunctioning,
     locked,
     ai_name,
+    has_pai,
+    is_ai,
   } = data.suit_status;
   const { display_time, shift_time, shift_id } = data.module_custom_status;
   const status = malfunctioning
@@ -384,7 +388,16 @@ const SuitStatusSection = (props, context) => {
           </LabeledList.Item>
         )}
         {!!ai_name && (
-          <LabeledList.Item label="AI Core">{ai_name}</LabeledList.Item>
+          <LabeledList.Item label="pAI Control">
+            {has_pai && (
+              <Button
+                icon="eject"
+                content="Eject pAI"
+                disabled={is_ai}
+                onClick={() => act('eject_pai')}
+              />
+            )}
+          </LabeledList.Item>
         )}
       </LabeledList>
 
@@ -409,8 +422,8 @@ const HardwareSection = (props, context) => {
   return (
     <Section title="Hardware" style={{ 'text-transform': 'capitalize' }}>
       <LabeledList>
-        <LabeledList.Item label="AI Card">
-          {ai_name || 'No AI Card Detected'}
+        <LabeledList.Item label="AI Assistant">
+          {ai_name || 'No AI Detected'}
         </LabeledList.Item>
         <LabeledList.Item label="Core">
           {core_name || 'No Core Detected'}


### PR DESCRIPTION
## About The Pull Request

Ressurects this old concept from (#64530), if we're making pAIs conform to being personal assistants more often then they should be better at assisting your person.

You can insert a pAI into a MODsuit simply by using the card on a MODsuit with an open panel. You can eject it again from the MODsuit control panel UI (though the maintenance panel still needs to be unscrewed).

Inserted pAIs can:
- Deploy and undeploy suit parts.
- Turn the suit on and off.
- Monitor any stats on the MODsuit panel.
- Activate any of your suit actions.

Inserted pAIs cannot:
- Move the suit.

This does not remove the ability to place AIs into your suit. AIs can do all of the above but can _also_ move the suit around while you are critically injured.
You can't have _both_ an AI and a pAI in your suit at the same time.

Additionally I had to mess around with the backend for pinning actions a little bit.
AIs who tried to pin MODsuit actions to their screen would pin them to the UI of the person wearing the suit instead, because it passed through `grant_item_action`. We _want_ to use that interface for the other stuff it does, but we need to catch and override who is _actually_ being granted the action so it goes to the person who pinned it rather than the person wearing the suit.

## Why It's Good For The Game

Gives more things for your pAI to do, now you can delegate manging some suit functions to your little buddy.

## Changelog

:cl:
add: pAIs can be inserted into MODsuits and can control suit modules (but are not capable of moving the suit).
fix: AIs/pAIs in MODsuits can properly pin actions
/:cl:
