### PR TITLE
Adds in the Tactical Deniability Implant for nukeops.

### DIFF
--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -182,7 +182,7 @@
 
 /obj/item/implant/explosive/deniability
 	name = "tactical deniability implant"
-	desc = "An enchanced version of the microbomb that directly plugs into the brain. No downsides, promise!"
+	desc = "An enhanced version of the microbomb that directly plugs into the brain. No downsides, promise!"
 	delay = 10 SECONDS
 	panic_beep_sound = TRUE
 	no_paralyze = TRUE

--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -169,7 +169,7 @@
 		imp_in.gib(TRUE)
 	qdel(src)
 
-//Macrobomb has the strength and delay of 10 microbombs
+///Macrobomb has the strength and delay of 10 microbombs
 /obj/item/implant/explosive/macro
 	name = "macrobomb implant"
 	desc = "And boom goes the weasel. And everything else nearby."
@@ -179,7 +179,7 @@
 	explosion_heavy = 10 * MICROBOMB_EXPLOSION_HEAVY
 	explosion_devastate = 10 * MICROBOMB_EXPLOSION_DEVASTATE
 
-//Microbomb which prevents you from going into critical condition but also explodes after a timer when you reach critical condition in the first place.
+///Microbomb which prevents you from going into critical condition but also explodes after a timer when you reach critical condition in the first place.
 /obj/item/implant/explosive/deniability
 	name = "tactical deniability implant"
 	desc = "An enhanced version of the microbomb that directly plugs into the brain. No downsides, promise!"

--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -79,11 +79,7 @@
 	message_admins("[ADMIN_LOOKUPFLW(imp_in)] has activated their [name] at [ADMIN_VERBOSEJMP(boomturf)], with cause of [cause].")
 	//If the delay is shorter or equal to the default delay, just blow up already jeez
 	if(delay <= MICROBOMB_DELAY)
-		explosion(src, devastation_range = explosion_devastate, heavy_impact_range = explosion_heavy, light_impact_range = explosion_light, flame_range = explosion_light, flash_range = explosion_light, explosion_cause = src)
-		if(imp_in)
-			imp_in.investigate_log("has been gibbed by an explosive implant.", INVESTIGATE_DEATHS)
-			imp_in.gib(TRUE)
-		qdel(src)
+		explode()
 		return
 	timed_explosion()
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -366,6 +366,12 @@
 /obj/item/storage/box/syndie_kit/imp_macrobomb/PopulateContents()
 	new /obj/item/implanter/explosive_macro(src)
 
+/obj/item/storage/box/syndie_kit/imp_deniability
+	name = "tactical deniability implant box"
+
+/obj/item/storage/box/syndie_kit/imp_deniability/PopulateContents()
+	new /obj/item/implanter/tactical_deniability(src)
+
 /obj/item/storage/box/syndie_kit/imp_uplink
 	name = "uplink implant box"
 

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -683,17 +683,14 @@
 	cost = 20
 	restricted = TRUE
 
-/datum/uplink_item/implants/nuclear/reviverplus
-/datum/uplink_item/implants/macrobomb
+/datum/uplink_item/implants/nuclear/deniability
 	name = "Tactical Deniability Implant"
 	desc = "An implant injected into the brain, and later activated either manually or automatically upon entering critical condition. \
 			Prevents collapsing from critical condition, but explodes after a while."
-	item = /obj/item/storage/box/syndie_kit/imp_macrobomb
+	item = /obj/item/storage/box/syndie_kit/imp_deniability
 	cost = 6
-	purchasable_from = UPLINK_NUKE_OPS
-	restricted = TRUE
 
-/datum/uplink_item/implants/reviver
+/datum/uplink_item/implants/nuclear/reviverplus
 	name = "Reviver Implant"
 	desc = "This implant will attempt to revive and heal you if you lose consciousness. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/syndicate/reviver

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -684,6 +684,16 @@
 	restricted = TRUE
 
 /datum/uplink_item/implants/nuclear/reviverplus
+/datum/uplink_item/implants/macrobomb
+	name = "Tactical Deniability Implant"
+	desc = "An implant injected into the brain, and later activated either manually or automatically upon entering critical condition. \
+			Prevents collapsing from critical condition, but explodes after a while."
+	item = /obj/item/storage/box/syndie_kit/imp_macrobomb
+	cost = 6
+	purchasable_from = UPLINK_NUKE_OPS
+	restricted = TRUE
+
+/datum/uplink_item/implants/reviver
 	name = "Reviver Implant"
 	desc = "This implant will attempt to revive and heal you if you lose consciousness. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/syndicate/reviver


### PR DESCRIPTION
## About The Pull Request

This PR adds in the Tactical Deniability Implant to the nuclear operative uplink for 6 TC. It's new version of the minibomb, implanted directly into your brain.
It disables softcrit and hardcrit, making it extremely powerful... For about 10.7 seconds (without stacked minibombs), before you realize what the increasing beeping is for, and proceed to explode. Even atropine can't save you from this one.

There is kind of a buff in that the delay of mini/macrobombs can no longer reach 30 seconds, since it just makes things a lot more interesting with a time cap (and also you'd need like 4 macrobombs to reach it so it mostly only impacts this new feature)

## Why It's Good For The Game

It's an interesting tradeoff where you can survive for a bit after critical condition, but whenever it triggers you've effectively sealed your own fate. Even if a helpful operative comes along to heal you, you WILL explode.

## Changelog

:cl:
add: The Syndicate has begun rolling out new Tactical Deniability Implants for their Nuclear Operative teams. It seems these implants are designed to make teams "fight harder" by "giving incentives for fighting to the bitter end", whatever they're talking about.
/:cl: