### PR TITLE
Reorders simplebot death code so that self-deletion happens last

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -27,6 +27,7 @@
 	light_system = MOVABLE_LIGHT
 	light_range = 3
 	light_power = 0.9
+	del_on_death = TRUE
 
 	///Will other (noncommissioned) bots salute this bot?
 	var/commissioned = FALSE
@@ -317,7 +318,6 @@
 	var/atom/location_destroyed = drop_location()
 	if(prob(50))
 		drop_part(robot_arm, location_destroyed)
-	qdel(src)
 
 /mob/living/simple_animal/bot/emag_act(mob/user, obj/item/card/emag/emag_card)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -203,9 +203,8 @@
 	pa_system.Grant(src)
 
 /mob/living/simple_animal/bot/Destroy()
-	if(paicard)
-		ejectpai()
 	GLOB.bots_list -= src
+	QDEL_NULL(paicard)
 	QDEL_NULL(pa_system)
 	QDEL_NULL(personality_download)
 	QDEL_NULL(internal_radio)
@@ -307,6 +306,8 @@
 	return TRUE
 
 /mob/living/simple_animal/bot/death(gibbed)
+	if(paicard)
+		ejectpai()
 	explode()
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Simplebot code had stuff happen after they had already qdeleted themselves (namely pai ejection if there was one in there, and more), so this PR moves their self-deletion to the very end of death code execution
## Why It's Good For The Game

Fixes #77213
## Changelog
:cl: distributivgesetz
fix: Fixes pAI mind transfer from a bot to their card runtiming when the bot gets broken.
/:cl:
