### PR TITLE
Restore photophobia, remove flash sensitivity on quirk removal

### DIFF
--- a/code/datums/quirks/negative_quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks/negative_quirks.dm
@@ -468,6 +468,7 @@
 	RegisterSignal(quirk_holder, COMSIG_MOVABLE_MOVED, PROC_REF(on_holder_moved))
 	update_eyes(quirk_holder.get_organ_slot(ORGAN_SLOT_EYES))
 
+/datum/quirk/photophobia/remove()
 	UnregisterSignal(quirk_holder, list(
 		COMSIG_CARBON_GAIN_ORGAN,
 		COMSIG_CARBON_LOSE_ORGAN,

--- a/code/datums/quirks/negative_quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks/negative_quirks.dm
@@ -476,7 +476,7 @@
 	quirk_holder.clear_mood_event(MOOD_CATEGORY_PHOTOPHOBIA)
 	var/obj/item/organ/internal/eyes/normal_eyes = quirk_holder.get_organ_slot(ORGAN_SLOT_EYES)
 	if(istype(normal_eyes))
-		normal_eyes.flash_protect = initial(eyes.flash_protect)
+		normal_eyes.flash_protect = initial(normal_eyes.flash_protect)
 
 /datum/quirk/photophobia/proc/check_eyes(obj/item/organ/internal/eyes/sensitive_eyes)
 	SIGNAL_HANDLER

--- a/code/datums/quirks/negative_quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks/negative_quirks.dm
@@ -474,6 +474,8 @@
 		COMSIG_CARBON_LOSE_ORGAN,
 		COMSIG_MOVABLE_MOVED,))
 	quirk_holder.clear_mood_event(MOOD_CATEGORY_PHOTOPHOBIA)
+	var/obj/item/organ/internal/eyes/normal_eyes = quirk_holder.get_organ_slot(ORGAN_SLOT_EYES)
+	normal_eyes.flash_protect = initial(eyes.flash_protect)
 
 /datum/quirk/photophobia/proc/check_eyes(obj/item/organ/internal/eyes/sensitive_eyes)
 	SIGNAL_HANDLER

--- a/code/datums/quirks/negative_quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks/negative_quirks.dm
@@ -475,7 +475,8 @@
 		COMSIG_MOVABLE_MOVED,))
 	quirk_holder.clear_mood_event(MOOD_CATEGORY_PHOTOPHOBIA)
 	var/obj/item/organ/internal/eyes/normal_eyes = quirk_holder.get_organ_slot(ORGAN_SLOT_EYES)
-	normal_eyes.flash_protect = initial(eyes.flash_protect)
+	if(istype(normal_eyes))
+		normal_eyes.flash_protect = initial(eyes.flash_protect)
 
 /datum/quirk/photophobia/proc/check_eyes(obj/item/organ/internal/eyes/sensitive_eyes)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
For some reason the `remove()` proc in code got eaten, meaning the quirk registered and immediately deregistered itself 
Also the eyes never returned to their original state, so that's fixed now too

## Why It's Good For The Game

This makes photophobia work.
## Changelog
:cl:
fix: Photophobia should work now.
fix: Eyes should return to their normal flash sensitivity when the quirk is removed.
/:cl:
