### PR TITLE
Geode Pirate Fixes

### DIFF
--- a/_maps/shuttles/pirate_geode.dmm
+++ b/_maps/shuttles/pirate_geode.dmm
@@ -326,6 +326,9 @@
 /obj/effect/turf_decal{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)
 "qO" = (
@@ -533,6 +536,9 @@
 /obj/effect/turf_decal{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)
 "Cg" = (
@@ -648,6 +654,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/shuttles/pirate_geode.dmm
+++ b/_maps/shuttles/pirate_geode.dmm
@@ -318,6 +318,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/misc/dirt/jungle,
 /area/shuttle/pirate)
+"qK" = (
+/obj/effect/turf_decal/lunar_sand/plating,
+/obj/machinery/computer/camera_advanced/syndie{
+	dir = 1
+	},
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/shuttle/pirate)
 "qO" = (
 /obj/effect/turf_decal/lunar_sand,
 /obj/structure/table/wood,
@@ -491,7 +501,8 @@
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "Pirate Ship";
-	port_direction = 2
+	port_direction = 2;
+	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -513,7 +524,13 @@
 /area/shuttle/pirate)
 "BI" = (
 /obj/effect/turf_decal/lunar_sand/plating,
-/obj/machinery/computer/launchpad{
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_y = -2;
+	pixel_x = 3
+	},
+/obj/effect/turf_decal{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -624,6 +641,16 @@
 "HY" = (
 /obj/machinery/loot_locator,
 /turf/open/misc/dirt/jungle,
+/area/shuttle/pirate)
+"Ig" = (
+/obj/effect/turf_decal/lunar_sand/plating,
+/obj/machinery/computer/launchpad{
+	dir = 1
+	},
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/shuttle/pirate)
 "Ih" = (
 /obj/effect/turf_decal/lunar_sand/plating,
@@ -1317,7 +1344,7 @@ Zw
 cx
 Js
 Ec
-Od
+qK
 Od
 jx
 lt
@@ -1359,7 +1386,7 @@ Rv
 uP
 JV
 QL
-Od
+Ig
 Od
 jx
 lt


### PR DESCRIPTION
## About The Pull Request
Upgraded the bluespace console room by adding a camera console and diagonostic hud in it. also adds a toolbox for it to be easier to link. since it isn't linked as it spawns
fixes pirate shuttle moving sideways
## Why It's Good For The Game
fixes good also makes geode pirates more fun by letting them do their sthick more easily
## Changelog
:cl:
balance: Geode Pirates have upgraded their launchpad room to be more usable
fix: Fixes a bug in the navigational computer of the Geode pirates causing their shuttle to move sideways.
/:cl:
