### PR TITLE
Fixes chat highlights with broken RegEx expressions and escapes RegEx characters from non-RegEx highlights

### DIFF
--- a/tgui/packages/tgui-panel/chat/renderer.js
+++ b/tgui/packages/tgui-panel/chat/renderer.js
@@ -193,6 +193,7 @@ class ChatRenderer {
       const matchWord = setting.matchWord;
       const matchCase = setting.matchCase;
       const allowedRegex = /^[a-z0-9_\-$/^[\s\]\\]+$/gi;
+      const regexEscapeCharacters = /[!#$%^&*)(+=.<>{}[\]:;'"|~`_\-\\/]/g;
       const lines = String(text)
         .split(',')
         .map((str) => str.trim())
@@ -229,7 +230,6 @@ class ChatRenderer {
             highlightWords = [];
           }
           // We're not going to let regex characters fuck up our RegEx operation.
-          const regexEscapeCharacters = /[!#$%^&*)(+=.<>{}[\]:;'"|~`_\-\\/]/g;
           line = line.replace(regexEscapeCharacters, '\\$&');
 
           highlightWords.push(line);


### PR DESCRIPTION
## About The Pull Request
Yeah, so, if you made a mistake in your chat highlight's regex, it would actually just straight up not work anymore, constant bluescreen pointing out your error, and there isn't a simple way for users to fix that issue. I'm not giving users an easy way to flush their highlights, but I'm making it far more robust so it shouldn't happen anymore.

Now, what I'm doing is that it's preventing the chat from breaking if the chat regex is broken, and so it's just `null` instead.

Not only that, but it's now also escaping anything that would be valid for RegEx from non-RegEx strings, so that stuff like `[AI Private]` don't make your whole client freeze to death.

Initially caught by https://github.com/Skyrat-SS13/Skyrat-tg/issues/22774.

## Why It's Good For The Game
Users not being stuck with a perma-bluescreened chat is good, methinks.

## Changelog

:cl: GoldenAlpharex
fix: Chat highlights now escape special RegEx characters from non-RegEx highlights.
fix: Broken RegEx expressions no longer cause the chat to bluescreen, allowing you to properly fix them.
/:cl: