### PR TITLE
[no gbp] Fixes runtime in SSstation

### DIFF
--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -17,7 +17,7 @@
 		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_2(null, src)
 		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/planet(null, src)
 		if(SSparallax.random_layer)
-			C.parallax_layers_cached += new SSparallax.random_layer.type(null, src, SSparallax.random_layer)
+			C.parallax_layers_cached += new SSparallax.random_layer.type(null, src, FALSE, SSparallax.random_layer)
 		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_3(null, src)
 
 	C.parallax_layers = C.parallax_layers_cached.Copy()

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -93,4 +93,8 @@ SUBSYSTEM_DEF(parallax)
 
 	random_layer = null
 
+/// Called at the end of SSstation setup, in-case we want to run some code that would otherwise be too early to run (like GLOB. stuff)
+/datum/controller/subsystem/parallax/proc/post_station_setup()
+	random_layer?.apply_global_effects()
+
 #undef PARALLAX_NONE

--- a/code/controllers/subsystem/processing/station.dm
+++ b/code/controllers/subsystem/processing/station.dm
@@ -21,7 +21,7 @@ PROCESSING_SUBSYSTEM_DEF(station)
 	#endif
 
 	announcer = new announcer() //Initialize the station's announcer datum
-	SSparallax.random_layer.apply_global_effects() //Apply station effects that parallax might have
+	SSparallax.post_station_setup() //Apply station effects that parallax might have
 
 	return SS_INIT_SUCCESS
 


### PR DESCRIPTION
No excuse, just dumb. Random layer is the randomly generated parallax layer, which is null 30% of the time, so this would runtime in SSstation setup in 30% of rounds

Also another thing where I added extra params and didn't add them to the proc, fucking parallax for some roundstart clients and latejoins

:cl:
fix: fixes a runtime in SSstation setup
fix: fixes parallax not rendering correctly for latejoins
/:cl:

![image](https://github.com/tgstation/tgstation/assets/7501474/650242f7-bc33-49eb-98d9-d8e3619ab808)
