### PR TITLE
fixes wizard loadouts

### DIFF
--- a/code/modules/antagonists/wizard/equipment/wizard_spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/wizard_spellbook.dm
@@ -216,7 +216,7 @@
 			return TRUE
 
 		if("purchase_loadout")
-			wizard_loadout(wizard, locate(params["id"]))
+			wizard_loadout(wizard, params["id"])
 			return TRUE
 
 /// Attempts to purchased the passed entry [to_buy] for [user].


### PR DESCRIPTION
why this shit try to get an instance of a string???

## Changelog
:cl:
fix: fixes wizard loadouts
/:cl:
