### PR TITLE
ghost notifs now set the pixel x/y properly with scaling

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -272,17 +272,23 @@
 		alert.target = source
 		if(!alert_overlay)
 			alert_overlay = new(source)
+			alert_overlay.pixel_x = 0
+			alert_overlay.pixel_y = 0
 			var/icon/size_check = icon(source.icon, source.icon_state)
 			var/scale = 1
 			var/width = size_check.Width()
 			var/height = size_check.Height()
+			if(width > world.icon_size)
+				alert_overlay.pixel_x = -(world.icon_size / 2) * ((width - world.icon_size) / world.icon_size)
+			if(height > world.icon_size)
+				alert_overlay.pixel_y = -(world.icon_size / 2) * ((height - world.icon_size) / world.icon_size)
 			if(width > world.icon_size || height > world.icon_size)
 				if(width >= height)
 					scale = world.icon_size / width
 				else
 					scale = world.icon_size / height
 			alert_overlay.transform = alert_overlay.transform.Scale(scale)
-			alert_overlay.appearance_flags |= TILE_BOUND
+		alert_overlay.appearance_flags |= TILE_BOUND
 		alert_overlay.layer = FLOAT_LAYER
 		alert_overlay.plane = FLOAT_PLANE
 		alert.add_overlay(alert_overlay)


### PR DESCRIPTION

## About The Pull Request
ghost notifs set pixel x y to 0 (so wallmounts for example are centered) and then large stuff like space dragons or singularities is properly brought down by calculations
before
![image](https://github.com/tgstation/tgstation/assets/23585223/73b198a1-3a5f-4d00-94b1-ae9690c9d948)
after
![image](https://github.com/tgstation/tgstation/assets/23585223/7a4bb949-36a6-4ba4-9339-d36ed56c6695)


## Changelog
:cl:
fix: ghost notification icons are now centered properly
/:cl:
