### PR TITLE
Bluespace bodybags no longer delete xenomorphs when folded

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -160,7 +160,7 @@
 			to_chat(content, span_userdanger("You're suddenly forced into a tiny, compressed space!"))
 		if(iscarbon(content))
 			var/mob/living/carbon/mob = content
-			if (mob.dna.get_mutation(/datum/mutation/human/dwarfism))
+			if (mob.dna?.get_mutation(/datum/mutation/human/dwarfism))
 				max_weight_of_contents = max(WEIGHT_CLASS_NORMAL, max_weight_of_contents)
 				continue
 		if(!isitem(content))


### PR DESCRIPTION
## About The Pull Request

`perform_fold()` was failing and eating up xenomorphs because during a dwarf check for adjusting bag's total capacity it would flop, as they are carbons, but they don't have DNA. this fixes that

## Why It's Good For The Game

fixes #66634

## Changelog

:cl:
fix: fixed bluespace bodybags consuming xenomorphs when folded
/:cl:
