### PR TITLE
Fixes former blobs being able to potentially respawn when having their mind transferred to a new body

### DIFF
--- a/code/modules/antagonists/blob/blob_antag.dm
+++ b/code/modules/antagonists/blob/blob_antag.dm
@@ -10,6 +10,8 @@
 	var/datum/action/innate/blobpop/pop_action
 	/// Initial points for a human blob
 	var/starting_points_human_blob = OVERMIND_STARTING_POINTS
+	/// Has the blob already popped inside of the round? This is here to prevent blobs from "respawning"
+	var/has_already_popped = FALSE
 
 /datum/antagonist/blob/roundend_report()
 	var/basic_report = ..()
@@ -26,6 +28,8 @@
 	owner.announce_objectives()
 	if(!isovermind(owner.current))
 		to_chat(owner.current, span_notice("Use the pop ability to place your blob core! It is recommended you do this away from anyone else, as you'll be taking on the entire crew!"))
+	else
+		has_already_popped = TRUE
 
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/blobalert.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 
@@ -74,7 +78,7 @@
 	objectives += main
 
 /datum/antagonist/blob/apply_innate_effects(mob/living/mob_override)
-	if(isovermind(owner.current))
+	if(isovermind(owner.current) || has_already_popped)
 		return FALSE
 	if(!pop_action)
 		pop_action = new
@@ -131,6 +135,7 @@
 	old_body.gib()
 	blob_cam.place_blob_core(placement_override, pop_override = TRUE)
 	playsound(get_turf(blob_cam), 'sound/ambience/antag/blobalert.ogg', 50, FALSE)
+	blobtag.has_already_popped = TRUE
 
 	notify_ghosts(
 		"A Blob host has burst in [get_area_name(blob_cam.blob_core)]",

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -141,9 +141,6 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 			if(autoplace_max_time && world.time >= autoplace_max_time)
 				place_blob_core(BLOB_RANDOM_PLACEMENT)
 		else
-			if(mind)
-				mind.remove_antag_datum(/datum/antagonist/blob)
-
 			// If we get here, it means yes: the blob is kill
 			SSticker.news_report = BLOB_DESTROYED
 			qdel(src)

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -141,6 +141,9 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 			if(autoplace_max_time && world.time >= autoplace_max_time)
 				place_blob_core(BLOB_RANDOM_PLACEMENT)
 		else
+			if(mind)
+				mind.remove_antag_datum(/datum/antagonist/blob)
+
 			// If we get here, it means yes: the blob is kill
 			SSticker.news_report = BLOB_DESTROYED
 			qdel(src)


### PR DESCRIPTION
## About The Pull Request
This PR fixes an oversight allowing blobs to "respawn" after having their mind placed in a new body, this is caused by the blob antag datum being left present in the mind after the blob is killed.
## Why It's Good For The Game
This is an upstream PR to deal with an issue that occurs due to a downstream mechanic https://github.com/Skyrat-SS13/Skyrat-tg/issues/22772. That being said, in any kind of scenario where we don't make a new mind, this glitch can occur and end up creating issues.

here's a example of me getting the glitch to work by ctrl+shift+clicking my ghost after they were killed as a blob
![image](https://github.com/tgstation/tgstation/assets/68373373/d9d5b8c9-c255-4909-89a4-d8602f3979be)

## Changelog
:cl:
fix: former blobs are no longer able to respawn after having their mind transferred to a new body.
/:cl:
