### PR TITLE
[Shuttles] Removes a stacked light on Kilo's Emergency Shuttle

### DIFF
--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -1257,7 +1257,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
-/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/escape/brig)
 "VD" = (


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
This is causing my linters to fail downstream and I forgot this is an upstream map 🙃 
I would like my linters to pass.

~~maybe we should put shuttles on ci now~~

## Changelog

:cl: Jolly
fix: [Shuttles] Kilo's Emergency Shuttle no longer has a stacked light in its brig.
/:cl:
