### PR TITLE
When Space Dragons devour people they get .extinguish()ed

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -354,6 +354,8 @@
 	if(A && A.loc != src)
 		playsound(src, 'sound/magic/demon_attack1.ogg', 60, TRUE)
 		visible_message(span_warning("[src] swallows [A] whole!"))
+		to_chat(src, span_notice("Your acids cleanse the flames off [A] on the way down. Delicious!"))
+		A.extinguish()
 		A.forceMove(src)
 		return TRUE
 	return FALSE


### PR DESCRIPTION

## About The Pull Request

When Space Dragons devour people they get extinguished, removing flames.
## Why It's Good For The Game

> When Space Dragons devour people they get extinguished, removing flames.

I find it quite annoying that even after you die to a space dragon, the jackass melts not just your jumpsuit, your suit, your hat, your mask, he also melts your entire skin off, leaving your body husked with 400 million burn damage when and if the dragon finally dies. I don't think there's any real reason for this to be necessary, it doesn't help the dragon in any way - It's just kind of a middle finger to the dead guy, or more accurately, an oversight.

Worse, because the flame sprite is stupidly noisy, when a dragon DOES die the corpses are all thrown around randomly and they all look the exact same, which makes it easier to ignore them.

If there's a concern about tracking sensors, I can make it disable them, but honestly if you can do that with demons I don't see why this would be a problem. Not even accounting for the fact that many jumpsuits ingame are fireproof.
## Changelog
:cl:
qol: When Space Dragons devour people they get extinguished, removing flames.
/:cl:
