### PR TITLE
Fixes holopara owners not always dusting

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -366,10 +366,10 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		return ..()
 
 /mob/living/simple_animal/hostile/guardian/death(gibbed)
-	. = ..()
 	if(!QDELETED(summoner))
 		to_chat(summoner, span_bolddanger("Your [name] died somehow!"))
 		summoner.dust()
+	. = ..()
 
 /mob/living/simple_animal/hostile/guardian/update_health_hud()
 	var/severity = 0

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -369,7 +369,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	if(!QDELETED(summoner))
 		to_chat(summoner, span_bolddanger("Your [name] died somehow!"))
 		summoner.dust()
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/guardian/update_health_hud()
 	var/severity = 0

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -369,7 +369,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	if(!QDELETED(summoner))
 		to_chat(summoner, span_bolddanger("Your [name] died somehow!"))
 		summoner.dust()
-	. = ..()
+	..()
 
 /mob/living/simple_animal/hostile/guardian/update_health_hud()
 	var/severity = 0


### PR DESCRIPTION

## About The Pull Request
Holoparas accidentally deleted themselves first when they die, which is bad because this happens before they try to dust their owner, so the owner reference is nulled before we can dust them too

## Why It's Good For The Game
Holoparas will always dust their owner now no matter what hopefully

## Changelog
:cl: distributivgesetz
fix: Fixes holoparasites not dusting their owners on death sometimes.
/:cl:
