### PR TITLE
Removes pulse carbine from NT mob on Forgotten Ship

### DIFF
--- a/code/modules/mapfluff/ruins/spaceruin_code/forgottenship.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/forgottenship.dm
@@ -162,4 +162,4 @@ GLOBAL_VAR_INIT(fscpassword, generate_password())
 	loot = list(/obj/effect/gibspawner/human)
 	faction = list(ROLE_DEATHSQUAD)
 	mob_spawner = /obj/effect/mob_spawn/corpse/human/nanotrasenelitesoldier
-	held_item = /obj/item/gun/energy/pulse/carbine/lethal
+	held_item = /obj/item/gun/energy/laser/hellgun


### PR DESCRIPTION

## About The Pull Request
Apparently the NT mob that's on the forgotten ship can drop a _fucking Pulse Carbine_? I replaced it with a hellgun, that's better balanced.

## Why It's Good For The Game
Pulse weapons should only be available via admin fuckery or the arcade machine lottery.

## Changelog
:cl: Vekter
balance: Replaced the pulse carbine that drops from an NT mob on the Forgotten Ship ruin with a hellfire laser.
/:cl:
