### PR TITLE
Fixes CentCom loot exploits

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -8881,7 +8881,7 @@
 	req_access = list("cent_captain")
 	},
 /obj/machinery/door/poddoor/shutters/indestructible{
-	id = null
+	id = "XCCadminstore"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
@@ -9198,7 +9198,7 @@
 /area/centcom/central_command_areas/supplypod/loading/one)
 "ST" = (
 /obj/machinery/door/poddoor/ert{
-	id = null
+	id = "XCCertstore"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -9817,7 +9817,7 @@
 /area/centcom/central_command_areas/armory)
 "VO" = (
 /obj/machinery/door/poddoor/ert{
-	id = null
+	id = "XCCertstore"
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -8880,7 +8880,9 @@
 /obj/machinery/door/airlock/vault{
 	req_access = list("cent_captain")
 	},
-/obj/machinery/door/poddoor/shutters/indestructible,
+/obj/machinery/door/poddoor/shutters/indestructible{
+	id = null
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
 "Rk" = (
@@ -9195,7 +9197,9 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
 "ST" = (
-/obj/machinery/door/poddoor/ert,
+/obj/machinery/door/poddoor/ert{
+	id = null
+	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
@@ -9812,7 +9816,9 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "VO" = (
-/obj/machinery/door/poddoor/ert,
+/obj/machinery/door/poddoor/ert{
+	id = null
+	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
 /turf/open/floor/iron,

--- a/code/game/area/areas/away_content.dm
+++ b/code/game/area/areas/away_content.dm
@@ -27,7 +27,7 @@ Unused icons for new areas are "awaycontent1" ~ "awaycontent30"
 	name = "Super Secret Room"
 	static_lighting = FALSE
 	base_lighting_alpha = 255
-
+	area_flags = UNIQUE_AREA|NOTELEPORT
 	has_gravity = STANDARD_GRAVITY
 
 /area/awaymission/secret


### PR DESCRIPTION

## About The Pull Request

Fixes a pair of exploits that can be used to enter and loot CentCom.

1. Adds NOTELEPORT to the Super Secret Room where nullspaced players are sent, this could be used in conjunction with a hand teleporter to escape into the CentCom z-level.
2. Changes the IDs on the administrative storage and ERT armoury blast doors from the number 1 to strings. This prevents player-built door buttons (which can be given numerical IDs) from being able to open them.

## Why It's Good For The Game

CentCom looting exploits are bad.

## Changelog
:cl:
fix: CentCom can no longer be raided by teleporting out of the Super Secret Room
fix: The Administrative Storage and ERT Armoury blast doors can no longer be opened by building a door button.
/:cl:
