### PR TITLE
Adds a Fugitive Locator machine to each bounty hunter shuttle

### DIFF
--- a/_maps/shuttles/hunter_bounty.dmm
+++ b/_maps/shuttles/hunter_bounty.dmm
@@ -102,6 +102,10 @@
 /obj/item/phone,
 /turf/open/floor/pod/dark,
 /area/shuttle/hunter)
+"x" = (
+/obj/machinery/fugitive_locator,
+/turf/open/floor/pod/light,
+/area/shuttle/hunter)
 "y" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -491,7 +495,7 @@ a
 b
 i
 A
-n
+x
 I
 i
 b

--- a/_maps/shuttles/hunter_psyker.dmm
+++ b/_maps/shuttles/hunter_psyker.dmm
@@ -280,6 +280,10 @@
 /obj/effect/turf_decal/tile/dark_blue/diagonal_centre,
 /turf/open/floor/iron/white/diagonal,
 /area/shuttle/hunter)
+"mc" = (
+/obj/machinery/fugitive_locator,
+/turf/open/floor/iron/kitchen/small,
+/area/shuttle/hunter)
 "mz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/etherealball,
@@ -1218,7 +1222,7 @@ oL
 CW
 zY
 xF
-lu
+mc
 PC
 XX
 CW

--- a/_maps/shuttles/hunter_russian.dmm
+++ b/_maps/shuttles/hunter_russian.dmm
@@ -381,6 +381,7 @@
 	req_access = list("hunter");
 	specialfunctions = 4
 	},
+/obj/item/soap,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/hunter/russian)
 "Dw" = (
@@ -451,8 +452,7 @@
 /area/shuttle/hunter/russian)
 "GF" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/soap,
+/obj/machinery/fugitive_locator,
 /turf/open/floor/pod/dark,
 /area/shuttle/hunter/russian)
 "IV" = (

--- a/_maps/shuttles/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter_space_cop.dmm
@@ -21,6 +21,7 @@
 /area/shuttle/hunter)
 "ag" = (
 /obj/effect/turf_decal/delivery,
+/obj/machinery/fugitive_locator,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/hunter)
 "ah" = (

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -199,7 +199,7 @@
 	B.other_pair = A
 
 /obj/item/pinpointer/shuttle
-	name = "fugitive pinpointer"
+	name = "bounty shuttle pinpointer"
 	desc = "A handheld tracking device that locates the bounty hunter shuttle for quick escapes."
 	icon_state = "pinpointer_hunter"
 	worn_icon_state = "pinpointer_black"

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -165,7 +165,7 @@
 	COOLDOWN_DECLARE(locate_cooldown)
 
 /obj/machinery/fugitive_locator/interact(mob/user)
-	if(COOLDOWN_FINISHED(src, locate_cooldown))
+	if(!COOLDOWN_FINISHED(src, locate_cooldown))
 		balloon_alert_to_viewers("locator recharging!", vision_distance = 3)
 		return
 	var/mob/living/bounty = locate_fugitive()
@@ -178,8 +178,14 @@
 
 ///Locates a random fugitive via their antag datum and returns them.
 /obj/machinery/fugitive_locator/proc/locate_fugitive()
-	for(var/datum/antagonist/fugitive/found_fugitive in GLOB.antagonists)
-		if(!found_fugitive.owner)
+	for(var/datum/antagonist/fugitive/fugitive_datum in GLOB.antagonists)
+		if(!fugitive_datum.owner)
 			stack_trace("Fugitive locator tried to locate a fugitive antag datum with no owner.")
 			continue
-		return found_fugitive.owner
+		if(fugitive_datum.is_captured)
+			continue
+		var/mob/living/found_fugitive = fugitive_datum.owner.current
+		if(found_fugitive.stat == DEAD)
+			continue
+
+		return found_fugitive

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -154,6 +154,14 @@
 	default_raw_text = "<b>Remember!</b> The customers love that gumball we have as a crystal ball. \
 		Even if it's completely useless to us, resist the urge to chew it."
 
+/**
+ * # Bounty Locator
+ *
+ * Locates a random, living fugitive and reports their name/location on a 40 second cooldown.
+ *
+ * Locates a random fugitive antagonist via the GLOB.antagonists list, and reads out their real name and area name.
+ * Captured or dead fugitives are not reported.
+ */
 /obj/machinery/fugitive_locator
 	name = "Bounty Locator"
 	desc = "Tracks the signatures of bounty targets in your sector. Nobody actually knows what mechanism this thing uses to track its targets. \

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -172,14 +172,14 @@
 	if(!bounty)
 		say("No bounty targets detected.")
 	else
-		say("Bounty Target Located. Bounty ID: [bounty.name]. Location: [get_area_name(bounty)]")
+		say("Bounty Target Located. Bounty ID: [bounty.real_name]. Location: [get_area_name(bounty)]")
 
-	//Since the target list doesn't shuffle, this always reports the same fugitive until they're dead/captured. We want to avoid being able to report a constant location so the delay is kind of long.
 	COOLDOWN_START(src, locate_cooldown, 40 SECONDS)
 
 ///Locates a random fugitive via their antag datum and returns them.
 /obj/machinery/fugitive_locator/proc/locate_fugitive()
-	for(var/datum/antagonist/fugitive/fugitive_datum in GLOB.antagonists)
+	var/list/datum_list = shuffle(GLOB.antagonists)
+	for(var/datum/antagonist/fugitive/fugitive_datum in datum_list)
 		if(!fugitive_datum.owner)
 			stack_trace("Fugitive locator tried to locate a fugitive antag datum with no owner.")
 			continue

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -174,7 +174,8 @@
 	else
 		say("Bounty Target Located. Bounty ID: [bounty.name]. Location: [get_area_name(bounty)]")
 
-	COOLDOWN_START(src, locate_cooldown, 20 SECONDS)
+	//Since the target list doesn't shuffle, this always reports the same fugitive until they're dead/captured. We want to avoid being able to report a constant location so the delay is kind of long.
+	COOLDOWN_START(src, locate_cooldown, 40 SECONDS)
 
 ///Locates a random fugitive via their antag datum and returns them.
 /obj/machinery/fugitive_locator/proc/locate_fugitive()

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -156,10 +156,10 @@
 
 /obj/machinery/fugitive_locator
 	name = "Bounty Locator"
-	desc = "Tracks the signatures of bounty targets in nearby space. Nobody actually knows what mechanism this thing uses to track its targets. \
-		Whether it be bluespace entanglement or a simple RFID implant, this machine will find you who you're looking for."
-	icon = 'icons/obj/machines/research.dmi'
-	icon_state = "tdoppler"
+	desc = "Tracks the signatures of bounty targets in your sector. Nobody actually knows what mechanism this thing uses to track its targets. \
+		Whether it be bluespace entanglement or a simple RFID implant, this machine will find you who you're looking for no matter where they're hiding."
+	icon = 'icons/obj/machines/dominator.dmi'
+	icon_state = "dominator-Purple"
 	density = TRUE
 	/// Cooldown on locating a fugitive.
 	COOLDOWN_DECLARE(locate_cooldown)
@@ -170,7 +170,7 @@
 		return
 	var/mob/living/bounty = locate_fugitive()
 	if(!bounty)
-		say("No bounty targets in nearby space.")
+		say("No bounty targets detected.")
 	else
 		say("Bounty Target Located. Bounty ID: [bounty.name]. Location: [get_area_name(bounty)]")
 

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -154,3 +154,32 @@
 	default_raw_text = "<b>Remember!</b> The customers love that gumball we have as a crystal ball. \
 		Even if it's completely useless to us, resist the urge to chew it."
 
+/obj/machinery/fugitive_locator
+	name = "Bounty Locator"
+	desc = "Tracks the signatures of bounty targets in nearby space. Nobody actually knows what mechanism this thing uses to track its targets. \
+		Whether it be bluespace entanglement or a simple RFID implant, this machine will find you who you're looking for."
+	icon = 'icons/obj/machines/research.dmi'
+	icon_state = "tdoppler"
+	density = TRUE
+	/// Cooldown on locating a fugitive.
+	COOLDOWN_DECLARE(locate_cooldown)
+
+/obj/machinery/fugitive_locator/interact(mob/user)
+	if(COOLDOWN_FINISHED(src, locate_cooldown))
+		balloon_alert_to_viewers("locator recharging!", vision_distance = 3)
+		return
+	var/mob/living/bounty = locate_fugitive()
+	if(!bounty)
+		say("No bounty targets in nearby space.")
+	else
+		say("Bounty Target Located. Bounty ID: [bounty.name]. Location: [get_area_name(bounty)]")
+
+	COOLDOWN_START(src, locate_cooldown, 20 SECONDS)
+
+///Locates a random fugitive via their antag datum and returns them.
+/obj/machinery/fugitive_locator/proc/locate_fugitive()
+	for(var/datum/antagonist/fugitive/found_fugitive in GLOB.antagonists)
+		if(!found_fugitive.owner)
+			stack_trace("Fugitive locator tried to locate a fugitive antag datum with no owner.")
+			continue
+		return found_fugitive.owner

--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -123,32 +123,20 @@
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "tdoppler"
 	density = TRUE
-	var/cooldown = 300
-	var/next_use = 0
-
-/// Surgery disk for the space IRS (I don't know where to dump them anywhere else)
-/obj/item/disk/surgery/irs
-	name = "Advanced Surgery Disk"
-	desc = "A disk that contains advanced surgery procedures, must be loaded into an Operating Console."
-	surgeries = list(
-		/datum/surgery/advanced/lobotomy,
-		/datum/surgery/advanced/bioware/vein_threading,
-		/datum/surgery/advanced/bioware/nerve_splicing,
-		/datum/surgery_step/heal/combo/upgraded,
-		/datum/surgery_step/pacify,
-		/datum/surgery_step/revive,
-	)
+	/// Cooldown on locating booty.
+	COOLDOWN_DECLARE(locate_cooldown)
 
 /obj/machinery/loot_locator/interact(mob/user)
-	if(world.time <= next_use)
-		to_chat(user,span_warning("[src] is recharging."))
+	if(!COOLDOWN_FINISHED(src, locate_cooldown))
+		balloon_alert_to_viewers("locator recharging!", vision_distance = 3)
 		return
-	next_use = world.time + cooldown
 	var/atom/movable/found_loot = find_random_loot()
 	if(!found_loot)
 		say("No valuables located. Try again later.")
 	else
 		say("Located: [found_loot.name] at [get_area_name(found_loot)]")
+
+	COOLDOWN_START(src, locate_cooldown, 10 SECONDS)
 
 /// Looks across the station for items that are pirate specific exports
 /obj/machinery/loot_locator/proc/find_random_loot()
@@ -163,6 +151,19 @@
 		selected_export = pick_n_take(possible_loot)
 		found_loot = selected_export.find_loot()
 	return found_loot
+
+/// Surgery disk for the space IRS (I don't know where to dump them anywhere else)
+/obj/item/disk/surgery/irs
+	name = "Advanced Surgery Disk"
+	desc = "A disk that contains advanced surgery procedures, must be loaded into an Operating Console."
+	surgeries = list(
+		/datum/surgery/advanced/lobotomy,
+		/datum/surgery/advanced/bioware/vein_threading,
+		/datum/surgery/advanced/bioware/nerve_splicing,
+		/datum/surgery_step/heal/combo/upgraded,
+		/datum/surgery_step/pacify,
+		/datum/surgery_step/revive,
+	)
 
 //Pad & Pad Terminal
 /obj/machinery/piratepad


### PR DESCRIPTION

## About The Pull Request

This adds a simple but important piece of machinery to every bounty hunter shuttle, the Fugitive Locator. 

Functioning near identically to the Booty Locator (the pirate loot tracker machine), this machine selects a random fugitive, reads their _real_ name, and reads the name of the area they occupy. It has a 40 second cooldown, and will track a random fugitive each time.

![image](https://github.com/tgstation/tgstation/assets/28870487/e879344b-c241-4f30-ba28-210cfddc14a6)

The locator will report any location you are in, be it space, lavaland, some distant ruin or the wastes, the hunters will always know where to start looking for you.

Since a lot of this code was referenced from the booty locator, that has also been touched up slightly. A bit of code was moved out of the way, and the cooldown now uses a COOLDOWN_DECLARE() instead of time tracking.

Lastly, this renames the "fugitive tracker" (which tracks the bounty hunter shuttle) to the "bounty shuttle tracker", because the name is misleading.
## Why It's Good For The Game

This seeks to solve the issue of fugitive hunters not knowing who their targets are, and having no way of knowing where their targets may be.

I decided on this particular implementation because it gives only a vague area and identity for the fugitives to work with. This allows for fugitives to make use of hiding spots, disguises, potted plants, and other popular tactics that would be invalidated if the mechanism were a hud tracker or pinpointer of sorts. The intent isn't to lead hunters straight to their targets, but to give them somewhere to start.

As for the impact this may have on the Fugitive experience -- It will be more difficult to coast through the round in a single hiding spot or disappear from the z-level and never be heard from again.

Directing the hunters towards the fugitives should lead to a more active experience, encouraging evasion over just plain hiding. Just remember: the less fugitives there are, the easier it is for the hunters to consistently track your area, so make sure you're looking out for each other!
## Changelog
:cl:
add: Fugitive shuttles now have a "Fugitive Tracker" machine, which gives a readout on the location of a random fugitive on a 40 second cooldown.
spellcheck: Renames the fugitive pinpointer to the bounty shuttle pinpointer.
/:cl:
