### PR TITLE
Fix TTS leaking identity of `TRAIT_UNKNOWN` mobs

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -376,7 +376,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 				speech_bubble_recipients.Add(M.client)
 			found_client = TRUE
 
-	if(voice && found_client && !message_mods[MODE_CUSTOM_SAY_ERASE_INPUT] && !HAS_TRAIT(src, TRAIT_SIGN_LANG))
+	if(voice && found_client && !message_mods[MODE_CUSTOM_SAY_ERASE_INPUT] && !HAS_TRAIT(src, TRAIT_SIGN_LANG) && !HAS_TRAIT(src, TRAIT_UNKNOWN))
 		var/tts_message_to_use = tts_message
 		if(!tts_message_to_use)
 			tts_message_to_use = message_raw


### PR DESCRIPTION
## About The Pull Request

If you have `TRAIT_UNKNOWN`, your chat messages will not TTS. 

Maybe a more fun alternative is to pick a generic voice for `TRAIT_UNKNOWN` mobs, with a filter that makes the voice sound obscured or something, idk. This is easy though.

## Why It's Good For The Game

`TRAIT_UNKNOWN` is intended to leave no hint you are who you are, so to suddenly speak in a very distinguishable voice that becomes useless quick. 

This means someone paying attention can easily pinpoint who the traitor behind the suit is, or the heretic behind the cloak. 

(It also probably means that this screws up for people wearing a disguise (+voice changer) or lings. Should visit that later)

## Changelog

:cl: Melbert
fix: Traitors using the sneak suit and heretics under the effects of cloak no longer leak their identity via Text to Speech
/:cl:
