### PR TITLE
guns' projectile damage multiplier reflected in examines, gives guns a vareditable projectile wound bonus modifier

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -238,6 +238,8 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 
 #define isgun(A) (istype(A, /obj/item/gun))
 
+#define isammobox(A) (istype(A, /obj/item/ammo_box))
+
 #define isinstrument(A) (istype(A, /obj/item/instrument) || istype(A, /obj/structure/musician))
 
 #define is_reagent_container(O) (istype(O, /obj/item/reagent_containers))

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -85,16 +85,14 @@
 		var/obj/item/gun/our_gun = loc
 		// grab the damage multiplier.
 		proj_damage_mult = our_gun.projectile_damage_multiplier
-
 	var/list/readout = list()
-	// No dividing by 0
-	if(proj_damage_mult)
-		if(initial(exam_proj.damage) > 0)
-			readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * proj_damage_mult) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round."
-		if(initial(exam_proj.stamina) > 0)
-			readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * proj_damage_mult) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds."
-	if(!readout.len) // Everything else failed, give generic text
+	if(!proj_damage_mult || proj_damage_mult <= 0)
 		return "Our legal team has determined the offensive nature of these [span_warning(caliber)] rounds to be esoteric."
+	// No dividing by 0
+	if(initial(exam_proj.damage) > 0)
+		readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * proj_damage_mult) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round."
+	if(initial(exam_proj.stamina) > 0)
+		readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * proj_damage_mult) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds."
 	return readout.Join("\n") // Sending over a single string, rather than the whole list
 
 /obj/item/ammo_casing/update_icon_state()

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -67,6 +67,8 @@
 /obj/item/ammo_casing/proc/add_notes_ammo()
 	// Try to get a projectile to derive stats from
 	var/obj/projectile/exam_proj = projectile_type
+	var/initial_damage = initial(exam_proj.damage)
+	var/initial_stamina = initial(exam_proj.stamina)
 	// projectile damage multiplier for guns with snowflaked damage multipliers
 	var/proj_damage_mult = 1
 	if(!ispath(exam_proj) || pellets == 0)
@@ -86,12 +88,12 @@
 		// grab the damage multiplier.
 		proj_damage_mult = our_gun.projectile_damage_multiplier
 	var/list/readout = list()
-	if(!proj_damage_mult || proj_damage_mult <= 0)
+	if(proj_damage_mult <= 0 || (initial_damage <= 0 && initial_stamina <= 0))
 		return "Our legal team has determined the offensive nature of these [span_warning(caliber)] rounds to be esoteric."
 	// No dividing by 0
-	if(initial(exam_proj.damage) > 0)
+	if(initial_damage)
 		readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * proj_damage_mult) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round."
-	if(initial(exam_proj.stamina) > 0)
+	if(initial_stamina)
 		readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * proj_damage_mult) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds."
 	return readout.Join("\n") // Sending over a single string, rather than the whole list
 

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -67,17 +67,33 @@
 /obj/item/ammo_casing/proc/add_notes_ammo()
 	// Try to get a projectile to derive stats from
 	var/obj/projectile/exam_proj = projectile_type
+	// projectile damage multiplier for guns with snowflaked damage multipliers
+	var/proj_damage_mult = 1
 	if(!ispath(exam_proj) || pellets == 0)
 		return
+
+	// are we in an ammo box?
+	if(isammobox(loc))
+		var/obj/item/ammo_box/our_box = loc
+		// is our ammo box in a gun?
+		if(isgun(our_box.loc))
+			var/obj/item/gun/our_gun = our_box.loc
+			// grab the damage multiplier
+			proj_damage_mult = our_gun.projectile_damage_multiplier
+	// if not, are we just in a gun e.g. chambered
+	else if(isgun(loc))
+		var/obj/item/gun/our_gun = loc
+		// grab the damage multiplier.
+		proj_damage_mult = our_gun.projectile_damage_multiplier
 
 	var/list/readout = list()
 	// No dividing by 0
 	if(initial(exam_proj.damage) > 0)
-		readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT(initial(exam_proj.damage) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round"
+		readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * proj_damage_mult) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round."
 	if(initial(exam_proj.stamina) > 0)
-		readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT(initial(exam_proj.stamina) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds"
+		readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * proj_damage_mult) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds."
 	if(!readout.len) // Everything else failed, give generic text
-		return "Our legal team has determined the offensive nature of these [span_warning(caliber)] rounds to be esoteric"
+		return "Our legal team has determined the offensive nature of these [span_warning(caliber)] rounds to be esoteric."
 	return readout.Join("\n") // Sending over a single string, rather than the whole list
 
 /obj/item/ammo_casing/update_icon_state()

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -88,10 +88,11 @@
 
 	var/list/readout = list()
 	// No dividing by 0
-	if(initial(exam_proj.damage) > 0)
-		readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * proj_damage_mult) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round."
-	if(initial(exam_proj.stamina) > 0)
-		readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * proj_damage_mult) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds."
+	if(proj_damage_mult)
+		if(initial(exam_proj.damage) > 0)
+			readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * proj_damage_mult) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round."
+		if(initial(exam_proj.stamina) > 0)
+			readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * proj_damage_mult) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds."
 	if(!readout.len) // Everything else failed, give generic text
 		return "Our legal team has determined the offensive nature of these [span_warning(caliber)] rounds to be esoteric."
 	return readout.Join("\n") // Sending over a single string, rather than the whole list

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -56,6 +56,9 @@
 		loaded_projectile.damage *= G.projectile_damage_multiplier
 		loaded_projectile.stamina *= G.projectile_damage_multiplier
 
+		loaded_projectile.wound_bonus *= G.projectile_wound_multiplier
+		loaded_projectile.bare_wound_bonus *= G.projectile_wound_multiplier
+
 	if(tk_firing(user, fired_from))
 		loaded_projectile.ignore_source_check = TRUE
 

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -56,8 +56,8 @@
 		loaded_projectile.damage *= G.projectile_damage_multiplier
 		loaded_projectile.stamina *= G.projectile_damage_multiplier
 
-		loaded_projectile.wound_bonus *= G.projectile_wound_multiplier
-		loaded_projectile.bare_wound_bonus *= G.projectile_wound_multiplier
+		loaded_projectile.wound_bonus += G.projectile_wound_bonus
+		loaded_projectile.bare_wound_bonus += G.projectile_wound_bonus
 
 	if(tk_firing(user, fired_from))
 		loaded_projectile.ignore_source_check = TRUE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -50,6 +50,9 @@
 	/// Just 'slightly' snowflakey way to modify projectile damage for projectiles fired from this gun.
 	var/projectile_damage_multiplier = 1
 
+	/// Also slightly snowflakey way to modify projectile wound bonus for projectiles fired from this gun.
+	var/projectile_wound_multiplier = 1
+
 	var/spread = 0 //Spread induced by the gun itself.
 	var/randomspread = 1 //Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -51,6 +51,7 @@
 	var/projectile_damage_multiplier = 1
 
 	/// Also slightly snowflakey way to modify projectile wound bonus for projectiles fired from this gun.
+	/// Most bullets don't really have a non-zero wound bonus, actually, on further testing, so...
 	var/projectile_wound_multiplier = 1
 
 	var/spread = 0 //Spread induced by the gun itself.

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -50,9 +50,8 @@
 	/// Just 'slightly' snowflakey way to modify projectile damage for projectiles fired from this gun.
 	var/projectile_damage_multiplier = 1
 
-	/// Also slightly snowflakey way to modify projectile wound bonus for projectiles fired from this gun.
-	/// Most bullets don't really have a non-zero wound bonus, actually, on further testing, so...
-	var/projectile_wound_multiplier = 1
+	/// Even snowflakier way to modify projectile wounding bonus/potential for projectiles fired from this gun.
+	var/projectile_wound_bonus = 0
 
 	var/spread = 0 //Spread induced by the gun itself.
 	var/randomspread = 1 //Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -181,8 +181,10 @@
 /obj/item/gun/ballistic/proc/add_notes_ballistic()
 	if(magazine) // Make sure you have a magazine, to get the notes from
 		return "\n[magazine.add_notes_box()]"
-	else
-		return "\nThe warning attached to the magazine is missing..."
+	else if(chambered) // if you don't have a magazine, is there something chambered?
+		return "\n[chambered.add_notes_ammo()]"
+	else // we have a very expensive mechanical paperweight.
+		return "\nThe lack of magazine and usable cartridge in chamber makes its usefulness questionable, at best."
 
 /obj/item/gun/ballistic/vv_edit_var(vname, vval)
 	. = ..()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -97,21 +97,21 @@
 	if(!ammo_type.len)
 		return
 	var/obj/projectile/exam_proj
-	readout += "\nStandard models of this projectile weapon have [span_warning("[ammo_type.len] mode\s")]"
+	readout += "\nStandard models of this projectile weapon have [span_warning("[ammo_type.len] mode\s")]."
 	readout += "Our heroic interns have shown that one can theoretically stay standing after..."
+	if(projectile_damage_multiplier <= 0)
+		readout += "a theoretically infinite number of shots on [span_warning("every")] mode due to esoteric or nonexistent offensive potential."
+		return readout.Join("\n") // Sending over the singular string, rather than the whole list
 	for(var/obj/item/ammo_casing/energy/for_ammo as anything in ammo_type)
 		exam_proj = for_ammo.projectile_type
 		if(!ispath(exam_proj))
 			continue
-		if(projectile_damage_multiplier)
-			if(initial(exam_proj.damage) > 0) // Don't divide by 0!!!!!
-				readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from [initial(exam_proj.damage_type) == STAMINA ? "immense pain" : "their wounds"]."
-				if(initial(exam_proj.stamina) > 0) // In case a projectile does damage AND stamina damage (Energy Crossbow)
-					readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from immense pain."
-			else
-				readout += "a theoretically infinite number of shots on [span_warning("[for_ammo.select_name]")] mode."
+		if(initial(exam_proj.damage) > 0) // Don't divide by 0!!!!!
+			readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from [initial(exam_proj.damage_type) == STAMINA ? "immense pain" : "their wounds"]."
+			if(initial(exam_proj.stamina) > 0) // In case a projectile does damage AND stamina damage (Energy Crossbow)
+				readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from immense pain."
 		else
-			readout += "a theoretically infinite number of shots on [span_warning("[for_ammo.select_name]")] mode due to esoteric or nonexistent offensive potential."
+			readout += "a theoretically infinite number of shots on [span_warning("[for_ammo.select_name]")] mode."
 
 	return readout.Join("\n") // Sending over the singular string, rather than the whole list
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -103,13 +103,15 @@
 		exam_proj = for_ammo.projectile_type
 		if(!ispath(exam_proj))
 			continue
-
-		if(initial(exam_proj.damage) > 0) // Don't divide by 0!!!!!
-			readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from [initial(exam_proj.damage_type) == STAMINA ? "immense pain" : "their wounds"]."
-			if(initial(exam_proj.stamina) > 0) // In case a projectile does damage AND stamina damage (Energy Crossbow)
-				readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from immense pain."
+		if(projectile_damage_multiplier)
+			if(initial(exam_proj.damage) > 0) // Don't divide by 0!!!!!
+				readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from [initial(exam_proj.damage_type) == STAMINA ? "immense pain" : "their wounds"]."
+				if(initial(exam_proj.stamina) > 0) // In case a projectile does damage AND stamina damage (Energy Crossbow)
+					readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from immense pain."
+			else
+				readout += "a theoretically infinite number of shots on [span_warning("[for_ammo.select_name]")] mode."
 		else
-			readout += "a theoretically infinite number of shots on [span_warning("[for_ammo.select_name]")] mode."
+			readout += "a theoretically infinite number of shots on [span_warning("[for_ammo.select_name]")] mode due to esoteric or nonexistent offensive potential."
 
 	return readout.Join("\n") // Sending over the singular string, rather than the whole list
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -105,9 +105,9 @@
 			continue
 
 		if(initial(exam_proj.damage) > 0) // Don't divide by 0!!!!!
-			readout += "[span_warning("[HITS_TO_CRIT(initial(exam_proj.damage) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from [initial(exam_proj.damage_type) == STAMINA ? "immense pain" : "their wounds"]."
+			readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from [initial(exam_proj.damage_type) == STAMINA ? "immense pain" : "their wounds"]."
 			if(initial(exam_proj.stamina) > 0) // In case a projectile does damage AND stamina damage (Energy Crossbow)
-				readout += "[span_warning("[HITS_TO_CRIT(initial(exam_proj.stamina) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from immense pain."
+				readout += "[span_warning("[HITS_TO_CRIT((initial(exam_proj.stamina) * projectile_damage_multiplier) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from immense pain."
 		else
 			readout += "a theoretically infinite number of shots on [span_warning("[for_ammo.select_name]")] mode."
 


### PR DESCRIPTION
## About The Pull Request
A gun's projectile damage multiplier is now reflected in its "show combat info" examine, so now the shots-to-crit on guns with a modified projectile damage multiplier (say, the PP-95 SMG, under the slightly inaccurate typepath `automatic/plastikov`) is accurate. This applies to both energy weapons and ballistics.

Also, added a new variable that multiplies a fired projectile's wound bonus. Could be used to make guns really bad at wounding or good at wounding innately for... reasons? Not really touched by anything for now.

## Why It's Good For The Game

Being able to account for projectile damage multiplier probably helps in regards to "how many bullets DOES it take to crit someone else?", since you don't really get told about it in-game.

The wound bonus thing could be used for adminbus as a joke or to make a gun more distinct in regards to "how often do I make someone's blood fall out/leg break/etc."

## Changelog
:cl:
fix: Projectile damage multipliers on guns are now reflected in their combat information.
admin: Admins can now make a gun's fired projectiles better or worse at wounding by changing the gun's projectile_wound_bonus. Surely this will not have any repercussions.
/:cl: