### PR TITLE
Fixed uplink discount stocks affecting normal uplink item stocks

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -234,9 +234,9 @@
 	var/list/extra_purchasable_stock = list()
 	var/list/extra_purchasable = list()
 	for(var/datum/uplink_item/item as anything in uplink_handler.extra_purchasable)
-		if(WEAKREF(item) in stock_list)
-			extra_purchasable_stock[REF(item)] = stock_list[WEAKREF(item)]
-			stock_list -= WEAKREF(item)
+		if(item.stock_key in stock_list)
+			extra_purchasable_stock[REF(item)] = stock_list[item.stock_key]
+			stock_list -= item.stock_key
 		extra_purchasable += list(list(
 			"id" = item.type,
 			"name" = item.name,

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -234,8 +234,8 @@
 	var/list/extra_purchasable_stock = list()
 	var/list/extra_purchasable = list()
 	for(var/datum/uplink_item/item as anything in uplink_handler.extra_purchasable)
-		if(item in stock_list)
-			extra_purchasable_stock[REF(item)] = stock_list[item]
+		if(WEAKREF(item) in stock_list)
+			extra_purchasable_stock[REF(item)] = stock_list[WEAKREF(item)]
 			stock_list -= item
 		extra_purchasable += list(list(
 			"id" = item.type,

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -236,7 +236,7 @@
 	for(var/datum/uplink_item/item as anything in uplink_handler.extra_purchasable)
 		if(WEAKREF(item) in stock_list)
 			extra_purchasable_stock[REF(item)] = stock_list[WEAKREF(item)]
-			stock_list -= item
+			stock_list -= WEAKREF(item)
 		extra_purchasable += list(list(
 			"id" = item.type,
 			"name" = item.name,

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -236,7 +236,6 @@
 	for(var/datum/uplink_item/item as anything in uplink_handler.extra_purchasable)
 		if(item.stock_key in stock_list)
 			extra_purchasable_stock[REF(item)] = stock_list[item.stock_key]
-			stock_list -= item.stock_key
 		extra_purchasable += list(list(
 			"id" = item.type,
 			"name" = item.name,

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -12,6 +12,7 @@
 		uplink_item.limited_stock = limited_stock
 		if(uplink_item.cost >= 20) //Tough love for nuke ops
 			discount *= 0.5
+		uplink_item.stock_key = WEAKREF(uplink_item)
 		uplink_item.category = category
 		uplink_item.cost = max(round(uplink_item.cost * (1 - discount)),1)
 		uplink_item.name += " ([round(((initial(uplink_item.cost)-uplink_item.cost)/initial(uplink_item.cost))*100)]% off!)"


### PR DESCRIPTION
## About The Pull Request
If an uplink item was discounted and purchased, it would prevent purchase of the normal-priced uplink item, which is supposed to be infinitely buyable. This fixes that

Closes #73560

## Why It's Good For The Game
Fixes an oversight in the uplink stock system.

## Changelog
:cl:
fix: Fixed being unable to purchase regular-priced uplink items if you bought the discounted variant of it.
/:cl:
