### PR TITLE
[no gbp] Don't dump pai cards out of PDAs for no reason

### DIFF
--- a/code/modules/pai/shell.dm
+++ b/code/modules/pai/shell.dm
@@ -122,11 +122,6 @@
 	REMOVE_TRAIT(src, TRAIT_IMMOBILIZED, PAI_FOLDED)
 	REMOVE_TRAIT(src, TRAIT_HANDS_BLOCKED, PAI_FOLDED)
 	REMOVE_TRAIT(src, TRAIT_UNDENSE, PAI_FOLDED)
-	if(istype(card.loc, /obj/item/modular_computer))
-		var/obj/item/modular_computer/pc = card.loc
-		pc.inserted_pai = null
-		pc.visible_message(span_notice("[src] ejects itself from [pc]!"))
-		card.forceMove(get_turf(pc))
 	forceMove(get_turf(card))
 	if(client)
 		client.perspective = EYE_PERSPECTIVE


### PR DESCRIPTION
## About The Pull Request

Fixes #77285
This code block was written to eject pAIs from things when they were carrying their card around with them. Now that that isn't true, we shouldn't be doing it.

## Why It's Good For The Game

Reduces ability to accidentally leave your friend on the floor.

## Changelog

:cl:
fix: Your pAI card won't pop out of your PDA onto the floor alongside its hologram if it enters hologram form while inside a PDA.
/:cl:
