### PR TITLE
[NO GBP] Fix parasitic infection to cure upon liver removal

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -68,6 +68,7 @@
 
 	if(required_organ)
 		if(!has_required_infectious_organ(affected_mob, required_organ))
+			cure()
 			return FALSE
 
 	if(has_cure())

--- a/code/datums/diseases/parasitic_infection.dm
+++ b/code/datums/diseases/parasitic_infection.dm
@@ -19,12 +19,6 @@
 	if(!.)
 		return
 
-	var/obj/item/organ/internal/liver/affected_liver = affected_mob.get_organ_by_type(/obj/item/organ/internal/liver)
-	if(!affected_liver)
-		affected_mob.visible_message(span_notice("<B>[affected_mob]'s liver is covered in tiny larva! They quickly shrivel and die after being exposed to the open air.</B>"))
-		cure()
-		return FALSE
-
 	switch(stage)
 		if(1)
 			if(SPT_PROB(2.5, seconds_per_tick))
@@ -48,6 +42,8 @@
 				else
 					to_chat(affected_mob, span_warning("You feel much, MUCH lighter!"))
 					affected_mob.vomit(20, TRUE)
+					// disease code already checks if the liver exists otherwise it is cured
+					var/obj/item/organ/internal/liver/affected_liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 					affected_liver.Remove(affected_mob)
 					affected_liver.forceMove(get_turf(affected_mob))
 					cure()


### PR DESCRIPTION

## About The Pull Request

Fixes #77275

In #76766 I had reworked diseases and organs to have optional required organs.  The parasitic infection disease required livers, but it only skipped the harmful effects from processing instead of curing the disease like it should have.

I have to be careful doing this to advanced diseases since they can have multiple symptoms, so sypmtoms are considered neutered if the required organ isn't present.  Regular diseases however don't have multiple symptoms and should be cured.

Also the parastic infection is a non contagious disease, so upon the liver being removed, the disease is cured from both the person and the organ itself.

## Why It's Good For The Game

One more bug destroyed.


## Changelog

:cl:
fix: Fix parasitic infection to cure upon liver removal
/:cl:

