### PR TITLE
Fixes particle holders sometimes dropping from objects

### DIFF
--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -12,31 +12,34 @@
 	/// See \code\__DEFINES\particles.dm
 	var/particle_flags = NONE
 
+	var/atom/parent
+
 /obj/effect/abstract/particle_holder/Initialize(mapload, particle_path = /particles/smoke, particle_flags = NONE)
 	. = ..()
 	if(!loc)
 		stack_trace("particle holder was created with no loc!")
 		return INITIALIZE_HINT_QDEL
-	// We assert this isn't an /area
+	// We nullspace ourselves because some objects use their contents (e.g. storage) and some items may drop everything in their contents on deconstruct.
+	parent = loc
+	loc = null
 
 	src.particle_flags = particle_flags
-	particles = new particle_path
+	particles = new particle_path()
 	// /atom doesn't have vis_contents, /turf and /atom/movable do
-	var/atom/movable/lie_about_areas = loc
+	var/atom/movable/lie_about_areas = parent
 	lie_about_areas.vis_contents += src
-	if(!ismovable(loc))
-		RegisterSignal(loc, COMSIG_QDELETING, PROC_REF(immovable_deleted))
+	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(parent_deleted))
 
 	if(particle_flags & PARTICLE_ATTACH_MOB)
-		RegisterSignal(loc, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
-	on_move(loc, null, NORTH)
+		RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
+	on_move(parent, null, NORTH)
 
 /obj/effect/abstract/particle_holder/Destroy(force)
 	QDEL_NULL(particles)
 	return ..()
 
 /// Non movables don't delete contents on destroy, so we gotta do this
-/obj/effect/abstract/particle_holder/proc/immovable_deleted(datum/source)
+/obj/effect/abstract/particle_holder/proc/parent_deleted(datum/source)
 	SIGNAL_HANDLER
 	qdel(src)
 

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -23,6 +23,8 @@
 	parent = loc
 	loc = null
 
+	// Mouse opacity can get set to opaque by some objects when placed into the object's contents (storage containers).
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	src.particle_flags = particle_flags
 	particles = new particle_path()
 	// /atom doesn't have vis_contents, /turf and /atom/movable do


### PR DESCRIPTION

## About The Pull Request
Particle holders are placed into the contents of the thing they're showing the particles off of. This creates problems as some items can drop all their contents to the ground or, in the case of storage items, use their contents in some way

## Why It's Good For The Game
Fixes particle holders falling out of items.

## Changelog
:cl:
fix: Fixed particles sometimes being left behind when an object drops all of its contents whilst having a particle active.
/:cl:
