### PR TITLE
Adds slider component for preferences, converts TTS volume, and pitch to use it

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,7 @@
 	},
 	"[typescriptreact]": {
 		"editor.rulers": [80],
-		"editor.defaultFormatter": "esbenp.prettier-vscode",
+		"editor.defaultFormatter": "vscode.typescript-language-features",
 		"editor.formatOnSave": true
 	},
 	"[scss]": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,7 @@
 	},
 	"[typescriptreact]": {
 		"editor.rulers": [80],
-		"editor.defaultFormatter": "vscode.typescript-language-features",
+		"editor.defaultFormatter": "esbenp.prettier-vscode",
 		"editor.formatOnSave": true
 	},
 	"[scss]": {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -3,7 +3,7 @@ import { BooleanLike, classes } from 'common/react';
 import { ComponentType, createComponentVNode, InfernoNode } from 'inferno';
 import { VNodeFlags } from 'inferno-vnode-flags';
 import { sendAct, useBackend, useLocalState } from '../../../../backend';
-import { Box, Button, Dropdown, Input, NumberInput, Stack } from '../../../../components';
+import { Box, Button, Dropdown, Input, NumberInput, Slider, Stack } from '../../../../components';
 import { createSetPreference, PreferencesMenuData } from '../../data';
 import { ServerPreferencesFetcher } from '../../ServerPreferencesFetcher';
 
@@ -298,6 +298,27 @@ export const FeatureNumberInput = (
       maxValue={props.serverData.maximum}
       step={props.serverData.step}
       value={props.value}
+    />
+  );
+};
+
+export const FeatureSliderInput = (
+  props: FeatureValueProps<number, number, FeatureNumericData>
+) => {
+  if (!props.serverData) {
+    return <Box>Loading...</Box>;
+  }
+
+  return (
+      <Slider
+      onChange={(e, value) => {
+        props.handleSetValue(value);
+      }}
+      minValue={props.serverData.minimum}
+      maxValue={props.serverData.maximum}
+      step={props.serverData.step}
+      value={props.value}
+      stepPixelSize={10}
     />
   );
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -310,7 +310,7 @@ export const FeatureSliderInput = (
   }
 
   return (
-      <Slider
+    <Slider
       onChange={(e, value) => {
         props.handleSetValue(value);
       }}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/tts_voice.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/tts_voice.tsx
@@ -1,4 +1,4 @@
-import { FeatureChoiced, FeatureChoicedServerData, FeatureDropdownInput, FeatureValueProps, FeatureNumeric, FeatureNumberInput } from '../base';
+import { FeatureChoiced, FeatureChoicedServerData, FeatureDropdownInput, FeatureValueProps, FeatureNumeric, FeatureSliderInput } from '../base';
 import { Stack, Button } from '../../../../../components';
 
 const FeatureTTSDropdownInput = (
@@ -40,5 +40,5 @@ export const tts_voice: FeatureChoiced = {
 
 export const tts_voice_pitch: FeatureNumeric = {
   name: 'Voice Pitch Adjustment',
-  component: FeatureNumberInput,
+  component: FeatureSliderInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/sounds.tsx
@@ -1,5 +1,5 @@
 import { multiline } from 'common/string';
-import { CheckboxInput, FeatureChoiced, FeatureDropdownInput, FeatureToggle, Feature, FeatureNumberInput } from '../base';
+import { CheckboxInput, FeatureChoiced, FeatureDropdownInput, FeatureToggle, Feature, FeatureSliderInput } from '../base';
 
 export const sound_ambience: FeatureToggle = {
   name: 'Enable ambience',
@@ -49,7 +49,7 @@ export const sound_tts_volume: Feature<number> = {
   name: 'TTS Volume',
   category: 'SOUND',
   description: 'The volume that the text-to-speech sounds will play at.',
-  component: FeatureNumberInput,
+  component: FeatureSliderInput,
 };
 
 export const sound_jukebox: FeatureToggle = {


### PR DESCRIPTION

## About The Pull Request

I want to add volume sliders, so I made a slider component.

## Why It's Good For The Game

In my opinion, volume sliders should probably be, uh, sliders.

## Changelog
:cl:
qol: TTS volume preference is not actually a volume slider, instead of a volume number input.
/:cl:
