### PR TITLE
Revert "Bumps rust-g to `3.0.0` "

### DIFF
--- a/.github/workflows/autowiki.yml
+++ b/.github/workflows/autowiki.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   autowiki:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: "Check for AUTOWIKI_USERNAME"
       id: secrets_set
@@ -30,6 +30,9 @@ jobs:
     - name: Install rust-g
       if: steps.secrets_set.outputs.SECRETS_ENABLED
       run: |
+        sudo dpkg --add-architecture i386
+        sudo apt update || true
+        sudo apt install -o APT::Immediate-Configure=false libssl1.1:i386
         bash tools/ci/install_rust_g.sh
     - name: Compile and generate Autowiki files
       if: steps.secrets_set.outputs.SECRETS_ENABLED

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -18,7 +18,7 @@ on:
         type: string
 jobs:
   run_integration_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       mysql:
         image: mysql:latest
@@ -43,6 +43,9 @@ jobs:
           mysql -u root -proot tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
       - name: Install rust-g
         run: |
+          sudo dpkg --add-architecture i386
+          sudo apt update || true
+          sudo apt install -o APT::Immediate-Configure=false libssl1.1:i386
           bash tools/ci/install_rust_g.sh
       - name: Install auxlua
         run: |

--- a/code/__DEFINES/rust_g.dm
+++ b/code/__DEFINES/rust_g.dm
@@ -110,12 +110,6 @@
 #define rustg_dmi_strip_metadata(fname) RUSTG_CALL(RUST_G, "dmi_strip_metadata")(fname)
 #define rustg_dmi_create_png(path, width, height, data) RUSTG_CALL(RUST_G, "dmi_create_png")(path, width, height, data)
 #define rustg_dmi_resize_png(path, width, height, resizetype) RUSTG_CALL(RUST_G, "dmi_resize_png")(path, width, height, resizetype)
-/**
- * input: must be a path, not an /icon; you have to do your own handling if it is one, as icon objects can't be directly passed to rustg.
- *
- * output: json_encode'd list. json_decode to get a flat list with icon states in the order they're in inside the .dmi
- */
-#define rustg_dmi_icon_states(fname) RUSTG_CALL(RUST_G, "dmi_icon_states")(fname)
 
 #define rustg_file_read(fname) RUSTG_CALL(RUST_G, "file_read")(fname)
 #define rustg_file_exists(fname) RUSTG_CALL(RUST_G, "file_exists")(fname)
@@ -164,9 +158,8 @@
 #define rustg_time_milliseconds(id) text2num(RUSTG_CALL(RUST_G, "time_milliseconds")(id))
 #define rustg_time_reset(id) RUSTG_CALL(RUST_G, "time_reset")(id)
 
-/// Returns the timestamp as a string
 /proc/rustg_unix_timestamp()
-	return RUSTG_CALL(RUST_G, "unix_timestamp")()
+	return text2num(RUSTG_CALL(RUST_G, "unix_timestamp")())
 
 #define rustg_raw_read_toml_file(path) json_decode(RUSTG_CALL(RUST_G, "toml_file_to_json")(path) || "null")
 

--- a/code/datums/helper_datums/getrev.dm
+++ b/code/datums/helper_datums/getrev.dm
@@ -37,8 +37,6 @@
 	else if(!originmastercommit)
 		msg += "No commit information"
 
-	msg += "Running rust-g version [rustg_get_version()]"
-
 	return msg.Join("\n")
 
 /datum/getrev/proc/GetTestMergeInfo(header = TRUE)

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -8,7 +8,7 @@ export BYOND_MAJOR=514
 export BYOND_MINOR=1588
 
 #rust_g git tag
-export RUST_G_VERSION=3.0.0
+export RUST_G_VERSION=1.2.0
 
 #node version
 export NODE_VERSION=14

--- a/tools/tgs_scripts/PreCompile.sh
+++ b/tools/tgs_scripts/PreCompile.sh
@@ -12,7 +12,6 @@ cd "$1"
 . dependencies.sh
 cd "$original_dir"
 
-
 # update rust-g
 if [ ! -d "rust-g" ]; then
 	echo "Cloning rust-g..."


### PR DESCRIPTION
Reverts tgstation/tgstation#76663

3.0.0 Makes the server crash on round restart on windows.

This kills pop counts because people don't always reconnect and its common for players to decide to end a play session if they meet the slightest resistance.

Related:  tgstation/rust-g#148