### PR TITLE
Removes stray obj/item Metastation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55926,10 +55926,6 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
-"ulb" = (
-/obj/item,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/solars/port/aft)
 "ulv" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/stripes/white/line{
@@ -85910,7 +85906,7 @@ kNV
 gnL
 ckz
 dWA
-ulb
+ecz
 aaa
 aaa
 lMJ

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -55926,6 +55926,10 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
+"ulb" = (
+/obj/item,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/solars/port/aft)
 "ulv" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/stripes/white/line{
@@ -85906,7 +85910,7 @@ kNV
 gnL
 ckz
 dWA
-ecz
+ulb
 aaa
 aaa
 lMJ

--- a/tools/maplint/lints/stray_item.yml
+++ b/tools/maplint/lints/stray_item.yml
@@ -1,0 +1,3 @@
+/turf/closed:
+  banned_neighbors:
+  - =/obj/item


### PR DESCRIPTION
## About The Pull Request
Removes a stray obj/item from a random Metastation wall in Port Quarter Solars and adds a maplint so that this doesn't happen again.
Closes #77267
## Why It's Good For The Game
A obj/item in a random wall is not good and should as it is a bug, this fixes that.
## Changelog
:cl:
fix: removes a stray obj/item from random metastation wall
/:cl:
