### PR TITLE
Fixes runtime relating to hard TGS reboots (PROBABLY WON'T FIX REBOOT CRASHES)

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -326,6 +326,7 @@ GLOBAL_VAR(restart_counter)
 			shutdown_logging() // See comment below.
 			auxcleanup()
 			TgsEndProcess()
+			return
 
 	log_world("World rebooted at [time_stamp()]")
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -326,7 +326,7 @@ GLOBAL_VAR(restart_counter)
 			shutdown_logging() // See comment below.
 			auxcleanup()
 			TgsEndProcess()
-			return
+			return ..()
 
 	log_world("World rebooted at [time_stamp()]")
 


### PR DESCRIPTION
## About The Pull Request

Servers are crashing on every round restart and I have absolutely no idea where to start, but I noticed this so I figure I'll throw up a PR to fix it.

This is the runtime (only found in dd.log, sorry non-admin/maintainer gamers https://[tgstation13.org/raw-logs/sybil/data/logs/2023/08/01/round-211577/dd.log](https://tgstation13.org/raw-logs/sybil/data/logs/2023/08/01/round-211577/dd.log) )

```txt
[00:07:07] Runtime in code/modules/logging/log_holder.dm,166: Attempted to call shutdown_logging twice!
  proc name: shutdown logging (/datum/log_holder/proc/shutdown_logging)
  src: /datum/log_holder (/datum/log_holder)
  call stack:
  /datum/log_holder (/datum/log_holder): shutdown logging()
  shutdown logging()
  world: Reboot(0, 0)
  Ticker (/datum/controller/subsystem/ticker): Reboot("Round ended.", "proper completion", 600)
```

This is the full log:

![image](https://github.com/tgstation/tgstation/assets/34697715/af938235-3076-41d5-98b2-02907dedb6d5)

This is the code:

![image](https://github.com/tgstation/tgstation/assets/34697715/371b11cb-3bc9-4a99-a17c-73968ded308d)

For some reason, even though we invoke `TGSEndProcess`, we still continue on in this `if()` chain. I don't know why we keep executing DM code after TGS is supposed to be shut down (which may be why no one has ever included a `return` here, but let's be safe instead of sorry.

If you really want to investigate why TGS is running DM code after we end the process, I am amenable to including a stack trace or crash of this phenomenon instead.
## Why It's Good For The Game

Since we aren't invoking `LOG_CLOSE_ALL` to rust-g twice (which seems to be really unwanted per the code I read), hopefully thing no crash? Rust-g had two breaking changes (one with logs, and one with SQL), so I'm presuming that this might be related to the log one (which is why we didn't see this sorta thing happen pre-#77307)... Worst case scenario less runtimes in the funny runtime log.

I hope this wasn't loadbearing either... Likely requires testmerging since TGS and I don't get along on my machine.
## Changelog
:cl:
server: Added a preventative measure to prevent calling both TGSHardRestart and TGSReboot, as well as potentially invoking sensitive procs that are only meant to be called once.
/:cl:

TL;DR- I do not definitively know why servers are crashing but I noticed this runtime so I'll put out this open flame while I have the time to do so.
