### PR TITLE
Update client click handling for 514

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -823,11 +823,13 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	var/ab = FALSE
 	var/list/modifiers = params2list(params)
 
+	var/button_clicked = LAZYACCESS(modifiers, "button")
+	
 	var/dragged = LAZYACCESS(modifiers, DRAG)
-	if(dragged && !LAZYACCESS(modifiers, dragged)) //I don't know what's going on here, but I don't trust it
+	if(dragged && button_clicked != dragged) 
 		return
 
-	if (object && IS_WEAKREF_OF(object, middle_drag_atom_ref) && LAZYACCESS(modifiers, LEFT_CLICK))
+	if (object && IS_WEAKREF_OF(object, middle_drag_atom_ref) && button_clicked == LEFT_CLICK)
 		ab = max(0, 5 SECONDS-(world.time-middragtime)*0.1)
 
 	var/mcl = CONFIG_GET(number/minute_click_limit)


### PR DESCRIPTION
Hey! its 515 time, so i thought we should close up the last compability change from 514 that slipped thru the cracks.

under 514 the LEFT/RIGHT/MIDDLE mouse button keys to the mouse param list are set if they are pressed at all, while the `button` param says which mouse button being clicked triggered that action. This code was thinking normal clicks were drag clicks and skipping the aimbot detector

More mouse code likely needs to be changed to account for this, but this is the most critical path that cared about the distinction between which buttons are being held and which button triggered the current mouse action.

Fixes #76836 maybe?
