### PR TITLE
Dump donkpokets into microwave

### DIFF
--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -290,6 +290,13 @@
 	if(istype(O, /obj/item/storage))
 		var/obj/item/storage/T = O
 		var/loaded = 0
+
+		if(!istype(O, /obj/item/storage/bag/tray))
+			// Non-tray dumping requires a do_after
+			to_chat(user, span_notice("You start dumping out the contents of [O] into [T]..."))
+			if(!do_after(user, 2 SECONDS, target = T))
+				return
+
 		for(var/obj/S in T.contents)
 			if(!IS_EDIBLE(S))
 				continue

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -287,7 +287,7 @@
 		balloon_alert(user, "it's too dirty!")
 		return TRUE
 
-	if(istype(O, /obj/item/storage/bag/tray))
+	if(istype(O, /obj/item/storage))
 		var/obj/item/storage/T = O
 		var/loaded = 0
 		for(var/obj/S in T.contents)

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -293,7 +293,7 @@
 
 		if(!istype(O, /obj/item/storage/bag/tray))
 			// Non-tray dumping requires a do_after
-			to_chat(user, span_notice("You start dumping out the contents of [O] into [T]..."))
+			to_chat(user, span_notice("You start dumping out the contents of [O] into [src]..."))
 			if(!do_after(user, 2 SECONDS, target = T))
 				return
 


### PR DESCRIPTION
![dreamseeker_KMA1Il7OcN](https://github.com/tgstation/tgstation/assets/3625094/b33bcb45-0798-4b22-92d3-836b880fa9d0)

## About The Pull Request

Makes it possible to use any storage, not just tray, to fill the microwave.

## Why It's Good For The Game

You can dump the entire box of donk pockets in one click.

## Changelog

:cl:
qol: You can fill microwave with stuff by hitting it with a box full of stuff.
/:cl:

