### PR TITLE
Fix spell burger having two recipes

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_burger.dm
@@ -202,15 +202,6 @@
 /datum/crafting_recipe/food/spellburger
 	name = "Spell burger"
 	reqs = list(
-		/obj/item/clothing/head/wizard/fake = 1,
-		/obj/item/food/bun = 1
-	)
-	result = /obj/item/food/burger/spell
-	category = CAT_BURGER
-
-/datum/crafting_recipe/food/spellburger2
-	name = "Spell burger"
-	reqs = list(
 		/obj/item/clothing/head/wizard = 1,
 		/obj/item/food/bun = 1
 	)


### PR DESCRIPTION

## About The Pull Request
Fixes #77301 
## Why It's Good For The Game
Fake wizard hat is a subtype of the regular wizard hat, so different recipes with the same result for fake/real hats are not needed
## Changelog
:cl:
fix: Spell burger now has only one recipe
/:cl:
