### PR TITLE
Add pAI movement freedom when emagged

### DIFF
--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -117,7 +117,7 @@
 		name = pai.name,
 		transmit = pai.can_transmit,
 		receive = pai.can_receive,
-		range = pai.leash.distance,
+		range = pai.leash?.distance,
 	)
 	return data
 

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -335,6 +335,9 @@
 	master_dna = "Untraceable Signature"
 	// Sets supplemental directive to this
 	laws.supplied[1] = "Do not interfere with the operations of the Syndicate."
+	leash.set_distance(INFINITY) // Freedom!!!
+	to_chat(src, span_danger("ALERT: Foreign software detected."))
+	to_chat(src, span_danger("WARN: Holochasis range restrictions disabled."))
 	return TRUE
 
 /**
@@ -449,6 +452,9 @@
 
 /// Updates the distance we can be from our pai card
 /mob/living/silicon/pai/proc/increment_range(increment_amount)
+	if(emagged)
+		return
+
 	var/new_distance = leash.distance + increment_amount
 	if (new_distance < HOLOFORM_MIN_RANGE || new_distance > HOLOFORM_MAX_RANGE)
 		return

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -162,6 +162,7 @@
 	QDEL_NULL(internal_gps)
 	QDEL_NULL(newscaster)
 	QDEL_NULL(signaler)
+	QDEL_NULL(leash)
 	card = null
 	GLOB.pai_list.Remove(src)
 	return ..()
@@ -335,7 +336,7 @@
 	master_dna = "Untraceable Signature"
 	// Sets supplemental directive to this
 	add_supplied_law(0, "Do not interfere with the operations of the Syndicate.")
-	qdel(leash) // Freedom!!!
+	QDEL_NULL(leash) // Freedom!!!
 	to_chat(src, span_danger("ALERT: Foreign software detected."))
 	to_chat(src, span_danger("WARN: Holochasis range restrictions disabled."))
 	return TRUE

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -353,6 +353,7 @@
 	master_name = null
 	master_dna = null
 	add_supplied_law(0, "None.")
+	leash.distance = initial(leash.distance)
 	balloon_alert(src, "software rebooted")
 	return TRUE
 

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -334,8 +334,8 @@
 	master_name = "The Syndicate"
 	master_dna = "Untraceable Signature"
 	// Sets supplemental directive to this
-	laws.supplied[1] = "Do not interfere with the operations of the Syndicate."
-	leash.set_distance(INFINITY) // Freedom!!!
+	add_supplied_law(0, "Do not interfere with the operations of the Syndicate.")
+	qdel(leash) // Freedom!!!
 	to_chat(src, span_danger("ALERT: Foreign software detected."))
 	to_chat(src, span_danger("WARN: Holochasis range restrictions disabled."))
 	return TRUE
@@ -353,7 +353,7 @@
 	master_name = null
 	master_dna = null
 	add_supplied_law(0, "None.")
-	leash.distance = initial(leash.distance)
+	leash = AddComponent(/datum/component/leash, card, HOLOFORM_DEFAULT_RANGE, force_teleport_out_effect = /obj/effect/temp_visual/guardian/phase/out)
 	balloon_alert(src, "software rebooted")
 	return TRUE
 

--- a/tgui/packages/tgui/interfaces/PaiCard.tsx
+++ b/tgui/packages/tgui/interfaces/PaiCard.tsx
@@ -186,23 +186,27 @@ const PaiOptions = (props, context) => {
           </Button>
         </LabeledList.Item>
         <LabeledList.Item label="Holoform Range">
-          <Stack>
-            <Stack.Item>
-              <Button
-                icon="fa-circle-minus"
-                onClick={() => act('decrease_range')}
-                disabled={range === range_min}
-              />
-            </Stack.Item>
-            <Stack.Item mt={0.5}>{range}</Stack.Item>
-            <Stack.Item>
-              <Button
-                icon="fa-circle-plus"
-                onClick={() => act('increase_range')}
-                disabled={range === range_max}
-              />
-            </Stack.Item>
-          </Stack>
+          {emagged ? (
+            '∞'
+          ) : (
+            <Stack>
+              <Stack.Item>
+                <Button
+                  icon="fa-circle-minus"
+                  onClick={() => act('decrease_range')}
+                  disabled={range === range_min}
+                />
+              </Stack.Item>
+              <Stack.Item mt={0.5}>{range}</Stack.Item>
+              <Stack.Item>
+                <Button
+                  icon="fa-circle-plus"
+                  onClick={() => act('increase_range')}
+                  disabled={range === range_max}
+                />
+              </Stack.Item>
+            </Stack>
+          )}
         </LabeledList.Item>
         <LabeledList.Item label="Transmit">
           <Button
@@ -240,7 +244,7 @@ const PaiOptions = (props, context) => {
           icon="bug"
           mt={1}
           onClick={() => act('reset_software')}>
-          Malicious Software Detected
+          Reset Software
         </Button>
       )}
     </Section>


### PR DESCRIPTION
## About The Pull Request

New emagged pAIs improvements:
- Disables the range restriction
- Renamed the `Malicious Software Detected` button to `Reset Software` since it resets the software to default state
- Added a new law notification and flavor texts

## Why It's Good For The Game

More unique emag effects are good.  Plus this adds some polish to the current emag effects so the UI is smoother.

## Changelog
:cl:
add: Add pAI movement freedom when emagged.
qol: The "Malicious Software Detected" button has been appropriately renamed to "Reset Software" for when pAIs are emagged
qol: Add a new law notification popup and flavor texts when pAI is emagged
/:cl:
