### PR TITLE
Adds cool existing suit to ClothesMate

### DIFF
--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -187,6 +187,7 @@
 		/obj/item/clothing/under/rank/centcom/officer_skirt/replica = 1,
 	)
 	premium = list(/obj/item/clothing/under/suit/checkered = 1,
+		/obj/item/clothing/under/misc/vice_officer = 1,
 		/obj/item/clothing/head/costume/mailman = 1,
 		/obj/item/clothing/under/misc/mailman = 1,
 		/obj/item/clothing/suit/jacket/leather = 1,


### PR DESCRIPTION
## About The Pull Request
Right now this suit spawns only in MetaStation maints, one copy, determined place. There is no other ways to acquire it.
This PR adds a "Vice Officer Suit" to ClothesMate. Now everyone can enjoy it. Premium to preserve rarity of costume.
![Анимация](https://github.com/tgstation/tgstation/assets/57627192/541f445d-9d9e-44a8-b818-cd82c26f830e)
## Why It's Good For The Game
More drip for the drip Lord. Also it doesn't adds anything "new", just a use for almost unused existing item in code.
## Changelog
Added "Vice Officer Suit" to ClothesMate, premium category, 100 cr.
<!-- If your PR modifies aspects of the game that can be concretely observed by players 
or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: NeinAnimas
add: There is new (old not used anywhere) suit in ClothesMate. Check premium category.
/:cl:
