### PR TITLE
Makes the bulbs of lights emissive

### DIFF
--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -170,7 +170,10 @@
 	if(!on || status != LIGHT_OK)
 		return
 
+	. += emissive_appearance(overlay_icon, "[base_state]", src, alpha = src.alpha)
+
 	var/area/local_area = get_room_area(src)
+
 	if(low_power_mode || major_emergency || (local_area?.fire))
 		. += mutable_appearance(overlay_icon, "[base_state]_emergency")
 		return


### PR DESCRIPTION
## About The Pull Request

As Vekter pointed out, the lights can look like they aren't actually on in certain situations now that they longer have that awful active overlay with a million invisible pixels. This fixes that problem by making the bulbs emissive when they're on.
## Why It's Good For The Game

Light looking like they're on when they're on is important for a lot of things.

![image](https://github.com/tgstation/tgstation/assets/82386923/b362e38c-064e-4e26-9d91-33c4833a7e33)

## Changelog
:cl:
fix: The bulbs of lights will now have an emissive glow when on, making it so they appear active no matter how dark the area surrounding them happens to be.
/:cl:
