### PR TITLE
Restores some mechs being able to pivot step (move and turn in the same keypress) and diagonal movement

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -66,7 +66,9 @@
 	///Just stop the mech from doing anything
 	var/completely_disabled = FALSE
 	///Whether this mech is allowed to move diagonally
-	var/allow_diagonal_movement = FALSE
+	var/allow_diagonal_movement = TRUE
+	///Whether this mech moves into a direct as soon as it goes to move. Basically, turn and step in the same key press.
+	var/pivot_step = FALSE
 	///Whether or not the mech destroys walls by running into it.
 	var/bumpsmash = FALSE
 

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -3,7 +3,6 @@
 	name = "\improper Gygax"
 	icon_state = "gygax"
 	base_icon_state = "gygax"
-	allow_diagonal_movement = TRUE
 	movedelay = 3
 	max_integrity = 250
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_SECURITY)

--- a/code/modules/vehicles/mecha/mecha_movement.dm
+++ b/code/modules/vehicles/mecha/mecha_movement.dm
@@ -130,7 +130,8 @@
 		if(dir != direction && !(mecha_flags & QUIET_TURNS) && !step_silent)
 			playsound(src,turnsound,40,TRUE)
 		setDir(direction)
-		return TRUE
+		if(!pivot_step) //If we pivot step, we don't return here so we don't just come to a stop
+			return TRUE
 
 	set_glide_size(DELAY_TO_GLIDE_SIZE(movedelay))
 	//Otherwise just walk normally

--- a/code/modules/vehicles/mecha/medical/odysseus.dm
+++ b/code/modules/vehicles/mecha/medical/odysseus.dm
@@ -3,7 +3,6 @@
 	name = "\improper Odysseus"
 	icon_state = "odysseus"
 	base_icon_state = "odysseus"
-	allow_diagonal_movement = TRUE
 	movedelay = 2
 	max_temperature = 15000
 	max_integrity = 120
@@ -11,6 +10,7 @@
 	mech_type = EXOSUIT_MODULE_ODYSSEUS
 	step_energy_drain = 6
 	internals_req_access = list(ACCESS_MECH_SCIENCE, ACCESS_MECH_MEDICAL)
+	pivot_step = TRUE
 
 /obj/vehicle/sealed/mecha/odysseus/moved_inside(mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/vehicles/mecha/working/clarke.dm
+++ b/code/modules/vehicles/mecha/working/clarke.dm
@@ -28,7 +28,8 @@
 	enter_delay = 40
 	mecha_flags = ADDING_ACCESS_POSSIBLE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE | OMNIDIRECTIONAL_ATTACKS
 	internals_req_access = list(ACCESS_MECH_ENGINE, ACCESS_MECH_SCIENCE, ACCESS_MECH_MINING)
-	allow_diagonal_movement = TRUE
+	allow_diagonal_movement = FALSE
+	pivot_step = TRUE
 
 /datum/armor/mecha_clarke
 	melee = 20

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -32,7 +32,6 @@
 		MECHA_POWER = list(),
 		MECHA_ARMOR = list(),
 	)
-	allow_diagonal_movement = TRUE
 	/// Amount of Goliath hides attached to the mech
 	var/hides = 0
 	/// List of all things in Ripley's Cargo Compartment


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Most mechs couldn't move diagonally. This restores that for all but the Clarke (which is a vehicle on treads)

The Clarke and Odysseus once again have pivot step, lost during the refactor for unknown reasons. It was literally just right there, it was an easy fix. Clarkes once again move like a tank!

## Why It's Good For The Game

So the way that mech movement works, by blocking diagonal movement, what instead happens is that the mech eats the move command and goes on movement cooldown. By pressing two buttons rather than one, you come to a full stop and no longer can move. I cannot think of a more hostile player-facing feature than this. It utterly gutted the usability of mechs for no real apparent benefit. As such, I'm just removing it on all but the most relevant mech, the Clarke. This should make it much more approachable to pilot mechs and not feel like the game is malfunctioning half the time.

Clarkes and Odysseus mechs had a really cool feature. They turned and moved in the same button press. This made them very nimble mechs and fun to utilize. They lost this feature in the refactor for, once again, not much apparent reason since this was literally a line change to restore.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Restores a lost feature, Clarkes and Odysseus mechs once again can pivot on a dime and step in the same button press.
qol: Mechs universally have diagonal movement as to avoid unresponsive movement, as block diagonal movement was having unintended side effects and was actually intended for pivot step mechs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
