### PR TITLE
Tons of minor fixes on the Birdshot Library

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -5858,6 +5858,10 @@
 /obj/machinery/air_sensor/incinerator_tank,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"cre" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "crm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -9100,6 +9104,7 @@
 	name = "Study"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_half{
 	dir = 1
 	},
@@ -12951,7 +12956,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "eUW" = (
-/obj/structure/bookcase/random,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
@@ -24234,7 +24238,6 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/command/nuke_storage)
 "iTv" = (
-/obj/structure/cable,
 /obj/structure/falsewall,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/library)
@@ -31225,10 +31228,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
 "lpa" = (
-/obj/structure/lattice,
 /obj/structure/sign/poster/official/random/directional/north,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/bookcase/random,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "lpC" = (
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
@@ -39660,6 +39663,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"orW" = (
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "osf" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -42519,9 +42526,12 @@
 /area/station/maintenance/port/greater)
 "pum" = (
 /obj/structure/cable,
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/arrows{
 	dir = 4
+	},
+/obj/machinery/door/window/right/directional/north{
+	name = "Library Desk Door";
+	req_access = list("library")
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
@@ -44044,7 +44054,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/obj/structure/bookcase/random,
+/obj/structure/bookcase/random/adult,
 /turf/open/floor/iron/grimy,
 /area/station/service/library)
 "pST" = (
@@ -44972,6 +44982,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "qgK" = (
@@ -44989,6 +45000,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
+/obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/service/library)
 "qgR" = (
@@ -91455,9 +91467,9 @@ xRV
 owR
 nAx
 tmQ
-xRV
-xRV
-xRV
+xeO
+xeO
+xeO
 xeO
 mnn
 naO
@@ -91712,9 +91724,9 @@ jXl
 vrn
 nzK
 lkZ
-xRV
+xeO
 lpa
-blb
+cre
 xeO
 izB
 jFY
@@ -91970,8 +91982,8 @@ vrn
 ncL
 qwz
 xeO
-wMg
-wMg
+wKr
+lql
 xeO
 wJV
 nbu
@@ -93772,7 +93784,7 @@ xeO
 ltl
 hzY
 pum
-wKr
+orW
 qgH
 wKr
 jVM
@@ -94286,7 +94298,7 @@ xeO
 oCc
 xeO
 nTg
-lql
+orW
 qgN
 pEC
 qYc

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -5858,10 +5858,6 @@
 /obj/machinery/air_sensor/incinerator_tank,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
-"cre" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "crm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -24238,8 +24234,8 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/command/nuke_storage)
 "iTv" = (
-/obj/structure/falsewall,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood/parquet,
 /area/station/service/library)
 "iTB" = (
 /obj/structure/cable,
@@ -25383,6 +25379,10 @@
 /obj/structure/chair/stool/directional/south,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"joy" = (
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/station/service/library)
 "joS" = (
 /obj/machinery/light/broken/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -39663,10 +39663,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"orW" = (
-/obj/structure/cable,
-/turf/open/floor/wood/parquet,
-/area/station/service/library)
 "osf" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
@@ -91726,7 +91722,7 @@ nzK
 lkZ
 xeO
 lpa
-cre
+iTv
 xeO
 izB
 jFY
@@ -93784,7 +93780,7 @@ xeO
 ltl
 hzY
 pum
-orW
+joy
 qgH
 wKr
 jVM
@@ -94040,7 +94036,7 @@ smf
 xeO
 lty
 xeO
-iTv
+xeO
 wMg
 dCm
 wMg
@@ -94298,7 +94294,7 @@ xeO
 oCc
 xeO
 nTg
-orW
+joy
 qgN
 pEC
 qYc


### PR DESCRIPTION
Changes in Birdshot:
-> Makes the curator's bookshelf be Adult rather than Random -> Makes it so the curator can actually leave his desk to the main room -> In order to do that I had to move one of the bookshelves away; removed the spacewindow behind bookshelves since they didn't make any sense in-universe and put the moved bookcase there -> Makes a wire no longer go through a wall to reach the library APC

## About The Pull Request

This station is a mess. This PR will make the curator in Birdshot station to be a lot more playable

## Why It's Good For The Game

Tons of minor fixes in Birdshot's library - fixes a wallwire + makes it so the curator can leave his balcony and go to the main library room without having to do a loop around the entire solar system. Moves a bookshelf in order to do that and makes the curator's private collection erotica.

## Changelog

:cl: Fazzie
qol: Many changes in Birdshot's Library.
Makes the curator's bookshelf be Adult rather than Random 
Makes it so the curator can actually leave his desk to the main room 
In order to do that I had to move one of the bookshelves away; removed the spacewindow behind bookshelves since they didn't make any sense in-universe and put the moved bookcase there 
Makes a wire no longer go through a wall to reach the library APC
/:cl:
