### PR TITLE
Eating plasma grants golems ash storm immunity for the duration of the buff

### DIFF
--- a/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_status_effects.dm
@@ -176,14 +176,14 @@
 	. = ..()
 	if (!.)
 		return FALSE
-	owner.add_traits(list(TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTHEAT), TRAIT_STATUS_EFFECT(id))
+	owner.add_traits(list(TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTHEAT, TRAIT_ASHSTORM_IMMUNE), TRAIT_STATUS_EFFECT(id))
 	RegisterSignal(owner, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(on_burned))
 	var/mob/living/carbon/human/human_owner = owner
 	human_owner.physiology.burn_mod *= burn_multiplier
 	return TRUE
 
 /datum/status_effect/golem/plasma/on_remove()
-	owner.remove_traits(list(TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTHEAT), TRAIT_STATUS_EFFECT(id))
+	owner.remove_traits(list(TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTHEAT, TRAIT_ASHSTORM_IMMUNE), TRAIT_STATUS_EFFECT(id))
 	UnregisterSignal(owner, COMSIG_MOB_APPLY_DAMAGE)
 	var/mob/living/carbon/human/human_owner = owner
 	human_owner.physiology.burn_mod /= burn_multiplier


### PR DESCRIPTION
## About The Pull Request

ash storms use `adjustFireLoss()` to apply burn damage, which completely bypasses any fire damage reductions you might have, which includes the mob's `burn_mob`. plasma golem buff was using that and ash storms just ignored it.
there's maybe some food for thought about maybe moving the ash storm's effect to something like `apply_damage()` but that would entail looking into all possible fire damage reductions, starting with the basic explorer armor(?)

## Why It's Good For The Game

Fixes #77349

## Changelog

:cl:
fix: golems that ate plasma are properly immune to ash storms
/:cl: