### PR TITLE
Areas created with the "land claim" are no longer hazardous to free golems

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -138,10 +138,7 @@
 /obj/item/storage/medkit/brute,
 /obj/structure/table/wood,
 /obj/item/storage/medkit/brute,
-/obj/item/areaeditor/blueprints{
-	desc = "Use to build new structures in the wastes.";
-	name = "land claim"
-	},
+/obj/item/areaeditor/blueprints/golem,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "D" = (

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 			return
 		counter += 1 //increment by one so the next loop will start at the next position in the list
 
-/proc/create_area(mob/creator)
+/proc/create_area(mob/creator, new_area_type = /area)
 	// Passed into the above proc as list/break_if_found
 	var/static/list/area_or_turf_fail_types = typecacheof(list(
 		/turf/open/space,
@@ -100,7 +100,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/station/en
 		return
 
 	var/list/apc_map = list()
-	var/list/areas = list("New Area" = /area)
+	var/list/areas = list("New Area" = new_area_type)
 	for(var/i in 1 to turf_count)
 		var/turf/the_turf = turfs[i]
 		var/area/place = get_area(the_turf)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -557,3 +557,10 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if(name == initial(name))
 		return name
 	return "[name] ([initial(name)])"
+
+/**
+ * A blank area subtype solely used by the golem area editor for the purpose of
+ * allowing golems to create new areas without suffering from the hazard_area debuffs.
+ */
+/area/golem
+	name = "Golem Territory"

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -7,6 +7,8 @@
 	attack_verb_simple = list("attack", "bap", "hit")
 	var/fluffnotice = "Nobody's gonna read this stuff!"
 	var/in_use = FALSE
+	///When using it to create a new area, this will be its type.
+	var/new_area_type = /area
 
 /obj/item/areaeditor/attack_self(mob/user)
 	add_fingerprint(user)
@@ -35,7 +37,7 @@
 			to_chat(usr, span_warning("You cannot edit restricted areas."))
 			return
 		in_use = TRUE
-		create_area(usr)
+		create_area(usr, new_area_type)
 		in_use = FALSE
 	updateUsrDialog()
 
@@ -209,6 +211,12 @@
 	icon = 'icons/obj/scrolls.dmi'
 	icon_state = "blueprints"
 	fluffnotice = "Intellectual Property of Nanotrasen. For use in engineering cyborgs only. Wipe from memory upon departure from the station."
+
+/obj/item/areaeditor/blueprints/golem
+	name = "land claim"
+	desc = "Use it to build new structures in the wastes."
+	fluffnotice = "In memory of the Liberator's brother, Delaminator, and his Scarlet Macaw-iathan, from which this artifact was stolen."
+	new_area_type = /area/golem
 
 /proc/rename_area(a, new_name)
 	var/area/A = get_area(a)

--- a/code/modules/mob_spawn/ghost_roles/golem_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/golem_roles.dm
@@ -56,7 +56,7 @@
 
 /// Makes free golems slow and sad on the space station
 /obj/effect/mob_spawn/ghost_role/human/golem/proc/try_keep_home(mob/new_spawn)
-	var/static/list/allowed_areas = typecacheof(list(/area/icemoon, /area/lavaland, /area/ruin)) + typecacheof(/area/misc/survivalpod)
+	var/static/list/allowed_areas = typecacheof(list(/area/icemoon, /area/lavaland, /area/ruin, /area/misc/survivalpod, /area/golem))
 	ADD_TRAIT(new_spawn, TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION, INNATE_TRAIT)
 	new_spawn.AddComponent(/datum/component/hazard_area, area_whitelist = allowed_areas)
 


### PR DESCRIPTION
## About The Pull Request
New areas created by standard blueprints are not safe for golems, which is why I'm touching blueprints and create_area code and making the blueprints found in the free golem ship an actual subtype rather than a map-edited instance.

## Why It's Good For The Game
This will fix #77354.

## Changelog

:cl:
fix: Areas created with the "land claim" blueprints are no longer hazardous to free golems.
/:cl:
