### PR TITLE
Operating Console now requires "Computer Consoles" research, board can be bought in the Autopsy Kit

### DIFF
--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -38,6 +38,7 @@
 	contains = list(
 		/obj/item/autopsy_scanner = 1,
 		/obj/item/storage/medkit/coroner = 1,
+		/obj/item/circuitboard/computer/operating = 1,
 	)
 	crate_name = "autopsy kit crate"
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -277,7 +277,6 @@
 		"hemostat",
 		"large_beaker",
 		"mmi_m",
-		"operating",
 		"petri_dish",
 		"pillbottle",
 		"plumbing_rcd",
@@ -1149,6 +1148,7 @@
 		"mining",
 		"rdcamera",
 		"seccamera",
+		"operating",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 


### PR DESCRIPTION

## About The Pull Request

Moves the Operating Computer design to be unlocked with the Computer Consoles research, this means it is no longer available at round start.
Restricting access to operating computers, even insignificantly, promotes the usage of the operating theaters, which are generally less stressful for patients anyway and considerably safer.  A private locker to store their materials, access to an organ storage immediately nearby, and usually a locker with some chemicals in it plus a full set of surgery tools.

## Why It's Good For The Game
Assuming that the medical department immediately makes two operating computers upon starting a round, they consume 10 iron sheets plus whatever materials in circuit boards and wires, and a sheet of glass. However insignificant, this is something I've seen regularly, it is not uncommon for medical doctors to place operating computers in the main treatment room, and while this can be a very nice feature for keeping all the doctors in a centralized location, it should be noted that this is not a very conventional strategy and goes against the way that the station is set up.

The additional restrictions to silver now (noticeably rarer to see in the lathe early) also mean that you can't reasonably build surgical tables right away anyway without dismantling one of the associated ones in the adjacent rooms that already have a computer next to them.

## Changelog
:cl:Senefi
balance: Operating Console now requires "Computer Consoles" research to print the circuit board.
balance: Operating Console circuit board now comes with the Cargo "Autopsy Kit" to help prevent possible softlock scenario.
/:cl:
