### PR TITLE
Drill module automatically disables if it's about to drill into gibtonite

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -158,9 +158,10 @@
 	if(!ismineralturf(bumped_into) || !drain_power(use_power_cost))
 		return
 	var/turf/closed/mineral/mineral_turf = bumped_into
-	if(istype(mineral_turf, /turf/closed/mineral/gibtonite))
+	var/turf/closed/mineral/gibtonite/giberal_turf = mineral_turf
+	if(istype(giberal_turf) && giberal_turf.stage != GIBTONITE_UNSTRUCK)
 		playsound(bumper, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
-		to_chat(bumper, span_warning("[icon2html(src, bumper)] Gibtonite ore deposit detected! Drills disabled."))
+		to_chat(bumper, span_warning("[icon2html(src, bumper)] Unstable gibtonite ore deposit detected! Drills disabled."))
 		on_deactivation()
 		return
 	mineral_turf.gets_drilled(mod.wearer)

--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -158,6 +158,11 @@
 	if(!ismineralturf(bumped_into) || !drain_power(use_power_cost))
 		return
 	var/turf/closed/mineral/mineral_turf = bumped_into
+	if(istype(mineral_turf, /turf/closed/mineral/gibtonite))
+		playsound(bumper, 'sound/machines/scanbuzz.ogg', 25, TRUE, SILENCED_SOUND_EXTRARANGE)
+		to_chat(bumper, span_warning("[icon2html(src, bumper)] Gibtonite ore deposit detected! Drills disabled."))
+		on_deactivation()
+		return
 	mineral_turf.gets_drilled(mod.wearer)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 


### PR DESCRIPTION

## About The Pull Request

Drill module automatically disables if it's about to drill into gibtonite.

## Why It's Good For The Game

> Drill module automatically disables if it's about to drill into gibtonite

There's not enough time to react, the mining scanner is surprisingly slow sometimes and it means you drill straight into gibtonite, which primes it the first drill and blows it up the second, which is a lot more of a pain than it sounds because drilling is night-instant. These explosions are usually enough to crit you, and if they don't, the stun and area clear means any fauna can wander in and finish you off.

The auto-disable still makes it an annoyance to stumble upon gibtonite, but it won't round end you for using modsuits.

## Changelog

:cl:
qol: Drill module automatically disables if it's about to drill into gibtonite
/:cl:

