### PR TITLE
Fixes champagne froth icon missing

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -150,7 +150,7 @@
 		if(3)
 			intensity_state = "high"
 	///The froth fountain that we are sticking onto the bottle
-	var/mutable_appearance/froth = mutable_appearance(icon, "froth_bottle_[intensity_state]")
+	var/mutable_appearance/froth = mutable_appearance('icons/obj/drinks/drink_effects.dmi', "froth_bottle_[intensity_state]")
 	froth.pixel_x = offset_x
 	froth.pixel_y = offset_y
 	add_overlay(froth)


### PR DESCRIPTION
## About The Pull Request

#71810 split up `drinks.dmi` and moved froth effects to `drink_effects.dmi` but `make_froth()` was referencing the drink's `icon` aka `drinks.dmi`.

## Why It's Good For The Game

froth was killed after a month of it existing and nobody noticed this is so sad can we hit 50 lilkes

## Changelog

:cl:
fix: fixed missing froth sprites
/:cl:
