### PR TITLE
Fixed lua-created atoms from hard deleting

### DIFF
--- a/code/modules/admin/verbs/lua/lua_state.dm
+++ b/code/modules/admin/verbs/lua/lua_state.dm
@@ -168,4 +168,11 @@ GLOBAL_PROTECT(lua_usr)
 		for(var/datum/lua_editor/editor as anything in editor_list)
 			SStgui.update_uis(editor)
 
+/datum/lua_state/proc/clear_on_delete(datum/to_clear)
+	RegisterSignal(to_clear, COMSIG_QDELETING, PROC_REF(on_delete))
+
+/datum/lua_state/proc/on_delete(datum/to_clear)
+	SIGNAL_HANDLER
+	references -= to_clear
+
 #undef MAX_LOG_REPEAT_LOOKBACK

--- a/code/modules/admin/verbs/lua/lua_state.dm
+++ b/code/modules/admin/verbs/lua/lua_state.dm
@@ -168,6 +168,7 @@ GLOBAL_PROTECT(lua_usr)
 		for(var/datum/lua_editor/editor as anything in editor_list)
 			SStgui.update_uis(editor)
 
+// Called by lua scripts when they add an atom to var/list/references so that it gets cleared up on delete.
 /datum/lua_state/proc/clear_on_delete(datum/to_clear)
 	RegisterSignal(to_clear, COMSIG_QDELETING, PROC_REF(on_delete))
 

--- a/lua/SS13.lua
+++ b/lua/SS13.lua
@@ -17,9 +17,12 @@ end
 
 function SS13.new(type, ...)
 	local datum = dm.global_proc("_new", type, { ... })
-	local references = SS13.state.vars.references
-	references:add(datum)
-	return datum
+	if datum then
+		local references = SS13.state.vars.references
+		references:add(datum)
+		SS13.state:call_proc("clear_on_delete", datum)
+		return datum
+	end
 end
 
 function SS13.await(thing_to_call, proc_to_call, ...)


### PR DESCRIPTION

## About The Pull Request
Lua created atoms hard delete because they get added to a references list without ever being cleared. This fixes that by registering a qdeleting signal on them and removing them from the list on delete.

## Why It's Good For The Game
Harddel fixes

## Changelog
:cl:
fix: Fixed a hard delete that would occur with lua-created atoms.
/:cl:
