### PR TITLE
Fixes things about goliaths: wallhacks/range hacks(no, really) and tentacles not spawning in mineral turfs; also fixes `find_potential_targets` wallhacks

### DIFF
--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/targetting.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/targetting.dm
@@ -14,7 +14,7 @@
 		CRASH("No target datum was supplied in the blackboard for [controller.pawn]")
 
 	var/atom/current_target = controller.blackboard[target_key]
-	if (targetting_datum.can_attack(living_mob, current_target) && can_see(living_mob, current_target, vision_range))
+	if (targetting_datum.can_attack(living_mob, current_target, vision_range))
 		finish_action(controller, succeeded = FALSE)
 		return
 

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/targetting.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/targetting.dm
@@ -14,7 +14,7 @@
 		CRASH("No target datum was supplied in the blackboard for [controller.pawn]")
 
 	var/atom/current_target = controller.blackboard[target_key]
-	if (targetting_datum.can_attack(living_mob, current_target))
+	if (targetting_datum.can_attack(living_mob, current_target) && can_see(living_mob, current_target, vision_range))
 		finish_action(controller, succeeded = FALSE)
 		return
 

--- a/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
+++ b/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
@@ -2,7 +2,7 @@
 /datum/targetting_datum
 
 ///Returns true or false depending on if the target can be attacked by the mob
-/datum/targetting_datum/proc/can_attack(mob/living/living_mob, atom/target)
+/datum/targetting_datum/proc/can_attack(mob/living/living_mob, atom/target, vision_range)
 	return
 
 ///Returns something the target might be hiding inside of
@@ -17,8 +17,10 @@
 	var/check_factions_exactly = FALSE
 	/// Minimum status to attack living beings
 	var/stat_attack = CONSCIOUS
+	///Whether we care for seeing the target or not
+	var/ignore_sight = FALSE
 
-/datum/targetting_datum/basic/can_attack(mob/living/living_mob, atom/the_target)
+/datum/targetting_datum/basic/can_attack(mob/living/living_mob, atom/the_target, vision_range)
 	if(isturf(the_target) || !the_target) // bail out on invalids
 		return FALSE
 
@@ -31,6 +33,9 @@
 		var/mob/M = the_target
 		if(M.status_flags & GODMODE)
 			return FALSE
+
+	if(!ignore_sight && can_see(living_mob, the_target, vision_range)) //Target has moved behind cover and we have lost line of sight to it
+		return FALSE
 
 	if(living_mob.see_invisible < the_target.invisibility) //Target's invisible to us, forget it
 		return FALSE

--- a/code/datums/components/basic_mob_attack_telegraph.dm
+++ b/code/datums/components/basic_mob_attack_telegraph.dm
@@ -58,7 +58,8 @@
 	RegisterSignal(target, COMSIG_MOVABLE_MOVED, PROC_REF(target_moved))
 
 	on_began_forecast?.Invoke(target)
-	if (!do_after(source, delay = telegraph_duration, target = source, interaction_key = INTERACTION_BASIC_ATTACK_FORCEAST))
+	//we stop the do_after if the target moves out of neighboring turfs but if they dance around us they get their face smashed
+	if (!do_after(source, delay = telegraph_duration, target = target, timed_action_flags = IGNORE_TARGET_LOC_CHANGE, extra_checks = CALLBACK(source, TYPE_PROC_REF(/atom/movable, Adjacent), target), interaction_key = INTERACTION_BASIC_ATTACK_FORCEAST))
 		forget_target(target)
 		return
 	if (isnull(target)) // They got out of the way :(

--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_ai.dm
@@ -1,6 +1,6 @@
 /datum/ai_controller/basic_controller/bileworm
 	blackboard = list(
-		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic(),
+		BB_TARGETTING_DATUM = new /datum/targetting_datum/basic/bileworm(),
 	)
 
 	planning_subtrees = list(
@@ -8,6 +8,9 @@
 		/datum/ai_planning_subtree/bileworm_attack,
 		/datum/ai_planning_subtree/bileworm_execute,
 	)
+
+/datum/targetting_datum/basic/bileworm
+	ignore_sight = TRUE
 
 /datum/ai_planning_subtree/bileworm_attack
 

--- a/code/modules/mob/living/basic/lavaland/goliath/goliath_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/goliath_ai.dm
@@ -107,6 +107,8 @@
 	. = ..()
 	var/turf/target_turf = controller.blackboard[target_key]
 	var/mob/living/basic/basic_mob = controller.pawn
+	if(!basic_mob.CanReach(target_turf))
+		return
 	basic_mob.melee_attack(target_turf)
 	finish_action(controller, succeeded = TRUE)
 

--- a/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
@@ -17,14 +17,14 @@
 
 /obj/effect/goliath_tentacle/Initialize(mapload)
 	. = ..()
+	if (ismineralturf(loc))
+		var/turf/closed/mineral/floor = loc
+		floor.gets_drilled()
 	if (!isopenturf(loc) || isspaceturf(loc) || isopenspaceturf(loc))
 		return INITIALIZE_HINT_QDEL
 	for (var/obj/effect/goliath_tentacle/tentacle in loc)
 		if (tentacle != src)
 			return INITIALIZE_HINT_QDEL
-	if (ismineralturf(loc))
-		var/turf/closed/mineral/floor = loc
-		floor.gets_drilled()
 	deltimer(action_timer)
 	action_timer = addtimer(CALLBACK(src, PROC_REF(animate_grab)), 0.7 SECONDS, TIMER_STOPPABLE)
 


### PR DESCRIPTION
## About The Pull Request

Goliath's sand digging behaviour could potentially target a turf that's actually unreachable by the goliath, e.g.
```
G#
#T
```
where G - goliath # - wall T - target turf. fixed that, but i think there could be something easier here, maybe instead grabbing turfs in goliath's `view()`? unsure

The component goliaths use to telegraph their attacks (`basic_mob_attack_telegraph`) casts a `do_after()` to perform the attack, but it was not actually checking for the target staying in melee range, as it was using the source goliath as both `user` and `target`, so it didn't actually care at all for the target. Implemented an `extra_checks` to `Adjacent()` since that's the closest we get for melee range shenanigans I suppose
This still allows the source basicmob to attack the target if the target moves around the source basicmob.

`!`Goliaths were also able to summon tentacles on a target that moved into cover and still stayed in the `find_potential_targets` target range. Which meant more wallhacks. This was a thing for the base `find_potential_targets`, meaning that every basic mob using it was a dirty haxxor (or very vengeful). Fixed that by making `find_potential_targets` also check for `can_see()` before proceeding further down `find_potential_targets/perform()`. `!` The only exception to this check currently are bileworms.

`!`Goliath tentacles were not spawning in mineral turfs as their `Initialize()` checked for closed turfs before handling mineral turf mining. Fixed that as well.

## Why It's Good For The Game
![Dr__Hax_by_Didgeridoo_Dealer](https://github.com/tgstation/tgstation/assets/75863639/fbcbfc1b-f489-435e-bb01-677f55398787)

## Changelog

:cl:
fix: fixed goliaths digging sand that they can't actually reach (behind windows or inbetween closed turfs)
fix: fixed goliaths melee attacking their target despite the target running away from goliath melee range
fix: fixed goliath tentacles not spawning in mineral turfs
fix: fixed goliaths summoning tentacles on targets that moved behind cover but stayed in their targeting range. this applies for most basic mobs, really, so if any basic mob was targeting you despite you hauling ass behind cover, they shouldn't anymore
/:cl:
