### PR TITLE
Fixes Meta's Xenobio's Windoors

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8583,9 +8583,8 @@
 /area/station/medical/chemistry)
 "diq" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/left/directional/south{
-	dir = 8;
-	name = "Maximum Security Test Chamber";
+/obj/machinery/door/window/left/directional/west{
+	name = "Containment Pen #5";
 	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron,
@@ -12889,10 +12888,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "eOP" = (
-/obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
+/obj/machinery/door/window/left/directional/west{
 	name = "Containment Pen #6";
 	req_access = list("xenobiology")
 	},
@@ -16439,11 +16435,8 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "gjv" = (
-/obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #5";
+/obj/machinery/door/window/left/directional/west{
+	name = "Maximum Security Test Chamber";
 	req_access = list("xenobiology")
 	},
 /turf/open/floor/engine,
@@ -17263,16 +17256,13 @@
 /area/station/engineering/main)
 "gyI" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Containment Pen #8";
-	req_access = list("xenobiology")
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
 	name = "Xenobio Pen 8 Blast Door"
+	},
+/obj/machinery/door/window/left/directional/east{
+	req_access = list("xenobiology");
+	name = "Containment Pen #8"
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -20649,14 +20639,13 @@
 /area/station/medical/treatment_center)
 "hMv" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/left/directional/north{
-	dir = 4;
-	name = "Containment Pen #1";
-	req_access = list("xenobiology")
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio1";
 	name = "Xenobio Pen 1 Blast Door"
+	},
+/obj/machinery/door/window/left/directional/east{
+	req_access = list("xenobiology");
+	name = "Containment Pen #1"
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -21072,10 +21061,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "hVn" = (
-/obj/machinery/door/window/left/directional/north{
-	dir = 4;
-	name = "Containment Pen #8";
-	req_access = list("xenobiology")
+/obj/machinery/door/window/right/directional/east{
+	req_access = list("xenobiology");
+	name = "Containment Pen #8"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -22074,8 +22062,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "imw" = (
-/obj/machinery/door/window/left/directional/north{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Containment Pen #3";
 	req_access = list("xenobiology")
 	},
@@ -39006,14 +38993,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/window/left/directional/north{
-	dir = 8;
-	name = "Containment Pen #6";
-	req_access = list("xenobiology")
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
 	name = "Xenobio Pen 6 Blast Door"
+	},
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen #6";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -42293,12 +42279,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "psU" = (
-/obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Containment Pen #1";
-	req_access = list("xenobiology")
+/obj/machinery/door/window/right/directional/east{
+	req_access = list("xenobiology");
+	name = "Containment Pen #1"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -42809,8 +42792,6 @@
 "pDl" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	icon_state = "right";
 	name = "Containment Pen #7";
 	req_access = list("xenobiology")
 	},
@@ -45074,8 +45055,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "qvQ" = (
-/obj/machinery/door/window/left/directional/north{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Containment Pen #4";
 	req_access = list("xenobiology")
 	},
@@ -47700,16 +47680,13 @@
 /area/station/service/bar)
 "rrL" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #4";
-	req_access = list("xenobiology")
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
 	name = "Xenobio Pen 4 Blast Door"
+	},
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen #4";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -47955,10 +47932,9 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/door/window/left/directional/south{
-	dir = 4;
-	name = "Maximum Security Test Chamber";
-	req_access = list("xenobiology")
+/obj/machinery/door/window/left/directional/east{
+	req_access = list("xenobiology");
+	name = "Maximum Security Test Chamber"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -48026,16 +48002,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Containment Pen #3";
-	req_access = list("xenobiology")
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
 	name = "Xenobio Pen 3 Blast Door"
+	},
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen #3";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -51140,14 +51113,13 @@
 /area/station/engineering/atmospherics_engine)
 "sCv" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/left/directional/north{
-	dir = 8;
-	name = "Containment Pen #5";
-	req_access = list("xenobiology")
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
 	name = "Xenobio Pen 5 Blast Door"
+	},
+/obj/machinery/door/window/right/directional/west{
+	name = "Containment Pen #5";
+	req_access = list("xenobiology")
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
@@ -54156,8 +54128,7 @@
 /area/station/hallway/primary/central)
 "tGS" = (
 /obj/structure/cable,
-/obj/machinery/door/window/left/directional/north{
-	dir = 2;
+/obj/machinery/door/window/left/directional/south{
 	name = "Containment Pen #2";
 	req_access = list("xenobiology")
 	},
@@ -57410,16 +57381,13 @@
 /area/station/commons/fitness/recreation)
 "uKW" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/door/window/left/directional/north{
-	base_state = "right";
-	dir = 2;
-	icon_state = "right";
-	name = "Containment Pen #2";
-	req_access = list("xenobiology")
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
 	name = "Xenobio Pen 2 Blast Door"
+	},
+/obj/machinery/door/window/right/directional/south{
+	req_access = list("xenobiology");
+	name = "Containment Pen #2"
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)


### PR DESCRIPTION

## About The Pull Request

This is how Meta's Xenobio's windoors look like if you remove all dir and iconstate varedits.

![image](https://github.com/tgstation/tgstation/assets/84548101/72de54d5-36b0-41e7-a281-b6ce2154fea6)

Yes, it's literally all northwindoors, varedited to hell and back to look like other windoors. Fucked up.
## Changelog
:cl:
fix: Exorcised uneeded variables from windoors in Meta's Xenobio
/:cl:
