### PR TITLE
Disable Rust based url decoding and encoding overrides

### DIFF
--- a/code/__DEFINES/rust_g_overrides.dm
+++ b/code/__DEFINES/rust_g_overrides.dm
@@ -1,3 +1,3 @@
 // RUSTG_OVERRIDE_BUILTINS is not used since the file APIs don't work well over Linux.
-#define url_encode(text) rustg_url_encode("[text]")
-#define url_decode(text) rustg_url_decode("[text]")
+//#define url_encode(text) rustg_url_encode("[text]")
+//#define url_decode(text) rustg_url_decode("[text]")


### PR DESCRIPTION
Latest info is that the crash happens in these routines potentially.

This will be a test merge candidate to see if it makes a difference
