### PR TITLE
Advanced robotics techweb node adjustment

### DIFF
--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -339,3 +339,15 @@
 	description = "As an extension of testing exosuit damage results, scanning examples of complete structural failure will accelerate our material stress simulations."
 	possible_types = list(/obj/structure/mecha_wreckage)
 	total_requirement = 2
+
+/datum/experiment/scanning/random/robot
+	name = "Robot Scanning Experiment"
+	description = "At the end of the day, cyborgs are just complicated robots. Scan a simple robot, the data will help us make better cyborgs."
+	total_requirement = 1
+	possible_types = list(
+		/mob/living/simple_animal/bot/medbot,
+		/mob/living/simple_animal/bot/cleanbot,
+		/mob/living/simple_animal/bot/hygienebot,
+		/mob/living/simple_animal/bot/firebot,
+		/mob/living/simple_animal/bot/floorbot,
+	)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -890,11 +890,12 @@
 	id = "adv_robotics"
 	display_name = "Advanced Robotics Research"
 	description = "Machines using actual neural networks to simulate human lives."
-	prereq_ids = list("neural_programming", "robotics")
+	prereq_ids = list("robotics")
 	design_ids = list(
 		"mmi_posi",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+	discount_experiments = list(/datum/experiment/scanning/random/robot = 5000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 
 /datum/techweb_node/adv_bots
 	id = "adv_bots"


### PR DESCRIPTION

## About The Pull Request

Since coroner was merged, the dissection experiment has been harder for roboticists to complete. However, a great deal of robotics content (positronic brains, most cyborg upgrades, artificial intelligence, and combat mechs) are all gated behind human dissection (through the biological technology->neural programming->advanced robotics branch of the techweb). This PR changes that. The advanced robotics node now no longer requires the neural programming node. The base cost has been increased by 5000 points, but there is a new scanning experiment which gives a 5000 point discount. This experiment requires you to scan a medibot, cleanbot, hygienebot, floorbot, or firebot, picked at random.
## Why It's Good For The Game

Robotics should not be dependent on an entirely different department to access their core job content. Such dependencies encourage tiding and other toxic interactions between departments. Furthermore, the new experiment gives an incentive for roboticists to build simple robots by offering a point discount for doing so.
## Changelog
:cl:
balance: The advanced robotics research node no longer requires neural programming. It has its own scanning experiment with a point discount now, but costs more by default to compensate.
/:cl:
