### PR TITLE
[NO GBP] Fixing a logic mistake for chasm fishing

### DIFF
--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -57,7 +57,7 @@
 	SIGNAL_HANDLER
 	var/list/chasm_contents = get_chasm_contents(fishing_spot)
 
-	if (length(chasm_contents))
+	if (!length(chasm_contents))
 		create_default_object()
 		return
 


### PR DESCRIPTION
## About The Pull Request
What it should do is spawn a generic item when the list of possible things to retrieve is empty, not the other way around. Surprised this weren't caught earlier.

## Why It's Good For The Game
See above.

## Changelog

:cl:
fix: Fixed a logic mistake for chasm fishing that resulted in only generic items being spawned.
/:cl:
