### PR TITLE
Crafting UI - Show craftables with most ingredients first, faster search

### DIFF
--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -233,10 +233,11 @@ export const PersonalCrafting = (props, context) => {
   const content = document.getElementById('content');
   const CATEGORY_ICONS =
     mode === MODE.cooking ? CATEGORY_ICONS_COOKING : CATEGORY_ICONS_CRAFTING;
-  const debounceSearch = debounce((value) => {
+  const searchRecipes = (value) => {
     setPages(1);
     setSearchText(value);
-  }, 500);
+  };
+  const debouncedSearch = debounce(searchRecipes, 500);
   return (
     <Window width={700} height={720}>
       <Window.Content>
@@ -253,7 +254,7 @@ export const PersonalCrafting = (props, context) => {
                       (mode === MODE.cooking ? ' recipes...' : ' designs...')
                     }
                     value={searchText}
-                    onInput={(e, value) => debounceSearch(value)}
+                    onInput={(e, value) => debouncedSearch(value)}
                     fluid
                   />
                 </Stack.Item>

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -206,7 +206,9 @@ export const PersonalCrafting = (props, context) => {
               recipe.category === activeCategory)))
     ),
     sortBy<Recipe>((recipe) => [
-      -Number(craftability[recipe.ref]),
+      activeCategory === 'Can Make'
+        ? 99 - Object.keys(recipe.reqs).length
+        : Number(craftability[recipe.ref]),
       recipe.name.toLowerCase(),
     ]),
   ])(data.recipes);
@@ -246,7 +248,7 @@ export const PersonalCrafting = (props, context) => {
                       (mode === MODE.cooking ? ' recipes...' : ' designs...')
                     }
                     value={searchText}
-                    onInput={(e, value) => {
+                    onChange={(e, value) => {
                       setPages(1);
                       setSearchText(value);
                     }}

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -233,6 +233,10 @@ export const PersonalCrafting = (props, context) => {
   const content = document.getElementById('content');
   const CATEGORY_ICONS =
     mode === MODE.cooking ? CATEGORY_ICONS_COOKING : CATEGORY_ICONS_CRAFTING;
+  const debounceSearch = debounce((value) => {
+    setPages(1);
+    setSearchText(value);
+  }, 500);
   return (
     <Window width={700} height={720}>
       <Window.Content>
@@ -249,10 +253,7 @@ export const PersonalCrafting = (props, context) => {
                       (mode === MODE.cooking ? ' recipes...' : ' designs...')
                     }
                     value={searchText}
-                    onInput={debounce((e, value) => {
-                      setPages(1);
-                      setSearchText(value);
-                    }, 500)}
+                    onInput={(e, value) => debounceSearch(value)}
                     fluid
                   />
                 </Stack.Item>

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -1,4 +1,5 @@
 import { BooleanLike, classes } from 'common/react';
+import { debounce } from 'common/timer';
 import { createSearch } from 'common/string';
 import { flow } from 'common/fp';
 import { filter, sortBy } from 'common/collections';
@@ -248,10 +249,10 @@ export const PersonalCrafting = (props, context) => {
                       (mode === MODE.cooking ? ' recipes...' : ' designs...')
                     }
                     value={searchText}
-                    onChange={(e, value) => {
+                    onInput={debounce((e, value) => {
                       setPages(1);
                       setSearchText(value);
-                    }}
+                    }, 500)}
                     fluid
                   />
                 </Stack.Item>


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/3625094/9d5802cc-59d8-41c4-ab49-e110594eb084)

## About The Pull Request

Due to the huge amount of recipes, crafting menu may be laggy for players with high latency. I made the search occuring with debounce (It will wait for 0.5 seconds after you stopped typing and then search) instead of searching on every letter typed. Now you can enter 'burger' and search once, instead of having the menu lagging while it searches for 'b', 'bu', 'bur', etc. 

Also made the Can Make category show items that require most ingredients first - so that when you want to craft something specific, the UI is not flooded with recipes that require only iron (there are plenty of these). It's done in a bit of hacky way, but it works. (Flow `SortBy` doesn't seem to work with negative numbers correctly)

## Why It's Good For The Game

Better UX for crafting menu.

## Changelog

:cl:
qol: Crafting menu "Can Make" category shows complex recipes first.
qol: Crafting menu search happens 0.5 sec after you stopped typing, instead of on every letter type.
/:cl:
