### PR TITLE
Fix engineered stealth viruses being visible [NO GBP]

### DIFF
--- a/code/__DEFINES/diseases.dm
+++ b/code/__DEFINES/diseases.dm
@@ -6,6 +6,12 @@
 #define HIDDEN_SCANNER (1<<0)
 #define HIDDEN_PANDEMIC (1<<1)
 
+//Bitfield for Visibility Flags
+DEFINE_BITFIELD(visibility_flags, list(
+	"HIDDEN_FROM_ANALYZER" = HIDDEN_SCANNER,
+	"HIDDEN_FROM_PANDEMIC" = HIDDEN_PANDEMIC,
+))
+
 //Disease Flags
 #define CURABLE (1<<0)
 #define CAN_CARRY (1<<1)

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -18,7 +18,7 @@
 	/// The probability of this infection advancing a stage every second the cure is not present.
 	var/stage_prob = 2
 	/// How long this infection incubates (non-visible) before revealing itself
-	var/incubation_time = 0
+	var/incubation_time
 
 	//Other
 	var/list/viable_mobtypes = list() //typepaths of viable mobs

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -535,10 +535,13 @@
 	return properties["transmittable"]
 
 /**
- *  If the disease has an incubation time (such as event diseases) start the timer
+ *  If the disease has an incubation time (such as event diseases) start the timer, let properties determine if there's no timer set.
  */
 /datum/disease/advance/after_add()
 	. = ..()
+
+	if(isnull(incubation_time))
+		return
 
 	if(incubation_time < world.time)
 		make_visible()


### PR DESCRIPTION
## About The Pull Request

Remember your isnull(), null is not the same as zero. Also adds the bitfield to make it human readable in VV.
Closes https://github.com/tgstation/tgstation/issues/77409 introduced by https://github.com/tgstation/tgstation/pull/77272

![image](https://github.com/tgstation/tgstation/assets/83487515/74043fa8-c912-43b8-ba27-54a1a19c61ab)

## Why It's Good For The Game

Fixes intentionally stealthy viruses becoming visible

## Changelog
:cl: LT3
fix: Advanced viruses that are supposed to be stealth will again actually be stealth to analyzers
code: Virus visibility flags can now be toggled in view variables
/:cl:
