### PR TITLE
Changeling armblade gets 35% armour penetration + better wounding.

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -192,7 +192,8 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
-	wound_bonus = 20
+	wound_bonus = 10
+	bare_wound_bonus = 10
 	armour_penetration = 30
 	var/can_drop = FALSE
 	var/fake = FALSE

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -194,7 +194,7 @@
 	sharpness = SHARP_EDGED
 	wound_bonus = 10
 	bare_wound_bonus = 10
-	armour_penetration = 30
+	armour_penetration = 35
 	var/can_drop = FALSE
 	var/fake = FALSE
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -192,8 +192,8 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
-	wound_bonus = -20
-	bare_wound_bonus = 20
+	wound_bonus = 20
+	armour_penetration = 30
 	var/can_drop = FALSE
 	var/fake = FALSE
 


### PR DESCRIPTION

## About The Pull Request
Gives the changeling armblade an armour penetration of 35%. Sets their bare_wound_bonus to 10 (from 20), and a wound_bonus of 10 (from -20).
## Why It's Good For The Game
The wound bonuses basically gave massive punishment if they attacked anything but the skin. It honestly felt kinda lame. The better wounding potential will help bring a bloodier and more exciting atmosphere when a changeling whips out the blade.

The armour penetration will help reduce dragged out fights that get a little silly, while keeping the wounding more consistent.
## Changelog
:cl:
balance: Changeling arm blade has an armour penetration of 35%.
balance: Changeling arm blade has a wound bonus of 10, from -20.
balance: Changeling has a bare wound bonus of 10, from 20.
/:cl:
