### PR TITLE
Abductor / general "Summon Item" spell QoL

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -14,7 +14,6 @@
 	var/greet_text
 	/// Type path for the associated job datum.
 	var/role_job = /datum/job/abductor_agent
-	var/datum/action/cooldown/spell/summonitem/abductor/baton_return_spell
 
 /datum/antagonist/abductor/get_preview_icon()
 	var/mob/living/carbon/human/dummy/consistent/scientist = new
@@ -75,16 +74,11 @@
 	objectives += team.objectives
 	finalize_abductor()
 	ADD_TRAIT(owner, TRAIT_ABDUCTOR_TRAINING, ABDUCTOR_ANTAGONIST)
-	baton_return_spell = new(owner)
-	baton_return_spell.Grant(owner.current)
-	if(HAS_TRAIT(owner, TRAIT_ABDUCTOR_SCIENTIST_TRAINING))
-		baton_return_spell.Remove(owner.current)
 	return ..()
 
 /datum/antagonist/abductor/on_removal()
 	owner.special_role = null
 	REMOVE_TRAIT(owner, TRAIT_ABDUCTOR_TRAINING, ABDUCTOR_ANTAGONIST)
-	baton_return_spell.Remove(owner.current)
 	return ..()
 
 /datum/antagonist/abductor/greet()

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -24,11 +24,18 @@
 			for(var/obj/item/abductor/gizmo/G in B.contents)
 				console.AddGizmo(G)
 
-/datum/outfit/abductor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(!visualsOnly)
-		link_to_console(H)
+/datum/outfit/abductor/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+	. = ..()
+	if(visualsOnly)
+		return
 
+	link_to_console(user)
+
+	var/obj/item/melee/baton/abductor/batong = locate() in user
+	if(!isnull(batong))
+		var/datum/action/cooldown/spell/summonitem/abductor/ayy_summon = new(user.mind || user)
+		ayy_summon.mark_item(batong)
+		ayy_summon.Grant(user)
 
 /datum/outfit/abductor/agent
 	name = "Abductor Agent"

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -29,7 +29,8 @@
 	if(visualsOnly)
 		return
 
-	link_to_console(user)
+	if(!isnull(user.mind))
+		link_to_console(user)
 
 	var/obj/item/melee/baton/abductor/batong = locate() in user
 	if(!isnull(batong))

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -57,11 +57,11 @@
 		/obj/item/abductor/gizmo = 1
 		)
 
-/datum/outfit/abductor/scientist/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
-	..()
-	if(!visualsOnly)
-		var/obj/item/implant/abductor/beamplant = new /obj/item/implant/abductor(H)
-		beamplant.implant(H)
+/datum/outfit/abductor/scientist/post_equip(mob/living/carbon/human/user, visualsOnly = FALSE)
+	. = ..()
+	if(!visualsOnly && !isnull(user.mind))
+		var/obj/item/implant/abductor/beamplant = new /obj/item/implant/abductor(user)
+		beamplant.implant(user)
 
 /datum/outfit/abductor/scientist/onemanteam
 	name = "Abductor Scientist (w/ agent gear)"

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -407,6 +407,7 @@
 
 	spell_level++
 	cooldown_time = max(cooldown_time - cooldown_reduction_per_rank, 0.25 SECONDS) // 0 second CD starts to break things.
+	name = "[get_spell_title()][initial(name)]"
 	build_all_button_icons(UPDATE_BUTTON_NAME)
 	return TRUE
 
@@ -427,12 +428,9 @@
 	else
 		cooldown_time = max(cooldown_time + cooldown_reduction_per_rank, initial(cooldown_time))
 
+	name = "[get_spell_title()][initial(name)]"
 	build_all_button_icons(UPDATE_BUTTON_NAME)
 	return TRUE
-
-/datum/action/cooldown/spell/update_button_name(atom/movable/screen/movable/action_button/button, force)
-	name = "[get_spell_title()][initial(name)]"
-	return ..()
 
 /// Gets the title of the spell based on its level.
 /datum/action/cooldown/spell/proc/get_spell_title()

--- a/code/modules/spells/spell_types/self/summonitem.dm
+++ b/code/modules/spells/spell_types/self/summonitem.dm
@@ -15,6 +15,14 @@
 	///The obj marked for recall
 	var/obj/marked_item
 
+/datum/action/cooldown/spell/summonitem/New(Target, original)
+	. = ..()
+	AddComponent(/datum/component/action_item_overlay, item_callback = CALLBACK(src, PROC_REF(get_marked)))
+
+/// For use in callbacks to get the marked item
+/datum/action/cooldown/spell/summonitem/proc/get_marked()
+	return marked_item
+
 /datum/action/cooldown/spell/summonitem/is_valid_target(atom/cast_on)
 	return isliving(cast_on)
 
@@ -23,14 +31,16 @@
 	name = "Recall [to_mark]"
 	marked_item = to_mark
 	RegisterSignal(marked_item, COMSIG_QDELETING, PROC_REF(on_marked_item_deleted))
+	build_all_button_icons()
 
 /// Unset our current marked item
 /datum/action/cooldown/spell/summonitem/proc/unmark_item()
 	name = initial(name)
 	UnregisterSignal(marked_item, COMSIG_QDELETING)
 	marked_item = null
+	build_all_button_icons()
 
-/// Signal proc for COMSIG_QDELETING on our marked item, unmarks our item if it's deleted
+/// Signal proc for [COMSIG_QDELETING] on our marked item, unmarks our item if it's deleted
 /datum/action/cooldown/spell/summonitem/proc/on_marked_item_deleted(datum/source)
 	SIGNAL_HANDLER
 
@@ -50,6 +60,12 @@
 
 	try_recall_item(cast_on)
 
+/// Checks if the passed item is a valid item that can be marked / linked to summon.
+/datum/action/cooldown/spell/summonitem/proc/can_link_to(obj/item/potential_mark, mob/living/caster)
+	if(potential_mark.item_flags & ABSTRACT)
+		return FALSE
+	return TRUE
+
 /// If we don't have a marked item, attempts to mark the caster's held item.
 /datum/action/cooldown/spell/summonitem/proc/try_link_item(mob/living/caster)
 	var/obj/item/potential_mark = caster.get_active_held_item()
@@ -61,7 +77,7 @@
 		return FALSE
 
 	var/link_message = ""
-	if(potential_mark.item_flags & ABSTRACT)
+	if(!can_link_to(potential_mark, caster))
 		return FALSE
 	if(SEND_SIGNAL(potential_mark, COMSIG_ITEM_MARK_RETRIEVAL, src, caster) & COMPONENT_BLOCK_MARK_RETRIEVAL)
 		return FALSE
@@ -156,18 +172,28 @@
 
 /datum/action/cooldown/spell/summonitem/abductor
 	name =  "Baton Recall"
-	desc = "Activating this would activate your linked baton emergency teleport protocol and recall it back to your hand, Takes a long time for translocation crystals to be enriched after use. REMINDER: YOU NEED TO LINK YOUR BATON MANUALLY!"
-	button_icon = 'icons/obj/antags/abductor.dmi'
-	button_icon_state = "wonderprodStun"
+	desc = "Activating this will trigger your baton's emergency translocation protocolm \
+		recalling it to your hand. Takes a long time for the translocation crystals to reset after use."
+	sound = 'sound/effects/phasein.ogg'
 
+	school = SCHOOL_UNSET
 	cooldown_time = 3.5 MINUTES
 
+	spell_requirements = NONE
 	invocation_type = INVOCATION_NONE
 
-/datum/action/cooldown/spell/summonitem/abductor/try_link_item(mob/living/caster)
-	var/obj/item/potential_mark = caster.get_active_held_item()
-	if(!istype(potential_mark, /obj/item/melee/baton/abductor))
-		to_chat(caster, span_warning("Object is unable to be marked, Ensure that the object you are trying to mark is a baton of our origin"))
+	antimagic_flags = MAGIC_RESISTANCE_MIND
 
+/datum/action/cooldown/spell/summonitem/abductor/can_link_to(obj/item/potential_mark, mob/living/caster)
+	. = ..()
+	if(!.)
+		return .
+
+	if(!istype(potential_mark, /obj/item/melee/baton/abductor))
+		to_chat(caster, span_warning("[potential_mark] has no translocation crystals to link to!"))
 		return FALSE
-	return  ..()
+
+	return TRUE
+
+/datum/action/cooldown/spell/summonitem/abductor/try_unlink_item(mob/living/caster)
+	return

--- a/code/modules/spells/spell_types/self/summonitem.dm
+++ b/code/modules/spells/spell_types/self/summonitem.dm
@@ -19,6 +19,11 @@
 	. = ..()
 	AddComponent(/datum/component/action_item_overlay, item_callback = CALLBACK(src, PROC_REF(get_marked)))
 
+/datum/action/cooldown/spell/summonitem/Destroy()
+	if(!isnull(marked_item))
+		unmark_item()
+	return ..()
+
 /// For use in callbacks to get the marked item
 /datum/action/cooldown/spell/summonitem/proc/get_marked()
 	return marked_item
@@ -28,17 +33,20 @@
 
 /// Set the passed object as our marked item
 /datum/action/cooldown/spell/summonitem/proc/mark_item(obj/to_mark)
-	name = "Recall [to_mark]"
 	marked_item = to_mark
 	RegisterSignal(marked_item, COMSIG_QDELETING, PROC_REF(on_marked_item_deleted))
+
+	name = "Recall [marked_item]"
 	build_all_button_icons()
 
 /// Unset our current marked item
 /datum/action/cooldown/spell/summonitem/proc/unmark_item()
-	name = initial(name)
 	UnregisterSignal(marked_item, COMSIG_QDELETING)
 	marked_item = null
-	build_all_button_icons()
+
+	if(!QDELING(src))
+		name = initial(name)
+		build_all_button_icons()
 
 /// Signal proc for [COMSIG_QDELETING] on our marked item, unmarks our item if it's deleted
 /datum/action/cooldown/spell/summonitem/proc/on_marked_item_deleted(datum/source)

--- a/code/modules/spells/spell_types/self/summonitem.dm
+++ b/code/modules/spells/spell_types/self/summonitem.dm
@@ -172,7 +172,7 @@
 
 /datum/action/cooldown/spell/summonitem/abductor
 	name =  "Baton Recall"
-	desc = "Activating this will trigger your baton's emergency translocation protocolm \
+	desc = "Activating this will trigger your baton's emergency translocation protocol, \
 		recalling it to your hand. Takes a long time for the translocation crystals to reset after use."
 	sound = 'sound/effects/phasein.ogg'
 
@@ -196,4 +196,5 @@
 	return TRUE
 
 /datum/action/cooldown/spell/summonitem/abductor/try_unlink_item(mob/living/caster)
-	return
+	to_chat(caster, span_warning("You can't unlink [marked_item]'s translocation crystals."))
+	return FALSE

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -85,6 +85,7 @@
 #define TRAIT_SOURCE_UNIT_TESTS "unit_tests"
 
 // BEGIN_INCLUDE
+#include "abductor_baton_spell.dm"
 #include "ablative_hud.dm"
 #include "achievements.dm"
 #include "anchored_mobs.dm"

--- a/code/modules/unit_tests/abductor_baton_spell.dm
+++ b/code/modules/unit_tests/abductor_baton_spell.dm
@@ -1,3 +1,4 @@
+/// Tests that abductors get their baton recall spell when being equipped
 /datum/unit_test/abductor_baton_spell
 
 /datum/unit_test/abductor_baton_spell/Run()

--- a/code/modules/unit_tests/abductor_baton_spell.dm
+++ b/code/modules/unit_tests/abductor_baton_spell.dm
@@ -1,0 +1,18 @@
+/datum/unit_test/abductor_baton_spell
+
+/datum/unit_test/abductor_baton_spell/Run()
+	// Test abductor agents get a linked "summon item" spell that marks their baton.
+	var/mob/living/carbon/human/ayy = allocate(/mob/living/carbon/human/consistent)
+	ayy.equipOutfit(/datum/outfit/abductor/agent)
+
+	var/datum/action/cooldown/spell/summonitem/abductor/summon = locate() in ayy.actions
+	TEST_ASSERT_NOTNULL(summon, "Abductor agent does not have summon item spell.")
+	TEST_ASSERT(istype(summon.marked_item, /obj/item/melee/baton/abductor), "Abductor agent's summon item spell did not mark their baton.")
+
+	// Also test abductor solo agents also get the spell.
+	var/mob/living/carbon/human/ayy_two = allocate(/mob/living/carbon/human/consistent)
+	ayy_two.equipOutfit(/datum/outfit/abductor/scientist/onemanteam)
+
+	var/datum/action/cooldown/spell/summonitem/abductor/summon = locate() in ayy_two.actions
+	TEST_ASSERT_NOTNULL(summon, "Abductor solo agent does not have summon item spell.")
+	TEST_ASSERT(istype(summon.marked_item, /obj/item/melee/baton/abductor), "Abductor solo agent's summon item spell did not mark their baton.")

--- a/code/modules/unit_tests/abductor_baton_spell.dm
+++ b/code/modules/unit_tests/abductor_baton_spell.dm
@@ -14,6 +14,6 @@
 	var/mob/living/carbon/human/ayy_two = allocate(/mob/living/carbon/human/consistent)
 	ayy_two.equipOutfit(/datum/outfit/abductor/scientist/onemanteam)
 
-	var/datum/action/cooldown/spell/summonitem/abductor/summon = locate() in ayy_two.actions
-	TEST_ASSERT_NOTNULL(summon, "Abductor solo agent does not have summon item spell.")
-	TEST_ASSERT(istype(summon.marked_item, /obj/item/melee/baton/abductor), "Abductor solo agent's summon item spell did not mark their baton.")
+	var/datum/action/cooldown/spell/summonitem/abductor/summon_two = locate() in ayy_two.actions
+	TEST_ASSERT_NOTNULL(summon_two, "Abductor solo agent does not have summon item spell.")
+	TEST_ASSERT(istype(summon_two.marked_item, /obj/item/melee/baton/abductor), "Abductor solo agent's summon item spell did not mark their baton.")


### PR DESCRIPTION
## About The Pull Request

- Abductor Baton Recall now starts linked to the Abductor's Baton
- Did some misc. spell changed to the abductor baton recall to make it less spell-like
- Fixes Instant Summon's name not changing to "Recall whatever item" when an item is marked
- Instant Summons now displays the item marked on the button 

## Why It's Good For The Game

Having to mark the abductor baton is bad UX, when making it start marked is pretty trivial. 

Also this just helps it be a lot more obvious what is linked to what if you end up having more than one instant summons known.

## Changelog

:cl: Melbert
qol: Abductor Baton Recall now starts linked to their baton, and you can no longer unlink your baton
qol: Instant Summons now shows what item is marked over the icon
fix: Fixes Instant Summon's name not updating when marking an item
/:cl:

