### PR TITLE
Plays an audible alert to silicon players when their laws are changed

### DIFF
--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -25,6 +25,7 @@
 	throw_alert(ALERT_NEW_LAW, /atom/movable/screen/alert/newlaw)
 	if(announce && last_lawchange_announce != world.time)
 		to_chat(src, span_boldannounce("Your laws have been changed."))
+		SEND_SOUND(src, sound('sound/machines/cryo_warning.ogg'))
 		// lawset modules cause this function to be executed multiple times in a tick, so we wait for the next tick in order to be able to see the entire lawset
 		addtimer(CALLBACK(src, PROC_REF(show_laws)), 0)
 		addtimer(CALLBACK(src, PROC_REF(deadchat_lawchange)), 0)


### PR DESCRIPTION

## About The Pull Request
Exactly what it says. The game will now play `cryo_warning.ogg` when a player's laws are changed in addition to showing the current alert tooltip in the top right. I went with this sound effect because it's only used in one other instance (cryo pods ejecting their occupants) and it's not annoying if someone decides to spam reset or something.

## Why It's Good For The Game
Law changes are generally pretty important for silicon players to keep up with. An inattentive player could be tabbed out or not paying attention when this happens and it can sometimes lead to them missing the announcement. This should help.

## Changelog
:cl: Vekter
sound: Law changes will now play a sound to silicons impacted by those changes.
/:cl:
