### PR TITLE
Fixes the shutters in metastation's law office

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -29769,7 +29769,10 @@
 	name = "Law Office Fax Machine"
 	},
 /obj/machinery/light/small/directional/south,
-/obj/machinery/button/door/directional/west,
+/obj/machinery/button/door/directional/west{
+	name = "Privacy Shutters";
+	id = "lawyer_shutters"
+	},
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "kRV" = (


### PR DESCRIPTION

## About The Pull Request
The button in the law office on metastation which controlled the shutters was turned into an ID-less generic button at some point, this fixes it by properly connecting the ID of the nearby shutters, as well as giving it a name.
## Why It's Good For The Game
Shutters work better, if the button that controls it also works.
## Changelog
:cl:
fix: The metastation law office's shutters now function again.
/:cl:
