### PR TITLE
Fixes FRAG-12 recipe leaving reagents in the beaker after crafting

### DIFF
--- a/code/datums/components/crafting/weapon_ammo.dm
+++ b/code/datums/components/crafting/weapon_ammo.dm
@@ -36,13 +36,12 @@
 	category = CAT_WEAPON_AMMO
 
 /datum/crafting_recipe/frag12
-	name = "FRAG-12 Shell"
+	name = "FRAG-12 Slug Shell"
 	result = /obj/item/ammo_casing/shotgun/frag12
 	reqs = list(
 		/obj/item/ammo_casing/shotgun/techshell = 1,
 		/datum/reagent/glycerol = 5,
-		/datum/reagent/toxin/acid = 5,
-		/datum/reagent/toxin/acid/fluacid = 5,
+		/datum/reagent/toxin/acid/fluacid = 10,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 0.5 SECONDS


### PR DESCRIPTION

## About The Pull Request
This PR changes the recipe to use 10 fluorosulfuric acid instead of 5 sulfuric and 5 fluorosulfuric. This doesn't function as a balance change as sulfuric acid is actually required to craft fluorosulfuric acid, so this shouldn't impact the difficulty of crafting it, just make it more consistent.

This also fixes a minor grammar issue with the name of the crafting recipe that bugged me. Just me being pedantic.

## Why It's Good For The Game
Fixes #77338.

There's probably something deeper going on with how crafting handles materials that turn into other materials in crafts, but this is a simple fix that makes sense in the short term to make them actually craft as expected instead of leaving byproducts.
## Changelog
:cl: Vekter
fix: FRAG-12 shells no longer require sulfuric acid, instead needing 10 fluorosulfuric acid. This should prevent them from leaving byproducts if crafted in a specific way.
/:cl:
