### PR TITLE
Adds the Storage Implanter to the spy kit.

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -56,10 +56,11 @@
 			new /obj/item/multitool/ai_detect(src) // 1 tc
 			new /obj/item/encryptionkey/syndicate(src) // 2 tc
 			new /obj/item/reagent_containers/syringe/mulligan(src) // 4 tc
-			new /obj/item/switchblade(src) //I'll count this as 2 tc
+			new /obj/item/switchblade(src) //basically 1 tc as it can be bought from BM kits
 			new /obj/item/storage/fancy/cigarettes/cigpack_syndicate (src) // 2 tc this shit heals
 			new /obj/item/flashlight/emp(src) // 2 tc
 			new /obj/item/chameleon(src) // 7 tc
+			new /obj/item/implanter/storage(src) // 6 tc
 
 		if(KIT_STEALTHY)
 			new /obj/item/gun/energy/recharge/ebow(src) // 10 tc


### PR DESCRIPTION
## About The Pull Request

Adds the storage implanter to the spy kit to make it decent.

## Why It's Good For The Game
This PR hopes to bring Spy at least a little more in-line with the rest of the syndie-kit specials, so it doesn’t feel like a complete dud to get.

Spy absolutely sucks as a syndie-kit and getting it is basically throwing away 20 TC. Not all of them should be equally powerful but all of them should be at least more satisfying to get. Spy is so bad that it’s listed in the official wiki as ‘honestly not that good’. It’s also _barely_ even above 25 telecrystals as the switchblade is a black market uplink item, not a syndicate uplink item, and not even that good of an item at that! And the chameleon kit inside isn’t even a full chameleon kit! Pitiful. Compare it to stealth right below it which totals to _36_ telecrystals.

Adding a storage implant adds a relatively useful item to the kit that still fits with the entire theme of ‘stealth and deception’, as you can be searched without having anything on you. To be stealthy, and deceive people. Like you should. Given the fact that searches are quite common. It doesn’t make it TOO overpowered as the rest of the gear is still ‘not that great’.


## Changelog

:cl:
balance: added the storage implanter to the syndie-kit tactical 'spy' kit to make it decent.
/:cl:
