### PR TITLE
Fix MetaStation APC Kitchen Wiring

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -66219,6 +66219,7 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "xPm" = (
@@ -67120,7 +67121,6 @@
 /area/station/commons/fitness)
 "yfn" = (
 /obj/machinery/vending/dinnerware,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 5
 	},


### PR DESCRIPTION

## About The Pull Request

Fixed kitchen APC wiring on metastation

#77282  had moved the APC up one tile, but didn't the cables, so the APC wasn't getting power at shift start until someone fixed the cabling.
![NVIDIA_Share_Ik6SyFEqTi](https://github.com/tgstation/tgstation/assets/1077971/33df3136-d2aa-4f1f-b597-19723a5fe745)

## Why It's Good For The Game

Cooks like having power.
## Changelog
:cl:
fix: Metastation Kitchen APC is wired to the grid again.
/:cl:
