### PR TITLE
Missing object Added

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -45935,11 +45935,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Cam #5";
-	dir = 5;
-	network = list("ss13","engine")
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lYu" = (
@@ -74012,6 +74007,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/camera/emp_proof/directional/east,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
@@ -86005,6 +86001,7 @@
 /area/station/medical/psychology)
 "wwW" = (
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/camera/emp_proof/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wxb" = (


### PR DESCRIPTION
## About The Pull Request
A camera in atmos was messed up so I fixed that and added a camera to a room that didnt have one in chem just incase the cameras in chem couldnt reach that room
## Why It's Good For The Game
It fixes an annoying camera that was not connected to the wall whatsoever and makes it so you wont go crazy over that
## Changelog
:cl:
fix: fixed a Camera in atmos
add: missing Camera in chem storage
/:cl:
