### PR TITLE
fixes virology typo

### DIFF
--- a/code/datums/diseases/advance/symptoms/itching.dm
+++ b/code/datums/diseases/advance/symptoms/itching.dm
@@ -21,7 +21,7 @@
 	var/scratch = FALSE
 	threshold_descs = list(
 		"Transmission 6" = "Increases frequency of itching.",
-		"Stage Speed 7" = "The host will scrath itself when itching, causing superficial damage.",
+		"Stage Speed 7" = "The host will scratch itself when itching, causing superficial damage.",
 	)
 	///emote cooldowns
 	COOLDOWN_DECLARE(itching_cooldown)


### PR DESCRIPTION

## About The Pull Request
fixes itching typo

## Why It's Good For The Game

typoes are bad

## Changelog


:cl:

spellcheck: fixes one of the virus thresholds saying "scrathing" instead of scratching

/:cl:
