### PR TITLE
Fixes Mechs two-shotting carp rifts

### DIFF
--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -125,6 +125,10 @@
 /obj/structure/carp_rift/ex_act(severity, target)
 	return ..(min(EXPLODE_HEAVY, severity))
 
+// Take less damage from mechs (So they don't get two-shotted)
+/obj/structure/carp_rift/get_obj_mecha_damage_multiplier()
+	return 0.75
+
 /obj/structure/carp_rift/examine(mob/user)
 	. = ..()
 	if(time_charged < max_charge)

--- a/code/modules/vehicles/mecha/mech_melee_attack.dm
+++ b/code/modules/vehicles/mecha/mech_melee_attack.dm
@@ -42,13 +42,14 @@
 			return 0
 	mecha_attacker.visible_message(span_danger("[mecha_attacker] hits [src]!"), span_danger("You hit [src]!"), null, COMBAT_MESSAGE_RANGE)
 	..()
-	return take_damage(mecha_attacker.force * get_obj_mecha_damage_multiplier(), mecha_attacker.damtype, "melee", FALSE, get_dir(src, mecha_attacker)) // multiplied by 3 so we can hit objs hard but not be overpowered against mobs.
+	return take_damage(mecha_attacker.force * get_obj_mecha_damage_multiplier(), mecha_attacker.damtype, "melee", FALSE, get_dir(src, mecha_attacker))
 
-/obj/proc/get_obj_mecha_damage_multiplier()
-	return 3
+/** Gets the object mecha damage multiplier.
+ * Some objects (carp rift) shouldn't have a high multiplier, override this proc if necessary.
+ */
+/obj/proc/get_obj_mecha_damage_multiplier(obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
+	return 3// multiplied by 3 so we can hit objs hard but not be overpowered against mobs.
 
-/obj/structure/carp_rift/get_obj_mecha_damage_multiplier()
-	return 0.75
 
 /obj/structure/window/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
 	if(!can_be_reached())

--- a/code/modules/vehicles/mecha/mech_melee_attack.dm
+++ b/code/modules/vehicles/mecha/mech_melee_attack.dm
@@ -42,7 +42,13 @@
 			return 0
 	mecha_attacker.visible_message(span_danger("[mecha_attacker] hits [src]!"), span_danger("You hit [src]!"), null, COMBAT_MESSAGE_RANGE)
 	..()
-	return take_damage(mecha_attacker.force * 3, mecha_attacker.damtype, "melee", FALSE, get_dir(src, mecha_attacker)) // multiplied by 3 so we can hit objs hard but not be overpowered against mobs.
+	return take_damage(mecha_attacker.force * get_obj_mecha_damage_multiplier(), mecha_attacker.damtype, "melee", FALSE, get_dir(src, mecha_attacker)) // multiplied by 3 so we can hit objs hard but not be overpowered against mobs.
+
+/obj/proc/get_obj_mecha_damage_multiplier()
+	return 3
+
+/obj/structure/carp_rift/get_obj_mecha_damage_multiplier()
+	return 0.75
 
 /obj/structure/window/mech_melee_attack(obj/vehicle/sealed/mecha/mecha_attacker, mob/living/user)
 	if(!can_be_reached())


### PR DESCRIPTION
## About The Pull Request

Fixes Mechs two-shotting carp rifts, by adding a get_mult proc that returns 0.75 on carp rifts (multiplier is 3 by default, so 4 times weaker).

## Why It's Good For The Game

Two-shotting bad. Additionally it's pretty easy to just facetank the dragon and slam the rift even if it's several times so I lowered the multiplier to 0.75, giving the dragon and le fishe more fighting chance.

## Changelog

:cl:
fix: Fixes Mechs two-shotting carp rifts, they're now considerably slower in breaking them with their fists.
/:cl:

