### PR TITLE
Fixes wizard fake challenges not showing up

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/challenges.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/challenges.dm
@@ -9,5 +9,5 @@
 	name = "Friendly Wizard Scum"
 	desc = "A \"Friendly\" Wizard will protect the station, and try to kill you. They get a spellbook much like you, but will use it for \"GOOD\"."
 
-/datum/spellbook_entry/challenge/can_be_purchased()
+/datum/spellbook_entry/challenge/can_buy(mob/living/carbon/human/user, obj/item/spellbook/book)
 	return FALSE

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/challenges.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/challenges.dm
@@ -8,6 +8,3 @@
 /datum/spellbook_entry/challenge/antiwizard
 	name = "Friendly Wizard Scum"
 	desc = "A \"Friendly\" Wizard will protect the station, and try to kill you. They get a spellbook much like you, but will use it for \"GOOD\"."
-
-/datum/spellbook_entry/challenge/can_buy(mob/living/carbon/human/user, obj/item/spellbook/book)
-	return FALSE


### PR DESCRIPTION
## About The Pull Request

I added this override because I saw some runtimes related to trying to randomize into a challenge and that was not good, but I forgot this proc is determines if it even shows up in the spellbook UI. I blame Arm

## Why It's Good For The Game

Flavor returns

## Changelog

:cl: Melbert
fix: Fix some missing wizard spellbook flavor
/:cl:
