### PR TITLE
Fix double send of `COMSIG_GLOB_CREWMEMBER_JOINED` for latejoins

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -240,8 +240,6 @@
 		humanc.put_in_hands(new /obj/item/crowbar/large/emergency(get_turf(humanc))) //if hands full then just drops on the floor
 	log_manifest(character.mind.key,character.mind,character,latejoin = TRUE)
 
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_CREWMEMBER_JOINED, character, rank)
-
 /mob/dead/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
 	//TODO:  figure out a way to exclude wizards/nukeops/demons from this.
 	for(var/C in GLOB.employmentCabinets)


### PR DESCRIPTION
## About The Pull Request

I saw this pop up on a port of one of my PRs and realized "damn that is an issue" 

`COMSIG_GLOB_CREWMEMBER_JOINED` was sent twice for latejoins, once in `transfer_character` and once at the end of `AttemptLateSpawn` 

This caused latejoiners to get the signal twice, so in the case of Summon Guns, they'd get two guns

## Why It's Good For The Game

Gee, how come your mom lets you get two guns?

## Changelog

:cl: Melbert
fix: Fixed latejoiners being affected by certain things twice, such as Summon Guns and Summon Magic
/:cl:

