### PR TITLE
[NO GBP] Fixes custom ice cream

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -181,6 +181,7 @@ DEFINE_BITFIELD(food_flags, list(
 #define ICE_CREAM_KORTA_VANILLA "korta vanilla"
 #define ICE_CREAM_MOB "mob"
 #define ICE_CREAM_CUSTOM "custom"
+#define ICE_CREAM_KORTA_CUSTOM "korta custom"
 #define ICE_CREAM_BLAND "bland"
 
 #define DEFAULT_MAX_ICE_CREAM_SCOOPS 3

--- a/code/datums/components/food/ice_cream_holder.dm
+++ b/code/datums/components/food/ice_cream_holder.dm
@@ -342,6 +342,7 @@ GLOBAL_LIST_INIT_TYPED(ice_cream_flavours, /datum/ice_cream_flavour, init_ice_cr
 	ingredients_text = "optional flavorings"
 
 /datum/ice_cream_flavour/custom/korta
+	name = ICE_CREAM_KORTA_CUSTOM
 	desc = "filled with artisanal lizard-friendly icecream. Made with real $CUSTOM_NAME. Ain't that something."
 	ingredients = list(/datum/reagent/consumable/korta_milk, /datum/reagent/consumable/ice)
 	ingredients_text = "optional flavorings"


### PR DESCRIPTION

## About The Pull Request

Defines a name for Korta milk custom ice creams because it was overriding the default custom ice cream recipe instead of adding it alongside as intended

## Why It's Good For The Game
bug fix 

## Changelog
I don't think anybody actually noticed this enough to justify a new changelog lol
