### PR TITLE
Prevents shuttle events running in-case of catastrophic failure

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -522,11 +522,14 @@
 				setTimer(SSshuttle.emergency_escape_time * engine_coeff)
 				priority_announce("The Emergency Shuttle has left the station. Estimate [timeLeft(600)] minutes until the shuttle docks at Central Command.", null, null, "Priority")
 				INVOKE_ASYNC(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, poll_hearts))
+				SSmapping.mapvote() //If no map vote has been run yet, start one.
+
+				if(!is_reserved_level(z))
+					CRASH("Emergency shuttle did not move to transit z-level!")
+
 				//Tell the events we're starting, so they can time their spawns or do some other stuff
 				for(var/datum/shuttle_event/event as anything in event_list)
 					event.start_up_event(SSshuttle.emergency_escape_time * engine_coeff)
-
-				SSmapping.mapvote() //If no map vote has been run yet, start one.
 
 		if(SHUTTLE_STRANDED, SHUTTLE_DISABLED)
 			SSshuttle.checkHostileEnvironment()


### PR DESCRIPTION
Closes #77433

When the rare "shuttle doesn't leave" bug happens, shuttle events can still run at the shuttles location. I have no idea why the shuttle sometimes doesn't leave, but this at least fixes shuttle events running when it doesnt

Also adds some logging to hopefully find out why this happens 

/:cl:
fix: Fixes shuttle events running when the shuttle breaks
/:cl: