### PR TITLE
fire extinguisher typo fix

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -67,7 +67,7 @@
 
 /obj/item/extinguisher/crafted
 	name = "Improvised cooling spray"
-	desc = "Spraycan turned coolant dipsenser. Can be sprayed on containers to cool them. Refll using water."
+	desc = "Spraycan turned coolant dispenser. Can be sprayed on containers to cool them. Refill using water."
 	icon_state = "coolant0"
 	worn_icon_state = "miniFE"
 	inhand_icon_state = "miniFE"


### PR DESCRIPTION

## About The Pull Request
fixes a typo in the improvised fire extinguisher....

where the fuck do you even get one and has anyone even used it in the history of TGstation? probably not, but who cares typo bad

## Why It's Good For The Game
typo bad
## Changelog
:cl:

spellcheck: improvised fire extinguishers aren't full of typoes now

/:cl:
