### PR TITLE
Change mousetraps to kill rats instantly (except regal rats)

### DIFF
--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -138,11 +138,7 @@
 	else if(ismouse(target))
 		var/mob/living/basic/mouse/splatted = target
 		visible_message(span_boldannounce("SPLAT!"))
-		if(splatted.health <= 5)
-			splatted.splat()
-		else
-			splatted.adjust_health(5)
-			splatted.Stun(1 SECONDS)
+		splatted.splat() // mousetraps are instadeath for mice
 
 	else if(isregalrat(target))
 		visible_message(span_boldannounce("Skreeeee!")) //He's simply too large to be affected by a tiny mouse trap.


### PR DESCRIPTION

## About The Pull Request
Today I witnessed a minefield of mousetraps against a horde of mice. To my surprise, they were able to tank multiple mousetraps without dying.  Mousetraps should insta kill any mice (or rats) caught in it otherwise it defeats the purpose of setting the traps especially when there is a horde of them.  Cat's instakill any mice they touch. This should follow the same formula. The only exception should be regal rats, which are already excluded from mousetrap damage code.

## Why It's Good For The Game
When you arm a dozen mousetraps, there should be a dozen dead mice.

## Changelog
:cl:
balance: Change mousetraps to kill mice instead of damaging them (except regal rats)
/:cl:
