### PR TITLE
Changes the flower's positions in Meta's Chapel

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4688,11 +4688,21 @@
 /area/station/medical/storage)
 "bJc" = (
 /obj/structure/table/wood,
-/obj/item/food/grown/harebell,
-/obj/item/food/grown/harebell,
-/obj/item/food/grown/harebell,
-/obj/item/food/grown/harebell,
-/obj/item/food/grown/harebell,
+/obj/item/food/grown/harebell{
+	pixel_y = 10;
+	pixel_x = -6
+	},
+/obj/item/food/grown/harebell{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/food/grown/harebell{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/food/grown/harebell{
+	pixel_y = 7
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
@@ -9462,22 +9472,14 @@
 /area/station/science/robotics/mechbay)
 "dEp" = (
 /obj/structure/table/wood,
-/obj/item/food/grown/poppy{
-	pixel_y = 2
-	},
-/obj/item/food/grown/poppy{
-	pixel_y = 2
-	},
-/obj/item/food/grown/poppy{
-	pixel_y = 2
-	},
-/obj/item/food/grown/poppy{
-	pixel_y = 2
-	},
-/obj/item/food/grown/poppy{
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/food/grown/poppy{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/food/grown/poppy{
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "dEx" = (
@@ -39631,7 +39633,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "oum" = (
-/obj/item/flashlight/flare/candle,
+/obj/item/flashlight/flare/candle{
+	pixel_y = 10;
+	pixel_x = 1
+	},
 /obj/machinery/light_switch/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/table/wood,
@@ -49145,11 +49150,22 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "rQB" = (
-/obj/item/flashlight/flare/candle,
 /obj/machinery/light_switch/directional/west,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/food/grown/poppy{
+	pixel_y = 3;
+	pixel_x = -3
+	},
+/obj/item/food/grown/poppy{
+	pixel_y = 7;
+	pixel_x = 7
+	},
+/obj/item/flashlight/flare/candle{
+	pixel_x = 12;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "rQS" = (
@@ -59584,13 +59600,22 @@
 /turf/closed/wall/r_wall,
 /area/station/command/corporate_showroom)
 "vyl" = (
-/obj/item/book/bible,
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Chapel - Fore"
 	},
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/food/grown/poppy{
+	pixel_y = 11
+	},
+/obj/item/book/bible{
+	pixel_y = 3
+	},
+/obj/item/food/grown/harebell{
+	pixel_x = -11;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "vyv" = (


### PR DESCRIPTION

## About The Pull Request

Title. The flowers in meta's chapels were all stacked atop one another and it was impossible to tell if it was just one flower or many.

## Why It's Good For The Game

Prettier chapel + it makes it easier to see at a glance how many flowers are there

## Changelog


:cl:
qol: The flowers in Meta's chapel are no longer stacked atop eachother
/:cl:
