### PR TITLE
Makes Baseballs and Rabbits and small-sized and able to be picked up and held.

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -917,6 +917,7 @@
 	icon = 'icons/obj/toys/balls.dmi'
 	icon_state = "baseball"
 	inhand_icon_state = "baseball"
+	w_class = WEIGHT_CLASS_SMALL
 	throw_range = 9
 	throw_speed = 0.5
 

--- a/code/modules/mob/living/basic/farm_animals/rabbit.dm
+++ b/code/modules/mob/living/basic/farm_animals/rabbit.dm
@@ -18,6 +18,7 @@
 	health = 15
 	maxHealth = 15
 	mob_size = MOB_SIZE_SMALL
+	can_be_held = TRUE
 	density = FALSE
 	gold_core_spawnable = FRIENDLY_SPAWN
 	speak_emote = list("sniffles", "twitches")

--- a/code/modules/mob/living/basic/farm_animals/rabbit.dm
+++ b/code/modules/mob/living/basic/farm_animals/rabbit.dm
@@ -17,6 +17,7 @@
 	mob_biotypes = MOB_ORGANIC | MOB_BEAST
 	health = 15
 	maxHealth = 15
+	mob_size = MOB_SIZE_SMALL
 	density = FALSE
 	gold_core_spawnable = FRIENDLY_SPAWN
 	speak_emote = list("sniffles", "twitches")


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. They previously inherited the size of a human from `/obj/item/beach_ball` and `/mob/living` respectively.
Also allows rabbits to be picked up and held.

## Why It's Good For The Game

Fixes #77509.
Baseballs shouldn't be as large as a beachball.
Bunnies should be small. Proof:
<img src ="https://github.com/tgstation/tgstation/assets/80640114/96d8574d-f8d2-4e9b-b09e-285196de04b1" width=200 height =200>
## Changelog
:cl:
fix: rabbits are now small-sized rather than human-sized, as well as capable of being picked up
fix: baseballs are now small sized rather than large
/:cl:
