### PR TITLE
Fixes mime book consuming itself when it isn't supposed to

### DIFF
--- a/code/game/objects/items/granters/_granters.dm
+++ b/code/game/objects/items/granters/_granters.dm
@@ -39,7 +39,8 @@
 		recoil(user)
 		return FALSE
 
-	on_reading_start(user)
+	if(!on_reading_start(user))
+		return
 	reading = TRUE
 	for(var/i in 1 to pages_to_mastery)
 		if(!turn_page(user))
@@ -56,6 +57,7 @@
 /// Called when the user starts to read the granter.
 /obj/item/book/granter/proc/on_reading_start(mob/living/user)
 	to_chat(user, span_notice("You start reading [name]..."))
+	return TRUE
 
 /// Called when the reading is interrupted without finishing.
 /obj/item/book/granter/proc/on_reading_stopped(mob/living/user)
@@ -99,6 +101,7 @@
 
 /obj/item/book/granter/action/on_reading_start(mob/living/user)
 	to_chat(user, span_notice("You start reading about [action_name]..."))
+	return TRUE
 
 /obj/item/book/granter/action/on_reading_finished(mob/living/user)
 	to_chat(user, span_notice("You feel like you've got a good handle on [action_name]!"))

--- a/code/game/objects/items/granters/magic/_spell_granter.dm
+++ b/code/game/objects/items/granters/magic/_spell_granter.dm
@@ -43,6 +43,7 @@
 
 /obj/item/book/granter/action/spell/on_reading_start(mob/living/user)
 	to_chat(user, span_notice("You start reading about casting [action_name]..."))
+	return TRUE
 
 /obj/item/book/granter/action/spell/on_reading_finished(mob/living/user)
 	to_chat(user, span_notice("You feel like you've experienced enough to cast [action_name]!"))

--- a/code/game/objects/items/granters/martial_arts/_martial_arts.dm
+++ b/code/game/objects/items/granters/martial_arts/_martial_arts.dm
@@ -16,6 +16,7 @@
 
 /obj/item/book/granter/martial/on_reading_start(mob/user)
 	to_chat(user, span_notice("You start reading about [martial_name]..."))
+	return TRUE
 
 /obj/item/book/granter/martial/on_reading_finished(mob/user)
 	to_chat(user, "[greet]")

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -97,7 +97,10 @@
 			spell_icons[initial(type.name)] = image(icon = initial(type.button_icon), icon_state = initial(type.button_icon_state))
 		name_to_spell[initial(type.name)] = type
 	var/picked_spell = show_radial_menu(user, src, spell_icons, custom_check = CALLBACK(src, PROC_REF(check_menu), user), radius = 36, require_near = TRUE)
+	if(!picked_spell)
+		return FALSE
 	granted_action = name_to_spell[picked_spell]
+	return TRUE
 
 /obj/item/book/granter/action/spell/mime/mimery/on_reading_finished(mob/living/user)
 	// Gives the user a vow ability too, if they don't already have one


### PR DESCRIPTION
## About The Pull Request

``on_start_reading`` now has a return value, which the mime book will use to early return out if an option isn't selected.
I also tested fikou's report of it eating its use while in the dark and this seems to fix that as well.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/77441
Fixes cancelling out of the mime book giving you the spells and removing its use.

## Changelog

:cl:
fix: Mime spell books don't eat itself when used in the dark or cancelled out of.
/:cl: