### PR TITLE
Plumbing Constructors can now de-construct every machine they can construct.

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -443,7 +443,7 @@
 	default_unfasten_wrench(user, tool)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
-/obj/machinery/iv_drip/deconstruct(disassembled = TRUE)
+/obj/machinery/iv_drip/plumbing/deconstruct(disassembled = TRUE)
 	qdel(src)
 
 /atom/movable/screen/alert/iv_connected

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -443,6 +443,9 @@
 	default_unfasten_wrench(user, tool)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
+/obj/machinery/iv_drip/deconstruct(disassembled = TRUE)
+	qdel(src)
+
 /atom/movable/screen/alert/iv_connected
 	name = "IV Connected"
 	desc = "You have an IV connected to your arm. Remember to remove it or drag the IV stand with you before moving, or else it will rip out!"

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -249,7 +249,7 @@
 	. = ..()
 	if(!proximity)
 		return
-	if(istype(target, /obj/machinery/plumbing))
+	if(target.type in plumbing_design_types)
 		var/obj/machinery/machine_target = target
 		if(machine_target.anchored)
 			balloon_alert(user, "anchor first!")


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Some machines, like the plumbing IV, could not be deconstructed because they were not `/obj/machine/plumbing` subtypes. It now simply checks whether the item we're attacking is one of our designs and, if so, deconstructs it.

Additionally made the plumbing IV not drop metal when deconstructed for the sake of consistency. I'd say it's a fix, because it seems like an oversight, but if you'd like to label it as balance just tell me.
## Why It's Good For The Game

Fixes #77507 and avoids any similar issues in the future.
As mentioned, the removal of the metal is just for consistency. It inherits it from the base IV type when, in my mind, it should behave like a plumbing machine.
## Changelog
:cl:
fix: Plumbing Constructors can now deconstruct every machine they can make, including the plumbing IV.
fix: Plumbing IV drips no longer drop metal when deconstructed
/:cl:
