### PR TITLE
Add policy for sentient mobs that were revived by lazarus injector

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -58,6 +58,8 @@
 #define ROLE_PYROCLASTIC_SLIME "Pyroclastic Anomaly Slime"
 #define ROLE_ANOMALY_GHOST "Ectoplasmic Anomaly Ghost"
 #define ROLE_MIND_TRANSFER "Mind Transfer Potion"
+#define ROLE_LAZARUS_GOOD "Friendly Revived Mob"
+#define ROLE_LAZARUS_BAD "Slaved Revived Mob"
 #define ROLE_POSIBRAIN "Posibrain"
 #define ROLE_DRONE "Drone"
 #define ROLE_EMAGGED_BOT "Malfunctioning Bot"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2479,10 +2479,13 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	revive(HEAL_ALL)
 	befriend(reviver)
 	faction = (malfunctioning) ? list("[REF(reviver)]") : list(FACTION_NEUTRAL)
-	var/lazarus_policy = get_policy(ROLE_LAZARUS_GOOD)
+	var/lazarus_policy = get_policy(ROLE_LAZARUS_GOOD) || "The lazarus injector has brought you back to life! You are now friendly to everyone."
 	if (malfunctioning)
 		reviver.log_message("has revived mob [key_name(src)] with a malfunctioning lazarus injector.", LOG_GAME)
-		lazarus_policy = get_policy(ROLE_LAZARUS_BAD)
+		if(!isnull(src.mind))
+			src.mind.enslave_mind_to_creator(reviver)
+		to_chat(src, span_userdanger("Serve [reviver], and assist [reviver.p_them()] in completing [reviver.p_their()] goals at any cost."))
+		lazarus_policy = get_policy(ROLE_LAZARUS_BAD) || "You have been revived by a malfunctioning lazarus injector! You are now enslaved by whoever revived you."
 	to_chat(src, span_boldnotice(lazarus_policy))
 
 /// Proc for giving a mob a new 'friend', generally used for AI control and targetting. Returns false if already friends.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2483,8 +2483,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	if (malfunctioning)
 		reviver.log_message("has revived mob [key_name(src)] with a malfunctioning lazarus injector.", LOG_GAME)
 		lazarus_policy = get_policy(ROLE_LAZARUS_BAD)
-	if(lazarus_policy)
-		to_chat(src, span_boldnotice(lazarus_policy))
+	to_chat(src, span_boldnotice(lazarus_policy))
 
 /// Proc for giving a mob a new 'friend', generally used for AI control and targetting. Returns false if already friends.
 /mob/living/proc/befriend(mob/living/new_friend)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2479,11 +2479,10 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	revive(HEAL_ALL)
 	befriend(reviver)
 	faction = (malfunctioning) ? list("[REF(reviver)]") : list(FACTION_NEUTRAL)
+	var/lazarus_policy = get_policy(ROLE_LAZARUS_GOOD)
 	if (malfunctioning)
 		reviver.log_message("has revived mob [key_name(src)] with a malfunctioning lazarus injector.", LOG_GAME)
-		var/lazarus_policy = get_policy(ROLE_LAZARUS_BAD)
-	else
-		var/lazarus_policy = get_policy(ROLE_LAZARUS_GOOD)
+		lazarus_policy = get_policy(ROLE_LAZARUS_BAD)
 	if(lazarus_policy)
 		to_chat(src, span_boldnotice(lazarus_policy))
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2484,7 +2484,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 		reviver.log_message("has revived mob [key_name(src)] with a malfunctioning lazarus injector.", LOG_GAME)
 		if(!isnull(src.mind))
 			src.mind.enslave_mind_to_creator(reviver)
-		to_chat(src, span_userdanger("Serve [reviver], and assist [reviver.p_them()] in completing [reviver.p_their()] goals at any cost."))
+		to_chat(src, span_userdanger("Serve [reviver.real_name], and assist [reviver.p_them()] in completing [reviver.p_their()] goals at any cost."))
 		lazarus_policy = get_policy(ROLE_LAZARUS_BAD) || "You have been revived by a malfunctioning lazarus injector! You are now enslaved by whoever revived you."
 	to_chat(src, span_boldnotice(lazarus_policy))
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2481,6 +2481,11 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	faction = (malfunctioning) ? list("[REF(reviver)]") : list(FACTION_NEUTRAL)
 	if (malfunctioning)
 		reviver.log_message("has revived mob [key_name(src)] with a malfunctioning lazarus injector.", LOG_GAME)
+		var/lazarus_policy = get_policy(ROLE_LAZARUS_BAD)
+	else
+		var/lazarus_policy = get_policy(ROLE_LAZARUS_GOOD)
+	if(lazarus_policy)
+		to_chat(src, span_boldnotice(lazarus_policy))
 
 /// Proc for giving a mob a new 'friend', generally used for AI control and targetting. Returns false if already friends.
 /mob/living/proc/befriend(mob/living/new_friend)

--- a/code/modules/mob_spawn/ghost_roles/golem_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/golem_roles.dm
@@ -101,7 +101,7 @@
 		CRASH("[type] created a golem without a mind.")
 
 	new_spawn.mind.enslave_mind_to_creator(real_owner)
-	to_chat(new_spawn, span_userdanger("Serve [real_owner], and assist [real_owner.p_them()] in completing [real_owner.p_their()] goals at any cost."))
+	to_chat(new_spawn, span_userdanger("Serve [real_owner.real_name], and assist [real_owner.p_them()] in completing [real_owner.p_their()] goals at any cost."))
 
 /obj/effect/mob_spawn/ghost_role/human/golem/servant/name_mob(mob/living/spawned_mob, forced_name)
 	if(forced_name || !iscarbon(spawned_mob))


### PR DESCRIPTION
## About The Pull Request

There's two policies:
* Normal lazarus injector gives you the 'friendly revived mob' policy since it normally makes mobs friendly to everyone,
    * Default text: "The lazarus injector has brought you back to life! You are now friendly to everyone."
* EMPed lazarus injector gives you the 'slaved revived mob' policy since it normally makes mobs only friendly to you,
    * Default text: "You have been revived by a malfunctioning lazarus injector! You are now enslaved by whoever revived you."
    * The EMPed lazarus injector now also enslaves the mob to the person who revived them, giving them the text: "Serve [reviver], and assist [reviver.p_them()] in completing [reviver.p_their()] goals at any cost."

Suggestions for default text welcome,
## Why It's Good For The Game

There's currently no policy for lazarus revived mobs, so can be confusing. See https://tgstation13.org/phpBB/viewtopic.php?f=33&t=34538
Now it's more clear what they should do.
Admins can also change the text if they want.
## Changelog
:cl:
add: Add policy for sentient mobs that were revived by lazarus injector (depends on config)
add; Sentient mobs that were revived by malfunctioning lazarus injector now get enslaved to whoever revived them.
fix: Servant golems get their master's real name (Won't be serving "Unknown" if their master is wearing a mask)
/:cl:
