### PR TITLE
[NO GBP] Fixes wheelchairs being silent

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -30,7 +30,6 @@
 	if(!bell_attached)
 		return
 	initialize_controller_action_type(/datum/action/vehicle/ridden/wheelchair/bell, VEHICLE_CONTROL_DRIVE)
-	AddElement(/datum/element/noisy_movement, volume = 75)
 
 /obj/vehicle/ridden/wheelchair/Initialize(mapload)
 	. = ..()
@@ -38,6 +37,7 @@
 	wheels_overlay = image(icon, overlay_icon, ABOVE_MOB_LAYER)
 	ADD_TRAIT(src, TRAIT_NO_IMMOBILIZE, INNATE_TRAIT)
 	AddComponent(/datum/component/simple_rotation) //Since it's technically a chair I want it to have chair properties
+	AddElement(/datum/element/noisy_movement, volume = 75)
 
 /obj/vehicle/ridden/wheelchair/atom_destruction(damage_flag)
 	new /obj/item/stack/rods(drop_location(), 1)


### PR DESCRIPTION
## About The Pull Request
They didn't produce any rolling noise while moving because the element was being added in `generate_actions` rather than `Initialize`. A month old mistake.

## Why It's Good For The Game
Title.

## Changelog

:cl:
fix: Fixed wheelchairs being silent.
/:cl:
