### PR TITLE
Fixes department and name-less requests consoles in several maps

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -36915,9 +36915,12 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
-/obj/machinery/requests_console/directional/south,
 /obj/machinery/computer/records/security{
 	dir = 4
+	},
+/obj/machinery/requests_console/directional/south{
+	department = "Security";
+	name = "Security Requests Console"
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/supply)
@@ -49014,8 +49017,11 @@
 "rvD" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
-/obj/machinery/requests_console/directional/south,
 /obj/structure/closet/secure_closet/security,
+/obj/machinery/requests_console/directional/south{
+	department = "Security";
+	name = "Security Requests Console"
+	},
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "rvE" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -24817,6 +24817,7 @@
 	dir = 4
 	},
 /obj/machinery/requests_console/directional/north{
+	department = "Ordnance";
 	name = "Ordnance Mixing Lab Requests Console"
 	},
 /obj/effect/turf_decal/box/red,
@@ -78737,7 +78738,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
-/obj/machinery/requests_console/directional/east,
+/obj/machinery/requests_console/directional/east{
+	department = "Theater";
+	name = "Theater Requests Console"
+	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/service/theater)
@@ -80350,7 +80354,10 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
 /obj/item/pen,
-/obj/machinery/requests_console/directional/west,
+/obj/machinery/requests_console/directional/west{
+	department = "AI Chamber";
+	name = "AI Chamber Requests Console"
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -28628,7 +28628,10 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "jcC" = (
-/obj/machinery/requests_console/directional/north,
+/obj/machinery/requests_console/directional/north{
+	department = "Ordnance";
+	name = "Ordnance Lab Requests Console"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
 "jcP" = (
@@ -40583,9 +40586,12 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/machinery/requests_console/directional/east,
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/information,
+/obj/machinery/requests_console/directional/east{
+	department = "Security";
+	name = "Security Requests Console"
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
 "mYG" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7830,7 +7830,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/requests_console/directional/east,
+/obj/machinery/requests_console/directional/east{
+	department = "Genetics";
+	name = "Genetics Requests Console"
+	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
@@ -35341,10 +35344,13 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/obj/machinery/requests_console/directional/south,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
 /obj/effect/mapping_helpers/requests_console/announcement,
+/obj/machinery/requests_console/directional/south{
+	department = "Chief Medical Officer's Desk";
+	name = "Chief Medical Officer's Requests Console"
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "mSB" = (
@@ -52092,9 +52098,12 @@
 "sTD" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
-/obj/machinery/requests_console/directional/east,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/requests_console/directional/east{
+	department = "Security";
+	name = "Security Requests Console"
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs)
 "sTK" = (
@@ -64567,7 +64576,10 @@
 	},
 /obj/item/pen,
 /obj/machinery/light/small/directional/west,
-/obj/machinery/requests_console/directional/west,
+/obj/machinery/requests_console/directional/west{
+	department = "AI Chamber";
+	name = "AI Chamber Requests Console"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "xkV" = (
@@ -65182,9 +65194,12 @@
 	dir = 4
 	},
 /obj/effect/spawner/random/armory/disablers,
-/obj/machinery/requests_console/directional/west,
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/requests_console/directional/west{
+	department = "Security";
+	name = "Security Requests Console"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "xwV" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10539,7 +10539,8 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/machinery/requests_console/directional/north{
-	department = "Captain's Desk"
+	department = "Captain's Desk";
+	name = "CentCom Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/announcement,
 /obj/effect/mapping_helpers/requests_console/information,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17878,7 +17878,6 @@
 "fnv" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/south{
-	pixel_y = -26;
 	pixel_x = 3
 	},
 /obj/machinery/light_switch/directional/south{
@@ -27062,7 +27061,6 @@
 	pixel_y = -23
 	},
 /obj/machinery/firealarm/directional/south{
-	pixel_y = -26;
 	pixel_x = 3
 	},
 /turf/open/floor/carpet,
@@ -31253,7 +31251,8 @@
 	dir = 5
 	},
 /obj/machinery/requests_console/directional/north{
-	department = "Security"
+	department = "Security";
+	name = "Security Requests Console"
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
@@ -43935,7 +43934,6 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "oMP" = (
 /obj/machinery/firealarm/directional/south{
-	pixel_y = -26;
 	pixel_x = 3
 	},
 /turf/closed/mineral/random/stationside/asteroid/porus,
@@ -62270,8 +62268,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch/directional/south{
-	pixel_x = -8;
-	pixel_y = -26
+	pixel_x = -8
 	},
 /turf/open/floor/iron/dark/corner{
 	dir = 8
@@ -65099,7 +65096,8 @@
 	dir = 1
 	},
 /obj/machinery/requests_console/directional/south{
-	department = "Security"
+	department = "Security";
+	name = "Security Requests Console"
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)

--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -46,7 +46,8 @@
 /area/shuttle/arrival)
 "l" = (
 /obj/machinery/requests_console/directional/north{
-	department = "Arrival shuttle"
+	department = "Arrival shuttle";
+	name = "Arrival Shuttle Requests Console"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -231,7 +231,8 @@
 /area/shuttle/arrival)
 "aT" = (
 /obj/machinery/requests_console/directional/east{
-	department = "Arrivals shuttle"
+	department = "Arrivals shuttle";
+	name = "Arrival Shuttle Requests Console"
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/mineral/titanium/white,

--- a/_maps/shuttles/arrival_northstar.dmm
+++ b/_maps/shuttles/arrival_northstar.dmm
@@ -16,7 +16,8 @@
 /area/shuttle/arrival)
 "d" = (
 /obj/machinery/requests_console/directional/north{
-	department = "Arrivals shuttle"
+	department = "Arrivals shuttle";
+	name = "Arrival Shuttle Requests Console"
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/medkit/regular{

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -113,7 +113,8 @@
 /area/shuttle/arrival)
 "P" = (
 /obj/machinery/requests_console/directional/north{
-	department = "Arrivals shuttle"
+	department = "Arrivals shuttle";
+	name = "Arrival Shuttle Requests Console"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/arrival)

--- a/_maps/shuttles/emergency_monastery.dmm
+++ b/_maps/shuttles/emergency_monastery.dmm
@@ -2802,7 +2802,8 @@
 "NV" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/requests_console/directional/west{
-	department = "Chapel"
+	department = "Chapel";
+	name = "Monastery Requests Console"
 	},
 /obj/effect/mapping_helpers/requests_console/supplies,
 /obj/structure/closet,


### PR DESCRIPTION

## About The Pull Request
Fixes #77038

Adds missing names and departments to requests consoles in each station. Also fixes consoles in arrival shuttles and one emergency shuttle.
## Why It's Good For The Game

Fixes announcements coming from an unknown source, and makes department requests more clear.
## Changelog
:cl:
fix: fixed missing departments and names in request consoles
/:cl:
