### PR TITLE
Harvesting podpeople seeds now requires explicit approval

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -155,7 +155,7 @@
 		// Prevent accidental harvesting. Make sure the user REALLY wants to do this if there's a chance of this coming from a living creature.
 		if(mind || ckey)
 			var/choice = tgui_alert(usr,"The pod is currently devoid of soul. There is a possibility that a soul could claim this creature, or you could harvest it for seeds.", "Harvest Seeds?", list("Harvest Seeds", "Cancel"))
-			if(choice == "Cancel")
+			if(choice != "Harvest Seeds")
 				return result
 
 		// If this plant has already been harvested, return early.


### PR DESCRIPTION
## About The Pull Request

Podpeople seeds have a popup saying "This tray has no soul, are you sure you want to harvest right now?", but it will still harvest if you x out of the tab instead of clicking cancel. This flips it so you have to explicitely say yes for it to go through.

## Why It's Good For The Game

When you X out of a tab, you did not mean to say yes.

## Changelog

:cl:
fix: X'ing out of the podpeople no soul prompt will no longer harvest the seeds.
/:cl: