### PR TITLE
Xenomorphs and Monkeys Can Remove Embedded Objects Again

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -210,7 +210,7 @@
 
 /mob/living/carbon/Topic(href, href_list)
 	..()
-	if(href_list["embedded_object"] && usr.can_perform_action(src, NEED_DEXTERITY))
+	if(href_list["embedded_object"])
 		var/obj/item/bodypart/L = locate(href_list["embedded_limb"]) in bodyparts
 		if(!L)
 			return


### PR DESCRIPTION
## About The Pull Request

This is a simple bugfix PR that re-allows xenomorphs and monkeys to remove embedded objects from themselves. The reason this bug occurred was a hopefully erroneous use of NEEDS_DEXTERITY.

## Why It's Good For The Game

Xenomorphs and monkeys aren't that dumb, right? 

## Changelog
:cl:
fix: After a collective brain fart lasting for 6 months, monkeys and xenomorphs now know how to remove embedded objects from their own bodies.
/:cl: