### PR TITLE
The nukie sniper kit has a gun in it again.

### DIFF
--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -64,7 +64,7 @@
 	desc = "Its label reads \"genuine hardened Captain leather\", but suspiciously has no other tags or branding. Smells like L'Air du Temps."
 	force = 10
 
-/obj/item/storage/briefcase/sniperbundle/PopulateContents()
+/obj/item/storage/briefcase/sniper/PopulateContents()
 	..() // in case you need any paperwork done after your rampage
 	new /obj/item/gun/ballistic/rifle/sniper_rifle/syndicate(src)
 	new /obj/item/clothing/neck/tie/red/hitman(src)


### PR DESCRIPTION

## About The Pull Request

Closes #77527 

Due to a minor mistake in #77330, the nukie sniper rifle briefcase doesn't currently override PopulateContents(), meaning it contains nothing but a pen and some paper. This mistake has been fixed.
## Why It's Good For The Game

When you spend 18 TC on a sniper rifle, you should probably get a sniper rifle.
## Changelog
:cl:
fix: The Nuke Op/Lone Op sniper briefcase now properly contains a sniper rifle.
/:cl:
