### PR TITLE
Makes the Icebox bridge look better

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -3653,9 +3653,21 @@
 "bhK" = (
 /obj/structure/table,
 /obj/item/folder/blue{
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_y = 1;
+	pixel_x = -1
+	},
+/obj/item/paper_bin/carbon{
+	pixel_x = 5;
+	pixel_y = 18
+	},
+/obj/item/stamp/head/hop{
+	pixel_y = 5;
 	pixel_x = 8
 	},
-/obj/item/papercutter,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
 "bhV" = (
@@ -8204,7 +8216,10 @@
 "cyF" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/item/melee/chainofcommand,
+/obj/item/coin/plasma{
+	pixel_y = 13;
+	pixel_x = -6
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "cyG" = (
@@ -10498,7 +10513,9 @@
 /area/station/security/checkpoint/medical)
 "dho" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/secure/briefcase,
+/obj/item/storage/secure/briefcase{
+	pixel_y = 5
+	},
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -10826,8 +10843,7 @@
 /area/station/service/bar/backroom)
 "dmG" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/coin/plasma,
+/obj/item/camera,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "dmI" = (
@@ -10981,8 +10997,10 @@
 /turf/open/floor/wood/large,
 /area/mine/eva/lower)
 "doT" = (
-/obj/item/hand_labeler,
-/obj/item/assembly/timer,
+/obj/item/assembly/timer{
+	pixel_y = 15;
+	pixel_x = -3
+	},
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
@@ -16248,7 +16266,10 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen,
+/obj/item/pen{
+	pixel_x = 11;
+	pixel_y = 2
+	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
@@ -17423,8 +17444,13 @@
 /area/station/maintenance/starboard/aft)
 "fue" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 14
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_y = 5
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "fum" = (
@@ -20327,6 +20353,9 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/machinery/newscaster/directional/west,
+/obj/item/wrench{
+	pixel_y = 17
+	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "grD" = (
@@ -21349,7 +21378,9 @@
 "gKk" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/secure/safe/caps_spare/directional/east,
-/obj/item/papercutter,
+/obj/item/papercutter{
+	pixel_x = 7
+	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "gKl" = (
@@ -22166,7 +22197,9 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen,
+/obj/item/pen{
+	pixel_x = 12
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "gYG" = (
@@ -22196,11 +22229,18 @@
 /area/station/medical/virology)
 "gZj" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/emergency,
-/obj/item/wrench,
+/obj/item/storage/toolbox/emergency{
+	pixel_y = 9
+	},
 /obj/item/assembly/timer,
-/obj/item/assembly/signaler,
-/obj/item/assembly/signaler,
+/obj/item/assembly/signaler{
+	pixel_y = -7;
+	pixel_x = 7
+	},
+/obj/item/assembly/signaler{
+	pixel_y = -12;
+	pixel_x = -8
+	},
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/station/command/bridge)
@@ -23021,7 +23061,15 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Captain's Office"
 	},
-/obj/item/storage/lockbox/medal,
+/obj/item/storage/lockbox/medal{
+	pixel_y = 8
+	},
+/obj/item/pinpointer/nuke{
+	pixel_y = -9
+	},
+/obj/item/disk/nuclear{
+	pixel_y = -8
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "hpm" = (
@@ -23847,7 +23895,10 @@
 /area/station/commons/lounge)
 "hCV" = (
 /obj/structure/table/wood,
-/obj/item/hand_tele,
+/obj/item/hand_tele{
+	pixel_y = 11
+	},
+/obj/item/melee/chainofcommand,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
 "hDb" = (
@@ -32360,13 +32411,11 @@
 /area/station/security/holding_cell)
 "kpp" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/matches,
-/obj/item/razor{
-	pixel_x = -4;
-	pixel_y = 2
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_y = 10;
+	pixel_x = 7
 	},
-/obj/item/clothing/mask/cigarette/cigar,
-/obj/item/reagent_containers/cup/glass/flask/gold,
+/obj/item/storage/box/matches,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "kpu" = (
@@ -33094,6 +33143,10 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
+/obj/item/multitool{
+	pixel_x = 9;
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "kzG" = (
@@ -33227,7 +33280,9 @@
 /area/station/science/robotics/mechbay)
 "kBr" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/regular{
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "kBL" = (
@@ -36872,6 +36927,10 @@
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
 /obj/machinery/light/small/directional/north,
+/obj/item/razor{
+	pixel_x = 8;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/freezer,
 /area/station/command/heads_quarters/captain)
 "lIs" = (
@@ -39401,9 +39460,8 @@
 "mBX" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm/directional/east,
-/obj/item/camera,
 /obj/item/storage/photo_album{
-	pixel_y = -10
+	pixel_y = -1
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
@@ -43129,7 +43187,10 @@
 /area/station/security/checkpoint/medical)
 "nKe" = (
 /obj/structure/table,
-/obj/item/hand_tele,
+/obj/item/hand_tele{
+	pixel_y = 13;
+	pixel_x = 3
+	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "nKj" = (
@@ -46651,14 +46712,9 @@
 /area/station/science/lab)
 "oPt" = (
 /obj/structure/table,
-/obj/item/paper_bin/carbon{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/item/stamp/head/hop,
-/obj/item/storage/wallet/random{
-	pixel_x = 9
+/obj/item/papercutter{
+	pixel_y = 6;
+	pixel_x = 8
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
@@ -54492,8 +54548,9 @@
 /area/station/security/brig)
 "rns" = (
 /obj/structure/table/reinforced,
-/obj/item/aicard,
-/obj/item/multitool,
+/obj/item/aicard{
+	pixel_y = 6
+	},
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
@@ -58623,6 +58680,9 @@
 /area/station/service/library)
 "sEl" = (
 /obj/structure/table,
+/obj/item/hand_labeler{
+	pixel_y = 2
+	},
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "sEp" = (
@@ -60981,6 +61041,10 @@
 /obj/machinery/recharger{
 	pixel_x = 5;
 	pixel_y = 2
+	},
+/obj/item/storage/wallet/random{
+	pixel_x = 6;
+	pixel_y = -24
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/hop)
@@ -70409,8 +70473,6 @@
 /area/station/engineering/atmos)
 "wwB" = (
 /obj/structure/table/wood,
-/obj/item/pinpointer/nuke,
-/obj/item/disk/nuclear,
 /obj/item/storage/secure/safe/directional/east,
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood,
@@ -71227,7 +71289,13 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "wKw" = (
 /obj/structure/table/wood,
-/obj/item/flashlight/lamp/green,
+/obj/item/flashlight/lamp/green{
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/cup/glass/flask/gold{
+	pixel_x = 6;
+	pixel_y = 5
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "wKA" = (


### PR DESCRIPTION
## About The Pull Request
Makes the icebox bridge look better. Just general move stuff around so stuff don't seem stacked atop eachother and other minor visual improvements

## Why It's Good For The Game

Mapping good

## Changelog
:cl:
qol: The icebox bridge had its items moved to better positions. No items were added or removed, and none left their original room (except the captain's electric razor, which went to the bathroom).
/:cl:
