### PR TITLE
Doctors no longer spawn where assistants should spawn in Northstar

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -29944,10 +29944,10 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/vacant_room/commissary)
 "hTf" = (
-/obj/effect/landmark/start/medical_doctor,
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/checker,
 /area/station/commons/vacant_room/commissary)
 "hTj" = (
@@ -31564,10 +31564,10 @@
 /area/station/security/prison)
 "ipB" = (
 /obj/structure/sign/poster/official/random/directional/north,
-/obj/effect/landmark/start/medical_doctor,
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/checker,
 /area/station/commons/vacant_room/commissary)
 "ipI" = (
@@ -77067,7 +77067,9 @@
 /area/station/maintenance/disposal/incinerator)
 "uko" = (
 /obj/structure/table,
-/obj/item/pai_card,
+/obj/item/pai_card{
+	pixel_y = 6
+	},
 /turf/open/floor/iron/checker,
 /area/station/commons/vacant_room/commissary)
 "ukr" = (


### PR DESCRIPTION

## About The Pull Request

Swapped two doctor spawns for assistant spawns. also slightly moved up a pAI spawner because it wasn't properly on the table before

## Why It's Good For The Game

All other spawns in the area were assistants, + it's very unlikely they were put there intentionaly. Fix.

## Changelog
:cl:
fix: Doctors no longer spawn in the bedroom in the northstar
/:cl:
