### PR TITLE
The chef can no longer close the HoP's shutter in Meta

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -41178,7 +41178,7 @@
 /obj/machinery/button/door/directional/north{
 	id = "hop";
 	name = "Privacy Shutters Control";
-	req_access = list("kitchen")
+	req_access = list("hop")
 	},
 /obj/machinery/computer/accounting,
 /turf/open/floor/wood,


### PR DESCRIPTION

## About The Pull Request

The HoP's shutter had "Kitchen" as the access, meaning in addition to the HoP the Chef could also close these shutters. Only god knows how long this has been a thing for.

## Why It's Good For The Game

Fixes an oversight in access

## Changelog
:cl:
fix: The chef can no longer close the shutters in Meta's HoP office.
/:cl:
