### PR TITLE
Modular receiver now only appears in hacked autolathe.

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -89,7 +89,6 @@
 		"rdconsole",
 		"rdserver",
 		"rdservercontrol",
-		"receiver",
 		"recorder",
 		"rglass",
 		"roll",


### PR DESCRIPTION

## About The Pull Request

Resolves #77554 

Removes the modular receiver design from the base tech node, so that it only appears in the hacked autolathe. This fixes a bug where hacking an autolathe would make this recipe appear twice.

I assumed that _removing_ the receiver from the unhacked autolathe was the correct direction to go, since the design is in the hacked category. It would be easy enough to reverse this if desired, though.
## Why It's Good For The Game

Designs shouldn't be appearing in the autolathe twice. It also appears that the intention was that you have to hack the autolathe to print a modular receiver - which makes enough sense. Printing out gun parts _probably_ shouldn't be default autolathe behavior.
## Changelog
:cl:
fix: The modular receiver is now only printable from a hacked autolathe.
/:cl:
