### PR TITLE
More lua harddel fixes

### DIFF
--- a/code/controllers/subsystem/lua.dm
+++ b/code/controllers/subsystem/lua.dm
@@ -18,7 +18,8 @@ SUBSYSTEM_DEF(lua)
 	var/list/current_run = list()
 
 	/// Protects return values from getting GCed before getting converted to lua values
-	var/gc_guard
+	/// Gets cleared every tick.
+	var/list/gc_guard = list()
 
 /datum/controller/subsystem/lua/Initialize()
 	if(!CONFIG_GET(flag/auxtools_enabled))
@@ -99,6 +100,7 @@ SUBSYSTEM_DEF(lua)
 		sleeps.Cut()
 		resumes.Cut()
 
+	gc_guard.Cut()
 	var/list/current_sleeps = current_run["sleeps"]
 	var/list/affected_states = list()
 	while(length(current_sleeps))

--- a/code/modules/admin/verbs/lua/_wrappers.dm
+++ b/code/modules/admin/verbs/lua/_wrappers.dm
@@ -12,9 +12,7 @@
 	else
 		ret = HandleUserlessProcCall("lua", thing_to_call, proc_name, arguments)
 	if(isdatum(ret))
-		SSlua.gc_guard = ret
-		var/datum/ret_datum = ret
-		ret_datum.RegisterSignal(ret_datum, COMSIG_QDELETING, TYPE_PROC_REF(/datum, lua_reference_cleanup), override = TRUE)
+		SSlua.gc_guard += ret
 	return ret
 
 /proc/wrap_lua_global_proc_call(proc_name, list/arguments)
@@ -27,9 +25,7 @@
 	else
 		ret = HandleUserlessProcCall("lua", GLOBAL_PROC, proc_name, arguments)
 	if(isdatum(ret))
-		SSlua.gc_guard = ret
-		var/datum/ret_datum = ret
-		ret_datum.RegisterSignal(ret_datum, COMSIG_QDELETING, TYPE_PROC_REF(/datum, lua_reference_cleanup), override = TRUE)
+		SSlua.gc_guard += ret
 	return ret
 
 /proc/wrap_lua_print(state_id, list/arguments)

--- a/code/modules/admin/verbs/lua/helpers.dm
+++ b/code/modules/admin/verbs/lua/helpers.dm
@@ -34,17 +34,3 @@
 #undef PROMISE_PENDING
 #undef PROMISE_RESOLVED
 #undef PROMISE_REJECTED
-
-/**
- * When a datum is created from lua, it gets held in `SSlua.gc_guard`, and later,
- * in the calling state datum's `var/list/references`, just in case it would be garbage
- * collected due to there not being any references that BYOND recognizes. To avoid harddels,
- * we register this proc as a signal handler any time a DM function called from lua returns
- * a datum.
- */
-/datum/proc/lua_reference_cleanup()
-	SIGNAL_HANDLER
-	if(SSlua.gc_guard == src)
-		SSlua.gc_guard = null
-	for(var/datum/lua_state/state in SSlua.states)
-		state.references -= src


### PR DESCRIPTION

## About The Pull Request
Fixes some more lua harddel problems with lingering refs on the gc_guard variable. This variable has been changed to a list instead and will get cleared every time the SSlua subsystem fires so that lua instantiated objects that are not tracked by the subsystem will essentially delete themselves on the next tick, aka whenever the lua script sleeps.

Also removed the unnecessary and not completely functional lua_reference_cleanup proc which wasn't even being called reliably because the signal handler was the datum itself.

## Why It's Good For The Game
Fixes more harddel bugs, increases consistency.
