### PR TITLE
Moves the RD's plant to their office in Northstar

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -18904,11 +18904,11 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "eVs" = (
-/obj/item/kirbyplants/random/dead/research_director,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/computer/security/telescreen/rd{
 	pixel_x = -30
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "eVN" = (
@@ -46431,13 +46431,13 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard)
 "mfY" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera/directional/west{
 	c_tag = "Command - Research Director's Quarters #1"
 	},
 /obj/effect/baseturf_helper/reinforced_plating/ceiling,
 /obj/machinery/newscaster/directional/west,
+/obj/item/kirbyplants/random/dead/research_director,
 /turf/open/floor/iron/large,
 /area/station/command/heads_quarters/rd)
 "mge" = (
@@ -91277,7 +91277,9 @@
 /obj/item/knife/plastic{
 	pixel_x = 16
 	},
-/obj/item/food/donkpocket/warm/berry,
+/obj/item/food/donkpocket/warm/berry{
+	pixel_y = 7
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/command/heads_quarters/rd)
 "xRk" = (


### PR DESCRIPTION

## About The Pull Request

The RD's potted plant is not in its place in Northstar; the science rework accidentaly left it in the foyer and not in the RD's room.

## Why It's Good For The Game

The joke is a lot funnier when the plant is in the RD's shitty apartment than when it's out in the open

## Changelog
:cl:
fix: Moved the RD's plant to its proper place in Northstar
/:cl:
