### PR TITLE
Ports LETPASSCLICKS from Daedalus Dock

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -155,6 +155,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define PASSDOORS (1<<10)
 #define PASSVEHICLE (1<<11)
 #define PASSITEM (1<<12)
+/// Do not intercept click attempts during Adjacent() checks. See [turf/proc/ClickCross]. **ONLY MEANINGFUL ON pass_flags_self!**
+#define LETPASSCLICKS (1<<13)
 
 //Movement Types
 #define GROUND (1<<0)

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -87,19 +87,23 @@
 
 /*
 	This checks if you there is uninterrupted airspace between that turf and this one.
-	This is defined as any dense ON_BORDER_1 object, or any dense object without LETPASSTHROW.
+This is defined as any dense ON_BORDER_1 object, or any dense object without LETPASSTHROW or LETPASSCLICKS.
 	The border_only flag allows you to not objects (for source and destination squares)
 */
 /turf/proc/ClickCross(target_dir, border_only, atom/target, atom/movable/mover)
 	for(var/obj/O in src)
 		if((mover && O.CanPass(mover, target_dir)) || (!mover && !O.density))
 			continue
-		if(O == target || O == mover || (O.pass_flags_self & LETPASSTHROW)) //check if there's a dense object present on the turf
-			continue // LETPASSTHROW is used for anything you can click through (or the firedoor special case, see above)
+
+		//If there's a dense object on the turf, only allow the click to pass if you can throw items over it or it has a special flag.
+		if(O == target || O == mover || (O.pass_flags_self & (LETPASSTHROW|LETPASSCLICKS)))
+			continue
 
 		if( O.flags_1&ON_BORDER_1) // windows are on border, check them first
 			if( O.dir & target_dir || O.dir & (O.dir-1) ) // full tile windows are just diagonals mechanically
 				return FALSE   //O.dir&(O.dir-1) is false for any cardinal direction, but true for diagonal ones
+
 		else if( !border_only ) // dense, not on border, cannot pass over
 			return FALSE
+
 	return TRUE

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -91,7 +91,7 @@
 	verb_say = "beeps"
 	verb_yell = "blares"
 	pressure_resistance = 15
-	pass_flags_self = PASSMACHINE
+	pass_flags_self = PASSMACHINE | LETPASSCLICKS
 	max_integrity = 200
 	layer = BELOW_OBJ_LAYER //keeps shit coming out of the machine from ending up underneath it.
 	flags_ricochet = RICOCHET_HARD

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -15,6 +15,7 @@
 	contents_pressure_protection = 0
 	/// How insulated the thing is, for the purposes of calculating body temperature. Must be between 0 and 1!
 	contents_thermal_insulation = 0
+	pass_flags_self = LETPASSCLICKS
 
 	/// The overlay for the closet's door
 	var/obj/effect/overlay/closet_door/door_obj


### PR DESCRIPTION

## About The Pull Request
A deal with @Fikou 
- https://github.com/DaedalusDock/daedalusdock/pull/106

In layman's terms, you can grab this wrench now.
![205561405-902f1795-0c63-4dab-8435-d8902f9c4499](https://github.com/tgstation/tgstation/assets/75460809/08f2e782-7532-44a5-beea-fd1278985017)


Adds a new pass_flags_self value for click transparency, allowing objects to be dense without blocking click attempts.
## Why It's Good For The Game
## Changelog
:cl:
add: Lockers, crates, and machines no longer block click attempts in adjacency checks. Basically, you can reach tables cornered between lockers/machines.
/:cl:
