### PR TITLE
makes ninjas unable to hack more than one borg/scramble security records once

### DIFF
--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -146,6 +146,8 @@
 /obj/machinery/computer/records/security/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!ninja || !hacking_module)
 		return NONE
+	if(hacking_module.security_console_hack_success)
+		return NONE
 	if(!can_hack(ninja, feedback = TRUE))
 		return NONE
 
@@ -163,6 +165,7 @@
 	var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
 	if(!ninja_antag)
 		return
+	hacking_module.security_console_hack_success = TRUE
 	var/datum/objective/security_scramble/objective = locate() in ninja_antag.objectives
 	if(objective)
 		objective.completed = TRUE
@@ -284,6 +287,8 @@
 /mob/living/silicon/robot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!ninja || !hacking_module || (ROLE_NINJA in faction))
 		return NONE
+	if(hacking_module.borg_hack_success)
+		return
 
 	to_chat(src, span_danger("Warni-***BZZZZZZZZZRT*** UPLOADING SPYDERPATCHER VERSION 9.5.2..."))
 	INVOKE_ASYNC(src, PROC_REF(ninjadrain_charge), ninja, hacking_module)
@@ -305,6 +310,7 @@
 	var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
 	if(!ninja_antag)
 		return
+	hacking_module.borg_hack_success = TRUE
 	var/datum/objective/cyborg_hijack/objective = locate() in ninja_antag.objectives
 	if(objective)
 		objective.completed = TRUE

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -127,6 +127,10 @@
 	var/maxdrain = 400
 	/// Whether or not the communication console hack was used to summon another antagonist.
 	var/communication_console_hack_success = FALSE
+	///Whether or not the security console hack was used to set everyone to arrest
+	var/security_console_hack_success = FALSE
+	///Whether or not the cyborg hack was used to syndify a cyborg
+	var/borg_hack_success = FALSE
 	/// How many times the module has been used to force open doors.
 	var/door_hack_counter = 0
 


### PR DESCRIPTION

## About The Pull Request

Adds a check to see if a ninja's already hacked a cyborg and scrambled the security records when they try to do it again. If it's already been done, they can't.
## Why It's Good For The Game

Ninjas being able to disrupt the round by creating a fucking miniature army of assault cyborgs is so immesiely powerful I'm questioning why it was never patched out before this. I did it when I ported newja to Citadel, and thought it'd be getting done to here not too long after it.
## Changelog
:cl:
balance: makes ninjas unable to hack more than one borg/scramble security records once
/:cl:
