### PR TITLE
Dismemberment moodlets are alleviated when recovering your limbs.

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -82,7 +82,7 @@
 	mood_change = -10
 	timeout = 8 MINUTES
 
-/datum/mood_event/dismembered/add_effects(var/obj/item/bodypart/limb)
+/datum/mood_event/dismembered/add_effects(obj/item/bodypart/limb)
 	if(limb)
 		description = "AHH! I WAS USING THAT [full_capitalize(limb.plaintext_zone)]"
 
@@ -91,7 +91,7 @@
 	mood_change = -3
 	timeout = 60 SECONDS
 
-/datum/mood_event/reattachment/add_effects(var/obj/item/bodypart/limb)
+/datum/mood_event/reattachment/add_effects(obj/item/bodypart/limb)
 	if(limb)
 		description = "Ouch! My [limb.plaintext_zone] feels like I feel asleep on it."
 

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -87,7 +87,7 @@
 		description = "AHH! I WAS USING THAT [full_capitalize(limb.plaintext_zone)]"
 
 /datum/mood_event/reattachment
-	description = "Ouch! My limb feels like I feel asleep on it."
+	description = "Ouch! My limb feels like I fell asleep on it."
 	mood_change = -3
 	timeout = 2 MINUTES
 

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -93,7 +93,7 @@
 
 /datum/mood_event/reattachment/add_effects(obj/item/bodypart/limb)
 	if(limb)
-		description = "Ouch! My [limb.plaintext_zone] feels like I feel asleep on it."
+		description = "Ouch! My [limb.plaintext_zone] feels like I fell asleep on it."
 
 /datum/mood_event/tased
 	description = "There's no \"z\" in \"taser\". It's in the zap."

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -89,7 +89,7 @@
 /datum/mood_event/reattachment
 	description = "Ouch! My limb feels like I feel asleep on it."
 	mood_change = -3
-	timeout = 60 SECONDS
+	timeout = 2 MINUTES
 
 /datum/mood_event/reattachment/add_effects(obj/item/bodypart/limb)
 	if(limb)

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -82,6 +82,19 @@
 	mood_change = -10
 	timeout = 8 MINUTES
 
+/datum/mood_event/dismembered/add_effects(var/obj/item/bodypart/limb)
+	if(limb)
+		description = "AHH! I WAS USING THAT [full_capitalize(limb.plaintext_zone)]"
+
+/datum/mood_event/reattachment
+	description = "Ouch! My limb feels like I feel asleep on it."
+	mood_change = -3
+	timeout = 60 SECONDS
+
+/datum/mood_event/reattachment/add_effects(var/obj/item/bodypart/limb)
+	if(limb)
+		description = "Ouch! My [limb.plaintext_zone] feels like I feel asleep on it."
+
 /datum/mood_event/tased
 	description = "There's no \"z\" in \"taser\". It's in the zap."
 	mood_change = -3

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -352,7 +352,7 @@
 		LAZYADD(new_limb_owner.all_scars, scar)
 
 	if(new_limb_owner.mob_mood.has_mood_of_category("dismembered_[body_zone]"))
-		new_limb_onwer.clear_mood_event("dismembered_[body_zone]")
+		new_limb_owner.clear_mood_event("dismembered_[body_zone]")
 		new_limb_owner.add_mood_event("phantom_pain_[body_zone]", /datum/mood_event/reattachment, src)
 
 	update_bodypart_damage_state()

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -20,7 +20,7 @@
 		limb_owner.visible_message(span_danger("<B>[limb_owner]'s [name] is violently dismembered!</B>"))
 	INVOKE_ASYNC(limb_owner, TYPE_PROC_REF(/mob, emote), "scream")
 	playsound(get_turf(limb_owner), 'sound/effects/dismember.ogg', 80, TRUE)
-	limb_owner.add_mood_event("dismembered", /datum/mood_event/dismembered)
+	limb_owner.add_mood_event("[body_zone]", /datum/mood_event/dismembered)
 	limb_owner.add_mob_memory(/datum/memory/was_dismembered, lost_limb = src)
 	drop_limb()
 
@@ -350,6 +350,8 @@
 			continue
 		scar.victim = new_limb_owner
 		LAZYADD(new_limb_owner.all_scars, scar)
+
+	new_limb_owner.clear_mood_event("[body_zone]")
 
 	update_bodypart_damage_state()
 	if(can_be_disabled)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -20,7 +20,7 @@
 		limb_owner.visible_message(span_danger("<B>[limb_owner]'s [name] is violently dismembered!</B>"))
 	INVOKE_ASYNC(limb_owner, TYPE_PROC_REF(/mob, emote), "scream")
 	playsound(get_turf(limb_owner), 'sound/effects/dismember.ogg', 80, TRUE)
-	limb_owner.add_mood_event("dismembered_[body_zone]", /datum/mood_event/dismembered)
+	limb_owner.add_mood_event("dismembered_[body_zone]", /datum/mood_event/dismembered, src)
 	limb_owner.add_mob_memory(/datum/memory/was_dismembered, lost_limb = src)
 	drop_limb()
 
@@ -351,7 +351,9 @@
 		scar.victim = new_limb_owner
 		LAZYADD(new_limb_owner.all_scars, scar)
 
-	new_limb_owner.clear_mood_event("dismembered_[body_zone]")
+	if(new_limb_owner.mob_mood.has_mood_of_category("dismembered_[body_zone]"))
+		new_limb_onwer.clear_mood_event("dismembered_[body_zone]")
+		new_limb_owner.add_mood_event("phantom_pain_[body_zone]", /datum/mood_event/reattachment, src)
 
 	update_bodypart_damage_state()
 	if(can_be_disabled)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -351,7 +351,7 @@
 		scar.victim = new_limb_owner
 		LAZYADD(new_limb_owner.all_scars, scar)
 
-	new_limb_owner.clear_mood_event("[body_zone]")
+	new_limb_owner.clear_mood_event("dismembered_[body_zone]")
 
 	update_bodypart_damage_state()
 	if(can_be_disabled)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -351,7 +351,7 @@
 		scar.victim = new_limb_owner
 		LAZYADD(new_limb_owner.all_scars, scar)
 
-	if(new_limb_owner.mob_mood.has_mood_of_category("dismembered_[body_zone]"))
+	if(!special && new_limb_owner.mob_mood.has_mood_of_category("dismembered_[body_zone]"))
 		new_limb_owner.clear_mood_event("dismembered_[body_zone]")
 		new_limb_owner.add_mood_event("phantom_pain_[body_zone]", /datum/mood_event/reattachment, src)
 

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -20,7 +20,7 @@
 		limb_owner.visible_message(span_danger("<B>[limb_owner]'s [name] is violently dismembered!</B>"))
 	INVOKE_ASYNC(limb_owner, TYPE_PROC_REF(/mob, emote), "scream")
 	playsound(get_turf(limb_owner), 'sound/effects/dismember.ogg', 80, TRUE)
-	limb_owner.add_mood_event("[body_zone]", /datum/mood_event/dismembered)
+	limb_owner.add_mood_event("dismembered_[body_zone]", /datum/mood_event/dismembered)
 	limb_owner.add_mob_memory(/datum/memory/was_dismembered, lost_limb = src)
 	drop_limb()
 


### PR DESCRIPTION
## About The Pull Request

What it says on the tin.
When reattaching a limb, the respective dismemberment debuff will be replaced by a significantly less severe one (-3 for 2
minutes as opposed to -10 for 8 minutes)
However, the way I've done it, to that ensure replacing a leg when you're missing 4 limbs doesn't clear the moodbuff, has the entertaining side effect of **allowing dismemberment moodlets to stack for each limb you've lost, and being cleared separately.**
I honestly kind of like it. Their description changes in accordance to what limb it is as well.
## Why It's Good For The Game

It doesn't make much sense for your character to continue lamenting the loss of their arm/leg after they've already acquired a replacement. 
I also like that this makes losing multiple limbs worse than losing just one, as someone who's been nugget-ed would have a far worse day than someone who has simply lost an arm.

Closes #77388.
## Changelog
:cl:
fix: dismemberment moodlets are replaced by a lesser mood debuff when you recover the limb in question.
balance: dismemberment moodlets can now stack for each limb you lose, and are cleared separately. Their descriptions have been updated to reflect this.
/:cl:
