### PR TITLE
Adds a unique medibot to the Syndicate Infiltrator

### DIFF
--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -600,6 +600,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/mob/living/simple_animal/bot/medbot/nukie,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/medical)
 "bA" = (

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -676,6 +676,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/mob/living/simple_animal/bot/medbot/nukie,
 /turf/open/floor/iron/corner{
 	dir = 1
 	},

--- a/_maps/shuttles/pirate_Interdyne.dmm
+++ b/_maps/shuttles/pirate_Interdyne.dmm
@@ -491,6 +491,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/medbot/nukie{
+	name = "Dr. Thrax";
+	desc = "A twitchy medibot. It can't seem to hold still. Slightly concerning."
+	},
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)
 "fY" = (

--- a/_maps/shuttles/pirate_Interdyne.dmm
+++ b/_maps/shuttles/pirate_Interdyne.dmm
@@ -492,7 +492,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/bot/medbot/nukie{
-	name = "Dr. Thrax";
+	name = "Dr. Pax";
 	desc = "A twitchy medibot. It can't seem to hold still. Slightly concerning."
 	},
 /turf/open/floor/iron/dark,

--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -74,6 +74,9 @@
 /// global signal sent when a nuclear device is disarmed (/obj/machinery/nuclearbomb/nuke/disarmed_nuke)
 #define COMSIG_GLOB_NUKE_DEVICE_DISARMED "!nuclear_device_disarmed"
 
+/// global signal sent when a nuclear device is detonating (/obj/machinery/nuclearbomb/nuke/exploding_nuke)
+#define COMSIG_GLOB_NUKE_DEVICE_DETONATING "!nuclear_device_detonating"
+
 /// Global signal sent when a light mechanism is completed (try_id)
 #define COMSIG_GLOB_LIGHT_MECHANISM_COMPLETED "!light_mechanism_completed"
 

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -522,6 +522,8 @@ GLOBAL_VAR(station_nuke_source)
 	update_appearance()
 	sound_to_playing_players('sound/machines/alarm.ogg')
 
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NUKE_DEVICE_DETONATING, src)
+
 	if(SSticker?.mode)
 		SSticker.roundend_check_paused = TRUE
 	addtimer(CALLBACK(src, PROC_REF(actually_explode)), 10 SECONDS)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -132,6 +132,39 @@
 	heal_threshold = 0
 	heal_amount = 5
 
+/mob/living/simple_animal/bot/medbot/nukie
+	name = "Oppenheimer"
+	desc = "A Nanotrasen medibot, stolen and upgraded by the Syndicate. Despite their best efforts at reprogramming, it still appears visibly upset near nuclear explosives."
+	skin = "bezerk"
+	health = 40
+	maxHealth = 40
+	maints_access_required = list(ACCESS_SYNDICATE)
+	radio_key = /obj/item/encryptionkey/syndicate
+	radio_channel = RADIO_CHANNEL_SYNDICATE
+	damagetype_healer = "all"
+	heal_threshold = 0
+	heal_amount = 5
+
+/mob/living/simple_animal/bot/medbot/nukie/Initialize(mapload, new_skin)
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_DISARMED, PROC_REF(nuke_disarm))
+	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_ARMED, PROC_REF(nuke_arm))
+	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_DETONATING, PROC_REF(nuke_detonate))
+	internal_radio.set_frequency(FREQ_SYNDICATE)
+	internal_radio.freqlock = RADIO_FREQENCY_LOCKED
+
+/mob/living/simple_animal/bot/medbot/nukie/proc/nuke_disarm()
+	SIGNAL_HANDLER
+	INVOKE_ASYNC(src, PROC_REF(speak), pick(MEDIBOT_VOICED_FORGIVE, MEDIBOT_VOICED_THANKS, MEDIBOT_VOICED_GOOD_PERSON))
+
+/mob/living/simple_animal/bot/medbot/nukie/proc/nuke_arm()
+	SIGNAL_HANDLER
+	INVOKE_ASYNC(src, PROC_REF(speak), pick(MEDIBOT_VOICED_WAIT, MEDIBOT_VOICED_DONT, MEDIBOT_VOICED_IM_SCARED))
+
+/mob/living/simple_animal/bot/medbot/nukie/proc/nuke_detonate()
+	SIGNAL_HANDLER
+	INVOKE_ASYNC(src, PROC_REF(speak), pick(MEDIBOT_VOICED_THE_END, MEDIBOT_VOICED_NOOO, MEDIBOT_VOICED_SUFFER))
+
 /mob/living/simple_animal/bot/medbot/examine(mob/user)
 	. = ..()
 	if(tipped_status == MEDBOT_PANIC_NONE)
@@ -175,7 +208,8 @@
 	access_card.add_access(para_trim.access + para_trim.wildcard_access)
 	prev_access = access_card.access.Copy()
 
-	skin = new_skin
+	if(!isnull(new_skin))
+		skin = new_skin
 	update_appearance()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !linked_techweb)
 		linked_techweb = SSresearch.science_tech

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -134,7 +134,7 @@
 
 /mob/living/simple_animal/bot/medbot/nukie
 	name = "Oppenheimer"
-	desc = "A Nanotrasen medibot, stolen and upgraded by the Syndicate. Despite their best efforts at reprogramming, it still appears visibly upset near nuclear explosives."
+	desc = "A medibot stolen from a Nanotrasen station and upgraded by the Syndicate. Despite their best efforts at reprogramming, it still appears visibly upset near nuclear explosives."
 	skin = "bezerk"
 	health = 40
 	maxHealth = 40

--- a/code/modules/unit_tests/simple_animal_freeze.dm
+++ b/code/modules/unit_tests/simple_animal_freeze.dm
@@ -16,6 +16,7 @@
 		/mob/living/simple_animal/bot/medbot/autopatrol,
 		/mob/living/simple_animal/bot/medbot/derelict,
 		/mob/living/simple_animal/bot/medbot/mysterious,
+		/mob/living/simple_animal/bot/medbot/nukie,
 		/mob/living/simple_animal/bot/medbot/stationary,
 		/mob/living/simple_animal/bot/mulebot,
 		/mob/living/simple_animal/bot/mulebot/paranormal,


### PR DESCRIPTION

## About The Pull Request

Adds a unique medibot to the Syndicate Infiltrator. It doesn't like nukes - when one is armed, disarmed, or detonating, it says an unique line. Players can optionally enable personalities on it if they want to. Probably best to just let it stay on the shuttle though. (It's also in the Interdyne Pharmaceuticals ship, renamed)

Fixed an issue that made mapload medibots unable to load custom skins.

This PR adds a medibot subtype to the simple animal freeze list, which I don't think is a big deal as this isn't a 'true' simplemob but just a slightly altered medibot, similarly to my 'lesser Gorillas' in the summon simians PR.

## Why It's Good For The Game

> Adds a unique medibot to the Syndicate Infiltrator. It doesn't like nukes - when one is armed, disarmed, or detonating, it says an unique line. Players can optionally enable personalities on it if they want to. Probably best to just let it stay on the shuttle though.

I know what the inmediate reaction is here - but hear me out. Besides the meme of the month, it really, genuinely is cute and amusing to have a friendly medibot that shows dismay when you're arming the nuke and horror when it blows up (with you, hopefully, at the syndibase), and still fits quite well within SS13's charm and flavor. The reference isn't overt and in-your-face.

Besides that, slip-ups, friendly fire, and accidents are semi-common on the shuttle and, just like Wizards, nukies deserve a bot to patch their wounds up.

> (It's also in the Interdyne Pharmaceuticals ship, renamed)

I think it makes sense for the pharmacists to have an evil medibot!

> Fixed an issue that made mapload medibots unable to load custom skins.

Fixed "bezerk" skin not appearing. Didn't fix it being ugly as sin though.

## Changelog

:cl:
add: Adds a unique medibot to the Syndicate Infiltrator. It doesn't like nukes - when one is armed, disarmed, or detonating, it says an unique line. Players can optionally enable personalities on it if they want to. Probably best to just let it stay on the shuttle though. (It's also in the Interdyne Pharmaceuticals ship, renamed)
fix: Fixed an issue that made mapload medibots unable to load custom skins.
/:cl:

