### PR TITLE
Putting mobs into evidence bags no longer causes harddels

### DIFF
--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -86,6 +86,7 @@
 		user.visible_message(span_notice("[user] takes [I] out of [src]."), span_notice("You take [I] out of [src]."),\
 		span_hear("You hear someone rustle around in a plastic bag, and remove something."))
 		cut_overlays() //remove the overlays
+		user.put_in_hands
 		w_class = WEIGHT_CLASS_TINY
 		icon_state = "evidenceobj"
 		desc = "An empty evidence bag."

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -56,7 +56,7 @@
 	if(!isturf(I.loc)) //If it isn't on the floor. Do some checks to see if it's in our hands or a box. Otherwise give up.
 		if(I.loc.atom_storage) //in a container.
 			I.loc.atom_storage.remove_single(user, I, src)
-		if(!user.dropItemToGround(I))
+		if(!user.is_holding(I) || HAS_TRAIT(I, TRAIT_NODROP))
 			return
 
 	user.visible_message(span_notice("[user] puts [I] into [src]."), span_notice("You put [I] inside [src]."),\

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -59,6 +59,9 @@
 		if(!user.is_holding(I) || HAS_TRAIT(I, TRAIT_NODROP))
 			return
 
+	if(QDELETED(I))
+		return
+
 	user.visible_message(span_notice("[user] puts [I] into [src]."), span_notice("You put [I] inside [src]."),\
 	span_hear("You hear a rustle as someone puts something into a plastic bag."))
 
@@ -83,7 +86,6 @@
 		user.visible_message(span_notice("[user] takes [I] out of [src]."), span_notice("You take [I] out of [src]."),\
 		span_hear("You hear someone rustle around in a plastic bag, and remove something."))
 		cut_overlays() //remove the overlays
-		user.put_in_hands(I)
 		w_class = WEIGHT_CLASS_TINY
 		icon_state = "evidenceobj"
 		desc = "An empty evidence bag."

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -86,7 +86,7 @@
 		user.visible_message(span_notice("[user] takes [I] out of [src]."), span_notice("You take [I] out of [src]."),\
 		span_hear("You hear someone rustle around in a plastic bag, and remove something."))
 		cut_overlays() //remove the overlays
-		user.put_in_hands
+		user.put_in_hands(I)
 		w_class = WEIGHT_CLASS_TINY
 		icon_state = "evidenceobj"
 		desc = "An empty evidence bag."


### PR DESCRIPTION
## About The Pull Request

Fun interaction. Since evidence bags make you drop held items to the floor and then forcemove the item into the bag, mob holders would dump the mob on the floor, be qdeleted and have their references cleared and then be put inside the bag's contents, bugging the fuck out and staying in the bag (`put_in_hands()` fails if the item in question is qdeleted) until it's eventually harddeleted because the reference to it in the evidence bag never gets cleared.

![image](https://github.com/tgstation/tgstation/assets/80640114/42cc4748-653f-4ed7-98fa-4c9cd39615e9)
<details>

<summary>Harddel logs</summary>

```
[2023-08-13 12:05:25.908] RUNTIME: ## REF SEARCH Beginning search for references to a /obj/item/clothing/head/mob_holder.
[2023-08-13 12:05:26.089] RUNTIME: ## REF SEARCH Finished searching globals
[2023-08-13 12:05:26.353] RUNTIME: ## REF SEARCH Finished searching native globals
[2023-08-13 12:05:59.099] RUNTIME: ## REF SEARCH Found /obj/item/clothing/head/mob_holder [0x2001ffb] in list World -> /obj/item/evidencebag [0x20140e8] -> contents (list).
[2023-08-13 12:09:22.401] RUNTIME: ## REF SEARCH Finished searching atoms
[2023-08-13 12:09:50.415] RUNTIME: ## REF SEARCH Finished searching datums
[2023-08-13 12:09:50.419] RUNTIME: ## REF SEARCH Finished searching clients
[2023-08-13 12:09:50.421] RUNTIME: ## REF SEARCH Completed search for references to a /obj/item/clothing/head/mob_holder.
[2023-08-13 12:09:50.427] RUNTIME: ## TESTING: GC: -- [0x2001ffb] | /obj/item/clothing/head/mob_holder was unable to be GC'd
```

</details>



My solution was to change the checks of the evidence bag. Rather than making you drop the item, they will check that the item is in your hands and that it doesn't have `TRAIT_NODROP`. If either isn't true, it will fail, which I think covers all the relevant cases for this. It should avoid any similar issues in the future with items that dissapear when dropped. (Hand gestures would have also suffered from this if they weren't excluded in an earlier check, for example).

As an additional fallback, it will also check if the item is qdeleted before trying to forcemove it.
## Why It's Good For The Game

Closes #77197.
Hard deletes are bad, real bad.
## Changelog
:cl:
fix: mob holders no longer bug out and harddel when put into evidence bags.
/:cl:
