### PR TITLE
Fixes a bug with the immerse element

### DIFF
--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -88,8 +88,6 @@
 	RegisterSignal(source, COMSIG_ATOM_ABSTRACT_EXITED, PROC_REF(on_atom_exited))
 	attached_turfs_and_movables += source
 	for(var/atom/movable/movable as anything in source)
-		if(!(movable.flags_1 & INITIALIZED_1))
-			continue
 		on_init_or_entered(source, movable)
 
 ///Stops the element from affecting on the turf and its contents. Called on Detach() or when TRAIT_IMMERSE_STOPPED is added.
@@ -208,6 +206,7 @@
 	vis_overlay.overlay_appearance = overlay_appearance
 
 	generated_visual_overlays["[is_below_water][width]x[height]"] = vis_overlay
+	return vis_overlay
 
 ///This proc removes the vis_overlay, the keep together trait and some signals from the movable.
 /datum/element/immerse/proc/remove_immerse_overlay(atom/movable/movable)

--- a/code/datums/elements/immerse.dm
+++ b/code/datums/elements/immerse.dm
@@ -88,6 +88,8 @@
 	RegisterSignal(source, COMSIG_ATOM_ABSTRACT_EXITED, PROC_REF(on_atom_exited))
 	attached_turfs_and_movables += source
 	for(var/atom/movable/movable as anything in source)
+		if(!(movable.flags_1 & INITIALIZED_1))
+			continue
 		on_init_or_entered(source, movable)
 
 ///Stops the element from affecting on the turf and its contents. Called on Detach() or when TRAIT_IMMERSE_STOPPED is added.

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -22,10 +22,6 @@
 
 /turf/open/water/Initialize(mapload)
 	. = ..()
-	return INITIALIZE_HINT_LATELOAD
-
-/turf/open/water/LateInitialize()
-	. = ..()
 	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color)
 
 /turf/open/water/jungle

--- a/code/game/turfs/open/water.dm
+++ b/code/game/turfs/open/water.dm
@@ -22,6 +22,10 @@
 
 /turf/open/water/Initialize(mapload)
 	. = ..()
+	return INITIALIZE_HINT_LATELOAD
+
+/turf/open/water/LateInitialize()
+	. = ..()
 	AddElement(/datum/element/immerse, icon, icon_state, "immerse", immerse_overlay_color)
 
 /turf/open/water/jungle


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. This runtime was caught downstream in an away mission unit test where a mob is placed in a water turf.

![image](https://github.com/tgstation/tgstation/assets/13398309/8123321d-8bf4-4186-a63d-944080ad9f8a)

Basically the immerse overlay wasn't being added the very first time it was created, because it wasn't being returned by `generate_vis_overlay()`. Derp.

It went unnoticed because the overlays are cached and so every subsequent `add_immerse_overlay()` works fine. And I guess upstream doesn't have any mobs that spawn in water during tests so it was never caught.

Also stops `on_init_or_entered()` from needlessly being called twice in the case of a movable atom in water being initialized before the water turf. The signal `COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON` already sees to that.

## Why It's Good For The Game

Fixes a bug

## Changelog

:cl:
fix: fixes immerse overlays not being added the first time a mob enters a water turf
/:cl: