### PR TITLE
Fixes runtimes with arm implants in general and the Vorpal Scythe in particular

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -24,7 +24,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 		to_chat(owner, span_userdanger("[scythe] tears into you for your unworthy display of arrogance!"))
 		playsound(owner, 'sound/magic/demon_attack1.ogg', 50, TRUE)
 		part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED)
-	..()
+	return ..()
 
 /obj/item/vorpalscythe
 	name = "vorpal scythe"

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -17,7 +17,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 
 /obj/item/organ/internal/cyberimp/arm/shard/scythe/Retract()
 	var/obj/item/vorpalscythe/scythe = active_item
-	if(!active_item)
+	if(!scythe)
 		return FALSE
 	var/obj/item/bodypart/part = hand
 	if(scythe.empowerment < SCYTHE_SATED && part)

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -17,12 +17,14 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 
 /obj/item/organ/internal/cyberimp/arm/shard/scythe/Retract()
 	var/obj/item/vorpalscythe/scythe = active_item
-	. = ..() // The parent does the actual retracting, so we declare scythe first to get it from active_item
+	if(!active_item)
+		return FALSE
+	var/obj/item/bodypart/part = hand
 	if(scythe.empowerment < SCYTHE_SATED && part)
-		var/obj/item/bodypart/part = owner.get_bodypart(zone)
 		to_chat(owner, span_userdanger("[scythe] tears into you for your unworthy display of arrogance!"))
 		playsound(owner, 'sound/magic/demon_attack1.ogg', 50, TRUE)
-		part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED) // Will cause runtimes if it's called before the parent and dismembers.
+		part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED)
+	..()
 
 /obj/item/vorpalscythe
 	name = "vorpal scythe"

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -17,15 +17,17 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 
 /obj/item/organ/internal/cyberimp/arm/shard/scythe/Retract()
 	var/obj/item/vorpalscythe/scythe = active_item
+	var/obj/item/bodypart/part = owner?.get_holding_bodypart_of_item(scythe)
+	. = ..() // No, this line cannot be above get_holding_bodypart_of_item() OR below punish_the_arrogant. I'm sorry.
 	if(!scythe)
 		return FALSE
-	if(scythe.empowerment < SCYTHE_SATED)
-		to_chat(owner, span_userdanger("[scythe] tears into you for your unworthy display of arrogance!"))
-		playsound(owner, 'sound/magic/demon_attack1.ogg', 50, TRUE)
-		var/obj/item/bodypart/part = owner.get_holding_bodypart_of_item(scythe)
-		if(part)
-			part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED)
-	return ..()
+	if(scythe.empowerment < SCYTHE_SATED && part)
+		punish_the_arrogant(part)
+
+/obj/item/organ/internal/cyberimp/arm/shard/scythe/proc/punish_the_arrogant(var/obj/item/bodypart/held_part)
+	to_chat(owner, span_userdanger("[active_item] tears into you for your unworthy display of arrogance!"))
+	playsound(owner, 'sound/magic/demon_attack1.ogg', 50, TRUE)
+	held_part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED)
 
 /obj/item/vorpalscythe
 	name = "vorpal scythe"

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -19,11 +19,14 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 	var/obj/item/vorpalscythe/scythe = active_item
 	if(!scythe)
 		return FALSE
+
 	var/obj/item/bodypart/part = hand
-	if(scythe.empowerment < SCYTHE_SATED && part)
-		to_chat(owner, span_userdanger("[scythe] tears into you for your unworthy display of arrogance!"))
-		playsound(owner, 'sound/magic/demon_attack1.ogg', 50, TRUE)
-		part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED)
+	if(isnull(part) || scythe.empowerment > SCYTHE_SATED)
+		return ..()
+
+	to_chat(owner, span_userdanger("[scythe] tears into you for your unworthy display of arrogance!"))
+	playsound(owner, 'sound/magic/demon_attack1.ogg', 50, TRUE)
+	part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED)
 	return ..()
 
 /obj/item/vorpalscythe

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -17,16 +17,12 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 
 /obj/item/organ/internal/cyberimp/arm/shard/scythe/Retract()
 	var/obj/item/vorpalscythe/scythe = active_item
-	var/obj/item/bodypart/part = owner?.get_holding_bodypart_of_item(scythe)
-	if(!scythe)
-		return FALSE
-/* IMPORTANT!! - The parent call here has to be below the declarations for scythe and part (otherwise we'll retract first and
- they will always be null) and above receive_damage() (otherwise we will runtime if it dismembers us) */
-	. = ..()
+	. = ..() // The parent does the actual retracting, so we declare scythe first to get it from active_item
 	if(scythe.empowerment < SCYTHE_SATED && part)
+		var/obj/item/bodypart/part = owner.get_bodypart(zone)
 		to_chat(owner, span_userdanger("[scythe] tears into you for your unworthy display of arrogance!"))
 		playsound(owner, 'sound/magic/demon_attack1.ogg', 50, TRUE)
-		part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED)
+		part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED) // Will cause runtimes if it's called before the parent and dismembers.
 
 /obj/item/vorpalscythe
 	name = "vorpal scythe"

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -18,16 +18,15 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 /obj/item/organ/internal/cyberimp/arm/shard/scythe/Retract()
 	var/obj/item/vorpalscythe/scythe = active_item
 	var/obj/item/bodypart/part = owner?.get_holding_bodypart_of_item(scythe)
-	. = ..() // No, this line cannot be above get_holding_bodypart_of_item() OR below punish_the_arrogant. I'm sorry.
 	if(!scythe)
 		return FALSE
+/* IMPORTANT!! - The parent call here has to be below the declarations for scythe and part (otherwise we'll retract first and
+ they will always be null) and above receive_damage() (otherwise we will runtime if it dismembers us) */
+	. = ..()
 	if(scythe.empowerment < SCYTHE_SATED && part)
-		punish_the_arrogant(part)
-
-/obj/item/organ/internal/cyberimp/arm/shard/scythe/proc/punish_the_arrogant(var/obj/item/bodypart/held_part)
-	to_chat(owner, span_userdanger("[active_item] tears into you for your unworthy display of arrogance!"))
-	playsound(owner, 'sound/magic/demon_attack1.ogg', 50, TRUE)
-	held_part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED)
+		to_chat(owner, span_userdanger("[scythe] tears into you for your unworthy display of arrogance!"))
+		playsound(owner, 'sound/magic/demon_attack1.ogg', 50, TRUE)
+		part.receive_damage(brute = 25, wound_bonus = 10, sharpness = SHARP_EDGED)
 
 /obj/item/vorpalscythe
 	name = "vorpal scythe"

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -125,9 +125,11 @@
 	if(!active_item || (active_item in src))
 		return FALSE
 	if(owner)
-		owner.visible_message(span_notice("[owner] retracts [active_item] back into [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."),
+		owner.visible_message(
+			span_notice("[owner] retracts [active_item] back into [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."),
 			span_notice("[active_item] snaps back into your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."),
-			span_hear("You hear a short mechanical noise."))
+			span_hear("You hear a short mechanical noise."),
+		)
 
 		owner.transferItemToLoc(active_item, src, TRUE)
 	else

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -132,7 +132,6 @@
 		owner.transferItemToLoc(active_item, src, TRUE)
 	else
 		active_item.forceMove(src)
-		hand.visible_message(span_notice("[src] snaps back into [hand]."))
 
 	UnregisterSignal(active_item, COMSIG_ITEM_ATTACK_SELF)
 	active_item = null

--- a/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
+++ b/code/modules/surgery/organs/internal/cyberimp/augments_arms.dm
@@ -124,12 +124,16 @@
 /obj/item/organ/internal/cyberimp/arm/proc/Retract()
 	if(!active_item || (active_item in src))
 		return FALSE
+	if(owner)
+		owner.visible_message(span_notice("[owner] retracts [active_item] back into [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."),
+			span_notice("[active_item] snaps back into your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."),
+			span_hear("You hear a short mechanical noise."))
 
-	owner?.visible_message(span_notice("[owner] retracts [active_item] back into [owner.p_their()] [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."),
-		span_notice("[active_item] snaps back into your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm."),
-		span_hear("You hear a short mechanical noise."))
+		owner.transferItemToLoc(active_item, src, TRUE)
+	else
+		active_item.forceMove(src)
+		hand.visible_message(span_notice("[src] snaps back into [hand]."))
 
-	owner.transferItemToLoc(active_item, src, TRUE)
 	UnregisterSignal(active_item, COMSIG_ITEM_ATTACK_SELF)
 	active_item = null
 	playsound(get_turf(owner), retract_sound, 50, TRUE)


### PR DESCRIPTION

## About The Pull Request

Two batches of runtimes, somewhat related:

1. Being dismembered while holding an extended arm implant would runtime, because Retract() no longer has an owner to reference when moving the deployed item back into the implant. This, on top of runtiming, would make the item in question be permanently stuck (and usable) on your missing limb. (Described, along a similar but seemingly unrelated issue with the godhand, in #76899)

Solution: Sanity check for an owner, forcemove the item into the implant if we don't have one.

2. Spamming sheathe and unsheathe on a vorpal blade seems to occasionally cause it to retract while it isn't in your hand. Additionally, being self-dismembered by unsheathing an unsated vorpal blade would trigger runtime number 1 with a vengeance, as it calls Retract() twice in the same block. 

Solution: Sanity check to make sure we do have a scythe in hand before continuing and some other changes and minor re-structuring to more cleanly handle losing the limb.
## Why It's Good For The Game

The less runtimes, the better.
The less people running around with scythes and energy guns super-glued to the stump of their arm, the better.
## Changelog
:cl:
fix: items implanted on arms no longer become permanently stuck in-hand when their limb is dismembered
fix: quickly sheathing and unsheathing the vorpal scythe can no longer bug out and prevent its effects from being applied
/:cl:
