### PR TITLE
Makes the ectoplasm anomaly not randomly move so deadchat can actually control it

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -4,6 +4,7 @@
 	icon_state = "ectoplasm"
 	aSignal = /obj/item/assembly/signaler/anomaly/ectoplasm
 	lifespan = ANOMALY_COUNTDOWN_TIMER + 2 SECONDS //This one takes slightly longer, because it can run away.
+	immobile = TRUE //prevents it from moving around so ghosts can actually move it with decent accuracy
 
 	///Blocks the anomaly from updating ghost count. Used in case an admin wants to rig the anomaly to be a certain size or intensity.
 	var/override_ghosts = FALSE


### PR DESCRIPTION

## About The Pull Request

ectoplasmic anomalies randomly move. this makes it so trying to control it as deadchat is like wrangling a fish. it's probably an oversight more than anything as most other deadchat controlled things don't move on their own for no reason
## Why It's Good For The Game

this is probably an oversight more than anything. ectoplasm anomalies are supposed to be deadchat controllable but they move so damn often that really isn't feasible. discovered when deadchat was wondering why the anomaly was just wandering off into nowhere
## Changelog
:cl:
fix: Makes the ectoplasm anomaly not randomly move so deadchat can actually control it
/:cl:
