### PR TITLE
Buffs the metal (ablative) baseball bat

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -832,8 +832,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	inhand_icon_state = "baseball_bat_metal"
 	custom_materials = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 3.5)
 	resistance_flags = NONE
-	force = 12
-	throwforce = 15
+	force = 20
+	throwforce = 20
 	mob_thrower = TRUE
 	block_sound = 'sound/weapons/effects/batreflect.ogg'
 


### PR DESCRIPTION
## About The Pull Request

I looked through the code and I'm pretty sure the ONLY place to get this baseball bat is through the space IRS- so this is more of a Space IRS balance than anything.

Given that it's made out of pure fucking metal I think it should do a bit more damage than a regular wooden bat. More info on why in wigftg.
## Why It's Good For The Game

The space IRS currently spawn with 3 people. Two agents, and a head. The agents get armor and autorifles and the head gets.. A single pistol and two magazines. Not very good.

This at least lets the bat be a valuable weapon that the head can use, making it at LEAST on par damage-wise with the knives the two agents can get, while keeping that ablative ability. This also makes their thrown damage and hit damage the same because I have no fucking idea why the thrown damage is higher than the hit damage, when the bat doesn't reflect items yet, only laser weapons.

This is, at the moment, basically an IRS-only change.
## Changelog
:cl:
balance: metal bat damage changed from 12 -> 20
/:cl:
