### PR TITLE
ammo bands no longer disappear upon icon updates

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -180,13 +180,14 @@
 		if(AMMO_BOX_FULL_EMPTY)
 			icon_state = "[multiple_sprite_use_base ? base_icon_state : initial(icon_state)]-[shells_left ? "full" : "empty"]"
 
+	return ..()
+
+/obj/item/ammo_box/update_overlays()
+	. = ..()
 	if(ammo_band_color && ammo_band_icon)
 		update_ammo_band()
 
-	return ..()
-
 /obj/item/ammo_box/proc/update_ammo_band()
-	overlays.Cut()
 	var/band_icon = ammo_band_icon
 	if(!(length(stored_ammo)) && ammo_band_icon_empty)
 		band_icon = ammo_band_icon_empty

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -173,6 +173,7 @@
 	desc = "[initial(desc)] There [(shells_left == 1) ? "is" : "are"] [shells_left] shell\s left!"
 
 /obj/item/ammo_box/update_icon_state()
+	. = ..()
 	var/shells_left = LAZYLEN(stored_ammo)
 	switch(multiple_sprites)
 		if(AMMO_BOX_PER_BULLET)
@@ -180,12 +181,10 @@
 		if(AMMO_BOX_FULL_EMPTY)
 			icon_state = "[multiple_sprite_use_base ? base_icon_state : initial(icon_state)]-[shells_left ? "full" : "empty"]"
 
-	return ..()
-
 /obj/item/ammo_box/update_overlays()
 	. = ..()
 	if(ammo_band_color && ammo_band_icon)
-		update_ammo_band()
+		. += update_ammo_band()
 
 /obj/item/ammo_box/proc/update_ammo_band()
 	var/band_icon = ammo_band_icon
@@ -194,7 +193,7 @@
 	var/image/ammo_band_image = image(icon, src, band_icon)
 	ammo_band_image.color = ammo_band_color
 	ammo_band_image.appearance_flags = RESET_COLOR|KEEP_APART
-	overlays += ammo_band_image
+	return ammo_band_image
 
 ///Count of number of bullets in the magazine
 /obj/item/ammo_box/magazine/proc/ammo_count(countempties = TRUE)


### PR DESCRIPTION
## About The Pull Request
moves the `update_ammo_band()` call from `update_icon_state` to `update_overlays`, so that the ammo layer sticks around

## Why It's Good For The Game

visual clarity. i want to be able to see which speedloader/magazine/etc does what for my gun

## Changelog

:cl:
fix: Colored ammo bands, such as those on .357 and .38 speedloaders, no longer permanently disappear upon icon update.
/:cl: