### PR TITLE
prevents welding bodybags or at least the text

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -18,6 +18,7 @@
 	has_closed_overlay = FALSE
 	can_install_electronics = FALSE
 	paint_jobs = null
+	can_weld_shut = FALSE
 
 	var/foldedbag_path = /obj/item/bodybag
 	var/obj/item/bodybag/foldedbag_instance = null


### PR DESCRIPTION

## About The Pull Request

sets canweld = false
## Why It's Good For The Game

fixes #77596
## Changelog
:cl:
fix: removes bodybag welding tooltip
/:cl:
