### PR TITLE
Fixes some heretic bugs (?)

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -342,7 +342,7 @@
 			continue
 
 		var/obj/item/item = item_data.get_item(owner)
-		if (isnull(item) || (HAS_TRAIT(item, TRAIT_NO_STRIP)))
+		if (isnull(item) || (HAS_TRAIT(item, TRAIT_NO_STRIP) || (item.item_flags & EXAMINE_SKIP)))
 			items[strippable_key] = result
 			continue
 

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -194,7 +194,7 @@
 	name = "reality smash"
 	icon = 'icons/effects/eldritch.dmi'
 	anchored = TRUE
-	interaction_flags_atom = INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND
+	interaction_flags_atom = INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND|INTERACT_ATOM_NO_FINGERPRINT_INTERACT
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	invisibility = INVISIBILITY_OBSERVER
 	/// Whether we're currently being drained or not.
@@ -205,12 +205,25 @@
 	var/list/datum/mind/minds = list()
 	/// The image shown to heretics
 	var/image/heretic_image
+	/// We hold the turf we're on so we can remove and add the 'no prints' flag.
+	var/turf/on_turf
 
 /obj/effect/heretic_influence/Initialize(mapload)
 	. = ..()
 	GLOB.reality_smash_track.smashes += src
 	heretic_image = image(icon, src, real_icon_state, OBJ_LAYER)
 	generate_name()
+	on_turf = get_turf(src)
+	on_turf.interaction_flags_atom |= INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND
+	RegisterSignal(on_turf, COMSIG_TURF_CHANGE, PROC_REF(replace_our_turf))
+
+/obj/effect/heretic_influence/proc/replace_our_turf(datum/source, path, new_baseturfs, flags, post_change_callbacks)
+	post_change_callbacks += CALLBACK(src, PROC_REF(replace_our_turf_two))
+	on_turf = null //hard del ref?
+
+/obj/effect/heretic_influence/proc/replace_our_turf_two(turf/new_turf)
+	new_turf.interaction_flags_atom |= INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND
+	on_turf = new_turf
 
 /obj/effect/heretic_influence/Destroy()
 	GLOB.reality_smash_track.smashes -= src
@@ -218,6 +231,8 @@
 		remove_mind(heretic)
 
 	heretic_image = null
+	on_turf?.interaction_flags_atom &= ~INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND
+	on_turf = null
 	return ..()
 
 /obj/effect/heretic_influence/attack_hand_secondary(mob/user, list/modifiers)

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -220,6 +220,7 @@
 	RegisterSignal(on_turf, COMSIG_TURF_CHANGE, PROC_REF(replace_our_turf))
 
 /obj/effect/heretic_influence/proc/replace_our_turf(datum/source, path, new_baseturfs, flags, post_change_callbacks)
+	SIGNAL_HANDLER
 	post_change_callbacks += CALLBACK(src, PROC_REF(replace_our_turf_two))
 	on_turf = null //hard del ref?
 

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -115,7 +115,7 @@
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "pierced_illusion"
 	anchored = TRUE
-	interaction_flags_atom = INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND
+	interaction_flags_atom = INTERACT_ATOM_NO_FINGERPRINT_INTERACT
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	alpha = 0
 

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -115,7 +115,7 @@
 	icon = 'icons/effects/eldritch.dmi'
 	icon_state = "pierced_illusion"
 	anchored = TRUE
-	interaction_flags_atom = INTERACT_ATOM_NO_FINGERPRINT_INTERACT
+	interaction_flags_atom = INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND|INTERACT_ATOM_NO_FINGERPRINT_INTERACT
 	resistance_flags = FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	alpha = 0
 
@@ -214,6 +214,8 @@
 	heretic_image = image(icon, src, real_icon_state, OBJ_LAYER)
 	generate_name()
 	on_turf = get_turf(src)
+	if(!istype(on_turf))
+		return
 	on_turf.interaction_flags_atom |= INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND
 	RegisterSignal(on_turf, COMSIG_TURF_CHANGE, PROC_REF(replace_our_turf))
 

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -92,12 +92,27 @@
 
 /obj/item/clothing/suit/hooded/cultrobes/void/Initialize(mapload)
 	. = ..()
-
 	create_storage(storage_type = /datum/storage/pockets/void_cloak)
-
-/obj/item/clothing/suit/hooded/cultrobes/void/Initialize(mapload)
-	. = ..()
 	make_visible()
+
+/obj/item/clothing/suit/hooded/cultrobes/void/equipped(mob/user, slot)
+	. = ..()
+	if(slot & ITEM_SLOT_OCLOTHING)
+		RegisterSignal(user, COMSIG_MOB_EQUIPPED_ITEM, PROC_REF(hide_item))
+		RegisterSignal(user, COMSIG_MOB_UNEQUIPPED_ITEM, PROC_REF(show_item))
+
+/obj/item/clothing/suit/hooded/cultrobes/void/dropped(mob/user)
+	. = ..()
+	UnregisterSignal(user, list(COMSIG_MOB_UNEQUIPPED_ITEM, COMSIG_MOB_EQUIPPED_ITEM))
+
+/obj/item/clothing/suit/hooded/cultrobes/void/proc/hide_item(obj/item/item, slot)
+	SIGNAL_HANDLER
+	if(slot & ITEM_SLOT_SUITSTORE)
+		ADD_TRAIT(item, TRAIT_NO_STRIP, REF(src)) // i'd use examine hide but its a flag and yeah
+
+/obj/item/clothing/suit/hooded/cultrobes/void/proc/show_item(obj/item/item, slot)
+	SIGNAL_HANDLER
+	REMOVE_TRAIT(item, TRAIT_NO_STRIP, REF(src))
 
 /obj/item/clothing/suit/hooded/cultrobes/void/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Items worn on a void cloak's suit storage are no longer visible on the stripping menu.

Heretic influences don't leave scannable fingerprints anymore.

## Why It's Good For The Game

> Items worn on a void cloak's suit storage are no longer visible on the stripping menu.

Described as a bug by Melbert. Shouldn't be able to bypass the sneaky item with an oversight. This is done by giving any equipped item in the suit storage slot the no_strip trait with the cloak.

> Heretic influences don't leave scannable fingerprints anymore.

Likely a lot more controversial, but this is bad for a lot of reasons.

1. It screws over new heretic players with some turbonerd knowledge that they had no hope of figuring out.
Who in their right mind would assume that influences, literal rifts in reality, somehow have fingerprints in their non-existent surface that some detective could walk up and scan, despite that same rift being able to tear your arms off if you poke it too much? 

2. This is literally just bypassed by using a damp rag on the rift.

This means that this is a pure knowledge check, trivial to step over if you know it, impossible to figure out and potentially round-ending if you don't.

3. It's too easy!

Detectives shouldn't scan the influence directly for prints, they should scan the doors, check the prints and fibers, interview people whose fibers and/or prints match up... not get a 'Yep, Joe's A Heretic' huge blaring confirmation. It's not detective forensic analysis, it's just using jank on jank to confirm without a doubt the identity of a hapless antagonist. I'm all for emergent gameplay, but this isn't emergent gameplay, it's an emergent unfair knowledge check.

4. It appears to orgiinate from a bug?

It has a flag that makes it so that prints aren't left behind by attack_handing it, but the prints still show up? I changed it to the one that just makes fingerprints impossible to appear at all, so that should clear things up.

And yes, Ided from these thins

Untested, it's 3 am give me a break

## Changelog

:cl:
fix: Items worn on a void cloak's suit storage are no longer visible on the stripping menu.
qol: Misclicking the turf below a heretic influence no longer leaves a fingerprint. 
/:cl:

