### PR TITLE
Chemistry Heaters can now be unwrenched

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -155,6 +155,11 @@
 
 			use_power(active_power_usage * seconds_per_tick)
 
+/obj/machinery/chem_heater/wrench_act(mob/living/user, obj/item/tool)
+	. = ..()
+	default_unfasten_wrench(user, tool)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
 /obj/machinery/chem_heater/attackby(obj/item/I, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "mixer0b", "mixer0b", I))
 		return


### PR DESCRIPTION

## About The Pull Request
Chemistry heaters can now be unwrenched. now you can steal the ENTIRE chemistry setup
## Why It's Good For The Game
The dispenser and the chem master can be unwrenched, so I've made it more consistent, especially considering the sprite of the reaction chamber just has two tiny legs attaching it to the ground.

## Changelog
:cl:
qol: the chemistry heater can now be unwrenched.
/:cl:
