### PR TITLE
Held items are now dropped when their associated arm is dismembered

### DIFF
--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -236,10 +236,9 @@
 
 /obj/item/bodypart/arm/drop_limb(special)
 	var/mob/living/carbon/arm_owner = owner
-	. = ..()
 
 	if(special || !arm_owner)
-		return
+		return ..()
 
 	if(arm_owner.hand_bodyparts[held_index] == src)
 		// We only want to do this if the limb being removed is the active hand part.
@@ -256,6 +255,7 @@
 	if(arm_owner.gloves)
 		arm_owner.dropItemToGround(arm_owner.gloves, TRUE)
 	arm_owner.update_worn_gloves() //to remove the bloody hands overlay
+	return ..()
 
 /obj/item/bodypart/leg/drop_limb(special)
 	if(owner && !special)


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. The parent of `obj/item/bodypart/arm/drop_limb()` would remove the arm from the owner's hand_bodyparts list, which would then prevent the child proc from dropping the item held in the now missing hand.

Now we call the parent afterwards and it works just fine.
## Why It's Good For The Game

Addresses the issue with the GodHand described in #76899, although it's not limited to items you can't ordinarily drop. It's a bit more noticeable with them, because there's no risk of dropping the item in shock if the limb is being hit with a weapon, but you can verify using amputation shears that any ordinary item would also stay stuck on the arm. 
## Changelog
:cl:
fix: items no longer stay in your hands after their respective arm is dismembered
/:cl:
