### PR TITLE
Makes mob resizing a smidge more precise.

### DIFF
--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -10,8 +10,10 @@
 	 * That, coupled with the rendered interpolation, may make the
 	 * icons look awfuller than they would normally already be.
 	 * The solution to this nit is translating the missing decimals.
+	 * also flooring increases the distance from 0 for negative numbers.
 	 */
-	var/translate = (body_position_pixel_y_offset - round(body_position_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
+	var/abs_pixel_y_offset = abs(body_position_pixel_y_offset)
+	var/translate = (abs_pixel_y_offset - round(abs_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
 	var/final_dir = dir
 	var/changed = FALSE
 
@@ -37,7 +39,8 @@
 		if(!lying_angle || !rotate_on_lying) //But not if the mob has been rotated.
 			//Make sure the body position y offset is also updated
 			body_position_pixel_y_offset = get_pixel_y_offset_standing(current_size)
-			var/new_translate = (body_position_pixel_y_offset - round(body_position_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
+			abs_pixel_y_offset = abs(body_position_pixel_y_offset)
+			var/new_translate = (abs_pixel_y_offset - round(abs_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
 			if(translate || new_translate)
 				ntransform.Translate(0, new_translate - translate)
 			final_pixel_y = base_pixel_y + body_position_pixel_y_offset

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -18,11 +18,11 @@
 	if(lying_angle != lying_prev && rotate_on_lying)
 		changed = TRUE
 		ntransform.TurnTo(lying_prev, lying_angle)
-		if(lying_angle && lying_prev == 0) //Standing to lying
+		if(lying_angle && lying_prev == 0)
 			ntransform.Translate(0, -translate)
-			if(dir & (EAST|WEST)) //Facing east or west
+			if(dir & (EAST|WEST)) //Standing to lying and facing east or west
 				final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
-		else if(!lying_angle && lying_prev != 0) //Lying to standing
+		else if(!lying_angle && lying_prev != 0)
 			ntransform.Translate(0, translate)
 
 	if(resize != RESIZE_DEFAULT_SIZE)
@@ -38,7 +38,7 @@
 			//Make sure the body position y offset is also updated
 			body_position_pixel_y_offset = get_pixel_y_offset_standing(current_size)
 			var/new_translate = (body_position_pixel_y_offset - round(body_position_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
-			if(old_translate || new_translation_value)
+			if(translate || new_translate)
 				ntransform.Translate(0, new_translate - translate)
 			final_pixel_y = base_pixel_y + body_position_pixel_y_offset
 

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -5,14 +5,25 @@
 /mob/living/proc/update_transform(resize = RESIZE_DEFAULT_SIZE)
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/final_pixel_y = base_pixel_y + body_position_pixel_y_offset
+	/**
+	 * pixel x/y/w/z all discard values after the decimal separator.
+	 * That, coupled with the rendered interpolation, may make the
+	 * icons look awfuller than they would normally already be.
+	 * The solution to this nit is translating the missing decimals.
+	 */
+	var/translate = (body_position_pixel_y_offset - round(body_position_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
 	var/final_dir = dir
 	var/changed = FALSE
 
 	if(lying_angle != lying_prev && rotate_on_lying)
 		changed = TRUE
 		ntransform.TurnTo(lying_prev, lying_angle)
-		if(lying_angle && lying_prev == 0 && dir & (EAST|WEST)) //Standing to lying and facing east or west
-			final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
+		if(lying_angle && lying_prev == 0) //Standing to lying
+			ntransform.Translate(0, -translate)
+			if(dir & (EAST|WEST)) //Facing east or west
+				final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
+		else if(!lying_angle && lying_prev != 0) //Lying to standing
+			ntransform.Translate(0, translate)
 
 	if(resize != RESIZE_DEFAULT_SIZE)
 		changed = TRUE
@@ -26,6 +37,9 @@
 		if(!lying_angle || !rotate_on_lying) //But not if the mob has been rotated.
 			//Make sure the body position y offset is also updated
 			body_position_pixel_y_offset = get_pixel_y_offset_standing(current_size)
+			var/new_translate = (body_position_pixel_y_offset - round(body_position_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
+			if(old_translate || new_translation_value)
+				ntransform.Translate(0, new_translate - translate)
 			final_pixel_y = base_pixel_y + body_position_pixel_y_offset
 
 	if(!changed) //Nothing has been changed, nothing has to be done.


### PR DESCRIPTION
## About The Pull Request
I've recently come to learn recently that transform translation, unlike pixel x/y/w/z, doesn't disregard values after the decimal separator, and while that has little effect on atoms with identity transform/interpolation matrices, can alter how the atom is rendered slightly.
This way, there shouldn't be visible differences between an icon, scaled by, let's say, 1.23, translated by 2.4 vertically, and a similar icon scaled the same, offset by another 2pixels in the same direction yet translated by the remainder 0.4. 

## Why It's Good For The Game
Manily because I've a PR up on Skyrat to replace some of the code to actually use the current size variable, tho some players have reported it looks worse than before. Also, title.

## Changelog
N/A