### PR TITLE
Making sure the "Unlocked Achievements" score is properly saved in the DB

### DIFF
--- a/code/datums/achievements/_achievement_data.dm
+++ b/code/datums/achievements/_achievement_data.dm
@@ -49,9 +49,7 @@
 		var/datum/award/award = SSachievements.awards[award_type]
 		if(!award || !award.name) //Skip abstract achievements types
 			continue
-		if(!data[award_type])
-			data[award_type] = award.parse_value(kv[award.database_id], data)
-			original_cached_data[award_type] = data[award_type]
+		award.on_achievement_data_init(src, kv[award.database_id])
 
 ///Updates local cache with db data for the given achievement type if it wasn't loaded yet.
 /datum/achievement_data/proc/get_data(achievement_type)
@@ -81,17 +79,6 @@
 ///Getter for the status/score of an achievement
 /datum/achievement_data/proc/get_achievement_status(achievement_type)
 	return data[achievement_type]
-
-///Resets an achievement to default values.
-/datum/achievement_data/proc/reset(achievement_type)
-	if(!SSachievements.achievements_enabled)
-		return
-	var/datum/award/A = SSachievements.awards[achievement_type]
-	get_data(achievement_type)
-	if(istype(A, /datum/award/achievement))
-		data[achievement_type] = FALSE
-	else if(istype(A, /datum/award/score))
-		data[achievement_type] = 0
 
 /datum/achievement_data/ui_assets(mob/user)
 	return list(

--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -87,6 +87,7 @@
 /datum/award/achievement/on_unlock(mob/user)
 	. = ..()
 	to_chat(user, span_greenannounce("<B>Achievement unlocked: [name]!</B>"))
+	user.client.give_award(/datum/award/score/achievements_score, user, 1)
 
 ///Scores are for leaderboarded things, such as killcount of a specific boss
 /datum/award/score

--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -27,6 +27,9 @@
 	var/raw_value = get_raw_value(key)
 	return parse_value(raw_value)
 
+/datum/award/proc/on_achievement_data_init(datum/achievement_data/holder, database_value)
+	holder.original_cached_data[type] = holder.data[type] = parse_value(database_value)
+
 ///This saves the changed data to the hub.
 /datum/award/proc/get_changed_rows(key, value)
 	if(!database_id || !key || !name)
@@ -62,7 +65,7 @@
 	return result
 
 //Should return sanitized value for achievement cache
-/datum/award/proc/parse_value(raw_value, list/data)
+/datum/award/proc/parse_value(raw_value)
 	return default_value
 
 ///Can be overriden for achievement specific events
@@ -78,7 +81,7 @@
 	. = ..()
 	.["achievement_type"] = "achievement"
 
-/datum/award/achievement/parse_value(raw_value, list/data)
+/datum/award/achievement/parse_value(raw_value)
 	return raw_value > 0
 
 /datum/award/achievement/on_unlock(mob/user)
@@ -119,7 +122,7 @@
 			high_scores[key] = score
 		qdel(Q)
 
-/datum/award/score/parse_value(raw_value, list/data)
+/datum/award/score/parse_value(raw_value)
 	return isnum(raw_value) ? raw_value : 0
 
 ///Defining this here 'cause it's the first score a player should see in the Scores category.
@@ -135,11 +138,13 @@
  * So, let's start counting how many achievements have been unlocked so far and return its value instead,
  * which is why this award should always be loaded last.
  */
-/datum/award/score/achievements_score/parse_value(raw_value, list/data)
-	if(isnum(raw_value))
-		return raw_value
-	. = 0
-	for(var/award_type in data)
-		if(ispath(award_type, /datum/award/achievement) && data[award_type])
-			.++
-	return .
+/datum/award/score/achievements_score/on_achievement_data_init(datum/achievement_data/holder, database_value)
+	if(isnum(database_value))
+		return ..()
+	//We need to keep the value differents so that it's properly saved at the end of the round.
+	holder.original_cached_data[type] = null
+	var/value = 0
+	for(var/award_type in holder.data)
+		if(ispath(award_type, /datum/award/achievement) && holder.data[award_type])
+			value++
+	holder.data[type] = value

--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -87,7 +87,6 @@
 /datum/award/achievement/on_unlock(mob/user)
 	. = ..()
 	to_chat(user, span_greenannounce("<B>Achievement unlocked: [name]!</B>"))
-	user.client.give_award(/datum/award/score/achievements_score, user, 1)
 
 ///Scores are for leaderboarded things, such as killcount of a specific boss
 /datum/award/score
@@ -142,7 +141,7 @@
 	if(isnum(database_value))
 		return ..()
 	//We need to keep the value differents so that it's properly saved at the end of the round.
-	holder.original_cached_data[type] = null
+	holder.original_cached_data[type] = 0
 	var/value = 0
 	for(var/award_type in holder.data)
 		if(ispath(award_type, /datum/award/achievement) && holder.data[award_type])


### PR DESCRIPTION
## About The Pull Request
Previously, it was only saved if the player unlocked at least one achievement during the round, which explains why the high scores table took several rounds to fill up.
Also, removed an unused proc.

## Why It's Good For The Game
Fixing a peeve.

## Changelog

:cl:
fix: The "Unlocked Achievements" score will now be properly saved at the end of the round the first time it's loaded.
/:cl:
