### PR TITLE
fixes borderonly firedoors being able to be walked through while closed

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -698,6 +698,11 @@
 /obj/machinery/door/firedoor/border_only/Initialize(mapload)
 	. = ..()
 	adjust_lights_starting_offset()
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = PROC_REF(on_exit),
+	)
+
+	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/machinery/door/firedoor/border_only/adjust_lights_starting_offset()
 	light_xoffset = 0


### PR DESCRIPTION

## About The Pull Request

the proc wasnt even used

## Why It's Good For The Game

fixes #77535

## Changelog
:cl:
fix: fixed border-only firedoors being able to be walked through while closed
/:cl:
