### PR TITLE
Fixes harddel in particle holders

### DIFF
--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -12,7 +12,7 @@
 	/// See \code\__DEFINES\particles.dm
 	var/particle_flags = NONE
 
-	var/atom/parent
+	var/datum/weakref/parent_ref
 
 /obj/effect/abstract/particle_holder/Initialize(mapload, particle_path = /particles/smoke, particle_flags = NONE)
 	. = ..()
@@ -20,7 +20,7 @@
 		stack_trace("particle holder was created with no loc!")
 		return INITIALIZE_HINT_QDEL
 	// We nullspace ourselves because some objects use their contents (e.g. storage) and some items may drop everything in their contents on deconstruct.
-	parent = loc
+	parent_ref = WEAKREF(loc)
 	loc = null
 
 	// Mouse opacity can get set to opaque by some objects when placed into the object's contents (storage containers).
@@ -28,7 +28,12 @@
 	src.particle_flags = particle_flags
 	particles = new particle_path()
 	// /atom doesn't have vis_contents, /turf and /atom/movable do
-	var/atom/movable/lie_about_areas = parent
+	var/atom/movable/parent = parent_ref.resolve()
+	if(!parent)
+		parent_ref = null
+		stack_trace("particle holder was created without a valid parent!")
+		return INITIALIZE_HINT_QDEL
+
 	lie_about_areas.vis_contents += src
 	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(parent_deleted))
 

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -43,6 +43,7 @@
 
 /obj/effect/abstract/particle_holder/Destroy(force)
 	QDEL_NULL(particles)
+	parent_ref = null
 	return ..()
 
 /// Non movables don't delete contents on destroy, so we gotta do this

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -12,7 +12,7 @@
 	/// See \code\__DEFINES\particles.dm
 	var/particle_flags = NONE
 
-	var/atom/movable/parent
+	var/atom/parent
 
 /obj/effect/abstract/particle_holder/Initialize(mapload, particle_path = /particles/smoke, particle_flags = NONE)
 	. = ..()

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -29,7 +29,7 @@
 	particles = new particle_path()
 	// /atom doesn't have vis_contents, /turf and /atom/movable do
 	var/atom/movable/parent = parent_ref.resolve()
-	if(!parent)
+	if(isnull(parent))
 		parent_ref = null
 		stack_trace("particle holder was created without a valid parent!")
 		return INITIALIZE_HINT_QDEL

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -12,7 +12,7 @@
 	/// See \code\__DEFINES\particles.dm
 	var/particle_flags = NONE
 
-	var/datum/weakref/parent_ref
+	var/atom/movable/parent
 
 /obj/effect/abstract/particle_holder/Initialize(mapload, particle_path = /particles/smoke, particle_flags = NONE)
 	. = ..()
@@ -20,7 +20,7 @@
 		stack_trace("particle holder was created with no loc!")
 		return INITIALIZE_HINT_QDEL
 	// We nullspace ourselves because some objects use their contents (e.g. storage) and some items may drop everything in their contents on deconstruct.
-	parent_ref = WEAKREF(loc)
+	parent = loc
 	loc = null
 
 	// Mouse opacity can get set to opaque by some objects when placed into the object's contents (storage containers).
@@ -28,13 +28,8 @@
 	src.particle_flags = particle_flags
 	particles = new particle_path()
 	// /atom doesn't have vis_contents, /turf and /atom/movable do
-	var/atom/movable/parent = parent_ref.resolve()
-	if(isnull(parent))
-		parent_ref = null
-		stack_trace("particle holder was created without a valid parent!")
-		return INITIALIZE_HINT_QDEL
-
-	parent.vis_contents += src
+	var/atom/movable/lie_about_areas = parent
+	lie_about_areas.vis_contents += src
 	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(parent_deleted))
 
 	if(particle_flags & PARTICLE_ATTACH_MOB)
@@ -43,7 +38,7 @@
 
 /obj/effect/abstract/particle_holder/Destroy(force)
 	QDEL_NULL(particles)
-	parent_ref = null
+	parent = null
 	return ..()
 
 /// Non movables don't delete contents on destroy, so we gotta do this

--- a/code/game/objects/effects/particle_holder.dm
+++ b/code/game/objects/effects/particle_holder.dm
@@ -34,7 +34,7 @@
 		stack_trace("particle holder was created without a valid parent!")
 		return INITIALIZE_HINT_QDEL
 
-	lie_about_areas.vis_contents += src
+	parent.vis_contents += src
 	RegisterSignal(parent, COMSIG_QDELETING, PROC_REF(parent_deleted))
 
 	if(particle_flags & PARTICLE_ATTACH_MOB)


### PR DESCRIPTION
## About The Pull Request

The harddel hunt continues...

![image](https://github.com/tgstation/tgstation/assets/13398309/19fb7446-e667-4e4f-9ab5-b80e02541592)

This stupid mythril coin has come up a bunch of times in our CI recently and it is starting to annoy me. This should fix it hopefully.

Attempts to get rid of a potential source of harddels in particle_holder.dm

## Why It's Good For The Game


## Changelog

:cl:
fix: fixes a harddel in particle holders
/:cl:
