### PR TITLE
Fix spaceacillin's infection processing not applying to corpses

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -261,11 +261,11 @@
 	ph = 8.1
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
-/datum/reagent/medicine/spaceacillin/on_mob_metabolize(mob/living/L)
+/datum/reagent/medicine/spaceacillin/on_mob_add(mob/living/L)
 	. = ..()
 	ADD_TRAIT(L, TRAIT_VIRUS_RESISTANCE, type)
 
-/datum/reagent/medicine/spaceacillin/on_mob_end_metabolize(mob/living/L)
+/datum/reagent/medicine/spaceacillin/on_mob_delete(mob/living/L)
 	. = ..()
 	REMOVE_TRAIT(L, TRAIT_VIRUS_RESISTANCE, type)
 


### PR DESCRIPTION

## About The Pull Request
Spaceacillin used to be able to be able to treat infections on the dead as well as the living, and got unintentionally changed in #76393. Simply brings back old functionality
## Why It's Good For The Game
Fix bugs!
## Changelog
:cl:
fix: Spaceacillin will once again provide antiviral effects for the deceased
/:cl:
