### PR TITLE
Stopgap fix for polymorphed headrevs counting towards a rev loss

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 
 
 /datum/objective/mutiny/check_completion()
-	if(!target || !considered_alive(target, enforce_human = TRUE) || considered_afk(target) || considered_exiled(target))
+	if(!target || !considered_alive(target) || considered_afk(target) || considered_exiled(target))
 		return TRUE
 	var/turf/T = get_turf(target.current)
 	return !T || !is_station_level(T.z)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 
 
 /datum/objective/mutiny/check_completion()
-	if(!target || !considered_alive(target) || considered_afk(target) || considered_exiled(target))
+	if(!target || !considered_alive(target, enforce_human = TRUE) || considered_afk(target) || considered_exiled(target))
 		return TRUE
 	var/turf/T = get_turf(target.current)
 	return !T || !is_station_level(T.z)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -473,9 +473,8 @@
 /datum/team/revolution/proc/check_heads_victory()
 	for(var/datum/mind/rev_mind in get_head_revolutionaries())
 		var/turf/rev_turf = get_turf(rev_mind.current)
-		if(!considered_afk(rev_mind) && considered_alive(rev_mind) && is_station_level(rev_turf.z))
-			if(ishuman(rev_mind.current))
-				return FALSE
+		if(!considered_afk(rev_mind) && considered_alive(rev_mind, enforce_human = TRUE) && is_station_level(rev_turf.z))
+			return FALSE
 	return TRUE
 
 /// Updates the state of the world depending on if revs won or loss.

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -473,7 +473,7 @@
 /datum/team/revolution/proc/check_heads_victory()
 	for(var/datum/mind/rev_mind in get_head_revolutionaries())
 		var/turf/rev_turf = get_turf(rev_mind.current)
-		if(!considered_afk(rev_mind) && considered_alive(rev_mind, enforce_human = TRUE) && is_station_level(rev_turf.z))
+		if(!considered_afk(rev_mind) && considered_alive(rev_mind) && is_station_level(rev_turf.z))
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Revheads being a simplemob, basic mob, or xenomorph no longer count towards a rev loss.

## Why It's Good For The Game

Strictly checking that a revhead is a human introduces several edge cases in which a revolution would be considered defeated, even if the last headrev is alive, on station, and able to eliminate command staff. Such cases include:
- A promoted traitor getting the final objective that lets them turn into a dragon.
- A promoted, ascended Flesh heretic.
- A headrev getting brain transplanted into a xenomorph, especially a queen.
- The Polymorphic Field Inverter.
- Other crew-obtainable sources of polymorphing (ash drake/wendigo blood, colossus crystal, etc.)

Heads of staff don't count towards a rev win in any of these cases, so it should be fair that revheads in these cases don't count towards a loss either.

There are probably some more rigorous checks that should be done because the original intention of the strict humanity check for revheads probably had to do with being able to convert, but those seem a bit too complicated for now.

Fixes #77634 

## Changelog

:cl:
fix: Head Revolutionaries no longer count towards a revolution's defeat if they have become simplemobs, basic mobs, or xenomorphs.
/:cl: