### PR TITLE
Gives engineers the RCD round start and nerfs its base abilities to compensate

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -197,6 +197,8 @@ GLOBAL_LIST_INIT(crafting_category, list(
 #define RCD_UPGRADE_SIMPLE_CIRCUITS (1<<1)
 #define RCD_UPGRADE_SILO_LINK (1<<2)
 #define RCD_UPGRADE_FURNISHING (1<<3)
+#define RCD_UPGRADE_ANTI_INTERRUPT (1<<4)
+#define RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN (1<<5)
 
 #define RPD_UPGRADE_UNWRENCH (1<<0)
 
@@ -213,6 +215,9 @@ GLOBAL_LIST_INIT(crafting_category, list(
 
 /// How much less resources the RCD uses when reconstructing
 #define RCD_MEMORY_COST_BUFF 8
+
+/// If set to TRUE in rcd_vals, will bypass the cooldown on slowing down frequent use
+#define RCD_RESULT_BYPASS_FREQUENT_USE_COOLDOWN "bypass_frequent_use_cooldown"
 
 // Defines for the construction component
 #define FORWARD 1

--- a/code/__HELPERS/construction.dm
+++ b/code/__HELPERS/construction.dm
@@ -5,6 +5,7 @@
 		return defaults + list(
 			"cost" = defaults["cost"] / RCD_MEMORY_COST_BUFF,
 			"delay" = defaults["delay"] / RCD_MEMORY_SPEED_BUFF,
+			RCD_RESULT_BYPASS_FREQUENT_USE_COOLDOWN = TRUE,
 		)
 	else
 		return defaults

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -490,11 +490,12 @@
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
 	anchored = TRUE
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	obj_flags = CAN_BE_HIT
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	var/status = 0
 	var/delay = 0
 
-/obj/effect/constructing_effect/Initialize(mapload, rcd_delay, rcd_status)
+/obj/effect/constructing_effect/Initialize(mapload, rcd_delay, rcd_status, rcd_upgrades)
 	. = ..()
 	status = rcd_status
 	delay = rcd_delay
@@ -504,6 +505,24 @@
 		icon_state = "rcd_end_reverse"
 	else
 		update_appearance()
+
+	if (rcd_upgrades & RCD_UPGRADE_ANTI_INTERRUPT)
+		color = list(
+			1.0, 0.5, 0.5, 0.0,
+			0.1, 0.0, 0.0, 0.0,
+			0.1, 0.0, 0.0, 0.0,
+			0.0, 0.0, 0.0, 1.0,
+			0.0, 0.0, 0.0, 0.0,
+		)
+
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+		obj_flags &= ~CAN_BE_HIT
+
+/obj/effect/constructing_effect/update_name(updates)
+	if (status == RCD_DECONSTRUCT)
+		name = "deconstruction effect"
+	else
+		name = "construction effect"
 
 /obj/effect/constructing_effect/update_icon_state()
 	icon_state = "rcd"
@@ -529,6 +548,18 @@
 
 /obj/effect/constructing_effect/proc/end()
 	qdel(src)
+
+/obj/effect/constructing_effect/proc/attacked(mob/user)
+	user.do_attack_animation(src, ATTACK_EFFECT_PUNCH)
+	user.changeNext_move(CLICK_CD_MELEE)
+	playsound(loc, 'sound/weapons/egloves.ogg', vol = 80, vary = TRUE)
+	end()
+
+/obj/effect/constructing_effect/attackby(obj/item/weapon, mob/user, params)
+	attacked(user)
+
+/obj/effect/constructing_effect/attack_hand(mob/living/user, list/modifiers)
+	attacked(user)
 
 /obj/effect/temp_visual/electricity
 	icon_state = "electricity3"

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -519,6 +519,8 @@
 		obj_flags &= ~CAN_BE_HIT
 
 /obj/effect/constructing_effect/update_name(updates)
+	. = ..()
+
 	if (status == RCD_DECONSTRUCT)
 		name = "deconstruction effect"
 	else

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -28,7 +28,7 @@
 	worn_icon_state = "RCD"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	custom_premium_price = PAYCHECK_COMMAND * 10
+	custom_premium_price = PAYCHECK_COMMAND * 2
 	max_matter = 160
 	slot_flags = ITEM_SLOT_BELT
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -161,6 +161,9 @@
 
 	COOLDOWN_DECLARE(destructive_scan_cooldown)
 
+	var/current_active_effects = 0
+	var/frequent_use_debuff_multiplier = 3
+
 GLOBAL_VAR_INIT(icon_holographic_wall, init_holographic_wall())
 GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 
@@ -336,22 +339,38 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	var/list/rcd_results = A.rcd_vals(user, src)
 	if(!rcd_results)
 		return FALSE
+
 	var/delay = rcd_results["delay"] * delay_mod
-	var/obj/effect/constructing_effect/rcd_effect = new(get_turf(A), delay, src.mode)
+
+	if (
+		!(upgrade & RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN) \
+			&& !rcd_results[RCD_RESULT_BYPASS_FREQUENT_USE_COOLDOWN] \
+			&& current_active_effects > 0
+	)
+		delay *= frequent_use_debuff_multiplier
+
+	current_active_effects += 1
+	rcd_create_effect(A, user, delay, rcd_results)
+	current_active_effects -= 1
+
+/obj/item/construction/rcd/proc/rcd_create_effect(atom/target, mob/user, delay, list/rcd_results)
+	var/obj/effect/constructing_effect/rcd_effect = new(get_turf(target), delay, src.mode, upgrade)
 
 	//resource & structure placement sanity checks before & after delay along with beam effects
-	if(!checkResource(rcd_results["cost"], user) || !can_place(A, rcd_results, user))
+	if(!checkResource(rcd_results["cost"], user) || !can_place(target, rcd_results, user))
 		qdel(rcd_effect)
 		return FALSE
 	var/beam
 	if(ranged)
-		beam = user.Beam(A,icon_state="rped_upgrade", time = delay)
-	if(!do_after(user, delay, target = A))
+		beam = user.Beam(target,icon_state="rped_upgrade", time = delay)
+	if(!do_after(user, delay, target = target))
 		qdel(rcd_effect)
 		if(!isnull(beam))
 			qdel(beam)
 		return FALSE
-	if(!checkResource(rcd_results["cost"], user) || !can_place(A, rcd_results, user))
+	if (QDELETED(rcd_effect))
+		return FALSE
+	if(!checkResource(rcd_results["cost"], user) || !can_place(target, rcd_results, user))
 		qdel(rcd_effect)
 		return FALSE
 
@@ -359,7 +378,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 		qdel(rcd_effect)
 		return FALSE
 	activate()
-	if(!A.rcd_act(user, src, rcd_results["mode"]))
+	if(!target.rcd_act(user, src, rcd_results["mode"]))
 		qdel(rcd_effect)
 		return FALSE
 	playsound(loc, 'sound/machines/click.ogg', 50, TRUE)
@@ -612,7 +631,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	matter = 160
 
 /obj/item/construction/rcd/loaded/upgraded
-	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
+	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING | RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
 
 /obj/item/construction/rcd/combat
 	name = "industrial RCD"
@@ -621,7 +640,20 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	max_matter = 500
 	matter = 500
 	canRturf = TRUE
-	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
+	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING | RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
+
+/obj/item/construction/rcd/ce
+	name = "professional RCD"
+	desc = "A higher-end model of the rapid construction device, prefitted with improved cooling and disruption prevention. Provided to the chief engineer."
+	upgrade = RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
+	matter = 160
+	color = list(
+		0.3, 0.3, 0.7, 0.0,
+		1.0, 1.0, 0.2, 0.0,
+		-0.2, 0.0, 1.0, 0.0,
+		0.0, 0.0, 0.0, 1.0,
+		0.0, 0.0, 0.0, 0.0,
+	)
 
 #undef CONSTRUCTION_MODE
 #undef WINDOW_TYPE
@@ -656,7 +688,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	name = "admin RCD"
 	max_matter = INFINITY
 	matter = INFINITY
-	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
+	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING | RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
 
 
 // Ranged RCD
@@ -670,4 +702,4 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	icon_state = "arcd"
 	inhand_icon_state = "oldrcd"
 	has_ammobar = FALSE
-	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
+	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING | RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN

--- a/code/game/objects/items/rcd/RHD.dm
+++ b/code/game/objects/items/rcd/RHD.dm
@@ -286,6 +286,14 @@
 	desc = "It contains the design for firelock, air alarm, fire alarm, apc circuits and crap power cells."
 	upgrade = RCD_UPGRADE_SIMPLE_CIRCUITS
 
+/obj/item/rcd_upgrade/anti_interrupt
+	desc = "It contains the upgrades necessary to prevent interruption of RCD construction and deconstruction."
+	upgrade = RCD_UPGRADE_ANTI_INTERRUPT
+
+/obj/item/rcd_upgrade/cooling
+	desc = "It contains the upgrades necessary to allow more frequent use of the RCD."
+	upgrade = RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
+
 /obj/item/rcd_upgrade/silo_link
 	desc = "It contains direct silo connection RCD upgrade."
 	upgrade = RCD_UPGRADE_SILO_LINK

--- a/code/game/objects/items/rcd/RLD.dm
+++ b/code/game/objects/items/rcd/RLD.dm
@@ -18,7 +18,7 @@
 	has_ammobar = TRUE
 	ammo_sections = 6
 	///it does not make sense why any of these should be installed
-	banned_upgrades = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
+	banned_upgrades = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING | RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
 
 	var/mode = LIGHT_MODE
 	var/wallcost = 10

--- a/code/game/objects/items/rcd/RPLD.dm
+++ b/code/game/objects/items/rcd/RPLD.dm
@@ -10,7 +10,7 @@
 	icon = 'icons/obj/tools.dmi'
 	slot_flags = ITEM_SLOT_BELT
 	///it does not make sense why any of these should be installed.
-	banned_upgrades = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS  | RCD_UPGRADE_FURNISHING
+	banned_upgrades = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS  | RCD_UPGRADE_FURNISHING | RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
 	matter = 200
 	max_matter = 200
 

--- a/code/game/objects/items/rcd/RTD.dm
+++ b/code/game/objects/items/rcd/RTD.dm
@@ -23,7 +23,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON
 	has_ammobar = TRUE
-	banned_upgrades = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING
+	banned_upgrades = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING | RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
 
 	/// main category for tile design
 	var/root_category = "Conventional"

--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -61,7 +61,8 @@
 	uniform = /obj/item/clothing/under/rank/engineering/chief_engineer
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic = 1,
-		)
+		/obj/item/construction/rcd/ce = 1,
+	)
 	belt = /obj/item/storage/belt/utility/chief/full
 	ears = /obj/item/radio/headset/heads/ce
 	gloves = /obj/item/clothing/gloves/color/black

--- a/code/modules/jobs/job_types/station_engineer.dm
+++ b/code/modules/jobs/job_types/station_engineer.dm
@@ -56,6 +56,10 @@
 	satchel = /obj/item/storage/backpack/satchel/eng
 	duffelbag = /obj/item/storage/backpack/duffelbag/engineering
 
+	backpack_contents = list(
+		/obj/item/construction/rcd/loaded,
+	)
+
 	box = /obj/item/storage/box/survival/engineer
 	pda_slot = ITEM_SLOT_LPOCKET
 	skillchips = list(/obj/item/skillchip/job/engineer)

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -133,6 +133,39 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
+/datum/design/rcd_upgrade/anti_interrupt
+	name = "RCD stronger deconstruction designs upgrade"
+	desc = "Prevents interruption of RCD construction and deconstruction."
+	id = "rcd_upgrade_anti_interrupt"
+	build_type = PROTOLATHE
+	materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT * 1.25,
+		/datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT * 1.5,
+		/datum/material/titanium = SHEET_MATERIAL_AMOUNT,
+	)
+	build_path = /obj/item/rcd_upgrade/anti_interrupt
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+
+/datum/design/rcd_upgrade/cooling
+	name = "RCD cooling upgrade"
+	desc = "Allows the RCD to more quickly perform multiple actions at once."
+	id = "rcd_upgrade_cooling"
+	build_type = PROTOLATHE
+	materials = list(
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2,
+		/datum/material/glass = SHEET_MATERIAL_AMOUNT,
+		/datum/material/silver = HALF_SHEET_MATERIAL_AMOUNT,
+	)
+	build_path = /obj/item/rcd_upgrade/cooling
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_ENGINEERING_ADVANCED
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
+
 /datum/design/rcd_upgrade/furnishing
 	name = "RCD furnishing upgrade"
 	desc = "Adds the ability to furnish areas using the RCD."

--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -134,7 +134,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
 /datum/design/rcd_upgrade/anti_interrupt
-	name = "RCD stronger deconstruction designs upgrade"
+	name = "RCD anti disruption designs upgrade"
 	desc = "Prevents interruption of RCD construction and deconstruction."
 	id = "rcd_upgrade_anti_interrupt"
 	build_type = PROTOLATHE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1504,6 +1504,8 @@
 	description = "Unlocks new designs that improve rapid devices."
 	prereq_ids = list("adv_engi")
 	design_ids = list(
+		"rcd_upgrade_anti_interrupt",
+		"rcd_upgrade_cooling",
 		"rcd_upgrade_frames",
 		"rcd_upgrade_furnishing",
 		"rcd_upgrade_simple_circuits",


### PR DESCRIPTION

## About The Pull Request
- Gives engineers an RCD as part of their round start equipment
- RCD by default will build/deconstruct slower if you already have another one in progress. This can be upgraded with the new cooling upgrade disk. Reconstructing (anything that was there roundstart as per the destructive scan) doesn't have this downside, only construction/deconstruction.
- RCD construction effects can now be attacked in order to cancel them. This can be deterred with the anti-disruption upgrade disk.
- RCDs for nukies and whatever don't have these downsides
- The CE's roundstart RCD also doesn't have these downsides

## Why It's Good For The Game
Construction and reconstruction are currently one of the worst aspects of SS13--they are so slow and tedious that any sort of mass destruction goes unfixed for 10-30+ minutes, if fixed at all. This limits us because it means people don't want traitors to create large explosions, for instance--I do and so I think it's crucial that we fix construction.

Reconstruction has already been improved on the RCD with the destructive scans, but I see no reason to limit this to something so out of the way.

Ideally the RCD even gets more functionalities, like the ability to print stock parts (or having stock parts removed), etc, in order to lessen this burden. 

## Changelog
:cl:
add: Engineers now have an RCD round start.
balance: RCD construction/deconstruction effects can now be attacked in order to cancel them. You can get the anti-disruption upgrade disk to prevent this.
balance: RCD construction/deconstruction is now slower if you already have another effect up. This does not effect reconstruction.
balance: Both of the above effects do not effect the CE's roundstart RCD, nor any other RCDs such as combat RCDs.
/:cl:
