### PR TITLE
[no gbp] Goliath tentacles now damage mechs

### DIFF
--- a/code/modules/mob/living/basic/lavaland/goliath/goliath_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/goliath_ai.dm
@@ -28,7 +28,7 @@
 /datum/ai_behavior/basic_melee_attack/goliath/perform(seconds_per_tick, datum/ai_controller/controller, target_key, targetting_datum_key, hiding_location_key, health_ratio_key)
 	var/mob/living/target = controller.blackboard[target_key]
 	// Interrupt attack chain to use tentacles, unless the target is already tentacled
-	if (isliving(target) && !target.has_status_effect(/datum/status_effect/incapacitating/stun/goliath_tentacled))
+	if (ismecha(target) || (isliving(target) && !target.has_status_effect(/datum/status_effect/incapacitating/stun/goliath_tentacled)))
 		var/datum/action/cooldown/using_action = controller.blackboard[BB_GOLIATH_TENTACLES]
 		if (using_action?.IsAvailable())
 			finish_action(controller, succeeded = FALSE)
@@ -40,7 +40,7 @@
 
 /datum/ai_planning_subtree/targeted_mob_ability/goliath_tentacles/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	var/mob/living/target = controller.blackboard[target_key]
-	if (!isliving(target) || target.has_status_effect(/datum/status_effect/incapacitating/stun/goliath_tentacled))
+	if (!(isliving(target) || ismecha(target)) || (isliving(target) && target.has_status_effect(/datum/status_effect/incapacitating/stun/goliath_tentacled)))
 		return // Target can be an item or already grabbed, we don't want to tentacle those
 	return ..()
 

--- a/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/tentacle.dm
@@ -49,6 +49,8 @@
 		if (victim.apply_status_effect(/datum/status_effect/incapacitating/stun/goliath_tentacled, grapple_time, src))
 			buckle_mob(victim, TRUE)
 			SEND_SIGNAL(victim, COMSIG_GOLIATH_TENTACLED_GRABBED)
+	for (var/obj/vehicle/sealed/mecha/mech in loc)
+		mech.take_damage(rand(min_damage, max_damage), damage_type = BRUTE, damage_flag = MELEE, sound_effect = TRUE)
 	if (!has_buckled_mobs())
 		retract()
 		return


### PR DESCRIPTION
## About The Pull Request

Goliaths will now use said tentacles on mechs.
The tentacles aren't strong enough to grab mechs so they just damage them a bit, you're still better off driving through them than a human is.

## Why It's Good For The Game

Someone pointed out that these abilities were only being used on living mobs, but miners use mechs sometimes.

## Changelog

:cl:
fix: Goliaths will try to attack mechs with their tentacles.
/:cl:
