### PR TITLE
Gravitational Anomalies will not make areas permanently have weird gravity

### DIFF
--- a/code/datums/proximity_monitor/fields/gravity.dm
+++ b/code/datums/proximity_monitor/fields/gravity.dm
@@ -23,7 +23,7 @@
 	if(isnull(modified_turfs[target]))
 		return
 	var/grav_value = modified_turfs[target] || 0
-	target.RemoveElement(/datum/element/forced_gravity, grav_value)
+	target.RemoveElement(/datum/element/forced_gravity, grav_value, can_override = TRUE)
 	modified_turfs -= target
 
 // Subtype which pops up a balloon alert when a mob enters the field


### PR DESCRIPTION
## About The Pull Request

See title.
Someone added a new argument to this element, passed it in on creation, and forgot to pass it in on removal.

## Why It's Good For The Game

A shift where the whole of the cargo bay has no gravity is fun, but the crew can't fix it.
I might think of a way to bring it back in a more temporary fashion.

## Changelog

:cl:
fix: Gravitational Anomalies will now correctly clean up after themselves, instead of leaving an area of the station permanently heavy or with no gravity at all.
/:cl:

fixes https://github.com/tgstation/tgstation/issues/77249