### PR TITLE
Rat King mouse summoning grammar fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/regalrat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/regalrat.dm
@@ -285,7 +285,7 @@
 		to_chat(owner,span_warning("There's too many mice on this station to beckon a new one! Find them first!"))
 		return
 	new /mob/living/basic/mouse(owner.loc)
-	owner.visible_message(span_warning("[owner] commands a rat to their side!"))
+	owner.visible_message(span_warning("[owner] commands a mouse to their side!"))
 
 /// Makes a passed mob into our minion
 /datum/action/cooldown/riot/proc/make_minion(mob/living/new_minion, minion_desc, list/command_list = mouse_commands)


### PR DESCRIPTION
## About The Pull Request

the rat king commands mice to their side, not rats; they turn said mice into rats with a spell, but they do not summon mice.
`"[owner] commands a rat to their side!"`

this PR changes it from rat to mouse in the text.
`"[owner] commands a mouse to their side!"`

## Changelog

:cl:
spellcheck: fixed the rat king text saying that they're summoning rats
/:cl:
