### PR TITLE
Fixes cost values of RCDs

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1545,7 +1545,7 @@
 			if(security_level != AIRLOCK_SECURITY_NONE)
 				to_chat(user, span_notice("[src]'s reinforcement needs to be removed first."))
 				return FALSE
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 50, "cost" = 32)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 5 SECONDS, "cost" = 32)
 	return FALSE
 
 /obj/machinery/door/airlock/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -884,9 +884,9 @@
 
 /obj/structure/firelock_frame/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_DECONSTRUCT)
-		return list("mode" = RCD_DECONSTRUCT, "delay" = 50, "cost" = 16)
+		return list("mode" = RCD_DECONSTRUCT, "delay" = 5 SECONDS, "cost" = 16)
 	else if((constructionStep == CONSTRUCTION_NO_CIRCUIT) && (the_rcd.upgrade & RCD_UPGRADE_SIMPLE_CIRCUITS))
-		return list("mode" = RCD_UPGRADE_SIMPLE_CIRCUITS, "delay" = 20, "cost" = 1)
+		return list("mode" = RCD_UPGRADE_SIMPLE_CIRCUITS, "delay" = 2 SECONDS, "cost" = 1)
 	return FALSE
 
 /obj/structure/firelock_frame/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -441,7 +441,7 @@
 /obj/machinery/door/window/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 50, "cost" = 32)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 5 SECONDS, "cost" = 32)
 	return FALSE
 
 /obj/machinery/door/window/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -413,7 +413,7 @@
 
 /obj/machinery/firealarm/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if((buildstage == FIRE_ALARM_BUILD_NO_CIRCUIT) && (the_rcd.upgrade & RCD_UPGRADE_SIMPLE_CIRCUITS))
-		return list("mode" = RCD_WALLFRAME, "delay" = 20, "cost" = 1)
+		return list("mode" = RCD_WALLFRAME, "delay" = 2 SECONDS, "cost" = 1)
 	return FALSE
 
 /obj/machinery/firealarm/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -375,7 +375,7 @@
 
 /obj/structure/door_assembly/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_DECONSTRUCT)
-		return list("mode" = RCD_DECONSTRUCT, "delay" = 50, "cost" = 16)
+		return list("mode" = RCD_DECONSTRUCT, "delay" = 5 SECONDS, "cost" = 16)
 	return FALSE
 
 /obj/structure/door_assembly/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -450,7 +450,7 @@
 				get_turf(src), RCD_MEMORY_WALL,
 			)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 20, "cost" = 13)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 2 SECONDS, "cost" = 13)
 	return FALSE
 
 /obj/structure/girder/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -60,21 +60,21 @@
 /obj/structure/grille/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 20, "cost" = 5)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 2 SECONDS, "cost" = 5)
 		if(RCD_WINDOWGRILLE)
 			var/cost = 0
 			var/delay = 0
 			if(the_rcd.window_type  == /obj/structure/window)
-				cost = 6
+				cost = 4
 				delay = 2 SECONDS
 			else if(the_rcd.window_type  == /obj/structure/window/reinforced)
-				cost = 9
+				cost = 6
 				delay = 2.5 SECONDS
 			else if(the_rcd.window_type  == /obj/structure/window/fulltile)
-				cost = 12
+				cost = 8
 				delay = 3 SECONDS
 			else if(the_rcd.window_type  == /obj/structure/window/reinforced/fulltile)
-				cost = 15
+				cost = 12
 				delay = 4 SECONDS
 			if(!cost)
 				return FALSE

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -64,9 +64,9 @@
 
 /obj/structure/lattice/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_FLOORWALL)
-		return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 2)
+		return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 1)
 	if(the_rcd.mode == RCD_CATWALK)
-		return list("mode" = RCD_CATWALK, "delay" = 0, "cost" = 1)
+		return list("mode" = RCD_CATWALK, "delay" = 0, "cost" = 2)
 
 /obj/structure/lattice/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
 	if(passed_mode == RCD_FLOORWALL)
@@ -122,7 +122,7 @@
 
 /obj/structure/lattice/catwalk/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(the_rcd.mode == RCD_DECONSTRUCT)
-		return list("mode" = RCD_DECONSTRUCT, "delay" = 10, "cost" = 5)
+		return list("mode" = RCD_DECONSTRUCT, "delay" = 1 SECONDS, "cost" = 5)
 	return FALSE
 
 /obj/structure/lattice/catwalk/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -314,7 +314,7 @@
 /obj/structure/table/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 24, "cost" = 16)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 2.4 SECONDS, "cost" = 16)
 	return FALSE
 
 /obj/structure/table/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -93,7 +93,7 @@
 /obj/structure/window/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 20, "cost" = 5)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 2 SECONDS, "cost" = 5)
 	return FALSE
 
 /obj/structure/window/rcd_act(mob/user, obj/item/construction/rcd/the_rcd)
@@ -479,7 +479,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/unanchored/spawner, 0)
 /obj/structure/window/reinforced/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 30, "cost" = 15)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 3 SECONDS, "cost" = 15)
 	return FALSE
 
 /obj/structure/window/reinforced/attackby_secondary(obj/item/tool, mob/user, params)
@@ -670,7 +670,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/frosted/spaw
 /obj/structure/window/fulltile/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 25, "cost" = 10)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 2.5 SECONDS, "cost" = 10)
 	return FALSE
 
 /obj/structure/window/fulltile/unanchored
@@ -727,7 +727,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/frosted/spaw
 /obj/structure/window/reinforced/fulltile/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 40, "cost" = 20)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 4 SECONDS, "cost" = 20)
 	return FALSE
 
 /obj/structure/window/reinforced/fulltile/unanchored

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -315,9 +315,9 @@
 /turf/closed/wall/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 40, "cost" = 26)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 4 SECONDS, "cost" = 26)
 		if(RCD_WALLFRAME)
-			return list("mode" = RCD_WALLFRAME, "delay" = 10, "cost" = 25)
+			return list("mode" = RCD_WALLFRAME, "delay" = 1 SECONDS, "cost" = 8)
 	return FALSE
 
 /turf/closed/wall/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -213,51 +213,48 @@
 				src, RCD_MEMORY_WALL,
 			)
 		if(RCD_REFLECTOR)
-			return list("mode" = RCD_REFLECTOR, "delay" = 20, "cost" = 30)
+			return list("mode" = RCD_REFLECTOR, "delay" = 2 SECONDS, "cost" = 20)
 		if(RCD_AIRLOCK)
 			if(the_rcd.airlock_glass)
-				return list("mode" = RCD_AIRLOCK, "delay" = 50, "cost" = 20)
+				return list("mode" = RCD_AIRLOCK, "delay" = 5 SECONDS, "cost" = 20)
 			else
-				return list("mode" = RCD_AIRLOCK, "delay" = 50, "cost" = 16)
+				return list("mode" = RCD_AIRLOCK, "delay" = 5 SECONDS, "cost" = 16)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 50, "cost" = 33)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 5 SECONDS, "cost" = 33)
 		if(RCD_WINDOWGRILLE)
 			return rcd_result_with_memory(
 				list("mode" = RCD_WINDOWGRILLE, "delay" = 1 SECONDS, "cost" = 4),
 				src, RCD_MEMORY_WINDOWGRILLE,
 			)
 		if(RCD_MACHINE)
-			return list("mode" = RCD_MACHINE, "delay" = 20, "cost" = 25)
+			return list("mode" = RCD_MACHINE, "delay" = 2 SECONDS, "cost" = 20)
 		if(RCD_COMPUTER)
-			return list("mode" = RCD_COMPUTER, "delay" = 20, "cost" = 25)
+			return list("mode" = RCD_COMPUTER, "delay" = 2 SECONDS, "cost" = 20)
 		if(RCD_FLOODLIGHT)
-			return list("mode" = RCD_FLOODLIGHT, "delay" = 30, "cost" = 35)
+			return list("mode" = RCD_FLOODLIGHT, "delay" = 3 SECONDS, "cost" = 20)
 		if(RCD_GIRDER)
 			return list("mode" = RCD_GIRDER, "delay" = 1.3 SECONDS, "cost" = 8)
 		if(RCD_FURNISHING)
 			var/cost = 0
 			var/delay = 0
 			if(the_rcd.furnish_type == /obj/structure/chair || the_rcd.furnish_type == /obj/structure/chair/stool)
-				cost = 8
-				delay = 10
+				cost = 4
+				delay = 1 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/chair/stool/bar)
 				cost = 4
-				delay = 5
-			else if(the_rcd.furnish_type == /obj/structure/chair/stool/bar)
-				cost = 4
-				delay = 5
+				delay = 0.5 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/table)
-				cost = 15
-				delay = 20
+				cost = 8
+				delay = 2 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/table/glass)
-				cost = 12
-				delay = 15
+				cost = 8
+				delay = 2 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/rack)
-				cost = 20
-				delay = 25
+				cost = 4
+				delay = 2.5 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/bed)
-				cost = 10
-				delay = 15
+				cost = 8
+				delay = 1.5 SECONDS
 			if(cost == 0)
 				return FALSE
 			return list("mode" = RCD_FURNISHING, "delay" = cost, "cost" = delay)

--- a/code/game/turfs/open/misc.dm
+++ b/code/game/turfs/open/misc.dm
@@ -84,49 +84,46 @@
 			else
 				return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
 		if(RCD_REFLECTOR)
-			return list("mode" = RCD_REFLECTOR, "delay" = 20, "cost" = 30)
+			return list("mode" = RCD_REFLECTOR, "delay" = 2 SECONDS, "cost" = 20)
 		if(RCD_AIRLOCK)
 			if(the_rcd.airlock_glass)
-				return list("mode" = RCD_AIRLOCK, "delay" = 50, "cost" = 20)
+				return list("mode" = RCD_AIRLOCK, "delay" = 5 SECONDS, "cost" = 20)
 			else
-				return list("mode" = RCD_AIRLOCK, "delay" = 50, "cost" = 16)
+				return list("mode" = RCD_AIRLOCK, "delay" = 5 SECONDS, "cost" = 16)
 		if(RCD_WINDOWGRILLE)
 			return rcd_result_with_memory(
 				list("mode" = RCD_WINDOWGRILLE, "delay" = 1 SECONDS, "cost" = 4),
 				src, RCD_MEMORY_WINDOWGRILLE,
 			)
 		if(RCD_MACHINE)
-			return list("mode" = RCD_MACHINE, "delay" = 20, "cost" = 25)
+			return list("mode" = RCD_MACHINE, "delay" = 2 SECONDS, "cost" = 20)
 		if(RCD_COMPUTER)
-			return list("mode" = RCD_COMPUTER, "delay" = 20, "cost" = 25)
+			return list("mode" = RCD_COMPUTER, "delay" = 2 SECONDS, "cost" = 20)
 		if(RCD_FLOODLIGHT)
-			return list("mode" = RCD_FLOODLIGHT, "delay" = 30, "cost" = 35)
+			return list("mode" = RCD_FLOODLIGHT, "delay" = 3 SECONDS, "cost" = 20)
 		if(RCD_GIRDER)
 			return list("mode" = RCD_GIRDER, "delay" = 1.3 SECONDS, "cost" = 8)
 		if(RCD_FURNISHING)
 			var/cost = 0
 			var/delay = 0
 			if(the_rcd.furnish_type == /obj/structure/chair || the_rcd.furnish_type == /obj/structure/chair/stool)
-				cost = 8
-				delay = 10
+				cost = 4
+				delay = 1 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/chair/stool/bar)
 				cost = 4
-				delay = 5
-			else if(the_rcd.furnish_type == /obj/structure/chair/stool/bar)
-				cost = 4
-				delay = 5
+				delay = 0.5 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/table)
-				cost = 15
-				delay = 20
+				cost = 8
+				delay = 2 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/table/glass)
-				cost = 12
-				delay = 15
+				cost = 8
+				delay = 2 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/rack)
-				cost = 20
-				delay = 25
+				cost = 4
+				delay = 2.5 SECONDS
 			else if(the_rcd.furnish_type == /obj/structure/bed)
-				cost = 10
-				delay = 15
+				cost = 8
+				delay = 1.5 SECONDS
 			if(!cost)
 				return FALSE
 			return list("mode" = RCD_FURNISHING, "delay" = cost, "cost" = delay)

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -215,9 +215,9 @@ GLOBAL_VAR_INIT(starlight_color, COLOR_STARLIGHT)
 		if(RCD_CATWALK)
 			var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
 			if(lattice)
-				return list("mode" = RCD_CATWALK, "delay" = 0, "cost" = 1)
-			else
 				return list("mode" = RCD_CATWALK, "delay" = 0, "cost" = 2)
+			else
+				return list("mode" = RCD_CATWALK, "delay" = 0, "cost" = 4)
 	return FALSE
 
 /turf/open/space/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
@@ -47,7 +47,7 @@
 
 /obj/machinery/airalarm/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if((buildstage == AIR_ALARM_BUILD_NO_CIRCUIT) && (the_rcd.upgrade & RCD_UPGRADE_SIMPLE_CIRCUITS))
-		return list("mode" = RCD_WALLFRAME, "delay" = 20, "cost" = 1)
+		return list("mode" = RCD_WALLFRAME, "delay" = 2 SECONDS, "cost" = 1)
 	return FALSE
 
 /obj/machinery/airalarm/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -161,13 +161,13 @@
 		if(machine_stat & BROKEN)
 			balloon_alert(user, "frame is too damaged!")
 			return FALSE
-		return list("mode" = RCD_WALLFRAME, "delay" = 20, "cost" = 1)
+		return list("mode" = RCD_WALLFRAME, "delay" = 2 SECONDS, "cost" = 1)
 
 	if(!cell)
 		if(machine_stat & MAINT)
 			balloon_alert(user, "no board for a cell!")
 			return FALSE
-		return list("mode" = RCD_WALLFRAME, "delay" = 50, "cost" = 10)
+		return list("mode" = RCD_WALLFRAME, "delay" = 5 SECONDS, "cost" = 10)
 
 	balloon_alert(user, "has both board and cell!")
 	return FALSE


### PR DESCRIPTION
## About The Pull Request

fixes cost values to be 1:1 of what the construction would have costed in manual construction for the RCD. also changes all decaseconds to seconds in code for clarity.

the biggest change is windows, they used to cost more than they needed for manual construction:

grille - 4mu - 1 iron sheet - 100% efficiency
directional normal window - 6mu - 1 glass sheet - 66% efficiency
directional reinforced window - 9mu - 1 reinforced glass sheet - 66% efficiency
fulltile normal window - 12mu - 2 glass sheets - 66% efficiency
fulltile reinforced window - 15mu - 2 reinforced glass sheets - 80% efficiency

this PR fixes all of these to be 100% efficient by lowering their matter costs, among some other items like racks or reflector frames.

## Why It's Good For The Game

consistency for material costs is good. most of these incorrect material values are also for things that don't matter, like racks or reflector frames. also decaseconds are gross looking in code

## Changelog

:cl:
fix: Some RCD constructs took more material than manual construction. The RCD cost should be consistent in comparison to manual construction now.
/:cl:
