### PR TITLE
the big slappy is now immutably slow

### DIFF
--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -311,6 +311,7 @@
 	pickup_sound = 'sound/items/handling/crowbar_pickup.ogg'
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	block_sound = 'sound/weapons/sonic_jackhammer.ogg'
+	obj_flags = IMMUTABLE_SLOW
 	item_flags = SLOWS_WHILE_IN_HAND
 	slowdown = 3
 	attack_speed = 1.2 SECONDS


### PR DESCRIPTION
## About The Pull Request
the big slappy is now immutably slow, it cant be sped up by xenobio speed potion (because of how red slime crossbreed works, you can still avoid it with that bullshit, but at least that requires some effort for the xenobiologist to specifically create you one)

## Why It's Good For The Game
30 force
30 block chance
double object damage
throws tha guy away
KNOCKS DOWN FOR 2 SECONDS
and then your ass can literally just walk with it for FREE if you visit xenobio and they gloop out one potion with a slime and water (which if xenobio is staffed at all they probably will have at the point you made it)
![image](https://github.com/tgstation/tgstation/assets/23585223/00bba834-2944-4260-b26a-cf9608ee851d)
(also a bit sus that it was added by a xenobio powergamer but thats beside the point)

## Changelog
:cl:
balance: you cant speed up the big slappy with slime potion
/:cl:
