### PR TITLE
Emergency toolboxes are thrown faster

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -50,6 +50,7 @@
 	icon_state = "red"
 	inhand_icon_state = "toolbox_red"
 	material_flags = NONE
+	throw_speed = 3 // red ones go faster
 
 /obj/item/storage/toolbox/emergency/PopulateContents()
 	new /obj/item/crowbar/red(src)


### PR DESCRIPTION
## About The Pull Request

Emergency toolboxes have 3 throwspeed (up from 2)

## Why It's Good For The Game

Consitency with the red pen which also has +1 throw speed

## Changelog

:cl: Melbert
balance: Red toolboxes go faster
/:cl: