### PR TITLE
Fixes an invalid bartender suit spawn

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -11,7 +11,6 @@
 		/obj/item/clothing/head/hats/tophat = 2,
 		/obj/item/radio/headset/headset_srv = 2,
 		/obj/item/clothing/under/costume/buttondown/slacks/service = 2,
-		/obj/item/clothing/under/rank/civilian/bartender = 2,
 		/obj/item/clothing/accessory/waistcoat = 2,
 		/obj/item/clothing/head/soft/black = 2,
 		/obj/item/clothing/shoes/sneakers/black = 2,

--- a/code/modules/clothing/under/jobs/civilian/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian/civilian.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/under/civilian.dmi'
 	worn_icon = 'icons/mob/clothing/under/civilian.dmi'
 
-/obj/item/clothing/under/rank/civilian/bartender/purple
+/obj/item/clothing/under/rank/civilian/purple_bartender
 	desc = "It looks like it has lots of flair!"
 	name = "purple bartender's uniform"
 	icon_state = "purplebartender"

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -115,7 +115,7 @@
 				/obj/item/clothing/under/suit/white/skirt = 2,
 				/obj/item/clothing/under/rank/captain/suit/skirt = 2,
 				/obj/item/clothing/under/rank/civilian/head_of_personnel/suit/skirt = 2,
-				/obj/item/clothing/under/rank/civilian/bartender/purple = 2,
+				/obj/item/clothing/under/rank/civilian/purple_bartender = 2,
 				/obj/item/clothing/suit/jacket/miljacket = 1,
 				/obj/item/clothing/suit/apron/overalls = 2,
 			),

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -352,7 +352,7 @@
 		/obj/item/clothing/neck/bowtie = 2,
 		/obj/item/clothing/under/costume/buttondown/slacks/service = 2,
 		/obj/item/clothing/under/costume/buttondown/skirt/service = 2,
-		/obj/item/clothing/under/rank/civilian/bartender/purple = 2,
+		/obj/item/clothing/under/rank/civilian/purple_bartender = 2,
 		/obj/item/clothing/suit/toggle/lawyer/greyscale = 1,
 		/obj/item/clothing/suit/armor/vest/alt = 1,
 		/obj/item/clothing/shoes/sneakers/black = 2,


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/77558 removed the bartender outfit but there was still one instance of the path left over, leading to an invalid icon state bartender suit spawning in a locker.

![dreamseeker_mc0gjQkreo](https://github.com/tgstation/tgstation/assets/13398309/863f77ce-2cf2-463d-b552-2ac632b49624)

![image](https://github.com/tgstation/tgstation/assets/13398309/43aeb546-c3e1-44bb-8cb6-13b680a4aca4)

This gets rid of that. The bartender outfit has been replaced with the greyscale buttondown suit with slacks now.

Also repaths `/obj/item/clothing/under/rank/civilian/bartender/purple` to `/obj/item/clothing/under/rank/civilian/purple_bartender` to avoid having a defunct basetype for this same reason.

## Why It's Good For The Game

Fixes an oversight

## Changelog

:cl:
fix: formal closet will no longer spawn with two 'error' icon suits inside of it
/:cl:
