### PR TITLE
fixes a typo from unloading a revolver

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -512,7 +512,7 @@
 			if(T && is_station_level(T.z))
 				SSblackbox.record_feedback("tally", "station_mess_created", 1, CB.name)
 		if (num_unloaded)
-			balloon_alert(user, "[num_unloaded] [cartridge_wording] unloaded")
+			balloon_alert(user, "[num_unloaded] [cartridge_wording]\s unloaded")
 			playsound(user, eject_sound, eject_sound_volume, eject_sound_vary)
 			update_appearance()
 		else


### PR DESCRIPTION
## About The Pull Request
adds a single `\s` for proper plural handling if you eject multiple casings from a gun with an internal magazine e.g. revolvers

## Why It's Good For The Game
it's nitpicking over a typo

## Changelog

:cl:
spellcheck: Fixed a lack of plurality when ejecting multiple casings from a revolver.
/:cl: