### PR TITLE
Makes arrows reusable again

### DIFF
--- a/code/datums/elements/caseless.dm
+++ b/code/datums/elements/caseless.dm
@@ -20,7 +20,7 @@
 	if(!proj)
 		return
 
-	if(reusable)
+	if(reusable && proj.shrapnel_type != shell.type) // we will let the shrapnel handle the projectile 'dropping' if the shrapnel is the ammo type (e.g. arrows)
 		proj.AddElement(/datum/element/projectile_drop, shell.type)
 
 	if(isgun(fired_from))

--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -12,13 +12,13 @@
 	firing_effect_type = null
 	caliber = CALIBER_ARROW
 	is_cased_ammo = FALSE
-	/// Whether the arrow type is single use or reusable
-	var/is_retrievable = TRUE
+	/// Whether the arrow is single use. By default all arrows can be retrieved after firing.
+	var/is_single_use
 
 /obj/item/ammo_casing/arrow/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/envenomable_casing)
-	AddElement(/datum/element/caseless, reusable = is_retrievable)
+	AddElement(/datum/element/caseless, reusable = !is_single_use)
 
 /obj/item/ammo_casing/arrow/update_icon_state()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
+++ b/code/modules/projectiles/guns/ballistic/bows/bow_arrows.dm
@@ -12,11 +12,13 @@
 	firing_effect_type = null
 	caliber = CALIBER_ARROW
 	is_cased_ammo = FALSE
+	/// Whether the arrow type is single use or reusable
+	var/is_retrievable = TRUE
 
 /obj/item/ammo_casing/arrow/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/envenomable_casing)
-	AddElement(/datum/element/caseless)
+	AddElement(/datum/element/caseless, reusable = is_retrievable)
 
 /obj/item/ammo_casing/arrow/update_icon_state()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Closes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23103

When removing a defunct type of 'despawning' arrow in https://github.com/tgstation/tgstation/pull/77450 I think maybe the default arrow behavior got inadvertently changed.

This just makes them reusable again.

## Why It's Good For The Game

Gives bows back one of their main benefits.

## Changelog

:cl:
fix: arrows are now retrievable once more by default
/:cl:

