### PR TITLE
Fixes iron floor tiles instances without /base subtype.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/DJstation/radioroom_1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/radioroom_1.dmm
@@ -13,7 +13,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/djstation)
 "h" = (
-/obj/item/stack/tile/iron{
+/obj/item/stack/tile/iron/base{
 	pixel_x = -10;
 	pixel_y = -6
 	},
@@ -42,7 +42,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/djstation)
 "r" = (
-/obj/item/stack/tile/iron{
+/obj/item/stack/tile/iron/base{
 	pixel_x = -7;
 	pixel_y = 4
 	},

--- a/_maps/RandomRuins/SpaceRuins/DJstation/solars_1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/DJstation/solars_1.dmm
@@ -32,7 +32,7 @@
 /area/ruin/space/djstation/solars)
 "t" = (
 /obj/structure/lattice,
-/obj/item/stack/tile/iron{
+/obj/item/stack/tile/iron/base{
 	pixel_x = 3;
 	pixel_y = 4
 	},

--- a/_maps/RandomRuins/SpaceRuins/derelict7.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict7.dmm
@@ -66,7 +66,7 @@
 /area/ruin/space/has_grav)
 "gw" = (
 /obj/structure/lattice,
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /obj/structure/disposalpipe/broken,
 /turf/template_noop,
 /area/template_noop)
@@ -106,11 +106,11 @@
 /area/ruin/space/has_grav)
 "lQ" = (
 /obj/structure/lattice,
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /turf/template_noop,
 /area/template_noop)
 "lU" = (
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav)
@@ -118,7 +118,7 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/has_grav)
 "or" = (
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /turf/template_noop,
 /area/template_noop)
 "oy" = (
@@ -187,7 +187,7 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav)
 "tH" = (
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /obj/item/stack/rods,
 /turf/template_noop,
 /area/template_noop)
@@ -205,7 +205,7 @@
 /area/ruin/space/has_grav)
 "wz" = (
 /obj/structure/lattice,
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /obj/item/stack/sheet/iron,
 /turf/template_noop,
 /area/template_noop)

--- a/_maps/RandomRuins/SpaceRuins/derelict8.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict8.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "bY" = (
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
@@ -20,7 +20,7 @@
 /area/ruin/space/has_grav)
 "dL" = (
 /obj/structure/lattice,
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /turf/template_noop,
 /area/template_noop)
 "dS" = (
@@ -133,12 +133,12 @@
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav)
 "zc" = (
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /obj/item/stack/rods,
 /turf/template_noop,
 /area/template_noop)
 "zh" = (
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /turf/template_noop,
 /area/template_noop)
 "zt" = (

--- a/_maps/RandomZLevels/moonoutpost19.dmm
+++ b/_maps/RandomZLevels/moonoutpost19.dmm
@@ -361,7 +361,7 @@
 /turf/open/floor/iron/half,
 /area/awaymission/moonoutpost19/syndicate)
 "cF" = (
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /obj/effect/decal/cleanable/crayon,
 /turf/open/misc/asteroid/moon{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251"
@@ -4521,7 +4521,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/moonoutpost19/research)
 "Dw" = (
-/obj/item/stack/tile/iron,
+/obj/item/stack/tile/iron/base,
 /turf/open/misc/asteroid/moon{
 	initial_gas_mix = "co2=48.7;n2=13.2;o2=32.4;TEMP=251"
 	},

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -28047,7 +28047,7 @@
 	pixel_x = 4;
 	pixel_y = -2
 	},
-/obj/item/stack/tile/iron{
+/obj/item/stack/tile/iron/base{
 	pixel_y = 18
 	},
 /obj/item/key/janitor{

--- a/code/game/objects/items/stacks/tiles/tile_iron.dm
+++ b/code/game/objects/items/stacks/tiles/tile_iron.dm
@@ -16,7 +16,7 @@
 	source = /datum/robot_energy_storage/material/iron
 	merge_type = /obj/item/stack/tile/iron
 	tile_reskin_types = list(
-		/obj/item/stack/tile/iron,
+		/obj/item/stack/tile/iron/base,
 		/obj/item/stack/tile/iron/edge,
 		/obj/item/stack/tile/iron/half,
 		/obj/item/stack/tile/iron/corner,

--- a/tools/UpdatePaths/Scripts/77669_iron_floor_to_iron_floor_base.txt
+++ b/tools/UpdatePaths/Scripts/77669_iron_floor_to_iron_floor_base.txt
@@ -1,0 +1,1 @@
+/obj/item/stack/tile/iron : /obj/item/stack/tile/iron/base{@OLD}


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/77564.
As it was reskinning into the `/obj/item/stack/tile/iron` it couldn't merge with the `/obj/item/stack/tile/iron/base` tiles.
## Changelog
:cl:
fix: Base iron floor tiles now will be able to stack with other base iron floor tiles after being reskined to the base subtype.
/:cl:
