### PR TITLE
Polymorphic Inverter tweaks

### DIFF
--- a/code/modules/clothing/belts/polymorph_belt.dm
+++ b/code/modules/clothing/belts/polymorph_belt.dm
@@ -57,7 +57,7 @@
 		return
 	if (!isliving(target_mob))
 		return
-	if (ishuman(target_mob) && !ismonkey(target_mob))
+	if (!isanimal_or_basicmob(target_mob))
 		balloon_alert(user, "target too complex!")
 		return TRUE
 	if (!(target_mob.mob_biotypes & MOB_ORGANIC))

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -104,13 +104,26 @@
 /mob/living/simple_animal/hostile/space_dragon/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()
 	tiredness = max(tiredness - (0.5 * seconds_per_tick), 0)
-	for(var/mob/living/consumed_mob in src)
-		if(consumed_mob.stat == DEAD)
-			continue
-		playsound(src, 'sound/effects/splat.ogg', 50, TRUE)
-		visible_message(span_danger("[src] vomits up [consumed_mob]!"))
-		consumed_mob.forceMove(loc)
-		consumed_mob.Paralyze(50)
+
+/mob/living/simple_animal/hostile/space_dragon/Entered(atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	. = ..()
+	if (isliving(arrived))
+		RegisterSignal(arrived, COMSIG_MOB_STATCHANGE, PROC_REF(eaten_stat_changed))
+
+/mob/living/simple_animal/hostile/space_dragon/Exited(atom/movable/gone, direction)
+	. = ..()
+	if (isliving(gone))
+		UnregisterSignal(gone, COMSIG_MOB_STATCHANGE)
+
+/// Release consumed mobs if they transition from dead to alive
+/mob/living/simple_animal/hostile/space_dragon/proc/eaten_stat_changed(mob/living/eaten)
+	SIGNAL_HANDLER
+	if (eaten.stat == DEAD)
+		return
+	playsound(src, 'sound/effects/splat.ogg', vol = 50, vary = TRUE)
+	visible_message(span_danger("[src] vomits up [eaten]!"))
+	eaten.forceMove(loc)
+	eaten.Paralyze(5 SECONDS)
 
 /mob/living/simple_animal/hostile/space_dragon/AttackingTarget()
 	if(using_special)


### PR DESCRIPTION
## About The Pull Request

Fixes #77649

You can no longer use the belt to turn into any kind of carbon mob, sorry gamers it was a cool dream but it leads to too many problems.
Also I made space dragon "there's an alive guy in my stomach" code now work on signals instead of on Life tick which is slightly more efficient and also resolves an issue with the funny belt.

## Why It's Good For The Game

Too much room for weird edge cases as a result of doing this (messing with monkey DNA, producing infinite xeno organs, blocking legit xeno queens from being created) which had no graceful solution.
Moving stuff off Life if it can be event based is nice.

## Changelog

:cl:
fix: Turning into a space dragon with the polymorphic inverter will no longer leave you existing in two places
balance: You can no longer use the belt to transform into monkeys or xenomorphs, for technical reasons.
/:cl:
