### PR TITLE
Add Mob Ability menu now displays ability names before typepath

### DIFF
--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -352,13 +352,17 @@
 
 	var/mob/living/marked_mob = holder.marked_datum
 
-	var/list/all_mob_actions = sort_list(subtypesof(/datum/action/cooldown/mob_cooldown), GLOBAL_PROC_REF(cmp_typepaths_asc))
+	var/static/list/all_mob_actions = sort_list(subtypesof(/datum/action/cooldown/mob_cooldown), GLOBAL_PROC_REF(cmp_typepaths_asc))
+	var/static/list/actions_by_name = list()
+	if (!length(actions_by_name))
+		for (var/datum/action/cooldown/mob_cooldown as anything in all_mob_actions)
+			actions_by_name["[initial(mob_cooldown.name)] ([mob_cooldown])"] = mob_cooldown
 
-	var/ability_type = tgui_input_list(usr, "Choose an ability", "Ability", all_mob_actions)
-
-	if(!ability_type)
+	var/ability = tgui_input_list(usr, "Choose an ability", "Ability", actions_by_name)
+	if(isnull(ability))
 		return
 
+	var/ability_type = actions_by_name[ability]
 	var/datum/action/cooldown/mob_cooldown/add_ability
 
 	var/make_sequence = tgui_alert(usr, "Would you like this action to be a sequence of multiple abilities?", "Sequence Ability", list("Yes", "No"))

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
@@ -63,6 +63,7 @@
 
 /// Charge a long way, knock down for longer, and perform an instant melee attack
 /datum/action/cooldown/mob_cooldown/charge/basic_charge/lobster
+	name = "Lobster Rush"
 	charge_distance = 8
 	knockdown_duration = 2.5 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

Look at this menu:
![image](https://github.com/tgstation/tgstation/assets/7483112/2ecf0839-a7b6-4038-b772-7ffcdec8bd8d)

Isn't this basically useless?
When you try to add a mob ability to a mob, it displays a huge list of typepaths.
Literally none of the typepaths are short enough that they even fit in the window, and the data about what the ability actually is usually lies at the end of the typepath.
This is clearly silly.

I made it look like this instead:
![image](https://github.com/tgstation/tgstation/assets/7483112/13af9a9c-39b5-4a47-8ae4-3f6ac242f9f9)

Now you see the name _and_ the typepath (it's still useful information in cases where there are several similar abilities).
Also I gave the lobster charge ability its own name because it didn't have one.

## Why It's Good For The Game

Increases usability of this admin feature.

## Changelog

:cl:
admin: The Add Mob Ability menu now prefixes the typepath of the ability with the ability's name, so you can much more quickly see what the ability is.
/:cl: