### PR TITLE
Iron Rods no Longer Say They Take Energy for Cyborgs

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -153,7 +153,7 @@
 
 /obj/item/stack/grind_requirements()
 	if(is_cyborg)
-		to_chat(usr, span_warning("[src] is electronically synthesized in your chassis and can't be ground up!"))
+		to_chat(usr, span_warning("[src] is too integrated into your chassis and can't be ground up!"))
 		return
 	return TRUE
 
@@ -187,9 +187,9 @@
 	. = ..()
 	if(is_cyborg)
 		if(singular_name)
-			. += "There is enough energy for [get_amount()] [singular_name]\s."
+			. += "There are enough materials for [get_amount()] [singular_name]\s."
 		else
-			. += "There is enough energy for [get_amount()]."
+			. += "There are enough materials for [get_amount()]."
 		return
 	if(singular_name)
 		if(get_amount()>1)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -186,10 +186,6 @@
 /obj/item/stack/examine(mob/user)
 	. = ..()
 	if(is_cyborg)
-		if(singular_name)
-			. += "There are enough materials for [get_amount()] [singular_name]\s."
-		else
-			. += "There are enough materials for [get_amount()]."
 		return
 	if(singular_name)
 		if(get_amount()>1)


### PR DESCRIPTION
## About The Pull Request

Removes the "enough energy" description from when borgs look at their materials

## Why It's Good For The Game

They don't use energy anymore.

## Changelog
:cl: Vect0r
spellcheck: fixed a few typos
/:cl:
 