### PR TITLE
[NO GBP] Fixing a minor mistake with update_transform()

### DIFF
--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -8,7 +8,7 @@
 	/**
 	 * pixel x/y/w/z all discard values after the decimal separator.
 	 * That, coupled with the rendered interpolation, may make the
-	 * icons look awfuller than they would normally already be.
+	 * icons look awfuller than they already are, or not, whatever.
 	 * The solution to this nit is translating the missing decimals.
 	 * also flooring increases the distance from 0 for negative numbers.
 	 */

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -15,8 +15,9 @@
 	var/abs_pixel_y_offset = 0
 	var/translate = 0
 	if(current_size != RESIZE_DEFAULT_SIZE)
-		abs_pixel_y_offset = abs(get_pixel_y_offset_standing(current_size))
-		translate = (abs_pixel_y_offset - round(abs_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
+		var/standing_offset = get_pixel_y_offset_standing(current_size)
+		abs_pixel_y_offset = abs(standing_offset)
+		translate = (abs_pixel_y_offset - round(abs_pixel_y_offset)) * SIGN(standing_offset)
 	var/final_dir = dir
 	var/changed = FALSE
 

--- a/code/modules/mob/living/living_update_icons.dm
+++ b/code/modules/mob/living/living_update_icons.dm
@@ -12,8 +12,11 @@
 	 * The solution to this nit is translating the missing decimals.
 	 * also flooring increases the distance from 0 for negative numbers.
 	 */
-	var/abs_pixel_y_offset = abs(body_position_pixel_y_offset)
-	var/translate = (abs_pixel_y_offset - round(abs_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
+	var/abs_pixel_y_offset = 0
+	var/translate = 0
+	if(current_size != RESIZE_DEFAULT_SIZE)
+		abs_pixel_y_offset = abs(get_pixel_y_offset_standing(current_size))
+		translate = (abs_pixel_y_offset - round(abs_pixel_y_offset)) * SIGN(body_position_pixel_y_offset)
 	var/final_dir = dir
 	var/changed = FALSE
 
@@ -21,10 +24,11 @@
 		changed = TRUE
 		ntransform.TurnTo(lying_prev, lying_angle)
 		if(lying_angle && lying_prev == 0)
-			ntransform.Translate(0, -translate)
+			if(translate)
+				ntransform.Translate(0, -translate)
 			if(dir & (EAST|WEST)) //Standing to lying and facing east or west
 				final_dir = pick(NORTH, SOUTH) //So you fall on your side rather than your face or ass
-		else if(!lying_angle && lying_prev != 0)
+		else if(translate && !lying_angle && lying_prev != 0)
 			ntransform.Translate(0, translate)
 
 	if(resize != RESIZE_DEFAULT_SIZE)


### PR DESCRIPTION
## About The Pull Request
Well, while the translation for lying/standing from #77619 is supposed to work using the decimal place of whatever value the `body_position_pixel_y_offset` variable should be while the mob is in standing position (basically, `get_pixel_y_offset_standing()`), for a fleeting moment idiocy took the better of me, and instead I just used `body_position_pixel_y_offset` (which is of a different value when the mob is lying down), resulting in resized mobs slooowly ascending (if bigger) or descending (if smaller) each time they stood up.

Also taking a few seconds to add some `if` checks to avoid running these operations for the wide majority of mobs, which have a default size of 1 anyway.

~~I hope I won't have to make further such PRs for a while.~~

## Why It's Good For The Game
Read above.

## Changelog
N/A