### PR TITLE
Fixes vents having "infinite" pressure caps.

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -75,10 +75,6 @@
 	if((input_starting_pressure < VOLUME_PUMP_MINIMUM_OUTPUT_PRESSURE) || ((output_starting_pressure > VOLUME_PUMP_MAX_OUTPUT_PRESSURE)) && !overclocked)
 		return
 
-	if(overclocked && (output_starting_pressure-input_starting_pressure > VOLUME_PUMP_OVERPRESSURE_ALLOWANCE))//Overclocked pumps can only force gas a certain amount.
-		return
-
-
 	var/transfer_ratio = transfer_rate / air1.volume
 
 	var/datum/gas_mixture/removed = air1.remove_ratio(transfer_ratio)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -171,6 +171,8 @@
 
 		if(pressure_delta > 0)
 			if(air_contents.temperature > 0)
+				if(environment_pressure >= 50 * ONE_ATMOSPHERE)
+					return FALSE
 				var/transfer_moles = (pressure_delta * environment.volume) / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
 				var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 
@@ -188,6 +190,8 @@
 			pressure_delta = min(pressure_delta, (internal_pressure_bound - air_contents.return_pressure()))
 
 		if(pressure_delta > 0 && environment.temperature > 0)
+			if(air_contents.return_pressure() >= 50 * ONE_ATMOSPHERE)
+				return FALSE
 			var/transfer_moles = (pressure_delta * air_contents.volume) / (environment.temperature * R_IDEAL_GAS_EQUATION)
 
 			var/datum/gas_mixture/removed = loc.remove_air(transfer_moles)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Unary vents didn't have a pressure cap on either pressuring or siphoning mode.
This allowed 2 unintended behaviours that are now fixed:

The first is that unary vents on pressuring mode would work as "better" Injectors, there is some small pros and cons to each, but we shouldn't have 2 atmos devices that achieve the same goal of "put as much pressure as you have available gas" into a tile.

The second is that while on siphoning mode it could bypass the pressure caps other atmos pressure/volume pumps have and "put as much pressure as you have available gas" into pipelines, canisters, etc.

## Mid PR changes

As it was requested to add a new way to achieve infinite pressure, volume pumps that are overclocked will not have a pressure cap anymore in the most streamlined way for new and veteran players.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Atmos has a lot of cheese strats that we can use to achieve goals, it is part of the charm in mastering the system for a lot of players and it does add some interesting mentoring scenarios where an Elder Atmosian teaches Eldritch pipe knowledge to new players.

But then it comes the problem that a lot of these are unintented and thus are not taken in consideration when doing important balance changes, contradict other "atmos logic", are secret club knowledge that can only be passed from player to player, etc, etc.

The "put infinite pressure on a tile" change is not that important, as that is the injectors' job already.

Now the "put infinite pressure on a pipeline" is something unique (As far as I'm aware since I purposely avoid learning Eldritch atmos tricks) and it is used to achieve a few goals like high temperature/pressure burns.

This one is kinda sad to lose, but if we are going to have an atmos machinery that allows us to "put infinite pressure on a pipeline" that should be in the tin, new players should look into the device and know what atmos goals they can achieve with it, future coders should take that balance in consideration, etc, etc.

And as it was requested to keep the old trick in game, volume pumps do not have a pressure cap anymore.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Guillaume Prata
fix: Unary vents have a pressure cap on both their pressuring and siphoning mode now, preventing the bypass trick of putting "infinite" pressure on tiles/pipelines.
balance: Overclocked Volume Pumps do not have a pressure cap anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
