### PR TITLE
Fixes an issue with eyes not properly storing the old_eye_color var

### DIFF
--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -40,7 +40,9 @@
 	var/eye_color_left = "" //set to a hex code to override a mob's left eye color
 	var/eye_color_right = "" //set to a hex code to override a mob's right eye color
 	var/eye_icon_state = "eyes"
+	/// The color of the previous left eye before this one was inserted
 	var/old_eye_color_left = "fff"
+	/// The color of the previous right eye before this one was inserted
 	var/old_eye_color_right = "fff"
 
 	/// Glasses cannot be worn over these eyes. Currently unused
@@ -51,16 +53,23 @@
 	var/native_fov = FOV_90_DEGREES
 
 /obj/item/organ/internal/eyes/Insert(mob/living/carbon/eye_recipient, special = FALSE, drop_if_replaced = FALSE)
+	if(ishuman(eye_recipient))
+		var/mob/living/carbon/human/human_recipient = eye_recipient
+		old_eye_color_left = human_recipient.eye_color_left
+		old_eye_color_right = human_recipient.eye_color_right
+
 	. = ..()
+
 	if(!.)
 		return
+
 	eye_recipient.cure_blind(NO_EYES)
 	apply_damaged_eye_effects()
-	refresh(eye_recipient, inserting = TRUE, call_update = TRUE)
+	refresh(eye_recipient, call_update = TRUE)
 
 /// Refreshes the visuals of the eyes
 /// If call_update is TRUE, we also will call update_body
-/obj/item/organ/internal/eyes/proc/refresh(mob/living/carbon/eye_owner = owner, inserting = FALSE, call_update = TRUE)
+/obj/item/organ/internal/eyes/proc/refresh(mob/living/carbon/eye_owner = owner, call_update = TRUE)
 	owner.update_sight()
 	owner.update_tint()
 
@@ -68,9 +77,6 @@
 		return
 
 	var/mob/living/carbon/human/affected_human = eye_owner
-	if(inserting) // we only want to be setting old_eye_color the one time
-		old_eye_color_left = affected_human.eye_color_left
-		old_eye_color_right = affected_human.eye_color_right
 	if(initial(eye_color_left))
 		affected_human.eye_color_left = eye_color_left
 	else
@@ -420,9 +426,10 @@
 		return
 	deactivate(close_ui = TRUE)
 
-/// We have to do this here because on_insert gets called before refresh(), which we need to have been called for old_eye_color vars to be set
+/// Set the initial color of the eyes on insert to be the mob's previous eye color.
 /obj/item/organ/internal/eyes/robotic/glow/Insert(mob/living/carbon/eye_recipient, special = FALSE, drop_if_replaced = FALSE)
 	. = ..()
+	current_color_string = old_eye_color_left
 	current_left_color_string = old_eye_color_left
 	current_right_color_string = old_eye_color_right
 

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -53,7 +53,7 @@
 	var/native_fov = FOV_90_DEGREES
 
 /obj/item/organ/internal/eyes/Insert(mob/living/carbon/eye_recipient, special = FALSE, drop_if_replaced = FALSE)
-	// If we don't do this before everything else, heterochromia will be reset and we will get the wrong eye_color_right for mobs who had it
+	// If we don't do this before everything else, heterochromia will be reset leading to eye_color_right no longer being accurate
 	if(ishuman(eye_recipient))
 		var/mob/living/carbon/human/human_recipient = eye_recipient
 		old_eye_color_left = human_recipient.eye_color_left

--- a/code/modules/surgery/organs/internal/eyes/_eyes.dm
+++ b/code/modules/surgery/organs/internal/eyes/_eyes.dm
@@ -53,6 +53,7 @@
 	var/native_fov = FOV_90_DEGREES
 
 /obj/item/organ/internal/eyes/Insert(mob/living/carbon/eye_recipient, special = FALSE, drop_if_replaced = FALSE)
+	// If we don't do this before everything else, heterochromia will be reset and we will get the wrong eye_color_right for mobs who had it
 	if(ishuman(eye_recipient))
 		var/mob/living/carbon/human/human_recipient = eye_recipient
 		old_eye_color_left = human_recipient.eye_color_left


### PR DESCRIPTION
## About The Pull Request

Somewhere down the line with all the refactors the code that saved the previous eyes' color stopped working.

This just fixes it. It's used for things such as qol for the high luminosity eyes. It can be considered a fix and QoL alike but I'm going to label it as QoL.

![image](https://github.com/tgstation/tgstation/assets/13398309/74645c3a-92de-4ae0-86e4-f0d011549da0)

## Why It's Good For The Game

Restores previous functionality that was lost in a refactor

## Changelog

:cl:
qol: inserting new high luminosity eyes will now properly remember the previous eyes' color and default to that initially
/:cl:
