### PR TITLE
makes syndie modsuits not be irrevocably destroyed merely by being on fire

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -954,6 +954,7 @@
 	slowdown_inactive = 1
 	slowdown_active = 0.5
 	ui_theme = "syndicate"
+	resistance_flags = FIRE_PROOF
 	inbuilt_modules = list(/obj/item/mod/module/armor_booster)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,


### PR DESCRIPTION

## About The Pull Request

gives them FIRE_PROOF resistance flag
like every modsuit has that flag anyway

## Why It's Good For The Game

dropping your entire modsuits contents while fighting bad
fixes #77690

## Changelog
:cl:
fix: you can no longer destroy syndicate modsuits by just being on fire
/:cl:
