### PR TITLE
Adjusts martian fried noodles recipe.

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_martian.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_martian.dm
@@ -188,7 +188,7 @@
 	name = "Martian fried noodles"
 	reqs = list(
 		/obj/item/food/spaghetti/boilednoodles = 1,
-		/obj/item/food/peanuts/salted = 1,
+		/obj/item/food/grown/peanut = 2,
 		/obj/item/food/meat/cutlet = 1,
 		/obj/item/food/onion_slice = 1,
 		/obj/item/food/egg = 1,


### PR DESCRIPTION


## About The Pull Request

I saw a few people murmuring about the recipe for martian fried noodles being a bit impractical due to the randomness of getting salted peanuts. 

## Why It's Good For The Game

Uhhh, yummy food is good and yummy food should be accessible. Also, it promotes cross-departmental interactions. Maints like hearing that, right?

## Changelog

:cl:
qol: Martian fried noodles now requires 2 grown peanuts instead of salted peanut packet.
/:cl: