### PR TITLE
Fixes lavaland beach bartender closets.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -524,18 +524,7 @@
 /turf/closed/wall/mineral/sandstone,
 /area/ruin/powered/beach)
 "qK" = (
-/obj/structure/closet/secure_closet{
-	icon_state = "cabinet";
-	name = "bartender's closet";
-	req_access = list("bar")
-	},
-/obj/item/clothing/shoes/sandal{
-	desc = "A very fashionable pair of flip-flops.";
-	name = "flip-flops"
-	},
-/obj/item/clothing/neck/beads,
-/obj/item/clothing/glasses/sunglasses/reagent,
-/obj/item/clothing/suit/costume/hawaiian,
+/obj/structure/closet/secure_closet/bar/lavaland_bartender_clothes,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
@@ -960,34 +949,7 @@
 /turf/open/floor/iron/stairs/left,
 /area/ruin/powered/beach)
 "HW" = (
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/vending_refill/cigarette,
-/obj/item/vending_refill/boozeomat,
-/obj/structure/closet/secure_closet{
-	icon_state = "cabinet";
-	name = "booze storage";
-	req_access = list("bar")
-	},
-/obj/item/storage/backpack/duffelbag,
-/obj/item/etherealballdeployer,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/bottle/beer/light,
-/obj/item/reagent_containers/cup/glass/colocup,
-/obj/item/reagent_containers/cup/glass/colocup,
-/obj/item/reagent_containers/cup/glass/colocup,
-/obj/item/reagent_containers/cup/glass/colocup,
-/obj/item/reagent_containers/cup/glass/colocup,
+/obj/structure/closet/secure_closet/bar/lavaland_bartender_booze,
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "Il" = (
@@ -1223,10 +1185,7 @@
 /obj/item/storage/backpack/duffelbag,
 /obj/item/clothing/under/shorts/blue,
 /obj/item/clothing/suit/costume/ianshirt,
-/obj/item/clothing/shoes/sandal{
-	desc = "A very fashionable pair of flip-flops.";
-	name = "flip-flops"
-	},
+/obj/item/clothing/shoes/sandal/beach,
 /obj/item/clothing/glasses/sunglasses,
 /obj/item/clothing/neck/beads,
 /turf/open/floor/wood,

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -14,9 +14,29 @@
 /obj/structure/closet/secure_closet/bar/PopulateContents()
 	..()
 	for(var/i in 1 to 10)
-		new /obj/item/reagent_containers/cup/glass/bottle/beer( src )
+		new /obj/item/reagent_containers/cup/glass/bottle/beer(src)
 	new /obj/item/etherealballdeployer(src)
 	new /obj/item/roulette_wheel_beacon(src)
 
 /obj/structure/closet/secure_closet/bar/all_access
 	req_access = null
+
+/obj/structure/closet/secure_closet/bar/lavaland_bartender_booze/PopulateContents()
+	new /obj/item/vending_refill/cigarette(src)
+	new /obj/item/vending_refill/boozeomat(src)
+	new /obj/item/storage/backpack/duffelbag(src)
+	new /obj/item/etherealballdeployer(src)
+	for(var/i in 1 to 14)
+		new /obj/item/reagent_containers/cup/glass/bottle/beer/light(src)
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/cup/glass/colocup(src)
+
+/obj/structure/closet/secure/closet/bar/lavaland_bartender_clothes
+	name = "bartender's closet"
+
+/obj/structure/closet/secure_closet/bar/lavaland_bartender_clothes/PopulateContents()
+	new /obj/item/clothing/neck/beads(src)
+	new /obj/item/clothing/glasses/sunglasses/reagent(src)
+	new /obj/item/clothing/suit/costume/hawaiian(src)
+	new /obj/item/clothing/shoes/sandal/beach(src)
+

--- a/code/modules/clothing/shoes/sandals.dm
+++ b/code/modules/clothing/shoes/sandals.dm
@@ -18,3 +18,7 @@
 	name = "magical sandals"
 	desc = "A pair of sandals imbued with magic."
 	resistance_flags = FIRE_PROOF | ACID_PROOF
+
+/obj/item/clothing/shoes/sandal/beach
+	name = "flip-flops"
+	desc = "A very fashionable pair of flip-flops."


### PR DESCRIPTION

## About The Pull Request
I subtyped the closets under bar closet as we have no wooden closet subtype which is stupid, and this may not be the best solution. But hey, now it's not varedited just in the map.
Fixes https://github.com/tgstation/tgstation/issues/76943.
## Changelog
:cl:
fix: fixed lavaland beach bartender closets looking off.
/:cl:
