### PR TITLE
fixes some grammar and missing servo from the ripley MK2 upgrade

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -378,6 +378,11 @@
 		marktwo.capacitor = markone.capacitor
 		markone.capacitor.forceMove(marktwo)
 		markone.capacitor = null
+	QDEL_NULL(marktwo.servo)
+	if (markone.servo)
+		marktwo.servo = markone.servo
+		markone.servo.forceMove(marktwo)
+		markone.servo = null
 	marktwo.update_part_values()
 	for(var/obj/item/mecha_parts/mecha_equipment/equipment in markone.flat_equipment) //Move the equipment over...
 		if(istype(equipment, /obj/item/mecha_parts/mecha_equipment/ejector))

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -255,7 +255,7 @@
 			if(!user.transferItemToLoc(weapon, src, silent = FALSE))
 				return
 			cell = weapon
-			balloon_alert(user, "intalled power cell")
+			balloon_alert(user, "installed power cell")
 			diag_hud_set_mechcell()
 			playsound(src, 'sound/items/screwdriver2.ogg', 50, FALSE)
 			log_message("Power cell installed", LOG_MECHA)
@@ -268,7 +268,7 @@
 			if(!user.transferItemToLoc(weapon, src, silent = FALSE))
 				return
 			scanmod = weapon
-			balloon_alert(user, "intalled scanning module")
+			balloon_alert(user, "installed scanning module")
 			playsound(src, 'sound/items/screwdriver2.ogg', 50, FALSE)
 			log_message("[weapon] installed", LOG_MECHA)
 			update_part_values()
@@ -281,7 +281,7 @@
 			if(!user.transferItemToLoc(weapon, src, silent = FALSE))
 				return
 			capacitor = weapon
-			balloon_alert(user, "intalled capacitor")
+			balloon_alert(user, "installed capacitor")
 			playsound(src, 'sound/items/screwdriver2.ogg', 50, FALSE)
 			log_message("[weapon] installed", LOG_MECHA)
 			update_part_values()
@@ -294,7 +294,7 @@
 			if(!user.transferItemToLoc(weapon, src, silent = FALSE))
 				return
 			servo = weapon
-			balloon_alert(user, "intalled servo")
+			balloon_alert(user, "installed servo")
 			playsound(src, 'sound/items/screwdriver2.ogg', 50, FALSE)
 			log_message("[weapon] installed", LOG_MECHA)
 			update_part_values()


### PR DESCRIPTION

## About The Pull Request

MK2 upgrade now transfers servo
"intalled" -> "installed"

## Why It's Good For The Game

fixes #77677

## Changelog
:cl:
fix: ripley MK2 upgrade now properly transfers servos
spellcheck: inserting parts into mechas now properly says "installed" instead of "intalled"
/:cl:
