### PR TITLE
[no gbp] Adds missing chat feedback to watcher abilities

### DIFF
--- a/code/modules/mob/living/basic/lavaland/watcher/watcher_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher_ai.dm
@@ -18,6 +18,9 @@
 	ability_key = BB_WATCHER_OVERWATCH
 
 /datum/ai_planning_subtree/targeted_mob_ability/overwatch/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
+	var/mob/living/living_pawn = controller.pawn
+	if (LAZYLEN(living_pawn.do_afters))
+		return // Don't interrupt our other ability
 	var/atom/target = controller.blackboard[target_key]
 	if (QDELETED(target) || HAS_TRAIT(target, TRAIT_OVERWATCH_IMMUNE))
 		return // We should probably let miners move sometimes

--- a/code/modules/mob/living/basic/lavaland/watcher/watcher_gaze.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher_gaze.dm
@@ -27,6 +27,7 @@
 	show_indicator_overlay("eye_open")
 	stage_timer = addtimer(CALLBACK(src, PROC_REF(show_indicator_overlay), "eye_pulse"), animation_time, TIMER_STOPPABLE)
 	StartCooldown(360 SECONDS, 360 SECONDS)
+	owner.visible_message(span_warning("[owner]'s eye glows ominously!"))
 	if (do_after(owner, delay = wait_delay, target = owner))
 		trigger_effect()
 	else
@@ -64,12 +65,15 @@
 		)
 		flick_overlay_global(flashed_overlay, show_to = GLOB.clients, duration = animation_time)
 	stage_timer = addtimer(CALLBACK(src, PROC_REF(hide_eye)), animation_time, TIMER_STOPPABLE)
+	var/mob/living/living_owner = owner
+	living_owner.Stun(1.5 SECONDS, ignore_canstun = TRUE)
 
 /// Do something bad to someone who was looking at us
 /datum/action/cooldown/mob_cooldown/watcher_gaze/proc/apply_effect(mob/living/viewer)
 	if (!viewer.flash_act(intensity = 4, affect_silicon = TRUE, visual = TRUE, length = 3 SECONDS))
 		return FALSE
 	viewer.set_confusion_if_lower(12 SECONDS)
+	to_chat(viewer, span_warning("You are blinded by [owner]'s piercing gaze!"))
 	return TRUE
 
 /// Animate our effect out
@@ -96,6 +100,7 @@
 	desc = "After a delay, burn and stun everyone looking at you."
 
 /datum/action/cooldown/mob_cooldown/watcher_gaze/fire/apply_effect(mob/living/viewer)
+	to_chat(viewer, span_warning("[owner]'s searing glare forces you to the ground!"))
 	viewer.Paralyze(3 SECONDS)
 	viewer.adjust_fire_stacks(10)
 	viewer.ignite_mob()
@@ -109,6 +114,7 @@
 	var/max_throw = 3
 
 /datum/action/cooldown/mob_cooldown/watcher_gaze/ice/apply_effect(mob/living/viewer)
+	to_chat(viewer, span_warning("You are repulsed by the force of [owner]'s cold stare!"))
 	viewer.apply_status_effect(/datum/status_effect/freon/watcher/extended)
 	viewer.safe_throw_at(
 		target = get_edge_target_turf(owner, get_dir(owner, get_step_away(viewer, owner))),

--- a/code/modules/mob/living/basic/lavaland/watcher/watcher_overwatch.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher_overwatch.dm
@@ -45,6 +45,7 @@
 	living_owner.face_atom(target)
 	living_owner.Stun(overwatch_duration, ignore_canstun = TRUE)
 	target.apply_status_effect(/datum/status_effect/overwatch, overwatch_duration, owner, projectile_type, projectile_sound)
+	owner.visible_message(span_warning("[owner]'s eye locks on to [target]!"))
 	StartCooldown()
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

I kept meaning to add this in my last PR and kept thinking "I'll add that in with these review changes" and then forgot every time. This should make it clearer what is happening to you and why.

Also I made the gaze ability stun the user for a short period after it goes off because them shooting you instantly after they stop channeling _is_ sort of bullshit.
Also while testing this I noticed the AI interrupt one of its actions to do the other one which is a bit silly so now it cannot do that.

## Why It's Good For The Game

Outlines in the log why something bad just happened to you.

## Changelog

:cl:
qol: Added some textual feedback to new watcher abilities
balance: Watchers will not attack for a short period following their gaze attack
fix: Watchers won't interrupt one ability to use the other one
/:cl:
