### PR TITLE
Adds a handful of Ninja Hacking MODule interactions of varying usefulness

### DIFF
--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -322,3 +322,25 @@
 		visible_message(span_danger("[ninja] electrocutes [src] with [ninja.p_their()] touch!"), span_userdanger("[ninja] electrocutes you with [ninja.p_their()] touch!"))
 		Knockdown(3 SECONDS)
 	return NONE
+
+//CAMERAS//
+/obj/machinery/camera/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if(!status)
+		balloon_alert(ninja, "camera offline!")
+		return
+
+	if(isEmpProof(TRUE))
+		balloon_alert(ninja, "camera is shielded!") //This wouldn't do anything otherwise so it's nice to have feedback
+		return
+
+	emp_act(EMP_HEAVY)
+
+//MEDIBOTS//
+/mob/living/simple_animal/bot/medbot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	var/static/list/worried_line = list(
+		MEDIBOT_VOICED_NO_SAD,
+		MEDIBOT_VOICED_OH_FUCK,
+	)
+	speak(pick(worried_line))
+	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), get_turf(src), 0, 1, 2, 3), 2.5 SECONDS)

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -430,3 +430,9 @@
 	emag_act(ninja)
 
 	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+//WINDOOR//
+/obj/machinery/door/window/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if(!operating && density && hasPower() && !(obj_flags & EMAGGED))
+		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, emag_act))
+	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -335,12 +335,25 @@
 
 	emp_act(EMP_HEAVY)
 
-//MEDIBOTS//
+//BOTS//
+/mob/living/simple_animal/bot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
+	playsound(get_turf(src), 'sound/machines/warning-buzzer.ogg', 35, TRUE)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), get_turf(src), 0, 1, 2, 3), 2.5 SECONDS)
+
 /mob/living/simple_animal/bot/medbot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	var/static/list/worried_line = list(
 		MEDIBOT_VOICED_NO_SAD,
 		MEDIBOT_VOICED_OH_FUCK,
 	)
 	speak(pick(worried_line))
-	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), get_turf(src), 0, 1, 2, 3), 2.5 SECONDS)
+	. = ..()
+
+/obj/item/gun/energy/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if (do_after(ninja, 1 SECONDS, target = src))
+		hacking_module.mod.add_charge(cell.charge)
+		cell.charge = 0
+		update_appearance()
+		visible_message(span_warning("[ninja] drains the energy from the [src]!"))
+		do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
+		return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -337,12 +337,14 @@
 
 //BOTS//
 /mob/living/simple_animal/bot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 3))
+	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 7))
 		return
 
-	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
+	do_sparks(number = 3, cardinal_only = FALSE, source = src)
 	playsound(get_turf(src), 'sound/machines/warning-buzzer.ogg', 35, TRUE)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), get_turf(src), 0, 1, 2, 3), 2.5 SECONDS)
+	balloon_alert(ninja, "stand back!")
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), src, 0, 1, 2, 3), 2.5 SECONDS)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /mob/living/simple_animal/bot/medbot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	var/static/list/worried_line = list(
@@ -358,17 +360,32 @@
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	hacking_module.mod.add_charge(cell.charge)
+	hacking_module.charge_message(src, cell.charge)
 	cell.charge = 0
 	update_appearance()
 	visible_message(span_warning("[ninja] drains the energy from the [src]!"))
-	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
+	do_sparks(number = 3, cardinal_only = FALSE, source = src)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 //VENDING MACHINES//
 /obj/machinery/vending/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 2))
-		return
+	if(shoot_inventory)
+		balloon_alert(ninja, "already hacked!")
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
-	wires.on_pulse(WIRE_THROW)
+	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 5))
+		balloon_alert(ninja, "not enough charge!")
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
+	do_sparks(number = 3, cardinal_only = FALSE, source = src)
 	visible_message(span_warning("[ninja] fires an arc of electricity from their gloves at [src], overloading it!"))
+	wires.on_pulse(WIRE_THROW)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/obj/machinery/recycler/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	AI_notify_hack()
+	if(!do_after(ninja, 20 SECONDS, target = src))
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+	emag_act(ninja)
+
+	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -337,7 +337,7 @@
 
 //BOTS//
 /mob/living/simple_animal/bot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 2))
+	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 3))
 		return
 
 	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
@@ -352,6 +352,7 @@
 	speak(pick(worried_line))
 	. = ..()
 
+//ENERGY WEAPONS//
 /obj/item/gun/energy/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!do_after(ninja, 1 SECONDS, target = src))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
@@ -362,3 +363,12 @@
 	visible_message(span_warning("[ninja] drains the energy from the [src]!"))
 	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+//VENDING MACHINES//
+/obj/machinery/vending/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 2))
+		return
+
+	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
+	wires.on_pulse(WIRE_THROW)
+	visible_message(span_warning("[ninja] fires an arc of electricity from their gloves at [src], overloading it!"))

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -338,7 +338,7 @@
 //BOTS//
 /mob/living/simple_animal/bot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	to_chat(src, span_boldwarning("Your circutry suddenly begins heating up!"))
-	if(!do_after(ninja, 2 SECONDS, target = src))
+	if(!do_after(ninja, 1.5 SECONDS, target = src))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 7))
@@ -434,7 +434,7 @@
 
 	AI_notify_hack()
 
-	if(!do_after(ninja, 15 SECONDS, target = src)) //Shorter due to how incredibly easy it is for someone to (even accidentally) interrupt.
+	if(!do_after(ninja, 20 SECONDS, target = src)) //Shorter due to how incredibly easy it is for someone to (even accidentally) interrupt.
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	force_event(/datum/round_event_control/tram_malfunction, "ninja interference")

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -337,6 +337,9 @@
 
 //BOTS//
 /mob/living/simple_animal/bot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 2))
+		return
+
 	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
 	playsound(get_turf(src), 'sound/machines/warning-buzzer.ogg', 35, TRUE)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), get_turf(src), 0, 1, 2, 3), 2.5 SECONDS)
@@ -350,10 +353,12 @@
 	. = ..()
 
 /obj/item/gun/energy/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if (do_after(ninja, 1 SECONDS, target = src))
-		hacking_module.mod.add_charge(cell.charge)
-		cell.charge = 0
-		update_appearance()
-		visible_message(span_warning("[ninja] drains the energy from the [src]!"))
-		do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
+	if(!do_after(ninja, 1 SECONDS, target = src))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
+
+	hacking_module.mod.add_charge(cell.charge)
+	cell.charge = 0
+	update_appearance()
+	visible_message(span_warning("[ninja] drains the energy from the [src]!"))
+	do_sparks(number = 3, cardinal_only = FALSE, source = ninja)
+	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -334,6 +334,7 @@
 		return
 
 	emp_act(EMP_HEAVY)
+	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 //BOTS//
 /mob/living/simple_animal/bot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
@@ -347,15 +348,19 @@
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /mob/living/simple_animal/bot/medbot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	var/static/list/worried_line = list(
+	var/static/list/death_cry = list(
 		MEDIBOT_VOICED_NO_SAD,
 		MEDIBOT_VOICED_OH_FUCK,
 	)
-	speak(pick(worried_line))
+	speak(pick(death_cry))
 	. = ..()
 
 //ENERGY WEAPONS//
 /obj/item/gun/energy/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if(cell.charge == 0)
+		balloon_alert(ninja, "no energy!")
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
 	if(!do_after(ninja, 1 SECONDS, target = src))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
@@ -378,14 +383,50 @@
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	do_sparks(number = 3, cardinal_only = FALSE, source = src)
-	visible_message(span_warning("[ninja] fires an arc of electricity from their gloves at [src], overloading it!"))
+	balloon_alert(ninja, "system overloaded!")
 	wires.on_pulse(WIRE_THROW)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
+//RECYCLER//
 /obj/machinery/recycler/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	AI_notify_hack()
-	if(!do_after(ninja, 20 SECONDS, target = src))
+	if(obj_flags & EMAGGED)
+		balloon_alert(ninja, "already hacked!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
+
+	AI_notify_hack()
+	if(!do_after(ninja, 25 SECONDS, target = src))
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
+	do_sparks(3, cardinal_only = FALSE, source = hacking_module.mod)
+	emag_act(ninja)
+
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+//ELEVATOR CONTROLS//
+/obj/machinery/elevator_control_panel/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if(obj_flags & EMAGGED)
+		balloon_alert(ninja, "already hacked!")
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
+	if(!do_after(ninja, 5 SECONDS, target = src))
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
+	do_sparks(3, cardinal_only = FALSE, source = hacking_module.mod)
+	balloon_alert(ninja, "system overloaded!")
+	emag_act(ninja)
+
+	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+//TRAM CONTROLS//
+/obj/machinery/computer/tram_controls/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if(obj_flags & EMAGGED)
+		balloon_alert(ninja, "already hacked!")
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
+	AI_notify_hack()
+	if(!do_after(ninja, 30 SECONDS, target = src)) //Long hack duration, in a frequently travelled area. Completing this is, more than anything, an insult to the crew.
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+
 	emag_act(ninja)
 
 	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -447,3 +447,9 @@
 	if(!operating && density && hasPower() && !(obj_flags & EMAGGED))
 		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, emag_act))
 	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+//BUTTONS//
+/obj/machinery/button/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	if(is_operational && !(obj_flags & EMAGGED))
+		emag_act(ninja)
+	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -204,7 +204,7 @@
 /obj/machinery/door/airlock/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
 	if(!ninja || !hacking_module)
 		return NONE
-	if(!operating && density && hasPower() && !(obj_flags & EMAGGED))
+	if(!operating && density && hasPower() && !(obj_flags & EMAGGED) && hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 5))
 		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, emag_act))
 		hacking_module.door_hack_counter++
 		var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)
@@ -356,7 +356,7 @@
 		MEDIBOT_VOICED_OH_FUCK,
 	)
 	speak(pick(death_cry))
-	. = ..()
+	return ..()
 
 //ENERGY WEAPONS//
 /obj/item/gun/energy/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
@@ -445,7 +445,7 @@
 
 //WINDOOR//
 /obj/machinery/door/window/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if(!operating && density && hasPower() && !(obj_flags & EMAGGED))
+	if(!operating && density && hasPower() && !(obj_flags & EMAGGED) && hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 5))
 		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, emag_act))
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
@@ -454,3 +454,7 @@
 	if(is_operational && !(obj_flags & EMAGGED))
 		emag_act(ninja)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+//FIRELOCKS//
+/obj/machinery/door/firedoor/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	crack_open()

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -337,6 +337,7 @@
 
 //BOTS//
 /mob/living/simple_animal/bot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
+	to_chat(src, span_boldwarning("Your circutry suddenly begins heating up!"))
 	if(!do_after(ninja, 2 SECONDS, target = src))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -422,7 +422,7 @@
 
 //TRAM CONTROLS//
 /obj/machinery/computer/tram_controls/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	var/datum/round_event/tram_malfunction/malfunction_event = locate(/datum/round_event/tram_malfunction) in SSevents.running	//If we have a tram malfunction in progress, we extend it. Otherwise, we create one and lengthen its duration.
+	var/datum/round_event/tram_malfunction/malfunction_event = locate(/datum/round_event/tram_malfunction) in SSevents.running
 	if(malfunction_event)
 		balloon_alert(ninja, "tram is already malfunctioning!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
@@ -433,7 +433,7 @@
 
 	AI_notify_hack()
 
-	if(!do_after(ninja, 15 SECONDS, target = src)) //Shorter due to how incredibly easy it is for someone to (even unintentionally) interrupt.
+	if(!do_after(ninja, 15 SECONDS, target = src)) //Shorter due to how incredibly easy it is for someone to (even accidentally) interrupt.
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	force_event(/datum/round_event_control/tram_malfunction, "ninja interference")

--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -337,7 +337,7 @@
 
 //BOTS//
 /mob/living/simple_animal/bot/ninjadrain_act(mob/living/carbon/human/ninja, obj/item/mod/module/hacker/hacking_module)
-	if(!do_after(ninja, 1.5 SECONDS, target = src))
+	if(!do_after(ninja, 2 SECONDS, target = src))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 7))
@@ -363,7 +363,7 @@
 		balloon_alert(ninja, "no energy!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if(!do_after(ninja, 1 SECONDS, target = src))
+	if(!do_after(ninja, 1.5 SECONDS, target = src))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	hacking_module.mod.add_charge(cell.charge)
@@ -380,7 +380,7 @@
 		balloon_alert(ninja, "already hacked!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if(!do_after(ninja, 1 SECONDS, target = src))
+	if(!do_after(ninja, 2 SECONDS, target = src))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	if(!hacking_module.mod.subtract_charge(DEFAULT_CHARGE_DRAIN * 5))


### PR DESCRIPTION
## About The Pull Request

Adds a few new interactions with the Ninja's ~~right click multipurpose trolling tool~~ Hacking MOD Module. These new effects are not tied to objectives and are geared towards expanding the ninja's access, disabling equipment, and giving them more ways to punk the crew.

### **Useful additions**
Ninjas can now hack open **windoors** and **elevator control panels**. Both trigger emag_act() when hacked, opening in the case of the windoor, and disabling the access restrictions _(and also maybe the safeties)_ in the case of the elevator controls.

**Buttons** can also be emagged by the hacking modules, which removes their access restrictions.

Hacking a **camera** will now EMP it, disabling it for about 90 seconds. This can especially useful when trying to complete objectives, and works better than smashing the cameras with your sword or lugging around tools.

**Firelocks** can be right-click opened now too, thanks to the hacking MODule.

**Energy guns** of all variety, useless to a ninja since they can't use ranged weapons, can now be drained and used to charge your suit. This takes a brief do_after to complete, so pulling it off mid-combat may be as risky as it is stylish. 

### **Being a nuisance**

**Vendors** can be hacked, expending some charge to trigger the "throw" wire, making it launch inventory at anyone who passes by.

You can now hack **simplebots**, expending some charge from your suit to overload and detonate them. It's faster than tipping, and far more tragic. Sentient simplebots should take care when a ninja is around.

### **Sabotage opportunities**

The **recycler** can now be hacked. This takes 30 seconds and notifies the AI, just like the communications console hack. Completing the hack will emag it. That's it.

Hacking the **tram control console** will trigger an extended Tram Malfunction event, and can be repeated after the event is done. This can only be done to the "main" tram of the map, which I forsee will be an absolute nightmare to complete on highpop tramstation.

Neither of these, presently, contribute towards any objectives. They can be useful for diverting attention, but I see them more as ways for an overachieving ninja to flex or continue the chaos after their objectives are complete.

### **OH ALSO**

Hacking open doors costs energy. This really shouldn't be an issue just remember to recharge sometimes.

The charge drains and do_after lengths for all of these were chosen on vibes. In all honesty I think the drainage values don't _really_ matter, due to how easy recharging is, but I had a hard time settling on how long some of these hack do_afters should take (even if I know they probably won't matter either).

## Why It's Good For The Game

Being able to hack open airlocks but not windoors always irked me. I figured that they would be openable like any other door, and that losing their status as a "-1 dash charge gate" wouldn't be a big enough balance change to spark arguments. The same philosophy extends to buttons and elevator controls.

Sapping power from eguns expands on the list of sources energy can be siphoned from. You can also use it to disarm opponents (like the badass ninja you are), take emergency charge from a recently-gored officer's disabler, or dunk on security by draining their entire armory.

Hacking simplebots, vendors, and by extension elevator lifts (since that also disables the safeties!) give opportunities for minor sabotage. Not meant to be super disruptive, just a bit silly and annoying for the crew.

The recycler/tram hacking in particular are meant to be bonus goals, only sought out by the ballsiest (or more likely boredest) of ninjas. 

I see all of these additions as expanding upon the current abilities of the ninja (not really making them much more powerful, just expanding their flexibility), or providing more interactions to have fun (and antagonize the crew) with when not mainlining their objectives.
## Changelog
:cl: Rhials
add: Ninjas can now temporarily disable cameras with the Ninja MOD right-click hacking ability.
add: Ninjas can emag windoors, elevator controls, and buttons with their hacking ability.
add: Ninjas can drain the power from energy weaponry, adding the charge to their MODsuit.
add: Ninjas can now hack simplebots, overloading and detonating them after a brief delay.
add: Ninjas can now hack vendors, causing them to eject their inventory at people.
add: Ninjas can now hack the recycler, which notifies the AI and emags it once complete.
add: Ninjas can now trigger an extended tram malfunction by hacking the tram control console.
add: Ninjas can now hack open firelocks (temporarily) with right-click.
balance: Hacking open doors with the Ninja Hacking MODule will subtract a paltry amount of energy from your suit.
/:cl:
