### PR TITLE
[no gbp] Lavaland should no longer spawn one million goliaths and watchers

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -136,6 +136,8 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 
 #define ismining(A) (istype(A, /mob/living/simple_animal/hostile/asteroid) || istype(A, /mob/living/basic/mining))
 
+#define blocksminingmobspawn(A) (ismining(A) || istype(A, /obj/effect/spawner/random/lavaland_mob))
+
 //Simple animals
 #define isanimal(A) (istype(A, /mob/living/simple_animal))
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -136,8 +136,6 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 
 #define ismining(A) (istype(A, /mob/living/simple_animal/hostile/asteroid) || istype(A, /mob/living/basic/mining))
 
-#define blocksminingmobspawn(A) (ismining(A) || istype(A, /obj/effect/spawner/random/lavaland_mob))
-
 //Simple animals
 #define isanimal(A) (istype(A, /mob/living/simple_animal))
 

--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -158,12 +158,15 @@
 				for(var/obj/structure/spawner/lavaland/spawn_blocker in range(2, turf))
 					can_spawn = FALSE
 					break
-			// if the random is not a tendril (hopefully meaning it is a mob), avoid spawning if there's anything which blocks mob spawns within 12 tiles
+			// if the random is not a tendril (hopefully meaning it is a mob), avoid spawning if there's another one within 12 tiles
 			else
-				for(var/atom/mob_blocker in range(12, turf))
-					if(blocksminingmobspawn(mob_blocker))
+				var/list/things_in_range = range(12, turf)
+				for(var/mob/living/mob_blocker in things_in_range)
+					if(ismining(mob_blocker))
 						can_spawn = FALSE
 						break
+				// Also block spawns if there's a random lavaland mob spawner nearby
+				can_spawn = can_spawn && !(locate(/obj/effect/spawner/random/lavaland_mob) in things_in_range)
 			//if there's a megafauna within standard view don't spawn anything at all (This isn't really consistent, I don't know why we do this. you do you tho)
 			if(can_spawn)
 				for(var/mob/living/simple_animal/hostile/megafauna/found_fauna in range(7, turf))
@@ -180,4 +183,5 @@
 		CHECK_TICK
 
 	var/message = "[name] terrain population finished in [(REALTIMEOFDAY - start_time)/10]s!"
+	to_chat(world, span_boldannounce("[message]"))
 	log_world(message)

--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -158,10 +158,10 @@
 				for(var/obj/structure/spawner/lavaland/spawn_blocker in range(2, turf))
 					can_spawn = FALSE
 					break
-			//if the random is a standard mob, avoid spawning if there's another one within 12 tiles
-			else if(isminingpath(picked_mob))
-				for(var/mob/living/mob_blocker in range(12, turf))
-					if(ismining(mob_blocker))
+			// if the random is not a tendril (hopefully meaning it is a mob), avoid spawning if there's anything which blocks mob spawns within 12 tiles
+			else
+				for(var/atom/mob_blocker in range(12, turf))
+					if(blocksminingmobspawn(mob_blocker))
 						can_spawn = FALSE
 						break
 			//if there's a megafauna within standard view don't spawn anything at all (This isn't really consistent, I don't know why we do this. you do you tho)
@@ -180,5 +180,4 @@
 		CHECK_TICK
 
 	var/message = "[name] terrain population finished in [(REALTIMEOFDAY - start_time)/10]s!"
-	to_chat(world, span_boldannounce("[message]"))
 	log_world(message)

--- a/code/datums/mapgen/Cavegens/LavalandGenerator.dm
+++ b/code/datums/mapgen/Cavegens/LavalandGenerator.dm
@@ -4,13 +4,13 @@
 
 	weighted_mob_spawn_list = list(
 		SPAWN_MEGAFAUNA = 2,
+		/obj/effect/spawner/random/lavaland_mob/goliath = 50,
+		/obj/effect/spawner/random/lavaland_mob/legion = 30,
+		/obj/effect/spawner/random/lavaland_mob/watcher = 40,
 		/mob/living/basic/mining/bileworm = 20,
-		/obj/effect/spawner/random/goliath = 50,
 		/mob/living/basic/mining/lobstrosity/lava = 20,
-		/obj/effect/spawner/random/watcher = 40,
 		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,
 		/mob/living/simple_animal/hostile/asteroid/goldgrub = 10,
-		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/random = 30,
 		/obj/structure/spawner/lavaland = 2,
 		/obj/structure/spawner/lavaland/goliath = 3,
 		/obj/structure/spawner/lavaland/legion = 3,

--- a/code/game/objects/effects/spawners/random/lavaland_mobs.dm
+++ b/code/game/objects/effects/spawners/random/lavaland_mobs.dm
@@ -1,0 +1,51 @@
+
+/// For map generation, has a chance to instantiate as a special subtype
+/obj/effect/spawner/random/lavaland_mob
+	name = "random lavaland mob"
+	desc = "Spawns a random lavaland mob."
+	icon = 'icons/mob/simple/lavaland/lavaland_monsters.dmi'
+	icon_state = "large_egg"
+	loot = list(
+		/mob/living/basic/mining/bileworm = 1,
+		/mob/living/basic/mining/goliath = 1,
+		/mob/living/basic/mining/lobstrosity/lava = 1,
+		/mob/living/basic/mining/watcher = 1,
+		/mob/living/simple_animal/hostile/asteroid/brimdemon = 1,
+		/mob/living/simple_animal/hostile/asteroid/goldgrub = 1,
+		/mob/living/simple_animal/hostile/asteroid/hivelord/legion = 1,
+	)
+
+/// Spawns random watcher variants during map generation
+/obj/effect/spawner/random/lavaland_mob/watcher
+	name = "random watcher"
+	desc = "Chance to spawn a rare shiny version."
+	icon = 'icons/mob/simple/lavaland/lavaland_monsters_wide.dmi'
+	icon_state = "watcher"
+	pixel_x = -12
+	loot = list(
+		/mob/living/basic/mining/watcher = 80,
+		/mob/living/basic/mining/watcher/magmawing = 15,
+		/mob/living/basic/mining/watcher/icewing = 5,
+	)
+
+/// Spawns random goliath variants during map generation
+/obj/effect/spawner/random/lavaland_mob/goliath
+	name = "random goliath"
+	desc = "Chance to spawn a rare shiny version."
+	icon = 'icons/mob/simple/lavaland/lavaland_monsters_wide.dmi'
+	icon_state = "goliath"
+	pixel_x = -12
+	loot = list(
+		/mob/living/basic/mining/goliath = 99,
+		/mob/living/basic/mining/goliath/ancient/immortal = 1,
+	)
+
+/// Spawns random legion variants during map generation
+/obj/effect/spawner/random/lavaland_mob/legion
+	name = "random legion"
+	desc = "Chance to spawn a rare shiny version."
+	icon_state = "legion"
+	loot = list(
+		/mob/living/simple_animal/hostile/asteroid/hivelord/legion = 19,
+		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf = 1,
+	)

--- a/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
@@ -222,15 +222,3 @@
 	desc = "This rough saddle will give you a serviceable seat upon a goliath! Provided you can get one to stand still."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "goliath_saddle"
-
-/// For map generation, has a chance to instantiate as a special subtype
-/obj/effect/spawner/random/goliath
-	name = "random goliath"
-	desc = "Chance to spawn a rare shiny version."
-	icon = 'icons/mob/simple/lavaland/lavaland_monsters_wide.dmi'
-	icon_state = "goliath"
-	pixel_x = -12
-	loot = list(
-		/mob/living/basic/mining/goliath = 99,
-		/mob/living/basic/mining/goliath/ancient/immortal = 1,
-	)

--- a/code/modules/mob/living/basic/lavaland/watcher/watcher.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher.dm
@@ -105,16 +105,3 @@
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/bone = 1)
 	crusher_loot = /obj/item/crusher_trophy/watcher_wing/ice_wing
 	crusher_drop_chance = 100
-
-/// For map generation, has a chance to instantiate as a special subtype
-/obj/effect/spawner/random/watcher
-	name = "random watcher"
-	desc = "Chance to spawn a rare shiny version."
-	icon = 'icons/mob/simple/lavaland/lavaland_monsters_wide.dmi'
-	icon_state = "watcher"
-	pixel_x = -12
-	loot = list(
-		/mob/living/basic/mining/watcher = 80,
-		/mob/living/basic/mining/watcher/magmawing = 15,
-		/mob/living/basic/mining/watcher/icewing = 5,
-	)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -132,12 +132,6 @@
 	. = ..()
 	AddElement(/datum/element/content_barfer)
 
-/mob/living/simple_animal/hostile/asteroid/hivelord/legion/random/Initialize(mapload)
-	. = ..()
-	if(prob(5))
-		new /mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf(loc)
-		return INITIALIZE_HINT_QDEL
-
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf
 	name = "dwarf legion"
 	desc = "You can still see what was once a rather small human under the shifting mass of corruption."

--- a/code/modules/procedural_mapping/mapGenerators/lavaland.dm
+++ b/code/modules/procedural_mapping/mapGenerators/lavaland.dm
@@ -11,9 +11,9 @@
 /datum/map_generator_module/splatter_layer/lavaland_monsters
 	spawnableTurfs = list()
 	spawnableAtoms = list(
-		/mob/living/basic/mining/goliath = 10,
-		/obj/effect/spawner/random/watcher = 10,
-		/mob/living/simple_animal/hostile/asteroid/hivelord/legion = 10,
+		/obj/effect/spawner/random/lavaland_mob/goliath = 10,
+		/obj/effect/spawner/random/lavaland_mob/legion = 10,
+		/obj/effect/spawner/random/lavaland_mob/watcher = 10,
 	)
 
 /datum/map_generator_module/splatter_layer/lavaland_tendrils

--- a/code/modules/unit_tests/simple_animal_freeze.dm
+++ b/code/modules/unit_tests/simple_animal_freeze.dm
@@ -70,7 +70,6 @@
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/advanced,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/dwarf,
-		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/random,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow/portal,
 		/mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1924,6 +1924,7 @@
 #include "code\game\objects\effects\spawners\random\entertainment.dm"
 #include "code\game\objects\effects\spawners\random\exotic.dm"
 #include "code\game\objects\effects\spawners\random\food_or_drink.dm"
+#include "code\game\objects\effects\spawners\random\lavaland_mobs.dm"
 #include "code\game\objects\effects\spawners\random\maintenance.dm"
 #include "code\game\objects\effects\spawners\random\medical.dm"
 #include "code\game\objects\effects\spawners\random\mod.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes #77709

I made a very smart and sensible and handsome change in a recent PR to replace `mob/goliath/random` and `mob/watcher/random` subtypes with spawner effects rather than mobs which qdel themselves on init sometimes
however I neglected to account for how the lavaland map generation was reliant on those typepaths to space mobs apart

resultingly the map generator would attempt to place lavaland mobs about 12 spaces apart _unless_ they were goliaths or watchers which it would spawn basically as much as it wanted wherever it wanted

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/7483112/b6622b9f-f356-426c-9491-00ca4491799a)

## Changelog

:cl:
fix: the goliath and watcher mating season has ended and population has returned to normal levels
/:cl:
