### PR TITLE
[NO GBP] Makes settlers properly short (as in the SHORTEST size) (Not DWARF short, just SHORTER)

### DIFF
--- a/code/datums/quirks/positive_quirks/positive_quirks.dm
+++ b/code/datums/quirks/positive_quirks/positive_quirks.dm
@@ -384,7 +384,7 @@
 	give_item_to_holder(/obj/item/storage/box/papersack/wheat, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))
 	give_item_to_holder(/obj/item/storage/toolbox/fishing/small, list(LOCATION_BACKPACK = ITEM_SLOT_BACKPACK, LOCATION_HANDS = ITEM_SLOT_HANDS))
 	var/mob/living/carbon/human/human_quirkholder = quirk_holder
-	human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORT)
+	human_quirkholder.set_mob_height(HUMAN_HEIGHT_SHORTEST)
 	human_quirkholder.add_movespeed_modifier(/datum/movespeed_modifier/settler)
 	human_quirkholder.physiology.hunger_mod *= 0.5 //good for you, shortass, you don't get hungry nearly as often
 


### PR DESCRIPTION
## About The Pull Request

I somehow missed that there was a size below SHORT and above DWARF, fuck.

So we made them HUMAN_SIZE_SHORTEST like they should be.

## Why It's Good For The Game

Fuck

## Changelog
:cl:
fix: Makes sure settlers are SHORTEST.
/:cl:
