### PR TITLE
HITS_TO_CRIT now uses the MAX_LIVING_HEALTH define

### DIFF
--- a/code/__DEFINES/melee.dm
+++ b/code/__DEFINES/melee.dm
@@ -11,4 +11,4 @@
 #define MARTIALART_WRESTLING "wrestling"
 
 /// The number of hits required to crit a target
-#define HITS_TO_CRIT(damage) round(100 / damage, 0.1)
+#define HITS_TO_CRIT(damage) round(MAX_LIVING_HEALTH / damage, 0.1)

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -142,7 +142,11 @@
 #define DIGITIGRADE_LEGS "Digitigrade Legs"
 
 // Health/damage defines
+/// Maximum living health.
 #define MAX_LIVING_HEALTH 100
+/// Maximum living stamina damage. Doesn't change stamcrit threshold; that's still decided by HEALTH_THRESHOLD_CRIT. Just affects how much stamina loss you can have at a single instant.
+#define MAX_LIVING_STAMLOSS 120
+
 
 //for determining which type of heartbeat sound is playing
 ///Heartbeat is beating fast for hard crit

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -17,7 +17,7 @@
 	var/health = MAX_LIVING_HEALTH
 
 	/// The max amount of stamina damage we can have at once (Does NOT effect stamcrit thresholds. See crit_threshold)
-	var/max_stamina = 120
+	var/max_stamina = MAX_LIVING_STAMLOSS
 	///Stamina damage, or exhaustion. You recover it slowly naturally, and are knocked down if it gets too high. Holodeck and hallucinations deal this.
 	var/staminaloss = 0
 


### PR DESCRIPTION
## About The Pull Request
Adjusts the hits to crit define to use the max living health define, so that if someone has the idea to change the latter, the former still remains accurate.

Also defines `MAX_LIVING_STAMLOSS`, and gives it an informative comment.

## Why It's Good For The Game
Combat information accuracy... good?

## Changelog

:cl:
code: HITS_TO_CRIT now uses the MAX_LIVING_HEALTH define, so servers with increased living maxhealth should have slightly more accurate combat information examines.
/:cl: