### PR TITLE
Various jobs start with more job-related programs preloaded into their PDAs.

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -58375,9 +58375,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "oIL" = (
-/obj/item/computer_disk/atmos,
-/obj/item/computer_disk/atmos,
-/obj/item/computer_disk/atmos,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/item/computer_disk/engineering,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -68552,7 +68552,6 @@
 /obj/item/computer_disk/engineering,
 /obj/item/computer_disk/engineering,
 /obj/item/computer_disk/engineering,
-/obj/item/computer_disk/atmos,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9776,7 +9776,6 @@
 /obj/item/computer_disk/engineering,
 /obj/item/computer_disk/engineering,
 /obj/item/computer_disk/engineering,
-/obj/item/computer_disk/atmos,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -3821,7 +3821,6 @@
 /obj/item/computer_disk/engineering,
 /obj/item/computer_disk/engineering,
 /obj/item/computer_disk/engineering,
-/obj/item/computer_disk/atmos,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "axp" = (

--- a/code/modules/modular_computers/computers/item/disks/role_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/role_disks.dm
@@ -116,7 +116,7 @@
  * Engineering
  */
 /obj/item/computer_disk/engineering
-	name = "station engineer data disk"
+	name = "engineering data disk"
 	desc = "Removable disk used to download engineering-related tablet apps."
 	icon_state = "datadisk6"
 	starting_programs = list(
@@ -125,12 +125,3 @@
 		/datum/computer_file/program/alarm_monitor,
 	)
 
-/obj/item/computer_disk/atmos
-	name = "atmospheric technician data disk"
-	desc = "Removable disk used to download atmos-related tablet apps."
-	icon_state = "datadisk6"
-	starting_programs = list(
-		/datum/computer_file/program/supermatter_monitor,
-		/datum/computer_file/program/atmosscan,
-		/datum/computer_file/program/alarm_monitor,
-	)

--- a/code/modules/modular_computers/computers/item/disks/role_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/role_disks.dm
@@ -121,6 +121,8 @@
 	icon_state = "datadisk6"
 	starting_programs = list(
 		/datum/computer_file/program/supermatter_monitor,
+		/datum/computer_file/program/atmosscan,
+		/datum/computer_file/program/alarm_monitor,
 	)
 
 /obj/item/computer_disk/atmos
@@ -128,6 +130,7 @@
 	desc = "Removable disk used to download atmos-related tablet apps."
 	icon_state = "datadisk6"
 	starting_programs = list(
+		/datum/computer_file/program/supermatter_monitor,
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
 	)

--- a/code/modules/modular_computers/computers/item/disks/role_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/role_disks.dm
@@ -120,8 +120,9 @@
 	desc = "Removable disk used to download engineering-related tablet apps."
 	icon_state = "datadisk6"
 	starting_programs = list(
-		/datum/computer_file/program/supermatter_monitor,
-		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
+		/datum/computer_file/program/atmosscan,
+		/datum/computer_file/program/supermatter_monitor,
+		
 	)
 

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -156,6 +156,7 @@
 	greyscale_colors = "#D99A2E#69DBF3#E3DF3D"
 	starting_programs = list(
 		/datum/computer_file/program/supermatter_monitor,
+		/datum/computer_file/program/alarm_monitor,
 	)
 
 /obj/item/modular_computer/pda/atmos

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -7,6 +7,7 @@
 	greyscale_colors = "#67A364#a92323"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
+		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -35,6 +36,7 @@
 	greyscale_colors = "#374f7e#a52f29#a52f29"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
+		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -49,6 +51,7 @@
 	greyscale_colors = "#EA3232#0000CC"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
+		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -62,6 +65,7 @@
 	greyscale_colors = "#D99A2E#69DBF3#FAFAFA"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
+		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -77,6 +81,7 @@
 	greyscale_colors = "#FAFAFA#000099#3F96CC"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
+		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -92,9 +97,11 @@
 	inserted_item = /obj/item/pen/fountain
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
+		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
+		/datum/computer_file/program/borg_monitor,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/signal_commander,
 	)
@@ -107,6 +114,7 @@
 	stored_paper = 20
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
+		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -187,6 +195,7 @@
 	greyscale_colors = "#484848#0099CC#D94927"
 	starting_programs = list(
 		/datum/computer_file/program/robocontrol,
+		/datum/computer_file/program/borg_monitor,
 	)
 
 /obj/item/modular_computer/pda/geneticist

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -7,7 +7,6 @@
 	greyscale_colors = "#67A364#a92323"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
-		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -36,7 +35,6 @@
 	greyscale_colors = "#374f7e#a52f29#a52f29"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
-		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -51,7 +49,6 @@
 	greyscale_colors = "#EA3232#0000CC"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
-		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -65,7 +62,6 @@
 	greyscale_colors = "#D99A2E#69DBF3#FAFAFA"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
-		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -81,7 +77,6 @@
 	greyscale_colors = "#FAFAFA#000099#3F96CC"
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
-		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -97,7 +92,6 @@
 	inserted_item = /obj/item/pen/fountain
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
-		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
@@ -164,6 +158,7 @@
 	greyscale_colors = "#D99A2E#69DBF3#E3DF3D"
 	starting_programs = list(
 		/datum/computer_file/program/supermatter_monitor,
+		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
 	)
 
@@ -172,6 +167,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#EEDC43#00E5DA#727272"
 	starting_programs = list(
+		/datum/computer_file/program/supermatter_monitor,
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
 	)

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -180,6 +180,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#FAFAFA#000099#B347BC"
 	starting_programs = list(
+		/datum/computer_file/program/science,
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/signal_commander,
 	)
@@ -189,6 +190,7 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_double
 	greyscale_colors = "#484848#0099CC#D94927"
 	starting_programs = list(
+		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,
 		/datum/computer_file/program/borg_monitor,
 	)

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -91,12 +91,12 @@
 	greyscale_colors = "#FAFAFA#000099#B347BC"
 	inserted_item = /obj/item/pen/fountain
 	starting_programs = list(
-		/datum/computer_file/program/crew_manifest,
-		/datum/computer_file/program/status,
-		/datum/computer_file/program/science,
-		/datum/computer_file/program/robocontrol,
 		/datum/computer_file/program/borg_monitor,
 		/datum/computer_file/program/budgetorders,
+		/datum/computer_file/program/crew_manifest,
+		/datum/computer_file/program/robocontrol,
+		/datum/computer_file/program/science,
+		/datum/computer_file/program/status,
 		/datum/computer_file/program/signal_commander,
 	)
 
@@ -156,9 +156,9 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#D99A2E#69DBF3#E3DF3D"
 	starting_programs = list(
-		/datum/computer_file/program/supermatter_monitor,
-		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
+		/datum/computer_file/program/atmosscan,
+		/datum/computer_file/program/supermatter_monitor,
 	)
 
 /obj/item/modular_computer/pda/atmos
@@ -166,9 +166,9 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#EEDC43#00E5DA#727272"
 	starting_programs = list(
-		/datum/computer_file/program/supermatter_monitor,
-		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/alarm_monitor,
+		/datum/computer_file/program/atmosscan,
+		/datum/computer_file/program/supermatter_monitor,
 	)
 
 /**
@@ -180,8 +180,8 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#FAFAFA#000099#B347BC"
 	starting_programs = list(
-		/datum/computer_file/program/science,
 		/datum/computer_file/program/atmosscan,
+		/datum/computer_file/program/science,
 		/datum/computer_file/program/signal_commander,
 	)
 

--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -108,7 +108,6 @@
 	stored_paper = 20
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
-		/datum/computer_file/program/card_mod,
 		/datum/computer_file/program/status,
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/robocontrol,

--- a/tools/UpdatePaths/Scripts/77740_delete_atmos_disk.txt
+++ b/tools/UpdatePaths/Scripts/77740_delete_atmos_disk.txt
@@ -1,0 +1,3 @@
+/obj/item/computer_disk/atmos : @DELETE
+
+


### PR DESCRIPTION
## About The Pull Request

Engineers now start with the canary and atmosscan program, atmos techs start with the SM monitor program, and Robotisists start with the silliconnect program.

## Why It's Good For The Game
it's more convinient than downloadin em roundstart.

## Changelog
:cl:
qol: Various jobs have gotten additional programs uploaded at roundstart, engineers now have the canary and atmospheric scanner programs, atmospheric technicians now have the supermatter monitor, and Robotisists/RDs now have the silliconnect program.

/:cl:
