### PR TITLE
Fix airlock painter with GAGS airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1375,7 +1375,12 @@
 
 	// applies the user-chosen airlock's icon, overlays and assemblytype to the src airlock
 	painter.use_paint(user)
-	icon = initial(airlock.icon)
+	if(initial(airlock.greyscale_config))
+		greyscale_config = initial(airlock.greyscale_config)
+		greyscale_colors = initial(airlock.greyscale_colors)
+		update_greyscale()
+	else
+		icon = initial(airlock.icon)
 	overlays_file = initial(airlock.overlays_file)
 	assemblytype = initial(airlock.assemblytype)
 	update_appearance()


### PR DESCRIPTION
## About The Pull Request

Checks for greyscale_config before applying icon, preventing it from displaying the mapping helper icon in the event it has a GAGS config.

## Changelog

:cl: LT3
fix: Using an airlock painter on a GAGS airlock works properly
/:cl: