### PR TITLE
Replaces med surgery duffel to the coroner's surgery duffel in Morgue on Birdshot.

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -70484,7 +70484,7 @@
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/coroner/surgery,
 /turf/open/floor/iron/small,
 /area/station/medical/morgue)
 "yaL" = (


### PR DESCRIPTION

## About The Pull Request
Closes https://github.com/tgstation/tgstation/issues/77661.
## Changelog
:cl:
fix: [Birdshot] Morgue now has coroner's surgery duffel bag instead of regular surgery duffel.
/:cl:
