### PR TITLE
Inorganic mobs no longer have weird, undocumented resistances

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -87,8 +87,8 @@
 		return
 	adjustFireLoss(diff, updating_health, forced, required_bodytype)
 
-/mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype = MOB_ORGANIC)
-	if(!forced && !(mob_biotypes & required_biotype))
+/mob/living/carbon/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
+	if(!forced && required_biotype && !(mob_biotypes & required_biotype))
 		return
 	if(!forced && HAS_TRAIT(src, TRAIT_TOXINLOVER)) //damage becomes healing and healing becomes damage
 		amount = -amount

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -224,8 +224,8 @@
 /mob/living/proc/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	if(!forced && !(mob_biotypes & required_biotype))
-		return
+	if(!forced && required_biotype && !(mob_biotypes & required_biotype))
+		return FALSE
 	toxloss = clamp((toxloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	if(updating_health)
 		updatehealth()
@@ -234,8 +234,8 @@
 /mob/living/proc/setToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	if(!forced && !(mob_biotypes & required_biotype))
-		return
+	if(!forced && required_biotype && !(mob_biotypes & required_biotype))
+		return FALSE
 	toxloss = amount
 	if(updating_health)
 		updatehealth()
@@ -266,6 +266,8 @@
 /mob/living/proc/adjustCloneLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
 	if(!forced && ( (status_flags & GODMODE) || HAS_TRAIT(src, TRAIT_NOCLONELOSS)) )
 		return FALSE
+	if(!forced && required_biotype && !(mob_biotypes & required_biotype))
+		return FALSE
 	cloneloss = clamp((cloneloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)
 	if(updating_health)
 		updatehealth()
@@ -273,6 +275,8 @@
 
 /mob/living/proc/setCloneLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
 	if(!forced && ( (status_flags & GODMODE) || HAS_TRAIT(src, TRAIT_NOCLONELOSS)) )
+		return FALSE
+	if(!forced && required_biotype && !(mob_biotypes & required_biotype))
 		return FALSE
 	cloneloss = amount
 	if(updating_health)
@@ -294,8 +298,8 @@
 /mob/living/proc/adjustStaminaLoss(amount, updating_stamina = TRUE, forced = FALSE, required_biotype)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	if(required_biotype && !(mob_biotypes & required_biotype))
-		return
+	if(!forced && required_biotype && !(mob_biotypes & required_biotype))
+		return FALSE
 	staminaloss = clamp((staminaloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, max_stamina)
 	if(updating_stamina)
 		updatehealth()
@@ -303,6 +307,8 @@
 
 /mob/living/proc/setStaminaLoss(amount, updating_stamina = TRUE, forced = FALSE, required_biotype)
 	if(!forced && ( (status_flags & GODMODE) || HAS_TRAIT(src, TRAIT_NOCLONELOSS)) )
+		return FALSE
+	if(!forced && required_biotype && !(mob_biotypes & required_biotype))
 		return FALSE
 	staminaloss = amount
 	if(updating_stamina)

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/affected_bodytype = BODYTYPE_ORGANIC
 	/// The affected biotype, if the reagent damages/heals toxin damage of an affected mob.
 	/// See "Mob bio-types flags" in /code/_DEFINES/mobs.dm
-	var/affected_biotype = MOB_ORGANIC
+	var/affected_biotype = MOB_ORGANIC | MOB_MINERAL | MOB_UNDEAD
 	/// The affected respiration type, if the reagent damages/heals oxygen damage of an affected mob.
 	/// See "Mob bio-types flags" in /code/_DEFINES/mobs.dm
 	var/affected_respiration_type = ALL

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -247,8 +247,8 @@
 	var/oxycalc = 2.5 * REM * current_cycle
 	if(!overdosed)
 		oxycalc = min(oxycalc, affected_mob.getOxyLoss() + 0.5) //if NOT overdosing, we lower our toxdamage to only the damage we actually healed with a minimum of 0.1*current_cycle. IE if we only heal 10 oxygen damage but we COULD have healed 20, we will only take toxdamage for the 10. We would take the toxdamage for the extra 10 if we were overdosing.
-	affected_mob.adjustOxyLoss(-oxycalc * seconds_per_tick * normalise_creation_purity(), FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	affected_mob.adjustToxLoss(oxycalc * seconds_per_tick / CONVERMOL_RATIO, FALSE, required_biotype = affected_biotype)
+	affected_mob.adjustOxyLoss(-oxycalc * seconds_per_tick * normalise_creation_purity(), forced = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	affected_mob.adjustToxLoss(oxycalc * seconds_per_tick / CONVERMOL_RATIO, forced = FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(current_cycle / 2, seconds_per_tick) && affected_mob.losebreath)
 		affected_mob.losebreath--
 	..()
@@ -397,7 +397,7 @@
 
 /datum/reagent/medicine/c2/syriniver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustOrganLoss(ORGAN_SLOT_LIVER, 0.8 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	affected_mob.adjustToxLoss(-1 * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
+	affected_mob.adjustToxLoss(-1 * REM * seconds_per_tick, forced = FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/R in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(R))
 			continue
@@ -426,7 +426,7 @@
 
 /datum/reagent/medicine/c2/musiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustOrganLoss(ORGAN_SLOT_LIVER, 0.1 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	affected_mob.adjustToxLoss(-1 * REM * seconds_per_tick * normalise_creation_purity(), FALSE, required_biotype = affected_biotype)
+	affected_mob.adjustToxLoss(-1 * REM * seconds_per_tick * normalise_creation_purity(), forced = FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/R in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(R))
 			continue

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -247,8 +247,8 @@
 	var/oxycalc = 2.5 * REM * current_cycle
 	if(!overdosed)
 		oxycalc = min(oxycalc, affected_mob.getOxyLoss() + 0.5) //if NOT overdosing, we lower our toxdamage to only the damage we actually healed with a minimum of 0.1*current_cycle. IE if we only heal 10 oxygen damage but we COULD have healed 20, we will only take toxdamage for the 10. We would take the toxdamage for the extra 10 if we were overdosing.
-	affected_mob.adjustOxyLoss(-oxycalc * seconds_per_tick * normalise_creation_purity(), forced = FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	affected_mob.adjustToxLoss(oxycalc * seconds_per_tick / CONVERMOL_RATIO, forced = FALSE, required_biotype = affected_biotype)
+	affected_mob.adjustOxyLoss(-oxycalc * seconds_per_tick * normalise_creation_purity(), FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	affected_mob.adjustToxLoss(oxycalc * seconds_per_tick / CONVERMOL_RATIO, FALSE, required_biotype = affected_biotype)
 	if(SPT_PROB(current_cycle / 2, seconds_per_tick) && affected_mob.losebreath)
 		affected_mob.losebreath--
 	..()
@@ -397,7 +397,7 @@
 
 /datum/reagent/medicine/c2/syriniver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustOrganLoss(ORGAN_SLOT_LIVER, 0.8 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	affected_mob.adjustToxLoss(-1 * REM * seconds_per_tick, forced = FALSE, required_biotype = affected_biotype)
+	affected_mob.adjustToxLoss(-1 * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/R in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(R))
 			continue
@@ -426,7 +426,7 @@
 
 /datum/reagent/medicine/c2/musiver/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustOrganLoss(ORGAN_SLOT_LIVER, 0.1 * REM * seconds_per_tick, required_organ_flag = affected_organ_flags)
-	affected_mob.adjustToxLoss(-1 * REM * seconds_per_tick * normalise_creation_purity(), forced = FALSE, required_biotype = affected_biotype)
+	affected_mob.adjustToxLoss(-1 * REM * seconds_per_tick * normalise_creation_purity(), FALSE, required_biotype = affected_biotype)
 	for(var/datum/reagent/R in affected_mob.reagents.reagent_list)
 		if(issyrinormusc(R))
 			continue

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -210,7 +210,7 @@
 		affected_mob.adjustOxyLoss(-2 * power * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
 		affected_mob.adjustBruteLoss(-power * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
 		affected_mob.adjustFireLoss(-1.5 * power * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
-		affected_mob.adjustToxLoss(-power * REM * seconds_per_tick, FALSE, TRUE, affected_biotype)
+		affected_mob.adjustToxLoss(-power * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 		affected_mob.adjustCloneLoss(-power * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 		for(var/i in affected_mob.all_wounds)
 			var/datum/wound/iter_wound = i

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -979,7 +979,7 @@
 	mytray.adjust_weedlevel(-rand(1, 4))
 
 /datum/reagent/fluorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-	affected_mob.adjustToxLoss(0.5*REM*seconds_per_tick, forced = FALSE, required_biotype = affected_biotype)
+	affected_mob.adjustToxLoss(0.5*REM*seconds_per_tick, required_biotype = affected_biotype)
 	. = TRUE
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -420,19 +420,19 @@
 	if(IS_CULTIST(affected_mob))
 		affected_mob.adjust_drowsiness(-10 SECONDS * REM * seconds_per_tick)
 		affected_mob.AdjustAllImmobility(-40 * REM * seconds_per_tick)
-		affected_mob.adjustStaminaLoss(-10 * REM * seconds_per_tick, 0)
-		affected_mob.adjustToxLoss(-2 * REM * seconds_per_tick, 0)
-		affected_mob.adjustOxyLoss(-2 * REM * seconds_per_tick, 0)
-		affected_mob.adjustBruteLoss(-2 * REM * seconds_per_tick, 0)
-		affected_mob.adjustFireLoss(-2 * REM * seconds_per_tick, 0)
+		affected_mob.adjustStaminaLoss(-10 * REM * seconds_per_tick, FALSE)
+		affected_mob.adjustToxLoss(-2 * REM * seconds_per_tick, FALSE)
+		affected_mob.adjustOxyLoss(-2 * REM * seconds_per_tick, FALSE)
+		affected_mob.adjustBruteLoss(-2 * REM * seconds_per_tick, FALSE)
+		affected_mob.adjustFireLoss(-2 * REM * seconds_per_tick, FALSE)
 		if(ishuman(affected_mob) && affected_mob.blood_volume < BLOOD_VOLUME_NORMAL)
 			affected_mob.blood_volume += 3 * REM * seconds_per_tick
 	else  // Will deal about 90 damage when 50 units are thrown
 		affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3 * REM * seconds_per_tick, 150)
-		affected_mob.adjustToxLoss(1 * REM * seconds_per_tick, 0)
-		affected_mob.adjustFireLoss(1 * REM * seconds_per_tick, 0)
-		affected_mob.adjustOxyLoss(1 * REM * seconds_per_tick, 0)
-		affected_mob.adjustBruteLoss(1 * REM * seconds_per_tick, 0)
+		affected_mob.adjustToxLoss(1 * REM * seconds_per_tick, FALSE)
+		affected_mob.adjustFireLoss(1 * REM * seconds_per_tick, FALSE)
+		affected_mob.adjustOxyLoss(1 * REM * seconds_per_tick, FALSE)
+		affected_mob.adjustBruteLoss(1 * REM * seconds_per_tick, FALSE)
 	..()
 
 /datum/reagent/hellwater //if someone has this in their system they've really pissed off an eldrich god
@@ -445,8 +445,8 @@
 /datum/reagent/hellwater/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.set_fire_stacks(min(affected_mob.fire_stacks + (1.5 * seconds_per_tick), 5))
 	affected_mob.ignite_mob() //Only problem with igniting people is currently the commonly available fire suits make you immune to being on fire
-	affected_mob.adjustToxLoss(0.5*seconds_per_tick, 0)
-	affected_mob.adjustFireLoss(0.5*seconds_per_tick, 0) //Hence the other damages... ain't I a bastard?
+	affected_mob.adjustToxLoss(0.5*seconds_per_tick, FALSE)
+	affected_mob.adjustFireLoss(0.5*seconds_per_tick, FALSE) //Hence the other damages... ain't I a bastard?
 	affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2.5*seconds_per_tick, 150)
 	holder.remove_reagent(type, 0.5*seconds_per_tick)
 
@@ -979,7 +979,7 @@
 	mytray.adjust_weedlevel(-rand(1, 4))
 
 /datum/reagent/fluorine/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-	affected_mob.adjustToxLoss(0.5*REM*seconds_per_tick, 0)
+	affected_mob.adjustToxLoss(0.5*REM*seconds_per_tick, forced = FALSE, required_biotype = affected_biotype)
 	. = TRUE
 	..()
 
@@ -1094,7 +1094,7 @@
 	var/tox_damage = 0.5
 
 /datum/reagent/uranium/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-	affected_mob.adjustToxLoss(tox_damage * seconds_per_tick * REM)
+	affected_mob.adjustToxLoss(tox_damage * seconds_per_tick * REM, required_biotype = affected_biotype)
 	..()
 
 /datum/reagent/uranium/expose_turf(turf/exposed_turf, reac_volume)
@@ -1253,9 +1253,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/space_cleaner/ez_clean/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-	affected_mob.adjustBruteLoss(1.665*seconds_per_tick)
-	affected_mob.adjustFireLoss(1.665*seconds_per_tick)
-	affected_mob.adjustToxLoss(1.665*seconds_per_tick)
+	affected_mob.adjustBruteLoss(1.665*seconds_per_tick, required_bodytype = affected_bodytype)
+	affected_mob.adjustFireLoss(1.665*seconds_per_tick, required_bodytype = affected_bodytype)
+	affected_mob.adjustToxLoss(1.665*seconds_per_tick, required_biotype = affected_biotype)
 	..()
 
 /datum/reagent/space_cleaner/ez_clean/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)


### PR DESCRIPTION

## About The Pull Request

I found out about this stuff during a powergaming test of probital and modafinil.
What ensued was me being in infsleep, so I dug deeper.

As it turns out, all skeletons, golems, plasmamen, etc. have immunity to reagent toxin damage and reagent stamina damage.
This PR rectifies that as these are things that simply aren't documented anywhere and don't even make sense gameplay-wise since all of these races are affected by the other effects of these reagents. (including burn/brute damage)

Also fixed some formatting stuff, force checks using 0 instead of FALSE and added support for a few biotype things in some of the damage procs along the way.

Oh yeah and this also means plasmamen are affected by toxin damage in general now. Same goes for others. This MAY cause issues with stuff like plasma fixation, although it really shouldn't.
## Why It's Good For The Game

Undocumented, likely unintentional mechanics that cause balancing issues simply shouldn't stay around.

And neither should shitcode.
## Changelog
:cl:
fix: Removed undocumented toxin and stamina damage resistances from all inorganic species except androids.
refactor: Properly implemented some checks for a few damage procs, they were unused so this shouldn't affect anything.
/:cl:
