### PR TITLE
Changes Birdshot's coroner duffel to surgery one

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -70484,7 +70484,7 @@
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/coroner/surgery,
 /turf/open/floor/iron/small,
 /area/station/medical/morgue)
 "yaL" = (


### PR DESCRIPTION
## About The Pull Request

This was a minor merge conflict because Birdshot's duffelbag didn't exist at the time when I made the change.
This replaces the duffel with the proper one 👍 

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/77661

## Changelog

:cl:
fix: Coroner's duffelbag on Birdshot now has the Coroner's tools instead of regular ones.
/:cl: