### PR TITLE
Stronger cult runes now require sharpening your dagger to draw (also renames Offer)

### DIFF
--- a/code/__DEFINES/cult.dm
+++ b/code/__DEFINES/cult.dm
@@ -48,3 +48,8 @@ GLOBAL_DATUM(cult_narsie, /obj/narsie)
 #define CULT_VICTORY 1
 #define CULT_LOSS 0
 #define CULT_NARSIE_KILLED -1
+
+///Whether any ritual drawing knife can draw this.
+#define CAN_BE_SCRIBED_DEFAULT 1
+///Whether you need an advanced ritual drawing knife to draw this.
+#define CAN_BE_SCRIBED_ADVANCED 2

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -3,6 +3,8 @@
 GLOBAL_LIST(sacrificed)
 /// List of all teleport runes
 GLOBAL_LIST(teleport_runes)
+///List of 'advanced' runes.
+GLOBAL_LIST_EMPTY(advanced_runes)
 /// Assoc list of every rune that can be drawn by ritual daggers. [rune_name] = [typepath]
 GLOBAL_LIST_INIT(rune_types, generate_cult_rune_types())
 
@@ -12,9 +14,11 @@ GLOBAL_LIST_INIT(rune_types, generate_cult_rune_types())
 
 	var/list/runes = list()
 	for(var/obj/effect/rune/rune as anything in subtypesof(/obj/effect/rune))
-		if(!initial(rune.can_be_scribed))
-			continue
-		runes[initial(rune.cultist_name)] = rune // Uses the cultist name for displaying purposes
+		switch(initial(rune.scribe_level))
+			if(CAN_BE_SCRIBED_DEFAULT)
+				runes[initial(rune.cultist_name)] = rune // Uses the cultist name for displaying purposes
+			if(CAN_BE_SCRIBED_ADVANCED)
+				GLOB.advanced_runes[initial(rune.cultist_name)] = rune
 
 	return runes
 
@@ -53,8 +57,9 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 	var/rune_in_use = FALSE
 	/// Used when you want to keep track of who erased the rune
 	var/log_when_erased = FALSE
-	/// Whether this rune can be scribed or if it's admin only / special spawned / whatever
-	var/can_be_scribed = TRUE
+	/// If this can be scribed normally or requires an upgrade. FALSE means it's admin only / special spawned / whatever.
+	/// CAN_BE_SCRIBED_DEFAULT | CAN_BE_SCRIBED_ADVANCED
+	var/scribe_level = CAN_BE_SCRIBED_DEFAULT
 	/// How long the rune takes to erase
 	var/erase_time = 1.5 SECONDS
 	/// How long the rune takes to create
@@ -190,7 +195,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	cultist_desc = "a senseless rune written in gibberish. No good can come from invoking this."
 	invocation = "Ra'sha yoka!"
 	invoke_damage = 30
-	can_be_scribed = FALSE
+	scribe_level = FALSE
 
 /obj/effect/rune/malformed/Initialize(mapload, set_keyword)
 	. = ..()
@@ -203,7 +208,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 //Rite of Offering: Converts or sacrifices a target.
 /obj/effect/rune/convert
-	cultist_name = "Offer"
+	cultist_name = "Convert"
 	cultist_desc = "offers a noncultist above it to Nar'Sie, either converting them or sacrificing them."
 	req_cultists_text = "2 for conversion, 3 for living sacrifices and sacrifice targets."
 	invocation = "Mah'weyh pleggh at e'ntrath!"
@@ -680,6 +685,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	invocation = "Khari'd! Eske'te tannin!"
 	icon_state = "4"
 	color = RUNE_COLOR_DARKRED
+	scribe_level = CAN_BE_SCRIBED_ADVANCED
 	///The barrier summoned by the rune when invoked. Tracked as a variable to prevent refreshing the barrier's integrity.
 	var/obj/structure/emergency_shield/cult/barrier/barrier //barrier is the path and variable name.... i am not a clever man
 
@@ -773,6 +779,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	icon_state = "4"
 	color = RUNE_COLOR_BURNTORANGE
 	light_color = LIGHT_COLOR_LAVA
+	scribe_level = CAN_BE_SCRIBED_ADVANCED
 	req_cultists = 3
 	invoke_damage = 10
 	construct_invoke = FALSE
@@ -831,6 +838,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	invoke_damage = 10
 	construct_invoke = FALSE
 	color = RUNE_COLOR_DARKRED
+	scribe_level = CAN_BE_SCRIBED_ADVANCED
 	var/mob/living/affecting = null
 	var/ghost_limit = 3
 	var/ghosts = 0
@@ -965,6 +973,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	pixel_x = -32
 	pixel_y = -32
 	color = RUNE_COLOR_DARKRED
+	scribe_level = CAN_BE_SCRIBED_ADVANCED
 	req_cultists = 3
 	scribe_delay = 100
 

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -33,6 +33,7 @@ As a Cultist, check the alert in the upper-right of your screen for all the deta
 As a Cultist, do not cause too much chaos before your objective is completed. If the shuttle gets called too soon, you may not have enough time to win.
 As a Cultist, the Blood Boil rune will deal massive amounts of brute damage to non-cultists, and some damage to fellow cultists of Nar'Sie nearby, but will create a fire where the rune stands on use.
 As a Cultist, your team starts off very weak, but if necessary can quickly convert everything they have into raw power. Make sure you have the numbers and equipment to support going loud, or the cult will fall flat on its face.
+As a Cultist, you can use a sharpener from your altar onto your ritual dagger to draw better and stronger cult runes.
 As a Cyborg, choose your model carefully, as only cutting and mending your reset wire will let you re-pick it. If possible, refrain from choosing a model until a situation that requires one occurs.
 As a Cyborg, you are extremely vulnerable to EMPs as EMPs both stun you and damage you. The ion rifle in the armory or a traitor with an EMP kit can kill you in seconds.
 As a Cyborg, you are immune to most forms of stunning, and excel at almost everything far better than humans. However, flashes can easily stunlock you and you cannot do any precision work as you lack hands.


### PR DESCRIPTION
## About The Pull Request

I renamed "Offer" rune to "Convert" to make it more obvious as to what it does.

- Barrier (This is more just to cut down on the bloat in the list, I can put it back to the default list if necessary)
- Blood boil
- Spirit realm
- Apocalypse

These spells now require you to sharpen your ritual dagger to be available to draw.

https://github.com/tgstation/tgstation/assets/53777086/8d0920c6-9046-49c9-92be-75a238129225

## Why It's Good For The Game

A common issue with Cult is how unapproachable it is to new players. This aims to help alleviate that, with the following reasoning:
- New players are given 1 new actual ability; the ability to draw runes. This ability has many different things to choose from, so you really don't know where to start. Removing some of those will give them more room to try and test the limited spells they have.
- Players who know what they are doing can easily obtain a sharpener, Cultists can literally shit them out for free, so this is not hiding any of the content from them.
- Sharpening your dagger is pretty good and should be done more often. Personal bias thing.

## Changelog

:cl:
qol: Cult's "Offer" rune is now called "Convert"
balance: More niche/advanced runes now require you to sharpen your ritual dagger.
/:cl: