### PR TITLE
`_GetInverseTypeList()` correctly returns all parent types 

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -241,8 +241,8 @@
 	var/current_type = parent_type
 	//and since most components are root level + 1, this won't even have to run
 	while (current_type != /datum/component)
-		current_type = type2parent(current_type)
 		. += current_type
+		current_type = type2parent(current_type)
 
 // The type arg is casted so initial works, you shouldn't be passing a real instance into this
 /**


### PR DESCRIPTION
## About The Pull Request

Fixes #77774
Fixes #77795

There is a problem with `/datum/component/proc/_GetInverseTypeList()`

https://github.com/tgstation/tgstation/blob/e3a835b96043fad1269ee7b0c3a6cb340a466f3a/code/datums/components/_component.dm#L238-L245

Notice after we store the parent type here
https://github.com/tgstation/tgstation/blob/e3a835b96043fad1269ee7b0c3a6cb340a466f3a/code/datums/components/_component.dm#L241

The value is lost inside our while loop here, we go to `current_type` parent value before even adding it to the return list
https://github.com/tgstation/tgstation/blob/e3a835b96043fad1269ee7b0c3a6cb340a466f3a/code/datums/components/_component.dm#L244

And by the time we do add it to the list the parent type is lost and we have the grand parent value instead
https://github.com/tgstation/tgstation/blob/e3a835b96043fad1269ee7b0c3a6cb340a466f3a/code/datums/components/_component.dm#L245

To test this call this proc with the value `datum/component/plumbing/simple_supply`

**Expected result.**
`datum/component/plumbing/simple_supply`  <----- The type of param passed
`datum/component/plumbing`  <--------------------- The parent type of param passed

**Actual result**
![Screenshot (292)](https://github.com/tgstation/tgstation/assets/110812394/06603de6-109f-49bc-b9f2-22cd68dba560)


This crashes everything plumbing related.

The solution is simple just flip the while loop i.e. first add the current value to the list then move to its parent type
```
while (current_type != /datum/component)
  . += current_type  <-----add parent value
  current_type = type2parent(current_type) <----then move up
```

So you get the correct list here
![Screenshot (293)](https://github.com/tgstation/tgstation/assets/110812394/b3286ea3-4eb6-454b-ae84-b0b16390de86)


Broken by #77615 

## Changelog
:cl:
fix: plumbing ducts connects to other plumbing machinery again
/:cl:
