### PR TITLE
Multitool can be used to access APC/Teslacoil/SMES/emitter internal wires

### DIFF
--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -113,12 +113,6 @@
 		terminal.dismantle(user, W)
 		return TRUE
 
-/obj/machinery/power/apc/multitool_act(mob/living/user, obj/item/multitool/multi_tool)
-	if(panel_open && !opened)
-		wires.interact(user)
-		return
-	return ..()
-
 /obj/machinery/power/apc/welder_act(mob/living/user, obj/item/welder)
 	. = ..()
 

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -113,6 +113,12 @@
 		terminal.dismantle(user, W)
 		return TRUE
 
+/obj/machinery/power/apc/multitool_act(mob/living/user, obj/item/multitool/multi_tool)
+	if(panel_open && !opened)
+		wires.interact(user)
+		return
+	return ..()
+
 /obj/machinery/power/apc/welder_act(mob/living/user, obj/item/welder)
 	. = ..()
 

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -114,10 +114,10 @@
 		return TRUE
 
 /obj/machinery/power/apc/multitool_act(mob/living/user, obj/item/multitool/multi_tool)
-	. = ..()
 	if(panel_open && !opened)
 		wires.interact(user)
-		return TRUE
+		return
+	return ..()
 
 /obj/machinery/power/apc/welder_act(mob/living/user, obj/item/welder)
 	. = ..()

--- a/code/modules/power/apc/apc_tool_act.dm
+++ b/code/modules/power/apc/apc_tool_act.dm
@@ -114,10 +114,10 @@
 		return TRUE
 
 /obj/machinery/power/apc/multitool_act(mob/living/user, obj/item/multitool/multi_tool)
+	. = ..()
 	if(panel_open && !opened)
 		wires.interact(user)
-		return
-	return ..()
+		return TRUE
 
 /obj/machinery/power/apc/welder_act(mob/living/user, obj/item/welder)
 	. = ..()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -61,11 +61,11 @@
 
 /obj/machinery/power/multitool_act(mob/living/user, obj/item/tool)
 	if(!can_change_cable_layer || !cable_layer_change_checks(user, tool))
-		return TOOL_ACT_TOOLTYPE_SUCCESS
+		return
 
 	var/choice = tgui_input_list(user, "Select Power Line For Operation", "Select Cable Layer", GLOB.cable_name_to_layer)
 	if(isnull(choice))
-		return TOOL_ACT_TOOLTYPE_SUCCESS
+		return
 
 	cable_layer = GLOB.cable_name_to_layer[choice]
 	balloon_alert(user, "now operating on the [choice]")


### PR DESCRIPTION
## About The Pull Request
adjusted /obj/machinery/power/multitool_act to no longer return successful for all return paths. allowing attack_chain to continue and eventually hit the machine's attackby function and access machine wires

## Why It's Good For The Game
Multitool opens wire UI on doors and air alarms, it should be consistent with other machines with wires.

## Changelog
:cl:
fix: multitool can be used on APC/Teslacoil/SMES/emitter if it has exposed wires.
/:cl:
