### PR TITLE
Sets the dynamic human appearance via copy_overlays

### DIFF
--- a/code/__HELPERS/dynamic_human_icon_gen.dm
+++ b/code/__HELPERS/dynamic_human_icon_gen.dm
@@ -54,4 +54,5 @@ GLOBAL_LIST_EMPTY(dynamic_human_appearances)
 /proc/set_dynamic_human_appearance(list/arguments)
 	var/atom/target = arguments[1] //1st argument is the target
 	var/dynamic_appearance = get_dynamic_human_appearance(arglist(arguments.Copy(2))) //the rest of the arguments starting from 2 matter to the proc
-	target.appearance = dynamic_appearance
+	target.icon = null
+	target.copy_overlays(dynamic_appearance, cut_old = TRUE)


### PR DESCRIPTION


## About The Pull Request

Set_dynamic_human_appearance set the new appearance directly on the target mob. This has caused the mob's name to become Unknown, and its description to become empty, as it inherited the name and description of the appearance's source, which was a default spawned dummy human.

This PR makes it so that it nulls the icon of the target, and then copies the appearance via copy_overlays. 

Thank you Fikou for pointing out this simple solution, I almost  did something complicated with signals.

## Why It's Good For The Game

Mjor the Creative deserves to be recognized on sight!

## Changelog

:cl:
fix: Mobs whose human appearance is set dynamically will once again have their bespoke names and descriptions, instead of Unknown, with a blank description.
/:cl: