### PR TITLE
Fixes an issue with the "recolor from string" option in the greyscale modify menu

### DIFF
--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -241,7 +241,7 @@ This is highly likely to cause massive amounts of lag as every object in the gam
 /datum/greyscale_modify_menu/proc/ReadColorsFromString(colorString)
 	var/list/new_split_colors = list()
 	var/list/colors = splittext(colorString, "#")
-	for(var/index in 2 to length(colors))
+	for(var/index in 2 to min(length(colors), config.expected_colors + 1))
 		var/color = "#[colors[index]]"
 		if(!findtext(color, GLOB.is_color) && (!unlocked || !findtext(color, GLOB.is_alpha_color)))
 			return FALSE


### PR DESCRIPTION
## About The Pull Request
The number of colors has to match the expected color of the greyscale configuration, otherwise the whole proc chain behind the generation of the resulting icon will crash here: https://github.com/tgstation/tgstation/blob/ac446d8bad3596016217112a53fe91b8140dace2/code/datums/greyscale/_greyscale_config.dm#L253

## Why It's Good For The Game
One of the thousands runtimes I've seen in the runtime viewer.

## Changelog

:cl:
fix: Fixed an issue with the "recolor from string" option in the greyscale modify menu that resulted in invisible icons.
/:cl:
