### PR TITLE
Reverts Laser Ammo Capacity To Pre-Buff Values

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -1,6 +1,6 @@
 /obj/item/ammo_casing/energy/laser
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 63
+	e_cost = 83
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hellfire
@@ -13,7 +13,7 @@
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/projectile/beam/laser
-	e_cost = 52
+	e_cost = 62.5
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old


### PR DESCRIPTION
## About The Pull Request

Closes #77793

This PR reverts the buffs made to ammo capacity on laser weapons in PR #75329 . This PR does not touch anything else about the laser buffs (damage and wound chance).

## Why It's Good For The Game

In the eyes of some, the laser buffs were a necessity to prevent them feeling like a wet noodle (which I don't think was the case, but I digress). However, the laser buffs also brought along a reduction in energy cost per shot, which has allowed people to effectively spam the newly buffed lasers to an unhealthy degree, since they only need to land 4 of the many shots a laser gun can currently produce to win the fight.

The buff as a whole has created a massive power gap between the rest of the crew's weaponry and lasers, who wildly outclass anything else the crew can currently obtain along with some antag gear. The crew was already in a position of strength compared to the antagonists they face, so the buff has had negative implications regarding the current balance. However, if we allow antags to get buffed in line with the new lasers, then lasers will become the only option as opposed to the clear best option, which I don't think we want. So, I think nerfing the ammo capacity back down to what it was originally is the most healthy way to bring lasers back in line without making them feel weak. Let's see what happens.

## Changelog
:cl:
balance: Lasers now have increased energy cost, reverting the cost back to the initial value before the laser buff.
/:cl: