### PR TITLE
Fixes some `false`s in the sec records ui

### DIFF
--- a/tgui/packages/tgui/interfaces/SecurityRecords/RecordPrint.tsx
+++ b/tgui/packages/tgui/interfaces/SecurityRecords/RecordPrint.tsx
@@ -91,8 +91,8 @@ export const RecordPrint = (props, context) => {
             icon="file-alt"
             onClick={() => swapTabs(PRINTOUT.Rapsheet)}
             selected={printType === PRINTOUT.Rapsheet}
-            tooltip={`Prints a standard paper with the record on it. ${
-              innocent && ' (Requires crimes)'
+            tooltip={`Prints a standard paper with the record on it.${
+              innocent ? ' (Requires crimes)' : ''
             }`}
             tooltipPosition="bottom">
             Rapsheet
@@ -103,7 +103,7 @@ export const RecordPrint = (props, context) => {
             onClick={() => swapTabs(PRINTOUT.Wanted)}
             selected={printType === PRINTOUT.Wanted}
             tooltip={`Prints a poster with mugshot and crimes.${
-              innocent && ' (Requires crimes)'
+              innocent ? ' (Requires crimes)' : ''
             }`}
             tooltipPosition="bottom">
             Wanted


### PR DESCRIPTION
## About The Pull Request

If `innocent` was `false` this added `.false` to the tooltip.

So I replaced it with a ternany, to not append anything at all. 

## Changelog

:cl: Melbert
fix: Fixed some tooltips in the sec records UI showing "false"s where they shouldn't.
/:cl:
