### PR TITLE
Morgue dead body placer guarantees 1 human to dissect if non-human cadaver config is enabled. Morgues spawn with 1 additional body (except on Birdboat). 

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -37250,7 +37250,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/dead_body_placer,
+/obj/effect/mapping_helpers/dead_body_placer{
+	bodycount = 2
+	},
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "nxJ" = (

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -861,9 +861,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	var/list/obj/structure/bodycontainer/morgue/trays = list()
 	for(var/turf/area_turf as anything in morgue_area.get_contained_turfs())
 		var/obj/structure/bodycontainer/morgue/morgue_tray = locate() in area_turf
-		if(isnull(morgue_tray))
-			continue
-		if(admin_spawned && morgue_tray.connected.loc != morgue_tray)
+		if(isnull(morgue_tray) || !morgue_tray.beeper || morgue_tray.connected.loc != morgue_tray)
 			continue
 		trays += morgue_tray
 

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -844,6 +844,11 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	var/admin_spawned
 	///number of bodies to spawn
 	var/bodycount = 3
+	/// These species IDs will be barred from spawning if morgue_cadaver_disable_nonhumans is disabled (In the future, we can also dehardcode this)
+	var/list/blacklisted_from_rng_placement = list(
+		SPECIES_ETHEREAL, // they revive on death which is bad juju
+		SPECIES_HUMAN,  // already have a 50% chance of being selected
+	)
 
 /obj/effect/mapping_helpers/dead_body_placer/Initialize(mapload)
 	. = ..()
@@ -879,8 +884,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	if(use_species)
 		var/list/temp_list = get_selectable_species()
 		usable_races = temp_list.Copy()
-		LAZYREMOVE(usable_races, SPECIES_ETHEREAL) //they revive on death which is bad juju
-		LAZYREMOVE(usable_races, SPECIES_HUMAN)
+		LAZYREMOVE(usable_races, blacklisted_from_rng_placement)
 		if(!LAZYLEN(usable_races))
 			notice("morgue_cadaver_disable_nonhumans. There are no valid roundstart nonhuman races enabled. Defaulting to humans only!")
 		if(override_species)
@@ -929,7 +933,6 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 		morgue_tray.update_appearance()
 
 	qdel(src)
-
 
 //On Ian's birthday, the hop's office is decorated.
 /obj/effect/mapping_helpers/ianbirthday

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -11,8 +11,8 @@
 	usable_hands = 0 //Populated on init through list/bodyparts
 	mobility_flags = MOBILITY_FLAGS_CARBON_DEFAULT
 	blocks_emissive = EMISSIVE_BLOCK_NONE
-	///List of [/obj/item/organ/internal] in the mob. They don't go in the contents for some reason I don't want to know.
-	var/list/obj/item/organ/internal/organs = list()
+	///List of [/obj/item/organ]s in the mob. They don't go in the contents for some reason I don't want to know.
+	var/list/obj/item/organ/organs = list()
 	///Same as [above][/mob/living/carbon/var/organs], but stores "slot ID" - "organ" pairs for easy access.
 	var/list/organs_slot = list()
 	///How many dream images we have left to send


### PR DESCRIPTION
## About The Pull Request

- Morgue guarantees 1 human body to dissect even if `morgue_cadaver_disable_nonhumans` config flag is set. 

- All maps bar birdboat will now spawn with one additional morgue cadaver. 

- Did some minor code cleanup around the dead body placer, removes an `in world` loop, etc.

## Why It's Good For The Game

- Morgue guarantees 1 human body to dissect even if `morgue_cadaver_disable_nonhumans` config flag is set. 
    - This is mostly a downstream server issue but if your server enables this config and has additional species enabled, the odds of you getting a human to dissect tends to be very low.
    - Why is this a problem? Well, a human is necessary to dissect to get medical's tech.
    - Why not get genetics to get you a hu-monkey? This is an option, but if A. there's no geneticists or B. they are refusing to cooperate then you tend to be SOL unless you want to wait for a greytide to come in after drinking themselves to death. Given we have a role now dedicated to performing dissections, having no job to do for the first twenty or so minutes due to a lack of a human body is kind of sad. 
    - If this is an intended facet, I will revert this change and leave it to the code improvements / bodycount uptick. 

- All maps bar birdboat will now spawn with one additional morgue cadaver. 
   - This was actually intended on some maps but has been stealthily removed in some cases? Icebox and Delta used to have two dead body spawners to place 4 cadavers. So I decided to bring this back.
   - For the most part, this just gives higher population maps more bodies to mess around with. Higher pop means more people means more people need bodies, either for antagging, cooking, body replacements, or coron-ing. 
   - Also like, sometimes messing around with dead bodies are fun, and it's nice to not have to worry that you're running out of them for actual medical use. 
   - I can also make this scale on roundstart pop if we really care. But that seems overkill. Especially as these maps had their body counts higher for a while and were fine. 

## Changelog

:cl: Melbert
balance: If your server has non-human morgue cadavers enabled, you will be guaranteed one human cadaver no matter what. 
balance: All maps (with the exception of Birdboat) now have an additional morgue cadaver roundstart. 
/:cl:

