### PR TITLE
Implements byond_status() for harddel hunting

### DIFF
--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -232,6 +232,9 @@ SUBSYSTEM_DEF(garbage)
 				message = "[message] (ref count of [refcount(D)])"
 #endif
 				log_world(message)
+				var/detail = D.dump_harddel_info()
+				if(detail)
+					LAZYADD(I.extra_details, detail)
 
 				#ifdef TESTING
 				for(var/c in GLOB.admins) //Using testing() here would fill the logs with ADMIN_VV garbage

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -75,6 +75,10 @@
 	#endif
 #endif
 
+	// If we have called dump_harddel_info already. Used to avoid duped calls (since we call it immediately in some cases on failure to process)
+	// Create and destroy is weird and I wanna cover my bases
+	var/harddel_deets_dumped = FALSE
+
 #ifdef DATUMVAR_DEBUGGING_MODE
 	var/list/cached_vars
 #endif
@@ -406,5 +410,6 @@
 
 /// Return text from this proc to provide extra context to hard deletes that happen to it
 /// Optional, you should use this for cases where replication is difficult and extra context is required
+/// Can be called more then once per object, use harddel_deets_dumped to avoid duplicate calls (I am so sorry)
 /datum/proc/dump_harddel_info()
 	return

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -19,7 +19,6 @@
 	///The type of our last value for bar_loc, for debugging
 	var/location_type
 
-
 /datum/progressbar/New(mob/User, goal_number, atom/target)
 	. = ..()
 	if (!istype(target))
@@ -143,6 +142,9 @@
 ///Progress bars are very generic, and what hangs a ref to them depends heavily on the context in which they're used
 ///So let's make hunting harddels easier yeah?
 /datum/progressbar/dump_harddel_info()
+	if(harddel_deets_dumped)
+		return
+	harddel_deets_dumped = TRUE
 	return "Owner's type: [location_type]"
 
 #undef PROGRESSBAR_ANIMATION_TIME

--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -22,7 +22,9 @@
 	if(usr?.client)
 		usr.client.running_find_references = type
 
+#ifdef UNIT_TESTS
 	log_reftracker("Currently sleeping procs [byond_status()]")
+#endif
 
 	log_reftracker("Beginning search for references to a [type].")
 

--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -22,6 +22,8 @@
 	if(usr?.client)
 		usr.client.running_find_references = type
 
+	log_reftracker("Currently sleeping procs [byond_status()]")
+
 	log_reftracker("Beginning search for references to a [type].")
 
 	var/starting_time = world.time


### PR DESCRIPTION

## About The Pull Request

In addition, improves dump_harddel_deets usage to hopefully hit in unit testing

byond_status() will dump as a part of find_references(). While I'd like to expand that if we ever get a proper version, this is good for how we have things setup rn.
