### PR TITLE
Fixes apocalypse rune applying invisibility on mobs.

### DIFF
--- a/code/modules/antagonists/cult/cult_structure_altar.dm
+++ b/code/modules/antagonists/cult/cult_structure_altar.dm
@@ -22,7 +22,7 @@
 			OUTPUT_ITEMS = list(/obj/structure/constructshell),
 			),
 		UNHOLY_WATER = list(
-			PREVIEW_IMAGE = image(icon = 'icons/obj/drinks/bottles.dmi', icon_state = "holyflask"),
+			PREVIEW_IMAGE = image(icon = 'icons/obj/drinks/bottles.dmi', icon_state = "unholyflask"),
 			OUTPUT_ITEMS = list(/obj/item/reagent_containers/cup/beaker/unholywater),
 			),
 	)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -1019,8 +1019,8 @@ structure_check() searches for nearby cultist structures required for the invoca
 			images += A
 			SEND_SOUND(M, pick(sound('sound/ambience/antag/bloodcult.ogg'),sound('sound/voice/ghost_whisper.ogg'),sound('sound/misc/ghosty_wind.ogg')))
 		else
-			var/construct = pick("floater","artificer","behemoth")
-			var/image/B = image('icons/mob/simple/mob.dmi',M,construct, ABOVE_MOB_LAYER)
+			var/construct = pick("wraith","artificer","juggernaut")
+			var/image/B = image('icons/mob/nonhuman-player/cult.dmi',M,construct, ABOVE_MOB_LAYER)
 			B.override = 1
 			add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/noncult, "mob_apoc", B, NONE)
 			addtimer(CALLBACK(M, TYPE_PROC_REF(/atom/, remove_alt_appearance),"mob_apoc",TRUE), duration)


### PR DESCRIPTION
## About The Pull Request
Fixes https://github.com/tgstation/tgstation/issues/77714
Icons for apocalypse weren't pathed properly, so they were just applying non-existing icons.
Also changed preview image for unholy water bottle on the altar, as it was added it's own icon.
## Changelog
:cl:
fix: fixed apocalypse rune applying invisibility to mobs.
fix: Unholy water preview icon is now similar with the icon it has.
/:cl:
