### PR TITLE
Replaces the decloning virus clone damage with a status effect

### DIFF
--- a/code/datums/diseases/decloning.dm
+++ b/code/datums/diseases/decloning.dm
@@ -1,9 +1,12 @@
+/// The amount of mutadone we can process for strike recovery at once.
+#define MUTADONE_HEAL 1
+
 /datum/disease/decloning
 	form = "Virus"
 	name = "Cellular Degeneration"
 	max_stages = 5
 	stage_prob = 0.5
-	cure_text = "Rezadone or death."
+	cure_text = "Rezadone, Mutadone for prolonging, or death."
 	agent = "Severe Genetic Damage"
 	viable_mobtypes = list(/mob/living/carbon/human)
 	desc = @"If left untreated the subject will [REDACTED]!"
@@ -13,11 +16,17 @@
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	spread_text = "Organic meltdown"
 	process_dead = TRUE
+	/// How many strikes our virus holder has left before they are dusted.
+	var/strikes_left = 100
 
 /datum/disease/decloning/stage_act(seconds_per_tick, times_fired)
 	. = ..()
 	if(!.)
 		return
+
+	if(affected_mob.reagents?.has_reagent(/datum/reagent/medicine/mutadone, MUTADONE_HEAL * seconds_per_tick))
+		strikes_left = min(strikes_left + MUTADONE_HEAL * seconds_per_tick, 100)
+		affected_mob.reagents.remove_reagent(/datum/reagent/medicine/mutadone, MUTADONE_HEAL * seconds_per_tick)
 
 	if(affected_mob.stat == DEAD)
 		cure()
@@ -35,7 +44,7 @@
 			if(SPT_PROB(1, seconds_per_tick))
 				affected_mob.emote("drool")
 			if(SPT_PROB(1.5, seconds_per_tick))
-				affected_mob.adjustCloneLoss(1, FALSE)
+				strikes_left -= 5
 			if(SPT_PROB(1, seconds_per_tick))
 				to_chat(affected_mob, span_danger("Your skin feels strange."))
 
@@ -46,7 +55,7 @@
 				affected_mob.emote("drool")
 			if(SPT_PROB(2.5, seconds_per_tick))
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1, 170)
-				affected_mob.adjustCloneLoss(2, FALSE)
+				strikes_left = max(strikes_left - 2, 0)
 			if(SPT_PROB(7.5, seconds_per_tick))
 				affected_mob.adjust_stutter(6 SECONDS)
 		if(5)
@@ -57,9 +66,11 @@
 			if(SPT_PROB(2.5, seconds_per_tick))
 				to_chat(affected_mob, span_danger("Your skin starts degrading!"))
 			if(SPT_PROB(5, seconds_per_tick))
-				affected_mob.adjustCloneLoss(5, FALSE)
+				strikes_left = max(strikes_left - 5, 0)
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 170)
-			if(affected_mob.cloneloss >= 100)
+			if(strikes_left == 0)
 				affected_mob.visible_message(span_danger("[affected_mob] skin turns to dust!"), span_boldwarning("Your skin turns to dust!"))
 				affected_mob.dust()
 				return FALSE
+
+#undef MUTADONE_HEAL

--- a/code/datums/diseases/decloning.dm
+++ b/code/datums/diseases/decloning.dm
@@ -1,6 +1,3 @@
-/// The amount of mutadone we can process for strike recovery at once.
-#define MUTADONE_HEAL 1
-
 /datum/disease/decloning
 	form = "Virus"
 	name = "Cellular Degeneration"
@@ -12,21 +9,22 @@
 	desc = @"If left untreated the subject will [REDACTED]!"
 	severity = "Dangerous!"
 	cures = list(/datum/reagent/medicine/rezadone)
-	disease_flags = CAN_CARRY|CAN_RESIST
+	disease_flags = CAN_CARRY|CAN_RESIST|CURABLE
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	spread_text = "Organic meltdown"
 	process_dead = TRUE
-	/// How many strikes our virus holder has left before they are dusted.
+
 	var/strikes_left = 100
+
+/datum/disease/decloning/cure()
+	. = ..()
+	if(QDELETED(src))
+		affected_mob.remove_status_effect(/datum/status_effect/decloning)
 
 /datum/disease/decloning/stage_act(seconds_per_tick, times_fired)
 	. = ..()
 	if(!.)
 		return
-
-	if(affected_mob.reagents?.has_reagent(/datum/reagent/medicine/mutadone, MUTADONE_HEAL * seconds_per_tick))
-		strikes_left = min(strikes_left + MUTADONE_HEAL * seconds_per_tick, 100)
-		affected_mob.reagents.remove_reagent(/datum/reagent/medicine/mutadone, MUTADONE_HEAL * seconds_per_tick)
 
 	if(affected_mob.stat == DEAD)
 		cure()
@@ -54,8 +52,8 @@
 			if(SPT_PROB(1, seconds_per_tick))
 				affected_mob.emote("drool")
 			if(SPT_PROB(2.5, seconds_per_tick))
+				affected_mob.apply_status_effect(/datum/status_effect/decloning)
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1, 170)
-				strikes_left = max(strikes_left - 2, 0)
 			if(SPT_PROB(7.5, seconds_per_tick))
 				affected_mob.adjust_stutter(6 SECONDS)
 		if(5)
@@ -66,11 +64,5 @@
 			if(SPT_PROB(2.5, seconds_per_tick))
 				to_chat(affected_mob, span_danger("Your skin starts degrading!"))
 			if(SPT_PROB(5, seconds_per_tick))
-				strikes_left = max(strikes_left - 5, 0)
+				affected_mob.apply_status_effect(/datum/status_effect/decloning)
 				affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 2, 170)
-			if(strikes_left == 0)
-				affected_mob.visible_message(span_danger("[affected_mob] skin turns to dust!"), span_boldwarning("Your skin turns to dust!"))
-				affected_mob.dust()
-				return FALSE
-
-#undef MUTADONE_HEAL

--- a/code/datums/diseases/decloning.dm
+++ b/code/datums/diseases/decloning.dm
@@ -9,17 +9,13 @@
 	desc = @"If left untreated the subject will [REDACTED]!"
 	severity = "Dangerous!"
 	cures = list(/datum/reagent/medicine/rezadone)
-	disease_flags = CAN_CARRY|CAN_RESIST|CURABLE
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	spread_text = "Organic meltdown"
 	process_dead = TRUE
 
-	var/strikes_left = 100
-
 /datum/disease/decloning/cure()
-	. = ..()
-	if(QDELETED(src))
-		affected_mob.remove_status_effect(/datum/status_effect/decloning)
+	affected_mob.remove_status_effect(/datum/status_effect/decloning)
+	return ..()
 
 /datum/disease/decloning/stage_act(seconds_per_tick, times_fired)
 	. = ..()
@@ -42,10 +38,9 @@
 			if(SPT_PROB(1, seconds_per_tick))
 				affected_mob.emote("drool")
 			if(SPT_PROB(1.5, seconds_per_tick))
-				strikes_left -= 5
+				affected_mob.apply_status_effect(/datum/status_effect/decloning)
 			if(SPT_PROB(1, seconds_per_tick))
 				to_chat(affected_mob, span_danger("Your skin feels strange."))
-
 		if(4)
 			if(SPT_PROB(1, seconds_per_tick))
 				affected_mob.emote("itch")

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -850,7 +850,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 				apply_status_effect(/datum/status_effect/go_away)
 			if(7)
 				to_chat(src, span_notice("Oh, I actually feel quite alright!"))
-				ForceContractDisease(new/datum/disease/decloning()) //slow acting, non-viral clone damage based GBS
+				ForceContractDisease(new/datum/disease/decloning()) //slow acting, non-viral GBS
 			if(8)
 				var/list/elligible_organs = list()
 				for(var/obj/item/organ/internal/internal_organ in organs) //make sure we dont get an implant or cavity item

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -850,7 +850,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 				apply_status_effect(/datum/status_effect/go_away)
 			if(7)
 				to_chat(src, span_notice("Oh, I actually feel quite alright!"))
-				ForceContractDisease(new/datum/disease/decloning()) //slow acting, non-viral GBS
+				ForceContractDisease(new /datum/disease/decloning) // slow acting, non-viral GBS
 			if(8)
 				var/list/elligible_organs = list()
 				for(var/obj/item/organ/internal/internal_organ in organs) //make sure we dont get an implant or cavity item

--- a/code/datums/status_effects/debuffs/decloning.dm
+++ b/code/datums/status_effects/debuffs/decloning.dm
@@ -50,11 +50,11 @@
 	strikes_left = max(strikes_left - strike_reduce, 0)
 
 	if(prob(50))
-		to_chat(owner, span_danger(pick( \
-			"Your body is giving in.", \
-			"You feel some muscles twitching.", \
-			"Your skin feels sandy.", \
-			"You feel your limbs shifting around.", \
+		to_chat(owner, span_danger(pick(
+			"Your body is giving in.",
+			"You feel some muscles twitching.",
+			"Your skin feels sandy.",
+			"You feel your limbs shifting around.",
 		)))
 	else if(prob(33))
 		to_chat(owner, span_danger("You are twitching uncontrollably."))
@@ -72,12 +72,11 @@
 		if(34 to 67)
 			return span_warning("[owner.p_Their()] body looks <b>very</b> deformed.")
 		if(-INFINITY to 33)
-			return span_warning("<b>[owner.p_Their()] body looks severely deformed!</b>")
+			return span_boldwarning("[owner.p_Their()] body looks severely deformed!")
 
 /atom/movable/screen/alert/status_effect/decloning
 	name = "Cellular Meltdown"
-	desc = "Your body is deforming, and doesn't feel like it's going to hold up much longer. \
-		You are going to need treatment soon."
+	desc = "Your body is deforming, and doesn't feel like it's going to hold up much longer. You are going to need treatment soon."
 	icon_state = "dna_melt"
 
 /datum/movespeed_modifier/decloning

--- a/code/datums/status_effects/debuffs/decloning.dm
+++ b/code/datums/status_effects/debuffs/decloning.dm
@@ -7,7 +7,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/decloning
 	remove_on_fullheal = TRUE
 
-	/// How many strikes our virus holder has left before they are dusted.
+	/// How many strikes our status effect holder has left before they are dusted.
 	var/strikes_left = 100
 
 /datum/status_effect/decloning/on_apply()
@@ -25,9 +25,16 @@
 		if(strikes_left <= 50 && strikes_left + strike_restore > 50)
 			to_chat(owner, span_notice("Controlling your muscles feels easier now."))
 			owner.remove_movespeed_modifier(/datum/movespeed_modifier/decloning)
+		else if(SPT_PROB(5, seconds_between_ticks))
+			to_chat(owner, span_warning("Your body is growing and shifting back into place."))
 
 		strikes_left = min(strikes_left + strike_restore, 100)
+
 		owner.reagents.remove_reagent(/datum/reagent/medicine/mutadone, MUTADONE_HEAL * seconds_between_ticks)
+
+		if(strikes_left == 100)
+			qdel(src)
+
 		return
 
 	if(!SPT_PROB(5, seconds_between_ticks))

--- a/code/datums/status_effects/debuffs/decloning.dm
+++ b/code/datums/status_effects/debuffs/decloning.dm
@@ -11,15 +11,17 @@
 	var/strikes_left = 100
 
 /datum/status_effect/decloning/on_apply()
+	if(owner.has_reagent(/datum/reagent/medicine/mutadone))
+		return FALSE
 	to_chat(owner, span_userdanger("You've noticed your body has begun deforming. This can't be good."))
-	return ..()
+	return TRUE
 
 /datum/status_effect/decloning/on_remove()
 	if(!QDELETED(owner)) // bigger problems to worry about
 		owner.remove_movespeed_modifier(/datum/movespeed_modifier/decloning)
 
 /datum/status_effect/decloning/tick(seconds_between_ticks)
-	if(owner.reagents?.has_reagent(/datum/reagent/medicine/mutadone, MUTADONE_HEAL * seconds_between_ticks))
+	if(owner.has_reagent(/datum/reagent/medicine/mutadone, MUTADONE_HEAL * seconds_between_ticks))
 		var/strike_restore = MUTADONE_HEAL * seconds_between_ticks
 
 		if(strikes_left <= 50 && strikes_left + strike_restore > 50)

--- a/code/datums/status_effects/debuffs/decloning.dm
+++ b/code/datums/status_effects/debuffs/decloning.dm
@@ -1,0 +1,78 @@
+/// The amount of mutadone we can process for strike recovery at once.
+#define MUTADONE_HEAL 1
+
+/datum/status_effect/decloning
+	id = "decloning"
+	tick_interval = 3 SECONDS
+	alert_type = /atom/movable/screen/alert/status_effect/decloning
+	remove_on_fullheal = TRUE
+
+	/// How many strikes our virus holder has left before they are dusted.
+	var/strikes_left = 100
+
+/datum/status_effect/decloning/on_apply()
+	to_chat(owner, span_userdanger("You've noticed your body has begun deforming. This can't be good."))
+	return ..()
+
+/datum/status_effect/decloning/on_remove()
+	if(!QDELETED(owner)) // bigger problems to worry about
+		owner.remove_movespeed_modifier(/datum/movespeed_modifier/decloning)
+
+/datum/status_effect/decloning/tick(seconds_between_ticks)
+	if(owner.reagents?.has_reagent(/datum/reagent/medicine/mutadone, MUTADONE_HEAL * seconds_between_ticks))
+		var/strike_restore = MUTADONE_HEAL * seconds_between_ticks
+
+		if(strikes_left <= 50 && strikes_left + strike_restore > 50)
+			to_chat(owner, span_notice("Controlling your muscles feels easier now."))
+			owner.remove_movespeed_modifier(/datum/movespeed_modifier/decloning)
+
+		strikes_left = min(strikes_left + strike_restore, 100)
+		owner.reagents.remove_reagent(/datum/reagent/medicine/mutadone, MUTADONE_HEAL * seconds_between_ticks)
+		return
+
+	if(!SPT_PROB(5, seconds_between_ticks))
+		return
+
+	var/strike_reduce = 3
+	if(strikes_left > 50 && strikes_left - strike_reduce <= 50)
+		to_chat(owner, span_danger("You're having a hard time controlling your muscles."))
+		owner.add_movespeed_modifier(/datum/movespeed_modifier/decloning)
+
+	strikes_left = max(strikes_left - strike_reduce, 0)
+
+	if(prob(50))
+		to_chat(owner, span_danger(pick( \
+			"Your body is giving in.", \
+			"You feel some muscles twitching.", \
+			"Your skin feels sandy.", \
+			"You feel your limbs shifting around.", \
+		)))
+	else if(prob(33))
+		to_chat(owner, span_danger("You are twitching uncontrollably."))
+		owner.set_jitter_if_lower(30 SECONDS)
+
+	if(strikes_left == 0)
+		owner.visible_message(span_danger("[owner]'s skin turns to dust!"), span_boldwarning("Your skin turns to dust!"))
+		owner.dust()
+		return
+
+/datum/status_effect/decloning/get_examine_text()
+	switch(strikes_left)
+		if(68 to 100)
+			return span_warning("[owner.p_Their()] body looks a bit deformed.")
+		if(34 to 67)
+			return span_warning("[owner.p_Their()] body looks <b>very</b> deformed.")
+		if(-INFINITY to 33)
+			return span_warning("<b>[owner.p_Their()] body looks severely deformed!</b>")
+
+/atom/movable/screen/alert/status_effect/decloning
+	name = "Cellular Meltdown"
+	desc = "Your body is deforming, and doesn't feel like it's going to hold up much longer. \
+		You are going to need treatment soon."
+	icon_state = "dna_melt"
+
+/datum/movespeed_modifier/decloning
+	multiplicative_slowdown = 0.7
+	blacklisted_movetypes = (FLYING|FLOATING)
+
+#undef MUTADONE_HEAL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1539,6 +1539,7 @@
 #include "code\datums\status_effects\debuffs\choke.dm"
 #include "code\datums\status_effects\debuffs\confusion.dm"
 #include "code\datums\status_effects\debuffs\debuffs.dm"
+#include "code\datums\status_effects\debuffs\decloning.dm"
 #include "code\datums\status_effects\debuffs\dizziness.dm"
 #include "code\datums\status_effects\debuffs\drowsiness.dm"
 #include "code\datums\status_effects\debuffs\drugginess.dm"


### PR DESCRIPTION
## About The Pull Request

Simply replaces the decloning virus's dependency on clone loss with a status effect that operates on a strike system, very similar to how it was handled with clone damage. The strikes are reversed if you have mutadone in your blood, eventually removing the status effect entirely. If the virus is cured, the status effect is also removed.

Additionally, the decloning virus was not curable before. The cure hints suggested this shouldn't be the case, so I added it back again.

## Why It's Good For The Game

Explanation from #77569:

> Clone damage is a damage type that shouldn't exist anymore, it's a relic left from the era of cloning and it's so specific of a damage type that it rarely gets used as a result. It really should be a type of affliction (wound etc) instead of its own damage counter.

What's changed since then is that I don't think clone damage should not exist at all anymore. It only affects one department and a few odd situations anyways.

This PR should actually change very little about the virus, as it works with the same numbers as it did before, and since cloneloss healing is just as easy to come by as taking mutadone is.

## Changelog
:cl: distributivgesetz
add: Replaces decloning clone damage with a strike system that you can replenish with Mutadone.
fix: The decloning virus is curable with rezadone again.
/:cl:
