### PR TITLE
Fixes a 1-in-20 chance RNG CI failure.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -132,6 +132,7 @@
 /obj/structure/closet/toolcloset/populate_contents_immediate()
 	. = ..()
 
+	// Since they're a traitor objective, they have to be generated immediately.
 	if(prob(5))
 		new /obj/item/clothing/gloves/color/yellow(src)
 

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -124,11 +124,16 @@
 		new /obj/item/stack/cable_coil(src)
 	if(prob(20))
 		new /obj/item/multitool(src)
-	if(prob(5))
-		new /obj/item/clothing/gloves/color/yellow(src)
+
 	if(prob(40))
 		new /obj/item/clothing/head/utility/hardhat(src)
 
+
+/obj/structure/closet/toolcloset/populate_contents_immediate()
+	. = ..()
+
+	if(prob(5))
+		new /obj/item/clothing/gloves/color/yellow(src)
 
 /*
  * Radiation Closet


### PR DESCRIPTION
## About The Pull Request

Closes #77826

Fixes RNG CI failure. Insuls became a traitor objective and have to be created in populate_contents_immediate() instead of PopulateContents() for closets. Some closets only spawn insuls 5% of the time, so this slipped past CI and created a new CI failure that randomly does or doesn't fail.

Moved the offending item over the populate_contents_immediate().

![image](https://github.com/tgstation/tgstation/assets/24975989/5012f729-a410-4977-a555-abc29014a814)
## Why It's Good For The Game

Spurious CI failure bad.

No player-facing changes.
