### PR TITLE
Sets icebox perma doors to sec.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4943,6 +4943,7 @@
 	cycle_id = "perma-entrance"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/transfer)
 "bBr" = (
@@ -18902,6 +18903,7 @@
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution/transfer)
 "fTB" = (


### PR DESCRIPTION

## About The Pull Request

On icebox the perma back doors were set as normal doors when they should be sec to be consistent with all the other maps. This fixes it.

## Why It's Good For The Game

Bug fix

## Changelog

Labels sec doors as sec correctly.

:cl:
fix: Changed icebox permabrig door type to be correct 

/:cl:

