### PR TITLE
Damage resistance is now applied properly when synchronous mesh blobs deals damage to itself on hit

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/synchronous_mesh.dm
+++ b/code/modules/antagonists/blob/blobstrains/synchronous_mesh.dm
@@ -14,12 +14,13 @@
 /datum/blobstrain/reagent/synchronous_mesh/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_flag == MELEE || damage_flag == BULLET || damage_flag == LASER) //the cause isn't fire or bombs, so split the damage
 		var/damagesplit = 1 //maximum split is 9, reducing the damage each blob takes to 11% but doing that damage to 9 blobs
-		for(var/obj/structure/blob/C in orange(1, B))
+		var/list/blob_structures = orange(1, B)
+		for(var/obj/structure/blob/C in blob_structures)
 			if(!C.ignore_syncmesh_share && C.overmind && C.overmind.blobstrain.type == B.overmind.blobstrain.type) //if it doesn't have the same chemical or is a core or node, don't split damage to it
 				damagesplit += 1
-		for(var/obj/structure/blob/C in orange(1, B))
+		for(var/obj/structure/blob/C in blob_structures)
 			if(!C.ignore_syncmesh_share && C.overmind && C.overmind.blobstrain.type == B.overmind.blobstrain.type) //only hurt blobs that have the same overmind chemical and aren't cores or nodes
-				C.take_damage(damage/damagesplit, CLONE, 0, 0)
+				C.take_damage(damage/damagesplit, damage_type, 0, 0)
 		return damage / damagesplit
 	else
 		return damage * 1.25

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -293,7 +293,6 @@
 			damage_amount *= brute_resist
 		if(BURN)
 			damage_amount *= fire_resist
-		if(CLONE)
 		else
 			return 0
 	var/armor_protection = 0


### PR DESCRIPTION
## About The Pull Request

The synchronous mesh blobstrain bypasses damage resistance when dealing collateral damage to nearby blob... things? Structures? Meshes? Anyways, this is now fixed with this PR well as getting rid of an unnecessary double `orange()` call.
## Why It's Good For The Game

This is actually a weird consistency error, and I don't know why it exists. Why we have a bypass for damage resistance is really byond me, and I hope this puts a bit more balance into place of---

guys don't listen to her she's doing this to remove clone damage from the game do not listen to her lies about game balance
## Changelog
:cl: distributivgesetz
balance: Damaging synchronous mesh blobs now incorporates damage resistance of other blob structures when dealing shared damage to those nearby.
/:cl:
