### PR TITLE
Replaces or removes miscellaneous sources of clone damage from the game

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -401,15 +401,15 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		return ..()
 	if(!is_deployed())
 		return FALSE
-	summoner.adjustBruteLoss(amount)
+	var/damage_multiplier = 1
+	if(summoner.stat == UNCONSCIOUS || summoner.stat == HARD_CRIT)
+		to_chat(summoner, span_bolddanger("Your body can't take the strain of sustaining [src] in this condition!"))
+		damage_multiplier = 1.5
+	summoner.adjustBruteLoss(amount * damage_multiplier)
 	if(amount < 0 || QDELETED(summoner))
 		return
 	to_chat(summoner, span_bolddanger("Your [name] is under attack! You take damage!"))
 	summoner.visible_message(span_bolddanger("Blood sprays from [summoner] as [src] takes damage!"))
-	switch(summoner.stat)
-		if(UNCONSCIOUS, HARD_CRIT)
-			to_chat(summoner, span_bolddanger("Your body can't take the strain of sustaining [src] in this condition, it begins to fall apart!"))
-			summoner.adjustCloneLoss(amount * 0.5) //dying hosts take 50% bonus damage as cloneloss
 
 /mob/living/simple_animal/hostile/guardian/ex_act(severity, target)
 	switch(severity)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -401,15 +401,14 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		return ..()
 	if(!is_deployed())
 		return FALSE
-	var/damage_multiplier = 1
-	if(summoner.stat == UNCONSCIOUS || summoner.stat == HARD_CRIT)
-		to_chat(summoner, span_bolddanger("Your body can't take the strain of sustaining [src] in this condition!"))
-		damage_multiplier = 1.5
-	summoner.adjustBruteLoss(amount * damage_multiplier)
+	summoner.adjustBruteLoss(amount)
 	if(amount < 0 || QDELETED(summoner))
 		return
 	to_chat(summoner, span_bolddanger("Your [name] is under attack! You take damage!"))
 	summoner.visible_message(span_bolddanger("Blood sprays from [summoner] as [src] takes damage!"))
+	if(summoner.stat == UNCONSCIOUS || summoner.stat == HARD_CRIT)
+		to_chat(summoner, span_bolddanger("Your heart can't take the strain of sustaining [src] in this condition!"))
+		summoner.adjustOrganLoss(ORGAN_SLOT_HEART, amount * 0.5)
 
 /mob/living/simple_animal/hostile/guardian/ex_act(severity, target)
 	switch(severity)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -407,8 +407,8 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	to_chat(summoner, span_bolddanger("Your [name] is under attack! You take damage!"))
 	summoner.visible_message(span_bolddanger("Blood sprays from [summoner] as [src] takes damage!"))
 	if(summoner.stat == UNCONSCIOUS || summoner.stat == HARD_CRIT)
-		to_chat(summoner, span_bolddanger("Your heart can't take the strain of sustaining [src] in this condition!"))
-		summoner.adjustOrganLoss(ORGAN_SLOT_HEART, amount * 0.5)
+		to_chat(summoner, span_bolddanger("Your head pounds, you can't take the strain of sustaining [src] in this condition!"))
+		summoner.adjustOrganLoss(ORGAN_SLOT_BRAIN, amount * 0.5)
 
 /mob/living/simple_animal/hostile/guardian/ex_act(severity, target)
 	switch(severity)

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -192,11 +192,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/peptides_failed
 	name = "Prion Peptides"
 	taste_description = "spearmint frosting"
-	description = "These inhibitory peptides cause cellular damage and cost nutrition to the patient!"
+	description = "These inhibitory peptides drain nutrition from the patient!"
 	ph = 2.1
 
 /datum/reagent/peptides_failed/on_mob_life(mob/living/carbon/owner, seconds_per_tick, times_fired)
-	owner.adjustCloneLoss(0.25 * seconds_per_tick)
 	owner.adjust_nutrition(-5 * REAGENTS_METABOLISM * seconds_per_tick)
 	. = ..()
 

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -192,10 +192,11 @@ Basically, we fill the time between now and 2s from now with hands based off the
 /datum/reagent/peptides_failed
 	name = "Prion Peptides"
 	taste_description = "spearmint frosting"
-	description = "These inhibitory peptides drain nutrition from the patient!"
+	description = "These inhibitory peptides drains nutrition and causes brain damage in the patient!"
 	ph = 2.1
 
 /datum/reagent/peptides_failed/on_mob_life(mob/living/carbon/owner, seconds_per_tick, times_fired)
+	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25 * seconds_per_tick, 170)
 	owner.adjust_nutrition(-5 * REAGENTS_METABOLISM * seconds_per_tick)
 	. = ..()
 

--- a/code/modules/research/xenobiology/crossbreeding/_mobs.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_mobs.dm
@@ -14,6 +14,7 @@ Slimecrossing Mobs
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 
+	convert_damage_type = TOX
 	possible_shapes = list(/mob/living/simple_animal/slime/transformed_slime)
 
 	/// If TRUE, we self-delete (remove ourselves) the next time we turn back into a human

--- a/code/modules/research/xenobiology/crossbreeding/_mobs.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_mobs.dm
@@ -14,8 +14,6 @@ Slimecrossing Mobs
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE
 
-	convert_damage = TRUE
-	convert_damage_type = CLONE
 	possible_shapes = list(/mob/living/simple_animal/slime/transformed_slime)
 
 	/// If TRUE, we self-delete (remove ourselves) the next time we turn back into a human

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -992,7 +992,7 @@
 		owner.apply_damage_type(-heal_amount, damagetype = pick(healing_types))
 
 	owner.adjust_nutrition(3)
-	drained.adjustCloneLoss(heal_amount * DRAIN_DAMAGE_MULTIPLIER)
+	drained.apply_damage_type(heal_amount * DRAIN_DAMAGE_MULTIPLIER, damagetype = BRUTE)
 	return ..()
 
 #undef DRAIN_DAMAGE_MULTIPLIER

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -992,7 +992,7 @@
 		owner.apply_damage_type(-heal_amount, damagetype = pick(healing_types))
 
 	owner.adjust_nutrition(3)
-	drained.apply_damage_type(heal_amount * DRAIN_DAMAGE_MULTIPLIER, damagetype = BRUTE)
+	drained.apply_damage(heal_amount * DRAIN_DAMAGE_MULTIPLIER, damagetype = BRUTE, spread_damage = TRUE)
 	return ..()
 
 #undef DRAIN_DAMAGE_MULTIPLIER

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -310,7 +310,6 @@
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
 			to_chat(user, span_notice("You activate [src]. Your genome feels more stable!"))
-			user.adjustCloneLoss(-15)
 			user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10)
 			user.reagents.add_reagent(/datum/reagent/medicine/potass_iodide, 10)
 			return 250

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -310,6 +310,7 @@
 	switch(activation_type)
 		if(SLIME_ACTIVATE_MINOR)
 			to_chat(user, span_notice("You activate [src]. Your genome feels more stable!"))
+			user.adjustCloneLoss(-15)
 			user.reagents.add_reagent(/datum/reagent/medicine/mutadone, 10)
 			user.reagents.add_reagent(/datum/reagent/medicine/potass_iodide, 10)
 			return 250


### PR DESCRIPTION
## About The Pull Request

Might as well go over all of them here.

1. Holoparasites deal half of the damage they take as clone damage to their summoner when they are knocked out. Now it deals damage to the brain instead.
2. Prion peptides used to deal a little bit of clone damage every reagent tick. Now they do it to the brain.
3. When transforming back to human from a slime via a shapeshift spell, the total damage you have gets flat converted into clone damage. Now it gets flat converted to toxin damage.
4. Black stabilized slimes let you drain health from other people if you latched onto them, dealing clone damage to whoever you latched onto, same as slimes used to do. This has been converted to brute damage.

## Why It's Good For The Game

Explanation from #77569:

> Clone damage is a damage type that shouldn't exist anymore, it's a relic left from the era of cloning and it's so specific of a damage type that it rarely gets used as a result. It really should be a type of affliction (wound etc) instead of its own damage counter.

Only a few left to go, cosmic heretic lore, the greed ruin and the decloner gun. Then we can remove clone damage completely.

## Changelog
:cl:
del: Removes miscellaneous sources of clone damage from the game.
/:cl:
