### PR TITLE
Stops deleting callbacks in the integrated circuit subsystem.

### DIFF
--- a/code/controllers/subsystem/circuit_component.dm
+++ b/code/controllers/subsystem/circuit_component.dm
@@ -28,8 +28,6 @@ SUBSYSTEM_DEF(circuit_component)
 
 		to_call.user = null
 		to_call.InvokeAsync()
-		qdel(to_call)
-
 
 		if(MC_TICK_CHECK)
 			return

--- a/code/controllers/subsystem/circuit_component.dm
+++ b/code/controllers/subsystem/circuit_component.dm
@@ -74,7 +74,6 @@ SUBSYSTEM_DEF(circuit_component)
 			instant_run_currentrun.Cut(1,2)
 			to_call.user = null
 			to_call.InvokeAsync(received_inputs)
-			qdel(to_call)
 
 	if(length(instant_run_stack))
 		instant_run_callbacks_to_run = pop(instant_run_stack)


### PR DESCRIPTION

## About The Pull Request
The integrated circuit subsystem deletes callbacks. This changes that so that doesn't happen anymore.

## Why It's Good For The Game
Callbacks should not be directly deleted, they should quietly just be collected by the gc when no ref is held to them anymore.

## Changelog
:cl:
fix: Fixed some performance problems with integrated circuits.
/:cl:
