### PR TITLE
Adds error on qdeling callback, fixes errors this causes

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -337,7 +337,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 /datum/radial_menu/Destroy()
 	Reset()
 	hide()
-	QDEL_NULL(custom_check_callback)
+	custom_check_callback = null
 	. = ..()
 
 /*

--- a/code/controllers/subsystem/circuit_component.dm
+++ b/code/controllers/subsystem/circuit_component.dm
@@ -28,8 +28,6 @@ SUBSYSTEM_DEF(circuit_component)
 
 		to_call.user = null
 		to_call.InvokeAsync()
-		qdel(to_call)
-
 
 		if(MC_TICK_CHECK)
 			return
@@ -76,7 +74,6 @@ SUBSYSTEM_DEF(circuit_component)
 			instant_run_currentrun.Cut(1,2)
 			to_call.user = null
 			to_call.InvokeAsync(received_inputs)
-			qdel(to_call)
 
 	if(length(instant_run_stack))
 		instant_run_callbacks_to_run = pop(instant_run_stack)

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -115,8 +115,7 @@ SUBSYSTEM_DEF(throwing)
 	thrownthing = null
 	thrower = null
 	initial_target = null
-	if(callback)
-		QDEL_NULL(callback) //It stores a reference to the thrownthing, its source. Let's clean that.
+	callback = null
 	return ..()
 
 ///Defines the datum behavior on the thrownthing's qdeletion event.

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -80,7 +80,7 @@
 	SHOULD_CALL_PARENT(FALSE)
 	if (force)
 		return ..()
-	stack_trace("callbacks can not be qdeleted. if they are referenced they must exist. ([object == GLOBAL_PROC ? GLOBAL_PROC : object.type] [delegate])")
+	stack_trace("Callbacks can not be qdeleted. If they are referenced, they must exist. ([object == GLOBAL_PROC ? GLOBAL_PROC : object.type] [delegate])")
 	return QDEL_HINT_LETMELIVE
 
 /**

--- a/code/datums/callback.dm
+++ b/code/datums/callback.dm
@@ -69,6 +69,21 @@
 		user = WEAKREF(usr)
 
 /**
+ * Qdel a callback datum
+ * This is not allowed and will stack trace. callback datums are structs, if they are referenced they exist
+ *
+ * Arguments
+ * * force set to true to force the deletion to be allowed.
+ * * ... an optional list of extra arguments to pass to the proc
+ */
+/datum/callback/Destroy(force=FALSE, ...)
+	SHOULD_CALL_PARENT(FALSE)
+	if (force)
+		return ..()
+	stack_trace("callbacks can not be qdeleted. if they are referenced they must exist. ([object == GLOBAL_PROC ? GLOBAL_PROC : object.type] [delegate])")
+	return QDEL_HINT_LETMELIVE
+
+/**
  * Invoke this callback
  *
  * Calls the registered proc on the registered object, if the user ref

--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -52,7 +52,7 @@
 
 /datum/cinematic/Destroy()
 	QDEL_NULL(screen)
-	QDEL_NULL(special_callback)
+	special_callback = null
 	watching.Cut()
 	locked.Cut()
 	return ..()

--- a/code/datums/components/action_item_overlay.dm
+++ b/code/datums/components/action_item_overlay.dm
@@ -26,7 +26,7 @@
 
 /datum/component/action_item_overlay/Destroy(force, silent)
 	item_ref = null
-	QDEL_NULL(item_callback)
+	item_callback = null
 	item_appearance = null
 	return ..()
 

--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -56,8 +56,8 @@
 	src.expiration = expiration
 
 /datum/component/anti_magic/Destroy(force, silent)
-	QDEL_NULL(drain_antimagic)
-	QDEL_NULL(expiration)
+	drain_antimagic = null
+	expiration = null
 	return ..()
 
 /datum/component/anti_magic/proc/register_antimagic_signals(datum/on_what)

--- a/code/datums/components/bullet_intercepting.dm
+++ b/code/datums/components/bullet_intercepting.dm
@@ -26,7 +26,7 @@
 	RegisterSignal(parent, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(on_unequipped))
 
 /datum/component/bullet_intercepting/Destroy(force, silent)
-	QDEL_NULL(on_intercepted)
+	on_intercepted = null
 	return ..()
 
 /// Called when item changes slots, check if we're in a valid location to take bullets

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -30,10 +30,8 @@
 	src.on_cleaned_callback = on_cleaned_callback
 
 /datum/component/cleaner/Destroy(force, silent)
-	if(pre_clean_callback)
-		QDEL_NULL(pre_clean_callback)
-	if(on_cleaned_callback)
-		QDEL_NULL(on_cleaned_callback)
+	pre_clean_callback = null
+	on_cleaned_callback = null
 	return ..()
 
 /datum/component/cleaner/RegisterWithParent()

--- a/code/datums/components/effect_remover.dm
+++ b/code/datums/components/effect_remover.dm
@@ -42,7 +42,7 @@
 	src.time_to_remove = time_to_remove
 
 /datum/component/effect_remover/Destroy(force, silent)
-	QDEL_NULL(on_clear_callback)
+	on_clear_callback = null
 	return ..()
 
 /datum/component/effect_remover/RegisterWithParent()

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -187,9 +187,9 @@ Behavior that's still missing from this component that original food items had t
 	setup_initial_reagents(initial_reagents)
 
 /datum/component/edible/Destroy(force, silent)
-	QDEL_NULL(after_eat)
-	QDEL_NULL(on_consume)
-	QDEL_NULL(check_liked)
+	after_eat = null
+	on_consume = null
+	check_liked = null
 	return ..()
 
 /// Sets up the initial reagents of the food.

--- a/code/datums/components/food/golem_food.dm
+++ b/code/datums/components/food/golem_food.dm
@@ -31,7 +31,7 @@
 
 /datum/component/golem_food/Destroy(force, silent)
 	QDEL_NULL(golem_snack)
-	QDEL_NULL(extra_validation)
+	extra_validation = null
 	return ..()
 
 /// Attempt to feed this item to golem

--- a/code/datums/components/ghost_direct_control.dm
+++ b/code/datums/components/ghost_direct_control.dm
@@ -48,8 +48,8 @@
 	return ..()
 
 /datum/component/ghost_direct_control/Destroy(force, silent)
-	QDEL_NULL(extra_control_checks)
-	QDEL_NULL(after_assumed_control)
+	extra_control_checks = null
+	after_assumed_control = null
 
 	var/mob/mob_parent = parent
 	var/list/spawners = GLOB.joinable_mobs[format_text("[initial(mob_parent.name)]")]

--- a/code/datums/components/healing_touch.dm
+++ b/code/datums/components/healing_touch.dm
@@ -71,7 +71,7 @@
 	return ..()
 
 /datum/component/healing_touch/Destroy(force, silent)
-	QDEL_NULL(extra_checks)
+	extra_checks = null
 	return ..()
 
 /// Validate our target, and interrupt the attack chain to start healing it if it is allowed

--- a/code/datums/components/health_scaling_effects.dm
+++ b/code/datums/components/health_scaling_effects.dm
@@ -54,7 +54,7 @@
 	return ..()
 
 /datum/component/health_scaling_effects/Destroy(force, silent)
-	QDEL_NULL(additional_status_callback)
+	additional_status_callback = null
 	return ..()
 
 /// Called when mob health changes, recalculates the ratio between maximum and minimum

--- a/code/datums/components/jetpack.dm
+++ b/code/datums/components/jetpack.dm
@@ -66,7 +66,7 @@
 /datum/component/jetpack/Destroy()
 	if(trail)
 		QDEL_NULL(trail)
-	QDEL_NULL(check_on_move)
+	check_on_move = null
 	return ..()
 
 /datum/component/jetpack/proc/setup_trail(mob/user)

--- a/code/datums/components/mind_linker.dm
+++ b/code/datums/components/mind_linker.dm
@@ -64,7 +64,7 @@
 		unlink_mob(remaining_mob)
 	linked_mobs.Cut()
 	QDEL_NULL(master_speech)
-	QDEL_NULL(post_unlink_callback)
+	post_unlink_callback = null
 	return ..()
 
 /datum/component/mind_linker/RegisterWithParent()

--- a/code/datums/components/rotation.dm
+++ b/code/datums/components/rotation.dm
@@ -45,7 +45,7 @@
 	. = ..()
 
 /datum/component/simple_rotation/Destroy()
-	QDEL_NULL(AfterRotation)
+	AfterRotation = null
 	//Signals + verbs removed via UnRegister
 	. = ..()
 

--- a/code/datums/components/shielded.dm
+++ b/code/datums/components/shielded.dm
@@ -62,7 +62,7 @@
 		UnregisterSignal(wearer, COMSIG_ATOM_UPDATE_OVERLAYS)
 		wearer.update_appearance(UPDATE_ICON)
 		wearer = null
-	QDEL_NULL(on_hit_effects)
+	on_hit_effects = null
 	return ..()
 
 /datum/component/shielded/RegisterWithParent()

--- a/code/datums/components/singularity.dm
+++ b/code/datums/components/singularity.dm
@@ -110,7 +110,7 @@
 
 /datum/component/singularity/Destroy(force, silent)
 	GLOB.singularities -= src
-	QDEL_NULL(consume_callback)
+	consume_callback = null
 	target = null
 
 	return ..()

--- a/code/datums/components/spin2win.dm
+++ b/code/datums/components/spin2win.dm
@@ -37,8 +37,8 @@
 	src.end_spin_message = end_spin_message
 
 /datum/component/spin2win/Destroy(force, silent)
-	QDEL_NULL(on_spin_callback)
-	QDEL_NULL(on_unspin_callback)
+	on_spin_callback = null
+	on_unspin_callback = null
 	return ..()
 
 /datum/component/spin2win/RegisterWithParent()

--- a/code/datums/components/swabbing.dm
+++ b/code/datums/components/swabbing.dm
@@ -36,8 +36,8 @@ This component is used in vat growing to swab for microbiological samples which 
 	. = ..()
 	for(var/swabbed in swabbed_items)
 		qdel(swabbed)
-	QDEL_NULL(update_icons)
-	QDEL_NULL(update_overlays)
+	update_icons = null
+	update_overlays = null
 
 
 ///Changes examine based on your sample

--- a/code/datums/components/takes_reagent_appearance.dm
+++ b/code/datums/components/takes_reagent_appearance.dm
@@ -44,8 +44,8 @@
 	src.base_container_type = base_container_type || parent.type
 
 /datum/component/takes_reagent_appearance/Destroy()
-	QDEL_NULL(on_icon_changed)
-	QDEL_NULL(on_icon_reset)
+	on_icon_changed = null
+	on_icon_reset = null
 	return ..()
 
 /datum/component/takes_reagent_appearance/RegisterWithParent()

--- a/code/datums/components/tippable.dm
+++ b/code/datums/components/tippable.dm
@@ -63,14 +63,10 @@
 	UnregisterSignal(parent, COMSIG_ATOM_ATTACK_HAND_SECONDARY)
 
 /datum/component/tippable/Destroy()
-	if(pre_tipped_callback)
-		QDEL_NULL(pre_tipped_callback)
-	if(post_tipped_callback)
-		QDEL_NULL(post_tipped_callback)
-	if(post_untipped_callback)
-		QDEL_NULL(post_untipped_callback)
-	if(roleplay_callback)
-		QDEL_NULL(roleplay_callback)
+	pre_tipped_callback = null
+	post_tipped_callback = null
+	post_untipped_callback = null
+	roleplay_callback = null
 	return ..()
 
 /**

--- a/code/datums/components/toggle_attached_clothing.dm
+++ b/code/datums/components/toggle_attached_clothing.dm
@@ -82,9 +82,10 @@
 	unequip_deployable()
 	QDEL_NULL(deployable)
 	QDEL_NULL(toggle_action)
-	QDEL_NULL(on_created)
-	QDEL_NULL(on_deployed)
-	QDEL_NULL(on_removed)
+	pre_creation_check = null
+	on_created = null
+	on_deployed = null
+	on_removed = null
 	return ..()
 
 /// Toggle deployable when the UI button is clicked

--- a/code/datums/helper_datums/events.dm
+++ b/code/datums/helper_datums/events.dm
@@ -11,9 +11,6 @@
 	events = new
 
 /datum/events/Destroy()
-	for(var/elist in events)
-		for(var/e in events[elist])
-			qdel(e)
 	events = null
 	return ..()
 
@@ -23,8 +20,8 @@
 		return TRUE
 	return FALSE
 
-// Arguments: event_type as text, proc_holder as datum, proc_name as text
-// Returns: New event, null on error.
+/// Arguments: event_type as text, proc_holder as datum, proc_name as text
+/// Returns: New event, null on error.
 /datum/events/proc/addEvent(event_type as text, datum/callback/cb)
 	if(!event_type || !cb)
 		return
@@ -33,23 +30,20 @@
 	event += cb
 	return cb
 
-//  Arguments: event_type as text, any number of additional arguments to pass to event handler
-//  Returns: null
+/// Arguments: event_type as text, any number of additional arguments to pass to event handler
+/// Returns: null
 /datum/events/proc/fireEvent(eventName, ...)
-	
 	var/list/event = LAZYACCESS(events,eventName)
 	if(istype(event))
 		for(var/E in event)
 			var/datum/callback/cb = E
 			cb.InvokeAsync(arglist(args.Copy(2)))
 
-// Arguments: event_type as text, E as /datum/event
-// Returns: TRUE if event cleared, FALSE on error
-
+/// Arguments: event_type as text, E as /datum/event
+/// Returns: TRUE if event cleared, FALSE on error
 /datum/events/proc/clearEvent(event_type as text, datum/callback/cb)
 	if(!event_type || !cb)
 		return FALSE
 	var/list/event = LAZYACCESS(events,event_type)
 	event -= cb
-	qdel(cb)
 	return TRUE

--- a/code/modules/events/wizard/greentext.dm
+++ b/code/modules/events/wizard/greentext.dm
@@ -67,7 +67,7 @@
 
 /obj/item/greentext/Destroy(force)
 	LAZYREMOVE(SSticker.round_end_events, roundend_callback)
-	QDEL_NULL(roundend_callback) //This ought to free the callback datum, and prevent us from harddeling
+	roundend_callback = null //This ought to free the callback datum, and prevent us from harddeling
 	if(LAZYLEN(color_altered_mobs))
 		INVOKE_ASYNC(src, PROC_REF(release_victims))
 	return ..()

--- a/code/modules/mob/living/basic/pets/dog/corgi.dm
+++ b/code/modules/mob/living/basic/pets/dog/corgi.dm
@@ -372,7 +372,7 @@
 
 /mob/living/basic/pet/dog/corgi/ian/Destroy()
 	LAZYREMOVE(SSticker.round_end_events, i_will_survive) //cleanup the survival callback
-	QDEL_NULL(i_will_survive)
+	i_will_survive = null
 	return ..()
 
 /mob/living/basic/pet/dog/corgi/ian/death()

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -15,7 +15,7 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 	req_access = list(ACCESS_KEYCARD_AUTH)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
-	var/datum/callback/ev
+	var/datum/callback/activated
 	var/event = ""
 	var/obj/machinery/keycard_auth/event_source
 	var/mob/triggerer = null
@@ -27,11 +27,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 
 /obj/machinery/keycard_auth/Initialize(mapload)
 	. = ..()
-	ev = GLOB.keycard_events.addEvent("triggerEvent", CALLBACK(src, PROC_REF(triggerEvent)))
+	activated = GLOB.keycard_events.addEvent("triggerEvent", CALLBACK(src, PROC_REF(triggerEvent)))
 
 /obj/machinery/keycard_auth/Destroy()
-	GLOB.keycard_events.clearEvent("triggerEvent", ev)
-	QDEL_NULL(ev)
+	GLOB.keycard_events.clearEvent("triggerEvent", activated)
+	activated = null
 	return ..()
 
 /obj/machinery/keycard_auth/ui_state(mob/user)


### PR DESCRIPTION
## About The Pull Request

You shouldn't ever qdel a callback. If you don't want to own it free your ref (remove it from a list/set it to null). When all refs are cleared it'll get cleaned up by byond itself

## Why It's Good For The Game

Closes #77447
Closes #77846 


