### PR TITLE
Medical Kiosk right clickery, balloon alerts and screentips

### DIFF
--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -51,7 +51,7 @@
 	var/screentip_change = FALSE
 
 	if(!held_item && scanner_wand)
-		context[SCREENTIP_CONTEXT_RMB] = "Pick the scanner wand"
+		context[SCREENTIP_CONTEXT_RMB] = "Pick up scanner wand"
 		return screentip_change = TRUE
 
 	if(istype(held_item) && held_item.tool_behaviour == TOOL_WRENCH)

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -67,8 +67,6 @@
 		context[SCREENTIP_CONTEXT_LMB] = "Return the scanner wand"
 		return screentip_change = TRUE
 
-	return screentip_change ? CONTEXTUAL_SCREENTIP_SET : NONE
-
 /obj/machinery/medical_kiosk/proc/inuse()  //Verifies that the user can use the interface, followed by showing medical information.
 	var/mob/living/carbon/human/paying = paying_ref?.resolve()
 	if(!paying)

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -50,22 +50,22 @@
 	. = ..()
 	var/screentip_change = FALSE
 
-	if(!held_item)
+	if(!held_item && scanner_wand)
 		context[SCREENTIP_CONTEXT_RMB] = "Pick the scanner wand"
-		screentip_change = TRUE
+		return screentip_change = TRUE
 
-	else if(istype(held_item) && held_item.tool_behaviour == TOOL_WRENCH)
+	if(istype(held_item) && held_item.tool_behaviour == TOOL_WRENCH)
 		context[SCREENTIP_CONTEXT_LMB] = anchored ? "Unsecure" : "Secure"
-		screentip_change = TRUE
-	else if(istype(held_item) && held_item.tool_behaviour == TOOL_CROWBAR && panel_open)
+		return screentip_change = TRUE
+	if(istype(held_item) && held_item.tool_behaviour == TOOL_CROWBAR && panel_open)
 		context[SCREENTIP_CONTEXT_LMB] = "Deconstruct"
-		screentip_change = TRUE
-	else if(istype(held_item) && held_item.tool_behaviour == TOOL_SCREWDRIVER)
+		return screentip_change = TRUE
+	if(istype(held_item) && held_item.tool_behaviour == TOOL_SCREWDRIVER)
 		context[SCREENTIP_CONTEXT_LMB] = panel_open ? "Close panel" : "Open panel"
-		screentip_change = TRUE
-	else if(istype(held_item, /obj/item/scanner_wand))
+		return screentip_change = TRUE
+	if(istype(held_item, /obj/item/scanner_wand))
 		context[SCREENTIP_CONTEXT_LMB] = "Return the scanner wand"
-		screentip_change = TRUE
+		return screentip_change = TRUE
 
 	return screentip_change ? CONTEXTUAL_SCREENTIP_SET : NONE
 

--- a/code/game/machinery/medical_kiosk.dm
+++ b/code/game/machinery/medical_kiosk.dm
@@ -43,7 +43,31 @@
 /obj/machinery/medical_kiosk/Initialize(mapload) //loaded subtype for mapping use
 	. = ..()
 	AddComponent(/datum/component/payment, active_price, SSeconomy.get_dep_account(ACCOUNT_MED), PAYMENT_FRIENDLY)
+	register_context()
 	scanner_wand = new/obj/item/scanner_wand(src)
+
+/obj/machinery/medical_kiosk/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	var/screentip_change = FALSE
+
+	if(!held_item)
+		context[SCREENTIP_CONTEXT_RMB] = "Pick the scanner wand"
+		screentip_change = TRUE
+
+	else if(istype(held_item) && held_item.tool_behaviour == TOOL_WRENCH)
+		context[SCREENTIP_CONTEXT_LMB] = anchored ? "Unsecure" : "Secure"
+		screentip_change = TRUE
+	else if(istype(held_item) && held_item.tool_behaviour == TOOL_CROWBAR && panel_open)
+		context[SCREENTIP_CONTEXT_LMB] = "Deconstruct"
+		screentip_change = TRUE
+	else if(istype(held_item) && held_item.tool_behaviour == TOOL_SCREWDRIVER)
+		context[SCREENTIP_CONTEXT_LMB] = panel_open ? "Close panel" : "Open panel"
+		screentip_change = TRUE
+	else if(istype(held_item, /obj/item/scanner_wand))
+		context[SCREENTIP_CONTEXT_LMB] = "Return the scanner wand"
+		screentip_change = TRUE
+
+	return screentip_change ? CONTEXTUAL_SCREENTIP_SET : NONE
 
 /obj/machinery/medical_kiosk/proc/inuse()  //Verifies that the user can use the interface, followed by showing medical information.
 	var/mob/living/carbon/human/paying = paying_ref?.resolve()
@@ -104,13 +128,13 @@
 	if(istype(O, /obj/item/scanner_wand))
 		var/obj/item/scanner_wand/W = O
 		if(scanner_wand)
-			to_chat(user, span_warning("There's already a scanner wand in [src]!"))
+			balloon_alert(user, "already has a wand!")
 			return
 		if(HAS_TRAIT(O, TRAIT_NODROP) || !user.transferItemToLoc(O, src))
-			to_chat(user, span_warning("[O] is stuck to your hand!"))
+			balloon_alert(user, "stuck to your hand!")
 			return
-		user.visible_message(span_notice("[user] snaps [O] onto [src]!"), \
-		span_notice("You press [O] into the side of [src], clicking into place."))
+		user.visible_message(span_notice("[user] snaps [O] onto [src]!"))
+		balloon_alert(user, "wand returned")
 		//This will be the scanner returning scanner_wand's selected_target variable and assigning it to the altPatient var
 		if(W.selected_target)
 			var/datum/weakref/target_ref = WEAKREF(W.return_patient())
@@ -124,20 +148,24 @@
 		return
 	return ..()
 
-/obj/machinery/medical_kiosk/AltClick(mob/living/carbon/user)
-	if(!istype(user) || !user.can_perform_action(src))
-		return
+/obj/machinery/medical_kiosk/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	if(!ishuman(user) || !user.can_perform_action(src))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	if(!scanner_wand)
-		to_chat(user, span_warning("The scanner wand is currently removed from the machine."))
-		return
+		balloon_alert(user, "no scanner wand!")
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	if(!user.put_in_hands(scanner_wand))
-		to_chat(user, span_warning("The scanner wand falls to the floor."))
+		balloon_alert(user, "scanner wand falls!")
 		scanner_wand = null
-		return
-	user.visible_message(span_notice("[user] unhooks the [scanner_wand] from [src]."), \
-	span_notice("You detach the [scanner_wand] from [src]."))
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	user.visible_message(span_notice("[user] unhooks the [scanner_wand] from [src]."))
+	balloon_alert(user, "scanner pulled")
 	playsound(src, 'sound/machines/click.ogg', 60, TRUE)
 	scanner_wand = null
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/medical_kiosk/Destroy()
 	qdel(scanner_wand)
@@ -162,7 +190,7 @@
 	if(scanner_wand == null)
 		. += span_notice("\The [src] is missing its scanner.")
 	else
-		. += span_notice("\The [src] has its scanner clipped to the side. Alt-Click to remove.")
+		. += span_notice("\The [src] has its scanner clipped to the side. Right Click to remove.")
 
 /obj/machinery/medical_kiosk/ui_interact(mob/user, datum/tgui/ui)
 	var/patient_distance = 0


### PR DESCRIPTION

## About The Pull Request
Moves pulling the scanner wand from alt click into right clicking with an empty hand.
Turns a few `to_chat` into balloon alerts.
Screentips.
## Why It's Good For The Game
Firstly, right click is just better UX than Alt clicking IMO.
I often talk with people that have no idea you can pull the scanner wand from the kiosk to check on other patients.
That is such a neat feature and I just want it used more, so I hope this nudges people to learn about it easier.

I did plan on also adding a new sprite for when the kiosk has a wand, but after a few attempts I gave up for now, maybe someday I have more patience I come back to it because it would help way more than these changes...
## Changelog
:cl: Guillaume Prata
qol: Medical Kiosk now have their wand removed with a right click, got new screentips and have a few of its chat messages turned into balloon alerts.
/:cl:
