### PR TITLE
Grilles take 0-1 damage when shocking something, power sinks are available at lower reputation

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -60,21 +60,21 @@
 /obj/structure/grille/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 20, "cost" = 5)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 2 SECONDS, "cost" = 5)
 		if(RCD_WINDOWGRILLE)
 			var/cost = 0
 			var/delay = 0
 			if(the_rcd.window_type  == /obj/structure/window)
-				cost = 6
+				cost = 4
 				delay = 2 SECONDS
 			else if(the_rcd.window_type  == /obj/structure/window/reinforced)
-				cost = 9
+				cost = 6
 				delay = 2.5 SECONDS
 			else if(the_rcd.window_type  == /obj/structure/window/fulltile)
-				cost = 12
+				cost = 8
 				delay = 3 SECONDS
 			else if(the_rcd.window_type  == /obj/structure/window/reinforced/fulltile)
-				cost = 15
+				cost = 12
 				delay = 4 SECONDS
 			if(!cost)
 				return FALSE

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -60,21 +60,21 @@
 /obj/structure/grille/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 2 SECONDS, "cost" = 5)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 20, "cost" = 5)
 		if(RCD_WINDOWGRILLE)
 			var/cost = 0
 			var/delay = 0
 			if(the_rcd.window_type  == /obj/structure/window)
-				cost = 4
+				cost = 6
 				delay = 2 SECONDS
 			else if(the_rcd.window_type  == /obj/structure/window/reinforced)
-				cost = 6
+				cost = 9
 				delay = 2.5 SECONDS
 			else if(the_rcd.window_type  == /obj/structure/window/fulltile)
-				cost = 8
+				cost = 12
 				delay = 3 SECONDS
 			else if(the_rcd.window_type  == /obj/structure/window/reinforced/fulltile)
-				cost = 12
+				cost = 15
 				delay = 4 SECONDS
 			if(!cost)
 				return FALSE
@@ -141,6 +141,8 @@
 		return
 	var/mob/M = AM
 	shock(M, 70)
+	if(prob(50))
+		take_damage(1, BRUTE, "melee", FALSE)
 
 /obj/structure/grille/attack_animal(mob/user, list/modifiers)
 	. = ..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -142,7 +142,7 @@
 	var/mob/M = AM
 	shock(M, 70)
 	if(prob(50))
-		take_damage(1, FIRE, "fire", FALSE)
+		take_damage(1, BURN, FIRE, sound_effect = FALSE)
 
 /obj/structure/grille/attack_animal(mob/user, list/modifiers)
 	. = ..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -142,7 +142,7 @@
 	var/mob/M = AM
 	shock(M, 70)
 	if(prob(50))
-		take_damage(1, BRUTE, "melee", FALSE)
+		take_damage(1, FIRE, "fire", FALSE)
 
 /obj/structure/grille/attack_animal(mob/user, list/modifiers)
 	. = ..()

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -254,7 +254,7 @@
 	desc = "When screwed to wiring attached to a power grid and activated, this large device lights up and places excessive \
 			load on the grid, causing a station-wide blackout. The sink is large and cannot be stored in most \
 			traditional bags and boxes. Caution: Will explode if the powernet contains sufficient amounts of energy."
-	progression_minimum = 30 MINUTES
+	progression_minimum = 20 MINUTES
 	item = /obj/item/powersink
 	cost = 11
 


### PR DESCRIPTION

## About The Pull Request
Ports BeeStation/BeeStation-Hornet#3590. As it is right now, it's trivial to set up a contraption using a conveyor belt and a shocked grille to continuously shock monkey bodies. While this is very funny, it also serves as a ghetto powersink that's hard to locate, easy to replicate, and lasts effectively forever, since you can just keep shocking the same bodies over and over again.

This doesn't completely remove the ability to make these, but it makes them require at least a little maintenance and provides a way for them to stop working even if the crew isn't able to locate them.

In an attempt to finally get people using the _actual_ powersink, they'll show up a bit earlier in progression now. I'm not convinced 20 minutes is enough, but I don't want to put them in early enough that it fucks with Engineering's ability to set things up at round start. We can turn this down further if need be.

I'm also up for turning the TC requirement down, but 11 feels about right for what they're supposed to do, so I'd prefer we try this first and see how that works.

## Why It's Good For The Game
I'm all for goofy weird shit players have found, but there's an issue with being able to do what an antag item is supposed to do but just plain better. This shouldn't make creating these impossible or make them unusable, but it'll require players to actively monitor them if they want it to run for an extended period.

Additionally, we don't really see powersinks much anymore, and while that might be more because powernets are kind of buggy and unreliable, I think making them easier to get will make them show up a little more. 

## Changelog
:cl: Vekter
balance: Grilles will now take 0-1 damage every time they shock something.
balance: Powersinks are now available earlier in traitor progression.
/:cl:
