### PR TITLE
Roundend reporting now has a section for achievements earned during the round

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -4,6 +4,8 @@
 #define PERSONAL_LAST_ROUND "personal last round"
 #define SERVER_LAST_ROUND "server last round"
 
+GLOBAL_LIST_INIT(achievements_unlocked, list())
+
 /datum/controller/subsystem/ticker/proc/gather_roundend_feedback()
 	gather_antag_data()
 	record_nuke_disk_location()
@@ -311,6 +313,8 @@
 	parts += goal_report()
 	//Economy & Money
 	parts += market_report()
+	//Player Achievements
+	parts += cheevo_report()
 
 	list_clear_nulls(parts)
 
@@ -789,3 +793,25 @@
 				return
 			qdel(query_update_everything_ranks)
 		qdel(query_check_everything_ranks)
+
+/datum/controller/subsystem/ticker/proc/cheevo_report()
+	var/list/parts = list()
+	if(length(GLOB.achievements_unlocked))
+		parts += "<span class='header'>Achievement Get!</span><BR>"
+		parts += "<span class='infoplain'>Total Achievements Earned: <B>[length(GLOB.achievements_unlocked)]!</B></span><BR>"
+		parts += "<ul class='playerlist'>"
+		for(var/datum/achievement_report/cheevo_report in GLOB.achievements_unlocked)
+			parts += "<BR>[cheevo_report.winner_key] was <b>[cheevo_report.winner]</b>, who earned the [span_greentext("'[cheevo_report.cheevo]'")] achievement at [cheevo_report.award_location]!<BR>"
+		parts += "</ul>"
+		return "<div class='panel greenborder'><ul>[parts.Join()]</ul></div>"
+
+///A datum containing the info necessary for an achievement readout, reported and added to the global list in /datum/award/achievement/on_unlock(mob/user)
+/datum/achievement_report
+	///The winner of this achievement.
+	var/winner
+	///The achievement that was won.
+	var/cheevo
+	///The ckey of our winner
+	var/winner_key
+	///The name of the area we earned this cheevo in
+	var/award_location

--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -86,6 +86,19 @@
 	to_chat(user, span_greenannounce("<B>Achievement unlocked: [name]!</B>"))
 	user.client.give_award(/datum/award/score/achievements_score, user, 1)
 
+	var/datum/achievement_report/new_report = new /datum/achievement_report()
+
+	new_report.winner = "[(user.real_name == user.name) ? user.real_name : "[user.real_name], as [user.name]"]"
+	new_report.cheevo = name
+	if(user.ckey)
+		new_report.winner_key = user.ckey
+	else
+		stack_trace("[name] achievement earned by [user], who did not have a ckey.")
+
+	new_report.award_location = "[get_area_name(user)]"
+
+	GLOB.achievements_unlocked += new_report
+
 ///Scores are for leaderboarded things, such as killcount of a specific boss
 /datum/award/score
 	desc = "you did it sooo many times."


### PR DESCRIPTION

## About The Pull Request

The roundend report now has a section dedicated to achievements earned. It will report the ckey/identity of the player, the earned achievement, and where it was earned.

![image](https://github.com/tgstation/tgstation/assets/28870487/aa522eea-0334-4986-8177-557708e5d610)
## Why It's Good For The Game

Adds some more fun stuff to the roundend report, and contributes to the recent uptick in achievement-related PRs.
## Changelog
:cl: Rhials
add: The roundend report will now read out any achievements ("cheevos" as you may know them) earned by players over the course of the round. 
/:cl:
