### PR TITLE
Rotates a stationary water tank on Icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -46294,9 +46294,7 @@
 /area/station/command/heads_quarters/captain)
 "oGR" = (
 /obj/item/radio/intercom/directional/north,
-/obj/structure/reagent_dispensers/plumbed{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/plumbed,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},


### PR DESCRIPTION

## About The Pull Request
Did you know the lower service hallway's plumbing system which connects to the bar, wasn't connected to the reservoir? This properly connects the plumbing by rotating a water tank 90 degrees. 
## Why It's Good For The Game
The plumbing system and the bar's sinks work much better when connected to a water source.
## Changelog
:cl:
fix: Rotated a water tank in icebox's lower service hall, connecting the plumbing to the water source.
/:cl:
