### PR TITLE
Doafter cleanup, disables stoplag dynamic sleeping in unit tests

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -320,7 +320,7 @@ GLOBAL_LIST_EMPTY(species_list)
 		progbar.end_progress()
 
 	if(interaction_key)
-		var/reduced_interaction_count = LAZYACCESS(user.do_afters, interaction_key) - 1 || 0
+		var/reduced_interaction_count = (LAZYACCESS(user.do_afters, interaction_key) || 0) - 1
 		if(reduced_interaction_count > 0) // Not done yet!
 			LAZYSET(user.do_afters, interaction_key, reduced_interaction_count)
 			return

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -320,8 +320,20 @@ GLOBAL_LIST_EMPTY(species_list)
 		progbar.end_progress()
 
 	if(interaction_key)
+		var/reduced_interaction_count = LAZYACCESS(user.do_afters, interaction_key) - 1 || 0
+		if(reduced_interaction_count > 0) // Not done yet!
+			LAZYSET(user.do_afters, interaction_key, reduced_interaction_count)
+			return
+		// all out, let's clear er out fully
 		LAZYREMOVE(user.do_afters, interaction_key)
 	SEND_SIGNAL(user, COMSIG_DO_AFTER_ENDED)
+
+/// Returns the total amount of do_afters this mob is taking part in
+/mob/proc/do_after_count()
+	var/count = 0
+	for(var/key in do_afters)
+		count += do_afters[key]
+	return count
 
 /proc/is_species(A, species_datum)
 	. = FALSE

--- a/code/__HELPERS/stoplag.dm
+++ b/code/__HELPERS/stoplag.dm
@@ -10,6 +10,12 @@
 		return 1
 	if (!initial_delay)
 		initial_delay = world.tick_lag
+// Unit tests are not the normal environemnt. The mc can get absolutely thigh crushed, and sleeping procs running for ages is much more common
+// We don't want spurious hard deletes off this, so let's only sleep for the requested period of time here yeah?
+#ifdef UNIT_TESTS
+	sleep(initial_delay)
+	return CEILING(DS2TICKS(intial_delay), 1)
+#else
 	. = 0
 	var/i = DS2TICKS(initial_delay)
 	do
@@ -17,5 +23,6 @@
 		sleep(i * world.tick_lag * DELTA_CALC)
 		i *= 2
 	while (TICK_USAGE > min(TICK_LIMIT_TO_RUN, Master.current_ticklimit))
+#endif
 
 #undef DELTA_CALC

--- a/code/__HELPERS/stoplag.dm
+++ b/code/__HELPERS/stoplag.dm
@@ -14,7 +14,7 @@
 // We don't want spurious hard deletes off this, so let's only sleep for the requested period of time here yeah?
 #ifdef UNIT_TESTS
 	sleep(initial_delay)
-	return CEILING(DS2TICKS(intial_delay), 1)
+	return CEILING(DS2TICKS(initial_delay), 1)
 #else
 	. = 0
 	var/i = DS2TICKS(initial_delay)

--- a/code/modules/mob/living/basic/lavaland/watcher/watcher_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher_ai.dm
@@ -20,7 +20,7 @@
 
 /datum/ai_planning_subtree/targeted_mob_ability/overwatch/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	var/mob/living/living_pawn = controller.pawn
-	if (LAZYLEN(living_pawn.do_afters))
+	if (living_pawn.do_after_count())
 		return // Don't interrupt our other ability
 	var/atom/target = controller.blackboard[target_key]
 	if (QDELETED(target) || HAS_TRAIT(target, TRAIT_OVERWATCH_IMMUNE))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -615,7 +615,7 @@
 	//you can only initiate exaimines if you have a hand, it's not disabled, and only as many examines as you have hands
 	/// our active hand, to check if it's disabled/detatched
 	var/obj/item/bodypart/active_hand = has_active_hand()? get_active_hand() : null
-	if(!active_hand || active_hand.bodypart_disabled || LAZYLEN(do_afters) >= usable_hands)
+	if(!active_hand || active_hand.bodypart_disabled || do_after_count() >= usable_hands)
 		to_chat(src, span_warning("You don't have a free hand to examine this!"))
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request

[Makes the do_afters list behave as expected](https://github.com/tgstation/tgstation/commit/b7cd6c520f25bc9570edc1e478123bf69884eb6d)

Half the code expected it to be a flat list of things we are acting on, half expected it to be an assoc list of thing -> interaction count

Let's make that second dream a reality yeah?

[Disables stoplag's lag stoppage for unit tests](https://github.com/tgstation/tgstation/commit/88b2bb371cba4a0b2b042b866cb0d1f00453487c)

Because of the unique environment of unit tests (High cpu usage, lots of sleeping) this risks spurious hard deletes from neverending stoplag runs.

## Why It's Good For The Game

Less errors/guesswork in testing, better code
Potentially addresses #77865
