### PR TITLE
quartermasters get their voice of god power boost correctly

### DIFF
--- a/code/modules/jobs/job_types/quartermaster.dm
+++ b/code/modules/jobs/job_types/quartermaster.dm
@@ -34,6 +34,7 @@
 	)
 	rpg_title = "Steward"
 	job_flags = STATION_JOB_FLAGS | JOB_BOLD_SELECT_TEXT | JOB_CANNOT_OPEN_SLOTS
+	voice_of_god_power = 1.4 //Command staff has authority
 	ignore_human_authority = TRUE
 
 /datum/outfit/job/quartermaster


### PR DESCRIPTION

## About The Pull Request
we should really just have an easy way to set up new head jobs instead of manually doing the same shit for every single one

## Changelog
:cl:
fix: quartermasters get their voice of god power boost correctly
/:cl:
