### PR TITLE
[DISCUSSION PR NO REACTION RANDIES ALLOWED!!!] The CMO and CE ignore human authority

### DIFF
--- a/code/modules/jobs/job_types/chief_engineer.dm
+++ b/code/modules/jobs/job_types/chief_engineer.dm
@@ -46,6 +46,7 @@
 	job_flags = STATION_JOB_FLAGS | JOB_BOLD_SELECT_TEXT | JOB_CANNOT_OPEN_SLOTS
 
 	voice_of_god_power = 1.4 //Command staff has authority
+	ignore_human_authority = TRUE
 
 
 /datum/job/chief_engineer/get_captaincy_announcement(mob/living/captain)

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -43,6 +43,7 @@
 	job_flags = STATION_JOB_FLAGS | JOB_BOLD_SELECT_TEXT | JOB_CANNOT_OPEN_SLOTS
 
 	voice_of_god_power = 1.4 //Command staff has authority
+	ignore_human_authority = TRUE
 
 
 /datum/job/chief_medical_officer/get_captaincy_announcement(mob/living/captain)


### PR DESCRIPTION
## About The Pull Request
The CMO and CE ignore human authority like the QM (this can be toggled off by config).

## Why It's Good For The Game
The grandfathering of QM as the only head of staff position that can be non-human is very silly and I am not a fan of it. I think we should either go further in or remove it from the QM, and I think going further in is interesting to see what people think.
The reason it's these two specifically:
The Captain overlooks the whole station
The Captain and HoS are important combat-adjacent roles (We don't want AI messing with them)
The Captain and RD mess with the AI (We don't want AI messing with them)
The HoP is the second in command, though I'm not that opposed to it, but it'd be weird having the spare go to a lizard or something instantly.

The Chief Engineer and Chief Medical Officer on the other hand oversee secondary "supporting" departments, similar to Cargo, half their players play plasmamen and moths/catgirls respectively anyway and it makes sense for them that they would be picked just for their mastery over the craft of medicine/engineering (I don't think Nanotrasen would want the paper pusher handling civilian matters to not be a human for example).

Essentially, we already lose the "All the command roles are human" flavor with QM, so why not bring it to its reasonable extent?

Please comment your thoughts, I'm interested on the people's opinion.

## Changelog
:cl:
balance: The CMO and CE can be non-human now.
/:cl:
