### PR TITLE
Makes explosions consistently throw debris

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -288,8 +288,8 @@
 #define SSAIR_REBUILD_QUEUE 2
 
 // Explosion Subsystem subtasks
-#define SSEXPLOSIONS_MOVABLES 1
-#define SSEXPLOSIONS_TURFS 2
+#define SSEXPLOSIONS_TURFS 1
+#define SSEXPLOSIONS_MOVABLES 2
 #define SSEXPLOSIONS_THROWS 3
 
 // Wardrobe subsystem tasks

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -25,7 +25,11 @@ SUBSYSTEM_DEF(explosions)
 	var/list/highturf = list()
 	var/list/flameturf = list()
 
+	/// List of turfs to throw the contents of
 	var/list/throwturf = list()
+	/// List of turfs to throw the contents of... AFTER the next explosion processes
+	/// This avoids order of operations errors and shit
+	var/list/held_throwturf = list()
 
 	var/list/low_mov_atom = list()
 	var/list/med_mov_atom = list()
@@ -34,7 +38,7 @@ SUBSYSTEM_DEF(explosions)
 	// Track how many explosions have happened.
 	var/explosion_index = 0
 
-	var/currentpart = SSAIR_PIPENETS
+	var/currentpart = SSEXPLOSIONS_TURFS
 
 
 /datum/controller/subsystem/explosions/stat_entry(msg)
@@ -63,12 +67,13 @@ SUBSYSTEM_DEF(explosions)
 	msg += "HO:[high_mov_atom.len]|"
 
 	msg += "TO:[throwturf.len]"
+	msg += "HTO:[held_throwturf.len]"
 
 	msg += "} "
 	return ..()
 
 /datum/controller/subsystem/explosions/proc/is_exploding()
-	return (lowturf.len || medturf.len || highturf.len || flameturf.len || throwturf.len || low_mov_atom.len || med_mov_atom.len || high_mov_atom.len)
+	return (lowturf.len || medturf.len || highturf.len || flameturf.len || throwturf.len || held_throwturf.len || low_mov_atom.len || med_mov_atom.len || high_mov_atom.len)
 
 /datum/controller/subsystem/explosions/proc/wipe_turf(turf/T)
 	lowturf -= T
@@ -76,6 +81,7 @@ SUBSYSTEM_DEF(explosions)
 	highturf -= T
 	flameturf -= T
 	throwturf -= T
+	held_throwturf -= T
 
 /client/proc/check_bomb_impacts()
 	set name = "Check Bomb Impact"
@@ -383,6 +389,7 @@ SUBSYSTEM_DEF(explosions)
 	// we assert that turfs will be processed closed to farthest, so we can build this as we go along
 	// This is gonna be an array, index'd by turfs
 	var/list/cached_exp_block = list()
+	var/list/held_throwturf = src.held_throwturf
 
 	//lists are guaranteed to contain at least 1 turf at this point
 	//we presuppose that we'll be iterating away from the epicenter
@@ -442,11 +449,11 @@ SUBSYSTEM_DEF(explosions)
 			var/list/throwingturf = explode.explosion_throw_details
 			if (throwingturf[1] < max_range - dist)
 				throwingturf[1] = max_range - dist
-				throwingturf[2] = get_dir(epicenter, explode)
+				throwingturf[2] = epicenter
 				throwingturf[3] = max_range
 		else
-			explode.explosion_throw_details = list(max_range - dist, get_dir(epicenter, explode), max_range)
-			throwturf += explode
+			explode.explosion_throw_details = list(max_range - dist, epicenter, max_range)
+			held_throwturf += explode
 
 
 	var/took = (REALTIMEOFDAY - started_at) / 10
@@ -685,6 +692,9 @@ SUBSYSTEM_DEF(explosions)
 			EX_ACT(movable_thing, EXPLODE_LIGHT)
 		cost_low_mov_atom = MC_AVERAGE(cost_low_mov_atom, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
+		/// Throwing only becomes acceptable after the explosions process, so we don't miss stuff that explosions GENERATE
+		throwturf = held_throwturf
+		held_throwturf = list()
 
 	if (currentpart == SSEXPLOSIONS_THROWS)
 		currentpart = SSEXPLOSIONS_TURFS
@@ -700,14 +710,15 @@ SUBSYSTEM_DEF(explosions)
 			if (length(details) != 3)
 				continue
 			var/throw_range = details[1]
-			var/throw_dir = details[2]
+			var/turf/center = details[2]
 			var/max_range = details[3]
 			for(var/atom/movable/A in explode)
 				if(QDELETED(A))
 					continue
 				if(!A.anchored && A.move_resist != INFINITY)
-					var/atom_throw_range = rand(throw_range, max_range)
-					var/turf/throw_at = get_ranged_target_turf(A, throw_dir, atom_throw_range)
+					// We want to have our distance matter, but we do want to bias to a lot of throw, for the vibe
+					var/atom_throw_range = rand(throw_range, max_range) + max_range * 0.3
+					var/turf/throw_at = get_ranged_target_turf_direct(A, center, atom_throw_range, 180) // Throw 180 degrees away from the explosion source
 					A.throw_at(throw_at, atom_throw_range, EXPLOSION_THROW_SPEED, quickstart = FALSE)
 		cost_throwturf = MC_AVERAGE(cost_throwturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -55,7 +55,7 @@ SUBSYSTEM_DEF(throwing)
 	var/init_dir
 	///The maximum number of turfs that the thrownthing will travel to reach it's target.
 	var/maxrange
-	///The speed of the projectile thrownthing being thrown.
+	///Turfs to travel per tick
 	var/speed
 	///If a mob is the one who has thrown the object, then it's moved here. This can be null and must be null checked before trying to use it.
 	var/mob/thrower

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -317,6 +317,7 @@
 	// broken pipes always have dpdir=0 so they're not found as 'real' pipes
 	// i.e. will be treated as an empty turf
 	spawn_pipe = FALSE
+	anchored = FALSE
 
 /obj/structure/disposalpipe/broken/deconstruct()
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request

It was possible for explosions to process throwing FIRST, then the actual explosion. That's dumb, let's not do that.
Fixes a bug with SS explosions, it used SSair defines for its currentrun default, which because of misordered defines lead to it running throwing first for ONLY the first explosion. DUMB.
Changed how objects pick where they land. instead of using get_dir we get the angle to the center, then invert it. Should lead to a nicer picture 

Unanchors broken disposal pipes so they'll get flung around Ups the throw range for explosions. This needs more tweaking someday, but this is ok for now

## Why It's Good For The Game

Throwing will happen consistently now, less fuckin floating shit sitting in spac