### PR TITLE
Zipping a duffle bag closes UI of all storage items opened inside it

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -471,7 +471,7 @@
 		slowdown = initial(slowdown)
 		atom_storage.locked = STORAGE_SOFT_LOCKED
 		atom_storage.display_contents = FALSE
-		for(var/obj/item/weapon in get_all_contents_type(/obj/item)) //close ui of this and all items inside dufflebag
+		for(var/obj/item/weapon as anything in get_all_contents_type(/obj/item)) //close ui of this and all items inside dufflebag
 			weapon.atom_storage?.close_all() //not everything has storage initialized
 	else
 		slowdown = zip_slowdown

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -471,7 +471,8 @@
 		slowdown = initial(slowdown)
 		atom_storage.locked = STORAGE_SOFT_LOCKED
 		atom_storage.display_contents = FALSE
-		atom_storage.close_all()
+		for(var/obj/item/storage/storage_item in get_all_contents_type(/obj/item/storage)) //close ui of this and all storage items(e.g. boxes) inside dufflebag
+			storage_item.atom_storage.close_all()
 	else
 		slowdown = zip_slowdown
 		atom_storage.locked = STORAGE_NOT_LOCKED

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -471,8 +471,8 @@
 		slowdown = initial(slowdown)
 		atom_storage.locked = STORAGE_SOFT_LOCKED
 		atom_storage.display_contents = FALSE
-		for(var/obj/item/storage/storage_item in get_all_contents_type(/obj/item/storage)) //close ui of this and all storage items(e.g. boxes) inside dufflebag
-			storage_item.atom_storage.close_all()
+		for(var/obj/item/weapon in get_all_contents_type(/obj/item)) //close ui of this and all items inside dufflebag
+			weapon.atom_storage?.close_all() //not everything has storage initialized
 	else
 		slowdown = zip_slowdown
 		atom_storage.locked = STORAGE_NOT_LOCKED


### PR DESCRIPTION
## About The Pull Request
Fixes #77885

zipping it now looks for storage items inside its contents and closes their UI recursively, including its own UI as well.

## Changelog

:cl:
fix: zipping a duffle bag closes the UI of all storage items opened inside it
/:cl:
