### PR TITLE
Crafting menu shows complex craftables first

### DIFF
--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -206,7 +206,9 @@ export const PersonalCrafting = (props, context) => {
               recipe.category === activeCategory)))
     ),
     sortBy<Recipe>((recipe) => [
-      -Number(craftability[recipe.ref]),
+      activeCategory === 'Can Make'
+        ? 99 - Object.keys(recipe.reqs).length
+        : Number(craftability[recipe.ref]),
       recipe.name.toLowerCase(),
     ]),
   ])(data.recipes);


### PR DESCRIPTION
![image](https://github.com/tgstation/tgstation/assets/3625094/9d5802cc-59d8-41c4-ab49-e110594eb084)

## About The Pull Request

Made the Can Make category show items that require most ingredients first - so that when you want to craft something specific, the UI is not flooded with recipes that require only iron (there are plenty of these). It's done in a bit of hacky way, but it works. (Flow `SortBy` doesn't seem to work with negative numbers correctly)

## Why It's Good For The Game

Better UX for crafting menu.

## Changelog

:cl:
qol: Crafting menu "Can Make" category shows complex recipes first.
/:cl:
