### PR TITLE
Fixed phazon construction typo [NO GBP]

### DIFF
--- a/code/modules/vehicles/mecha/mecha_construction_paths.dm
+++ b/code/modules/vehicles/mecha/mecha_construction_paths.dm
@@ -679,7 +679,7 @@
 			"key" = /obj/item/stock_parts/servo,
 			"action" = ITEM_MOVE_INSIDE,
 			"back_key" = TOOL_SCREWDRIVER,
-			"desc" = "Scanning module is secured, the <b>capacitor</b> can be added.",
+			"desc" = "Capacitor is secured, the <b>micro-servo</b> can be added.",
 			"forward_message" = "added micro-servo",
 			"backward_message" = "unsecured capacitor"
 		),


### PR DESCRIPTION
## About The Pull Request

Phazon was saying that it needs capacitor when it actually needs a micro-servo.

## Why It's Good For The Game

Typo fix.

## Changelog

:cl:
fix: Fixed Phazon construction message typo
/:cl:

