### PR TITLE
Updates message for HREF Dock Exploit

### DIFF
--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -163,6 +163,8 @@
 		if(!isnull(user.client))
 			log_admin("[user] ([user.ckey]) attempted to href dock exploit on [src] with target location \"[dest_id]\"")
 			message_admins("[ADMIN_FLW(user)] ([user.ckey]) just attempted to href dock exploit on [src] with target location \"[url_encode(dest_id)]\"")
+		else
+			stack_trace("[user] ([user.type]) tried to send the shuttle [src] to the target location [dest_id], but the target location was not found in the list of valid destinations.")
 		return SHUTTLE_CONSOLE_DESTINVALID
 	switch(SSshuttle.moveShuttle(shuttleId, dest_id, TRUE))
 		if(DOCKING_SUCCESS)

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -161,8 +161,8 @@
 			break
 	if(!validdest) //Didn't find our destination in the list of valid destinations, something bad happening
 		if(!isnull(user.client))
-			log_admin("[user] ([user.ckey]) attempted to href dock exploit on [src] with target location \"[dest_id]\"")
-			message_admins("[ADMIN_FLW(user)] ([user.ckey]) just attempted to href dock exploit on [src] with target location \"[url_encode(dest_id)]\"")
+			log_admin("Warning: possible href exploit by [key_name(user)] - Attempted to dock [src] to illegal target location \"[url_encode(dest_id)]\"")
+			message_admins("Warning: possible href exploit by [key_name_admin(user)] [ADMIN_FLW(user)] - Attempted to dock [src] to illegal target location \"[url_encode(dest_id)]\"")
 		else
 			stack_trace("[user] ([user.type]) tried to send the shuttle [src] to the target location [dest_id], but the target location was not found in the list of valid destinations.")
 		return SHUTTLE_CONSOLE_DESTINVALID

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -160,8 +160,9 @@
 			validdest = TRUE //Found our destination, we can skip ahead now
 			break
 	if(!validdest) //Didn't find our destination in the list of valid destinations, something bad happening
-		log_admin("[user] attempted to href dock exploit on [src] with target location \"[dest_id]\"")
-		message_admins("[user] just attempted to href dock exploit on [src] with target location \"[url_encode(dest_id)]\"")
+		if(!isnull(user.client))
+			log_admin("[user] ([user.ckey]) attempted to href dock exploit on [src] with target location \"[dest_id]\"")
+			message_admins("[ADMIN_FLW(user)] ([user.ckey]) just attempted to href dock exploit on [src] with target location \"[url_encode(dest_id)]\"")
 		return SHUTTLE_CONSOLE_DESTINVALID
 	switch(SSshuttle.moveShuttle(shuttleId, dest_id, TRUE))
 		if(DOCKING_SUCCESS)


### PR DESCRIPTION

## About The Pull Request

Hey there,

![image](https://github.com/tgstation/tgstation/assets/34697715/86282805-5c5d-4e13-aec4-91a5877831ed)

This message randomly popped up while I was adminning, and it was completely dogshit useless (as well as not being an HREF exploit since Snowdin was loaded and you should be expected to do that, but that's indicative of a harder bug). Let's yeet the `message_admins()` portion (as well as make it actually actable information rather than just 'Unknown' and give it an actual follow jump button) and if then if we don't have a client, stack_trace (in case people want to make basic mobs keymash to send shuttles in the future). 
## Why It's Good For The Game

This is completely useless and confusing. It's not even an HREF exploit because this behavior is completely intended. It's more helpful to coders now too because this thing failing isn't just locked to admin-only logs, it stack traces (which is publically available).
## Changelog
:cl:
admin: The "HREF Dock Exploit" message should now contain a bit more usable information (such as a jump link) so you can investigate if something is really going wacky with shuttles.
/:cl:
