### PR TITLE
Makes railings easier to construct, while making them easier to destroy.

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -4,6 +4,9 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	new/datum/stack_recipe("scooter frame", /obj/item/scooter_frame, 10, time = 2.5 SECONDS, one_per_turf = FALSE, category = CAT_ENTERTAINMENT), \
 	new/datum/stack_recipe("linen bin", /obj/structure/bedsheetbin/empty, 2, time = 0.5 SECONDS, one_per_turf = FALSE, category = CAT_CONTAINERS), \
 	new/datum/stack_recipe("railing", /obj/structure/railing, 2, time = 1 SECONDS, check_direction = TRUE, category = CAT_STRUCTURE), \
+	new/datum/stack_recipe("railing corner", /obj/structure/railing/corner, 1, time = 1 SECONDS, check_direction = TRUE, category = CAT_STRUCTURE), \
+	new/datum/stack_recipe("railing end", /obj/structure/railing/corner/end, 1, time = 1 SECONDS, check_direction = TRUE, category = CAT_STRUCTURE), \
+	new/datum/stack_recipe("railing end (flipped)", /obj/structure/railing/corner/end/flip, 1, time = 1 SECONDS, check_direction = TRUE, category = CAT_STRUCTURE), \
 	new/datum/stack_recipe("tank holder", /obj/structure/tank_holder, 2, time = 0.5 SECONDS, one_per_turf = TRUE, on_solid_ground = FALSE, check_density = FALSE, category = CAT_FURNITURE), \
 	new/datum/stack_recipe("ladder", /obj/structure/ladder/crafted, 15, time = 15 SECONDS, one_per_turf = TRUE, on_solid_ground = FALSE, check_density = FALSE, category = CAT_STRUCTURE), \
 	new/datum/stack_recipe("catwalk floor tile", /obj/item/stack/tile/catwalk_tile, 1, 4, 20, category = CAT_TILES), \

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -1,14 +1,14 @@
 GLOBAL_LIST_INIT(rod_recipes, list ( \
-	new/datum/stack_recipe("grille", /obj/structure/grille, 2, time = 10, one_per_turf = TRUE, on_solid_ground = FALSE, check_density = FALSE, category = CAT_STRUCTURE), \
-	new/datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 10, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_FURNITURE), \
-	new/datum/stack_recipe("scooter frame", /obj/item/scooter_frame, 10, time = 25, one_per_turf = FALSE, category = CAT_ENTERTAINMENT), \
-	new/datum/stack_recipe("linen bin", /obj/structure/bedsheetbin/empty, 2, time = 5, one_per_turf = FALSE, category = CAT_CONTAINERS), \
-	new/datum/stack_recipe("railing", /obj/structure/railing, 6, time = 3.6 SECONDS, check_direction = TRUE, category = CAT_STRUCTURE), \
-	new/datum/stack_recipe("tank holder", /obj/structure/tank_holder, 2, time = 5, one_per_turf = TRUE, on_solid_ground = FALSE, check_density = FALSE, category = CAT_FURNITURE), \
-	new/datum/stack_recipe("ladder", /obj/structure/ladder/crafted, 15, time = 150, one_per_turf = TRUE, on_solid_ground = FALSE, check_density = FALSE, category = CAT_STRUCTURE), \
+	new/datum/stack_recipe("grille", /obj/structure/grille, 2, time = 1 SECONDS, one_per_turf = TRUE, on_solid_ground = FALSE, check_density = FALSE, category = CAT_STRUCTURE), \
+	new/datum/stack_recipe("table frame", /obj/structure/table_frame, 2, time = 1 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_FURNITURE), \
+	new/datum/stack_recipe("scooter frame", /obj/item/scooter_frame, 10, time = 2.5 SECONDS, one_per_turf = FALSE, category = CAT_ENTERTAINMENT), \
+	new/datum/stack_recipe("linen bin", /obj/structure/bedsheetbin/empty, 2, time = 0.5 SECONDS, one_per_turf = FALSE, category = CAT_CONTAINERS), \
+	new/datum/stack_recipe("railing", /obj/structure/railing, 2, time = 1 SECONDS, check_direction = TRUE, category = CAT_STRUCTURE), \
+	new/datum/stack_recipe("tank holder", /obj/structure/tank_holder, 2, time = 0.5 SECONDS, one_per_turf = TRUE, on_solid_ground = FALSE, check_density = FALSE, category = CAT_FURNITURE), \
+	new/datum/stack_recipe("ladder", /obj/structure/ladder/crafted, 15, time = 15 SECONDS, one_per_turf = TRUE, on_solid_ground = FALSE, check_density = FALSE, category = CAT_STRUCTURE), \
 	new/datum/stack_recipe("catwalk floor tile", /obj/item/stack/tile/catwalk_tile, 1, 4, 20, category = CAT_TILES), \
 	new/datum/stack_recipe("stairs frame", /obj/structure/stairs_frame, 10, time = 5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_STRUCTURE), \
-	new/datum/stack_recipe("white cane", /obj/item/cane/white, 3, time = 10, one_per_turf = FALSE, category = CAT_TOOLS), \
+	new/datum/stack_recipe("white cane", /obj/item/cane/white, 3, time = 1 SECONDS, one_per_turf = FALSE, category = CAT_TOOLS), \
 	))
 
 /obj/item/stack/rods

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -46,20 +46,20 @@
 		)
 		AddElement(/datum/element/connect_loc, loc_connections)
 
-	AddComponent(/datum/component/simple_rotation, ROTATION_NEEDS_ROOM)
-
 	var/static/list/tool_behaviors = list(
-        TOOL_WELDER = list(
-            SCREENTIP_CONTEXT_LMB = "Repair",
-        ),
+		TOOL_WELDER = list(
+			SCREENTIP_CONTEXT_LMB = "Repair",
+		),
 		TOOL_WRENCH = list(
-			SCREENTIP_CONTEXT_LMB = "Anchor/Unanchor"
+			SCREENTIP_CONTEXT_LMB = "Anchor/Unanchor",
 		),
 		TOOL_WIRECUTTER = list(
-			SCREENTIP_CONTEXT_LMB = "Deconstruct"
-		)
-    )
-    AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+			SCREENTIP_CONTEXT_LMB = "Deconstruct",
+		),
+	)
+	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+
+	AddComponent(/datum/component/simple_rotation, ROTATION_NEEDS_ROOM)
 
 /obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
 	..()

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -48,6 +48,19 @@
 
 	AddComponent(/datum/component/simple_rotation, ROTATION_NEEDS_ROOM)
 
+	var/static/list/tool_behaviors = list(
+        TOOL_WELDER = list(
+            SCREENTIP_CONTEXT_LMB = "Repair",
+        ),
+		TOOL_WRENCH = list(
+			SCREENTIP_CONTEXT_LMB = "Anchor/Unanchor"
+		),
+		TOOL_WIRECUTTER = list(
+			SCREENTIP_CONTEXT_LMB = "Deconstruct"
+		)
+    )
+    AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
+
 /obj/structure/railing/attackby(obj/item/I, mob/living/user, params)
 	..()
 	add_fingerprint(user)

--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -8,18 +8,18 @@
 	density = TRUE
 	anchored = TRUE
 	pass_flags_self = LETPASSTHROW|PASSSTRUCTURE
-	/// armor more or less consistent with grille. max_integrity about one time and a half that of a grille.
+	/// armor is a little bit less than a grille. max_integrity about half that of a grille.
 	armor_type = /datum/armor/structure_railing
-	max_integrity = 75
+	max_integrity = 25
 
 	var/climbable = TRUE
 	///Initial direction of the railing.
 	var/ini_dir
 
 /datum/armor/structure_railing
-	melee = 50
-	bullet = 70
-	laser = 70
+	melee = 35
+	bullet = 50
+	laser = 50
 	energy = 100
 	bomb = 10
 
@@ -70,11 +70,10 @@
 
 /obj/structure/railing/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()
-	if(!anchored)
-		to_chat(user, span_warning("You cut apart the railing."))
-		I.play_tool_sound(src, 100)
-		deconstruct()
-		return TRUE
+	to_chat(user, span_warning("You cut apart the railing."))
+	I.play_tool_sound(src, 100)
+	deconstruct()
+	return TRUE
 
 /obj/structure/railing/deconstruct(disassembled)
 	if(!(flags_1 & NODECONSTRUCT_1))


### PR DESCRIPTION
## About The Pull Request

Changes the cost of railings from 6 metal rods to 2 metal rods.
The time to construct has been reduced from 3.6 to 1 second to be in-line with the grille.
The health of railings has been reduced from 75 to 25.
Armor of railings have been reduced as well by about 30%.

I'm not positive on whether or not it should cost 1 metal rod or 2. I decided to play it safe and make it 2. If some maintainer is interested in making it only cost 1 rod then I will gladly do so- but this was my compromise.

Also changes decaseconds/ticks to seconds in the rod construction code to make it look better.

## Why It's Good For The Game

Railings look nice and it's an absolute pain in the ass that they cost 6 metal rods.

They're also currently substantially stronger than grilles for whatever reason. Grilles have 50 health, while railings have 75.
The armor of railings makes this health of 75 to a whopping effective health of 150.

Railings shouldn't be stronger than full-tile grilles. They should be fairly flimsy.
They also shouldn't take a wrench AND wirecutters to deconstruct. Grilles only take wirecutters and we should mirror that.

## Changelog

:cl:
balance: Railings now only cost 2 rods and are much easier to construct. But they can now be destroyed much easier and cut with wirecutters without unwrenching.
/:cl:
