### PR TITLE
Fixes RCD'ing lattices in open space

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -72,7 +72,7 @@
 	if(passed_mode == RCD_FLOORWALL)
 		to_chat(user, span_notice("You build a floor."))
 		var/turf/T = src.loc
-		if(isspaceturf(T))
+		if(isgroundlessturf(T))
 			T.PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 			qdel(src)
 			return TRUE


### PR DESCRIPTION
## About The Pull Request

If you RCD a lattice with floor/wall mode on icebox, it won't actually place down the floor because the open space is not "space" - this switches the check to openspace, allowing you to fix floors on icebox by clicking on lattices. For some reason this would also cause you to waste your matter units on this action.

## Why It's Good For The Game

fix good

## Changelog

:cl:
fix: You should be able to click on lattices on icebox with the RCD and construct a floor now
/:cl:
