### PR TITLE
Fixes hitting RCD effects when they're done

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -545,6 +545,8 @@
 	if (status == RCD_DECONSTRUCT)
 		qdel(src)
 	else
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+		obj_flags &= ~CAN_BE_HIT
 		icon_state = "rcd_end"
 		addtimer(CALLBACK(src, PROC_REF(end)), 15)
 


### PR DESCRIPTION
## About The Pull Request

https://github.com/tgstation/tgstation/pull/77641 made it so that RCD effects can be hit while they're constructing to stop their construction. however, the construction effect itself lingers a bit after things are done constructing, allowing it to eat up clicks. this fixes it by removing the flag when it's done constructing.

## Why It's Good For The Game

fix good 👯 👯‍♂️ 👯‍♀️ 🎉 🏖️ 🐝 

## Changelog

:cl:
fix: You should no longer attack RCD effects when they're done constructing.
/:cl:
