### PR TITLE
[no gbp] Watchers don't glow while they are dead

### DIFF
--- a/code/modules/mob/living/basic/lavaland/watcher/watcher.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher.dm
@@ -70,6 +70,8 @@
 
 /mob/living/basic/mining/watcher/update_overlays()
 	. = ..()
+	if (stat == DEAD)
+		return
 	. += emissive_appearance(icon, "watcher_emissive", src)
 
 /// I love eating diamonds yum


### PR DESCRIPTION
## About The Pull Request

Removes watcher emissive appearance while dead.

## Why It's Good For The Game

Made it look like they were haunted by their own ghost, spooky but inappropriate.

## Changelog

:cl:
fix: Watchers won't retain an ethereal outline of their wings hovering over their dead body.
/:cl:
