### PR TITLE
Lathe tax checks for access instead of account department

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -293,7 +293,7 @@
 		if(!card && istype(user.pulling, /obj/item/card/id))
 			card = user.pulling
 
-		if(card && tax_access && tax_access in card.access)
+		if(card && tax_access && (tax_access in card.access))
 			total_cost = 0 // We are not charging crew for printing their own supplies and equipment.
 
 	if(attempt_charge(src, usr, total_cost) & COMPONENT_OBJ_CANCEL_CHARGE)

--- a/code/modules/research/machinery/circuit_imprinter.dm
+++ b/code/modules/research/machinery/circuit_imprinter.dm
@@ -5,6 +5,7 @@
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter
 	production_animation = "circuit_imprinter_ani"
 	allowed_buildtypes = IMPRINTER
+	tax_access = ACCESS_ENGINEERING
 
 /obj/machinery/rnd/production/circuit_imprinter/calculate_efficiency()
 	. = ..()
@@ -21,4 +22,4 @@
 	desc = "Manufactures circuit boards for the construction of machines. Its ancient construction may limit its ability to print all known technology."
 	allowed_buildtypes = AWAY_IMPRINTER
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/offstation
-	charges_tax = FALSE
+	charges_tax = FALSE //tax_access is irrelevant if this is FALSE

--- a/code/modules/research/machinery/departmental_circuit_imprinter.dm
+++ b/code/modules/research/machinery/departmental_circuit_imprinter.dm
@@ -9,3 +9,4 @@
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/department/science
 	allowed_department_flags = DEPARTMENT_BITFLAG_SCIENCE
 	payment_department = ACCOUNT_SCI
+	tax_access = ACCESS_SCIENCE

--- a/code/modules/research/machinery/departmental_protolathe.dm
+++ b/code/modules/research/machinery/departmental_protolathe.dm
@@ -10,6 +10,7 @@
 	circuit = /obj/item/circuitboard/machine/protolathe/department/engineering
 	stripe_color = "#EFB341"
 	payment_department = ACCOUNT_ENG
+	tax_access = ACCESS_ENGINEERING
 
 /obj/machinery/rnd/production/protolathe/department/engineering/no_tax
 	circuit = /obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
@@ -21,6 +22,7 @@
 	circuit = /obj/item/circuitboard/machine/protolathe/department/service
 	stripe_color = "#83ca41"
 	payment_department = ACCOUNT_SRV
+	tax_access = ACCESS_SERVICE
 
 /obj/machinery/rnd/production/protolathe/department/medical
 	name = "department protolathe (Medical)"
@@ -28,6 +30,7 @@
 	circuit = /obj/item/circuitboard/machine/protolathe/department/medical
 	stripe_color = "#52B4E9"
 	payment_department = ACCOUNT_MED
+	tax_access = ACCESS_MEDICAL
 
 /obj/machinery/rnd/production/protolathe/department/cargo
 	name = "department protolathe (Cargo)"
@@ -35,6 +38,7 @@
 	circuit = /obj/item/circuitboard/machine/protolathe/department/cargo
 	stripe_color = "#956929"
 	payment_department = ACCOUNT_CAR
+	tax_access = ACCESS_CARGO
 
 /obj/machinery/rnd/production/protolathe/department/science
 	name = "department protolathe (Science)"
@@ -42,6 +46,7 @@
 	circuit = /obj/item/circuitboard/machine/protolathe/department/science
 	stripe_color = "#D381C9"
 	payment_department = ACCOUNT_SCI
+	tax_access = ACCESS_SCIENCE
 
 /obj/machinery/rnd/production/protolathe/department/security
 	name = "department protolathe (Security)"
@@ -49,3 +54,4 @@
 	circuit = /obj/item/circuitboard/machine/protolathe/department/security
 	stripe_color = "#DE3A3A"
 	payment_department = ACCOUNT_SEC
+	tax_access = ACCESS_SECURITY

--- a/code/modules/research/machinery/departmental_techfab.dm
+++ b/code/modules/research/machinery/departmental_techfab.dm
@@ -10,6 +10,7 @@
 	circuit = /obj/item/circuitboard/machine/techfab/department/engineering
 	stripe_color = "#EFB341"
 	payment_department = ACCOUNT_ENG
+	tax_access = ACCESS_ENGINEERING
 
 /obj/machinery/rnd/production/techfab/department/service
 	name = "department techfab (Service)"
@@ -17,6 +18,7 @@
 	circuit = /obj/item/circuitboard/machine/techfab/department/service
 	stripe_color = "#83ca41"
 	payment_department = ACCOUNT_SRV
+	tax_access = ACCESS_SERVICE
 
 /obj/machinery/rnd/production/techfab/department/medical
 	name = "department techfab (Medical)"
@@ -24,6 +26,7 @@
 	circuit = /obj/item/circuitboard/machine/techfab/department/medical
 	stripe_color = "#52B4E9"
 	payment_department = ACCOUNT_MED
+	tax_access = ACCESS_MEDICAL
 
 /obj/machinery/rnd/production/techfab/department/cargo
 	name = "department techfab (Cargo)"
@@ -31,6 +34,7 @@
 	circuit = /obj/item/circuitboard/machine/techfab/department/cargo
 	stripe_color = "#956929"
 	payment_department = ACCOUNT_CAR
+	tax_access = ACCESS_CARGO
 
 /obj/machinery/rnd/production/techfab/department/science
 	name = "department techfab (Science)"
@@ -38,6 +42,7 @@
 	circuit = /obj/item/circuitboard/machine/techfab/department/science
 	stripe_color = "#D381C9"
 	payment_department = ACCOUNT_SCI
+	tax_access = ACCESS_SCIENCE
 
 /obj/machinery/rnd/production/techfab/department/security
 	name = "department techfab (Security)"
@@ -45,3 +50,4 @@
 	circuit = /obj/item/circuitboard/machine/techfab/department/security
 	stripe_color = "#DE3A3A"
 	payment_department = ACCOUNT_SEC
+	tax_access = ACCESS_SECURITY


### PR DESCRIPTION
## About The Pull Request

(also applies to imprinters, techfabs, and the such)

Access requirements for lathes:
Science - R&D Lab
Cargo - Cargo
Security - Security
Engineering - Engineering
Medical - Medical

fixes #67009
fixes #66601

## Why It's Good For The Game

being the captain with my all access and getting taxed by the engi protolathe is silly
also helpful if youre like an assistant-made-scientist by HoP and need to use your protolathe

## Changelog
:cl:
qol: you will not get lathe taxed if your ID has the correct access
/:cl:
