### PR TITLE
fixes coroner medkit storage

### DIFF
--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -348,9 +348,9 @@
 
 /obj/item/storage/medkit/coroner/Initialize(mapload)
 	. = ..()
-	atom_storage.max_specific_storage = 24
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_slots = 14
-	atom_storage.max_total_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.max_total_storage = 24
 	atom_storage.set_holdable(list(
 		/obj/item/reagent_containers,
 		/obj/item/bodybag,


### PR DESCRIPTION

## About The Pull Request
atom_storage.max_specific_storage and atom_storage.max_total_storage had their values reversed. this fixes that, and i tested to confirm: the compact coroner medkit can now hold everything it spawns with
## Why It's Good For The Game
before this fix, the max storage of a coroner medkit was two items. it's very annoying to pull an item from it, only to find it can not go back in again - moreoever, this gives it consistency with other medkits.
## Changelog
:cl:
fix: the coroner medkit can now hold every item it spawns with
/:cl:
