### PR TITLE
Quartermaster's overcoat and cargo's gorka can now hold stamps and mail bags

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -229,7 +229,7 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(
-		/obj/item/stamp,
+		/obj/item/stamp
 	)
 
 /obj/item/clothing/suit/toggle/lawyer/greyscale

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -25,7 +25,7 @@
 		/obj/item/reagent_containers/spray/plantbgone,
 		/obj/item/secateurs,
 		/obj/item/seeds,
-		/obj/item/storage/bag/plants
+		/obj/item/storage/bag/plants,
 	)
 	species_exception = list(/datum/species/golem)
 	armor_type = /datum/armor/suit_apron
@@ -173,7 +173,7 @@
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
 		/obj/item/t_scanner,
-		/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime
+		/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime,
 	)
 	resistance_flags = NONE
 	species_exception = list(/datum/species/golem)
@@ -217,7 +217,8 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
 	allowed = list(
-		/obj/item/stamp
+		/obj/item/stamp,
+		/obj/item/storage/bag/mail,
 	)
 
 // Quartermaster
@@ -229,7 +230,8 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(
-		/obj/item/stamp
+		/obj/item/stamp,
+		/obj/item/storage/bag/mail,
 	)
 
 /obj/item/clothing/suit/toggle/lawyer/greyscale

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -25,7 +25,7 @@
 		/obj/item/reagent_containers/spray/plantbgone,
 		/obj/item/secateurs,
 		/obj/item/seeds,
-		/obj/item/storage/bag/plants,
+		/obj/item/storage/bag/plants
 	)
 	species_exception = list(/datum/species/golem)
 	armor_type = /datum/armor/suit_apron
@@ -173,7 +173,7 @@
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
 		/obj/item/t_scanner,
-		/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime,
+		/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime
 	)
 	resistance_flags = NONE
 	species_exception = list(/datum/species/golem)
@@ -225,6 +225,12 @@
 	icon_state = "qm_coat"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
+	allowed = list(
+		/obj/item/stamp,
+		/obj/item/paper,
+		/obj/item/folder,
+		/obj/item/clipboard
+	)
 
 /obj/item/clothing/suit/toggle/lawyer/greyscale
 	name = "formal suit jacket"

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -216,6 +216,9 @@
 	inhand_icon_state = null
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
+	allowed = list(
+		/obj/item/stamp
+	)
 
 // Quartermaster
 
@@ -227,9 +230,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(
 		/obj/item/stamp,
-		/obj/item/paper,
-		/obj/item/folder,
-		/obj/item/clipboard
 	)
 
 /obj/item/clothing/suit/toggle/lawyer/greyscale


### PR DESCRIPTION
## About The Pull Request

What it says on the tin
## Why It's Good For The Game

Consistency between these new items and the winter coat
## Changelog
:cl:
fix: Quartermaster's Overcoat and Cargo's gorka can now hold stamps in their suit slots, just like their winter coat counterpart
/:cl:
