### PR TITLE
Cryo improvements: Auto eject dead and turn on automatically

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -402,8 +402,8 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell/close_machine(mob/living/carbon/user, density_to_set = TRUE)
 	treating_wounds = FALSE
 	if((isnull(user) || istype(user)) && state_open && !panel_open)
-		if(loc == usr.loc)
-			to_chat(usr, span_warning("You can't close [src] on yourself!"))
+		if(loc == user?.loc)
+			to_chat(user, span_warning("You can't close [src] on yourself!"))
 			return
 		flick("pod-close-anim", src)
 		..(user)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -402,6 +402,9 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell/close_machine(mob/living/carbon/user, density_to_set = TRUE)
 	treating_wounds = FALSE
 	if((isnull(user) || istype(user)) && state_open && !panel_open)
+		if(loc == usr.loc)
+			to_chat(usr, span_warning("You can't close [src] on yourself!"))
+			return
 		flick("pod-close-anim", src)
 		..(user)
 		return occupant

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -270,6 +270,8 @@
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/process(seconds_per_tick)
 	..()
+	if(!occupant)
+		return
 
 	if(!on)
 		// Should turn on if set to auto
@@ -277,8 +279,6 @@
 			set_on(TRUE)
 		else
 			return
-	if(!occupant)
-		return
 
 	var/mob/living/mob_occupant = occupant
 	if(mob_occupant.on_fire)


### PR DESCRIPTION
## About The Pull Request
This PR makes two changes to cryo. First, if the patient inside is dead, it will notify medical over comms, and if auto mode is on, it will eject them. This is the exact same behaviour as if the patient is fully healed. Second, if auto is on, the tube will turn on as soon as it's closed, preventing negligent doctors from leaving people to die in a locked tube. To prevent people from putting themselves in cryo, you can no longer close the cryo tube yourself when you're standing in it. This is effectively the exact same as it was before, except now the game explicitly tells you that you cannot cryo yourself, instead of letting you jump in and die.

## Why It's Good For The Game
For the first change, there is absolutely zero reasons for a dead body to be in a cryotube, and it makes sense that a machine that can tell if someone is fully healed and eject them can tell if they're dead and eject them.

For the second change, there are few things worse than being left to die in a cryotube just because the doctor didn't turn it on. You're just locked in there until another doctor walks by and notices that the tube isn't actually on (if they ever do), and you likely die before then, leaving your organs decay, and turn what was once some simple brute and burn into a whole revival ordeal. "Auto" implies that treatment is automatic, so it makes sense that it actually is.
## Changelog
:cl:
qol: Cryotubes will now notify medbay if the patient within is dead, and will eject them if auto is on.
qol: Cryotubes will now automatically turn on when a patient enters it if auto is on, but you can no longer close the cryotube on yourself.
/:cl:
