### PR TITLE
Fixes tram deleting its own landmarks on reset_lift_contents()

### DIFF
--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -552,7 +552,7 @@ GLOBAL_LIST_INIT(all_radial_directions, list(
 		var/list/atom/movable/foreign_contents_in_loc = list()
 
 		for(var/atom/movable/foreign_movable as anything in (turf_loc.contents - original_contents))
-			if(foreign_objects && ismovable(foreign_movable) && !ismob(foreign_movable))
+			if(foreign_objects && ismovable(foreign_movable) && !ismob(foreign_movable) && !istype(foreign_movable, /obj/effect/landmark/tram))
 				foreign_contents_in_loc += foreign_movable
 				continue
 

--- a/code/modules/industrial_lift/tram/tram_lift_master.dm
+++ b/code/modules/industrial_lift/tram/tram_lift_master.dm
@@ -67,7 +67,7 @@
 		if(initial_destination)
 			idle_platform = initial_destination
 
-		if(initial_destination)
+		if(beacon)
 			nav_beacon = beacon
 
 /datum/lift_master/tram/proc/check_starting_landmark()


### PR DESCRIPTION
## About The Pull Request

Excludes tram landmarks from being deleted when reset_lift_contents() is called.

## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/77782

## Changelog

:cl: LT3
fix: Tram will no longer fly off into space when admins try to reset the contents
/:cl: