### PR TITLE
[NO GBP] Makes sure that ops buying the CQC Equipment Case actually get the case, not just the CQC book

### DIFF
--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -334,7 +334,7 @@
 /datum/uplink_item/weapon_kits/high_cost/cqc
 	name = "CQC Equipment Case (Very Hard)"
 	desc = "Contains a manual that instructs you in the ways of CQC, or Close Quarters Combat. Comes with a stealth implant and a snazzy bandana (and a hat stabilizer to go with it)."
-	item = /obj/item/book/granter/martial/cqc
+	item = /obj/item/storage/toolbox/guncase/cqc
 	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
 	surplus = 0
 


### PR DESCRIPTION

## About The Pull Request

The CQC entry in the nuclear operative uplink was incorrectly only giving the op the book. This fixes this.

## Why It's Good For The Game

Please use the issue tracker for reporting bugs, I beg you!

## Changelog
:cl:
fix: Ops wanting to get the CQC kit will actually get given the kit, and not just the CQC book.
/:cl:
