### PR TITLE
bitrunning - implements objects

### DIFF
--- a/code/modules/bitrunning/abilities.dm
+++ b/code/modules/bitrunning/abilities.dm
@@ -1,0 +1,40 @@
+
+/datum/avatar_help_text
+	/// Text to display in the window
+	var/help_text
+
+/datum/avatar_help_text/New(help_text)
+	src.help_text = help_text
+
+/datum/avatar_help_text/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "AvatarHelp")
+		ui.open()
+
+/datum/avatar_help_text/ui_state(mob/user)
+	return GLOB.always_state
+
+/datum/avatar_help_text/ui_static_data(mob/user)
+	var/list/data = list()
+
+	data["help_text"] = help_text
+
+	return data
+
+/// Displays information about the current virtual domain.
+/datum/action/avatar_domain_info
+	name = "Open Virtual Domain Information"
+	button_icon_state = "round_end"
+	show_to_observers = FALSE
+
+/datum/action/avatar_domain_info/New(Target)
+	. = ..()
+	name = "Open Domain Information"
+
+/datum/action/avatar_domain_info/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return
+
+	target.ui_interact(owner)

--- a/code/modules/bitrunning/alerts.dm
+++ b/code/modules/bitrunning/alerts.dm
@@ -1,0 +1,40 @@
+/atom/movable/screen/alert/bitrunning
+	name = "Generic Bitrunning Alert"
+	icon_state = "template"
+	timeout = 10 SECONDS
+
+/atom/movable/screen/alert/bitrunning/netpod_crowbar
+	name = "Forced Entry"
+	desc = "Someone is prying open the netpod door. Find an exit."
+
+/atom/movable/screen/alert/bitrunning/netpod_damaged
+	name = "Integrity Compromised"
+	desc = "The netpod is damaged. Find an exit."
+
+/atom/movable/screen/alert/bitrunning/qserver_shutting_down
+	name = "Domain Rebooting"
+	desc = "The domain is rebooting. Find an exit."
+
+/atom/movable/screen/alert/bitrunning/qserver_threat_deletion
+	name = "Queue Deletion"
+	desc = "The server is resetting. Oblivion awaits."
+
+/atom/movable/screen/alert/bitrunning/qserver_threat_spawned
+	name = "Threat Detected"
+	desc = "Data stream abnormalities present."
+
+/atom/movable/screen/alert/bitrunning/qserver_domain_complete
+	name = "Domain Completed"
+	desc = "The domain is completed. Activate to exit."
+	timeout = 20 SECONDS
+
+/atom/movable/screen/alert/bitrunning/qserver_domain_complete/Click(location, control, params)
+	if(..())
+		return
+
+	var/mob/living/living_owner = owner
+	if(!isliving(living_owner))
+		return
+
+	if(tgui_alert(living_owner, "Disconnect safely?", "Server Message", list("Exit", "Remain"), 10 SECONDS) == "Exit")
+		SEND_SIGNAL(living_owner.mind, COMSIG_BITRUNNER_SAFE_DISCONNECT)

--- a/code/modules/bitrunning/mind_connection.dm
+++ b/code/modules/bitrunning/mind_connection.dm
@@ -1,0 +1,175 @@
+/// Sets the pilot to the occupant in the chair, linking damage. Represents the start of the avatar process
+/datum/mind/proc/initial_avatar_connection(
+	mob/living/carbon/human/avatar,
+	obj/machinery/netpod/hosting_netpod,
+	obj/machinery/quantum_server/server,
+	help_text,
+)
+	var/mob/living/carbon/human/pilot_mob = current
+
+	if(!locate(/datum/action/avatar_domain_info) in avatar.actions)
+		var/datum/avatar_help_text/help_datum = new(help_text)
+		var/datum/action/avatar_domain_info/action = new(help_datum)
+		action.Grant(avatar)
+
+	pilot_ref = WEAKREF(pilot_mob)
+	netpod_ref = WEAKREF(hosting_netpod)
+
+	// Begin the swap - use a fake mind so it isn't cata
+	var/datum/mind/fake_mind = new(key + " (pilot)")
+	transfer_to(avatar)
+	fake_mind.active = TRUE
+	fake_mind.transfer_to(pilot_mob)
+
+	avatar.playsound_local(avatar, "sound/magic/blink.ogg", 25, TRUE)
+	avatar.set_static_vision(2 SECONDS)
+	avatar.set_temp_blindness(1 SECONDS)
+
+	connect_avatar_signals(avatar)
+	RegisterSignal(hosting_netpod, COMSIG_BITRUNNER_CROWBAR_ALERT, PROC_REF(on_netpod_crowbar))
+	RegisterSignal(hosting_netpod, COMSIG_BITRUNNER_NETPOD_INTEGRITY, PROC_REF(on_netpod_damaged))
+	RegisterSignal(hosting_netpod, COMSIG_BITRUNNER_SEVER_AVATAR, PROC_REF(on_sever_connection))
+	RegisterSignal(server, COMSIG_BITRUNNER_DOMAIN_COMPLETE, PROC_REF(on_domain_completed))
+	RegisterSignal(server, COMSIG_BITRUNNER_SEVER_AVATAR, PROC_REF(on_sever_connection))
+	RegisterSignal(server, COMSIG_BITRUNNER_SHUTDOWN_ALERT, PROC_REF(on_shutting_down))
+	RegisterSignal(server, COMSIG_BITRUNNER_THREAT_CREATED, PROC_REF(on_threat_created))
+	RegisterSignal(src, COMSIG_BITRUNNER_SAFE_DISCONNECT, PROC_REF(on_safe_disconnect))
+	RegisterSignal(src, COMSIG_MIND_TRANSFERRED, PROC_REF(on_mind_transfer))
+
+/// Links mob damage & death as long as the netpod is there
+/datum/mind/proc/connect_avatar_signals(mob/living/target)
+	var/obj/machinery/netpod/netpod = netpod_ref?.resolve()
+	if(isnull(netpod))
+		current.dust()
+		return
+
+	netpod.avatar_ref = WEAKREF(target) // we need to set this just in case there's a subsequent hop
+
+	RegisterSignal(target, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(on_linked_damage))
+	RegisterSignal(target, COMSIG_LIVING_DEATH, PROC_REF(on_sever_connection), override = TRUE)
+
+/// Unregisters damage & death signals
+/datum/mind/proc/disconnect_avatar_signals()
+	var/datum/action/avatar_domain_info/action = locate() in current.actions
+	if(action)
+		action.Remove(current)
+
+	UnregisterSignal(current, COMSIG_MOB_APPLY_DAMAGE)
+	UnregisterSignal(current, COMSIG_LIVING_DEATH)
+
+/// Disconnects the avatar and returns the mind to the pilot.
+/datum/mind/proc/full_avatar_disconnect(forced = FALSE, obj/machinery/netpod/broken_netpod)
+	var/mob/living/pilot = pilot_ref?.resolve()
+	var/obj/machinery/netpod/hosting_netpod = netpod_ref?.resolve() || broken_netpod
+	if(isnull(pilot) || isnull(hosting_netpod))
+		return
+
+	disconnect_avatar_signals()
+	UnregisterSignal(src, COMSIG_BITRUNNER_SAFE_DISCONNECT)
+	UnregisterSignal(src, COMSIG_MIND_TRANSFERRED)
+	UnregisterSignal(pilot, COMSIG_LIVING_DEATH)
+	UnregisterSignal(pilot, COMSIG_LIVING_STATUS_UNCONSCIOUS)
+	UnregisterSignal(pilot, COMSIG_MOVABLE_MOVED)
+
+	netpod_ref = null
+	pilot_ref = null
+
+	hosting_netpod.disconnect_occupant(src, forced)
+
+/// Triggers whenever the server gets a loot crate pushed to send area
+/datum/mind/proc/on_domain_completed(datum/source, atom/entered)
+	SIGNAL_HANDLER
+
+	current.playsound_local(current, 'sound/machines/terminal_success.ogg', 50, TRUE)
+	current.throw_alert(
+		ALERT_BITRUNNER_COMPLETED,
+		/atom/movable/screen/alert/bitrunning/qserver_domain_complete,
+		new_master = entered
+	)
+
+/// Transfers damage from the avatar to the pilot
+/datum/mind/proc/on_linked_damage(datum/source, damage, damage_type, def_zone, blocked, forced)
+	SIGNAL_HANDLER
+
+	var/mob/living/carbon/pilot = pilot_ref?.resolve()
+
+	if(isnull(pilot) || damage_type == STAMINA || damage_type == OXYLOSS)
+		return
+
+	if(damage >= (pilot.health + MAX_LIVING_HEALTH))
+		full_avatar_disconnect(forced = TRUE)
+		return
+
+	if(damage > 30 && prob(30))
+		INVOKE_ASYNC(pilot, TYPE_PROC_REF(/mob/living, emote), "scream")
+
+	pilot.apply_damage(damage, damage_type, def_zone, blocked, forced, wound_bonus = CANT_WOUND)
+
+	if(pilot.stat > SOFT_CRIT) // KO!
+		full_avatar_disconnect(forced = TRUE)
+
+/// Handles minds being swapped around in subsequent avatars
+/datum/mind/proc/on_mind_transfer(datum/mind/source, mob/living/previous_body)
+	SIGNAL_HANDLER
+
+	var/datum/action/avatar_domain_info/action = locate() in previous_body.actions
+	if(action)
+		action.Grant(current)
+		action.Remove(previous_body)
+
+	disconnect_avatar_signals(previous_body)
+	connect_avatar_signals(current)
+
+/// Triggers when someone starts prying open our netpod
+/datum/mind/proc/on_netpod_crowbar(datum/source, mob/living/intruder)
+	SIGNAL_HANDLER
+
+	current.playsound_local(current, 'sound/machines/terminal_alert.ogg', 50, TRUE)
+	current.throw_alert(
+		ALERT_BITRUNNER_CROWBAR,
+		/atom/movable/screen/alert/bitrunning/netpod_crowbar,
+		new_master = intruder
+	)
+
+/// Triggers when the netpod is taking damage and is under 50%
+/datum/mind/proc/on_netpod_damaged(datum/source)
+	SIGNAL_HANDLER
+
+	current.throw_alert(
+		ALERT_BITRUNNER_INTEGRITY,
+		/atom/movable/screen/alert/bitrunning/netpod_damaged,
+		new_master = source
+	)
+
+/// Safely exits without forced variables, etc
+/datum/mind/proc/on_safe_disconnect(datum/source)
+	SIGNAL_HANDLER
+
+	full_avatar_disconnect()
+
+/// Helper for calling sever with forced variables
+/datum/mind/proc/on_sever_connection(datum/source, obj/machinery/netpod/broken_netpod)
+	SIGNAL_HANDLER
+
+	full_avatar_disconnect(forced = TRUE, broken_netpod = broken_netpod)
+
+/// Triggers when the server is shutting down
+/datum/mind/proc/on_shutting_down(datum/source, mob/living/hackerman)
+	SIGNAL_HANDLER
+
+	current.playsound_local(current, 'sound/machines/terminal_alert.ogg', 50, TRUE)
+	current.throw_alert(
+		ALERT_BITRUNNER_SHUTDOWN,
+		/atom/movable/screen/alert/bitrunning/qserver_shutting_down,
+		new_master = hackerman,
+	)
+
+/// Server has spawned a ghost role threat
+/datum/mind/proc/on_threat_created(datum/source)
+	SIGNAL_HANDLER
+
+	current.throw_alert(
+		ALERT_BITRUNNER_THREAT,
+		/atom/movable/screen/alert/bitrunning/qserver_threat_spawned,
+		new_master = source,
+	)

--- a/code/modules/bitrunning/netpod_healing.dm
+++ b/code/modules/bitrunning/netpod_healing.dm
@@ -1,0 +1,69 @@
+/datum/component/netpod_healing
+	/// Brute damage to heal over a second
+	var/brute_heal = 0
+
+	/// Burn damage to heal over a second
+	var/burn_heal = 0
+
+	/// Toxin damage to heal over a second
+	var/toxin_heal = 0
+
+	/// Amount of cloning damage to heal over a second
+	var/clone_heal = 0
+
+	/// Amount of blood to heal over a second
+	var/blood_heal = 0
+
+/datum/component/netpod_healing/Initialize(
+	brute_heal = 0,
+	burn_heal = 0,
+	toxin_heal = 0,
+	clone_heal = 0,
+	blood_heal = 0,
+)
+	var/mob/living/carbon/player = parent
+	if (!iscarbon(player))
+		return COMPONENT_INCOMPATIBLE
+
+	player.apply_status_effect(/datum/status_effect/embryonic, STASIS_NETPOD_EFFECT)
+
+	START_PROCESSING(SSnetpod_healing, src)
+
+	src.brute_heal = brute_heal
+	src.burn_heal = burn_heal
+	src.toxin_heal = toxin_heal
+	src.clone_heal = clone_heal
+	src.blood_heal = blood_heal
+
+/datum/component/netpod_healing/Destroy(force, silent)
+	STOP_PROCESSING(SSnetpod_healing, src)
+
+	var/mob/living/carbon/player = parent
+	player.remove_status_effect(/datum/status_effect/embryonic)
+
+	return ..()
+
+/datum/component/netpod_healing/process(seconds_per_tick)
+	var/mob/living/carbon/owner = parent
+	if(isnull(owner))
+		qdel(src)
+		return
+
+	owner.adjustBruteLoss(-brute_heal * seconds_per_tick, updating_health = FALSE)
+	owner.adjustFireLoss(-burn_heal * seconds_per_tick, updating_health = FALSE)
+	owner.adjustToxLoss(-toxin_heal * seconds_per_tick, updating_health = FALSE, forced = TRUE)
+	owner.adjustCloneLoss(-clone_heal * seconds_per_tick, updating_health = FALSE)
+
+	if (owner.blood_volume < BLOOD_VOLUME_NORMAL)
+		owner.blood_volume += blood_heal * seconds_per_tick
+
+	owner.updatehealth()
+
+/datum/status_effect/embryonic
+	id = "embryonic"
+	alert_type = /atom/movable/screen/alert/status_effect/embryonic
+
+/atom/movable/screen/alert/status_effect/embryonic
+	name = "Embryonic Stasis"
+	icon_state = "netpod_stasis"
+	desc = "You feel like you're in a dream."

--- a/code/modules/bitrunning/objects/bit_vendor.dm
+++ b/code/modules/bitrunning/objects/bit_vendor.dm
@@ -1,0 +1,72 @@
+#define CREDIT_TYPE_BITRUNNING "np"
+
+/obj/machinery/computer/order_console/bitrunning
+	name = "bitrunning supplies order console"
+	desc = "NexaCache(tm)! Dubiously authentic gear for the digital daredevil."
+	icon = 'icons/obj/machines/bitrunning.dmi'
+	icon_state = "vendor"
+	icon_keyboard = null
+	icon_screen = null
+	circuit = /obj/item/circuitboard/computer/order_console/bitrunning
+	cooldown_time = 10 SECONDS
+	cargo_cost_multiplier = 0.65
+	express_cost_multiplier = 1
+	purchase_tooltip = @{"Your purchases will arrive at cargo,
+	and hopefully get delivered by them.
+	35% cheaper than express delivery."}
+	express_tooltip = @{"Sends your purchases instantly."}
+	credit_type = CREDIT_TYPE_BITRUNNING
+
+	order_categories = list(
+		CATEGORY_BITRUNNING,
+	)
+	blackbox_key = "bitrunning"
+
+/obj/machinery/computer/order_console/bitrunning/subtract_points(final_cost, obj/item/card/id/card)
+	if(final_cost <= card.registered_account.bitrunning_points)
+		card.registered_account.bitrunning_points -= final_cost
+		return TRUE
+	return FALSE
+
+/obj/machinery/computer/order_console/bitrunning/order_groceries(mob/living/purchaser, obj/item/card/id/card, list/groceries)
+	var/list/things_to_order = list()
+	for(var/datum/orderable_item/item as anything in groceries)
+		things_to_order[item.item_path] = groceries[item]
+
+	var/datum/supply_pack/custom/bitrunning_pack = new(
+		purchaser = purchaser, \
+		cost = get_total_cost(), \
+		contains = things_to_order,
+		pack_name = "Bitrunning",
+	)
+	var/datum/supply_order/new_order = new(
+		pack = bitrunning_pack,
+		orderer = purchaser,
+		orderer_rank = "Bitrunning Vendor",
+		orderer_ckey = purchaser.ckey,
+		reason = "",
+		paying_account = card.registered_account,
+		department_destination = null,
+		coupon = null,
+		charge_on_purchase = FALSE,
+		manifest_can_fail = FALSE,
+		cost_type = credit_type,
+		can_be_cancelled = FALSE,
+	)
+	say("Thank you for your purchase! It will arrive on the next cargo shuttle!")
+	radio.talk_into(src, "A bitrunner has ordered equipment which will arrive on the cargo shuttle! Please make sure it gets to them as soon as possible!", radio_channel)
+	SSshuttle.shopping_list += new_order
+
+/obj/machinery/computer/order_console/bitrunning/retrieve_points(obj/item/card/id/id_card)
+	return round(id_card.registered_account.bitrunning_points)
+
+/obj/machinery/computer/order_console/bitrunning/ui_act(action, params)
+	. = ..()
+	if(!.)
+		flick("vendor_off", src)
+
+/obj/machinery/computer/order_console/bitrunning/update_icon_state()
+	icon_state = "[initial(icon_state)][powered() ? null : "_off"]"
+	return ..()
+
+#undef CREDIT_TYPE_BITRUNNING

--- a/code/modules/bitrunning/objects/clothing.dm
+++ b/code/modules/bitrunning/objects/clothing.dm
@@ -1,0 +1,9 @@
+/obj/item/clothing/glasses/sunglasses/oval
+	name = "oval sunglasses"
+	desc = "Vintage wrap around sunglasses. Provides a little protection."
+	icon_state = "jensenshades"
+
+/obj/item/clothing/suit/jacket/trenchcoat
+	name = "trenchcoat"
+	desc = "A long, black trenchcoat. Makes you feel like you're the one, but you're not."
+	icon_state = "trenchcoat"

--- a/code/modules/bitrunning/objects/hololadder.dm
+++ b/code/modules/bitrunning/objects/hololadder.dm
@@ -1,0 +1,52 @@
+/obj/structure/hololadder
+	name = "hololadder"
+
+	anchored = TRUE
+	desc = "An abstract representation of the means to disconnect from the virtual domain."
+	icon = 'icons/obj/structures.dmi'
+	icon_state = "ladder11"
+	obj_flags = BLOCK_Z_OUT_DOWN
+	/// Time req to disconnect properly
+	var/travel_time = 3 SECONDS
+
+/obj/structure/hololadder/Initialize(mapload)
+	. = ..()
+
+	RegisterSignal(loc, COMSIG_ATOM_ENTERED, PROC_REF(on_enter))
+
+/obj/structure/hololadder/attack_hand(mob/user, list/modifiers)
+	. = ..()
+	if(.)
+		return
+
+	if(!in_range(src, user) || DOING_INTERACTION(user, DOAFTER_SOURCE_CLIMBING_LADDER))
+		return
+
+	disconnect(user)
+
+/// If there's a pilot ref- send the disconnect signal
+/obj/structure/hololadder/proc/disconnect(mob/user)
+	if(isnull(user.mind))
+		return
+
+	var/datum/mind/mob_mind = user.mind
+	if(isnull(mob_mind.pilot_ref))
+		balloon_alert(user, "no connection detected.")
+		return
+
+	balloon_alert(user, "disconnecting...")
+	if(do_after(user, travel_time, src))
+		SEND_SIGNAL(mob_mind, COMSIG_BITRUNNER_SAFE_DISCONNECT)
+
+/// Helper for times when you dont have hands (gondola??)
+/obj/structure/hololadder/proc/on_enter(datum/source, atom/movable/arrived, turf/old_loc)
+	SIGNAL_HANDLER
+
+	if(!isliving(arrived))
+		return
+
+	var/mob/living/user = arrived
+	if(isnull(user.mind))
+		return
+
+	INVOKE_ASYNC(src, PROC_REF(disconnect), user)

--- a/code/modules/bitrunning/objects/host_monitor.dm
+++ b/code/modules/bitrunning/objects/host_monitor.dm
@@ -1,0 +1,29 @@
+/obj/item/bitrunning_host_monitor
+	name = "host monitor"
+
+	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 2)
+	desc = "A complex medical device that, when attached to an avatar's data stream, can detect the user of their host's health."
+	flags_1 = CONDUCT_1
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gps-b"
+	inhand_icon_state = "electronic"
+	item_flags = NOBLUDGEON
+	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
+	slot_flags = ITEM_SLOT_BELT
+	throw_range = 7
+	throw_speed = 3
+	throwforce = 3
+	w_class = WEIGHT_CLASS_TINY
+	worn_icon_state = "electronic"
+
+/obj/item/bitrunning_host_monitor/attack_self(mob/user, modifiers)
+	. = ..()
+
+	var/datum/mind/our_mind = user.mind
+	var/mob/living/pilot = our_mind.pilot_ref?.resolve()
+	if(isnull(pilot))
+		balloon_alert(user, "data not recognized")
+		return
+
+	to_chat(user, span_notice("Current host health: [pilot.health / pilot.maxHealth * 100]%"))

--- a/code/modules/bitrunning/objects/netpod.dm
+++ b/code/modules/bitrunning/objects/netpod.dm
@@ -1,0 +1,482 @@
+#define BASE_DISCONNECT_DAMAGE 40
+
+/obj/machinery/netpod
+	name = "netpod"
+
+	base_icon_state = "netpod"
+	circuit = /obj/item/circuitboard/machine/netpod
+	desc = "A link to the netverse. It has an assortment of cables to connect yourself to a virtual domain."
+	icon = 'icons/obj/machines/bitrunning.dmi'
+	icon_state = "netpod"
+	max_integrity = 300
+	obj_flags = BLOCKS_CONSTRUCTION
+	state_open = TRUE
+	/// A player selected outfit by clicking the netpod
+	var/datum/outfit/netsuit = /datum/outfit/job/bitrunner
+	/// Holds this to see if it needs to generate a new one
+	var/datum/weakref/avatar_ref
+	/// Mind weakref used to keep track of the original mind
+	var/datum/weakref/occupant_mind_ref
+	/// The linked quantum server
+	var/datum/weakref/server_ref
+	/// The amount of brain damage done from force disconnects
+	var/disconnect_damage
+	/// Static list of outfits to select from
+	var/list/cached_outfits = list()
+
+/obj/machinery/netpod/Initialize(mapload)
+	. = ..()
+
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/netpod/LateInitialize()
+	. = ..()
+
+	disconnect_damage = BASE_DISCONNECT_DAMAGE
+
+	RegisterSignals(src, list(
+		COMSIG_QDELETING,
+		COMSIG_MACHINERY_BROKEN,
+		COMSIG_MACHINERY_POWER_LOST,
+		),
+		PROC_REF(on_broken),
+	)
+	RegisterSignal(src, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(src, COMSIG_ATOM_TAKE_DAMAGE, PROC_REF(on_take_damage))
+
+	register_context()
+	update_appearance()
+
+/obj/machinery/netpod/Destroy()
+	. = ..()
+	cached_outfits.Cut()
+
+/obj/machinery/netpod/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+
+	if(isnull(held_item))
+		context[SCREENTIP_CONTEXT_LMB] = "Select Outfit"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	if(istype(held_item, /obj/item/crowbar) && occupant)
+		context[SCREENTIP_CONTEXT_LMB] = "Pry Open"
+		return CONTEXTUAL_SCREENTIP_SET
+
+	return CONTEXTUAL_SCREENTIP_SET
+
+/obj/machinery/netpod/update_icon_state()
+	if(!is_operational)
+		icon_state = base_icon_state
+		return ..()
+
+	if(state_open)
+		icon_state = base_icon_state + "_open_active"
+		return ..()
+
+	if(panel_open)
+		icon_state = base_icon_state + "_panel"
+		return ..()
+
+	icon_state = base_icon_state + "_closed"
+	if(occupant)
+		icon_state += "_active"
+
+	return ..()
+
+/obj/machinery/netpod/MouseDrop_T(mob/target, mob/user)
+	var/mob/living/carbon/player = user
+	if(!iscarbon(player))
+		return
+
+	if((HAS_TRAIT(player, TRAIT_UI_BLOCKED) && !player.resting) || !Adjacent(player) || !player.Adjacent(target) || !ISADVANCEDTOOLUSER(player) || !is_operational)
+		return
+
+	close_machine(target)
+
+/obj/machinery/netpod/crowbar_act(mob/living/user, obj/item/tool)
+	if(user.combat_mode)
+		attack_hand(user)
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+	if(default_pry_open(tool, user) || default_deconstruction_crowbar(tool))
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+/obj/machinery/netpod/screwdriver_act(mob/living/user, obj/item/tool)
+	if(occupant)
+		balloon_alert(user, "in use!")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+	if(state_open)
+		balloon_alert(user, "close first.")
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+	if(default_deconstruction_screwdriver(user, "[base_icon_state]_panel", "[base_icon_state]_closed", tool))
+		update_appearance() // sometimes icon doesnt properly update during flick()
+		ui_close(user)
+		return TOOL_ACT_TOOLTYPE_SUCCESS
+
+/obj/machinery/netpod/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
+	if(!state_open && user == occupant)
+		container_resist_act(user)
+
+/obj/machinery/netpod/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(!state_open && gone == occupant)
+		container_resist_act(gone)
+
+/obj/machinery/netpod/Exited(atom/movable/gone, direction)
+	. = ..()
+	if(!state_open && gone == occupant)
+		container_resist_act(gone)
+
+/obj/machinery/netpod/relaymove(mob/living/user, direction)
+	if(!state_open)
+		container_resist_act(user)
+
+/obj/machinery/netpod/container_resist_act(mob/living/user)
+	user.visible_message(span_notice("[occupant] emerges from [src]!"),
+		span_notice("You climb out of [src]!"),
+		span_notice("With a hiss, you hear a machine opening."))
+	open_machine()
+
+/obj/machinery/netpod/open_machine(drop = TRUE, density_to_set = FALSE)
+	unprotect_and_signal()
+	playsound(src, 'sound/machines/tramopen.ogg', 60, TRUE, frequency = 65000)
+	flick("[base_icon_state]_opening", src)
+
+	return ..()
+
+/obj/machinery/netpod/close_machine(mob/user, density_to_set = TRUE)
+	if(!state_open || panel_open || !is_operational || !iscarbon(user))
+		return
+
+	playsound(src, 'sound/machines/tramclose.ogg', 60, TRUE, frequency = 65000)
+	flick("[base_icon_state]_closing", src)
+	..()
+
+	if(!iscarbon(occupant))
+		open_machine()
+		return
+
+	enter_matrix()
+
+/obj/machinery/netpod/default_pry_open(obj/item/crowbar, mob/living/pryer)
+	if(isnull(occupant) || !iscarbon(occupant))
+		if(!state_open)
+			if(panel_open)
+				return FALSE
+			open_machine()
+		else
+			shut_pod()
+
+		return TRUE
+
+	pryer.visible_message(
+		span_danger("[pryer] starts prying open [src]!"),
+		span_notice("You start to pry open [src]."),
+		span_notice("You hear loud prying on metal.")
+	)
+	playsound(src, 'sound/machines/airlock_alien_prying.ogg', 100, TRUE)
+
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_CROWBAR_ALERT, pryer)
+
+	if(do_after(pryer, 15 SECONDS, src))
+		if(!state_open)
+			open_machine()
+
+	return TRUE
+
+/obj/machinery/netpod/ui_interact(mob/user, datum/tgui/ui)
+	if(!is_operational)
+		return
+
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "NetpodOutfits")
+		ui.set_autoupdate(FALSE)
+		ui.open()
+
+/obj/machinery/netpod/ui_data()
+	var/list/data = list()
+
+	data["netsuit"] = netsuit
+	return data
+
+/obj/machinery/netpod/ui_static_data()
+	var/list/data = list()
+
+	if(!length(cached_outfits))
+		cached_outfits += make_outfit_collection("Jobs", subtypesof(/datum/outfit/job))
+
+	data["collections"] = cached_outfits
+
+	return data
+
+/obj/machinery/netpod/ui_act(action, params)
+	. = ..()
+	if(.)
+		return TRUE
+	switch(action)
+		if("select_outfit")
+			var/datum/outfit/new_suit = resolve_outfit(params["outfit"])
+			if(new_suit)
+				netsuit = new_suit
+				return TRUE
+
+	return FALSE
+
+/// Disconnects the occupant after a certain time so they aren't just hibernating in netpod stasis. A balance change
+/obj/machinery/netpod/proc/auto_disconnect()
+	if(isnull(occupant) || state_open)
+		return
+
+	if(!iscarbon(occupant))
+		open_machine()
+		return
+
+	var/mob/living/carbon/player = occupant
+
+	player.playsound_local(src, 'sound/effects/splash.ogg', 60, TRUE)
+	to_chat(player, span_notice("The machine disconnects itself and begins to drain."))
+	open_machine()
+
+/**
+ * ### Disconnect occupant
+ * If this goes smoothly, should reconnect a receiving mind to the occupant's body
+ *
+ * This is the second stage of the process -  if you want to disconn avatars start at the mind first
+ */
+/obj/machinery/netpod/proc/disconnect_occupant(datum/mind/receiving, forced = FALSE)
+	var/mob/living/mob_occupant = occupant
+	var/datum/mind/hosted_mind = occupant_mind_ref?.resolve()
+	if(!isliving(occupant) || receiving != hosted_mind)
+		return
+
+	mob_occupant.mind.key = null
+	mob_occupant.key = null
+	receiving.transfer_to(mob_occupant)
+
+	mob_occupant.playsound_local(src, "sound/magic/blink.ogg", 25, TRUE)
+	mob_occupant.set_static_vision(2 SECONDS)
+	mob_occupant.set_temp_blindness(1 SECONDS)
+
+	var/obj/machinery/quantum_server/server = find_server()
+	if(server)
+		SEND_SIGNAL(server, COMSIG_BITRUNNER_CLIENT_DISCONNECTED, occupant_mind_ref)
+		receiving.UnregisterSignal(server, COMSIG_BITRUNNER_DOMAIN_COMPLETE)
+		receiving.UnregisterSignal(server, COMSIG_BITRUNNER_SEVER_AVATAR)
+		receiving.UnregisterSignal(server, COMSIG_BITRUNNER_SHUTDOWN_ALERT)
+		receiving.UnregisterSignal(server, COMSIG_BITRUNNER_THREAT_CREATED)
+	receiving.UnregisterSignal(src, COMSIG_BITRUNNER_CROWBAR_ALERT)
+	receiving.UnregisterSignal(src, COMSIG_BITRUNNER_NETPOD_INTEGRITY)
+	receiving.UnregisterSignal(src, COMSIG_BITRUNNER_SEVER_AVATAR)
+	occupant_mind_ref = null
+
+	if(mob_occupant.stat == DEAD)
+		open_machine()
+		return
+
+	var/heal_time = (mob_occupant.stat + 2) * 5
+	addtimer(CALLBACK(src, PROC_REF(auto_disconnect)), heal_time SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE|TIMER_DELETE_ME)
+
+	if(!forced)
+		return
+
+	mob_occupant.Paralyze(2 SECONDS)
+	mob_occupant.flash_act(override_blindness_check = TRUE, visual = TRUE)
+	mob_occupant.adjustOrganLoss(ORGAN_SLOT_BRAIN, disconnect_damage)
+	INVOKE_ASYNC(mob_occupant, TYPE_PROC_REF(/mob/living, emote), "scream")
+	to_chat(mob_occupant, span_danger("You've been forcefully disconnected from your avatar! Your thoughts feel scrambled!"))
+
+/**
+ * ### Enter Matrix
+ * Finds any current avatars from this chair - or generates a new one
+ *
+ * New avatars cost 1 attempt, and this will eject if there's none left
+ *
+ * Connects the mind to the avatar if everything is ok
+ */
+/obj/machinery/netpod/proc/enter_matrix()
+	var/mob/living/carbon/human/neo = occupant
+	if(!ishuman(neo) || neo.stat == DEAD || isnull(neo.mind))
+		balloon_alert(neo, "invalid occupant.")
+		return
+
+	var/obj/machinery/quantum_server/server = find_server()
+	if(isnull(server))
+		balloon_alert(neo, "no server connected!")
+		return
+
+	var/datum/lazy_template/virtual_domain/generated_domain = server.generated_domain
+	if(isnull(generated_domain) || !server.is_ready)
+		balloon_alert(neo, "nothing loaded!")
+		return
+
+	var/mob/living/carbon/current_avatar = avatar_ref?.resolve()
+	var/obj/structure/hololadder/wayout
+	if(isnull(current_avatar) || current_avatar.stat != CONSCIOUS) // We need a viable avatar
+		wayout = server.generate_hololadder()
+		if(isnull(wayout))
+			balloon_alert(neo, "out of bandwidth!")
+			return
+		current_avatar = server.generate_avatar(wayout, netsuit)
+		avatar_ref = WEAKREF(current_avatar)
+
+	neo.set_static_vision(3 SECONDS)
+	protect_occupant(occupant)
+	if(!do_after(neo, 2 SECONDS, src))
+		return
+
+	// Very invalid
+	if(QDELETED(neo) || QDELETED(current_avatar) || QDELETED(src))
+		return
+
+	// Invalid
+	if(occupant != neo || isnull(neo.mind) || neo.stat == DEAD || current_avatar.stat == DEAD)
+		return
+
+	var/datum/weakref/neo_mind_ref = WEAKREF(neo.mind)
+	occupant_mind_ref = neo_mind_ref
+	SEND_SIGNAL(server, COMSIG_BITRUNNER_CLIENT_CONNECTED, neo_mind_ref)
+	neo.mind.initial_avatar_connection(
+		avatar = current_avatar,
+		hosting_netpod = src,
+		server = server,
+		help_text = generated_domain.help_text
+	)
+
+/// Finds a server and sets the server_ref
+/obj/machinery/netpod/proc/find_server()
+	var/obj/machinery/quantum_server/server = server_ref?.resolve()
+	if(server)
+		return server
+
+	server = locate(/obj/machinery/quantum_server) in oview(4, src)
+	if(isnull(server))
+		return
+
+	server_ref = WEAKREF(server)
+	RegisterSignal(server, COMSIG_BITRUNNER_SERVER_UPGRADED, PROC_REF(on_server_upgraded), override = TRUE)
+	RegisterSignal(server, COMSIG_BITRUNNER_DOMAIN_COMPLETE, PROC_REF(on_domain_complete), override = TRUE)
+
+	return server
+
+/// Creates a list of outfit entries for the UI.
+/obj/machinery/netpod/proc/make_outfit_collection(identifier, list/outfit_list)
+	var/list/collection = list(
+		"name" = identifier,
+		"outfits" = list()
+	)
+
+	for(var/path as anything in outfit_list)
+		var/datum/outfit/outfit = path
+
+		var/outfit_name = initial(outfit.name)
+		if(findtext(outfit_name, "(") != 0 || findtext(outfit_name, "-") != 0) // No special variants please
+			continue
+
+		collection["outfits"] += list(list("path" = path, "name" = outfit_name))
+
+	return list(collection)
+
+/// Machine has been broken - handles signals and reverting sprites
+/obj/machinery/netpod/proc/on_broken(datum/source)
+	SIGNAL_HANDLER
+
+	if(!state_open)
+		open_machine()
+
+	if(occupant)
+		unprotect_and_signal()
+
+/// Puts points on the current occupant's card account
+/obj/machinery/netpod/proc/on_domain_complete(datum/source, atom/movable/crate, reward_points)
+	SIGNAL_HANDLER
+
+	if(isnull(occupant) || isnull(occupant_mind_ref) || !iscarbon(occupant))
+		return
+
+	var/mob/living/carbon/player = occupant
+
+	var/datum/bank_account/account = player.get_bank_account()
+	if(isnull(account))
+		return
+
+	account.bitrunning_points += reward_points * 100
+
+/obj/machinery/netpod/proc/on_examine(datum/source, mob/examiner, list/examine_text)
+	SIGNAL_HANDLER
+
+	if(isnull(occupant))
+		examine_text += span_infoplain("It is currently unoccupied.")
+		return
+
+	examine_text += span_infoplain("It is currently occupied by [occupant].")
+
+/// On unbuckle or break, make sure the occupant ref is null
+/obj/machinery/netpod/proc/unprotect_and_signal()
+	unprotect_occupant(occupant)
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_SEVER_AVATAR, src)
+
+/// When the server is upgraded, drops brain damage a little
+/obj/machinery/netpod/proc/on_server_upgraded(datum/source, servo_rating)
+	SIGNAL_HANDLER
+
+	disconnect_damage = BASE_DISCONNECT_DAMAGE * (1 - servo_rating)
+
+/// Checks the integrity, alerts occupants
+/obj/machinery/netpod/proc/on_take_damage(datum/source, damage_amount)
+	SIGNAL_HANDLER
+
+	if(isnull(occupant))
+		return
+
+	var/total = max_integrity - damage_amount
+	var/integrity = (atom_integrity / total) * 100
+	if(integrity > 50)
+		return
+
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_NETPOD_INTEGRITY)
+
+/// Sets the owner to in_netpod state, basically short-circuiting environmental conditions
+/obj/machinery/netpod/proc/protect_occupant(mob/living/target)
+	if(target != occupant)
+		return
+
+	target.AddComponent(/datum/component/netpod_healing, \
+		brute_heal = 1, \
+		burn_heal = 1, \
+		toxin_heal = 1, \
+		clone_heal = 1, \
+		blood_heal = 1, \
+	)
+
+	target.playsound_local(src, 'sound/effects/submerge.ogg', 20, TRUE)
+	target.extinguish_mob()
+	update_use_power(ACTIVE_POWER_USE)
+
+/// Removes the in_netpod state
+/obj/machinery/netpod/proc/unprotect_occupant(mob/living/target)
+	var/datum/component/netpod_healing/healing_eff = target?.GetComponent(/datum/component/netpod_healing)
+	if(healing_eff)
+		qdel(healing_eff)
+
+	update_use_power(IDLE_POWER_USE)
+
+/// Resolves a path to an outfit.
+/obj/machinery/netpod/proc/resolve_outfit(text)
+	var/path = text2path(text)
+	if(ispath(path, /datum/outfit))
+		return path
+
+/// Closes the machine without shoving in an occupant
+/obj/machinery/netpod/proc/shut_pod()
+	state_open = FALSE
+	playsound(src, 'sound/machines/tramclose.ogg', 60, TRUE, frequency = 65000)
+	flick("[base_icon_state]_closing", src)
+	set_density(TRUE)
+
+	update_appearance()
+
+#undef BASE_DISCONNECT_DAMAGE

--- a/code/modules/bitrunning/objects/quantum_console.dm
+++ b/code/modules/bitrunning/objects/quantum_console.dm
@@ -1,0 +1,110 @@
+/obj/machinery/computer/quantum_console
+	name = "quantum console"
+
+	circuit = /obj/item/circuitboard/computer/quantum_console
+	icon_keyboard = "mining"
+	icon_screen = "bitrunning"
+	req_access = list(ACCESS_MINING)
+	/// The server this console is connected to.
+	var/datum/weakref/server_ref
+
+/obj/machinery/computer/quantum_console/Initialize(mapload, obj/item/circuitboard/circuit)
+	. = ..()
+	desc = "Even in the distant year [CURRENT_STATION_YEAR], Nanostrasen is still using REST APIs. How grim."
+
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/computer/quantum_console/LateInitialize()
+	. = ..()
+
+	if(isnull(server_ref))
+		find_server()
+
+/obj/machinery/computer/quantum_console/ui_interact(mob/user, datum/tgui/ui)
+	. = ..()
+
+	if(!is_operational)
+		return
+
+	if(isnull(server_ref))
+		find_server()
+
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "QuantumConsole")
+		ui.open()
+
+/obj/machinery/computer/quantum_console/ui_data()
+	var/list/data = list()
+
+	var/obj/machinery/quantum_server/server = find_server()
+	if(isnull(server))
+		data["connected"] = FALSE
+		return data
+
+	data["connected"] = TRUE
+	data["generated_domain"] = server.generated_domain?.key
+	data["occupants"] = length(server.occupant_mind_refs)
+	data["points"] = server.points
+	data["randomized"] = server.domain_randomized
+	data["ready"] = server.is_ready && server.is_operational
+	data["scanner_tier"] = server.scanner_tier
+	data["retries_left"] = length(server.exit_turfs) - server.retries_spent
+
+	return data
+
+/obj/machinery/computer/quantum_console/ui_static_data(mob/user)
+	var/list/data = list()
+
+	var/obj/machinery/quantum_server/server = find_server()
+	if(isnull(server))
+		return data
+
+	data["available_domains"] = server.get_available_domains()
+	data["avatars"] = server.get_avatar_data()
+
+	return data
+
+/obj/machinery/computer/quantum_console/ui_act(action, list/params, datum/tgui/ui)
+	. = ..()
+	if(.)
+		return TRUE
+
+	var/obj/machinery/quantum_server/server = find_server()
+	if(isnull(server))
+		return FALSE
+
+	switch(action)
+		if("random_domain")
+			var/map_id = server.get_random_domain_id()
+			if(!map_id)
+				return TRUE
+
+			server.cold_boot_map(usr, map_id)
+			return TRUE
+		if("refresh")
+			ui.send_full_update()
+			return TRUE
+		if("set_domain")
+			server.cold_boot_map(usr, params["id"])
+			return TRUE
+		if("stop_domain")
+			server.begin_shutdown(usr)
+			return TRUE
+
+	return FALSE
+
+/// Attempts to find a quantum server.
+/obj/machinery/computer/quantum_console/proc/find_server()
+	var/obj/machinery/quantum_server/server = server_ref?.resolve()
+	if(server)
+		return server
+
+	for(var/direction in GLOB.cardinals)
+		var/obj/machinery/quantum_server/nearby_server = locate(/obj/machinery/quantum_server, get_step(src, direction))
+		if(nearby_server)
+			server_ref = WEAKREF(nearby_server)
+			nearby_server.console_ref = WEAKREF(src)
+			return nearby_server
+
+	return

--- a/code/modules/bitrunning/objects/quantum_server.dm
+++ b/code/modules/bitrunning/objects/quantum_server.dm
@@ -1,0 +1,745 @@
+#define ONLY_TURF 1 // There should only ever be one turf at the bottom left of the map.
+#define REDACTED "???"
+#define MAX_DISTANCE 4 // How far crates can spawn from the server
+
+/obj/machinery/quantum_server
+	name = "quantum server"
+
+	circuit = /obj/item/circuitboard/machine/quantum_server
+	density = TRUE
+	desc = "A hulking computational machine designed to fabricate virtual domains."
+	icon = 'icons/obj/machines/bitrunning.dmi'
+	base_icon_state = "qserver"
+	icon_state = "qserver"
+	/// Affects server cooldown efficiency
+	var/capacitor_coefficient = 1
+	/// The loaded map template, map_template/virtual_domain
+	var/datum/lazy_template/virtual_domain/generated_domain
+	/// The loaded safehouse, map_template/safehouse
+	var/datum/map_template/safehouse/generated_safehouse
+	/// The connected console
+	var/datum/weakref/console_ref
+	/// If the current domain was a random selection
+	var/domain_randomized = FALSE
+	/// If any threats were spawned, adds to rewards
+	var/domain_threats = 0
+	/// Prevents multiple user actions. Handled by loading domains and cooldowns
+	var/is_ready = TRUE
+	/// List of available domains
+	var/list/available_domains = list()
+	/// Current plugged in users
+	var/list/datum/weakref/occupant_mind_refs = list()
+	/// Cached list of mutable mobs in zone for cybercops
+	var/list/mob/living/mutation_candidates = list()
+	/// Any ghosts that have spawned in
+	var/list/mob/living/spawned_threats = list()
+	/// Scales loot with extra players
+	var/multiplayer_bonus = 1.1
+	/// The amount of points in the system, used to purchase maps
+	var/points = 0
+	/// Keeps track of the number of times someone has built a hololadder
+	var/retries_spent = 0
+	/// Changes how much info is available on the domain
+	var/scanner_tier = 1
+	/// Length of time it takes for the server to cool down after resetting. Here to give runners downtime so their faces don't get stuck like that
+	var/server_cooldown_time = 3 MINUTES
+	/// Applies bonuses to rewards etc
+	var/servo_bonus = 0
+	/// The turfs we can place a hololadder on.
+	var/turf/exit_turfs = list()
+	/// The turfs on station where we generate loot.
+	var/turf/receive_turfs = list()
+
+/obj/machinery/quantum_server/Initialize(mapload)
+	. = ..()
+
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/quantum_server/LateInitialize()
+	. = ..()
+
+	if(isnull(console_ref))
+		find_console()
+
+	RegisterSignals(src, list(COMSIG_MACHINERY_BROKEN, COMSIG_MACHINERY_POWER_LOST), PROC_REF(on_broken))
+	RegisterSignal(src, COMSIG_QDELETING, PROC_REF(on_delete))
+	RegisterSignal(src, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(src, COMSIG_BITRUNNER_CLIENT_CONNECTED, PROC_REF(on_client_connected))
+	RegisterSignal(src, COMSIG_BITRUNNER_CLIENT_DISCONNECTED, PROC_REF(on_client_disconnected))
+	RegisterSignal(src, COMSIG_BITRUNNER_SPAWN_GLITCH, PROC_REF(on_threat_created))
+
+	// This further gets sorted in the client by cost so it's random and grouped
+	available_domains = shuffle(subtypesof(/datum/lazy_template/virtual_domain))
+
+/obj/machinery/quantum_server/Destroy(force)
+	. = ..()
+
+	available_domains.Cut()
+	QDEL_LIST(mutation_candidates)
+	QDEL_LIST(occupant_mind_refs)
+	QDEL_LIST(spawned_threats)
+	QDEL_NULL(exit_turfs)
+	QDEL_NULL(receive_turfs)
+	QDEL_NULL(generated_domain)
+	QDEL_NULL(generated_safehouse)
+
+/obj/machinery/quantum_server/update_appearance(updates)
+	if(isnull(generated_domain) || !is_operational)
+		set_light(0)
+		return ..()
+
+	set_light_color(is_ready ? LIGHT_COLOR_BABY_BLUE : LIGHT_COLOR_FIRE)
+	set_light(2, 1.5)
+
+	return ..()
+
+/obj/machinery/quantum_server/update_icon_state()
+	if(isnull(generated_domain) || !is_operational)
+		icon_state = base_icon_state
+		return ..()
+
+	icon_state = "[base_icon_state]_[is_ready ? "on" : "off"]"
+	return ..()
+
+/obj/machinery/quantum_server/crowbar_act(mob/living/user, obj/item/crowbar)
+	. = ..()
+
+	if(!is_ready)
+		balloon_alert(user, "it's scalding hot!")
+		return TRUE
+	if(length(occupant_mind_refs))
+		balloon_alert(user, "all clients must disconnect!")
+		return TRUE
+	if(default_deconstruction_crowbar(crowbar))
+		return TRUE
+	return FALSE
+
+/obj/machinery/quantum_server/screwdriver_act(mob/living/user, obj/item/screwdriver)
+	. = ..()
+
+	if(!is_ready)
+		balloon_alert(user, "it's scalding hot!")
+		return TRUE
+	if(default_deconstruction_screwdriver(user, "[base_icon_state]_panel", icon_state, screwdriver))
+		return TRUE
+	return FALSE
+
+/obj/machinery/quantum_server/RefreshParts()
+	. = ..()
+
+	var/capacitor_rating = 1.15
+	var/datum/stock_part/capacitor/cap = locate() in component_parts
+	capacitor_rating -= cap.tier * 0.15
+
+	capacitor_coefficient = capacitor_rating
+
+	var/datum/stock_part/scanning_module/scanner = locate() in component_parts
+	if(scanner)
+		scanner_tier = scanner.tier
+
+	var/servo_rating = 0
+	for(var/datum/stock_part/servo/servo in component_parts)
+		servo_rating += servo.tier * 0.1
+
+	servo_bonus = servo_rating
+
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_SERVER_UPGRADED, scanner_tier)
+
+/// Gives all current occupants a notification that the server is going down
+/obj/machinery/quantum_server/proc/begin_shutdown(mob/user)
+	if(isnull(generated_domain))
+		return
+
+	if(!length(occupant_mind_refs))
+		balloon_alert(user, "powering down domain...")
+		playsound(src, 'sound/machines/terminal_off.ogg', 40, 2)
+		reset()
+		return
+
+	balloon_alert(user, "notifying clients...")
+	playsound(src, 'sound/machines/terminal_alert.ogg', 100, TRUE)
+	user.visible_message(
+		span_danger("[user] begins depowering the server!"),
+		span_notice("You start disconnecting clients..."),
+		span_danger("You hear frantic keying on a keyboard."),
+	)
+
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_SHUTDOWN_ALERT, user)
+
+	if(!do_after(user, 20 SECONDS, src))
+		return
+
+	reset()
+
+/// Handles calculating rewards based on number of players, parts, threats, etc
+/obj/machinery/quantum_server/proc/calculate_rewards()
+	var/rewards_base = 0.8
+
+	if(domain_randomized)
+		rewards_base += 0.2
+
+	rewards_base += servo_bonus
+
+	rewards_base += (domain_threats * 2)
+
+	for(var/index in 2 to length(occupant_mind_refs))
+		rewards_base += multiplayer_bonus
+
+	return rewards_base
+
+/**
+ * ### Quantum Server Cold Boot
+ * Procedurally links the 3 booting processes together.
+ *
+ * This is the starting point if you have an id. Does validation and feedback on steps
+ */
+/obj/machinery/quantum_server/proc/cold_boot_map(mob/user, map_key)
+	if(!is_ready)
+		return FALSE
+
+	if(isnull(map_key))
+		balloon_alert(user, "no domain specified.")
+		return FALSE
+
+	if(generated_domain)
+		balloon_alert(user, "stop the current domain first.")
+		return FALSE
+
+	if(length(occupant_mind_refs))
+		balloon_alert(user, "all clients must disconnect!")
+		return FALSE
+
+	is_ready = FALSE
+	playsound(src, 'sound/machines/terminal_processing.ogg', 30, 2)
+
+	if(!initialize_domain(map_key) || !initialize_safehouse() || !initialize_map_items())
+		balloon_alert(user, "initialization failed.")
+		scrub_vdom()
+		is_ready = TRUE
+		return FALSE
+
+	is_ready = TRUE
+	playsound(src, 'sound/machines/terminal_insert_disc.ogg', 30, 2)
+	balloon_alert(user, "domain loaded.")
+	generated_domain.start_time = world.time
+	points -= generated_domain.cost
+	update_use_power(ACTIVE_POWER_USE)
+	update_appearance()
+
+	return TRUE
+
+/// Resets the cooldown state and updates icons
+/obj/machinery/quantum_server/proc/cool_off()
+	is_ready = TRUE
+	update_appearance()
+
+/// Attempts to connect to a quantum console
+/obj/machinery/quantum_server/proc/find_console()
+	var/obj/machinery/computer/quantum_console/console = console_ref?.resolve()
+	if(console)
+		return console
+
+	for(var/direction in GLOB.cardinals)
+		var/obj/machinery/computer/quantum_console/nearby_console = locate(/obj/machinery/computer/quantum_console, get_step(src, direction))
+		if(nearby_console)
+			console_ref = WEAKREF(nearby_console)
+			nearby_console.server_ref = WEAKREF(src)
+			return nearby_console
+
+/// Generates a new avatar for the bitrunner.
+/obj/machinery/quantum_server/proc/generate_avatar(obj/structure/hololadder/wayout, datum/outfit/netsuit)
+	var/mob/living/carbon/human/avatar = new(wayout.loc)
+
+	var/outfit_path = generated_domain.forced_outfit || netsuit
+	var/datum/outfit/to_wear = new outfit_path()
+
+	to_wear.suit_store = null
+	to_wear.belt = /obj/item/bitrunning_host_monitor
+	to_wear.glasses = null
+	to_wear.suit = null
+	to_wear.gloves = null
+
+	avatar.equipOutfit(to_wear, visualsOnly = TRUE)
+
+	var/obj/item/storage/backpack/bag = avatar.back
+	if(istype(bag))
+		bag.contents += list(
+			new /obj/item/storage/box/survival,
+			new /obj/item/storage/medkit/regular,
+			new /obj/item/flashlight,
+		)
+
+	var/obj/item/card/id/outfit_id = avatar.wear_id
+	if(outfit_id)
+		outfit_id.assignment = "Bit Avatar"
+		outfit_id.registered_name = avatar.real_name
+		SSid_access.apply_trim_to_card(outfit_id, /datum/id_trim/bit_avatar)
+
+	return avatar
+
+/// Generates a new hololadder for the bitrunner. Effectively a respawn attempt.
+/obj/machinery/quantum_server/proc/generate_hololadder()
+	if(!length(exit_turfs))
+		return
+
+	if(retries_spent >= length(exit_turfs))
+		return
+
+	var/turf/destination
+	for(var/turf/dest_turf in exit_turfs)
+		if(!locate(/obj/structure/hololadder) in dest_turf)
+			destination = dest_turf
+			break
+
+	if(isnull(destination))
+		return
+
+	var/obj/structure/hololadder/wayout = new(destination)
+	if(isnull(wayout))
+		return
+
+	retries_spent += 1
+
+	return wayout
+
+/// Generates a reward based on the given domain
+/obj/machinery/quantum_server/proc/generate_loot()
+	if(!length(receive_turfs) && !locate_receive_turfs())
+		return FALSE
+
+	points += generated_domain.reward_points
+	playsound(src, 'sound/machines/terminal_success.ogg', 30, 2)
+
+	var/turf/dest_turf = pick(receive_turfs)
+	if(isnull(dest_turf))
+		stack_trace("Failed to find a turf to spawn loot crate on.")
+		return FALSE
+
+	var/bonus = calculate_rewards()
+
+	var/obj/item/paper/certificate = new()
+	certificate.add_raw_text(get_completion_certificate())
+	certificate.name = "certificate of domain completion"
+	certificate.update_appearance()
+
+	var/obj/structure/closet/crate/secure/bitrunning/decrypted/reward_crate = new(dest_turf, generated_domain, bonus)
+	reward_crate.manifest = certificate
+	reward_crate.update_appearance()
+
+	spark_at_location(reward_crate)
+	return TRUE
+
+/// Compiles a list of available domains.
+/obj/machinery/quantum_server/proc/get_available_domains()
+	var/list/levels = list()
+
+	for(var/datum/lazy_template/virtual_domain/domain as anything in available_domains)
+		if(initial(domain.test_only))
+			continue
+		var/can_view = initial(domain.difficulty) < scanner_tier && initial(domain.cost) <= points + 5
+		var/can_view_reward = initial(domain.difficulty) < (scanner_tier + 1) && initial(domain.cost) <= points + 3
+
+		levels += list(list(
+			"cost" = initial(domain.cost),
+			"desc" = can_view ? initial(domain.desc) : "Limited scanning capabilities. Cannot infer domain details.",
+			"difficulty" = initial(domain.difficulty),
+			"id" = initial(domain.key),
+			"name" = can_view ? initial(domain.name) : REDACTED,
+			"reward" = can_view_reward ? initial(domain.reward_points) : REDACTED,
+		))
+
+	return levels
+
+/// If there are hosted minds, attempts to get a list of their current virtual bodies w/ vitals
+/obj/machinery/quantum_server/proc/get_avatar_data()
+	var/list/hosted_avatars = list()
+
+	for(var/datum/weakref/mind_ref in occupant_mind_refs)
+		var/datum/mind/this_mind = mind_ref.resolve()
+		if(isnull(this_mind))
+			occupant_mind_refs.Remove(this_mind)
+			continue
+
+		var/mob/living/creature = this_mind.current
+		var/mob/living/pilot = this_mind.pilot_ref?.resolve()
+
+		hosted_avatars += list(list(
+			"health" = creature.health,
+			"name" = creature.name,
+			"pilot" = pilot,
+			"brute" = creature.get_damage_amount(BRUTE),
+			"burn" = creature.get_damage_amount(BURN),
+			"tox" = creature.get_damage_amount(TOX),
+			"oxy" = creature.get_damage_amount(OXY),
+		))
+
+	return hosted_avatars
+
+/// Returns the markdown text containing domain completion information
+/obj/machinery/quantum_server/proc/get_completion_certificate()
+	var/base_points = generated_domain.reward_points
+	if(domain_randomized)
+		base_points -= 1
+
+	var/bonuses = calculate_rewards()
+
+	var/time_difference = world.time - generated_domain.start_time
+
+	var/completion_time = "### Completion Time: [DisplayTimeText(time_difference)]\n"
+
+	var/grade = "\n---\n\n# Rating: [grade_completion(generated_domain.difficulty, domain_threats, base_points, domain_randomized, time_difference)]"
+
+	var/text = "# Certificate of Domain Completion\n\n---\n\n"
+
+	text += "### [generated_domain.name][domain_randomized ? " (Randomized)" : ""]\n"
+	text += "- **Difficulty:** [generated_domain.difficulty]\n"
+	text += "- **Threats:** [domain_threats]\n"
+	text += "- **Base Points:** [base_points][domain_randomized ? " +1" : ""]\n\n"
+	text += "- **Total Bonus:** [bonuses]x\n\n"
+
+	if(bonuses <= 1)
+		text += completion_time
+		text += grade
+		return text
+
+	text += "### Bonuses\n"
+	if(domain_randomized)
+		text += "- **Randomized:** + 0.2\n"
+
+	if(length(occupant_mind_refs) > 1)
+		text += "- **Multiplayer:** + [(length(occupant_mind_refs) - 1) * multiplayer_bonus]\n"
+
+	if(domain_threats > 0)
+		text += "- **Threats:** + [domain_threats * 2]\n"
+
+	var/servo_rating = servo_bonus
+
+	if(servo_rating > 0.2)
+		text += "- **Components:** + [servo_rating]\n"
+
+	text += completion_time
+	text += grade
+
+	return text
+
+/// Gets a random available domain given the current points. Weighted towards higher cost domains.
+/obj/machinery/quantum_server/proc/get_random_domain_id()
+	if(points < 1)
+		return
+
+	var/list/random_domains = list()
+	var/total_cost = 0
+
+	for(var/datum/lazy_template/virtual_domain/available as anything in subtypesof(/datum/lazy_template/virtual_domain))
+		var/init_cost = initial(available.cost)
+		if(!initial(available.test_only) && init_cost > 0 && init_cost < 4 && init_cost <= points)
+			random_domains += list(list(
+				cost = init_cost,
+				id = initial(available.key),
+			))
+
+	var/random_value = rand(0, total_cost)
+	var/accumulated_cost = 0
+
+	for(var/available as anything in random_domains)
+		accumulated_cost += available["cost"]
+		if(accumulated_cost >= random_value)
+			domain_randomized = TRUE
+			return available["id"]
+
+/// Gets all mobs originally generated by the loaded domain and returns a list that are capable of being antagged
+/obj/machinery/quantum_server/proc/get_valid_domain_targets()
+	// A: No one is playing
+	// B: The domain is not loaded
+	// C: The domain is shutting down
+	// D: There are no mobs
+	if(!length(occupant_mind_refs) || isnull(generated_domain) || !is_ready || !is_operational || !length(mutation_candidates))
+		return list()
+
+	for(var/mob/living/creature as anything in mutation_candidates)
+		if(QDELETED(creature) || creature.mind)
+			mutation_candidates.Remove(creature)
+
+	return shuffle(mutation_candidates)
+
+/// Grades the player's run based on several factors
+/obj/machinery/quantum_server/proc/grade_completion(difficulty, threats, points, randomized, completion_time)
+	var/score = threats * 5
+	score += points
+	score += randomized ? 1 : 0
+
+	if(completion_time <= 2 MINUTES)
+		score += difficulty * 4
+	else if(completion_time <= 5 MINUTES)
+		score += difficulty * 3
+	else if (completion_time <= 10 MINUTES)
+		score += difficulty * 2
+	else
+		score += 1
+
+	switch(score)
+		if(1 to 4)
+			return "D"
+		if(5 to 7)
+			return "C"
+		if(8 to 10)
+			return "B"
+		if(11 to 13)
+			return "A"
+		else
+			return "S"
+
+/// Initializes a new domain if the given key is valid and the user has enough points
+/obj/machinery/quantum_server/proc/initialize_domain(map_key)
+	var/datum/lazy_template/virtual_domain/to_load
+
+	for(var/datum/lazy_template/virtual_domain/available as anything in subtypesof(/datum/lazy_template/virtual_domain))
+		if(map_key != initial(available.key) || points < initial(available.cost))
+			continue
+		to_load = available
+		break
+
+	if(isnull(to_load))
+		return FALSE
+
+	generated_domain = new to_load()
+	generated_domain.lazy_load()
+
+	return TRUE
+
+/// Loads in necessary map items, sets mutation targets, etc
+/obj/machinery/quantum_server/proc/initialize_map_items()
+	for(var/thing in generated_domain.created_atoms_list)
+		if(isliving(thing)) // so we can mutate them
+			var/mob/living/creature = thing
+
+			if(creature.can_be_cybercop)
+				mutation_candidates += creature
+			continue
+
+		if(istype(thing, /obj/effect/mob_spawn/ghost_role)) // so we get threat alerts
+			RegisterSignal(thing, COMSIG_GHOSTROLE_SPAWNED, PROC_REF(on_threat_created))
+			continue
+
+		if(istype(thing, /obj/effect/mob_spawn/corpse)) // corpses are valid targets too
+			var/obj/effect/mob_spawn/corpse/spawner = thing
+			var/mob/living/creature = spawner.mob_ref?.resolve()
+
+			if(!creature?.can_be_cybercop)
+				continue
+
+			mutation_candidates += creature
+			qdel(spawner)
+
+	var/turf/goal_turfs = list()
+	var/turf/crate_turfs = list()
+	for(var/thing in GLOB.landmarks_list)
+		if(istype(thing, /obj/effect/landmark/bitrunning/hololadder_spawn))
+			exit_turfs += get_turf(thing)
+			qdel(thing) // i'm worried about multiple servers getting confused so lets clean em up
+			continue
+
+		if(istype(thing, /obj/effect/landmark/bitrunning/cache_goal_turf))
+			var/turf/tile = get_turf(thing)
+			goal_turfs += tile
+			RegisterSignal(tile, COMSIG_ATOM_ENTERED, PROC_REF(on_goal_turf_entered))
+			RegisterSignal(tile, COMSIG_ATOM_EXAMINE, PROC_REF(on_goal_turf_examined))
+			qdel(thing)
+			continue
+
+		if(istype(thing, /obj/effect/landmark/bitrunning/cache_spawn))
+			crate_turfs += get_turf(thing)
+			qdel(thing)
+			continue
+
+	if(!length(exit_turfs))
+		CRASH("Failed to find exit turfs on generated domain.")
+	if(!length(goal_turfs))
+		CRASH("Failed to find send turfs on generated domain.")
+
+	if(length(crate_turfs))
+		shuffle_inplace(crate_turfs)
+		new /obj/structure/closet/crate/secure/bitrunning/encrypted(pick(crate_turfs))
+
+	return TRUE
+
+/// Loads the safehouse
+/obj/machinery/quantum_server/proc/initialize_safehouse()
+	var/turf/safehouse_load_turf = list()
+	for(var/obj/effect/landmark/bitrunning/safehouse_spawn/spawner in GLOB.landmarks_list)
+		safehouse_load_turf += get_turf(spawner)
+		qdel(spawner)
+		break
+
+	if(!length(safehouse_load_turf))
+		CRASH("Failed to find safehouse load landmark on map.")
+
+	var/datum/map_template/safehouse/safehouse = new generated_domain.safehouse_path()
+	safehouse.load(safehouse_load_turf[ONLY_TURF])
+	generated_safehouse = safehouse
+
+	return TRUE
+
+/// Locates any turfs with crate out landmarks
+/obj/machinery/quantum_server/proc/locate_receive_turfs()
+	for(var/obj/effect/landmark/bitrunning/station_reward_spawn/spawner in GLOB.landmarks_list)
+		if(IN_GIVEN_RANGE(src, spawner, MAX_DISTANCE))
+			receive_turfs += get_turf(spawner)
+			qdel(spawner)
+
+	return length(receive_turfs) > 0
+
+/// Finds any mobs with minds in the zones and gives them the bad news
+/obj/machinery/quantum_server/proc/notify_spawned_threats()
+	for(var/mob/living/baddie as anything in spawned_threats)
+		if(QDELETED(baddie) || baddie.stat >= UNCONSCIOUS || isnull(baddie.mind))
+			continue
+
+		baddie.throw_alert(
+			ALERT_BITRUNNER_RESET,
+			/atom/movable/screen/alert/bitrunning/qserver_threat_deletion,
+			new_master = src,
+		)
+
+		to_chat(baddie, span_userdanger("You have been flagged for deletion! Thank you for your service."))
+
+/// If broken via signal, disconnects all users
+/obj/machinery/quantum_server/proc/on_broken(datum/source)
+	SIGNAL_HANDLER
+
+	if(isnull(generated_domain))
+		return
+
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_SEVER_AVATAR)
+
+/// Someone connected via netpod
+/obj/machinery/quantum_server/proc/on_client_connected(datum/source, datum/weakref/new_mind)
+	SIGNAL_HANDLER
+
+	occupant_mind_refs.Add(new_mind)
+
+/// Someone disconnected
+/obj/machinery/quantum_server/proc/on_client_disconnected(datum/source, datum/weakref/old_mind)
+	SIGNAL_HANDLER
+
+	occupant_mind_refs.Remove(old_mind)
+
+/// Being qdeleted - make sure the circuit and connected mobs go with it
+/obj/machinery/quantum_server/proc/on_delete(datum/source)
+	SIGNAL_HANDLER
+
+	if(generated_domain)
+		SEND_SIGNAL(src, COMSIG_BITRUNNER_SEVER_AVATAR)
+		scrub_vdom()
+
+	if(is_ready)
+		return
+	// in case they're trying to cheese cooldown
+	var/obj/item/circuitboard/machine/quantum_server/circuit = locate(/obj/item/circuitboard/machine/quantum_server) in contents
+	if(circuit)
+		qdel(circuit)
+
+/// Handles examining the server. Shows cooldown time and efficiency.
+/obj/machinery/quantum_server/proc/on_examine(datum/source, mob/examiner, list/examine_text)
+	SIGNAL_HANDLER
+
+	if(capacitor_coefficient < 1)
+		examine_text += span_infoplain("Its coolant capacity reduces cooldown time by [(1 - capacitor_coefficient) * 100]%.")
+
+	if(servo_bonus > 0.2)
+		examine_text += span_infoplain("Its manipulation potential is increasing rewards by [servo_bonus]x.")
+		examine_text += span_infoplain("Injury from unsafe ejection reduced [servo_bonus * 100]%.")
+
+	if(!is_ready)
+		examine_text += span_notice("It is currently cooling down. Give it a few moments.")
+		return
+
+/// Whenever something enters the send tiles, check if it's a loot crate. If so, alert players.
+/obj/machinery/quantum_server/proc/on_goal_turf_entered(datum/source, atom/movable/arrived, atom/old_loc, list/atom/old_locs)
+	SIGNAL_HANDLER
+
+	if(!istype(arrived, /obj/structure/closet/crate/secure/bitrunning/encrypted))
+		return
+
+	var/obj/structure/closet/crate/secure/bitrunning/encrypted/loot_crate = arrived
+	if(!istype(loot_crate))
+		return
+
+	for(var/mob/person in loot_crate.contents)
+		if(isnull(person.mind))
+			person.forceMove(get_turf(loot_crate))
+
+		var/datum/mind/this_mind = person.mind
+		this_mind.full_avatar_disconnect()
+
+	spark_at_location(loot_crate)
+	qdel(loot_crate)
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_DOMAIN_COMPLETE, arrived, generated_domain.reward_points)
+	generate_loot()
+
+/// Handles examining the server. Shows cooldown time and efficiency.
+/obj/machinery/quantum_server/proc/on_goal_turf_examined(datum/source, mob/examiner, list/examine_text)
+	SIGNAL_HANDLER
+
+	examine_text += span_info("Beneath your gaze, the floor pulses subtly with streams of encoded data.")
+	examine_text += span_info("It seems to be part of the location designated for retrieving encrypted payloads.")
+
+/// Handles when cybercops are summoned into the area or ghosts click a ghost role spawner
+/obj/machinery/quantum_server/proc/on_threat_created(datum/source, mob/living/threat)
+	SIGNAL_HANDLER
+
+	domain_threats += 1
+	spawned_threats += threat
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_THREAT_CREATED) // notify players
+
+/// Stops the current virtual domain and disconnects all users
+/obj/machinery/quantum_server/proc/reset(fast = FALSE)
+	is_ready = FALSE
+
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_SEVER_AVATAR)
+
+	if(!fast)
+		notify_spawned_threats()
+		addtimer(CALLBACK(src, PROC_REF(scrub_vdom)), 15 SECONDS, TIMER_UNIQUE|TIMER_STOPPABLE)
+	else
+		scrub_vdom() // used in unit testing, no need to wait for callbacks
+
+	addtimer(CALLBACK(src, PROC_REF(cool_off)), min(server_cooldown_time * capacitor_coefficient), TIMER_UNIQUE|TIMER_STOPPABLE|TIMER_DELETE_ME)
+	update_appearance()
+
+	update_use_power(IDLE_POWER_USE)
+	domain_randomized = FALSE
+	domain_threats = 0
+	retries_spent = 0
+
+/// Deletes all the tile contents
+/obj/machinery/quantum_server/proc/scrub_vdom()
+	SEND_SIGNAL(src, COMSIG_BITRUNNER_SEVER_AVATAR) // just in case
+
+	if(length(generated_domain.reservations))
+		var/datum/turf_reservation/res = generated_domain.reservations[1]
+		res.Release()
+
+	var/list/mob/living/creatures = spawned_threats + mutation_candidates
+	for(var/mob/living/creature as anything in creatures)
+		if(QDELETED(creature))
+			continue
+
+		creature.dust() // sometimes mobs just don't die
+
+	exit_turfs = list()
+	generated_domain = null
+	generated_safehouse = null
+	mutation_candidates.Cut()
+	spawned_threats.Cut()
+
+/// Do some magic teleport sparks
+/obj/machinery/quantum_server/proc/spark_at_location(obj/crate)
+	playsound(crate, 'sound/magic/blink.ogg', 50, TRUE)
+	var/datum/effect_system/spark_spread/quantum/sparks = new()
+	sparks.set_up(5, 1, get_turf(crate))
+	sparks.start()
+
+#undef ONLY_TURF
+#undef REDACTED
+#undef MAX_DISTANCE


### PR DESCRIPTION
## About The Pull Request
Atomized #77927
The core pieces of bitrunning. Does nothing on its own, nothing without the rest

Note: If anything, this should receive more scrutiny than any other piece.

## Why It's Good For The Game
See #77259
## Changelog
:cl:
add: Adds new machines for bitrunning - quantum server, console, vendor, and netpods.
add: Adds bitrunner avatars and the shared damage link.
add: Adds bitrunning host monitors to visualize host health.
/:cl:
