### PR TITLE
Fixes alien alloy's destructive analysis not giving the Alien Technology node (the one that lets you print alien alloy)

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -2090,6 +2090,7 @@
 	description = "Things used by the greys."
 	prereq_ids = list("biotech","engineering")
 	boost_item_paths = list(
+		/obj/item/stack/sheet/mineral/abductor,
 		/obj/item/abductor,
 		/obj/item/cautery/alien,
 		/obj/item/circuitboard/machine/abductor,


### PR DESCRIPTION
## About The Pull Request

Title.
Was a thing in the old days of yore of `origin_tech` (`Nov 7, 2017` - the commit before the techweb refactor)
https://github.com/tgstation/tgstation/blob/044ea0ba40a8dfb1ea9569aef13caadb63111488/code/game/objects/items/stacks/sheets/mineral.dm#L369-L375

but was removed in #31026 with seemingly no discussion of the fact and not added to the Alien Technology's node's `boost_item_paths`. the 300+ files changed probably have something to do with that. (`Nov 19, 2017`)
https://github.com/tgstation/tgstation/blob/caa1e1f400c8b6a535e03cff28cf57f919e9378c/code/modules/research/techweb/all_nodes.dm#L798-L810

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/47044 (it's moderately amusing how the issue was opened 2 years after the alloy lost this quirk)
Though the destuctive analyzer has been walking the plank for a good while now, things like ayy tech are stil reliant on it to become accessible to the crew.
Letting the alloy unlock the creation of the alloy on station can allow abductors that want to do that to sacrifice only a locker or a table instead of a more valuable gadget, which can be used for alien alloy toolboxes for example (i'd say ayy golems but we don't have em reimplemented yet haha oops)

## Changelog

:cl:
fix: after a long 6 years, alien alloy once again unlocks the Alien Technology node (the one that lets you print alien alloy)
/:cl: