### PR TITLE
Makes it easier to place tiles on multi-z holes

### DIFF
--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -20,11 +20,10 @@
 	if(target.z == user.z)
 		return
 	var/turf/checked_turf = get_turf(target)
-	do
-		checked_turf = checked_turf?.above()
+	while(!isnull(checked_turf))
+		checked_turf = checked_turf.above()
 		if(checked_turf?.z == user.z)
 			INVOKE_ASYNC(source, TYPE_PROC_REF(/obj/item, handle_openspace_click), checked_turf, user, user.CanReach(checked_turf, source), click_parameters)
 			break
-	while(!isnull(checked_turf))
 
 	return COMPONENT_AFTERATTACK_PROCESSED_ITEM

--- a/code/datums/elements/openspace_item_click_handler.dm
+++ b/code/datums/elements/openspace_item_click_handler.dm
@@ -19,7 +19,12 @@
 	SIGNAL_HANDLER
 	if(target.z == user.z)
 		return
-	var/turf/turf_above = get_step_multiz(target, UP)
-	if(turf_above?.z == user.z)
-		INVOKE_ASYNC(source, TYPE_PROC_REF(/obj/item, handle_openspace_click), turf_above, user, user.CanReach(turf_above, source), click_parameters)
+	var/turf/checked_turf = get_turf(target)
+	do
+		checked_turf = checked_turf?.above()
+		if(checked_turf?.z == user.z)
+			INVOKE_ASYNC(source, TYPE_PROC_REF(/obj/item, handle_openspace_click), checked_turf, user, user.CanReach(checked_turf, source), click_parameters)
+			break
+	while(!isnull(checked_turf))
+
 	return COMPONENT_AFTERATTACK_PROCESSED_ITEM

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -33,6 +33,7 @@
 	. = ..()
 	pixel_x = rand(-3, 3)
 	pixel_y = rand(-3, 3) //randomize a little
+	AddElement(/datum/element/openspace_item_click_handler)
 	if(tile_reskin_types)
 		tile_reskin_types = tile_reskin_list(tile_reskin_types)
 	if(tile_rotate_dirs)
@@ -99,6 +100,10 @@
 	target_plating.setDir(turf_dir)
 	playsound(target_plating, 'sound/weapons/genhit.ogg', 50, TRUE)
 	return target_plating
+
+/obj/item/stack/tile/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
+	if(proximity_flag)
+		target.attackby(src, user, click_parameters)
 
 //Grass
 /obj/item/stack/tile/grass


### PR DESCRIPTION
## About The Pull Request
Adds the "open space click handler" to tile stacks, which makes it so you don't have to pixel hunt for a turf on the BELOW z level in order to fix a hole.
This exists on rods and rpds since they're often used to fix holes.
But wasn't added to tiles when they were made to be able to fix holes directly, without rods.

Additionally, closes #77540 by having the open space click handler loop up z levels so that it works if you're clicking on items from multiple z levels away.
## Why It's Good For The Game
The current behavior can be very frustrating to work around, and appears to not be intended.
## Changelog
:cl:
fix: Made it easier to place tiles on multi z level holes 
/:cl:
