### PR TITLE
[FUCK] [s] Fixes the infinite loop caused by recent material changes

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -116,7 +116,8 @@
 /obj/machinery/recycler/proc/on_entered(datum/source, atom/movable/enterer, old_loc)
 	SIGNAL_HANDLER
 
-	// This is explicitly so we avoid processing items that are entering from nullspace.
+	// This is explicitly so we avoid processing items that are entering from nullspace,
+	// to avoid infinite loops.
 	if(!old_loc)
 		return
 

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -113,9 +113,14 @@
 	if(border_dir == eat_dir)
 		return TRUE
 
-/obj/machinery/recycler/proc/on_entered(datum/source, atom/movable/AM)
+/obj/machinery/recycler/proc/on_entered(datum/source, atom/movable/enterer, old_loc)
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, PROC_REF(eat), AM)
+
+	// This is explicitly so we avoid processing items that are entering from nullspace.
+	if(!old_loc)
+		return
+
+	INVOKE_ASYNC(src, PROC_REF(eat), enterer)
 
 /obj/machinery/recycler/proc/eat(atom/movable/morsel, sound=TRUE)
 	if(machine_stat & (BROKEN|NOPOWER))


### PR DESCRIPTION
## About The Pull Request
Fixes the infinite loop introduced by #77671 that was caused by materials entering the recycler by ensuring that they have an old location when entering the recycler. If they don't, that means they're coming from nullspace and thus were very likely just created, so they shouldn't be getting recycled (which was the cause of the MC dying from inserting enough materials to cause one sheet to be salvaged from a recycler).

Adding [s] because it can be abused to basically grind a server to a halt, so I recommend merging this as soon as possible.

Closes https://github.com/tgstation/tgstation/pull/77936.

## Why It's Good For The Game
Infinite loops causing the master controller to die aren't that good, I think we can all agree that the game working is nice.

## Changelog

:cl: GoldenAlpharex
fix: Fixes the recycler being able to grind the server to a halt by trying to recycle the same sheet worth of material over and over and over again.
/:cl: