### PR TITLE
[no gbp] Removes a source of self-ling

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/headslug.dm
+++ b/code/modules/mob/living/basic/space_fauna/headslug.dm
@@ -43,6 +43,8 @@
 		. += span_notice("It appears to be moving around listlessly.")
 	else
 		. += span_warning("It's moving around intelligently!")
+	if (egg_lain)
+		. += span_notice("Its reproductive equipment appears to have withered.")
 
 /// Signal Handler proc that runs on every attack and checks to see if this is a valid target for implantation. If so, it implants the egg and starts the countdown to death.
 /mob/living/basic/headslug/proc/check_and_implant(mob/living/basic/attacker, atom/target)
@@ -90,3 +92,7 @@
 /datum/ai_controller/basic_controller/headslug
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
+
+/// Neutered version to prevent people from turning themselves into changelings with sentience potions or transformation
+/mob/living/basic/headslug/beakless
+	egg_lain = TRUE

--- a/code/modules/mob_spawn/corpses/nonhuman_corpses.dm
+++ b/code/modules/mob_spawn/corpses/nonhuman_corpses.dm
@@ -48,10 +48,6 @@
 
 /// Dead headcrab for changeling-themed ruins
 /obj/effect/mob_spawn/corpse/headcrab
-	mob_type = /mob/living/basic/headslug
+	mob_type = /mob/living/basic/headslug/beakless
 	icon = 'icons/mob/simple/animal.dmi'
 	icon_state = "headslug_dead"
-
-/obj/effect/mob_spawn/corpse/headcrab/special(mob/living/basic/headslug/crab)
-	. = ..()
-	crab.egg_lain = TRUE // Prevents using mad science to become a changeling


### PR DESCRIPTION
## About The Pull Request

The protection from allowing a possessing mob to lay changeling eggs of the dead headslug corpses present in the meateor ruin was a post-creation variable edit rather than an immutable property of the typepath, so if for instance you had some kind of item of clothing which allows you to turn yourself into an instance of a mob via its typepath you could use them to turn into a headslug, bite a monkeyman, commit suicide, and then become a changeling.

An unintended consequene of two things added by the same developer? Starting to stop looking like a coincidence, someone should investigate this guy...

## Why It's Good For The Game

This is undesirable, which is exactly why nobody reported it even though they knew they could do it.

## Changelog

:cl:
fix: You can't use the bioscrambler belt to turn yourself into a changeling.
/:cl:
