### PR TITLE
adds the rest of the HFR boxes to birdshot HFR room, some xeno stuff, and a new gaming den

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -12378,6 +12378,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "eHN" = (
+/obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/maintenance/port/lesser)
 "eHR" = (
@@ -20658,6 +20659,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"hzV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/lesser)
 "hzX" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -23526,6 +23532,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/smooth,
 /area/station/hallway/secondary/command)
+"iBE" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/cable,
+/turf/open/floor/wood/tile,
+/area/station/service/abandoned_gambling_den/gaming)
 "iBV" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -26577,6 +26588,10 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
+"jGO" = (
+/obj/structure/cable,
+/turf/open/floor/wood/tile,
+/area/station/service/abandoned_gambling_den/gaming)
 "jGW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -55342,6 +55357,7 @@
 /area/station/command/heads_quarters/captain/private)
 "tvZ" = (
 /obj/effect/spawner/random/trash,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "twf" = (
@@ -60316,6 +60332,14 @@
 	dir = 1
 	},
 /area/station/service/lawoffice)
+"vcY" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/tile,
+/area/station/service/abandoned_gambling_den/gaming)
 "vdf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -82288,7 +82312,7 @@ kCo
 peR
 dyW
 fEC
-vAD
+vcY
 vAD
 vAD
 roq
@@ -82545,7 +82569,7 @@ qXB
 tmT
 qXB
 fEC
-vAD
+jGO
 uhq
 tXl
 vAD
@@ -82802,7 +82826,7 @@ hbm
 aZw
 vSW
 fEC
-roq
+iBE
 uhq
 tXl
 roq
@@ -83057,9 +83081,9 @@ qVP
 wmV
 cpH
 tqo
-tqo
+hzV
 eHN
-roq
+iBE
 roq
 roq
 roq
@@ -83314,7 +83338,7 @@ qVP
 fEC
 cpH
 fEC
-tqo
+hzV
 fEC
 qVP
 fNu
@@ -83571,7 +83595,7 @@ qVP
 nHu
 dpt
 tvZ
-tqo
+hzV
 efr
 qVP
 ets

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -1359,6 +1359,7 @@
 /area/station/engineering/storage/tech)
 "aCM" = (
 /obj/effect/spawner/random/structure/crate_abandoned,
+/obj/structure/alien/weeds,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "aCO" = (
@@ -2526,6 +2527,7 @@
 	pixel_x = -8;
 	pixel_y = 6
 	},
+/obj/structure/alien/weeds,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "baW" = (
@@ -3140,6 +3142,12 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"bnr" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "bnz" = (
 /obj/machinery/light_switch/directional/south,
 /obj/structure/cable,
@@ -3317,6 +3325,13 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
+"brz" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
+/obj/vehicle/ridden/scooter/skateboard/hoverboard,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "brD" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile/neutral{
@@ -3695,6 +3710,14 @@
 /obj/effect/turf_decal/stripes/asteroid/end,
 /turf/open/floor/circuit/green,
 /area/station/science/robotics/mechbay)
+"byU" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/egg/fake,
+/obj/structure/alien/weeds,
+/obj/effect/gibspawner,
+/turf/open/floor/wood,
+/area/station/maintenance/starboard/greater)
 "byV" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/item/radio/intercom/directional/west,
@@ -3712,6 +3735,7 @@
 /obj/item/stack/sheet/plasteel/fifty,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/rack,
+/obj/item/stock_parts/cell/emproof,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "bzs" = (
@@ -3977,6 +4001,7 @@
 "bDq" = (
 /obj/structure/table,
 /obj/item/shovel,
+/obj/structure/alien/weeds,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "bDr" = (
@@ -4478,6 +4503,7 @@
 /obj/structure/cable,
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "bNQ" = (
@@ -4628,6 +4654,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"bRm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
+/turf/open/floor/wood,
+/area/station/maintenance/starboard/greater)
 "bRo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -4713,6 +4744,14 @@
 /obj/structure/table/reinforced/titaniumglass,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/item/hfr_box/core,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/fuel_input,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "bTv" = (
@@ -9704,6 +9743,7 @@
 /area/station/hallway/secondary/entry)
 "dOb" = (
 /obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "dOd" = (
@@ -9969,6 +10009,8 @@
 /obj/structure/broken_flooring/pile/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "dTI" = (
@@ -12335,6 +12377,9 @@
 /obj/structure/holosign/barrier/atmos/tram,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"eHN" = (
+/turf/open/floor/wood/tile,
+/area/station/maintenance/port/lesser)
 "eHR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -12414,6 +12459,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
+"eJH" = (
+/obj/structure/urinal/directional/west,
+/turf/open/misc/asteroid/airless,
+/area/space/nearstation)
 "eJP" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -13009,6 +13058,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/table,
 /obj/item/stack/ore/bananium,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "eUH" = (
@@ -13389,6 +13439,10 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
+"fcq" = (
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid,
+/area/station/maintenance/starboard/greater)
 "fcs" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -13730,6 +13784,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"fkT" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/alien/weeds,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "flg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -15649,6 +15708,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "fQi" = (
@@ -16217,6 +16277,7 @@
 "gbD" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/food/grown/mushroom/reishi,
+/obj/structure/alien/weeds,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "gbH" = (
@@ -18540,6 +18601,14 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood/tile,
 /area/station/command/meeting_room)
+"gSk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/power/floodlight,
+/obj/structure/alien/weeds,
+/obj/effect/gibspawner/human,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "gSD" = (
 /obj/machinery/mass_driver/chapelgun{
 	dir = 8
@@ -24839,6 +24908,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"jaP" = (
+/obj/effect/mob_spawn/corpse/human/clown,
+/turf/open/floor/plating/airless,
+/area/station/science/ordnance/bomb)
 "jaQ" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/processing)
@@ -24896,6 +24969,7 @@
 /obj/effect/spawner/random/entertainment/plushie,
 /obj/effect/spawner/random/entertainment/plushie,
 /obj/effect/spawner/random/entertainment/plushie,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "jco" = (
@@ -25489,6 +25563,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/showcase/machinery/tv/broken,
 /obj/effect/decal/cleanable/glass,
+/obj/structure/alien/weeds,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "jpm" = (
@@ -28805,6 +28880,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/old,
+/obj/structure/alien/weeds,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "kxp" = (
@@ -31072,6 +31148,7 @@
 /area/station/security/prison/workout)
 "lkd" = (
 /obj/structure/cable,
+/obj/structure/alien/weeds,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "lku" = (
@@ -31960,6 +32037,8 @@
 /obj/structure/sign/picture_frame/portrait{
 	pixel_x = -26
 	},
+/obj/structure/alien/resin/membrane,
+/obj/structure/alien/weeds,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "lAS" = (
@@ -32863,6 +32942,8 @@
 /obj/machinery/light/broken/directional/south,
 /obj/effect/spawner/random/trash/bin,
 /obj/effect/decal/cleanable/glass,
+/obj/structure/alien/resin/membrane,
+/obj/structure/alien/weeds,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "lQA" = (
@@ -33610,6 +33691,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"mcl" = (
+/obj/structure/alien/weeds,
+/obj/effect/gibspawner/xeno,
+/turf/open/misc/asteroid,
+/area/station/maintenance/starboard/greater)
 "mcn" = (
 /obj/machinery/status_display/ai/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -34046,6 +34132,11 @@
 /obj/machinery/light/floor,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/server)
+"mlm" = (
+/obj/structure/cable,
+/obj/structure/alien/weeds,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "mlr" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -34543,6 +34634,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/crowbar,
+/obj/structure/alien/egg/burst,
+/obj/structure/alien/weeds,
+/obj/effect/gibspawner,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "mwy" = (
@@ -35499,6 +35593,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/paramedic)
+"mMr" = (
+/obj/structure/alien/weeds,
+/turf/closed/wall,
+/area/station/maintenance/starboard/greater)
 "mMt" = (
 /obj/structure/cable,
 /obj/structure/chair{
@@ -35886,6 +35984,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "mUt" = (
@@ -36142,6 +36241,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Old Dorms"
 	},
+/obj/structure/alien/weeds,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "mZX" = (
@@ -36260,6 +36360,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/item/paper/calling_card,
+/obj/structure/alien/resin/membrane,
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "ncf" = (
@@ -37173,6 +37276,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"num" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/closed/wall,
+/area/station/service/abandoned_gambling_den/gaming)
 "nuo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -37239,6 +37346,11 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/carpet/blue,
 /area/station/cargo/boutique)
+"nuY" = (
+/obj/structure/broken_flooring/pile/directional/east,
+/obj/structure/alien/weeds/node,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "nvo" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -39090,6 +39202,9 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical/central)
+"ofZ" = (
+/turf/closed/mineral/random/stationside,
+/area/station/service/abandoned_gambling_den/gaming)
 "ogi" = (
 /obj/effect/landmark/start/captain,
 /obj/structure/cable,
@@ -39360,6 +39475,13 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white/small,
 /area/station/science/ordnance/storage)
+"oiU" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/resin/membrane,
+/obj/structure/alien/weeds,
+/turf/open/floor/wood,
+/area/station/maintenance/starboard/greater)
 "ojw" = (
 /obj/item/kirbyplants/random,
 /obj/effect/mapping_helpers/broken_floor,
@@ -39428,6 +39550,7 @@
 "olm" = (
 /obj/structure/table,
 /obj/item/mining_voucher,
+/obj/structure/alien/weeds,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "olI" = (
@@ -39947,6 +40070,11 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/maintenance/aft)
+"ovB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "ovQ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -40203,6 +40331,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron/textured_half,
 /area/station/security/brig)
+"oBh" = (
+/obj/structure/alien/weeds/node,
+/turf/open/misc/asteroid,
+/area/station/maintenance/starboard/greater)
 "oBm" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -40786,6 +40918,7 @@
 "oNH" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "oNM" = (
@@ -41263,6 +41396,7 @@
 "oWk" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/item/clothing/suit/caution,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "oWl" = (
@@ -41730,6 +41864,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/small,
 /area/station/maintenance/port/lesser)
+"pfh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
+/obj/effect/spawner/random/food_or_drink/soup,
+/obj/effect/gibspawner,
+/turf/open/floor/wood,
+/area/station/maintenance/starboard/greater)
 "pfv" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -43299,6 +43440,7 @@
 "pFk" = (
 /obj/structure/broken_flooring/singular/directional/east,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "pFr" = (
@@ -43432,6 +43574,7 @@
 "pHn" = (
 /obj/structure/cable,
 /obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "pHo" = (
@@ -43986,6 +44129,10 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology)
+"pRb" = (
+/obj/item/computer_disk/virus/mime,
+/turf/closed/mineral/random/stationside,
+/area/space/nearstation)
 "pRe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
@@ -48638,6 +48785,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"roq" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/wood/tile,
+/area/station/service/abandoned_gambling_den/gaming)
 "row" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/plumbed,
@@ -49625,6 +49776,8 @@
 "rEb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/generic_maintenance_landmark,
+/obj/structure/alien/gelpod,
+/obj/structure/alien/weeds,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "rEt" = (
@@ -50976,6 +51129,7 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "rZH" = (
@@ -53179,6 +53333,8 @@
 "sKS" = (
 /obj/structure/sign/poster/official/pda_ad/directional/north,
 /obj/structure/tank_holder/extinguisher,
+/obj/structure/alien/weeds,
+/obj/effect/gibspawner,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "sKX" = (
@@ -53460,6 +53616,7 @@
 /obj/item/stack/ore/iron{
 	amount = 25
 	},
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "sQA" = (
@@ -54516,6 +54673,7 @@
 /obj/item/stack/ore/glass{
 	amount = 20
 	},
+/obj/structure/alien/weeds,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "tiQ" = (
@@ -55389,6 +55547,11 @@
 	dir = 4
 	},
 /area/station/science/ordnance/testlab)
+"tzo" = (
+/obj/structure/alien/egg/burst,
+/obj/structure/alien/weeds,
+/turf/open/misc/asteroid,
+/area/station/maintenance/starboard/greater)
 "tzq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -56792,6 +56955,11 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"tXl" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/table/bronze,
+/turf/open/floor/wood/tile,
+/area/station/service/abandoned_gambling_den/gaming)
 "tXw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57486,6 +57654,10 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/small,
 /area/station/medical/morgue)
+"uhq" = (
+/obj/structure/chair/bronze,
+/turf/open/floor/wood/tile,
+/area/station/service/abandoned_gambling_den/gaming)
 "uhu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -58000,6 +58172,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"uqU" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/trap/stun,
+/obj/structure/alien/weeds,
+/turf/open/floor/iron,
+/area/station/maintenance/starboard/greater)
 "urd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58356,6 +58535,7 @@
 /area/station/medical/pharmacy)
 "uxL" = (
 /obj/structure/broken_flooring/pile/directional/east,
+/obj/structure/trap/stun,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "uya" = (
@@ -60527,6 +60707,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/sand/plating,
 /obj/machinery/power/floodlight,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "vjx" = (
@@ -61610,6 +61791,7 @@
 /obj/item/cultivator/rake,
 /obj/machinery/light/small/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "vzy" = (
@@ -61725,6 +61907,9 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/station/security/tram)
+"vAD" = (
+/turf/open/floor/wood/tile,
+/area/station/service/abandoned_gambling_den/gaming)
 "vAK" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance"
@@ -62423,6 +62608,7 @@
 /area/station/medical/pharmacy)
 "vMr" = (
 /obj/effect/turf_decal/sand/plating,
+/obj/structure/alien/weeds,
 /turf/open/misc/asteroid,
 /area/station/maintenance/starboard/greater)
 "vMs" = (
@@ -62590,6 +62776,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/station/hallway/secondary/spacebridge)
+"vPJ" = (
+/obj/structure/broken_flooring/singular/directional/east,
+/obj/structure/alien/weeds,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "vPK" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -64972,6 +65163,9 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
+"wBQ" = (
+/turf/open/space/basic,
+/area/station/construction/mining)
 "wCa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -64996,6 +65190,10 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/medical/chemistry)
+"wCz" = (
+/obj/machinery/computer/arcade/orion_trail/kobayashi,
+/turf/open/floor/wood/tile,
+/area/station/service/abandoned_gambling_den/gaming)
 "wCH" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -65173,6 +65371,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/table,
 /obj/item/storage/belt/mining,
+/obj/structure/alien/weeds,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "wFQ" = (
@@ -65507,6 +65706,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "wKG" = (
+/obj/structure/alien/resin/wall,
+/obj/structure/alien/weeds,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "wKT" = (
@@ -65842,6 +66043,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/small,
 /area/station/security/detectives_office)
+"wPu" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/weeds,
+/obj/effect/gibspawner,
+/turf/open/floor/wood,
+/area/station/maintenance/starboard/greater)
 "wPK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair/office/light{
@@ -70348,6 +70556,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/security/processing)
+"xYz" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds,
+/obj/effect/gibspawner/human,
+/turf/open/misc/asteroid,
+/area/station/maintenance/starboard/greater)
 "xYD" = (
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
@@ -71357,6 +71571,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/commons/fitness/locker_room)
+"yma" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/alien/resin/wall,
+/obj/structure/alien/weeds,
+/turf/open/floor/wood,
+/area/station/maintenance/starboard/greater)
 "ymd" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -81037,7 +81257,7 @@ dDB
 dDB
 blb
 dDB
-dDB
+wBQ
 dDB
 blb
 dDB
@@ -81554,10 +81774,10 @@ tYT
 cCE
 tYT
 fEC
-aJq
-aJq
-tYT
-tYT
+ofZ
+ofZ
+xQJ
+xQJ
 dDB
 dDB
 dDB
@@ -81811,11 +82031,11 @@ qkK
 cFS
 qkK
 fEC
-aJq
-aJq
-vmL
-tYT
-tYT
+wCz
+vAD
+roq
+xQJ
+xQJ
 tYT
 tYT
 aJq
@@ -82068,11 +82288,11 @@ kCo
 peR
 dyW
 fEC
-aJq
-tYT
-tYT
-vmL
-tYT
+vAD
+vAD
+vAD
+roq
+xQJ
 vmL
 aJq
 aJq
@@ -82325,13 +82545,11 @@ qXB
 tmT
 qXB
 fEC
-aJq
-tYT
-vmL
-tYT
-vmL
-aJq
-aJq
+vAD
+uhq
+tXl
+vAD
+num
 aJq
 aJq
 aJq
@@ -82339,6 +82557,8 @@ aJq
 aJq
 aJq
 aJq
+aJq
+pRb
 dDB
 dDB
 dDB
@@ -82582,11 +82802,11 @@ hbm
 aZw
 vSW
 fEC
-vmL
-tYT
-vmL
-vmL
-gcs
+roq
+uhq
+tXl
+roq
+xQJ
 aJq
 aJq
 aJq
@@ -82595,7 +82815,7 @@ aJq
 aJq
 aJq
 aJq
-aJq
+pRb
 aJq
 aJq
 aJq
@@ -82838,12 +83058,12 @@ wmV
 cpH
 tqo
 tqo
-fEC
-vmL
-vmL
-vmL
-vmL
-gcs
+eHN
+roq
+roq
+roq
+roq
+xQJ
 aJq
 aJq
 aJq
@@ -82852,7 +83072,7 @@ aJq
 aJq
 aJq
 aJq
-aJq
+pRb
 aJq
 aJq
 aJq
@@ -123072,7 +123292,7 @@ atE
 atE
 atG
 axq
-axq
+jaP
 aMa
 aPx
 atE
@@ -126002,8 +126222,8 @@ cCl
 cCl
 oGQ
 oGQ
-oGQ
-oGQ
+bnr
+bnr
 qkp
 rfZ
 sEB
@@ -126260,7 +126480,7 @@ ylD
 ylD
 ylD
 mUn
-ylD
+mMr
 ylD
 rhL
 rTq
@@ -126511,11 +126731,11 @@ eDI
 xZy
 ylD
 jmd
-sCH
+bRm
 wKG
 lAO
 ncb
-ylD
+mMr
 oNH
 pFk
 ylD
@@ -126523,8 +126743,8 @@ rir
 sIZ
 sEB
 bGi
-ylD
-vlb
+mMr
+vPJ
 dTB
 ylD
 pdt
@@ -126770,19 +126990,19 @@ ylD
 joS
 kxm
 rEb
-nhB
-nhB
+oiU
+oiU
 mZA
-oNH
+uqU
 naC
 ylD
 rlg
 tTA
 bAI
 fbj
-ylD
-uxL
-xlx
+mMr
+nuY
+ovB
 ylD
 ylD
 ylD
@@ -127025,11 +127245,11 @@ lgf
 xZy
 ylD
 sKS
-nhB
-sCH
+wPu
+yma
 lQu
-ylD
-ylD
+mMr
+mMr
 oWk
 qHt
 ylD
@@ -127037,9 +127257,9 @@ ylD
 ylD
 ylD
 ylD
-ylD
+mMr
 dOb
-xlx
+ovB
 cFq
 xZy
 xZy
@@ -127281,13 +127501,13 @@ wdk
 goZ
 fmq
 ylD
-nhB
-sCH
+byU
+pfh
 mwx
 wgF
 ylD
 rZG
-xlx
+ovB
 bNP
 fii
 fNv
@@ -127546,7 +127766,7 @@ ylD
 xcH
 xmg
 pHn
-qHt
+mlm
 vlb
 xgz
 iKo
@@ -127557,7 +127777,7 @@ jxD
 ylD
 hqH
 vzv
-wyj
+brz
 cgM
 ylD
 wyj
@@ -127813,7 +128033,7 @@ ylD
 ylD
 ylD
 aEB
-cgM
+tzo
 vMr
 gbD
 ylD
@@ -128059,10 +128279,10 @@ tZt
 ylD
 wFz
 baE
-cgM
+fcq
 lkd
-lgf
-cgM
+fkT
+fcq
 sQv
 xwd
 wdk
@@ -128315,8 +128535,8 @@ ylD
 ylD
 ylD
 olm
-cgM
-lgf
+fcq
+fkT
 jcm
 lkd
 lkd
@@ -128571,15 +128791,15 @@ cgM
 lnI
 cgM
 cgM
-cgM
-cgM
-cgM
-cgM
+fcq
+fcq
+mcl
+xYz
 lkd
-cgM
-lgf
-cgM
-cgM
+fcq
+fkT
+fcq
+fcq
 cgM
 wdk
 wdk
@@ -128828,17 +129048,17 @@ wdk
 wdk
 lhQ
 lgf
-lgf
-cgM
-cgM
-cgM
-vjp
-cgM
-cgM
-cgM
-cgM
-cgM
-cgM
+fkT
+mcl
+mcl
+xYz
+gSk
+fcq
+oBh
+fcq
+fcq
+fcq
+fcq
 wdk
 wdk
 wdk
@@ -129087,14 +129307,14 @@ wdk
 wdk
 wdk
 wdk
-cgM
-cgM
+fcq
+fcq
 tiN
 aCM
 bDq
 eUF
 jar
-ylD
+mMr
 fPR
 ylD
 aJq
@@ -129865,9 +130085,9 @@ aJq
 tYT
 tYT
 tYT
+eJH
 tYT
-tYT
-tYT
+eJH
 tYT
 aJq
 aJq

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -23536,7 +23536,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/maintenance/port/lesser)
 "iBV" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -26588,10 +26588,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
-"jGO" = (
-/obj/structure/cable,
-/turf/open/floor/wood/tile,
-/area/station/service/abandoned_gambling_den/gaming)
 "jGW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -37294,7 +37290,7 @@
 "num" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/closed/wall,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/maintenance/port/lesser)
 "nuo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -39219,7 +39215,7 @@
 /area/station/maintenance/department/medical/central)
 "ofZ" = (
 /turf/closed/mineral/random/stationside,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/maintenance/port/lesser)
 "ogi" = (
 /obj/effect/landmark/start/captain,
 /obj/structure/cable,
@@ -48803,7 +48799,7 @@
 "roq" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/wood/tile,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/maintenance/port/lesser)
 "row" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/plumbed,
@@ -56975,7 +56971,7 @@
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/table/bronze,
 /turf/open/floor/wood/tile,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/maintenance/port/lesser)
 "tXw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57673,7 +57669,7 @@
 "uhq" = (
 /obj/structure/chair/bronze,
 /turf/open/floor/wood/tile,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/maintenance/port/lesser)
 "uhu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
@@ -60339,7 +60335,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/maintenance/port/lesser)
 "vdf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -61933,7 +61929,7 @@
 /area/station/security/tram)
 "vAD" = (
 /turf/open/floor/wood/tile,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/maintenance/port/lesser)
 "vAK" = (
 /obj/machinery/door/airlock{
 	name = "Maintenance"
@@ -65217,7 +65213,7 @@
 "wCz" = (
 /obj/machinery/computer/arcade/orion_trail/kobayashi,
 /turf/open/floor/wood/tile,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/maintenance/port/lesser)
 "wCH" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 9
@@ -81800,8 +81796,8 @@ tYT
 fEC
 ofZ
 ofZ
-xQJ
-xQJ
+fEC
+fEC
 dDB
 dDB
 dDB
@@ -82058,8 +82054,8 @@ fEC
 wCz
 vAD
 roq
-xQJ
-xQJ
+fEC
+fEC
 tYT
 tYT
 aJq
@@ -82316,7 +82312,7 @@ vcY
 vAD
 vAD
 roq
-xQJ
+fEC
 vmL
 aJq
 aJq
@@ -82569,7 +82565,7 @@ qXB
 tmT
 qXB
 fEC
-jGO
+eHN
 uhq
 tXl
 vAD
@@ -82830,7 +82826,7 @@ iBE
 uhq
 tXl
 roq
-xQJ
+fEC
 aJq
 aJq
 aJq
@@ -83087,7 +83083,7 @@ iBE
 roq
 roq
 roq
-xQJ
+fEC
 aJq
 aJq
 aJq

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -60328,14 +60328,6 @@
 	dir = 1
 	},
 /area/station/service/lawoffice)
-"vcY" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/wood/tile,
-/area/station/maintenance/port/lesser)
 "vdf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -82308,7 +82300,7 @@ kCo
 peR
 dyW
 fEC
-vcY
+eHN
 vAD
 vAD
 roq


### PR DESCRIPTION

## About The Pull Request

adds the rest of the missing HFR boxes to birdshot HFR room
adds some xeno environmental storytelling to the right-side maintenance of birdshot
adds a abandoned gaming den below arrivals birdshot
## Why It's Good For The Game

atmos techs being able to make their engine is good, some xeno story telling is fun, and a new place for assistants to play blackjack is always appreciated

## Changelog
:cl:
fix: birdshot HFR room now has all of its HFR boxes
map: new birdshot abandoned gaming den and some gross xeno story telling
/:cl:
