### PR TITLE
Violent debraining no longer strands clients

### DIFF
--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -190,7 +190,8 @@
 
 /obj/item/bodypart/head/update_limb(dropping_limb, is_creating)
 	. = ..()
-	real_name = owner.real_name
+	if(!isnull(owner))
+		real_name = owner.real_name
 	if(HAS_TRAIT(owner, TRAIT_HUSK))
 		real_name = "Unknown"
 	update_hair_and_lips(dropping_limb, is_creating)

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -165,7 +165,6 @@
 				user.visible_message(span_warning("[user] saws [src] open and pulls out a brain!"), span_notice("You saw [src] open and pull out a brain."))
 			if(brainmob)
 				brainmob.container = null
-				brainmob.forceMove(brain)
 				brain.brainmob = brainmob
 				brainmob = null
 			if(violent_removal && prob(rand(80, 100))) //ghetto surgery can damage the brain.


### PR DESCRIPTION

## About The Pull Request
Man this took me forever to diagnose.

Currently, when debraining a dismembered head, the brain doesn't properly get its brainmob set. This both prevents the brain from being usable even in MMI's, displaying a devoid of life message, and sends an admin log that the brainmob was stranded.

This fixes both that and a nearby runtime that I encountered while testing.
I believe introduced by #77339 when handle_atom_del's code was switched to run whenever anything exited the head instead of just when deleted
## Why It's Good For The Game
Fix bugs! Stranded clients very bad
## Changelog
:cl:
fix: Non-surgically debraining someone no longer makes their brain unusuable
/:cl:
