### PR TITLE
Syndicate mobs no longer drop """unspent""" shells

### DIFF
--- a/code/datums/components/ranged_attacks.dm
+++ b/code/datums/components/ranged_attacks.dm
@@ -66,7 +66,7 @@
 	else
 		target_zone = ran_zone()
 	casing.fire_casing(target, firer, null, null, null, target_zone, 0,  firer)
-	casing.update_desc()
+	casing.update_appearance()
 	casing.AddElement(/datum/element/temporary_atom, 30 SECONDS)
 	return
 

--- a/code/datums/components/ranged_attacks.dm
+++ b/code/datums/components/ranged_attacks.dm
@@ -66,6 +66,7 @@
 	else
 		target_zone = ran_zone()
 	casing.fire_casing(target, firer, null, null, null, target_zone, 0,  firer)
+	casing.update_desc()
 	casing.AddElement(/datum/element/temporary_atom, 30 SECONDS)
 	return
 


### PR DESCRIPTION
## About The Pull Request

Fixes: #76815
The shells the basic syndicate mobs were dropping were not actually unspent, but they were not updating their description. They do that now.

## Why It's Good For The Game

small bugfix

## Changelog

:cl: Seven
fix: Syndicate ranged mobs (and probably other basic mobs) properly update their shell's description to show they are spent.
/:cl:
