### PR TITLE
A fix for those who have found themselves in an early grave

### DIFF
--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -282,14 +282,18 @@
 	// The player is trying to dig themselves out of an early grave
 	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + CLICK_CD_BREAKOUT
-	user.visible_message(span_warning("[src]'s dirt begins to shift and rumble!"), \
+	user.visible_message(
+		span_warning("[src]'s dirt begins to shift and rumble!"),
 		span_notice("You desperately begin to claw at the dirt around you, trying to force yourself upwards through the soil... (this will take about [DisplayTimeText(breakout_time)].)"), \
-		span_hear("You hear the sound of shifting dirt from [src]."))
-	if(do_after(user, (breakout_time), target = src))
-		if(!user || user.stat != CONSCIOUS || user.loc != src || opened)
+		span_hear("You hear the sound of shifting dirt from [src].")
+		)
+	if(do_after(user, breakout_time, target = src))
+		if(opened)
 			return
-		user.visible_message(span_danger("[user] emerges from [src], scattering dirt everywhere!"),
-							span_notice("You triumphantly surface out of [src], scattering dirt around the earthen prison!"))
+		user.visible_message(
+			span_danger("[user] emerges from [src], scattering dirt everywhere!"),
+			span_notice("You triumphantly surface out of [src], scattering dirt around the earthen prison!")
+			)
 		bust_open()
 	else
 		if(user.loc == src)

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -284,15 +284,15 @@
 	user.last_special = world.time + CLICK_CD_BREAKOUT
 	user.visible_message(
 		span_warning("[src]'s dirt begins to shift and rumble!"),
-		span_notice("You desperately begin to claw at the dirt around you, trying to force yourself upwards through the soil... (this will take about [DisplayTimeText(breakout_time)].)"), \
-		span_hear("You hear the sound of shifting dirt from [src].")
-		)
+		span_notice("You desperately begin to claw at the dirt around you, trying to force yourself upwards through the soil... (this will take about [DisplayTimeText(breakout_time)].)"),
+		span_hear("You hear the sound of shifting dirt from [src]."),
+	)
 	if(do_after(user, breakout_time, target = src))
 		if(opened)
 			return
 		user.visible_message(
 			span_danger("[user] emerges from [src], scattering dirt everywhere!"),
-			span_notice("You triumphantly surface out of [src], scattering dirt all around the grave!")
+			span_notice("You triumphantly surface out of [src], scattering dirt all around the grave!"),
 			)
 		bust_open()
 	else

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -132,13 +132,13 @@
 	icon = 'icons/obj/storage/crates.dmi'
 	icon_state = "grave"
 	base_icon_state = "grave"
-	dense_when_open = TRUE
+	density = FALSE
 	material_drop = /obj/item/stack/ore/glass/basalt
 	material_drop_amount = 5
 	anchorable = FALSE
 	anchored = TRUE
 	divable = FALSE //As funny as it may be, it would make little sense how you got yourself inside it in first place.
-	breakout_time = 90 SECONDS
+	breakout_time = 2 MINUTES
 	open_sound = 'sound/effects/shovel_dig.ogg'
 	close_sound = 'sound/effects/shovel_dig.ogg'
 	can_install_electronics = FALSE
@@ -162,6 +162,11 @@
 		return CONTEXTUAL_SCREENTIP_SET
 
 	return NONE
+
+/obj/structure/closet/crate/grave/close(mob/living/user)
+	. = ..()
+	// So that graves stay undense
+	set_density(FALSE)
 
 /obj/structure/closet/crate/grave/examine(mob/user)
 	. = ..()
@@ -270,6 +275,25 @@
 		user.add_mood_event("graverobbing", /datum/mood_event/graverobbing)
 		deconstruct(TRUE)
 		return TRUE
+
+/obj/structure/closet/crate/grave/container_resist_act(mob/living/user)
+	if(opened)
+		return
+	// The player is trying to dig themselves out of an early grave
+	user.changeNext_move(CLICK_CD_BREAKOUT)
+	user.last_special = world.time + CLICK_CD_BREAKOUT
+	user.visible_message(span_warning("[src]'s dirt begins to shift and rumble!"), \
+		span_notice("You desperately begin to claw at the dirt around you, trying to force yourself upwards through the soil... (this will take about [DisplayTimeText(breakout_time)].)"), \
+		span_hear("You hear the sound of shifting dirt from [src]."))
+	if(do_after(user, (breakout_time), target = src))
+		if(!user || user.stat != CONSCIOUS || user.loc != src || opened)
+			return
+		user.visible_message(span_danger("[user] emerges from [src], scattering dirt everywhere!"),
+							span_notice("You triumphantly surface out of [src], scattering dirt around the earthen prison!"))
+		bust_open()
+	else
+		if(user.loc == src)
+			to_chat(user, span_warning("You fail to dig yourself out of [src]!"))
 
 /obj/structure/closet/crate/grave/filled/lead_researcher
 	name = "ominous burial mound"

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -292,7 +292,7 @@
 			return
 		user.visible_message(
 			span_danger("[user] emerges from [src], scattering dirt everywhere!"),
-			span_notice("You triumphantly surface out of [src], scattering dirt around the earthen prison!")
+			span_notice("You triumphantly surface out of [src], scattering dirt all around the grave!")
 			)
 		bust_open()
 	else

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -293,7 +293,7 @@
 		user.visible_message(
 			span_danger("[user] emerges from [src], scattering dirt everywhere!"),
 			span_notice("You triumphantly surface out of [src], scattering dirt all around the grave!"),
-			)
+		)
 		bust_open()
 	else
 		if(user.loc == src)


### PR DESCRIPTION
## About The Pull Request

Fixes: #76918
Fixes not being able to break out of a grave, where it was implied that you could.
Technically (I doubt it ever worked) increases the breakout time on the grave, before it was sitting below welded lockers, now it is in line with them.
Graves are no longer dense, it looked and felt ugly and I think is just a carryover from them being subtypes of crates, now you can walk over them.

## Why It's Good For The Game

Fixes some bugs that limited interaction with graves. You can still breathe under them and stuff, but that starts to veer into balance changes, even though that should be looked at in the future.

## Changelog

:cl: Seven
fix: Fixes not being able to break out of graves
qol: Graves are no longer dense (you can walk over them now)
/:cl:

