### PR TITLE
fixes the compact fishing toolbox holding normal sized objects

### DIFF
--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -188,7 +188,10 @@
 /obj/item/storage/toolbox/fishing/Initialize(mapload)
 	. = ..()
 	// Can hold fishing rod despite the size
-	var/static/list/exception_cache = typecacheof(/obj/item/fishing_rod)
+	var/static/list/exception_cache = typecacheof(
+		/obj/item/fishing_rod,
+		/obj/item/fishing_line,
+	)
 	atom_storage.exception_hold = exception_cache
 
 /obj/item/storage/toolbox/fishing/PopulateContents()

--- a/code/modules/fishing/fishing_equipment.dm
+++ b/code/modules/fishing/fishing_equipment.dm
@@ -204,6 +204,10 @@
 	force = 5
 	throwforce = 5
 
+/obj/item/storage/toolbox/fishing/small/Initialize(mapload)
+	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL //It can still hold a fishing rod
+
 /obj/item/storage/toolbox/fishing/small/PopulateContents()
 	new /obj/item/fishing_rod(src)
 	new /obj/item/fishing_hook(src)


### PR DESCRIPTION

## About The Pull Request

This ensures that the compact fishing toolbox only holds small objects, like a cardboard box, with the exception of a fishing rod.

## Why It's Good For The Game

I fucked up and gave settlers a smuggler satchel.

## Changelog
:cl:
fix: Compact fishing toolboxes no longer break space and time to contain any normal-sized object. Instead, they only break space and time to contain fishing rods. Settlers migrating to Nanotrasen space have no reasonable explanation for this phenomenon.
/:cl:
