### PR TITLE
removes the nukie tool parcel

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -90,9 +90,9 @@
 
 /obj/item/storage/box/survival/syndie/PopulateContents()
 	..()
-	new /obj/item/crowbar/red(get_turf(user))
-	new /obj/item/screwdriver/red(get_turf(user))
-	new /obj/item/weldingtool/mini(get_turf(user))
+	new /obj/item/crowbar/red(src)
+	new /obj/item/screwdriver/red(src)
+	new /obj/item/weldingtool/mini(src)
 	new /obj/item/paper/fluff/operative(src)
 
 /obj/item/storage/box/survival/centcom

--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -90,28 +90,10 @@
 
 /obj/item/storage/box/survival/syndie/PopulateContents()
 	..()
-	new /obj/item/tool_parcel(src)
-	new /obj/item/paper/fluff/operative(src)
-
-/obj/item/tool_parcel
-	name = "operative toolkit care package"
-	desc = "A small parcel. It contains a few items every operative needs."
-	w_class =  WEIGHT_CLASS_SMALL
-	icon = 'icons/obj/storage/wrapping.dmi'
-	icon_state = "deliverypackage2"
-
-/obj/item/tool_parcel/attack_self(mob/user)
-	. = ..()
 	new /obj/item/crowbar/red(get_turf(user))
 	new /obj/item/screwdriver/red(get_turf(user))
 	new /obj/item/weldingtool/mini(get_turf(user))
-	new /obj/effect/decal/cleanable/wrapping(get_turf(user))
-	if(prob(5))
-		new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(get_turf(user))
-		new /obj/item/lighter(get_turf(user))
-		to_chat(user, span_notice("...oh, someone left some cigarettes in here."))
-	playsound(loc, 'sound/items/poster_ripped.ogg', 20, TRUE)
-	qdel(src)
+	new /obj/item/paper/fluff/operative(src)
 
 /obj/item/storage/box/survival/centcom
 	name = "emergency response survival box"


### PR DESCRIPTION

## About The Pull Request
removes the tool parcel and places tools directly in their box

## Why It's Good For The Game
the step of having to pick up your tools invalidates why we put em there in the first place - so nukies can use them in an emergency. its annoying to put them back in your box.
the parcel was added because the tools could make the box go above 7 slots during the extended box station trait, but i fixed that in the pr that made it so that trait increases the box size of that box

## Changelog
:cl:
qol: removes the nukie tool parcel and places the tools directly in their box
/:cl:
