### PR TITLE
Nerfs Confusion symptom for diseases

### DIFF
--- a/code/datums/diseases/advance/symptoms/confusion.dm
+++ b/code/datums/diseases/advance/symptoms/confusion.dm
@@ -20,7 +20,6 @@
 	symptom_delay_min = 10
 	symptom_delay_max = 30
 	threshold_descs = list(
-		"Stage Speed 6" = "Prevents any form of reading or writing.",
 		"Resistance 6" = "Causes brain damage over time.",
 		"Transmission 6" = "Increases confusion duration and strength.",
 		"Stealth 4" = "The symptom remains hidden until active.",
@@ -43,7 +42,6 @@
 
 /datum/symptom/confusion/End(datum/disease/advance/advanced_disease)
 	advanced_disease.affected_mob.remove_status_effect(/datum/status_effect/confusion)
-	REMOVE_TRAIT(advanced_disease.affected_mob, TRAIT_ILLITERATE, DISEASE_TRAIT)
 	return ..()
 
 /datum/symptom/confusion/Activate(datum/disease/advance/advanced_disease)
@@ -57,17 +55,8 @@
 				to_chat(infected_mob, span_warning("[pick("Your head hurts.", "Your mind blanks for a moment.")]"))
 		else
 			to_chat(infected_mob, span_userdanger("You can't think straight!"))
-			infected_mob.adjust_confusion(16 SECONDS * power)
+			infected_mob.adjust_confusion_up_to(16 SECONDS * power, 30 SECONDS)
 			if(brain_damage)
 				infected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 3 * power, 80)
 				infected_mob.updatehealth()
 	return
-
-/datum/symptom/confusion/on_stage_change(datum/disease/advance/advanced_disease)
-	. = ..()
-	if(!.)
-		return FALSE
-	var/mob/living/carbon/infected_mob = advanced_disease.affected_mob
-	if(advanced_disease.stage >= 5 && causes_illiteracy)
-		ADD_TRAIT(infected_mob, TRAIT_ILLITERATE, DISEASE_TRAIT)
-	return TRUE

--- a/code/datums/status_effects/debuffs/confusion.dm
+++ b/code/datums/status_effects/debuffs/confusion.dm
@@ -31,7 +31,7 @@
 	var/direction = move_args[MOVE_ARG_DIRECTION]
 	var/new_dir
 
-	if(time_left > CONFUSION_FULL_THRESHOLD)
+	if(time_left > CONFUSION_FULL_THRESHOLD && !owner.resting)
 		new_dir = pick(GLOB.alldirs)
 
 	else if(prob(time_left * CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND))

--- a/code/datums/status_effects/debuffs/confusion.dm
+++ b/code/datums/status_effects/debuffs/confusion.dm
@@ -1,5 +1,5 @@
-/// The threshold in which all of our movements are fully randomized, in seconds.
-#define CONFUSION_FULL_THRESHOLD 40
+/// The threshold in a third of our movements are fully randomized, in seconds.
+#define CONFUSION_FINAL_THRESHOLD 40
 /// A multiplier applied on how much time is left (in seconds) that determines the chance of moving sideways randomly
 #define CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND 1.5
 /// A multiplier applied on how much time is left (in seconds) that determines the chance of moving diagonally randomly
@@ -31,7 +31,7 @@
 	var/direction = move_args[MOVE_ARG_DIRECTION]
 	var/new_dir
 
-	if(time_left > CONFUSION_FULL_THRESHOLD)
+	if(time_left > CONFUSION_FINAL_THRESHOLD && prob(30))
 		new_dir = pick(GLOB.alldirs)
 
 	else if(prob(time_left * CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND))
@@ -44,6 +44,6 @@
 		move_args[MOVE_ARG_NEW_LOC] = get_step(owner, new_dir)
 		move_args[MOVE_ARG_DIRECTION] = new_dir
 
-#undef CONFUSION_FULL_THRESHOLD
+#undef CONFUSION_FINAL_THRESHOLD
 #undef CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND
 #undef CONFUSION_DIAGONAL_MOVE_PROB_PER_SECOND

--- a/code/datums/status_effects/debuffs/confusion.dm
+++ b/code/datums/status_effects/debuffs/confusion.dm
@@ -1,5 +1,5 @@
-/// The threshold in a third of our movements are fully randomized, in seconds.
-#define CONFUSION_FINAL_THRESHOLD 40
+/// The threshold in which all of our movements are fully randomized, in seconds.
+#define CONFUSION_FULL_THRESHOLD 40
 /// A multiplier applied on how much time is left (in seconds) that determines the chance of moving sideways randomly
 #define CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND 1.5
 /// A multiplier applied on how much time is left (in seconds) that determines the chance of moving diagonally randomly
@@ -31,7 +31,7 @@
 	var/direction = move_args[MOVE_ARG_DIRECTION]
 	var/new_dir
 
-	if(time_left > CONFUSION_FINAL_THRESHOLD && prob(30))
+	if(time_left > CONFUSION_FULL_THRESHOLD)
 		new_dir = pick(GLOB.alldirs)
 
 	else if(prob(time_left * CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND))
@@ -44,6 +44,6 @@
 		move_args[MOVE_ARG_NEW_LOC] = get_step(owner, new_dir)
 		move_args[MOVE_ARG_DIRECTION] = new_dir
 
-#undef CONFUSION_FINAL_THRESHOLD
+#undef CONFUSION_FULL_THRESHOLD
 #undef CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND
 #undef CONFUSION_DIAGONAL_MOVE_PROB_PER_SECOND


### PR DESCRIPTION
## About The Pull Request

Removed the threshold for confusion symptom that adds illiteracy to the disease.

Clamps confusion symptom's confusion to a maximum of 30 seconds.

Confusion as a debuff no longer guarantees random movement if you're resting.

## Why It's Good For The Game

> Removed the threshold for confusion symptom that adds illiteracy to the disease.

This virus makes you unable to actually treat yourself when cured, which is frankly bonkers. Viruses are too virulent and it's rare that a doctor actually gets to a biosuit in time to inoculate themselves, and if they forget internals they're screwed anyways. People should be able to fix their own got damn disease, this is asinine.

> Clamps confusion symptom's confusion to a maximum of 30 seconds.

The lack of clamping literally makes this symptom send your confusion level to the fucking atmosphere, you can easily get upwards of 5 minutes of confusion left because it doesn't clamp, adds 16 seconds per activation, which is made even worse by the fact that confusion gets stronger the more duration confusion has on you.

> Confusion as a debuff no longer guarantees random movement if you're resting.

This remedies the last bit by not making it a literal guarantee that you can't move in any direction after...... *3* triggers of confusion. It should be obvious to anyone how absurd this is. 

Honestly, it's plain as day that the only reason any of this ended up like it is because of poor coding and oversights. This is just bringing things down to their designed level.

## Changelog

:cl:
del: Removed the threshold for confusion symptom that adds illiteracy to the disease.
balance: Clamps confusion symptom's confusion to a maximum of 30 seconds.
qol: Confusion as a debuff no longer guarantees random movement if you're resting.
/:cl:

