### PR TITLE
Fixes space heaters dropping cells when they get deconstructed without one

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -77,7 +77,7 @@
 
 /obj/machinery/space_heater/on_construction()
 	set_panel_open(TRUE)
-	cell = null
+	QDEL_NULL(cell)
 
 /obj/machinery/space_heater/on_deconstruction()
 	if(cell)


### PR DESCRIPTION
## About The Pull Request

Space heaters would drop cells when you construct and then immediately deconstruct it, despite a cell never being put in.

This is because the space heaters would spawn in with a cell, and when they're constructed they would set the cell reference to nul... but they never actually deleted the cell. so it'd drop the cell anyways.

This makes sure the cell gets deleted when you construct it, so you wouldn't get any extra cells when deconstructing.

closes https://github.com/tgstation/tgstation/issues/77990

## Changelog

:cl:
fix: Space heaters no longer give extra cells when deconstructed
/:cl:
