### PR TITLE
Fixes space heaters spawning free power cells

### DIFF
--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -77,7 +77,7 @@
 
 /obj/machinery/space_heater/on_construction()
 	set_panel_open(TRUE)
-	cell = null
+	QDEL_NULL(cell)
 
 /obj/machinery/space_heater/on_deconstruction()
 	if(cell)


### PR DESCRIPTION

## About The Pull Request
Space heaters will no longer drop a power cell when deconstructing, even though there was never a power cell inserted.
## Why It's Good For The Game
Fixes #77990 
## Changelog
:cl:
fix: Space heaters will no longer drop a power cell when deconstructing, even though there was never a power cell inserted.
/:cl:
