### PR TITLE
Fixes meth explosion occurring in the body

### DIFF
--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -63,6 +63,7 @@
 	if(ismob(holder.my_atom))
 		var/mob/M = holder.my_atom
 		inside_msg = " inside [ADMIN_LOOKUPFLW(M)]"
+		return
 	var/lastkey = holder.my_atom.fingerprintslast
 	var/touch_msg = "N/A"
 	if(lastkey)


### PR DESCRIPTION

## About The Pull Request
The meth explosion isn't supposed to happen in a body, but it does anyway. This PR fixes that, so no more meth explosion syringes (sorry!)
## Why It's Good For The Game
Fixes #77909
## Changelog
:cl:
fix: Meth will no longer explode when reacting in a body
/:cl:
