### PR TITLE
Includes chicken breast to the produce console for variety

### DIFF
--- a/code/game/machinery/computer/orders/order_items/cook/order_milk_eggs.dm
+++ b/code/game/machinery/computer/orders/order_items/cook/order_milk_eggs.dm
@@ -36,6 +36,11 @@
 	item_path = /obj/item/food/fishmeat/octopus
 	cost_per_order = 12
 
+/datum/orderable_item/milk_eggs/chicken
+	name = "Chicken Breast"
+	item_path = /obj/item/food/meat/slab/chicken
+	cost_per_order = 15
+
 /datum/orderable_item/milk_eggs/spider_eggs
 	name = "Spider Eggs"
 	item_path = /obj/item/food/spidereggs


### PR DESCRIPTION
## About The Pull Request

You fell for the bait title. I haven't seen any chicken recipes made in weeks, by adding an orderable single breast at the produce console we add the possibility of more varied recipes being made. 

## Why It's Good For The Game

More varied use of cooking needs to take place, adding accessibility to less used ingredients hopes to amend the current lack of variety in chef players creations. 

## Changelog

:cl:
qol: Adds accessibility to breasts for service members
/:cl:

