### PR TITLE
Buffs blazing oil

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -15,7 +15,7 @@
 	fire_based = TRUE
 
 /datum/blobstrain/reagent/blazing_oil/extinguish_reaction(obj/structure/blob/B)
-	B.take_damage(4.5, BURN, ENERGY)
+	B.take_damage(1, BURN, ENERGY)
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BURN && damage_flag != ENERGY)


### PR DESCRIPTION

## About The Pull Request

Blazing oil takes 1/4 of the damage from water

## Why It's Good For The Game

Blazing oil is shit. Blazing oil get fucked with extinguishers, and it doesn't get any cool powers besides "fire", which a lot of the heavy hitters will already have fire protection. I could remove the extinguishers interactions and it would still be underpowered, but that is soul.

## Changelog
:cl: Vect0r
balance: Blazing oil blobs are now buffed
/:cl:
