### PR TITLE
Adds a failsafe to getviewsize to avoid disconnection loops

### DIFF
--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -1,10 +1,14 @@
 /proc/getviewsize(view)
+	if(!view) // Just to avoid any runtimes that could otherwise cause constant disconnect loops.
+		view = world.view
+
 	if(isnum(view))
 		var/totalviewrange = (view < 0 ? -1 : 1) + 2 * view
 		return list(totalviewrange, totalviewrange)
 	else
-		var/list/viewrangelist = splittext(view,"x")
+		var/list/viewrangelist = splittext(view, "x")
 		return list(text2num(viewrangelist[1]), text2num(viewrangelist[2]))
+
 
 /// Takes a string or num view, and converts it to pixel width/height in a list(pixel_width, pixel_height)
 /proc/view_to_pixels(view)

--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -1,5 +1,6 @@
 /proc/getviewsize(view)
 	if(!view) // Just to avoid any runtimes that could otherwise cause constant disconnect loops.
+		stack_trace("Missing value for 'view' in getviewsize(), defaulting to world.view!")
 		view = world.view
 
 	if(isnum(view))


### PR DESCRIPTION
## About The Pull Request
If you somehow had a null value for `view` in `getviewsize()`, it would crash the players affected and wouldn't let them back into the game for the rest of the round, which to me sounds wrong. I thus made it default to world.view and produce a stack_trace, so it can be properly investigated without having to sacrifice the players that end up on the receiving end of that bug.

For anyone interested, it was achieved by repeatedly going to observe one person and then moving away from them, over and over and over again while moving away from that person, with others observing you. Eventually that led to a null viewsize.

## Why It's Good For The Game
Infinite disconnection loops are bad, methinks.

## Changelog

:cl:GoldenAlpharex
fix: Fixes a rare issue that could lead to players entering an infinite disconnection loop from having a null view.
/:cl: