### PR TITLE
Watering hydroponic trays can no longer add more water than the container has.

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -865,7 +865,7 @@
 			transfer_amount = reagent_source.reagents.total_volume
 			SEND_SIGNAL(reagent_source, COMSIG_ITEM_ON_COMPOSTED, user)
 		else
-			transfer_amount = reagent_source.amount_per_transfer_from_this
+			transfer_amount = min(reagent_source.amount_per_transfer_from_this, reagent_source.reagents.total_volume)
 			if(istype(reagent_source, /obj/item/reagent_containers/syringe/))
 				var/obj/item/reagent_containers/syringe/syr = reagent_source
 				visi_msg="[user] injects [target] with [syr]"
@@ -882,7 +882,7 @@
 		for(var/obj/machinery/hydroponics/H in trays)
 		//cause I don't want to feel like im juggling 15 tamagotchis and I can get to my real work of ripping flooring apart in hopes of validating my life choices of becoming a space-gardener
 			//This was originally in apply_chemicals, but due to apply_chemicals only holding nutrients, we handle it here now.
-			if(reagent_source.reagents.has_reagent(/datum/reagent/water, 1))
+			if(reagent_source.reagents.has_reagent(/datum/reagent/water))
 				var/water_amt = reagent_source.reagents.get_reagent_amount(/datum/reagent/water) * transfer_amount / reagent_source.reagents.total_volume
 				var/water_amt_adjusted = H.adjust_waterlevel(round(water_amt))
 				reagent_source.reagents.remove_reagent(/datum/reagent/water, water_amt_adjusted)


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Previously it would not check whether the amount set to transfer was greater than the amount contained, and so you could have a gardening can with 10u of water fill the tray with 100u if you set it to that.

Also, I removed a (seemingly) pointless part of the check in line 885. All it achieves as far as I can tell is that if you have decimal (less than 1) amounts of water in a container, it will be incorrectly added to the nutrient count rather than the water count.
## Why It's Good For The Game
## Changelog
:cl:
fix: containers can no longer add more water to hydroponic trays than they actually contain.
fix: watering a hydroponic tray with amounts of water lesser than 1 will no longer be added to nutrients rather than water
/:cl:
