### PR TITLE
Changes stop drop and roll into a knockdown

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -258,8 +258,10 @@
 		buckled.user_unbuckle_mob(src,src)
 
 /mob/living/carbon/resist_fire()
+	if(IsKnockdown())
+		return
 	adjust_fire_stacks(-5)
-	Paralyze(60, ignore_canstun = TRUE)
+	Knockdown(60, ignore_canstun = TRUE)
 	spin(32,2)
 	visible_message(span_danger("[src] rolls on the floor, trying to put [p_them()]self out!"), \
 		span_notice("You stop, drop, and roll!"))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -260,12 +260,14 @@
 /mob/living/carbon/resist_fire()
 	if(IsKnockdown())
 		return
-	adjust_fire_stacks(-5)
-	Knockdown(60, ignore_canstun = TRUE)
-	spin(32,2)
+	Knockdown(6 SECONDS, ignore_canstun = TRUE)
+	spin(6 SECONDS,2)
 	visible_message(span_danger("[src] rolls on the floor, trying to put [p_them()]self out!"), \
 		span_notice("You stop, drop, and roll!"))
-	sleep(3 SECONDS)
+	if(do_after(src, 6 SECONDS))
+		adjust_fire_stacks(-5)
+	else
+		to_chat(src, span_notice("You fail to extinguish yourself."))
 	if(fire_stacks <= 0 && !QDELETED(src))
 		visible_message(span_danger("[src] successfully extinguishes [p_them()]self!"), \
 			span_notice("You extinguish yourself."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Changes stop drop and roll from a 6 paralyze stun to a 6 second unspammable knockdown.

This idea comes from Paradise and is basically identical in implementation.
https://github.com/ParadiseSS13/Paradise/pull/21500
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
I don't like the fact that this still hardstuns, I think we should make this a knockdown instead since stuns kind of suck in this day and age of TG.

Besides that it's stop drop and _roll_, right? You should still be able to roll around.
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Changed stop drop and roll from stun to knockdown.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
