### PR TITLE
Fishable content in the fish_counts table can now actually be fished

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -116,7 +116,7 @@ GLOBAL_LIST_INIT(preset_fish_sources, init_subtypes_w_path_keys(/datum/fish_sour
 	if((reward_path in fish_counts)) // This is limited count result
 		fish_counts[reward_path] -= 1
 		if(!fish_counts[reward_path])
-			fish_counts -= reward_path //Ran out of these since rolling (multiple fishermen on same source most likely)ù
+			fish_counts -= reward_path //Ran out of these since rolling (multiple fishermen on same source most likely)
 
 	var/atom/movable/reward = spawn_reward(reward_path, fisherman, fishing_spot)
 	if(!reward) //baloon alert instead
@@ -182,7 +182,7 @@ GLOBAL_LIST(fishing_property_cache)
 
 	var/list/fish_list_properties = collect_fish_properties()
 
-	var/list/final_table = fish_table.Copy()
+	var/list/final_table = fish_table + fish_counts
 	for(var/result in final_table)
 		if((result in fish_counts) && fish_counts[result] <= 0) //ran out of these, ignore
 			final_table -= result

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -48,7 +48,6 @@
 	fish_table = list(
 		FISHING_DUD = 5,
 		/obj/item/stack/ore/slag = 20,
-		/obj/structure/closet/crate/necropolis/tendril = 1,
 		/obj/effect/mob_spawn/corpse/human/charredskeleton = 1
 	)
 	fish_counts = list(


### PR DESCRIPTION
## About The Pull Request
Fikou has told me it didn't work because the final table only contained sources from the `fish_table` and not `fish_counts`, so here we go.

## Why It's Good For The Game
Fixing a bug...

## Changelog

:cl:
fix: You can now actually fish limited content such as a necropolis chest on lavaland and some soggy wallets from toilets.
/:cl:
