### PR TITLE
Revert "Only checks for greyscale json config folder (#74782)"

### DIFF
--- a/code/datums/greyscale/_greyscale_config.dm
+++ b/code/datums/greyscale/_greyscale_config.dm
@@ -57,8 +57,8 @@
 	if(!json_config)
 		stack_trace("Greyscale config object [DebugName()] is missing a json configuration, make sure `json_config` has been assigned a value.")
 	string_json_config = "[json_config]"
-	if(findtext(string_json_config, "greyscale/json_configs/") == 0)
-		stack_trace("All greyscale json configuration files should be located within '/greyscale/json_configs/'")
+	if(findtext(string_json_config, "code/datums/greyscale/json_configs/") != 1)
+		stack_trace("All greyscale json configuration files should be located within 'code/datums/greyscale/json_configs/'")
 	if(!icon_file)
 		stack_trace("Greyscale config object [DebugName()] is missing an icon file, make sure `icon_file` has been assigned a value.")
 	string_icon_file = "[icon_file]"


### PR DESCRIPTION
Puts back the restriction on greyscale config location so that all the configs have to be in the same overall place. Having all the configs in a single folder *is* a mess, but this is why subfolders exist. Having configs scattered throughout the code folder would make it a pain to keep track of all the different configs, especially when it comes time for breaking changes. The config folder should be thought of similarly to the icons folder.

Put your configs in subfolders meant for their type, and make new ones if it seems appropriate just like how we do with icons.