### PR TITLE
Actually fixing fishable contents for some sources.

### DIFF
--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -18,6 +18,13 @@ GLOBAL_LIST_INIT(preset_fish_sources, init_subtypes_w_path_keys(/datum/fish_sour
 	/// Background image name from /datum/asset/simple/fishing_minigame
 	var/background = "fishing_background_default"
 
+/datum/fish_source/New()
+	if(!PERFORM_ALL_TESTS(focus_only/fish_sources_tables))
+		return
+	for(var/path in fish_counts)
+		if(!(path in fish_table))
+			stack_trace("path [path] found in the 'fish_counts' list but not in the fish_table one of [type]")
+
 /// Can we fish in this spot at all. Returns DENIAL_REASON or null if we're good to go
 /datum/fish_source/proc/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman)
 	return rod.reason_we_cant_fish(src)
@@ -116,7 +123,8 @@ GLOBAL_LIST_INIT(preset_fish_sources, init_subtypes_w_path_keys(/datum/fish_sour
 	if((reward_path in fish_counts)) // This is limited count result
 		fish_counts[reward_path] -= 1
 		if(!fish_counts[reward_path])
-			fish_counts -= reward_path //Ran out of these since rolling (multiple fishermen on same source most likely)ù
+			fish_counts -= reward_path //Ran out of these since rolling (multiple fishermen on same source most likely)
+			fish_table -= reward_path
 
 	var/atom/movable/reward = spawn_reward(reward_path, fisherman, fishing_spot)
 	if(!reward) //baloon alert instead
@@ -184,10 +192,6 @@ GLOBAL_LIST(fishing_property_cache)
 
 	var/list/final_table = fish_table.Copy()
 	for(var/result in final_table)
-		if((result in fish_counts) && fish_counts[result] <= 0) //ran out of these, ignore
-			final_table -= result
-			continue
-
 		final_table[result] *= rod.multiplicative_fish_bonus(result, src)
 		final_table[result] += rod.additive_fish_bonus(result, src) //Decide on order here so it can be multiplicative
 		if(ispath(result, /obj/item/fish))

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -6,7 +6,8 @@
 		/obj/item/fish/pufferfish = 15,
 		/obj/item/fish/cardinal = 15,
 		/obj/item/fish/greenchromis = 15,
-		/obj/item/fish/lanternfish = 5
+		/obj/item/fish/lanternfish = 5,
+		/obj/item/fish/clownfish/lube = 3,
 	)
 	fish_counts = list(
 		/obj/item/fish/clownfish/lube = 2,
@@ -74,7 +75,8 @@
 		/obj/item/stack/ore/plasma = 3,
 		/mob/living/basic/mining/lobstrosity = 1,
 		/obj/effect/decal/remains/plasma = 1,
-
+		/obj/item/stack/sheet/mineral/mythril = 1,
+		/obj/item/stack/sheet/mineral/adamantine = 1,
 	)
 	fish_counts = list(
 		/obj/item/stack/sheet/mineral/adamantine = 3,
@@ -97,6 +99,7 @@
 		FISHING_DUD = 18,
 		/obj/item/fish/sludgefish = 18,
 		/obj/item/fish/slimefish = 2,
+		/obj/item/storage/wallet/money = 2,
 	)
 	fish_counts = list(
 		/obj/item/storage/wallet/money = 2,
@@ -139,6 +142,9 @@
 		FISHING_DUD = 5,
 		/obj/item/fish/boned = 10,
 		/obj/item/stack/sheet/bone = 2,
+		/obj/item/clothing/gloves/bracer = 2,
+		/obj/effect/decal/remains/human = 2,
+		/obj/item/fish/mastodon = 1,
 	)
 	fish_counts = list(
 		/obj/item/clothing/gloves/bracer = 1,

--- a/code/modules/unit_tests/focus_only_tests.dm
+++ b/code/modules/unit_tests/focus_only_tests.dm
@@ -41,3 +41,6 @@
 
 /// Checks to ensure that variables expected to exist in a job datum (for config reasons) actually exist
 /datum/unit_test/focus_only/missing_job_datum_variables
+
+/// Checks that the contents of the fish_counts list are also present in fish_table
+/datum/unit_test/focus_only/fish_sources_tables


### PR DESCRIPTION
## About The Pull Request
During my first fishing related PR, I hadn't yet know that for the `fish_counts` var to work, its contents also had to be within the `fish_table` list, thus I ended up adding stuff that's not actually fishable. Also there was no unit test to enforce that design, which is lame.

## Why It's Good For The Game
Fixing the issues explained above. Basically #78019 but done right.

## Changelog

:cl:
fix: You can now actually fish soggy wallets from toilets, rare ores on ice moon, some boney stuff in oil puddles (good luck finding them) and lube-fishes by the seawater.
/:cl:
