### PR TITLE
Change gas mixer to mix by molar instead of volumetric

### DIFF
--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -88,8 +88,8 @@
 	var/combined_heat_capacity = air1.heat_capacity() + air2.heat_capacity()
 	var/equalized_temperature = combined_heat_capacity ? (air1.thermal_energy() + air2.thermal_energy()) / combined_heat_capacity : 0
 
-	var/transfer_moles1 = equalized_temperature ? node1_concentration * general_transfer / equalized_temperature : 0
-	var/transfer_moles2 = equalized_temperature ? node2_concentration * general_transfer / equalized_temperature : 0
+	var/transfer_moles1 = equalized_temperature ? (node1_concentration * general_transfer) / equalized_temperature : 0
+	var/transfer_moles2 = equalized_temperature ? (node2_concentration * general_transfer) / equalized_temperature : 0
 
 	var/air1_moles = air1.total_moles()
 	var/air2_moles = air2.total_moles()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -84,8 +84,10 @@
 	//Calculate necessary moles to transfer using PV=nRT
 	var/general_transfer = (target_pressure - output_starting_pressure) * air3.volume / R_IDEAL_GAS_EQUATION
 
-	var/transfer_moles1 = air1.temperature ? node1_concentration * general_transfer / air1.temperature : 0
-	var/transfer_moles2 = air2.temperature ? node2_concentration * general_transfer / air2.temperature : 0
+	var/equalized_temperature = (air1.thermal_energy() + air2.thermal_energy()) / (air1.heat_capacity() + air2.heat_capacity())
+
+	var/transfer_moles1 = air1.temperature ? node1_concentration * general_transfer / equalized_temperature : 0
+	var/transfer_moles2 = air2.temperature ? node2_concentration * general_transfer / equalized_temperature : 0
 
 	var/air1_moles = air1.total_moles()
 	var/air2_moles = air2.total_moles()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -73,10 +73,6 @@
 	if(!air1 || !air2)
 		return
 
-	if(air1.temperature <= 0 && air2.temperature <= 0)
-		//No air, no mix
-		return
-
 	var/datum/gas_mixture/air3 = airs[3]
 
 	var/output_starting_pressure = air3.return_pressure()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -85,10 +85,11 @@
 	var/general_transfer = (target_pressure - output_starting_pressure) * air3.volume / R_IDEAL_GAS_EQUATION
 
 	//Calculate combined temperature for accurate output ratio
-	var/equalized_temperature = (air1.thermal_energy() + air2.thermal_energy()) / (air1.heat_capacity() + air2.heat_capacity())
+	var/combined_heat_capacity = air1.heat_capacity() + air2.heat_capacity()
+	var/equalized_temperature = combined_heat_capacity ? (air1.thermal_energy() + air2.thermal_energy()) / combined_heat_capacity : 0
 
-	var/transfer_moles1 = air1.temperature ? node1_concentration * general_transfer / equalized_temperature : 0
-	var/transfer_moles2 = air2.temperature ? node2_concentration * general_transfer / equalized_temperature : 0
+	var/transfer_moles1 = equalized_temperature ? node1_concentration * general_transfer / equalized_temperature : 0
+	var/transfer_moles2 = equalized_temperature ? node2_concentration * general_transfer / equalized_temperature : 0
 
 	var/air1_moles = air1.total_moles()
 	var/air2_moles = air2.total_moles()

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -84,6 +84,7 @@
 	//Calculate necessary moles to transfer using PV=nRT
 	var/general_transfer = (target_pressure - output_starting_pressure) * air3.volume / R_IDEAL_GAS_EQUATION
 
+	//Calculate combined temperature for accurate output ratio
 	var/equalized_temperature = (air1.thermal_energy() + air2.thermal_energy()) / (air1.heat_capacity() + air2.heat_capacity())
 
 	var/transfer_moles1 = air1.temperature ? node1_concentration * general_transfer / equalized_temperature : 0

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -73,6 +73,10 @@
 	if(!air1 || !air2)
 		return
 
+	if(air1.temperature <= 0 && air2.temperature <= 0)
+		//No air, no mix
+		return
+
 	var/datum/gas_mixture/air3 = airs[3]
 
 	var/output_starting_pressure = air3.return_pressure()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Gas mixer output now accurate to set ratio regardless of mismatched input temperatures
Input
![53c841b2db6c6d5f0db15634c613c50c-1](https://github.com/tgstation/tgstation/assets/109347230/086a4c3b-f76e-4e8b-8b38-9669e6bfaffd)

Mixer
![c619537ba1cdbfc5ec8a6c384aabc6c3](https://github.com/tgstation/tgstation/assets/109347230/388ecead-9a19-45da-8b54-33ed6e11ec7e)

Output
![2d9c662f348838f427c1523fd86c092b](https://github.com/tgstation/tgstation/assets/109347230/bbc8dbaf-f529-4ba6-ac65-a19214f1c8de)

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
 
We can start by looking at what gas mixers are actually good for. First we have air supply mix and burn mixes, these are the main uses for a mixer, but the resulting mix becomes inaccurate if one of your gas supply tanks is cooler or warmer than another (this often happens when someone adds a bunch of cold n2 or o2 to wastes). A gas mix for the HFR or crystallizer, usually these are set up with a constant supply of gasses with temperature of an input often varying, eventually clogging if the mix becomes inaccurate. Finally we have bomb and internal mixes, I would argue that this is the most important reason to keep things the way they are, but are actually currently the easiest to manage. All of these uses require molar precision, something the gas mixer doesn't really provide on its own, making it almost useless if two inputs do not match in temperature.

In my experience, in order to mix gasses accurately, you must do one of three things. First, you must use a combination of heat gates and thermomachines to equalize the temperatures before mixing. Second, you can combine the mixtures into one to equalize the temperature, filter the gasses apart, and mix again with your desired ratios. Or the third option, you could create a custom calculator to take in your desired ratio and the current temperatures of your input and plug the resulting ratio into the mixer. 

The way gas mixers work currently serves no real purpose outside of tripping up new players and providing 'busy work' for the experienced ones. Many newer players expect gas mixers to provide the set ratio to the output, not knowing that the temperatures on the input mixes must match. It requires a lot of additional effort and knowledge to accurately mix gasses, something that should just be provided by the tool itself. 

This change is good because it helps makes atmos a bit simpler and more intuitive. Unfortunately we will lose complexity in setups and make atmos a bit easier, but maybe these are good things

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: gas mixer output now accurate to set ratio regardless of input temperatures
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
