### PR TITLE
Fixes the Hilbert's research tram

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -330,7 +330,7 @@
 	},
 /obj/structure/industrial_lift/tram/purple,
 /obj/effect/landmark/tram/platform/hilbert/middle,
-/obj/effect/landmark/tram/nav/hilbert/research,
+/obj/effect/landmark/tram/nav/hilbert,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "iY" = (

--- a/code/modules/industrial_lift/tram/tram_landmark.dm
+++ b/code/modules/industrial_lift/tram/tram_landmark.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_EMPTY(tram_landmarks)
 	name = "DESTINATION/NOT/FOUND"
 	specific_lift_id = IMMOVABLE_ROD_DESTINATIONS
 
-/obj/effect/landmark/tram/nav/hilbert/research
+/obj/effect/landmark/tram/nav/hilbert
 	name = HILBERT_TRAM
 	specific_lift_id = TRAM_NAV_BEACONS
 	dir = WEST

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -504,10 +504,10 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 			to_chat(user, "No vacated rooms.")
 		return .
 
-/obj/effect/landmark/lift_id/hilbert/research
+/obj/effect/landmark/lift_id/hilbert
 	specific_lift_id = HILBERT_TRAM
 
-/obj/effect/landmark/tram/nav/hilbert/research
+/obj/effect/landmark/tram/nav/hilbert
 	name = HILBERT_TRAM
 	specific_lift_id = TRAM_NAV_BEACONS
 


### PR DESCRIPTION

## About The Pull Request

Corrects the specific_tram_id helper for the Hilbert's Research to use the hilbert tram ID. I've also dropped the `.../hilbert/research` (tram-specific) paths in favor of simply `.../hilbert`

## Why It's Good For The Game

Fixes the Hilbert Hotel Research ruin's tram, and also stops the malfunctioning tram event from being able to use that tram to start. (No more trams going haywire on maps without trams!)

Closes #78018 

## Changelog
:cl:
fix: Hilbert's Hotel Research ruin now has a functioning tram. As a side effect, the malfunctioning tram event should now only fire on maps with a tram!
/:cl:
