### PR TITLE
Fixes implanted legion cores being available for use when dead/unconscious

### DIFF
--- a/code/__DEFINES/actions.dm
+++ b/code/__DEFINES/actions.dm
@@ -19,6 +19,8 @@ DEFINE_BITFIELD(check_flags, list(
 
 ///Action button triggered with right click
 #define TRIGGER_SECONDARY_ACTION (1<<0)
+///Action triggered to ignore any availability checks
+#define TRIGGER_FORCE_AVAILABLE (1<<1)
 
 // Defines for formatting cooldown actions for the stat panel.
 /// The stat panel the action is displayed in.

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -139,7 +139,7 @@
 /// Actually triggers the effects of the action.
 /// Called when the on-screen button is clicked, for example.
 /datum/action/proc/Trigger(trigger_flags)
-	if(!IsAvailable(feedback = TRUE))
+	if(!(trigger_flags & TRIGGER_FORCE_AVAILABLE) && !IsAvailable(feedback = TRUE))
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_ACTION_TRIGGER, src) & COMPONENT_ACTION_BLOCK_TRIGGER)
 		return FALSE

--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -183,9 +183,9 @@
  * Utility proc to find the associated monster organ action and trigger it.
  * Call this instead of on_triggered_internal() if the action needs to trigger automatically, or the cooldown won't happen.
  */
-/obj/item/organ/internal/monster_core/proc/trigger_organ_action()
+/obj/item/organ/internal/monster_core/proc/trigger_organ_action(trigger_flags)
 	var/datum/action/cooldown/monster_core_action/action = locate() in actions
-	action?.Trigger()
+	action?.Trigger(trigger_flags = trigger_flags)
 
 /**
  * Called when activated while implanted inside someone.

--- a/code/modules/mining/equipment/monster_organs/regenerative_core.dm
+++ b/code/modules/mining/equipment/monster_organs/regenerative_core.dm
@@ -28,7 +28,7 @@
 /obj/item/organ/internal/monster_core/regenerative_core/on_life(seconds_per_tick, times_fired)
 	. = ..()
 	if (owner.health <= owner.crit_threshold)
-		trigger_organ_action()
+		trigger_organ_action(TRIGGER_FORCE_AVAILABLE)
 
 /obj/item/organ/internal/monster_core/regenerative_core/on_triggered_internal()
 	owner.revive(HEAL_ALL)

--- a/code/modules/mining/equipment/monster_organs/regenerative_core.dm
+++ b/code/modules/mining/equipment/monster_organs/regenerative_core.dm
@@ -60,4 +60,4 @@
 	desc = "Fully regenerate your body, consuming your regenerative core in the process. \
 		This process will trigger automatically if you are badly wounded."
 	button_icon_state = "legion_core_stable"
-	check_flags = NONE
+	check_flags = AB_CHECK_CONSCIOUS

--- a/code/modules/mining/equipment/monster_organs/regenerative_core.dm
+++ b/code/modules/mining/equipment/monster_organs/regenerative_core.dm
@@ -60,4 +60,3 @@
 	desc = "Fully regenerate your body, consuming your regenerative core in the process. \
 		This process will trigger automatically if you are badly wounded."
 	button_icon_state = "legion_core_stable"
-	check_flags = AB_CHECK_CONSCIOUS


### PR DESCRIPTION
## About The Pull Request

Ever since #70546 implanted legion cores have become available for use when the user is unconscious/dead, which was not the case before — it was using an organ action, which checks for `AB_CHECK_CONSCIOUS`

#### cores before #70546
https://github.com/tgstation/tgstation/blob/475a4ab7f50ab8e0e9f394905c78586d66696485/code/modules/mining/equipment/regenerative_core.dm#L23-L34

https://github.com/tgstation/tgstation/blob/07fbdbb4e44d27774f0d06ce919ebbcce705d5c0/code/datums/actions/items/organ_action.dm#L1-L3

## Why It's Good For The Game

Prevents this

https://user-images.githubusercontent.com/104979184/264586219-8cab1fef-d2ea-4e1c-af43-158865b42b23.mp4

## Changelog

:cl:
fix: fixed implanted legion cores being available for use when unconscious/dead.
/:cl: