### PR TITLE
Don't gib a player if you click the 'X' button in the confirmation window

### DIFF
--- a/code/modules/admin/verbs/adminfun.dm
+++ b/code/modules/admin/verbs/adminfun.dm
@@ -60,11 +60,11 @@
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/confirm = tgui_alert(usr, "Drop a brain?", "Confirm", list("Yes", "No","Cancel"))
+	var/confirm = tgui_alert(usr, "Drop a brain?", "Confirm", list("Yes", "No","Cancel")) || "Cancel"
 	if(confirm == "Cancel")
 		return
 	//Due to the delay here its easy for something to have happened to the mob
-	if(!victim)
+	if(isnull(victim))
 		return
 
 	log_admin("[key_name(usr)] has gibbed [key_name(victim)]")
@@ -89,14 +89,15 @@
 	set category = "Admin.Fun"
 
 	var/confirm = tgui_alert(usr, "You sure?", "Confirm", list("Yes", "No"))
-	if(confirm == "Yes")
-		log_admin("[key_name(usr)] used gibself.")
-		message_admins(span_adminnotice("[key_name_admin(usr)] used gibself."))
-		SSblackbox.record_feedback("tally", "admin_verb", 1, "Gib Self") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
+	if(confirm != "Yes")
+		return
+	log_admin("[key_name(usr)] used gibself.")
+	message_admins(span_adminnotice("[key_name_admin(usr)] used gibself."))
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Gib Self") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
 
-		var/mob/living/ourself = mob
-		if (istype(ourself))
-			ourself.gib(TRUE, TRUE, TRUE)
+	var/mob/living/ourself = mob
+	if (istype(ourself))
+		ourself.gib(TRUE, TRUE, TRUE)
 
 /client/proc/everyone_random()
 	set category = "Admin.Fun"
@@ -114,7 +115,7 @@
 		to_chat(usr, "Disabled.", confidential = TRUE)
 		return
 
-	var/notifyplayers = tgui_alert(usr, "Do you want to notify the players?", "Options", list("Yes", "No", "Cancel"))
+	var/notifyplayers = tgui_alert(usr, "Do you want to notify the players?", "Options", list("Yes", "No", "Cancel")) || "Cancel"
 	if(notifyplayers == "Cancel")
 		return
 


### PR DESCRIPTION
## About The Pull Request

Fixes #78011
Does the same thing also for the "force everyone to play as a random character" button.

## Why It's Good For The Game

It shouldn't do that.

## Changelog

:cl:
fix: Prevents admins from accidentally gibbing people by closing a confirmation window.
/:cl:
