### PR TITLE
converts some assembly part to_chat alerts to balloon alerts

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -1,4 +1,3 @@
-
 /obj/item/assembly
 	name = "assembly"
 	desc = "A small electronic device that should never exist."
@@ -66,7 +65,7 @@
 
 /obj/item/assembly/proc/is_secured(mob/user)
 	if(!secured)
-		to_chat(user, span_warning("The [name] is unsecured!"))
+		balloon_alert(user, "[src] is unsecured!")
 		return FALSE
 	return TRUE
 
@@ -141,9 +140,9 @@
 	if(..())
 		return TRUE
 	if(toggle_secure())
-		to_chat(user, span_notice("\The [src] is ready!"))
+		balloon_alert(user, "[src] is ready")
 	else
-		to_chat(user, span_notice("\The [src] can now be attached!"))
+		balloon_alert(user, "[src] can now be attached")
 	add_fingerprint(user)
 	return TRUE
 

--- a/code/modules/assembly/bomb.dm
+++ b/code/modules/assembly/bomb.dm
@@ -1,6 +1,6 @@
 /obj/item/onetankbomb
 	name = "bomb"
-	icon = 'icons/obj/atmospherics/tank.dmi'
+	icon = 'icons/obj/canisters.dmi'
 	inhand_icon_state = "assembly"
 	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
@@ -57,9 +57,9 @@
 	..()
 	. = FALSE
 	if(status)
-		to_chat(user, span_warning("[bombtank] already has a pressure hole!"))
+		balloon_alert(user, "[bombtank] already has a pressure hole!")
 		return
-	if(!I.tool_start_check(user, amount=0))
+	if(!I.tool_start_check(user, amount=1))
 		return
 	if(I.use_tool(src, user, 0, volume=40))
 		status = TRUE
@@ -127,7 +127,7 @@
 		return
 
 	if(!user.canUnEquip(assembly))
-		to_chat(user, span_warning("[assembly] is stuck to your hand!"))
+		to_chat(user, span_warning("[assembly] is stuck to your hand!")) //reason you exploded (dumbass) is worth logging in chat
 		return
 
 	var/obj/item/onetankbomb/bomb = new
@@ -145,7 +145,7 @@
 	bomb.update_appearance()
 
 	user.put_in_hands(bomb) //Equips the bomb if possible, or puts it on the floor.
-	to_chat(user, span_notice("You attach [assembly] to [src]."))
+	balloon_alert(user, "you attach [assembly] to [src]")
 	return
 
 /obj/item/onetankbomb/return_analyzable_air()

--- a/code/modules/assembly/health.dm
+++ b/code/modules/assembly/health.dm
@@ -40,10 +40,10 @@
 /obj/item/assembly/health/AltClick(mob/living/user)
 	if(alarm_health == HEALTH_THRESHOLD_CRIT)
 		alarm_health = HEALTH_THRESHOLD_DEAD
-		to_chat(user, span_notice("You toggle [src] to \"detect death\" mode."))
+		balloon_alert(user, "will activate on death")
 	else
 		alarm_health = HEALTH_THRESHOLD_CRIT
-		to_chat(user, span_notice("You toggle [src] to \"detect critical state\" mode."))
+		balloon_alert(user, "will activate on critical state")
 
 /obj/item/assembly/health/process()
 	if(!scanning || !secured)

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -171,11 +171,10 @@
 
 /obj/item/assembly/mousetrap/attack_self(mob/living/carbon/human/user)
 	if(!armed)
-		to_chat(user, span_notice("You arm [src]."))
-	else
+		balloon_alert(user, "you arm [src]")
 		if(clumsy_check(user))
 			return
-		to_chat(user, span_notice("You disarm [src]."))
+		balloon_alert(user, "you disarm [src]")
 	armed = !armed
 	update_appearance()
 	playsound(src, 'sound/weapons/handcuffs.ogg', 30, TRUE, -3)
@@ -238,3 +237,4 @@
 /obj/item/assembly/mousetrap/armed
 	icon_state = "mousetraparmed"
 	armed = TRUE
+

--- a/code/modules/assembly/shock_kit.dm
+++ b/code/modules/assembly/shock_kit.dm
@@ -24,7 +24,7 @@
 
 /obj/item/assembly/shock_kit/wrench_act(mob/living/user, obj/item/I)
 	..()
-	to_chat(user, span_notice("You disassemble [src]."))
+	balloon_alert(user, "you disassemble [src]")
 	if(helmet_part)
 		helmet_part.forceMove(drop_location())
 		helmet_part.master = null

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -90,7 +90,7 @@
 	switch(action)
 		if("signal")
 			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
-				to_chat(usr, span_warning("[src] is still recharging..."))
+				balloon_alert(user, "[src] is still recharging...")
 				return
 			TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
 			INVOKE_ASYNC(src, PROC_REF(signal))

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -90,7 +90,7 @@
 	switch(action)
 		if("signal")
 			if(TIMER_COOLDOWN_CHECK(src, COOLDOWN_SIGNALLER_SEND))
-				balloon_alert(user, "[src] is still recharging...")
+				balloon_alert(usr, "[src] is still recharging!")
 				return
 			TIMER_COOLDOWN_START(src, COOLDOWN_SIGNALLER_SEND, 1 SECONDS)
 			INVOKE_ASYNC(src, PROC_REF(signal))

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -98,7 +98,7 @@
 	..()
 	mode %= modes.len
 	mode++
-	to_chat(user, span_notice("You set [src] into [modes[mode]] mode."))
+	balloon_alert(user, "you set [src] into [modes[mode]] mode")
 	listening = FALSE
 	recorded = ""
 	return TRUE


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

less clutter in chat and more consistency

generally i think disassembling stuff has enough visual/audio feedback (progress bar, sprite disappearing, sound, etc) but with assembly parts its only in to_chat and it doesn't feel worth logging so it's a balloon alert now

## Changelog

:cl: mikederkan
qol: Some messages regarding assemblies are now balloon alerts.
/:cl: