### PR TITLE
Generate theft objective target list more consistently

### DIFF
--- a/code/controllers/subsystem/traitor.dm
+++ b/code/controllers/subsystem/traitor.dm
@@ -44,6 +44,9 @@ SUBSYSTEM_DEF(traitor)
 	category_handler = new()
 	traitor_debug_panel = new(category_handler)
 
+	for(var/theft_item in subtypesof(/datum/objective_item/steal))
+		new theft_item
+
 	if(fexists(configuration_path))
 		var/list/data = json_decode(file2text(file(configuration_path)))
 		for(var/typepath in data)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -578,12 +578,6 @@ GLOBAL_LIST_EMPTY(possible_items)
 /datum/objective/steal/get_target()
 	return steal_target
 
-/datum/objective/steal/New()
-	..()
-	if(!GLOB.possible_items.len)//Only need to fill the list when it's needed.
-		for(var/I in subtypesof(/datum/objective_item/steal))
-			new I
-
 /datum/objective/steal/find_target(dupe_search_range, list/blacklist)
 	var/list/datum/mind/owners = get_owners()
 	if(!dupe_search_range)


### PR DESCRIPTION
## About The Pull Request

Fixes #77943
Moves the generation of traitor theft objective targets from `new` of `/datum/objective/steal` to `initialize` of `/datum/controller/subsystem/traitor`

`/datum/objective/steal` we would generate the full list of possible theft targets _only_ if the list was already empty.
A recent PR added a secondary "destroy item" objective which has no rep prerequisite, as a result it is initialised as soon as a traitor datum is assigned. Importantly this happens _before_ the traitor's theft objective is assigned.
The "destroy item" objective generates its own item targets using the "theft item" datum as it is a type of thievery, this pollutes the list to contain more than 0 entries.
From this point on the only things people can be assigned to steal are the items that traitors can be assigned to destroy early in a round, which aren't valid for most kinds of theft objective.

Making the subsystem generate the list before traitor datums are assigned resolves the race condition, the number of rounds where _nobody_ has any kind of theft objective and this list is unused is exceedingly small.

## Why It's Good For The Game

You can get primary theft objectives again.

## Changelog

:cl:
fix: Traitors should generate with "free objective" less often, and will once more be assigned to steal things.
/:cl:
