### PR TITLE
[No GBP] Gives a proper blank icon to dynamic human appearance

### DIFF
--- a/code/__HELPERS/dynamic_human_icon_gen.dm
+++ b/code/__HELPERS/dynamic_human_icon_gen.dm
@@ -54,5 +54,6 @@ GLOBAL_LIST_EMPTY(dynamic_human_appearances)
 /proc/set_dynamic_human_appearance(list/arguments)
 	var/atom/target = arguments[1] //1st argument is the target
 	var/dynamic_appearance = get_dynamic_human_appearance(arglist(arguments.Copy(2))) //the rest of the arguments starting from 2 matter to the proc
-	target.icon = null
+	target.icon = 'icons/blanks/32x32.dmi'
+	target.icon_state = "nothing"
 	target.copy_overlays(dynamic_appearance, cut_old = TRUE)


### PR DESCRIPTION

## About The Pull Request
In an earlier PR, I have fixed how the dynamic human appearance is applied to mobs, to ensure their name and description stays. The solution nulled the icon, which caused the HUD to not appear, as they had no image height data to pull from. This PR fixes that by assigning them a blank icon state.

## Why It's Good For The Game

Its nice if you can see the HUDs of various mobs.

## Changelog

:cl:
fix: The HUDs of mobs with dynamic human appearance will appear properly.
/:cl:

