### PR TITLE
Soup is food according to the smartfridge

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -513,7 +513,7 @@
 	base_build_path = /obj/machinery/smartfridge/drinks
 
 /obj/machinery/smartfridge/drinks/accept_check(obj/item/O)
-	if(!is_reagent_container(O) || (O.item_flags & ABSTRACT) || !O.reagents || !O.reagents.reagent_list.len)
+	if(!is_reagent_container(O) || (O.item_flags & ABSTRACT) || istype(O,/obj/item/reagent_containers/cup/bowl) || !O.reagents || !O.reagents.reagent_list.len)
 		return FALSE
 	if(istype(O, /obj/item/reagent_containers/cup) || istype(O, /obj/item/reagent_containers/cup/glass) || istype(O, /obj/item/reagent_containers/condiment))
 		return TRUE
@@ -526,7 +526,7 @@
 	base_build_path = /obj/machinery/smartfridge/food
 
 /obj/machinery/smartfridge/food/accept_check(obj/item/O)
-	if(IS_EDIBLE(O))
+	if(IS_EDIBLE(O) || (istype(O,/obj/item/reagent_containers/cup/bowl) && O.reagents && O.reagents.reagent_list.len))
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request

Bowls are no longer allowed in drink showcases, and Bowls are now allowed within Kitchen Smartfridges
## Why It's Good For The Game

Generally, it makes sense that soup, a food, can be placed in food smartfridge and not the drink smartfridge. This check is based on the container. Bowls of, for example, sulfuric acid are accepted by the food smartfridge. Empty bowls are not accepted. However, the drink smartfridge has analogous behavior, and so this will keep consistency between the 2 smartfridge versions

Fixes #77334
## Changelog
:cl:
fix: Soups are accepted by Kitchen Smartfridges
fix: Soups are not accepted by drink showcases
/:cl:
