### PR TITLE
Adds pirate gang information to pirate candidate/orbit popups

### DIFF
--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -59,7 +59,7 @@
 	if(chosen_gang.paid_off)
 		return
 
-	var/list/candidates = poll_ghost_candidates("Do you wish to be considered for pirate crew?", ROLE_TRAITOR)
+	var/list/candidates = poll_ghost_candidates("Do you wish to be considered for a pirate crew of [chosen_gang.name]?", ROLE_TRAITOR)
 	shuffle_inplace(candidates)
 
 	var/template_key = "pirate_[chosen_gang.ship_template_id]"
@@ -80,9 +80,9 @@
 				var/mob/our_candidate = candidates[1]
 				var/mob/spawned_mob = spawner.create_from_ghost(our_candidate)
 				candidates -= our_candidate
-				notify_ghosts("The pirate ship has an object of interest: [spawned_mob]!", source = spawned_mob, action = NOTIFY_ORBIT, header="Pirates!")
+				notify_ghosts("The [chosen_gang.ship_name] has an object of interest: [spawned_mob]!", source = spawned_mob, action = NOTIFY_ORBIT, header="Pirates!")
 			else
-				notify_ghosts("The pirate ship has an object of interest: [spawner]!", source = spawner, action = NOTIFY_ORBIT, header="Pirate Spawn Here!")
+				notify_ghosts("The [chosen_gang.ship_name] has an object of interest: [spawner]!", source = spawner, action = NOTIFY_ORBIT, header="Pirate Spawn Here!")
 
 	priority_announce(chosen_gang.arrival_announcement, sender_override = chosen_gang.ship_name)
 

--- a/code/modules/antagonists/pirate/pirate_gangs.dm
+++ b/code/modules/antagonists/pirate/pirate_gangs.dm
@@ -118,7 +118,7 @@ GLOBAL_LIST_INIT(heavy_pirate_gangs, init_pirate_gangs(is_heavy = TRUE))
 
 ///Expirienced formed employes of Interdyne Pharmaceutics now in a path of thievery and reckoning
 /datum/pirate_gang/interdyne
-	name = "Expharmacist Unrest"
+	name = "Restless Ex-Pharmacists"
 
 	is_heavy_threat = TRUE
 	ship_template_id = "ex_interdyne"
@@ -153,7 +153,7 @@ GLOBAL_LIST_INIT(heavy_pirate_gangs, init_pirate_gangs(is_heavy = TRUE))
 
 ///Agents from the space I.R.S. heavily armed to stea- I mean, collect the station's tax dues
 /datum/pirate_gang/irs
-	name = "Space IRS"
+	name = "Space IRS Agents"
 
 	is_heavy_threat = TRUE
 	ship_template_id = "irs"


### PR DESCRIPTION

## About The Pull Request

Pirate candidate gathering now gives more info on the type of pirates being polled for in the popup message.

This slightly changes two pirate gang datum names, for better readability.

This also makes the orbit popup say the name of the shuttle instead of just "the pirate shuttle".

![image](https://github.com/tgstation/tgstation/assets/28870487/e1f90045-8ae6-4fea-8327-2ae0670059f6)

![image](https://github.com/tgstation/tgstation/assets/28870487/eb97cb51-9960-469a-9aa4-2517a2ae36b5)

wa la 
## Why It's Good For The Game

Ease of observation, more information provided to players.
## Changelog
:cl:
qol: The pirate candidate gathering poll will now mention which pirate gang it is gathering candidates for.
/:cl:
