### PR TITLE
Rice Dough can be made in a beaker

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -97,6 +97,10 @@
 	required_reagents = list(/datum/reagent/consumable/corn_starch = 1, /datum/reagent/toxin/acid = 1)
 	required_temp = 374
 
+/datum/chemical_reaction/food/rice_flour
+	results = list(/datum/reagent/consumable/rice_flour = 10)
+	required_reagents = list(/datum/reagent/consumable/flour = 5,/datum/reagent/consumable/rice = 5)
+
 /datum/chemical_reaction/food/caramel
 	results = list(/datum/reagent/consumable/caramel = 1)
 	required_reagents = list(/datum/reagent/consumable/sugar = 1)
@@ -151,7 +155,7 @@
 	resulting_food_path = /obj/item/food/dough
 
 /datum/chemical_reaction/food/rice_dough
-	required_reagents = list(/datum/reagent/consumable/flour = 10,/datum/reagent/consumable/rice = 10,/datum/reagent/water = 10)
+	required_reagents = list(/datum/reagent/consumable/rice_flour = 20,/datum/reagent/water = 10)
 	mix_message = "The ingredients form a rice dough."
 	reaction_flags = REACTION_INSTANT
 	resulting_food_path = /obj/item/food/rice_dough
@@ -170,7 +174,7 @@
 	required_reagents = list(/datum/reagent/consumable/eggyolk = 6, /datum/reagent/consumable/eggwhite = 12, /datum/reagent/consumable/milk = 10, /datum/reagent/consumable/flour = 5)
 
 /datum/chemical_reaction/food/uncooked_rice
-	required_reagents = list(/datum/reagent/consumable/rice = 10, /datum/reagent/water = 15)
+	required_reagents = list(/datum/reagent/consumable/rice = 10, /datum/reagent/water = 10)
 	mix_message = "The rice absorbs the water."
 	reaction_flags = REACTION_INSTANT
 

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -150,6 +150,12 @@
 	reaction_flags = REACTION_INSTANT
 	resulting_food_path = /obj/item/food/dough
 
+/datum/chemical_reaction/food/rice_dough
+	required_reagents = list(/datum/reagent/consumable/flour = 10,/datum/reagent/consumable/rice = 10,/datum/reagent/water = 10)
+	mix_message = "The ingredients form a rice dough."
+	reaction_flags = REACTION_INSTANT
+	resulting_food_path = /obj/item/food/rice_dough
+
 /datum/chemical_reaction/food/cakebatter
 	required_reagents = list(/datum/reagent/consumable/eggyolk = 6, /datum/reagent/consumable/eggwhite = 12, /datum/reagent/consumable/flour = 15, /datum/reagent/consumable/sugar = 5)
 	mix_message = "The ingredients form a cake batter."
@@ -164,7 +170,7 @@
 	required_reagents = list(/datum/reagent/consumable/eggyolk = 6, /datum/reagent/consumable/eggwhite = 12, /datum/reagent/consumable/milk = 10, /datum/reagent/consumable/flour = 5)
 
 /datum/chemical_reaction/food/uncooked_rice
-	required_reagents = list(/datum/reagent/consumable/rice = 10, /datum/reagent/water = 10)
+	required_reagents = list(/datum/reagent/consumable/rice = 10, /datum/reagent/water = 15)
 	mix_message = "The rice absorbs the water."
 	reaction_flags = REACTION_INSTANT
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -643,6 +643,14 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	default_container = /obj/item/reagent_containers/condiment/rice
 
+/datum/reagent/consumable/rice_flour
+	name = "Rice Flour"
+	description = "Flour mixed with Rice"
+	reagent_state = SOLID
+	color = "#FFFFFF" // rgb: 0, 0, 0
+	taste_description = "chalky wheat with rice"
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	
 /datum/reagent/consumable/vanilla
 	name = "Vanilla Powder"
 	description = "A fatty, bitter paste made from vanilla pods."


### PR DESCRIPTION
## About The Pull Request

Rice dough can be made in a beaker using 20u of Rice Flour and 10u of Water. 10u of Rice Flour is made from 5u of Rice and 5u of Flour. Rice dough can still be crafted manually using the crafting menu and the original recipe. 
## Why It's Good For The Game

Cooks can sometimes get swamped with work, especially on a high-pop shift or when there are no botanists. By making rice dough more convenient to make, cooks don't need to spend as much time in the crafting menu. 
Rice Flour is made from mixing equal parts Rice and Flour. Since no recipe other than Rice dough uses both Rice and Flour in it's Recipe, it should be fine to turn those regents into the intermediate reagent "Rice Flour".
Fixes #77966
## Changelog
:cl:
qol: Rice Dough may be made in beaker instead of being crafted, but the rice and flour must be added first
/:cl:
