### PR TITLE
Fixes typo 'transfered', olive oil reaction repath

### DIFF
--- a/code/datums/components/customizable_reagent_holder.dm
+++ b/code/datums/components/customizable_reagent_holder.dm
@@ -2,7 +2,7 @@
  * # Custom Atom Component
  *
  * When added to an atom, item ingredients can be put into that.
- * The sprite is updated and reagents are transfered.
+ * The sprite is updated and reagents are transferred.
  *
  * If the component is added to something that is processed, creating new objects (being cut, for example),
  * the replacement type needs to also have the component. The ingredients will be copied over. Reagents are not

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -461,7 +461,7 @@ Behavior that's still missing from this component that original food items had t
 		apply_buff(eater)
 
 	var/fraction = min(bite_consumption / owner.reagents.total_volume, 1)
-	owner.reagents.trans_to(eater, bite_consumption, transfered_by = feeder, methods = INGEST)
+	owner.reagents.trans_to(eater, bite_consumption, transferred_by = feeder, methods = INGEST)
 	bitecount++
 
 	checkLiked(fraction, eater)
@@ -654,7 +654,7 @@ Behavior that's still missing from this component that original food items had t
 
 	if(foodtypes & edible_flags)
 		var/atom/eaten_food = parent
-		eaten_food.reagents.trans_to(eater, eaten_food.reagents.total_volume, transfered_by = eater)
+		eaten_food.reagents.trans_to(eater, eaten_food.reagents.total_volume, transferred_by = eater)
 		eater.visible_message(span_warning("[src] eats [eaten_food]!"), span_notice("You eat [eaten_food]."))
 		playsound(get_turf(eater),'sound/items/eatfood.ogg', rand(30,50), TRUE)
 		qdel(eaten_food)

--- a/code/datums/components/udder.dm
+++ b/code/datums/components/udder.dm
@@ -117,8 +117,8 @@
 	if(milk_holder.reagents.total_volume >= milk_holder.volume)
 		to_chat(user, span_warning("[milk_holder] is full."))
 		return
-	var/transfered = reagents.trans_to(milk_holder, rand(5,10))
-	if(transfered)
+	var/transferred = reagents.trans_to(milk_holder, rand(5,10))
+	if(transferred)
 		user.visible_message(span_notice("[user] milks [src] using \the [milk_holder]."), span_notice("You milk [src] using \the [milk_holder]."))
 	else
 		to_chat(user, span_warning("The udder is dry. Wait a bit longer..."))

--- a/code/datums/elements/chemical_transfer.dm
+++ b/code/datums/elements/chemical_transfer.dm
@@ -58,7 +58,7 @@
 		return
 	var/built_attacker_message = replacetext(attacker_message, "%VICTIM", transfer_victim)
 	var/built_victim_message = replacetext(attacker_message, "%ATTACKER", transfer_attacker)
-	transfer_attacker.reagents?.trans_to(transfer_victim, transfer_attacker.reagents.total_volume, multiplier = 1, preserve_data = 1, no_react = 0, transfered_by = transfer_attacker)
+	transfer_attacker.reagents?.trans_to(transfer_victim, transfer_attacker.reagents.total_volume, multiplier = 1, preserve_data = 1, no_react = 0, transferred_by = transfer_attacker)
 	to_chat(transfer_attacker, built_attacker_message)
 	to_chat(transfer_victim, built_victim_message)
 

--- a/code/datums/elements/food/dunkable.dm
+++ b/code/datums/elements/food/dunkable.dm
@@ -3,7 +3,7 @@
 /datum/element/dunkable
 	element_flags = ELEMENT_BESPOKE
 	argument_hash_start_idx = 2
-	var/dunk_amount // the amount of reagents that will be transfered from the container to the item on each click
+	var/dunk_amount // the amount of reagents that will be transferred from the container to the item on each click
 
 /datum/element/dunkable/Attach(datum/target, amount_per_dunk)
 	. = ..()
@@ -28,7 +28,7 @@
 			to_chat(user, span_warning("[container] is unable to be dunked in!"))
 			return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 		var/obj/item/I = source // the item that has the dunkable element
-		if(container.reagents.trans_to(I, dunk_amount, transfered_by = user)) //if reagents were transfered, show the message
+		if(container.reagents.trans_to(I, dunk_amount, transferred_by = user)) //if reagents were transferred, show the message
 			to_chat(user, span_notice("You dunk \the [I] into \the [container]."))
 			return COMPONENT_AFTERATTACK_PROCESSED_ITEM
 		if(!container.reagents.total_volume)

--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -8,7 +8,7 @@
 		ghost.mind is however used as a reference to the ghost's corpse
 
 	- When creating a new mob for an existing IC character (e.g. cloning a dead guy or borging a brain of a human)
-		the existing mind of the old mob should be transfered to the new mob like so:
+		the existing mind of the old mob should be transferred to the new mob like so:
 
 			mind.transfer_to(new_mob)
 

--- a/code/datums/mutations/tongue_spike.dm
+++ b/code/datums/mutations/tongue_spike.dm
@@ -130,7 +130,7 @@
 		return
 
 	var/datum/action/send_chems/chem_action = new(src)
-	chem_action.transfered_ref = WEAKREF(embedded_mob)
+	chem_action.transferred_ref = WEAKREF(embedded_mob)
 	chem_action.Grant(fired_by)
 
 	to_chat(fired_by, span_notice("Link established! Use the \"Transfer Chemicals\" ability \
@@ -154,7 +154,7 @@
 	check_flags = AB_CHECK_CONSCIOUS
 
 	/// Weakref to the mob target that we transfer chemicals to on activation
-	var/datum/weakref/transfered_ref
+	var/datum/weakref/transferred_ref
 
 /datum/action/send_chems/New(Target)
 	. = ..()
@@ -168,12 +168,12 @@
 	if(!ishuman(owner) || !owner.reagents)
 		return FALSE
 	var/mob/living/carbon/human/transferer = owner
-	var/mob/living/carbon/human/transfered = transfered_ref?.resolve()
-	if(!ishuman(transfered))
+	var/mob/living/carbon/human/transferred = transferred_ref?.resolve()
+	if(!ishuman(transferred))
 		return FALSE
 
-	to_chat(transfered, span_warning("You feel a tiny prick!"))
-	transferer.reagents.trans_to(transfered, transferer.reagents.total_volume, 1, 1, 0, transfered_by = transferer)
+	to_chat(transferred, span_warning("You feel a tiny prick!"))
+	transferer.reagents.trans_to(transferred, transferer.reagents.total_volume, 1, 1, 0, transferred_by = transferer)
 
 	var/obj/item/hardened_spike/chem/chem_spike = target
 	var/obj/item/bodypart/spike_location = chem_spike.check_embedded()

--- a/code/datums/wires/conveyor.dm
+++ b/code/datums/wires/conveyor.dm
@@ -1,7 +1,7 @@
 /datum/wires/conveyor
 	holder_type = /obj/machinery/conveyor_switch
 	proper_name = "Conveyor"
-	/// var holder that logs who put the assembly inside and gets transfered to the switch on pulse
+	/// var holder that logs who put the assembly inside and gets transferred to the switch on pulse
 	var/datum/weakref/fingerman_ref
 
 /datum/wires/conveyor/New(atom/holder)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -689,16 +689,16 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	if(!LAZYLEN(masters) || !masters[owner])
 		return TRUE
 	var/obj/effect/overlay/holo_pad_hologram/holo = masters[owner]
-	var/transfered = FALSE
+	var/transferred = FALSE
 	if(!validate_location(new_turf))
 		if(!transfer_to_nearby_pad(new_turf, owner))
 			return FALSE
 		else
-			transfered = TRUE
+			transferred = TRUE
 	//All is good.
 	holo.abstract_move(new_turf)
 	SET_PLANE(holo, ABOVE_GAME_PLANE, new_turf)
-	if(!transfered)
+	if(!transferred)
 		update_holoray(owner, new_turf)
 	return TRUE
 

--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -57,9 +57,9 @@
 		if(!length(reagent_container.reagents.reagent_list))
 			balloon_alert(user, "nothing to transfer!")
 			return
-		var/units = reagent_container.reagents.trans_to(src, reagent_container.amount_per_transfer_from_this, transfered_by = user)
+		var/units = reagent_container.reagents.trans_to(src, reagent_container.amount_per_transfer_from_this, transferred_by = user)
 		if(units)
-			balloon_alert(user, "[units] units transfered")
+			balloon_alert(user, "[units] units transferred")
 		else
 			balloon_alert(user, "reagent storage full!")
 		return

--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -28,7 +28,7 @@
 	var/mob/living/carbon/human/H = user
 	var/obj/W = new /obj/item/reagent_containers/cup/glass/bottle/whiskey(H.loc)
 	playsound(H.loc, 'sound/items/drink.ogg', rand(10,50), TRUE)
-	W.reagents.trans_to(H, W.reagents.total_volume, transfered_by = user)
+	W.reagents.trans_to(H, W.reagents.total_volume, transferred_by = user)
 	user.visible_message(span_suicide("[user] downs the contents of [W.name] in one gulp! Shoulda stuck to sudoku!"))
 	return TOXLOSS
 

--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -79,7 +79,7 @@
 				to_chat(user, span_notice("[W] is full!"))
 				return
 			to_chat(user, span_notice("You scoop up [src] into [W]!"))
-			reagents.trans_to(W, reagents.total_volume, transfered_by = user)
+			reagents.trans_to(W, reagents.total_volume, transferred_by = user)
 			if(!reagents.total_volume) //scooped up all of it
 				qdel(src)
 				return

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -171,7 +171,7 @@
 		if(isflyperson(H))
 			playsound(get_turf(src), 'sound/items/drink.ogg', 50, TRUE) //slurp
 			H.visible_message(span_alert("[H] extends a small proboscis into the vomit pool, sucking it with a slurping sound."))
-			reagents.trans_to(H, reagents.total_volume, transfered_by = user, methods = INGEST)
+			reagents.trans_to(H, reagents.total_volume, transferred_by = user, methods = INGEST)
 			qdel(src)
 
 /obj/effect/decal/cleanable/vomit/nebula

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -962,7 +962,7 @@
 		reagents = new()
 	reagents.add_reagent_list(grind_results)
 	if(reagents && target_holder)
-		reagents.trans_to(target_holder, reagents.total_volume, transfered_by = user)
+		reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
 	return TRUE
 
 ///Called BEFORE the object is ground up - use this to change grind results based on conditions. Return "-1" to prevent the grinding from occurring
@@ -977,7 +977,7 @@
 		return FALSE
 	reagents.convert_reagent(/datum/reagent/consumable, juice_typepath, include_source_subtypes = TRUE)
 	if(reagents && target_holder)
-		reagents.trans_to(target_holder, reagents.total_volume, transfered_by = user)
+		reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
 	return TRUE
 
 /obj/item/proc/set_force_string()

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -231,7 +231,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!istype(glass)) //you can dip cigarettes into beakers
 		return
 
-	if(glass.reagents.trans_to(src, chem_volume, transfered_by = user)) //if reagents were transfered, show the message
+	if(glass.reagents.trans_to(src, chem_volume, transferred_by = user)) //if reagents were transferred, show the message
 		to_chat(user, span_notice("You dip \the [src] into \the [glass]."))
 	//if not, either the beaker was empty, or the cigarette was full
 	else if(!glass.reagents.total_volume)
@@ -670,7 +670,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	packeditem = to_smoke.name
 	update_name()
 	if(to_smoke.reagents)
-		to_smoke.reagents.trans_to(src, to_smoke.reagents.total_volume, transfered_by = user)
+		to_smoke.reagents.trans_to(src, to_smoke.reagents.total_volume, transferred_by = user)
 	qdel(to_smoke)
 
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -767,7 +767,7 @@
 	update_appearance()
 	if(actually_paints)
 		H.update_lips("spray_face", paint_color)
-	reagents.trans_to(user, used, volume_multiplier, transfered_by = user, methods = VAPOR)
+	reagents.trans_to(user, used, volume_multiplier, transferred_by = user, methods = VAPOR)
 	return OXYLOSS
 
 /obj/item/toy/crayon/spraycan/Initialize(mapload)
@@ -824,7 +824,7 @@
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 			SEND_SIGNAL(target, COMSIG_LIVING_MOB_PAINTED)
 		use_charges(user, 2, requires_full = FALSE)
-		reagents.trans_to(target, ., volume_multiplier, transfered_by = user, methods = VAPOR)
+		reagents.trans_to(target, ., volume_multiplier, transferred_by = user, methods = VAPOR)
 
 		if(pre_noise || post_noise)
 			playsound(user.loc, 'sound/effects/spray.ogg', 5, TRUE, 5)
@@ -851,7 +851,7 @@
 					holder.update_clothing(target_item.slot_flags)
 		if(!(SEND_SIGNAL(target, COMSIG_OBJ_PAINTED, user, src, color_is_dark) & DONT_USE_SPRAYCAN_CHARGES))
 			use_charges(user, 2, requires_full = FALSE)
-		reagents.trans_to(target, ., volume_multiplier, transfered_by = user, methods = VAPOR)
+		reagents.trans_to(target, ., volume_multiplier, transferred_by = user, methods = VAPOR)
 
 		if(pre_noise || post_noise)
 			playsound(user.loc, 'sound/effects/spray.ogg', 5, TRUE, 5)

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -163,7 +163,7 @@
 			balloon_alert(user, "already full!")
 			return TRUE
 		var/obj/structure/reagent_dispensers/W = target //will it work?
-		var/transferred = W.reagents.trans_to(src, max_water, transfered_by = user)
+		var/transferred = W.reagents.trans_to(src, max_water, transferred_by = user)
 		if(transferred > 0)
 			to_chat(user, span_notice("\The [src] has been refilled by [transferred] units."))
 			playsound(src.loc, 'sound/effects/refill.ogg', 50, TRUE, -6)
@@ -231,7 +231,7 @@
 			var/datum/reagents/water_reagents = new /datum/reagents(5)
 			water.reagents = water_reagents
 			water_reagents.my_atom = water
-			reagents.trans_to(water, 1, transfered_by = user)
+			reagents.trans_to(water, 1, transferred_by = user)
 
 		//Make em move dat ass, hun
 		move_particles(water_particles)

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -224,7 +224,7 @@
 	if(air_transfer.gases[/datum/gas/plasma])
 		air_transfer.gases[/datum/gas/plasma][MOLES] *= 5 //Suffering
 	target.assume_air(air_transfer)
-	//Burn it based on transfered gas
+	//Burn it based on transferred gas
 	target.hotspot_expose((tank_mix.temperature*2) + 380,500)
 	//location.hotspot_expose(1000,500,1)
 

--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -190,7 +190,7 @@
 		to_chat(user, span_notice("You inject [injectee] with the injector ([selected_reagent.name])."))
 
 		if(injectee.reagents)
-			hypospray_injector.trans_to(injectee, amount_per_transfer_from_this, transfered_by = user, methods = INJECT)
+			hypospray_injector.trans_to(injectee, amount_per_transfer_from_this, transferred_by = user, methods = INJECT)
 			balloon_alert(user, "[amount_per_transfer_from_this] unit\s injected")
 			log_combat(user, injectee, "injected", src, "(CHEMICALS: [selected_reagent])")
 	else
@@ -382,7 +382,7 @@
 		stored_reagents.remove_reagent(selected_reagent.type, amount_per_transfer_from_this)
 		shaker.add_reagent(selected_reagent.type, amount_per_transfer_from_this, reagtemp = dispensed_temperature, no_react = TRUE)
 
-		shaker.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
+		shaker.trans_to(target, amount_per_transfer_from_this, transferred_by = user)
 		balloon_alert(user, "[amount_per_transfer_from_this] unit\s poured")
 	return .
 
@@ -446,7 +446,7 @@
 	var/datum/reagents/shaker = new()
 	stored_reagents.remove_reagent(selected_reagent.type, amount_per_transfer_from_this)
 	shaker.add_reagent(selected_reagent.type, amount_per_transfer_from_this, reagtemp = dispensed_temperature, no_react = TRUE)
-	shaker.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
+	shaker.trans_to(target, amount_per_transfer_from_this, transferred_by = user)
 	balloon_alert(user, "[amount_per_transfer_from_this] unit\s poured")
 
 

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -711,7 +711,7 @@
 /obj/item/storage/organbox/attackby(obj/item/I, mob/user, params)
 	if(is_reagent_container(I) && I.is_open_container())
 		var/obj/item/reagent_containers/RC = I
-		var/units = RC.reagents.trans_to(src, RC.amount_per_transfer_from_this, transfered_by = user)
+		var/units = RC.reagents.trans_to(src, RC.amount_per_transfer_from_this, transferred_by = user)
 		if(units)
 			balloon_alert(user, "[units]u transferred")
 			return

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -167,7 +167,7 @@
 
 	if(!status && attacked_atom.is_refillable())
 		. |= AFTERATTACK_PROCESSED_ITEM
-		reagents.trans_to(attacked_atom, reagents.total_volume, transfered_by = user)
+		reagents.trans_to(attacked_atom, reagents.total_volume, transferred_by = user)
 		to_chat(user, span_notice("You empty [src]'s fuel tank into [attacked_atom]."))
 		update_appearance()
 

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -62,7 +62,7 @@
 		else if(reagents.total_volume >= 10)
 			to_chat(user, span_warning("[src] is full."))
 		else
-			A.reagents.trans_to(src, 10, transfered_by = user)
+			A.reagents.trans_to(src, 10, transferred_by = user)
 			to_chat(user, span_notice("You fill the balloon with the contents of [A]."))
 			desc = "A translucent balloon with some form of liquid sloshing around in it."
 			update_appearance()
@@ -77,7 +77,7 @@
 			else
 				desc = "A translucent balloon with some form of liquid sloshing around in it."
 				to_chat(user, span_notice("You fill the balloon with the contents of [I]."))
-				I.reagents.trans_to(src, 10, transfered_by = user)
+				I.reagents.trans_to(src, 10, transferred_by = user)
 				update_appearance()
 	else if(I.get_sharpness())
 		balloon_burst()

--- a/code/game/objects/structures/janitor.dm
+++ b/code/game/objects/structures/janitor.dm
@@ -43,7 +43,7 @@
 		if(!CART_HAS_MINIMUM_REAGENT_VOLUME)
 			balloon_alert(user, "empty!")
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-		reagents.trans_to(weapon, weapon.reagents.maximum_volume, transfered_by = user)
+		reagents.trans_to(weapon, weapon.reagents.maximum_volume, transferred_by = user)
 		balloon_alert(user, "doused mop")
 		playsound(src, 'sound/effects/slosh.ogg', 25, vary = TRUE)
 

--- a/code/game/objects/structures/petrified_statue.dm
+++ b/code/game/objects/structures/petrified_statue.dm
@@ -68,7 +68,7 @@
 		petrified_mob.status_flags &= ~GODMODE
 		REMOVE_TRAIT(petrified_mob, TRAIT_MUTE, STATUE_MUTE)
 		REMOVE_TRAIT(petrified_mob, TRAIT_NOBLOOD, MAGIC_TRAIT)
-		petrified_mob.take_overall_damage((petrified_mob.health - atom_integrity + 100)) //any new damage the statue incurred is transfered to the mob
+		petrified_mob.take_overall_damage((petrified_mob.health - atom_integrity + 100)) //any new damage the statue incurred is transferred to the mob
 		petrified_mob.faction -= FACTION_MIMIC
 		petrified_mob.forceMove(loc)
 	return ..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -389,7 +389,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 			return FALSE
 		if(RG.is_refillable())
 			if(!RG.reagents.holder_full())
-				reagents.trans_to(RG, RG.amount_per_transfer_from_this, transfered_by = user)
+				reagents.trans_to(RG, RG.amount_per_transfer_from_this, transferred_by = user)
 				begin_reclamation()
 				to_chat(user, span_notice("You fill [RG] from [src]."))
 				return TRUE
@@ -412,7 +412,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 		if(reagents.total_volume <= 0)
 			to_chat(user, span_notice("\The [src] is dry."))
 			return FALSE
-		reagents.trans_to(O, 5, transfered_by = user)
+		reagents.trans_to(O, 5, transferred_by = user)
 		begin_reclamation()
 		to_chat(user, span_notice("You wet [O] in [src]."))
 		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -663,7 +663,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	if(!belly?.reagents.total_volume)
 		return
 	var/chemicals_lost = belly.reagents.total_volume * purge_ratio
-	belly.reagents.trans_to(V, chemicals_lost, transfered_by = M)
+	belly.reagents.trans_to(V, chemicals_lost, transferred_by = M)
 	//clear the stomach of anything even not food
 	for(var/bile in belly.reagents.reagent_list)
 		var/datum/reagent/reagent = bile

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -168,7 +168,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/specialization(datum/mind/new_owner)
 	return src
 
-///Called by the transfer_to() mind proc after the mind (mind.current and new_character.mind) has moved but before the player (key and client) is transfered.
+///Called by the transfer_to() mind proc after the mind (mind.current and new_character.mind) has moved but before the player (key and client) is transferred.
 /datum/antagonist/proc/on_body_transfer(mob/living/old_body, mob/living/new_body)
 	SHOULD_CALL_PARENT(TRUE)
 	remove_innate_effects(old_body)

--- a/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/pump.dm
@@ -5,7 +5,7 @@
 //
 // Thus, the two variables affect pump operation are set in New():
 //   air1.volume
-//     This is the volume of gas available to the pump that may be transfered to the output
+//     This is the volume of gas available to the pump that may be transferred to the output
 //   air2.volume
 //     Higher quantities of this cause more air to be perfected later
 //     but overall network volume is also increased as this increases...

--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -5,7 +5,7 @@
 //
 // Thus, the two variables affect pump operation are set in New():
 //   air1.volume
-//     This is the volume of gas available to the pump that may be transfered to the output
+//     This is the volume of gas available to the pump that may be transferred to the output
 //   air2.volume
 //     Higher quantities of this cause more air to be perfected later
 //     but overall network volume is also increased as this increases...

--- a/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
+++ b/code/modules/atmospherics/machinery/components/trinary_devices/mixer.dm
@@ -11,9 +11,9 @@
 
 	///Output pressure target
 	var/target_pressure = ONE_ATMOSPHERE
-	///Ratio between the node 1 and 2, determines the amount of gas transfered, sums up to 1
+	///Ratio between the node 1 and 2, determines the amount of gas transferred, sums up to 1
 	var/node1_concentration = 0.5
-	///Ratio between the node 1 and 2, determines the amount of gas transfered, sums up to 1
+	///Ratio between the node 1 and 2, determines the amount of gas transferred, sums up to 1
 	var/node2_concentration = 0.5
 	//node 3 is the outlet, nodes 1 & 2 are intakes
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_scrubber.dm
@@ -261,10 +261,10 @@
 			for(var/gas in filter_types & env_gases)
 				filtered_out.add_gas(gas)
 				//take this gases portion of removal_ratio of the turfs air, or all of that gas if less than or equal to MINIMUM_MOLES_TO_SCRUB
-				var/transfered_moles = max(QUANTIZE(env_gases[gas][MOLES] * removal_ratio * (env_gases[gas][MOLES] / total_moles_to_remove)), min(MINIMUM_MOLES_TO_SCRUB, env_gases[gas][MOLES]))
+				var/transferred_moles = max(QUANTIZE(env_gases[gas][MOLES] * removal_ratio * (env_gases[gas][MOLES] / total_moles_to_remove)), min(MINIMUM_MOLES_TO_SCRUB, env_gases[gas][MOLES]))
 
-				filtered_gases[gas][MOLES] = transfered_moles
-				env_gases[gas][MOLES] -= transfered_moles
+				filtered_gases[gas][MOLES] = transferred_moles
+				env_gases[gas][MOLES] -= transferred_moles
 
 			environment.garbage_collect()
 

--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -93,7 +93,7 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 			to_chat(user, span_warning("There's nothing to dissolve [weapon] in!"))
 			return
 		user.visible_message(span_notice("[user] drops [weapon] into [src]."), span_notice("You dissolve [weapon] in [src]."))
-		weapon.reagents.trans_to(src, weapon.reagents.total_volume, transfered_by = user)
+		weapon.reagents.trans_to(src, weapon.reagents.total_volume, transferred_by = user)
 		qdel(weapon)
 		return
 	// Make sure we have cooking oil

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -242,13 +242,13 @@
 	mix_message = "The mixture thickens into yoghurt."
 	reaction_flags = REACTION_INSTANT
 
-/datum/chemical_reaction/food/quality_oil_upconvert
+/datum/chemical_reaction/food/olive_oil_upconvert
 	required_reagents = list(/datum/reagent/consumable/nutriment/fat/oil/olive = 1, /datum/reagent/consumable/nutriment/fat/oil = 2)
 	results = list(/datum/reagent/consumable/nutriment/fat/oil/olive = 2)
 	mix_message = "The cooking oil dilutes the quality oil- how delightfully devilish..."
 	reaction_flags = REACTION_INSTANT
 
-/datum/chemical_reaction/food/quality_oil
+/datum/chemical_reaction/food/olive_oil
 	results = list(/datum/reagent/consumable/nutriment/fat/oil/olive = 2)
 	required_reagents = list(/datum/reagent/consumable/olivepaste = 4, /datum/reagent/water = 1)
 	reaction_flags = REACTION_INSTANT

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -47,7 +47,7 @@
 	/// Tracks the total number of ingredient items needed, for calculating multipliers. Only done once in first on_reaction
 	VAR_FINAL/total_ingredient_max
 
-	/// Multiplier applied to all reagents transfered from reagents to pot when the soup is cooked
+	/// Multiplier applied to all reagents transferred from reagents to pot when the soup is cooked
 	var/ingredient_reagent_multiplier = 0.8
 	/// What percent of nutriment is converted to "soup" (what percent does not stay final product)?
 	/// Raise this if your ingredients have a lot of nutriment and is overpowering your other reagents

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
@@ -180,12 +180,12 @@
 	result = /datum/reagent/consumable/yoghurt
 	reaction = /datum/chemical_reaction/food/yoghurt
 
-/datum/crafting_recipe/food/reaction/quality_oil
+/datum/crafting_recipe/food/reaction/olive_oil
 	result = /datum/reagent/consumable/nutriment/fat/oil/olive
-	reaction = /datum/chemical_reaction/food/quality_oil
+	reaction = /datum/chemical_reaction/food/olive_oil
 
-/datum/crafting_recipe/food/reaction/quality_oil/upconvert
-	reaction = /datum/chemical_reaction/food/quality_oil_upconvert
+/datum/crafting_recipe/food/reaction/olive_oil/upconvert
+	reaction = /datum/chemical_reaction/food/olive_oil_upconvert
 
 /datum/crafting_recipe/food/reaction/moonshine
 	reaction = /datum/chemical_reaction/drink/moonshine

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -149,7 +149,7 @@
 			reagents.add_reagent(reagent, single_reagent_amount, added_purity = average_purity)
 
 	if(reagents && target_holder)
-		reagents.trans_to(target_holder, reagents.total_volume, transfered_by = user)
+		reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
 	return TRUE
 
 #undef BITE_SIZE_POTENCY_MULTIPLIER

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -892,7 +892,7 @@
 					var/transfer_me_to_tray = reagent_source.reagents.get_reagent_amount(not_water_reagent.type) * transfer_amount / reagent_source.reagents.total_volume
 					reagent_source.reagents.trans_id_to(H.reagents, not_water_reagent.type, transfer_me_to_tray)
 			else
-				reagent_source.reagents.trans_to(H.reagents, transfer_amount, transfered_by = user)
+				reagent_source.reagents.trans_to(H.reagents, transfer_amount, transferred_by = user)
 			lastuser = WEAKREF(user)
 			if(IS_EDIBLE(reagent_source) || istype(reagent_source, /obj/item/reagent_containers/pill))
 				qdel(reagent_source)

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -124,20 +124,20 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 		brainmob.set_suicide(FALSE)
 	transfer_personality(user)
 
-/obj/item/mmi/posibrain/transfer_identity(mob/living/carbon/transfered_user)
-	name = "[initial(name)] ([transfered_user])"
-	brainmob.name = transfered_user.real_name
-	brainmob.real_name = transfered_user.real_name
-	if(transfered_user.has_dna())
+/obj/item/mmi/posibrain/transfer_identity(mob/living/carbon/transferred_user)
+	name = "[initial(name)] ([transferred_user])"
+	brainmob.name = transferred_user.real_name
+	brainmob.real_name = transferred_user.real_name
+	if(transferred_user.has_dna())
 		if(!brainmob.stored_dna)
 			brainmob.stored_dna = new /datum/dna/stored(brainmob)
-		transfered_user.dna.copy_dna(brainmob.stored_dna)
-	brainmob.timeofdeath = transfered_user.timeofdeath
+		transferred_user.dna.copy_dna(brainmob.stored_dna)
+	brainmob.timeofdeath = transferred_user.timeofdeath
 	brainmob.set_stat(CONSCIOUS)
 	if(brainmob.mind)
 		brainmob.mind.set_assigned_role(SSjob.GetJobType(posibrain_job_path))
-	if(transfered_user.mind)
-		transfered_user.mind.transfer_to(brainmob)
+	if(transferred_user.mind)
+		transferred_user.mind.transfer_to(brainmob)
 
 	brainmob.mind.remove_all_antag_datums()
 	brainmob.mind.wipe_memory()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -473,7 +473,7 @@
 
 	var/turf/floor = get_turf(src)
 	var/obj/effect/decal/cleanable/vomit/spew = new(floor, get_static_viruses())
-	bite.reagents.trans_to(spew, amount, transfered_by = src)
+	bite.reagents.trans_to(spew, amount, transferred_by = src)
 
 /mob/living/carbon/proc/spew_organ(power = 5, amt = 1)
 	for(var/i in 1 to amt)

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -40,14 +40,14 @@
 /mob/living/carbon/spill_organs(no_brain, no_organs, no_bodyparts)
 	var/atom/Tsec = drop_location()
 	if(!no_bodyparts)
-		if(no_organs)//so the organs don't get transfered inside the bodyparts we'll drop.
+		if(no_organs)//so the organs don't get transferred inside the bodyparts we'll drop.
 			for(var/organ in organs)
 				if(no_brain || !istype(organ, /obj/item/organ/internal/brain))
 					qdel(organ)
 		else //we're going to drop all bodyparts except chest, so the only organs that needs spilling are those inside it.
 			for(var/obj/item/organ/organ as anything in organs)
 				if(no_brain && istype(organ, /obj/item/organ/internal/brain))
-					qdel(organ) //so the brain isn't transfered to the head when the head drops.
+					qdel(organ) //so the brain isn't transferred to the head when the head drops.
 					continue
 				var/org_zone = check_zone(organ.zone) //both groin and chest organs.
 				if(org_zone == BODY_ZONE_CHEST)

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -208,7 +208,7 @@
  */
 /obj/effect/mob_spawn/ghost_role/proc/create_from_ghost(mob/dead/user)
 	ASSERT(istype(user))
-	var/user_ckey = user.ckey // We need to do it before everything else, because after the create() the ckey will already have been transfered.
+	var/user_ckey = user.ckey // We need to do it before everything else, because after the create() the ckey will already have been transferred.
 
 	user.log_message("became a [prompt_name].", LOG_GAME)
 	uses -= 1 // Remove a use before trying to spawn to prevent strangeness like the spawner trying to spawn more mobs than it should be able to

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -237,7 +237,7 @@
 		return
 	if(!M.reagents)
 		return
-	reagents.trans_to(M, reagents.total_volume, transfered_by = user, methods = INJECT)
+	reagents.trans_to(M, reagents.total_volume, transferred_by = user, methods = INJECT)
 
 
 /obj/item/pen/sleepy/Initialize(mapload)

--- a/code/modules/plumbing/plumbers/bottler.dm
+++ b/code/modules/plumbing/plumbers/bottler.dm
@@ -85,15 +85,15 @@
 			var/obj/item/reagent_containers/B = AM
 			///see if it would overflow else inject
 			if((B.reagents.total_volume + wanted_amount) <= B.reagents.maximum_volume)
-				reagents.trans_to(B, wanted_amount, transfered_by = src)
+				reagents.trans_to(B, wanted_amount, transferred_by = src)
 				B.forceMove(goodspot)
 				return
 			///glass was full so we move it away
 			AM.forceMove(badspot)
 		if(istype(AM, /obj/item/slime_extract)) ///slime extracts need inject
 			AM.forceMove(goodspot)
-			reagents.trans_to(AM, wanted_amount, transfered_by = src, methods = INJECT)
+			reagents.trans_to(AM, wanted_amount, transferred_by = src, methods = INJECT)
 			return
 		if(istype(AM, /obj/item/slimecross/industrial)) ///no need to move slimecross industrial things
-			reagents.trans_to(AM, wanted_amount, transfered_by = src, methods = INJECT)
+			reagents.trans_to(AM, wanted_amount, transferred_by = src, methods = INJECT)
 			return

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -243,7 +243,7 @@
 		balloon_alert(ethereal, "can't transfer power!")
 		return
 	if(istype(stomach))
-		balloon_alert(ethereal, "transfered power")
+		balloon_alert(ethereal, "transferred power")
 		stomach.adjust_charge(-APC_POWER_GAIN)
 		cell.give(APC_POWER_GAIN)
 	else

--- a/code/modules/power/turbine/turbine.dm
+++ b/code/modules/power/turbine/turbine.dm
@@ -69,14 +69,14 @@
  * Handles all the calculations needed for the gases, work done, temperature increase/decrease
  */
 /obj/machinery/power/turbine/proc/transfer_gases(datum/gas_mixture/input_mix, datum/gas_mixture/output_mix, work_amount_to_remove, intake_size = 1)
-	//pump gases. if no gases were transfered then no work was done
+	//pump gases. if no gases were transferred then no work was done
 	var/output_pressure = PRESSURE_MAX(output_mix.return_pressure())
-	var/datum/gas_mixture/transfered_gases = input_mix.pump_gas_to(output_mix, input_mix.return_pressure() * intake_size)
-	if(!transfered_gases)
+	var/datum/gas_mixture/transferred_gases = input_mix.pump_gas_to(output_mix, input_mix.return_pressure() * intake_size)
+	if(!transferred_gases)
 		return 0
 
 	//compute work done
-	var/work_done = QUANTIZE(transfered_gases.total_moles()) * R_IDEAL_GAS_EQUATION * transfered_gases.temperature * log((transfered_gases.volume * PRESSURE_MAX(transfered_gases.return_pressure())) / (output_mix.volume * output_pressure)) * TURBINE_WORK_CONVERSION_MULTIPLIER
+	var/work_done = QUANTIZE(transferred_gases.total_moles()) * R_IDEAL_GAS_EQUATION * transferred_gases.temperature * log((transferred_gases.volume * PRESSURE_MAX(transferred_gases.return_pressure())) / (output_mix.volume * output_pressure)) * TURBINE_WORK_CONVERSION_MULTIPLIER
 	if(work_amount_to_remove)
 		work_done = work_done - work_amount_to_remove
 

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -63,7 +63,7 @@
 		loaded_projectile.ignore_source_check = TRUE
 
 	if(reagents && loaded_projectile.reagents)
-		reagents.trans_to(loaded_projectile, reagents.total_volume, transfered_by = user) //For chemical darts/bullets
+		reagents.trans_to(loaded_projectile, reagents.total_volume, transferred_by = user) //For chemical darts/bullets
 		qdel(reagents)
 
 /obj/item/ammo_casing/proc/throw_proj(atom/target, turf/targloc, mob/living/user, params, spread, atom/fired_from)

--- a/code/modules/projectiles/ammunition/special/syringe.dm
+++ b/code/modules/projectiles/ammunition/special/syringe.dm
@@ -15,7 +15,7 @@
 
 		var/obj/item/reagent_containers/syringe/S = SG.syringes[1]
 
-		S.reagents.trans_to(loaded_projectile, S.reagents.total_volume, transfered_by = user)
+		S.reagents.trans_to(loaded_projectile, S.reagents.total_volume, transferred_by = user)
 		loaded_projectile.name = S.name
 		var/obj/projectile/bullet/dart/D = loaded_projectile
 		D.inject_flags = S.inject_flags
@@ -25,7 +25,7 @@
 		var/obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/syringe_gun = loc
 		var/obj/item/reagent_containers/syringe/loaded_syringe = syringe_gun.syringes[1]
 		var/obj/projectile/bullet/dart/shot_dart = loaded_projectile
-		syringe_gun.reagents.trans_to(shot_dart, min(loaded_syringe.volume, syringe_gun.reagents.total_volume), transfered_by = user)
+		syringe_gun.reagents.trans_to(shot_dart, min(loaded_syringe.volume, syringe_gun.reagents.total_volume), transferred_by = user)
 		shot_dart.name = loaded_syringe.name
 		shot_dart.inject_flags = loaded_syringe.inject_flags
 		LAZYREMOVE(syringe_gun.syringes, loaded_syringe)
@@ -45,7 +45,7 @@
 		var/obj/item/gun/chem/CG = loc
 		if(CG.syringes_left <= 0)
 			return
-		CG.reagents.trans_to(loaded_projectile, 15, transfered_by = user)
+		CG.reagents.trans_to(loaded_projectile, 15, transferred_by = user)
 		loaded_projectile.name = "piercing chemical dart"
 		CG.syringes_left--
 	return ..()

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -519,14 +519,14 @@
  * * multiplier - multiplies amount of each reagent by this number
  * * preserve_data - if preserve_data=0, the reagents data will be lost. Usefull if you use data for some strange stuff and don't want it to be transferred.
  * * no_react - passed through to [/datum/reagents/proc/add_reagent]
- * * mob/transfered_by - used for logging
+ * * mob/transferred_by - used for logging
  * * remove_blacklisted - skips transferring of reagents without REAGENT_CAN_BE_SYNTHESIZED in chemical_flags
  * * methods - passed through to [/datum/reagents/proc/expose_single] and [/datum/reagent/proc/on_transfer]
  * * show_message - passed through to [/datum/reagents/proc/expose_single]
  * * round_robin - if round_robin=TRUE, so transfer 5 from 15 water, 15 sugar and 15 plasma becomes 10, 15, 15 instead of 13.3333, 13.3333 13.3333. Good if you hate floating point errors
  * * ignore_stomach - when using methods INGEST will not use the stomach as the target
  */
-/datum/reagents/proc/trans_to(obj/target, amount = 1, multiplier = 1, preserve_data = TRUE, no_react = FALSE, mob/transfered_by, remove_blacklisted = FALSE, methods = NONE, show_message = TRUE, round_robin = FALSE, ignore_stomach = FALSE)
+/datum/reagents/proc/trans_to(obj/target, amount = 1, multiplier = 1, preserve_data = TRUE, no_react = FALSE, mob/transferred_by, remove_blacklisted = FALSE, methods = NONE, show_message = TRUE, round_robin = FALSE, ignore_stomach = FALSE)
 	var/list/cached_reagents = reagent_list
 	if(!target || !total_volume)
 		return
@@ -573,7 +573,7 @@
 				trans_data = copy_data(reagent)
 			if(reagent.intercept_reagents_transfer(R, cached_amount))//Use input amount instead.
 				continue
-			if(!R.add_reagent(reagent.type, transfer_amount * multiplier, trans_data, chem_temp, reagent.purity, reagent.ph, no_react = TRUE, ignore_splitting = reagent.chemical_flags & REAGENT_DONOTSPLIT)) //we only handle reaction after every reagent has been transfered.
+			if(!R.add_reagent(reagent.type, transfer_amount * multiplier, trans_data, chem_temp, reagent.purity, reagent.ph, no_react = TRUE, ignore_splitting = reagent.chemical_flags & REAGENT_DONOTSPLIT)) //we only handle reaction after every reagent has been transferred.
 				continue
 			if(methods)
 				r_to_send += reagent
@@ -607,7 +607,7 @@
 				transfer_amount = reagent.volume
 			if(reagent.intercept_reagents_transfer(R, cached_amount))//Use input amount instead.
 				continue
-			if(!R.add_reagent(reagent.type, transfer_amount * multiplier, trans_data, chem_temp, reagent.purity, reagent.ph, no_react = TRUE, ignore_splitting = reagent.chemical_flags & REAGENT_DONOTSPLIT)) //we only handle reaction after every reagent has been transfered.
+			if(!R.add_reagent(reagent.type, transfer_amount * multiplier, trans_data, chem_temp, reagent.purity, reagent.ph, no_react = TRUE, ignore_splitting = reagent.chemical_flags & REAGENT_DONOTSPLIT)) //we only handle reaction after every reagent has been transferred.
 				continue
 			to_transfer = max(to_transfer - transfer_amount , 0)
 			if(methods)
@@ -620,9 +620,9 @@
 			var/list/reagent_qualities = list(REAGENT_TRANSFER_AMOUNT = transfer_amount, REAGENT_PURITY = reagent.purity)
 			transfer_log[reagent.type] = reagent_qualities
 
-	if(transfered_by && target_atom)
-		target_atom.add_hiddenprint(transfered_by) //log prints so admins can figure out who touched it last.
-		log_combat(transfered_by, target_atom, "transferred reagents ([get_external_reagent_log_string(transfer_log)]) from [my_atom] to")
+	if(transferred_by && target_atom)
+		target_atom.add_hiddenprint(transferred_by) //log prints so admins can figure out who touched it last.
+		log_combat(transferred_by, target_atom, "transferred reagents ([get_external_reagent_log_string(transfer_log)]) from [my_atom] to")
 
 	update_total()
 	R.update_total()
@@ -935,7 +935,7 @@
 		return FALSE //Yup, no reactions here. No siree.
 
 	if(is_reacting)//Prevent wasteful calculations
-		if(!(datum_flags & DF_ISPROCESSING))//If we're reacting - but not processing (i.e. we've transfered)
+		if(!(datum_flags & DF_ISPROCESSING))//If we're reacting - but not processing (i.e. we've transferred)
 			START_PROCESSING(SSreagents, src)
 		if(!(has_changed_state()))
 			return FALSE
@@ -1133,7 +1133,7 @@
 * Force stops the current holder/reagents datum from reacting
 *
 * Calls end_reaction() for each equlilbrium datum in reaction_list and finish_reacting()
-* Usually only called when a datum is transfered into a NO_REACT container
+* Usually only called when a datum is transferred into a NO_REACT container
 */
 /datum/reagents/proc/force_stop_reacting()
 	var/list/mix_message = list()
@@ -1168,7 +1168,7 @@
 * Transfers the reaction_list to a new reagents datum
 *
 * Arguments:
-* * target - the datum/reagents that this src is being transfered into
+* * target - the datum/reagents that this src is being transferred into
 */
 /datum/reagents/proc/transfer_reactions(datum/reagents/target)
 	if(QDELETED(target))

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -180,7 +180,7 @@
 				to_chat(user, span_warning("[src] is full."))
 				return
 
-			var/trans = container.reagents.trans_to(src, container.amount_per_transfer_from_this, transfered_by = user)
+			var/trans = container.reagents.trans_to(src, container.amount_per_transfer_from_this, transferred_by = user)
 			to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [container]."))
 	if(I.heat < 1000)
 		return

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -409,7 +409,7 @@ GLOBAL_LIST_INIT(chem_master_containers, list(
 			adjust_item_drop_location(item)
 			item.name = item_name
 			item.reagents.clear_reagents()
-			reagents.trans_to(item, volume_in_each, transfered_by = src)
+			reagents.trans_to(item, volume_in_each, transferred_by = src)
 			printing_progress++
 			item_count--
 		update_appearance(UPDATE_ICON)

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -103,7 +103,7 @@
 	add_fingerprint(user)
 	if(is_reagent_container(I) && I.is_open_container())
 		var/obj/item/reagent_containers/RC = I
-		var/units = RC.reagents.trans_to(src, RC.amount_per_transfer_from_this, transfered_by = user)
+		var/units = RC.reagents.trans_to(src, RC.amount_per_transfer_from_this, transferred_by = user)
 		if(units)
 			to_chat(user, span_notice("You transfer [units] units of the solution to [src]."))
 			return

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -163,13 +163,13 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	holder.remove_reagent(type, metabolization_rate * M.metabolism_efficiency * seconds_per_tick) //By default it slowly disappears.
 
 /*
-Used to run functions before a reagent is transfered. Returning TRUE will block the transfer attempt.
+Used to run functions before a reagent is transferred. Returning TRUE will block the transfer attempt.
 Primarily used in reagents/reaction_agents
 */
 /datum/reagent/proc/intercept_reagents_transfer(datum/reagents/target)
 	return FALSE
 
-///Called after a reagent is transfered
+///Called after a reagent is transferred
 /datum/reagent/proc/on_transfer(atom/A, methods=TOUCH, trans_volume)
 	return
 

--- a/code/modules/reagents/chemistry/reagents/reaction_agents_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/reaction_agents_reagents.dm
@@ -35,7 +35,7 @@
 	if(target.ph <= ph)
 		target.my_atom.audible_message(span_warning("The beaker froths as the buffer is added, to no effect."))
 		playsound(target.my_atom, 'sound/chemistry/bufferadd.ogg', 50, TRUE)
-		holder.remove_reagent(type, amount)//Remove from holder because it's not transfered
+		holder.remove_reagent(type, amount)//Remove from holder because it's not transferred
 		return
 	var/ph_change = -((amount/target.total_volume)*strength)
 	target.adjust_all_reagents_ph(ph_change, ph, 14)
@@ -61,7 +61,7 @@
 	if(target.ph >= ph)
 		target.my_atom.audible_message(span_warning("The beaker froths as the buffer is added, to no effect."))
 		playsound(target.my_atom, 'sound/chemistry/bufferadd.ogg', 50, TRUE)
-		holder.remove_reagent(type, amount)//Remove from holder because it's not transfered
+		holder.remove_reagent(type, amount)//Remove from holder because it's not transferred
 		return
 	var/ph_change = (amount/target.total_volume)*strength
 	target.adjust_all_reagents_ph(ph_change, 0, ph)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -192,9 +192,9 @@
  */
 /obj/item/reagent_containers/on_accidental_consumption(mob/living/carbon/M, mob/living/carbon/user, obj/item/source_item,  discover_after = TRUE)
 	M.losebreath += 2
-	reagents?.trans_to(M, min(15, reagents.total_volume / rand(5,10)), transfered_by = user, methods = INGEST)
+	reagents?.trans_to(M, min(15, reagents.total_volume / rand(5,10)), transferred_by = user, methods = INGEST)
 	if(source_item?.reagents)
-		reagents.trans_to(source_item, min(source_item.reagents.total_volume / 2, reagents.total_volume / 5), transfered_by = user, methods = TOUCH)
+		reagents.trans_to(source_item, min(source_item.reagents.total_volume / 2, reagents.total_volume / 5), transferred_by = user, methods = TOUCH)
 
 	return ..()
 

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -62,7 +62,7 @@
 		M.visible_message(span_warning("[user] fed [M] from [src]."), \
 			span_warning("[user] fed you from [src]."))
 		log_combat(user, M, "fed", reagents.get_reagent_log_string())
-	reagents.trans_to(M, 10, transfered_by = user, methods = INGEST)
+	reagents.trans_to(M, 10, transferred_by = user, methods = INGEST)
 	playsound(M.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
 	return TRUE
 
@@ -81,7 +81,7 @@
 			to_chat(user, span_warning("[src] is full!"))
 			return
 
-		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user)
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transferred_by = user)
 		to_chat(user, span_notice("You fill [src] with [trans] units of the contents of [target]."))
 
 	//Something like a glass or a food item. Player probably wants to transfer TO it.
@@ -92,7 +92,7 @@
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
 			to_chat(user, span_warning("you can't add anymore to [target]!"))
 			return
-		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
+		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this, transferred_by = user)
 		to_chat(user, span_notice("You transfer [trans] units of the condiment to [target]."))
 
 /obj/item/reagent_containers/condiment/enzyme
@@ -456,7 +456,7 @@
 			return
 		else
 			to_chat(user, span_notice("You tear open [src] above [target] and the condiments drip onto it."))
-			src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
+			src.reagents.trans_to(target, amount_per_transfer_from_this, transferred_by = user)
 			qdel(src)
 			return
 	return . | ..()

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -85,7 +85,7 @@
 
 	SEND_SIGNAL(src, COMSIG_GLASS_DRANK, target_mob, user)
 	var/fraction = min(gulp_size/reagents.total_volume, 1)
-	reagents.trans_to(target_mob, gulp_size, transfered_by = user, methods = INGEST)
+	reagents.trans_to(target_mob, gulp_size, transferred_by = user, methods = INGEST)
 	checkLiked(fraction, target_mob)
 	playsound(target_mob.loc,'sound/items/drink.ogg', rand(10,50), TRUE)
 	if(!iscarbon(target_mob))
@@ -123,7 +123,7 @@
 			to_chat(user, span_warning("[target] is full."))
 			return
 
-		var/trans = reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
+		var/trans = reagents.trans_to(target, amount_per_transfer_from_this, transferred_by = user)
 		to_chat(user, span_notice("You transfer [trans] unit\s of the solution to [target]."))
 
 	else if(target.is_drainable()) //A dispenser. Transfer FROM it TO us.
@@ -135,7 +135,7 @@
 			to_chat(user, span_warning("[src] is full."))
 			return
 
-		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user)
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transferred_by = user)
 		to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [target]."))
 
 	target.update_appearance()
@@ -156,7 +156,7 @@
 			to_chat(user, span_warning("[src] is full."))
 			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user)
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transferred_by = user)
 		to_chat(user, span_notice("You fill [src] with [trans] unit\s of the contents of [target]."))
 
 	target.update_appearance()
@@ -192,7 +192,7 @@
 			to_chat(user, span_notice("[src] is full."))
 		else
 			to_chat(user, span_notice("You break [attacking_egg] in [src]."))
-			attacking_egg.reagents.trans_to(src, attacking_egg.reagents.total_volume, transfered_by = user)
+			attacking_egg.reagents.trans_to(src, attacking_egg.reagents.total_volume, transferred_by = user)
 			qdel(attacking_egg)
 		return
 
@@ -407,7 +407,7 @@
 		if(reagents.total_volume < 1)
 			user.balloon_alert(user, "empty!")
 		else
-			reagents.trans_to(O, 5, transfered_by = user)
+			reagents.trans_to(O, 5, transferred_by = user)
 			user.balloon_alert(user, "doused [O]")
 			playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
 		return

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -501,7 +501,7 @@
 			balloon_alert(user, "container full!")
 			return TRUE
 
-		var/transfer_amount = reagents.trans_to(attacking_item, amount_per_transfer_from_this, transfered_by = user)
+		var/transfer_amount = reagents.trans_to(attacking_item, amount_per_transfer_from_this, transferred_by = user)
 		balloon_alert(user, "transferred [transfer_amount] unit\s")
 		flick("syrup_anim",src)
 

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -36,7 +36,7 @@
 		sleep(1 SECONDS)
 	H.visible_message(span_suicide("[H] takes a big sip from [src]! It looks like [H.p_theyre()] trying to commit suicide!"))
 	playsound(H,'sound/items/drink.ogg', 80, TRUE)
-	reagents.trans_to(H, src.reagents.total_volume, transfered_by = H) //a big sip
+	reagents.trans_to(H, src.reagents.total_volume, transferred_by = H) //a big sip
 	sleep(0.5 SECONDS)
 	H.say(pick(
 		"Now, Outbomb Cuban Pete, THAT was a game.",

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -41,7 +41,7 @@
 					if(!safe_thing.reagents)
 						safe_thing.create_reagents(100)
 
-					trans = reagents.trans_to(safe_thing, amount_per_transfer_from_this, transfered_by = user, methods = TOUCH)
+					trans = reagents.trans_to(safe_thing, amount_per_transfer_from_this, transferred_by = user, methods = TOUCH)
 
 					target.visible_message(span_danger("[user] tries to squirt something into [target]'s eyes, but fails!"), \
 											span_userdanger("[user] tries to squirt something into your eyes, but fails!"))
@@ -65,7 +65,7 @@
 
 			log_combat(user, M, "squirted", R)
 
-		trans = src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
+		trans = src.reagents.trans_to(target, amount_per_transfer_from_this, transferred_by = user)
 		to_chat(user, span_notice("You transfer [trans] unit\s of the solution."))
 		update_appearance()
 		target.update_appearance()
@@ -80,7 +80,7 @@
 			to_chat(user, span_warning("[target] is empty!"))
 			return
 
-		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user)
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transferred_by = user)
 
 		to_chat(user, span_notice("You fill [src] with [trans] unit\s of the solution."))
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -46,7 +46,7 @@
 		if(affected_mob.reagents)
 			var/trans = 0
 			if(!infinite)
-				trans = reagents.trans_to(affected_mob, amount_per_transfer_from_this, transfered_by = user, methods = INJECT)
+				trans = reagents.trans_to(affected_mob, amount_per_transfer_from_this, transferred_by = user, methods = INJECT)
 			else
 				reagents.expose(affected_mob, INJECT, fraction)
 				trans = reagents.copy_to(affected_mob, amount_per_transfer_from_this)

--- a/code/modules/reagents/reagent_containers/medigel.dm
+++ b/code/modules/reagents/reagent_containers/medigel.dm
@@ -67,7 +67,7 @@
 	else
 		log_combat(user, M, "applied", src, reagents.get_reagent_log_string())
 		playsound(src, 'sound/effects/spray.ogg', 30, TRUE, -6)
-		reagents.trans_to(M, amount_per_transfer_from_this, transfered_by = user, methods = apply_type)
+		reagents.trans_to(M, amount_per_transfer_from_this, transferred_by = user, methods = apply_type)
 	return
 
 /obj/item/reagent_containers/medigel/libital

--- a/code/modules/reagents/reagent_containers/misc.dm
+++ b/code/modules/reagents/reagent_containers/misc.dm
@@ -146,7 +146,7 @@
 	var/reagentlist = pretty_string_from_reagent_list(reagents.reagent_list)
 	var/log_object = "containing [reagentlist]"
 	if(user.combat_mode && !carbon_target.is_mouth_covered())
-		reagents.trans_to(carbon_target, reagents.total_volume, transfered_by = user, methods = INGEST)
+		reagents.trans_to(carbon_target, reagents.total_volume, transferred_by = user, methods = INGEST)
 		carbon_target.visible_message(span_danger("[user] smothers \the [carbon_target] with \the [src]!"), span_userdanger("[user] smothers you with \the [src]!"), span_hear("You hear some struggling and muffled cries of surprise."))
 		log_combat(user, carbon_target, "smothered", src, log_object)
 	else

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -53,7 +53,7 @@
 	if(apply_type == INGEST)
 		SEND_SIGNAL(src, COMSIG_PILL_CONSUMED, eater = M, feeder = user)
 	if(reagents.total_volume)
-		reagents.trans_to(M, reagents.total_volume, transfered_by = user, methods = apply_type)
+		reagents.trans_to(M, reagents.total_volume, transferred_by = user, methods = apply_type)
 	qdel(src)
 	return TRUE
 
@@ -74,7 +74,7 @@
 		return
 
 	user.visible_message(span_warning("[user] slips something into [target]!"), span_notice("You dissolve [src] in [target]."), null, 2)
-	reagents.trans_to(target, reagents.total_volume, transfered_by = user)
+	reagents.trans_to(target, reagents.total_volume, transferred_by = user)
 	qdel(src)
 
 /*
@@ -82,7 +82,7 @@
  */
 /obj/item/reagent_containers/pill/on_accidental_consumption(mob/living/carbon/victim, mob/living/carbon/user, obj/item/source_item, discover_after = FALSE)
 	to_chat(victim, span_warning("You swallow something small. [source_item ? "Was that in [source_item]?" : ""]"))
-	reagents?.trans_to(victim, reagents.total_volume, transfered_by = user, methods = INGEST)
+	reagents?.trans_to(victim, reagents.total_volume, transferred_by = user, methods = INGEST)
 	qdel(src)
 	return discover_after
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -42,7 +42,7 @@
 			to_chat(user, span_warning("[src] is full."))
 			return
 
-		var/trans = target.reagents.trans_to(src, 50, transfered_by = user) //transfer 50u , using the spray's transfer amount would take too long to refill
+		var/trans = target.reagents.trans_to(src, 50, transferred_by = user) //transfer 50u , using the spray's transfer amount would take too long to refill
 		to_chat(user, span_notice("You fill \the [src] with [trans] units of the contents of \the [target]."))
 		return
 

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -82,7 +82,7 @@
 			living_target.log_message("injected themselves ([contained]) with [name]", LOG_ATTACK, color="orange")
 		else
 			log_combat(user, living_target, "injected", src, addition="which had [contained]")
-	reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user, methods = INJECT)
+	reagents.trans_to(target, amount_per_transfer_from_this, transferred_by = user, methods = INJECT)
 	to_chat(user, span_notice("You inject [amount_per_transfer_from_this] units of the solution. The syringe now contains [reagents.total_volume] units."))
 	target.update_appearance()
 
@@ -117,7 +117,7 @@
 			to_chat(user, span_warning("You cannot directly remove reagents from [target]!"))
 			return SECONDARY_ATTACK_CONTINUE_CHAIN
 
-		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user) // transfer from, transfer to - who cares?
+		var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transferred_by = user) // transfer from, transfer to - who cares?
 
 		to_chat(user, span_notice("You fill [src] with [trans] units of the solution. It now contains [reagents.total_volume] units."))
 		target.update_appearance()
@@ -134,7 +134,7 @@
 		to_chat(victim, span_boldwarning("[src] injects you!"))
 
 	victim.apply_damage(5, BRUTE, BODY_ZONE_HEAD)
-	reagents?.trans_to(victim, round(reagents.total_volume*(2/3)), transfered_by = user, methods = INJECT)
+	reagents?.trans_to(victim, round(reagents.total_volume*(2/3)), transferred_by = user, methods = INJECT)
 
 	return discover_after
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -286,7 +286,7 @@
 			if(W.reagents.has_reagent(/datum/reagent/fuel, W.max_fuel))
 				to_chat(user, span_warning("Your [W.name] is already full!"))
 				return
-			reagents.trans_to(W, W.max_fuel, transfered_by = user)
+			reagents.trans_to(W, W.max_fuel, transferred_by = user)
 			user.visible_message(span_notice("[user] refills [user.p_their()] [W.name]."), span_notice("You refill [W]."))
 			playsound(src, 'sound/effects/refill.ogg', 50, TRUE)
 			W.update_appearance()

--- a/code/modules/research/xenobiology/crossbreeding/__corecross.dm
+++ b/code/modules/research/xenobiology/crossbreeding/__corecross.dm
@@ -152,7 +152,7 @@ To add a crossbreed:
 		to_chat(user, span_warning("This can only be used on yourself."))
 		return
 	if(reagents.total_volume && (ignore_flags || M.try_inject(user, injection_flags = INJECT_TRY_SHOW_ERROR_MESSAGE)))
-		reagents.trans_to(M, reagents.total_volume, transfered_by = user)
+		reagents.trans_to(M, reagents.total_volume, transferred_by = user)
 		if(user != M)
 			to_chat(M, span_warning("[user] presses [src] against you!"))
 			to_chat(user, span_notice("You press [src] against [M], injecting [M.p_them()]."))

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -52,6 +52,6 @@
 	to_chat(owner, span_notice("You grit your teeth and burst the implanted [item_target.name]!"))
 	owner.log_message("swallowed an implanted pill, [target]", LOG_ATTACK)
 	if(item_target.reagents.total_volume)
-		item_target.reagents.trans_to(owner, item_target.reagents.total_volume, transfered_by = owner, methods = INGEST)
+		item_target.reagents.trans_to(owner, item_target.reagents.total_volume, transferred_by = owner, methods = INGEST)
 	qdel(target)
 	return TRUE

--- a/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/medical_tools.dm
@@ -428,7 +428,7 @@
 	if(!chassis.Adjacent(S))
 		to_chat(user, "[icon2html(src, user)][span_warning("Unable to load syringe!")]")
 		return FALSE
-	S.reagents.trans_to(src, S.reagents.total_volume, transfered_by = user)
+	S.reagents.trans_to(src, S.reagents.total_volume, transferred_by = user)
 	S.forceMove(src)
 	LAZYADD(syringes,S)
 	to_chat(user, "[icon2html(src, user)][span_notice("Syringe loaded.")]")

--- a/html/changelogs/archive/2013-02.yml
+++ b/html/changelogs/archive/2013-02.yml
@@ -3,7 +3,7 @@
   - rscadd: Signallers, prox sensors, mouse traps and infrared beams can now be attacheed
       to grenades to create a variety of mines.
   - rscadd: A slime core can be placed in a large grenade in place of a beaker. When
-      the grenade goes off, the chemicals from the second container will be transferred
+      the grenade goes off, the chemicals from the second container will be transfered
       to the slime core, triggering the usual reaction.
 2013-02-13:
   Petethegoat:

--- a/html/changelogs/archive/2013-02.yml
+++ b/html/changelogs/archive/2013-02.yml
@@ -3,7 +3,7 @@
   - rscadd: Signallers, prox sensors, mouse traps and infrared beams can now be attacheed
       to grenades to create a variety of mines.
   - rscadd: A slime core can be placed in a large grenade in place of a beaker. When
-      the grenade goes off, the chemicals from the second container will be transfered
+      the grenade goes off, the chemicals from the second container will be transferred
       to the slime core, triggering the usual reaction.
 2013-02-13:
   Petethegoat:

--- a/html/changelogs/archive/2018-01.yml
+++ b/html/changelogs/archive/2018-01.yml
@@ -30,7 +30,7 @@
       on Omegastation
   XDTM:
   - bugfix: Fixed Runic Golem's Abyssal Gaze blinding permanently.
-  - balance: Ocular Restoration has been removed, its effect transfered on Sensory
+  - balance: Ocular Restoration has been removed, its effect transferred on Sensory
       Restoration.
   - balance: Sensory Restoration now heals both eye and ear damage.
   - balance: Mind Restoration now no longer heals ear damage, but now heals brain

--- a/html/changelogs/archive/2018-01.yml
+++ b/html/changelogs/archive/2018-01.yml
@@ -30,7 +30,7 @@
       on Omegastation
   XDTM:
   - bugfix: Fixed Runic Golem's Abyssal Gaze blinding permanently.
-  - balance: Ocular Restoration has been removed, its effect transferred on Sensory
+  - balance: Ocular Restoration has been removed, its effect transfered on Sensory
       Restoration.
   - balance: Sensory Restoration now heals both eye and ear damage.
   - balance: Mind Restoration now no longer heals ear damage, but now heals brain

--- a/html/changelogs/archive/2022-01.yml
+++ b/html/changelogs/archive/2022-01.yml
@@ -41,7 +41,7 @@
   - bugfix: Massively decreased initialization times in best case scenarios.
   SmArtKar:
   - bugfix: Sacrificing a mindshielded person no longer causes their soul to be left
-      in their brain instead of getting transfered to the soulstone
+      in their brain instead of getting transferred to the soulstone
   interestingusernam3:
   - bugfix: Silicons and other mobs that shouldn't be able to lie down now won't lie
       down no matter what happens.

--- a/html/changelogs/archive/2022-01.yml
+++ b/html/changelogs/archive/2022-01.yml
@@ -41,7 +41,7 @@
   - bugfix: Massively decreased initialization times in best case scenarios.
   SmArtKar:
   - bugfix: Sacrificing a mindshielded person no longer causes their soul to be left
-      in their brain instead of getting transferred to the soulstone
+      in their brain instead of getting transfered to the soulstone
   interestingusernam3:
   - bugfix: Silicons and other mobs that shouldn't be able to lie down now won't lie
       down no matter what happens.

--- a/html/changelogs/archive/2023-08.yml
+++ b/html/changelogs/archive/2023-08.yml
@@ -268,7 +268,7 @@
   Ben10Omintrix:
   - bugfix: the bee will now care more about polinating
   - qol: in case u miscliked the bee queen with a seringe 2 times, the raegent will
-      not be transfered to the quen if he alredy have this raegent
+      not be transferred to the quen if he alredy have this raegent
   BlueMemesauce:
   - rscadd: Emagged player-controlled bots now get different flavor text (depends
       on policy)

--- a/html/changelogs/archive/2023-08.yml
+++ b/html/changelogs/archive/2023-08.yml
@@ -268,7 +268,7 @@
   Ben10Omintrix:
   - bugfix: the bee will now care more about polinating
   - qol: in case u miscliked the bee queen with a seringe 2 times, the raegent will
-      not be transferred to the quen if he alredy have this raegent
+      not be transfered to the quen if he alredy have this raegent
   BlueMemesauce:
   - rscadd: Emagged player-controlled bots now get different flavor text (depends
       on policy)


### PR DESCRIPTION
## About The Pull Request

Transferred.

## Why It's Good For The Game

How did this get to be in 71 files?! This bothers me.

Also changes 'quality_oil' typepath in the reactions to 'olive_oil' to match its rename post-foodening.

## Changelog
N/A