### PR TITLE
Updates some missed synthetic meats with lower reagent purity

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -55,6 +55,7 @@
 	name = "imitation carp fillet"
 	desc = "Almost just like the real thing, kinda."
 	cell_line = null
+	starting_reagent_purity = 0.3
 
 /obj/item/food/fishmeat/moonfish
 	name = "moonfish fillet"

--- a/code/game/objects/items/food/meatslab.dm
+++ b/code/game/objects/items/food/meatslab.dm
@@ -160,6 +160,7 @@
 	desc = "A slab of station reclaimed and chemically processed meat product."
 	tastes = list("meat flavoring" = 2, "modified starches" = 2, "natural & artificial dyes" = 1, "butyric acid" = 1)
 	foodtypes = RAW | MEAT
+	starting_reagent_purity = 0.3
 
 /obj/item/food/meat/slab/meatproduct/make_grillable()
 	AddComponent(/datum/component/grillable, /obj/item/food/meat/steak/meatproduct, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE)


### PR DESCRIPTION
## About The Pull Request

These synthetic meats appear to have been missed in the foodening PR.

## Why It's Good For The Game

Consistency

## Changelog

:cl:
fix: 'meat product' and imitation carp meat are now considered synthetic meats for the purposes of reagent purity
/:cl:

