### PR TITLE
Resolves parallax harddels

### DIFF
--- a/code/_onclick/hud/parallax/parallax.dm
+++ b/code/_onclick/hud/parallax/parallax.dm
@@ -273,6 +273,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 
 /atom/movable/screen/parallax_layer/Initialize(mapload, datum/hud/hud_owner, template = FALSE)
 	. = ..()
+	// Parallax layers are independant of hud, they care about client
+	// Not doing this will just create a bunch of hard deletes
+	hud = null
 
 	if(template)
 		return


### PR DESCRIPTION

## About The Pull Request

JOHNNNNNNNNNNNNNNNNNNNNNNNN
Parallax layers are independent of the hud they're spawned from, tied instead to the client. #76772 caused them to hang a bunch of improper hard references to huds, so let's just make our own edge case here

Hopefully this'll clear up #78015 and the logs it produces, make em more helpful