### PR TITLE
[NO GBP] Add some istype guards to the PDA messenger's `get_messengers` proc

### DIFF
--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -91,6 +91,8 @@
 
 	for(var/messenger_ref in messengers_sorted)
 		var/datum/computer_file/program/messenger/messenger = messengers_sorted[messenger_ref]
+		if(!istype(messenger) || !istype(messenger.computer))
+			continue
 		if(messenger == src || messenger.invisible)
 			continue
 


### PR DESCRIPTION
## About The Pull Request

Read title, not having these checks can knock out the messenger for everyone for the entire round
## Why It's Good For The Game

I didn't think about hard deletes in my original NT Messenger PR, and as far as I know this hasn't happened on this codebase yet. 
However this PR doesn't only help downstreams that struggle with hard deletes, it also implements some pretty critical guards as not having a messenger for an entire round is pretty bad and sometimes hard deletes are very hard to track and fix, so it could potentially break the messenger for a lot of rounds.
