### PR TITLE
You can no longer create non-synthesizable chemicals with bees.

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -259,7 +259,7 @@
 	if(isnull(chemical))
 		return
 	if(!(chemical.chemical_flags & REAGENT_CAN_BE_SYNTHESIZED))
-		to_chat(user, span_warning("[queen] backs away from the syringe, fearful of the non-synthesizable contents!"))
+		to_chat(user, span_warning("[queen] does not react to the contents of the syringe. It appears that the contents are not able to be synthesized naturally!"))
 		return
 	if(chemical.type == queen.beegent?.type)
 		to_chat(user, span_warning("[queen] already has this chemical!"))

--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -258,6 +258,9 @@
 	var/datum/reagent/chemical = needle.reagents.get_master_reagent()
 	if(isnull(chemical))
 		return
+	if(!(chemical.chemical_flags & REAGENT_CAN_BE_SYNTHESIZED))
+		to_chat(user, span_warning("[queen] backs away from the syringe, fearful of the non-synthesizable contents!"))
+		return
 	if(chemical.type == queen.beegent?.type)
 		to_chat(user, span_warning("[queen] already has this chemical!"))
 		return

--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -259,7 +259,7 @@
 	if(isnull(chemical))
 		return
 	if(!(chemical.chemical_flags & REAGENT_CAN_BE_SYNTHESIZED))
-		to_chat(user, span_warning("[queen] does not react to the contents of the syringe. It appears that the contents are not able to be synthesized naturally!"))
+		to_chat(user, span_warning("[chemical.name] cannot be inserted into a bee's genome!"))
 		return
 	if(chemical.type == queen.beegent?.type)
 		to_chat(user, span_warning("[queen] already has this chemical!"))


### PR DESCRIPTION
## About The Pull Request

You can no longer create non-synthesizable chemicals with bees.

## Why It's Good For The Game

Fixes the ability to mass produce reagents that aren't supposed to be directly synthesized.

## Changelog

:cl:
fix: You can no longer create non-synthesizable chemicals with bees.
/:cl: