### PR TITLE
Service borg extra apparatus upgrade

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -190,6 +190,7 @@
 	handle_reflling(arrived)
 	return ..()
 
+///Used by the service borg drink apparatus upgrade, holds drink-related items
 /obj/item/borg/apparatus/beaker/drink
 	name = "secondary beverage storage apparatus"
 	desc = "A special apparatus for carrying drinks and condiment packets without spilling their contents. Will NOT resynthesize drinks unlike your standard apparatus."

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -190,7 +190,7 @@
 	handle_reflling(arrived)
 	return ..()
 
-/obj/item/borg/apparatus/beaker/service2
+/obj/item/borg/apparatus/beaker/drink
 	name = "secondary beverage storage apparatus"
 	desc = "A special apparatus for carrying drinks and condiment packets without spilling their contents. Will NOT resynthesize drinks unlike your standard apparatus."
 	icon_state = "borg_beaker_apparatus"

--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -190,6 +190,20 @@
 	handle_reflling(arrived)
 	return ..()
 
+/obj/item/borg/apparatus/beaker/service2
+	name = "secondary beverage storage apparatus"
+	desc = "A special apparatus for carrying drinks and condiment packets without spilling their contents. Will NOT resynthesize drinks unlike your standard apparatus."
+	icon_state = "borg_beaker_apparatus"
+	storable = list(
+		/obj/item/reagent_containers/cup/glass,
+		/obj/item/reagent_containers/condiment,
+		/obj/item/reagent_containers/cup/coffeepot,
+		/obj/item/reagent_containers/cup/bottle/syrup_bottle,
+	)
+
+/obj/item/borg/apparatus/beaker/service2/add_glass()
+	stored = new /obj/item/reagent_containers/cup/glass/drinkingglass(src)
+
 /// allows medical cyborgs to manipulate organs without hands
 /obj/item/borg/apparatus/organ_storage
 	name = "organ storage bag"

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -732,7 +732,7 @@
 /obj/item/borg/upgrade/drink_app/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
-		var/obj/item/borg/apparatus/beaker/service2/E = locate() in R.model.modules
+		var/obj/item/borg/apparatus/beaker/drink/E = locate() in R.model.modules
 		if(E)
 			to_chat(user, span_warning("This unit has no room for additional drink storage!"))
 			return FALSE
@@ -744,7 +744,7 @@
 /obj/item/borg/upgrade/drink_app/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
-		var/obj/item/borg/apparatus/beaker/service2/E = locate() in R.model.modules
+		var/obj/item/borg/apparatus/beaker/drink/E = locate() in R.model.modules
 		if (E)
 			R.model.remove_module(E, TRUE)
 

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -721,6 +721,33 @@
 		if (E)
 			R.model.remove_module(E, TRUE)
 
+/obj/item/borg/upgrade/drink_app
+	name = "glass storage apparatus"
+	desc = "A supplementary drinking glass storage apparatus for service cyborgs."
+	icon_state = "cyborg_upgrade3"
+	require_model = TRUE
+	model_type = list(/obj/item/robot_model/service)
+	model_flags = BORG_MODEL_SERVICE
+
+/obj/item/borg/upgrade/drink_app/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		var/obj/item/borg/apparatus/beaker/service2/E = locate() in R.model.modules
+		if(E)
+			to_chat(user, span_warning("This unit has no room for additional drink storage!"))
+			return FALSE
+
+		E = new(R.model)
+		R.model.basic_modules += E
+		R.model.add_module(E, FALSE, TRUE)
+
+/obj/item/borg/upgrade/drink_app/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if (.)
+		var/obj/item/borg/apparatus/beaker/service2/E = locate() in R.model.modules
+		if (E)
+			R.model.remove_module(E, TRUE)
+
 /obj/item/borg/upgrade/broomer
 	name = "experimental push broom"
 	desc = "An experimental push broom used for efficiently pushing refuse."

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1173,6 +1173,17 @@
 		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_SERVICE
 	)
 
+/datum/design/borg_upgrade_drink_apparatus
+	name = "Drink Apparatus"
+	id = "borg_upgrade_drink_apparatus"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/drink_app
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = SHEET_MATERIAL_AMOUNT)
+	construction_time = 4 SECONDS
+	category = list(
+		RND_CATEGORY_MECHFAB_CYBORG_MODULES + RND_SUBCATEGORY_MECHFAB_CYBORG_MODULES_SERVICE
+	)
+	
 /datum/design/borg_upgrade_service_apparatus
 	name = "Service Apparatus"
 	id = "borg_upgrade_service_apparatus"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -965,7 +965,7 @@
 		"borg_upgrade_condiment_synthesizer",
 		"borg_upgrade_silicon_knife",
 		"borg_upgrade_service_apparatus",
-		"borg_upgrade_drink_aparatus",
+		"borg_upgrade_drink_apparatus",
 		"borg_upgrade_service_cookbook",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -965,6 +965,7 @@
 		"borg_upgrade_condiment_synthesizer",
 		"borg_upgrade_silicon_knife",
 		"borg_upgrade_service_apparatus",
+		"borg_upgrade_drink_aparatus",
 		"borg_upgrade_service_cookbook",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)


### PR DESCRIPTION

## About The Pull Request

Adds an upgrade similar to the extra beaker storage for mediborgs to service borgs, which adds an additional drink apparatus (that also doesn't do the weird drink refilling thing)
## Why It's Good For The Game

This can allow the service borg to carry a wider variety of drinks, also considering they specialize in chemistry, they should get an apparatus upgrade like mediborgs.

## Changelog
:cl:
add: Added the service borg "drink apparatus" upgrade, which adds an extra drinking apparatus to the borg, up to a maximum of 5 extra.
:cl:
