### PR TITLE
Fixed walking into grilles to destroy them

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -133,8 +133,6 @@
 		return
 	var/mob/M = AM
 	shock(M, 70)
-	if(prob(50))
-		take_damage(1, BURN, FIRE, sound_effect = FALSE)
 
 /obj/structure/grille/attack_animal(mob/user, list/modifiers)
 	. = ..()
@@ -321,6 +319,9 @@
 	var/turf/T = get_turf(src)
 	if(T.overfloor_placed)//cant be a floor in the way!
 		return FALSE
+	// Shocking hurts the grille (to weaken monkey powersinks)
+	if(prob(50))
+		take_damage(1, BURN, FIRE, sound_effect = FALSE)
 	var/obj/structure/cable/C = T.get_cable_node()
 	if(C)
 		if(electrocute_mob(user, C, src, 1, TRUE))


### PR DESCRIPTION

## About The Pull Request

Fixed walking into grilles to destroy them because the take damage proc was always called on bump rather than checking if shock worked or not. I did that by moving the dmg entirely to the shock proc, 'cuz that just makes more sense than 'only' bumps damaging the grille

## Why It's Good For The Game

Presumably you are not intended to walk into grilles to destroy them

## Changelog

:cl:
fix: Fixed walking into grilles to destroy them
/:cl:

