### PR TITLE
Basic mobs drop their butcher results when gibbed

### DIFF
--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -141,6 +141,19 @@
 		health = 0
 		look_dead()
 
+/mob/living/basic/gib()
+	if(butcher_results || guaranteed_butcher_results)
+		var/list/butcher_loot = list()
+		if(butcher_results)
+			butcher_loot += butcher_results
+		if(guaranteed_butcher_results)
+			butcher_loot += guaranteed_butcher_results
+		var/atom/loot_destination = drop_location()
+		for(var/path in butcher_loot)
+			for(var/i in 1 to butcher_loot[path])
+				new path(loot_destination)
+	return ..()
+
 /**
  * Apply the appearance and properties this mob has when it dies
  * This is called by the mob pretending to be dead too so don't put loot drops in here or something


### PR DESCRIPTION
## About The Pull Request

Title.

## Why It's Good For The Game

Fixes #78089
Simple mobs drop their meats when gibbed but basic mobs don't which is weird and inconsistent.

## Changelog

:cl:
fix: fixed basic mobs not dropping their butcher results when gibbed
/:cl: