### PR TITLE
Move some job related achievements into the job achievement category

### DIFF
--- a/code/datums/achievements/job_achievements.dm
+++ b/code/datums/achievements/job_achievements.dm
@@ -2,13 +2,55 @@
 /datum/award/achievement/jobs
 	category = "Jobs"
 
-//chemistry
+//engineering
+
+/datum/award/achievement/jobs/theoretical_limits
+	name = "All Within Theoretical Limits"
+	desc = "I never thought I'd see a resonance cascade, let alone prevent one..."
+	database_id = MEDAL_THEORETICAL_LIMITS
+	icon = "theoreticallimits"
+
+//medical
+
+/datum/award/achievement/jobs/sandman
+	name = "Mister Sandman"
+	desc = "Mechanically speaking, there's no real benefit to being unconscious during surgery. Weird how insistent this doctor is about using the N2O anyway though, huh?"
+	database_id = MEDAL_SANDMAN
+	icon = "basemisc"
+
+/datum/award/achievement/jobs/helbitaljanken
+	name = "Helbitaljanken"
+	desc = "You janked hard"
+	database_id = MEDAL_HELBITALJANKEN
+	icon = "helbital"
 
 /datum/award/achievement/jobs/chemistry_tut
 	name = "Perfect chemistry blossom"
 	desc = "Passed the chemistry tutorial with perfect purity!"
 	database_id = MEDAL_CHEM_TUT
 	icon = "chem_tut"
+
+//mining
+
+/datum/award/achievement/jobs/frenching
+	name = "Frenching"
+	desc = "Just a taste, for science!"
+	database_id = MEDAL_FRENCHING
+	icon = "frenchingthebubble"
+
+//science
+
+/datum/award/achievement/jobs/feat_of_strength
+	name = "Feat of Strength"
+	desc = "If the rod is immovable, is it passing you or are you passing it?"
+	database_id = MEDAL_RODSUPLEX
+	icon = "featofstrength"
+
+/datum/award/achievement/jobs/snail
+	name = "KKKiiilll mmmeee"
+	desc = "You were a little too ambitious, but hey, I guess you're still alive?"
+	database_id = MEDAL_SNAIL
+	icon = "snail"
 
 //all of service! hip hip!
 

--- a/code/datums/achievements/misc_achievements.dm
+++ b/code/datums/achievements/misc_achievements.dm
@@ -20,12 +20,6 @@
 	database_id = MEDAL_TIMEWASTE
 	icon = "timewaste"
 
-/datum/award/achievement/misc/feat_of_strength
-	name = "Feat of Strength"
-	desc = "If the rod is immovable, is it passing you or are you passing it?"
-	database_id = MEDAL_RODSUPLEX
-	icon = "featofstrength"
-
 /datum/award/achievement/misc/round_and_full
 	name = "Round and Full"
 	desc = "Well at least you aren't down the river, I hear they eat people there."
@@ -37,12 +31,6 @@
 	desc = "100 honks later"
 	database_id = MEDAL_THANKSALOT
 	icon = "clownthanks"
-
-/datum/award/achievement/misc/helbitaljanken
-	name = "Helbitaljanken"
-	desc = "You janked hard"
-	database_id = MEDAL_HELBITALJANKEN
-	icon = "helbital"
 
 /datum/award/achievement/misc/getting_an_upgrade
 	name = "Getting an upgrade"
@@ -76,11 +64,6 @@
 	desc = "If you saw someone casually club themselves upside the head with a toolbox anywhere in the galaxy but here, you'd probably be pretty concerned for them."
 	database_id = MEDAL_SELFOUCH
 
-/datum/award/achievement/misc/sandman
-	name = "Mister Sandman"
-	desc = "Mechanically speaking, there's no real benefit to being unconscious during surgery. Weird how insistent this doctor is about using the N2O anyway though, huh?"
-	database_id = MEDAL_SANDMAN
-
 /datum/award/achievement/misc/cleanboss
 	name = "One Lean, Mean, Cleaning Machine"
 	desc = "How does it feel to know that your workplace values a mop bucket on wheels more than you?" // i can do better than this give me time
@@ -97,12 +80,6 @@
 	desc = "Well, that didn't take long."
 	database_id = MEDAL_LONGSHIFT
 	icon = "longshift"
-
-/datum/award/achievement/misc/snail
-	name = "KKKiiilll mmmeee"
-	desc = "You were a little too ambitious, but hey, I guess you're still alive?"
-	database_id = MEDAL_SNAIL
-	icon = "snail"
 
 /datum/award/achievement/misc/lookoutsir
 	name = "Look Out, Sir!"
@@ -121,12 +98,6 @@
 	desc = "Caedite eos. Novit enim Dominus qui sunt eius."
 	database_id = MEDAL_ASCENSION
 	icon = "ascension"
-
-/datum/award/achievement/misc/frenching
-	name = "Frenching"
-	desc = "Just a taste, for science!"
-	database_id = MEDAL_FRENCHING
-	icon = "frenchingthebubble"
 
 /datum/award/achievement/misc/ash_ascension
 	name = "Nightwatcher's Eyes"
@@ -242,8 +213,3 @@
 	database_id = MEDAL_DEBT_EXTINGUISHED
 	icon = "outdebted"
 
-/datum/award/achievement/misc/theoretical_limits
-	name = "All Within Theoretical Limits"
-	desc = "I never thought I'd see a resonance cascade, let alone prevent one..."
-	database_id = MEDAL_THEORETICAL_LIMITS
-	icon = "theoreticallimits"

--- a/code/datums/diseases/gastrolisis.dm
+++ b/code/datums/diseases/gastrolisis.dm
@@ -65,7 +65,7 @@
 
 			if(shell && eyes && tongue && SPT_PROB(2.5, seconds_per_tick))
 				affected_mob.set_species(/datum/species/snail)
-				affected_mob.client?.give_award(/datum/award/achievement/misc/snail, affected_mob)
+				affected_mob.client?.give_award(/datum/award/achievement/jobs/snail, affected_mob)
 				affected_mob.visible_message(span_warning("[affected_mob] turns into a snail!"), \
 				span_boldnotice("You turned into a snail person! You feel an urge to cccrrraaawwwlll..."))
 				cure()

--- a/code/modules/events/immovable_rod/immovable_rod.dm
+++ b/code/modules/events/immovable_rod/immovable_rod.dm
@@ -249,7 +249,7 @@
  * * strongman - the suplexer of the rod.
  */
 /obj/effect/immovablerod/proc/suplex_rod(mob/living/strongman)
-	strongman.client?.give_award(/datum/award/achievement/misc/feat_of_strength, strongman)
+	strongman.client?.give_award(/datum/award/achievement/jobs/feat_of_strength, strongman)
 	strongman.visible_message(
 		span_boldwarning("[strongman] suplexes [src] into the ground!"),
 		span_warning("You suplex [src] into the ground!")

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -153,7 +153,7 @@ Difficulty: Hard
 /mob/living/simple_animal/hostile/megafauna/bubblegum/attackby(obj/item/W, mob/user, params)
 	. = ..()
 	if(istype(W, /obj/item/organ/internal/tongue))
-		user.client?.give_award(/datum/award/achievement/misc/frenching, user)
+		user.client?.give_award(/datum/award/achievement/jobs/frenching, user)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/proc/try_bloodattack()
 	var/list/targets = get_mobs_on_blood()

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -322,7 +322,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			var/mob/living/savior = savior_ref.resolve()
 			if(!istype(savior)) // didn't live to tell the tale, sadly.
 				continue
-			savior.client?.give_award(/datum/award/achievement/misc/theoretical_limits, savior)
+			savior.client?.give_award(/datum/award/achievement/jobs/theoretical_limits, savior)
 		LAZYNULL(saviors)
 
 	if(prob(15))

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -70,7 +70,7 @@
 			return
 		else //VICTORY ROYALE
 			to_chat(affected_mob, span_hierophant("You win, and the malevolent spirits fade away as well as your wounds."))
-			affected_mob.client.give_award(/datum/award/achievement/misc/helbitaljanken, affected_mob)
+			affected_mob.client.give_award(/datum/award/achievement/jobs/helbitaljanken, affected_mob)
 			affected_mob.revive(HEAL_ALL)
 			holder.del_reagent(type)
 			return

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -129,7 +129,7 @@
 				surgery.complete(user)
 
 	if(target.stat == DEAD && was_sleeping && user.client)
-		user.client.give_award(/datum/award/achievement/misc/sandman, user)
+		user.client.give_award(/datum/award/achievement/jobs/sandman, user)
 
 	surgery.step_in_progress = FALSE
 	return advance


### PR DESCRIPTION
## About The Pull Request

Read title, this only affects the UI and not the database as far as I am aware
## Why It's Good For The Game

The jobs category is painfully empty, only being home to four achievements total. Meanwhile we have a ton of achievements inside the miscellaneous category, a lot of which are not miscellaneous achievements at all. Right now I just wanna focus on moving around achievements from existing category to existing category though. This improves achievement category spread overall by a small but necessary amount.
## Changelog
:cl: distributivgesetz
code: Moved some job-related achievements from the misc category to the jobs category.
/:cl:
