### PR TITLE
`mob_transformation_simple` sends a `COMSIG_MOB_CHANGED_TYPE` signal, letting `content_barfer` mobs spit things out

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -214,3 +214,6 @@
 
 /// from mob/proc/dropItemToGround()
 #define COMSIG_MOB_DROPPING_ITEM "mob_dropping_item"
+
+/// from /mob/proc/change_mob_type_unchecked() : ()
+#define COMSIG_MOB_CHANGED_TYPE "mob_changed_type"

--- a/code/datums/elements/content_barfer.dm
+++ b/code/datums/elements/content_barfer.dm
@@ -12,10 +12,10 @@
 	if(!isliving(target))
 		return ELEMENT_INCOMPATIBLE
 
-	RegisterSignals(target, list(COMSIG_LIVING_DEATH, COMSIG_LIVING_ON_WABBAJACKED, COMSIG_LIVING_UNSHAPESHIFTED), PROC_REF(barf_contents))
+	RegisterSignals(target, list(COMSIG_LIVING_DEATH, COMSIG_LIVING_ON_WABBAJACKED, COMSIG_LIVING_UNSHAPESHIFTED, COMSIG_MOB_CHANGED_TYPE), PROC_REF(barf_contents))
 
 /datum/element/content_barfer/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_LIVING_DEATH, COMSIG_LIVING_ON_WABBAJACKED, COMSIG_LIVING_UNSHAPESHIFTED))
+	UnregisterSignal(target, list(COMSIG_LIVING_DEATH, COMSIG_LIVING_ON_WABBAJACKED, COMSIG_LIVING_UNSHAPESHIFTED, COMSIG_MOB_CHANGED_TYPE))
 	return ..()
 
 /datum/element/content_barfer/proc/barf_contents(mob/living/target)

--- a/code/modules/mob/living/basic/lavaland/bileworm/bileworm_actions.dm
+++ b/code/modules/mob/living/basic/lavaland/bileworm/bileworm_actions.dm
@@ -117,7 +117,7 @@
 		to_chat(devourer, span_warning("Someone stole your dinner!"))
 		return
 	to_chat(target, span_userdanger("You are consumed by [devourer]!"))
-	devourer.visible_message("[devourer] consumes [target]!")
+	devourer.visible_message(span_warning("[devourer] consumes [target]!"))
 	devourer.fully_heal()
 	playsound(devourer, 'sound/effects/splat.ogg', 50, TRUE)
 	//to be recieved on death

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -66,6 +66,7 @@
 	else
 		desired_mob.key = key
 
+	SEND_SIGNAL(src, COMSIG_LIVING_ON_WABBAJACKED)
 	if(delete_old_mob)
 		QDEL_IN(src, 1)
 	return desired_mob

--- a/code/modules/mob/mob_transformation_simple.dm
+++ b/code/modules/mob/mob_transformation_simple.dm
@@ -66,7 +66,7 @@
 	else
 		desired_mob.key = key
 
-	SEND_SIGNAL(src, COMSIG_LIVING_ON_WABBAJACKED)
+	SEND_SIGNAL(src, COMSIG_MOB_CHANGED_TYPE)
 	if(delete_old_mob)
 		QDEL_IN(src, 1)
 	return desired_mob


### PR DESCRIPTION
## About The Pull Request

Title; also makes bileworm devour message have a warning span.
~~it's a bit cheeky but i didn't want to add a deletion signal to the content_barfer's signal list, and the wabbajack signal here kinda makes sense?~~

## Why It's Good For The Game

Fixes #76791

## Changelog

:cl:
fix: fixed bileworm evolution deleting anything they devoured; they will now eject their contents upon evolution to vileworms
/:cl: