### PR TITLE
Cursed actually breaks mirrors when it procs

### DIFF
--- a/code/datums/components/omen.dm
+++ b/code/datums/components/omen.dm
@@ -138,6 +138,7 @@
 			switch(rand(1, 5))
 				if(1)
 					to_chat(living_guy, span_warning("The mirror explodes into a million pieces! Wait, does that mean you're even more unlucky?"))
+					evil_mirror.take_damage(evil_mirror.max_integrity, BRUTE, MELEE, FALSE)
 					if(prob(50 * luck_mod)) // sometimes
 						luck_mod += 0.25
 						damage_mod += 0.25


### PR DESCRIPTION
## About The Pull Request

just `take_damage()` lmao
#77175 didn't implement this properly and didn't remove it so i went ahead and implemented it because why not

## Why It's Good For The Game

Closes #78082
Is this a fix? Is this a feature? I can't decide. Marking as a fix though :^)

## Changelog

:cl:
fix: fixed mirrors not breaking when a curse effect is triggered
/:cl: