### PR TITLE
(no gbp) small improvement to bee pollination

### DIFF
--- a/code/modules/mob/living/basic/farm_animals/bee/bee_ai_behavior.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/bee_ai_behavior.dm
@@ -1,3 +1,5 @@
+/// if we have a hive, this will be our aggro distance
+#define AGGRO_DISTANCE_FROM_HIVE 2
 /datum/ai_behavior/hunt_target/pollinate
 	always_reset_target = TRUE
 
@@ -89,5 +91,14 @@
 	. = ..()
 	if(!.)
 		return FALSE
+
 	var/mob/living/mob_target = target
+	var/datum/ai_controller/basic_controller/bee_ai = owner.ai_controller
+	if(isnull(bee_ai))
+		return FALSE
+
+	var/atom/bee_hive = bee_ai.blackboard[BB_CURRENT_HOME]
+	if(bee_hive && get_dist(target, bee_hive) > AGGRO_DISTANCE_FROM_HIVE)
+		return FALSE
+
 	return !(mob_target.bee_friendly())

--- a/code/modules/mob/living/basic/farm_animals/bee/bee_ai_behavior.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/bee_ai_behavior.dm
@@ -102,3 +102,5 @@
 		return FALSE
 
 	return !(mob_target.bee_friendly())
+
+#undef AGGRO_DISTANCE_FROM_HIVE


### PR DESCRIPTION

## About The Pull Request
i saw some players are upset because the hive bees aggro towards people so it makes them harder to control for the pollination. bees will now only aggro to people if they are standing very near their hive. if they move out of range of the beehive they will ignore them and focus on pollination. 

## Why It's Good For The Game
improvements to pollination

## Changelog
:cl:
qol: pollinating bees will now only attack players that are standing near the beehive
/:cl:
