### PR TITLE
That part where I make the fishing minigame easier without reworking it completely.

### DIFF
--- a/tgui/packages/tgui/interfaces/Fishing.tsx
+++ b/tgui/packages/tgui/interfaces/Fishing.tsx
@@ -335,9 +335,10 @@ class FishingMinigame extends Component<
         acceleration = -acceleration_up;
         break;
       case ReelingState.Idle:
-        acceleration = this.bidirectional && newVelocity > 0
-          ? -acceleration_down
-          : acceleration_down;
+        acceleration =
+          this.bidirectional && newVelocity > 0
+            ? -acceleration_down
+            : acceleration_down;
         break;
     }
 

--- a/tgui/packages/tgui/interfaces/Fishing.tsx
+++ b/tgui/packages/tgui/interfaces/Fishing.tsx
@@ -335,7 +335,7 @@ class FishingMinigame extends Component<
         acceleration = -acceleration_up;
         break;
       case ReelingState.Idle:
-        acceleration = this.bidirectional
+        acceleration = this.bidirectional && newVelocity > 0
           ? -acceleration_down
           : acceleration_down;
         break;
@@ -354,9 +354,9 @@ class FishingMinigame extends Component<
      * towards 0 velocity, making it less slippery, thus easier to control.
      */
     if (newVelocity > 0 && velocity_change < 0) {
-      newVelocity += Math.min(-newVelocity, velocity_change * brake_coeff);
-    } else if (newVelocity < 0 && velocity_change > 0) {
       newVelocity += Math.max(-newVelocity, velocity_change * brake_coeff);
+    } else if (newVelocity < 0 && velocity_change > 0) {
+      newVelocity += Math.min(-newVelocity, velocity_change * brake_coeff);
     }
 
     newVelocity += velocity_change;

--- a/tgui/packages/tgui/interfaces/Fishing.tsx
+++ b/tgui/packages/tgui/interfaces/Fishing.tsx
@@ -296,9 +296,9 @@ class FishingMinigame extends Component<
     const { fish, bait } = this.state;
 
     // Speedup when reeling
-    const acceleration_up = -1500 * this.accel_up_coeff;
+    const acceleration_up = -1200 * this.accel_up_coeff;
     // Gravity
-    const acceleration_down = 1000;
+    const acceleration_down = 800;
     // Velocity is multiplied by this when bouncing off the bottom/top
     const bounce_coeff = this.baitBounceCoeff;
     // Acceleration mod when bait is over fish
@@ -326,26 +326,46 @@ class FishingMinigame extends Component<
       }
     }
 
-    const acceleration =
-      this.reeling === ReelingState.Reeling
-        ? acceleration_up
-        : this.reeling === ReelingState.ReelingDown
-          ? -acceleration_up
+    let acceleration = 0;
+    switch (this.reeling) {
+      case ReelingState.Reeling:
+        acceleration = acceleration_up;
+        break;
+      case ReelingState.ReelingDown:
+        acceleration = -acceleration_up;
+        break;
+      case ReelingState.Idle:
+        acceleration = this.bidirectional
+          ? -acceleration_down
           : acceleration_down;
+        break;
+    }
+
     // Slowdown both ways when on fish
     const velocity_change =
       acceleration *
       seconds *
       (this.fishOnBait(fish, bait) ? on_point_coeff : 1);
 
+    const brake_coeff = 2;
+    /*
+     * Basically, if current velocity and the change of velocity
+     * are going in different directions, we ensure the bait decelerates
+     * towards 0 velocity, making it less slippery, thus easier to control.
+     */
+    if (newVelocity > 0 && velocity_change < 0) {
+      newVelocity += Math.min(-newVelocity, velocity_change * brake_coeff);
+    } else if (newVelocity < 0 && velocity_change > 0) {
+      newVelocity += Math.max(-newVelocity, velocity_change * brake_coeff);
+    }
+
+    newVelocity += velocity_change;
+    // Ensure that bidirectional baits stay in place
     if (this.bidirectional && this.reeling === ReelingState.Idle) {
-      if (newVelocity < 0) {
-        newVelocity = Math.min(newVelocity + velocity_change, 0);
-      } else {
-        newVelocity = Math.max(newVelocity - velocity_change, 0);
-      }
-    } else {
-      newVelocity += velocity_change;
+      newVelocity =
+        velocity_change < 0
+          ? Math.max(newVelocity, 0)
+          : Math.min(newVelocity, 0);
     }
 
     // Round it off and cap


### PR DESCRIPTION
## About The Pull Request
This PR tones down the gravity and reeling acceleration values of the bait by 1/5 and implements a "brake", so that the bait will decelerate toward zero velocity more rapidly, making it easier to control.

## Why It's Good For The Game
The fishing minigame is too hard (even tho the fish tends to hug the bottom of the minigame slider on the TGUI, for me), lag or no lag. The bait feels too slippery and moves too fast.

Beside, Mothblocks has called #78052 bs, and there's a chance he may be right, though it would be difficult to make a proper comparison while the old UI lacks the extra alleviation to the user experience.

## Changelog

:cl:
balance: The fishing minigame should be easier now.
/:cl:
