### PR TITLE
Portable atmos resin thrower

### DIFF
--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -43,7 +43,7 @@
 /obj/item/watertank/proc/toggle_mister(mob/living/user)
 	if(!istype(user))
 		return
-	if(user.get_item_by_slot(user.getBackSlot()) != src)
+	if(slot_flags & ITEM_SLOT_BACK && user.get_item_by_slot(user.getBackSlot()) != src)
 		to_chat(user, span_warning("The watertank must be worn properly to use!"))
 		return
 	if(user.incapacitated())
@@ -221,7 +221,7 @@
 
 /obj/item/watertank/atmos/Initialize(mapload)
 	. = ..()
-	reagents.add_reagent(/datum/reagent/water, 200)
+	reagents.add_reagent(/datum/reagent/water, volume)
 
 /obj/item/watertank/atmos/make_noz()
 	return new /obj/item/extinguisher/mini/nozzle(src)
@@ -390,29 +390,6 @@
 	slot_flags = NONE
 	volume = 50
 	slowdown = 0
-
-/obj/item/watertank/atmos/portable/Initialize(mapload)
-	. = ..()
-	reagents.add_reagent(/datum/reagent/water, volume)
-
-/obj/item/watertank/atmos/portable/toggle_mister(mob/living/user)
-	if(!istype(user))
-		return
-
-	if(user.incapacitated())
-		return
-
-	if(QDELETED(noz))
-		noz = make_noz()
-		RegisterSignal(noz, COMSIG_MOVABLE_MOVED, PROC_REF(noz_move))
-	if(noz in src)
-		//Detach the nozzle into the user's hands
-		if(!user.put_in_hands(noz))
-			to_chat(user, span_warning("You need a free hand to hold the mister!"))
-			return
-	else
-		//Remove from their hands and put back "into" the tank
-		remove_noz()
 
 /obj/item/watertank/atmos/portable/make_noz()
 	return new /obj/item/extinguisher/mini/nozzle/portable(src)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -388,7 +388,7 @@
 	worn_icon_state = "waterbackpackatmos"
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = NONE
-	volume = 100
+	volume = 50
 	slowdown = 0
 
 /obj/item/watertank/atmos/portable/Initialize(mapload)
@@ -430,15 +430,15 @@
 		return ..()
 
 /obj/item/extinguisher/mini/nozzle/portable
-	desc = "A heavy duty nozzle attached to a firefighter's backpack tank."
+	desc = "A heavy duty nozzle attached to a firefighter's portable tank."
 	icon = 'icons/obj/service/hydroponics/equipment.dmi'
 	icon_state = "atmos_nozzle"
 	inhand_icon_state = "nozzleatmos"
 	lefthand_file = 'icons/mob/inhands/equipment/mister_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mister_righthand.dmi'
-	max_water = 100
-	launcher_cost = 40
-	launcher_size = 3
+	max_water = 50
+	launcher_cost = 25
+	launcher_size = 2
 
 #undef EXTINGUISHER
 #undef RESIN_LAUNCHER

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -40,10 +40,13 @@
 	if(slot & user.getBackSlot())
 		return 1
 
+/obj/item/watertank/proc/can_noz(mob/user)
+	return user.get_item_by_slot(user.getBackSlot()) == src
+
 /obj/item/watertank/proc/toggle_mister(mob/living/user)
 	if(!istype(user))
 		return
-	if(slot_flags & ITEM_SLOT_BACK && user.get_item_by_slot(user.getBackSlot()) != src)
+	if(!can_noz(user))
 		to_chat(user, span_warning("The watertank must be worn properly to use!"))
 		return
 	if(user.incapacitated())
@@ -88,7 +91,7 @@
 		noz.forceMove(src)
 
 /obj/item/watertank/attack_hand(mob/user, list/modifiers)
-	if (user.get_item_by_slot(user.getBackSlot()) == src)
+	if (can_noz(user))
 		toggle_mister(user)
 	else
 		return ..()
@@ -394,14 +397,11 @@
 /obj/item/watertank/atmos/portable/make_noz()
 	return new /obj/item/extinguisher/mini/nozzle/portable(src)
 
-/obj/item/watertank/atmos/portable/attack_hand(mob/user, list/modifiers)
-	if (user.is_holding(src))
-		toggle_mister(user)
-	else
-		return ..()
+/obj/item/watertank/atmos/portable/can_noz(mob/user)
+	return user.is_holding(src)
 
 /obj/item/watertank/atmos/portable/attack_self(mob/user)
-	if (user.is_holding(src))
+	if (can_noz(user))
 		toggle_mister(user)
 	else
 		return ..()

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -366,7 +366,7 @@
 	var/size = 0
 
 /obj/effect/resin_container/Initialize(mapload, size)
-	..()
+	. = ..()
 	src.size = size
 
 /obj/effect/resin_container/proc/Smoke()
@@ -393,7 +393,7 @@
 
 /obj/item/watertank/atmos/portable/Initialize(mapload)
 	. = ..()
-	reagents.add_reagent(/datum/reagent/water, 100)
+	reagents.add_reagent(/datum/reagent/water, volume)
 
 /obj/item/watertank/atmos/portable/toggle_mister(mob/living/user)
 	if(!istype(user))


### PR DESCRIPTION
## About The Pull Request
Adds a more portable atmos resin thrower

https://github.com/tgstation/tgstation/assets/109347230/e1b3493e-20fd-4bc7-82a5-427930bdfe6e

TODO :
Resprite
Add to research
Add to lathe
Balance

I'm open for feedback.
Current values are as follows.
Volume of 50u
Resin launcher takes 25u and has a size of 14-16 tiles
Size is same as regular fire extinguisher
planned research tier is advanced engineering
planned lathe cost is probably titanium, glass, and bluespace crystal

## Why It's Good For The Game
The current atmos resin mister is a really fun tool that is available at round start. The current resin mister is mostly used to contain a plasma fire and fix the air, but it has many other potential uses. Unfortunately these other uses are very niche and it is extremely unwieldy, it can't fit anywhere on your person except the backpack slot. It's very rarely worth trekking all the way back to atmos to grab for anything other than the extremely rare plasma fires.

This new portable resin mister does not make the previous one irrelevant. The portable version has a much smaller range for the resin launcher mode, making the larger version still very relevant for fighting large plasma fires. It would also fit somewhere in the intermediate research tiers and not be available at round start.

It also competes for that very scarce engineering backpack space :)

## Changelog
:cl:
add: Adds a more portable atmos resin thrower
/:cl:
