### PR TITLE
[NO GBP] Fixes the fishing skill.

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -41,7 +41,5 @@
 #define CLEAN_SKILL_GENERIC_WASH_XP 1.5//Value. Higher number = more XP when cleaning non-cleanables (walls/floors/lips)
 ///The multiplier of the extra experience given by the fishing minigame based on difficulty. At the default difficulty of 15, the bonus will be of 21%.
 #define FISHING_SKILL_DIFFIULTY_EXP_MULT 0.015
-///How much exp one would gain per spent playing the fishing minigame at minimum difficulty.
-#define FISHING_SKILL_EXP_PER_SECOND (SKILL_EXP_LEGENDARY / (22 MINUTES))
-///The maximum amount of experience one can get per fishing minigame. I appreciate the effort though.
-#define FISHING_SKILL_EXP_CAP_PER_GAME (SKILL_EXP_LEGENDARY / 5)
+///How much exp one would gain per spent playing the fishing minigame at minimum difficulty. the time is multiplied by 0.1 because deciseconds...
+#define FISHING_SKILL_EXP_PER_SECOND (SKILL_EXP_LEGENDARY / (15 MINUTES * 0.1))

--- a/code/modules/fishing/fishing_minigame.dm
+++ b/code/modules/fishing/fishing_minigame.dm
@@ -153,9 +153,9 @@
 	if(user)
 		REMOVE_TRAIT(user, TRAIT_GONE_FISHING, REF(src))
 		if(start_time)
-			var/seconds_spent = (world.time - start_time)/10
+			var/seconds_spent = (world.time - start_time) * 0.1
 			if(!(FISHING_MINIGAME_RULE_NO_EXP in special_effects))
-				user.mind?.adjust_experience(/datum/skill/fishing, min(round(seconds_spent * FISHING_SKILL_EXP_PER_SECOND * experience_multiplier), FISHING_SKILL_EXP_CAP_PER_GAME))
+				user.mind?.adjust_experience(/datum/skill/fishing, round(seconds_spent * FISHING_SKILL_EXP_PER_SECOND * experience_multiplier))
 				if(win && user.mind?.get_skill_level(/datum/skill/fishing) >= SKILL_LEVEL_LEGENDARY)
 					user.client?.give_award(/datum/award/achievement/skill/legendary_fisher, user)
 	if(win)


### PR DESCRIPTION
## About The Pull Request
The gain for second were 10 lower than they were supposed to be, since I hadn't taken into account the deciseconds. I've also a cap on the gain and lowered the necessary time just to be sure it doesn't take too much time to attain the legendary tier anyway. I may bump it up later if people say it's too easy.

## Why It's Good For The Game
This will fix #77972.

## Changelog

:cl:
fix: It's now humanly possible to reach the legendary fisherman rank, get the achievement and the hat.
/:cl:
