### PR TITLE
[NO GBP] Fixing a small issue with chasm fishing

### DIFF
--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -40,24 +40,24 @@ GLOBAL_LIST_INIT_TYPED(chasm_detritus_types, /datum/chasm_detritus, init_chasm_d
 		),
 	)
 
-/datum/chasm_detritus/proc/dispense_reward(turf/fishing_spot)
+/datum/chasm_detritus/proc/dispense_reward(turf/fishing_spot, turf/fisher_turf)
 	if (prob(default_contents_chance))
 		var/default_spawn = pick(default_contents[default_contents_key])
-		return new default_spawn(fishing_spot)
-	return find_chasm_contents(fishing_spot)
+		return new default_spawn(fisher_turf)
+	return find_chasm_contents(fishing_spot, fisher_turf)
 
 /// Returns the chosen detritus from the given list of things to choose from
 /datum/chasm_detritus/proc/determine_detritus(list/chasm_stuff)
 	return pick(chasm_stuff)
 
 /// Returns an objected which is currently inside of a nearby chasm.
-/datum/chasm_detritus/proc/find_chasm_contents(datum/source, turf/fishing_spot)
+/datum/chasm_detritus/proc/find_chasm_contents(datum/source, turf/fishing_spot, turf/fisher_turf)
 	SIGNAL_HANDLER
 	var/list/chasm_contents = get_chasm_contents(fishing_spot)
 
 	if (!length(chasm_contents))
 		var/default_spawn = pick(default_contents[default_contents_key])
-		return new default_spawn(fishing_spot)
+		return new default_spawn(fisher_turf)
 
 	return determine_detritus(chasm_contents)
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -141,7 +141,7 @@ GLOBAL_LIST_INIT(preset_fish_sources, init_subtypes_w_path_keys(/datum/fish_sour
 	if(reward_path == FISHING_DUD)
 		return
 	if(ispath(reward_path, /datum/chasm_detritus))
-		return GLOB.chasm_detritus_types[reward_path].dispense_reward(fishing_spot)
+		return GLOB.chasm_detritus_types[reward_path].dispense_reward(fishing_spot, get_turf(fisherman))
 	if(!ispath(reward_path, /atom/movable))
 		CRASH("Unsupported /datum path [reward_path] passed to fish_source/proc/spawn_reward()")
 	var/atom/movable/reward = new reward_path(get_turf(fisherman))

--- a/code/modules/mob_spawn/corpses/species_corpses.dm
+++ b/code/modules/mob_spawn/corpses/species_corpses.dm
@@ -2,6 +2,8 @@
 //corpses that only differentiate themselves by representing a species
 
 /obj/effect/mob_spawn/corpse/human/skeleton
+	//these are also fished in chasms so it wouldn't hurt giving them an apter name than "mob spawner"
+	name = "skeleton"
 	mob_species = /datum/species/skeleton
 
 /obj/effect/mob_spawn/corpse/human/zombie


### PR DESCRIPTION
## About The Pull Request
The default spawnables from chasms are spawned on top of the chasm rather than on the user's turf, and that can be an issue.

## Why It's Good For The Game
This will fix #77982.

## Changelog

:cl:
fix: fixed fishing skeleton mob spawners that immediately crumble back into the void of whatever chasm you fished them from.
/:cl:
