### PR TITLE
Soup recipes that make items spawn the correct number of items

### DIFF
--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -86,7 +86,7 @@
 		return
 
 	// If a food item is supposed to be made, remove relevant ingredients from the pot, then make the item 
-	if(resulting_food_path)
+	if(!isnull(resulting_food_path))
 		var/list/tracked_ingredients
 		LAZYINITLIST(tracked_ingredients)
 		var/ingredient_max_multiplier = INFINITY

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -215,17 +215,17 @@
 			if(ingredient.resistance_flags & INDESTRUCTIBLE)
 				continue
 
-			// Things that had reagents or ingredients in the soup will get deleted
-			else if(!isnull(ingredient.reagents) || is_type_in_list(ingredient, required_ingredients))
-				LAZYREMOVE(pot.added_ingredients, ingredient)
-				// Send everything left behind
-				transfer_ingredient_reagents(ingredient, holder)
-				// Delete, it's done
-				qdel(ingredient)
-
 			// Everything else will just get fried
-			else
+			if(isnull(ingredient.reagents) && !is_type_in_list(ingredient, required_ingredients))
 				ingredient.AddElement(/datum/element/fried_item, 30)
+				continue
+
+			// Things that had reagents or ingredients in the soup will get deleted
+			LAZYREMOVE(pot.added_ingredients, ingredient)
+			// Send everything left behind
+			transfer_ingredient_reagents(ingredient, holder)
+			// Delete, it's done
+			qdel(ingredient)
 
 	// Anything left in the ingredient list will get dumped out
 	pot.dump_ingredients(get_turf(pot), y_offset = 8)

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -82,7 +82,6 @@
 	return TRUE
 
 /datum/chemical_reaction/food/soup/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
-	log_world("Soup reaction started, c_vol: " + num2text(created_volume))
 	if(!length(required_ingredients))
 		return
 
@@ -142,8 +141,6 @@
 /datum/chemical_reaction/food/soup/reaction_step(datum/reagents/holder, datum/equilibrium/reaction, delta_t, delta_ph, step_reaction_vol)
 	if(!length(required_ingredients))
 		return
-	log_world("step_reaction_vol: " + num2text(step_reaction_vol))
-	log_world("delta_t: " + num2text(delta_t))
 	testing("Soup reaction step progressing with an increment volume of [step_reaction_vol] and delta_t of [delta_t].")
 	var/obj/item/reagent_containers/cup/soup_pot/pot = holder.my_atom
 	var/list/cached_ingredients = reaction.data["ingredients"]
@@ -191,7 +188,6 @@
 
 /datum/chemical_reaction/food/soup/reaction_finish(datum/reagents/holder, datum/equilibrium/reaction, react_vol)
 	. = ..()
-	log_world("Soup reaction finished, react_vol: " + num2text(react_vol))
 	var/obj/item/reagent_containers/cup/soup_pot/pot = holder.my_atom
 	if(!istype(pot))
 		CRASH("[pot ? "Non-pot atom" : "Null pot"]) made it to the end of the [type] reaction chain.")
@@ -207,7 +203,6 @@
  * * react_vol: How much soup was produced
  */
 /datum/chemical_reaction/food/soup/proc/clean_up(datum/reagents/holder, datum/equilibrium/reaction, react_vol)
-	log_world("Soup cleanup, react_vol: " + num2text(react_vol))
 	var/obj/item/reagent_containers/cup/soup_pot/pot = holder.my_atom
 
 	reaction?.data["ingredients"] = null


### PR DESCRIPTION
## About The Pull Request

Soup recipes, that make items, spawn the correct number of items per reaction instead of just one item
Soup recipes, that make and consume items, re-add unused reagents
Soup recipes that produce no reagents do not delete all required ingredients
## Why It's Good For The Game

Soup recipes should be correctly followed, however, there's some issues that happen with a soup recipe creates an item with no corresponding soup reagents.
1. Only 1 item is produced, no matter how many reagents or ingredients are used
2. All ingredients that are required_ingredients are deleted, this is done because the standard soup behavior would have transferred some of the reagents from any "required_ingredients into the soup. However, since no soup is made, the ingredients are wasted.
3. The reagents for the soup recipe itself are consumed to the highest multiple, even if there is insufficient  required_ingredients in the pot.

This PR ensure the proper number of items are spawned, the proper amount of required_reagents are used, and the proper amount of ingredients are used.

Fixes #77821
## Changelog
:cl:
fix: Soup recipes, that make items, spawn the correct number of items per reaction instead of just one item
fix: Soup recipes, that make items, consumes the correct number of reagents instead of the largest multiple of the reagents
/:cl:
