### PR TITLE
[NO GBP] Name-wise, the telescopic fishing rod is no longer just a fishing rod

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -445,6 +445,7 @@
 	category = CAT_TOOLS
 
 /obj/item/fishing_rod/telescopic
+	name = "telescopic fishing rod"
 	icon_state = "fishing_rod_telescopic"
 	desc = "A lightweight, ergonomic, easy to store telescopic fishing rod. "
 	inhand_icon_state = null


### PR DESCRIPTION
## About The Pull Request
Gives the telescopic fishing rod its own name.

## Why It's Good For The Game
Guess why.

## Changelog

:cl:
spellcheck: Corrected the name of the telescopic fishing rod to "telescopic fishing rod" from the more generic "fishing rod"
/:cl:
