### PR TITLE
Improved dismemberment mood messages.

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -78,13 +78,13 @@
 	timeout = 60 SECONDS
 
 /datum/mood_event/dismembered
-	description = "AHH! I WAS USING THAT LIMB!"
+	description = "AHH! MY LIMB! I WAS USING THAT!"
 	mood_change = -10
 	timeout = 8 MINUTES
 
 /datum/mood_event/dismembered/add_effects(obj/item/bodypart/limb)
 	if(limb)
-		description = "AHH! I WAS USING THAT [full_capitalize(limb.plaintext_zone)]"
+		description = "AHH! MY [uppertext(limb.plaintext_zone)]! I WAS USING THAT!"
 
 /datum/mood_event/reattachment
 	description = "Ouch! My limb feels like I fell asleep on it."


### PR DESCRIPTION

## About The Pull Request

Implements suggestions in #78107 

Old:
![265254748-b7a2d9e6-1be8-4246-bd67-3c13a9dd2d6c](https://github.com/tgstation/tgstation/assets/105025397/8473ccc4-957b-4a7e-a3c5-9bdb52899f19)

New:
![image](https://github.com/tgstation/tgstation/assets/105025397/bff75fdd-046b-4a25-a3f5-5dcc3d68d537)
## Why It's Good For The Game

Proper all-caps looks significantly less awkward than the current message, and the rearranged phrasing flows better than "I WAS USING THAT LEFT LEG!" and such.
## Changelog
:cl:
spellcheck: Improved phrasing and syntax on dismemberment mood messages.
/:cl:
