### PR TITLE
Fixed reagent grinding (and juicing?)

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -967,7 +967,7 @@
 		return FALSE
 	if(!reagents)
 		reagents = new()
-	reagents.add_reagent_list(grind_results)
+	target_holder.add_reagent_list(grind_results)
 	if(reagents && target_holder)
 		reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
 	return TRUE

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -317,7 +317,7 @@
 			juice_item(I, user)
 
 /obj/machinery/reagentgrinder/proc/juice_item(obj/item/I, mob/user) //Juicing results can be found in respective object definitions
-	if(!I.juice(beaker, user))
+	if(!I.juice(beaker.reagents, user))
 		to_chat(usr, span_danger("[src] shorts out as it tries to juice up [I], and transfers it back to storage."))
 		return
 	remove_object(I)
@@ -336,7 +336,7 @@
 			grind_item(i, user)
 
 /obj/machinery/reagentgrinder/proc/grind_item(obj/item/I, mob/user) //Grind results can be found in respective object definitions
-	if(!I.grind(beaker, user))
+	if(!I.grind(beaker.reagents, user))
 		to_chat(usr, span_danger("[src] shorts out as it tries to grind up [I], and transfers it back to storage."))
 		return
 	remove_object(I)


### PR DESCRIPTION

## About The Pull Request

Resolves #78063 

The Foodening refactored grinding and juicing in the reagent grinder, but there were a few mistakes along the way. Most notably, items that gave extra reagents when ground were not doing that (such as peptides in livers) due to an error in adding those reagents. This error has been corrected.

I've also fixed the code for juicing, which was erroneously passing a beaker as its own reagents datum, though I couldn't tell if this actually had any negative effects. Somehow. Better safe than sorry.
## Why It's Good For The Game

It's good to get everything you're supposed to get when you grind stuff. The main source of peptides being inadvertently removed also made cytology harder, and cytology really doesn't need to be made _more_ inconvenient.
## Changelog
:cl:
fix: Fixed all-in-one grinders not giving all the correct reagents when grinding.
/:cl:
