### PR TITLE
Fixes a lavaland camera's network

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -69,7 +69,7 @@
 /area/mine/maintenance/living/south)
 "aq" = (
 /obj/machinery/camera/autoname/directional/east{
-	network = list("labor")
+	network = list("mine")
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5


### PR DESCRIPTION

## About The Pull Request

Changes the network of the mining public storage room's camera from the gulag to mining

## Why It's Good For The Game

It's a bug

## Changelog
:cl:
fix: Public mining storage's camera is now on the mining network instead of the gulag.
/:cl:
