### PR TITLE
Replaces Generic Circuit Boards and Unusuable Frames in Birdshot Gaming Den

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -10905,10 +10905,10 @@
 /turf/open/floor/iron,
 /area/station/security)
 "ejn" = (
-/obj/structure/frame,
 /obj/item/stack/cable_coil/five,
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/spawner/random/techstorage/arcade_boards,
+/obj/structure/frame/computer,
 /turf/open/floor/eighties/red,
 /area/station/service/abandoned_gambling_den/gaming)
 "ejt" = (
@@ -69614,10 +69614,12 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/bridge)
 "xMo" = (
-/obj/structure/frame,
 /obj/item/stack/cable_coil/five,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/spawner/random/techstorage/arcade_boards,
+/obj/structure/frame/computer{
+	dir = 1
+	},
 /turf/open/floor/eighties/red,
 /area/station/service/abandoned_gambling_den/gaming)
 "xMr" = (

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -10907,8 +10907,8 @@
 "ejn" = (
 /obj/structure/frame,
 /obj/item/stack/cable_coil/five,
-/obj/item/circuitboard/computer/arcade,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/random/techstorage/arcade_boards,
 /turf/open/floor/eighties/red,
 /area/station/service/abandoned_gambling_den/gaming)
 "ejt" = (
@@ -69616,8 +69616,8 @@
 "xMo" = (
 /obj/structure/frame,
 /obj/item/stack/cable_coil/five,
-/obj/item/circuitboard/computer/arcade,
 /obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/techstorage/arcade_boards,
 /turf/open/floor/eighties/red,
 /area/station/service/abandoned_gambling_den/gaming)
 "xMr" = (


### PR DESCRIPTION
## About The Pull Request

In the Birdshot gaming den there were two generic frames and two arcade generic circuit boards that did nothing. I don't think that was the intention given that these broken machines were next to a bunch of arcade machines. Removes those boards and adds in two empty computer consoles and two random arcade board spawners to replace them.

![consolesthatwork](https://github.com/tgstation/tgstation/assets/59387501/f1753b25-3a62-493e-8c20-348411052da4)

## Why It's Good For The Game

More consistency is good. Helps keep immersion for those higher RP players and whatnot.
## Changelog

:cl:
fix: The Birdshot Gaming Den now has arcade circuit boards and computer frames that actually work.
/:cl:
