### PR TITLE
The ninja mask is no longer pepperproof.

### DIFF
--- a/code/modules/antagonists/ninja/ninja_clothing.dm
+++ b/code/modules/antagonists/ninja/ninja_clothing.dm
@@ -14,7 +14,7 @@
 	strip_delay = 12 SECONDS
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flags_inv = HIDEFACIALHAIR | HIDEFACE | HIDESNOUT
-	flags_cover = MASKCOVERSMOUTH | PEPPERPROOF
+	flags_cover = MASKCOVERSMOUTH
 	has_fov = FALSE
 
 /obj/item/clothing/under/syndicate/ninja


### PR DESCRIPTION

## About The Pull Request

Title
## Why It's Good For The Game

This is mainly done for consistency. This shouldn't affect balance at all, considering that the chances of a ninja get caught with pepperspray while they have their modsuit off for... some reason is negligible
## Changelog
:cl:
fix: Ninja's gas mask no longer somehow stops pepper from going into your eyes
/:cl:
