### PR TITLE
Refactors the `notransform` variable into a trait.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -192,6 +192,10 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Makes the owner appear as dead to most forms of medical examination
 #define TRAIT_FAKEDEATH "fakedeath"
 #define TRAIT_DISFIGURED "disfigured"
+/// "Magic" trait that blocks the mob from moving or interacting with anything. Used for transient stuff like mob transformations or incorporality in special cases.
+/// The macro name is rather antiquated as to its purpose, but it's remained to express the original intent of the trait while retaining the modern use in the string it ties to
+/// Should always be sourced to the REF(src) of the thing that's applying it.
+#define TRAIT_NO_TRANSFORM "block_all_interaction_for_ongoing_transformation_or_other_critical_event"
 /// Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_XENO_HOST "xeno_host"
 /// This mob is immune to stun causing status effects and stamcrit.

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -193,8 +193,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_FAKEDEATH "fakedeath"
 #define TRAIT_DISFIGURED "disfigured"
 /// "Magic" trait that blocks the mob from moving or interacting with anything. Used for transient stuff like mob transformations or incorporality in special cases.
-/// The macro name is rather antiquated as to its purpose, but it's remained to express the original intent of the trait while retaining the modern use in the string it ties to
-/// Ensure you track this as properly as possible! Nine times out of ten, this is sourcing it to the REF(src) that we currently have going on.
+/// Will block movement, `Life()` (!!!), and other stuff based on the mob.
 #define TRAIT_NO_TRANSFORM "block_transformations"
 /// Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_XENO_HOST "xeno_host"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -194,7 +194,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_DISFIGURED "disfigured"
 /// "Magic" trait that blocks the mob from moving or interacting with anything. Used for transient stuff like mob transformations or incorporality in special cases.
 /// The macro name is rather antiquated as to its purpose, but it's remained to express the original intent of the trait while retaining the modern use in the string it ties to
-/// #nsure you track this as properly as possible! Nine times out of ten, this is sourcing it to the REF(src) that we currently have going on.
+/// Ensure you track this as properly as possible! Nine times out of ten, this is sourcing it to the REF(src) that we currently have going on.
 #define TRAIT_NO_TRANSFORM "block_transformations"
 /// Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_XENO_HOST "xeno_host"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -194,8 +194,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_DISFIGURED "disfigured"
 /// "Magic" trait that blocks the mob from moving or interacting with anything. Used for transient stuff like mob transformations or incorporality in special cases.
 /// The macro name is rather antiquated as to its purpose, but it's remained to express the original intent of the trait while retaining the modern use in the string it ties to
-/// Should always be sourced to the REF(src) of the thing that's applying it.
-#define TRAIT_NO_TRANSFORM "block_all_interaction_for_ongoing_transformation_or_other_critical_event"
+/// #nsure you track this as properly as possible! Nine times out of ten, this is sourcing it to the REF(src) that we currently have going on.
+#define TRAIT_NO_TRANSFORM "block_interactions_(like_transformations)_for_ongoing_transformation_or_other_critical_event"
 /// Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_XENO_HOST "xeno_host"
 /// This mob is immune to stun causing status effects and stamcrit.

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -195,7 +195,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// "Magic" trait that blocks the mob from moving or interacting with anything. Used for transient stuff like mob transformations or incorporality in special cases.
 /// The macro name is rather antiquated as to its purpose, but it's remained to express the original intent of the trait while retaining the modern use in the string it ties to
 /// #nsure you track this as properly as possible! Nine times out of ten, this is sourcing it to the REF(src) that we currently have going on.
-#define TRAIT_NO_TRANSFORM "block_interactions_(like_transformations)_for_ongoing_transformation_or_other_critical_event"
+#define TRAIT_NO_TRANSFORM "block_transformations"
 /// Tracks whether we're gonna be a baby alien's mummy.
 #define TRAIT_XENO_HOST "xeno_host"
 /// This mob is immune to stun causing status effects and stamcrit.

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -69,7 +69,7 @@
 		return
 	next_click = world.time + 1
 
-	if(check_click_intercept(params,A) || notransform)
+	if(check_click_intercept(params,A) || HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
 	var/list/modifiers = params2list(params)

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -29,7 +29,7 @@ SUBSYSTEM_DEF(npcpool)
 			stack_trace("Found a null in simple_animals active list [SA.type]!")
 			continue
 
-		if(!SA.ckey && !SA.notransform)
+		if(!SA.ckey && !HAS_TRAIT(SA, TRAIT_NO_TRANSFORM))
 			if(SA.stat != DEAD)
 				SA.handle_automated_movement()
 			if(SA.stat != DEAD)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -1,4 +1,5 @@
 #define ROUND_START_MUSIC_LIST "strings/round_start_sounds.txt"
+#define SS_TICKER_TRAIT "SS_Ticker"
 
 SUBSYSTEM_DEF(ticker)
 	name = "Ticker"
@@ -462,7 +463,7 @@ SUBSYSTEM_DEF(ticker)
 		var/mob/living = player.transfer_character()
 		if(living)
 			qdel(player)
-			ADD_TRAIT(living, TRAIT_NO_TRANSFORM, REF(src))
+			ADD_TRAIT(living, TRAIT_NO_TRANSFORM, SS_TICKER_TRAIT)
 			if(living.client)
 				var/atom/movable/screen/splash/S = new(null, living.client, TRUE)
 				S.Fade(TRUE)
@@ -473,7 +474,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/release_characters(list/livings)
 	for(var/mob/living/living_mob as anything in livings)
-		REMOVE_TRAIT(living_mob, TRAIT_NO_TRANSFORM, REF(src))
+		REMOVE_TRAIT(living_mob, TRAIT_NO_TRANSFORM, SS_TICKER_TRAIT)
 
 /datum/controller/subsystem/ticker/proc/check_queue()
 	if(!queued_players.len)
@@ -737,3 +738,4 @@ SUBSYSTEM_DEF(ticker)
 		return "[global.config.directory]/reboot_themes/[pick(possible_themes)]"
 
 #undef ROUND_START_MUSIC_LIST
+#undef SS_TICKER_TRAIT

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -462,7 +462,7 @@ SUBSYSTEM_DEF(ticker)
 		var/mob/living = player.transfer_character()
 		if(living)
 			qdel(player)
-			living.notransform = TRUE
+			ADD_TRAIT(living, TRAIT_NO_TRANSFORM, REF(src))
 			if(living.client)
 				var/atom/movable/screen/splash/S = new(null, living.client, TRUE)
 				S.Fade(TRUE)
@@ -472,9 +472,9 @@ SUBSYSTEM_DEF(ticker)
 		addtimer(CALLBACK(src, PROC_REF(release_characters), livings), 30, TIMER_CLIENT_TIME)
 
 /datum/controller/subsystem/ticker/proc/release_characters(list/livings)
-	for(var/I in livings)
-		var/mob/living/L = I
-		L.notransform = FALSE
+	for(var/iterable in livings)
+		var/mob/living/living_mob = iterable
+		REMOVE_TRAIT(living_mob, TRAIT_NO_TRANSFORM, REF(src))
 
 /datum/controller/subsystem/ticker/proc/check_queue()
 	if(!queued_players.len)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -469,11 +469,10 @@ SUBSYSTEM_DEF(ticker)
 				living.client.init_verbs()
 			livings += living
 	if(livings.len)
-		addtimer(CALLBACK(src, PROC_REF(release_characters), livings), 30, TIMER_CLIENT_TIME)
+		addtimer(CALLBACK(src, PROC_REF(release_characters), livings), 3 SECONDS, TIMER_CLIENT_TIME)
 
 /datum/controller/subsystem/ticker/proc/release_characters(list/livings)
-	for(var/iterable in livings)
-		var/mob/living/living_mob = iterable
+	for(var/mob/living/living_mob as anything in livings)
 		REMOVE_TRAIT(living_mob, TRAIT_NO_TRANSFORM, REF(src))
 
 /datum/controller/subsystem/ticker/proc/check_queue()

--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -155,7 +155,7 @@
 	var/mob/locked_mob = mob_ref.resolve()
 	if(isnull(locked_mob))
 		return
-	REMOVE_TRAIT(to_lock, TRAIT_NO_TRANSFORM, REF(src))
+	REMOVE_TRAIT(locked_mob, TRAIT_NO_TRANSFORM, REF(src))
 	UnregisterSignal(locked_mob, COMSIG_MOB_CLIENT_LOGIN)
 
 /// Removes the passed client from our watching list.

--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -30,7 +30,7 @@
 /datum/cinematic
 	/// A list of all clients watching the cinematic
 	var/list/client/watching = list()
-	/// A list of all mobs who have notransform set while watching the cinematic
+	/// A list of all mobs who have TRAIT_NO_TRANSFORM set while watching the cinematic
 	var/list/datum/weakref/locked = list()
 	/// Whether the cinematic is a global cinematic or not
 	var/is_global = FALSE
@@ -106,11 +106,7 @@
 /datum/cinematic/proc/show_to(mob/watching_mob, client/watching_client)
 	SIGNAL_HANDLER
 
-	// We could technically rip people out of notransform who shouldn't be,
-	// so we'll only lock down all viewing mobs who don't have it already set.
-	// This does potentially mean some mobs could lose their notrasnform and
-	// not be locked down by cinematics, but that should be very unlikely.
-	if(!watching_mob.notransform)
+	if(!HAS_TRAIT_FROM(watching_mob, TRAIT_NO_TRANSFORM, REF(src)))
 		lock_mob(watching_mob)
 
 	// Only show the actual cinematic to cliented mobs.
@@ -152,14 +148,14 @@
 /// Locks a mob, preventing them from moving, being hurt, or acting
 /datum/cinematic/proc/lock_mob(mob/to_lock)
 	locked += WEAKREF(to_lock)
-	to_lock.notransform = TRUE
+	ADD_TRAIT(to_lock, TRAIT_NO_TRANSFORM, REF(src))
 
 /// Unlocks a previously locked weakref
 /datum/cinematic/proc/unlock_mob(datum/weakref/mob_ref)
 	var/mob/locked_mob = mob_ref.resolve()
 	if(isnull(locked_mob))
 		return
-	locked_mob.notransform = FALSE
+	REMOVE_TRAIT(to_lock, TRAIT_NO_TRANSFORM, REF(src))
 	UnregisterSignal(locked_mob, COMSIG_MOB_CLIENT_LOGIN)
 
 /// Removes the passed client from our watching list.
@@ -171,7 +167,7 @@
 
 	UnregisterSignal(no_longer_watching, COMSIG_QDELETING)
 	// We'll clear the cinematic if they have a mob which has one,
-	// but we won't remove notransform. Wait for the cinematic end to do that.
+	// but we won't remove TRAIT_NO_TRANSFORM. Wait for the cinematic end to do that.
 	no_longer_watching.mob?.clear_fullscreen("cinematic")
 	no_longer_watching.screen -= screen
 

--- a/code/datums/cinematics/_cinematic.dm
+++ b/code/datums/cinematics/_cinematic.dm
@@ -1,3 +1,5 @@
+#define CINEMATIC_SOURCE "cinematic"
+
 /**
  * Plays a cinematic, duh. Can be to a select few people, or everyone.
  *
@@ -106,7 +108,7 @@
 /datum/cinematic/proc/show_to(mob/watching_mob, client/watching_client)
 	SIGNAL_HANDLER
 
-	if(!HAS_TRAIT_FROM(watching_mob, TRAIT_NO_TRANSFORM, REF(src)))
+	if(!HAS_TRAIT_FROM(watching_mob, TRAIT_NO_TRANSFORM, CINEMATIC_SOURCE))
 		lock_mob(watching_mob)
 
 	// Only show the actual cinematic to cliented mobs.
@@ -148,14 +150,14 @@
 /// Locks a mob, preventing them from moving, being hurt, or acting
 /datum/cinematic/proc/lock_mob(mob/to_lock)
 	locked += WEAKREF(to_lock)
-	ADD_TRAIT(to_lock, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(to_lock, TRAIT_NO_TRANSFORM, CINEMATIC_SOURCE)
 
 /// Unlocks a previously locked weakref
 /datum/cinematic/proc/unlock_mob(datum/weakref/mob_ref)
 	var/mob/locked_mob = mob_ref.resolve()
 	if(isnull(locked_mob))
 		return
-	REMOVE_TRAIT(locked_mob, TRAIT_NO_TRANSFORM, REF(src))
+	REMOVE_TRAIT(locked_mob, TRAIT_NO_TRANSFORM, CINEMATIC_SOURCE)
 	UnregisterSignal(locked_mob, COMSIG_MOB_CLIENT_LOGIN)
 
 /// Removes the passed client from our watching list.
@@ -172,3 +174,5 @@
 	no_longer_watching.screen -= screen
 
 	watching -= no_longer_watching
+
+#undef CINEMATIC_SOURCE

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -198,7 +198,7 @@
 
 	else if(isliving(dropped_thing))
 		var/mob/living/fallen_mob = dropped_thing
-		REMOVE_TRAIT(falling_mob, TRAIT_NO_TRANSFORM, REF(src))
+		REMOVE_TRAIT(fallen_mob, TRAIT_NO_TRANSFORM, REF(src))
 		if (fallen_mob.stat != DEAD)
 			fallen_mob.investigate_log("has died from falling into a chasm.", INVESTIGATE_DEATHS)
 			fallen_mob.death(TRUE)

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -157,7 +157,7 @@
 	dropped_thing.visible_message(span_boldwarning("[dropped_thing] falls into [parent]!"), span_userdanger("[oblivion_message]"))
 	if (isliving(dropped_thing))
 		var/mob/living/falling_mob = dropped_thing
-		falling_mob.notransform = TRUE
+		ADD_TRAIT(falling_mob, TRAIT_NO_TRANSFORM, REF(src))
 		falling_mob.Paralyze(20 SECONDS)
 
 	var/oldtransform = dropped_thing.transform
@@ -198,7 +198,7 @@
 
 	else if(isliving(dropped_thing))
 		var/mob/living/fallen_mob = dropped_thing
-		fallen_mob.notransform = FALSE
+		REMOVE_TRAIT(falling_mob, TRAIT_NO_TRANSFORM, REF(src))
 		if (fallen_mob.stat != DEAD)
 			fallen_mob.investigate_log("has died from falling into a chasm.", INVESTIGATE_DEATHS)
 			fallen_mob.death(TRUE)

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -60,7 +60,7 @@
 			return
 		if(HAS_TRAIT_FROM(affected_mob, TRAIT_NO_TRANSFORM, REF(src)))
 			return
-		ADD_TRAIT(affected_mob, TRAIT_NO_TRANSFORM)
+		ADD_TRAIT(affected_mob, TRAIT_NO_TRANSFORM, REF(src))
 		for(var/obj/item/W in affected_mob.get_equipped_items(include_pockets = TRUE))
 			affected_mob.dropItemToGround(W)
 		for(var/obj/item/I in affected_mob.held_items)

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -58,9 +58,9 @@
 			to_chat(affected_mob, pick(stage5))
 		if(QDELETED(affected_mob))
 			return
-		if(affected_mob.notransform)
+		if(HAS_TRAIT_FROM(affected_mob, TRAIT_NO_TRANSFORM, REF(src)))
 			return
-		affected_mob.notransform = 1
+		ADD_TRAIT(affected_mob, TRAIT_NO_TRANSFORM)
 		for(var/obj/item/W in affected_mob.get_equipped_items(include_pockets = TRUE))
 			affected_mob.dropItemToGround(W)
 		for(var/obj/item/I in affected_mob.held_items)

--- a/code/datums/mutations/void_magnet.dm
+++ b/code/datums/mutations/void_magnet.dm
@@ -60,7 +60,7 @@
 /datum/action/cooldown/spell/void/cursed/proc/on_life(mob/living/source, seconds_per_tick, times_fired)
 	SIGNAL_HANDLER
 
-	if(!isliving(source) || IS_IN_STASIS(source) || source.stat == DEAD || source.notransform)
+	if(!isliving(source) || IS_IN_STASIS(source) || source.stat == DEAD || HAS_TRAIT(source, TRAIT_NO_TRANSFORM))
 		return
 
 	if(!is_valid_target(source))

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -545,7 +545,7 @@
 
 /obj/item/borg/upgrade/expand/action(mob/living/silicon/robot/robot, user = usr)
 	. = ..()
-	if(!.)
+	if(!. || HAS_TRAIT(robot, TRAIT_NO_TRANSFORM))
 		return FALSE
 
 	if(robot.hasExpanded)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -545,29 +545,30 @@
 
 /obj/item/borg/upgrade/expand/action(mob/living/silicon/robot/robot, user = usr)
 	. = ..()
-	if(.)
+	if(!.)
+		return FALSE
 
-		if(robot.hasExpanded)
-			to_chat(usr, span_warning("This unit already has an expand module installed!"))
-			return FALSE
+	if(robot.hasExpanded)
+		to_chat(usr, span_warning("This unit already has an expand module installed!"))
+		return FALSE
 
-		robot.notransform = TRUE
-		var/prev_lockcharge = robot.lockcharge
-		robot.SetLockdown(TRUE)
-		robot.set_anchored(TRUE)
-		var/datum/effect_system/fluid_spread/smoke/smoke = new
-		smoke.set_up(1, holder = robot, location = robot.loc)
-		smoke.start()
-		sleep(0.2 SECONDS)
-		for(var/i in 1 to 4)
-			playsound(robot, pick('sound/items/drill_use.ogg', 'sound/items/jaws_cut.ogg', 'sound/items/jaws_pry.ogg', 'sound/items/welder.ogg', 'sound/items/ratchet.ogg'), 80, TRUE, -1)
-			sleep(1.2 SECONDS)
-		if(!prev_lockcharge)
-			robot.SetLockdown(FALSE)
-		robot.set_anchored(FALSE)
-		robot.notransform = FALSE
-		robot.hasExpanded = TRUE
-		robot.update_transform(2)
+	ADD_TRAIT(robot, TRAIT_NO_TRANSFORM, REF(src))
+	var/prev_lockcharge = robot.lockcharge
+	robot.SetLockdown(TRUE)
+	robot.set_anchored(TRUE)
+	var/datum/effect_system/fluid_spread/smoke/smoke = new
+	smoke.set_up(1, holder = robot, location = robot.loc)
+	smoke.start()
+	sleep(0.2 SECONDS)
+	for(var/i in 1 to 4)
+		playsound(robot, pick('sound/items/drill_use.ogg', 'sound/items/jaws_cut.ogg', 'sound/items/jaws_pry.ogg', 'sound/items/welder.ogg', 'sound/items/ratchet.ogg'), 80, TRUE, -1)
+		sleep(1.2 SECONDS)
+	if(!prev_lockcharge)
+		robot.SetLockdown(FALSE)
+	robot.set_anchored(FALSE)
+	REMOVE_TRAIT(robot, TRAIT_NO_TRANSFORM, REF(src))
+	robot.hasExpanded = TRUE
+	robot.update_transform(2)
 
 /obj/item/borg/upgrade/expand/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -20,7 +20,7 @@
 
 //Transform into a monkey.
 /datum/action/changeling/lesserform/sting_action(mob/living/carbon/human/user)
-	if(!user || user.notransform)
+	if(!user || HAS_TRAIT(user, TRAIT_NO_TRANSFORM))
 		return FALSE
 	..()
 	return ismonkey(user) ? unmonkey(user) : become_monkey(user)

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -511,7 +511,7 @@
 	// Fade in the summon while the ghost poll is ongoing.
 	// Also don't let them mess with the summon while waiting
 	summoned.alpha = 0
-	summoned.notransform = TRUE
+	ADD_TRAIT(summoned, TRAIT_NO_TRANSFORM, REF(src))
 	summoned.move_resist = MOVE_FORCE_OVERPOWERING
 	animate(summoned, 10 SECONDS, alpha = 155)
 
@@ -526,7 +526,7 @@
 	var/mob/dead/observer/picked_candidate = pick(candidates)
 	// Ok let's make them an interactable mob now, since we got a ghost
 	summoned.alpha = 255
-	summoned.notransform = FALSE
+	REMOVE_TRAIT(summoned, TRAIT_NO_TRANSFORM, REF(src))
 	summoned.move_resist = initial(summoned.move_resist)
 
 	summoned.ghostize(FALSE)

--- a/code/modules/antagonists/heretic/magic/space_crawl.dm
+++ b/code/modules/antagonists/heretic/magic/space_crawl.dm
@@ -60,10 +60,10 @@
  */
 /datum/action/cooldown/spell/jaunt/space_crawl/proc/try_enter_jaunt(turf/our_turf, mob/living/jaunter)
 	// Begin the jaunt
-	jaunter.notransform = TRUE
+	ADD_TRAIT(jaunter, TRAIT_NO_TRANSFORM, REF(src))
 	var/obj/effect/dummy/phased_mob/holder = enter_jaunt(jaunter, our_turf)
-	if(!holder)
-		jaunter.notransform = FALSE
+	if(isnull(holder))
+		REMOVE_TRAIT(jaunter, TRAIT_NO_TRANSFORM, REF(src))
 		return FALSE
 
 	RegisterSignal(holder, COMSIG_MOVABLE_MOVED, PROC_REF(update_status_on_signal))
@@ -82,14 +82,14 @@
 	new /obj/effect/temp_visual/space_explosion(our_turf)
 	jaunter.extinguish_mob()
 
-	jaunter.notransform = FALSE
+	REMOVE_TRAIT(jaunter, TRAIT_NO_TRANSFORM, REF(src))
 	return TRUE
 
 /**
  * Attempts to Exit the passed space or misc turf.
  */
 /datum/action/cooldown/spell/jaunt/space_crawl/proc/try_exit_jaunt(turf/our_turf, mob/living/jaunter)
-	if(jaunter.notransform)
+	if(HAS_TRAIT_FROM(jaunter, TRAIT_NO_TRANSFORM, REF(src)))
 		to_chat(jaunter, span_warning("You cannot exit yet!!"))
 		return FALSE
 

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -22,7 +22,7 @@
 			Harvest(A)
 
 /mob/living/simple_animal/revenant/ranged_secondary_attack(atom/target, modifiers)
-	if(revealed || notransform || inhibited || !Adjacent(target) || !incorporeal_move_check(target))
+	if(revealed || inhibited || HAS_TRAIT(src, TRAIT_NO_TRANSFORM) || !Adjacent(target) || !incorporeal_move_check(target))
 		return
 
 	var/list/icon_dimensions = get_icon_dimensions(target.icon)

--- a/code/modules/mapfluff/ruins/lavalandruin_code/puzzle.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/puzzle.dm
@@ -295,7 +295,7 @@
 
 /obj/effect/sliding_puzzle/prison/dispense_reward()
 	prisoner.forceMove(get_turf(src))
-	prisoner.notransform = FALSE
+	REMOVE_TRAIT(prisoner, TRAIT_NO_TRANSFORM, element_type)
 	prisoner = null
 
 //Some armor so it's harder to kill someone by mistake.
@@ -344,7 +344,7 @@
 		return FALSE
 
 	//First grab the prisoner and move them temporarily into the generator so they won't get thrown around.
-	prisoner.notransform = TRUE
+	ADD_TRAIT(prisoner, TRAIT_NO_TRANSFORM, cube.element_type)
 	prisoner.forceMove(cube)
 	to_chat(prisoner,span_userdanger("You're trapped by the prison cube! You will remain trapped until someone solves it."))
 

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -457,14 +457,14 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 		entered_light.end_processing()
 	. = ..()
 	if(ismob(arrived))
-		var/mob/M = arrived
-		M.notransform = TRUE
+		var/mob/target = arrived
+		ADD_TRAIT(target, TRAIT_NO_TRANSFORM, REF(src))
 
 /obj/item/abstracthotelstorage/Exited(atom/movable/gone, direction)
 	. = ..()
 	if(ismob(gone))
-		var/mob/M = gone
-		M.notransform = FALSE
+		var/mob/target = gone
+		REMOVE_TRAIT(target, TRAIT_NO_TRANSFORM, REF(src))
 	if(istype(gone, /obj/machinery/light))
 		var/obj/machinery/light/exited_light = gone
 		exited_light.begin_processing()

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -421,7 +421,7 @@
 		return
 
 	user.status_flags &= ~GODMODE
-	user.notransform = FALSE
+	REMOVE_TRAIT(user, TRAIT_NO_TRANSFORM, REF(src))
 	user.forceMove(get_turf(src))
 	user.visible_message(span_danger("[user] pops back into reality!"))
 
@@ -432,7 +432,7 @@
 	setDir(user.dir)
 
 	user.forceMove(src)
-	user.notransform = TRUE
+	ADD_TRAIT(user, TRAIT_NO_TRANSFORM, REF(src))
 	user.status_flags |= GODMODE
 
 	user_ref = WEAKREF(user)
@@ -446,8 +446,8 @@
 	return
 
 /obj/effect/immortality_talisman/relaymove(mob/living/user, direction)
-	// Won't really come into play since our mob has notransform and cannot move,
-	// but regardless block all relayed moves, becuase no, you cannot move in the void.
+	// Won't really come into play since our mob has TRAIT_NO_TRANSFORM and cannot move,
+	// but regardless block all relayed moves, because no, you cannot move in the void.
 	return
 
 /obj/effect/immortality_talisman/singularity_pull()

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -46,11 +46,13 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 		. += "Players Ready: [SSticker.totalPlayersReady]"
 		. += "Admins Ready: [SSticker.total_admins_ready] / [length(GLOB.admins)]"
 
+#define SERVER_HOPPER_TRAIT "server_hopper"
+
 /mob/dead/proc/server_hop()
 	set category = "OOC"
 	set name = "Server Hop"
 	set desc= "Jump to the other server"
-	if(notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM)) // in case the round is ending and a cinematic is already playing we don't wanna clash with that (yes i know)
 		return
 	var/list/our_id = CONFIG_GET(string/cross_comms_name)
 	var/list/csa = CONFIG_GET(keyed_list/cross_server) - our_id
@@ -76,9 +78,9 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	to_chat(C, span_notice("Sending you to [pick]."))
 	new /atom/movable/screen/splash(null, null, C)
 
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, SERVER_HOPPER_TRAIT)
 	sleep(2.9 SECONDS) //let the animation play
-	notransform = FALSE
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, SERVER_HOPPER_TRAIT)
 
 	if(!C)
 		return
@@ -86,6 +88,8 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	winset(src, null, "command=.options") //other wise the user never knows if byond is downloading resources
 
 	C << link("[addr]")
+
+#undef TRAIT_SERVER_HOPPING
 
 /mob/dead/proc/update_z(new_z) // 1+ to register, null to unregister
 	if (registered_z != new_z)

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -89,7 +89,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 	C << link("[addr]")
 
-#undef TRAIT_SERVER_HOPPING
+#undef SERVER_HOPPER_TRAIT
 
 /mob/dead/proc/update_z(new_z) // 1+ to register, null to unregister
 	if (registered_z != new_z)

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -1,8 +1,6 @@
 
 /mob/living/brain/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if (notransform)
-		return
-	if(!loc)
+	if(isnull(loc) || HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
 	if(!isnull(container))

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -1,7 +1,7 @@
 
 
 /mob/living/carbon/alien/larva/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if (notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 	if(!..() || IS_IN_STASIS(src) || (amount_grown >= max_grown))
 		return // We're dead, in stasis, or already grown.

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -3,7 +3,10 @@
 /mob/living/carbon/alien/larva/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	if(!..() || IS_IN_STASIS(src) || (amount_grown >= max_grown))
+
+	. = ..()
+
+	if(!. || IS_IN_STASIS(src) || (amount_grown >= max_grown))
 		return // We're dead, in stasis, or already grown.
 	// GROW!
 	amount_grown = min(amount_grown + (0.5 * seconds_per_tick), max_grown)

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -3,10 +3,7 @@
 /mob/living/carbon/alien/larva/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-
-	. = ..()
-
-	if(!. || IS_IN_STASIS(src) || (amount_grown >= max_grown))
+	if(!..() || IS_IN_STASIS(src) || (amount_grown >= max_grown))
 		return // We're dead, in stasis, or already grown.
 	// GROW!
 	amount_grown = min(amount_grown + (0.5 * seconds_per_tick), max_grown)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -121,7 +121,7 @@
 		CRASH("AttemptGrow failed due to the early qdeletion of source or owner.")
 
 	if(!isnull(new_xeno))
-		remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_NO_TRANSFORM), type)
+		new_xeno.remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_NO_TRANSFORM), type)
 		new_xeno.invisibility = 0
 
 	if(gib_on_success)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -111,8 +111,7 @@
 	var/mob/living/carbon/alien/larva/new_xeno = new(xeno_loc)
 	new_xeno.key = ghost.key
 	SEND_SOUND(new_xeno, sound('sound/voice/hiss5.ogg',0,0,0,100)) //To get the player's attention
-	new_xeno.add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), type) //so we don't move during the bursting animation
-	new_xeno.notransform = 1
+	new_xeno.add_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_NO_TRANSFORM), type) //so we don't move during the bursting animation
 	new_xeno.invisibility = INVISIBILITY_MAXIMUM
 
 	sleep(0.6 SECONDS)
@@ -121,10 +120,8 @@
 		qdel(new_xeno)
 		CRASH("AttemptGrow failed due to the early qdeletion of source or owner.")
 
-	if(new_xeno)
-		REMOVE_TRAIT(new_xeno, TRAIT_IMMOBILIZED, type)
-		REMOVE_TRAIT(new_xeno, TRAIT_HANDS_BLOCKED, type)
-		new_xeno.notransform = 0
+	if(!isnull(new_xeno))
+		remove_traits(list(TRAIT_HANDS_BLOCKED, TRAIT_IMMOBILIZED, TRAIT_NO_TRANSFORM), type)
 		new_xeno.invisibility = 0
 
 	if(gib_on_success)

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -272,8 +272,8 @@
 #undef NEXT_PARENT_COMMAND
 
 /mob/living/carbon/regenerate_icons()
-	if(notransform)
-		return 1
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
+		return
 	icon_render_keys = list() //Clear this bad larry out
 	update_held_items()
 	update_worn_handcuffs()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -19,7 +19,7 @@
 #define THERMAL_PROTECTION_HAND_RIGHT 0.025
 
 /mob/living/carbon/human/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if(notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
 	. = ..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -19,6 +19,9 @@
 #define THERMAL_PROTECTION_HAND_RIGHT 0.025
 
 /mob/living/carbon/human/Life(seconds_per_tick = SSMOBS_DT, times_fired)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
+		return
+
 	. = ..()
 	if(QDELETED(src))
 		return FALSE

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -19,9 +19,6 @@
 #define THERMAL_PROTECTION_HAND_RIGHT 0.025
 
 /mob/living/carbon/human/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
-		return
-
 	. = ..()
 	if(QDELETED(src))
 		return FALSE

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -268,12 +268,12 @@
 	if(!isslimeperson(H))
 		return
 	CHECK_DNA_AND_SPECIES(H)
-	H.visible_message("<span class='notice'>[owner] gains a look of \
-		concentration while standing perfectly still.</span>",
-		"<span class='notice'>You focus intently on moving your body while \
-		standing perfectly still...</span>")
+	H.visible_message(
+		span_notice("[owner] gains a look of concentration while standing perfectly still."),
+		span_notice("You focus intently on moving your body while standing perfectly still..."),
+	)
 
-	H.notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 
 	if(do_after(owner, delay = 6 SECONDS, target = owner, timed_action_flags = IGNORE_HELD_ITEM))
 		if(H.blood_volume >= BLOOD_VOLUME_SLIME_SPLIT)
@@ -283,7 +283,7 @@
 	else
 		to_chat(H, span_warning("...but fail to stand perfectly still!"))
 
-	H.notransform = FALSE
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 
 /datum/action/innate/split_body/proc/make_dupe()
 	var/mob/living/carbon/human/H = owner
@@ -302,7 +302,7 @@
 	spare.Move(get_step(H.loc, pick(NORTH,SOUTH,EAST,WEST)))
 
 	H.blood_volume *= 0.45
-	H.notransform = 0
+	REMOVE_TRAIT(H, TRAIT_NO_TRANSFORM, REF(src))
 
 	var/datum/species/jelly/slime/origin_datum = H.dna.species
 	origin_datum.bodies |= spare
@@ -312,10 +312,10 @@
 
 	H.transfer_quirk_datums(spare)
 	H.mind.transfer_to(spare)
-	spare.visible_message("<span class='warning'>[H] distorts as a new body \
-		\"steps out\" of [H.p_them()].</span>",
-		"<span class='notice'>...and after a moment of disorentation, \
-		you're besides yourself!</span>")
+	spare.visible_message(
+		span_warning("[H] distorts as a new body \"steps out\" of [H.p_them()]."),
+		span_notice("...and after a moment of disorentation, you're besides yourself!"),
+	)
 
 
 /datum/action/innate/swap_body

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -1,5 +1,5 @@
 /mob/living/carbon/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if(notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
 	if(damageoverlaytemp)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -34,9 +34,7 @@
 		log_game("Z-TRACKING: [src] of type [src.type] has a Z-registration despite not having a client.")
 		update_z(null)
 
-	if (notransform)
-		return
-	if(!loc)
+	if(isnull(loc) || HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
 	if(!IS_IN_STASIS(src))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1315,14 +1315,13 @@
  * Returns a mob (what our mob turned into) or null (if we failed).
  */
 /mob/living/proc/wabbajack(what_to_randomize, change_flags = WABBAJACK)
-	if(stat == DEAD || notransform || (GODMODE & status_flags))
+	if(stat == DEAD || (GODMODE & status_flags) || HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
 	if(SEND_SIGNAL(src, COMSIG_LIVING_PRE_WABBAJACKED, what_to_randomize) & STOP_WABBAJACK)
 		return
 
-	notransform = TRUE
-	add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), MAGIC_TRAIT)
+	add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED, TRAIT_NO_TRANSFORM), MAGIC_TRAIT)
 	icon = null
 	cut_overlays()
 	invisibility = INVISIBILITY_ABSTRACT

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,5 +1,5 @@
 /mob/living/silicon/robot/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if (src.notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
 	..()

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,8 +1,5 @@
 /mob/living/silicon/robot/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
-		return
-
-	..()
+	. = ..()
 	handle_robot_hud_updates()
 	handle_robot_cell(seconds_per_tick, times_fired)
 

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -1,5 +1,8 @@
 /mob/living/silicon/robot/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	. = ..()
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
+		return
+
+	..()
 	handle_robot_hud_updates()
 	handle_robot_cell(seconds_per_tick, times_fired)
 

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -232,7 +232,7 @@
 
 /obj/item/robot_model/proc/be_transformed_to(obj/item/robot_model/old_model, forced = FALSE)
 	if(HAS_TRAIT(robot, TRAIT_NO_TRANSFORM))
-		robot.balloon_alert("can't transform right now!")
+		robot.balloon_alert(robot, "can't transform right now!")
 		return FALSE
 	if(islist(borg_skins) && !forced)
 		var/mob/living/silicon/robot/cyborg = loc

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -273,7 +273,7 @@
 	var/mob/living/silicon/robot/cyborg = loc
 	sleep(0.1 SECONDS)
 	flick("[cyborg_base_icon]_transform", cyborg)
-	cyborg.notransform = TRUE
+	ADD_TRAIT(cyborg, TRAIT_NO_TRANSFORM, REF(src))
 	if(locked_transform)
 		cyborg.ai_lockdown = TRUE
 		cyborg.SetLockdown(TRUE)
@@ -287,7 +287,7 @@
 	cyborg.ai_lockdown = FALSE
 	cyborg.setDir(SOUTH)
 	cyborg.set_anchored(FALSE)
-	cyborg.notransform = FALSE
+	REMOVE_TRAIT(cyborg, TRAIT_NO_TRANSFORM, REF(src))
 	cyborg.updatehealth()
 	cyborg.update_icons()
 	cyborg.notify_ai(AI_NOTIFICATION_NEW_MODEL)

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -231,6 +231,9 @@
 	return new_model
 
 /obj/item/robot_model/proc/be_transformed_to(obj/item/robot_model/old_model, forced = FALSE)
+	if(HAS_TRAIT(robot, TRAIT_NO_TRANSFORM))
+		robot.balloon_alert("can't transform right now!")
+		return FALSE
 	if(islist(borg_skins) && !forced)
 		var/mob/living/silicon/robot/cyborg = loc
 		var/list/reskin_icons = list()

--- a/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
@@ -216,9 +216,8 @@
 	if(z != target.z)
 		return
 	hopping = TRUE
-	ADD_TRAIT(src, TRAIT_UNDENSE, LEAPING_TRAIT)
+	add_traits(list(TRAIT_UNDENSE, TRAIT_NO_TRANSFORM), LEAPING_TRAIT)
 	pass_flags |= PASSMOB
-	notransform = TRUE
 	var/turf/new_turf = locate((target.x + rand(-3,3)),(target.y + rand(-3,3)),target.z)
 	if(player_hop)
 		new_turf = get_turf(target)
@@ -229,8 +228,7 @@
 	throw_at(new_turf, max(3,get_dist(src,new_turf)), 1, src, FALSE, callback = CALLBACK(src, PROC_REF(FinishHop)))
 
 /mob/living/simple_animal/hostile/jungle/leaper/proc/FinishHop()
-	REMOVE_TRAIT(src, TRAIT_UNDENSE, LEAPING_TRAIT)
-	notransform = FALSE
+	remove_traits(list(TRAIT_UNDENSE, TRAIT_NO_TRANSFORM), LEAPING_TRAIT)
 	pass_flags &= ~PASSMOB
 	hopping = FALSE
 	playsound(src.loc, 'sound/effects/meteorimpact.ogg', 100, TRUE)
@@ -241,9 +239,9 @@
 /mob/living/simple_animal/hostile/jungle/leaper/proc/BellyFlop()
 	var/turf/new_turf = get_turf(target)
 	hopping = TRUE
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, LEAPING_TRAIT)
 	new /obj/effect/temp_visual/leaper_crush(new_turf)
-	addtimer(CALLBACK(src, PROC_REF(BellyFlopHop), new_turf), 30)
+	addtimer(CALLBACK(src, PROC_REF(BellyFlopHop), new_turf), 3 SECONDS)
 
 /mob/living/simple_animal/hostile/jungle/leaper/proc/BellyFlopHop(turf/T)
 	ADD_TRAIT(src, TRAIT_UNDENSE, LEAPING_TRAIT)
@@ -251,8 +249,7 @@
 
 /mob/living/simple_animal/hostile/jungle/leaper/proc/Crush()
 	hopping = FALSE
-	REMOVE_TRAIT(src, TRAIT_UNDENSE, LEAPING_TRAIT)
-	notransform = FALSE
+	remove_traits(list(TRAIT_UNDENSE, TRAIT_NO_TRANSFORM), LEAPING_TRAIT)
 	playsound(src, 'sound/effects/meteorimpact.ogg', 200, TRUE)
 	for(var/mob/living/L in orange(1, src))
 		L.adjustBruteLoss(35)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -588,8 +588,7 @@
 	. = ..()
 	if(isliving(arrived) && holder_animal)
 		var/mob/living/possessor = arrived
-		possessor.notransform = TRUE
-		ADD_TRAIT(possessor, TRAIT_MUTE, STASIS_MUTE)
+		add_traits(list(TRAIT_UNDENSE, TRAIT_NO_TRANSFORM), STASIS_MUTE)
 		possessor.status_flags |= GODMODE
 		possessor.mind.transfer_to(holder_animal)
 		var/datum/action/exit_possession/escape = new(holder_animal)
@@ -598,9 +597,8 @@
 
 /obj/structure/closet/stasis/dump_contents(kill = TRUE)
 	for(var/mob/living/possessor in src)
-		REMOVE_TRAIT(possessor, TRAIT_MUTE, STASIS_MUTE)
+		remove_traits(list(TRAIT_UNDENSE, TRAIT_NO_TRANSFORM), STASIS_MUTE)
 		possessor.status_flags &= ~GODMODE
-		possessor.notransform = FALSE
 		if(kill || !isanimal_or_basicmob(loc))
 			possessor.investigate_log("has died from [src].", INVESTIGATE_DEATHS)
 			possessor.death(FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -588,7 +588,7 @@
 	. = ..()
 	if(isliving(arrived) && holder_animal)
 		var/mob/living/possessor = arrived
-		add_traits(list(TRAIT_UNDENSE, TRAIT_NO_TRANSFORM), STASIS_MUTE)
+		possessor.add_traits(list(TRAIT_UNDENSE, TRAIT_NO_TRANSFORM), STASIS_MUTE)
 		possessor.status_flags |= GODMODE
 		possessor.mind.transfer_to(holder_animal)
 		var/datum/action/exit_possession/escape = new(holder_animal)
@@ -597,7 +597,7 @@
 
 /obj/structure/closet/stasis/dump_contents(kill = TRUE)
 	for(var/mob/living/possessor in src)
-		remove_traits(list(TRAIT_UNDENSE, TRAIT_NO_TRANSFORM), STASIS_MUTE)
+		possessor.remove_traits(list(TRAIT_UNDENSE, TRAIT_NO_TRANSFORM), STASIS_MUTE)
 		possessor.status_flags &= ~GODMODE
 		if(kill || !isanimal_or_basicmob(loc))
 			possessor.investigate_log("has died from [src].", INVESTIGATE_DEATHS)

--- a/code/modules/mob/living/simple_animal/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant.dm
@@ -351,7 +351,7 @@
 /mob/living/simple_animal/revenant/proc/death_reset()
 	revealed = FALSE
 	unreveal_time = 0
-	notransform = 0
+	notransform = FALSE
 	unstun_time = 0
 	inhibited = FALSE
 	draining = FALSE

--- a/code/modules/mob/living/simple_animal/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant.dm
@@ -139,7 +139,7 @@
 		to_chat(src, span_revenboldnotice("You are once more concealed."))
 	if(unstun_time && world.time >= unstun_time)
 		unstun_time = 0
-		remove_trait(src, TRAIT_NO_TRANSFORM, REF(src))
+		REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 		to_chat(src, span_revenboldnotice("You can move again!"))
 	if(essence_regenerating && !inhibited && essence < essence_regen_cap) //While inhibited, essence will not regenerate
 		essence = min(essence + (essence_regen_amount * seconds_per_tick), essence_regen_cap)

--- a/code/modules/mob/living/simple_animal/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant.dm
@@ -139,7 +139,7 @@
 		to_chat(src, span_revenboldnotice("You are once more concealed."))
 	if(unstun_time && world.time >= unstun_time)
 		unstun_time = 0
-		notransform = FALSE
+		remove_trait(src, TRAIT_NO_TRANSFORM, REF(src))
 		to_chat(src, span_revenboldnotice("You can move again!"))
 	if(essence_regenerating && !inhibited && essence < essence_regen_cap) //While inhibited, essence will not regenerate
 		essence = min(essence + (essence_regen_amount * seconds_per_tick), essence_regen_cap)
@@ -239,7 +239,7 @@
 		return
 	stasis = TRUE
 	to_chat(src, span_revendanger("NO! No... it's too late, you can feel your essence [pick("breaking apart", "drifting away")]..."))
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	revealed = TRUE
 	invisibility = 0
 	playsound(src, 'sound/effects/screech.ogg', 100, TRUE)
@@ -282,7 +282,7 @@
 		return
 	if(time <= 0)
 		return
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	if(!unstun_time)
 		to_chat(src, span_revendanger("You cannot move!"))
 		unstun_time = world.time + time
@@ -294,7 +294,7 @@
 
 /mob/living/simple_animal/revenant/proc/update_spooky_icon()
 	if(revealed)
-		if(notransform)
+		if(HAS_TRAIT_FROM(src, TRAIT_NO_TRANSFORM, REF(src)))
 			if(draining)
 				icon_state = icon_drain
 			else
@@ -351,7 +351,7 @@
 /mob/living/simple_animal/revenant/proc/death_reset()
 	revealed = FALSE
 	unreveal_time = 0
-	notransform = FALSE
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	unstun_time = 0
 	inhibited = FALSE
 	draining = FALSE

--- a/code/modules/mob/living/simple_animal/revenant.dm
+++ b/code/modules/mob/living/simple_animal/revenant.dm
@@ -3,6 +3,9 @@
 //Can hear deadchat, but are NOT normal ghosts and do NOT have x-ray vision
 //Admin-spawn or random event
 
+/// Source for a trait we get when we're stunned
+#define REVENANT_STUNNED_TRAIT "revenant_got_stunned"
+
 /mob/living/simple_animal/revenant
 	name = "revenant"
 	desc = "A malevolent spirit."
@@ -139,7 +142,7 @@
 		to_chat(src, span_revenboldnotice("You are once more concealed."))
 	if(unstun_time && world.time >= unstun_time)
 		unstun_time = 0
-		REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+		REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REVENANT_STUNNED_TRAIT)
 		to_chat(src, span_revenboldnotice("You can move again!"))
 	if(essence_regenerating && !inhibited && essence < essence_regen_cap) //While inhibited, essence will not regenerate
 		essence = min(essence + (essence_regen_amount * seconds_per_tick), essence_regen_cap)
@@ -239,7 +242,7 @@
 		return
 	stasis = TRUE
 	to_chat(src, span_revendanger("NO! No... it's too late, you can feel your essence [pick("breaking apart", "drifting away")]..."))
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REVENANT_STUNNED_TRAIT)
 	revealed = TRUE
 	invisibility = 0
 	playsound(src, 'sound/effects/screech.ogg', 100, TRUE)
@@ -282,7 +285,7 @@
 		return
 	if(time <= 0)
 		return
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REVENANT_STUNNED_TRAIT)
 	if(!unstun_time)
 		to_chat(src, span_revendanger("You cannot move!"))
 		unstun_time = world.time + time
@@ -294,7 +297,7 @@
 
 /mob/living/simple_animal/revenant/proc/update_spooky_icon()
 	if(revealed)
-		if(HAS_TRAIT_FROM(src, TRAIT_NO_TRANSFORM, REF(src)))
+		if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 			if(draining)
 				icon_state = icon_drain
 			else
@@ -351,7 +354,7 @@
 /mob/living/simple_animal/revenant/proc/death_reset()
 	revealed = FALSE
 	unreveal_time = 0
-	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REVENANT_STUNNED_TRAIT)
 	unstun_time = 0
 	inhibited = FALSE
 	draining = FALSE
@@ -541,3 +544,4 @@
 /datum/objective/revenant_fluff/check_completion()
 	return TRUE
 
+#undef REVENANT_STUNNED_TRAIT

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/slime/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if (notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 	. = ..()
 	if(!.)

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -1,4 +1,6 @@
 /mob/living/simple_animal/slime/Life(seconds_per_tick = SSMOBS_DT, times_fired)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
+		return
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -1,6 +1,4 @@
 /mob/living/simple_animal/slime/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
-		return
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -84,14 +84,6 @@
 	/// Tick time the mob can next move
 	var/next_move = null
 
-	/**
-	  * Magic var that stops you moving and interacting with anything
-	  *
-	  * Set when you're being turned into something else and also used in a bunch of places
-	  * it probably shouldn't really be
-	  */
-	var/notransform = TRUE
-
 	/// What is the mobs real name (name is overridden for disguises etc)
 	var/real_name = null
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -90,7 +90,7 @@
 	  * Set when you're being turned into something else and also used in a bunch of places
 	  * it probably shouldn't really be
 	  */
-	var/notransform = null //Carbon
+	var/notransform = TRUE
 
 	/// What is the mobs real name (name is overridden for disguises etc)
 	var/real_name = null

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -74,7 +74,7 @@
 		return FALSE
 	if(!mob?.loc)
 		return FALSE
-	if(mob.notransform)
+	if(HAS_TRAIT(mob, TRAIT_NO_TRANSFORM))
 		return FALSE //This is sota the goto stop mobs from moving var
 	if(mob.control_object)
 		return Move_object(direct)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -75,7 +75,7 @@
 	if(!mob?.loc)
 		return FALSE
 	if(HAS_TRAIT(mob, TRAIT_NO_TRANSFORM))
-		return FALSE //This is sota the goto stop mobs from moving var
+		return FALSE //This is sorta the goto stop mobs from moving trait
 	if(mob.control_object)
 		return Move_object(direct)
 	if(!isliving(mob))

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,4 +1,8 @@
 #define TRANSFORMATION_DURATION 22
+/// Will be removed once the transformation is complete.
+#define TEMPORARY_TRANSFORMATION_TRAIT "temporary_transformation"
+/// Considered "permanent" since we'll be deleting the old mob and the client will be inserted into a new one (without this trait)
+#define PERMANENT_TRANSFORMATION_TRAIT "permanent_transformation"
 
 /mob/living/carbon/proc/monkeyize(instant = FALSE)
 	if (transformation_timer || HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
@@ -12,7 +16,7 @@
 		return
 
 	//Make mob invisible and spawn animation
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
 	Paralyze(TRANSFORMATION_DURATION, ignore_canstun = TRUE)
 	icon = null
 	cut_overlays()
@@ -24,7 +28,7 @@
 /mob/living/carbon/proc/finish_monkeyize()
 	transformation_timer = null
 	to_chat(src, span_boldnotice("You are now a monkey."))
-	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
 	icon = initial(icon)
 	invisibility = 0
 	set_species(/datum/species/monkey)
@@ -50,7 +54,7 @@
 		return
 
 	//Make mob invisible and spawn animation
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
 	Paralyze(TRANSFORMATION_DURATION, ignore_canstun = TRUE)
 	icon = null
 	cut_overlays()
@@ -62,7 +66,7 @@
 /mob/living/carbon/proc/finish_humanize(species = /datum/species/human)
 	transformation_timer = null
 	to_chat(src, span_boldnotice("You are now a human."))
-	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
 	icon = initial(icon)
 	invisibility = 0
 	set_species(species)
@@ -109,7 +113,7 @@
 /mob/living/carbon/AIize(client/preference_source, transfer_after = TRUE)
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, PERMANENT_TRANSFORMATION_TRAIT)
 	Paralyze(1, ignore_canstun = TRUE)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
@@ -129,7 +133,7 @@
 /mob/proc/Robotize(delete_items = 0, transfer_after = TRUE)
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, PERMANENT_TRANSFORMATION_TRAIT)
 	var/mob/living/silicon/robot/new_borg = new /mob/living/silicon/robot(loc)
 
 	new_borg.gender = gender
@@ -164,7 +168,7 @@
 /mob/living/Robotize(delete_items = 0, transfer_after = TRUE)
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
 	Paralyze(1, ignore_canstun = TRUE)
 
 	for(var/obj/item/W in src)
@@ -176,7 +180,7 @@
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
 
-	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, TEMPORARY_TRANSFORMATION_TRAIT)
 	return ..()
 
 /mob/living/silicon/robot/proc/replace_banned_cyborg()
@@ -193,7 +197,7 @@
 /mob/living/carbon/human/proc/Alienize()
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, PERMANENT_TRANSFORMATION_TRAIT)
 	add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), TRAIT_GENERIC)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
@@ -223,7 +227,7 @@
 /mob/living/carbon/human/proc/slimeize(reproduce as num)
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, PERMANENT_TRANSFORMATION_TRAIT)
 	add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), TRAIT_GENERIC)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
@@ -262,7 +266,7 @@
 /mob/living/carbon/human/proc/corgize()
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, PERMANENT_TRANSFORMATION_TRAIT)
 	Paralyze(1, ignore_canstun = TRUE)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
@@ -283,7 +287,7 @@
 /mob/living/carbon/proc/gorillize()
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, PERMANENT_TRANSFORMATION_TRAIT)
 	Paralyze(1, ignore_canstun = TRUE)
 
 	SSblackbox.record_feedback("amount", "gorillas_created", 1)
@@ -318,7 +322,7 @@
 
 	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, PERMANENT_TRANSFORMATION_TRAIT)
 	Paralyze(1, ignore_canstun = TRUE)
 
 	for(var/obj/item/W in src)
@@ -398,4 +402,6 @@
 	//Not in here? Must be untested!
 	return FALSE
 
+#undef PERMANENT_TRANSFORMATION_TRAIT
+#undef TEMPORARY_TRANSFORMATION_TRAIT
 #undef TRANSFORMATION_DURATION

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -1,7 +1,7 @@
 #define TRANSFORMATION_DURATION 22
 
 /mob/living/carbon/proc/monkeyize(instant = FALSE)
-	if (notransform || transformation_timer)
+	if (transformation_timer || HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
 	if(ismonkey(src))
@@ -12,7 +12,7 @@
 		return
 
 	//Make mob invisible and spawn animation
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	Paralyze(TRANSFORMATION_DURATION, ignore_canstun = TRUE)
 	icon = null
 	cut_overlays()
@@ -23,8 +23,8 @@
 
 /mob/living/carbon/proc/finish_monkeyize()
 	transformation_timer = null
-	to_chat(src, "<B>You are now a monkey.</B>")
-	notransform = FALSE
+	to_chat(src, span_boldnotice("You are now a monkey."))
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	icon = initial(icon)
 	invisibility = 0
 	set_species(/datum/species/monkey)
@@ -39,7 +39,7 @@
 //Could probably be merged with monkeyize but other transformations got their own procs, too
 
 /mob/living/carbon/proc/humanize(species = /datum/species/human, instant = FALSE)
-	if (notransform || transformation_timer)
+	if (transformation_timer || HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 
 	if(!ismonkey(src))
@@ -50,7 +50,7 @@
 		return
 
 	//Make mob invisible and spawn animation
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	Paralyze(TRANSFORMATION_DURATION, ignore_canstun = TRUE)
 	icon = null
 	cut_overlays()
@@ -61,8 +61,8 @@
 
 /mob/living/carbon/proc/finish_humanize(species = /datum/species/human)
 	transformation_timer = null
-	to_chat(src, "<B>You are now a human.</B>")
-	notransform = FALSE
+	to_chat(src, span_boldnotice("You are now a human."))
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	icon = initial(icon)
 	invisibility = 0
 	set_species(species)
@@ -107,9 +107,9 @@
 	qdel(src)
 
 /mob/living/carbon/AIize(client/preference_source, transfer_after = TRUE)
-	if (notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	Paralyze(1, ignore_canstun = TRUE)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
@@ -119,7 +119,7 @@
 	return ..()
 
 /mob/living/carbon/human/AIize(client/preference_source, transfer_after = TRUE)
-	if (notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
 	for(var/t in bodyparts)
 		qdel(t)
@@ -127,9 +127,9 @@
 	return ..()
 
 /mob/proc/Robotize(delete_items = 0, transfer_after = TRUE)
-	if(notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	var/mob/living/silicon/robot/new_borg = new /mob/living/silicon/robot(loc)
 
 	new_borg.gender = gender
@@ -162,9 +162,9 @@
 	qdel(src)
 
 /mob/living/Robotize(delete_items = 0, transfer_after = TRUE)
-	if(notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	Paralyze(1, ignore_canstun = TRUE)
 
 	for(var/obj/item/W in src)
@@ -176,7 +176,7 @@
 	icon = null
 	invisibility = INVISIBILITY_MAXIMUM
 
-	notransform = FALSE
+	REMOVE_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	return ..()
 
 /mob/living/silicon/robot/proc/replace_banned_cyborg()
@@ -191,9 +191,9 @@
 
 //human -> alien
 /mob/living/carbon/human/proc/Alienize()
-	if (notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), TRAIT_GENERIC)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
@@ -216,14 +216,14 @@
 	new_xeno.set_combat_mode(TRUE)
 	new_xeno.key = key
 
-	to_chat(new_xeno, "<B>You are now an alien.</B>")
-	. = new_xeno
+	to_chat(new_xeno, span_boldnotice("You are now an alien."))
 	qdel(src)
+	return new_xeno
 
 /mob/living/carbon/human/proc/slimeize(reproduce as num)
-	if (notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), TRAIT_GENERIC)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
@@ -248,9 +248,9 @@
 	new_slime.set_combat_mode(TRUE)
 	new_slime.key = key
 
-	to_chat(new_slime, "<B>You are now a slime. Skreee!</B>")
-	. = new_slime
+	to_chat(new_slime, span_boldnotice("You are now a slime. Skreee!"))
 	qdel(src)
+	return new_slime
 
 /mob/proc/become_overmind(starting_points = OVERMIND_STARTING_POINTS)
 	var/mob/camera/blob/B = new /mob/camera/blob(get_turf(src), starting_points)
@@ -260,9 +260,9 @@
 
 
 /mob/living/carbon/human/proc/corgize()
-	if (notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	Paralyze(1, ignore_canstun = TRUE)
 	for(var/obj/item/W in src)
 		dropItemToGround(W)
@@ -276,14 +276,14 @@
 	new_corgi.set_combat_mode(TRUE)
 	new_corgi.key = key
 
-	to_chat(new_corgi, "<B>You are now a Corgi. Yap Yap!</B>")
-	. = new_corgi
+	to_chat(new_corgi, span_boldnotice("You are now a Corgi. Yap Yap!"))
 	qdel(src)
+	return new_corgi
 
 /mob/living/carbon/proc/gorillize()
-	if(notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	Paralyze(1, ignore_canstun = TRUE)
 
 	SSblackbox.record_feedback("amount", "gorillas_created", 1)
@@ -302,9 +302,9 @@
 		mind.transfer_to(new_gorilla)
 	else
 		new_gorilla.key = key
-	to_chat(new_gorilla, "<B>You are now a gorilla. Ooga ooga!</B>")
-	. = new_gorilla
+	to_chat(new_gorilla, span_boldnotice("You are now a gorilla. Ooga ooga!"))
 	qdel(src)
+	return new_gorilla
 
 /mob/living/carbon/human/Animalize()
 
@@ -316,9 +316,9 @@
 		to_chat(usr, span_danger("Sorry but this mob type is currently unavailable."))
 		return
 
-	if(notransform)
+	if(HAS_TRAIT(src, TRAIT_NO_TRANSFORM))
 		return
-	notransform = TRUE
+	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, REF(src))
 	Paralyze(1, ignore_canstun = TRUE)
 
 	for(var/obj/item/W in src)
@@ -337,8 +337,8 @@
 	new_mob.set_combat_mode(TRUE)
 
 	to_chat(new_mob, span_boldnotice("You suddenly feel more... animalistic."))
-	. = new_mob
 	qdel(src)
+	return new_mob
 
 /mob/proc/Animalize()
 

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -89,13 +89,13 @@
 	user.visible_message(span_warning("[user] aims [src] at the ground! It looks like [user.p_theyre()] performing a sick rocket jump!"), \
 		span_userdanger("You aim [src] at the ground to perform a bisnasty rocket jump..."))
 	if(can_shoot())
-		user.notransform = TRUE
+		ADD_TRAIT(user, TRAIT_NO_TRANSFORM, REF(src))
 		playsound(src, 'sound/vehicles/rocketlaunch.ogg', 80, TRUE, 5)
 		animate(user, pixel_z = 300, time = 30, easing = LINEAR_EASING)
 		sleep(7 SECONDS)
 		animate(user, pixel_z = 0, time = 5, easing = LINEAR_EASING)
 		sleep(0.5 SECONDS)
-		user.notransform = FALSE
+		REMOVE_TRAIT(user, TRAIT_NO_TRANSFORM, REF(src))
 		process_fire(user, user, TRUE)
 		if(!QDELETED(user)) //if they weren't gibbed by the explosion, take care of them for good.
 			user.gib()

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -787,7 +787,7 @@
 			if(sunset_mobs.mind && !istype(get_area(sunset_mobs), /area/shuttle/escape/brig))
 				sunset_mobs.mind.force_escaped = TRUE
 			// Ghostize them and put them in nullspace stasis (for stat & possession checks)
-			sunset_mobs.notransform = TRUE
+			ADD_TRAIT(sunset_mobs, TRAIT_NO_TRANSFORM, REF(src))
 			sunset_mobs.ghostize(FALSE)
 			sunset_mobs.moveToNullspace()
 

--- a/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
@@ -83,10 +83,10 @@
 	var/turf/jaunt_turf = get_turf(blood)
 
 	// Begin the jaunt
-	jaunter.notransform = TRUE
+	ADD_TRAIT(jaunter, TRAIT_NO_TRANSFORM, REF(src))
 	var/obj/effect/dummy/phased_mob/holder = enter_jaunt(jaunter, jaunt_turf)
 	if(!holder)
-		jaunter.notransform = FALSE
+		REMOVE_TRAIT(jaunter, TRAIT_NO_TRANSFORM, REF(src))
 		return FALSE
 
 	RegisterSignal(holder, COMSIG_MOVABLE_MOVED, PROC_REF(update_status_on_signal))
@@ -104,7 +104,7 @@
 	playsound(jaunt_turf, 'sound/magic/enter_blood.ogg', 50, TRUE, -1)
 	jaunter.extinguish_mob()
 
-	jaunter.notransform = FALSE
+	REMOVE_TRAIT(jaunter, TRAIT_NO_TRANSFORM, REF(src))
 	return TRUE
 
 /**
@@ -113,7 +113,7 @@
  */
 /datum/action/cooldown/spell/jaunt/bloodcrawl/proc/try_exit_jaunt(obj/effect/decal/cleanable/blood, mob/living/jaunter, forced = FALSE)
 	if(!forced)
-		if(jaunter.notransform)
+		if(HAS_TRAIT(jaunter, TRAIT_NO_TRANSFORM))
 			to_chat(jaunter, span_warning("You cannot exit yet!!"))
 			return FALSE
 
@@ -196,9 +196,9 @@
 		blind_message = span_notice("You hear a splash."),
 	)
 
-	jaunter.notransform = TRUE
+	ADD_TRAIT(jaunter, TRAIT_NO_TRANSFORM, REF(src))
 	consume_victim(victim, jaunter)
-	jaunter.notransform = FALSE
+	REMOVE_TRAIT(jaunter, TRAIT_NO_TRANSFORM, REF(src))
 
 	return TRUE
 

--- a/code/modules/spells/spell_types/jaunt/ethereal_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/ethereal_jaunt.dm
@@ -49,9 +49,9 @@
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/proc/do_jaunt(mob/living/cast_on)
 	// Makes sure they don't die or get jostled or something during the jaunt entry
 	// Honestly probably not necessary anymore, but better safe than sorry
-	cast_on.notransform = TRUE
+	ADD_TRAIT(cast_on, TRAIT_NO_TRANSFORM, REF(src))
 	var/obj/effect/dummy/phased_mob/holder = enter_jaunt(cast_on)
-	cast_on.notransform = FALSE
+	REMOVE_TRAIT(cast_on, TRAIT_NO_TRANSFORM, REF(src))
 
 	if(!holder)
 		CRASH("[type] attempted do_jaunt but failed to create a jaunt holder via enter_jaunt.")
@@ -167,9 +167,10 @@
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/proc/end_jaunt(mob/living/cast_on, obj/effect/dummy/phased_mob/spell_jaunt/holder, turf/final_point)
 	if(QDELETED(cast_on) || QDELETED(holder) || QDELETED(src))
 		return
-	cast_on.notransform = TRUE
+
+	ADD_TRAIT(cast_on, TRAIT_NO_TRANSFORM, REF(src))
 	exit_jaunt(cast_on)
-	cast_on.notransform = FALSE
+	REMOVE_TRAIT(cast_on, TRAIT_NO_TRANSFORM, REF(src))
 
 	REMOVE_TRAIT(cast_on, TRAIT_IMMOBILIZED, REF(src))
 

--- a/code/modules/spells/spell_types/self/rod_form.dm
+++ b/code/modules/spells/spell_types/self/rod_form.dm
@@ -138,9 +138,8 @@
 	our_wizard = WEAKREF(wizard)
 
 	wizard.forceMove(src)
-	wizard.notransform = TRUE
 	wizard.status_flags |= GODMODE
-	ADD_TRAIT(wizard, TRAIT_MAGICALLY_PHASED, REF(src))
+	add_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_NO_TRANSFORM), REF(src))
 
 /**
  * Eject our current wizard, removing them from the rod
@@ -152,9 +151,8 @@
 		return
 
 	wizard.status_flags &= ~GODMODE
-	wizard.notransform = FALSE
+	remove_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_NO_TRANSFORM), REF(src))
 	wizard.forceMove(get_turf(src))
 	our_wizard = null
-	REMOVE_TRAIT(wizard, TRAIT_MAGICALLY_PHASED, REF(src))
 
 #undef BASE_WIZ_ROD_RANGE

--- a/code/modules/spells/spell_types/self/rod_form.dm
+++ b/code/modules/spells/spell_types/self/rod_form.dm
@@ -139,7 +139,7 @@
 
 	wizard.forceMove(src)
 	wizard.status_flags |= GODMODE
-	add_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_NO_TRANSFORM), REF(src))
+	wizard.add_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_NO_TRANSFORM), REF(src))
 
 /**
  * Eject our current wizard, removing them from the rod
@@ -151,7 +151,7 @@
 		return
 
 	wizard.status_flags &= ~GODMODE
-	remove_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_NO_TRANSFORM), REF(src))
+	wizard.remove_traits(list(TRAIT_MAGICALLY_PHASED, TRAIT_NO_TRANSFORM), REF(src))
 	wizard.forceMove(get_turf(src))
 	our_wizard = null
 

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -32,7 +32,7 @@
 /datum/status_effect/shapechange_mob/on_apply()
 	caster_mob.mind?.transfer_to(owner)
 	caster_mob.forceMove(owner)
-	caster_mob.notransform = TRUE
+	ADD_TRAIT(caster_mob, TRAIT_NO_TRANSFORM, REF(src))
 	caster_mob.apply_status_effect(/datum/status_effect/grouped/stasis, STASIS_SHAPECHANGE_EFFECT)
 
 	RegisterSignal(owner, COMSIG_LIVING_PRE_WABBAJACKED, PROC_REF(on_wabbajacked))
@@ -77,7 +77,7 @@
 	UnregisterSignal(caster_mob, list(COMSIG_QDELETING, COMSIG_LIVING_DEATH))
 
 	caster_mob.forceMove(owner.loc)
-	caster_mob.notransform = FALSE
+	REMOVE_TRAIT(caster_mob, TRAIT_NO_TRANSFORM, REF(src))
 	caster_mob.remove_status_effect(/datum/status_effect/grouped/stasis, STASIS_SHAPECHANGE_EFFECT)
 	owner.mind?.transfer_to(caster_mob)
 


### PR DESCRIPTION
## About The Pull Request

Hey there,

There were more than a few times (like in cinematic code) where we might need to accurately know the source of what's adding this trait (or have multiple sources for the whole 'we don't want this mob to do shit while we transform this mob'), so in order to rectify this potential issue, let's refactor it into a trait.

## Why It's Good For The Game

Some code already declared that there might be issues with this being a boolean var (with no way of knowing _why_ we don't want this mob to not transform (or not do anything idk). Let's remove those comments and any future doubt in those instances with the trait macros. Also, stuff like `TRAIT_IMMOBILIZED` which does a similar thing in many contexts was already a trait that was regularly added in conjunction with flipping the variable, so we're able to flatten all that stuff into `add_traits()` and `remove_traits()` now. nice

I also cleaned up quite a bit of code as I saw it, let me know if it should be split out but I guarantee that if I didn't do it- no one will for the next two years.

## Changelog

:cl:
refactor: If you transform into another mob and notice bugs with interacting with the game world, please create a bug report as this framework was recently refactored.
/:cl:

Probably fucked up somewhere, lmk
