### PR TITLE
Fixed snow legion corpse spawning.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -160,9 +160,7 @@
 		else if(dwarf_mob)
 			new /obj/effect/mob_spawn/corpse/human/legioninfested/dwarf(our_turf)
 		else if(snow_legion)
-			new /obj/effect/mob_spawn/corpse/human/legioninfested/snow(our_turf)
-
-			new /obj/effect/mob_spawn/corpse/human/legioninfested/dwarf(our_turf)
+			new /obj/effect/mob_spawn/corpse/human/snowlegioninfested(our_turf)
 		else
 			new /obj/effect/mob_spawn/corpse/human/legioninfested(our_turf)
 	return ..()

--- a/code/modules/mob_spawn/corpses/mining_corpses.dm
+++ b/code/modules/mob_spawn/corpses/mining_corpses.dm
@@ -59,7 +59,7 @@
 			outfit = /datum/outfit/consumed_shadowperson
 	. = ..()
 
-/obj/effect/mob_spawn/corpse/human/legioninfested/snow/Initialize(mapload)
+/obj/effect/mob_spawn/corpse/human/snowlegioninfested/Initialize(mapload)
 	var/corpse_theme = pick_weight(list(
 		"Miner" = 64,
 		"Clown" = 5,


### PR DESCRIPTION

## About The Pull Request

Resolves #77973 

Due to a pair of oversights, snow legions erroneously drop two corpses when killed, and both of these corpses use the spawnlists for Lavaland legions. The duplicate has been removed, and the snow legion corpse spawner is no longer a subtype of the regular one - which was causing the issue. Now the new corpses will actually spawn.
## Why It's Good For The Game

Makes #76898 actually work.
## Changelog
:cl:
fix: Snow legions now drop only one corpse, and no longer drop Lavaland corpses.
/:cl:
