### PR TITLE
Replaces NorthStar Cyto frames with fuctional frames.

### DIFF
--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -1601,11 +1601,13 @@
 /area/station/construction)
 "auv" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/outlet_injector{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	volume_rate = 200;
+	dir = 8;
+	initialize_directions = 8
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
@@ -79078,8 +79080,9 @@
 /area/station/maintenance/floor2/port/aft)
 "uLB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	volume_rate = 200;
 	dir = 8;
-	volume_rate = 200
+	initialize_directions = 8
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
 	dir = 8

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -2102,6 +2102,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "aCl" = (
@@ -3847,6 +3848,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
 "aYv" = (
@@ -8341,6 +8343,7 @@
 /obj/machinery/light/cold/no_nightlight/directional/east,
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
 "cdf" = (
@@ -10542,6 +10545,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "cHf" = (
@@ -19344,6 +19348,7 @@
 /obj/effect/turf_decal/stripes,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
 "fdr" = (
@@ -24239,7 +24244,7 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/storage)
 "gup" = (
-/obj/structure/frame{
+/obj/structure/frame/machine{
 	anchored = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -42683,6 +42688,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "lhT" = (
@@ -56154,7 +56160,7 @@
 /turf/open/floor/iron/smooth_half,
 /area/station/tcommsat/server)
 "oFH" = (
-/obj/structure/frame{
+/obj/structure/frame/machine{
 	anchored = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57531,6 +57537,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
 "oYL" = (
@@ -59379,6 +59386,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
 "pyQ" = (
@@ -63584,6 +63592,7 @@
 /obj/effect/turf_decal/trimline/purple/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "qEe" = (
@@ -68185,6 +68194,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/science/cytology)
 "rQV" = (
@@ -76164,6 +76174,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "tXF" = (
@@ -87936,6 +87947,7 @@
 	dir = 5
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "wXi" = (


### PR DESCRIPTION

## About The Pull Request
Replaces NorthStar Cyto parent frames with functional machine frames that can be used now for construction, same anchored state as the old ones just probably serving the intended purpose now.
Adds missing wires to power the xeno containment chamber shields.
Defaults xeno containment chamber gas injector to on.
## Why It's Good For The Game
Better to use the player functional object over its parent.
For the cables, all stations have powered lines to xeno containment without having players tearing up the floors._(I know Birdshot I can see your missing cables, you are next)_.
For the injector most(?) stations default theirs to on version so that’s what I’m changing here.

## Changelog
:cl:

fix: Machine frames in NorthStar Cyto are now functional.
qol: Minor cable/pipe changes to NorthStar the xeno containment.

/:cl:
