### PR TITLE
Fixing this dead mouse related harddel

### DIFF
--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -53,7 +53,7 @@
 	if(istype(source, /obj/item/food/grown) && ispath(trash, /obj/item/food))
 		var/obj/item/food/grown/plant = source
 		var/reagent_purity = plant.seed.get_reagent_purity()
-		trash_item = new trash(edible_object.drop_location(), starting_reagent_purity = reagent_purity)
+		trash_item = new trash(edible_object.drop_location(), reagent_purity)
 	else
 		trash_item = generate_trash_procpath ? call(source, generate_trash_procpath)() : new trash(edible_object.drop_location())
 

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -52,7 +52,6 @@
 	var/datum/status_effect/food/crafted_food_buff = null
 
 /obj/item/food/Initialize(mapload, starting_reagent_purity, no_base_reagents = FALSE)
-	. = ..()
 	src.starting_reagent_purity = starting_reagent_purity
 	if(no_base_reagents)
 		food_reagents = null

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -51,13 +51,13 @@
 	///Buff given when a hand-crafted version of this item is consumed. Randomized according to crafting_complexity if not assigned.
 	var/datum/status_effect/food/crafted_food_buff = null
 
-/obj/item/food/New(loc, starting_reagent_purity, no_base_reagents = FALSE, ...)
+/obj/item/food/Initialize(mapload, starting_reagent_purity, no_base_reagents = FALSE)
+	. = ..()
 	src.starting_reagent_purity = starting_reagent_purity
 	if(no_base_reagents)
 		food_reagents = null
-	return ..()
-
-/obj/item/food/Initialize(mapload)
+	if(food_reagents)
+		food_reagents = string_assoc_list(food_reagents)
 	. = ..()
 	if(food_reagents)
 		food_reagents = string_assoc_list(food_reagents)

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -367,7 +367,7 @@
 	 */
 	var/list/prefill_flavours
 
-/obj/item/food/icecream/Initialize(mapload, list/prefill_flavours)
+/obj/item/food/icecream/Initialize(mapload, starting_reagent_purity, no_base_reagents, list/prefill_flavours)
 	if(prefill_flavours)
 		src.prefill_flavours = prefill_flavours
 	return ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/structure/bodycontainer/crematorium/creamatorium/cremate(mob/user)
 	var/list/icecreams = new()
 	for(var/mob/living/i_scream as anything in get_all_contents_type(/mob/living))
-		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null, null, FALSE, /* prefill_flavors = */ list(ICE_CREAM_MOB = list(null, i_scream.name)))
+		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null,  /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, list(ICE_CREAM_MOB = list(null, i_scream.name)))
 		icecreams += IC
 	. = ..()
 	for(var/obj/IC in icecreams)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/structure/bodycontainer/crematorium/creamatorium/cremate(mob/user)
 	var/list/icecreams = new()
 	for(var/mob/living/i_scream as anything in get_all_contents_type(/mob/living))
-		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null, starting_reagent_purity = null, no_base_reagents = FALSE, /* prefill_flavors = */ list(ICE_CREAM_MOB = list(null, i_scream.name)))
+		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null, null, FALSE, /* prefill_flavors = */ list(ICE_CREAM_MOB = list(null, i_scream.name)))
 		icecreams += IC
 	. = ..()
 	for(var/obj/IC in icecreams)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/structure/bodycontainer/crematorium/creamatorium/cremate(mob/user)
 	var/list/icecreams = new()
 	for(var/mob/living/i_scream as anything in get_all_contents_type(/mob/living))
-		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null,  /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, list(ICE_CREAM_MOB = list(null, i_scream.name)))
+		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null, /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, list(ICE_CREAM_MOB = list(null, i_scream.name)))
 		icecreams += IC
 	. = ..()
 	for(var/obj/IC in icecreams)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -355,7 +355,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	desc = "A human incinerator. Works well during ice cream socials."
 
 /obj/structure/bodycontainer/crematorium/creamatorium/cremate(mob/user)
-	var/list/icecreams = new()
+	var/list/icecreams = list()
 	for(var/mob/living/i_scream as anything in get_all_contents_type(/mob/living))
 		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null, /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, list(ICE_CREAM_MOB = list(null, i_scream.name)))
 		icecreams += IC

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/structure/bodycontainer/crematorium/creamatorium/cremate(mob/user)
 	var/list/icecreams = new()
 	for(var/mob/living/i_scream as anything in get_all_contents_type(/mob/living))
-		var/obj/item/food/icecream/IC = new(null, list(ICE_CREAM_MOB = list(null, i_scream.name)))
+		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null, prefill_flavors = list(ICE_CREAM_MOB = list(null, i_scream.name)))
 		icecreams += IC
 	. = ..()
 	for(var/obj/IC in icecreams)

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/structure/bodycontainer/crematorium/creamatorium/cremate(mob/user)
 	var/list/icecreams = new()
 	for(var/mob/living/i_scream as anything in get_all_contents_type(/mob/living))
-		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null, prefill_flavors = list(ICE_CREAM_MOB = list(null, i_scream.name)))
+		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null, starting_reagent_purity = null, no_base_reagents = FALSE, /* prefill_flavors = */ list(ICE_CREAM_MOB = list(null, i_scream.name)))
 		icecreams += IC
 	. = ..()
 	for(var/obj/IC in icecreams)

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -46,7 +46,7 @@
 		var/atom/location = holder.my_atom.drop_location()
 		for(var/i in 1 to created_volume)
 			if(ispath(resulting_food_path, /obj/item/food) && !isnull(resulting_reagent_purity))
-				new resulting_food_path(location, starting_reagent_purity = resulting_reagent_purity)
+				new resulting_food_path(location, resulting_reagent_purity)
 			else
 				new resulting_food_path(location)
 

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -98,7 +98,7 @@
 	user.visible_message(span_notice("[user] crushes [src] into meat."), span_notice("You crush [src] into something that resembles meat."))
 	playsound(user, 'sound/effects/blobattack.ogg', 50, TRUE)
 	var/reagent_purity = seed.get_reagent_purity()
-	var/obj/item/food/meat/slab/meatwheat/M = new(starting_reagent_purity = reagent_purity)
+	var/obj/item/food/meat/slab/meatwheat/M = new(null, reagent_purity)
 	qdel(src)
 	user.put_in_hands(M)
 	return 1

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -116,7 +116,7 @@
 	. = ..(TRUE)
 	// Now if we were't ACTUALLY gibbed, spawn the dead mouse
 	if(!gibbed)
-		var/obj/item/food/deadmouse/mouse = new(loc, /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, /* dead_critter = */ src)
+		var/obj/item/food/deadmouse/mouse = new(loc, /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, src)
 		if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
 			mouse.desc = "They're toast."
 			mouse.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -116,7 +116,7 @@
 	. = ..(TRUE)
 	// Now if we were't ACTUALLY gibbed, spawn the dead mouse
 	if(!gibbed)
-		var/obj/item/food/deadmouse/mouse = new(loc)
+		var/obj/item/food/deadmouse/mouse = new(loc, /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, /* dead_critter = */ src)
 		if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
 			mouse.desc = "They're toast."
 			mouse.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)
@@ -301,7 +301,7 @@
 	var/body_color = "gray"
 	var/critter_type = /mob/living/basic/mouse
 
-/obj/item/food/deadmouse/Initialize(mapload, mob/living/basic/mouse/dead_critter)
+/obj/item/food/deadmouse/Initialize(mapload, loc, starting_reagent_purity, no_base_reagents, mob/living/basic/mouse/dead_critter)
 	. = ..()
 	if(dead_critter)
 		body_color = dead_critter.body_color

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -301,7 +301,7 @@
 	var/body_color = "gray"
 	var/critter_type = /mob/living/basic/mouse
 
-/obj/item/food/deadmouse/Initialize(mapload, loc, starting_reagent_purity, no_base_reagents, mob/living/basic/mouse/dead_critter)
+/obj/item/food/deadmouse/Initialize(mapload, starting_reagent_purity, no_base_reagents, mob/living/basic/mouse/dead_critter)
 	. = ..()
 	if(dead_critter)
 		body_color = dead_critter.body_color

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -116,7 +116,7 @@
 	. = ..(TRUE)
 	// Now if we were't ACTUALLY gibbed, spawn the dead mouse
 	if(!gibbed)
-		var/obj/item/food/deadmouse/mouse = new(loc, src)
+		var/obj/item/food/deadmouse/mouse = new(loc)
 		if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
 			mouse.desc = "They're toast."
 			mouse.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -116,7 +116,7 @@
 	. = ..(TRUE)
 	// Now if we were't ACTUALLY gibbed, spawn the dead mouse
 	if(!gibbed)
-		var/obj/item/food/deadmouse/mouse = new(loc, /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, src)
+		var/obj/item/food/deadmouse/mouse = new(loc, /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, /* dead_critter = */ src)
 		if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
 			mouse.desc = "They're toast."
 			mouse.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -356,7 +356,7 @@
 		var/purity = beaker.reagents.get_reagent_purity(/datum/reagent/consumable/milk)
 		beaker.reagents.remove_reagent(/datum/reagent/consumable/milk, MILK_TO_BUTTER_COEFF * butter_amt)
 		for(var/i in 1 to butter_amt)
-			new /obj/item/food/butter(drop_location(), starting_reagent_purity = purity)
+			new /obj/item/food/butter(drop_location(), purity)
 		//Recipe to make Mayonnaise
 		if (beaker.reagents.has_reagent(/datum/reagent/consumable/eggyolk))
 			beaker.reagents.convert_reagent(/datum/reagent/consumable/eggyolk, /datum/reagent/consumable/mayonnaise)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/78085

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23510
Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23506

![image](https://github.com/tgstation/tgstation/assets/13398309/fab09657-12e8-4fb8-9e84-05ef48c9d55e)

When the foodening added some args to the constructor of `/obj/item/food` some instances of the constructor being passed stuff got overlooked and were not updated. 

This resulted in a mob ref potentially being passed in to `starting_reagent_purity` in some cases, ultimately resulting in this harddel.

@SyncIt21 this is exactly the reason I was being so paranoid with #77946 the other day. Tracking constructor uses down can be such a pain when they aren't prefaced with a type, and are almost guaranteed to get overlooked during refactors if the compiler does not say anything about it.

I hate DM.

edit: and I just tested this only to find a second bug with the ice cream. I can confirm that it is in fact working now after fixing that one too.

<details><summary>evil ice cream</summary>

![image](https://github.com/tgstation/tgstation/assets/13398309/46cd85cd-1051-46d9-9642-0275af098dbe)

</details>

## Why It's Good For The Game

Fixing a harddel that was causing many CI failures

## Changelog

:cl:
fix: fixes creamatorium not producing any suspicious ice cream, and fixes a dead mouse related harrdel
/:cl:
