### PR TITLE
Adds cable under BirdShot Xeno containment shield generators.

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -14377,6 +14377,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable/multilayer,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "fuC" = (
@@ -67668,6 +67669,7 @@
 /obj/machinery/light/small/directional/east,
 /obj/machinery/power/shieldwallgen/xenobiologyaccess,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/multilayer,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
 "xlP" = (


### PR DESCRIPTION

## About The Pull Request
Adds multilayer cables under Birdshot’s Xeno containment shield generators.
## Why It's Good For The Game
Stops scientists having to shock themselves or get proper insules in order to power their equipment for the xeno egg trait.
Used multilayer purely for aesthetic as it looks industrial and messy like the room.
## Changelog
:cl:

qol: Adds cables under birdshot xeno containment shielding.

/:cl:
