### PR TITLE
Adds grab chance multipliers for having free/occupied hands, wearing grappling gloves, being a hulk, etc.

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -123,6 +123,21 @@ DEFINE_BITFIELD(status_flags, list(
 //Grab breakout odds
 #define BASE_GRAB_RESIST_CHANCE 60 //base chance for whether or not you can escape from a grab
 
+/// If none of our hands are occupied, we will multiply our grab resilience by this
+#define ALL_HANDS_FREE_GRAB_RESILIENCE_MULT 1.4
+/// If only one of our hands are occupied, we will multiply our grab resilience by this
+#define ONE_HAND_FREE_GRAB_RESILIENCE_MULT 1
+/// If all of our hands are occupied, we will multiply our grab resilience by this
+#define BOTH_HANDS_OCCUPIED_GRAB_RESILIENCE_MULT 0.3 // you should really have at least one hand free!
+
+/// If we are a hulk, we will multiply our grab resilience by this
+#define HULK_GRAB_RESILIENCE_MULT 3
+/// If we are a hulk, we will multipliy our grab resist chance by this
+#define HULK_GRAB_RESIST_MULT 3
+
+/// If our grabbed level is below neckgrab and we are on the ground, we will multiply this against our resist chance
+#define KNOCKED_DOWN_GRAB_RESIST_MULT 0.75 // doesnt apply to neckgrabs and above
+
 //slowdown when in softcrit. Note that crawling slowdown will also apply at the same time!
 #define SOFTCRIT_ADD_SLOWDOWN 2
 //slowdown when crawling

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -123,10 +123,8 @@ DEFINE_BITFIELD(status_flags, list(
 //Grab breakout odds
 #define BASE_GRAB_RESIST_CHANCE 60 //base chance for whether or not you can escape from a grab
 
-/// If none of our hands are occupied, we will multiply our grab resilience by this
-#define ALL_HANDS_FREE_GRAB_RESILIENCE_MULT 1.4
-/// If only one of our hands are occupied, we will multiply our grab resilience by this
-#define ONE_HAND_FREE_GRAB_RESILIENCE_MULT 1
+/// If we have less/more usable hands than 2, our grab strength will be multiplied against this for each extra/occupied hand. 
+#define GRAB_RESILIENCE_PER_HAND 1.3
 /// If all of our hands are occupied, we will multiply our grab resilience by this
 #define BOTH_HANDS_OCCUPIED_GRAB_RESILIENCE_MULT 0.3 // you should really have at least one hand free!
 

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -123,10 +123,10 @@ DEFINE_BITFIELD(status_flags, list(
 //Grab breakout odds
 #define BASE_GRAB_RESIST_CHANCE 60 //base chance for whether or not you can escape from a grab
 
-/// If we have less/more usable hands than 2, our grab strength will be multiplied against this for each extra/occupied hand. 
-#define GRAB_RESILIENCE_PER_HAND 1.3
+/// If we have less/more usable hands than 2, our grab strength will be multiplied against this for each extra/occupied hand.
+#define GRAB_RESILIENCE_PER_HAND 1.2
 /// If all of our hands are occupied, we will multiply our grab resilience by this
-#define BOTH_HANDS_OCCUPIED_GRAB_RESILIENCE_MULT 0.3 // you should really have at least one hand free!
+#define BOTH_HANDS_OCCUPIED_GRAB_RESILIENCE_MULT 0.4 // you should really have at least one hand free!
 
 /// If we are a hulk, we will multiply our grab resilience by this
 #define HULK_GRAB_RESILIENCE_MULT 3

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -165,6 +165,8 @@
 /obj/item/clothing/gloves/krav_maga
 	var/datum/martial_art/krav_maga/style = new
 
+	grab_resilience_mult = 1.5
+
 /obj/item/clothing/gloves/krav_maga/equipped(mob/user, slot)
 	. = ..()
 	if(slot & ITEM_SLOT_GLOVES)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -43,6 +43,11 @@
 	/// How many zones (body parts, not precise) we have disabled so far, for naming purposes
 	var/zones_disabled
 
+	/// If on the hands, the multiplier we will apply to our wearer's grab resilience mult, which decreases the chance of victims escaping grabs.
+	var/grab_resilience_mult = 1
+	/// If on the hands, the increment we will apply to our wearer's grab resilience mult, which decreases the chance of victims escaping grabs.
+	var/grab_resilience_increment = 0
+
 	/// A lazily initiated "food" version of the clothing for moths.
 	// This intentionally does not use the edible component, for a few reasons.
 	// 1. Effectively everything that wants something edible, from now and into the future,

--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -10,6 +10,8 @@
 	undyeable = TRUE
 	var/datum/weakref/pull_component_weakref
 
+	grab_resilience_mult = 1.4
+
 /obj/item/clothing/gloves/cargo_gauntlet/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_ITEM_EQUIPPED, PROC_REF(on_glove_equip))

--- a/code/modules/clothing/gloves/tacklers.dm
+++ b/code/modules/clothing/gloves/tacklers.dm
@@ -23,6 +23,8 @@
 	/// See: [/datum/component/tackler/var/skill_mod]
 	var/skill_mod = 0
 
+	grab_resilience_mult = 1.35
+
 /obj/item/clothing/gloves/tackler/Destroy()
 	tackler = null
 	return ..()
@@ -56,6 +58,8 @@
 	min_distance = 2
 	skill_mod = -2
 
+	grab_resilience_mult = 1.15
+
 /obj/item/clothing/gloves/tackler/combat
 	name = "gorilla gloves"
 	desc = "Premium quality combative gloves, heavily reinforced to give the user an edge in close combat tackles, though they are more taxing to use than normal gripper gloves. Fireproof to boot!"
@@ -74,11 +78,15 @@
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = NONE
 
+	grab_resilience_mult = 1.8
+
 /obj/item/clothing/gloves/tackler/combat/insulated
 	name = "guerrilla gloves"
 	desc = "Superior quality combative gloves, good for performing tackle takedowns as well as absorbing electrical shocks."
 	siemens_coefficient = 0
 	armor_type = /datum/armor/combat_insulated
+
+	grab_resilience_mult = 2
 
 /datum/armor/combat_insulated
 	bio = 50
@@ -96,6 +104,8 @@
 	tackle_speed = 6
 	skill_mod = 7
 
+	grab_resilience_mult = 1.25
+
 /obj/item/clothing/gloves/tackler/offbrand
 	name = "improvised gripper gloves"
 	desc = "Ratty looking fingerless gloves wrapped with sticky tape. Beware anyone wearing these, for they clearly have no shame and nothing to lose."
@@ -106,6 +116,8 @@
 	base_knockdown = 1.75 SECONDS
 	min_distance = 2
 	skill_mod = -1
+
+	grab_resilience_mult = 1.25
 
 /obj/item/clothing/gloves/tackler/football
 	name = "football gloves"

--- a/code/modules/clothing/gloves/tacklers.dm
+++ b/code/modules/clothing/gloves/tacklers.dm
@@ -23,7 +23,7 @@
 	/// See: [/datum/component/tackler/var/skill_mod]
 	var/skill_mod = 0
 
-	grab_resilience_mult = 1.35
+	grab_resilience_mult = 1.3
 
 /obj/item/clothing/gloves/tackler/Destroy()
 	tackler = null
@@ -58,7 +58,7 @@
 	min_distance = 2
 	skill_mod = -2
 
-	grab_resilience_mult = 1.15
+	grab_resilience_mult = 1.2
 
 /obj/item/clothing/gloves/tackler/combat
 	name = "gorilla gloves"
@@ -78,7 +78,7 @@
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = NONE
 
-	grab_resilience_mult = 1.8
+	grab_resilience_mult = 2
 
 /obj/item/clothing/gloves/tackler/combat/insulated
 	name = "guerrilla gloves"
@@ -104,7 +104,7 @@
 	tackle_speed = 6
 	skill_mod = 7
 
-	grab_resilience_mult = 1.25
+	grab_resilience_mult = 1.2
 
 /obj/item/clothing/gloves/tackler/offbrand
 	name = "improvised gripper gloves"
@@ -117,7 +117,7 @@
 	min_distance = 2
 	skill_mod = -1
 
-	grab_resilience_mult = 1.25
+	grab_resilience_mult = 1.2
 
 /obj/item/clothing/gloves/tackler/football
 	name = "football gloves"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -329,16 +329,23 @@
 
 		log_combat(src, M, "grabbed", addition="passive grab")
 		if(!supress_message && !(iscarbon(AM) && HAS_TRAIT(src, TRAIT_STRONG_GRABBER)))
+			var/resilience_mult = get_grab_resilience_mult()
+			var/resilience_text = ""
+			if (resilience_mult > 1)
+				resilience_text = "<b><i>tightly </i></b>"
+			else if (resilience_mult < 1)
+				resilience_text = "<i>weakly </i>"
+
 			if(ishuman(M))
 				var/mob/living/carbon/human/grabbed_human = M
 				var/grabbed_by_hands = (zone_selected == "l_arm" || zone_selected == "r_arm") && grabbed_human.usable_hands > 0
-				M.visible_message(span_warning("[src] grabs [M] [grabbed_by_hands ? "by their hands":"passively"]!"), \
-								span_warning("[src] grabs you [grabbed_by_hands ? "by your hands":"passively"]!"), null, null, src)
-				to_chat(src, span_notice("You grab [M] [grabbed_by_hands ? "by their hands":"passively"]!"))
+				M.visible_message(span_warning("[src] [resilience_text]grabs [M] [grabbed_by_hands ? "by their hands":"passively"]!"), \
+								span_warning("[src] [resilience_text]grabs you [grabbed_by_hands ? "by your hands":"passively"]!"), null, null, src)
+				to_chat(src, span_notice("You [resilience_text]grab [M] [grabbed_by_hands ? "by their hands":"passively"]!"))
 			else
-				M.visible_message(span_warning("[src] grabs [M] passively!"), \
-								span_warning("[src] grabs you passively!"), null, null, src)
-				to_chat(src, span_notice("You grab [M] passively!"))
+				M.visible_message(span_warning("[src] [resilience_text]grabs [M] passively!"), \
+								span_warning("[src] [resilience_text]grabs you passively!"), null, null, src)
+				to_chat(src, span_notice("You [resilience_text]grab [M] passively!"))
 
 		if(!iscarbon(src))
 			M.LAssailant = null
@@ -1145,7 +1152,7 @@
 	var/base_hand_mult = ((max(num_hands, 2) - 2) * GRAB_RESILIENCE_PER_HAND) + 1 // the -2 ensures at 2 hands you have x1 resilience
 
 	var/occupied_hands = num_hands - usable_hands // disabled hands are "occupied"
-	for (var/obj/item/held_item as anything in held_items)
+	for (var/obj/item/held_item in held_items)
 		// items like slappers/zombie claws/etc. should be ignored
 		if (held_item.item_flags & HAND_ITEM)
 			continue
@@ -1154,9 +1161,9 @@
 
 	if (occupied_hands >= num_hands) // its a little different if you literally have NOTHING to hold them with
 		base_hand_mult = BOTH_HANDS_OCCUPIED_GRAB_RESILIENCE_MULT
-	else // 0.7x at one hand occupied, 0.3x at both hands occupied because of ^
-		var/occupied_hand_mult_decrement = -(occupied_hands * GRAB_RESILIENCE_PER_HAND)
-		base_hand_mult += occupied_hand_mult_decrement
+	else // 0.8x at one hand occupied, 0.4x at both hands occupied because of ^
+		var/occupied_hand_mult_decrement = (occupied_hands * (GRAB_RESILIENCE_PER_HAND - 1))
+		base_hand_mult -= occupied_hand_mult_decrement
 
 	. *= base_hand_mult
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -211,25 +211,31 @@
 		if(!user.pulling || user.pulling != src || user.grab_state != old_grab_state)
 			return FALSE
 	user.setGrabState(user.grab_state + 1)
+	var/resilience_mult = user.get_grab_resilience_mult()
+	var/resilience_text = ""
+	if (resilience_mult > 1)
+		resilience_text = "<b><i>tightly </i></b>"
+	else if (resilience_mult < 1)
+		resilience_text = "<i>weakly </i>"
 	switch(user.grab_state)
 		if(GRAB_AGGRESSIVE)
 			var/add_log = ""
 			if(HAS_TRAIT(user, TRAIT_PACIFISM))
-				visible_message(span_danger("[user] firmly grips [src]!"),
-								span_danger("[user] firmly grips you!"), span_hear("You hear aggressive shuffling!"), null, user)
-				to_chat(user, span_danger("You firmly grip [src]!"))
+				visible_message(span_danger("[user] [resilience_text]firmly grips [src]!"),
+								span_danger("[user] [resilience_text]firmly grips you!"), span_hear("You hear aggressive shuffling!"), null, user)
+				to_chat(user, span_danger("You [resilience_text]firmly grip [src]!"))
 				add_log = " (pacifist)"
 			else
-				visible_message(span_danger("[user] grabs [src] aggressively!"), \
-								span_userdanger("[user] grabs you aggressively!"), span_hear("You hear aggressive shuffling!"), null, user)
-				to_chat(user, span_danger("You grab [src] aggressively!"))
+				visible_message(span_danger("[user] [resilience_text]grabs [src] aggressively!"), \
+								span_userdanger("[user] [resilience_text]grabs you aggressively!"), span_hear("You hear aggressive shuffling!"), null, user)
+				to_chat(user, span_danger("You [resilience_text]grab [src] aggressively!"))
 			stop_pulling()
 			log_combat(user, src, "grabbed", addition="aggressive grab[add_log]")
 		if(GRAB_NECK)
 			log_combat(user, src, "grabbed", addition="neck grab")
-			visible_message(span_danger("[user] grabs [src] by the neck!"),\
-							span_userdanger("[user] grabs you by the neck!"), span_hear("You hear aggressive shuffling!"), null, user)
-			to_chat(user, span_danger("You grab [src] by the neck!"))
+			visible_message(span_danger("[user] [resilience_text]grabs [src] by the neck!"),\
+							span_userdanger("[user] [resilience_text]grabs you by the neck!"), span_hear("You hear aggressive shuffling!"), null, user)
+			to_chat(user, span_danger("You [resilience_text]grab [src] by the neck!"))
 			if(!buckled && !density)
 				Move(user.loc)
 		if(GRAB_KILL)


### PR DESCRIPTION
## About The Pull Request

This PR was born out of me thinking "it doesnt really make sense how we can so easily grab people when our hands are occupied" and then going "wouldn't it be cool if there was a debuff for having occupied hands", and THEN going "why don't hulks get a buff to their grabs/resists?" and THEN going "why not let grappling gloves increase grab effectiveness".

Basically - hulks can maintain and break out of grabs more easily, gripper gloves/krav maga gloves increase grab resilience, having free hands increases your grab resilience - but having occupied hands massively decreases it, to encourage having a hand to grab someone with at _least_.
## Why It's Good For The Game

I'd like to clarify this is one of those PRs mainly made out of "you know, this seems cool".

Firstly - it just makes _sense_ to have grab resilience scale with how many hands you have available to grab someone. And, as I was informed, it might help beat some cheese strategies like shovecuff, grab+block, etc.

For the other changes - I'm a lot less sold on them, and frankly I just made them because I thought they were cool, but...

Gloves: Gripper gloves are honestly kinda underwhelming, so having them increase grab strength would be a neat buff to something so underused. For krav maga gloves - they don't allow people to instantly get an aggrograb, so it SHOULD be fine, but I'm fine with removing it. It was msotly just added for thematics.

Hulk: It just makes sense, honestly. You are extremely strong, so grabs should be easy to keep, and easy to break out of.
## Changelog
:cl:
balance: Grab resilience now scales off how occupied your hands are, scaling inversely with how many of your hands are occupied
balance: Hulks now have significantly stronger grabs and can break out of grabs significantly easier
balance: Gripper/Krav maga gloves now boost the resilience of your grabs
/:cl:
