### PR TITLE
Antihol now makes surgeries slower

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1116,7 +1116,7 @@
 		return
 
 	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier -= 0.1
+		surgery.speed_modifier = max(surgery.speed_modifier  - 0.1, -0.9)
 
 /datum/reagent/medicine/stimulants
 	name = "Stimulants"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1116,7 +1116,7 @@
 		return
 
 	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier = surgery.speed_modifier-0.1
+		surgery.speed_modifier -= 0.1
 
 /datum/reagent/medicine/stimulants
 	name = "Stimulants"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1110,6 +1110,14 @@
 	..()
 	. = TRUE
 
+/datum/reagent/medicine/antihol/expose_mob(mob/living/carbon/exposed_carbon, methods=TOUCH, reac_volume)
+	. = ..()
+	if(!(methods & (TOUCH|VAPOR|PATCH)))
+		return
+
+	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
+		surgery.speed_modifier = surgery.speed_modifier-0.1
+
 /datum/reagent/medicine/stimulants
 	name = "Stimulants"
 	description = "Increases resistance to batons and movement speed in addition to restoring minor damage and weakness. Overdose causes weakness and toxin damage."


### PR DESCRIPTION
## About The Pull Request

Splashing antihol on someone will now cause surgeries to go a bit slower. This should completely counteract ethanol's speed buff.

## Why It's Good For The Game

Someone suggested this on the discord and I found it a funny idea, adds a bit more flavor to antihol as the opposite of ethanol.

## Changelog

:cl:
add: Splashing antihol on a patient before surgery will make it to go slower.
/:cl:
