### PR TITLE
Fix megafauna's `celebrate_kill()` not printing the victim's name

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/_megafauna.dm
@@ -127,7 +127,7 @@
 /mob/living/simple_animal/hostile/megafauna/proc/devour(mob/living/L)
 	if(!L || L.has_status_effect(/datum/status_effect/gutted))
 		return FALSE
-	celebrate_kill()
+	celebrate_kill(L)
 	if(!is_station_level(z) || client) //NPC monsters won't heal while on station
 		adjustBruteLoss(-L.maxHealth/2)
 	L.investigate_log("has been devoured by [src].", INVESTIGATE_DEATHS)


### PR DESCRIPTION

## About The Pull Request
One symbol fix. `celebrate_kill()` expects a `mob/living` to be passed into it, but it was called without arguments, I fixed that
Before:
![wrongtext](https://github.com/tgstation/tgstation/assets/113535457/d06c203e-1a6b-4eec-93d6-685a1adb4b86)
After:
![correcttext](https://github.com/tgstation/tgstation/assets/113535457/0283bfcd-14de-4fb8-b53e-619b4b95b0d0)
## Why It's Good For The Game
It's a bugfix
## Changelog
:cl:
fix: Megafauna now correctly prints the victim's name after a kill
/:cl:
