### PR TITLE
Fixes traitor objective brainwashing deadchat broadcast double-punctuation and doubles the number of default directives

### DIFF
--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -22,7 +22,7 @@
 	var/rendered = begin_message + obj_message
 	if(!rendered[length(rendered)] in list(",",":",";",".","?","!","\'","-"))
 		rendered += "." //Good punctuation is important :)
-	deadchat_broadcast(rendered, "<b>[brainwash_victim]</b>", follow_target = brainwash_victim, turf_target = get_turf(brainwash_victim), message_type=DEADCHAT_ANNOUNCEMENT) //MAKE THIS AN ORBIT BRO
+	deadchat_broadcast(rendered, "<b>[brainwash_victim]</b>", follow_target = brainwash_victim, turf_target = get_turf(brainwash_victim), message_type=DEADCHAT_ANNOUNCEMENT)
 	if(check_holidays(APRIL_FOOLS))
 		// Note: most of the time you're getting brainwashed you're unconscious
 		brainwash_victim.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in. (April Fools)")

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -19,8 +19,7 @@
 
 	var/begin_message = " has been brainwashed with the following objectives: "
 	var/obj_message = english_list(directives)
-	var/end_message = "."
-	var/rendered = begin_message + obj_message + end_message
+	var/rendered = begin_message + obj_message
 	deadchat_broadcast(rendered, "<b>[L]</b>", follow_target = L, turf_target = get_turf(L), message_type=DEADCHAT_ANNOUNCEMENT)
 	if(check_holidays(APRIL_FOOLS))
 		// Note: most of the time you're getting brainwashed you're unconscious

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -20,7 +20,7 @@
 	var/begin_message = " has been brainwashed with the following objectives: "
 	var/obj_message = english_list(directives)
 	var/rendered = begin_message + obj_message
-	if(!rendered[length(rendered)] in list(",",":",";",".","?","!","\'","-"))
+	if(!(rendered[length(rendered)] in list(",",":",";",".","?","!","\'","-")))
 		rendered += "." //Good punctuation is important :)
 	deadchat_broadcast(rendered, "<b>[brainwash_victim]</b>", follow_target = brainwash_victim, turf_target = get_turf(brainwash_victim), message_type=DEADCHAT_ANNOUNCEMENT)
 	if(check_holidays(APRIL_FOOLS))

--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -1,29 +1,31 @@
-/proc/brainwash(mob/living/L, directives)
-	if(!L.mind)
+/proc/brainwash(mob/living/brainwash_victim, directives)
+	if(!brainwash_victim.mind)
 		return
 	if(!islist(directives))
 		directives = list(directives)
-	var/datum/mind/M = L.mind
-	var/datum/antagonist/brainwashed/B = M.has_antag_datum(/datum/antagonist/brainwashed)
-	if(B)
+	var/datum/mind/brainwash_mind = brainwash_victim.mind
+	var/datum/antagonist/brainwashed/brainwashed_datum = brainwash_mind.has_antag_datum(/datum/antagonist/brainwashed)
+	if(brainwashed_datum)
 		for(var/O in directives)
 			var/datum/objective/brainwashing/objective = new(O)
-			B.objectives += objective
-		B.greet()
+			brainwashed_datum.objectives += objective
+		brainwashed_datum.greet()
 	else
-		B = new()
+		brainwashed_datum = new()
 		for(var/O in directives)
 			var/datum/objective/brainwashing/objective = new(O)
-			B.objectives += objective
-		M.add_antag_datum(B)
+			brainwashed_datum.objectives += objective
+		brainwash_mind.add_antag_datum(brainwashed_datum)
 
 	var/begin_message = " has been brainwashed with the following objectives: "
 	var/obj_message = english_list(directives)
 	var/rendered = begin_message + obj_message
-	deadchat_broadcast(rendered, "<b>[L]</b>", follow_target = L, turf_target = get_turf(L), message_type=DEADCHAT_ANNOUNCEMENT)
+	if(!rendered[length(rendered)] in list(",",":",";",".","?","!","\'","-"))
+		rendered += "." //Good punctuation is important :)
+	deadchat_broadcast(rendered, "<b>[brainwash_victim]</b>", follow_target = brainwash_victim, turf_target = get_turf(brainwash_victim), message_type=DEADCHAT_ANNOUNCEMENT) //MAKE THIS AN ORBIT BRO
 	if(check_holidays(APRIL_FOOLS))
 		// Note: most of the time you're getting brainwashed you're unconscious
-		L.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in. (April Fools)")
+		brainwash_victim.say("You son of a bitch! I'm in.", forced = "That son of a bitch! They're in. (April Fools)")
 
 /datum/antagonist/brainwashed
 	name = "\improper Brainwashed Victim"

--- a/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
+++ b/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
@@ -102,6 +102,12 @@
 		"Nanotrasen isn't real.",
 		"They put something in the food to make you forget.",
 		"You are the only real person on the station."
+		"Things would be a lot better on the station if more people were screaming, someone should do something about that.",
+		"The people in charge around here have only ill intentions for the crew.",
+		"Help the crew? What have they ever done for you anyways?",
+		"Does your bag feel lighter? I bet those guys in Security stole something from it. Go get it back.",
+		"Command is incompetent, someone with some REAL authority should take over around here.",
+		"The cyborgs and the AI are stalking you. What are they planning?",
 	)
 
 /datum/surgery_step/brainwash/sleeper_agent/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
+++ b/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
@@ -101,7 +101,7 @@
 		"The Captain is a lizardperson.",
 		"Nanotrasen isn't real.",
 		"They put something in the food to make you forget.",
-		"You are the only real person on the station."
+		"You are the only real person on the station.",
 		"Things would be a lot better on the station if more people were screaming, someone should do something about that.",
 		"The people in charge around here have only ill intentions for the crew.",
 		"Help the crew? What have they ever done for you anyways?",


### PR DESCRIPTION

## About The Pull Request

This fixes the double-period at the end of brainwashing deadchat broadcasts. If you know what I'm talking about, you know, but I didn't want to go back to get screenshots to show what I mean.

The broadcast would automatically put a period at the end of the compiled message, and the default brainwashing directives already came with a period at the end. Not content with removing the period at the end of the directives or the automatic period, I made something that works both ways.

This also adds some more default directives (the ones given by the brainwash surgery objective). These objectives aren't too direct or commanding but still open up opportunities to run with the prompt.
## Why It's Good For The Game

The double punctuation was really annoying me.

The new directives are meant to give variety to the same boring-ish 6 directives by turning 6 into 12. Hopefully they're flexible enough for more creative spessmen to work with.
## Changelog
:cl:
qol: adds some more traitor objective brainwashing default objectives.
spellcheck: fixes the double-punctuation on traitor objective brainwashing broadcasts.
spellcheck: brainwashing deadchat broadcasts will now auto-punctuate.
/:cl:
