### PR TITLE
fix basic mobs ranged burst attacks

### DIFF
--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -48,10 +48,6 @@
 	action_cooldown = 0.6 SECONDS
 	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT | AI_BEHAVIOR_MOVE_AND_PERFORM
 	required_distance = 3
-	/// How many shots to fire
-	var/shots = 1
-	/// The interval between individual shots in a burst
-	var/burst_interval = 0.2 SECONDS
 	/// range we will try chasing the target before giving up
 	var/chase_range = 9
 
@@ -79,16 +75,7 @@
 		return
 
 	controller.set_blackboard_key(hiding_location_key, hiding_target)
-
-	if(shots>1)
-		var/atom/burst_target = final_target
-		var/datum/callback/callback = CALLBACK(basic_mob, TYPE_PROC_REF(/mob/living/basic,RangedAttack), burst_target)
-		for(var/i in 2 to shots)
-			addtimer(callback, (i - 1) * burst_interval)
-		callback.Invoke()
-	else
-		basic_mob.RangedAttack(final_target)
-
+	basic_mob.RangedAttack(final_target)
 	return ..() //only start the cooldown when the shot is shot
 
 /datum/ai_behavior/basic_ranged_attack/finish_action(datum/ai_controller/controller, succeeded, target_key, targetting_datum_key, hiding_location_key)

--- a/code/datums/components/ranged_attacks.dm
+++ b/code/datums/components/ranged_attacks.dm
@@ -10,6 +10,8 @@
 	var/projectile_sound
 	/// Time to wait between shots
 	var/cooldown_time
+	var/burst_shots
+	var/burst_intervals
 	/// Tracks time between shots
 	COOLDOWN_DECLARE(fire_cooldown)
 
@@ -17,6 +19,8 @@
 	casing_type,
 	projectile_type,
 	projectile_sound = 'sound/weapons/gun/pistol/shot.ogg',
+	burst_shots,
+	burst_intervals = 0.2 SECONDS,
 	cooldown_time = 3 SECONDS,
 )
 	. = ..()
@@ -32,6 +36,10 @@
 		CRASH("Set both casing type and projectile type in [parent]'s ranged attacks component! uhoh! stinky!")
 	if (!casing_type && !projectile_type)
 		CRASH("Set neither casing type nor projectile type in [parent]'s ranged attacks component! What are they supposed to be attacking with, air?")
+	if(burst_shots <= 1)
+		return
+	src.burst_shots = burst_shots
+	src.burst_intervals = burst_intervals
 
 /datum/component/ranged_attacks/RegisterWithParent()
 	. = ..()
@@ -49,12 +57,16 @@
 		return
 	COOLDOWN_START(src, fire_cooldown, cooldown_time)
 	INVOKE_ASYNC(src, PROC_REF(async_fire_ranged_attack), firer, target, modifiers)
-	SEND_SIGNAL(parent, COMSIG_BASICMOB_POST_ATTACK_RANGED, target, modifiers)
+	if(isnull(burst_shots))
+		return
+	for(var/i in 1 to (burst_shots - 1))
+		addtimer(CALLBACK(src, PROC_REF(async_fire_ranged_attack), firer, target, modifiers), i * burst_intervals)
 
 /// Actually fire the damn thing
 /datum/component/ranged_attacks/proc/async_fire_ranged_attack(mob/living/basic/firer, atom/target, modifiers)
 	if(projectile_type)
 		firer.fire_projectile(projectile_type, target, projectile_sound)
+		SEND_SIGNAL(parent, COMSIG_BASICMOB_POST_ATTACK_RANGED, target, modifiers)
 		return
 	playsound(firer, projectile_sound, 100, TRUE)
 	var/turf/startloc = get_turf(firer)
@@ -68,5 +80,6 @@
 	casing.fire_casing(target, firer, null, null, null, target_zone, 0,  firer)
 	casing.update_appearance()
 	casing.AddElement(/datum/element/temporary_atom, 30 SECONDS)
+	SEND_SIGNAL(parent, COMSIG_BASICMOB_POST_ATTACK_RANGED, target, modifiers)
 	return
 

--- a/code/datums/components/ranged_attacks.dm
+++ b/code/datums/components/ranged_attacks.dm
@@ -8,10 +8,12 @@
 	var/projectile_type
 	/// Sound to play when we fire our projectile
 	var/projectile_sound
+	/// how many shots we will fire
+	var/burst_shots
+	/// intervals between shots
+	var/burst_intervals
 	/// Time to wait between shots
 	var/cooldown_time
-	var/burst_shots
-	var/burst_intervals
 	/// Tracks time between shots
 	COOLDOWN_DECLARE(fire_cooldown)
 

--- a/code/modules/mob/living/basic/syndicate/syndicate.dm
+++ b/code/modules/mob/living/basic/syndicate/syndicate.dm
@@ -138,12 +138,20 @@
 	var/casingtype = /obj/item/ammo_casing/c9mm
 	/// Sound to play when firing weapon
 	var/projectilesound = 'sound/weapons/gun/pistol/shot.ogg'
+	/// number of burst shots
+	var/burst_shots
 	/// Time between taking shots
 	var/ranged_cooldown = 1 SECONDS
 
 /mob/living/basic/syndicate/ranged/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/ranged_attacks, casing_type = casingtype, projectile_sound = projectilesound, cooldown_time = ranged_cooldown)
+	AddComponent(\
+		/datum/component/ranged_attacks,\
+		casing_type = casingtype,\
+		projectile_sound = projectilesound,\
+		cooldown_time = ranged_cooldown,\
+		burst_shots = burst_shots,\
+	)
 
 /mob/living/basic/syndicate/ranged/infiltrator //shuttle loan event
 	projectilesound = 'sound/weapons/gun/smg/shot_suppressed.ogg'
@@ -172,6 +180,7 @@
 	casingtype = /obj/item/ammo_casing/c45
 	projectilesound = 'sound/weapons/gun/smg/shot.ogg'
 	ai_controller = /datum/ai_controller/basic_controller/syndicate/ranged/burst
+	burst_shots = 3
 	ranged_cooldown = 3 SECONDS
 	r_hand = /obj/item/gun/ballistic/automatic/c20r
 
@@ -203,6 +212,7 @@
 	casingtype = /obj/item/ammo_casing/shotgun/buckshot //buckshot (up to 72.5 brute) fired in a two-round burst
 	ai_controller = /datum/ai_controller/basic_controller/syndicate/ranged/shotgunner
 	ranged_cooldown = 3 SECONDS
+	burst_shots = 2
 	r_hand = /obj/item/gun/ballistic/shotgun/bulldog
 
 /mob/living/basic/syndicate/ranged/shotgun/space

--- a/code/modules/mob/living/basic/syndicate/syndicate_ai.dm
+++ b/code/modules/mob/living/basic/syndicate/syndicate_ai.dm
@@ -49,7 +49,6 @@
 	ranged_attack_behavior = /datum/ai_behavior/basic_ranged_attack/syndicate_burst
 
 /datum/ai_behavior/basic_ranged_attack/syndicate_burst
-	shots = 3
 	action_cooldown = 3 SECONDS
 
 /datum/ai_controller/basic_controller/syndicate/ranged/shotgunner
@@ -62,8 +61,6 @@
 	ranged_attack_behavior = /datum/ai_behavior/basic_ranged_attack/syndicate_shotgun
 
 /datum/ai_behavior/basic_ranged_attack/syndicate_shotgun
-	shots = 2
-	burst_interval = 0.6 SECONDS
 	action_cooldown = 3 SECONDS
 	required_distance = 1
 

--- a/code/modules/mob/living/basic/vermin/cockroach.dm
+++ b/code/modules/mob/living/basic/vermin/cockroach.dm
@@ -93,10 +93,19 @@
 	faction = list(FACTION_HOSTILE, FACTION_MAINT_CREATURES)
 	ai_controller = /datum/ai_controller/basic_controller/cockroach/glockroach
 	cockroach_cell_line = CELL_LINE_TABLE_GLOCKROACH
+	///number of burst shots
+	var/burst_shots
+	///cooldown between attacks
+	var/ranged_cooldown = 1 SECONDS
 
 /mob/living/basic/cockroach/glockroach/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/ranged_attacks, casing_type = /obj/item/ammo_casing/glockroach, cooldown_time = 1 SECONDS)
+	AddComponent(\
+		/datum/component/ranged_attacks,\
+		casing_type = /obj/item/ammo_casing/glockroach,\
+		burst_shots = burst_shots,\
+		cooldown_time = ranged_cooldown,\
+	)
 
 /datum/ai_controller/basic_controller/cockroach/glockroach
 	planning_subtrees = list(
@@ -186,6 +195,8 @@
 	desc = "WE'RE FUCKED, THAT GLOCKROACH HAS A TOMMYGUN!"
 	icon_state = "mobroach"
 	ai_controller = /datum/ai_controller/basic_controller/cockroach/mobroach
+	burst_shots = 4
+	ranged_cooldown = 2 SECONDS
 
 /datum/ai_controller/basic_controller/cockroach/mobroach
 	planning_subtrees = list(
@@ -200,5 +211,4 @@
 	ranged_attack_behavior = /datum/ai_behavior/basic_ranged_attack/mobroach
 
 /datum/ai_behavior/basic_ranged_attack/mobroach
-	shots = 4
 	action_cooldown = 2 SECONDS


### PR DESCRIPTION

## About The Pull Request
the burst attacks wasnt working because a cooldown in the ranged component qwas added recently. this now moves the burst attacks option to the component itself so even sapiant player mobs can use these burst ranged attacks

## Why It's Good For The Game
fix basic mobs ranged burst attacks

## Changelog
:cl:
fix: basic mobs can now use ranged burst attacks
/:cl:
