### PR TITLE
Fixes beams rendering below mobs by default. The fishing line is no longer emissive.

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -41,7 +41,7 @@
 	/// If set will be used instead of targets's pixel_y in offset calculations
 	var/override_target_pixel_y = null
 
-/datum/beam/New(origin, target,	icon = 'icons/effects/beam.dmi', icon_state = "b_beam",	time = INFINITY, max_distance = INFINITY, beam_type = /obj/effect/ebeam, beam_color = null, emissive = TRUE, override_origin_pixel_x = null,	override_origin_pixel_y = null, override_target_pixel_x = null, override_target_pixel_y = null)
+/datum/beam/New(origin, target, icon = 'icons/effects/beam.dmi', icon_state = "b_beam", time = INFINITY, max_distance = INFINITY, beam_type = /obj/effect/ebeam, beam_color = null, emissive = TRUE, override_origin_pixel_x = null, override_origin_pixel_y = null, override_target_pixel_x = null, override_target_pixel_y = null)
 	src.origin = origin
 	src.target = target
 	src.icon = icon
@@ -65,8 +65,7 @@
 	visuals.icon = icon
 	visuals.icon_state = icon_state
 	visuals.color = beam_color
-	visuals.layer = ABOVE_ALL_MOB_LAYER
-	visuals.vis_flags = VIS_INHERIT_PLANE
+	visuals.vis_flags = VIS_INHERIT_PLANE|VIS_INHERIT_LAYER
 	visuals.emissive = emissive
 	visuals.update_appearance()
 	Draw()
@@ -166,6 +165,8 @@
 
 /obj/effect/ebeam
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	plane = GAME_PLANE_UPPER_FOV_HIDDEN
+	layer = ABOVE_ALL_MOB_LAYER
 	anchored = TRUE
 	var/emissive = TRUE
 	var/datum/beam/owner

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -41,7 +41,21 @@
 	/// If set will be used instead of targets's pixel_y in offset calculations
 	var/override_target_pixel_y = null
 
-/datum/beam/New(origin, target, icon = 'icons/effects/beam.dmi', icon_state = "b_beam", time = INFINITY, max_distance = INFINITY, beam_type = /obj/effect/ebeam, beam_color = null, emissive = TRUE, override_origin_pixel_x = null, override_origin_pixel_y = null, override_target_pixel_x = null, override_target_pixel_y = null)
+/datum/beam/New(
+	origin,
+	target,
+	icon = 'icons/effects/beam.dmi',
+	icon_state = "b_beam",
+	time = INFINITY,
+	max_distance = INFINITY,
+	beam_type = /obj/effect/ebeam,
+	beam_color = null,
+	emissive = TRUE,
+	override_origin_pixel_x = null,
+	override_origin_pixel_y = null,
+	override_target_pixel_x = null,
+	override_target_pixel_y = null,
+)
 	src.origin = origin
 	src.target = target
 	src.icon = icon

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -157,7 +157,7 @@
 	if(!istype(user))
 		return
 	var/beam_color = line?.line_color || default_line_color
-	var/datum/beam/fishing_line/fishing_line_beam = new(user, target, icon_state = "fishing_line", beam_color = beam_color, override_target_pixel_y = target_py)
+	var/datum/beam/fishing_line/fishing_line_beam = new(user, target, icon_state = "fishing_line", beam_color = beam_color,  emissive = FALSE, override_target_pixel_y = target_py)
 	fishing_line_beam.lefthand = user.get_held_index_of_item(src) % 2 == 1
 	RegisterSignal(fishing_line_beam, COMSIG_BEAM_BEFORE_DRAW, PROC_REF(check_los))
 	RegisterSignal(fishing_line_beam, COMSIG_QDELETING, PROC_REF(clear_line))
@@ -570,8 +570,34 @@
 
 
 /datum/beam/fishing_line
+	emissive = FALSE
 	// Is the fishing rod held in left side hand
 	var/lefthand = FALSE
+
+	// Make these inline with final sprites
+	var/righthand_s_px = 13
+	var/righthand_s_py = 16
+
+	var/righthand_e_px = 18
+	var/righthand_e_py = 16
+
+	var/righthand_w_px = -20
+	var/righthand_w_py = 18
+
+	var/righthand_n_px = -14
+	var/righthand_n_py = 16
+
+	var/lefthand_s_px = -13
+	var/lefthand_s_py = 15
+
+	var/lefthand_e_px = 24
+	var/lefthand_e_py = 18
+
+	var/lefthand_w_px = -17
+	var/lefthand_w_py = 16
+
+	var/lefthand_n_px = 13
+	var/lefthand_n_py = 15
 
 /datum/beam/fishing_line/Start()
 	update_offsets(origin.dir)
@@ -601,29 +627,3 @@
 		if(NORTH)
 			override_origin_pixel_x = lefthand ? lefthand_n_px : righthand_n_px
 			override_origin_pixel_y = lefthand ? lefthand_n_py : righthand_n_py
-
-// Make these inline with final sprites
-/datum/beam/fishing_line
-	var/righthand_s_px = 13
-	var/righthand_s_py = 16
-
-	var/righthand_e_px = 18
-	var/righthand_e_py = 16
-
-	var/righthand_w_px = -20
-	var/righthand_w_py = 18
-
-	var/righthand_n_px = -14
-	var/righthand_n_py = 16
-
-	var/lefthand_s_px = -13
-	var/lefthand_s_py = 15
-
-	var/lefthand_e_px = 24
-	var/lefthand_e_py = 18
-
-	var/lefthand_w_px = -17
-	var/lefthand_w_py = 16
-
-	var/lefthand_n_px = 13
-	var/lefthand_n_py = 15

--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -570,7 +570,6 @@
 
 
 /datum/beam/fishing_line
-	emissive = FALSE
 	// Is the fishing rod held in left side hand
 	var/lefthand = FALSE
 

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -1,7 +1,5 @@
 /obj/effect/ebeam/curse_arm
 	name = "curse arm"
-	layer = LARGE_MOB_LAYER
-	plane = GAME_PLANE_UPPER_FOV_HIDDEN
 
 /obj/projectile/curse_hand
 	name = "curse hand"


### PR DESCRIPTION
## About The Pull Request
That of beams being layered below mobs has been a minor issue ever since that mess that is FoV was implemented (with the exception of chain lighting of the 'lighting' holoparasite type). I'm changing the plane of beams to GAME_PLANE_UPPER_FOV_HIDDEN along a couple other things.

## Why It's Good For The Game
Re-read the above section, also fishing lines shouldn't generally glow in the dark like very thin lightsabers, and them being layered below mobs has always been a peeve to me.

## Changelog

:cl:
fix: Fixed beams rendering below mobs by default.
fix: The fishing line beam is no longer emissive (it doesn't glow in the dark).
/:cl:
