### PR TITLE
Colossus' Titan's Finale ability has a 0.5 seconds delay before starting the attack

### DIFF
--- a/code/datums/actions/mobs/projectileattack.dm
+++ b/code/datums/actions/mobs/projectileattack.dm
@@ -297,6 +297,7 @@
 		colossus = firer
 		colossus.say("Perish.", spans = list("colossus", "yell"))
 
+	SLEEP_CHECK_DEATH(0.5 SECONDS, firer) //gives dumbasses in melee range a slim chance to retreat
 	var/finale_counter = 10
 	for(var/i in 1 to 20)
 		if(finale_counter > 4 && colossus)


### PR DESCRIPTION
## About The Pull Request

ided pls nerf

## Why It's Good For The Game

This motherfucker is horrid to fight with a crusher because the first attack that he does in this action is a shotgun blast, which you just eat with your face and die. The only reasonable way to trigger this attack is with a ranged weapon or with a hiero's trophy, the former being antithetical to the challenge/playstyle that is crusher mining and the latter being wildly uncontrollable.
Half a second should be ample time to dodge out of harm's way before server-lagging touhou begins.

## Changelog

:cl:
balance: colossus' near-death attack now starts after a 0.5 seconds delay
/:cl: