### PR TITLE
Canonizes Robot Yawns

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -195,12 +195,12 @@
 		. = message_alien
 	else if(islarva(user) && message_larva)
 		. = message_larva
-	else if(iscyborg(user) && message_robot)
-		. = message_robot
 	else if(isAI(user) && message_AI)
 		. = message_AI
 	else if(ismonkey(user) && message_monkey)
 		. = message_monkey
+	else if(iscyborg(user) && message_robot || (user.mob_biotypes & MOB_ROBOTIC))
+		. = message_robot
 	else if(isanimal_or_basicmob(user) && message_animal_or_basic)
 		. = message_animal_or_basic
 

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -187,6 +187,10 @@
 /datum/emote/proc/select_message_type(mob/user, msg, intentional)
 	// Basically, we don't care that the others can use datum variables, because they're never going to change.
 	. = msg
+	if(!isliving(user))
+		return .
+	var/mob/living/living_user = user
+
 	if(!muzzle_ignore && user.is_muzzled() && emote_type & EMOTE_AUDIBLE)
 		return "makes a [pick("strong ", "weak ", "")]noise."
 	if(HAS_MIND_TRAIT(user, TRAIT_MIMING) && message_mime)
@@ -199,10 +203,12 @@
 		. = message_AI
 	else if(ismonkey(user) && message_monkey)
 		. = message_monkey
-	else if(iscyborg(user) && message_robot || (user.mob_biotypes & MOB_ROBOTIC))
+	else if((iscyborg(user) || (living_user.mob_biotypes & MOB_ROBOTIC)) && message_robot)
 		. = message_robot
 	else if(isanimal_or_basicmob(user) && message_animal_or_basic)
 		. = message_animal_or_basic
+
+	return .
 
 /**
  * Replaces the %t in the message in message_param by params.

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -531,6 +531,8 @@
 	key_third_person = "yawns"
 	message = "yawns."
 	message_mime = "acts out an exaggerated silent yawn."
+	message_robot = "symphathetically yawns."
+	message_AI = "symphathetically yawns."
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
 	cooldown = 5 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

Closes #77592

I agree that it's silly that robots shouldn't be able to yawn, but I think that instead of removing the potential for this interaction to occur outright (which can be done with moving around a check), it should be embraced instead.

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/34697715/43aaeda1-4cb2-4ca5-b9ef-fd11a37ee583)

Robots fake-yawning to make them feel more realistic to the workers of the station (and if they aren't station based, their once-creators (which is fine because we removed swarmers)) and not being exempt from a really cutesy niche interaction greatly appeals to me.

## Changelog

:cl:
add: Ever see a robot yawn? Don't worry, it makes sense now.
/:cl:
