### PR TITLE
Misc mapping fixes and QoL additions

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -3732,10 +3732,11 @@
 "bzn" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/item/stack/sheet/plasteel/fifty,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/rack,
-/obj/item/stock_parts/cell/emproof,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "bzs" = (

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -13551,13 +13551,10 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ffD" = (
-/obj/machinery/disposal/delivery_chute{
-	dir = 8
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "garbage"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "ffO" = (
@@ -27164,10 +27161,7 @@
 /area/station/cargo/warehouse)
 "jPq" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/centcom{
-	name = "Disposals Access:"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/janitor,
+/obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "jQo" = (
@@ -27716,13 +27710,11 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
 "kaF" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/stripes/end{
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/mineral/stacking_unit_console{
-	pixel_x = 32
-	},
+/obj/machinery/disposal/delivery_chute,
+/obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "kaI" = (
@@ -29190,7 +29182,9 @@
 	dir = 1
 	},
 /obj/structure/mop_bucket/janitorialcart,
-/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/door/window/left/directional/north{
+	name = "Trash Chute"
+	},
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "kCT" = (
@@ -35134,6 +35128,9 @@
 	id = "garbage"
 	},
 /obj/machinery/light/cold/directional/north,
+/obj/machinery/mineral/stacking_unit_console{
+	pixel_y = 27
+	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "mEB" = (
@@ -42179,6 +42176,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/recreation)
+"pke" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Disposals Access:"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/janitor,
+/turf/open/floor/plating,
+/area/station/maintenance/fore/greater)
 "pkh" = (
 /obj/effect/spawner/random/decoration/showcase,
 /obj/structure/window/spawner/directional/south,
@@ -55620,7 +55624,6 @@
 	dir = 8;
 	id = "garbage"
 	},
-/obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "tzF" = (
@@ -104338,7 +104341,7 @@ kCW
 xID
 xmO
 sHs
-nFW
+pke
 tzD
 cqS
 kCN
@@ -105368,9 +105371,9 @@ jsn
 sIS
 nFW
 sRL
+sRL
 xVV
-xVV
-xVV
+sRL
 xVV
 sRL
 bFg

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -916,6 +916,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/textured_half,
 /area/station/service/cafeteria)
+"asZ" = (
+/obj/structure/disposalpipe/trunk,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
+/area/station/service/janitor)
 "ata" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/machinery/light/small/directional/west,
@@ -3201,19 +3211,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/robotics/augments)
 "boX" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/orange{
-	pixel_x = 4;
-	pixel_y = -2
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
 	},
-/obj/item/stack/tile/iron/base{
-	pixel_y = 18
-	},
-/obj/item/key/janitor{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/white/small,
+/turf/open/floor/plating,
 /area/station/service/janitor)
 "boY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
@@ -5933,6 +5935,16 @@
 /obj/machinery/air_sensor/incinerator_tank,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"cqS" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/obj/effect/spawner/random/trash/garbage{
+	spawn_loot_count = 3
+	},
+/turf/open/floor/plating,
+/area/station/service/janitor)
 "crm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
@@ -7676,7 +7688,11 @@
 /obj/item/reagent_containers/cup/bucket,
 /obj/item/mop,
 /obj/structure/sink/kitchen/directional/east,
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/button/door/directional/west{
+	pixel_y = 8;
+	id = "custodialshutters"
+	},
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "cZM" = (
@@ -10277,6 +10293,13 @@
 	dir = 9
 	},
 /area/station/engineering/atmos)
+"dXO" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/service/janitor)
 "dXT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -13526,6 +13549,16 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ffD" = (
+/obj/machinery/disposal/delivery_chute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating,
+/area/station/service/janitor)
 "ffO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/plating/airless,
@@ -16643,16 +16676,10 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/command/nuke_storage)
 "ghW" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/mineral/stacking_machine{
+	input_dir = 2
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
+/turf/open/floor/plating,
 /area/station/service/janitor)
 "gic" = (
 /obj/effect/turf_decal/siding/blue{
@@ -21655,19 +21682,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "hTW" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/vehicle/ridden/janicart,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage";
-	name = "trash belt"
-	},
-/obj/machinery/recycler,
-/turf/open/floor/plating,
+/turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "hTZ" = (
 /obj/structure/chair/sofa/bench/left{
@@ -23346,11 +23366,14 @@
 "ixP" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/south,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/stack/tile/iron/base{
+	pixel_y = 18
+	},
 /obj/item/grenade/chem_grenade/cleaner{
 	pixel_x = -7;
 	pixel_y = 12
 	},
-/obj/item/restraints/legcuffs/beartrap,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "ixU" = (
@@ -24774,7 +24797,7 @@
 /obj/structure/railing{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer2{
 	dir = 8
 	},
 /turf/open/space/basic,
@@ -27132,7 +27155,11 @@
 /area/station/cargo/warehouse)
 "jPq" = (
 /obj/structure/disposalpipe/segment,
-/turf/closed/wall,
+/obj/machinery/door/airlock/centcom{
+	name = "Disposals Access:"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/janitor,
+/turf/open/floor/plating,
 /area/station/maintenance/fore/greater)
 "jQo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27606,10 +27633,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "jZK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
 "jZL" = (
@@ -27636,16 +27660,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "kam" = (
-/obj/structure/cable,
-/obj/structure/table,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
-/obj/item/storage/box/mousetraps{
-	pixel_x = -3;
-	pixel_y = 8
+/obj/machinery/disposal/delivery_chute{
+	dir = 4
 	},
-/turf/open/floor/iron/white/small,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plating,
 /area/station/service/janitor)
 "kar" = (
 /obj/structure/disposalpipe/segment,
@@ -27683,14 +27707,13 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/science/auxlab/firing_range)
 "kaF" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
-/obj/machinery/disposal/delivery_chute,
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/machinery/mineral/stacking_unit_console{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "kaI" = (
@@ -27723,22 +27746,6 @@
 /obj/structure/broken_flooring/corner/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
-"kbc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/door/window/left/directional/east{
-	name = "Trash Chute";
-	req_access = list("janitor")
-	},
-/obj/machinery/conveyor_switch/oneway{
-	dir = 4;
-	id = "garbage";
-	name = "trash chute"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/small,
-/area/station/service/janitor)
 "kbE" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/machinery/light/small/broken/directional/north,
@@ -28106,10 +28113,8 @@
 "kjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
 "kjl" = (
@@ -28217,9 +28222,8 @@
 "kkD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
 "kkL" = (
@@ -29162,16 +29166,22 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kCN" = (
-/obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/left/directional/north{
+	name = "Trash Chute"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "kCP" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/mop_bucket/janitorialcart,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "kCT" = (
@@ -30554,27 +30564,25 @@
 /turf/open/floor/iron/small,
 /area/station/engineering/atmos)
 "lcW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
 	},
+/obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "lde" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/item/radio/intercom/directional/south,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/disposaloutlet{
 	dir = 1
 	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage";
-	name = "trash belt"
-	},
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "ldo" = (
 /obj/structure/chair/comfy/brown{
@@ -31881,6 +31889,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/curtain/cloth,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/service/janitor)
 "lyQ" = (
@@ -33940,14 +33949,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
-"mhW" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Custodial Closet Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/janitor,
-/turf/open/floor/plating,
-/area/station/maintenance/fore/greater)
 "mhY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35119,15 +35120,12 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/maintenance/starboard/greater)
 "mEy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/small,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/plating,
 /area/station/service/janitor)
 "mEB" = (
 /obj/effect/spawner/structure/window,
@@ -36375,9 +36373,12 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/greater)
 "ncf" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/small,
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
 /area/station/service/janitor)
 "ncl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37895,20 +37896,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"nEJ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	id = "custodialshutters";
-	name = "Custodial Closet Shutters"
-	},
-/obj/machinery/button/door/directional/north{
-	id = "custodialshutters";
-	name = "shutters control";
-	pixel_x = 8
-	},
-/turf/open/floor/iron/large,
-/area/station/service/janitor)
 "nEY" = (
 /obj/structure/closet/firecloset,
 /obj/effect/decal/cleanable/dirt,
@@ -37957,8 +37944,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "nFA" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/janitor,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor_switch/oneway{
+	dir = 4;
+	id = "garbage";
+	name = "trash chute"
+	},
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "nFD" = (
@@ -38221,7 +38216,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/light/small/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/hallway/abandoned_command)
 "nJU" = (
@@ -39660,14 +39657,19 @@
 /turf/open/floor/iron/white/small,
 /area/station/medical/cryo)
 "onR" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery/white{
-	color = "#52B4E9"
+/obj/structure/table,
+/obj/item/clothing/gloves/color/orange{
+	pixel_x = 4;
+	pixel_y = -2
 	},
-/obj/vehicle/ridden/janicart,
-/obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
+/obj/item/key/janitor{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "onX" = (
@@ -42046,6 +42048,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/janitor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "pil" = (
@@ -42904,6 +42907,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "pwA" = (
@@ -44578,6 +44582,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Custodial Closet"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/service/janitor)
 "pWZ" = (
@@ -48811,18 +48816,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "roB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage";
-	name = "trash belt"
-	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "roC" = (
 /obj/structure/cable,
@@ -51183,20 +51179,26 @@
 /turf/open/floor/iron/white/small,
 /area/station/service/hydroponics)
 "saD" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/camera/directional/south,
 /obj/machinery/light/small/directional/south,
-/turf/open/floor/plating,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/box/mousetraps{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/restraints/legcuffs/beartrap{
+	pixel_x = 8;
+	pixel_y = 13
+	},
+/obj/item/flashlight{
+	pixel_y = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "saY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -55605,21 +55607,12 @@
 /turf/open/floor/plating,
 /area/station/science/lobby)
 "tzD" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
 	},
-/obj/structure/table,
-/obj/item/restraints/legcuffs/beartrap{
-	pixel_x = 8;
-	pixel_y = 13
-	},
-/obj/item/flashlight{
-	pixel_y = 4
-	},
-/obj/machinery/light/cold/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/white/small,
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/plating,
 /area/station/service/janitor)
 "tzF" = (
 /obj/structure/cable,
@@ -57793,13 +57786,6 @@
 /obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"ujl" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/station/service/janitor)
 "ujq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/closet/emcloset,
@@ -57888,6 +57874,12 @@
 /area/station/security/checkpoint/science)
 "ukW" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "ulb" = (
@@ -57920,18 +57912,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"ulM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 2
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/station/service/janitor)
 "ulO" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
@@ -64051,8 +64031,14 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
 "wjM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
 "wjY" = (
@@ -103830,9 +103816,9 @@ sOs
 xmO
 lKn
 nFW
+dXO
 sRL
 sRL
-nEJ
 nVX
 sRL
 sRL
@@ -104089,10 +104075,10 @@ sHe
 nFW
 kam
 boX
-kBH
+asZ
 ukW
 cZL
-xVV
+sRL
 dCH
 ixP
 sRL
@@ -104345,7 +104331,7 @@ xmO
 sHs
 nFW
 tzD
-ukW
+cqS
 kCN
 wjM
 lcW
@@ -104600,11 +104586,11 @@ rIJ
 rAG
 xmO
 sHe
-mhW
+nFW
 mEy
 ncf
 nFA
-ujl
+kBH
 onR
 xVV
 lOt
@@ -104859,9 +104845,9 @@ xmO
 qzO
 nFW
 ghW
-ulM
+boX
 kCP
-kbc
+kBH
 saD
 sRL
 sRL
@@ -105116,7 +105102,7 @@ sJR
 sIA
 jPq
 kaF
-roB
+ffD
 hTW
 roB
 lde
@@ -105372,7 +105358,7 @@ xmO
 jsn
 sIS
 nFW
-xVV
+sRL
 xVV
 xVV
 xVV

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -13800,6 +13800,7 @@
 /obj/item/mod/module/thermal_regulator,
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/status_display/ai/directional/south,
+/obj/item/mod/module/signlang_radio,
 /turf/open/floor/iron/small,
 /area/station/medical/storage)
 "fkt" = (
@@ -19691,6 +19692,10 @@
 /obj/item/storage/fancy/cigarettes{
 	pixel_x = 20;
 	pixel_y = 11
+	},
+/obj/item/mod/module/signlang_radio{
+	pixel_y = 2;
+	pixel_x = -2
 	},
 /turf/open/floor/iron/small,
 /area/station/security/office)
@@ -25884,6 +25889,9 @@
 	},
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/package_wrap{
+	pixel_y = 5
+	},
 /obj/item/storage/box/matches,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -61095,6 +61095,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/item/mod/module/tether,
 /obj/item/mod/module/tether,
+/obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "ptC" = (
@@ -78413,7 +78414,6 @@
 /area/station/medical/morgue)
 "tGm" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/plasteel/fifty,
 /obj/item/stack/sheet/rglass{
 	amount = 50;
 	pixel_x = 2;

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -8180,13 +8180,13 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "bWw" = (
-/obj/machinery/button/flasher{
-	id = "Cell 6";
-	name = "Prisoner Flash";
-	pixel_x = -25
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/status_display/door_timer{
+	id = "Isolation_Cell";
+	name = "Isolation Cell";
+	pixel_x = -32
 	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
@@ -23598,6 +23598,7 @@
 	dir = 5
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/item/mod/module/signlang_radio,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "fQF" = (
@@ -28123,7 +28124,7 @@
 /area/station/medical/cryo)
 "gTH" = (
 /obj/machinery/flasher/directional/south{
-	id = "Cell 6"
+	id = "Isolation_Cell"
 	},
 /obj/machinery/light/small/broken/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -78427,6 +78428,7 @@
 /obj/item/mod/module/plasma_stabilizer,
 /obj/item/mod/module/thermal_regulator,
 /obj/item/mod/module/magboot,
+/obj/item/mod/module/signlang_radio,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "tGq" = (
@@ -93506,6 +93508,7 @@
 	dir = 1
 	},
 /obj/machinery/digital_clock/directional/south,
+/obj/item/mod/module/signlang_radio,
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "xtZ" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5050,12 +5050,13 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/structure/cable,
 /obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
 /obj/item/stock_parts/cell/emproof{
 	pixel_x = -4;
 	pixel_y = -1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "bAR" = (
@@ -15534,13 +15535,6 @@
 /obj/item/clothing/under/costume/jabroni,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"eHK" = (
-/obj/item/radio/intercom/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/security/execution/transfer)
 "eHT" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -18654,7 +18648,6 @@
 /area/station/science/robotics/lab)
 "fJG" = (
 /obj/structure/rack,
-/obj/item/hand_labeler,
 /obj/item/hand_labeler,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -26314,6 +26307,11 @@
 "ihD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/machinery/status_display/door_timer{
+	id = "Isolation_Cell";
+	name = "Isolation Cell";
+	pixel_x = -32
 	},
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
@@ -34808,6 +34806,7 @@
 /obj/item/mod/module/plasma_stabilizer,
 /obj/item/mod/module/thermal_regulator,
 /obj/effect/turf_decal/tile/blue/full,
+/obj/item/mod/module/signlang_radio,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/storage)
 "kKa" = (
@@ -47315,6 +47314,9 @@
 	pixel_y = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/item/radio/intercom/directional/east{
+	pixel_y = -6
+	},
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
 "oBp" = (
@@ -53423,6 +53425,7 @@
 /obj/machinery/door/window/left/directional/north{
 	name = "Armory Desk"
 	},
+/obj/item/hand_labeler,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory/upper)
 "quB" = (
@@ -57026,8 +57029,9 @@
 "rzr" = (
 /obj/structure/table,
 /obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
 /obj/item/assembly/flash/handheld,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -171409,7 +171413,7 @@ xHE
 xHE
 hgM
 fvO
-eHK
+mBa
 hgM
 mKq
 xEd
@@ -171666,7 +171670,7 @@ uME
 uME
 uME
 bYB
-mBa
+hBg
 hgM
 xhK
 xhK

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -65075,7 +65075,6 @@
 /area/station/engineering/storage)
 "uaI" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/security/execution/transfer)
 "uaT" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -8267,7 +8267,7 @@
 /obj/item/bedsheet/red,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/flasher/directional/north{
-	id = "IsolationFlash"
+	id = "IsolationCell"
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/white,
@@ -11944,7 +11944,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/greater)
 "esK" = (
-/obj/machinery/firealarm/directional/east,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
@@ -20014,6 +20013,7 @@
 	},
 /obj/item/mod/module/plasma_stabilizer,
 /obj/item/mod/module/thermal_regulator,
+/obj/item/mod/module/signlang_radio,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "hwg" = (
@@ -26881,14 +26881,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "jJp" = (
-/obj/machinery/button/flasher{
-	id = "IsolationFlash";
-	pixel_x = -23;
-	pixel_y = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/door_timer{
+	id = "IsolationCell";
+	name = "Isolation Cell";
+	pixel_x = -32
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "jJC" = (
@@ -38209,6 +38209,7 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/item/mod/module/signlang_radio,
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -41912,6 +41913,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/coroner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "pdX" = (
@@ -54902,6 +54904,9 @@
 /obj/item/mod/module/plasma_stabilizer{
 	pixel_x = 16
 	},
+/obj/item/mod/module/signlang_radio{
+	pixel_x = 16
+	},
 /obj/item/mod/module/thermal_regulator{
 	pixel_x = 16
 	},
@@ -56805,6 +56810,7 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "urs" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16143,6 +16143,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "fYC" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -16236,7 +16236,7 @@
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "fore_vator";
 	pixel_x = -24;
-	preset_destination_names = list("2"="Supply-Engi                Floor","3"="Med-Sci                Floor","4"="Service                Floor")
+	preset_destination_names = list("2"="Supply-Engi        Floor","3"="Med-Sci        Floor","4"="Service        Floor")
 	},
 /obj/machinery/lift_indicator/directional/west{
 	linked_elevator_id = "fore_vator";

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -32227,7 +32227,6 @@
 "iyT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iyU" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -53560,7 +53560,7 @@
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "aft_vator";
 	pixel_x = 24;
-	preset_destination_names = list("2"="Supply-Engi                Floor","3"="Med-Sci                Floor","4"="Service                Floor")
+	preset_destination_names = list("2"="Supply-Engi        Floor","3"="Med-Sci        Floor","4"="Service        Floor")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/floor1/aft)

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -20832,14 +20832,9 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
 	},
-/obj/item/stock_parts/matter_bin{
-	pixel_x = 2;
-	pixel_y = -5
-	},
-/obj/item/stock_parts/micro_laser{
-	pixel_y = 7
-	},
-/obj/item/trash/boritos/green,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/corner{
 	dir = 1
 	},
@@ -31982,6 +31977,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/dark,
 /area/station/security/eva)
 "iuE" = (
@@ -46117,7 +46115,6 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/regular,
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/window/right/directional/south{
 	name = "First Aid Supplies";
@@ -54241,11 +54238,8 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/storage/medkit/regular,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/window/left/directional/south{
-	name = "First Aid Supplies";
-	req_access = list("medical")
-	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
 "odz" = (
@@ -68092,6 +68086,12 @@
 "rOY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
 "rPi" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -937,12 +937,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"alE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "alK" = (
 /obj/machinery/modular_computer/preset/id{
 	dir = 4
@@ -6595,7 +6589,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/north,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "bDU" = (
@@ -7219,6 +7212,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Atmospherics-Supermatter Connection"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "bNU" = (
@@ -25998,7 +25992,6 @@
 /area/station/engineering/supermatter)
 "gSf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/structure/cable,
 /obj/machinery/light/floor,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/supermatter/room)
@@ -32234,6 +32227,7 @@
 "iyT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iyU" = (
@@ -33240,7 +33234,6 @@
 "iMV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/status_display/evac/directional/south,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "iMX" = (
@@ -45898,6 +45891,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor2/starboard/aft)
+"lZi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "lZl" = (
 /obj/structure/reagent_dispensers/plumbed,
 /obj/effect/decal/cleanable/dirt,
@@ -49119,6 +49116,7 @@
 "mOT" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "mPs" = (
@@ -59289,7 +59287,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "pxw" = (
@@ -59489,8 +59486,8 @@
 /area/station/service/hydroponics)
 "pzm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/structure/cable,
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "pzu" = (
@@ -60340,7 +60337,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/camera/autoname/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/supermatter/room)
 "pMe" = (
@@ -60903,6 +60899,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_corner,
 /area/station/engineering/supermatter/room)
 "pUl" = (
@@ -66365,6 +66362,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "rpA" = (
@@ -67120,11 +67118,6 @@
 "rAy" = (
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard)
-"rAD" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "rAE" = (
 /obj/machinery/computer/records/security{
 	dir = 4
@@ -69101,7 +69094,6 @@
 "sdt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/meter,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half,
 /area/station/engineering/supermatter/room)
 "sdA" = (
@@ -72243,7 +72235,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/supermatter/room)
 "sWC" = (
@@ -72652,6 +72643,7 @@
 /obj/machinery/button/door/directional/south{
 	id = "radshutnorth"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tat" = (
@@ -74603,6 +74595,12 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"tAC" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "tAE" = (
 /obj/machinery/vending/cola/starkist,
 /turf/open/floor/wood,
@@ -78309,6 +78307,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
 "uCv" = (
@@ -84765,6 +84764,7 @@
 /area/station/security/courtroom)
 "wiF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wiJ" = (
@@ -85581,6 +85581,7 @@
 "wth" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "wtl" = (
@@ -87391,14 +87392,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/station/service/chapel/funeral)
-"wOP" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "wPn" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -137904,7 +137897,7 @@ rBP
 jcr
 rBP
 rBP
-wOP
+xgW
 xgW
 xgW
 xgW
@@ -138417,7 +138410,7 @@ oIy
 oIy
 tjV
 xgW
-xgW
+mVF
 pUf
 eCQ
 uyD
@@ -138674,7 +138667,7 @@ whF
 oIy
 aDf
 xgW
-xgW
+mVF
 wmC
 sly
 uyD
@@ -139443,7 +139436,7 @@ nIJ
 uLB
 rAm
 sAH
-xgW
+tAC
 jSD
 fcp
 iCk
@@ -139702,7 +139695,7 @@ qEw
 sAH
 xgW
 kfo
-iyT
+lZi
 kcB
 ppO
 fJE
@@ -139712,7 +139705,7 @@ wCu
 vap
 kBK
 juf
-klY
+wOm
 kfo
 wfl
 dEc
@@ -140216,17 +140209,17 @@ uEu
 sAH
 bQz
 uCe
-iyT
-mVF
-alE
+lZi
+xgW
+pIZ
 gSf
 sWB
 sdt
 pMa
 gSf
 pxv
-rAD
-klY
+jER
+wOm
 rpD
 tyQ
 dEc

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -16236,7 +16236,7 @@
 /obj/machinery/elevator_control_panel/directional/west{
 	linked_elevator_id = "fore_vator";
 	pixel_x = -24;
-	preset_destination_names = list("2"="Supply-Engi        Floor","3"="Med-Sci        Floor","4"="Service        Floor")
+	preset_destination_names = list("2"="Supply-Engi                Floor","3"="Med-Sci                Floor","4"="Service                Floor")
 	},
 /obj/machinery/lift_indicator/directional/west{
 	linked_elevator_id = "fore_vator";
@@ -48444,7 +48444,10 @@
 	},
 /obj/machinery/computer/pod/old/mass_driver_controller/ordnancedriver,
 /obj/structure/table,
-/obj/item/binoculars,
+/obj/item/binoculars{
+	pixel_x = 6;
+	pixel_y = 6
+	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
 	},
@@ -53560,7 +53563,7 @@
 /obj/machinery/elevator_control_panel/directional/east{
 	linked_elevator_id = "aft_vator";
 	pixel_x = 24;
-	preset_destination_names = list("2"="Supply-Engi        Floor","3"="Med-Sci        Floor","4"="Service        Floor")
+	preset_destination_names = list("2"="Supply-Engi                Floor","3"="Med-Sci                Floor","4"="Service                Floor")
 	},
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/floor1/aft)
@@ -66367,7 +66370,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
@@ -78306,7 +78308,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
@@ -84764,7 +84765,6 @@
 /area/station/security/courtroom)
 "wiF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "wiJ" = (
@@ -85581,7 +85581,6 @@
 "wth" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/small/directional/west,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "wtl" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -15308,6 +15308,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/item/bedsheet/black,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "emK" = (
@@ -18132,6 +18133,17 @@
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"frL" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/machinery/status_display/door_timer{
+	id = "Isolation_C";
+	name = "Isolation Cell C";
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "frN" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -20253,6 +20265,7 @@
 	},
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/light/small/directional/east,
+/obj/item/bedsheet/black,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "gjb" = (
@@ -27391,6 +27404,9 @@
 /obj/effect/landmark/start/prisoner,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
+/obj/item/bedsheet/black{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "iUw" = (
@@ -27469,6 +27485,7 @@
 	},
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/light/small/directional/east,
+/obj/item/bedsheet/black,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "iVy" = (
@@ -32058,6 +32075,7 @@
 /area/station/hallway/primary/tram/center)
 "kwG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "kwN" = (
@@ -32491,8 +32509,6 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/item/mod/module/plasma_stabilizer,
-/obj/item/mod/module/thermal_regulator,
-/obj/item/gun/syringe,
 /obj/machinery/door/window/left/directional/west{
 	name = "Secure Medical Storage";
 	req_access = list("medical")
@@ -32500,6 +32516,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
+/obj/item/mod/module/signlang_radio,
+/obj/item/mod/module/thermal_regulator,
+/obj/item/gun/syringe,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "kGo" = (
@@ -40600,6 +40619,7 @@
 	},
 /obj/structure/rack,
 /obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
 /obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
@@ -42936,6 +42956,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/status_display/door_timer{
+	id = "Isolation_D";
+	name = "Isolation Cell D";
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "onc" = (
@@ -42961,6 +42986,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/item/bedsheet/black,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "onl" = (
@@ -48682,6 +48708,9 @@
 	},
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/light/small/directional/west,
+/obj/item/bedsheet/black{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "qvF" = (
@@ -48737,6 +48766,15 @@
 /obj/item/storage/bag/money,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/oresilo)
+"qwV" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/status_display/door_timer{
+	id = "Isolation_B";
+	name = "Isolation Cell B";
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "qwX" = (
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
@@ -49871,6 +49909,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"qTt" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/machinery/status_display/door_timer{
+	id = "Isolation_A";
+	name = "Isolation Cell A";
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/station/security/execution/transfer)
 "qTv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -67666,6 +67715,7 @@
 "xfW" = (
 /obj/structure/table,
 /obj/item/mod/module/plasma_stabilizer,
+/obj/item/mod/module/signlang_radio,
 /obj/item/mod/module/thermal_regulator,
 /turf/open/floor/iron,
 /area/station/security/office)
@@ -83566,7 +83616,7 @@ jWs
 cuM
 uUD
 cWF
-rnm
+frL
 ajM
 ona
 cWF
@@ -84337,9 +84387,9 @@ jWs
 cuM
 uUD
 cWF
-fIH
+qTt
 eTl
-kwG
+qwV
 cWF
 udO
 lrq

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -15308,7 +15308,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/item/bedsheet/black,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "emK" = (
@@ -20265,7 +20264,6 @@
 	},
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/light/small/directional/east,
-/obj/item/bedsheet/black,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "gjb" = (
@@ -27404,9 +27402,6 @@
 /obj/effect/landmark/start/prisoner,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
-/obj/item/bedsheet/black{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "iUw" = (
@@ -27485,7 +27480,6 @@
 	},
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/light/small/directional/east,
-/obj/item/bedsheet/black,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "iVy" = (
@@ -42986,7 +42980,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/item/bedsheet/black,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "onl" = (
@@ -48708,9 +48701,6 @@
 	},
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/light/small/directional/west,
-/obj/item/bedsheet/black{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "qvF" = (


### PR DESCRIPTION
## About The Pull Request

fix: #78135
fix: #78059

This PR remaps Birdshot's disposals room, makes several small fixes on Icebox and Metastation, adds cell timers to isolation cells where such cells are present (they don't open the door, effectively just an in-game timer) (in-cell flashes are now controlled with the timer, where applicable); and adds translator glove modules to the stacks of "accessibility" modules found in most security, medical, and engineering storage rooms. (adds these stacks in their entirety to Northstar).

Specific changes are as follows:
Birdshot
- Adds a roll of package paper to the cargo office
- Translator module [med,sec]
- Accessibility modules [eng]
- Recycler remap

Delta
- Translator module [med,sec,eng]
- Isolation cell timer

Icebox
- Translator module [med,sec,eng]
- Remove duplicate hand labeler on the rack near brig cells
- Adds a hand labeler to armory desk in gear room
- Isolation cell timer

Meta
- Translator module [med,sec,eng]
- Isolation cell timer
- Mends a broken corpse disposal pipe from aux surgery to the morgue

Northstar
- Accessibility modules [med,sec,eng]
- Nudges the binoculars off of the mass driver controls in ordnance
- Fixes the SM starting out hotwired (Rewires the SM room)

Tram
- Translator module [med,sec,eng]
- Isolation cell timers
## Why It's Good For The Game

Bug fixes with respect to Birdshot's recycler, Meta's corpse disposal, Northstar starting out hotwired, and Icebox's duplicated hand labeler.

Nudging Northstar's ordnance binoculars should make it a bit easier to find the mass driver controls.

Adding some packaging paper to Birdshot to make the techs' lives a little easier with a little less round-start fuss.

Adding a hand labeler to Icebox's gear room brings it in line with other maps in terms of rounds-start gear and locker labeling potential.

For players with characters running the Mute/Signer quirks, stock MODsuits are a pain to use. Suit gauntlets will replace their translator gloves. Unless they're able to get a suit put together ahead of time, they'll be stuck doing the retract gauntlets > send radio message > Extend Gauntlets shuffle. Adding a translator glove module to the stack of similar items (plasma fixation module / therma regulator) should alleviate that issue some.

Getting abandoned in an isolation cell sucks, and setting timers on your phone or some such is a hassle. Adding cell timers to isolation cells should go some way to alleviating those frustrations.
## Proof of Testing

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

<details>
<summary>Screenshots/Videos</summary>

### Birdshot

Disposal Room Remap
![bird_jani_v2](https://github.com/tgstation/tgstation/assets/107971606/aecc805f-08c9-469c-9963-860822c75f63)
Cargo Packing Paper
![tg-bird-packingPaper](https://github.com/tgstation/tgstation/assets/107971606/c0330acf-c64e-4dc4-9879-c7d8ae6047c4)
Engineering Accessibility Modules
![tg-bird-acc-eng](https://github.com/tgstation/tgstation/assets/107971606/ab055b28-2b40-453e-8850-1ceffb9c55ea)
Medbay Translator
![tg-bird-acc-med](https://github.com/tgstation/tgstation/assets/107971606/ecad5352-692d-4559-a1d3-4ee387fe449c)
Security Translator
![tg-bird-acc-sec](https://github.com/tgstation/tgstation/assets/107971606/045fa684-29f8-4112-ba58-59b90c135103)

### Deltastation

Engineering Translator
![tg-delta-acc-eng](https://github.com/tgstation/tgstation/assets/107971606/9289e303-e37a-4c11-b4c9-a6803cddcfd8)
Medbay Translator
![tg-delta-acc-med](https://github.com/tgstation/tgstation/assets/107971606/9a36819b-fbc4-4403-a0dd-199ba1c29cb3)
Security Translator
![tg-delta-acc-sec](https://github.com/tgstation/tgstation/assets/107971606/1d62d0d1-c564-4bfd-ad53-e41147682cba)
Isolation Cell Timer
![tg-delta-iso](https://github.com/tgstation/tgstation/assets/107971606/2c1579f4-d1a9-4d98-8e81-29b1cf0719d7)

### Icebox

Engineering Translator
![tg-ice-acc-eng](https://github.com/tgstation/tgstation/assets/107971606/9805b72e-cad6-4ddd-a7fd-adc271e6a341)
Medbay Translator
![tg-ice-acc-med](https://github.com/tgstation/tgstation/assets/107971606/8ab57572-0193-40c5-87ee-df95c7e5f9d8)
Security Translator
![tg-ice-acc-sec](https://github.com/tgstation/tgstation/assets/107971606/e234a98f-f429-4ed0-b465-3b795b1ff0bc)
Isolation Cell Timer
![tg-ice-iso](https://github.com/tgstation/tgstation/assets/107971606/9a0a7dc1-e369-46c8-8061-9c4635a63b5a)
Gear Room Hand Labeler
![tg-ice-label-armory](https://github.com/tgstation/tgstation/assets/107971606/36a58996-ac69-4978-8c79-eaa2478ce457)

### Metastation

Engineering Translator
![meta-acc-eng](https://github.com/tgstation/tgstation/assets/107971606/edbc746a-0c9c-4953-a744-1af064126c34)
Medbay Translator
![meta-acc-med](https://github.com/tgstation/tgstation/assets/107971606/a9b24f61-515e-40d1-b657-2a4b16920e51)
Security Translator
![meta-acc-sec](https://github.com/tgstation/tgstation/assets/107971606/55b91615-765e-42fe-adab-1a12e145ef48)
Isolation Cell Timer
![tg-meta-iso](https://github.com/tgstation/tgstation/assets/107971606/3bf6825c-0242-4332-ba71-db953a2e3902)

### Northstar

Engineering Accessibility Modules
![tg-north-acc-eng](https://github.com/tgstation/tgstation/assets/107971606/d32c1787-31e6-4ef7-964c-26eb87025888)
Medbay Accessibility Modules
![tg-north-acc-med](https://github.com/tgstation/tgstation/assets/107971606/fa3883f5-1e95-490a-b0b0-18ac08583221)
Security Accessibility Modules
![north-acc-sec](https://github.com/tgstation/tgstation/assets/107971606/d9308760-ac2f-4ae2-b91e-9d8dbcaaf0fd)
Supermatter Rewiring
![sm_annotate_2](https://github.com/tgstation/tgstation/assets/107971606/7c127678-6a55-454b-8e82-b615b41f0bcd)
Ordnance Binoculars
![tgqol_Northstar_Binos](https://github.com/tgstation/tgstation/assets/107971606/ce214728-48bf-436d-981e-bac40f8ca205)

### Tramstation

Engineering Translator
![tg-tram-acc-eng](https://github.com/tgstation/tgstation/assets/107971606/55b9993b-60b7-4e04-9073-0c8b3e7d9189)
Medbay Translator
![tg-tram-acc-med](https://github.com/tgstation/tgstation/assets/107971606/f4ac7a88-e3b1-4e4a-9914-70620c625b75)
Security Translator
![tg-tram-acc-sec](https://github.com/tgstation/tgstation/assets/107971606/8460cacb-a30a-45d0-b2bd-6c8666434055)
Isolation Cell Timer
![tg-tram-iso](https://github.com/tgstation/tgstation/assets/107971606/334be379-f6e6-45f0-93e9-b0e2f5d30b94)

</details>

## Changelog
:cl:
qol: [Deltastation, Icebox, Metastation, Tramstation] Adds cell timers to isolation cells. (they do not auto-open the doors)
qol: [Birdshot, Deltastation, Icebox, Metastation, Northstar, Tramstation] Adds translator glove modules to the stacks of "accessibility" (e.g. plasma fixation / thermal regulator) modules found in security, medical, and engineering storage rooms.
qol: [Birdshot] Adds a roll of packaging paper to the cargo office.
qol: [Icebox] Adds a hand labeler to security's gear room.
qol: [Northstar] Nudges the set of binoculars covering the mass driver controls in ordnance over a few inches.
fix: [Birdshot] Remaps the janitor's closet such that the recycling machine will now work.
fix: [Icebox] Removes a duplicated hand labeler from the rack near security's brig cells.
fix: [Metastation] Patches a broken corpse disposal pipe running from aux surgery to the morgue.
fix: [Northstar] Fixes the SM being hotwired at round-start (partially rewires the SM room, moves the APC to the North wall).
/:cl:
