### PR TITLE
Update clothing appearance following species change

### DIFF
--- a/code/modules/antagonists/changeling/powers/lesserform.dm
+++ b/code/modules/antagonists/changeling/powers/lesserform.dm
@@ -40,7 +40,6 @@
 	user.humanize(species = chosen_species, instant = transform_instantly)
 
 	changeling.transform(user, chosen_form)
-	user.regenerate_icons()
 	return TRUE
 
 /// Returns the form to transform back into, automatically selects your only profile if you only have one

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -506,6 +506,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		C.grant_language(language, SPOKEN_LANGUAGE, LANGUAGE_SPECIES)
 	for(var/language in gaining_holder.blocked_languages)
 		C.add_blocked_language(language, LANGUAGE_SPECIES)
+	C.regenerate_icons()
 
 	SEND_SIGNAL(C, COMSIG_SPECIES_GAIN, src, old_species)
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -36,7 +36,6 @@
 	set_name()
 	SEND_SIGNAL(src, COMSIG_HUMAN_MONKEYIZE)
 	uncuff()
-	regenerate_icons()
 	return src
 
 //////////////////////////           Humanize               //////////////////////////////
@@ -71,7 +70,6 @@
 	invisibility = 0
 	set_species(species)
 	SEND_SIGNAL(src, COMSIG_MONKEY_HUMANIZE)
-	regenerate_icons()
 	return src
 
 /mob/proc/AIize(client/preference_source, move = TRUE)

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -245,12 +245,11 @@ Charged extracts:
 		if(initial(try_species.changesource_flags) & SLIME_EXTRACT)
 			allowed_species += stype
 
-	// var/datum/species/changed = pick(allowed_species)
-	var/datum/species/changed = /datum/species/monkey
+	var/datum/species/changed = pick(allowed_species)
 	if(isnull(changed))
 		visible_message(span_notice("[src] fizzes uselessly."))
 		return
-	experiment_subject.set_species(changed, icon_update = 1)
+	experiment_subject.set_species(changed, icon_update = TRUE)
 	to_chat(experiment_subject, span_danger("You feel very different!"))
 	return ..()
 

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -235,21 +235,24 @@ Charged extracts:
 	effect_desc = "Randomizes the user's species."
 
 /obj/item/slimecross/charged/black/do_effect(mob/user)
-	var/mob/living/carbon/human/H = user
-	if(!istype(H))
-		to_chat(user, span_warning("You have to be able to have a species to get your species changed."))
+	var/mob/living/carbon/human/experiment_subject = user
+	if(!istype(experiment_subject))
+		balloon_alert(experiment_subject, "incompatible biology!")
 		return
 	var/list/allowed_species = list()
 	for(var/stype in subtypesof(/datum/species))
-		var/datum/species/X = stype
-		if(initial(X.changesource_flags) & SLIME_EXTRACT)
+		var/datum/species/try_species = stype
+		if(initial(try_species.changesource_flags) & SLIME_EXTRACT)
 			allowed_species += stype
 
-	var/datum/species/changed = pick(allowed_species)
-	if(changed)
-		H.set_species(changed, icon_update = 1)
-		to_chat(H, span_danger("You feel very different!"))
-	..()
+	// var/datum/species/changed = pick(allowed_species)
+	var/datum/species/changed = /datum/species/monkey
+	if(isnull(changed))
+		visible_message(span_notice("[src] fizzes uselessly."))
+		return
+	experiment_subject.set_species(changed, icon_update = 1)
+	to_chat(experiment_subject, span_danger("You feel very different!"))
+	return ..()
 
 /obj/item/slimecross/charged/lightpink
 	colour = SLIME_TYPE_LIGHT_PINK


### PR DESCRIPTION
## About The Pull Request

Fixes #78179
Monkey clothes didn't fit following black charged slime transformation (I hate xenobiology)
Moved the proc call which updated the clothing appearance from turning into or returning from being a monkey into generic `on_species_gain` on the basis that this would effect any species with weird clothing offsets (such as transforming into a golem from the same source) and we don't want a bunch of specific checks against it.

Also I just tidied up that proc a little bit.

## Changelog

:cl:
fix: Your clothes and such should correctly reposition themselves if a black charged slime extract turns you into a monkey.
/:cl:
