### PR TITLE
Allow spawner component to be instantiated with an empty list

### DIFF
--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -15,6 +15,8 @@
 	COOLDOWN_DECLARE(spawn_delay)
 
 /datum/component/spawner/Initialize(spawn_types = list(), spawn_time = 30 SECONDS, max_spawned = 5, faction = list(FACTION_MINING), spawn_text = null)
+	if (!islist(spawn_types))
+		CRASH("invalid spawn_types to spawn specified for spawner component!")
 	src.spawn_time = spawn_time
 	src.spawn_types = spawn_types
 	src.faction = faction

--- a/code/datums/components/spawner.dm
+++ b/code/datums/components/spawner.dm
@@ -15,8 +15,6 @@
 	COOLDOWN_DECLARE(spawn_delay)
 
 /datum/component/spawner/Initialize(spawn_types = list(), spawn_time = 30 SECONDS, max_spawned = 5, faction = list(FACTION_MINING), spawn_text = null)
-	if (!islist(spawn_types))
-		CRASH("invalid spawn_types to spawn specified for spawner component!")
 	src.spawn_time = spawn_time
 	src.spawn_types = spawn_types
 	src.faction = faction
@@ -38,6 +36,8 @@
 
 /// Try to create a new mob
 /datum/component/spawner/proc/try_spawn_mob()
+	if(!length(spawn_types))
+		return
 	if(!COOLDOWN_FINISHED(src, spawn_delay))
 		return
 	validate_references()


### PR DESCRIPTION
## About The Pull Request

Fixes #78172
The spawner component could be added to arbitrary items by admins but would always throw an error because it was passed an empty list. Admins were not capable of providing anything _other_ than an empty list to it on init, due to limitations in our interface.
We (I but I had help) broke this in #73645 by removing the default "spawns carp" list.
It is still silly for it to default to spawning carp, but instead it can now be instantiated with an empty list without breaking, and an admin can then VV it to further modify the list to what they actually want it to do.

## Changelog

:cl: 
admin: Admins can add/remove the spawner component from arbitrary items again.
/:cl: