### PR TITLE
Increases midround traitor starting reputation

### DIFF
--- a/code/controllers/subsystem/traitor.dm
+++ b/code/controllers/subsystem/traitor.dm
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(traitor)
 	var/configuration_data = list()
 
 	/// The coefficient multiplied by the current_global_progression for new joining traitors to calculate their progression
-	var/newjoin_progression_coeff = 0.6
+	var/newjoin_progression_coeff = 1
 	/// The current progression that all traitors should be at in the round
 	var/current_global_progression = 0
 	/// The amount of deviance from the current global progression before you start getting 2x the current scaling or no scaling at all


### PR DESCRIPTION
## About The Pull Request

Reputation for traitors serves two goals:
_Primarily_ it is a timelock. Secondarily, it can drive interaction with secondary objectives by giving you a little reward.

The way that progression traitors work is that reputation is earned every minute, so that when a developer is adding a new item for the rep cost they can just write "30 MINUTES" and it means that the item will be available when 30 minutes have passed, or a little earlier if the traitor does some secondary objectives.

_Currently_ when traitors arrive on the station they get reputation equal to _60%_ of the reputation that they would have had if they became a traitor at the start of the round and then had hidden in a locker until the current time.
This PR increases that to 100%, so if you are activated as a sleeper agent 30 minutes into the round you will immediately have 30 minutes of reputation. With this and your standard 20TC you can buy almost anything in the uplink, such as a syndicate bomb.

## Why It's Good For The Game

Given that it is primarily supposed to be a time lock to prevent people from immediately accessing items which can rapidly pivot the round, it doesn't make sense that late joining traitors are "penalised" in this way. If we're ok with a roundstart traitor having a bomb right now, we should be ok with a latejoin one having one too.
As far as I am concerned secondary objectives should be something you do for a _bonus_, and anything which can drag people away from being 100% mechanically focused in order to chase the increasing number in favour of just being able to do their damn gimmick is a good thing.

## Changelog

:cl:
balance: Traitors who are activated as sleeper agents or arrive late on the arrivals shuttle will begin with more reputation and likely be able to immediately access most of the uplink catalogue.
/:cl:
