### PR TITLE
Collected food fixes

### DIFF
--- a/code/__DEFINES/clothing.dm
+++ b/code/__DEFINES/clothing.dm
@@ -30,3 +30,6 @@
 #define ADD_CLOTHING_TRAIT(mob, trait) ADD_TRAIT(mob, trait, "[CLOTHING_TRAIT]_[REF(src)]")
 /// Wrapper for removing clothing based traits
 #define REMOVE_CLOTHING_TRAIT(mob, trait) REMOVE_TRAIT(mob, trait, "[CLOTHING_TRAIT]_[REF(src)]")
+
+/// How much integrity does a shirt lose every time we bite it?
+#define MOTH_EATING_CLOTHING_DAMAGE 15

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -66,7 +66,11 @@
 /datum/component/bakeable/proc/finish_baking(atom/used_oven)
 	var/atom/original_object = parent
 	var/obj/item/plate/oven_tray/used_tray = original_object.loc
-	var/atom/baked_result = new bake_result(used_tray, no_base_reagents = TRUE)
+	var/atom/baked_result = new bake_result(
+		used_tray,
+		/* starting_reagent_purity = */ null,
+		/* no_base_reagents = */ TRUE,
+	)
 	original_object.reagents?.trans_to(baked_result, original_object.reagents.total_volume)
 
 	if(who_baked_us)

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -206,7 +206,11 @@
 			if(ispath(recipe.result, /obj/item/stack))
 				result = new recipe.result(get_turf(crafter.loc), recipe.result_amount || 1)
 			else if (ispath(recipe.result, /obj/item/food))
-				result = new recipe.result(get_turf(crafter.loc), no_base_reagents = TRUE)
+				result = new recipe.result(
+					get_turf(crafter.loc),
+					/* starting_reagent_purity = */ null,
+					/* no_base_reagents = */ TRUE,
+				)
 			else
 				result = new recipe.result(get_turf(crafter.loc))
 				if(result.atom_storage && recipe.delete_contents)

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -580,9 +580,10 @@ Behavior that's still missing from this component that original food items had t
 	if(HAS_TRAIT(parent, TRAIT_FOOD_SILVER)) // it's not real food
 		food_quality += isjellyperson(eater) ? 2 : -4
 
-	food_quality += TOXIC_FOOD_QUALITY_CHANGE * count_matching_foodtypes(foodtypes, eater.get_toxic_foodtypes())
-	food_quality += DISLIKED_FOOD_QUALITY_CHANGE * count_matching_foodtypes(foodtypes, eater.get_disliked_foodtypes())
-	food_quality += LIKED_FOOD_QUALITY_CHANGE * count_matching_foodtypes(foodtypes, eater.get_liked_foodtypes())
+	if (ishuman(eater))
+		food_quality += TOXIC_FOOD_QUALITY_CHANGE * count_matching_foodtypes(foodtypes, eater.get_toxic_foodtypes())
+		food_quality += DISLIKED_FOOD_QUALITY_CHANGE * count_matching_foodtypes(foodtypes, eater.get_disliked_foodtypes())
+		food_quality += LIKED_FOOD_QUALITY_CHANGE * count_matching_foodtypes(foodtypes, eater.get_liked_foodtypes())
 
 	return food_quality
 

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -46,7 +46,7 @@ Behavior that's still missing from this component that original food items had t
 	food_flags = NONE,
 	foodtypes = NONE,
 	volume = 50,
-	eat_time = 10,
+	eat_time = 1 SECONDS,
 	list/tastes,
 	list/eatverbs = list("bite", "chew", "nibble", "gnaw", "gobble", "chomp"),
 	bite_consumption = 2,
@@ -350,7 +350,7 @@ Behavior that's still missing from this component that original food items had t
 			time_to_eat *= (fullness / NUTRITION_LEVEL_FAT) * EAT_TIME_VORACIOUS_FULL_MULT // takes longer to eat the more well fed you are
 
 	if(eater == feeder)//If you're eating it yourself.
-		if(eat_time && !do_after(feeder, time_to_eat, eater, timed_action_flags = food_flags & FOOD_FINGER_FOOD ? IGNORE_USER_LOC_CHANGE | IGNORE_TARGET_LOC_CHANGE : NONE)) //Gotta pass the minimal eat time
+		if(eat_time > 0 && !do_after(feeder, time_to_eat, eater, timed_action_flags = food_flags & FOOD_FINGER_FOOD ? IGNORE_USER_LOC_CHANGE | IGNORE_TARGET_LOC_CHANGE : NONE)) //Gotta pass the minimal eat time
 			return
 		if(IsFoodGone(owner, feeder))
 			return
@@ -431,7 +431,7 @@ Behavior that's still missing from this component that original food items had t
 	TakeBite(eater, feeder)
 
 	//If we're not force-feeding and there's an eat delay, try take another bite
-	if(eater == feeder && eat_time)
+	if(eater == feeder && eat_time > 0)
 		INVOKE_ASYNC(src, PROC_REF(TryToEat), eater, feeder)
 
 #undef EAT_TIME_FORCE_FEED

--- a/code/datums/components/food/golem_food.dm
+++ b/code/datums/components/food/golem_food.dm
@@ -46,9 +46,11 @@
 	if (!snack_type.can_consume(target))
 		source.balloon_alert(user, "can't consume!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
-	if (!golem_snack)
+	if (isnull(golem_snack))
 		golem_snack = new(
 			/* loc = */ null,
+			/* starting_reagent_purity = */ null,
+			/* no_base_reagents = */ FALSE,
 			/* name = */ source.name,
 			/* consume_food = */ consume_on_eat,
 			/* food_buff = */ snack_type,
@@ -84,7 +86,15 @@
 	/// Golem food buff to apply on consumption
 	var/datum/golem_food_buff/food_buff
 
-/obj/item/food/golem_food/Initialize(mapload, name, consume_food, datum/golem_food_buff/food_buff, atom/owner)
+/obj/item/food/golem_food/Initialize(
+	mapload,
+	starting_reagent_purity,
+	no_base_reagents = FALSE,
+	name,
+	consume_food,
+	datum/golem_food_buff/food_buff,
+	atom/owner,
+)
 	. = ..()
 	src.name = name
 	src.consume_food = consume_food

--- a/code/datums/components/food/golem_food.dm
+++ b/code/datums/components/food/golem_food.dm
@@ -47,18 +47,22 @@
 		source.balloon_alert(user, "can't consume!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 	if (isnull(golem_snack))
-		golem_snack = new(
-			/* loc = */ null,
-			/* starting_reagent_purity = */ null,
-			/* no_base_reagents = */ FALSE,
-			/* name = */ source.name,
-			/* consume_food = */ consume_on_eat,
-			/* food_buff = */ snack_type,
-			/* owner = */ parent,
-		)
-		RegisterSignal(golem_snack, COMSIG_QDELETING, PROC_REF(on_food_destroyed))
+		create_golem_snack(source)
 	golem_snack.attack(target, user, click_parameters)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
+
+/// Creates our golem snack atom instance
+/datum/component/golem_food/proc/create_golem_snack(atom/source)
+	golem_snack = new(
+		/* loc = */ null,
+		/* starting_reagent_purity = */ null,
+		/* no_base_reagents = */ FALSE,
+		/* name = */ source.name,
+		/* consume_food = */ consume_on_eat,
+		/* food_buff = */ snack_type,
+		/* owner = */ parent,
+	)
+	RegisterSignal(golem_snack, COMSIG_QDELETING, PROC_REF(on_food_destroyed))
 
 /// Reference handling for abstract food object
 /datum/component/golem_food/proc/on_food_destroyed()

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -95,7 +95,11 @@
 		grilled_result = new cook_result(original_object.loc, stack_parent.amount)
 
 	else
-		grilled_result = new cook_result(original_object.loc, no_base_reagents = TRUE)
+		grilled_result = new cook_result(
+			original_object.loc,
+			/* starting_reagent_purity = */ null,
+			/* no_base_reagents = */ TRUE,
+		)
 		if(original_object.custom_materials)
 			grilled_result.set_custom_materials(original_object.custom_materials)
 

--- a/code/datums/elements/dryable.dm
+++ b/code/datums/elements/dryable.dm
@@ -38,7 +38,11 @@
 		return
 	else if(istype(source, /obj/item/food) && ispath(dry_result, /obj/item/food))
 		var/obj/item/food/source_food = source
-		var/obj/item/food/resulting_food = new dry_result(source.drop_location(), no_base_reagents = TRUE)
+		var/obj/item/food/resulting_food = new dry_result(
+			source.drop_location(),
+			/* starting_reagent_purity = */ null,
+			/* no_base_reagents = */ TRUE,
+		)
 		source_food.reagents.trans_to(resulting_food, source_food.reagents.total_volume)
 		ADD_TRAIT(resulting_food, TRAIT_DRIED, ELEMENT_TRAIT(type))
 		qdel(source)

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -36,7 +36,11 @@
 		var/obj/item/stack/stack_source = source
 		result = new result_typepath(result_loc, stack_source.amount)
 	else
-		result = new result_typepath(result_loc, no_base_reagents = TRUE)
+		result = new result_typepath(
+			result_loc,
+			/* starting_reagent_purity = */ null,
+			/* no_base_reagents = */ TRUE,
+		)
 
 	var/efficiency = istype(used_microwave) ? used_microwave.efficiency : 1
 	SEND_SIGNAL(result, COMSIG_ITEM_MICROWAVE_COOKED, source, efficiency)

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -58,8 +58,6 @@
 	if(food_reagents)
 		food_reagents = string_assoc_list(food_reagents)
 	. = ..()
-	if(food_reagents)
-		food_reagents = string_assoc_list(food_reagents)
 	if(tastes)
 		tastes = string_assoc_list(tastes)
 	if(eatverbs)

--- a/code/game/objects/items/robot/items/food.dm
+++ b/code/game/objects/items/robot/items/food.dm
@@ -60,7 +60,12 @@
 		if(DISPENSE_LOLLIPOP_MODE)
 			food_item = new /obj/item/food/lollipop/cyborg(turf_to_dispense_to)
 		if(DISPENSE_ICECREAM_MODE)
-			food_item = new /obj/item/food/icecream(turf_to_dispense_to, list(ICE_CREAM_VANILLA))
+			food_item = new /obj/item/food/icecream(
+				/* loc = */ turf_to_dispense_to,
+				/* starting_reagent_purity = */ null,
+				/* no_base_reagents = */ FALSE,
+				/* prefill_flavours = */ list(ICE_CREAM_VANILLA),
+			)
 			food_item.desc = "Eat the ice cream."
 
 	var/into_hands = FALSE

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -357,7 +357,12 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/structure/bodycontainer/crematorium/creamatorium/cremate(mob/user)
 	var/list/icecreams = list()
 	for(var/mob/living/i_scream as anything in get_all_contents_type(/mob/living))
-		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(null, /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, list(ICE_CREAM_MOB = list(null, i_scream.name)))
+		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(
+			/* loc = */ null,
+			/* starting_reagent_purity = */ null,
+			/* no_base_reagents = */ FALSE,
+			/* prefill_flavours = */ list(ICE_CREAM_MOB = list(null, i_scream.name))
+		)
 		icecreams += IC
 	. = ..()
 	for(var/obj/IC in icecreams)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -1,5 +1,3 @@
-#define MOTH_EATING_CLOTHING_DAMAGE 15
-
 /obj/item/clothing
 	name = "clothing"
 	resistance_flags = FLAMMABLE
@@ -108,10 +106,14 @@
 	if((clothing_flags & INEDIBLE_CLOTHING) || (resistance_flags & INDESTRUCTIBLE))
 		return ..()
 	if(isnull(moth_snack))
-		moth_snack = new
-		moth_snack.name = name
-		moth_snack.clothing = WEAKREF(src)
+		create_moth_snack()
 	moth_snack.attack(target, user, params)
+
+/// Creates a food object in null space which we can eat and imagine we're eating this pair of shoes
+/obj/item/clothing/proc/create_moth_snack()
+	moth_snack = new
+	moth_snack.name = name
+	moth_snack.clothing = WEAKREF(src)
 
 /obj/item/clothing/attackby(obj/item/W, mob/user, params)
 	if(!istype(W, repairable_by))
@@ -543,8 +545,6 @@ BLIND     // can't see anything
 		return
 	if(prob(0.2))
 		to_chat(L, span_warning("The damaged threads on your [src.name] chafe!"))
-
-#undef MOTH_EATING_CLOTHING_DAMAGE
 
 /obj/item/clothing/apply_fantasy_bonuses(bonus)
 	. = ..()

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -68,7 +68,11 @@
 		var/list/cached_mats = recipe.preserve_materials && what.custom_materials
 		var/cached_multiplier = (recipe.food_multiplier * rating_amount)
 		for(var/i in 1 to cached_multiplier)
-			var/atom/processed_food = new recipe.output(drop_location(), no_base_reagents = TRUE)
+			var/atom/processed_food = new recipe.output(
+				drop_location(),
+				/* starting_reagent_purity = */ null,
+				/* no_base_reagents = */ TRUE,
+			)
 			what.reagents.copy_to(processed_food, what.reagents.total_volume, multiplier = 1 / cached_multiplier)
 			if(cached_mats)
 				processed_food.set_custom_materials(cached_mats, 1 / cached_multiplier)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -356,7 +356,7 @@
 		var/purity = beaker.reagents.get_reagent_purity(/datum/reagent/consumable/milk)
 		beaker.reagents.remove_reagent(/datum/reagent/consumable/milk, MILK_TO_BUTTER_COEFF * butter_amt)
 		for(var/i in 1 to butter_amt)
-			new /obj/item/food/butter(drop_location(), purity)
+			new /obj/item/food/butter(/* loc = */ drop_location(), /* starting_reagent_purity = */ purity)
 		//Recipe to make Mayonnaise
 		if (beaker.reagents.has_reagent(/datum/reagent/consumable/eggyolk))
 			beaker.reagents.convert_reagent(/datum/reagent/consumable/eggyolk, /datum/reagent/consumable/mayonnaise)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -261,6 +261,7 @@
 #include "unit_test.dm"
 #include "verify_config_tags.dm"
 #include "verify_emoji_names.dm"
+#include "weird_food.dm"
 #include "wizard_loadout.dm"
 #include "worn_icons.dm"
 // END_INCLUDE

--- a/code/modules/unit_tests/weird_food.dm
+++ b/code/modules/unit_tests/weird_food.dm
@@ -1,0 +1,40 @@
+/// Unit test to ensure that moths can eat t-shirts successfully
+/datum/unit_test/moth_food
+
+/datum/unit_test/moth_food/Run()
+	var/obj/item/clothing/suit/armor/bulletproof/light_snack = allocate(/obj/item/clothing/suit/armor/bulletproof)
+	light_snack.create_moth_snack()
+	var/datum/component/edible/eatability = light_snack.moth_snack.GetComponent(/datum/component/edible)
+	eatability.eat_time = 0
+
+	var/mob/living/carbon/human/species/moth/gourmet = allocate(/mob/living/carbon/human/species/moth)
+	gourmet.nutrition = 0 // We need to be sufficiently hungry
+	gourmet.put_in_active_hand(light_snack)
+
+	var/times_to_bite = round(light_snack.max_integrity / MOTH_EATING_CLOTHING_DAMAGE) + 1
+	for (var/i in 1 to times_to_bite)
+		TEST_ASSERT(!QDELETED(light_snack), "Moth finished eating clothes faster than expected.")
+		light_snack.attack(gourmet, gourmet)
+	TEST_ASSERT(QDELETED(light_snack), "Moth failed to finish eating clothing.")
+
+/// Unit test to ensure that golems can eat rocks successfully
+/datum/unit_test/golem_food
+
+/datum/unit_test/golem_food/Run()
+	var/obj/item/stack/sheet/mineral/uranium/five/dinner = allocate(/obj/item/stack/sheet/mineral/uranium/five)
+	var/datum/component/golem_food/golem_food_data = dinner.GetComponent(/datum/component/golem_food)
+	golem_food_data.create_golem_snack(dinner)
+	var/datum/component/edible/eatability = golem_food_data.golem_snack.GetComponent(/datum/component/edible)
+	eatability.eat_time = 0
+
+	var/mob/living/carbon/human/species/golem/rock_enjoyer = allocate(/mob/living/carbon/human/species/golem)
+	rock_enjoyer.nutrition = 0 // We need to be sufficiently hungry
+	rock_enjoyer.put_in_active_hand(dinner)
+
+	var/status_applied = golem_food_data.snack_type.status_effect
+	var/times_to_bite = dinner.amount
+	for (var/i in 1 to times_to_bite)
+		TEST_ASSERT(!QDELETED(dinner), "Golem finished eating rocks faster than expected.")
+		dinner.attack(rock_enjoyer, rock_enjoyer)
+	TEST_ASSERT(QDELETED(dinner), "Golem failed to finish eating rocks.")
+	TEST_ASSERT(rock_enjoyer.has_status_effect(status_applied), "Golem didn't gain a food buff from eating its rocks.")


### PR DESCRIPTION
## About The Pull Request

Fixes #78167
Fixes #78192
Fixes #78194

I went through the code and tried to find all of the remaining places we forgot to update the arguments passed into `item/food/Initialize` after more arguments were added to it, because there were a couple and they caused things to stop working.
Most notably, golems were unable to eat anything because nothing would correctly spawn "golem food".

_Additionally_ we were using a bunch of named arguments in new whenever crafting or cooking food. This runtimed, causing the food not to init properly.
_On top of that_ a late code review on a recent PR processed a list into a string_assoc_list twice causing it to become null.

Finally, we were trying to check the food preferences of examining ghosts or dogs or other non-human mobs. We shouldn't do that.

I also added a unit test for moth and golem food in the hopes that we'll notice them breaking.

## Changelog

:cl:
fix: Golems can eat
fix: Cooked and crafted food should be edible
fix: Medborgs can now spawn vanilla ice cream instead of nothing ice cream
fix: Ghosts can examine food
/:cl:
