### PR TITLE
Reverts Makes Spacers Taller #76909 

### DIFF
--- a/code/datums/quirks/positive_quirks/spacer.dm
+++ b/code/datums/quirks/positive_quirks/spacer.dm
@@ -15,6 +15,8 @@
 		/obj/item/storage/pill_bottle/ondansetron,
 		/obj/item/reagent_containers/pill/gravitum,
 	)
+	/// How high spacers get bumped up to
+	var/modded_height = HUMAN_HEIGHT_TALLER
 	/// How long on a planet before we get averse effects
 	var/planet_period = 3 MINUTES
 	/// TimerID for time spend on a planet
@@ -44,7 +46,7 @@
 	quirk_holder.inertia_move_delay *= 0.8
 
 	var/mob/living/carbon/human/human_quirker = quirk_holder
-	human_quirker.set_mob_height(HUMAN_HEIGHT_TALLEST)
+	human_quirker.set_mob_height(modded_height)
 	human_quirker.physiology.pressure_mod *= 0.8
 	human_quirker.physiology.cold_mod *= 0.8
 


### PR DESCRIPTION
## About The Pull Request

Reverts Makes Spacers Taller #76909 

Spacers are back to "Taller" height rather than "Tallest"

## Why It's Good For The Game

Quite simply, I don't like the look of it on humans, the filters really weren't designed to stretch that much. If someone wants another shot at making the spacers taller again they'll probably need to make a new displacement map. 

I did move it out to a var so downstreams can override it and set their own if they'd like. 

## Changelog

:cl: Melbert
del: Spacers are slightly shorter. They're still taller than other people, just not as much.
/:cl:

