### PR TITLE
Exploration drones can no longer be used to get to centcom

### DIFF
--- a/code/modules/explorer_drone/control_console.dm
+++ b/code/modules/explorer_drone/control_console.dm
@@ -132,7 +132,7 @@
 					if(!target_site)
 						return TRUE
 					if(!controlled_drone.check_blacklist())
-						say("Error - An unauthorized object was found inside the drone's storage")
+						say("Error - An unauthorized object was found inside the cargo!")
 						return TRUE
 				controlled_drone.launch_for(target_site)
 			return TRUE

--- a/code/modules/explorer_drone/control_console.dm
+++ b/code/modules/explorer_drone/control_console.dm
@@ -132,7 +132,7 @@
 					if(!target_site)
 						return TRUE
 					if(!controlled_drone.check_blacklist())
-						say("Error - An unauthorized object detected inside drone's storage")
+						say("Error - An unauthorized object was found inside the drone's storage")
 						return TRUE
 				controlled_drone.launch_for(target_site)
 			return TRUE

--- a/code/modules/explorer_drone/control_console.dm
+++ b/code/modules/explorer_drone/control_console.dm
@@ -131,6 +131,9 @@
 					target_site = locate(params["target_site"]) in GLOB.exploration_sites
 					if(!target_site)
 						return TRUE
+					if(!controlled_drone.check_blacklist())
+						say("Error - An unauthorized object detected inside drone's storage")
+						return TRUE
 				controlled_drone.launch_for(target_site)
 			return TRUE
 		if("explore")

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -17,6 +17,10 @@
 GLOBAL_LIST_EMPTY(exodrones)
 /// All exodrone launchers.
 GLOBAL_LIST_EMPTY(exodrone_launchers)
+// Blacklist for exodrones
+GLOBAL_LIST_INIT(blacklisted_exodrone_types, typecacheof(list(
+	/obj/item/bodybag/bluespace
+	)))
 
 /// Exploration drone
 /obj/item/exodrone
@@ -72,7 +76,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 	GLOB.exodrones += src
 	/// Cargo storage
 	create_storage(max_slots = EXODRONE_CARGO_SLOTS)
-	atom_storage.set_holdable(cant_hold_list = GLOB.blacklisted_cargo_types)
+	atom_storage.set_holdable(cant_hold_list = GLOB.blacklisted_cargo_types + GLOB.blacklisted_exodrone_types)
 
 /obj/item/exodrone/Destroy()
 	. = ..()

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -17,10 +17,6 @@
 GLOBAL_LIST_EMPTY(exodrones)
 /// All exodrone launchers.
 GLOBAL_LIST_EMPTY(exodrone_launchers)
-// Blacklist for exodrones
-GLOBAL_LIST_INIT(blacklisted_exodrone_types, typecacheof(list(
-	/obj/item/bodybag/bluespace
-	)))
 
 /// Exploration drone
 /obj/item/exodrone
@@ -76,7 +72,7 @@ GLOBAL_LIST_INIT(blacklisted_exodrone_types, typecacheof(list(
 	GLOB.exodrones += src
 	/// Cargo storage
 	create_storage(max_slots = EXODRONE_CARGO_SLOTS)
-	atom_storage.set_holdable(cant_hold_list = GLOB.blacklisted_cargo_types + GLOB.blacklisted_exodrone_types)
+	atom_storage.set_holdable(cant_hold_list = GLOB.blacklisted_cargo_types)
 
 /obj/item/exodrone/Destroy()
 	. = ..()
@@ -91,6 +87,15 @@ GLOBAL_LIST_INIT(blacklisted_exodrone_types, typecacheof(list(
 			return "Exploring [location?.display_name() || "ERROR"]." // better safe than sorry.
 		if(EXODRONE_IDLE)
 			return "Idle."
+
+// Search for blacklisted items hidden inside other containers
+/obj/item/exodrone/proc/check_blacklist()
+	for(var/obj/item/contained_item in contents)
+		if(contained_item.contents)
+			for(var/subcontained_object in contained_item.get_all_contents())
+				if(is_type_in_typecache(subcontained_object, GLOB.blacklisted_cargo_types))
+					return FALSE
+	return TRUE
 
 /// Starts travel for site, does not validate if it's possible
 /obj/item/exodrone/proc/launch_for(datum/exploration_site/target_site)

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 		if(EXODRONE_IDLE)
 			return "Idle."
 
-// Searches for blacklisted items hidden inside other containers
+// Searches for blacklisted items hidden inside containers
 /obj/item/exodrone/proc/check_blacklist()
 	for(var/obj/item/contained_item in contents)
 		if(contained_item.contents)

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 		if(EXODRONE_IDLE)
 			return "Idle."
 
-// Search for blacklisted items hidden inside other containers
+// Searches for blacklisted items hidden inside other containers
 /obj/item/exodrone/proc/check_blacklist()
 	for(var/obj/item/contained_item in contents)
 		if(contained_item.contents)

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -25,6 +25,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/item/swapper,
 		/obj/docking_port,
 		/obj/machinery/launchpad,
+		/obj/machinery/exodrone_launcher,
 		/obj/machinery/disposal,
 		/obj/structure/disposalpipe,
 		/obj/item/mail,


### PR DESCRIPTION
## About The Pull Request
Fixes #73417
Implements a check for exploration drones to make sure that containers inside the storage don't have blacklisted items in them before launch. Now you won't able to hide beacons and living beings inside bluespace body bags.

Also adds exploration drone launchers to cargo shuttle's blacklist to prevent potential shenanigans in the future.

[I suck at explaining, so here's a poorly made video that shows how to do this](https://www.youtube.com/watch?v=U45ifQGQxzI)

~also, why does it take 10 hours to get the "Time Waster" achievement. how did 6 people even get it??~

## Why It's Good For The Game
centcom is scary and exploits are bad

## Changelog
:cl:
fix: Exploration drones can't be used to reach Centcom anymore.
/:cl:
