### PR TITLE
Bloodchiller and ling tentacle work with antimagic

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -278,6 +278,7 @@
 	flags_1 = NONE
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = NONE
+	antimagic_flags = NONE
 	pinless = TRUE
 	ammo_type = /obj/item/ammo_casing/magic/tentacle
 	fire_sound = 'sound/effects/splat.ogg'

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -96,6 +96,7 @@ Slimecrossing Weapons
 	item_flags = ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = NONE
+	antimagic_flags = NONE
 	force = 5
 	max_charges = 1 //Recharging costs blood.
 	recharge_rate = 1


### PR DESCRIPTION

## About The Pull Request
Fixes #78198 
Tentacle and bloodchiller had antimagic flags that they inherited from `gun/magic` and were unusable if you had magic immunity. I set those flags to `NONE`
## Why It's Good For The Game
Fixes a bug
## Changelog
:cl:
fix: Changeling tentacle and bloodchiller from xenobio will no longer stop working if you have antimagic
/:cl:
