### PR TITLE
The Create Command Report verb has the option to prevent printing reports now

### DIFF
--- a/code/modules/admin/verbs/commandreport.dm
+++ b/code/modules/admin/verbs/commandreport.dm
@@ -46,6 +46,8 @@
 	var/command_report_content
 	/// Whether the report's contents are announced.
 	var/announce_contents = TRUE
+	/// Whether a copy of the report is printed at every console.
+	var/print_report = TRUE
 	/// The sound that's going to accompany our message.
 	var/played_sound = DEFAULT_ANNOUNCEMENT_SOUND
 	/// A static list of preset names that can be chosen.
@@ -75,6 +77,7 @@
 	data["custom_name"] = custom_name
 	data["command_report_content"] = command_report_content
 	data["announce_contents"] = announce_contents
+	data["print_report"] = print_report
 	data["played_sound"] = played_sound
 
 	return data
@@ -103,6 +106,8 @@
 			played_sound = params["picked_sound"]
 		if("toggle_announce")
 			announce_contents = !announce_contents
+		if("toggle_printing")
+			print_report = !print_report
 		if("submit_report")
 			if(!command_name)
 				to_chat(ui_user, span_danger("You can't send a report with no command name."))
@@ -132,7 +137,9 @@
 
 	if(announce_contents)
 		priority_announce(command_report_content, null, report_sound, has_important_message = TRUE)
-	print_command_report(command_report_content, "[announce_contents ? "" : "Classified "][command_name] Update", !announce_contents)
+
+	if(!announce_contents || print_report)
+		print_command_report(command_report_content, "[announce_contents ? "" : "Classified "][command_name] Update", !announce_contents)
 
 	change_command_name(original_command_name)
 

--- a/tgui/packages/tgui/interfaces/CommandReport.tsx
+++ b/tgui/packages/tgui/interfaces/CommandReport.tsx
@@ -10,6 +10,7 @@ type Data = {
   command_report_content: string;
   custom_name: string;
   played_sound: string;
+  print_report: string;
 };
 
 export const CommandReport = () => {
@@ -94,7 +95,7 @@ const AnnouncementSound = (props, context) => {
 /** Creates the report textarea with a submit button. */
 const ReportText = (props, context) => {
   const { act, data } = useBackend<Data>(context);
-  const { announce_contents, command_report_content } = data;
+  const { announce_contents, print_report, command_report_content } = data;
   const [commandReport, setCommandReport] = useLocalState<string>(
     context,
     'textArea',
@@ -116,6 +117,18 @@ const ReportText = (props, context) => {
             checked={announce_contents}
             onClick={() => act('toggle_announce')}>
             Announce Contents
+          </Button.Checkbox>
+          <Button.Checkbox
+            fluid
+            checked={print_report || !announce_contents}
+            disabled={!announce_contents}
+            onClick={() => act('toggle_printing')}
+            tooltip={
+              !announce_contents &&
+              "Printing the report is required since we aren't announcing its contents."
+            }
+            tooltipPosition="top">
+            Print Report
           </Button.Checkbox>
         </Stack.Item>
         <Stack.Item>


### PR DESCRIPTION
## About The Pull Request

Title summarizes all.
## Why It's Good For The Game

<details>

![image](https://github.com/tgstation/tgstation/assets/47710522/ae71a6f9-b22d-467a-8da9-6a0bec576215)

</details>

Prevents this nightmare on a comms console during an event with particularly high centcom announcement traffic.

No, don't come at me with "it's soul", it's just highly annoying to deal with and having the option to prevent it is better. If you leave a downvote and tell me in the comments that I'm "taking" soul out of the game then I will come find you and actually take your soul out of your body.
## Changelog
:cl:
admin: The "Create Command Report" verb now has the option to not print report papers at communications consoles.
/:cl:
