### PR TITLE
An Assortment of Positive Station Traits

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1183,6 +1183,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_LOANER_SHUTTLE "station_trait_loaner_shuttle"
 #define STATION_TRAIT_WISE_COWS "station_trait_wise_cows"
 #define STATION_TRAIT_SHUTTLE_SALE "station_trait_shuttle_sale"
+#define STATION_TRAIT_MISSING_WALLET "station_trait_missing_wallet"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1181,9 +1181,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_VENDING_SHORTAGE "station_trait_vending_shortage"
 #define STATION_TRAIT_MEDBOT_MANIA "station_trait_medbot_mania"
 #define STATION_TRAIT_LOANER_SHUTTLE "station_trait_loaner_shuttle"
-#define STATION_TRAIT_WISE_COWS "station_trait_wise_cows"
 #define STATION_TRAIT_SHUTTLE_SALE "station_trait_shuttle_sale"
-#define STATION_TRAIT_MISSING_WALLET "station_trait_missing_wallet"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1181,6 +1181,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_VENDING_SHORTAGE "station_trait_vending_shortage"
 #define STATION_TRAIT_MEDBOT_MANIA "station_trait_medbot_mania"
 #define STATION_TRAIT_LOANER_SHUTTLE "station_trait_loaner_shuttle"
+#define STATION_TRAIT_WISE_COWS "station_trait_wise_cows"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1179,6 +1179,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_RADIOACTIVE_NEBULA "station_trait_radioactive_nebula"
 #define STATION_TRAIT_FORESTED "station_trait_forested"
 #define STATION_TRAIT_VENDING_SHORTAGE "station_trait_vending_shortage"
+#define STATION_TRAIT_MEDBOT_MANIA "station_trait_medbot_mania"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1182,6 +1182,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_MEDBOT_MANIA "station_trait_medbot_mania"
 #define STATION_TRAIT_LOANER_SHUTTLE "station_trait_loaner_shuttle"
 #define STATION_TRAIT_WISE_COWS "station_trait_wise_cows"
+#define STATION_TRAIT_SHUTTLE_SALE "station_trait_shuttle_sale"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1180,6 +1180,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define STATION_TRAIT_FORESTED "station_trait_forested"
 #define STATION_TRAIT_VENDING_SHORTAGE "station_trait_vending_shortage"
 #define STATION_TRAIT_MEDBOT_MANIA "station_trait_medbot_mania"
+#define STATION_TRAIT_LOANER_SHUTTLE "station_trait_loaner_shuttle"
 
 ///From the market_crash event
 #define MARKET_CRASH_EVENT_TRAIT "crashed_market_event"

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -147,3 +147,6 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(
 	/mob/living/simple_animal/hostile/megafauna/colossus = 2,
 	/mob/living/simple_animal/hostile/megafauna/dragon = 4,
 ))
+
+///A comprehensive list of all closets in the game world
+GLOBAL_LIST_EMPTY(all_closets)

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -147,6 +147,3 @@ GLOBAL_LIST_INIT(megafauna_spawn_list, list(
 	/mob/living/simple_animal/hostile/megafauna/colossus = 2,
 	/mob/living/simple_animal/hostile/megafauna/dragon = 4,
 ))
-
-///A comprehensive list of all closets in the game world
-GLOBAL_LIST_EMPTY(all_closets)

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -9,10 +9,10 @@
 	if(!occupancy_limit && who_can_purchase)
 		CRASH("The [name] needs an occupancy limit!")
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_SHUTTLE_SALE) && credit_cost > 0 && prob(15))
-		var/discount_amount = rand(55, 80)
-		name += " ([discount_amount]% Price!)"
-		credit_cost *= (discount_amount * 0.01)
-		credit_cost = round(credit_cost, 10) //Easier to read and makes no difference.
+		var/discount_amount = round(rand(25, 80), 5)
+		name += " ([discount_amount]% Discount!)"
+		var/discount_multiplier = 100 - discount_amount
+		credit_cost = ((credit_cost * discount_multiplier) / 100)
 
 /datum/map_template/shuttle/emergency/backup
 	suffix = "backup"

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -8,9 +8,9 @@
 	. = ..()
 	if(!occupancy_limit && who_can_purchase)
 		CRASH("The [name] needs an occupancy limit!")
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_SHUTTLE_SALE) && prob(15))
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_SHUTTLE_SALE) && credit_cost > 0 && prob(15))
 		var/discount_amount = rand(40, 75)
-		description += "This shuttle on sale, for a [discount_amount]% discount!"
+		name += " ([discount_amount]% discount!)"
 		credit_cost *= (discount_amount * 0.01)
 		credit_cost = round(credit_cost, 10) //For better readability
 

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -9,10 +9,10 @@
 	if(!occupancy_limit && who_can_purchase)
 		CRASH("The [name] needs an occupancy limit!")
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_SHUTTLE_SALE) && credit_cost > 0 && prob(15))
-		var/discount_amount = rand(40, 75)
+		var/discount_amount = rand(55, 80)
 		name += " ([discount_amount]% Price!)"
 		credit_cost *= (discount_amount * 0.01)
-		credit_cost = round(credit_cost, 10) //For better readability
+		credit_cost = round(credit_cost, 10) //Easier to read and makes no difference.
 
 /datum/map_template/shuttle/emergency/backup
 	suffix = "backup"

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -10,7 +10,7 @@
 		CRASH("The [name] needs an occupancy limit!")
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_SHUTTLE_SALE) && credit_cost > 0 && prob(15))
 		var/discount_amount = rand(40, 75)
-		name += " ([discount_amount]% discount!)"
+		name += " ([discount_amount]% Price!)"
 		credit_cost *= (discount_amount * 0.01)
 		credit_cost = round(credit_cost, 10) //For better readability
 

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -8,6 +8,11 @@
 	. = ..()
 	if(!occupancy_limit && who_can_purchase)
 		CRASH("The [name] needs an occupancy limit!")
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_SHUTTLE_SALE) && prob(15))
+		var/discount_amount = rand(40, 75)
+		description += "This shuttle on sale, for a [discount_amount]% discount!"
+		credit_cost *= (discount_amount * 0.01)
+		credit_cost = round(credit_cost, 10) //For better readability
 
 /datum/map_template/shuttle/emergency/backup
 	suffix = "backup"

--- a/code/datums/station_traits/_station_trait.dm
+++ b/code/datums/station_traits/_station_trait.dm
@@ -52,7 +52,7 @@
 
 ///type of info the centcom report has on this trait, if any.
 /datum/station_trait/proc/get_report()
-	return "[name] - [report_message]"
+	return "<i>[name]</i> - [report_message]"
 
 /// Will attempt to revert the station trait, used by admins.
 /datum/station_trait/proc/revert()

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -364,7 +364,7 @@
 
 /datum/station_trait/random_event_weight_modifier/wise_cows
 	name = "Wise Cow Invasion"
-	report_message = "Bluespace harmonic readings show unusual interpolative readings between your sector and agricultural sector MMF-D-02. Expect an increase in cow encounters. Encownters, if you will."
+	report_message = "Bluespace harmonic readings show unusual interpolative signals between your sector and agricultural sector MMF-D-02. Expect an increase in cow encounters. Encownters, if you will."
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 1
 	event_control_path = /datum/round_event_control/wisdomcow

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -398,13 +398,13 @@
 
 	var/obj/item/storage/wallet/new_wallet = new(locker_to_fill)
 
-	new /obj/item/stack/spacecash/c1000(new_wallet)
+	new /obj/item/stack/spacecash/c500(new_wallet)
 	if(prob(25)) //Jackpot!
 		new /obj/item/stack/spacecash/c1000(new_wallet)
 
 	new /obj/item/card/id/advanced/technician_id(new_wallet)
 
-	if(prob(35)) //DEBUG CHANGE TO 30
+	if(prob(35))
 		report_message += " The technician reports they last remember having their wallet around [get_area_name(new_wallet)]."
 
 /obj/item/card/id/advanced/technician_id

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -370,7 +370,6 @@
 	event_control_path = /datum/round_event_control/wisdomcow
 	weight_multiplier = 3
 	max_occurrences_modifier = 10 //lotta cows
-	trait_to_give = STATION_TRAIT_WISE_COWS
 
 /datum/station_trait/shuttle_sale
 	name = "Shuttle Firesale"
@@ -385,7 +384,6 @@
 	report_message = "A repair technician left their wallet in a locker somewhere. They would greatly appreciate if you could locate and return it to them when the shift has ended."
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
-	trait_to_give = STATION_TRAIT_MISSING_WALLET
 	show_in_report = TRUE
 
 /datum/station_trait/missing_wallet/on_round_start()

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -356,7 +356,7 @@
 	name = "Loaner Shuttle"
 	report_message = "Due to an uptick in pirate attacks around your sector, there are few supply vessels in nearby space willing to assist with special requests. Expect to recieve more shuttle loan opportunities, with slightly higher payouts."
 	trait_type = STATION_TRAIT_POSITIVE
-	weight = 3
+	weight = 4
 	event_control_path = /datum/round_event_control/shuttle_loan
 	weight_multiplier = 2.5
 	max_occurrences_modifier = 5 //All but one loan event will occur over the course of a round.
@@ -376,7 +376,7 @@
 	name = "Shuttle Firesale"
 	report_message = "The Nanotrasen Emergency Dispatch team is celebrating a record number of shuttle calls in the recent quarter. Check your shuttle purchase list for discounted options."
 	trait_type = STATION_TRAIT_POSITIVE
-	weight = 2
+	weight = 4
 	trait_to_give = STATION_TRAIT_SHUTTLE_SALE
 	show_in_report = TRUE
 
@@ -384,7 +384,7 @@
 	name = "Misplaced Wallet"
 	report_message = "A repair technician left their wallet in a locker somewhere. They would greatly appreciate if you could locate and return it to them when the shift has ended."
 	trait_type = STATION_TRAIT_POSITIVE
-	weight = 4
+	weight = 5
 	trait_to_give = STATION_TRAIT_MISSING_WALLET
 	show_in_report = TRUE
 

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -354,7 +354,7 @@
 
 /datum/station_trait/random_event_weight_modifier/shuttle_loans
 	name = "Loaner Shuttle"
-	report_message = "Due to an uptick in pirate attacks around your sector, there are few supply vessels in nearby space to assist with special requests. Expect to recieve more shuttle loan opportunities, and slightly higher payouts."
+	report_message = "Due to an uptick in pirate attacks around your sector, there are few supply vessels in nearby space willing to assist with special requests. Expect to recieve more shuttle loan opportunities, with slightly higher payouts."
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 3
 	event_control_path = /datum/round_event_control/shuttle_loan
@@ -379,6 +379,47 @@
 	weight = 2
 	trait_to_give = STATION_TRAIT_SHUTTLE_SALE
 	show_in_report = TRUE
+
+/datum/station_trait/missing_wallet
+	name = "Misplaced Wallet"
+	report_message = "A repair technician left their wallet in a locker somewhere. They would greatly appreciate if you could locate and return it to them when the shift has ended."
+	trait_type = STATION_TRAIT_POSITIVE
+	weight = 4
+	trait_to_give = STATION_TRAIT_MISSING_WALLET
+	show_in_report = TRUE
+
+/datum/station_trait/missing_wallet/on_round_start()
+	. = ..()
+
+	var/obj/structure/closet/locker_to_fill
+	var/list/locker_list = GLOB.all_closets.Copy()
+	while(!is_station_level(locker_to_fill) && length(locker_list))
+		locker_to_fill = pick_n_take(locker_list)
+
+	var/obj/item/storage/wallet/new_wallet = new(locker_to_fill)
+
+	new /obj/item/stack/spacecash/c1000(new_wallet)
+	if(prob(25)) //Jackpot!
+		new /obj/item/stack/spacecash/c1000(new_wallet)
+
+	new /obj/item/card/id/advanced/technician_id(new_wallet)
+
+	if(prob(35)) //DEBUG CHANGE TO 30
+		report_message += " The technician reports they last remember having their wallet around [get_area_name(new_wallet)]."
+
+/obj/item/card/id/advanced/technician_id
+	name = "Repair Technician ID"
+	desc = "Repair Technician? We don't have those in this sector, just a bunch of lazy engineers! This must have been from the between-shift crew..."
+	registered_name = "Pluoxium LXVII"
+	registered_age = 67
+	trim = /datum/id_trim/technician_id
+
+/datum/id_trim/technician_id
+	access = list(ACCESS_EXTERNAL_AIRLOCKS, ACCESS_MAINT_TUNNELS)
+	assignment = "Repair Technician"
+	trim_state = "trim_stationengineer"
+	department_color = COLOR_ENGINEERING_ORANGE
+	subdepartment_color = COLOR_ENGINEERING_ORANGE
 
 #undef PARTY_COOLDOWN_LENGTH_MIN
 #undef PARTY_COOLDOWN_LENGTH_MAX

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -389,13 +389,7 @@
 /datum/station_trait/missing_wallet/on_round_start()
 	. = ..()
 
-	var/obj/structure/closet/locker_to_fill
-	var/list/locker_list = GLOB.all_closets.Copy()
-	for(var/obj/structure/closet in locker_list)
-		if(!is_station_level(closet.z))
-			locker_list -= closet
-
-	locker_to_fill = pick(locker_list)
+	var/obj/structure/closet/locker_to_fill = pick(GLOB.roundstart_station_closets)
 
 	var/obj/item/storage/wallet/new_wallet = new(locker_to_fill)
 

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -374,7 +374,7 @@
 
 /datum/station_trait/shuttle_sale
 	name = "Shuttle Firesale"
-	report_message = "The Nanotrasen Emergency Dispatch team is celebrating a record number of shuttle calls in the recent quarter. Check your shuttle purchase list for discounted options."
+	report_message = "The Nanotrasen Emergency Dispatch team is celebrating a record number of shuttle calls in the recent quarter. Some of your emergency shuttle options have been discounted!"
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 4
 	trait_to_give = STATION_TRAIT_SHUTTLE_SALE
@@ -393,8 +393,11 @@
 
 	var/obj/structure/closet/locker_to_fill
 	var/list/locker_list = GLOB.all_closets.Copy()
-	while(!is_station_level(locker_to_fill) && length(locker_list))
-		locker_to_fill = pick_n_take(locker_list)
+	for(var/obj/structure/closet in locker_list)
+		if(!is_station_level(closet.z))
+			locker_list -= closet
+
+	locker_to_fill = pick(locker_list)
 
 	var/obj/item/storage/wallet/new_wallet = new(locker_to_fill)
 
@@ -403,9 +406,12 @@
 		new /obj/item/stack/spacecash/c1000(new_wallet)
 
 	new /obj/item/card/id/advanced/technician_id(new_wallet)
+	new_wallet.refreshID()
 
 	if(prob(35))
 		report_message += " The technician reports they last remember having their wallet around [get_area_name(new_wallet)]."
+
+	message_admins("A missing wallet has been placed in the [locker_to_fill] locker, in the [get_area_name(locker_to_fill)] area.")
 
 /obj/item/card/id/advanced/technician_id
 	name = "Repair Technician ID"

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -422,8 +422,7 @@
 	access = list(ACCESS_EXTERNAL_AIRLOCKS, ACCESS_MAINT_TUNNELS)
 	assignment = "Repair Technician"
 	trim_state = "trim_stationengineer"
-	department_color = COLOR_ENGINEERING_ORANGE
-	subdepartment_color = COLOR_ENGINEERING_ORANGE
+	department_color = COLOR_ASSISTANT_GRAY
 
 #undef PARTY_COOLDOWN_LENGTH_MIN
 #undef PARTY_COOLDOWN_LENGTH_MAX

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -344,5 +344,14 @@
 	trait_to_give = STATION_TRAIT_BIGGER_PODS
 	blacklist = list(/datum/station_trait/cramped_escape_pods)
 
+/datum/station_trait/medbot_mania
+	name = "Advanced Medbots"
+	trait_type = STATION_TRAIT_POSITIVE
+	weight = 5
+	show_in_report = TRUE
+	report_message = "Your station's "
+	trait_to_give = STATION_TRAIT_MEDBOT_MANIA
+	blacklist = list(/datum/station_trait/medbot_mania)
+
 #undef PARTY_COOLDOWN_LENGTH_MIN
 #undef PARTY_COOLDOWN_LENGTH_MAX

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -362,5 +362,15 @@
 	max_occurrences_modifier = 5 //All but one loan event will occur over the course of a round.
 	trait_to_give = STATION_TRAIT_LOANER_SHUTTLE
 
+/datum/station_trait/random_event_weight_modifier/wise_cows
+	name = "Wise Cow Invasion"
+	report_message = "Bluespace harmonics readings show unusual interpolative readings between your sector and sector MMF-D-02. Expect an increase in cow encounters. Encownters, if you will."
+	trait_type = STATION_TRAIT_POSITIVE
+	weight = 1
+	event_control_path = /datum/round_event_control/wisdomcow
+	weight_multiplier = 3
+	max_occurrences_modifier = 10 //lotta cows
+	trait_to_give = STATION_TRAIT_WISE_COWS
+
 #undef PARTY_COOLDOWN_LENGTH_MIN
 #undef PARTY_COOLDOWN_LENGTH_MAX

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -351,16 +351,16 @@
 	show_in_report = TRUE
 	report_message = "Your station's medibots have recieved a hardware upgrade, enabling expanded healing capabilities."
 	trait_to_give = STATION_TRAIT_MEDBOT_MANIA
-	blacklist = list(/datum/station_trait/medbot_mania)
 
 /datum/station_trait/random_event_weight_modifier/shuttle_loans
 	name = "Loaner Shuttle"
-	report_message = "Due to an uptick in pirate attacks around your sector, there are few supply vessels in nearby space to assist with special requests. Expect to recieve more shuttle loan opportunities."
+	report_message = "Due to an uptick in pirate attacks around your sector, there are few supply vessels in nearby space to assist with special requests. Expect to recieve more shuttle loan opportunities, and slightly higher payouts."
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 3
 	event_control_path = /datum/round_event_control/shuttle_loan
 	weight_multiplier = 2.5
-	max_occurrences_modifier = 5 //All but one loan event should occur over the course of a round.
+	max_occurrences_modifier = 5 //All but one loan event will occur over the course of a round.
+	trait_to_give = STATION_TRAIT_LOANER_SHUTTLE
 
 #undef PARTY_COOLDOWN_LENGTH_MIN
 #undef PARTY_COOLDOWN_LENGTH_MAX

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -364,13 +364,21 @@
 
 /datum/station_trait/random_event_weight_modifier/wise_cows
 	name = "Wise Cow Invasion"
-	report_message = "Bluespace harmonics readings show unusual interpolative readings between your sector and sector MMF-D-02. Expect an increase in cow encounters. Encownters, if you will."
+	report_message = "Bluespace harmonic readings show unusual interpolative readings between your sector and agricultural sector MMF-D-02. Expect an increase in cow encounters. Encownters, if you will."
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 1
 	event_control_path = /datum/round_event_control/wisdomcow
 	weight_multiplier = 3
 	max_occurrences_modifier = 10 //lotta cows
 	trait_to_give = STATION_TRAIT_WISE_COWS
+
+/datum/station_trait/shuttle_sale
+	name = "Shuttle Firesale"
+	report_message = "The Nanotrasen Emergency Dispatch team is celebrating a record number of shuttle calls in the recent quarter. Check your shuttle purchase list for discounted options."
+	trait_type = STATION_TRAIT_POSITIVE
+	weight = 2
+	trait_to_give = STATION_TRAIT_SHUTTLE_SALE
+	show_in_report = TRUE
 
 #undef PARTY_COOLDOWN_LENGTH_MIN
 #undef PARTY_COOLDOWN_LENGTH_MAX

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -349,7 +349,7 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
 	show_in_report = TRUE
-	report_message = "Your station's "
+	report_message = "Your station's medibots have recieved a hardware upgrade."
 	trait_to_give = STATION_TRAIT_MEDBOT_MANIA
 	blacklist = list(/datum/station_trait/medbot_mania)
 

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -353,5 +353,14 @@
 	trait_to_give = STATION_TRAIT_MEDBOT_MANIA
 	blacklist = list(/datum/station_trait/medbot_mania)
 
+/datum/station_trait/random_event_weight_modifier/shuttle_loans
+	name = "Loaner Shuttle"
+	report_message = "Due to an uptick in pirate attacks around your sector, there are few supply vessels in nearby space to assist with special requests. Expect to recieve more shuttle loan opportunities."
+	trait_type = STATION_TRAIT_POSITIVE
+	weight = 3
+	event_control_path = /datum/round_event_control/shuttle_loan
+	weight_multiplier = 2.5
+	max_occurrences_modifier = 5 //All but one loan event should occur over the course of a round.
+
 #undef PARTY_COOLDOWN_LENGTH_MIN
 #undef PARTY_COOLDOWN_LENGTH_MAX

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -349,7 +349,7 @@
 	trait_type = STATION_TRAIT_POSITIVE
 	weight = 5
 	show_in_report = TRUE
-	report_message = "Your station's medibots have recieved a hardware upgrade."
+	report_message = "Your station's medibots have recieved a hardware upgrade, enabling expanded healing capabilities."
 	trait_to_give = STATION_TRAIT_MEDBOT_MANIA
 	blacklist = list(/datum/station_trait/medbot_mania)
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -602,6 +602,7 @@
 						"description" = shuttle_template.description,
 						"occupancy_limit" = shuttle_template.occupancy_limit,
 						"creditCost" = shuttle_template.credit_cost,
+						"initial_cost" = initial(shuttle_template.credit_cost),
 						"emagOnly" = shuttle_template.emag_only,
 						"prerequisites" = shuttle_template.prerequisites,
 						"ref" = REF(shuttle_template),

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -120,6 +120,8 @@
 	if(access_choices)
 		access_choices = card_reader_choices
 
+	GLOB.all_closets += src
+
 	// if closed, any item at the crate's loc is put in the contents
 	if (mapload && !opened)
 		. = INITIALIZE_HINT_LATELOAD
@@ -155,6 +157,7 @@
 /obj/structure/closet/Destroy()
 	id_card = null
 	QDEL_NULL(door_obj)
+	GLOB.all_closets -= src
 	return ..()
 
 /obj/structure/closet/update_appearance(updates=ALL)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1,5 +1,9 @@
 #define LOCKER_FULL -1
 
+///A comprehensive list of all closets in the game world
+GLOBAL_LIST_EMPTY(roundstart_station_closets)
+
+
 /obj/structure/closet
 	name = "closet"
 	desc = "It's a basic storage unit."
@@ -120,7 +124,8 @@
 	if(access_choices)
 		access_choices = card_reader_choices
 
-	GLOB.all_closets += src
+	if(is_station_level(z))
+		GLOB.roundstart_station_closets += src
 
 	// if closed, any item at the crate's loc is put in the contents
 	if (mapload && !opened)
@@ -157,7 +162,7 @@
 /obj/structure/closet/Destroy()
 	id_card = null
 	QDEL_NULL(door_obj)
-	GLOB.all_closets -= src
+	GLOB.roundstart_station_closets -= src
 	return ..()
 
 /obj/structure/closet/update_appearance(updates=ALL)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -1,6 +1,6 @@
 #define LOCKER_FULL -1
 
-///A comprehensive list of all closets in the game world
+///A comprehensive list of all closets (NOT CRATES) in the game world
 GLOBAL_LIST_EMPTY(roundstart_station_closets)
 
 
@@ -124,8 +124,8 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 	if(access_choices)
 		access_choices = card_reader_choices
 
-	if(is_station_level(z))
-		GLOB.roundstart_station_closets += src
+	if(is_station_level(z) && mapload)
+		add_to_roundstart_list()
 
 	// if closed, any item at the crate's loc is put in the contents
 	if (mapload && !opened)
@@ -1149,5 +1149,9 @@ GLOBAL_LIST_EMPTY(roundstart_station_closets)
 
 /obj/structure/closet/preopen
 	opened = TRUE
+
+///Adds the closet to a global list. Placed in its own proc so that crates may be excluded.
+/obj/structure/closet/proc/add_to_roundstart_list()
+	GLOB.roundstart_station_closets += src
 
 #undef LOCKER_FULL

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -352,3 +352,6 @@
 	. = ..()
 	for(var/i in 1 to 4)
 		new /obj/effect/spawner/random/decoration/generic(src)
+
+/obj/structure/closet/crate/add_to_roundstart_list()
+	return

--- a/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
@@ -18,7 +18,7 @@
 	if(!logging_desc)
 		stack_trace("No logging blurb set for [src.type]!")
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_LOANER_SHUTTLE))
-		bonus_points *= 1.2
+		bonus_points *= 1.15
 
 /// Spawns paths added to `spawn_list`, and passes empty shuttle turfs so you can spawn more complicated things like dead bodies.
 /datum/shuttle_loan_situation/proc/spawn_items(list/spawn_list, list/empty_shuttle_turfs)

--- a/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_datum.dm
@@ -17,6 +17,8 @@
 	. = ..()
 	if(!logging_desc)
 		stack_trace("No logging blurb set for [src.type]!")
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_LOANER_SHUTTLE))
+		bonus_points *= 1.2
 
 /// Spawns paths added to `spawn_list`, and passes empty shuttle turfs so you can spawn more complicated things like dead bodies.
 /datum/shuttle_loan_situation/proc/spawn_items(list/spawn_list, list/empty_shuttle_turfs)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -203,8 +203,6 @@
 /mob/living/simple_animal/bot/medbot/Initialize(mapload, new_skin)
 	. = ..()
 
-	var/is_roundstart = mapload
-
 	// Doing this hurts my soul, but simplebot access reworks are for another day.
 	var/datum/id_trim/job/para_trim = SSid_access.trim_singletons_by_path[/datum/id_trim/job/paramedic]
 	access_card.add_access(para_trim.access + para_trim.wildcard_access)
@@ -216,9 +214,7 @@
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !linked_techweb)
 		linked_techweb = SSresearch.science_tech
 
-	var/advanced_bot_trait = HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA)
-
-	if(is_roundstart && advanced_bot_trait && is_station_level(z))
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA) && mapload && is_station_level(z))
 		skin = "advanced"
 		update_appearance(UPDATE_OVERLAYS)
 		damagetype_healer = "all"

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -231,9 +231,6 @@
 		if(prob(50))
 			name += ", PhD."
 
-	if(mapload)
-		to_chat(src, "wa la")
-
 /mob/living/simple_animal/bot/medbot/bot_reset()
 	..()
 	patient = null

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -222,7 +222,7 @@
 		post_tipped_callback = CALLBACK(src, PROC_REF(after_tip_over)), \
 		post_untipped_callback = CALLBACK(src, PROC_REF(after_righted)))
 
-	if(mapload && HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA) && is_station_level(z))
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA) && mapload && is_station_level(z))
 		skin = "advanced"
 		update_appearance(UPDATE_OVERLAYS)
 		damagetype_healer = "all"

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -203,6 +203,8 @@
 /mob/living/simple_animal/bot/medbot/Initialize(mapload, new_skin)
 	. = ..()
 
+	var/is_roundstart = mapload
+
 	// Doing this hurts my soul, but simplebot access reworks are for another day.
 	var/datum/id_trim/job/para_trim = SSid_access.trim_singletons_by_path[/datum/id_trim/job/paramedic]
 	access_card.add_access(para_trim.access + para_trim.wildcard_access)
@@ -224,7 +226,7 @@
 
 	var/advanced_bot_trait = HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA)
 
-	if(advanced_bot_trait && is_station_level(z))
+	if(is_roundstart && advanced_bot_trait && is_station_level(z))
 		skin = "advanced"
 		update_appearance(UPDATE_OVERLAYS)
 		damagetype_healer = "all"

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -224,12 +224,15 @@
 
 	var/advanced_bot_trait = HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA)
 
-	if(advanced_bot_trait && mapload && is_station_level(z))
+	if(advanced_bot_trait && is_station_level(z))
 		skin = "advanced"
 		update_appearance(UPDATE_OVERLAYS)
 		damagetype_healer = "all"
 		if(prob(50))
 			name += ", PhD."
+
+	if(mapload)
+		to_chat(src, "wa la")
 
 /mob/living/simple_animal/bot/medbot/bot_reset()
 	..()

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -222,11 +222,11 @@
 		post_tipped_callback = CALLBACK(src, PROC_REF(after_tip_over)), \
 		post_untipped_callback = CALLBACK(src, PROC_REF(after_righted)))
 
-	if(mapload && HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA))
+	if(mapload && HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA) && is_station_level(z))
 		skin = "advanced"
 		update_appearance(UPDATE_OVERLAYS)
 		damagetype_healer = "all"
-		if(prob(20))
+		if(prob(50))
 			name += ", PhD."
 
 /mob/living/simple_animal/bot/medbot/bot_reset()

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -222,7 +222,9 @@
 		post_tipped_callback = CALLBACK(src, PROC_REF(after_tip_over)), \
 		post_untipped_callback = CALLBACK(src, PROC_REF(after_righted)))
 
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA) && mapload && is_station_level(z))
+	var/advanced_bot_trait = HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA)
+
+	if(advanced_bot_trait && mapload && is_station_level(z))
 		skin = "advanced"
 		update_appearance(UPDATE_OVERLAYS)
 		damagetype_healer = "all"

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -216,14 +216,6 @@
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !linked_techweb)
 		linked_techweb = SSresearch.science_tech
 
-	AddComponent(/datum/component/tippable, \
-		tip_time = 3 SECONDS, \
-		untip_time = 3 SECONDS, \
-		self_right_time = 3.5 MINUTES, \
-		pre_tipped_callback = CALLBACK(src, PROC_REF(pre_tip_over)), \
-		post_tipped_callback = CALLBACK(src, PROC_REF(after_tip_over)), \
-		post_untipped_callback = CALLBACK(src, PROC_REF(after_righted)))
-
 	var/advanced_bot_trait = HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA)
 
 	if(is_roundstart && advanced_bot_trait && is_station_level(z))
@@ -232,6 +224,14 @@
 		damagetype_healer = "all"
 		if(prob(50))
 			name += ", PhD."
+
+	AddComponent(/datum/component/tippable, \
+		tip_time = 3 SECONDS, \
+		untip_time = 3 SECONDS, \
+		self_right_time = 3.5 MINUTES, \
+		pre_tipped_callback = CALLBACK(src, PROC_REF(pre_tip_over)), \
+		post_tipped_callback = CALLBACK(src, PROC_REF(after_tip_over)), \
+		post_untipped_callback = CALLBACK(src, PROC_REF(after_righted)))
 
 /mob/living/simple_animal/bot/medbot/bot_reset()
 	..()

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -227,7 +227,7 @@
 		update_appearance(UPDATE_OVERLAYS)
 		damagetype_healer = "all"
 		if(prob(20))
-			name += ", PHD."
+			name += ", PhD."
 
 /mob/living/simple_animal/bot/medbot/bot_reset()
 	..()

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -226,6 +226,8 @@
 		skin = "advanced"
 		update_appearance(UPDATE_OVERLAYS)
 		damagetype_healer = "all"
+		if(prob(20))
+			name += ", PHD."
 
 /mob/living/simple_animal/bot/medbot/bot_reset()
 	..()

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -222,6 +222,11 @@
 		post_tipped_callback = CALLBACK(src, PROC_REF(after_tip_over)), \
 		post_untipped_callback = CALLBACK(src, PROC_REF(after_righted)))
 
+	if(mapload && HAS_TRAIT(SSstation, STATION_TRAIT_MEDBOT_MANIA))
+		skin = "advanced"
+		update_appearance(UPDATE_OVERLAYS)
+		damagetype_healer = "all"
+
 /mob/living/simple_animal/bot/medbot/bot_reset()
 	..()
 	patient = null

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -19,7 +19,7 @@ const EMAG_SHUTTLE_NOTICE =
 
 const sortShuttles = sortBy(
   (shuttle) => !shuttle.emagOnly,
-  (shuttle) => shuttle.creditCost
+  (shuttle) => shuttle.initial_cost
 );
 
 const AlertButton = (props, context) => {

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -198,7 +198,7 @@ const PageBuyingShuttle = (props, context) => {
           </Box>
           <Box color="violet" fontSize="10px" bold>
             {shuttle.prerequisites ? (
-              <b>Prerequisitces: {shuttle.prerequisites}</b>
+              <b>Prerequisites: {shuttle.prerequisites}</b>
             ) : null}
           </Box>
         </Section>


### PR DESCRIPTION
## About The Pull Request

This adds five new positive station traits, of varying weight and impact.

**Loaner Shuttle** (Weight - 4): The shuttle loan event will occur more frequently, can occur more times per round, and has a 1.15x payout multiplier (only for the loan offers that pay out with credits).

**Medibot Mania** (Weight - 5): Station medibots will start as advanced medibots, able to heal all damage types. Medbot hiring scope has expanded to include medbots that have recently earned their doctorates as well.

**Wise Cow Invasion** (Weight - 1): Wisdom Cow visits can happen more than once during the round, and will occur more frequently. _"You will give someone a piece of your mind, which you can ill afford." -Wisdom Cow_

**Shuttle Firesale** (Weight - 4): Some emergency shuttle options are offered at a discount. Neat!

![the sales](https://github.com/tgstation/tgstation/assets/28870487/4dec2fa6-5874-44bf-98f6-c11b97aaf3f2)

The shuttle purchase menu has been changed to sort by initial value, so the list order shouldn't get scrambled.

**Misplaced Wallet** (Weight - 5): A repair technician from the between-shift crew left their wallet in a locker somewhere. Good thing the famously trustworthy crew of Space Station 13 will get it back to them safe and sound! Is your integrity as an honest person worth more than free maintenance access and 500 credits?

**OH ALSO**

The station trait report will now italicize trait titles, for easier reading.

Also, this fixes a small typo in the shuttle purchase screen.
## Why It's Good For The Game

A fair number of the positive traits are just inverses of negative traits, and there's more negative ones than positive ones (I think). This adds some more fun, unique-ish entries to the roster.
## Changelog
:cl: Rhials
add: Shuttle Firesale positive station trait. Some emergency shuttle options have been put on sale!
add: Misplaced Wallet positive station trait. You wouldn't steal from a missing wallet, would you??
add: Wisdom Cow Invasion positive station trait.
add: Advanced Medbots positive station trait. Better roundstart medbots!
add: Loaner Shuttle positive station trait. More shuttle loan offers and more payout!
qol: Station Trait titles are now italicized for easier reading.
spellcheck: Fixes a "prerequisites" typo in the shuttle purchase menu.
/:cl:
