### PR TITLE
Fixes mortars grinding and juicing

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -508,7 +508,7 @@
 	to_chat(user, span_warning("You can't grind this!"))
 
 /obj/item/reagent_containers/cup/mortar/proc/grind_item(obj/item/item, mob/living/carbon/human/user)
-	if(!item.grind(src, user))
+	if(!item.grind(src.reagents, user))
 		to_chat(user, span_notice("You fail to grind [item]."))
 		return
 	to_chat(user, span_notice("You grind [item] into a nice powder."))
@@ -516,7 +516,7 @@
 	QDEL_NULL(item)
 
 /obj/item/reagent_containers/cup/mortar/proc/juice_item(obj/item/item, mob/living/carbon/human/user)
-	if(!item.juice(src, user))
+	if(!item.juice(src.reagents, user))
 		to_chat(user, span_notice("You fail to juice [item]."))
 		return
 	to_chat(user, span_notice("You juice [item] into a fine liquid."))

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -508,7 +508,7 @@
 	to_chat(user, span_warning("You can't grind this!"))
 
 /obj/item/reagent_containers/cup/mortar/proc/grind_item(obj/item/item, mob/living/carbon/human/user)
-	if(!item.grind(src.reagents, user))
+	if(!item.grind(reagents, user))
 		to_chat(user, span_notice("You fail to grind [item]."))
 		return
 	to_chat(user, span_notice("You grind [item] into a nice powder."))
@@ -516,7 +516,7 @@
 	QDEL_NULL(item)
 
 /obj/item/reagent_containers/cup/mortar/proc/juice_item(obj/item/item, mob/living/carbon/human/user)
-	if(!item.juice(src.reagents, user))
+	if(!item.juice(reagents, user))
 		to_chat(user, span_notice("You fail to juice [item]."))
 		return
 	to_chat(user, span_notice("You juice [item] into a fine liquid."))


### PR DESCRIPTION

## About The Pull Request
 
Mortal and pestle failed to grind items, as the proc passed over the item itself, instead of the reagent holder. This PR fixes that.

## Why It's Good For The Game

Its good to have a way to grind some chemicals and fruits without an All-in One Grinder.
Fixes #78205

## Changelog

:cl:
fix: Mortar and pestle can grind stuff again
/:cl:

