### PR TITLE
Allows Universal Scanner Equip on Cargo Coats/Jackets

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -219,6 +219,7 @@
 	allowed = list(
 		/obj/item/stamp,
 		/obj/item/storage/bag/mail,
+		/obj/item/universal_scanner,
 	)
 
 // Quartermaster
@@ -232,6 +233,7 @@
 	allowed = list(
 		/obj/item/stamp,
 		/obj/item/storage/bag/mail,
+		/obj/item/universal_scanner,
 	)
 
 /obj/item/clothing/suit/toggle/lawyer/greyscale

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -589,6 +589,7 @@
 	allowed = list(
 		/obj/item/storage/bag/mail,
 		/obj/item/stamp,
+		/obj/item/universal_scanner,
 	)
 
 /obj/item/clothing/head/hooded/winterhood/cargo


### PR DESCRIPTION
## About The Pull Request
title
## Why It's Good For The Game
its already a pocket-sized item, usually pretty important for cargonians to carry around - easy spot to not forget where it is compared to randomly shoving it into bag/box/pockets!

also just nice to have a little more options on what you can carry with departmental coats
## Changelog

:cl: SuicidalPickles
qol: Cargo Coats/Jackets can now equip universal scanners on their suit-slots.
/:cl: