### PR TITLE
[NO GBP] Sets the correct icon state for the holographic pufferfish.

### DIFF
--- a/code/modules/fishing/fish/fish_types.dm
+++ b/code/modules/fishing/fish/fish_types.dm
@@ -465,6 +465,7 @@
 /obj/item/fish/holo/puffer
 	name = "holographic pufferfish"
 	desc ="A holographic representation of 100% safe-to-eat pufferfish... that is, if holographic fishes were even edible."
+	icon_state = "pufferfish"
 	sprite_width = 8
 	sprite_height = 8
 	average_size = 60


### PR DESCRIPTION
## About The Pull Request
It shouldn't look like a goldfish.

## Why It's Good For The Game
Ditto.

## Changelog

:cl:
fix: The holographic pufferfish from the holographic beach from the holodeck no longer looks like a goldfish.
/:cl:
