### PR TITLE
chem dispensers now use plasma to work

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_pizza.dmm
@@ -1188,7 +1188,7 @@
 /area/ruin/pizzeria)
 "UJ" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners{

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -326,7 +326,7 @@
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "hS" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 1
 	},
 /obj/structure/table/wood,
@@ -411,7 +411,7 @@
 /turf/open/misc/beach/sand,
 /area/ruin/powered/beach)
 "mE" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade{
 	dir = 1
 	},
 /obj/structure/table/wood,

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -349,7 +349,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "bd" = (
-/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/mutagensaltpeter,
 /obj/effect/turf_decal/trimline/green/corner,
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 9

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -10,7 +10,7 @@
 /area/ruin/syndicate_lava_base/testlab)
 "ai" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -71,7 +71,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/chem_dispenser/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/fullupgrade,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/chemistry)
 "aO" = (
@@ -544,7 +544,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/chem_dispenser/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/fullupgrade,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/syndicate_lava_base/chemistry)
@@ -2765,7 +2765,7 @@
 /area/ruin/syndicate_lava_base/engineering)
 "AJ" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 1
 	},
 /obj/machinery/barsign/all_access/directional/south{

--- a/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
+++ b/_maps/RandomRuins/SpaceRuins/allamericandiner.dmm
@@ -332,7 +332,7 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/allamericandiner)
 "qp" = (
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 8;
 	pixel_x = 17;
 	pixel_y = 0

--- a/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
+++ b/_maps/RandomRuins/SpaceRuins/dangerous_research.dmm
@@ -880,7 +880,7 @@
 /area/ruin/space/has_grav/dangerous_research/medical)
 "mo" = (
 /obj/effect/turf_decal/trimline/purple/line,
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/dangerous_research/medical)
 "mp" = (

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -1795,7 +1795,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/airlock)
 "wu" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "wK" = (

--- a/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertresearchfacility.dmm
@@ -1076,7 +1076,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "zO" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/ruin/space/has_grav/powered/hilbertresearchfacility)
 "Ax" = (

--- a/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
+++ b/_maps/RandomRuins/SpaceRuins/infested_frigate.dmm
@@ -446,7 +446,7 @@
 /obj/effect/spawner/random/food_or_drink/booze,
 /obj/effect/spawner/random/food_or_drink/booze,
 /obj/item/bodypart/head,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	pixel_y = 32
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -2900,7 +2900,7 @@
 	pixel_y = 7
 	},
 /obj/structure/cable,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade{
 	pixel_y = 32
 	},
 /turf/open/floor/mineral/titanium/tiled/white,

--- a/_maps/RandomRuins/SpaceRuins/interdyne.dmm
+++ b/_maps/RandomRuins/SpaceRuins/interdyne.dmm
@@ -385,7 +385,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "pI" = (
-/obj/machinery/chem_dispenser/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/fullupgrade,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
@@ -542,7 +542,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "wY" = (
-/obj/machinery/chem_dispenser/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/fullupgrade,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "xb" = (
@@ -563,7 +563,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/interdyne)
 "yt" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade{
 	dir = 8
 	},
 /obj/structure/table/reinforced,
@@ -685,7 +685,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
 "DP" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 8
 	},
 /obj/structure/cable,

--- a/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacehotel.dmm
@@ -2342,7 +2342,7 @@
 "yd" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 4;
 	pixel_x = -4;
 	pixel_y = 2
@@ -2514,7 +2514,7 @@
 "AT" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 4;
 	pixel_x = -4;
 	pixel_y = 0

--- a/_maps/RandomRuins/SpaceRuins/spinwardsmoothies.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spinwardsmoothies.dmm
@@ -65,7 +65,7 @@
 /obj/effect/turf_decal/siding/thinplating/terracotta{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /turf/open/floor/bamboo,
@@ -92,7 +92,7 @@
 /obj/effect/turf_decal/siding/thinplating/terracotta{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 1
 	},
 /turf/open/floor/bamboo,
@@ -101,7 +101,7 @@
 /obj/effect/turf_decal/siding/thinplating/terracotta{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /turf/open/floor/bamboo,
 /area/ruin/space/has_grav/spinwardsmoothies)
 "DW" = (

--- a/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
+++ b/_maps/RandomRuins/SpaceRuins/the_outlet.dmm
@@ -1581,7 +1581,7 @@
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/the_outlet/researchrooms)
 "LR" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/the_outlet/researchrooms)

--- a/_maps/RandomRuins/SpaceRuins/travelers_rest.dmm
+++ b/_maps/RandomRuins/SpaceRuins/travelers_rest.dmm
@@ -69,7 +69,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/machinery/chem_dispenser{
+/obj/machinery/atmospherics/components/unary/chem_dispenser{
 	layer = 2.7
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -114,7 +114,7 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 8
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 4;
 	pixel_y = 0
 	},
@@ -306,7 +306,7 @@
 /obj/effect/turf_decal/trimline/dark_green/filled/line{
 	dir = 10
 	},
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 4;
 	pixel_y = 0
 	},

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -191,7 +191,7 @@
 /area/awaymission/cabin)
 "aP" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	desc = "Contains a large reservoir of soft drinks so that you can refill your cup. For free.";
 	name = "free refill dispenser"
 	},
@@ -383,7 +383,7 @@
 /area/awaymission/cabin)
 "bv" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -5145,7 +5145,7 @@
 /area/awaymission/cabin/caves/mountain)
 "TK" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 8
 	},
 /turf/open/floor/wood,

--- a/_maps/RandomZLevels/TheBeach.dmm
+++ b/_maps/RandomZLevels/TheBeach.dmm
@@ -626,7 +626,7 @@
 /area/awaymission/beach)
 "co" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade,
 /obj/structure/sign/picture_frame{
 	pixel_y = 32
 	},
@@ -634,7 +634,7 @@
 /area/awaymission/beach)
 "cp" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade,
 /turf/open/floor/wood,
 /area/awaymission/beach)
 "cq" = (

--- a/_maps/RandomZLevels/snowdin.dmm
+++ b/_maps/RandomZLevels/snowdin.dmm
@@ -1399,13 +1399,13 @@
 /area/awaymission/snowdin/post)
 "er" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/messhall)
 "es" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/awaymission/snowdin/post/messhall)

--- a/_maps/map_files/Basketball/stadium.dmm
+++ b/_maps/map_files/Basketball/stadium.dmm
@@ -110,7 +110,7 @@
 /area/centcom/basketball)
 "fu" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -420,7 +420,7 @@
 /area/centcom/basketball)
 "AU" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 1
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2754,7 +2754,7 @@
 "bfI" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/brown/full,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /obj/machinery/requests_console/directional/south{
@@ -38684,7 +38684,7 @@
 /area/station/hallway/secondary/dock)
 "nTz" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/obj/machinery/chem_dispenser{
+/obj/machinery/atmospherics/components/unary/chem_dispenser{
 	layer = 2.7
 	},
 /obj/machinery/light/small/directional/south,
@@ -51758,7 +51758,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/chem_dispenser{
+/obj/machinery/atmospherics/components/unary/chem_dispenser{
 	layer = 2.7
 	},
 /obj/machinery/camera/autoname/directional/west,
@@ -52780,7 +52780,7 @@
 "szS" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/full,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 1
 	},
 /turf/open/floor/iron/smooth_large,
@@ -61141,7 +61141,7 @@
 /area/station/commons/storage/tools)
 "voF" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks,
 /obj/machinery/light/cold/directional/north,
 /obj/structure/sign/poster/official/random/directional/north,
 /turf/open/floor/iron/cafeteria,
@@ -64932,7 +64932,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser{
+/obj/machinery/atmospherics/components/unary/chem_dispenser{
 	layer = 2.7
 	},
 /obj/effect/decal/cleanable/cobweb,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1170,6 +1170,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "anY" = (
@@ -1587,6 +1588,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "aso" = (
@@ -2020,6 +2022,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "awL" = (
@@ -5217,6 +5220,13 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"bnm" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "bnt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -9538,7 +9548,7 @@
 /area/station/science/robotics/lab)
 "cnl" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
@@ -11817,7 +11827,7 @@
 /area/station/science/xenobiology)
 "cQZ" = (
 /obj/structure/sign/warning/chem_diamond/directional/west,
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -12815,6 +12825,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "deA" = (
@@ -13356,6 +13367,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dlx" = (
@@ -15326,6 +15338,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dMh" = (
@@ -16039,6 +16052,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "dUH" = (
@@ -16149,6 +16163,7 @@
 /obj/effect/landmark/start/chemist,
 /obj/effect/turf_decal/trimline/neutral,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "dWf" = (
@@ -16623,11 +16638,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "ecq" = (
 /obj/structure/cable,
@@ -16867,7 +16878,7 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "efh" = (
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 8
 	},
 /obj/structure/table,
@@ -17052,6 +17063,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "eiw" = (
@@ -17609,6 +17621,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "eqP" = (
@@ -18243,6 +18256,11 @@
 	dir = 1
 	},
 /area/station/engineering/atmos/pumproom)
+"exY" = (
+/obj/structure/closet/firecloset,
+/obj/item/wrench,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "eya" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
@@ -18444,6 +18462,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "eBY" = (
@@ -20360,6 +20379,7 @@
 	desc = "A sign that notes the room within is the Cold Room. Not that it's actually cold.";
 	name = "COLD ROOM"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "eYY" = (
@@ -21728,6 +21748,7 @@
 	name = "CMO Junction"
 	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "fqO" = (
@@ -22715,9 +22736,12 @@
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/disposal/incinerator)
 "fEu" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Chemistry Lab Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/turf/open/floor/plating,
 /area/station/medical/chemistry)
 "fEx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23268,6 +23292,7 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fLV" = (
@@ -24525,6 +24550,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "gbK" = (
@@ -26307,6 +26333,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/chemistry)
 "gvF" = (
@@ -28279,6 +28306,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "gVh" = (
@@ -28858,6 +28886,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "hdL" = (
@@ -32664,6 +32693,7 @@
 /area/station/service/library)
 "idk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "idp" = (
@@ -35027,7 +35057,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "iJG" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
@@ -36347,6 +36377,7 @@
 	pixel_y = -1
 	},
 /obj/item/pen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "jbn" = (
@@ -36645,6 +36676,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"jes" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "jew" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
@@ -39761,6 +39796,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
 "jQl" = (
@@ -39848,6 +39884,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "jRc" = (
@@ -42562,6 +42599,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "kBN" = (
@@ -43311,6 +43349,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/processing)
+"kMy" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/port/aft)
 "kMI" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -44217,6 +44262,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"kZb" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kZc" = (
 /turf/closed/wall,
 /area/station/service/chapel/office)
@@ -45157,7 +45209,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "lks" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser{
+	dir = 1
+	},
 /obj/structure/sign/warning/chem_diamond/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
@@ -46258,6 +46312,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "lzc" = (
@@ -46852,6 +46907,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/report_crimes/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "lGf" = (
@@ -49771,6 +49827,7 @@
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "muT" = (
@@ -50551,13 +50608,14 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "mDU" = (
-/obj/machinery/button/door/directional/east{
-	id = "chem_lab_maint_windows";
-	name = "Shutter Control"
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/port/aft)
 "mEb" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/spawner/random/trash/caution_sign,
@@ -50832,6 +50890,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "mHE" = (
@@ -51745,6 +51804,7 @@
 /area/station/maintenance/disposal/incinerator)
 "mTn" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/backroom)
 "mTo" = (
@@ -52433,6 +52493,11 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel)
+"ndR" = (
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/turf/open/floor/engine,
+/area/station/medical/chemistry)
 "ndY" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
@@ -53196,6 +53261,7 @@
 	pixel_y = 6
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "nou" = (
@@ -54064,6 +54130,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "nAb" = (
@@ -54754,6 +54821,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "nJx" = (
@@ -55874,6 +55942,7 @@
 	name = "Medbay Junction"
 	},
 /obj/effect/mapping_helpers/mail_sorting/medbay/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "nZi" = (
@@ -62974,6 +63043,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "pOY" = (
@@ -64688,6 +64758,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "qjO" = (
@@ -68338,6 +68409,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "rgY" = (
@@ -72173,6 +72245,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "sca" = (
@@ -72701,6 +72774,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "sjt" = (
@@ -73089,7 +73163,7 @@
 "spa" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /obj/structure/table/wood/poker,
@@ -73362,6 +73436,7 @@
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/duct,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/backroom)
 "ssM" = (
@@ -75559,6 +75634,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/depsec/medical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "sUv" = (
@@ -76129,6 +76205,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tcd" = (
@@ -76646,6 +76723,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "tke" = (
@@ -79310,6 +79388,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "tQM" = (
@@ -80402,6 +80481,7 @@
 "ued" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/medical/pharmacy)
 "uen" = (
@@ -84888,6 +84968,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "vjz" = (
@@ -87715,6 +87796,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "vVR" = (
@@ -87840,7 +87922,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "vXK" = (
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/item/wrench,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
 "vXP" = (
@@ -88375,6 +88461,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
+"wfj" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/east{
+	id = "chem_lab_maint_windows";
+	name = "Shutter Control"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wfv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -88850,6 +88946,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/chemistry)
 "wly" = (
@@ -89870,6 +89967,7 @@
 /obj/effect/landmark/start/chemist,
 /obj/effect/turf_decal/trimline/neutral,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "wwr" = (
@@ -90896,6 +90994,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "wJa" = (
@@ -92724,6 +92823,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "xka" = (
@@ -94480,6 +94580,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/service/library/lounge)
+"xGe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/turf/open/floor/iron/white,
+/area/station/medical/medbay)
 "xGh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -95685,6 +95789,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "xWr" = (
@@ -96058,6 +96163,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/engineering/tracking_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "ybJ" = (
@@ -133221,8 +133327,8 @@ kzX
 eKe
 bgd
 swY
-lJl
-uYH
+mDU
+bJA
 qQM
 qYo
 tgT
@@ -133476,10 +133582,10 @@ kXQ
 kXQ
 kzX
 eKe
-bgd
-kzc
+vMp
+vMp
+vMp
 ecm
-uYH
 qQM
 uXF
 tgT
@@ -133733,10 +133839,10 @@ qya
 qya
 jvQ
 eKe
-bgd
-swY
-lJl
-bMV
+vMp
+bnm
+vMp
+kMy
 qQM
 qYo
 tgT
@@ -133982,18 +134088,18 @@ mAW
 wlr
 eBH
 not
-nuI
-eKe
-eKe
+kZb
+jes
+jes
 qjC
 idk
 idk
 gvE
-eKe
+jes
 fEu
-kzc
-wdl
-bJA
+ndR
+vMp
+gBx
 qQM
 aaa
 gqm
@@ -134246,10 +134352,10 @@ gpw
 caw
 xRa
 eug
-eug
-mDU
-swY
-uYH
+wfj
+vMp
+exY
+vMp
 ejE
 qQM
 qYo
@@ -134503,10 +134609,10 @@ xzO
 eoE
 etc
 eoE
-eoE
 vMp
-kzc
-qQM
+vMp
+vMp
+vMp
 vsy
 qQM
 tgT
@@ -135007,7 +135113,7 @@ tQn
 xHL
 boC
 qEf
-qEf
+xGe
 qEf
 cku
 hVx

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4293,7 +4293,7 @@
 /area/station/security/prison)
 "bpZ" = (
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /turf/open/floor/glass/reinforced,
 /area/station/medical/treatment_center)
 "bqe" = (
@@ -24763,7 +24763,7 @@
 /turf/open/cliff/snowrock,
 /area/icemoon/surface/outdoors/nospawn)
 "hHI" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow/full,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/pharmacy)
@@ -39265,7 +39265,7 @@
 /turf/open/floor/wood/parquet,
 /area/station/service/bar/atrium)
 "meF" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/light/directional/north,
 /obj/structure/sign/warning/no_smoking/directional/north,
@@ -53887,7 +53887,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54855,7 +54855,7 @@
 /area/station/medical/medbay/central)
 "qPw" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -63459,7 +63459,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4229,6 +4229,7 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bxX" = (
@@ -4632,7 +4633,7 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "bFN" = (
-/obj/machinery/chem_dispenser{
+/obj/machinery/atmospherics/components/unary/chem_dispenser{
 	layer = 2.7
 	},
 /obj/machinery/button/door/directional/north{
@@ -5764,15 +5765,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "cdk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/medical/central)
 "cdv" = (
 /obj/machinery/door/airlock{
 	id_tag = "AuxToilet1";
@@ -6375,6 +6372,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "cqL" = (
@@ -7011,6 +7009,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "cBy" = (
@@ -8388,6 +8387,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "deU" = (
@@ -10433,7 +10433,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "dTX" = (
-/obj/effect/landmark/start/chemist,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dUj" = (
@@ -10711,11 +10711,14 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "dYG" = (
-/obj/structure/sign/poster/official/anniversary_vintage_reprint/directional/north,
-/obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dYK" = (
@@ -11774,6 +11777,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "eqc" = (
@@ -12475,6 +12479,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "eEn" = (
@@ -12620,6 +12625,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/central)
+"eGP" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/anniversary_vintage_reprint/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "eGV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -13905,6 +13917,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/pharmacy)
 "fhi" = (
@@ -14469,6 +14482,12 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/medbay/central)
+"fok" = (
+/obj/effect/landmark/start/chemist,
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "foB" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/effect/turf_decal/stripes/line{
@@ -15432,6 +15451,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fKf" = (
@@ -17192,6 +17212,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gtb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "gtk" = (
@@ -18972,6 +18993,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hbQ" = (
@@ -19085,6 +19107,7 @@
 /area/station/engineering/atmospherics_engine)
 "hdk" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hdp" = (
@@ -19102,12 +19125,10 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "hdI" = (
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical/central)
 "hdM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -19374,6 +19395,7 @@
 "hjx" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/status_display/ai/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hjG" = (
@@ -20233,6 +20255,7 @@
 "hyX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "hyZ" = (
@@ -20817,6 +20840,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "hKV" = (
@@ -21639,6 +21663,14 @@
 "hZV" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/morgue)
+"hZY" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Starboard Bow Solar Access"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "hZZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21669,6 +21701,7 @@
 "iaK" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "iaQ" = (
@@ -22456,6 +22489,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "inX" = (
@@ -22579,9 +22613,10 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "iqt" = (
@@ -25600,6 +25635,11 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"jnL" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "jnQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/structure/cable,
@@ -28146,6 +28186,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "keL" = (
@@ -29218,6 +29259,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "kzD" = (
@@ -29727,26 +29769,10 @@
 /turf/open/floor/iron/white,
 /area/station/security/prison)
 "kKT" = (
-/obj/item/reagent_containers/cup/bottle/multiver{
-	pixel_x = 7;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/cup/bottle/epinephrine{
-	pixel_x = -4;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/beaker{
-	pixel_x = 8;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/dropper,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/item/wrench,
+/obj/structure/closet/firecloset,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical/central)
 "kKZ" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable,
@@ -29819,27 +29845,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "kMk" = (
-/obj/item/book/manual/wiki/chemistry{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/book/manual/wiki/grenades,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/book/manual/wiki/plumbing{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/reagent_containers/dropper,
-/obj/structure/table,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/periodic_table/directional/east,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/medical/central)
 "kMl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31313,6 +31323,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "loA" = (
@@ -32941,6 +32952,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "lWg" = (
@@ -33128,6 +33143,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "lZk" = (
@@ -34991,8 +35007,12 @@
 /area/station/medical/virology)
 "mFC" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/beerkeg,
 /obj/structure/sign/poster/random/directional/north,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/item/wrench,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "mFQ" = (
@@ -35887,6 +35907,7 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "mWd" = (
@@ -36854,6 +36875,7 @@
 	dir = 10
 	},
 /obj/machinery/light/small/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "nnn" = (
@@ -37039,6 +37061,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "nqD" = (
@@ -37542,6 +37565,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "nxO" = (
@@ -38135,7 +38159,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "nJn" = (
-/obj/machinery/chem_dispenser{
+/obj/machinery/atmospherics/components/unary/chem_dispenser{
 	layer = 2.7
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -39405,6 +39429,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ogL" = (
@@ -40818,6 +40843,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "oHJ" = (
@@ -41534,6 +41560,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "oWQ" = (
@@ -43226,7 +43253,7 @@
 /area/station/command/heads_quarters/ce)
 "pCw" = (
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -44963,6 +44990,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "qhI" = (
@@ -45375,7 +45403,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
 "qrO" = (
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/south,
@@ -45999,6 +46027,32 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"qEx" = (
+/obj/item/reagent_containers/cup/bottle/multiver{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/bottle/epinephrine{
+	pixel_x = -4;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/dropper,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/north{
+	id = "chem_lockdown";
+	name = "chemistry lockdown control";
+	req_access = list("pharmacy")
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qEy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46288,6 +46342,7 @@
 /obj/structure/noticeboard/directional/east,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "qJH" = (
@@ -47145,13 +47200,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "qWK" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Chemistry Maintenance"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
-/turf/open/floor/plating,
-/area/station/maintenance/department/medical/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qWR" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -48196,7 +48248,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "rrz" = (
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /obj/structure/table,
@@ -51878,12 +51930,14 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "sGn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "sGw" = (
@@ -52860,16 +52914,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "sWv" = (
-/obj/machinery/button/door/directional/north{
-	id = "chem_lockdown";
-	name = "chemistry lockdown control";
-	req_access = list("pharmacy")
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/engine,
+/area/station/maintenance/department/medical/central)
 "sWB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54950,6 +55000,15 @@
 "tKE" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/engineering)
+"tKM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Chemistry Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/department/medical/central)
 "tKN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -56759,7 +56818,24 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uqA" = (
-/obj/structure/disposalpipe/segment,
+/obj/item/book/manual/wiki/chemistry{
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/obj/item/book/manual/wiki/grenades,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/book/manual/wiki/plumbing{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/dropper,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "uqL" = (
@@ -59177,8 +59253,9 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "vhb" = (
-/obj/machinery/chem_dispenser{
-	layer = 2.7
+/obj/machinery/atmospherics/components/unary/chem_dispenser{
+	layer = 2.7;
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
@@ -61875,6 +61952,7 @@
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/chemist,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "vZM" = (
@@ -67216,6 +67294,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/hidden,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "xWF" = (
@@ -91965,8 +92044,8 @@ iqz
 iqz
 dVN
 dVN
-iqz
-iqz
+dTX
+dTX
 vZF
 xCR
 kiz
@@ -92470,7 +92549,7 @@ cNk
 bEA
 bqX
 bqX
-jYy
+eGP
 iqz
 iqz
 iqz
@@ -92479,7 +92558,7 @@ iqz
 iqz
 dVN
 iqz
-iqz
+dTX
 iqz
 ubF
 hZV
@@ -92736,7 +92815,7 @@ wOl
 skx
 bjy
 iqz
-tqd
+jnL
 pbz
 dpl
 hZV
@@ -93753,17 +93832,17 @@ bSs
 rla
 eIO
 sGn
-fvE
+tKM
 dYG
-iqz
-iqz
-iqz
-iqz
-iqz
+qWK
+qWK
+qWK
+qWK
+qWK
 lWd
 cBg
 hbO
-iqz
+dTX
 ogk
 hZV
 daa
@@ -94010,13 +94089,13 @@ xWE
 kzj
 qhG
 iqq
-qWK
+fvE
 cdk
+fvE
 uqA
-uqA
-uqA
-uqA
-uqA
+iqz
+iqz
+iqz
 pCw
 iqz
 jOw
@@ -94269,8 +94348,8 @@ eIO
 deO
 fvE
 sWv
-iqz
-iqz
+fvE
+qEx
 fnc
 bCo
 bCo
@@ -94524,10 +94603,10 @@ nqB
 kxa
 eIO
 hKG
-fvE
+hZY
 hdI
-dTX
-iqz
+fvE
+fok
 iqz
 iqz
 iqz
@@ -95039,8 +95118,8 @@ lLq
 eIO
 qbZ
 lRT
-bqX
-bqX
+fvE
+fvE
 bqX
 pJV
 bqX

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -3604,7 +3604,7 @@
 /area/station/security/prison/safe)
 "aWj" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -34493,7 +34493,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/structure/sign/poster/official/random/directional/north,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/bar)
 "jdp" = (
@@ -43882,7 +43882,7 @@
 /obj/effect/turf_decal/siding/wideplating,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
 "lzf" = (
@@ -48629,7 +48629,7 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/fore)
 "mIK" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /turf/open/floor/iron/textured_large,
 /area/station/medical/chemistry)
 "mIO" = (
@@ -71991,7 +71991,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "sTG" = (
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks,
 /obj/structure/table/glass,
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
@@ -74696,7 +74696,7 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "tBY" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/structure/sign/poster/official/periodic_table/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
@@ -75155,7 +75155,7 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/bar)
@@ -80809,7 +80809,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "vjC" = (
-/obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer,
 /obj/structure/table/glass,
 /obj/machinery/light/directional/north,
 /obj/machinery/firealarm/directional/north,

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -410,7 +410,7 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "bS" = (
-/obj/machinery/chem_dispenser/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/fullupgrade,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "bT" = (
@@ -2220,7 +2220,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "Ly" = (
-/obj/machinery/chem_dispenser/chem_synthesizer,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/chem_synthesizer,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
 "LH" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -816,7 +816,7 @@
 /area/centcom/central_command_areas/control)
 "dG" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/east,
@@ -1762,7 +1762,7 @@
 /area/centcom/central_command_areas/prison/cells)
 "iC" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 8;
 	pixel_x = 4
 	},
@@ -6208,7 +6208,7 @@
 /area/centcom/central_command_areas/control)
 "Cy" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 8;
 	pixel_x = 4;
 	pixel_y = 4
@@ -7347,7 +7347,7 @@
 /area/centcom/central_command_areas/evacuation)
 "JV" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -19820,7 +19820,7 @@
 /area/station/commons/vacant_room/office)
 "fZR" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -32390,7 +32390,7 @@
 /area/station/service/kitchen)
 "kFf" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
@@ -48199,7 +48199,7 @@
 /area/station/engineering/atmos)
 "qkP" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
@@ -51402,7 +51402,7 @@
 /area/station/security/courtroom/holding)
 "rro" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -67786,7 +67786,7 @@
 /area/station/science/research)
 "xiP" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)

--- a/_maps/shuttles/emergency_bar.dmm
+++ b/_maps/shuttles/emergency_bar.dmm
@@ -11,7 +11,7 @@
 /area/shuttle/escape)
 "ad" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -46,7 +46,7 @@
 /area/shuttle/escape)
 "aj" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,

--- a/_maps/shuttles/emergency_casino.dmm
+++ b/_maps/shuttles/emergency_casino.dmm
@@ -885,7 +885,7 @@
 /area/shuttle/escape)
 "Aw" = (
 /obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/shuttle/escape)
@@ -1096,7 +1096,7 @@
 /area/shuttle/escape)
 "KN" = (
 /obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade,
 /obj/structure/sign/poster/official/cohiba_robusto_ad/directional/north,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -58,7 +58,7 @@
 /area/shuttle/escape)
 "fB" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -237,7 +237,7 @@
 /area/shuttle/escape)
 "qI" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 8
 	},
 /turf/open/floor/wood,

--- a/_maps/shuttles/emergency_luxury.dmm
+++ b/_maps/shuttles/emergency_luxury.dmm
@@ -1075,7 +1075,7 @@
 /area/shuttle/escape/luxury)
 "QQ" = (
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade{
 	dir = 4;
 	pixel_y = 0
 	},
@@ -1230,7 +1230,7 @@
 /area/shuttle/escape/luxury)
 "YF" = (
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 4;
 	pixel_y = 0
 	},

--- a/_maps/shuttles/emergency_rollerdome.dmm
+++ b/_maps/shuttles/emergency_rollerdome.dmm
@@ -30,7 +30,7 @@
 /area/shuttle/escape)
 "fX" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -79,7 +79,7 @@
 /area/shuttle/escape)
 "nw" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 1
 	},
 /turf/open/floor/wood,

--- a/_maps/shuttles/emergency_shadow.dmm
+++ b/_maps/shuttles/emergency_shadow.dmm
@@ -724,7 +724,7 @@
 /area/shuttle/escape)
 "GB" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark{

--- a/_maps/shuttles/emergency_tranquility.dmm
+++ b/_maps/shuttles/emergency_tranquility.dmm
@@ -98,7 +98,7 @@
 /area/shuttle/escape)
 "cD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 4;
 	pixel_y = 4
 	},
@@ -1528,7 +1528,7 @@
 /area/shuttle/escape)
 "CV" = (
 /obj/structure/table/reinforced,
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade{
 	dir = 4;
 	pixel_y = 4
 	},

--- a/_maps/shuttles/emergency_wabbajack.dmm
+++ b/_maps/shuttles/emergency_wabbajack.dmm
@@ -185,7 +185,7 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "aM" = (
-/obj/machinery/chem_dispenser,
+/obj/machinery/atmospherics/components/unary/chem_dispenser,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -240,7 +240,7 @@
 "az" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,

--- a/_maps/shuttles/pirate_ex_interdyne.dmm
+++ b/_maps/shuttles/pirate_ex_interdyne.dmm
@@ -284,7 +284,7 @@
 /obj/effect/turf_decal/tile/dark_blue/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/chem_dispenser/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/fullupgrade,
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)
 "aR" = (

--- a/_maps/shuttles/pirate_irs.dmm
+++ b/_maps/shuttles/pirate_irs.dmm
@@ -531,7 +531,7 @@
 /turf/open/floor/iron,
 /area/shuttle/pirate)
 "qj" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 1;
 	pixel_y = -16
 	},
@@ -700,7 +700,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "uy" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade{
 	dir = 1;
 	pixel_y = -18
 	},

--- a/_maps/shuttles/pirate_silverscale.dmm
+++ b/_maps/shuttles/pirate_silverscale.dmm
@@ -386,7 +386,7 @@
 /area/shuttle/pirate)
 "zB" = (
 /obj/structure/table/glass,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -546,7 +546,7 @@
 /area/shuttle/pirate)
 "Ig" = (
 /obj/structure/table/glass,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,

--- a/_maps/shuttles/whiteship_obelisk.dmm
+++ b/_maps/shuttles/whiteship_obelisk.dmm
@@ -296,7 +296,7 @@
 /area/shuttle/abandoned/bridge)
 "oU" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/purple,
@@ -684,7 +684,7 @@
 "NG" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /obj/effect/spawner/random/food_or_drink/booze,

--- a/_maps/templates/battlecruiser_starfury.dmm
+++ b/_maps/templates/battlecruiser_starfury.dmm
@@ -2497,7 +2497,7 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/sbc_starfury)
 "iA" = (
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 1
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
@@ -4050,7 +4050,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/sbc_starfury)
 "uu" = (
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /obj/structure/table/reinforced/plastitaniumglass,

--- a/_maps/templates/lazy_templates/ninja_den.dmm
+++ b/_maps/templates/lazy_templates/ninja_den.dmm
@@ -794,7 +794,7 @@
 /area/centcom/central_command_areas/holding)
 "rn" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 4;
 	pixel_x = -8;
 	pixel_y = 1
@@ -1685,7 +1685,7 @@
 /area/centcom/central_command_areas/holding)
 "Nt" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 4;
 	pixel_x = -8;
 	pixel_y = 4

--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -1063,7 +1063,7 @@
 /obj/machinery/camera/autoname/directional/east{
 	network = list("nukie")
 	},
-/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/mutagensaltpeter,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "my" = (
@@ -1897,7 +1897,7 @@
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "wN" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks{
 	dir = 1
 	},
 /obj/structure/sign/poster/contraband/andromeda_bitters/directional/south,
@@ -2503,7 +2503,7 @@
 /area/centcom/syndicate_mothership/control)
 "EL" = (
 /obj/structure/sign/poster/contraband/masked_men/directional/east,
-/obj/machinery/chem_dispenser/fullupgrade,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/fullupgrade,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
 "EM" = (
@@ -2928,7 +2928,7 @@
 /area/centcom/syndicate_mothership/control)
 "Jc" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer{
 	dir = 1
 	},
 /obj/structure/sign/poster/contraband/space_cube/directional/south,

--- a/_maps/templates/shelter_3.dmm
+++ b/_maps/templates/shelter_3.dmm
@@ -25,12 +25,12 @@
 /area/misc/survivalpod)
 "f" = (
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks,
 /turf/open/floor/pod/dark,
 /area/misc/survivalpod)
 "g" = (
 /obj/structure/table/wood/fancy/black,
-/obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer,
 /obj/machinery/light/directional/north,
 /turf/open/floor/pod/dark,
 /area/misc/survivalpod)

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -718,7 +718,7 @@
 /obj/item/circuitboard/machine/chem_dispenser
 	name = "Chem Dispenser"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
-	build_path = /obj/machinery/chem_dispenser
+	build_path = /obj/machinery/atmospherics/components/unary/chem_dispenser
 	req_components = list(
 		/datum/stock_part/matter_bin = 2,
 		/datum/stock_part/capacitor = 1,
@@ -727,9 +727,19 @@
 		/obj/item/stock_parts/cell = 1)
 	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
 	needs_anchored = FALSE
+	var/pipe_layer = PIPING_LAYER_DEFAULT
+
+/obj/item/circuitboard/machine/chem_dispenser/multitool_act(mob/living/user, obj/item/multitool/multitool)
+	. = ..()
+	pipe_layer = (pipe_layer >= PIPING_LAYER_MAX) ? PIPING_LAYER_MIN : (pipe_layer + 1)
+	to_chat(user, span_notice("You change the circuitboard to layer [pipe_layer]."))
+
+/obj/item/circuitboard/machine/chem_dispenser/examine()
+	. = ..()
+	. += span_notice("It is set to layer [pipe_layer].")
 
 /obj/item/circuitboard/machine/chem_dispenser/fullupgrade
-	build_path = /obj/machinery/chem_dispenser/fullupgrade
+	build_path = /obj/machinery/atmospherics/components/unary/chem_dispenser/fullupgrade
 	specific_parts = TRUE
 	req_components = list(
 		/datum/stock_part/matter_bin/tier4 = 2,
@@ -740,7 +750,7 @@
 	)
 
 /obj/item/circuitboard/machine/chem_dispenser/mutagensaltpeter
-	build_path = /obj/machinery/chem_dispenser/mutagensaltpeter
+	build_path = /obj/machinery/atmospherics/components/unary/chem_dispenser/mutagensaltpeter
 	specific_parts = TRUE
 	req_components = list(
 		/datum/stock_part/matter_bin/tier4 = 2,
@@ -754,7 +764,7 @@
 	name = "Reagent Synthesizer"
 	name_extension = "(Abductor Machine Board)"
 	icon_state = "abductor_mod"
-	build_path = /obj/machinery/chem_dispenser/abductor
+	build_path = /obj/machinery/atmospherics/components/unary/chem_dispenser/abductor
 	specific_parts = TRUE
 	req_components = list(
 		/datum/stock_part/matter_bin/tier4 = 2,
@@ -1118,10 +1128,10 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks
 	name = "Soda Dispenser"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
-	build_path = /obj/machinery/chem_dispenser/drinks
+	build_path = /obj/machinery/atmospherics/components/unary/chem_dispenser/drinks
 
 /obj/item/circuitboard/machine/chem_dispenser/drinks/fullupgrade
-	build_path = /obj/machinery/chem_dispenser/drinks/fullupgrade
+	build_path = /obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/fullupgrade
 	req_components = list(
 		/datum/stock_part/matter_bin/tier4 = 2,
 		/datum/stock_part/capacitor/tier4 = 2,
@@ -1133,10 +1143,10 @@
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer
 	name = "Booze Dispenser"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
-	build_path = /obj/machinery/chem_dispenser/drinks/beer
+	build_path = /obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer
 
 /obj/item/circuitboard/machine/chem_dispenser/drinks/beer/fullupgrade
-	build_path = /obj/machinery/chem_dispenser/drinks/beer/fullupgrade
+	build_path = /obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer/fullupgrade
 	req_components = list(
 		/datum/stock_part/matter_bin/tier4 = 2,
 		/datum/stock_part/capacitor/tier4 = 2,

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -550,7 +550,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 
 /obj/item/abductor_machine_beacon/chem_dispenser
 	name = "beacon - Reagent Synthesizer"
-	spawned_machine = /obj/machinery/chem_dispenser/abductor
+	spawned_machine = /obj/machinery/atmospherics/components/unary/chem_dispenser/abductor
 
 /obj/item/scalpel/alien
 	name = "alien scalpel"

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -268,9 +268,9 @@
 		/obj/machinery/mech_bay_recharge_port = 1,
 		/obj/machinery/recharger = 2,
 		/obj/machinery/power/smes = 2,
-		/obj/machinery/chem_dispenser = 3,
-		/obj/machinery/chem_dispenser/drinks = 3, /*actually having only the chem dispenser works for scanning soda/booze dispensers but im not quite sure how would i go about actually pointing that out w/o these two lines*/
-		/obj/machinery/chem_dispenser/drinks/beer = 3
+		/obj/machinery/atmospherics/components/unary/chem_dispenser = 3,
+		/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks = 3, /*actually having only the chem dispenser works for scanning soda/booze dispensers but im not quite sure how would i go about actually pointing that out w/o these two lines*/
+		/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer = 3
 	)
 	required_stock_part = /obj/item/stock_parts/capacitor/adv
 
@@ -293,9 +293,9 @@
 	required_points = 8
 	required_atoms = list(
 		/obj/machinery/recharge_station = 1,
-		/obj/machinery/chem_dispenser = 1,
-		/obj/machinery/chem_dispenser/drinks = 1,
-		/obj/machinery/chem_dispenser/drinks/beer = 1,
+		/obj/machinery/atmospherics/components/unary/chem_dispenser = 1,
+		/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks = 1,
+		/obj/machinery/atmospherics/components/unary/chem_dispenser/drinks/beer = 1,
 		/obj/machinery/power/smes = 2
 	)
 	required_stock_part = /obj/item/stock_parts/cell/hyper

--- a/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_synthesizer.dm
@@ -1,4 +1,4 @@
-/obj/machinery/chem_dispenser/chem_synthesizer //formerly SCP-294 made by mrty, but now only for testing purposes
+/obj/machinery/atmospherics/components/unary/chem_dispenser/chem_synthesizer //formerly SCP-294 made by mrty, but now only for testing purposes
 	name = "\improper debug chemical synthesizer"
 	desc = "If you see this, yell at adminbus."
 	icon = 'icons/obj/medical/chemical.dmi'
@@ -14,13 +14,13 @@
 	///The purity of the created reagent in % (purity uses 0-1 values)
 	var/purity = 100
 
-/obj/machinery/chem_dispenser/chem_synthesizer/ui_interact(mob/user, datum/tgui/ui)
+/obj/machinery/atmospherics/components/unary/chem_dispenser/chem_synthesizer/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "ChemDebugSynthesizer", name)
 		ui.open()
 
-/obj/machinery/chem_dispenser/chem_synthesizer/ui_act(action, params)
+/obj/machinery/atmospherics/components/unary/chem_dispenser/chem_synthesizer/ui_act(action, params)
 	. = ..()
 	if(.)
 		return
@@ -57,16 +57,16 @@
 				purity = input
 	update_appearance()
 
-/obj/machinery/chem_dispenser/chem_synthesizer/Destroy()
+/obj/machinery/atmospherics/components/unary/chem_dispenser/chem_synthesizer/Destroy()
 	QDEL_NULL(beaker)
 	return ..()
 
-/obj/machinery/chem_dispenser/chem_synthesizer/ui_data(mob/user)
+/obj/machinery/atmospherics/components/unary/chem_dispenser/chem_synthesizer/ui_data(mob/user)
 	. = ..()
 	.["purity"] = purity
 	return .
 
-/obj/machinery/chem_dispenser/chem_synthesizer/proc/find_reagent(input)
+/obj/machinery/atmospherics/components/unary/chem_dispenser/chem_synthesizer/proc/find_reagent(input)
 	. = FALSE
 	if(GLOB.chemical_reagents_list[input]) //prefer IDs!
 		return input

--- a/html/changelogs/archive/2017-08.yml
+++ b/html/changelogs/archive/2017-08.yml
@@ -164,7 +164,7 @@
   - balance: Lowers the chance for monkeys to become gorillas
   - rscadd: Holoparasite prompts now have a "Never For This Round" option
   Naksu:
-  - spellcheck: fixed inconsistent grammar between machines that derive from /obj/machinery/chem_dispenser
+  - spellcheck: fixed inconsistent grammar between machines that derive from /obj/machinery/atmospherics/components/unary/chem_dispenser
   - spellcheck: touched up some chat messages to include references to objects instead
       of "that" or "the machine" etc., also removed references to beakers being loaded
       in machines that can accept any container


### PR DESCRIPTION

## About The Pull Request

Chem dispensers now uses plasma gas with power to  refill their internal buffer. The plasma consumption is half of the power consumption

Help with mapping would be greatly appreciated
## Why It's Good For The Game

dispensers now use some kind of material for their production, in this case plasma; 
the idea is to add a small layer of dept to the production of chemicals so that it expands many factors of the game, from the lore aspect (plasma research station), to the roleplay aspect (the requirement to ask atmos/engi or cargo for a fresh canister), the dangers of plasma handling and a potential new source of fires for atmos to fight (currently the only source is atmos and most of the times they cause the fires as antag).
## Changelog
:cl:
add: chem dispensers now use plasma to work.
/:cl:
