### PR TITLE
[no gbp] Ninjas can get credit for placing their bombs

### DIFF
--- a/code/modules/antagonists/ninja/ninja_explosive.dm
+++ b/code/modules/antagonists/ninja/ninja_explosive.dm
@@ -66,12 +66,12 @@
 		qdel(src)
 		return
 	//Since we already did the checks in afterattack, the denonator must be a ninja with the bomb objective.
-	if(!detonator)
+	if(isnull(detonator))
 		return
+	var/mob/ninja = detonator.resolve()
 	. = ..()
 	if(!.)
 		return
-	var/mob/ninja = detonator.resolve()
 	if (isnull(ninja))
 		return
 	var/datum/antagonist/ninja/ninja_antag = ninja.mind.has_antag_datum(/datum/antagonist/ninja)


### PR DESCRIPTION
## About The Pull Request

I made a mistake while refactoring this item. 
We check if the weakref exists, then blow up the bomb. Destroy nulls our weakref, then we try to resolve it. This obviously doesn't work and so it never succeeds the Ninja's objective.
I swapped the order of operations around so now it works.

## Changelog

:cl:
fix: Ninjas should be correctly credited for using their spider bombs
/:cl:
