### PR TITLE
Allows circuit module/typecast components to use lists/assoc lists, improves typecast somewhat

### DIFF
--- a/code/__DEFINES/wiremod.dm
+++ b/code/__DEFINES/wiremod.dm
@@ -31,6 +31,9 @@
 /// Options datatype. Derivative of string.
 #define PORT_TYPE_OPTION "option"
 
+/// Used when a port has no list, specifically for checking what type of list it's set as.
+#define PORT_LIST_NONE "none"
+
 // Composite datatypes
 #define PORT_COMPOSITE_TYPE_LIST "list"
 /// List datatype

--- a/code/_globalvars/lists/wiremod.dm
+++ b/code/_globalvars/lists/wiremod.dm
@@ -18,3 +18,10 @@ GLOBAL_LIST_INIT(wiremod_fundamental_types, list(
 	PORT_TYPE_NUMBER,
 	PORT_TYPE_STRING,
 ))
+
+/// All possible types of list something can be.
+GLOBAL_LIST_INIT(wiremod_list_types, list(
+	PORT_NO_LIST,
+	PORT_COMPOSITE_TYPE_LIST,
+	PORT_COMPOSITE_TYPE_ASSOC_LIST
+))

--- a/code/_globalvars/lists/wiremod.dm
+++ b/code/_globalvars/lists/wiremod.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_INIT(wiremod_fundamental_types, list(
 
 /// All possible types of list something can be.
 GLOBAL_LIST_INIT(wiremod_list_types, list(
-	PORT_NO_LIST,
+	PORT_LIST_NONE,
 	PORT_COMPOSITE_TYPE_LIST,
 	PORT_COMPOSITE_TYPE_ASSOC_LIST
 ))

--- a/code/modules/wiremod/components/utility/typecast.dm
+++ b/code/modules/wiremod/components/utility/typecast.dm
@@ -5,20 +5,25 @@
  */
 /obj/item/circuit_component/typecast
 	display_name = "Typecast"
-	desc = "A component that casts a value to a type if it matches or outputs null."
+	desc = "A component with a customizable output that allows typing of ambiguous inputs. If an input is NOT of the output's type, (or \
+	, if a list, if its contents are not correctly typed) the component will return null."
 	category = "Utility"
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL|CIRCUIT_FLAG_OUTPUT_SIGNAL
 
 	var/datum/port/input/option/typecast_options
+	var/datum/port/input/option/list_type_options
 
 	var/datum/port/input/input_value
+	var/datum/port/input/list_type_input
 
 	var/datum/port/output/output_value
 
 	var/current_type
+	var/current_list_type
 
 /obj/item/circuit_component/typecast/populate_ports()
 	current_type = typecast_options.value
+	current_list_type = list_type_options.value
 	input_value = add_input_port("Input", PORT_TYPE_ANY)
 	output_value = add_output_port("Output", current_type)
 
@@ -27,33 +32,86 @@
 		PORT_TYPE_STRING,
 		PORT_TYPE_NUMBER,
 		PORT_COMPOSITE_TYPE_LIST,
+		PORT_COMPOSITE_TYPE_ASSOC_LIST,
 		PORT_TYPE_ATOM,
+		PORT_TYPE_TABLE,
 	)
+
 	typecast_options = add_option_port("Typecast Options", component_options)
 
-/obj/item/circuit_component/typecast/pre_input_received(datum/port/input/port)
-	var/current_option = typecast_options.value
-	if(current_type != current_option)
-		current_type = current_option
-		output_value.set_datatype(current_type)
+	list_type_options = add_option_port("List Type", (GLOB.wiremod_basic_types) - PORT_TYPE_SIGNAL)
 
+/obj/item/circuit_component/typecast/pre_input_received(datum/port/input/port)
+	update_output()
 
 /obj/item/circuit_component/typecast/input_received(datum/port/input/port)
 	var/current_option = typecast_options.value
 	var/value = input_value.value
 	var/value_to_set = null
-	switch(current_option)
-		if(PORT_TYPE_STRING)
-			if(istext(value))
-				value_to_set = value
-		if(PORT_TYPE_NUMBER)
-			if(isnum(value))
-				value_to_set = value
-		if(PORT_COMPOSITE_TYPE_LIST)
-			if(islist(value))
-				value_to_set = value
-		if(PORT_TYPE_ATOM)
-			if(isatom(value))
+
+	if (current_option == PORT_COMPOSITE_TYPE_LIST || current_option == PORT_COMPOSITE_TYPE_ASSOC_LIST)
+		if(islist(value))
+			var/is_correct_format = TRUE
+			var/is_correctly_typed = TRUE
+			var/want_assoc = (current_option == PORT_COMPOSITE_TYPE_ASSOC_LIST)
+
+			for (var/key as anything in value)
+				if (!isnull(value[key]))
+					is_correct_format = want_assoc
+					break
+
+			if (is_correct_format)
+				for (var/entry as anything in value)
+					if (want_assoc)
+						entry = value[entry]
+					if (!entry_valid(entry, list_type_options.value))
+						is_correctly_typed = FALSE
+						break
+
+			if (is_correct_format && is_correctly_typed)
 				value_to_set = value
 
+	else if (entry_valid(value, current_option))
+		value_to_set = value
+
+	update_output()
 	output_value.set_output(value_to_set)
+
+/obj/item/circuit_component/typecast/proc/entry_valid(entry, comparison_type)
+	switch (comparison_type)
+		if (PORT_TYPE_ANY)
+			return TRUE
+		if (PORT_TYPE_ATOM)
+			return isatom(entry)
+		if (PORT_TYPE_NUMBER)
+			return isnum(entry)
+		if (PORT_TYPE_STRING)
+			return istext(entry)
+		if (PORT_TYPE_TABLE)
+			if (islist(entry))
+				if (!length(entry))
+					return FALSE
+				for (var/potential_list as anything in entry)
+					if (!islist(potential_list)) // if any entry isnt a nested list, nope
+						return FALSE
+				return TRUE // only occurs if every entry is a list, and entry itself is a list
+			return FALSE
+		else
+			return FALSE
+
+/obj/item/circuit_component/typecast/proc/update_output()
+	var/current_option = typecast_options.value
+	var/current_list_option = list_type_options.value
+	if (!current_option) // sanity
+		output_value.set_datatype(PORT_TYPE_ANY)
+		return
+
+	current_type = current_option
+	current_list_type = current_list_option
+
+	if (current_type == PORT_COMPOSITE_TYPE_LIST)
+		output_value.set_datatype(PORT_TYPE_LIST(current_list_type))
+	else if (current_type == PORT_COMPOSITE_TYPE_ASSOC_LIST)
+		output_value.set_datatype(PORT_TYPE_ASSOC_LIST(PORT_TYPE_STRING, current_list_type))
+	else
+		output_value.set_datatype(current_type)

--- a/code/modules/wiremod/core/port.dm
+++ b/code/modules/wiremod/core/port.dm
@@ -115,6 +115,20 @@
 /datum/port/proc/datatype_ui_data(mob/user)
 	return datatype_handler.datatype_ui_data(src)
 
+/// Returns the type of list this port is set as, from assoc, to list, to none.
+/datum/port/proc/get_list_type()
+	if (istype(datatype_handler, /datum/circuit_datatype/composite_instance))
+		var/datum/circuit_datatype/composite_instance/list_datatype = datatype_handler
+		return list_datatype.base_datatype
+	return PORT_LIST_NONE
+
+/// Returns the datatype of this port if not a list - however, if it IS a list, it will return whatever the list is typed as/whatever the assoc list's values are typed as.
+/datum/port/proc/get_core_datatype()
+	if (istype(datatype_handler, /datum/circuit_datatype/composite_instance))
+		var/datum/circuit_datatype/composite_instance/list_datatype = datatype_handler
+		return list_datatype.primary_composited_datatype
+	return datatype
+
 /**
  * # Output Port
  *

--- a/code/modules/wiremod/datatypes/composite/composite.dm
+++ b/code/modules/wiremod/datatypes/composite/composite.dm
@@ -77,6 +77,9 @@
 	/// A list composed of the composite datatypes sent to the UI.
 	var/list/composite_datatypes_style
 
+	/// The primary datatype aside from list used in this datatype, e.g. entity for entity list, number for string -> number assoc list
+	var/primary_composited_datatype
+
 /datum/circuit_datatype/composite_instance/New(datatype, base_datatype, list/composite_datatypes)
 	. = ..()
 	if(!datatype || !composite_datatypes)
@@ -85,11 +88,18 @@
 	src.datatype = datatype
 	src.base_datatype = base_datatype
 	src.composite_datatypes = composite_datatypes
+	src.primary_composited_datatype = generate_primary_composite()
 	abstract = FALSE
 
 	composite_datatypes_style += list()
 	for(var/datatype_to_check in composite_datatypes)
 		composite_datatypes_style += GLOB.circuit_datatypes[datatype_to_check].color
+
+/datum/circuit_datatype/composite_instance/proc/generate_primary_composite()
+	if (base_datatype == PORT_COMPOSITE_TYPE_LIST)
+		return composite_datatypes[1]
+	else
+		return composite_datatypes[2] // assoc, the 2nd is our non-key
 
 /datum/circuit_datatype/composite_instance/can_receive_from_datatype(datatype_to_check)
 	. = ..()

--- a/tgui/packages/tgui/interfaces/CircuitModule.js
+++ b/tgui/packages/tgui/interfaces/CircuitModule.js
@@ -4,7 +4,8 @@ import { Window } from '../layouts';
 
 export const CircuitModule = (props, context) => {
   const { act, data } = useBackend(context);
-  const { input_ports, output_ports, global_port_types } = data;
+  const { input_ports, output_ports, global_port_types, global_list_types } =
+    data;
   return (
     <Window width={600} height={300}>
       <Window.Content scrollable>
@@ -27,7 +28,9 @@ export const CircuitModule = (props, context) => {
                         key={index}
                         name={val.name}
                         datatype={val.type}
+                        listtype={val.listtype}
                         datatypeOptions={global_port_types}
+                        datalistOptions={global_list_types}
                         onRemove={() =>
                           act('remove_input_port', {
                             port_id: index + 1,
@@ -45,6 +48,13 @@ export const CircuitModule = (props, context) => {
                             port_id: index + 1,
                             is_input: true,
                             port_name: value,
+                          })
+                        }
+                        onSetListType={(type) =>
+                          act('set_port_list_type', {
+                            port_id: index + 1,
+                            is_input: true,
+                            port_list_type: type,
                           })
                         }
                       />
@@ -69,7 +79,9 @@ export const CircuitModule = (props, context) => {
                         key={index}
                         name={val.name}
                         datatype={val.type}
+                        listtype={val.listtype}
                         datatypeOptions={global_port_types}
+                        datalistOptions={global_list_types}
                         onRemove={() =>
                           act('remove_output_port', {
                             port_id: index + 1,
@@ -87,6 +99,13 @@ export const CircuitModule = (props, context) => {
                             port_id: index + 1,
                             is_input: false,
                             port_name: value,
+                          })
+                        }
+                        onSetListType={(type) =>
+                          act('set_port_list_type', {
+                            port_id: index + 1,
+                            is_input: false,
+                            port_list_type: type,
                           })
                         }
                       />
@@ -116,9 +135,12 @@ const PortEntry = (props, context) => {
     onRemove,
     onEnter,
     onSetType,
+    onSetListType,
     name,
     datatype,
+    listtype,
     datatypeOptions = [],
+    datalistOptions = [],
     ...rest
   } = props;
 
@@ -133,6 +155,13 @@ const PortEntry = (props, context) => {
             displayText={datatype}
             options={datatypeOptions}
             onSelected={onSetType}
+          />
+        </Stack.Item>
+        <Stack.Item>
+          <Dropdown
+            displayText={listtype}
+            options={datalistOptions}
+            onSelected={onSetListType}
           />
         </Stack.Item>
         <Stack.Item>


### PR DESCRIPTION

## About The Pull Request

Title.

Module component input/output can now use typed and untyped lists/assoc lists.

Typecast can now cast things to typed and untyped lists/assoc lists, can now cast to table, and now sets its output datatype to the casted datatype.
## Why It's Good For The Game

Modules having no list inputs/outputs seems like more of an oversight than anything, so this is just general improvement. Same goes for typecast but for assoc.

Typecast not using table also, in the code, mostly just seemed to be a result of either not knowing or not caring to check to see if a entry really is a list of lists - I couldn't think of a more practical reason than that, so I just plopped it in.

The biggest "balance" change I made here was allowing typecast to set its output to whatever its casting to, but in my opinion, this is a really important change. In my experience, typecast is kinda useless because you can't actually _use_ it to cast to anything. Im not sure if this was the intent, I'm not sure if it was broken, but as it stands - if you try to cast, say, a number typed to any back into a number, it will succeed, sure, but the output will stay typed to any.
This changes that, allowing that number to be cast back to normal and put in anything that can use it.
## Changelog
:cl:
qol: Circuit modules can now input and output lists/assoc lists
qol: Typecast can now cast to assoc list
qol: Typecast can now cast to table
qol: Typecast's output now changes to whatever its casting to
/:cl:
