### PR TITLE
Stops the Vorpal Scythe harming you even when sated

### DIFF
--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -21,7 +21,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 		return FALSE
 
 	var/obj/item/bodypart/part = hand
-	if(isnull(part) || scythe.empowerment > SCYTHE_SATED)
+	if(isnull(part) || scythe.empowerment >= SCYTHE_SATED)
 		return ..()
 
 	to_chat(owner, span_userdanger("[scythe] tears into you for your unworthy display of arrogance!"))


### PR DESCRIPTION

## About The Pull Request

As it says on the tin. Fixes https://github.com/tgstation/tgstation/issues/78218

## Why It's Good For The Game

Broke in a recent refactor.

## Changelog
:cl:
fix: The vorpal scythe is no longer as greedy about you murdering people, and will once again accept striking any living creature to be sated.
/:cl:
