### PR TITLE
[Fuck Shotties] Old Yellers Old Yeller (Improvised Shell Nerf)

### DIFF
--- a/code/datums/components/crafting/weapon_ammo.dm
+++ b/code/datums/components/crafting/weapon_ammo.dm
@@ -65,6 +65,7 @@
 	reqs = list(
 		/obj/item/stack/sheet/iron = 2,
 		/obj/item/stack/cable_coil = 1,
+		/obj/item/shard = 1,
 		/datum/reagent/fuel = 10,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -105,12 +105,12 @@
 
 /obj/item/ammo_casing/shotgun/improvised
 	name = "improvised shell"
-	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
+	desc = "A homemade shotgun casing filled with crushed glass, used to commmit vandalism and property damage."
 	icon_state = "improvshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
-	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*2.5)
-	pellets = 10
-	variance = 25
+	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*2, /datum/material/glass=SMALL_MATERIAL_AMOUNT*1)
+	pellets = 6
+	variance = 30
 
 /obj/item/ammo_casing/shotgun/ion
 	name = "ion shell"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -118,14 +118,13 @@
 	embedding = null
 
 /obj/projectile/bullet/pellet/shotgun_improvised
-	tile_dropoff = 0.35 //Come on it does 6 damage don't be like that.
-	damage = 6
-	wound_bonus = 0
-	bare_wound_bonus = 7.5
+	damage = 5
+	wound_bonus = -5
+	demolition_mod = 3 //Very good at acts of vandalism
 
 /obj/projectile/bullet/pellet/shotgun_improvised/Initialize(mapload)
 	. = ..()
-	range = rand(1, 8)
+	range = rand(3, 8)
 
 /obj/projectile/bullet/pellet/shotgun_improvised/on_range()
 	do_sparks(1, TRUE, src)


### PR DESCRIPTION

## About The Pull Request

Reworks improv shells to not be equal or even superior to buckshot, by cutting their damage in half and reducing the wound bonuses. In return they have a demolition_mod of 3, so do more damage overall to the environment, a true vandal's paradise.

Added a glass shard to the recipe as an actual projectile instead of just sheets of metal.

## Why It's Good For The Game

When buckshot was originally removed from the station (#55663) the intended purpose was, as requested by oranges, to make shotguns a specialist weapon instead of general purpose lethals.

It has come to my attention that improvised shells (which were initially intended to be a weaker alternative made form commonly available materials) are in fact better buckshot, and had no right to survive the original nerf. I am now fixing that oversight by turning improvised shells into a more specialised vandalism tool.

## Changelog
:cl:
balance: Improvised shotgun shells now deal half as much damage to humans and cause less wounds, but do 50% more damage to structures and machines. They also require a glass shard for crafting.
/:cl:
