### PR TITLE
Vents & Injectors now link properly with air sensors via multitool both ways

### DIFF
--- a/code/game/machinery/computer/atmos_computers/_air_sensor.dm
+++ b/code/game/machinery/computer/atmos_computers/_air_sensor.dm
@@ -110,7 +110,7 @@
 
 	else
 		multi_tool.set_buffer(src)
-		balloon_alert(user, "sensor added to multitool buffer")
+		balloon_alert(user, "sensor added to buffer")
 
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 

--- a/code/game/machinery/computer/atmos_computers/_air_sensor.dm
+++ b/code/game/machinery/computer/atmos_computers/_air_sensor.dm
@@ -91,28 +91,28 @@
 	if(istype(multi_tool.buffer, /obj/machinery/atmospherics/components/unary/outlet_injector))
 		var/obj/machinery/atmospherics/components/unary/outlet_injector/input = multi_tool.buffer
 		inlet_id = input.id_tag
-		multi_tool.set_buffer(null)
+		multi_tool.set_buffer(src)
 		balloon_alert(user, "connected to input")
 
 	else if(istype(multi_tool.buffer, /obj/machinery/atmospherics/components/unary/vent_pump))
 		var/obj/machinery/atmospherics/components/unary/vent_pump/output = multi_tool.buffer
 		//so its no longer controlled by air alarm
 		output.disconnect_from_area()
-		//configuration copied from /obj/machinery/atmospherics/components/unary/vent_pump/siphon
+		//configuration copied from /obj/machinery/atmospherics/components/unary/vent_pump/siphon but with max pressure
 		output.pump_direction = ATMOS_DIRECTION_SIPHONING
 		output.pressure_checks = ATMOS_INTERNAL_BOUND
-		output.internal_pressure_bound = 4000
+		output.internal_pressure_bound = MAX_OUTPUT_PRESSURE
 		output.external_pressure_bound = 0
 		//finally assign it to this sensor
 		outlet_id = output.id_tag
-		multi_tool.set_buffer(null)
+		multi_tool.set_buffer(src)
 		balloon_alert(user, "connected to output")
 
 	else
 		multi_tool.set_buffer(src)
-		balloon_alert(user, "added to multitool buffer")
+		balloon_alert(user, "sensor added to multitool buffer")
 
-	return TRUE
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /**
  * A portable version of the /obj/machinery/air_sensor

--- a/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/outlet_injector.dm
@@ -43,16 +43,13 @@
 	. += span_notice("You can link it with an air sensor using a multitool.")
 
 /obj/machinery/atmospherics/components/unary/outlet_injector/multitool_act(mob/living/user, obj/item/multitool/multi_tool)
-	. = ..()
-
 	if(istype(multi_tool.buffer, /obj/machinery/air_sensor))
 		var/obj/machinery/air_sensor/sensor = multi_tool.buffer
-		sensor.inlet_id = id_tag
-		multi_tool.set_buffer(null)
-		balloon_alert(user, "input linked to sensor")
+		multi_tool.set_buffer(src)
+		sensor.multitool_act(user, multi_tool)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
-	balloon_alert(user, "saved in buffer")
+	balloon_alert(user, "injector saved in buffer")
 	multi_tool.set_buffer(src)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -53,16 +53,13 @@
 	. += span_notice("You can link it with an air sensor using a multitool.")
 
 /obj/machinery/atmospherics/components/unary/vent_pump/multitool_act(mob/living/user, obj/item/multitool/multi_tool)
-	. = ..()
-
 	if(istype(multi_tool.buffer, /obj/machinery/air_sensor))
 		var/obj/machinery/air_sensor/sensor = multi_tool.buffer
-		sensor.outlet_id = id_tag
-		multi_tool.set_buffer(null)
-		balloon_alert(user, "output linked to sensor")
+		multi_tool.set_buffer(src)
+		sensor.multitool_act(user, multi_tool)
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
-	balloon_alert(user, "saved in buffer")
+	balloon_alert(user, "vent saved in buffer")
 	multi_tool.set_buffer(src)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 


### PR DESCRIPTION
## About The Pull Request
If you first log a unary vent/injector in an multitool and then link it with an air sensor(i.e. you invoke the air sensors multitool_act) everything works correctly.

But if you first log a air sensor in an multitool and then link it with an unary vent/injector (i.e. you invoke the vents/injectors multitool_act), the vent gets set up incorrectly i.e., its output pressure, operating mode is not set and it does not function.

This PR fixes that

## Changelog
:cl:
fix: Unary vents & Injectors now link properly with air sensors via multitool both ways
/:cl:
