### PR TITLE
Status display: remove scrolling during countdown

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -232,7 +232,7 @@
 		set_messages("shutl","not in service")
 		return PROCESS_KILL
 	else if(shuttle.timer)
-		var/line1 = "<<< [shuttle.getModeStr()]"
+		var/line1 = shuttle.getModeStr()
 		var/line2 = shuttle.getTimerStr()
 
 		set_messages(line1, line2)
@@ -397,7 +397,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/status_display/evac, 32)
 			line1 = ""
 			line2 = ""
 	else
-		line1 = "<<< [SSshuttle.supply.getModeStr()]"
+		line1 = SSshuttle.supply.getModeStr()
 		line2 = SSshuttle.supply.getTimerStr()
 	set_messages(line1, line2)
 


### PR DESCRIPTION

## About The Pull Request
Removes the unnecessary scrolling of the shuttle status during countdown

![image](https://github.com/tgstation/tgstation/assets/83487515/e7771b18-9629-4171-9662-e49a71bb961f)

## Why It's Good For The Game

Looks better, less visually distracting

## Changelog

:cl: LT3
code: Status display shuttle timer no longer scrolls
/:cl: