### PR TITLE
Fix capture devices allowing mob actions while inside

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -209,9 +209,13 @@ Slimecrossing Items
 	else
 		to_chat(user, span_warning("The device is empty..."))
 
-/obj/item/capturedevice/proc/store(mob/living/M)
-	M.forceMove(src)
+/obj/item/capturedevice/proc/store(mob/living/pokemon)
+	pokemon.forceMove(src)
+	pokemon.add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), ABSTRACT_ITEM_TRAIT)
+	pokemon.cancel_camera()
 
 /obj/item/capturedevice/proc/release()
-	for(var/atom/movable/M in contents)
-		M.forceMove(get_turf(loc))
+	for(var/mob/living/pokemon in contents)
+		pokemon.forceMove(get_turf(loc))
+		pokemon.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), ABSTRACT_ITEM_TRAIT)
+		pokemon.cancel_camera()


### PR DESCRIPTION

## About The Pull Request
This immobilizes and restricts actions from any mob inside a capture device.  Players were abusing this exploit to have a capture device in their pocket and being able to launch fireballs at will with chaos magicarp and other fauna.

Any device like a soul shard or guardian does not allow the controlled mobs to attack from inside their stored containers.  

## Why It's Good For The Game
Exploits are bad... m'kay?

## Changelog
:cl:
fix: Fix capture devices allowing mob actions while inside
/:cl:
