### PR TITLE
Fixes the admin log when adding a new admin from the permissions panel not displaying the ckey of the new admin

### DIFF
--- a/code/modules/admin/permissionedit.dm
+++ b/code/modules/admin/permissionedit.dm
@@ -192,6 +192,10 @@
 			admin_ckey = add_admin(admin_ckey, admin_key, use_db)
 			if(!admin_ckey)
 				return
+
+			if(!admin_key) // Prevents failures in logging admin rank changes.
+				admin_key = admin_ckey
+
 			change_admin_rank(admin_ckey, admin_key, use_db, null, legacy_only)
 		if("remove")
 			remove_admin(admin_ckey, admin_key, use_db, D)


### PR DESCRIPTION
## About The Pull Request
It was just displaying nothing, which was only a mild annoyance, but after tolerating it for a few years, today I've had enough and fixed it.

## Why It's Good For The Game
Finally others can know who was added to the team without having `R_PERMISSIONS` themselves.
![image](https://github.com/tgstation/tgstation/assets/58045821/5a945bea-1f1f-4b3d-bd96-c18062cecae4)


## Changelog

:cl: GoldenAlpharex
fix: The message sent to admins when a new admin has been added via the Permissions Panel will now properly show the new admin's ckey.
/:cl: