### PR TITLE
Does a stack trace if a scar cant get a valid description

### DIFF
--- a/code/datums/wounds/scars/_scars.dm
+++ b/code/datums/wounds/scars/_scars.dm
@@ -81,12 +81,9 @@
 		qdel(src)
 		return
 
-	var/file = W.get_scar_file(BP, add_to_scars)
-	var/keyword = W.get_scar_keyword(BP, add_to_scars)
-
-	description = pick_list(W.get_scar_file(BP, add_to_scars), W.get_scar_keyword(BP, add_to_scars))
+	description = pick_list(scar_file, scar_keyword)
 	if (!description)
-		stack_trace("no valid description found for scar! file: [file] keyword: [keyword] wound: [W.type]")
+		stack_trace("no valid description found for scar! file: [scar_file] keyword: [scar_keyword] wound: [W.type]")
 		description = "general disfigurement"
 
 	precise_location = pick_list_replacements(SCAR_LOC_FILE, limb.body_zone)

--- a/code/datums/wounds/scars/_scars.dm
+++ b/code/datums/wounds/scars/_scars.dm
@@ -81,7 +81,13 @@
 		qdel(src)
 		return
 
-	description = pick_list(W.get_scar_file(BP, add_to_scars), W.get_scar_keyword(BP, add_to_scars)) || "general disfigurement"
+	var/file = W.get_scar_file(BP, add_to_scars)
+	var/keyword = W.get_scar_keyword(BP, add_to_scars)
+
+	description = pick_list(W.get_scar_file(BP, add_to_scars), W.get_scar_keyword(BP, add_to_scars))
+	if (!description)
+		stack_trace("no valid description found for scar! file: [file] keyword: [keyword] wound: [W.type]")
+		description = "general disfigurement"
 
 	precise_location = pick_list_replacements(SCAR_LOC_FILE, limb.body_zone)
 	switch(W.severity)


### PR DESCRIPTION

## About The Pull Request

Title. Logs the file, keyword, and scar type.
## Why It's Good For The Game

This is basically an error state already, and we shouldn't be passing in invalid files/keywords. This helps people (me specifically) figure out what's wrong with scars, especially since I'm already seeing a few general disfigurements floating about without being able to replicate.
## Changelog
:cl:
code: Scars now stack trace if they fail to get a valid description
/:cl:
