### PR TITLE
Blacklists quantum medicine from allergy

### DIFF
--- a/code/datums/quirks/negative_quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks/negative_quirks.dm
@@ -1256,6 +1256,7 @@
 		/datum/reagent/medicine/c2,
 		/datum/reagent/medicine/epinephrine,
 		/datum/reagent/medicine/adminordrazine,
+		/datum/reagent/medicine/adminordrazine/quantum_heal,
 		/datum/reagent/medicine/omnizine/godblood,
 		/datum/reagent/medicine/cordiolis_hepatico,
 		/datum/reagent/medicine/synaphydramine,


### PR DESCRIPTION

## About The Pull Request

Title.
## Why It's Good For The Game

Its a subtype of adminorazine that you're probably never going to ever get (only high alert ERTs can spawn with them, meaning its admin-only) and was probably unintentionally left in.

Getting quantum medicine is basically just getting a free "empty" allergy slot.
## Changelog
:cl:
fix: Medicine allergy can no longer roll quantum medicine
/:cl:
