### PR TITLE
Dish Drive QOL features

### DIFF
--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -9,7 +9,9 @@
 	density = FALSE
 	circuit = /obj/item/circuitboard/machine/dish_drive
 	pass_flags = PASSTABLE
-	var/static/list/collectable_items = list(/obj/item/trash/waffles,
+	/// List of dishes the drive can hold
+	var/static/list/collectable_items = list(
+		/obj/item/trash/waffles,
 		/obj/item/broken_bottle,
 		/obj/item/kitchen/fork,
 		/obj/item/plate,
@@ -19,16 +21,24 @@
 		/obj/item/shard,
 		/obj/item/trash/tray,
 	)
-	var/static/list/disposable_items = list(/obj/item/trash/waffles,
+	/// List of items the drive detects as trash
+	var/static/list/disposable_items = list(
+		/obj/item/trash/waffles,
 		/obj/item/broken_bottle,
 		/obj/item/plate_shard,
 		/obj/item/shard,
 		/obj/item/trash/tray,
 	)
-	var/time_since_dishes = 0
+	/// Can this suck up dishes?
 	var/suction_enabled = TRUE
+	/// Does this automatically dispose of trash?
 	var/transmit_enabled = TRUE
+	/// List of dishes currently inside
 	var/list/dish_drive_contents
+	/// Distance this is capable of sucking dishes up over. (3 + servo tier)
+	var/suck_distance = 0
+
+	COOLDOWN_DECLARE(time_since_dishes)
 
 /obj/machinery/dish_drive/Initialize(mapload)
 	. = ..()
@@ -38,16 +48,34 @@
 	. = ..()
 	if(user.Adjacent(src))
 		. += span_notice("Alt-click it to beam its contents to any nearby disposal bins.")
+	if(!LAZYLEN(dish_drive_contents))
+		. += "[src] is empty!"
+		return
+	// Makes a list of all dishes in the drive, as well as what dish will be taken out next.
+	var/list/dish_list = list()
+	// All the types in our list
+	var/list/dish_types = list()
+	for(var/obj/dish in dish_drive_contents)
+		dish_types[dish.type] += 1
+	for(var/dish_path in unique_list(dish_types))
+		// Counts our dish
+		var/dish_amount = dish_types[dish_path]
+		// Handles plurals
+		var/obj/dish = dish_path
+		var/dish_name = dish_amount == 1 ? initial(dish.name) : "[initial(dish.name)][plural_s(initial(dish.name))]"
+		dish_list += list("[dish_amount] [dish_name]")
+
+	. += span_info("It contains [english_list(dish_list)].\n[peek(dish_drive_contents)] is at the top of the pile.")
 
 /obj/machinery/dish_drive/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(!LAZYLEN(dish_drive_contents))
-		to_chat(user, span_warning("There's nothing in [src]!"))
+		balloon_alert(user, "drive empty")
 		return
-	var/obj/item/I = LAZYACCESS(dish_drive_contents, LAZYLEN(dish_drive_contents)) //the most recently-added item
-	LAZYREMOVE(dish_drive_contents, I)
-	user.put_in_hands(I)
-	to_chat(user, span_notice("You take out [I] from [src]."))
+	var/obj/item/dish = LAZYACCESS(dish_drive_contents, LAZYLEN(dish_drive_contents)) //the most recently-added item
+	LAZYREMOVE(dish_drive_contents, dish)
+	user.put_in_hands(dish)
+	balloon_alert(user, "[dish] taken")
 	playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
 	flick("synthesizer_beam", src)
 
@@ -56,23 +84,27 @@
 	default_unfasten_wrench(user, tool)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
-/obj/machinery/dish_drive/attackby(obj/item/I, mob/living/user, params)
-	if(is_type_in_list(I, collectable_items) && !user.combat_mode)
-		if(!user.transferItemToLoc(I, src))
+/obj/machinery/dish_drive/attackby(obj/item/dish, mob/living/user, params)
+	if(is_type_in_list(dish, collectable_items) && !user.combat_mode)
+		if(!user.transferItemToLoc(dish, src))
 			return
-		LAZYADD(dish_drive_contents, I)
-		to_chat(user, span_notice("You put [I] in [src], and it's beamed into energy!"))
+		LAZYADD(dish_drive_contents, dish)
+		balloon_alert(user, "[dish] placed in drive")
 		playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
 		flick("synthesizer_beam", src)
 		return
-	else if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-o", initial(icon_state), I))
+	else if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-o", initial(icon_state), dish))
 		return
-	else if(default_deconstruction_crowbar(I, FALSE))
+	else if(default_deconstruction_crowbar(dish, FALSE))
 		return
 	..()
 
 /obj/machinery/dish_drive/RefreshParts()
 	. = ..()
+	suck_distance = 0
+	for(var/datum/stock_part/servo/servo in component_parts)
+		suck_distance = servo.tier
+	// Lowers power use for total tier
 	var/total_rating = 0
 	for(var/datum/stock_part/stock_part in component_parts)
 		total_rating += stock_part.tier
@@ -81,31 +113,32 @@
 	else
 		update_mode_power_usage(IDLE_POWER_USE, max(0, initial(idle_power_usage) - total_rating))
 		update_mode_power_usage(ACTIVE_POWER_USE, max(0, initial(active_power_usage) - total_rating))
+	// Board options
 	var/obj/item/circuitboard/machine/dish_drive/board = locate() in component_parts
 	if(board)
 		suction_enabled = board.suction
 		transmit_enabled = board.transmit
 
 /obj/machinery/dish_drive/process()
-	if(time_since_dishes <= world.time && transmit_enabled)
+	if(COOLDOWN_FINISHED(src, time_since_dishes) && transmit_enabled)
 		do_the_dishes()
 	if(!suction_enabled)
 		return
-	for(var/obj/item/I in view(4, src))
-		if(is_type_in_list(I, collectable_items) && I.loc != src && (!I.reagents || !I.reagents.total_volume) && (I.contents.len < 1))
-			if(I.Adjacent(src))
-				LAZYADD(dish_drive_contents, I)
-				visible_message(span_notice("[src] beams up [I]!"))
-				I.forceMove(src)
+	for(var/obj/item/dish in view(3 + suck_distance, src))
+		if(is_type_in_list(dish, collectable_items) && dish.loc != src && (!dish.reagents || !dish.reagents.total_volume) && (dish.contents.len < 1))
+			if(dish.Adjacent(src))
+				LAZYADD(dish_drive_contents, dish)
+				visible_message(span_notice("[src] beams up [dish]!"))
+				dish.forceMove(src)
 				playsound(src, 'sound/items/pshoom.ogg', 50, TRUE)
 				flick("synthesizer_beam", src)
 			else
-				step_towards(I, src)
+				step_towards(dish, src)
 
 /obj/machinery/dish_drive/attack_ai(mob/living/user)
 	if(machine_stat)
 		return
-	to_chat(user, span_notice("You send a disposal transmission signal to [src]."))
+	balloon_alert(user, "disposal signal sent")
 	do_the_dishes(TRUE)
 
 /obj/machinery/dish_drive/AltClick(mob/living/user)
@@ -124,10 +157,10 @@
 			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, TRUE)
 		return
 	var/disposed = 0
-	for(var/obj/item/I in dish_drive_contents)
-		if(is_type_in_list(I, disposable_items))
-			LAZYREMOVE(dish_drive_contents, I)
-			I.forceMove(bin)
+	for(var/obj/item/dish in dish_drive_contents)
+		if(is_type_in_list(dish, disposable_items))
+			LAZYREMOVE(dish_drive_contents, dish)
+			dish.forceMove(bin)
 			use_power(active_power_usage)
 			disposed++
 	if (disposed)
@@ -141,4 +174,4 @@
 		if(manual)
 			visible_message(span_notice("There are no disposable items in [src]!"))
 		return
-	time_since_dishes = world.time + 600
+	COOLDOWN_START(src, time_since_dishes, 1 MINUTES)

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -35,7 +35,7 @@
 	var/transmit_enabled = TRUE
 	/// List of dishes currently inside
 	var/list/dish_drive_contents
-	/// Distance this is capable of sucking dishes up over. (3 + servo tier)
+	/// Distance this is capable of sucking dishes up over. (2 + servo tier)
 	var/suck_distance = 0
 
 	COOLDOWN_DECLARE(time_since_dishes)
@@ -124,7 +124,7 @@
 		do_the_dishes()
 	if(!suction_enabled)
 		return
-	for(var/obj/item/dish in view(3 + suck_distance, src))
+	for(var/obj/item/dish in view(2 + suck_distance, src))
 		if(is_type_in_list(dish, collectable_items) && dish.loc != src && (!dish.reagents || !dish.reagents.total_volume) && (dish.contents.len < 1))
 			if(dish.Adjacent(src))
 				LAZYADD(dish_drive_contents, dish)


### PR DESCRIPTION

## About The Pull Request
Adds various QOL features to the Dish Drive

- Examining will give you a list of all items in the dish drive, along with what item you'll take off the top of the pile.
- Swaps some messages to balloon alerts
- Dish Drive range is based off the tier of servo you put in it. You can go up to 6 meters (or 7?, `view()` is a confusing proc)
- Some non-player-facing refactoring
## Why It's Good For The Game
I find it annoying when I'm bartending and I run out of glasses in the middle of an order and I have to go get more because I didn't know how many glasses were in the dish drive
## Changelog
:cl: Wallem
qol: Examine a Dish Drive to see all the items inside of it, as well as the item you'll pull out when you interact with it.
qol: Dish Drive servo tier increases suction range
/:cl:
