### PR TITLE
Shuttle engines screentips and better examine

### DIFF
--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -59,9 +59,9 @@
 		if(ENGINE_UNWRENCHED)
 			. += span_notice("\The [src] is unbolted from the floor. It needs to be wrenched to the floor to be installed.")
 		if(ENGINE_WRENCHED)
-			. += span_notice("\The [src] is bolted to the floor. It needs to be welded to the floor to finish installation.")
+			. += span_notice("\The [src] is bolted to the floor and can be unbolted with a wrench. It needs to be welded to the floor to finish installation.")
 		if(ENGINE_WELDED)
-			. += span_notice("\The [src] is welded to the floor. It is ready to be used.")
+			. += span_notice("\The [src] is welded to the floor and can be unwelded. It is currently fully installed.")
 
 /obj/machinery/power/shuttle_engine/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	if(held_item?.tool_behaviour == TOOL_WELDER && engine_state == ENGINE_WRENCHED)

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -33,6 +33,10 @@
 	fire = 50
 	acid = 70
 
+/obj/machinery/power/shuttle_engine/Initialize(mapload)
+	. = ..()
+	register_context()
+
 /obj/machinery/power/shuttle_engine/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	. = ..()
 	if(!port)
@@ -58,6 +62,17 @@
 			. += span_notice("\The [src] is bolted to the floor. It needs to be welded to the floor to finish installation.")
 		if(ENGINE_WELDED)
 			. += span_notice("\The [src] is welded to the floor. It is ready to be used.")
+
+/obj/machinery/power/shuttle_engine/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(held_item?.tool_behaviour == TOOL_WELDER && engine_state == ENGINE_WRENCHED)
+		context[SCREENTIP_CONTEXT_LMB] = "Weld to Floor"
+	if(held_item?.tool_behaviour == TOOL_WELDER && engine_state == ENGINE_WELDED)
+		context[SCREENTIP_CONTEXT_LMB] = "Unweld from Floor"
+	if(held_item?.tool_behaviour == TOOL_WRENCH && engine_state == ENGINE_UNWRENCHED)
+		context[SCREENTIP_CONTEXT_LMB] = "Wrench to Floor"
+	if(held_item?.tool_behaviour == TOOL_WRENCH && engine_state == ENGINE_WRENCHED)
+		context[SCREENTIP_CONTEXT_LMB] = "Unwrench from Floor"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /**
  * Called on destroy and when we need to unsync an engine from their ship.

--- a/code/game/shuttle_engines.dm
+++ b/code/game/shuttle_engines.dm
@@ -49,6 +49,16 @@
 	unsync_ship()
 	return ..()
 
+/obj/machinery/power/shuttle_engine/examine(mob/user)
+	. = ..()
+	switch(engine_state)
+		if(ENGINE_UNWRENCHED)
+			. += span_notice("\The [src] is unbolted from the floor. It needs to be wrenched to the floor to be installed.")
+		if(ENGINE_WRENCHED)
+			. += span_notice("\The [src] is bolted to the floor. It needs to be welded to the floor to finish installation.")
+		if(ENGINE_WELDED)
+			. += span_notice("\The [src] is welded to the floor. It is ready to be used.")
+
 /**
  * Called on destroy and when we need to unsync an engine from their ship.
  */


### PR DESCRIPTION
## About The Pull Request

Shuttle engines now tell you how to install them based on what tool is necessary to progress to the next step.
This information is included in the examine text of the engine, as well as giving proper screentips when holding the correct tools.

## Why It's Good For The Game

Improves visual clarity on otherwise VERY hard to determine information. The installation steps for the engine are literally nowhere in the game so you are required to code dive to find out.

## Changelog

:cl:
qol: Shuttle engines now tell you how to install them in their screentips and their examine text.
/:cl:
