### PR TITLE
buffs embed pulling with hemostats, allows wirecutters to pull embeds too

### DIFF
--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -297,7 +297,7 @@
 	to_chat(victim, span_notice("[user] [tweezer_safe ? "safely" : span_warning("painfully")] plucks [weapon] from your [limb.plaintext_zone]."))
 	if(!tweezer_safe)
 		// sure it still hurts but it sucks less
-		damaging_removal(victim, weapon, limb, 0.3)
+		damaging_removal(victim, weapon, limb, (0.4 * possible_tweezers.w_class))
 	safeRemove(user)
 
 /// Called when an object is ripped out of someone's body by magic or other abnormal means

--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -278,12 +278,12 @@
 	var/pluck_time = rip_time * (weapon.w_class * 0.3) * (self_pluck ? 1.5 : 1) * tweezer_speed * (tweezer_safe ? 1 : 1.5)
 
 	if(self_pluck)
-		user.visible_message(span_danger("[user] begins plucking [weapon] from [user.p_their()] [limb.plaintext_zone]..."), span_notice("You start plucking [weapon] from your [limb.plaintext_zone]... (It will take [DisplayTimeText(pluck_time)].)"),\
+		user.visible_message(span_danger("[user] begins plucking [weapon] from [user.p_their()] [limb.plaintext_zone] with [possible_tweezers]..."), span_notice("You start plucking [weapon] from your [limb.plaintext_zone] with [possible_tweezers]... (It will take [DisplayTimeText(pluck_time)].)"),\
 			vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=victim)
 	else
-		user.visible_message(span_danger("[user] begins plucking [weapon] from [victim]'s [limb.plaintext_zone]..."),span_notice("You start plucking [weapon] from [victim]'s [limb.plaintext_zone]... (It will take [DisplayTimeText(pluck_time)]."), \
+		user.visible_message(span_danger("[user] begins plucking [weapon] from [victim]'s [limb.plaintext_zone] with [possible_tweezers]..."),span_notice("You start plucking [weapon] from [victim]'s [limb.plaintext_zone] with [possible_tweezers]... (It will take [DisplayTimeText(pluck_time)]."), \
 			vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=victim)
-		to_chat(victim, span_userdanger("[user] begins plucking [weapon] from your [limb.plaintext_zone]... (It will take [DisplayTimeText(pluck_time)]."))
+		to_chat(victim, span_userdanger("[user] begins plucking [weapon] from your [limb.plaintext_zone] with [possible_tweezers]... (It will take [DisplayTimeText(pluck_time)]."))
 
 	if(!do_after(user, pluck_time, victim))
 		if(self_pluck)
@@ -293,8 +293,8 @@
 			to_chat(victim, span_danger("[user] fails to pluck [weapon] from your [limb.plaintext_zone]."))
 		return
 
-	to_chat(user, span_notice("You [tweezer_safe ? "safely" : "unsafely, but"] successfully pluck [weapon] from [victim]'s [limb.plaintext_zone]."))
-	to_chat(victim, span_notice("[user] [tweezer_safe ? "safely" : span_warning("painfully")] plucks [weapon] from your [limb.plaintext_zone]."))
+	to_chat(user, span_notice("You successfully pluck [weapon] from [victim]'s [limb.plaintext_zone][tweezer_safe ? "." : ", but hurt [victim.p_them()] in the process."]"))
+	to_chat(victim, span_notice("[user] plucks [weapon] from your [limb.plaintext_zone][tweezer_safe ? "." : ", but it's not perfect."]"))
 	if(!tweezer_safe)
 		// sure it still hurts but it sucks less
 		damaging_removal(victim, weapon, limb, (0.4 * possible_tweezers.w_class))


### PR DESCRIPTION
## About The Pull Request
- Wirecutters or tools with wirecutter behaviors are now valid for plucking embeds.
- Pluck speed no longer **starts** at 2.5 seconds, which is a pretty dang long time, especially if you have bad embed RNG. I'll do the math and run some more tests in the morning.
- Wirecutters have a speed malus in regards to plucking embeds. I should probably make it worse to account for, like, jaws of life or something.
- Plucking embeds with wirecutters now hurts! It hurts way less than ripping it out with your hands, but it still hurts!

For comparison's sake, bare-handed throwing star removal compared to possible tools.
![image](https://github.com/tgstation/tgstation/assets/31829017/96730fa5-77b8-4f31-83ba-48d36e4e419b)


## Why It's Good For The Game
Embeds kinda suck to deal with. This is intentional - I get that.

However, hemostat pulling is kind of... kind of bad. Awful, really. 2.5 seconds is a lot of time. I know it's not supposed to be the best option, but if you've got a tool, I'd at least like to think it'd be slightly less bad than shoving your fingers into your wound?

## Changelog

:cl:
balance: Pulling embedded items e.g. shrapnel with hemostats is now a lot faster, and scales appropriately with toolspeed.
balance: You can now pull embedded items with wirecutters, at a speed penalty.
/:cl: