### PR TITLE
decks of cards no longer have their own wielded var

### DIFF
--- a/code/datums/components/twohanded.dm
+++ b/code/datums/components/twohanded.dm
@@ -63,7 +63,7 @@
 	return ..()
 
 // Inherit the new values passed to the component
-/datum/component/two_handed/InheritComponent(datum/component/two_handed/new_comp, original, require_twohands, wieldsound, unwieldsound, \
+/datum/component/two_handed/InheritComponent(datum/component/two_handed/new_comp, original, require_twohands, wieldsound, unwieldsound, attacksound, \
 											force_multiplier, force_wielded, force_unwielded, icon_wielded, \
 											datum/callback/wield_callback, datum/callback/unwield_callback)
 	if(!original)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -66,7 +66,7 @@
 
 	if(istype(held_item, /obj/item/toy/cards/deck))
 		var/obj/item/toy/cards/deck/dealer_deck = held_item
-		if(dealer_deck.wielded)
+		if(HAS_TRAIT(dealer_deck, TRAIT_WIELDED))
 			context[SCREENTIP_CONTEXT_LMB] = "Deal card"
 			context[SCREENTIP_CONTEXT_RMB] = "Deal card faceup"
 			. = CONTEXTUAL_SCREENTIP_SET
@@ -238,7 +238,7 @@
 
 	if(istype(I, /obj/item/toy/cards/deck))
 		var/obj/item/toy/cards/deck/dealer_deck = I
-		if(dealer_deck.wielded) // deal a card facedown on the table
+		if(HAS_TRAIT(dealer_deck, TRAIT_WIELDED)) // deal a card facedown on the table
 			var/obj/item/toy/singlecard/card = dealer_deck.draw(user)
 			if(card)
 				attackby(card, user, params)
@@ -284,7 +284,7 @@
 /obj/structure/table/attackby_secondary(obj/item/weapon, mob/user, params)
 	if(istype(weapon, /obj/item/toy/cards/deck))
 		var/obj/item/toy/cards/deck/dealer_deck = weapon
-		if(dealer_deck.wielded) // deal a card faceup on the table
+		if(HAS_TRAIT(dealer_deck, TRAIT_WIELDED)) // deal a card faceup on the table
 			var/obj/item/toy/singlecard/card = dealer_deck.draw(user)
 			if(card)
 				card.Flip()

--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -77,7 +77,7 @@
 
 	if(istype(weapon, /obj/item/toy/cards/deck))
 		var/obj/item/toy/cards/deck/dealer_deck = weapon
-		if(!HAS_TRAIT(dealer_deck, TRAIT_WIELDED) // recycle cardhand into deck (if unwielded)
+		if(!HAS_TRAIT(dealer_deck, TRAIT_WIELDED)) // recycle cardhand into deck (if unwielded)
 			dealer_deck.insert(src)
 			user.balloon_alert_to_viewers("puts card in deck")
 			return

--- a/code/modules/cards/cardhand.dm
+++ b/code/modules/cards/cardhand.dm
@@ -29,7 +29,7 @@
 /obj/item/toy/cards/cardhand/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	if(istype(held_item, /obj/item/toy/cards/deck))
 		var/obj/item/toy/cards/deck/dealer_deck = held_item
-		if(dealer_deck.wielded)
+		if(HAS_TRAIT(dealer_deck, TRAIT_WIELDED))
 			context[SCREENTIP_CONTEXT_LMB] = "Deal card"
 			context[SCREENTIP_CONTEXT_RMB] = "Deal card faceup"
 			return CONTEXTUAL_SCREENTIP_SET
@@ -77,7 +77,7 @@
 
 	if(istype(weapon, /obj/item/toy/cards/deck))
 		var/obj/item/toy/cards/deck/dealer_deck = weapon
-		if(!dealer_deck.wielded) // recycle cardhand into deck (if unwielded)
+		if(!HAS_TRAIT(dealer_deck, TRAIT_WIELDED) // recycle cardhand into deck (if unwielded)
 			dealer_deck.insert(src)
 			user.balloon_alert_to_viewers("puts card in deck")
 			return

--- a/code/modules/cards/deck/deck.dm
+++ b/code/modules/cards/deck/deck.dm
@@ -21,8 +21,6 @@
 	var/decksize = INFINITY
 	/// The description of the cardgame that is played with this deck (used for memories)
 	var/cardgame_desc = "card game"
-	/// Wielding status for holding with two hands
-	var/wielded = FALSE
 	/// The holodeck computer used to spawn a holographic deck (see /obj/item/toy/cards/deck/syndicate/holographic)
 	var/obj/machinery/computer/holodeck/holodeck
 	/// If the cards in the deck have different card faces icons (blank and CAS decks do not)
@@ -33,8 +31,6 @@
 /obj/item/toy/cards/deck/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/drag_pickup)
-	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_wield))
-	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
 	AddComponent(/datum/component/two_handed, attacksound='sound/items/cardflip.ogg')
 	register_context()
 
@@ -50,18 +46,6 @@
 			initial_cards += "[i] of [suit]"
 		for(var/person in list("Jack", "Queen", "King"))
 			initial_cards += "[person] of [suit]"
-
-/// triggered on wield of two handed item
-/obj/item/toy/cards/deck/proc/on_wield(obj/item/source, mob/user)
-	SIGNAL_HANDLER
-
-	wielded = TRUE
-
-/// triggered on unwield of two handed item
-/obj/item/toy/cards/deck/proc/on_unwield(obj/item/source, mob/user)
-	SIGNAL_HANDLER
-
-	wielded = FALSE
 
 /obj/item/toy/cards/deck/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] wrists with \the [src]! It looks like their luck ran out!"))
@@ -87,7 +71,7 @@
 /obj/item/toy/cards/deck/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	if(src == held_item)
 		var/obj/item/toy/cards/deck/dealer_deck = held_item
-		context[SCREENTIP_CONTEXT_LMB] = dealer_deck.wielded ? "Recycle mode" : "Dealer mode"
+		context[SCREENTIP_CONTEXT_LMB] = HAS_TRAIT(dealer_deck, TRAIT_WIELDED) ? "Recycle mode" : "Dealer mode"
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Shuffle"
 		return CONTEXTUAL_SCREENTIP_SET
 
@@ -161,7 +145,7 @@
 
 /obj/item/toy/cards/deck/AltClick(mob/living/user)
 	if(user.can_perform_action(src, NEED_DEXTERITY|FORBID_TELEKINESIS_REACH))
-		if(wielded)
+		if(HAS_TRAIT(src, TRAIT_WIELDED))
 			shuffle_cards(user)
 		else
 			to_chat(user, span_notice("You must hold the [src] with both hands to shuffle."))

--- a/code/modules/cards/deck/tarot.dm
+++ b/code/modules/cards/deck/tarot.dm
@@ -11,6 +11,12 @@
 
 /obj/item/toy/cards/deck/tarot/Initialize(mapload)
 	. = ..()
+	AddComponent( \
+		/datum/component/two_handed, \
+		attacksound = 'sound/items/cardflip.ogg', \
+		wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
+		unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
+	)
 	for(var/suit in list("Hearts", "Pikes", "Clovers", "Tiles"))
 		for(var/i in 1 to 10)
 			initial_cards += "[i] of [suit]"
@@ -36,8 +42,7 @@
 	/// ghost notification cooldown
 	COOLDOWN_DECLARE(ghost_alert_cooldown)
 
-/obj/item/toy/cards/deck/tarot/haunted/on_wield(obj/item/source, mob/living/carbon/user)
-	. = ..()
+/obj/item/toy/cards/deck/tarot/haunted/proc/on_wield(obj/item/source, mob/living/carbon/user)
 	ADD_TRAIT(user, TRAIT_SIXTHSENSE, MAGIC_TRAIT)
 	to_chat(user, span_notice("The veil to the underworld is opened. You can sense the dead souls calling out..."))
 
@@ -54,14 +59,13 @@
 		action = NOTIFY_ORBIT,
 	)
 
-/obj/item/toy/cards/deck/tarot/haunted/on_unwield(obj/item/source, mob/living/carbon/user)
-	. = ..()
+/obj/item/toy/cards/deck/tarot/haunted/proc/on_unwield(obj/item/source, mob/living/carbon/user)
 	REMOVE_TRAIT(user, TRAIT_SIXTHSENSE, MAGIC_TRAIT)
 	to_chat(user, span_notice("The veil to the underworld closes shut. You feel your senses returning to normal."))
 
 /obj/item/toy/cards/deck/tarot/haunted/dropped(mob/living/carbon/user, silent)
 	. = ..()
-	if(wielded)
+	if(HAS_TRAIT(dealer_deck, TRAIT_WIELDED))
 		REMOVE_TRAIT(user, TRAIT_SIXTHSENSE, MAGIC_TRAIT)
 		to_chat(user, span_notice("The veil to the underworld closes shut. You feel your senses returning to normal."))
 

--- a/code/modules/cards/deck/tarot.dm
+++ b/code/modules/cards/deck/tarot.dm
@@ -11,12 +11,6 @@
 
 /obj/item/toy/cards/deck/tarot/Initialize(mapload)
 	. = ..()
-	AddComponent( \
-		/datum/component/two_handed, \
-		attacksound = 'sound/items/cardflip.ogg', \
-		wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
-		unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
-	)
 	for(var/suit in list("Hearts", "Pikes", "Clovers", "Tiles"))
 		for(var/i in 1 to 10)
 			initial_cards += "[i] of [suit]"
@@ -42,6 +36,15 @@
 	/// ghost notification cooldown
 	COOLDOWN_DECLARE(ghost_alert_cooldown)
 
+/obj/item/toy/cards/deck/tarot/haunted/Initialize(mapload)
+	. = ..()
+	AddComponent( \
+		/datum/component/two_handed, \
+		attacksound = 'sound/items/cardflip.ogg', \
+		wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
+		unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
+	)
+
 /obj/item/toy/cards/deck/tarot/haunted/proc/on_wield(obj/item/source, mob/living/carbon/user)
 	ADD_TRAIT(user, TRAIT_SIXTHSENSE, MAGIC_TRAIT)
 	to_chat(user, span_notice("The veil to the underworld is opened. You can sense the dead souls calling out..."))
@@ -62,11 +65,5 @@
 /obj/item/toy/cards/deck/tarot/haunted/proc/on_unwield(obj/item/source, mob/living/carbon/user)
 	REMOVE_TRAIT(user, TRAIT_SIXTHSENSE, MAGIC_TRAIT)
 	to_chat(user, span_notice("The veil to the underworld closes shut. You feel your senses returning to normal."))
-
-/obj/item/toy/cards/deck/tarot/haunted/dropped(mob/living/carbon/user, silent)
-	. = ..()
-	if(HAS_TRAIT(dealer_deck, TRAIT_WIELDED))
-		REMOVE_TRAIT(user, TRAIT_SIXTHSENSE, MAGIC_TRAIT)
-		to_chat(user, span_notice("The veil to the underworld closes shut. You feel your senses returning to normal."))
 
 #undef TAROT_GHOST_TIMER

--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -78,7 +78,7 @@
 
 	if(istype(held_item, /obj/item/toy/cards/deck))
 		var/obj/item/toy/cards/deck/dealer_deck = held_item
-		if(dealer_deck.wielded)
+		if(HAS_TRAIT(dealer_deck, TRAIT_WIELDED))
 			context[SCREENTIP_CONTEXT_LMB] = "Deal card"
 			context[SCREENTIP_CONTEXT_RMB] = "Deal card faceup"
 			return CONTEXTUAL_SCREENTIP_SET
@@ -151,7 +151,7 @@
 
 	if(istype(item, /obj/item/toy/cards/deck))
 		var/obj/item/toy/cards/deck/dealer_deck = item
-		if(!dealer_deck.wielded) // recycle card into deck (if unwielded)
+		if(!HAS_TRAIT(dealer_deck, TRAIT_WIELDED) // recycle card into deck (if unwielded)
 			dealer_deck.insert(src)
 			user.balloon_alert_to_viewers("puts card in deck")
 			return

--- a/code/modules/cards/singlecard.dm
+++ b/code/modules/cards/singlecard.dm
@@ -151,7 +151,7 @@
 
 	if(istype(item, /obj/item/toy/cards/deck))
 		var/obj/item/toy/cards/deck/dealer_deck = item
-		if(!HAS_TRAIT(dealer_deck, TRAIT_WIELDED) // recycle card into deck (if unwielded)
+		if(!HAS_TRAIT(dealer_deck, TRAIT_WIELDED)) // recycle card into deck (if unwielded)
 			dealer_deck.insert(src)
 			user.balloon_alert_to_viewers("puts card in deck")
 			return


### PR DESCRIPTION
## About The Pull Request
we have the trait for that

## Why It's Good For The Game
Throughout UNDERTALE, we get treated to three story sequences (4 if you include flowey's fakeout but that's not important). The first is the intro story, telling the tale of humans and monsters, which shortly thereafter leads into 201X, and Chara (Toriel's house has “An old calendar from 201X.”) falling into the underground.

The second is the waterfall flashback, its contents taking place immediately after the intro segment, as a voice (Asriel) finds the fallen child.

And finally, the third takes place in the True Pacifist final boss. We'll get to it in due course, and it will have its own section, but let's address the first two. Regarding the intro, the first thought one might have is that simply, while narratively relevant, is not a diegetic presentation. However, We know that everything after the “201X” frame is Chara's memory (from an outside perspective, that is,) and we also know that UNDERTALE LOVES bringing the non-diegetic, the mechanical, the game, INTO the narrative. Saving, RPG Stats, hell, even the NarratorChara. Surely the intro can be as well? On top of this, what does the intro do for the player, as the player? Well, aside from setting the tone, the intro gives us some setting backstory. It's all important context, and it certainly helps… but it being in the intro sequence is not that important; It's all presented throughout the game via diegetic signs, books, and expositional tortoise war heroes/angry fish guardswomen. The second half is how Chara fell to the underground, and while also setting tone and informing the player how their character arrived. It also creates the false impression for the player that their character is Frisk, feeding into UNDERTALE's meta narrative; “You are not your character, and their happy ending is not yours.” If we weren't playing Chara, this would have no narrative impact. The story beat fails to land by showing us someone elses' character. But, sure. This could be a purely non-diegetic intro sequence. Simply put, The 201X portion of the intro sequence does not make sense from a diegetic or a storytelling perspective unless we play as Chara.

Flashback number two is explicitly a canonical, diegetic flashback. It occurs when Frisk escapes Undyne by falling down a massive pit… again. This time, they land in the garbage zone, black out, and have a flashback sequence of the first time Asriel found Chara. While serving the main narrative by setting up Asriel as a character, furthering the final twist of the meta narrative's pacifist route, and neatly transitioning between overworld areas, it's also very explicitly diegetic and cannot be dismissed as an intro sequence. With this in mind, one question is raised. Why do we see this flashback? If the player character is Frisk, this makes little sense, why would we see someone else's flashback and not our own? Same thing applies for a Third Entity, but even more abstract and illogical. What even are we? Sure, you could say Chara is somehow attached to us/Frisk and that somehow we get a flashback from Chara who is somehow knocked unconscious by Frisk also being knocked unconscious. I used the word somehow three times. That's not good storytelling. A simpler answer, at least in my view, is that We Are Chara. When Frisk is knocked unconscious, we, being ostensibly linked to them as a Spirit/Ghost/Reincarnation/Possessing Dead Frisk/Demon/Insert fan-theory here/SOUL Fragment, have our only connection to the world temporarily disabled, rendering us effectively unconscious and prompting a flashback. Nothing weird with multiple entities or memory sharing. The waterfall flashback is simply our memory. Simple. The simplest answers are usually the correct ones.

<details>
<summary>DO NOT RESEARCH</summary>
The third sequence is a connection/extension of the first two, displayed when we SAVE “Someone Else” during the true pacifist battle with Asriel. To refresh everyone, here is the direct quotes, taken from the Wiki:


[SAVE]: Someone Else
Strangely, as your friends remembered you... Something else began resonating within the SOUL, stronger and stronger. It seems that there's still one last person that needs to be saved. But who...? ... Suddenly, you realize. You reach out and call their name.
Asriel: “Huh? What are you doing...?”
s
It's at this point that the sequence plays. There's no narration, but we see the sequence of interactions between Asriel and Chara. There are no panels (except for the first) that don't contain the both of them. Following this, we get:

You feel your friends' SOULs resonating within ASRIEL! [This is the generic flavour text for saving all 6, before “Someone Else”, and appears at the asterisk above as well]
[SAVE]: Asriel Dreemurr
Asriel:
> “Wh... what did you do...?”
“What's this feeling…? What's happening to me?”
Etc. etc. let me win…
During my first and consecutive playthroughs of UNDERTALE, I came to the conclusion that Asriel's soul still “Had Some Chara In It.” Saving “Someone Else” was saving Chara, and then you save Asriel Dreemurr after the story sequence.

This interpretation no longer feels particularly potent to me, but in the spirit of completeness I'll address it alongside the more reasonable “You just save Asriel.” Assuming for a moment though, that we do “Save Chara”, it's not unreasonable to assume that some of Chara's ‘essence' (or whatever) was merged with Asriel's and by SAVING them, we're SAVING the part of them that's inside Asriel.

But I don't like that theory.

Let's talk about SAVING Asriel for a moment.

What is the motivation for doing that? Why would we, in universe, wish to SAVE him, something that the narration explicitly prompts us to do? He tried and probably succeeded to kill us, at least once, he wants to reset the entire timeline, he wants to erase all our friendships, all our progress.

So, why? Well, it's simple. He's our brother. And we know better than anyone that he's worth saving. And at the very least, there's something about Frisk (who appears to have absolutely no personality) that reminds him of Chara, of us. This is, by his own admission, weird;

Asriel:
“Frisk… You really ARE different from Chara. In fact, though you have similar, uh, fashion choices… I don't know why I ever acted as if you were the same person.”

To summarise.

The player SAVING Asriel Dreemurr works best if they are Chara, it becomes Chara encouraging Frisk to SAVE Asriel too.

Asriel recognises Frisk as Chara throughout the True Pacifist battle (And Beyond), despite his own admission that this is basically unfounded. Something is causing this recognition.

In Alphys' true lab, there lies a dusty TV and a stack of VHSes. On them, lie some of the last words Chara had ever heard from their father.

[Asgore] Chara! You have to stay determined! You can't give up... You are the future of humans and monsters...

These tapes are not the first time they are heard. Sleeping in Toriel's guest bed, we dream about them. Suffering a fatal injury, they echo in our ears. Watching the tape is yet another reveal. It's the chilling truth that in fact, the words we (if we die a lot) are so familiar with, are in fact the words we hear on our deathbed.

Storytelling-wise, this reveal; like all the others, fails if we do not play as Chara.

Aside from Asriel's dialogue, Chara's genocide Narration, and the coffin in Asgore's basement, this is the only time we hear Chara's name. That and, this following exchange.

[Flowey]
Hi.
…
Monsters have returned to the surface
Peace and prosperity will rule across the land.
…
Well.
There is one last thing.
…
One being with the power to erase EVERYTHING…
…
I'm talking about YOU.
…
So, please.
Just let them go.
Let Frisk be happy.
…
Well, that's all.
See you later…
Chara.
This, I think, is pretty explicitly definitive. Flowey comes to you. To us. Tells us to take a deep breath and leave the happy ending intact, then bids us farewell by our own name.

Regardless of anything else, this definitively proves Chara is the entity with the power to reset everything by the end of True Pacifist (Which is a power we have). Flowey positively identifies us as “Chara”, despite his mistake we discussed in 3C. He's not talking to Frisk, because he refers to them in the third person.

He is talking to Us. Chara.

I don't want to discuss Flowey's use of “Chara” in Genocide all that much, because the counter-argument is blindingly simple.

“By the time Flowey first says that name, Chara has overtaken Frisk by feeding on the power we create for them.”

Of course, under PlayerChara, Flowey's lines still make sense, and arguably more.

Implications
At this point, I believe the evidence is sufficient to support the theory. With this in mind, I want to discuss the implications this has on the narrative and meta-narrative. This is where all those funny glossary terms come into play.

The pacifist route in UNDERTALE, as discussed above, is textually quite simple when accepting PlayerChara. The meta-text is also relatively simple. Meta textually, the Pacifist Route is a dissection of the suspension of disbelief, examining how we emotionally place ourselves within fictional worlds, and are often-times torn away from those worlds as the game comes to an end, left wanting the true emotional connection, wanting a happy ending that cannot be good enough for us because we're real and it's not. The reflection of this meta narrative in the textual narrative, quite naturally flows. We, Chara, want a happy ending. But we can't have it, it's not our happy ending. We're gone. We've been gone a long time. Frisk's happy ending can't be good enough for us, because we won't be around to see it. So, we're left with a choice.

To let Frisk live happily? To accept an ending that might leave us emotionally wanting, yet preserves our emotional journey?

To reset? To refuse an ending and satiate our emotional emptiness, yet destroy that very emotional journey we took in the process?

The choice is the same. There is practically no separation between the diegetic and the meta.

“Can a happy ending be good enough for you?” This question applies to us, as the real world player running UNDERTALE.exe on our computer, and us, Chara, the long deceased human who can do little but watch as Frisk lives the life they wish they still had, or can destroy everything for a hollow mimicry of that very life.

This message, however, breaks down under one specific circumstance. Where we force a Third Entity into the mix. This one decision fractures the cohesion and creates a meta-textually dissonant mess. Now, all of a sudden, “Can a happy ending be good enough for you?” no longer runs parallel through both narratives. There is no reason for the Player Entity to wish to remain, the happy ending should automatically be good enough because it's the happy ending. Meanwhile, Chara, despite being an inextricable representation of “A happy ending I can't achieve,” gets absolutely nothing to do with this meta-narrative because they're just… not you.

“we are mario in Super Mario 64, but when he says "Thank you so much for playing my game!" that doesn't mean we aren't still playing as mario” - PopitTart

This is where things get weird. See, in the Genocide route.. Well, we see Chara. On Screen. Talk to us.

Now, it can easily be argued that this completely shatters the theory, but I would disagree. I'm going to endeavour to present a textual explanation (or two) for this. But first, I want to dissect the meta-text here.

Now, I'm sure the idea that “The Genocide Route's Meta-Narratve is Fading Emotional Investment and the way emotional connection with video games can lead to the very sabotage of that emotional connection” is not revolutionary. However, what's conspicuously absent from all of the third entity theorising is the way that this meta-text is mirrored in the textual narrative.

Once satisfied with a game, having extracted all lines of dialogue and stat boosts, once reaching all endings, a user will close the game down. And at some point, perhaps to make room for a new game or perhaps on a new device, will leave the game uninstalled, either deliberately, or simply as a consequence of time.

Textually, what happens in the Genocide ending?
Now we have reached the absolute.
There is nothing left for us here.
Let us erase this pointless world, and move on to the next.

The world is destroyed. So much is left unanswered here.
Who is Chara talking to?
Where did Frisk go?
How do they have this much power?
Why would they want this?
If we ‘corrupted' them, what the hell does that even mean?
What is Chara?
For now, let's talk about who Chara is talking to.

The simplest answer is “Perspective switch.” Suddenly, we're not Chara anymore, now we are Frisk. This meets all the dialogue options and even vaguely mirrors the meta-text. It also manages to avoid bringing a third entity along and so is automatically better! But, I find myself still not fully enjoying this idea.

Remember what I said about Occam's Razor?

I think there's another option. One that doesn't involve three entities, or even two entities, just Chara. One that mirrors the meta-text to a degree only Toby Fox could pull off. It's a weird one, and I don't fault you if you don't get it on your first read, but bear with me here, because things are about to get

A little
Fucking
Abstract

Let's discard any and all pre-concieved notions of anything and hold one singular truth above all else. “Chara Is The Player.” What does this mean for this cutscene?

Well… it means the player is talking to…

THe player?

It also neatly answers the question of motive, so let's throw that out the skeleton-shaped hole in the window for now.

If the player is talking to the player, this frames Chara's words in a whole new light.

Every time a number increases, that feeling… That's me. “Chara.”

This line becomes explicitly literal. The Chara on-screen is literally the player's feeling of satisfaction watching stat increases. But this is all meta-textual, right? What does this mean for the textual narrative?

Here's the thing. It can't mean anything, yet means everything.

There is no way to reconcile the fact that a Textually Real character is directly talking about what the player feels when playing a game to completion. The barrier between Meta and Textual no longer exists. It can't. Not here. And with this revelation, everything begins to make sense.

Your power awakened me from death.

Our power. Our desire to complete UNDERTALE awakens Chara from death. They become startlingly real. We imbue this fictional character with the real world desire to consume fiction, destroying enemies and worlds as we go, increasing our power and our stats. Video Game Accomplishments. And UNDERTALE has just finished being consumed.

My “human soul”... My “determination”... They were not mine, but YOURS.

Chara, the textual player, acknowledges the meta-textual player's control over the game world. A control that we surrendered. By engaging in UNDERTALE in a fully immersed way, we have fed the Diegetic character that is our player character, Chara. This has continued until we haul ourself out of the Internal Mode and into the External Mode, revoking our immersion to make the consumption of content easier, to distance ourself from the killing.

Raising our LV.

The more we distance ourselves, the less real UNDERTALE's world appears to us. Once it's done, we're ready to erase this pointless world and move onto the next. There's just one problem. UNDERTALE knows about us. It knows we exist and it will abuse that to convey meaning. By revoking our immersion in UNDERTALE, we end up shattering the barrier between Meta and Textual, and this occurs because revoking our immersion is a diegetic decision. Without this barrier, WE, as a character, gain control of UNDERTALE and use this external mode control to

Erase the world. To uninstall.


This code doesn't actually work, of course. That was pretty obvious by the fact that it didn't delete your game. But still, this exists in the code that makes the game window shake when Chara attacks it. This is, quite literally, intent for Chara to delete UNDERTALE. If you didn't think Chara was capable of uninstalling your game before, you should now.

Who is chara talking to?

Us.
How do hey have this much power?

We gave it to them. We Are them, and we deleted UNDERTALE when we were done with it.
Why would they want this?

We wanted to move onto a new game.
What is Chara?

Us. ( I'll come back to this.)
But wait! What about soulless pacifist?
Well, at that point, you've surrendered Frisk's SOUL to Chara, as in, you the real player has revoked your emotional attachment to UNDERTALE and accepted that Chara can have control over the game. You've revoked your immersion AS Chara, you no longer see yourself a Chara and as such Chara becomes their own being. You've surrendered, basically. But they let you play through it. Because why not. You might get attached again, but that's fine. All that means is that the happy ending that was once Frisk's, that you, the player, and you, Chara, both once lamented not being able to live, has now been surrendered to Chara. A warped, completionist, Chara.

You don't get your happy ending. But Chara does.

You don't even get the solace of knowing someone gets their happy ending. Because Chara gets it.

Frankly, outside of being “The Player”, I don't think the exact nature of “Chara” is that crucial. My personal thought is that they're a SOUL fragment, absorbed by Frisk when they fell on Chara's grave (Frisk could absorb a human SOUL fragment because said fragment was part monster SOUL). This fragment gives Frisk the final edge of determination needed to SAVE.

But, ultimately, that's little more than a fanfiction. And frankly, I think that's okay. Not everything needs to be impenetrable, as long as there's enough there to build a stable foundation.

I'd also like to address the nature of SAVING quickly, specifically the normal version, not the Asriel fight version. People have asked “Why do we save if it's Frisk's SOUL.” There could be many reasons. Frisk might just defer control to us. Because we're pushing Frisk over that Determination limit, we might be privileged to have that control.
</details>

## Changelog

not player visible
