### PR TITLE
Fixes some construction bugs with airlocks & windoors

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -22,6 +22,25 @@
 	. = ..()
 	. += span_notice("Has a neat <i>selection menu</i> for modifying airlock access levels.")
 
+/**
+ * Create a copy of the electronics
+ * Arguments
+ * * [location][atom]- the location to create the new copy in
+ */
+/obj/item/electronics/airlock/proc/create_copy(atom/location)
+	//create a copy
+	var/obj/item/electronics/airlock/new_electronics = new(location)
+	//copy all params
+	new_electronics.accesses = accesses.Copy()
+	new_electronics.one_access = one_access
+	new_electronics.unres_sides = unres_sides
+	new_electronics.passed_name = passed_name
+	new_electronics.passed_cycle_id = passed_cycle_id
+	new_electronics.shell = shell
+	//return copy
+	return new_electronics
+
+
 /obj/item/electronics/airlock/ui_state(mob/user)
 	return GLOB.hands_state
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -64,30 +64,6 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 	AddElement(/datum/element/atmos_sensitive, mapload)
 
-/**
- * set electronics for this windoor
- * Arguments
- * * [electronics][obj/item/electronics/airlock] - the electronics for this door
- */
-/obj/machinery/door/window/proc/set_electronics(obj/item/electronics/airlock/electronics)
-	name = electronics.passed_name || initial(name)
-	if(electronics.one_access)
-		req_one_access = electronics.accesses
-	else
-		req_access = electronics.accesses
-	if(electronics.unres_sides)
-		unres_sides = electronics.unres_sides
-		switch(dir)
-			if(NORTH,SOUTH)
-				unres_sides &= ~EAST
-				unres_sides &= ~WEST
-			if(EAST,WEST)
-				unres_sides &= ~NORTH
-				unres_sides &= ~SOUTH
-		unres_sensor = TRUE
-	src.electronics = electronics
-	electronics.forceMove(src)
-
 /obj/machinery/door/window/Destroy()
 	set_density(FALSE)
 	if(atom_integrity == 0)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -64,6 +64,30 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 	AddElement(/datum/element/atmos_sensitive, mapload)
 
+/**
+ * set electronics for this windoor
+ * Arguments
+ * * [electronics][obj/item/electronics/airlock] - the electronics for this door
+ */
+/obj/machinery/door/window/proc/set_electronics(obj/item/electronics/airlock/electronics)
+	name = electronics.passed_name || initial(name)
+	if(electronics.one_access)
+		req_one_access = electronics.accesses
+	else
+		req_access = electronics.accesses
+	if(electronics.unres_sides)
+		unres_sides = electronics.unres_sides
+		switch(dir)
+			if(NORTH,SOUTH)
+				unres_sides &= ~EAST
+				unres_sides &= ~WEST
+			if(EAST,WEST)
+				unres_sides &= ~NORTH
+				unres_sides &= ~SOUTH
+		unres_sensor = TRUE
+	src.electronics = electronics
+	electronics.forceMove(src)
+
 /obj/machinery/door/window/Destroy()
 	set_density(FALSE)
 	if(atom_integrity == 0)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -320,9 +320,11 @@
 		door.unres_sensor = TRUE
 	door.previous_airlock = previous_assembly
 	electronics.forceMove(door)
+	door.autoclose = TRUE
+	door.close()
 	door.update_appearance()
+
 	qdel(src)
-	return door
 
 /obj/structure/door_assembly/update_overlays()
 	. = ..()

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -293,7 +293,6 @@
 		door = new airlock_type( loc )
 	door.setDir(dir)
 	door.unres_sides = electronics.unres_sides
-	//door.req_access = req_access
 	door.electronics = electronics
 	door.heat_proof = heat_proof_finished
 	door.security_level = 0

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -271,51 +271,32 @@
 					set_density(TRUE) //Shouldn't matter but just incase
 					to_chat(user, span_notice("You finish the windoor."))
 
+					var/obj/machinery/door/window/windoor
 					if(secure)
-						var/obj/machinery/door/window/brigdoor/windoor = new /obj/machinery/door/window/brigdoor(loc)
+						windoor = new /obj/machinery/door/window/brigdoor(loc)
 						if(facing == "l")
 							windoor.icon_state = "leftsecureopen"
 							windoor.base_state = "leftsecure"
 						else
 							windoor.icon_state = "rightsecureopen"
 							windoor.base_state = "rightsecure"
-						windoor.setDir(dir)
-						windoor.set_density(FALSE)
-
-						if(electronics.one_access)
-							windoor.req_one_access = electronics.accesses
-						else
-							windoor.req_access = electronics.accesses
-						windoor.electronics = electronics
-						electronics.forceMove(windoor)
-						if(created_name)
-							windoor.name = created_name
-						qdel(src)
-						windoor.close()
-
 
 					else
-						var/obj/machinery/door/window/windoor = new /obj/machinery/door/window(loc)
+						windoor = new /obj/machinery/door/window(loc)
 						if(facing == "l")
 							windoor.icon_state = "leftopen"
 							windoor.base_state = "left"
 						else
 							windoor.icon_state = "rightopen"
 							windoor.base_state = "right"
-						windoor.setDir(dir)
-						windoor.set_density(FALSE)
 
-						if(electronics.one_access)
-							windoor.req_one_access = electronics.accesses
-						else
-							windoor.req_access = electronics.accesses
-						windoor.electronics = electronics
-						electronics.forceMove(windoor)
-						if(created_name)
-							windoor.name = created_name
-						qdel(src)
-						windoor.close()
-
+					windoor.setDir(dir)
+					windoor.set_density(FALSE)
+					windoor.set_electronics(electronics)
+					if(created_name)
+						windoor.name = created_name
+					qdel(src)
+					windoor.close()
 
 			else
 				return ..()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -30,7 +30,7 @@
 	var/state = "01" //How far the door assembly has progressed
 	can_atmos_pass = ATMOS_PASS_PROC
 
-/obj/structure/windoor_assembly/Initialize(mapload, loc, set_dir)
+/obj/structure/windoor_assembly/Initialize(mapload, set_dir)
 	. = ..()
 	if(set_dir)
 		setDir(set_dir)
@@ -267,42 +267,65 @@
 					span_notice("You start prying the windoor into the frame..."))
 
 				if(W.use_tool(src, user, 40, volume=100) && electronics)
-
 					set_density(TRUE) //Shouldn't matter but just incase
+
 					to_chat(user, span_notice("You finish the windoor."))
 
-					var/obj/machinery/door/window/windoor
-					if(secure)
-						windoor = new /obj/machinery/door/window/brigdoor(loc)
-						if(facing == "l")
-							windoor.icon_state = "leftsecureopen"
-							windoor.base_state = "leftsecure"
-						else
-							windoor.icon_state = "rightsecureopen"
-							windoor.base_state = "rightsecure"
-
-					else
-						windoor = new /obj/machinery/door/window(loc)
-						if(facing == "l")
-							windoor.icon_state = "leftopen"
-							windoor.base_state = "left"
-						else
-							windoor.icon_state = "rightopen"
-							windoor.base_state = "right"
-
-					windoor.setDir(dir)
-					windoor.set_density(FALSE)
-					windoor.set_electronics(electronics)
-					if(created_name)
-						windoor.name = created_name
-					qdel(src)
-					windoor.close()
+					finish_door()
 
 			else
 				return ..()
 
 	//Update to reflect changes(if applicable)
 	update_appearance()
+
+/obj/structure/windoor_assembly/proc/finish_door()
+	var/obj/machinery/door/window/windoor
+	if(secure)
+		windoor = new /obj/machinery/door/window/brigdoor(loc)
+		if(facing == "l")
+			windoor.icon_state = "leftsecureopen"
+			windoor.base_state = "leftsecure"
+		else
+			windoor.icon_state = "rightsecureopen"
+			windoor.base_state = "rightsecure"
+
+	else
+		windoor = new /obj/machinery/door/window(loc)
+		if(facing == "l")
+			windoor.icon_state = "leftopen"
+			windoor.base_state = "left"
+		else
+			windoor.icon_state = "rightopen"
+			windoor.base_state = "right"
+
+	windoor.setDir(dir)
+	windoor.set_density(FALSE)
+	if(created_name)
+		windoor.name = created_name
+	else if(electronics.passed_name)
+		windoor.name = electronics.passed_name
+	if(electronics.one_access)
+		windoor.req_one_access = electronics.accesses
+	else
+		windoor.req_access = electronics.accesses
+	if(electronics.unres_sides)
+		windoor.unres_sides = electronics.unres_sides
+		switch(dir)
+			if(NORTH,SOUTH)
+				windoor.unres_sides &= ~EAST
+				windoor.unres_sides &= ~WEST
+			if(EAST,WEST)
+				windoor.unres_sides &= ~NORTH
+				windoor.unres_sides &= ~SOUTH
+		windoor.unres_sensor = TRUE
+	electronics.forceMove(windoor)
+	windoor.electronics = electronics
+	windoor.autoclose = TRUE
+	windoor.close()
+	windoor.update_appearance()
+
+	qdel(src)
 
 /obj/structure/windoor_assembly/AltClick(mob/user)
 	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -295,10 +295,11 @@
 						continue
 					balloon_alert(user, "there's already a door!")
 					return FALSE
-				var/obj/machinery/door/window/new_window = new the_rcd.airlock_type(src, user.dir)
-				new_window.set_electronics(the_rcd.airlock_electronics.create_copy(new_window))
-				new_window.autoclose = TRUE
-				new_window.update_appearance()
+				//create the assembly and let it finish itself
+				var/obj/structure/windoor_assembly/assembly = new /obj/structure/windoor_assembly(src, user.dir)
+				assembly.secure = ispath(the_rcd.airlock_type, /obj/machinery/door/window/brigdoor)
+				assembly.electronics = the_rcd.airlock_electronics.create_copy(assembly)
+				assembly.finish_door()
 				return TRUE
 
 			for(var/obj/machinery/door/door in src)
@@ -306,6 +307,7 @@
 					continue
 				balloon_alert(user, "there's already a door!")
 				return FALSE
+			//create the assembly and let it finish itself
 			var/obj/structure/door_assembly/assembly = new (src)
 			if(ispath(the_rcd.airlock_type, /obj/machinery/door/airlock/glass))
 				assembly.glass = TRUE

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -295,13 +295,8 @@
 						continue
 					balloon_alert(user, "there's already a door!")
 					return FALSE
-				var/obj/machinery/door/window/new_window = new the_rcd.airlock_type(src, user.dir, the_rcd.airlock_electronics?.unres_sides)
-				if(the_rcd.airlock_electronics)
-					new_window.name = the_rcd.airlock_electronics.passed_name || initial(new_window.name)
-					if(the_rcd.airlock_electronics.one_access)
-						new_window.req_one_access = the_rcd.airlock_electronics.accesses.Copy()
-					else
-						new_window.req_access = the_rcd.airlock_electronics.accesses.Copy()
+				var/obj/machinery/door/window/new_window = new the_rcd.airlock_type(src, user.dir)
+				new_window.set_electronics(the_rcd.airlock_electronics.create_copy(new_window))
 				new_window.autoclose = TRUE
 				new_window.update_appearance()
 				return TRUE
@@ -311,29 +306,14 @@
 					continue
 				balloon_alert(user, "there's already a door!")
 				return FALSE
-			var/obj/machinery/door/airlock/new_airlock = new the_rcd.airlock_type(src)
-			new_airlock.electronics = new /obj/item/electronics/airlock(new_airlock)
-			if(the_rcd.airlock_electronics)
-				new_airlock.electronics.accesses = the_rcd.airlock_electronics.accesses.Copy()
-				new_airlock.electronics.one_access = the_rcd.airlock_electronics.one_access
-				new_airlock.electronics.unres_sides = the_rcd.airlock_electronics.unres_sides
-				new_airlock.electronics.passed_name = the_rcd.airlock_electronics.passed_name
-				new_airlock.electronics.passed_cycle_id = the_rcd.airlock_electronics.passed_cycle_id
-				new_airlock.electronics.shell = the_rcd.airlock_electronics.shell
-			if(new_airlock.electronics.one_access)
-				new_airlock.req_one_access = new_airlock.electronics.accesses
+			var/obj/structure/door_assembly/assembly = new(src)
+			if(ispath(the_rcd.airlock_type, /obj/machinery/door/airlock/glass))
+				assembly.glass = TRUE
+				assembly.glass_type = the_rcd.airlock_type
 			else
-				new_airlock.req_access = new_airlock.electronics.accesses
-			if(new_airlock.electronics.unres_sides)
-				new_airlock.unres_sides = new_airlock.electronics.unres_sides
-				new_airlock.unres_sensor = TRUE
-			if(new_airlock.electronics.passed_name)
-				new_airlock.name = sanitize(new_airlock.electronics.passed_name)
-			if(new_airlock.electronics.passed_cycle_id)
-				new_airlock.closeOtherId = new_airlock.electronics.passed_cycle_id
-				new_airlock.update_other_id()
-			new_airlock.autoclose = TRUE
-			new_airlock.update_appearance()
+				assembly.airlock_type = the_rcd.airlock_type
+			assembly.electronics = the_rcd.airlock_electronics.create_copy(assembly)
+			assembly.finish_door()
 			return TRUE
 		if(RCD_DECONSTRUCT)
 			if(rcd_proof)

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -306,7 +306,7 @@
 					continue
 				balloon_alert(user, "there's already a door!")
 				return FALSE
-			var/obj/structure/door_assembly/assembly = new(src)
+			var/obj/structure/door_assembly/assembly = new (src)
 			if(ispath(the_rcd.airlock_type, /obj/machinery/door/airlock/glass))
 				assembly.glass = TRUE
 				assembly.glass_type = the_rcd.airlock_type


### PR DESCRIPTION
## About The Pull Request
1. Fixes #77981. the airlock electronics `unres_sides` and `unres_sensor` vars were not copied onto the windoor after its construction was finished manually without RCD. Now a windoor assembly is spawned and it is finished by the RCD just like you would do manually

2. Windoors created via RCD did not have any electronics installed inside them. It would only copy the `access` and `passed_name` vars onto the windoor, leaving its `electronics` var blank. It's also fixed by the windoor assembly

3. Airlocks constructed via RCD now uses the `finish_door()` proc of an airlock assembly to correctly complete an airlock. This proc does important stuff such as adding the `/datum/component/shell` component when the airlock electronics requests shell control and the RCD was skipping over these steps. That's fixed now too

## Changelog
:cl:
fix: Manually constructed windoors have correct unrestricted accesses applied to them
fix: Windoors created via RCD now actually have electronics inside them
fix: Airlocks constructed via RCD have the shell component correctly installed inside them and have no other missing variables 
/:cl:
