### PR TITLE
Split Run Linters step into multiple steps

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -55,47 +55,44 @@ jobs:
         id: linter-setup
         run: ':'
       - name: Check File Directories
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: bash tools/ci/check_filedirs.sh tgstation.dme
       - name: Check Changelogs
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: bash tools/ci/check_changelogs.sh
-      - name: Check File Names
-        if: steps.linter-setup.conclusion == 'success'
-        run: bash tools/ci/check_filenames.sh tgstation.dme
       - name: Run Grep Checks
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: bash tools/ci/check_grep.sh
       - name: Check Miscellaneous Files
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: bash tools/ci/check_misc.sh
       - name: Ticked File Enforcement (tgstation.dme)
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/tgstation_dme.json
       - name: Ticked File Enforcement (unit_tests.json)
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/unit_tests.json
       - name: Run Map Linter
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: tools/bootstrap/python -m tools.maplint.source
       - name: Run TGUI Tests
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: tools/build/build --ci lint tgui-test
       - name: Run Define Sanity Check
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: tools/bootstrap/python -m define_sanity.check
       - name: Run DMI Tests
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: tools/bootstrap/python -m dmi.test
       - name: Run Mapmerge2 Tests
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: tools/bootstrap/python -m mapmerge2.dmm_test
       - name: Run DreamChecker
-        if: steps.linter-setup.conclusion == 'success'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
         id: dreamchecker
         run: ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
-        if: steps.linter-setup.conclusion == 'success' && steps.dreamchecker.outcome == 'failure'
+        if: steps.linter-setup.conclusion == 'success' && !cancelled() && steps.dreamchecker.outcome == 'failure'
         uses: yogstation13/DreamAnnotate@v2
         with:
           outputFile: output-annotations.txt

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -87,13 +87,13 @@ jobs:
       - name: Run Mapmerge2 Tests
         if: "!cancelled()"
         run: tools/bootstrap/python -m mapmerge2.dmm_test
-      - name: Run Dreamchecker
-        id: dreamchecker
+      - name: Run DreamChecker
         if: "!cancelled()"
+        id: dreamchecker
         run: ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
+        if: steps.dreamchecker.outcome == 'failure' && !cancelled()
         uses: yogstation13/DreamAnnotate@v2
-        if: steps.dreamchecker.outcome == 'failure'
         with:
           outputFile: output-annotations.txt
 

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -51,23 +51,49 @@ jobs:
           bash tools/ci/install_spaceman_dmm.sh dreamchecker
           cargo install ripgrep --features pcre2
           tools/bootstrap/python -c ''
-      - name: Run Linters
-        run: |
-          bash tools/ci/check_filedirs.sh tgstation.dme
-          bash tools/ci/check_changelogs.sh
-          bash tools/ci/check_grep.sh
-          bash tools/ci/check_misc.sh
-          tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/tgstation_dme.json
-          tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/unit_tests.json
-          tools/bootstrap/python -m tools.maplint.source --github
-          tools/build/build --ci lint tgui-test
-          tools/bootstrap/python -m define_sanity.check
-          tools/bootstrap/python -m dmi.test
-          tools/bootstrap/python -m mapmerge2.dmm_test
-          ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
+      - name: Check File Directories
+        if: "!cancelled()"
+        run: bash tools/ci/check_filedirs.sh tgstation.dme
+      - name: Check Changelogs
+        if: "!cancelled()"
+        run: bash tools/ci/check_changelogs.sh
+      - name: Check File Names
+        if: "!cancelled()"
+        run: bash tools/ci/check_filenames.sh tgstation.dme
+      - name: Run Grep Checks
+        if: "!cancelled()"
+        run: bash tools/ci/check_grep.sh
+      - name: Check Miscellaneous Files
+        if: "!cancelled()"
+        run: bash tools/ci/check_misc.sh
+      - name: Ticked File Enforcement (tgstation.dme)
+        if: "!cancelled()"
+        run: tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/tgstation_dme.json
+      - name: Ticked File Enforcement (unit_tests.json)
+        if: "!cancelled()"
+        run: tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/unit_tests.json
+      - name: Run Map Linter
+        if: "!cancelled()"
+        run: tools/bootstrap/python -m tools.maplint.source
+      - name: Run TGUI Tests
+        if: "!cancelled()"
+        run: tools/build/build --ci lint tgui-test
+      - name: Run Define Sanity Check
+        if: "!cancelled()"
+        run: tools/bootstrap/python -m define_sanity.check
+      - name: Run DMI Tests
+        if: "!cancelled()"
+        run: tools/bootstrap/python -m dmi.test
+      - name: Run Mapmerge2 Tests
+        if: "!cancelled()"
+        run: tools/bootstrap/python -m mapmerge2.dmm_test
+      - name: Run Dreamchecker
+        id: dreamchecker
+        if: "!cancelled()"
+        run: ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
         uses: yogstation13/DreamAnnotate@v2
-        if: success() || failure()
+        if: steps.dreamchecker.outcome == 'failure'
         with:
           outputFile: output-annotations.txt
 

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -51,48 +51,51 @@ jobs:
           bash tools/ci/install_spaceman_dmm.sh dreamchecker
           cargo install ripgrep --features pcre2
           tools/bootstrap/python -c ''
+      - name: Give Linters A Go
+        id: linter-setup
+        run: ':'
       - name: Check File Directories
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: bash tools/ci/check_filedirs.sh tgstation.dme
       - name: Check Changelogs
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: bash tools/ci/check_changelogs.sh
       - name: Check File Names
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: bash tools/ci/check_filenames.sh tgstation.dme
       - name: Run Grep Checks
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: bash tools/ci/check_grep.sh
       - name: Check Miscellaneous Files
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: bash tools/ci/check_misc.sh
       - name: Ticked File Enforcement (tgstation.dme)
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/tgstation_dme.json
       - name: Ticked File Enforcement (unit_tests.json)
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/unit_tests.json
       - name: Run Map Linter
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: tools/bootstrap/python -m tools.maplint.source
       - name: Run TGUI Tests
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: tools/build/build --ci lint tgui-test
       - name: Run Define Sanity Check
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: tools/bootstrap/python -m define_sanity.check
       - name: Run DMI Tests
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: tools/bootstrap/python -m dmi.test
       - name: Run Mapmerge2 Tests
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         run: tools/bootstrap/python -m mapmerge2.dmm_test
       - name: Run DreamChecker
-        if: "!cancelled()"
+        if: steps.linter-setup.conclusion == 'success'
         id: dreamchecker
         run: ~/dreamchecker > ${GITHUB_WORKSPACE}/output-annotations.txt 2>&1
       - name: Annotate Lints
-        if: steps.dreamchecker.outcome == 'failure' && !cancelled()
+        if: steps.linter-setup.conclusion == 'success' && steps.dreamchecker.outcome == 'failure'
         uses: yogstation13/DreamAnnotate@v2
         with:
           outputFile: output-annotations.txt

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -54,42 +54,41 @@ jobs:
       - name: Give Linters A Go
         id: linter-setup
         run: ':'
+      - name: Run Grep Checks
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
+        run: bash tools/ci/check_grep.sh
+      - name: Ticked File Enforcement
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
+        run: |
+          set +e
+          tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/tgstation_dme.json
+          tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/unit_tests.json
+      - name: Check Define Sanity
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
+        run: tools/bootstrap/python -m define_sanity.check
+      - name: Run DreamChecker
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
+        run: ~/dreamchecker 2>&1 | bash tools/ci/annotate_dm.sh
+      - name: Run Map Checks
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
+        run: |
+          tools/bootstrap/python -m mapmerge2.dmm_test
+          tools/bootstrap/python -m tools.maplint.source
+      - name: Run DMI Tests
+        if: steps.linter-setup.conclusion == 'success' && !cancelled()
+        run: tools/bootstrap/python -m dmi.test
       - name: Check File Directories
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: bash tools/ci/check_filedirs.sh tgstation.dme
       - name: Check Changelogs
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: bash tools/ci/check_changelogs.sh
-      - name: Run Grep Checks
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        run: bash tools/ci/check_grep.sh
       - name: Check Miscellaneous Files
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: bash tools/ci/check_misc.sh
-      - name: Ticked File Enforcement (tgstation.dme)
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        run: tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/tgstation_dme.json
-      - name: Ticked File Enforcement (unit_tests.json)
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        run: tools/bootstrap/python tools/ticked_file_enforcement/ticked_file_enforcement.py < tools/ticked_file_enforcement/schemas/unit_tests.json
-      - name: Run Map Linter
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        run: tools/bootstrap/python -m tools.maplint.source
-      - name: Run TGUI Tests
+      - name: Run TGUI Checks
         if: steps.linter-setup.conclusion == 'success' && !cancelled()
         run: tools/build/build --ci lint tgui-test
-      - name: Run Define Sanity Check
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        run: tools/bootstrap/python -m define_sanity.check
-      - name: Run DMI Tests
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        run: tools/bootstrap/python -m dmi.test
-      - name: Run Mapmerge2 Tests
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        run: tools/bootstrap/python -m mapmerge2.dmm_test
-      - name: Run DreamChecker
-        if: steps.linter-setup.conclusion == 'success' && !cancelled()
-        run: ~/dreamchecker 2>&1 | bash tools/ci/annotate_dm.sh
 
   compile_all_maps:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"


### PR DESCRIPTION
## About The Pull Request

Splits the big "Run Linters" step into multiple steps. Also since all of these steps are independent of eachother, I've made them all run regardless of if the job is currently failing.

<details>
<summary>Proof of testing:</summary>

Fail in install tools, all linting steps are skipped: https://github.com/distributivgesetz/tgstation/actions/runs/6151628214/job/16692089726
Fail in Run DreamChecker, other steps continue to run: https://github.com/distributivgesetz/tgstation/actions/runs/6151664705/job/16692203569?pr=2
</details>

<details>
<summary>Pictured: me breaking CI for a day</summary>

https://github.com/tgstation/tgstation/assets/47710522/ea12ad30-2b69-4aa3-9642-7d0818eab2d1


</details>

## Why It's Good For The Game

Going through the Run Linters step has always been a slog. Finding an error is like finding a needle in a haystack. Seeing what command exactly went wrong is going to go a long way in helping people find out which linters have failed.

## Changelog
nothing playerfacing
