### PR TITLE
Add hypnosis vulnerability for drugged victims

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1162,7 +1162,7 @@
 /mob/living/carbon/proc/hypnosis_vulnerable()
 	if(HAS_TRAIT(src, TRAIT_MINDSHIELD))
 		return FALSE
-	if(has_status_effect(/datum/status_effect/hallucination))
+	if(has_status_effect(/datum/status_effect/hallucination) || has_status_effect(/datum/status_effect/drugginess))
 		return TRUE
 	if(IsSleeping() || IsUnconscious())
 		return TRUE


### PR DESCRIPTION
## About The Pull Request
This allows you to hypnotize drugged victims.

## Why It's Good For The Game
I was surprised to discover that not all drug induced effects allow people to be vulnerable to hypnosis.

## Changelog
:cl:
balance: Add hypnosis vulnerability for drugged victims
/:cl:
