### PR TITLE
Refactors & patches for grinding & juicing

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -965,11 +965,10 @@
 /obj/item/proc/grind(datum/reagents/target_holder, mob/user)
 	if(on_grind() == -1)
 		return FALSE
-	if(!reagents)
-		reagents = new()
-	target_holder.add_reagent_list(grind_results)
-	if(reagents && target_holder)
-		reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
+	if(target_holder)
+		target_holder.add_reagent_list(grind_results)
+		if(reagents)
+			reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
 	return TRUE
 
 ///Called BEFORE the object is ground up - use this to change grind results based on conditions. Return "-1" to prevent the grinding from occurring
@@ -982,9 +981,10 @@
 /obj/item/proc/juice(datum/reagents/target_holder, mob/user)
 	if(on_juice() == -1)
 		return FALSE
-	reagents.convert_reagent(/datum/reagent/consumable, juice_typepath, include_source_subtypes = TRUE)
-	if(reagents && target_holder)
-		reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
+	if(reagents)
+		reagents.convert_reagent(/datum/reagent/consumable, juice_typepath, include_source_subtypes = TRUE)
+		if(target_holder)
+			reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
 	return TRUE
 
 /obj/item/proc/set_force_string()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -145,16 +145,48 @@
 /obj/item/stack/set_custom_materials(list/materials, multiplier=1, is_update=FALSE)
 	return is_update ? ..() : set_mats_per_unit(materials, multiplier/(amount || 1))
 
-
-/obj/item/stack/on_grind()
-	. = ..()
-	for(var/i in 1 to length(grind_results)) //This should only call if it's ground, so no need to check if grind_results exists
-		grind_results[grind_results[i]] *= get_amount() //Gets the key at position i, then the reagent amount of that key, then multiplies it by stack size
-
 /obj/item/stack/grind_requirements()
 	if(is_cyborg)
 		to_chat(usr, span_warning("[src] is too integrated into your chassis and can't be ground up!"))
 		return
+	return TRUE
+
+/obj/item/stack/grind(datum/reagents/target_holder, mob/user)
+	var/current_amount = get_amount()
+	if(current_amount <= 0 || QDELETED(src)) //just to get rid of this 0 amount/deleted stack we return suceess
+		return TRUE
+	if(on_grind() == -1)
+		return FALSE
+
+	if(target_holder)
+		if(reagents)
+			reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
+		var/available_volume = target_holder.maximum_volume - target_holder.total_volume
+
+		//compute total volume of reagents that will be occupied by grind_results
+		var/total_volume = 0
+		for(var/reagent in grind_results)
+			total_volume += grind_results[reagent]
+
+		//compute number of pieces(or sheets) from available_volume
+		var/available_amount = min(current_amount, round(available_volume / total_volume))
+		if(available_amount <= 0)
+			return FALSE
+
+		//Now transfer the grind results scaled by available_amount
+		var/list/grind_reagents = grind_results.Copy()
+		for(var/reagent in grind_reagents)
+			grind_reagents[reagent] *= available_amount
+		target_holder.add_reagent_list(grind_reagents)
+
+		/**
+		 * use available_amount of sheets/pieces, return TRUE only if all sheets/pieces of this stack were used
+		 * we don't delete this stack when it reaches 0 because we expect the all in one grinder, etc to delete
+		 * this stack when grinding if successfull
+		 */
+		use(available_amount, check = FALSE)
+		return available_amount == current_amount
+
 	return TRUE
 
 /obj/item/stack/proc/get_main_recipes()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -157,37 +157,36 @@
 		return TRUE
 	if(on_grind() == -1)
 		return FALSE
+	if(isnull(target_holder))
+		return TRUE
 
-	if(target_holder)
-		if(reagents)
-			reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
-		var/available_volume = target_holder.maximum_volume - target_holder.total_volume
+	if(reagents)
+		reagents.trans_to(target_holder, reagents.total_volume, transferred_by = user)
+	var/available_volume = target_holder.maximum_volume - target_holder.total_volume
 
-		//compute total volume of reagents that will be occupied by grind_results
-		var/total_volume = 0
-		for(var/reagent in grind_results)
-			total_volume += grind_results[reagent]
+	//compute total volume of reagents that will be occupied by grind_results
+	var/total_volume = 0
+	for(var/reagent in grind_results)
+		total_volume += grind_results[reagent]
 
-		//compute number of pieces(or sheets) from available_volume
-		var/available_amount = min(current_amount, round(available_volume / total_volume))
-		if(available_amount <= 0)
-			return FALSE
+	//compute number of pieces(or sheets) from available_volume
+	var/available_amount = min(current_amount, round(available_volume / total_volume))
+	if(available_amount <= 0)
+		return FALSE
 
-		//Now transfer the grind results scaled by available_amount
-		var/list/grind_reagents = grind_results.Copy()
-		for(var/reagent in grind_reagents)
-			grind_reagents[reagent] *= available_amount
-		target_holder.add_reagent_list(grind_reagents)
+	//Now transfer the grind results scaled by available_amount
+	var/list/grind_reagents = grind_results.Copy()
+	for(var/reagent in grind_reagents)
+		grind_reagents[reagent] *= available_amount
+	target_holder.add_reagent_list(grind_reagents)
 
-		/**
-		 * use available_amount of sheets/pieces, return TRUE only if all sheets/pieces of this stack were used
-		 * we don't delete this stack when it reaches 0 because we expect the all in one grinder, etc to delete
-		 * this stack if grinding was successfull
-		 */
-		use(available_amount, check = FALSE)
-		return available_amount == current_amount
-
-	return TRUE
+	/**
+	 * use available_amount of sheets/pieces, return TRUE only if all sheets/pieces of this stack were used
+	 * we don't delete this stack when it reaches 0 because we expect the all in one grinder, etc to delete
+	 * this stack if grinding was successfull
+	 */
+	use(available_amount, check = FALSE)
+	return available_amount == current_amount
 
 /obj/item/stack/proc/get_main_recipes()
 	RETURN_TYPE(/list)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -153,7 +153,7 @@
 
 /obj/item/stack/grind(datum/reagents/target_holder, mob/user)
 	var/current_amount = get_amount()
-	if(current_amount <= 0 || QDELETED(src)) //just to get rid of this 0 amount/deleted stack we return suceess
+	if(current_amount <= 0 || QDELETED(src)) //just to get rid of this 0 amount/deleted stack we return success
 		return TRUE
 	if(on_grind() == -1)
 		return FALSE
@@ -182,7 +182,7 @@
 		/**
 		 * use available_amount of sheets/pieces, return TRUE only if all sheets/pieces of this stack were used
 		 * we don't delete this stack when it reaches 0 because we expect the all in one grinder, etc to delete
-		 * this stack when grinding if successfull
+		 * this stack if grinding was successfull
 		 */
 		use(available_amount, check = FALSE)
 		return available_amount == current_amount

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -44,7 +44,7 @@
 /**
  * Grinds/Juices the atom
  * Arguments
- * * [AM][atom] - the atom to grind
+ * * [AM][atom] - the atom to grind or juice
  */
 /obj/machinery/plumbing/grinder_chemical/proc/grind(atom/AM)
 	if(machine_stat & NOPOWER)

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -1,6 +1,6 @@
 /obj/machinery/plumbing/grinder_chemical
 	name = "chemical grinder"
-	desc = "Chemical grinder. Can either grind or juice stuff you put in"
+	desc = "Chemical grinder. Can either grind or juice stuff you put in."
 	icon_state = "grinder_chemical"
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = ABOVE_GAME_PLANE

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -19,7 +19,7 @@
 
 /obj/machinery/plumbing/grinder_chemical/attackby(obj/item/weapon, mob/user, params)
 	if(istype(weapon, /obj/item/storage))
-		to_chat(user, span_notice("You dump items from the bag into the grinder."))
+		to_chat(user, span_notice("You dump items from [weapon] into the grinder."))
 		for(var/obj/item/item as anything in weapon.contents)
 			grind(item)
 	else

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -1,6 +1,3 @@
-#define GRIND 1
-#define JUICE 0
-
 /obj/machinery/plumbing/grinder_chemical
 	name = "chemical grinder"
 	desc = "Chemical grinder. Can either grind or juice stuff you put in"
@@ -11,80 +8,59 @@
 	reagent_flags = TRANSPARENT | DRAINABLE
 	buffer = 400
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2
-	/// Operation mode
-	var/operation_mode = GRIND
-	/// Radial menu to change operating mode
-	var/static/list/operations
 
 /obj/machinery/plumbing/grinder_chemical/Initialize(mapload, bolt, layer)
 	. = ..()
 	AddComponent(/datum/component/plumbing/simple_supply, bolt, layer)
-
-	if(!length(operations))
-		operations = list(
-			"grind" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_grind"),
-			"juice" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_juice")
-		)
-
-/obj/machinery/plumbing/grinder_chemical/examine(mob/user)
-	. = ..()
-	var/text_mode = operation_mode == GRIND ? "grind" : "juice"
-	. += span_notice("Its currently in [EXAMINE_HINT(text_mode)] mode")
-
-/obj/machinery/plumbing/grinder_chemical/attack_hand(mob/living/user, list/modifiers)
-	. = ..()
-	if(!user.can_perform_action(src, ALLOW_SILICON_REACH) || !anchored)
-		return
-
-	var/choice = show_radial_menu(user, src, operations, require_near = !issilicon(user))
-	if(!choice)
-		return
-
-	switch(choice)
-		if("grind")
-			operation_mode = GRIND
-		else
-			operation_mode = JUICE
-
-	to_chat(user, "operating mode changed to [operation_mode = GRIND ? "grind" : "juice"]")
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/machinery/plumbing/grinder_chemical/attackby(obj/item/weapon, mob/user, params)
-	. = TRUE
+	if(istype(weapon, /obj/item/storage))
+		to_chat(user, span_notice("You dump items from the bag into the grinder."))
+		for(var/obj/item/item as anything in weapon.contents)
+			grind(item)
+	else
+		to_chat(user, span_notice("You attempt to grind [weapon]."))
+		grind(weapon)
 
+	return TRUE
+
+/obj/machinery/plumbing/grinder_chemical/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
 	if(!anchored)
 		return
+	if(!istype(mover, /obj/item))
+		return FALSE
+	return TRUE
+
+/obj/machinery/plumbing/grinder_chemical/proc/on_entered(datum/source, atom/movable/AM)
+	SIGNAL_HANDLER
+
+	grind(AM)
+
+/**
+ * Grinds/Juices the atom
+ * Arguments
+ * * [AM][atom] - the atom to grind
+ */
+/obj/machinery/plumbing/grinder_chemical/proc/grind(atom/AM)
 	if(machine_stat & NOPOWER)
 		return
 	if(reagents.holder_full())
-		to_chat(user, span_warning("[src] has no more space."))
+		return
+	if(!isitem(AM))
 		return
 
-	if(operation_mode == GRIND)
-		to_chat(user, span_notice("[src] attempts to grind [weapon]."))
-		if(weapon.grind_results)
-			use_power(active_power_usage)
-			if(weapon.grind(reagents, user))
-				to_chat(user, span_green("[src] succeeds in grinding [weapon]."))
-				qdel(weapon)
-			else
-				if(isstack(weapon))
-					to_chat(user, span_notice("[src] grinds as many pieces of [weapon] as possible."))
-				else
-					to_chat(user, span_warning("[src] failed to grind [weapon]."))
-		else
-			to_chat(user, span_warning("[src] is unable to grind [weapon]."))
-
-	else
-		to_chat(user, span_notice("[src] attempts to juice [weapon]."))
-		if(weapon.juice_typepath)
-			use_power(active_power_usage)
-			if(weapon.juice(reagents, user))
-				to_chat(user, span_green("[src] succeeds in juicing [weapon]."))
-				qdel(weapon)
-			else
-				to_chat(user, span_warning("[src] failed to juice [weapon]."))
-		else
-			to_chat(user, span_warning("[src] is unable to juice [weapon]."))
-
-#undef GRIND
-#undef JUICE
+	var/obj/item/I = AM
+	var/result
+	if(I.grind_results || I.juice_typepath)
+		use_power(active_power_usage)
+		if(I.grind_results)
+			result = I.grind(reagents, usr)
+		else if (I.juice_typepath)
+			result = I.juice(reagents, usr)
+		if(result)
+			qdel(I)

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -18,10 +18,10 @@
 	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/machinery/plumbing/grinder_chemical/attackby(obj/item/weapon, mob/user, params)
-	if(istype(weapon, /obj/item/storage))
+	if(istype(weapon, /obj/item/storage/bag))
 		to_chat(user, span_notice("You dump items from [weapon] into the grinder."))
-		for(var/obj/item/item as anything in weapon.contents)
-			grind(item)
+		for(var/obj/item/obj_item in weapon.contents)
+			grind(obj_item)
 	else
 		to_chat(user, span_notice("You attempt to grind [weapon]."))
 		grind(weapon)

--- a/code/modules/plumbing/plumbers/grinder_chemical.dm
+++ b/code/modules/plumbing/plumbers/grinder_chemical.dm
@@ -1,6 +1,9 @@
+#define GRIND 1
+#define JUICE 0
+
 /obj/machinery/plumbing/grinder_chemical
 	name = "chemical grinder"
-	desc = "chemical grinder."
+	desc = "Chemical grinder. Can either grind or juice stuff you put in"
 	icon_state = "grinder_chemical"
 	layer = ABOVE_ALL_MOB_LAYER
 	plane = ABOVE_GAME_PLANE
@@ -8,43 +11,80 @@
 	reagent_flags = TRANSPARENT | DRAINABLE
 	buffer = 400
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2
-	var/eat_dir = SOUTH
+	/// Operation mode
+	var/operation_mode = GRIND
+	/// Radial menu to change operating mode
+	var/static/list/operations
 
 /obj/machinery/plumbing/grinder_chemical/Initialize(mapload, bolt, layer)
 	. = ..()
 	AddComponent(/datum/component/plumbing/simple_supply, bolt, layer)
-	var/static/list/loc_connections = list(
-		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
-	)
-	AddElement(/datum/element/connect_loc, loc_connections)
 
-/obj/machinery/plumbing/grinder_chemical/setDir(newdir)
-	. = ..()
-	eat_dir = newdir
+	if(!length(operations))
+		operations = list(
+			"grind" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_grind"),
+			"juice" = image(icon = 'icons/hud/radial.dmi', icon_state = "radial_juice")
+		)
 
-/obj/machinery/plumbing/grinder_chemical/CanAllowThrough(atom/movable/mover, border_dir)
+/obj/machinery/plumbing/grinder_chemical/examine(mob/user)
 	. = ..()
+	var/text_mode = operation_mode == GRIND ? "grind" : "juice"
+	. += span_notice("Its currently in [EXAMINE_HINT(text_mode)] mode")
+
+/obj/machinery/plumbing/grinder_chemical/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
+	if(!user.can_perform_action(src, ALLOW_SILICON_REACH) || !anchored)
+		return
+
+	var/choice = show_radial_menu(user, src, operations, require_near = !issilicon(user))
+	if(!choice)
+		return
+
+	switch(choice)
+		if("grind")
+			operation_mode = GRIND
+		else
+			operation_mode = JUICE
+
+	to_chat(user, "operating mode changed to [operation_mode = GRIND ? "grind" : "juice"]")
+
+/obj/machinery/plumbing/grinder_chemical/attackby(obj/item/weapon, mob/user, params)
+	. = TRUE
+
 	if(!anchored)
 		return
-	if(border_dir == eat_dir)
-		return TRUE
-
-/obj/machinery/plumbing/grinder_chemical/proc/on_entered(datum/source, atom/movable/AM)
-	SIGNAL_HANDLER
-	grind(AM)
-
-/obj/machinery/plumbing/grinder_chemical/proc/grind(atom/AM)
 	if(machine_stat & NOPOWER)
 		return
 	if(reagents.holder_full())
+		to_chat(user, span_warning("[src] has no more space."))
 		return
-	if(!isitem(AM))
-		return
-	var/obj/item/I = AM
-	if(I.grind_results || I.juice_typepath)
-		use_power(active_power_usage)
-		if(I.grind_results)
-			I.grind(src, src)
-		else if (I.juice_typepath)
-			I.juice(src, src)
-		qdel(I)
+
+	if(operation_mode == GRIND)
+		to_chat(user, span_notice("[src] attempts to grind [weapon]."))
+		if(weapon.grind_results)
+			use_power(active_power_usage)
+			if(weapon.grind(reagents, user))
+				to_chat(user, span_green("[src] succeeds in grinding [weapon]."))
+				qdel(weapon)
+			else
+				if(isstack(weapon))
+					to_chat(user, span_notice("[src] grinds as many pieces of [weapon] as possible."))
+				else
+					to_chat(user, span_warning("[src] failed to grind [weapon]."))
+		else
+			to_chat(user, span_warning("[src] is unable to grind [weapon]."))
+
+	else
+		to_chat(user, span_notice("[src] attempts to juice [weapon]."))
+		if(weapon.juice_typepath)
+			use_power(active_power_usage)
+			if(weapon.juice(reagents, user))
+				to_chat(user, span_green("[src] succeeds in juicing [weapon]."))
+				qdel(weapon)
+			else
+				to_chat(user, span_warning("[src] failed to juice [weapon]."))
+		else
+			to_chat(user, span_warning("[src] is unable to juice [weapon]."))
+
+#undef GRIND
+#undef JUICE

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1354,9 +1354,7 @@
 
 /// Is this holder full or not
 /datum/reagents/proc/holder_full()
-	if(total_volume >= maximum_volume)
-		return TRUE
-	return FALSE
+	return total_volume >= maximum_volume
 
 /// Get the amount of this reagent
 /datum/reagents/proc/get_reagent_amount(reagent, include_subtypes = FALSE)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -99,11 +99,9 @@
 	. = ..()
 	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
 		return
-	if(!can_interact(user) || !user.can_perform_action(src, ALLOW_SILICON_REACH|FORBID_TELEKINESIS_REACH))
+	if(operating || !user.can_perform_action(src, ALLOW_SILICON_REACH | FORBID_TELEKINESIS_REACH))
 		return
-	if(operating)
-		return
-	replace_beaker(user)
+	eject(user)
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/machinery/reagentgrinder/attack_robot_secondary(mob/user, list/modifiers)
@@ -146,24 +144,28 @@
 	default_unfasten_wrench(user, tool)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
-/obj/machinery/reagentgrinder/attackby(obj/item/I, mob/living/user, params)
-	//You can only screw open empty grinder
-	if(!beaker && !length(holdingitems) && default_deconstruction_screwdriver(user, icon_state, icon_state, I))
-		return
+/obj/machinery/reagentgrinder/screwdriver_act(mob/living/user, obj/item/tool)
+	. = TOOL_ACT_TOOLTYPE_SUCCESS
+	if(!beaker && !length(holdingitems))
+		return default_deconstruction_screwdriver(user, icon_state, icon_state, tool)
 
-	if(default_deconstruction_crowbar(I))
-		return
+/obj/machinery/reagentgrinder/crowbar_act(mob/living/user, obj/item/tool)
+	return default_deconstruction_crowbar(tool)
 
+/obj/machinery/reagentgrinder/attackby(obj/item/weapon, mob/living/user, params)
 	if(panel_open) //Can't insert objects when its screwed open
 		return TRUE
 
-	if (is_reagent_container(I) && !(I.item_flags & ABSTRACT) && I.is_open_container())
-		var/obj/item/reagent_containers/B = I
+	if(!weapon.grind_requirements(src)) //Error messages should be in the objects' definitions
+		return
+
+	if (is_reagent_container(weapon) && !(weapon.item_flags & ABSTRACT) && weapon.is_open_container())
+		var/obj/item/reagent_containers/container = weapon
 		. = TRUE //no afterattack
-		if(!user.transferItemToLoc(B, src))
+		if(!user.transferItemToLoc(container, src))
 			return
-		replace_beaker(user, B)
-		to_chat(user, span_notice("You add [B] to [src]."))
+		replace_beaker(user, container)
+		to_chat(user, span_notice("You add [container] to [src]."))
 		update_appearance()
 		return TRUE //no afterattack
 
@@ -172,39 +174,36 @@
 		return TRUE
 
 	//Fill machine with a bag!
-	if(istype(I, /obj/item/storage/bag))
-		if(!I.contents.len)
-			to_chat(user, span_notice("[I] is empty!"))
+	if(istype(weapon, /obj/item/storage/bag))
+		if(!weapon.contents.len)
+			to_chat(user, span_notice("[weapon] is empty!"))
 			return TRUE
 
 		var/list/inserted = list()
-		if(I.atom_storage.remove_type(/obj/item/food/grown, src, limit - length(holdingitems), TRUE, FALSE, user, inserted))
+		if(weapon.atom_storage.remove_type(/obj/item/food/grown, src, limit - length(holdingitems), TRUE, FALSE, user, inserted))
 			for(var/i in inserted)
 				holdingitems[i] = TRUE
 			inserted = list()
-		if(I.atom_storage.remove_type(/obj/item/food/honeycomb, src, limit - length(holdingitems), TRUE, FALSE, user, inserted))
+		if(weapon.atom_storage.remove_type(/obj/item/food/honeycomb, src, limit - length(holdingitems), TRUE, FALSE, user, inserted))
 			for(var/i in inserted)
 				holdingitems[i] = TRUE
 
-		if(!I.contents.len)
-			to_chat(user, span_notice("You empty [I] into [src]."))
+		if(!weapon.contents.len)
+			to_chat(user, span_notice("You empty [weapon] into [src]."))
 		else
 			to_chat(user, span_notice("You fill [src] to the brim."))
 		return TRUE
 
-	if(!I.grind_results && !I.juice_typepath)
+	if(!weapon.grind_results && !weapon.juice_typepath)
 		if(user.combat_mode)
 			return ..()
 		else
-			to_chat(user, span_warning("You cannot grind [I] into reagents!"))
+			to_chat(user, span_warning("You cannot grind/juice [weapon] into reagents!"))
 			return TRUE
 
-	if(!I.grind_requirements(src)) //Error messages should be in the objects' definitions
-		return
-
-	if(user.transferItemToLoc(I, src))
-		to_chat(user, span_notice("You add [I] to [src]."))
-		holdingitems[I] = TRUE
+	if(user.transferItemToLoc(weapon, src))
+		to_chat(user, span_notice("You add [weapon] to [src]."))
+		holdingitems[weapon] = TRUE
 		return FALSE
 
 /obj/machinery/reagentgrinder/ui_interact(mob/user) // The microwave Menu //I am reasonably certain that this is not a microwave
@@ -261,9 +260,9 @@
 	if(beaker)
 		replace_beaker(user)
 
-/obj/machinery/reagentgrinder/proc/remove_object(obj/item/O)
-	holdingitems -= O
-	qdel(O)
+/obj/machinery/reagentgrinder/proc/remove_object(obj/item/weapon)
+	holdingitems -= weapon
+	qdel(weapon)
 
 /obj/machinery/reagentgrinder/proc/start_shaking()
 	var/static/list/transforms
@@ -306,11 +305,11 @@
 
 /obj/machinery/reagentgrinder/proc/juice(mob/user)
 	power_change()
-	if(!beaker || machine_stat & (NOPOWER|BROKEN) || beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
+	if(!beaker || machine_stat & (NOPOWER|BROKEN) || beaker.reagents.holder_full())
 		return
 	operate_for(50, juicing = TRUE)
 	for(var/obj/item/i in holdingitems)
-		if(beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
+		if(beaker.reagents.holder_full())
 			break
 		var/obj/item/I = i
 		if(I.juice_typepath)
@@ -324,7 +323,7 @@
 
 /obj/machinery/reagentgrinder/proc/grind(mob/user)
 	power_change()
-	if(!beaker || machine_stat & (NOPOWER|BROKEN) || beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
+	if(!beaker || machine_stat & (NOPOWER|BROKEN) || beaker.reagents.holder_full())
 		return
 	operate_for(60)
 	warn_of_dust() // don't breathe this.
@@ -350,7 +349,7 @@
 	if(!beaker || machine_stat & (NOPOWER|BROKEN))
 		return
 	operate_for(50, juicing = TRUE)
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/machinery/reagentgrinder, mix_complete)), 50)
+	mix_complete()
 
 /obj/machinery/reagentgrinder/proc/mix_complete()
 	if(beaker?.reagents.total_volume)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -329,7 +329,7 @@
 	operate_for(60)
 	warn_of_dust() // don't breathe this.
 	for(var/i in holdingitems)
-		if(beaker.reagents.total_volume >= beaker.reagents.maximum_volume)
+		if(beaker.reagents.holder_full())
 			break
 		var/obj/item/I = i
 		if(I.grind_results)
@@ -337,7 +337,10 @@
 
 /obj/machinery/reagentgrinder/proc/grind_item(obj/item/I, mob/user) //Grind results can be found in respective object definitions
 	if(!I.grind(beaker.reagents, user))
-		to_chat(usr, span_danger("[src] shorts out as it tries to grind up [I], and transfers it back to storage."))
+		if(isstack(I))
+			to_chat(usr, span_notice("[src] attempts to grind as many pieces of [I] as possible."))
+		else
+			to_chat(usr, span_danger("[src] shorts out as it tries to grind up [I], and transfers it back to storage."))
 		return
 	remove_object(I)
 

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -349,7 +349,7 @@
 	if(!beaker || machine_stat & (NOPOWER|BROKEN))
 		return
 	operate_for(50, juicing = TRUE)
-	mix_complete()
+	addtimer(CALLBACK(src, PROC_REF(mix_complete)), 50 / speed)
 
 /obj/machinery/reagentgrinder/proc/mix_complete()
 	if(beaker?.reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -509,7 +509,10 @@
 
 /obj/item/reagent_containers/cup/mortar/proc/grind_item(obj/item/item, mob/living/carbon/human/user)
 	if(!item.grind(reagents, user))
-		to_chat(user, span_notice("You fail to grind [item]."))
+		if(isstack(item))
+			to_chat(usr, span_notice("[src] attempts to grind as many pieces of [item] as possible."))
+		else
+			to_chat(user, span_danger("You fail to grind [item]."))
 		return
 	to_chat(user, span_notice("You grind [item] into a nice powder."))
 	grinded = null


### PR DESCRIPTION
## About The Pull Request

This deals with grinding & juicing in 4 stages

**1. General grinding & juicing**
Nothing player facing, just added some extra null checks to ensure we use `reagents` and `target_holder` only when they are not null. The current way it was setup did not check for this

**2. Grinding Stacks**
- Fixes #48387
- Fixes #78180
- Fixes #77878

This changes the way stacks are grinded. Rather than grinding the whole stack and have reagents wasted from grinding because there isn't enough space in the beaker we do the reverse.
We calculate how many pieces of cable(or sheets of material) can be grinded "based" on the available volume inside the `target_holder`(i.e. beaker for all in 1 grinder, or internal buffer for chemical plumbing grinder, mortar & pedestal)

**For example**
Say you have a beaker of 100 ml capacity and you have a stack of 50 iron sheets where each sheet of iron when grinded yields 20 units of iron reagent. Doing some simple math we should only be able to grind 5 sheets of iron(20 units of iron per sheet x 5 = 100 ml capacity). This means the remaining 45 sheets of iron should be left untouched and we should be able to eject and regrind them in a different beaker if we don't have the space for it.

This PR does exactly that. It computes how many pieces/sheets can be grinded based on the available volume for grinding (e.g. based on the available volume in your beaker for the all in 1 grinder) and grinds exactly that many pieces, leaving the rest of stack untouched so you can reuse them

This way you avoid wasting stacks when your beaker doesn't have the required space to hold its reagents

**3. Plumbing Chemical Grinder**
- Not sure how nobody noticed but the plumbing chemical grinder completely stopped working because wrong arguments were passed to the items grind & juice procs
https://github.com/tgstation/tgstation/blob/2ddbdca1b7fb5cb85cbdcd566a489cbc4794edcf/code/modules/plumbing/plumbers/grinder_chemical.dm#L47
When it fact it should have been
`I.grind(reagents, usr)`
So yeah the plumbing chemical grinder works again

- Fixes #75429
The plumbing chemical grinder now blocks anything that isn't an `obj/item` from entering inside it. The `grind` proc is set up to accept only items anyway so allowing mobs to enter is just a waste of processing power. That way nobody gets stuck inside, 

- Fixes #62822
The chemical grinder now accepts items coming at it from any direction.  if you don't want to throw stuff at it you can manually put stuff in it with hand. If you try to use a storage item like a bag(plant bag or any bag) it dumps all its contents in the grinder.

**4. All in 1 Grinder**  
- Fixes #76983
You can now remove the beaker when the blender is unpowered with right click. The left click does not work when power is off because `ui_interact()` proc is disabled which was responsible for ejecting the beaker & its contents. The right click was meant to compensate for this but it also checked if power was available and it also failed. Now that check has been removed meaning you can eject the beaker & its contents via right click 

- Fixes #54813 
The delay and shake animation is already handled by the `operate()` proc but the mix settings would add an additional timer on top of that with a fixed delay of 50 deciseconds. That timer is adjusted so its reduced from upgraded parts

## Changelog
:cl:
code: added some null checks for general juicing & grinding items
fix: grinding stacks now grinds as many pieces/sheets from the stack as possible that can fit in a beaker/container without wasting the whole stack
fix: plumbing chemical grinder now actually works again
fix: the plumbing chemical grinder allows stuff to enter from any direction but not mobs and also accepts items put inside it via hand including bags
fix: You can remove the beaker from the all in 1 grinder when power is off via right click
fix: All in 1 grinder now mixes faster with upgraded parts
refactor: you can no longer walk into a plumbing chemical grinder
/:cl:
