### PR TITLE
[NO GBP] Removes syndie comms from psyker headsets

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -133,21 +133,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	name = "team leader headset"
 	command = TRUE
 
-/obj/item/radio/headset/syndicate/alt/psyker
-	name = "psychic headset"
-	desc = "A headset designed to boost psychic waves. Protects ears from flashbangs."
-	icon_state = "psyker_headset"
-	worn_icon_state = "syndie_headset"
-
-/obj/item/radio/headset/syndicate/alt/psyker/equipped(mob/living/user, slot)
-	. = ..()
-	if(slot_flags & slot)
-		ADD_CLOTHING_TRAIT(user, TRAIT_ECHOLOCATION_EXTRA_RANGE)
-
-/obj/item/radio/headset/syndicate/alt/psyker/dropped(mob/user, silent)
-	. = ..()
-	REMOVE_CLOTHING_TRAIT(user, TRAIT_ECHOLOCATION_EXTRA_RANGE)
-
 /obj/item/radio/headset/binary
 	keyslot = /obj/item/encryptionkey/binary
 

--- a/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_gear.dm
@@ -198,3 +198,22 @@
 			continue
 
 		return found_fugitive
+
+/obj/item/radio/headset/psyker
+	name = "psychic headset"
+	desc = "A headset designed to boost psychic waves. Protects ears from flashbangs."
+	icon_state = "psyker_headset"
+	worn_icon_state = "syndie_headset"
+
+/obj/item/radio/headset/psyker/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
+
+/obj/item/radio/headset/psyker/equipped(mob/living/user, slot)
+	. = ..()
+	if(slot_flags & slot)
+		ADD_CLOTHING_TRAIT(user, TRAIT_ECHOLOCATION_EXTRA_RANGE)
+
+/obj/item/radio/headset/psyker/dropped(mob/user, silent)
+	. = ..()
+	REMOVE_CLOTHING_TRAIT(user, TRAIT_ECHOLOCATION_EXTRA_RANGE)

--- a/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
@@ -187,7 +187,7 @@
 	name = "Psyker-Shikari Hunter"
 	glasses = null
 	head = null
-	ears = /obj/item/radio/headset/syndicate/alt/psyker
+	ears = /obj/item/radio/headset/psyker
 	uniform = /obj/item/clothing/under/pants/track
 	gloves = /obj/item/clothing/gloves/fingerless
 	shoes = /obj/item/clothing/shoes/jackboots


### PR DESCRIPTION

## About The Pull Request

I forgot to move the echolocation headsets off of being a syndie headset subtype when converting psykers to bounty hunters. As a result, the psykers members of the team would have syndie comms (bad!).
## Why It's Good For The Game

Hunters shouldn't get syndie comms! OOPS.
## Changelog
:cl: Rhials
fix: The psyker headset is no longer a syndicate headset subtype, and no longer has syndie comms.
/:cl:
