### PR TITLE
Massively improves dynamic lowpop threat distribution.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -397,6 +397,7 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 	// At lower pop levels we run a Liner Interpolation against the max threat based proportionally on the number
 	// of players ready. This creates a balanced lorentz curve within a smaller range than 0 to max_threat_level.
 	var/calculated_max_threat = (SSticker.totalPlayersReady < low_pop_player_threshold) ? LERP(low_pop_maximum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold) : max_threat_level
+	log_dynamic("Calculated maximum threat level based on player count of [SSticker.totalPlayersReady]: [calculated_max_threat]")
 
 	threat_level = lorentz_to_amount(threat_curve_centre, threat_curve_width, calculated_max_threat)
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -394,14 +394,15 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 
 /// Generates the threat level using lorentz distribution and assigns peaceful_percentage.
 /datum/game_mode/dynamic/proc/generate_threat()
-	threat_level = lorentz_to_amount(threat_curve_centre, threat_curve_width, max_threat_level)
+	// At lower pop levels we run a Liner Interpolation against the max threat based proportionally on the number
+	// of players ready. This creates a balanced lorentz curve within a smaller range than 0 to max_threat_level.
+	var/calculated_max_threat = (SSticker.totalPlayersReady < low_pop_player_threshold) ? LERP(low_pop_maximum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold) : max_threat_level
+
+	threat_level = lorentz_to_amount(threat_curve_centre, threat_curve_width, calculated_max_threat)
 
 	for(var/datum/station_trait/station_trait in GLOB.dynamic_station_traits)
 		threat_level = max(threat_level - GLOB.dynamic_station_traits[station_trait], 0)
 		log_dynamic("Threat reduced by [GLOB.dynamic_station_traits[station_trait]]. Source: [type].")
-
-	if (SSticker.totalPlayersReady < low_pop_player_threshold)
-		threat_level = min(threat_level, LERP(low_pop_maximum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold))
 
 	peaceful_percentage = (threat_level/max_threat_level)*100
 


### PR DESCRIPTION

## About The Pull Request

Let's take an example of a threat roll of 50 on 0 pop.

```
threat_level = 50
low_pop_maximum_threat = 40
max_threat_level = 100
SSticker.totalPlayersReady = 0
low_pop_player_threshold = 20

threat_level = min(threat_level, LERP(low_pop_maximum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold))
```

Subbing in, we get

```
threat_level = min(50, LERP(40, 100, 0 / 20))
```

What does the LERP churn out?

```
#define LERP(a, b, amount) ( amount ? ((a) + ((b) - (a)) * (amount)) : a )

a = low_pop_maximum_threat = 40
b = max_threat_level = 100
amount = SSticker.totalPlayersReady / low_pop_player_threshold = 0 / 20

LERP(40, 100, 0 / 20)
```

( 0 ? ((40) + ((100) - (40)) * (0 / 20)) : 40 )

So, for 0 pop - since 0 is FALSEY, it always returns 40 threat no matter what. This effectively means all threat rolls > 40 on 0 pop get clamped down to 40.

And how about 10 pop, somewhere in the middle of that and the 20 lowpop limit?

( 10 ? ((40) + ((100) - (40)) * (10 / 20)) : 40 )

Which means we're using ((40) + ((100) - (40)) * (10 / 20). Which equals 70. So all threat rolls > 70 get clamped to 70.

So all LERP(low_pop_maximum_threat, max_threat_level, SSticker.totalPlayersReady / low_pop_player_threshold) is doing is LERPing the max_threat level.

Of course I didn't need to really break it down, but I felt it was useful to showcase that yes the LERP is LERPing as expected. It's fed two max threat levels, an amount and lerps between them.

So we're not really **scaling** the threat in any way for low pops, we're just clamping it to this LERP'd max threat value. It massively biases the high threat ranges at lowpop. How does this look in practice?

Well, I quickly mocked up a dynamic sim in Python. Here's what I found:
0 pop, current dynamic config, old code
![Old-0-pop](https://github.com/tgstation/tgstation/assets/24975989/bf2be209-b0f7-4606-88e6-9d66cad76862)

10 pop, current dynamic config, old code
![Old-10-pop](https://github.com/tgstation/tgstation/assets/24975989/ac4f185d-91de-4bf2-9681-f82e173cf086)

20 pop, current dynamic config, old code
![Old-20-pop](https://github.com/tgstation/tgstation/assets/24975989/4f96ad17-16a8-4315-b3bb-8044bd66ba70)

Instead of using the LERP'd max threat to clamp after we've calculated everything, I think it would be better to use the LERP'd max threat **in the Lorentz calculation itself** to create more predictable lowpop threat curves.

This is my simulated output using the LERP'd max threat to generate the Lorentz curve:
0 pop, current dynamic config, new code
![New-0-pop](https://github.com/tgstation/tgstation/assets/24975989/f66fa2a9-8c58-4a76-a173-5fc0a7b6cd67)

10 pop, current dynamic config, new code
![New-10-pop](https://github.com/tgstation/tgstation/assets/24975989/a5ddd9e6-3469-48bf-94a8-c8a59e949639)

20 pop, current dynamic config, new code
![New-20-pop](https://github.com/tgstation/tgstation/assets/24975989/4204981a-74af-4fba-8cd4-d278f9345711)

And just for good measure, 100 pop, current dynamic config, new code
![New-100-pop](https://github.com/tgstation/tgstation/assets/24975989/8915b6e7-3748-4c03-af58-c659a4e580f6)

This should lead to WAY more sensible threat scaling for dynamic at low and **especially** extreme low pop levels.
## Why It's Good For The Game

Current low pop threat distribution is really bad and biases towards the highest threat dynamic could possibly role for that pop level the farther away from the lowpop limit the shift starts as.

This really shouldn't be the intent and it makes balancing lowpop threat basically impossible. By generating a more constrained Lortentz curve, dynamic threat scales across all population levels in a more sensible and balanced way.
## Changelog
:cl:
fix: Fix poor dynamic threat distribution at lower population levels, causing dynamic to generate better threat curves at lower population levels than it did before.
/:cl:
