### PR TITLE
surgery cap default changed to loosened state

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -445,7 +445,6 @@
 	name = "blue surgery cap"
 	icon_state = "surgicalcap"
 	desc = "A blue medical surgery cap to prevent the surgeon's hair from entering the insides of the patient!"
-	flags_inv = HIDEHAIR //Cover your head doctor!
 
 /obj/item/clothing/head/utility/surgerycap/attack_self(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
title

## Why It's Good For The Game
https://github.com/tgstation/tgstation/pull/76906 added tightening/loosening surgical caps; that function **still is here** with this line gone for like the (2) people that still want the 'professional' doctor look.

makes all 3 jobs that use this as default hat look less like balding surgeon number fifty on job previews
![266178497-abbe2f10-1901-4946-8bbc-ef77e591270d](https://github.com/tgstation/tgstation/assets/64238802/1bba693a-6341-474c-a7bf-69292b2f4829)



## Changelog

:cl: SuicidalPickles
qol: Surgery Cap strings have loosened by default due to a mishap in manufacturing lines - you can still tighten them in-hand.
/:cl:
