### PR TITLE
[NO GBP] Chasm fishing now correctly gathers items from the location of the lure and not the user.

### DIFF
--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -51,8 +51,7 @@ GLOBAL_LIST_INIT_TYPED(chasm_detritus_types, /datum/chasm_detritus, init_chasm_d
 	return pick(chasm_stuff)
 
 /// Returns an objected which is currently inside of a nearby chasm.
-/datum/chasm_detritus/proc/find_chasm_contents(datum/source, turf/fishing_spot, turf/fisher_turf)
-	SIGNAL_HANDLER
+/datum/chasm_detritus/proc/find_chasm_contents(turf/fishing_spot, turf/fisher_turf)
 	var/list/chasm_contents = get_chasm_contents(fishing_spot)
 
 	if (!length(chasm_contents))
@@ -64,8 +63,7 @@ GLOBAL_LIST_INIT_TYPED(chasm_detritus_types, /datum/chasm_detritus, init_chasm_d
 /datum/chasm_detritus/proc/get_chasm_contents(turf/fishing_spot)
 	. = list()
 	for (var/obj/effect/abstract/chasm_storage/storage in range(5, fishing_spot))
-		for (var/thing as anything in storage.contents)
-			. += thing
+		. += storage.contents
 
 /// Variant of the chasm detritus that allows for an easier time at fishing out
 /// bodies, and sometimes less desireable monsters too.


### PR DESCRIPTION
## About The Pull Request
Cleans up the remnants of a signal proc behind the titled issue.

And no, this doesn't necessarily make rescueing people out of chasms easier, especially if you're using a bait, which only makes you more likely to catch a chrab instead.

## Why It's Good For The Game
Fixing a small issue.

## Changelog


:cl:
fix: Fishing on a chasm now correctly gathers items from the location of the lure and not that of the user, along with some nullspace fuckery for the default rewards.
/:cl:
