### PR TITLE
Fix dynamic biasing towards the middle distance harder than it is supposed to

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -251,3 +251,6 @@
 
 /// The number of cells in a taxicab circle (rasterized diamond) of radius X.
 #define DIAMOND_AREA(X) (1 + 2*(X)*((X)+1))
+
+/// Returns a random decimal between x and y.
+#define RANDOM_DECIMAL(x, y) LERP((x), (y), rand())

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -841,7 +841,7 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
  * rand() calls without arguments returns a value between 0 and 1, allowing for smaller intervals.
  */
 /datum/game_mode/dynamic/proc/lorentz_to_amount(centre = 0, scale = 1.8, max_threat = 100, interval = 1)
-	var/location = rand(-MAXIMUM_DYN_DISTANCE, MAXIMUM_DYN_DISTANCE) * rand()
+	var/location = RANDOM_DECIMAL(-MAXIMUM_DYN_DISTANCE, MAXIMUM_DYN_DISTANCE) * rand()
 	var/lorentz_result = LORENTZ_CUMULATIVE_DISTRIBUTION(centre, location, scale)
 	var/std_threat = lorentz_result * max_threat
 	///Without these, the amount won't come close to hitting 0% or 100% of the max threat.


### PR DESCRIPTION
When we receive 0 from rand, the location would end up being 0 as well. This was happening far more often than expected as rand produces an integer. Changes it to instead produce a float between the two values which gives nicer curves.

Before, at curve center 0.2 and width 2.5
![Untitled](https://github.com/tgstation/tgstation/assets/35135081/82ecfa01-a79d-49f2-acb6-0150854e3360)


After, at same values:
![image](https://github.com/tgstation/tgstation/assets/35135081/911198bd-5264-4e9d-a51f-a1889938f7e4)


## Changelog

:cl:
fix: Dynamic now biases less heavily towards the exact average.
/:cl:
