### PR TITLE
Fixes returning items to vending machines

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -194,8 +194,6 @@
 
 	///Items that the players have loaded into the vendor
 	var/list/vending_machine_input = list()
-	///Display header on the input view
-	var/input_display_header = "Custom Vendor"
 
 	//The type of refill canisters used by this machine.
 	var/obj/item/vending_refill/refill_canister = null
@@ -1038,7 +1036,7 @@
 	to_chat(user, span_notice("You insert [inserted_item] into [src]'s input compartment."))
 
 	for(var/datum/data/vending_product/product_datum in product_records + coin_records + hidden_records)
-		if(ispath(inserted_item.type, product_datum.product_path))
+		if(inserted_item.type == product_datum.product_path)
 			product_datum.amount++
 			LAZYADD(product_datum.returned_products, inserted_item)
 			return
@@ -1532,7 +1530,7 @@
  * * user - the user doing the loading
  */
 /obj/machinery/vending/proc/canLoadItem(obj/item/loaded_item, mob/user)
-	if((loaded_item.type in products) || (loaded_item.type in premium) || (loaded_item.type in contraband))
+	if(!length(loaded_item.contents) && ((loaded_item.type in products) || (loaded_item.type in premium) || (loaded_item.type in contraband)))
 		return TRUE
 	to_chat(user, span_warning("[src] does not accept [loaded_item]!"))
 	return FALSE

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -44,7 +44,6 @@
 	default_price = PAYCHECK_CREW * 0.6
 	extra_price = PAYCHECK_CREW
 	payment_department = ACCOUNT_SRV
-	input_display_header = "Chef's Food Selection"
 
 /obj/item/vending_refill/snack
 	machine_name = "Getmore Chocolate Corp"

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -5,7 +5,6 @@
 	default_price = PAYCHECK_CREW
 	extra_price = PAYCHECK_COMMAND
 	payment_department = NO_FREEBIES
-	input_display_header = "Returned Clothing"
 	panel_type = "panel19"
 	light_mask = "wardrobe-light-mask"
 


### PR DESCRIPTION
## About The Pull Request
- Fixes #77719
- Fixes #68848

The problem was items that are subtypes of other items creates problems for e.g. the medical winter coat & the paramedic winter coats

Type path for medical winter coat
![Screenshot (295)](https://github.com/tgstation/tgstation/assets/110812394/87661390-b9ae-4c89-9284-832017151af9)

Type path for paramedic winter coat
![Screenshot (296)](https://github.com/tgstation/tgstation/assets/110812394/c9fb3bf7-27c2-44b3-b5ff-3d814c7d3391)

The problem? paramedic winter coat is a subtype of  `/obj/item/clothing/suit/hooded/wintercoat/medical` but medical winter coat type is `/obj/item/clothing/suit/hooded/wintercoat/medical` so when returning these subtypes back to the vendor the `ispath()` check
https://github.com/tgstation/tgstation/blob/7c0064c04cc4d4804aac9bb92e4dea638579e723/code/modules/vending/_vending.dm#L1041
Gets confused and it ends up returning the paramedic winter coat to the medical wintercoat section cause it thought it was a subtype. The solution is check if the returned products typepath absolutly matches the products category typepath and not do a relative check.

The same problem applied to foods bought from a food vending machine. Also removed the unused var `input_display_header` cause it did nothing.

- Fixes #76314

You now cannot return items to a vending machine if it has items in it's contents so no returning vending trays with food on them or duffle bags with items inside it or whatever. 


## Changelog
:cl:
fix: returning items to vendors works correctly
fix: you can't return items that has stuff in it for e.g. a serving tray with food in it
/:cl:
