### PR TITLE
Adds surgery tray to Runtime Station

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -662,6 +662,7 @@
 "cK" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table/glass,
+/obj/item/disk/surgery/debug,
 /obj/item/storage/box/monkeycubes{
 	pixel_x = 6;
 	pixel_y = 1
@@ -676,8 +677,7 @@
 /turf/open/floor/iron/white/corner,
 /area/station/medical/medbay)
 "cL" = (
-/obj/item/storage/backpack/duffelbag/syndie/surgery,
-/obj/item/disk/surgery/debug,
+/obj/item/surgery_tray/advanced,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8

--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -1,8 +1,31 @@
+/datum/storage/surgery_tray
+	max_total_storage = 30
+	max_specific_storage = WEIGHT_CLASS_NORMAL
+	max_slots = 14
+
+/datum/storage/surgery_tray/New()
+	. = ..()
+	set_holdable(list(
+		/obj/item/blood_filter,
+		/obj/item/bonesetter,
+		/obj/item/cautery,
+		/obj/item/circular_saw,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/hemostat,
+		/obj/item/razor,
+		/obj/item/reagent_containers/medigel,
+		/obj/item/retractor,
+		/obj/item/scalpel,
+		/obj/item/stack/medical/bone_gel,
+		/obj/item/stack/sticky_tape/surgical,
+		/obj/item/surgical_drapes,
+		/obj/item/surgicaldrill,
+	))
+
 /**
  * Surgery Trays
  * A storage object that displays tools in its contents based on tier, better tools are more visible.
  * Can be folded up and carried. Click it to draw a random tool.
- *
  */
 /obj/item/surgery_tray
 	name = "surgery tray"
@@ -183,25 +206,17 @@
 		/obj/item/surgicaldrill,
 	)
 
-/datum/storage/surgery_tray
-	max_total_storage = 30
-	max_specific_storage = WEIGHT_CLASS_NORMAL
-	max_slots = 14
-
-/datum/storage/surgery_tray/New()
-	. = ..()
-	set_holdable(list(
-		/obj/item/blood_filter,
+/// Surgery tray with advanced tools for debug
+/obj/item/surgery_tray/advanced
+	initial_contents = list(
+		/obj/item/scalpel/advanced,
+		/obj/item/retractor/advanced,
+		/obj/item/cautery/advanced,
+		/obj/item/surgical_drapes,
+		/obj/item/reagent_containers/medigel/sterilizine,
 		/obj/item/bonesetter,
-		/obj/item/cautery,
-		/obj/item/circular_saw,
-		/obj/item/clothing/mask/surgical,
-		/obj/item/hemostat,
-		/obj/item/razor,
-		/obj/item/retractor,
-		/obj/item/scalpel,
+		/obj/item/blood_filter,
 		/obj/item/stack/medical/bone_gel,
 		/obj/item/stack/sticky_tape/surgical,
-		/obj/item/surgical_drapes,
-		/obj/item/surgicaldrill,
-	))
+		/obj/item/clothing/mask/surgical,
+	)


### PR DESCRIPTION
## About The Pull Request

Replaces syndicate surgical bag on Runtime Station with Advanced Surgery Tray which contains all the advanced tools (no syndicate MMI or straightjacket but im going to go out on a limb and say you dont need it when debugging surgery)
Allows medigel containers to be placed in surgery tray (I didnt add an overlay sorry)
Moved the debug disk slightly to the right so its not under the tray/bag
![image](https://github.com/tgstation/tgstation/assets/7483112/2f5c6cad-9407-4593-9aca-71fcae8fc914)

## Why It's Good For The Game

Unzipping the duffel bag is annoying me
Want to add autotool functionality to the tray when next to a surgery bed at some point so I'd want this then anyway

## Changelog

not player facing