### PR TITLE
birdshot access helper fixes and small service nitpick 

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -1683,7 +1683,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
@@ -41415,7 +41414,7 @@
 /obj/machinery/door/airlock{
 	name = "Maintenance"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
 "oWr" = (
@@ -41924,6 +41923,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/structure/barricade/wooden/crude,
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/welded,
 /turf/open/floor/iron/textured_half{
 	dir = 8
 	},


### PR DESCRIPTION

## About The Pull Request

changes the access helper located across from gateway to the proper access helper (was originally service maints, is now command maints) and deletes a duplicate science access helper in starboard aft maints. 

the more opinionated part of this PR is (what i believe to be) an oversight on the map makers part, the bar backroom/kitchen coldroom airlock is only blocked by a single barricade, making it dead simple easy for a chef to just grab their roundstart cleaver, tear down the barricade, and buy both armor and sunglasses (of course the bartender could stop them, but that depends on if the bartender even notices), so i added the welded and bolted access helpers to the airlock to help keep them out (at least at immediate roundstart, we don't need chefs trying to steal the bartenders stuff immediately into the round). i'm willing to drop this part of the PR or edit it to use proper ID access instead, i just simply do not believe its a good idea for chefs to be able to buy out flash protection and pretty decent armor for barely any work on their part roundstart.

## Why It's Good For The Game

might as well make the airlock helpers mirror their intention, i don't personally think its egregious to think that the command hallway would all use command helpers for their accesses, removing duplicate helpers is also good. 

the luxury of armor and sunglasses are extended to the bartender as a courtesy for having to put up with assistants, much in the same way chefs receive CQC, and as such neither should be able to claim the others stake for legitimately 0 work involved, while this doesn't outright make it that much harder to break in, it does prevent it from being as easy as smashing a wood panel and then walking in.

## Changelog


:cl:

fix: adds the bolted and welded helper to the bar backroom/kitchen coldroom airlock on birdshot, as to prevent chefs from being able to access armor and sunglasses roundstart with barely any work involved

/:cl:
