### PR TITLE
Buffs emp's effects on organs

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -743,7 +743,7 @@
 	if(!needs_heart())
 		return FALSE
 	var/obj/item/organ/internal/heart/heart = get_organ_slot(ORGAN_SLOT_HEART)
-	if(!heart || IS_ROBOTIC_ORGAN(heart))
+	if(!heart)
 		return FALSE
 	return TRUE
 

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -207,7 +207,8 @@
 	var/dose_available = FALSE
 	var/rid = /datum/reagent/medicine/epinephrine
 	var/ramount = 10
-	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
+	/// What percentage of the heart's max health an emp immediatley does
+	var/emp_percent_damage = 0.9
 
 /obj/item/organ/internal/heart/cybernetic/emp_act(severity)
 	. = ..()
@@ -221,15 +222,15 @@
 		owner.losebreath += 10
 		COOLDOWN_START(src, severe_cooldown, 20 SECONDS)
 
-	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
-		organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.
-		Stop()
-		addtimer(CALLBACK(src, PROC_REF(Restart)), 10 SECONDS)
-		if(owner_needs_us)
-			owner.visible_message(
-				span_danger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"),
-				span_userdanger("You feel a terrible pain in your chest, as if your heart has stopped!"),
-			)
+	organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.
+	apply_organ_damage(damage_amount = emp_percent_damage * maxHealth) //Do damage to the organ
+	Stop()
+	addtimer(CALLBACK(src, PROC_REF(Restart)), 10 SECONDS)
+	if(owner_needs_us)
+		owner.visible_message(
+			span_danger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"),
+			span_userdanger("You feel a terrible pain in your chest, as if your heart has stopped!"),
+		)
 
 /obj/item/organ/internal/heart/cybernetic/on_life(seconds_per_tick, times_fired)
 	. = ..()
@@ -247,7 +248,6 @@
 	base_icon_state = "heart-c-u"
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
 	dose_available = TRUE
-	emp_vulnerability = 40
 
 /obj/item/organ/internal/heart/cybernetic/tier3
 	name = "upgraded cybernetic heart"
@@ -256,7 +256,6 @@
 	base_icon_state = "heart-c-u2"
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
 	dose_available = TRUE
-	emp_vulnerability = 20
 
 /obj/item/organ/internal/heart/cybernetic/tier3/used_dose()
 	. = ..()
@@ -269,7 +268,6 @@
 	icon_state = "heart-c-s-on"
 	base_icon_state = "heart-c-s"
 	maxHealth = STANDARD_ORGAN_THRESHOLD*0.5
-	emp_vulnerability = 100
 
 //surplus organs are so awful that they explode when removed, unless failing
 /obj/item/organ/internal/heart/cybernetic/surplus/Initialize(mapload)

--- a/code/modules/surgery/organs/internal/liver/_liver.dm
+++ b/code/modules/surgery/organs/internal/liver/_liver.dm
@@ -250,7 +250,9 @@
 	maxHealth = STANDARD_ORGAN_THRESHOLD*0.5
 	toxTolerance = 2
 	liver_resistance = 0.9 * LIVER_DEFAULT_TOX_RESISTANCE // -10%
-	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
+
+	/// What percentage of the liver's max health an emp immediatley does
+	var/emp_percent_damage = 0.9
 
 /obj/item/organ/internal/liver/cybernetic/emp_act(severity)
 	. = ..()
@@ -259,8 +261,8 @@
 	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
 		owner.adjustToxLoss(10)
 		COOLDOWN_START(src, severe_cooldown, 10 SECONDS)
-	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
-		organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.
+	organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.
+	apply_organ_damage(damage_amount = emp_percent_damage * maxHealth) //Do damage to the organ
 
 /obj/item/organ/internal/liver/cybernetic/tier2
 	name = "cybernetic liver"
@@ -269,7 +271,6 @@
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
 	toxTolerance = 5 //can shrug off up to 5u of toxins
 	liver_resistance = 1.2 * LIVER_DEFAULT_TOX_RESISTANCE // +20%
-	emp_vulnerability = 40
 
 /obj/item/organ/internal/liver/cybernetic/tier3
 	name = "upgraded cybernetic liver"
@@ -279,7 +280,6 @@
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
 	toxTolerance = 10 //can shrug off up to 10u of toxins
 	liver_resistance = 1.5 * LIVER_DEFAULT_TOX_RESISTANCE // +50%
-	emp_vulnerability = 20
 
 /obj/item/organ/internal/liver/cybernetic/surplus
 	name = "surplus prosthetic liver"
@@ -292,7 +292,6 @@
 	alcohol_tolerance = ALCOHOL_RATE * 2 // can barely handle alcohol
 	toxTolerance = 1 //basically can't shrug off any toxins
 	liver_resistance = 0.75 * LIVER_DEFAULT_TOX_RESISTANCE // -25%
-	emp_vulnerability = 100
 
 //surplus organs are so awful that they explode when removed, unless failing
 /obj/item/organ/internal/liver/cybernetic/surplus/Initialize(mapload)

--- a/code/modules/surgery/organs/internal/lungs/_lungs.dm
+++ b/code/modules/surgery/organs/internal/lungs/_lungs.dm
@@ -840,7 +840,9 @@
 	icon_state = "lungs-c"
 	organ_flags = ORGAN_ROBOTIC
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
-	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
+
+	/// What percentage of the lungs' max health an emp immediatley does
+	var/emp_percent_damage = 0.9
 
 /obj/item/organ/internal/lungs/cybernetic/emp_act(severity)
 	. = ..()
@@ -849,8 +851,8 @@
 	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
 		owner.losebreath += 20
 		COOLDOWN_START(src, severe_cooldown, 30 SECONDS)
-	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
-		organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.
+	organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.
+	apply_organ_damage(damage_amount = emp_percent_damage * maxHealth) //Do damage to the organ
 
 /obj/item/organ/internal/lungs/cybernetic/tier2
 	name = "cybernetic lungs"
@@ -858,7 +860,6 @@
 	icon_state = "lungs-c-u"
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
 	safe_oxygen_min = 13
-	emp_vulnerability = 40
 
 /obj/item/organ/internal/lungs/cybernetic/tier3
 	name = "upgraded cybernetic lungs"
@@ -868,7 +869,6 @@
 	safe_co2_max = 20
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
 	safe_oxygen_min = 13
-	emp_vulnerability = 20
 
 	cold_level_1_threshold = 200
 	cold_level_2_threshold = 140
@@ -880,7 +880,6 @@
 		Offer no protection against EMPs."
 	icon_state = "lungs-c-s"
 	maxHealth = 0.35 * STANDARD_ORGAN_THRESHOLD
-	emp_vulnerability = 100
 
 //surplus organs are so awful that they explode when removed, unless failing
 /obj/item/organ/internal/lungs/cybernetic/surplus/Initialize(mapload)

--- a/code/modules/surgery/organs/internal/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach/_stomach.dm
@@ -292,7 +292,9 @@
 	organ_flags = ORGAN_ROBOTIC
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.5
 	metabolism_efficiency = 0.035 // not as good at digestion
-	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
+
+	/// What percentage of the stomach's max health an emp immediatley does
+	var/emp_percent_damage = 0.9
 
 /obj/item/organ/internal/stomach/cybernetic/emp_act(severity)
 	. = ..()
@@ -301,8 +303,8 @@
 	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
 		owner.vomit(vomit_flags = (MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM))
 		COOLDOWN_START(src, severe_cooldown, 10 SECONDS)
-	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
-		organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.
+	organ_flags |= ORGAN_EMP //Starts organ faliure - gonna need replacing soon.
+	apply_organ_damage(damage_amount = emp_percent_damage * maxHealth) //Do damage to the organ
 
 /obj/item/organ/internal/stomach/cybernetic/tier2
 	name = "cybernetic stomach"
@@ -310,7 +312,6 @@
 	icon_state = "stomach-c-u"
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
 	disgust_metabolism = 2
-	emp_vulnerability = 40
 	metabolism_efficiency = 0.07
 
 /obj/item/organ/internal/stomach/cybernetic/tier3
@@ -319,7 +320,6 @@
 	icon_state = "stomach-c-u2"
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
 	disgust_metabolism = 3
-	emp_vulnerability = 20
 	metabolism_efficiency = 0.1
 
 /obj/item/organ/internal/stomach/cybernetic/surplus
@@ -329,7 +329,6 @@
 		Offers no protection against EMPs."
 	icon_state = "stomach-c-s"
 	maxHealth = STANDARD_ORGAN_THRESHOLD * 0.35
-	emp_vulnerability = 100
 	metabolism_efficiency = 0.025
 
 //surplus organs are so awful that they explode when removed, unless failing


### PR DESCRIPTION

## About The Pull Request

Emp's effects on robotic organs are now guarantied and not a chance.
Emp's immediately do 90% of the robotic organ's max health in damage to them.
Robotic hearts can now have heart attacks.

## Why It's Good For The Game

While testing some quirks I found that having the tin man quirk and getting hit by an emp is laughably ignorable. Its a 10 second stun, then 6 MINUTES until your heart fails, like twice as long for the rest of your organs fail, and when your heart DOES fail it doesn't matter, your robotic heart cannot have a heart attack and so its completely ignorable till your lungs fail.

Most cyber organs are better than default, and the ones that aren't are easily printable and replaceable. In return getting hit by a emp is supposed to be a death sentence for whatever robotic organs you have. In practice they just start failing, slowly, and there is a chance that an emp will do nothing. Now emp's effects will always trigger on organs, do 90% of their max health in damage, and the robotic heart can actually have a heart attack, which means it can actually stop from damage. Gameplay wise this is about 30 seconds till your robotic heart fails, and ~ 2 minutes for any other robotic organ. This still gives you a chance to throw your dying body in front of somebody that can help, but puts you an a very tense timer.

## Changelog

:cl: Seven
balance: Robotic hearts can now have heart attacks, which means they actually stop when they take enough damage.
balance: EMP effects will always trigger on robotic organs, they used to have a chance to do nothing at all.
balance: An EMP will immediately do 90% of a robotic organ's max health to it. This means you now have about 30 seconds to death if your robotic heart gets EMPed, and 2 minutes for every other organ. I would get to a doctor if I were you.
/:cl:
