### PR TITLE
Readds (some) Knockdown Vomits

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -863,6 +863,8 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define MOB_VOMIT_STUN (1<<1)
 /// Flag which makes the mob incur damage upon vomiting.
 #define MOB_VOMIT_HARM (1<<2)
+/// Flag which makes the mob vomit blood
+#define MOB_VOMIT_BLOOD (1<<3)
 /// Flag which will cause the mob to fall over when vomiting.
 #define MOB_VOMIT_KNOCKDOWN (1<<4)
 /// Flag which will make the proc skip certain checks when it comes to forcing a vomit.

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -874,8 +874,8 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define VOMIT_CATEGORY_DEFAULT (MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM | MOB_VOMIT_STUN)
 /// The vomit you've all come to know and love, but with a little extra "spice" (blood)
 #define VOMIT_CATEGORY_BLOOD (VOMIT_CATEGORY_DEFAULT | MOB_VOMIT_BLOOD)
-/// Another vomit variant that causes you to get knocked down and paralyzed instead of just stunned, but is standard enough otherwise.
-#define VOMIT_CATEGORY_KNOCKDOWN (MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM | MOB_VOMIT_KNOCKDOWN)
+/// Another vomit variant that causes you to get knocked down instead of just only getting a stun. Standard otherwise.
+#define VOMIT_CATEGORY_KNOCKDOWN (VOMIT_CATEGORY_DEFAULT | MOB_VOMIT_KNOCKDOWN)
 
 /// Possible value of [/atom/movable/buckle_lying]. If set to a different (positive-or-zero) value than this, the buckling thing will force a lying angle on the buckled.
 #define NO_BUCKLE_LYING -1

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -863,15 +863,17 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define MOB_VOMIT_STUN (1<<1)
 /// Flag which makes the mob incur damage upon vomiting.
 #define MOB_VOMIT_HARM (1<<2)
-/// Flag which makes the mob vomit blood
-#define MOB_VOMIT_BLOOD (1<<3)
+/// Flag which will cause the mob to fall over when vomiting.
+#define MOB_VOMIT_KNOCKDOWN (1<<4)
 /// Flag which will make the proc skip certain checks when it comes to forcing a vomit.
-#define MOB_VOMIT_FORCE (1<<4)
+#define MOB_VOMIT_FORCE (1<<5)
 
-/// The default "vomit" color green, which will ultinately give you might typically expect to happen when you vomit.
-#define VOMIT_CATEGORY_DEFAULT (MOB_VOMIT_MESSAGE | MOB_VOMIT_STUN | MOB_VOMIT_HARM)
-/// The green vomit you've all come to know and love, but with a little extra "spice" (blood)
+/// The default. Gives you might typically expect to happen when you vomit.
+#define VOMIT_CATEGORY_DEFAULT (MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM | MOB_VOMIT_STUN)
+/// The vomit you've all come to know and love, but with a little extra "spice" (blood)
 #define VOMIT_CATEGORY_BLOOD (VOMIT_CATEGORY_DEFAULT | MOB_VOMIT_BLOOD)
+/// Another vomit variant that causes you to get knocked down and paralyzed instead of just stunned, but is standard enough otherwise.
+#define VOMIT_CATEGORY_KNOCKDOWN (MOB_VOMIT_MESSAGE | MOB_VOMIT_HARM | MOB_VOMIT_KNOCKDOWN)
 
 /// Possible value of [/atom/movable/buckle_lying]. If set to a different (positive-or-zero) value than this, the buckling thing will force a lying angle on the buckled.
 #define NO_BUCKLE_LYING -1

--- a/code/modules/antagonists/abductor/equipment/glands/heal.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/heal.dm
@@ -1,4 +1,4 @@
-#define REJECTION_VOMIT_FLAGS (MOB_VOMIT_BLOOD | MOB_VOMIT_STUN | MOB_VOMIT_FORCE)
+#define REJECTION_VOMIT_FLAGS (MOB_VOMIT_BLOOD | MOB_VOMIT_KNOCKDOWN | MOB_VOMIT_FORCE)
 
 /obj/item/organ/internal/heart/gland/heal
 	abductor_hint = "organic replicator. Forcibly ejects damaged and robotic organs from the abductee and regenerates them. Additionally, forcibly removes reagents (via vomit) from the abductee if they have moderate toxin damage or poison within the bloodstream, and regenerates blood to a healthy threshold if too low. The abductee will also reject implants such as mindshields."

--- a/code/modules/antagonists/abductor/equipment/glands/heal.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/heal.dm
@@ -1,4 +1,4 @@
-#define REJECTION_VOMIT_FLAGS (MOB_VOMIT_BLOOD | MOB_VOMIT_KNOCKDOWN | MOB_VOMIT_FORCE)
+#define REJECTION_VOMIT_FLAGS (MOB_VOMIT_BLOOD | MOB_VOMIT_STUN | MOB_VOMIT_KNOCKDOWN | MOB_VOMIT_FORCE)
 
 /obj/item/organ/internal/heart/gland/heal
 	abductor_hint = "organic replicator. Forcibly ejects damaged and robotic organs from the abductee and regenerates them. Additionally, forcibly removes reagents (via vomit) from the abductee if they have moderate toxin damage or poison within the bloodstream, and regenerates blood to a healthy threshold if too low. The abductee will also reject implants such as mindshields."

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -117,7 +117,7 @@
 		return
 
 	if(user.get_timed_status_effect_duration(/datum/status_effect/confusion) > BEYBLADE_PUKE_THRESHOLD)
-		user.vomit(VOMIT_CATEGORY_DEFAULT, lost_nutrition = BEYBLADE_PUKE_NUTRIENT_LOSS, distance = 0)
+		user.vomit(VOMIT_CATEGORY_KNOCKDOWN, lost_nutrition = BEYBLADE_PUKE_NUTRIENT_LOSS, distance = 0)
 		return
 
 	if(prob(BEYBLADE_DIZZINESS_PROBABILITY))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -420,6 +420,7 @@
 	var/starting_dir = dir
 	var/message = (vomit_flags & MOB_VOMIT_MESSAGE)
 	var/stun = (vomit_flags & MOB_VOMIT_STUN)
+	var/knockdown = (vomit_flags & MOB_VOMIT_KNOCKDOWN)
 	var/blood = (vomit_flags & MOB_VOMIT_BLOOD)
 
 	if(!force && !blood && (nutrition < 100))
@@ -430,6 +431,8 @@
 			)
 		if(stun)
 			Stun(20 SECONDS)
+		if(knockdown)
+			Paralyze(20 SECONDS)
 		return TRUE
 
 	if(is_mouth_covered()) //make this add a blood/vomit overlay later it'll be hilarious
@@ -451,6 +454,9 @@
 
 	if(stun)
 		Stun(8 SECONDS)
+	if(knockdown)
+		Paralyze(8 SECONDS)
+
 
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 50, TRUE)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -432,7 +432,7 @@
 		if(stun)
 			Stun(20 SECONDS)
 		if(knockdown)
-			Paralyze(20 SECONDS)
+			Knockdown(20 SECONDS)
 		return TRUE
 
 	if(is_mouth_covered()) //make this add a blood/vomit overlay later it'll be hilarious
@@ -455,8 +455,7 @@
 	if(stun)
 		Stun(8 SECONDS)
 	if(knockdown)
-		Paralyze(8 SECONDS)
-
+		Knockdown(8 SECONDS)
 
 	playsound(get_turf(src), 'sound/effects/splat.ogg', 50, TRUE)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -708,6 +708,9 @@
 		)
 	if(vomit_flags & MOB_VOMIT_STUN)
 		Stun(20 SECONDS)
+	if(vomit_flags & MOB_VOMIT_KNOCKDOWN)
+		Knockdown(20 SECONDS)
+
 	return TRUE
 
 /mob/living/carbon/human/vv_edit_var(var_name, var_value)


### PR DESCRIPTION
## About The Pull Request

ALL stunning vomits were nerfed to have just a motionless stun in #70245 (14438a2b7d5d781c340713983f8f07fb09179f08), and while it didn't really affect game balance beyond just making you not fall on the floor... I really didn't like it since it was all-or-nothing. Fortunately with #78191 (a7060641bb0165a7531a3cee007989d9e95741ee), we are able to add more expression to how a vomit should go down using the new bitflag system, so I decided to rewrite it back in for a special number of cases.

I only did it for two cases, but anyone is free to change anything they think they deserve it via changing the vomit flags that are passed into the proc. Those cases are:

* Places where you vomit after spinning too hard. You lost balance and threw up. That makes more sense to me than just being suddenly and completely motionless without any sign of loss of inertia.
* Organ heal rejections. You literally vomit out an organ. How are you still standing up? Beyond making no sense in anatomy, you should really feel the _oomph_ from literally puking out an organ.
## Why It's Good For The Game

This is a bit of flavor that really ensaddened me when I realized it was removed because it really does miss out on the real and true impact. While I do agree with some merits of the aforementioned balance PR that removed it, I do not think that it works at all for a blanket case. Now that we are able to add this expression, we should, because it's cool.

Also cleaned up some comments I forgot to update from the last time.
## Changelog
:cl:
balance: You will be knocked down again on certain vomits. Don't worry, you'll deserve it when it happens.
/:cl:
