### PR TITLE
Ghosts can eat ghost burgers

### DIFF
--- a/code/datums/components/food/ghost_edible.dm
+++ b/code/datums/components/food/ghost_edible.dm
@@ -1,6 +1,6 @@
 /**
  * Allows ghosts to eat this by orbiting it
- * They do this by consuming
+ * They do this by consuming the reagents in the object, so if it doesn't have any then it won't work
  */
 /datum/component/ghost_edible
 	/// Amount of reagents which will be consumed by each bite

--- a/code/datums/components/food/ghost_edible.dm
+++ b/code/datums/components/food/ghost_edible.dm
@@ -1,0 +1,60 @@
+/**
+ * Allows ghosts to eat this by orbiting it
+ * They do this by consuming
+ */
+/datum/component/ghost_edible
+	/// Amount of reagents which will be consumed by each bite
+	var/bite_consumption
+	/// Chance per ghost that a bite will be taken
+	var/bite_chance
+	/// Minimum size the food will display as before being deleted
+	var/minimum_scale
+	/// How many reagents this had on initialisation, used to figure out how eaten we are
+	var/initial_reagent_volume = 0
+
+/datum/component/ghost_edible/Initialize(bite_consumption = 3, bite_chance = 20, minimum_scale = 0.6)
+	. = ..()
+	if (!isatom(parent))
+		return COMPONENT_INCOMPATIBLE
+	var/atom/atom_parent = parent
+	if (isnull(atom_parent.reagents) || atom_parent.reagents.total_volume == 0)
+		return COMPONENT_INCOMPATIBLE
+	src.bite_consumption = bite_consumption
+	src.bite_chance = bite_chance
+	src.minimum_scale = minimum_scale
+	initial_reagent_volume = atom_parent.reagents.total_volume
+
+/datum/component/ghost_edible/RegisterWithParent()
+	. = ..()
+	START_PROCESSING(SSdcs, src)
+
+/datum/component/ghost_edible/UnregisterFromParent()
+	. = ..()
+	STOP_PROCESSING(SSdcs, src)
+
+/datum/component/ghost_edible/Destroy(force, silent)
+	STOP_PROCESSING(SSdcs, src)
+	return ..()
+
+/datum/component/ghost_edible/process(seconds_per_tick)
+	var/atom/atom_parent = parent
+	// Ghosts can eat this burger
+	var/munch_chance = 0
+	for(var/mob/dead/observer/ghost in atom_parent.orbiters?.orbiter_list)
+		munch_chance += bite_chance
+		if (munch_chance >= 100)
+			break
+	if (!prob(munch_chance))
+		return
+	playsound(atom_parent.loc,'sound/items/eatfood.ogg', vol = rand(10,50), vary = TRUE)
+	atom_parent.reagents.remove_any(bite_consumption)
+	if (atom_parent.reagents.total_volume <= 0)
+		atom_parent.visible_message(span_notice("[atom_parent] disappears completely!"))
+		new /obj/item/ectoplasm(atom_parent.loc)
+		qdel(parent)
+		return
+
+	var/final_transform = matrix().Scale(LERP(minimum_scale, 1, atom_parent.reagents.total_volume / initial_reagent_volume))
+	var/animate_transform = matrix(final_transform).Scale(0.8)
+	animate(parent, transform = animate_transform, time = 0.1 SECONDS)
+	animate(transform = final_transform, time = 0.1 SECONDS)

--- a/code/datums/components/food/ghost_edible.dm
+++ b/code/datums/components/food/ghost_edible.dm
@@ -26,11 +26,9 @@
 	notify_ghosts("[parent] is edible by ghosts!", source = parent, action = NOTIFY_ORBIT, header="Something Tasty!")
 
 /datum/component/ghost_edible/RegisterWithParent()
-	. = ..()
 	START_PROCESSING(SSdcs, src)
 
 /datum/component/ghost_edible/UnregisterFromParent()
-	. = ..()
 	STOP_PROCESSING(SSdcs, src)
 
 /datum/component/ghost_edible/Destroy(force, silent)

--- a/code/datums/components/food/ghost_edible.dm
+++ b/code/datums/components/food/ghost_edible.dm
@@ -23,6 +23,7 @@
 	src.bite_chance = bite_chance
 	src.minimum_scale = minimum_scale
 	initial_reagent_volume = atom_parent.reagents.total_volume
+	notify_ghosts("[parent] is edible by ghosts!", source = parent, action = NOTIFY_ORBIT, header="Something Tasty!")
 
 /datum/component/ghost_edible/RegisterWithParent()
 	. = ..()

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -280,7 +280,7 @@
 	reagents.remove_any(bite_consumption)
 	if (reagents.total_volume <= 0)
 		visible_message(span_notice("[src] disappears completely!"))
-		new /obj/effect/decal/cleanable/greenglow/ecto(loc)
+		new /obj/item/ectoplasm(loc)
 		qdel(src)
 		return
 

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -209,11 +209,6 @@
 	venue_value = FOOD_PRICE_CHEAP
 	crafting_complexity = FOOD_COMPLEXITY_2
 
-/// How likely is a ghost to take a little bite of this burger?
-#define GHOST_BITE_CHANCE 20
-/// How small does a burger get while ghosts are eating it
-#define MIN_GHOST_BURGER_SCALE 0.6
-
 /obj/item/food/burger/ghost
 	name = "ghost burger"
 	desc = "Too Spooky!"
@@ -232,13 +227,11 @@
 	venue_value = FOOD_PRICE_EXOTIC
 	crafting_complexity = FOOD_COMPLEXITY_3
 	preserved_food = TRUE // It's made of ghosts
-	/// How many reagents did we contain when created?
-	var/initial_volume = 0
 
-/obj/item/food/burger/ghost/Initialize(mapload)
+/obj/item/food/burger/ghost/Initialize(mapload, starting_reagent_purity, no_base_reagents)
 	. = ..()
 	START_PROCESSING(SSobj, src)
-	initial_volume = reagents.total_volume
+	AddComponent(/datum/component/ghost_edible, bite_consumption = bite_consumption)
 
 /obj/item/food/burger/ghost/make_germ_sensitive()
 	return // This burger moves itself so it shouldn't pick up germs from walking onto the floor
@@ -268,33 +261,9 @@
 			new /obj/effect/decal/cleanable/greenglow/ecto(loc)
 			playsound(loc, 'sound/effects/splat.ogg', 200, TRUE)
 
-	// Ghosts can eat this burger
-	var/munch_chance = 0
-	for(var/mob/dead/observer/ghost in orbiters?.orbiter_list)
-		munch_chance += GHOST_BITE_CHANCE
-		if (munch_chance >= 100)
-			break
-	if (!prob(munch_chance))
-		return
-	playsound(loc,'sound/items/eatfood.ogg', vol = rand(10,50), vary = TRUE)
-	reagents.remove_any(bite_consumption)
-	if (reagents.total_volume <= 0)
-		visible_message(span_notice("[src] disappears completely!"))
-		new /obj/item/ectoplasm(loc)
-		qdel(src)
-		return
-
-	var/final_transform = matrix().Scale(LERP(MIN_GHOST_BURGER_SCALE, 1, reagents.total_volume / initial_volume))
-	var/animate_transform = matrix(final_transform).Scale(0.8)
-	animate(src, transform = animate_transform, time = 0.1 SECONDS)
-	animate(transform = final_transform, time = 0.1 SECONDS)
-
 /obj/item/food/burger/ghost/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
-
-#undef GHOST_BITE_CHANCE
-#undef MIN_GHOST_BURGER_SCALE
 
 /obj/item/food/burger/red
 	name = "red burger"

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -209,6 +209,11 @@
 	venue_value = FOOD_PRICE_CHEAP
 	crafting_complexity = FOOD_COMPLEXITY_2
 
+/// How likely is a ghost to take a little bite of this burger?
+#define GHOST_BITE_CHANCE 20
+/// How small does a burger get while ghosts are eating it
+#define MIN_GHOST_BURGER_SCALE 0.6
+
 /obj/item/food/burger/ghost
 	name = "ghost burger"
 	desc = "Too Spooky!"
@@ -226,10 +231,17 @@
 	verb_yell = "wails"
 	venue_value = FOOD_PRICE_EXOTIC
 	crafting_complexity = FOOD_COMPLEXITY_3
+	preserved_food = TRUE // It's made of ghosts
+	/// How many reagents did we contain when created?
+	var/initial_volume = 0
 
 /obj/item/food/burger/ghost/Initialize(mapload)
 	. = ..()
 	START_PROCESSING(SSobj, src)
+	initial_volume = reagents.total_volume
+
+/obj/item/food/burger/ghost/make_germ_sensitive()
+	return // This burger moves itself so it shouldn't pick up germs from walking onto the floor
 
 /obj/item/food/burger/ghost/process()
 	if(!isturf(loc)) //no floating out of bags
@@ -256,11 +268,33 @@
 			new /obj/effect/decal/cleanable/greenglow/ecto(loc)
 			playsound(loc, 'sound/effects/splat.ogg', 200, TRUE)
 
-		//If i was less lazy i would make the burger forcefeed itself to a nearby mob here.
+	// Ghosts can eat this burger
+	var/munch_chance = 0
+	for(var/mob/dead/observer/ghost in orbiters?.orbiter_list)
+		munch_chance += GHOST_BITE_CHANCE
+		if (munch_chance >= 100)
+			break
+	if (!prob(munch_chance))
+		return
+	playsound(loc,'sound/items/eatfood.ogg', vol = rand(10,50), vary = TRUE)
+	reagents.remove_any(bite_consumption)
+	if (reagents.total_volume <= 0)
+		visible_message(span_notice("[src] disappears completely!"))
+		new /obj/effect/decal/cleanable/greenglow/ecto(loc)
+		qdel(src)
+		return
+
+	var/final_transform = matrix().Scale(LERP(MIN_GHOST_BURGER_SCALE, 1, reagents.total_volume / initial_volume))
+	var/animate_transform = matrix(final_transform).Scale(0.8)
+	animate(src, transform = animate_transform, time = 0.1 SECONDS)
+	animate(transform = final_transform, time = 0.1 SECONDS)
 
 /obj/item/food/burger/ghost/Destroy()
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
+
+#undef GHOST_BITE_CHANCE
+#undef MIN_GHOST_BURGER_SCALE
 
 /obj/item/food/burger/red
 	name = "red burger"

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -34,6 +34,10 @@
 	foodtypes = GRAIN | FRUIT | SUGAR | BREAKFAST
 	crafting_complexity = FOOD_COMPLEXITY_4
 
+/obj/item/food/muffin/booberry/Initialize(mapload, starting_reagent_purity, no_base_reagents)
+	. = ..()
+	AddComponent(/datum/component/ghost_edible, bite_consumption = bite_consumption)
+
 /obj/item/food/muffin/moffin
 	name = "moffin"
 	icon_state = "moffin_1"

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -641,9 +641,10 @@
 	spirits = list()
 	START_PROCESSING(SSobj, src)
 	SSpoints_of_interest.make_point_of_interest(src)
-	AddComponent(/datum/component/butchering, \
-	speed = 15 SECONDS, \
-	effectiveness = 90, \
+	AddComponent(\
+		/datum/component/butchering, \
+		speed = 15 SECONDS, \
+		effectiveness = 90, \
 	)
 
 /obj/item/melee/ghost_sword/Destroy()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1138,6 +1138,7 @@
 #include "code\datums\components\food\decomposition.dm"
 #include "code\datums\components\food\edible.dm"
 #include "code\datums\components\food\germ_sensitive.dm"
+#include "code\datums\components\food\ghost_edible.dm"
 #include "code\datums\components\food\golem_food.dm"
 #include "code\datums\components\food\ice_cream_holder.dm"
 #include "code\datums\components\material\material_container.dm"


### PR DESCRIPTION
## About The Pull Request

Every tick while a ghost is orbiting a ghost burger there is a 20% chance per ghost (capping at 100% at 5 ghosts) that they will take a bite out of the ghost burger, shrinking it and depleting its reagents until it is completely consumed.
It leaves some ectoplasm behind which you could use to make another burger.
Also ghost burgers can no longer decay or pick up floor germs, the burger moves itself so this would happen reasonably often because it doesn't stay on tables. Also: it is a ghost.

Also just before I posted this PR I noticed that "booberry muffins" also exist so there was nothing for it but to componentise this behaviour and attach it to both food items, so I guess admins can also make anything with reagents edible to ghosts also.

## Why It's Good For The Game

I think the chef should be able to make food for ghosts. It's not fair if only living people get to eat.

## Changelog

:cl:
add: Ghosts (observers) can eat ghost burgers and booberry muffins.
balance: Ghost burgers will not decay or pick up germs due to the fact that they moved themselves off a table.
/:cl:
