### PR TITLE
Caches Node and Python Bootstrap for GH Actions

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -33,33 +33,21 @@ jobs:
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Restore Node cache
         uses: actions/cache@v3
         with:
           path: ~/.nvm
           key: ${{ runner.os }}-node-${{ hashFiles('dependencies.sh') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Restore Bootstrap cache
         uses: actions/cache@v3
         with:
           path: tools/bootstrap/.cache
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Restore Rust cache
         uses: actions/cache@v3
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-rust
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Install Tools
         run: |
           pip3 install setuptools

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -36,6 +36,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      - name: Restore Node cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.nvm
+          key: ${{ runner.os }}-nodeBREAKING-${{ hashFiles('dependencies.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Restore Bootstrap cache
+        uses: actions/cache@v3
+        with:
+          path: tools/bootstrap/.cache
+          key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Restore Rust cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -33,16 +33,22 @@ jobs:
         with:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Restore Node cache
         uses: actions/cache@v3
         with:
           path: ~/.nvm
           key: ${{ runner.os }}-node-${{ hashFiles('dependencies.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: Restore Bootstrap cache
         uses: actions/cache@v3
         with:
           path: tools/bootstrap/.cache
           key: ${{ runner.os }}-bootstrap-${{ hashFiles('tools/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-bootstrap-
       - name: Restore Rust cache
         uses: actions/cache@v3
         with:
@@ -244,8 +250,7 @@ jobs:
           path: tgui/.yarn/cache
           key: ${{ runner.os }}-yarn-${{ hashFiles('tgui/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            ${{ runner.os }}-yarn-
       - name: Compile
         run: pwsh tools/ci/build.ps1
         env:

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.nvm
-          key: ${{ runner.os }}-nodeBREAKING-${{ hashFiles('dependencies.sh') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('dependencies.sh') }}
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-


### PR DESCRIPTION
## About The Pull Request

I was planning on doing this a lot earlier but ran into some weird roadblocks, but this time I finally did the research and it's done properly.

We do a lot of useless work on every single CI run, and in the interest of saving the world's energy (by a matter of at least 10 seconds per my testing), lets stop doing so much extra work by caching both the work we do on the python bootstrap installation (we literally call it `cache` for a reason) and the Node installation by sharing it between github actions runners.

Here's a random CI run on master where you can see that the `Install Tools` portion takes about 19 seconds - https://github.com/tgstation/tgstation/actions/runs/6167104927/job/16737570519

Here's the CI run I was testing with where you can see we slim it down to about 6 seconds for the `Install Tools` step, but with a second-or-so taken to restore the cache since the runner needs to download+unzip the cache. it tends to be shorter or longer by a second at times but i'm certain this is just noise - https://github.com/san7890/bruhstation/actions/runs/6167245722/job/16737919874

On average, we save about **10 seconds** a run on Run Linters, which is meant to be the fastest CI step. Future improvements would lie in making either maplint or the tgui test suite faster, but that would be a much more complicated and code-intensive task. cache go weeeee

## Changelog

Nothing that concerns players.