### PR TITLE
Lowpop stations will be freed from the burden of spontaneous brain trauma.

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -2,6 +2,7 @@
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
 	weight = 25
+	min_players = 13
 	category = EVENT_CATEGORY_HEALTH
 	description = "A crewmember gains a random trauma."
 	min_wizard_trigger_potency = 2


### PR DESCRIPTION
## About The Pull Request

Adds a minimum player count of 13 to the spontaneous brain trauma event so it doesn't screw over players on lowpop when there aren't many people that can help. 

## Why It's Good For The Game

With a minimum player count, this will make playing on lowpop a bit smoother as people aren't getting bombarded by traumas when there may not be any people with sufficient access to required tools for treatment.

## Changelog

:cl:
balance: The spontaneous brain trauma event will no longer occur if there are fewer than 13 players.
/:cl:
