### PR TITLE
Fixes infinite power exploit.

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -921,7 +921,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				multi = 8
 		if(zap_flags & ZAP_SUPERMATTER_FLAGS)
 			var/remaining_power = target.zap_act(zap_str * multi, zap_flags)
-			zap_str = remaining_power * 0.5 //Coils should take a lot out of the power of the zap
+			zap_str = remaining_power / multi //Coils should take a lot out of the power of the zap
 		else
 			zap_str /= 3
 


### PR DESCRIPTION
Fixes an exploit that allows tesla coils to duplicate >7GeV supermatter zaps. Does this by dividing the new zap value by the power multiplier instead of blindly halving it.
## About The Pull Request
Tesla coils no longer exponentially duplicate >7GeV supermatter zap power.
## Why It's Good For The Game
Prevents this from happening:
![DA66945A-8135-472F-BA9B-EA387A831469](https://github.com/tgstation/tgstation/assets/58013024/1dadc9a5-8790-4a84-8d42-0ad9f176eb9f)
## Changelog
:cl:
fix: Fixes tesla coils duplicating the power of >7GeV supermatter zaps.
/:cl:
