### PR TITLE
Removes some food initialize arguments

### DIFF
--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -66,11 +66,8 @@
 /datum/component/bakeable/proc/finish_baking(atom/used_oven)
 	var/atom/original_object = parent
 	var/obj/item/plate/oven_tray/used_tray = original_object.loc
-	var/atom/baked_result = new bake_result(
-		used_tray,
-		/* starting_reagent_purity = */ null,
-		/* no_base_reagents = */ TRUE,
-	)
+	var/atom/baked_result = new bake_result(used_tray)
+	bake_result.reagents.clear_reagents()
 	original_object.reagents?.trans_to(baked_result, original_object.reagents.total_volume)
 
 	if(who_baked_us)

--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -205,17 +205,13 @@
 			var/atom/movable/result
 			if(ispath(recipe.result, /obj/item/stack))
 				result = new recipe.result(get_turf(crafter.loc), recipe.result_amount || 1)
-			else if (ispath(recipe.result, /obj/item/food))
-				result = new recipe.result(
-					get_turf(crafter.loc),
-					/* starting_reagent_purity = */ null,
-					/* no_base_reagents = */ TRUE,
-				)
 			else
 				result = new recipe.result(get_turf(crafter.loc))
 				if(result.atom_storage && recipe.delete_contents)
 					for(var/obj/item/thing in result)
 						qdel(thing)
+			if (IsEdible(result))
+				result.reagents?.clear_reagents()
 			result.CheckParts(parts, recipe)
 			if(send_feedback)
 				SSblackbox.record_feedback("tally", "object_crafted", 1, result.type)

--- a/code/datums/components/food/golem_food.dm
+++ b/code/datums/components/food/golem_food.dm
@@ -53,14 +53,12 @@
 
 /// Creates our golem snack atom instance
 /datum/component/golem_food/proc/create_golem_snack(atom/source)
-	golem_snack = new(
-		/* loc = */ null,
-		/* starting_reagent_purity = */ null,
-		/* no_base_reagents = */ FALSE,
-		/* name = */ source.name,
-		/* consume_food = */ consume_on_eat,
-		/* food_buff = */ snack_type,
-		/* owner = */ parent,
+	golem_snack = new(null)
+	golem_snack.setup(
+		name = source.name,
+		consume_food = consume_on_eat,
+		food_buff = snack_type,
+		owner = parent,
 	)
 	RegisterSignal(golem_snack, COMSIG_QDELETING, PROC_REF(on_food_destroyed))
 
@@ -90,21 +88,17 @@
 	/// Golem food buff to apply on consumption
 	var/datum/golem_food_buff/food_buff
 
-/obj/item/food/golem_food/Initialize(
-	mapload,
-	starting_reagent_purity,
-	no_base_reagents = FALSE,
+/// Set up some properties based on a passed-in item that the golem will pretend to eat
+/obj/item/food/golem_food/proc/setup(
 	name,
-	consume_food,
+	consume_food = TRUE,
 	datum/golem_food_buff/food_buff,
 	atom/owner,
 )
-	. = ..()
 	src.name = name
 	src.consume_food = consume_food
 	src.food_buff = food_buff
 	src.owner = owner
-
 	RegisterSignal(owner, COMSIG_QDELETING, PROC_REF(on_parent_destroyed))
 
 /// Clean ourselves up if our parent dies

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -95,16 +95,13 @@
 		grilled_result = new cook_result(original_object.loc, stack_parent.amount)
 
 	else
-		grilled_result = new cook_result(
-			original_object.loc,
-			/* starting_reagent_purity = */ null,
-			/* no_base_reagents = */ TRUE,
-		)
+		grilled_result = new cook_result(original_object.loc)
 		if(original_object.custom_materials)
 			grilled_result.set_custom_materials(original_object.custom_materials)
 
-	if(IS_EDIBLE(grilled_result))
+	if(IsEdible(grilled_result))
 		BLACKBOX_LOG_FOOD_MADE(grilled_result.type)
+		grilled_result.reagents.clear_reagents()
 		original_object.reagents?.trans_to(grilled_result, original_object.reagents.total_volume)
 
 	SEND_SIGNAL(parent, COMSIG_ITEM_GRILLED, grilled_result)

--- a/code/datums/elements/dryable.dm
+++ b/code/datums/elements/dryable.dm
@@ -38,11 +38,8 @@
 		return
 	else if(istype(source, /obj/item/food) && ispath(dry_result, /obj/item/food))
 		var/obj/item/food/source_food = source
-		var/obj/item/food/resulting_food = new dry_result(
-			source.drop_location(),
-			/* starting_reagent_purity = */ null,
-			/* no_base_reagents = */ TRUE,
-		)
+		var/obj/item/food/resulting_food = new dry_result(source.drop_location())
+		resulting_food.reagents.clear_reagents()
 		source_food.reagents.trans_to(resulting_food, source_food.reagents.total_volume)
 		ADD_TRAIT(resulting_food, TRAIT_DRIED, ELEMENT_TRAIT(type))
 		qdel(source)

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -36,11 +36,7 @@
 		var/obj/item/stack/stack_source = source
 		result = new result_typepath(result_loc, stack_source.amount)
 	else
-		result = new result_typepath(
-			result_loc,
-			/* starting_reagent_purity = */ null,
-			/* no_base_reagents = */ TRUE,
-		)
+		result = new result_typepath(result_loc)
 
 	var/efficiency = istype(used_microwave) ? used_microwave.efficiency : 1
 	SEND_SIGNAL(result, COMSIG_ITEM_MICROWAVE_COOKED, source, efficiency)
@@ -48,7 +44,7 @@
 	if(IS_EDIBLE(result))
 		if(microwaver && microwaver.mind)
 			ADD_TRAIT(result, TRAIT_FOOD_CHEF_MADE, REF(microwaver.mind))
-
+		result.reagents.clear_reagents()
 		source.reagents?.trans_to(result, source.reagents.total_volume)
 
 		BLACKBOX_LOG_FOOD_MADE(result.type)

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -51,10 +51,7 @@
 	///Buff given when a hand-crafted version of this item is consumed. Randomized according to crafting_complexity if not assigned.
 	var/datum/status_effect/food/crafted_food_buff = null
 
-/obj/item/food/Initialize(mapload, starting_reagent_purity, no_base_reagents = FALSE)
-	src.starting_reagent_purity = starting_reagent_purity
-	if(no_base_reagents)
-		food_reagents = null
+/obj/item/food/Initialize(mapload)
 	if(food_reagents)
 		food_reagents = string_assoc_list(food_reagents)
 	. = ..()

--- a/code/game/objects/items/food/pastries.dm
+++ b/code/game/objects/items/food/pastries.dm
@@ -367,7 +367,10 @@
 	 */
 	var/list/prefill_flavours
 
-/obj/item/food/icecream/Initialize(mapload, starting_reagent_purity, no_base_reagents, list/prefill_flavours)
+/obj/item/food/icecream/New(loc, list/prefill_flavours)
+	return ..()
+
+/obj/item/food/icecream/Initialize(mapload, list/prefill_flavours)
 	if(prefill_flavours)
 		src.prefill_flavours = prefill_flavours
 	return ..()

--- a/code/game/objects/items/robot/items/food.dm
+++ b/code/game/objects/items/robot/items/food.dm
@@ -61,10 +61,8 @@
 			food_item = new /obj/item/food/lollipop/cyborg(turf_to_dispense_to)
 		if(DISPENSE_ICECREAM_MODE)
 			food_item = new /obj/item/food/icecream(
-				/* loc = */ turf_to_dispense_to,
-				/* starting_reagent_purity = */ null,
-				/* no_base_reagents = */ FALSE,
-				/* prefill_flavours = */ list(ICE_CREAM_VANILLA),
+				loc = turf_to_dispense_to,
+				prefill_flavours = list(ICE_CREAM_VANILLA),
 			)
 			food_item.desc = "Eat the ice cream."
 

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -358,10 +358,8 @@ GLOBAL_LIST_EMPTY(crematoriums)
 	var/list/icecreams = list()
 	for(var/mob/living/i_scream as anything in get_all_contents_type(/mob/living))
 		var/obj/item/food/icecream/IC = new /obj/item/food/icecream(
-			/* loc = */ null,
-			/* starting_reagent_purity = */ null,
-			/* no_base_reagents = */ FALSE,
-			/* prefill_flavours = */ list(ICE_CREAM_MOB = list(null, i_scream.name))
+			loc = null,
+			prefill_flavours = list(ICE_CREAM_MOB = list(null, i_scream.name))
 		)
 		icecreams += IC
 	. = ..()

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -68,11 +68,8 @@
 		var/list/cached_mats = recipe.preserve_materials && what.custom_materials
 		var/cached_multiplier = (recipe.food_multiplier * rating_amount)
 		for(var/i in 1 to cached_multiplier)
-			var/atom/processed_food = new recipe.output(
-				drop_location(),
-				/* starting_reagent_purity = */ null,
-				/* no_base_reagents = */ TRUE,
-			)
+			var/atom/processed_food = new recipe.output(drop_location())
+			processed_food.reagents.clear_reagents()
 			what.reagents.copy_to(processed_food, what.reagents.total_volume, multiplier = 1 / cached_multiplier)
 			if(cached_mats)
 				processed_food.set_custom_materials(cached_mats, 1 / cached_multiplier)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -78,6 +78,7 @@
 
 	. = ..() //Only call it here because we want all the genes and shit to be applied before we add edibility. God this code is a mess.
 
+	reagents.clear_reagents()
 	seed.prepare_result(src)
 	transform *= TRANSFORM_USING_VARIABLE(seed.potency, 100) + 0.5 //Makes the resulting produce's sprite larger or smaller based on potency!
 

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -43,12 +43,10 @@
 	/// Should we pixel offset ourselves at init? for mapping
 	var/offset_at_init = TRUE
 
-/obj/item/food/grown/Initialize(
-		mapload,
-		starting_reagent_purity = null,
-		no_base_reagents = TRUE,
-		obj/item/seeds/new_seed,
-	)
+/obj/item/food/grown/New(loc, obj/item/seeds/new_seed)
+	return ..()
+
+/obj/item/food/grown/Initialize(mapload, obj/item/seeds/new_seed)
 	if(!tastes)
 		tastes = list("[name]" = 1) //This happens first else the component already inits
 

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -167,13 +167,9 @@
 	bite_consumption_mod = 4
 	var/is_ripening = FALSE
 
-/obj/item/food/grown/banana/bunch/Initialize(
-		mapload,
-		starting_reagent_purity = null,
-		no_base_reagents = TRUE,
-		obj/item/seeds/new_seed,
-	)
+/obj/item/food/grown/banana/bunch/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()
+	reagents.clear_reagents()
 	reagents.add_reagent(/datum/reagent/consumable/monkey_energy, 10)
 	reagents.add_reagent(/datum/reagent/consumable/banana, 10)
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -237,7 +237,6 @@
 			t_prod.name = lowertext(parent.myseed.plantname)
 		if(productdesc)
 			t_prod.desc = productdesc
-		t_prod.reagents?.clear_reagents()
 		t_prod.seed.name = parent.myseed.name
 		t_prod.seed.desc = parent.myseed.desc
 		t_prod.seed.plantname = parent.myseed.plantname

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -223,12 +223,7 @@
 			for(var/datum/plant_gene/trait/trait in parent.myseed.genes)
 				if((trait.mutability_flags & PLANT_GENE_MUTATABLE) && trait.can_add(mutated_seed))
 					mutated_seed.genes += trait.Copy()
-			t_prod = new t_prod(
-				output_loc,
-				/* starting_reagent_purity = */ null,
-				/* no_base_reagents = */ TRUE,
-				/* new_seed = */ mutated_seed,
-			)
+			t_prod = new t_prod(output_loc, new_seed = mutated_seed)
 			t_prod.transform = initial(t_prod.transform)
 			t_prod.transform *= TRANSFORM_USING_VARIABLE(t_prod.seed.potency, 100) + 0.5
 			ADD_TRAIT(t_prod, TRAIT_PLANT_WILDMUTATE, INNATE_TRAIT)
@@ -237,16 +232,12 @@
 				t_prod.seed.set_instability(round(instability * 0.5))
 			continue
 		else
-			t_prod = new product(
-				output_loc,
-				/* starting_reagent_purity = */ null,
-				/* no_base_reagents = */ TRUE,
-				/* new_seed = */ src,
-			)
+			t_prod = new product(output_loc, new_seed = src)
 		if(parent.myseed.plantname != initial(parent.myseed.plantname))
 			t_prod.name = lowertext(parent.myseed.plantname)
 		if(productdesc)
 			t_prod.desc = productdesc
+		t_prod.reagents?.clear_reagents()
 		t_prod.seed.name = parent.myseed.name
 		t_prod.seed.desc = parent.myseed.desc
 		t_prod.seed.plantname = parent.myseed.plantname

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -116,7 +116,8 @@
 	. = ..(TRUE)
 	// Now if we were't ACTUALLY gibbed, spawn the dead mouse
 	if(!gibbed)
-		var/obj/item/food/deadmouse/mouse = new(loc, /* starting_reagent_purity = */ null, /* no_base_reagents = */ FALSE, /* dead_critter = */ src)
+		var/obj/item/food/deadmouse/mouse = new(loc)
+		mouse.copy_corpse(src)
 		if(HAS_TRAIT(src, TRAIT_BEING_SHOCKED))
 			mouse.desc = "They're toast."
 			mouse.add_atom_colour("#3A3A3A", FIXED_COLOUR_PRIORITY)
@@ -301,15 +302,17 @@
 	var/body_color = "gray"
 	var/critter_type = /mob/living/basic/mouse
 
-/obj/item/food/deadmouse/Initialize(mapload, starting_reagent_purity, no_base_reagents, mob/living/basic/mouse/dead_critter)
+/obj/item/food/deadmouse/Initialize(mapload)
 	. = ..()
-	if(dead_critter)
-		body_color = dead_critter.body_color
-		critter_type = dead_critter.type
-		name = dead_critter.name
-		icon_state = dead_critter.icon_dead
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_MOUSE, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 10)
 	RegisterSignal(src, COMSIG_ATOM_ON_LAZARUS_INJECTOR, PROC_REF(use_lazarus))
+
+/// Copy properties from an imminently dead mouse
+/obj/item/food/deadmouse/proc/copy_corpse(mob/living/basic/mouse/dead_critter)
+	body_color = dead_critter.body_color
+	critter_type = dead_critter.type
+	name = dead_critter.name
+	icon_state = dead_critter.icon_dead
 
 /obj/item/food/deadmouse/examine(mob/user)
 	. = ..()

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1383,6 +1383,12 @@
 			return round(cached_reagent.purity, 0.01)
 	return 0
 
+/// Directly set the purity of all contained reagents to a new value
+/datum/reagents/proc/set_all_reagents_purity(new_purity = 0)
+	var/list/cached_reagents = reagent_list
+	for(var/datum/reagent/cached_reagent as anything in cached_reagents)
+		cached_reagent.purity = max(0, new_purity)
+
 /// Get the average purity of all reagents (or all subtypes of provided typepath)
 /datum/reagents/proc/get_average_purity(parent_type = null)
 	var/total_amount

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -350,16 +350,18 @@
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/machinery/reagentgrinder, mix_complete)), 50)
 
 /obj/machinery/reagentgrinder/proc/mix_complete()
-	if(beaker?.reagents.total_volume)
-		//Recipe to make Butter
-		var/butter_amt = FLOOR(beaker.reagents.get_reagent_amount(/datum/reagent/consumable/milk) / MILK_TO_BUTTER_COEFF, 1)
-		var/purity = beaker.reagents.get_reagent_purity(/datum/reagent/consumable/milk)
-		beaker.reagents.remove_reagent(/datum/reagent/consumable/milk, MILK_TO_BUTTER_COEFF * butter_amt)
-		for(var/i in 1 to butter_amt)
-			new /obj/item/food/butter(/* loc = */ drop_location(), /* starting_reagent_purity = */ purity)
-		//Recipe to make Mayonnaise
-		if (beaker.reagents.has_reagent(/datum/reagent/consumable/eggyolk))
-			beaker.reagents.convert_reagent(/datum/reagent/consumable/eggyolk, /datum/reagent/consumable/mayonnaise)
-		//Recipe to make whipped cream
-		if (beaker.reagents.has_reagent(/datum/reagent/consumable/cream))
-			beaker.reagents.convert_reagent(/datum/reagent/consumable/cream, /datum/reagent/consumable/whipped_cream)
+	if(beaker?.reagents.total_volume <= 0)
+		return
+	//Recipe to make Butter
+	var/butter_amt = FLOOR(beaker.reagents.get_reagent_amount(/datum/reagent/consumable/milk) / MILK_TO_BUTTER_COEFF, 1)
+	var/purity = beaker.reagents.get_reagent_purity(/datum/reagent/consumable/milk)
+	beaker.reagents.remove_reagent(/datum/reagent/consumable/milk, MILK_TO_BUTTER_COEFF * butter_amt)
+	for(var/i in 1 to butter_amt)
+		var/obj/item/food/butter/tasty_butter = new(drop_location())
+		tasty_butter.reagents.set_all_reagents_purity(purity)
+	//Recipe to make Mayonnaise
+	if (beaker.reagents.has_reagent(/datum/reagent/consumable/eggyolk))
+		beaker.reagents.convert_reagent(/datum/reagent/consumable/eggyolk, /datum/reagent/consumable/mayonnaise)
+	//Recipe to make whipped cream
+	if (beaker.reagents.has_reagent(/datum/reagent/consumable/cream))
+		beaker.reagents.convert_reagent(/datum/reagent/consumable/cream, /datum/reagent/consumable/whipped_cream)


### PR DESCRIPTION
## About The Pull Request

A prior PR added some new initialize arguments to the food subtype which did not strictly need to be there, this caused a large number of bugs as a result of places which already had extra initialize arguments not correctly accounting for these new ones.
As a result I have removed these again in favour of performing the required operations in a different way (one of these arguments was seemingly used for butter purity and literally nothing else), for this food and also some of its subtypes.

In some other cases where it _did_ make sense to have arguments in `initialize` I also added them to `new` so they can be passed by name.

This will hopefully make the food more maintainable if in the future if someone does something similar, and solve any remaining bugs related to "not passing the arguments properly".

## Changelog

Hopefully not player facing
