### PR TITLE
Items created from durathread are now 50% more resistant to consuming

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -505,6 +505,9 @@ GLOBAL_LIST_INIT(durathread_recipes, list ( \
 	. = ..()
 	. += GLOB.durathread_recipes
 
+/obj/item/stack/sheet/durathread/on_item_crafted(mob/builder, atom/created)
+	created.set_armor_rating(CONSUME, max(50, created.get_armor_rating(CONSUME)))
+
 /obj/item/stack/sheet/cotton
 	name = "raw cotton bundle"
 	desc = "A bundle of raw cotton ready to be spun on the loom."

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -401,6 +401,7 @@
 
 	if(created)
 		created.setDir(builder.dir)
+		on_item_crafted(builder, created)
 
 	// Use up the material
 	use(recipe.req_amount * multiplier)
@@ -430,6 +431,10 @@
 	//BubbleWrap END
 
 	return TRUE
+
+/// Run special logic on created items after they've been successfully crafted.
+/obj/item/stack/proc/on_item_crafted(mob/builder, atom/created)
+	return
 
 /obj/item/stack/vv_edit_var(vname, vval)
 	if(vname == NAMEOF(src, amount))


### PR DESCRIPTION

## About The Pull Request

Title.
This means that a moth can take, on average due to rounding, double the normal bites from an article of durathread clothing.
## Why It's Good For The Game

Minor moth and botanist buff. Means that moths will prefer eating durathread items where possible and will either work with botany or perhaps steal from others to get it
## Changelog
:cl:
add: NanoTrasen improved the quality of the local durathread strain; resulting in it now being twice as filling!
/:cl:
