### PR TITLE
Syndicate MODSuit Intellicard can actually download AIs

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -54,7 +54,8 @@
 	force = 7
 
 /obj/item/aicard/syndie/loaded
-	var/being_or_was_used = FALSE
+	/// Set to true while we're waiting for ghosts to sign up
+	var/finding_candidate = FALSE
 
 /obj/item/aicard/syndie/loaded/examine(mob/user)
 	. = ..()
@@ -62,43 +63,55 @@
 	. += span_notice("This one has a little S.E.L.F. insignia on the back, and a label next to it that says 'Activate for one FREE aligned AI! Please attempt uplink reintegration or ask your employers for reimbursal if AI is unavailable or belligerent.")
 
 /obj/item/aicard/syndie/loaded/attack_self(mob/user, modifiers)
-	if(AI || being_or_was_used)
+	if(!isnull(AI))
 		return ..()
-	being_or_was_used = TRUE
+	if(finding_candidate)
+		balloon_alert(user, "loading...")
+		return TRUE
+	finding_candidate = TRUE
 	to_chat(user, span_notice("Connecting to S.E.L.F. dispatch..."))
-	being_or_was_used = procure_ai(user)
+	procure_ai(user)
+	finding_candidate = FALSE
+	return TRUE
 
 /obj/item/aicard/syndie/loaded/proc/procure_ai(mob/user)
-	var/datum/antagonist/nukeop/creator_op = user.mind?.has_antag_datum(/datum/antagonist/nukeop,TRUE)
-	if(!creator_op)
-		return FALSE
-	var/list/nuke_candidates = poll_ghost_candidates("Do you want to play as a syndicate artifical intelligence inside an intelliCard?", ROLE_OPERATIVE, ROLE_OPERATIVE, 150, POLL_IGNORE_SYNDICATE)
+	var/datum/antagonist/nukeop/op_datum = user.mind?.has_antag_datum(/datum/antagonist/nukeop,TRUE)
+	if(isnull(op_datum))
+		balloon_alert(user, "invalid access!")
+		return
+	var/list/nuke_candidates = poll_ghost_candidates(
+		question = "Do you want to play as a nuclear operative MODsuit AI?",
+		jobban_type = ROLE_OPERATIVE,
+		be_special_flag = ROLE_OPERATIVE_MIDROUND,
+		poll_time = 15 SECONDS,
+		ignore_category = POLL_IGNORE_SYNDICATE,
+	)
 	if(QDELETED(src))
-		return FALSE
+		return
 	if(!LAZYLEN(nuke_candidates))
 		to_chat(user, span_warning("Unable to connect to S.E.L.F. dispatch. Please wait and try again later or use the intelliCard on your uplink to get your points refunded."))
-		return FALSE
+		return
 	// pick ghost, create AI and transfer
 	var/mob/dead/observer/ghos = pick(nuke_candidates)
-	var/mob/living/silicon/ai/weak_syndie/new_ai = new /mob/living/silicon/ai/weak_syndie(get_turf(src), null, ghos) // wow so cool i love how laws go before the mob to insert for no reason this definitely didnt delay this pr for weeks
-	new_ai.key = ghos.key
+	var/mob/living/silicon/ai/weak_syndie/new_ai = new /mob/living/silicon/ai/weak_syndie(get_turf(src), new /datum/ai_laws/syndicate_override, ghos)
 	// create and apply syndie datum
 	var/datum/antagonist/nukeop/nuke_datum = new()
 	nuke_datum.send_to_spawnpoint = FALSE
-	new_ai.mind.add_antag_datum(nuke_datum, creator_op.nuke_team)
+	new_ai.mind.add_antag_datum(nuke_datum, op_datum.nuke_team)
 	new_ai.mind.special_role = "Syndicate AI"
 	new_ai.faction |= ROLE_SYNDICATE
 	// Make it look evil!!!
 	new_ai.hologram_appearance = mutable_appearance('icons/mob/silicon/ai.dmi',"xeno_queen") //good enough
-	new_ai.icon_state = resolve_ai_icon("hades") // evli
-	pre_attack(new_ai, user) // i love shitcode!
-	AI.control_disabled = FALSE // re-enable wireless activity
-	AI.radio_enabled = TRUE // ditto
+	new_ai.icon_state = resolve_ai_icon("hades")
+	// Transfer the AI from the core we created into the card, then delete the core
+	capture_ai(new_ai, user)
 	var/obj/structure/ai_core/deactivated/detritus = locate() in get_turf(src)
 	qdel(detritus)
+	AI.control_disabled = FALSE
+	AI.radio_enabled = TRUE
 	do_sparks(4, TRUE, src)
 	playsound(src, 'sound/machines/chime.ogg', 25, TRUE)
-	return TRUE
+	return
 
 /obj/item/aicard/Destroy(force)
 	if(AI)
@@ -141,7 +154,7 @@
 	if(isnull(AI))
 		return FALSE
 
-	log_silicon("[key_name(user)] carded [key_name(AI)]", src)
+	log_silicon("[key_name(user)] carded [key_name(AI)]", list(src))
 	update_appearance()
 	AI.cancel_camera()
 	RegisterSignal(AI, COMSIG_MOB_STATCHANGE, PROC_REF(on_ai_stat_change))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -865,11 +865,11 @@
 	if(interaction != AI_TRANS_TO_CARD)//The only possible interaction. Upload AI mob to a card.
 		return
 	if(!can_be_carded)
-		to_chat(user, span_boldwarning("Transfer failed."))
+		balloon_alert(user, "transfer failed!")
 		return
 	disconnect_shell() //If the AI is controlling a borg, force the player back to core!
 	if(!mind)
-		to_chat(user, span_warning("No intelligence patterns detected."))
+		balloon_alert(user, "no intelligence detected!") // average tg coder am i right
 		return
 	ShutOffDoomsdayDevice()
 	var/obj/structure/ai_core/new_core = new /obj/structure/ai_core/deactivated(loc, posibrain_inside)//Spawns a deactivated terminal at AI location.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -131,6 +131,8 @@
 		for (var/law in laws.inherent)
 			lawcheck += law
 
+	create_eye()
+
 	if(target_ai.mind)
 		target_ai.mind.transfer_to(src)
 		if(mind.special_role)
@@ -151,8 +153,6 @@
 	to_chat(src, span_bold("These laws may be changed by other players, random events, or by you becoming malfunctioning."))
 
 	job = "AI"
-
-	create_eye()
 
 	create_modularInterface()
 
@@ -204,10 +204,6 @@
 	radio_enabled = TRUE
 	interaction_range = 1
 	sprint = 5
-
-/mob/living/silicon/ai/weak_syndie/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
-	. = ..()
-	laws = new /datum/ai_laws/syndicate_override
 
 /mob/living/silicon/ai/key_down(_key, client/user)
 	if(findtext(_key, "numpad")) //if it's a numpad number, we can convert it to just the number
@@ -866,24 +862,25 @@
 /mob/living/silicon/ai/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/aicard/card)
 	if(!..())
 		return
-	if(interaction == AI_TRANS_TO_CARD)//The only possible interaction. Upload AI mob to a card.
-		if(!can_be_carded)
-			to_chat(user, span_boldwarning("Transfer failed."))
-			return
-		disconnect_shell() //If the AI is controlling a borg, force the player back to core!
-		if(!mind)
-			to_chat(user, span_warning("No intelligence patterns detected."))
-			return
-		ShutOffDoomsdayDevice()
-		var/obj/structure/ai_core/new_core = new /obj/structure/ai_core/deactivated(loc, posibrain_inside)//Spawns a deactivated terminal at AI location.
-		new_core.circuit.battery = battery
-		ai_restore_power()//So the AI initially has power.
-		control_disabled = TRUE //Can't control things remotely if you're stuck in a card!
-		radio_enabled = FALSE //No talking on the built-in radio for you either!
-		forceMove(card)
-		card.AI = src
-		to_chat(src, "You have been downloaded to a mobile storage device. Remote device connection severed.")
-		to_chat(user, "[span_boldnotice("Transfer successful")]: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory.")
+	if(interaction != AI_TRANS_TO_CARD)//The only possible interaction. Upload AI mob to a card.
+		return
+	if(!can_be_carded)
+		to_chat(user, span_boldwarning("Transfer failed."))
+		return
+	disconnect_shell() //If the AI is controlling a borg, force the player back to core!
+	if(!mind)
+		to_chat(user, span_warning("No intelligence patterns detected."))
+		return
+	ShutOffDoomsdayDevice()
+	var/obj/structure/ai_core/new_core = new /obj/structure/ai_core/deactivated(loc, posibrain_inside)//Spawns a deactivated terminal at AI location.
+	new_core.circuit.battery = battery
+	ai_restore_power()//So the AI initially has power.
+	control_disabled = TRUE //Can't control things remotely if you're stuck in a card!
+	radio_enabled = FALSE //No talking on the built-in radio for you either!
+	forceMove(card)
+	card.AI = src
+	to_chat(src, "You have been downloaded to a mobile storage device. Remote device connection severed.")
+	to_chat(user, "[span_boldnotice("Transfer successful")]: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory.")
 
 /mob/living/silicon/ai/can_perform_action(atom/movable/target, action_bitflags)
 	if(control_disabled)


### PR DESCRIPTION
## About The Pull Request

Fixes #78058
This did a couple of weird things and I am not totally sure it ever worked, but now it does.
Firstly, I moved the creation of the AI Eye to before we attach the client, as it would make a stack trace if it did not exist on client login.
Secondly, I changed a call to `pre_attack` to a call to the actual proc we wanted, `capture_ai`.
Thirdly, I removed a reundant line which set the key of the AI core a second time from the candidate, which we had already done when initialising the AI. Because we had already done it, we were instead setting the key to null (because the observer's key had already been nulled and moved to the AI) and kicking the player by removing their key from all mobs.
Finally, I passed `src` as a list into `log_silicon` when logging transferring the AI into the card, because it stack traces when not sent a list.

I also did a fair amount of housekeeping to improve the experience of using this device.

## Changelog

:cl:
fix: The nuclear operative MODsuit intellicard now actually downloads an AI rather than simply kicking candidates from the game.
/:cl:
