### PR TITLE
[BIRDSHOT] Deletes a weird status display that was on top of an airlock

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -12246,7 +12246,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/landmark/navigate_destination/eva,
-/obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "eFV" = (


### PR DESCRIPTION

## Why It's Good For The Game

I don't think this issue is on the issue tracker
## Changelog
DATA_:cl:
fix: Removed an AI display that was in front of an airlock in Birdshot
/:cl:
