### PR TITLE
second pass over the SC/FISHER code, incl. bitflags and PDAs

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_saboteur.dm
+++ b/code/__DEFINES/dcs/signals/signals_saboteur.dm
@@ -1,4 +1,5 @@
 // Light disruptor. Not to be confused with the light eater, which permanently disables lights.
 
 /// from /obj/projectile/energy/fisher/on_hit() or /obj/item/gun/energy/recharge/fisher when striking a target
-#define COMSIG_HIT_BY_SABOTEUR "hit_by_saboteur"
+#define COMSIG_HIT_BY_SABOTEUR "HIT_BY_SABOTEUR"
+	#define COMSIG_SABOTEUR_SUCCESS (1<<0)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -180,7 +180,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
 /obj/machinery/camera/proc/on_saboteur(datum/source, disrupt_duration)
 	SIGNAL_HANDLER
 	emp_act(EMP_LIGHT, reset_time = disrupt_duration)
-	return TRUE
+	return COMSIG_SABOTEUR_SUCCESS
 
 /obj/machinery/camera/proc/post_emp_reset(thisemp, previous_network)
 	if(QDELETED(src))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -70,8 +70,8 @@
 
 /obj/item/flashlight/proc/toggle_light(mob/user)
 	var/disrupted = FALSE
-	playsound(src, on ? sound_on : sound_off, 40, TRUE)
 	on = !on
+	playsound(src, on ? sound_on : sound_off, 40, TRUE)
 	if(!COOLDOWN_FINISHED(src, disabled_time))
 		if(user)
 			balloon_alert(user, "disrupted!")

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -270,7 +270,7 @@
 	if(on)
 		toggle_light()
 	COOLDOWN_START(src, disabled_time, disrupt_duration)
-	return TRUE
+	return COMSIG_SABOTEUR_SUCCESS
 
 /obj/item/flashlight/pen
 	name = "penlight"

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -169,7 +169,7 @@
 /obj/item/kinetic_crusher/proc/on_saboteur(datum/source, disrupt_duration)
 	set_light_on(FALSE)
 	playsound(src, 'sound/weapons/empty.ogg', 100, TRUE)
-	return TRUE
+	return COMSIG_SABOTEUR_SUCCESS
 
 /obj/item/kinetic_crusher/update_icon_state()
 	inhand_icon_state = "crusher[HAS_TRAIT(src, TRAIT_WIELDED)]" // this is not icon_state and not supported by 2hcomponent

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -157,6 +157,7 @@
 	to_chat(our_target, span_warning("Something inside of you crackles in a bad way."))
 	our_target.take_bodypart_damage(burn = 3, wound_bonus = CANT_WOUND)
 	addtimer(CALLBACK(src, PROC_REF(stop_emp), our_target), disrupt_duration, TIMER_UNIQUE|TIMER_OVERRIDE)
+	return COMSIG_SABOTEUR_SUCCESS
 
 /datum/species/ethereal/proc/on_emag_act(mob/living/carbon/human/H, mob/user)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -469,7 +469,7 @@
 	if(lamp_enabled)
 		toggle_headlamp(TRUE)
 		to_chat(src, span_warning("Your headlamp was forcibly turned off. Restarting it should fix it, though."))
-	return TRUE
+	return COMSIG_SABOTEUR_SUCCESS
 
 /**
  * Handles headlamp smashing

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -374,7 +374,7 @@
 		.["comp_light_color"] = robo.lamp_color
 
 //Makes the flashlight button affect the borg rather than the tablet
-/obj/item/modular_computer/pda/silicon/toggle_flashlight()
+/obj/item/modular_computer/pda/silicon/toggle_flashlight(mob/user)
 	if(!silicon_owner || QDELETED(silicon_owner))
 		return FALSE
 	if(iscyborg(silicon_owner))

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -293,7 +293,7 @@
 /obj/machinery/power/floodlight/proc/on_saboteur(datum/source, disrupt_duration)
 	SIGNAL_HANDLER
 	atom_break(ENERGY) // technically,
-	return TRUE
+	return COMSIG_SABOTEUR_SUCCESS
 
 /obj/machinery/power/floodlight/atom_break(damage_flag)
 	. = ..()

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -678,7 +678,7 @@
 /obj/machinery/light/proc/on_saboteur(datum/source, disrupt_duration)
 	SIGNAL_HANDLER
 	break_light_tube()
-	return TRUE
+	return COMSIG_SABOTEUR_SUCCESS
 
 /obj/machinery/light/proc/grey_tide(datum/source, list/grey_tide_areas)
 	SIGNAL_HANDLER

--- a/code/modules/projectiles/projectile/special/lightbreaker.dm
+++ b/code/modules/projectiles/projectile/special/lightbreaker.dm
@@ -11,11 +11,12 @@
 
 /obj/projectile/energy/fisher/on_hit(atom/target, blocked, pierce_hit)
 	. = ..()
-	SEND_SIGNAL(target, COMSIG_HIT_BY_SABOTEUR, disrupt_duration)
+	var/lights_flickered = 0
+	if(SEND_SIGNAL(target, COMSIG_HIT_BY_SABOTEUR, disrupt_duration) & COMSIG_SABOTEUR_SUCCESS)
+		lights_flickered++
 	if(!isliving(target))
 		return
 	var/list/things_to_disrupt = list()
-	var/lights_flickered = 0
 	if(ishuman(target))
 		var/mob/living/carbon/human/human_target = target
 		things_to_disrupt = human_target.get_all_gear()
@@ -23,7 +24,7 @@
 		var/mob/living/living_target = target // i guess this covers borgs too?
 		things_to_disrupt = living_target.get_equipped_items(include_pockets = TRUE, include_accessories = TRUE)
 	for(var/obj/item/thingy as anything in things_to_disrupt)
-		if(SEND_SIGNAL(thingy, COMSIG_HIT_BY_SABOTEUR, disrupt_duration))
+		if(SEND_SIGNAL(thingy, COMSIG_HIT_BY_SABOTEUR, disrupt_duration) & COMSIG_SABOTEUR_SUCCESS)
 			lights_flickered++
 	if(lights_flickered)
 		to_chat(target, span_warning("Your light [lights_flickered > 1 ? "sources flick" : "source flicks"] off."))


### PR DESCRIPTION
## About The Pull Request
makes `COMSIG_HIT_BY_SABOTEUR` return a bitflag in order to close #78297 (i am very sorry)
fixes #78298
extends flashlight disabling to modular computers incl. PDAs because somehow i forgot that they had flashlights.
## Why It's Good For The Game
my code sucks and i should make it suck less, actually

## Changelog
i don't think i get to put a code improvement tag if it's not playerfacing and it's my own fault
:cl:
fix: Flares and candles no longer sound like flashlights when being turned on.
fix: Getting shot by an SC/FISHER now disables PDA lights for consistency's sake.
/:cl:
