### PR TITLE
makes the bank machine not print 0 credit holochips

### DIFF
--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -116,7 +116,8 @@
 /obj/machinery/computer/bank_machine/proc/end_siphon()
 	siphoning = FALSE
 	unauthorized = FALSE
-	new /obj/item/holochip(drop_location(), syphoning_credits) //get the loot
+	if(syphoning_credits > 0)
+		new /obj/item/holochip(drop_location(), syphoning_credits) //get the loot
 	syphoning_credits = 0
 
 /obj/machinery/computer/bank_machine/proc/start_siphon(mob/living/carbon/user)


### PR DESCRIPTION
## About The Pull Request

syphoned credits must be above 0 to print a holocihp now

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: the bank machine cannot print holochips worth 0 credits now
/:cl:
