### PR TITLE
Nerfs peacekeeper borg shock hugs

### DIFF
--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -142,7 +142,9 @@
 			if (!COOLDOWN_FINISHED(src, shock_cooldown))
 				return
 			if(ishuman(attacked_mob))
-				attacked_mob.electrocute_act(5, "[user]", flags = SHOCK_NOGLOVES)
+				attacked_mob.electrocute_act(5, "[user]", flags = SHOCK_NOGLOVES | SHOCK_NOSTUN)
+				attacked_mob.dropItemToGround(attacked_mob.get_active_held_item())
+				attacked_mob.dropItemToGround(attacked_mob.get_inactive_held_item())
 				user.visible_message(span_userdanger("[user] electrocutes [attacked_mob] with [user.p_their()] touch!"), \
 					span_danger("You electrocute [attacked_mob] with your touch!"))
 			else


### PR DESCRIPTION
## About The Pull Request

Modifies the flags of the peacekeeper cyborg's emagged shock hug, changing the hardstun to one similar to the shock hand mutation.
## Why It's Good For The Game

Most players will agree that hardstuns are something that should be phased out, however, there are some situations where hardstuns are necessary for glass cannons to balance out their achilles heel. Peacekeeper borg shock hugs are not one of those things.

Right now, the shock hug is a discreet (i.e iconless) electrocution hardstun weapon that ignores insuls, arguably making it more effective than the engineer borg's stun arm despite being a side module.

One of the things that balances this out on the engineer borg is that the stun arm is a dead giveaway, it has a visible icon and makes a distinct stun noise. Meanwhile, shock hugs have no icon, and the ubiquitous shock effect combined with the relative obscurity of the shock hug can cause some confusion among the crew.

Although borgs _should_ be powerful in many cases, this powerful of a combat tool feels unwarranted considering the peacekeeper already has multiple other stunning tools.

Replacing the stun effect with a disarming effect should act as a soft nerf while playing into the peacekeeper borg's anti harm theming, and hopefully keep it viable as disarming can very well make or break a fight.
## Changelog
:cl:
balance: Peacekeeper cyborg's emagged hug is no longer a hardstun.
/:cl:
