### PR TITLE
Tongueless humans cannot cast vocal spells, handless humans cannot invoke emote spells

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -398,15 +398,29 @@
 	if(invoke_sig_return & SPELL_INVOCATION_FAIL)
 		return FALSE
 
-	if(invocation_type == INVOCATION_EMOTE && HAS_TRAIT(invoker, TRAIT_EMOTEMUTE))
-		if(feedback)
-			to_chat(invoker, span_warning("You can't position your hands correctly to invoke [src]!"))
-		return FALSE
+	if(invocation_type == INVOCATION_EMOTE)
+		if(HAS_TRAIT(invoker, TRAIT_EMOTEMUTE))
+			if(feedback)
+				to_chat(invoker, span_warning("You can't position your hands correctly to invoke [src]!"))
+			return FALSE
+		if(ishuman(invoker) && invoker.usable_hands <= 0)
+			if(feedback)
+				to_chat(invoker, span_warning("You don't have the usable hands to invoke [src]!"))
+			return FALSE
 
-	if((invocation_type == INVOCATION_WHISPER || invocation_type == INVOCATION_SHOUT) && !invoker.can_speak())
-		if(feedback)
-			to_chat(invoker, span_warning("You can't get the words out to invoke [src]!"))
-		return FALSE
+		return TRUE
+
+	if(invocation_type == INVOCATION_WHISPER || invocation_type == INVOCATION_SHOUT)
+		if(!invoker.can_speak())
+			if(feedback)
+				to_chat(invoker, span_warning("You can't get the words out to invoke [src]!"))
+			return FALSE
+
+		if(ishuman(invoker) && !invoker.get_organ_slot(ORGAN_SLOT_TONGUE))
+			if(feedback)
+				to_chat(invoker, span_warning("You can't get correct words out to invoke [src]!"))
+			return FALSE
+		return TRUE
 
 	return TRUE
 

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -209,12 +209,16 @@
 
 		// Otherwise, we can check for contents if they have wizardly apparel. This isn't *quite* perfect, but it'll do, especially since many of the edge cases (gorilla holding a wizard hat) still more or less make sense.
 		if(spell_requirements & SPELL_REQUIRES_WIZARD_GARB)
-			for(var/atom/movable/item in owner.contents)
-				var/obj/item/clothing/clothem = item
-				if(istype(clothem) && clothem.clothing_flags & CASTING_CLOTHES)
-					return TRUE
-			to_chat(owner, span_warning("You don't feel strong enough without your hat!"))
-			return FALSE
+			var/any_casting = FALSE
+			for(var/obj/item/clothing/item in owner)
+				if(item.clothing_flags & CASTING_CLOTHES)
+					any_casting = TRUE
+					break
+
+			if(!any_casting)
+				if(feedback)
+					to_chat(owner, span_warning("You don't feel strong enough without your hat!"))
+				return FALSE
 
 		if(!(spell_requirements & SPELL_CASTABLE_AS_BRAIN) && isbrain(owner))
 			if(feedback)
@@ -297,6 +301,31 @@
  */
 /datum/action/cooldown/spell/proc/before_cast(atom/cast_on)
 	SHOULD_CALL_PARENT(TRUE)
+
+	// Bonus invocation check done here:
+	// If the caster has no tongue and it's a verbal spell,
+	// Or has no hands and is a gesture spell - cancel it,
+	// and show a funny message that they tried
+	if(ishuman(owner) && !(spell_requirements & SPELL_CASTABLE_WITHOUT_INVOCATION))
+		var/mob/living/carbon/human/caster = owner
+		switch(invocation_type)
+			if(INVOCATION_WHISPER, INVOCATION_SHOUT)
+				if(!caster.get_organ_slot(ORGAN_SLOT_TONGUE))
+					invocation(caster)
+					to_chat(caster, span_warning("Your lack of tongue is making it difficult to say the correct words to cast [src]..."))
+					StartCooldown(2 SECONDS)
+					return SPELL_CANCEL_CAST
+
+			if(INVOCATION_EMOTE)
+				if(caster.usable_hands <= 0)
+					var/arm_describer = (caster.num_hands >= 2 ? "arms limply" : (caster.num_hands == 1 ? "arm wildly" : "arm stumps"))
+					caster.visible_message(
+						span_warning("[caster] wiggles around [caster.p_their()] [arm_describer]."),
+						ignored_mobs = caster,
+					)
+					to_chat(caster, span_warning("You can't position your hands correctly to invoke [src][caster.num_hands > 0 ? "" : ", as you have none"]..."))
+					StartCooldown(2 SECONDS)
+					return SPELL_CANCEL_CAST
 
 	var/sig_return = SEND_SIGNAL(src, COMSIG_SPELL_BEFORE_CAST, cast_on)
 	if(owner)
@@ -398,29 +427,15 @@
 	if(invoke_sig_return & SPELL_INVOCATION_FAIL)
 		return FALSE
 
-	if(invocation_type == INVOCATION_EMOTE)
-		if(HAS_TRAIT(invoker, TRAIT_EMOTEMUTE))
-			if(feedback)
-				to_chat(invoker, span_warning("You can't position your hands correctly to invoke [src]!"))
-			return FALSE
-		if(ishuman(invoker) && invoker.usable_hands <= 0)
-			if(feedback)
-				to_chat(invoker, span_warning("You don't have the usable hands to invoke [src]!"))
-			return FALSE
+	if(invocation_type == INVOCATION_EMOTE && HAS_TRAIT(invoker, TRAIT_EMOTEMUTE))
+		if(feedback)
+			to_chat(invoker, span_warning("You can't position your hands correctly to invoke [src]!"))
+		return FALSE
 
-		return TRUE
-
-	if(invocation_type == INVOCATION_WHISPER || invocation_type == INVOCATION_SHOUT)
-		if(!invoker.can_speak())
-			if(feedback)
-				to_chat(invoker, span_warning("You can't get the words out to invoke [src]!"))
-			return FALSE
-
-		if(ishuman(invoker) && !invoker.get_organ_slot(ORGAN_SLOT_TONGUE))
-			if(feedback)
-				to_chat(invoker, span_warning("You can't get correct words out to invoke [src]!"))
-			return FALSE
-		return TRUE
+	if((invocation_type == INVOCATION_WHISPER || invocation_type == INVOCATION_SHOUT) && !invoker.can_speak())
+		if(feedback)
+			to_chat(invoker, span_warning("You can't get the words out to invoke [src]!"))
+		return FALSE
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

- Humans without tongues cannot cast vocal spells
- Humans without hands cannot cast emote spells

## Why It's Good For The Game

It stands to reason if you cannot get the correct invocation to the spell out, you should not be able to cast. 

(I thought this was already the case and I broke it at some point, but honestly I'm not entirely sure.)

In other words, this opens up tongue removal as counter for heretic spellcasting, which I think is quite funny. If you get to that point, you already lost. 

This leaves slurring up in the air, it stays though, since it's close enough.

## Changelog

:cl: Melbert
balance: Humanoids without tongues cannot cast spells with vocal components
balance: Humanoids without arms cannot cast spells with emotive components
/:cl:
