### PR TITLE
Rounded supermatter delamination times to 5 seconds, restored old mood messages

### DIFF
--- a/code/__DEFINES/supermatter.dm
+++ b/code/__DEFINES/supermatter.dm
@@ -52,9 +52,9 @@
 #define DIMENSIONAL_ANOMALY "dimensional_anomaly"
 
 /// How long it takes for the supermatter to delaminate after hitting 0 integrity
-#define SUPERMATTER_COUNTDOWN_TIME (13 SECONDS)
+#define SUPERMATTER_COUNTDOWN_TIME (15 SECONDS)
 /// How long it takes for the supermatter to delaminate after hitting 0 integrity if a sliver has been removed
-#define SUPERMATTER_SLIVER_REMOVED_COUNTDOWN_TIME (3 SECONDS)
+#define SUPERMATTER_SLIVER_REMOVED_COUNTDOWN_TIME (5 SECONDS)
 
 ///to prevent accent sounds from layering
 #define SUPERMATTER_ACCENT_SOUND_MIN_COOLDOWN (2 SECONDS)

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -43,12 +43,12 @@
 	timeout = 3 MINUTES
 
 /datum/mood_event/delam //SM delamination
-	description = "Ever since that supermatter delamination, my head has been killing me..."
+	description = "Those goddamn engineers can't do anything right..."
 	mood_change = -2
 	timeout = 4 MINUTES
 
 /datum/mood_event/cascade // Big boi delamination
-	description = "I never thought I'd see a resonance cascade, let alone be near one..."
+	description = "The engineers have finally done it, we are all going to die..."
 	mood_change = -8
 	timeout = 5 MINUTES
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the supermatter delaminate in 15 seconds instead of 13 and 5 seconds instead of 3 if a sliver has been taken from it, mainly to please perfectionists (me and some others who commented on the PR) as well as giving people at least a chance to escape delam round removal.

I don't like it when flavorful text is replaced by bland and not-as-funny alternatives.
Also, how the hell is it gamey for staff to know the engineers are in charge of the power?
It's honestly more gamey for them to know what a resonance cascade or supermatter delamination is, so I'd say you've done the opposite of what the goal was with the message changes on top of making them less fun in general. I disapprove.

Oh, yeah, and the SM now reports the times correctly due to it reporting them every 5 seconds, meaning people would only see the 10 second announcement. Now there is going to be a 15 second announcement as well.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Watering down messages to be bland is just, like, less fun, ya know?
I didn't see a single person in support of the message changes apart from the PR author, everyone else was just complaining about them, including myself.

Also, several people mentioned the fact it could just be 15 instead of 13 for a nice round number, including myself. I also made the sliver delamination time 5 seconds instead of 3 seconds because you pretty much can't get out in time, especially if the game is laggy. 3 - 5 people being round removed because of one traitor objective with no chance to escape it is just bad gameplay.

Oh, and, bugfix good, I suppose.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Supermatter now takes 15 seconds to delaminate normally and 5 if a sliver has been taken from it. Gives a little more time to escape in the case of the sliver and also evens out the times to please perfectionists.
fix: Supermatter now accurately reports it's detonation time.
spellcheck: Supermatter mood descriptions have been reverted back to their old, more flavorful selves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
