### PR TITLE
Make hercuri spray use a medical sprite

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -443,6 +443,7 @@
 
 /obj/item/reagent_containers/spray/hercuri
 	name = "medical spray (hercuri)"
-	desc = "A medical spray bottle.This one contains hercuri, a medicine used to negate the effects of dangerous high-temperature environments. Careful not to freeze the patient!"
-	icon_state = "sprayer_large"
+	desc = "A medical spray bottle. This one contains hercuri, a medicine used to negate the effects of dangerous high-temperature environments. Careful not to freeze the patient!"
+	icon = 'icons/obj/medical/chemical.dmi'
+	icon_state = "sprayer_med_blue"
 	list_reagents = list(/datum/reagent/medicine/c2/hercuri = 100)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -445,5 +445,5 @@
 	name = "medical spray (hercuri)"
 	desc = "A medical spray bottle. This one contains hercuri, a medicine used to negate the effects of dangerous high-temperature environments. Careful not to freeze the patient!"
 	icon = 'icons/obj/medical/chemical.dmi'
-	icon_state = "sprayer_med_blue"
+	icon_state = "sprayer_med_yellow"
 	list_reagents = list(/datum/reagent/medicine/c2/hercuri = 100)


### PR DESCRIPTION
## About The Pull Request
Changed the hercuri spray's sprite to look like the yellow med spray
Before:
![spraybefore](https://github.com/tgstation/tgstation/assets/113535457/13891b98-9b93-4b61-8e12-72efc83937d7)
After:
![sprayafter](https://github.com/tgstation/tgstation/assets/113535457/59a7596e-c8cc-44d5-93fe-f903e063cb0c)
Originally wanted to make it blue because blue = cold but decided to go with yellow because hercuri itself is yellow and a yellow bottle fits the yellow burn medkit
## Why It's Good For The Game
The large spray sprite that hercuri used was changed to look more like a cleaner bottle, making it look out of place in medkits. A medical spray sprite makes it look better
## Changelog
:cl:
image: Hercuri spray now uses the same sprite as the yellow medical spray
spellcheck: Added a missing space to hercuri spray's description
/:cl:
