### PR TITLE
Rebalance CQC legsweeps and knockout kicks

### DIFF
--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -85,7 +85,7 @@
 
 	var/helmet_protection = defender.run_armor_check(BODY_ZONE_HEAD, MELEE)
 	var/knockout_prob = rand(-15,15) + defender.getStaminaLoss() - helmet_protection
-	if(defender.body_position == LYING_DOWN && !defender.IsUnconscious() !&& prob(knockout_prob))
+	if(defender.body_position == LYING_DOWN && !defender.IsUnconscious() && prob(knockout_prob))
 		log_combat(attacker, defender, "knocked out (Head kick)(CQC)")
 		defender.visible_message(span_danger("[attacker] kicks [defender]'s head, knocking [defender.p_them()] out!"), \
 						span_userdanger("You're knocked unconscious by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -171,7 +171,7 @@
 	if(!can_use(attacker))
 		return FALSE
 
-	if(attacker.resting && !defender.stat && defender.body_position == STANDING_UP)
+	if(attacker.resting && defender.stat != DEAD && defender.body_position == STANDING_UP)
 		defender.visible_message(span_danger("[attacker] leg sweeps [defender]!"), \
 						span_userdanger("Your legs are sweeped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
 		to_chat(attacker, span_danger("You leg sweep [defender]!"))
@@ -180,6 +180,7 @@
 		defender.apply_damage(10, BRUTE)
 		defender.Knockdown(5 SECONDS)
 		log_combat(attacker, defender, "sweeped (CQC)")
+		reset_streak()
 		return TRUE
 
 	add_to_streak("H", defender)

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -83,16 +83,16 @@
 	if(!can_use(attacker) || defender.stat != CONSCIOUS)
 		return FALSE
 
-	var/helmet_protection = defender.run_armor_check(BODY_ZONE_HEAD, MELEE)
-	var/knockout_prob = rand(-15,15) + defender.getStaminaLoss() - helmet_protection
-	if(defender.body_position == LYING_DOWN && !defender.IsUnconscious() && prob(knockout_prob))
+	if(defender.body_position == LYING_DOWN && !defender.IsUnconscious() && defender.getStaminaLoss() >= 100)
 		log_combat(attacker, defender, "knocked out (Head kick)(CQC)")
 		defender.visible_message(span_danger("[attacker] kicks [defender]'s head, knocking [defender.p_them()] out!"), \
 						span_userdanger("You're knocked unconscious by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
 		to_chat(attacker, span_danger("You kick [defender]'s head, knocking [defender.p_them()] out!"))
 		playsound(get_turf(attacker), 'sound/weapons/genhit1.ogg', 50, TRUE, -1)
+
+		var/helmet_protection = defender.run_armor_check(BODY_ZONE_HEAD, MELEE)
 		defender.apply_effect(20 SECONDS, EFFECT_KNOCKDOWN, helmet_protection)
-		defender.SetUnconscious(10 SECONDS)
+		defender.apply_effect(10 SECONDS, EFFECT_UNCONSCIOUS, helmet_protection)
 		defender.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15, 150)
 	else
 		defender.visible_message(span_danger("[attacker] kicks [defender] back!"), \
@@ -102,8 +102,8 @@
 		var/atom/throw_target = get_edge_target_turf(defender, attacker.dir)
 		defender.throw_at(throw_target, 1, 14, attacker)
 		defender.apply_damage(10, attacker.get_attack_type())
+		defender.adjustStaminaLoss(45)
 		log_combat(attacker, defender, "kicked (CQC)")
-
 	. = TRUE
 
 /datum/martial_art/cqc/proc/Pressure(mob/living/attacker, mob/living/defender)
@@ -249,7 +249,7 @@
 	to_chat(usr, "<b><i>You try to remember some of the basics of CQC.</i></b>")
 
 	to_chat(usr, "[span_notice("Slam")]: Grab Punch. Slam opponent into the ground, knocking them down.")
-	to_chat(usr, "[span_notice("CQC Kick")]: Punch Punch. Knocks opponent away. Knocks out stunned or knocked down opponents.")
+	to_chat(usr, "[span_notice("CQC Kick")]: Punch Punch. Knocks opponent away. Knocks out stunned opponents and does stamina damage.")
 	to_chat(usr, "[span_notice("Restrain")]: Grab Grab. Locks opponents into a restraining position, disarm to knock them out with a chokehold.")
 	to_chat(usr, "[span_notice("Pressure")]: Shove Grab. Decent stamina damage.")
 	to_chat(usr, "[span_notice("Consecutive CQC")]: Shove Shove Punch. Mainly offensive move, huge damage and decent stamina damage.")

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -80,7 +80,7 @@
 		return TRUE
 
 /datum/martial_art/cqc/proc/Kick(mob/living/attacker, mob/living/defender)
-	if(!can_use(attacker) || defender.stat == DEAD)
+	if(!can_use(attacker) || defender.stat != CONSCIOUS)
 		return FALSE
 
 	var/helmet_protection = defender.run_armor_check(BODY_ZONE_HEAD, MELEE)

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -166,6 +166,18 @@
 /datum/martial_art/cqc/harm_act(mob/living/attacker, mob/living/defender)
 	if(!can_use(attacker))
 		return FALSE
+
+	if(attacker.resting && !defender.stat && defender.body_position == STANDING_UP)
+		defender.visible_message(span_danger("[attacker] leg sweeps [defender]!"), \
+						span_userdanger("Your legs are sweeped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
+		to_chat(attacker, span_danger("You leg sweep [defender]!"))
+		playsound(get_turf(attacker), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
+		attacker.do_attack_animation(defender)
+		defender.apply_damage(10, BRUTE)
+		defender.Knockdown(5 SECONDS)
+		log_combat(attacker, defender, "sweeped (CQC)")
+		return TRUE
+
 	add_to_streak("H", defender)
 	if(check_streak(attacker, defender))
 		return TRUE
@@ -185,14 +197,7 @@
 					span_userdanger("You're [picked_hit_type]ed by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker)
 	to_chat(attacker, span_danger("You [picked_hit_type] [defender]!"))
 	log_combat(attacker, defender, "[picked_hit_type]s (CQC)")
-	if(attacker.resting && !defender.stat && !defender.IsParalyzed())
-		defender.visible_message(span_danger("[attacker] leg sweeps [defender]!"), \
-						span_userdanger("Your legs are sweeped by [attacker]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, attacker)
-		to_chat(attacker, span_danger("You leg sweep [defender]!"))
-		playsound(get_turf(attacker), 'sound/effects/hit_kick.ogg', 50, TRUE, -1)
-		defender.apply_damage(10, BRUTE)
-		defender.Paralyze(6 SECONDS)
-		log_combat(attacker, defender, "sweeped (CQC)")
+
 	return TRUE
 
 /datum/martial_art/cqc/disarm_act(mob/living/attacker, mob/living/defender)


### PR DESCRIPTION
## About The Pull Request
This is a remake of #74764 but focused only on kicks.

#### Before my changes:
- Legsweeps dealt 6 seconds of paralysis for **23 damage**
- Knockout kicks dealt **30 seconds** of sleep that was guaranteed if the target was on the floor

#### After my changes:
- Legsweeps deal 5 seconds of knockdown for 10 damage
- Knockout kick happens when a mob reaches 100 stamina loss and lasts 10 seconds. Helmet protection shortens the time length.

## Why It's Good For The Game
![chrome_UvcQ6vBQpH](https://github.com/tgstation/tgstation/assets/5195984/ea568e0f-7217-4e3c-be75-fa36996b73ae)

## Changelog
:cl:
balance: CQC legsweeps now cause knockdown instead of paralysis. 
balance: CQC kicks now knockout a target on the floor for ten seconds if they reach stam crit. Helmet protection shortens the knockout length.
/:cl:
