### PR TITLE
[NO GBP] A big blunder with my latest fishing fix PR

### DIFF
--- a/code/modules/fishing/fishing_rod.dm
+++ b/code/modules/fishing/fishing_rod.dm
@@ -211,7 +211,7 @@
 	SIGNAL_HANDLER
 	. = NONE
 
-	if(!isturf(source.origin) || !isturf(source.target) || !CheckToolReach(src, source.target, cast_range))
+	if(!isturf(source.origin.loc) || !isturf(source.target.loc) || !CheckToolReach(src, source.target, cast_range))
 		SEND_SIGNAL(source, COMSIG_FISHING_LINE_SNAPPED) //Stepped out of range or los interrupted
 		return BEAM_CANCEL_DRAW
 


### PR DESCRIPTION
## About The Pull Request
In no case, neither the origin nor the target of a fishing line are turfs. This was actually meant to check their locations.

## Why It's Good For The Game
Forgive me, I was busy an other PR so I couldn't get to it in time. This PR has been tested tho.

## Changelog

:cl:
fix: fixed fishing.
/:cl:
