### PR TITLE
Restores drone holiday headwear and extends it to assistants

### DIFF
--- a/code/__DEFINES/holiday.dm
+++ b/code/__DEFINES/holiday.dm
@@ -1,0 +1,1 @@
+#define HOLIDAY_HAT_CHANCE 20

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -397,6 +397,7 @@
 	begin_day = 4
 	begin_month = JULY
 	mail_holiday = TRUE
+	holiday_hat = /obj/item/clothing/head/cowboy/brown
 
 /datum/holiday/usa/getStationPrefix()
 	return pick("Independent","American","Burger","Bald Eagle","Star-Spangled", "Fireworks")

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -109,6 +109,7 @@
 	name = "Fleet Day"
 	begin_month = JANUARY
 	begin_day = 19
+	holiday_hat = /obj/item/clothing/head/mothcap
 
 /datum/holiday/fleet_day/greet()
 	return "This day commemorates another year of successful survival aboard the Mothic Grand Nomad Fleet. Moths galaxywide are encouraged to eat, drink, and be merry."
@@ -235,6 +236,7 @@
 	begin_month = APRIL
 	begin_day = 1
 	end_day = 2
+	holiday_hat = /obj/item/clothing/head/chameleon/broken
 
 /datum/holiday/april_fools/celebrate()
 	. = ..()
@@ -261,6 +263,7 @@
 	name = "Four-Twenty"
 	begin_day = 20
 	begin_month = APRIL
+	holiday_hat = /obj/item/clothing/head/rasta
 
 /datum/holiday/fourtwenty/getStationPrefix()
 	return pick("Snoop","Blunt","Toke","Dank","Cheech","Chong")
@@ -354,6 +357,7 @@
 	name = "Summer Solstice"
 	begin_day = 21
 	begin_month = JUNE
+	holiday_hat = /obj/item/clothing/head/costume/garland
 
 /datum/holiday/pride_week
 	name = PRIDE_WEEK
@@ -382,6 +386,7 @@
 	name = "UFO Day"
 	begin_day = 2
 	begin_month = JULY
+	holiday_hat = /obj/item/clothing/head/collectable/xenom
 
 /datum/holiday/ufo/getStationPrefix() //Is such a thing even possible?
 	return pick("Ayy","Truth","Tsoukalos","Mulder","Scully") //Yes it is!
@@ -647,6 +652,7 @@
 	name = "Mayan Doomsday Anniversary"
 	begin_day = 21
 	begin_month = DECEMBER
+	holiday_hat = /obj/item/clothing/head/costume/garland
 
 /datum/holiday/xmas
 	name = CHRISTMAS

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -322,7 +322,6 @@
 	name = "Bee Day"
 	begin_day = 20
 	begin_month = MAY
-	holiday_hat = /obj/item/clothing/mask/animal/small/bee //change off of mask
 
 /datum/holiday/bee/getStationPrefix()
 	return pick("Bee","Honey","Hive","Africanized","Mead","Buzz")
@@ -383,7 +382,6 @@
 	name = "UFO Day"
 	begin_day = 2
 	begin_month = JULY
-	holiday_hat = /obj/item/clothing/mask/facehugger/dead
 
 /datum/holiday/ufo/getStationPrefix() //Is such a thing even possible?
 	return pick("Ayy","Truth","Tsoukalos","Mulder","Scully") //Yes it is!
@@ -470,6 +468,7 @@
 	name = "Tiziran Unification Day"
 	begin_month = SEPTEMBER
 	begin_day = 1
+	holiday_hat = /obj/item/clothing/head/costume/lizard
 
 /datum/holiday/tiziran_unification/greet()
 	return "On this day over 400 years ago, Lizardkind first united under a single banner, ready to face the stars as one unified people."
@@ -643,13 +642,11 @@
 	name = MONKEYDAY
 	begin_day = 14
 	begin_month = DECEMBER
-	holiday_hat = /obj/item/clothing/mask/gas/monkeymask
 
 /datum/holiday/doomsday
 	name = "Mayan Doomsday Anniversary"
 	begin_day = 21
 	begin_month = DECEMBER
-	holiday_hat = /obj/item/clothing/mask/animal/small/tribal
 
 /datum/holiday/xmas
 	name = CHRISTMAS

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -18,7 +18,7 @@
 	var/year_offset = 0
 	///Timezones this holiday is celebrated in (defaults to three timezones spanning a 50 hour window covering all timezones)
 	var/list/timezones = list(TIMEZONE_LINT, TIMEZONE_UTC, TIMEZONE_ANYWHERE_ON_EARTH)
-	///If this is defined, drones/assistants without a default hat will spawn with this one during the holiday.
+	///If this is defined, drones/assistants without a default hat will spawn with this item in their head clothing slot.
 	var/obj/item/holiday_hat
 	///When this holiday is active, does this prevent mail from arriving to cargo? Try not to use this for longer holidays.
 	var/mail_holiday = FALSE
@@ -653,7 +653,6 @@
 	name = "Mayan Doomsday Anniversary"
 	begin_day = 21
 	begin_month = DECEMBER
-	holiday_hat = /obj/item/clothing/head/costume/garland
 
 /datum/holiday/xmas
 	name = CHRISTMAS

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -322,7 +322,7 @@
 	name = "Bee Day"
 	begin_day = 20
 	begin_month = MAY
-	holiday_hat = /obj/item/clothing/mask/animal/small/bee
+	holiday_hat = /obj/item/clothing/mask/animal/small/bee //change off of mask
 
 /datum/holiday/bee/getStationPrefix()
 	return pick("Bee","Honey","Hive","Africanized","Mead","Buzz")

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -18,8 +18,8 @@
 	var/year_offset = 0
 	///Timezones this holiday is celebrated in (defaults to three timezones spanning a 50 hour window covering all timezones)
 	var/list/timezones = list(TIMEZONE_LINT, TIMEZONE_UTC, TIMEZONE_ANYWHERE_ON_EARTH)
-	///If this is defined, drones without a default hat will spawn with this one during the holiday; check drones_as_items.dm to see this used
-	var/obj/item/drone_hat
+	///If this is defined, drones/assistants without a default hat will spawn with this one during the holiday.
+	var/obj/item/holiday_hat
 	///When this holiday is active, does this prevent mail from arriving to cargo? Try not to use this for longer holidays.
 	var/mail_holiday = FALSE
 	var/poster_name = "generic celebration poster"
@@ -155,7 +155,7 @@
 	name = "Birthday of Space Station 13"
 	begin_day = 16
 	begin_month = FEBRUARY
-	drone_hat = /obj/item/clothing/head/costume/festive
+	holiday_hat = /obj/item/clothing/head/costume/festive
 	poster_name = "station birthday poster"
 	poster_desc = "A poster celebrating another year of the station's operation. Why anyone would be happy to be here is byond you."
 	poster_icon = "holiday_cake" // is a lie
@@ -220,7 +220,7 @@
 	name = "St. Patrick's Day"
 	begin_day = 17
 	begin_month = MARCH
-	drone_hat = /obj/item/clothing/head/soft/green
+	holiday_hat = /obj/item/clothing/head/soft/green
 
 /datum/holiday/no_this_is_patrick/getStationPrefix()
 	return pick("Blarney","Green","Leprechaun","Booze")
@@ -252,7 +252,7 @@
 	name = "Cosmonautics Day"
 	begin_day = 12
 	begin_month = APRIL
-	drone_hat = /obj/item/clothing/head/syndicatefake
+	holiday_hat = /obj/item/clothing/head/syndicatefake
 
 /datum/holiday/spess/greet()
 	return "On this day over 600 years ago, Comrade Yuri Gagarin first ventured into space!"
@@ -283,7 +283,7 @@
 	timezones = list(TIMEZONE_TKT, TIMEZONE_TOT, TIMEZONE_NZST, TIMEZONE_NFT, TIMEZONE_LHST, TIMEZONE_AEST, TIMEZONE_ACST, TIMEZONE_ACWST, TIMEZONE_AWST, TIMEZONE_CXT, TIMEZONE_CCT, TIMEZONE_CKT, TIMEZONE_NUT)
 	begin_day = 25
 	begin_month = APRIL
-	drone_hat = /obj/item/food/grown/poppy
+	holiday_hat = /obj/item/food/grown/poppy
 
 /datum/holiday/anz/getStationPrefix()
 	return pick("Australian","New Zealand","Poppy", "Southern Cross")
@@ -294,7 +294,7 @@
 	name = "Labor Day"
 	begin_day = 1
 	begin_month = MAY
-	drone_hat = /obj/item/clothing/head/utility/hardhat
+	holiday_hat = /obj/item/clothing/head/utility/hardhat
 	mail_holiday = TRUE
 
 //Draconic Day is celebrated on May 3rd, the date on which the Draconic language was merged (#26780)
@@ -313,7 +313,7 @@
 	name = "Firefighter's Day"
 	begin_day = 4
 	begin_month = MAY
-	drone_hat = /obj/item/clothing/head/utility/hardhat/red
+	holiday_hat = /obj/item/clothing/head/utility/hardhat/red
 
 /datum/holiday/firefighter/getStationPrefix()
 	return pick("Burning","Blazing","Plasma","Fire")
@@ -322,7 +322,7 @@
 	name = "Bee Day"
 	begin_day = 20
 	begin_month = MAY
-	drone_hat = /obj/item/clothing/mask/animal/small/bee
+	holiday_hat = /obj/item/clothing/mask/animal/small/bee
 
 /datum/holiday/bee/getStationPrefix()
 	return pick("Bee","Honey","Hive","Africanized","Mead","Buzz")
@@ -377,13 +377,13 @@
 	name = "Doctor's Day"
 	begin_day = 1
 	begin_month = JULY
-	drone_hat = /obj/item/clothing/head/costume/nursehat
+	holiday_hat = /obj/item/clothing/head/costume/nursehat
 
 /datum/holiday/ufo
 	name = "UFO Day"
 	begin_day = 2
 	begin_month = JULY
-	drone_hat = /obj/item/clothing/mask/facehugger/dead
+	holiday_hat = /obj/item/clothing/mask/facehugger/dead
 
 /datum/holiday/ufo/getStationPrefix() //Is such a thing even possible?
 	return pick("Ayy","Truth","Tsoukalos","Mulder","Scully") //Yes it is!
@@ -408,7 +408,7 @@
 	timezones = list(TIMEZONE_CEST)
 	begin_day = 14
 	begin_month = JULY
-	drone_hat = /obj/item/clothing/head/beret
+	holiday_hat = /obj/item/clothing/head/beret
 	mail_holiday = TRUE
 
 /datum/holiday/france/getStationPrefix()
@@ -430,7 +430,7 @@
 	name = "Wizard's Day"
 	begin_month = JULY
 	begin_day = 27
-	drone_hat = /obj/item/clothing/head/wizard
+	holiday_hat = /obj/item/clothing/head/wizard
 
 /datum/holiday/wizards_day/getStationPrefix()
 	return pick("Dungeon", "Elf", "Magic", "D20", "Edition")
@@ -493,7 +493,7 @@
 	name = "Talk-Like-a-Pirate Day"
 	begin_day = 19
 	begin_month = SEPTEMBER
-	drone_hat = /obj/item/clothing/head/costume/pirate
+	holiday_hat = /obj/item/clothing/head/costume/pirate
 
 /datum/holiday/pirate/greet()
 	return "Ye be talkin' like a pirate today or else ye'r walkin' tha plank, matey!"
@@ -523,13 +523,13 @@
 	name = "Smiling Day"
 	begin_day = 7
 	begin_month = OCTOBER
-	drone_hat = /obj/item/clothing/head/costume/papersack/smiley
+	holiday_hat = /obj/item/clothing/head/costume/papersack/smiley
 
 /datum/holiday/boss
 	name = "Boss' Day"
 	begin_day = 16
 	begin_month = OCTOBER
-	drone_hat = /obj/item/clothing/head/hats/tophat
+	holiday_hat = /obj/item/clothing/head/hats/tophat
 
 /datum/holiday/un_day
 	name = "Anniversary of the Foundation of the United Nations"
@@ -578,7 +578,7 @@
 	name = "Remembrance Day"
 	begin_month = NOVEMBER
 	begin_day = 11
-	drone_hat = /obj/item/food/grown/poppy
+	holiday_hat = /obj/item/food/grown/poppy
 
 /datum/holiday/remembrance_day/getStationPrefix()
 	return pick("Peace", "Armistice", "Poppy")
@@ -600,7 +600,7 @@
 	name = "Flowers Day"
 	begin_day = 19
 	begin_month = NOVEMBER
-	drone_hat = /obj/item/food/grown/moonflower
+	holiday_hat = /obj/item/food/grown/moonflower
 
 /datum/holiday/hello
 	name = "Saying-'Hello' Day"
@@ -629,7 +629,7 @@
 	begin_day = 1
 	begin_month = DECEMBER
 	end_day = 31
-	drone_hat = /obj/item/clothing/head/costume/santa
+	holiday_hat = /obj/item/clothing/head/costume/santa
 
 /datum/holiday/festive_season/greet()
 	return "Have a nice festive season!"
@@ -643,20 +643,20 @@
 	name = MONKEYDAY
 	begin_day = 14
 	begin_month = DECEMBER
-	drone_hat = /obj/item/clothing/mask/gas/monkeymask
+	holiday_hat = /obj/item/clothing/mask/gas/monkeymask
 
 /datum/holiday/doomsday
 	name = "Mayan Doomsday Anniversary"
 	begin_day = 21
 	begin_month = DECEMBER
-	drone_hat = /obj/item/clothing/mask/animal/small/tribal
+	holiday_hat = /obj/item/clothing/mask/animal/small/tribal
 
 /datum/holiday/xmas
 	name = CHRISTMAS
 	begin_day = 23
 	begin_month = DECEMBER
 	end_day = 27
-	drone_hat = /obj/item/clothing/head/costume/santa
+	holiday_hat = /obj/item/clothing/head/costume/santa
 	mail_holiday = TRUE
 
 /datum/holiday/xmas/getStationPrefix()
@@ -693,7 +693,7 @@
 	begin_month = DECEMBER
 	end_day = 2
 	end_month = JANUARY
-	drone_hat = /obj/item/clothing/head/costume/festive
+	holiday_hat = /obj/item/clothing/head/costume/festive
 	mail_holiday = TRUE
 
 /datum/holiday/new_year/getStationPrefix()
@@ -808,7 +808,7 @@
 
 /datum/holiday/easter
 	name = EASTER
-	drone_hat = /obj/item/clothing/head/costume/rabbitears
+	holiday_hat = /obj/item/clothing/head/costume/rabbitears
 	var/const/days_early = 1 //to make editing the holiday easier
 	var/const/days_extra = 1
 

--- a/code/modules/holiday/nth_week.dm
+++ b/code/modules/holiday/nth_week.dm
@@ -35,7 +35,7 @@
 	begin_week = 4
 	begin_month = NOVEMBER
 	begin_weekday = THURSDAY
-	drone_hat = /obj/item/clothing/head/hats/tophat //This is the closest we can get to a pilgrim's hat
+	holiday_hat = /obj/item/clothing/head/hats/tophat //This is the closest we can get to a pilgrim's hat
 
 /datum/holiday/nth_week/thanksgiving/canada
 	name = "Thanksgiving in Canada"

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -48,7 +48,7 @@ Assistant
 	for(var/holidayname in GLOB.holidays)
 		var/datum/holiday/holiday_today = GLOB.holidays[holidayname]
 		var/obj/item/special_hat = holiday_today.holiday_hat
-		if(!isnull(special_hat) && isnull(head))
+		if(prob(HOLIDAY_HAT_CHANCE) && !isnull(special_hat) && isnull(head))
 			head = special_hat
 
 	give_jumpsuit(target)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -45,6 +45,11 @@ Assistant
 
 /datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/target)
 	..()
+	for(var/holidayname in GLOB.holidays)
+		var/datum/holiday/holiday_today = GLOB.holidays[holidayname]
+		if(holiday_today.holiday_hat)
+			head = holiday_today.holiday_hat
+
 	give_jumpsuit(target)
 
 /datum/outfit/job/assistant/proc/give_jumpsuit(mob/living/carbon/human/target)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -47,8 +47,9 @@ Assistant
 	..()
 	for(var/holidayname in GLOB.holidays)
 		var/datum/holiday/holiday_today = GLOB.holidays[holidayname]
-		if(holiday_today.holiday_hat && !head)
-			head = holiday_today.holiday_hat
+		var/obj/item/special_hat = holiday_today.holiday_hat
+		if(!isnull(special_hat) && isnull(head))
+			head = special_hat
 
 	give_jumpsuit(target)
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -47,7 +47,7 @@ Assistant
 	..()
 	for(var/holidayname in GLOB.holidays)
 		var/datum/holiday/holiday_today = GLOB.holidays[holidayname]
-		if(holiday_today.holiday_hat)
+		if(holiday_today.holiday_hat && !head)
 			head = holiday_today.holiday_hat
 
 	give_jumpsuit(target)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -182,15 +182,14 @@
 		var/obj/item/I = new default_storage(src)
 		equip_to_slot_or_del(I, ITEM_SLOT_DEX_STORAGE)
 
-	for(var/holidayname in GLOB.holidays)
-		var/datum/holiday/holiday_today = GLOB.holidays[holidayname]
-
-		if(holiday_today.holiday_hat && !default_headwear) //If we don't already have a hat (no secret syndiedrones), we take the holiday one.
+	for(var/holiday_name in GLOB.holidays)
+		var/datum/holiday/holiday_today = GLOB.holidays[holiday_name]
+		if(holiday_today.holiday_hat && !default_headwear) //If our drone type doesn't start with a hat, we take the holiday one.
 			default_headwear = holiday_today.holiday_hat
 
 	if(default_headwear)
-		var/obj/item/I = new default_headwear(src)
-		equip_to_slot_or_del(I, ITEM_SLOT_HEAD)
+		var/obj/item/new_hat = new default_headwear(src)
+		equip_to_slot_or_del(new_hat, ITEM_SLOT_HEAD)
 
 	ADD_TRAIT(access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -184,8 +184,9 @@
 
 	for(var/holiday_name in GLOB.holidays)
 		var/datum/holiday/holiday_today = GLOB.holidays[holiday_name]
-		if(holiday_today.holiday_hat && !default_headwear) //If our drone type doesn't start with a hat, we take the holiday one.
-			default_headwear = holiday_today.holiday_hat
+		var/obj/item/potential_hat = holiday_today.holiday_hat
+		if(!isnull(potential_hat) && isnull(default_headwear)) //If our drone type doesn't start with a hat, we take the holiday one.
+			default_headwear = potential_hat
 
 	if(default_headwear)
 		var/obj/item/new_hat = new default_headwear(src)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -74,7 +74,7 @@
 	/// Default [/mob/living/simple_animal/drone/var/internal_storage] item
 	var/obj/item/default_storage = /obj/item/storage/drone_tools
 	/// Default [/mob/living/simple_animal/drone/var/head] item
-	var/obj/item/default_hatmask
+	var/obj/item/default_headwear
 	/**
 	  * icon_state of drone from icons/mobs/drone.dmi
 	  *
@@ -185,11 +185,11 @@
 	for(var/holidayname in GLOB.holidays)
 		var/datum/holiday/holiday_today = GLOB.holidays[holidayname]
 
-		if(holiday_today.holiday_hat && !default_hatmask) //If we don't already have a hat (no secret syndiedrones), we take the holiday one.
-			default_hatmask = holiday_today.holiday_hat
+		if(holiday_today.holiday_hat && !default_headwear) //If we don't already have a hat (no secret syndiedrones), we take the holiday one.
+			default_headwear = holiday_today.holiday_hat
 
-	if(default_hatmask)
-		var/obj/item/I = new default_hatmask(src)
+	if(default_headwear)
+		var/obj/item/I = new default_headwear(src)
 		equip_to_slot_or_del(I, ITEM_SLOT_HEAD)
 
 	ADD_TRAIT(access_card, TRAIT_NODROP, ABSTRACT_ITEM_TRAIT)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -181,6 +181,13 @@
 	if(default_storage)
 		var/obj/item/I = new default_storage(src)
 		equip_to_slot_or_del(I, ITEM_SLOT_DEX_STORAGE)
+
+	for(var/holidayname in GLOB.holidays)
+		var/datum/holiday/holiday_today = GLOB.holidays[holidayname]
+
+		if(holiday_today.holiday_hat && !default_hatmask) //If we don't already have a hat (no secret syndiedrones), we take the holiday one.
+			default_hatmask = holiday_today.holiday_hat
+
 	if(default_hatmask)
 		var/obj/item/I = new default_hatmask(src)
 		equip_to_slot_or_del(I, ITEM_SLOT_HEAD)

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -27,7 +27,7 @@
 	"2. Kill.\n"+\
 	"3. Destroy."
 	default_storage = /obj/item/uplink
-	default_hatmask = /obj/item/clothing/head/helmet/swat
+	default_headwear = /obj/item/clothing/head/helmet/swat
 	hacked = TRUE
 	shy = FALSE
 	flavortext = null
@@ -49,7 +49,7 @@
 	W.implant(src, force = TRUE)
 
 /mob/living/simple_animal/drone/snowflake
-	default_hatmask = /obj/item/clothing/head/chameleon/drone
+	default_headwear = /obj/item/clothing/head/chameleon/drone
 
 /mob/living/simple_animal/drone/snowflake/Initialize(mapload)
 	. = ..()
@@ -87,7 +87,7 @@
 
 /mob/living/simple_animal/drone/polymorphed
 	default_storage = null
-	default_hatmask = null
+	default_headwear = null
 	picked = TRUE
 	flavortext = null
 
@@ -132,7 +132,7 @@
 
 /mob/living/simple_animal/drone/derelict
 	name = "derelict drone"
-	default_hatmask = /obj/item/clothing/head/costume/ushanka
+	default_headwear = /obj/item/clothing/head/costume/ushanka
 	laws = \
 	"1. You may not involve yourself in the matters of another sentient being outside the station that housed your activation, even if such matters conflict with Law Two or Law Three, unless the other being is another Drone.\n"+\
 	"2. You may not harm any sentient being, regardless of intent or circumstance.\n"+\

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -104,6 +104,7 @@
 #include "code\__DEFINES\ghost.dm"
 #include "code\__DEFINES\gravity.dm"
 #include "code\__DEFINES\guardian_defines.dm"
+#include "code\__DEFINES\holiday.dm"
 #include "code\__DEFINES\holopads.dm"
 #include "code\__DEFINES\hud.dm"
 #include "code\__DEFINES\icon_smoothing.dm"


### PR DESCRIPTION

## About The Pull Request

drone_hat defined a piece of headwear that drones would spawn with when the corresponding holiday is active. While peeking at holiday code for my own amusement, I noticed that it wasn't actually used anywhere and must have become deprecated at some point. I have re-implemented that functionality, and extended it to assistants.

Now, all drones/assistants spawning without headwear during a holiday will receive the holiday's defined holiday_hat (if there is one). This modifies a few of the holiday_hat entries, particularly the mask entries since the new system is head-only, and adds a few more in there as well.

![image](https://github.com/tgstation/tgstation/assets/28870487/f44d8499-957c-4b71-843b-26ab77f46ff4)

There's probably some balance implications to, say, spawning all the assistants with fire helmets or pirate bandanas, but I see that as being balanced out by the infrequency of these cases.
## Why It's Good For The Game

Restores an piece of drone code that fell off the wagon somewhere amongst the removals and reworks.

As for implementing it for assistants, seeing assistants in funny hats makes me laugh a lil bit :)
## Changelog
:cl: Rhials
qol: Restores holiday hats for drones.
qol: Extends holiday hat behavior to assistants. Get festive!
/:cl:
