### PR TITLE
Removes junk entry so random recipes can work now

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -82,10 +82,10 @@
 			if(reagent_to_react_count[reagent_id] < reagent_to_react_count[preferred_id])
 				preferred_id = reagent_id
 				continue
-
-		if(!reaction_lookup[preferred_id])
-			reaction_lookup[preferred_id] = list()
-		reaction_lookup[preferred_id] += reaction
+		if (preferred_id != null)
+			if(!reaction_lookup[preferred_id])
+				reaction_lookup[preferred_id] = list()
+			reaction_lookup[preferred_id] += reaction
 
 	for(var/datum/chemical_reaction/reaction as anything in reactions)
 		var/list/product_ids = list()

--- a/code/modules/reagents/chemistry/recipes/special.dm
+++ b/code/modules/reagents/chemistry/recipes/special.dm
@@ -217,6 +217,9 @@ GLOBAL_LIST_INIT(medicine_reagents, build_medicine_reagents())
 		return FALSE
 	required_reagents = req_reag
 
+	if (required_reagents.len == 0)
+		return FALSE
+
 	var/req_catalysts = unwrap_reagent_list(recipe_data["required_catalysts"])
 	if(!req_catalysts)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Ensure that there are no null entries in the `chemical_reactions_list_reactant_index` so that `get_chemical_reaction` can now work properly

## Why It's Good For The Game

Fixes #77139

## Changelog
:cl:
fix: Recipe paper in the ruins now shows a normal recipe for Metalgen and Secret sauce.
/:cl:
