### PR TITLE
Adds a new lavaland ruin, the ancient battle site.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_battle_site.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_battle_site.dmm
@@ -5,8 +5,10 @@
 "f" = (
 /obj/effect/mob_spawn/corpse/human/skeleton,
 /obj/item/clothing/head/costume/crown{
-	pixel_x = 10;
-	pixel_y = 6
+	pixel_x = 15;
+	pixel_y = 6;
+	desc = "A crown that was fit for a king, looks like it didn't get them very far.";
+	name = "dented crown"
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -22,12 +24,8 @@
 "j" = (
 /turf/template_noop,
 /area/template_noop)
-"l" = (
-/obj/structure/statue/bone/rib,
-/turf/open/misc/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
 "m" = (
-/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/shreds,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "n" = (
@@ -63,21 +61,39 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"u" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "x" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"D" = (
+/obj/structure/statue/bone/rib{
+	name = "colossal tailbone"
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "F" = (
-/obj/structure/stone_tile/block/burnt,
 /obj/effect/decal/cleanable/blood/drip,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/obj/structure/statue/bone/rib,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "G" = (
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"H" = (
+/obj/structure/firepit,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
 "I" = (
 /obj/structure/closet/crate/wooden,
 /obj/item/stack/sheet/animalhide/goliath_hide,
+/obj/item/flashlight/flare/torch,
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "J" = (
@@ -87,6 +103,12 @@
 "K" = (
 /obj/structure/closet/crate/wooden,
 /obj/item/stack/sheet/sinew,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"L" = (
+/obj/effect/decal/cleanable/blood/hitsplatter{
+	dir = 4
+	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "M" = (
@@ -214,7 +236,7 @@ a
 G
 K
 G
-m
+u
 T
 x
 J
@@ -233,7 +255,7 @@ I
 G
 G
 q
-G
+L
 G
 s
 g
@@ -256,7 +278,7 @@ G
 x
 G
 G
-G
+D
 j
 j
 "}
@@ -271,8 +293,8 @@ t
 J
 G
 q
-G
 J
+O
 q
 G
 j
@@ -282,7 +304,7 @@ j
 j
 j
 m
-G
+u
 G
 q
 f
@@ -290,7 +312,7 @@ O
 J
 O
 G
-O
+n
 J
 x
 j
@@ -309,8 +331,8 @@ o
 n
 X
 F
+u
 G
-l
 j
 j
 "}
@@ -320,13 +342,13 @@ j
 J
 G
 G
-G
+u
 J
 U
 G
 U
 J
-U
+G
 G
 G
 j
@@ -338,7 +360,7 @@ j
 j
 q
 h
-m
+G
 G
 G
 q
@@ -357,7 +379,7 @@ j
 G
 G
 x
-G
+H
 x
 G
 G
@@ -377,8 +399,8 @@ J
 G
 G
 P
-m
 G
+u
 G
 a
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_battle_site.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_battle_site.dmm
@@ -1,0 +1,442 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/mineral/strong/wasteland,
+/area/lavaland/surface/outdoors)
+"f" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/item/clothing/head/costume/crown{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"g" = (
+/obj/structure/water_source/puddle,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"h" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/item/shield/buckler,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"j" = (
+/turf/template_noop,
+/area/template_noop)
+"l" = (
+/obj/structure/statue/bone/rib,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"m" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"n" = (
+/obj/structure/stone_tile/block/burnt,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"o" = (
+/obj/structure/stone_tile/burnt{
+	dir = 1
+	},
+/obj/structure/stone_tile/burnt{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/mob/living/basic/mining/goliath,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"p" = (
+/obj/item/stack/rods{
+	pixel_x = 10
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"q" = (
+/obj/structure/flora/rock,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"s" = (
+/mob/living/basic/mining/goliath,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"t" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"x" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"F" = (
+/obj/structure/stone_tile/block/burnt,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"G" = (
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"I" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/stack/sheet/animalhide/goliath_hide,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"J" = (
+/obj/structure/flora/ash/cap_shroom,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"K" = (
+/obj/structure/closet/crate/wooden,
+/obj/item/stack/sheet/sinew,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"M" = (
+/obj/structure/statue/bone/skull,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"O" = (
+/obj/structure/statue/bone/rib{
+	dir = 1
+	},
+/obj/structure/stone_tile/cracked{
+	dir = 4
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"P" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/item/shovel/spade,
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"S" = (
+/obj/structure/chair/wood/wings{
+	color = "#ffff00"
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"T" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/item/spear/bonespear{
+	pixel_x = 13;
+	pixel_y = 12
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"U" = (
+/obj/structure/statue/bone/rib,
+/obj/structure/stone_tile/cracked{
+	dir = 1
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"V" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/item/stack/rods{
+	pixel_x = -1;
+	pixel_y = -7
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"X" = (
+/obj/structure/stone_tile/burnt,
+/obj/structure/stone_tile/burnt{
+	dir = 4
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"Y" = (
+/obj/effect/mob_spawn/corpse/human/skeleton,
+/obj/item/stack/rods{
+	pixel_y = -12;
+	pixel_x = 2
+	},
+/turf/open/misc/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+
+(1,1,1) = {"
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+"}
+(2,1,1) = {"
+j
+j
+a
+j
+j
+j
+j
+j
+j
+j
+j
+j
+a
+j
+j
+j
+"}
+(3,1,1) = {"
+j
+a
+a
+a
+j
+j
+J
+G
+G
+G
+j
+j
+a
+a
+a
+j
+"}
+(4,1,1) = {"
+j
+j
+a
+a
+G
+K
+G
+m
+T
+x
+J
+a
+a
+a
+j
+j
+"}
+(5,1,1) = {"
+j
+j
+j
+J
+I
+G
+G
+q
+G
+G
+s
+g
+a
+G
+j
+j
+"}
+(6,1,1) = {"
+j
+j
+j
+G
+s
+x
+x
+G
+x
+G
+x
+G
+G
+G
+j
+j
+"}
+(7,1,1) = {"
+j
+j
+V
+q
+G
+p
+t
+J
+G
+q
+G
+J
+q
+G
+j
+j
+"}
+(8,1,1) = {"
+j
+j
+m
+G
+G
+q
+f
+O
+J
+O
+G
+O
+J
+x
+j
+j
+"}
+(9,1,1) = {"
+j
+j
+G
+x
+G
+M
+S
+n
+o
+n
+X
+F
+G
+l
+j
+j
+"}
+(10,1,1) = {"
+j
+j
+J
+G
+G
+G
+J
+U
+G
+U
+J
+U
+G
+G
+j
+j
+"}
+(11,1,1) = {"
+j
+j
+j
+q
+h
+m
+G
+G
+q
+G
+G
+J
+m
+q
+j
+j
+"}
+(12,1,1) = {"
+j
+j
+j
+G
+G
+x
+G
+x
+G
+G
+q
+Y
+G
+a
+j
+j
+"}
+(13,1,1) = {"
+j
+j
+a
+G
+J
+G
+G
+P
+m
+G
+G
+a
+a
+a
+a
+j
+"}
+(14,1,1) = {"
+j
+a
+a
+a
+j
+j
+G
+G
+q
+G
+j
+j
+a
+a
+j
+j
+"}
+(15,1,1) = {"
+j
+a
+a
+j
+j
+j
+j
+j
+j
+j
+j
+a
+a
+a
+j
+j
+"}
+(16,1,1) = {"
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+j
+"}

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -275,3 +275,11 @@
 	suffix = "lavaland_surface_phonebooth.dmm"
 	allow_duplicates = FALSE
 	cost = 5
+
+/datum/map_template/ruin/lavaland/battle_site
+	name = "Battle Site"
+	id = "battle_site"
+	description = "The long past site of a battle between beast and humanoids. The victor is unknown, but the losers are clear."
+	suffix = "lavaland_battle_site.dmm"
+	allow_duplicates = TRUE
+	cost = 3


### PR DESCRIPTION

## About The Pull Request
Adds a new ruin to lavaland, the Battle Site ruin. This ruin features the site of an old battle, with the only inhabitants now being goliaths and mushrooms. The cycle continues, one would imagine.

No new uniques or rewards or anything, as this just spawns in standard items found on or around lavaland already.

![image](https://github.com/tgstation/tgstation/assets/41715314/01a05391-831e-46ac-a4b1-3bfb378c84c2)

## Why It's Good For The Game

Full disclosure I just got bored this afternoon and decided to do a little mini project and bump up the lavaland ruin diversity a little bit. 
I'm of the opinion that we could always use new ruins on lavaland so that there's new things to explore and so that we can introduce some new elements to the map generation.

## Changelog
:cl:
add: A new ruin has appeared on lavaland, featuring the site of an ancient battle.
/:cl:
