### PR TITLE
[NO GBP] Fix barricade description element spam

### DIFF
--- a/code/datums/elements/can_barricade.dm
+++ b/code/datums/elements/can_barricade.dm
@@ -11,22 +11,17 @@
 		return ELEMENT_INCOMPATIBLE
 
 	RegisterSignal(target, COMSIG_ATOM_ATTACKBY, PROC_REF(on_start_barricade))
-	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 
 	target.flags_1 |= HAS_CONTEXTUAL_SCREENTIPS_1
 	RegisterSignal(target, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM, PROC_REF(on_requesting_context_from_item))
 
 /datum/element/can_barricade/Detach(atom/target)
-	UnregisterSignal(target, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_EXAMINE, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM))
+	UnregisterSignal(target, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM))
 	// We don't remove HAS_CONTEXTUAL_SCREENTIPS_1, since there could be other stuff still hooked to it,
 	// and being set without signals is not dangerous, just less performant.
 	// A lot of things don't do this, perhaps make a proc that checks if any signals are still set, and if not,
 	// remove the flag.
 	return ..()
-
-/datum/element/can_barricade/proc/on_examine(atom/source, mob/user, list/examine_texts)
-	SIGNAL_HANDLER
-	examine_texts += span_notice("This looks like it can be barricaded with planks of wood.")
 
 /datum/element/can_barricade/proc/on_start_barricade(atom/source, obj/item/stack/sheet/mineral/wood/plank, mob/living/user, params)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request
In #69676 I added constructable wooden barricades that can be constructed.  I went overboard and added a `This looks like it can be barricaded with planks of wood.` examine description to the element without considering the implications that it would get spammed on many objects. (windows, doors, etc.)

The description spam is unnecessary since we already have contextual screentips telling people how to use wood to make barricades.

## Why It's Good For The Game
Less description spam.

## Changelog
:cl:
fix: Fix wooden barricade description "This looks like it can be barricaded with planks of wood" being spammed on objects.
/:cl:
