### PR TITLE
HoS compact shotgun weight rebalance

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -68,7 +68,7 @@
 	desc = "A compact version of the semi automatic combat shotgun. For close encounters."
 	icon_state = "cshotgunc"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 
 //Dual Feed Shotgun
 


### PR DESCRIPTION

## About The Pull Request
this pull request changes the HoS shotgun (compact shotgun) to mirror the HoS laser gun in weight
## Why It's Good For The Game
I believe this is good for the game to encourage different ways of playing head of security, as of this moment the compact shotgun is too heavy to fit in a backpack or expanded storage modsuit with all of the basic HoS gear and discourages sawing off a riot shotgun instead

with this change when you retract all the parts of your MODsuit instead of having it drop to the floor it will sit safe and snug on your person at all times without you having to worry about losing it or having it used against you
## Changelog
:cl:
qol: the compact shotgun will now fit in your MOD storage without falling out
balance: changed the weight of the compact shotgun to mirror the HoS laser
/:cl:
