### PR TITLE
fix basic mobs retaliate target not filtering targets

### DIFF
--- a/code/__DEFINES/ai/ai_blackboard.dm
+++ b/code/__DEFINES/ai/ai_blackboard.dm
@@ -67,6 +67,8 @@
 
 ///List of mobs who have damaged us
 #define BB_BASIC_MOB_RETALIATE_LIST "BB_basic_mob_shitlist"
+///do we currently have a retaliate target?
+#define BB_BASIC_MOB_RETALIATE "BB_basic_mob_retaliate"
 
 /// Flag to set on or off if you want your mob to prioritise running away
 #define BB_BASIC_MOB_FLEEING "BB_basic_fleeing"

--- a/code/__DEFINES/ai/ai_blackboard.dm
+++ b/code/__DEFINES/ai/ai_blackboard.dm
@@ -68,7 +68,7 @@
 ///List of mobs who have damaged us
 #define BB_BASIC_MOB_RETALIATE_LIST "BB_basic_mob_shitlist"
 ///do we currently have a retaliate target?
-#define BB_BASIC_MOB_RETALIATE "BB_basic_mob_retaliate"
+#define BB_BASIC_MOB_CURRENTLY_RETALIATTING "BB_basic_mob_currently_retaliating"
 
 /// Flag to set on or off if you want your mob to prioritise running away
 #define BB_BASIC_MOB_FLEEING "BB_basic_fleeing"

--- a/code/__DEFINES/ai/ai_blackboard.dm
+++ b/code/__DEFINES/ai/ai_blackboard.dm
@@ -67,8 +67,6 @@
 
 ///List of mobs who have damaged us
 #define BB_BASIC_MOB_RETALIATE_LIST "BB_basic_mob_shitlist"
-///do we currently have a retaliate target?
-#define BB_BASIC_MOB_CURRENTLY_RETALIATTING "BB_basic_mob_currently_retaliating"
 
 /// Flag to set on or off if you want your mob to prioritise running away
 #define BB_BASIC_MOB_FLEEING "BB_basic_fleeing"
@@ -85,3 +83,6 @@
 #define BB_MOD_IMPLANT "BB_mod_implant"
 ///Range for a MOD AI controller.
 #define MOD_AI_RANGE 200
+
+///should we skip the faction check for the targetting datum?
+#define BB_BASIC_MOB_SKIP_FACTION_CHECK "BB_basic_mob_skip_faction_check"

--- a/code/datums/ai/basic_mobs/basic_subtrees/target_retaliate.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/target_retaliate.dm
@@ -36,8 +36,16 @@
 	if(!targetting_datum)
 		CRASH("No target datum was supplied in the blackboard for [controller.pawn]")
 
-	var/list/enemies_list = controller.blackboard[shitlist_key]
-	if (!length(enemies_list))
+
+	var/list/enemies_list = list()
+
+	for(var/mob/living/potential_target as anything in controller.blackboard[shitlist_key])
+		if(!targetting_datum.can_attack(living_mob, potential_target, vision_range))
+			continue
+		enemies_list += potential_target
+
+
+	if(!length(enemies_list))
 		finish_action(controller, succeeded = FALSE)
 		return
 
@@ -54,16 +62,6 @@
 		controller.set_blackboard_key(hiding_location_key, potential_hiding_location)
 
 	finish_action(controller, succeeded = TRUE)
-
-/// Returns true if this target is valid for attacking based on current conditions
-/datum/ai_behavior/target_from_retaliate_list/proc/can_attack_target(mob/living/living_mob, atom/target, datum/targetting_datum/targetting_datum)
-	if (!target)
-		return FALSE
-	if (target == living_mob)
-		return FALSE
-	if (!can_see(living_mob, target, vision_range))
-		return FALSE
-	return targetting_datum.can_attack(living_mob, target)
 
 /// Returns the desired final target from the filtered list of enemies
 /datum/ai_behavior/target_from_retaliate_list/proc/pick_final_target(datum/ai_controller/controller, list/enemies_list)

--- a/code/datums/ai/basic_mobs/basic_subtrees/target_retaliate.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/target_retaliate.dm
@@ -51,11 +51,11 @@
 
 
 	if(!length(enemies_list))
-		finish_action(controller, succeeded = FALSE)
+		finish_action(controller, succeeded = FALSE, check_faction = check_faction)
 		return
 
 	if (controller.blackboard[target_key] in enemies_list) // Don't bother changing
-		finish_action(controller, succeeded = TRUE)
+		finish_action(controller, succeeded = TRUE, check_faction = check_faction)
 		return
 
 	var/atom/new_target = pick_final_target(controller, enemies_list)
@@ -66,13 +66,15 @@
 	if(potential_hiding_location) //If they're hiding inside of something, we need to know so we can go for that instead initially.
 		controller.set_blackboard_key(hiding_location_key, potential_hiding_location)
 
-	finish_action(controller, succeeded = TRUE)
+	finish_action(controller, succeeded = TRUE, check_faction = check_faction)
 
 /// Returns the desired final target from the filtered list of enemies
 /datum/ai_behavior/target_from_retaliate_list/proc/pick_final_target(datum/ai_controller/controller, list/enemies_list)
 	return pick(enemies_list)
 
 
-/datum/ai_behavior/target_from_retaliate_list/finish_action(datum/ai_controller/controller, succeeded, target_key)
+/datum/ai_behavior/target_from_retaliate_list/finish_action(datum/ai_controller/controller, succeeded, target_key, check_faction)
 	. = ..()
-	controller.set_blackboard_key(BB_BASIC_MOB_RETALIATE, succeeded)
+	if(check_faction)
+		return
+	controller.set_blackboard_key(BB_BASIC_MOB_CURRENTLY_RETALIATTING, succeeded)

--- a/code/datums/ai/basic_mobs/basic_subtrees/target_retaliate.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/target_retaliate.dm
@@ -77,4 +77,4 @@
 	. = ..()
 	if(check_faction)
 		return
-	controller.set_blackboard_key(BB_BASIC_MOB_CURRENTLY_RETALIATTING, succeeded)
+	controller.set_blackboard_key(BB_BASIC_MOB_SKIP_FACTION_CHECK, succeeded)

--- a/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
+++ b/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
@@ -20,7 +20,12 @@
 	///Whether we care for seeing the target or not
 	var/ignore_sight = FALSE
 
-/datum/targetting_datum/basic/can_attack(mob/living/living_mob, atom/the_target, vision_range)
+/datum/targetting_datum/basic/can_attack(mob/living/living_mob, atom/the_target, vision_range, check_faction = TRUE)
+	var/datum/ai_controller/basic_controller/our_controller = living_mob.ai_controller
+
+	if(isnull(our_controller))
+		return FALSE
+
 	if(isturf(the_target) || !the_target) // bail out on invalids
 		return FALSE
 
@@ -44,9 +49,13 @@
 		return FALSE
 
 	if(isliving(the_target)) //Targeting vs living mobs
-		var/mob/living/L = the_target
-		if(faction_check(living_mob, L)  || (L.stat > stat_attack))
+		var/mob/living/living_target = the_target
+		var/bypass_faction_check = !check_faction || our_controller.blackboard[BB_BASIC_MOB_RETALIATE]
+		if(faction_check(living_mob, living_target) && !bypass_faction_check)
 			return FALSE
+		if(living_target.stat > stat_attack)
+			return FALSE
+
 		return TRUE
 
 	if(ismecha(the_target)) //Targeting vs mechas

--- a/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
+++ b/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
@@ -50,7 +50,7 @@
 
 	if(isliving(the_target)) //Targeting vs living mobs
 		var/mob/living/living_target = the_target
-		var/bypass_faction_check = !check_faction || our_controller.blackboard[BB_BASIC_MOB_RETALIATE]
+		var/bypass_faction_check = !check_faction || our_controller.blackboard[BB_BASIC_MOB_CURRENTLY_RETALIATTING]
 		if(faction_check(living_mob, living_target) && !bypass_faction_check)
 			return FALSE
 		if(living_target.stat > stat_attack)

--- a/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
+++ b/code/datums/ai/basic_mobs/targetting_datums/basic_targetting_datum.dm
@@ -50,7 +50,7 @@
 
 	if(isliving(the_target)) //Targeting vs living mobs
 		var/mob/living/living_target = the_target
-		var/bypass_faction_check = !check_faction || our_controller.blackboard[BB_BASIC_MOB_CURRENTLY_RETALIATTING]
+		var/bypass_faction_check = !check_faction || our_controller.blackboard[BB_BASIC_MOB_SKIP_FACTION_CHECK]
 		if(faction_check(living_mob, living_target) && !bypass_faction_check)
 			return FALSE
 		if(living_target.stat > stat_attack)

--- a/code/modules/mob/living/basic/lavaland/goliath/goliath_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/goliath_ai.dm
@@ -9,7 +9,7 @@
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(
-		/datum/ai_planning_subtree/target_retaliate,
+		/datum/ai_planning_subtree/target_retaliate/check_faction,
 		/datum/ai_planning_subtree/simple_find_target,
 		/datum/ai_planning_subtree/find_food,
 		/datum/ai_planning_subtree/targeted_mob_ability/goliath_tentacles,

--- a/code/modules/mob/living/basic/lavaland/watcher/watcher_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher_ai.dm
@@ -6,7 +6,7 @@
 	ai_movement = /datum/ai_movement/basic_avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(
-		/datum/ai_planning_subtree/target_retaliate,
+		/datum/ai_planning_subtree/target_retaliate/check_faction,
 		/datum/ai_planning_subtree/simple_find_target,
 		/datum/ai_planning_subtree/use_mob_ability/gaze,
 		/datum/ai_planning_subtree/targeted_mob_ability/overwatch,


### PR DESCRIPTION
## About The Pull Request
basic mobs retaliate targeting would try to target players that they cant attack anymore,

## Why It's Good For The Game
fixes basic mobs retaliate targeting would try to target players that they cant attack anymore,

## Changelog
:cl:
fix: basic mobs retaliate targetting now selects targets they can attack
/:cl:
