### PR TITLE
Oppenheimer (nukie medibot) doesnt get smited by syndicate turrets and has syndicate access

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -102,6 +102,8 @@
 	var/tipped_status = MEDBOT_PANIC_NONE
 	///The name we got when we were tipped
 	var/tipper_name
+	///The trim type that will grant additional access to this medibot
+	var/datum/id_trim/additional_access = /datum/id_trim/job/paramedic
 
 	///Last announced healing a person in critical condition
 	COOLDOWN_DECLARE(last_patient_message)
@@ -144,6 +146,7 @@
 	damagetype_healer = "all"
 	heal_threshold = 0
 	heal_amount = 5
+	additional_access = /datum/id_trim/syndicom/crew
 
 /mob/living/simple_animal/bot/medbot/nukie/Initialize(mapload, new_skin)
 	. = ..()
@@ -152,6 +155,7 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DEVICE_DETONATING, PROC_REF(nuke_detonate))
 	internal_radio.set_frequency(FREQ_SYNDICATE)
 	internal_radio.freqlock = RADIO_FREQENCY_LOCKED
+	faction += ROLE_SYNDICATE //one of us
 
 /mob/living/simple_animal/bot/medbot/nukie/proc/nuke_disarm()
 	SIGNAL_HANDLER
@@ -204,8 +208,8 @@
 	. = ..()
 
 	// Doing this hurts my soul, but simplebot access reworks are for another day.
-	var/datum/id_trim/job/para_trim = SSid_access.trim_singletons_by_path[/datum/id_trim/job/paramedic]
-	access_card.add_access(para_trim.access + para_trim.wildcard_access)
+	var/datum/id_trim/additional_trim = SSid_access.trim_singletons_by_path[additional_access]
+	access_card.add_access(additional_trim.access + additional_trim.wildcard_access)
 	prev_access = access_card.access.Copy()
 
 	if(!isnull(new_skin))


### PR DESCRIPTION

## About The Pull Request

Gives the syndicate faction to the oppenheimer medibot that spawns in the nukie infiltrator, which prevents them from being shot by its turrets

Also, they get syndicate access which allows them to open the doors on the ship its on and the nuclear operative base
However, bots cannot interact with like 90% of objects so that means they cant open the blastdoor and wander into the nukie base

## Why It's Good For The Game

fixes #78343

also oppenheimer as a true syndie should be able to open doors on the infiltrator to get to dying nukies

## Changelog
:cl:
fix: the nukie medibot (oppenheimer) has access to the doors of the infiltrator and is not shot at by the turrets
/:cl:
