### PR TITLE
Prevents moonicorns from placing fairy grass on space/chasm/lava/water turfs

### DIFF
--- a/code/datums/elements/movement_turf_changer.dm
+++ b/code/datums/elements/movement_turf_changer.dm
@@ -26,7 +26,7 @@
 	SIGNAL_HANDLER
 
 	var/turf/destination = target.loc
-	if(!isturf(destination) || istype(destination, turf_type) || isspaceturf(destination) || isopenspaceturf(destination))
+	if(!isturf(destination) || istype(destination, turf_type) || isspaceturf(destination) || isopenspaceturf(destination) || ischasm(destination))
 		return
 
 	destination.PlaceOnTop(turf_type)

--- a/code/datums/elements/movement_turf_changer.dm
+++ b/code/datums/elements/movement_turf_changer.dm
@@ -26,7 +26,7 @@
 	SIGNAL_HANDLER
 
 	var/turf/destination = target.loc
-	if(!isturf(destination) || istype(destination, turf_type) || isspaceturf(destination) || isopenspaceturf(destination) || ischasm(destination))
+	if(!isturf(destination) || istype(destination, turf_type) || isgroundlessturf(destination))
 		return
 
 	destination.PlaceOnTop(turf_type)

--- a/code/datums/elements/movement_turf_changer.dm
+++ b/code/datums/elements/movement_turf_changer.dm
@@ -26,7 +26,7 @@
 	SIGNAL_HANDLER
 
 	var/turf/destination = target.loc
-	if(!isturf(destination) || istype(destination, turf_type) || isopenspaceturf(destination))
+	if(!isturf(destination) || istype(destination, turf_type) || isspaceturf(destination) || isopenspaceturf(destination))
 		return
 
 	destination.PlaceOnTop(turf_type)


### PR DESCRIPTION
## About The Pull Request

Apparently space turfs aren't openspace. Who knew!
They already don't create bridges over openspace turfs, so no reason for em to make space bridges either.

## Changelog

:cl:
fix: fixed moonicorns making space/chasm/lava/water bridges with their fairy grass
/:cl:
