### PR TITLE
radiation suit crate fix

### DIFF
--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -117,8 +117,6 @@
 	contains = list(/obj/item/clothing/head/utility/radiation = 2,
 					/obj/item/clothing/suit/utility/radiation = 2,
 					/obj/item/geiger_counter = 2,
-					/obj/item/clothing/suit/utility/radiation,
-					/obj/item/geiger_counter,
 					/obj/item/reagent_containers/cup/glass/bottle/vodka,
 					/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass = 2,
 				)


### PR DESCRIPTION

## About The Pull Request

deletes duplicates in the radiation suit crate

## Why It's Good For The Game

it's bad for things to be broken, like, the third radiation suit didnt even come with a radiation hood

## Changelog
:cl:
fix: made the radiation protection crate's contents match it's description
/:cl:
