### PR TITLE
fixes pizzabox+pancake stack layering, pizzabox bomb labelling

### DIFF
--- a/code/game/objects/items/food/pancakes.dm
+++ b/code/game/objects/items/food/pancakes.dm
@@ -147,6 +147,7 @@
 	var/mutable_appearance/pancake_visual = mutable_appearance(icon, "[pancake.stack_name]_[rand(1, 3)]")
 	pancake_visual.pixel_x = rand(-1, 1)
 	pancake_visual.pixel_y = 3 * contents.len - 1
+	pancake_visual.layer = layer + (contents.len * 0.01)
 	add_overlay(pancake_visual)
 	update_appearance()
 

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -100,7 +100,7 @@
 			pizza_overlay.pixel_y = -2
 			. += pizza_overlay
 		if(bomb)
-			var/mutable_appearance/bomb_overlay = mutable_appearance(bomb.icon, bomb.icon_state)
+			var/mutable_appearance/bomb_overlay = mutable_appearance(bomb.icon, bomb.icon_state, layer = layer + 0.01)
 			bomb_overlay.pixel_y = 8
 			. += bomb_overlay
 		return
@@ -115,7 +115,7 @@
 
 	var/obj/item/pizzabox/box = LAZYLEN(length(boxes)) ? boxes[length(boxes)] : src
 	if(box.boxtag != "")
-		var/mutable_appearance/tag_overlay = mutable_appearance(icon, "pizzabox_tag")
+		var/mutable_appearance/tag_overlay = mutable_appearance(icon, "pizzabox_tag", layer = layer + (box_offset * 0.02))
 		tag_overlay.pixel_y = box_offset
 		. += tag_overlay
 

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -109,7 +109,7 @@
 	for(var/stacked_box in boxes)
 		box_offset += 3
 		var/obj/item/pizzabox/box = stacked_box
-		var/mutable_appearance/box_overlay = mutable_appearance(box.icon, box.icon_state)
+		var/mutable_appearance/box_overlay = mutable_appearance(box.icon, box.icon_state, layer = layer + (box_offset * 0.01))
 		box_overlay.pixel_y = box_offset
 		. += box_overlay
 
@@ -306,8 +306,9 @@
 /obj/item/pizzabox/bomb/Initialize(mapload)
 	. = ..()
 	if(!pizza)
-		var/randompizza = pick(subtypesof(/obj/item/food/pizza))
+		var/randompizza = pick(subtypesof(/obj/item/food/pizza) - /obj/item/food/pizza/flatbread) //also disincludes another base type
 		pizza = new randompizza(src)
+		update_appearance()
 	register_bomb(new /obj/item/bombcore/miniature/pizza(src))
 	set_wires(new /datum/wires/explosive/pizza(src))
 


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/tgstation/tgstation/assets/70376633/7238b875-903a-4fbb-aaba-b29a2887b497)

pizzabox stacks now layer correctly
pancake stacks now layer correctly

the pizzabox bombs that arent armed that can come with the cargo shuttle
now update their label so theyre slightly less obvious
also they can no longer spawn the base flatbread type that just looks like an error

## Why It's Good For The Game

fixes #77380

## Changelog
:cl:
fix: pancake stack layering
fix: pizzabox stack layering
fix: pizzabox bombs that spawn unarmed now label their pizza correctly and cannot spawn a spriteless pizza
/:cl:
