### PR TITLE
Fixes an issue with ovens that generates infinite food.

### DIFF
--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -67,7 +67,7 @@
 	var/atom/original_object = parent
 	var/obj/item/plate/oven_tray/used_tray = original_object.loc
 	var/atom/baked_result = new bake_result(used_tray)
-	bake_result.reagents.clear_reagents()
+	baked_result.reagents.clear_reagents()
 	original_object.reagents?.trans_to(baked_result, original_object.reagents.total_volume)
 
 	if(who_baked_us)


### PR DESCRIPTION

## About The Pull Request

Introduced by #78322

![image](https://github.com/tgstation/tgstation/assets/24975989/ee3f8015-f0e0-4c47-acb2-b598c1279919)

Using the wrong var (uwupsie, path var instead of object var) meant an early runtime. The early runtime meant the code path never qdel'd parent on the bakeable reagent.

So every oven process, the dough would cook into bread without being consumed.
Every oven process, the bread would cook into badrecipe without being consumed.
Every often process, the badrecipe would cook into more badrecipe without being consumed.

Every time this happened, it made ash.

After about ~250 oven processing ticks on Terry, 17k ash was Initialised in a certain kitchen and it would crash anyone that walked near it.

![image](https://github.com/tgstation/tgstation/assets/24975989/c8a67d60-d86e-4ef4-9461-006822cf69d0)

(Yes, I crashed my client opening this list)

Replication steps are as simple as... Putting dough in an oven on a tray, closing the oven and waiting 10 minutes for the kitchen to be a client crash zone. Also lags the server due to the code paths involved. Like 17k ash creating 129 million proc calls to replace_decal.

![image](https://github.com/tgstation/tgstation/assets/24975989/52b06984-b9ff-4450-aaf9-de3e84257077)
![image](https://github.com/tgstation/tgstation/assets/24975989/9135634b-4aaf-4954-888c-3b93ba2899c9)

That should probably be optimised at some point.

Due to how destructive this bug is with client crashes and significant server lag, plus the VERY strong potential for this to happen purely by accident (just putting dough in the oven and forgetting) I'm marking this high priority.
## Why It's Good For The Game

Forgetting to take dough out of the oven no longer progresses the server to a crash-worthy state.
## Changelog
:cl:
fix: Forgetting to take dough out of the oven no longer progresses the server to a crash-worthy state with infinite bread and ash and burned food products for all.
/:cl:
