### PR TITLE
Fix a duplicate status display on a window in Meta Medical Storage

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -45294,7 +45294,6 @@
 	},
 /obj/item/defibrillator/loaded,
 /obj/structure/window/spawner/directional/west,
-/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
 "qph" = (


### PR DESCRIPTION

## About The Pull Request

Title summarizes all.
## Why It's Good For The Game

It bugs the hell out of me.
## Changelog
:cl:
fix: Fixes a misplaced status display in Meta's medical storage.
/:cl:
