### PR TITLE
Fix a runtime in toggle_move_intent keybindings

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -49,6 +49,8 @@
 #define COMSIG_KB_LIVING_TOGGLE_COMBAT_DOWN "keybinding_living_toggle_combat_down"
 #define COMSIG_KB_LIVING_ENABLE_COMBAT_DOWN "keybinding_living_enable_combat_down"
 #define COMSIG_KB_LIVING_DISABLE_COMBAT_DOWN "keybinding_living_disable_combat_down"
+#define COMSIG_KB_LIVING_TOGGLEMOVEINTENT_DOWN "keybinding_mob_togglemoveintent_down"
+#define COMSIG_KB_LIVING_TOGGLEMOVEINTENTALT_DOWN "keybinding_mob_togglemoveintentalt_down"
 
 //Mob
 #define COMSIG_KB_MOB_FACENORTH_DOWN "keybinding_mob_facenorth_down"
@@ -61,8 +63,6 @@
 #define COMSIG_KB_MOB_SWAPHANDS_DOWN "keybinding_mob_swaphands_down"
 #define COMSIG_KB_MOB_ACTIVATEINHAND_DOWN "keybinding_mob_activateinhand_down"
 #define COMSIG_KB_MOB_DROPITEM_DOWN "keybinding_mob_dropitem_down"
-#define COMSIG_KB_MOB_TOGGLEMOVEINTENT_DOWN "keybinding_mob_togglemoveintent_down"
-#define COMSIG_KB_MOB_TOGGLEMOVEINTENTALT_DOWN "keybinding_mob_togglemoveintentalt_down"
 #define COMSIG_KB_MOB_TARGETCYCLEHEAD_DOWN "keybinding_mob_targetcyclehead_down"
 #define COMSIG_KB_MOB_TARGETEYES_DOWN "keybinding_mob_targeteyes_down"
 #define COMSIG_KB_MOB_TARGETMOUTH_DOWN "keybinding_mob_targetmouth_down"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -117,3 +117,38 @@
 		return
 	var/mob/living/user_mob = user.mob
 	user_mob.set_combat_mode(FALSE, silent = FALSE)
+
+/datum/keybinding/living/toggle_move_intent
+	hotkey_keys = list("C")
+	name = "toggle_move_intent"
+	full_name = "Hold to toggle move intent"
+	description = "Held down to cycle to the other move intent, release to cycle back"
+	keybind_signal = COMSIG_KB_LIVING_TOGGLEMOVEINTENT_DOWN
+
+/datum/keybinding/living/toggle_move_intent/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/M = user.mob
+	M.toggle_move_intent()
+	return TRUE
+
+/datum/keybinding/living/toggle_move_intent/up(client/user)
+	var/mob/living/M = user.mob
+	M.toggle_move_intent()
+	return TRUE
+
+/datum/keybinding/living/toggle_move_intent_alternative
+	hotkey_keys = list("Unbound")
+	name = "toggle_move_intent_alt"
+	full_name = "press to cycle move intent"
+	description = "Pressing this cycle to the opposite move intent, does not cycle back"
+	keybind_signal = COMSIG_KB_LIVING_TOGGLEMOVEINTENTALT_DOWN
+
+/datum/keybinding/living/toggle_move_intent_alternative/down(client/user)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/M = user.mob
+	M.toggle_move_intent()
+	return TRUE

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -78,6 +78,11 @@
 	description = "Held down to cycle to the other move intent, release to cycle back"
 	keybind_signal = COMSIG_KB_MOB_TOGGLEMOVEINTENT_DOWN
 
+/datum/keybinding/mob/toggle_move_intent/can_use(client/user)
+	if(!isliving(user.mob))
+		return FALSE
+	return ..()
+
 /datum/keybinding/mob/toggle_move_intent/down(client/user)
 	. = ..()
 	if(.)
@@ -97,6 +102,11 @@
 	full_name = "press to cycle move intent"
 	description = "Pressing this cycle to the opposite move intent, does not cycle back"
 	keybind_signal = COMSIG_KB_MOB_TOGGLEMOVEINTENTALT_DOWN
+
+/datum/keybinding/mob/toggle_move_intent_alternative/can_use(client/user)
+	if(!isliving(user.mob))
+		return FALSE
+	return ..()
 
 /datum/keybinding/mob/toggle_move_intent_alternative/down(client/user)
 	. = ..()

--- a/code/datums/keybinding/mob.dm
+++ b/code/datums/keybinding/mob.dm
@@ -71,51 +71,6 @@
 		user.mob.dropItemToGround(I)
 	return TRUE
 
-/datum/keybinding/mob/toggle_move_intent
-	hotkey_keys = list("C")
-	name = "toggle_move_intent"
-	full_name = "Hold to toggle move intent"
-	description = "Held down to cycle to the other move intent, release to cycle back"
-	keybind_signal = COMSIG_KB_MOB_TOGGLEMOVEINTENT_DOWN
-
-/datum/keybinding/mob/toggle_move_intent/can_use(client/user)
-	if(!isliving(user.mob))
-		return FALSE
-	return ..()
-
-/datum/keybinding/mob/toggle_move_intent/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/living/M = user.mob
-	M.toggle_move_intent()
-	return TRUE
-
-/datum/keybinding/mob/toggle_move_intent/up(client/user)
-	var/mob/living/M = user.mob
-	M.toggle_move_intent()
-	return TRUE
-
-/datum/keybinding/mob/toggle_move_intent_alternative
-	hotkey_keys = list("Unbound")
-	name = "toggle_move_intent_alt"
-	full_name = "press to cycle move intent"
-	description = "Pressing this cycle to the opposite move intent, does not cycle back"
-	keybind_signal = COMSIG_KB_MOB_TOGGLEMOVEINTENTALT_DOWN
-
-/datum/keybinding/mob/toggle_move_intent_alternative/can_use(client/user)
-	if(!isliving(user.mob))
-		return FALSE
-	return ..()
-
-/datum/keybinding/mob/toggle_move_intent_alternative/down(client/user)
-	. = ..()
-	if(.)
-		return
-	var/mob/living/M = user.mob
-	M.toggle_move_intent()
-	return TRUE
-
 /datum/keybinding/mob/target/down(client/user)
 	. = ..()
 	if(.)


### PR DESCRIPTION

## About The Pull Request

The keybindings did not check if the mob was dead after the toggle_move_intent proc was moved to living mobs in #77820.
## Why It's Good For The Game

Less runtimetytime.
## Changelog
:cl:
fix: Fix a runtime when trying to cycle move intents with a hotkey as a dead mob.
/:cl:
