### PR TITLE
Sanguirite (coagulant) recipe!

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1618,7 +1618,7 @@
 	ph = 8
 	color = "#bb2424"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
-	overdose_threshold = 6 // so we can be sure that people are not able to pump themselfs with it. 
+	overdose_threshold = 10 // so we can be sure that people are not able to pump themselfs with it. 
 	/// The bloodiest wound that the patient has will have its blood_flow reduced by about half this much each second
 	var/clot_rate = 0.3
 	/// While this reagent is in our bloodstream, we reduce all bleeding by this factor

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1615,9 +1615,10 @@
 	name = "Sanguirite"
 	description = "A proprietary coagulant used to help bleeding wounds clot faster. It is purged by heparin."
 	reagent_state = LIQUID
+	ph = 8
 	color = "#bb2424"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
-	overdose_threshold = 20
+	overdose_threshold = 6 // so we can be sure that people are not able to pump themselfs with it. 
 	/// The bloodiest wound that the patient has will have its blood_flow reduced by about half this much each second
 	var/clot_rate = 0.3
 	/// While this reagent is in our bloodstream, we reduce all bleeding by this factor

--- a/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
+++ b/code/modules/reagents/chemistry/recipes/cat2_medicines.dm
@@ -363,3 +363,15 @@
 //enabling hardmode
 /datum/chemical_reaction/medicine/penthrite/overly_impure(datum/reagents/holder, datum/equilibrium/equilibrium, step_volume_added)
 	holder.chem_temp += 15
+
+/datum/chemical_reaction/medicine/coagulant
+	results = list(/datum/reagent/medicine/coagulant = 4)
+	required_reagents = list(/datum/reagent/medicine/salglu_solution = 1, /datum/reagent/phenol = 1, /datum/reagent/carbon = 1, /datum/reagent/water = 1)
+	required_temp = 300
+	optimal_temp = 500
+	overheat_temp = 620 
+	optimal_ph_min = 7
+	optimal_ph_max = 9
+	thermic_constant = 15
+	H_ion_release = 0.20
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_HEALING


### PR DESCRIPTION
## About The Pull Request

This PR adds Sanguirite (coagulant) recipe. The recipe is not too easy and not too hard.
Also Sanguirite (coagulant) overdose threshold has been changed to 10 units, so people will not be able to pump themselfs with it.

## Why It's Good For The Game

It would be nice if players will be able to obtain Sanguirite (coagulant) without medipens.

## Changelog

:cl:
add: Added a recipe for Sanguirite (coagulant)!
balance: Sanguirite (coagulant) overdose threshold has been changed to 10 units.
/:cl:
