### PR TITLE
Add blackout drunk

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_attack.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_attack.dm
@@ -57,6 +57,8 @@
 	#define COMPONENT_IMMUNE_TO_TILT_AND_CRUSH (1<<0)
 ///Called when a atom gets something tilted on them
 #define COMSIG_POST_TILT_AND_CRUSH "atom_post_tilt_and_crush"
+/// Called when an atom is splashed with something
+#define COMSIG_ATOM_SPLASHED "atom_splashed"
 
 	///The damage type of the weapon projectile is non-lethal stamina
 	#define ATTACKER_STAMINA_ATTACK (1<<0)

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_attack.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_attack.dm
@@ -52,12 +52,12 @@
 #define COMSIG_ATOM_ATTACK_ROBOT_SECONDARY "atom_attack_robot_secondary"
 ///from relay_attackers element: (atom/attacker, attack_flags)
 #define COMSIG_ATOM_WAS_ATTACKED "atom_was_attacked"
-///Called before a atom gets something tilted on them. If [COMPONENT_IMMUNE_TO_TILT_AND_CRUSH] is returned in a signal, the atom will be unaffected.
+///Called before a atom gets something tilted on them. If [COMPONENT_IMMUNE_TO_TILT_AND_CRUSH] is returned in a signal, the atom will be unaffected: (atom/target, atom/source)
 #define COMSIG_PRE_TILT_AND_CRUSH "atom_pre_tilt_and_crush"
 	#define COMPONENT_IMMUNE_TO_TILT_AND_CRUSH (1<<0)
-///Called when a atom gets something tilted on them
+///Called when a atom gets something tilted on them: (atom/target, atom/source)
 #define COMSIG_POST_TILT_AND_CRUSH "atom_post_tilt_and_crush"
-/// Called when an atom is splashed with something
+/// Called when an atom is splashed with something: (atom/source)
 #define COMSIG_ATOM_SPLASHED "atom_splashed"
 
 	///The damage type of the weapon projectile is non-lethal stamina

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -39,6 +39,9 @@
 #define COMSIG_BODYPART_GAUZED "bodypart_gauzed" // from /obj/item/bodypart/proc/apply_gauze(/obj/item/stack/gauze)
 #define COMSIG_BODYPART_GAUZE_DESTROYED "bodypart_degauzed" // from [/obj/item/bodypart/proc/seep_gauze] when it runs out of absorption
 
+/// Called when a carbon is splashed with something
+#define COMSIG_CARBON_SPLASHED "carbon_splashed"
+
 /// Called from bodypart changing owner, which could be on attach or detachment. Either argument can be null. (mob/living/carbon/new_owner, mob/living/carbon/old_owner)
 #define COMSIG_BODYPART_CHANGED_OWNER "bodypart_changed_owner"
 

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -39,8 +39,6 @@
 #define COMSIG_BODYPART_GAUZED "bodypart_gauzed" // from /obj/item/bodypart/proc/apply_gauze(/obj/item/stack/gauze)
 #define COMSIG_BODYPART_GAUZE_DESTROYED "bodypart_degauzed" // from [/obj/item/bodypart/proc/seep_gauze] when it runs out of absorption
 
-/// Called when a carbon is splashed with something
-#define COMSIG_CARBON_SPLASHED "carbon_splashed"
 
 /// Called from bodypart changing owner, which could be on attach or detachment. Either argument can be null. (mob/living/carbon/new_owner, mob/living/carbon/old_owner)
 #define COMSIG_BODYPART_CHANGED_OWNER "bodypart_changed_owner"

--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_carbon.dm
@@ -39,7 +39,6 @@
 #define COMSIG_BODYPART_GAUZED "bodypart_gauzed" // from /obj/item/bodypart/proc/apply_gauze(/obj/item/stack/gauze)
 #define COMSIG_BODYPART_GAUZE_DESTROYED "bodypart_degauzed" // from [/obj/item/bodypart/proc/seep_gauze] when it runs out of absorption
 
-
 /// Called from bodypart changing owner, which could be on attach or detachment. Either argument can be null. (mob/living/carbon/new_owner, mob/living/carbon/old_owner)
 #define COMSIG_BODYPART_CHANGED_OWNER "bodypart_changed_owner"
 

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -272,6 +272,7 @@
 	duration_in_seconds -= seconds_per_tick
 
 /datum/brain_trauma/severe/split_personality/blackout/Destroy()
+	. = ..()
 	return
 
 

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -258,9 +258,10 @@
 	. = ..()
 	UnregisterSignal(SSobj, COMSIG_CARBON_SPLASHED)
 
-/datum/brain_trauma/severe/split_personality/blackout/proc/on_splashed()
+/datum/brain_trauma/severe/split_personality/blackout/proc/on_splashed(volume)
 	SIGNAL_HANDLER
-	Destroy()
+	if(prob(20))//we don't want every single splash to wake them up now do we
+		Destroy()
 
 /datum/brain_trauma/severe/split_personality/blackout/on_life(seconds_per_tick, times_fired)
 	if(current_controller == OWNER)

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -258,7 +258,7 @@
 	. = ..()
 	UnregisterSignal(SSobj, COMSIG_CARBON_SPLASHED)
 
-/datum/brain_trauma/severe/split_personality/blackout/proc/on_splashed(volume)
+/datum/brain_trauma/severe/split_personality/blackout/proc/on_splashed()
 	SIGNAL_HANDLER
 	if(prob(20))//we don't want every single splash to wake them up now do we
 		Destroy()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -252,11 +252,15 @@
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()
-	RegisterSignal(SSobj, COMSIG_CARBON_SPLASHED, PROC_REF(Destroy()))
+	RegisterSignal(SSobj, COMSIG_CARBON_SPLASHED, PROC_REF(on_splashed))
 
 /datum/brain_trauma/severe/split_personality/blackout/on_lose()
 	. = ..()
 	UnregisterSignal(SSobj, COMSIG_CARBON_SPLASHED)
+
+/datum/brain_trauma/severe/split_personality/blackout/proc/on_splashed()
+	SIGNAL_HANDLER
+	Destroy()
 
 /datum/brain_trauma/severe/split_personality/blackout/on_life(seconds_per_tick, times_fired)
 	if(current_controller == OWNER)

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -248,7 +248,7 @@
 	lose_text = "You wake up very, very confused and hungover. All you can remember is drinking a lot of alcohol... what happened?"
 	poll_role = "blacked out drunkard"
 	/// Duration of effect, tracked in seconds, not deciseconds. qdels when reaching 0.
-	var/duration_in_seconds = 120
+	var/duration_in_seconds = 180
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -11,6 +11,7 @@
 	var/initialized = FALSE //to prevent personalities deleting themselves while we wait for ghosts
 	var/mob/living/split_personality/stranger_backseat //there's two so they can swap without overwriting
 	var/mob/living/split_personality/owner_backseat
+	var/poll_role= "split personality"
 
 /datum/brain_trauma/severe/split_personality/on_gain()
 	var/mob/living/M = owner
@@ -33,7 +34,7 @@
 
 /datum/brain_trauma/severe/split_personality/proc/get_ghost()
 	set waitfor = FALSE
-	var/list/mob/dead/observer/candidates = poll_candidates_for_mob("Do you want to play as [owner.real_name]'s split personality?", ROLE_PAI, null, 7.5 SECONDS, stranger_backseat, POLL_IGNORE_SPLITPERSONALITY)
+	var/list/mob/dead/observer/candidates = poll_candidates_for_mob("Do you want to play as [owner.real_name]'s [poll_role]?", ROLE_PAI, null, 7.5 SECONDS, stranger_backseat, POLL_IGNORE_SPLITPERSONALITY)
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		stranger_backseat.key = C.key
@@ -237,6 +238,37 @@
 	to_chat(src, span_notice("Your activation codeword is: <b>[codeword]</b>"))
 	if(objective)
 		to_chat(src, span_notice("Your master left you an objective: <b>[objective]</b>. Follow it at all costs when in control."))
+
+/datum/brain_trauma/severe/split_personality/blackout
+	name = "Blackout Drunk"
+	desc = "Patient brain is filled with alcohol and thus formed a new personality temporarily to survive."
+	scan_desc = "complete alcohol takeover"
+	gain_text = span_warning("You feel your consioucness fading...")
+	lose_text = "You have no memory of what happened while blacked out, try to trace your step and find out what happened while your were out."
+	poll_role = "black out character"
+	var/duration = 300 //Should last 5 minute
+
+/datum/brain_trauma/severe/split_personality/blackout/on_life(seconds_per_tick, times_fired)
+	if(current_controller == OWNER)
+		switch_personalities()
+	if(owner.stat == DEAD)
+		if(current_controller != OWNER)
+			switch_personalities(TRUE)
+		qdel(src)
+	if(duration == 0)
+		qdel(src)
+	duration--
+
+/mob/living/split_personality/blackout
+	name = "black out character"
+	real_name = "unknown conscience"
+
+/mob/living/split_personality/blackout/Login()
+	. = ..()
+	if(!. || !client)
+		return FALSE
+	to_chat(src, span_notice("As a blackout character behave like a loose cannon but do not kill anyone, be unpredictable so that when the original self return they will have to backtrack and find out what happened."))
+	to_chat(src, span_warning("<b>Do not commit suicide or put the body in a deadly position. Behave like you care about it as much as the owner.</b>"))
 
 #undef OWNER
 #undef STRANGER

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -268,7 +268,7 @@
 	if(!. || !client)
 		return FALSE
 	to_chat(src, span_notice("You're the incredibly inebriated leftovers of your host's consciousness! Make sure to act the part and leave a trail of confusion and chaos in your wake."))
-	to_chat(src, span_userdanger("<b>Do not commit suicide or put the body in danger. While you're drunk, you're not suicidal. </b>"))
+	to_chat(src, span_warning("<b>Do not commit suicide or put the body in danger. While you're drunk, you're not suicidal. </b>"))
 
 #undef OWNER
 #undef STRANGER

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -252,11 +252,11 @@
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()
-	RegisterSignal(owner, COMSIG_CARBON_SPLASHED, PROC_REF(on_splashed))
+	RegisterSignal(owner, COMSIG_ATOM_SPLASHED, PROC_REF(on_splashed))
 
 /datum/brain_trauma/severe/split_personality/blackout/on_lose()
 	. = ..()
-	UnregisterSignal(owner, COMSIG_CARBON_SPLASHED)
+	UnregisterSignal(owner, COMSIG_ATOM_SPLASHED)
 
 /datum/brain_trauma/severe/split_personality/blackout/proc/on_splashed()
 	SIGNAL_HANDLER

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -246,7 +246,7 @@
 	gain_text = span_warning("Crap, that was one drink too many. You black out...")
 	lose_text = "You wake up very, very confused and hungover. All you can remember is drinking a lot of alcohol... what happened?"
 	poll_role = "blacked out drunkard"
-	var/duration = 60 ///Duration of effect, 30 seconds = 1 minute
+	var/duration_in_seconds = 60 ///Duration of effect
 
 /datum/brain_trauma/severe/split_personality/blackout/on_life(seconds_per_tick, times_fired)
 	if(current_controller == OWNER)
@@ -255,9 +255,9 @@
 		if(current_controller != OWNER)
 			switch_personalities(TRUE)
 		qdel(src)
-	if(duration <= 0)
+	if(duration_in_seconds <= 0)
 		qdel(src)
-	duration -= seconds_per_tick
+	duraduration_in_secondstion -= seconds_per_tick
 
 /mob/living/split_personality/blackout
 	name = "blacked-out drunkard"

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -252,6 +252,7 @@
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()
+	to_chat(owner, spawn_warning"You black out!")
 	RegisterSignal(owner, COMSIG_CARBON_SPLASHED, PROC_REF(on_splashed))
 
 /datum/brain_trauma/severe/split_personality/blackout/on_lose()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -252,7 +252,6 @@
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()
-	to_chat(owner, span_warning("You black out!"))
 	RegisterSignal(owner, COMSIG_CARBON_SPLASHED, PROC_REF(on_splashed))
 
 /datum/brain_trauma/severe/split_personality/blackout/on_lose()
@@ -262,7 +261,7 @@
 /datum/brain_trauma/severe/split_personality/blackout/proc/on_splashed()
 	SIGNAL_HANDLER
 	if(prob(20))//we don't want every single splash to wake them up now do we
-		Destroy()
+		qdel(src)
 
 /datum/brain_trauma/severe/split_personality/blackout/on_life(seconds_per_tick, times_fired)
 	if(current_controller == OWNER)
@@ -270,17 +269,12 @@
 	if(owner.stat == DEAD)
 		if(current_controller != OWNER)
 			switch_personalities(TRUE)
-		Destroy()
+		qdel(src)
 		return
 	if(duration_in_seconds <= 0)
-		Destroy()
+		qdel(src)
 		return
 	duration_in_seconds -= seconds_per_tick
-
-/datum/brain_trauma/severe/split_personality/blackout/Destroy()
-	. = ..()
-	return
-
 
 /mob/living/split_personality/blackout
 	name = "blacked-out drunkard"
@@ -291,7 +285,7 @@
 	if(!. || !client)
 		return FALSE
 	to_chat(src, span_notice("You're the incredibly inebriated leftovers of your host's consciousness! Make sure to act the part and leave a trail of confusion and chaos in your wake."))
-	to_chat(src, span_boldwarning("<b>Do not commit suicide or put the body in danger, you have a minor liscense to grief just like a clown, do not kill anyone or create a situation leading to the body being in danger or in harm ways. While you're drunk, you're not suicidal. </b>"))
+	to_chat(src, span_boldwarning("Do not commit suicide or put the body in danger, you have a minor liscense to grief just like a clown, do not kill anyone or create a situation leading to the body being in danger or in harm ways. While you're drunk, you're not suicidal."))
 
 #undef OWNER
 #undef STRANGER

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -252,7 +252,7 @@
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()
-	to_chat(owner, spawn_warning"You black out!")
+	to_chat(owner, spawn_warning("You black out!"))
 	RegisterSignal(owner, COMSIG_CARBON_SPLASHED, PROC_REF(on_splashed))
 
 /datum/brain_trauma/severe/split_personality/blackout/on_lose()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -252,11 +252,11 @@
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()
-	RegisterSignal(SSobj, COMSIG_CARBON_SPLASHED, PROC_REF(on_splashed))
+	RegisterSignal(owner, COMSIG_CARBON_SPLASHED, PROC_REF(on_splashed))
 
 /datum/brain_trauma/severe/split_personality/blackout/on_lose()
 	. = ..()
-	UnregisterSignal(SSobj, COMSIG_CARBON_SPLASHED)
+	UnregisterSignal(owner, COMSIG_CARBON_SPLASHED)
 
 /datum/brain_trauma/severe/split_personality/blackout/proc/on_splashed()
 	SIGNAL_HANDLER

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -11,7 +11,7 @@
 	var/initialized = FALSE //to prevent personalities deleting themselves while we wait for ghosts
 	var/mob/living/split_personality/stranger_backseat //there's two so they can swap without overwriting
 	var/mob/living/split_personality/owner_backseat
-	var/poll_role= "split personality"
+	var/poll_role = "split personality"
 
 /datum/brain_trauma/severe/split_personality/on_gain()
 	var/mob/living/M = owner
@@ -246,7 +246,7 @@
 	gain_text = span_warning("Crap, that was one drink too many. You black out...")
 	lose_text = "You wake up very, very confused and hungover. All you can remember is drinking a lot of alcohol... what happened?"
 	poll_role = "blacked out drunkard"
-	var/duration = 300 //Should last 5 minute
+	var/duration = 60 ///Duration of effect, 30 seconds = 1 minute
 
 /datum/brain_trauma/severe/split_personality/blackout/on_life(seconds_per_tick, times_fired)
 	if(current_controller == OWNER)
@@ -255,9 +255,9 @@
 		if(current_controller != OWNER)
 			switch_personalities(TRUE)
 		qdel(src)
-	if(duration == 0)
+	if(duration <= 0)
 		qdel(src)
-	duration--
+	duration -= seconds_per_tick
 
 /mob/living/split_personality/blackout
 	name = "blacked-out drunkard"

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -257,7 +257,7 @@
 		qdel(src)
 	if(duration_in_seconds <= 0)
 		qdel(src)
-	duraduration_in_secondstion -= seconds_per_tick
+	duration_in_seconds -= seconds_per_tick
 
 /mob/living/split_personality/blackout
 	name = "blacked-out drunkard"

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -284,7 +284,7 @@
 	if(!. || !client)
 		return FALSE
 	to_chat(src, span_notice("You're the incredibly inebriated leftovers of your host's consciousness! Make sure to act the part and leave a trail of confusion and chaos in your wake."))
-	to_chat(src, span_boldwarning("<b>Do not commit suicide or put the body in danger. While you're drunk, you're not suicidal. </b>"))
+	to_chat(src, span_boldwarning("<b>Do not commit suicide or put the body in danger, you have a minor liscense to grief just like a clown, do not kill anyone or create a situation leading to the body being in danger or in harm ways. While you're drunk, you're not suicidal. </b>"))
 
 #undef OWNER
 #undef STRANGER

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -248,7 +248,7 @@
 	lose_text = "You wake up very, very confused and hungover. All you can remember is drinking a lot of alcohol... what happened?"
 	poll_role = "blacked out drunkard"
 	/// Duration of effect, tracked in seconds, not deciseconds. qdels when reaching 0.
-	var/duration_in_seconds = 60
+	var/duration_in_seconds = 120
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -240,12 +240,12 @@
 		to_chat(src, span_notice("Your master left you an objective: <b>[objective]</b>. Follow it at all costs when in control."))
 
 /datum/brain_trauma/severe/split_personality/blackout
-	name = "Blackout Drunk"
-	desc = "Patient brain is filled with alcohol and thus formed a new personality temporarily to survive."
-	scan_desc = "complete alcohol takeover"
-	gain_text = span_warning("You feel your consioucness fading...")
-	lose_text = "You have no memory of what happened while blacked out, try to trace your step and find out what happened while your were out."
-	poll_role = "black out character"
+	name = "Alcohol-Induced CNS Impairment"
+	desc = "Patient's CNS has been temporarily impaired by imbibed alcohol, blocking memory formation, and causing reduced cognition and stupefaction."
+	scan_desc = "alcohol-induced CNS impairment"
+	gain_text = span_warning("Crap, that was one drink too many. You black out...")
+	lose_text = "You wake up very, very confused and hungover. All you can remember is drinking a lot of alcohol... what happened?"
+	poll_role = "blacked out drunkard"
 	var/duration = 300 //Should last 5 minute
 
 /datum/brain_trauma/severe/split_personality/blackout/on_life(seconds_per_tick, times_fired)
@@ -260,15 +260,15 @@
 	duration--
 
 /mob/living/split_personality/blackout
-	name = "black out character"
-	real_name = "unknown conscience"
+	name = "blacked-out drunkard"
+	real_name = "drunken consciousness"
 
 /mob/living/split_personality/blackout/Login()
 	. = ..()
 	if(!. || !client)
 		return FALSE
-	to_chat(src, span_notice("As a blackout character behave like a loose cannon but do not kill anyone, be unpredictable so that when the original self return they will have to backtrack and find out what happened."))
-	to_chat(src, span_warning("<b>Do not commit suicide or put the body in a deadly position. Behave like you care about it as much as the owner.</b>"))
+	to_chat(src, span_notice("You're the incredibly inebriated leftovers of your host's consciousness! Make sure to act the part and leave a trail of confusion and chaos in your wake."))
+	to_chat(src, span_userdanger("<b>Do not commit suicide or put the body in danger. While you're drunk, you're not suicidal. </b>"))
 
 #undef OWNER
 #undef STRANGER

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -252,7 +252,7 @@
 
 /datum/brain_trauma/severe/split_personality/blackout/on_gain()
 	. = ..()
-	to_chat(owner, spawn_warning("You black out!"))
+	to_chat(owner, span_warning("You black out!"))
 	RegisterSignal(owner, COMSIG_CARBON_SPLASHED, PROC_REF(on_splashed))
 
 /datum/brain_trauma/severe/split_personality/blackout/on_lose()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -256,6 +256,7 @@
 
 /datum/brain_trauma/severe/split_personality/blackout/on_lose()
 	. = ..()
+	owner.add_mood_event("hang_over", /datum/mood_event/hang_over)
 	UnregisterSignal(owner, COMSIG_ATOM_SPLASHED)
 
 /datum/brain_trauma/severe/split_personality/blackout/proc/on_splashed()

--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -19,6 +19,10 @@
 	else
 		description = initial(description)
 
+/datum/mood_event/hang_over
+	mood_change = -4
+	description = "I have a killer hang over!"
+	timeout = 1 MINUTES
 
 /datum/mood_event/smoked
 	description = "I have had a smoke recently."

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -201,7 +201,7 @@
 		return
 	else if(drunkyard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
 		to_chat(owner, span_warning("You stumbled while walking, next time don't walk and drink 4 head!"))
-		owner.slip(4 SECONDS)
+		owner.slip(1 SECONDS)
 	else
 		owner.Sleeping(90 SECONDS)
 

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -196,7 +196,7 @@
 
 /datum/status_effect/inebriated/drunk/proc/attempt_to_blackout()
 	var/mob/living/carbon/drunkyard = owner
-	if(!drunkyard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout, TRAUMA_LIMIT_ABSOLUTE))
+	if(!drunkyard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout, TRAUMA_LIMIT_ABSOLUTE) || drunkyard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout))
 		owner.Sleeping(90 SECONDS)
 
 /// Status effect for being fully drunk (not tipsy).

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -196,7 +196,13 @@
 
 /datum/status_effect/inebriated/drunk/proc/attempt_to_blackout()
 	var/mob/living/carbon/drunkyard = owner
-	if(!drunkyard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout, TRAUMA_LIMIT_ABSOLUTE) || drunkyard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout))
+	if(drunkyard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout, TRAUMA_LIMIT_ABSOLUTE))
+		drunk_value -= 50
+		return
+	else if(drunkyard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
+		to_chat(owner, span_warning("You stumbled while walking, next time don't walk and drink 4 head!"))
+		owner.slip(4 SECONDS)
+	else
 		owner.Sleeping(90 SECONDS)
 
 /// Status effect for being fully drunk (not tipsy).

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -182,13 +182,8 @@
 	if(drunk_value >= 91)
 		owner.adjustToxLoss(1)
 		owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.4)
-		if(owner.stat == CONSCIOUS && prob(20))
-			// Don't put us in a deep sleep if the shuttle's here. QoL, mainly.
-			if(SSshuttle.emergency.mode == SHUTTLE_DOCKED && is_station_level(owner.z))
-				to_chat(owner, span_warning("You're so tired... but you can't miss that shuttle..."))
-
-			else
-				attempt_to_blackout()
+		if(owner.stat == CONSCIOUS)
+			attempt_to_blackout()
 
 	// And finally, over 100 - let's be honest, you shouldn't be alive by now.
 	if(drunk_value >= 101)
@@ -202,6 +197,8 @@
 	else if(drunkard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
 		to_chat(owner, span_warning("You stumbled and fall over!"))
 		owner.slip(1 SECONDS)
+	else if(SSshuttle.emergency.mode == SHUTTLE_DOCKED && is_station_level(owner.z))// Don't put us in a deep sleep if the shuttle's here. QoL, mainly.
+		to_chat(owner, span_warning("You're so tired... but you can't miss that shuttle..."))
 	else
 		owner.Sleeping(90 SECONDS)
 

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -195,12 +195,12 @@
 		owner.adjustToxLoss(2)
 
 /datum/status_effect/inebriated/drunk/proc/attempt_to_blackout()
-	var/mob/living/carbon/drunkyard = owner
-	if(drunkyard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout, TRAUMA_LIMIT_ABSOLUTE))
+	var/mob/living/carbon/drunkard = owner
+	if(drunkard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout, TRAUMA_LIMIT_ABSOLUTE))
 		drunk_value -= 50
 		return
-	else if(drunkyard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
-		to_chat(owner, span_warning("You stumbled while walking, next time don't walk and drink 4 head!"))
+	else if(drunkard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
+		to_chat(owner, span_warning("You stumbled and fall over!"))
 		owner.slip(1 SECONDS)
 	else
 		owner.Sleeping(90 SECONDS)

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -197,7 +197,7 @@
 /datum/status_effect/inebriated/drunk/proc/attempt_to_blackout()
 	var/mob/living/carbon/drunkard = owner
 	if(drunkard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout, TRAUMA_LIMIT_ABSOLUTE))
-		drunk_value -= 50
+		drunk_value -= 50 //So that the drunk personality can spice things up without being killed by liver failure
 		return
 	else if(drunkard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
 		to_chat(owner, span_warning("You stumbled and fall over!"))

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -188,8 +188,11 @@
 				to_chat(owner, span_warning("You're so tired... but you can't miss that shuttle..."))
 
 			else
-				to_chat(owner, span_warning("Just a quick nap..."))
-				owner.Sleeping(90 SECONDS)
+				blackout()
+
+/datum/status_effect/inebriated/drunk/proc/blackout()
+	var/mob/living/carbon/drunkyard = owner
+	drunkyard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout)
 
 	// And finally, over 100 - let's be honest, you shouldn't be alive by now.
 	if(drunk_value >= 101)

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -188,15 +188,16 @@
 				to_chat(owner, span_warning("You're so tired... but you can't miss that shuttle..."))
 
 			else
-				blackout()
-
-/datum/status_effect/inebriated/drunk/proc/blackout()
-	var/mob/living/carbon/drunkyard = owner
-	drunkyard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout)
+				attempt_to_blackout()
 
 	// And finally, over 100 - let's be honest, you shouldn't be alive by now.
 	if(drunk_value >= 101)
 		owner.adjustToxLoss(2)
+
+/datum/status_effect/inebriated/drunk/proc/attempt_to_blackout()
+	var/mob/living/carbon/drunkyard = owner
+	if(!drunkyard.gain_trauma(/datum/brain_trauma/severe/split_personality/blackout, TRAUMA_LIMIT_ABSOLUTE))
+		owner.Sleeping(90 SECONDS)
 
 /// Status effect for being fully drunk (not tipsy).
 /atom/movable/screen/alert/status_effect/drunk

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -149,6 +149,10 @@
 			MSG_VISUAL,
 			span_userdanger("You feel drenched!"),
 		)
+		if(iscarbon(target))
+			var/mob/living/carbon/drunkyard = target
+			if(target.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout))
+				target.cure_trauma_type(/datum/brain_trauma/severe/split_personality/blackout)
 
 	playsound(target, 'sound/effects/slosh.ogg', 25, TRUE)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -150,9 +150,7 @@
 			span_userdanger("You feel drenched!"),
 		)
 		if(iscarbon(target))
-			var/mob/living/carbon/drunkyard = target
-			if(drunkyard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
-				drunkyard.cure_trauma_type(/datum/brain_trauma/severe/split_personality/blackout)
+			SEND_SIGNAL(target, COMSIG_CARBON_SPLASHED)
 
 	playsound(target, 'sound/effects/slosh.ogg', 25, TRUE)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -151,7 +151,7 @@
 		)
 		if(iscarbon(target))
 			var/mob/living/carbon/drunkyard = target
-			if(target.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout))
+			if(target.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
 				target.cure_trauma_type(/datum/brain_trauma/severe/split_personality/blackout)
 
 	playsound(target, 'sound/effects/slosh.ogg', 25, TRUE)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -150,7 +150,7 @@
 			span_userdanger("You feel drenched!"),
 		)
 		if(iscarbon(target))
-			SEND_SIGNAL(target, COMSIG_CARBON_SPLASHED)
+			SEND_SIGNAL(target, COMSIG_CARBON_SPLASHED, volume)
 
 	playsound(target, 'sound/effects/slosh.ogg', 25, TRUE)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -151,8 +151,8 @@
 		)
 		if(iscarbon(target))
 			var/mob/living/carbon/drunkyard = target
-			if(target.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
-				target.cure_trauma_type(/datum/brain_trauma/severe/split_personality/blackout)
+			if(drunkyard.has_trauma_type(/datum/brain_trauma/severe/split_personality/blackout) && prob(10))
+				drunkyard.cure_trauma_type(/datum/brain_trauma/severe/split_personality/blackout)
 
 	playsound(target, 'sound/effects/slosh.ogg', 25, TRUE)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -150,7 +150,7 @@
 			span_userdanger("You feel drenched!"),
 		)
 		if(iscarbon(target))
-			SEND_SIGNAL(target, COMSIG_CARBON_SPLASHED, volume)
+			SEND_SIGNAL(target, COMSIG_CARBON_SPLASHED)
 
 	playsound(target, 'sound/effects/slosh.ogg', 25, TRUE)
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -141,7 +141,7 @@
 		span_danger("You splash the contents of [src] onto [target][punctuation]"),
 		ignored_mobs = target,
 	)
-
+	SEND_SIGNAL(target, COMSIG_ATOM_SPLASHED)
 	if (ismob(target))
 		var/mob/target_mob = target
 		target_mob.show_message(
@@ -149,8 +149,6 @@
 			MSG_VISUAL,
 			span_userdanger("You feel drenched!"),
 		)
-		if(iscarbon(target))
-			SEND_SIGNAL(target, COMSIG_CARBON_SPLASHED)
 
 	playsound(target, 'sound/effects/slosh.ogg', 25, TRUE)
 


### PR DESCRIPTION

## About The Pull Request
You drink too much you lose your memory, but we cant really do that so instead a ghost will take control of your body temporary. The drunk character will then be given objective to do wild, wacky and otherwise unusual stuff until the original returns to backtrack what transpired. The blackout character will not be able to kill or hurt the body. Oh and the duration is about 10 minutes
## Why It's Good For The Game
![image](https://github.com/tgstation/tgstation/assets/92416224/16808551-43a3-4495-848a-4707412fc049)
## Changelog
:cl:
add: Added blackout, happens when you drink...ALOT
/:cl:
