### PR TITLE
[GBP: NO UPDATE] Fixes a bug where update_inefficiencies() would call update_wounds() and cause gauze to fall off on promotion/demotion of wound

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -185,7 +185,7 @@
  * * attack_direction: For bloodsplatters, if relevant
  * * wound_source: The source of the wound, such as a weapon.
  */
-/datum/wound/proc/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE, attack_direction = null, wound_source = "Unknown")
+/datum/wound/proc/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE, attack_direction = null, wound_source = "Unknown", replacing = FALSE)
 
 	if (!can_be_applied_to(L, old_wound))
 		qdel(src)
@@ -202,7 +202,7 @@
 	LAZYADD(victim.all_wounds, src)
 	LAZYADD(limb.wounds, src)
 	update_descriptions()
-	limb.update_wounds()
+	limb.update_wounds(replacing)
 	if(status_effect_type)
 		victim.apply_status_effect(status_effect_type, src)
 	SEND_SIGNAL(victim, COMSIG_CARBON_GAIN_WOUND, src, limb)
@@ -345,9 +345,7 @@
 	null_victim() // we use the proc here because some behaviors may depend on changing victim to some new value
 
 	if(limb && !ignore_limb)
-		var/limb_cached = limb
 		set_limb(null, replaced) // since we're removing limb's ref to us, we should do the same
-		limb.update_wounds(replaced)
 		// if you want to keep the ref, do it externally, theres no reason for us to remember it
 
 	if (ismob(old_victim))
@@ -373,7 +371,7 @@
 	already_scarred = TRUE
 	var/obj/item/bodypart/cached_limb = limb // remove_wound() nulls limb so we have to track it locally
 	remove_wound(replaced=TRUE)
-	new_wound.apply_wound(cached_limb, old_wound = src, smited = smited, attack_direction = attack_direction, wound_source = wound_source)
+	new_wound.apply_wound(cached_limb, old_wound = src, smited = smited, attack_direction = attack_direction, wound_source = wound_source, replacing = TRUE)
 	. = new_wound
 	qdel(src)
 

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -185,7 +185,7 @@
  * * attack_direction: For bloodsplatters, if relevant
  * * wound_source: The source of the wound, such as a weapon.
  */
-/datum/wound/proc/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE, attack_direction = null, wound_source = "Unknown", replacing = FALSE)
+/datum/wound/proc/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE, attack_direction = null, wound_source = "Unknown")
 
 	if (!can_be_applied_to(L, old_wound))
 		qdel(src)
@@ -202,7 +202,7 @@
 	LAZYADD(victim.all_wounds, src)
 	LAZYADD(limb.wounds, src)
 	update_descriptions()
-	limb.update_wounds(replacing)
+	limb.update_wounds()
 	if(status_effect_type)
 		victim.apply_status_effect(status_effect_type, src)
 	SEND_SIGNAL(victim, COMSIG_CARBON_GAIN_WOUND, src, limb)
@@ -310,7 +310,7 @@
 			start_limping_if_we_should() // the status effect already handles removing itself
 			add_or_remove_actionspeed_mod()
 
-		update_inefficiencies()
+		update_inefficiencies(replaced)
 
 /datum/wound/proc/add_or_remove_actionspeed_mod()
 	update_actionspeed_modifier()
@@ -371,7 +371,7 @@
 	already_scarred = TRUE
 	var/obj/item/bodypart/cached_limb = limb // remove_wound() nulls limb so we have to track it locally
 	remove_wound(replaced=TRUE)
-	new_wound.apply_wound(cached_limb, old_wound = src, smited = smited, attack_direction = attack_direction, wound_source = wound_source, replacing = TRUE)
+	new_wound.apply_wound(cached_limb, old_wound = src, smited = smited, attack_direction = attack_direction, wound_source = wound_source)
 	. = new_wound
 	qdel(src)
 
@@ -426,7 +426,7 @@
 		update_inefficiencies()
 
 /// Updates our limping and interaction penalties in accordance with our gauze.
-/datum/wound/proc/update_inefficiencies()
+/datum/wound/proc/update_inefficiencies(replaced_or_replacing = FALSE)
 	if (wound_flags & ACCEPTS_GAUZE)
 		if(limb.body_zone in list(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
 			if(limb.current_gauze?.splint_factor)
@@ -444,7 +444,7 @@
 		if(initial(disabling))
 			set_disabling(!limb.current_gauze)
 
-		limb.update_wounds()
+		limb.update_wounds(replaced_or_replacing)
 
 	start_limping_if_we_should()
 

--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -345,7 +345,9 @@
 	null_victim() // we use the proc here because some behaviors may depend on changing victim to some new value
 
 	if(limb && !ignore_limb)
+		var/limb_cached = limb
 		set_limb(null, replaced) // since we're removing limb's ref to us, we should do the same
+		limb.update_wounds(replaced)
 		// if you want to keep the ref, do it externally, theres no reason for us to remember it
 
 	if (ismob(old_victim))

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -385,7 +385,7 @@
 	threshold_minimum = 115
 
 // doesn't make much sense for "a" bone to stick out of your head
-/datum/wound/blunt/bone/critical/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE, attack_direction = null, wound_source = "Unknown")
+/datum/wound/blunt/bone/critical/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE, attack_direction = null, wound_source = "Unknown", replacing = FALSE)
 	if(L.body_zone == BODY_ZONE_HEAD)
 		occur_text = "splits open, exposing a bare, cracked skull through the flesh and blood"
 		examine_desc = "has an unsettling indent, with bits of skull poking out"

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -385,7 +385,7 @@
 	threshold_minimum = 115
 
 // doesn't make much sense for "a" bone to stick out of your head
-/datum/wound/blunt/bone/critical/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE, attack_direction = null, wound_source = "Unknown", replacing = FALSE)
+/datum/wound/blunt/bone/critical/apply_wound(obj/item/bodypart/L, silent = FALSE, datum/wound/old_wound = null, smited = FALSE, attack_direction = null, wound_source = "Unknown")
 	if(L.body_zone == BODY_ZONE_HEAD)
 		occur_text = "splits open, exposing a bare, cracked skull through the flesh and blood"
 		examine_desc = "has an unsettling indent, with bits of skull poking out"

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -306,7 +306,6 @@
 
 	var/dam_mul = 1
 
-	var/any_wound_uses_gauze = FALSE
 	// we can (normally) only have one wound per type, but remember there's multiple types (smites like :B:loodless can generate multiple cuts on a limb)
 	for(var/datum/wound/iter_wound as anything in wounds)
 		dam_mul *= iter_wound.damage_multiplier_penalty

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -304,13 +304,16 @@
 /obj/item/bodypart/proc/update_wounds(replaced = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 
-	var/dam_mul = 1 //initial(wound_damage_multiplier)
+	var/dam_mul = 1
 
+	var/any_wound_uses_gauze = FALSE
 	// we can (normally) only have one wound per type, but remember there's multiple types (smites like :B:loodless can generate multiple cuts on a limb)
 	for(var/datum/wound/iter_wound as anything in wounds)
 		dam_mul *= iter_wound.damage_multiplier_penalty
+		if (!any_wound_uses_gauze && iter_wound.wound_flags & ACCEPTS_GAUZE)
+			any_wound_uses_gauze = TRUE
 
-	if(!LAZYLEN(wounds) && current_gauze && !replaced) // no more wounds = no need for the gauze anymore
+	if(!any_wound_uses_gauze && !LAZYLEN(wounds) && current_gauze && !replaced) // no more wounds = no need for the gauze anymore
 		owner.visible_message(span_notice("\The [current_gauze.name] on [owner]'s [name] falls away."), span_notice("The [current_gauze.name] on your [parse_zone(body_zone)] falls away."))
 		QDEL_NULL(current_gauze)
 

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -310,10 +310,8 @@
 	// we can (normally) only have one wound per type, but remember there's multiple types (smites like :B:loodless can generate multiple cuts on a limb)
 	for(var/datum/wound/iter_wound as anything in wounds)
 		dam_mul *= iter_wound.damage_multiplier_penalty
-		if (!any_wound_uses_gauze && iter_wound.wound_flags & ACCEPTS_GAUZE)
-			any_wound_uses_gauze = TRUE
 
-	if(!any_wound_uses_gauze && !LAZYLEN(wounds) && current_gauze && !replaced) // no more wounds = no need for the gauze anymore
+	if(!LAZYLEN(wounds) && current_gauze && !replaced) // no more wounds = no need for the gauze anymore
 		owner.visible_message(span_notice("\The [current_gauze.name] on [owner]'s [name] falls away."), span_notice("The [current_gauze.name] on your [parse_zone(body_zone)] falls away."))
 		QDEL_NULL(current_gauze)
 


### PR DESCRIPTION

## About The Pull Request

Title.
## Why It's Good For The Game

On some testing on a downstream, I found that demoting a wound to a lower level via replace_wound caused gauze to fall off. Same thing happened for promoting. I found the issue lied in the fact update_inefficiencies always called update_wounds which didnt tell the proc if a replacement was going on.
## Changelog
:cl:
fix: Gauze no longer falls off if a wound is demoted or promoted
/:cl:
