### PR TITLE
Adds withdrawal multiplier to ORM

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -370,7 +370,7 @@
 				var/amount = round(min(text2num(params["sheets"]), 50, can_smelt_alloy(alloy)))
 				if(amount < 1) //no negative mats
 					return
-				materials.use_materials(alloy.materials, action = "released", name = "sheets")
+				materials.use_materials(alloy.materials, multiplier = amount, action = "released", name = "sheets")
 				var/output
 				if(ispath(alloy.build_path, /obj/item/stack/sheet))
 					output = new alloy.build_path(src, amount)


### PR DESCRIPTION

## About The Pull Request
Pulling an alloy stack from the ORM always counted as 1. No matter the stack size
## Why It's Good For The Game
Sadly, no more infinite resources
## Changelog
:cl:
fix: Fixed a resource dupe in the ORM.
/:cl:
