### PR TITLE
Removes bare wound bonus from eldritch longsword, nerfs wound chance aswell.

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -70,8 +70,8 @@ Striking a noncultist, however, will tear their flesh."}
 	force = 30 // whoever balanced this got beat in the head by a bible too many times good lord
 	throwforce = 10
 	block_chance = 50 // now it's officially a cult esword
-	wound_bonus = -50
-	bare_wound_bonus = 20
+	wound_bonus = -60 // intentionally low wounds so you don't bleed out everyone
+	bare_wound_bonus = 0
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	block_sound = 'sound/weapons/parry.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")


### PR DESCRIPTION
## About The Pull Request

This PR "nerfs" the eldritch longsword by removing it's bare wound bonus of 20, aswell as reducing the wound bonus by 10.

## Why It's Good For The Game

Yeah yeah yeah it's an "i bled" PR shut up

This is actually a cult buff, since the issue currently with the eldritch longsword is that if you use it, you will likely have to drag the person you just hit to critical condition over to an offer rune. Dragging someone causes their blood loss to be worse. So what goes on is that if some complete dumbass on your cult team uses a darkened eldritch longsword for putting converts in critical condition, your converts end up becoming shades instead of proper converts. It sucks.

admittedly the sword needs a nerf to its damage overall but i dont wanna open up an even bigger can of worms

## Changelog

:cl:
balance: The eldritch longsword has been nerfed/buffed (depending on context) by removing it's bare wound bonus of 20, aswell as reducing the wound bonus by 10.
/:cl: