### PR TITLE
Fixes lingering bugs with inedible grown food items

### DIFF
--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -13,6 +13,7 @@
 	/// The reagent this plant distill to. If NULL, it uses a generic fruit_wine reagent and adjusts its variables.
 	var/distill_reagent
 
+// This may look like it's doing nothing but it's necessary, we do this to have kwargs work in New (for passing into Initialize)  
 /obj/item/grown/New(loc, obj/item/seeds/new_seed)
 	return ..()
 

--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -13,6 +13,9 @@
 	/// The reagent this plant distill to. If NULL, it uses a generic fruit_wine reagent and adjusts its variables.
 	var/distill_reagent
 
+/obj/item/grown/New(loc, obj/item/seeds/new_seed)
+	return ..()
+
 /obj/item/grown/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()
 	create_reagents(100)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/78375
Fixes  #78402
Fixes #78389

This is a followup to https://github.com/tgstation/tgstation/pull/78322

I am not really a fan of the solution in the above PR being overridding the `New()` for `obj/item/food/grown`--I was told we should not be doing that for atoms, hence my removing them, and now they're back! lol. 

If we are going to do this (which please let's just do it, I'm tired of being pinged for this and I'm sure Jacquerel is too) then we need to do the same for the constructor of `/obj/item/grown`

This is because `to_prod` gets cast as `obj/item/food/grown` (shown below) and the args must match the constructor for both types if we are using a keyword there.

https://github.com/tgstation/tgstation/blob/b44fcdedfb7c7d8425bd75b9caf71644a86375d1/code/modules/hydroponics/seeds.dm#L226

Why do we have to do this? because keyword args in constructors do not work unless you explicitly override the New() proc with those kwargs. Just doing it in Initialize() is not going to work. And once again, because `t_prod` can be either `obj/item/food/grown` or `obj/item/grown` we have to override `New()` for both types if we want that keyword constructor arg above to work.

## Why It's Good For The Game

Bugfix

![phnEOuTK0U](https://github.com/tgstation/tgstation/assets/13398309/c9a65403-db77-49b3-ada4-8081aac5b81c)

## Changelog

:cl:
fix: fixes inedible grown items (such as tower caps) becoming unclickable when harvested, fixes their seeds disappearing when inserted into the seed machine
/:cl:

