### PR TITLE
Gun kits don't need cable coil or tools, halved crafting time

### DIFF
--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -45,14 +45,12 @@
 
 /datum/crafting_recipe/advancedegun
 	name = "Advanced Energy Gun"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/gun/energy/e_gun/nuclear
 	reqs = list(
 		/obj/item/gun/energy/e_gun = 1,
-		/obj/item/stack/cable_coil = 5,
 		/obj/item/weaponcrafting/gunkit/nuclear = 1,
 	)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/advancedegun/New()
@@ -61,14 +59,12 @@
 
 /datum/crafting_recipe/tempgun
 	name = "Temperature Gun"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/gun/energy/temperature
 	reqs = list(
-		/obj/item/gun/energy/e_gun = 1,
-		/obj/item/stack/cable_coil = 5,
+		/obj/item/gun/energy/disabler = 1,
 		/obj/item/weaponcrafting/gunkit/temperature = 1,
 	)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/tempgun/New()
@@ -77,16 +73,14 @@
 
 /datum/crafting_recipe/beam_rifle
 	name = "Particle Acceleration Rifle"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/gun/energy/beam_rifle
 	reqs = list(
 		/obj/item/gun/energy/e_gun = 1,
 		/obj/item/assembly/signaler/anomaly/flux = 1,
 		/obj/item/assembly/signaler/anomaly/grav = 1,
-		/obj/item/stack/cable_coil = 5,
 		/obj/item/weaponcrafting/gunkit/beam_rifle = 1,
 	)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/beam_rifle/New()
@@ -95,27 +89,23 @@
 
 /datum/crafting_recipe/ebow
 	name = "Energy Crossbow"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/gun/energy/recharge/ebow/large
 	reqs = list(
 		/obj/item/gun/energy/recharge/kinetic_accelerator = 1,
-		/obj/item/stack/cable_coil = 5,
 		/obj/item/weaponcrafting/gunkit/ebow = 1,
 		/datum/reagent/uranium/radium = 15,
 	)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/xraylaser
 	name = "X-ray Laser Gun"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/gun/energy/xray
 	reqs = list(
 		/obj/item/gun/energy/laser = 1,
-		/obj/item/stack/cable_coil = 5,
 		/obj/item/weaponcrafting/gunkit/xray = 1,
 	)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/xraylaser/New()
@@ -124,14 +114,12 @@
 
 /datum/crafting_recipe/hellgun
 	name = "Hellfire Laser Gun"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/gun/energy/laser/hellgun
 	reqs = list(
 		/obj/item/gun/energy/laser = 1,
-		/obj/item/stack/cable_coil = 5,
 		/obj/item/weaponcrafting/gunkit/hellgun = 1,
 	)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/hellgun/New()
@@ -140,14 +128,12 @@
 
 /datum/crafting_recipe/ioncarbine
 	name = "Ion Carbine"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/gun/energy/ionrifle/carbine
 	reqs = list(
 		/obj/item/gun/energy/laser = 1,
-		/obj/item/stack/cable_coil = 5,
 		/obj/item/weaponcrafting/gunkit/ion = 1,
 	)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/ioncarbine/New()
@@ -156,16 +142,14 @@
 
 /datum/crafting_recipe/decloner
 	name = "Biological Demolecularisor"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/gun/energy/decloner
 	reqs = list(
 		/obj/item/gun/energy/laser = 1,
-		/obj/item/stack/cable_coil = 5,
 		/obj/item/weaponcrafting/gunkit/decloner = 1,
 		/datum/reagent/baldium = 30,
 		/datum/reagent/toxin/mutagen = 4,
 	)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/decloner/New()
@@ -174,14 +158,12 @@
 
 /datum/crafting_recipe/teslacannon
 	name = "Tesla Cannon"
-	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WIRECUTTER)
 	result = /obj/item/gun/energy/tesla_cannon
 	reqs = list(
 		/obj/item/assembly/signaler/anomaly/flux = 1,
-		/obj/item/stack/cable_coil = 5,
 		/obj/item/weaponcrafting/gunkit/tesla = 1,
 	)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/improvised_pneumatic_cannon //Pretty easy to obtain but


### PR DESCRIPTION

## About The Pull Request

Crafting R&D guns from gun kits no longer requires tools or cable coil. The decloner and energy crossbow still need reagents.

Halved R&D gun crafting time. 20->10 seconds.

## Why It's Good For The Game

These changes were made a long, long while ago and honestly while I understand gun kits I don't understand why it was made So. Annoying. To make the fucking guns once you got everything ready. It makes it a total annoyance. You spent 40 minutes getting all the tech for it, you shouldn't have to also get tools and cables and wait 20 seconds standing still.

Anyone who has played ingame like any time after that change can attest how underused any R&D gun is now. X-ray laser guns still DESTROY blobs but people don't even THINK about them because of the dumb annoying recipe (alongside RnD being a pain now).

Simply put this just. Makes life easier for security officers. And reduces tool dependency.

## Changelog

:cl:
qol: Crafting R&D guns from gun kits no longer requires tools or cable coil. The decloner and energy crossbow still need reagents.
qol: Halved R&D gun crafting time. 20->10 seconds.
/:cl:

