### PR TITLE
Nerfs universally hated achievement

### DIFF
--- a/code/datums/achievements/mafia_achievements.dm
+++ b/code/datums/achievements/mafia_achievements.dm
@@ -109,6 +109,6 @@
 
 /datum/award/achievement/mafia/universally_hated
 	name = "Universally Hated"
-	desc = "Managed to get more than 12 votes when put up on trial, jesus christ."
+	desc = "Managed to get more than 9 votes when put up on trial, jesus christ."
 	database_id = MAFIA_MEDAL_HATED
 	icon = "hated"

--- a/code/modules/mafia/controller.dm
+++ b/code/modules/mafia/controller.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_INIT(mafia_role_by_alignment, setup_mafia_role_by_alignment())
 	var/datum/mafia_role/loser = get_vote_winner("Day")//, majority_of_town = TRUE)
 	var/loser_votes = get_vote_count(loser, "Day")
 	if(loser)
-		if(loser_votes > 12)
+		if(loser_votes > 9)
 			award_role(/datum/award/achievement/mafia/universally_hated, loser)
 		//refresh the lists
 		judgement_abstain_votes = list()


### PR DESCRIPTION
There universally hated achievement is gained when you get voted to the stand in maffia with more than 12 votes
![image](https://github.com/tgstation/tgstation/assets/7501474/e2269114-d7e4-487b-a359-c2075c76cc3a)

There is only one way to get this:
1. Have a medical doctor protect the changelings target (can changelings not attack?, not sure)
2. Have the HoP self reveal
3. Have every single person vote the same person, including the HoP. HoP has double vote, putting it on 13 votes against a person.

This cannot be obtained in good faith. I got to witness a lot of maffia matches where a certain youtube was trying to convince everyone to do the above so they can get the achievement. I am not really a fan of this behaviour, but then again this is strongly encouraged by the achievement. I'm going to change this right now before anyone gets this so no one is being cheated

Needing 10 or more votes against you is something that can happen in Maffia somewhat naturally. Getting exposed on the first night as a changeling could get you there pretty fast, even without a HoP and with a kill. 

There are other problematic achievements, but more so as in being impossible to get no matter how hard you try. 

:cl:
balance: You now need 10 or more players to vote against you to get the Universally Hated achievement, down from 13 or more
/:cl: