### PR TITLE
Adds the message monitor to the tcomm research node

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1220,6 +1220,7 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	design_ids = list(
 		"comm_monitor",
+		"message_monitor",
 		"comm_server",
 		"ntnet_relay",
 		"s_amplifier",

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1220,8 +1220,9 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	design_ids = list(
 		"comm_monitor",
-		"message_monitor",
 		"comm_server",
+		"gigabeacon",
+		"message_monitor",
 		"ntnet_relay",
 		"s_amplifier",
 		"s_analyzer",
@@ -1238,7 +1239,6 @@
 		"s_server",
 		"s_transmitter",
 		"s_treatment",
-		"gigabeacon",
 	)
 
 /datum/techweb_node/integrated_hud


### PR DESCRIPTION

## About The Pull Request

After five long years of waiting, adds the messaging monitor board to the tcomm research node.
Closes #35946

## Why It's Good For The Game

Consistency!

## Changelog
:cl:
add: The Message Monitor console's board can now be obtained via the telecoms research node. 
/:cl:
