### PR TITLE
Allows admins to overrule God

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -89,3 +89,8 @@
 
 /// Global signal when light debugging is canceled
 #define COMSIG_LIGHT_DEBUG_DISABLED "!light_debug_disabled"
+
+/// Global signal sent when a religious sect is chosen
+#define COMSIG_RELIGIOUS_SECT_CHANGED "!religious_sect_changed"
+/// Global signal sent when a religious sect is reset
+#define COMSIG_RELIGIOUS_SECT_RESET "!religious_sect_reset"

--- a/code/_globalvars/religion.dm
+++ b/code/_globalvars/religion.dm
@@ -14,3 +14,37 @@ GLOBAL_LIST_EMPTY(chaplain_altars)
 //gear
 GLOBAL_VAR(holy_weapon_type)
 GLOBAL_VAR(holy_armor_type)
+
+/// Sets a new religious sect used by all chaplains int he round
+/proc/set_new_religious_sect(path, reset_existing = FALSE)
+	if(!ispath(path, /datum/religion_sect))
+		message_admins("[ADMIN_LOOKUPFLW(usr)] has tried to spawn an item when selecting a sect.")
+		return
+
+	if(!isnull(GLOB.religious_sect))
+		if (!reset_existing)
+			return
+		reset_religious_sect()
+
+	GLOB.religious_sect = new path()
+	for(var/i in GLOB.player_list)
+		if(!isliving(i))
+			continue
+		var/mob/living/am_i_holy_living = i
+		if(!am_i_holy_living.mind?.holy_role)
+			continue
+		GLOB.religious_sect.on_conversion(am_i_holy_living)
+	SEND_GLOBAL_SIGNAL(COMSIG_RELIGIOUS_SECT_CHANGED)
+
+/// Removes any existing religious sect from chaplains, allowing another to be selected
+/proc/reset_religious_sect()
+	for(var/i in GLOB.player_list)
+		if(!isliving(i))
+			continue
+		var/mob/living/am_i_holy_living = i
+		if(!am_i_holy_living.mind?.holy_role)
+			continue
+		GLOB.religious_sect.on_deconversion(am_i_holy_living)
+
+	GLOB.religious_sect = null
+	SEND_GLOBAL_SIGNAL(COMSIG_RELIGIOUS_SECT_RESET)

--- a/code/datums/components/religious_tool.dm
+++ b/code/datums/components/religious_tool.dm
@@ -27,6 +27,8 @@
 	after_sect_select_cb = _after_sect_select_cb
 	if(override_catalyst_type)
 		catalyst_type = override_catalyst_type
+	RegisterSignal(SSdcs, COMSIG_RELIGIOUS_SECT_CHANGED, PROC_REF(SetGlobalToLocal))
+	RegisterSignal(SSdcs, COMSIG_RELIGIOUS_SECT_RESET, PROC_REF(on_sect_reset))
 
 /datum/component/religious_tool/Destroy(force, silent)
 	easy_access_sect = null
@@ -46,14 +48,20 @@
  * Sets the easy access variable to the global if it exists.
  */
 /datum/component/religious_tool/proc/SetGlobalToLocal()
+	SIGNAL_HANDLER
 	if(easy_access_sect)
 		return TRUE
 	if(!GLOB.religious_sect)
 		return FALSE
 	easy_access_sect = GLOB.religious_sect
-	if(after_sect_select_cb)
-		after_sect_select_cb.Invoke()
+	after_sect_select_cb?.Invoke()
 	return TRUE
+
+/// Sets the easy access variable to null in case an admin needed to change it
+/datum/component/religious_tool/proc/on_sect_reset()
+	SIGNAL_HANDLER
+	easy_access_sect = null
+	after_sect_select_cb?.Invoke()
 
 /**
  * Since all of these involve attackby, we require mega proc. Handles Invocation, Sacrificing, And Selection of Sects.
@@ -66,7 +74,7 @@
 
 	/**********Sacrificing**********/
 	else if(operation_flags & RELIGION_TOOL_SACRIFICE)
-		if(!easy_access_sect?.can_sacrifice(the_item,user))
+		if(easy_access_sect?.can_sacrifice(the_item,user))
 			return
 		easy_access_sect.on_sacrifice(the_item,user)
 		return COMPONENT_NO_AFTERATTACK
@@ -123,27 +131,13 @@
 
 /// Select the sect, called from [/datum/component/religious_tool/proc/AttemptActions]
 /datum/component/religious_tool/proc/select_sect(mob/living/user, path)
-	if(!ispath(text2path(path), /datum/religion_sect))
-		message_admins("[ADMIN_LOOKUPFLW(usr)] has tried to spawn an item when selecting a sect.")
-		return
 	if(user.mind.holy_role != HOLY_ROLE_HIGHPRIEST)
 		to_chat(user, span_warning("You are not the high priest, and therefore cannot select a religious sect."))
 		return
 	if(!user.can_perform_action(parent, FORBID_TELEKINESIS_REACH))
 		to_chat(user,span_warning("You cannot select a sect at this time."))
 		return
-	if(GLOB.religious_sect)
-		return
-	GLOB.religious_sect = new path()
-	for(var/i in GLOB.player_list)
-		if(!isliving(i))
-			continue
-		var/mob/living/am_i_holy_living = i
-		if(!am_i_holy_living.mind?.holy_role)
-			continue
-		GLOB.religious_sect.on_conversion(am_i_holy_living)
-	easy_access_sect = GLOB.religious_sect
-	after_sect_select_cb.Invoke()
+	set_new_religious_sect(text2path(path))
 
 /// Perform the rite, called from [/datum/component/religious_tool/proc/AttemptActions]
 /datum/component/religious_tool/proc/perform_rite(mob/living/user, path)
@@ -212,7 +206,7 @@
  * Generates an english list (so string) of wanted sac items. Returns null if no targets!
  */
 /datum/component/religious_tool/proc/generate_sacrifice_list()
-	if(!easy_access_sect.desired_items)
+	if(!length(easy_access_sect?.desired_items))
 		return //specifically null so the data sends as such
 	var/list/item_names = list()
 	for(var/atom/sac_type as anything in easy_access_sect.desired_items)
@@ -238,7 +232,7 @@
 	if(!can_i_see)
 		return
 	examine_list += span_notice("Use a bible to interact with this.")
-	if(!easy_access_sect)
+	if(isnull(easy_access_sect))
 		if(operation_flags & RELIGION_TOOL_SECTSELECT)
 			examine_list += span_notice("This looks like it can be used to select a sect.")
 			return

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -85,6 +85,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	/client/proc/list_fingerprints,
 	/client/proc/list_law_changes,
 	/client/proc/list_signalers,
+	/client/proc/manage_sect, /*manage chaplain religious sect*/
 	/client/proc/message_pda, /*send a message to somebody on PDA*/
 	/client/proc/respawn_character,
 	/client/proc/show_manifest,
@@ -796,6 +797,33 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	set category = "Admin.Game"
 	if(holder)
 		src.holder.output_ai_laws()
+
+/client/proc/manage_sect()
+	set name = "Manage Religious Sect"
+	set category = "Admin.Game"
+
+	if (!isnull(GLOB.religious_sect))
+		var/you_sure = tgui_alert(
+			usr,
+			"The Chaplain has already chosen [GLOB.religious_sect.name], override their selection?",
+			"Replace God?",
+			list("Yes", "Cancel"),
+		)
+		if (you_sure != "Yes")
+			return
+
+	var/static/list/choices = list()
+	if (!length(choices))
+		choices["nothing"] = null
+		for(var/datum/religion_sect/sect as anything in subtypesof(/datum/religion_sect))
+			choices[initial(sect.name)] = sect
+	var/choice = tgui_input_list(usr, "Set new Chaplain sect", "God Picker", choices)
+	if(isnull(choice))
+		return
+	if(choice == "nothing")
+		reset_religious_sect()
+		return
+	set_new_religious_sect(choices[choice], reset_existing = TRUE)
 
 /client/proc/deadmin()
 	set name = "Deadmin"

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -58,6 +58,13 @@
 	to_chat(chap, "<span class='bold notice'>\"[quote]\"</span>")
 	to_chat(chap, "<span class='notice'>[desc]</span>")
 
+/// Activates if religious sect is reset by admins, should clean up anything you added on conversion.
+/datum/religion_sect/proc/on_deconversion(mob/living/chap)
+	SHOULD_CALL_PARENT(TRUE)
+	to_chat(chap, span_boldnotice("You have lost the approval of \the [name]."))
+	if(chap.mind.holy_role == HOLY_ROLE_HIGHPRIEST)
+		to_chat(chap, span_notice("Return to an altar to reform your sect."))
+
 /// Returns TRUE if the item can be sacrificed. Can be modified to fit item being tested as well as person offering. Returning TRUE will stop the attackby sequence and proceed to on_sacrifice.
 /datum/religion_sect/proc/can_sacrifice(obj/item/I, mob/living/chap)
 	. = TRUE
@@ -292,6 +299,11 @@
 		return
 	new_convert.gain_trauma(/datum/brain_trauma/special/burdened, TRAUMA_RESILIENCE_MAGIC)
 
+/datum/religion_sect/burden/on_deconversion(mob/living/carbon/human/new_convert)
+	if (ishuman(new_convert))
+		new_convert.cure_trauma_type(/datum/brain_trauma/special/burdened, TRAUMA_RESILIENCE_MAGIC)
+	return ..()
+
 /datum/religion_sect/burden/tool_examine(mob/living/carbon/human/burdened) //display burden level
 	if(!ishuman(burdened))
 		return FALSE
@@ -332,6 +344,11 @@
 		to_chat(new_convert, span_warning("[GLOB.deity] has no respect for lower creatures, and refuses to make you honorbound."))
 		return FALSE
 	new_convert.gain_trauma(/datum/brain_trauma/special/honorbound, TRAUMA_RESILIENCE_MAGIC)
+
+/datum/religion_sect/honorbound/on_deconversion(mob/living/carbon/human/new_convert)
+	if (ishuman(new_convert))
+		new_convert.cure_trauma_type(/datum/brain_trauma/special/honorbound, TRAUMA_RESILIENCE_MAGIC)
+	return ..()
 
 #define MINIMUM_YUCK_REQUIRED 5
 

--- a/code/modules/religion/religion_structures.dm
+++ b/code/modules/religion/religion_structures.dm
@@ -61,7 +61,10 @@
 		. += list(span_notice("Chaplains: [chaplains]."))
 
 /obj/structure/altar_of_gods/proc/reflect_sect_in_icons()
-	if(GLOB.religious_sect)
+	if(isnull(GLOB.religious_sect))
+		icon = initial(icon)
+		icon_state = initial(icon_state)
+	else
 		sect_to_altar = GLOB.religious_sect
 		if(sect_to_altar.altar_icon)
 			icon = sect_to_altar.altar_icon


### PR DESCRIPTION
## About The Pull Request

Adds a "manage religious sect" verb to the "game" menu of the admin panel.
It can be used to assign the chaplain's sect if they haven't picked one yet, or reassign it (to a different one, or to nothing) if they already have.
This is likely mostly going to be used for ahelps where someone misclicks or suddenly logs off and wants to be replaced by a different chaplain with different ideas.

## Why It's Good For The Game

Admins asked me to make it

## Changelog

:cl:
admin: Admins can now reset or modify the chaplain's sect from a UI panel
/:cl:
