### PR TITLE
Makes the Olive Oil recipe work properly

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -253,7 +253,8 @@
 	reaction_flags = REACTION_INSTANT
 
 /datum/chemical_reaction/food/olive_oil_upconvert
-	required_reagents = list(/datum/reagent/consumable/nutriment/fat/oil/olive = 1, /datum/reagent/consumable/nutriment/fat/oil = 2)
+	required_catalysts = list(/datum/reagent/consumable/nutriment/fat/oil/olive = 1)
+	required_reagents = list( /datum/reagent/consumable/nutriment/fat/oil = 2)
 	results = list(/datum/reagent/consumable/nutriment/fat/oil/olive = 2)
 	mix_message = "The cooking oil dilutes the quality oil- how delightfully devilish..."
 	reaction_flags = REACTION_INSTANT


### PR DESCRIPTION

## About The Pull Request

Makes the Olive Oil recipe work properly.
## Why It's Good For The Game

The Oliver Oil recipe now makes Olive Oil a catalyst. This makes it work correctly.

Fixes #78421
## Changelog
:cl:
fix: Recipe that converts Vegetable Oil into Olive Oil works properly
/:cl:
