### PR TITLE
Holo para refund fix

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -247,7 +247,7 @@
 /// Called on component/uplink/OnAttackBy(..)
 #define COMSIG_ITEM_ATTEMPT_TC_REIMBURSE "item_attempt_tc_reimburse"
 ///Called when a holoparasite/guardiancreator is used. 
-#define COMSIG_TRAITOR_ITEM_USED(guardiancreator) "traitor_item_used_[guardiancreator]"
+#define COMSIG_TRAITOR_ITEM_USED(type) "traitor_item_used_[type]"
 
 // /obj/item/clothing signals
 

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -246,8 +246,8 @@
 
 /// Called on component/uplink/OnAttackBy(..)
 #define COMSIG_ITEM_ATTEMPT_TC_REIMBURSE "item_attempt_tc_reimburse"
-///Called when a traitor item is used and no longer refundable.
-#define COMSIG_ITEM_TC_USED "item_tc_used"
+///Called when a holoparasite/guardiancreator is used. 
+#define COMSIG_TRAITOR_ITEM_USED(guardiancreator) "traitor_item_used_[guardiancreator]"
 
 // /obj/item/clothing signals
 

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -247,7 +247,7 @@
 /// Called on component/uplink/OnAttackBy(..)
 #define COMSIG_ITEM_ATTEMPT_TC_REIMBURSE "item_attempt_tc_reimburse"
 ///Called when a holoparasite/guardiancreator is used. 
-#define COMSIG_TRAITOR_ITEM_USED(guardiancreator) "traitor_item_used_[guardiancreator]"
+#define COMSIG_TRAITOR_ITEM_USED(/obj/item/guardiancreator) "traitor_item_used_[/obj/item/guardiancreator]"
 
 // /obj/item/clothing signals
 

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -247,7 +247,7 @@
 /// Called on component/uplink/OnAttackBy(..)
 #define COMSIG_ITEM_ATTEMPT_TC_REIMBURSE "item_attempt_tc_reimburse"
 ///Called when a holoparasite/guardiancreator is used. 
-#define COMSIG_TRAITOR_ITEM_USED(/obj/item/guardiancreator) "traitor_item_used_[/obj/item/guardiancreator]"
+#define COMSIG_TRAITOR_ITEM_USED(guardiancreator) "traitor_item_used_[guardiancreator]"
 
 // /obj/item/clothing signals
 

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -246,6 +246,8 @@
 
 /// Called on component/uplink/OnAttackBy(..)
 #define COMSIG_ITEM_ATTEMPT_TC_REIMBURSE "item_attempt_tc_reimburse"
+///Called when a traitor item is used and no longer refundable.
+#define COMSIG_ITEM_TC_USED "item_tc_used"
 
 // /obj/item/clothing signals
 

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -21,10 +21,10 @@
 
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(target, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, PROC_REF(reimburse))
-	RegisterSignal(target,COMSIG_ITEM_TC_USED, PROC_REF(used))
+	RegisterSignal(target,COMSIG_TRAITOR_ITEM_USED(guardiancreator), PROC_REF(used))
 	
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_ITEM_TC_USED, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
+	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_TRAITOR_ITEM_USED(guardiancreator), COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
 
 
 	return ..()

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -23,7 +23,8 @@
 	RegisterSignal(target, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, PROC_REF(reimburse))
 
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_EXAMINE))
+	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
+
 
 	return ..()
 

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -24,7 +24,7 @@
 	RegisterSignal(target,COMSIG_ITEM_TC_USED, PROC_REF(used))
 	
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ITEM__TC_USED, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, COMSIG_ATOM_EXAMINE))
+	UnregisterSignal(target, list(COMSIG_ITEM_TC_USED, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, COMSIG_ATOM_EXAMINE))
 
 
 	return ..()

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -24,7 +24,7 @@
 	RegisterSignal(target,COMSIG_ITEM_TC_USED, PROC_REF(used))
 	
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ITEM_ATTEMPT_TC_USED, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, COMSIG_ATOM_EXAMINE))
+	UnregisterSignal(target, list(COMSIG_ITEM__TC_USED, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, COMSIG_ATOM_EXAMINE))
 
 
 	return ..()

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -23,7 +23,7 @@
 	RegisterSignal(target, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, PROC_REF(reimburse))
 
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
+	UnregisterSignal(target, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_EXAMINE))
 
 
 	return ..()
@@ -48,3 +48,4 @@
 	do_sparks(2, source = uplink_comp.uplink_handler)
 	uplink_comp.add_telecrystals(refundable_tc)
 	qdel(refund_item)
+a

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -1,5 +1,5 @@
 /**
- * Uplinik Reimburse element.
+ * Uplink Reimburse element.
  * When element is applied onto items, it allows them to be reimbursed if an user pokes an item with a uplink component with them.
  *
  * Element is only compatible with items.
@@ -21,9 +21,10 @@
 
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(target, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, PROC_REF(reimburse))
-
+	RegisterSignal(target,COMSIG_ITEM_TC_USED, PROC_REF(used))
+	
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_EXAMINE))
+	UnregisterSignal(target, list(COMSIG_ITEM_ATTEMPT_TC_USED, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, COMSIG_ATOM_EXAMINE))
 
 
 	return ..()
@@ -48,4 +49,6 @@
 	do_sparks(2, source = uplink_comp.uplink_handler)
 	uplink_comp.add_telecrystals(refundable_tc)
 	qdel(refund_item)
-a
+/// The item was used, it needs to no longer be refundable
+/datum/element/uplink_reimburse/proc/used(datum/target)
+ src.Detach(target)

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -21,10 +21,10 @@
 
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(target, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, PROC_REF(reimburse))
-	RegisterSignal(target,COMSIG_TRAITOR_ITEM_USED(guardiancreator), PROC_REF(used))
+	RegisterSignal(target,COMSIG_TRAITOR_ITEM_USED(/obj/item/guardiancreator), PROC_REF(used))
 	
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_TRAITOR_ITEM_USED(guardiancreator), COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
+	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_TRAITOR_ITEM_USED(/obj/item/guardiancreator), COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
 
 
 	return ..()

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -51,4 +51,6 @@
 	qdel(refund_item)
 /// The item was used, it needs to no longer be refundable
 /datum/element/uplink_reimburse/proc/used(datum/target)
- src.Detach(target)
+	SIGNAL_HANDLER
+	
+	src.Detach(target)

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -24,7 +24,7 @@
 	RegisterSignal(target,COMSIG_ITEM_TC_USED, PROC_REF(used))
 	
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ITEM_TC_USED, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, COMSIG_ATOM_EXAMINE))
+	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_ITEM_TC_USED, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
 
 
 	return ..()
@@ -49,8 +49,8 @@
 	do_sparks(2, source = uplink_comp.uplink_handler)
 	uplink_comp.add_telecrystals(refundable_tc)
 	qdel(refund_item)
-/// The item was used, it needs to no longer be refundable
+/// If the item is used, it needs to no longer be refundable
 /datum/element/uplink_reimburse/proc/used(datum/target)
 	SIGNAL_HANDLER
 	
-	src.Detach(target)
+	Detach(target)

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -21,10 +21,10 @@
 
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(target, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, PROC_REF(reimburse))
-	RegisterSignal(target,COMSIG_TRAITOR_ITEM_USED(/obj/item/guardiancreator), PROC_REF(used))
+	RegisterSignal(target,COMSIG_TRAITOR_ITEM_USED(target.type), PROC_REF(used))
 	
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_TRAITOR_ITEM_USED(/obj/item/guardiancreator), COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
+	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_TRAITOR_ITEM_USED(target.type), COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
 
 
 	return ..()

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
 		used = TRUE
-		SEND_SIGNAL(src, COMSIG_TRAITOR_ITEM_USED(/obj/item/guardiancreator))
+		SEND_SIGNAL(src, COMSIG_TRAITOR_ITEM_USED(type))
 	else
 		to_chat(user, failure_message)
 

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -91,7 +91,6 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		SEND_SIGNAL(src, COMSIG_ITEM_TC_USED)
 	else
 		to_chat(user, failure_message)
-		
 
 /obj/item/guardiancreator/proc/spawn_guardian(mob/living/user, mob/dead/candidate, guardian_path)
 	if(QDELETED(user) || user.stat == DEAD)

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
 		used = TRUE
-		guardiancreator.RemoveElement(/datum/element/uplink_reimburse)
+		RemoveElement(/datum/element/uplink_reimburse, tc_refund.refundable_tc)
 	else
 		to_chat(user, failure_message)
 		

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -80,7 +80,6 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 			return
 	used = TRUE
 	to_chat(user, use_message)
-	RemoveElement(/datum/element/uplink_reimburse)
 	var/guardian_type_name = "a random"
 	if(!random)
 		guardian_type_name = "the " + lowertext(initial(guardian_path.creator_name))
@@ -88,9 +87,11 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
+		used = TRUE
+		RemoveElement(/datum/element/uplink_reimburse)
 	else
 		to_chat(user, failure_message)
-		used = FALSE
+		
 
 /obj/item/guardiancreator/proc/spawn_guardian(mob/living/user, mob/dead/candidate, guardian_path)
 	if(QDELETED(user) || user.stat == DEAD)

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -80,6 +80,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 			return
 	used = TRUE
 	to_chat(user, use_message)
+	RemoveElement(/datum/element/uplink_reimburse)
 	var/guardian_type_name = "a random"
 	if(!random)
 		guardian_type_name = "the " + lowertext(initial(guardian_path.creator_name))

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
 		used = TRUE
-		SEND_SIGNAL(src, COMSIG_ITEM_TC_USED)
+		SEND_SIGNAL(src, COMSIG_ITEM_TC_USED(guardiancreator))
 	else
 		to_chat(user, failure_message)
 

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
 		used = TRUE
-		SEND_SIGNAL(src, COMSIG_ITEM_TC_USED, src)
+		SEND_SIGNAL(src, COMSIG_ITEM_TC_USED)
 	else
 		to_chat(user, failure_message)
 		

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
 		used = TRUE
-		RemoveElement(/datum/element/uplink_reimburse, tc_refund.refundable_tc)
+		SEND_SIGNAL(src, COMSIG_ITEM_TC_USED, src)
 	else
 		to_chat(user, failure_message)
 		

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
 		used = TRUE
-		SEND_SIGNAL(src, COMSIG_ITEM_TC_USED(guardiancreator))
+		SEND_SIGNAL(src, COMSIG_TRAITOR_ITEM_USED(guardiancreator))
 	else
 		to_chat(user, failure_message)
 

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
 		used = TRUE
-		RemoveElement(/datum/element/uplink_reimburse)
+		guardiancreator.RemoveElement(/datum/element/uplink_reimburse)
 	else
 		to_chat(user, failure_message)
 		

--- a/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian_creator.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
 		used = TRUE
-		SEND_SIGNAL(src, COMSIG_TRAITOR_ITEM_USED(guardiancreator))
+		SEND_SIGNAL(src, COMSIG_TRAITOR_ITEM_USED(/obj/item/guardiancreator))
 	else
 		to_chat(user, failure_message)
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -128,8 +128,7 @@
 	else
 		A = spawn_path
 	if(refundable)
-		var/tc_refund = new /datum/element/uplink_reimburse
-		A.AddElement(tc_refund, (refund_amount ? refund_amount : cost))
+		A.AddElement(/datum/element/uplink_reimburse, (refund_amount ? refund_amount : cost))
 	if(ishuman(user) && isitem(A))
 		var/mob/living/carbon/human/H = user
 		if(H.put_in_hands(A))

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -128,7 +128,8 @@
 	else
 		A = spawn_path
 	if(refundable)
-		A.AddElement(/datum/element/uplink_reimburse, (refund_amount ? refund_amount : cost))
+		var/tc_refund = new /datum/element/uplink_reimburse
+		A.AddElement(tc_refund, (refund_amount ? refund_amount : cost))
 	if(ishuman(user) && isitem(A))
 		var/mob/living/carbon/human/H = user
 		if(H.put_in_hands(A))


### PR DESCRIPTION
## About The Pull Request
Holoparasite injector can be refunded if its been used, this is because the uplink_reimburse element is not removed from it when its used. Added some signal code to it so that this is fixed. 

## Why It's Good For The Game
Fixes a bug.

## Changelog

Fixes a bug allowing holopara injectors to be refundable when used. 

:cl:
fix: Fixes a bug allowing holopara injectors to be refundable when used. 
/:cl:
