### PR TITLE
Makes `/datum/component/wall_mounted` actually do it's job

### DIFF
--- a/code/datums/components/wall_mounted.dm
+++ b/code/datums/components/wall_mounted.dm
@@ -49,7 +49,6 @@
 	SIGNAL_HANDLER
 	var/obj/hanging_parent = parent
 
-	var/msg
 	if(on_drop)
 		hanging_parent.visible_message(message = span_warning("\The [hanging_parent] falls off the wall!"), vision_distance = 5)
 		on_drop.Invoke(hanging_parent)

--- a/code/datums/components/wall_mounted.dm
+++ b/code/datums/components/wall_mounted.dm
@@ -12,8 +12,6 @@
 		return COMPONENT_INCOMPATIBLE
 	if(!isturf(target_wall))
 		return COMPONENT_INCOMPATIBLE
-	if(!on_drop_callback)
-		on_drop = TYPE_PROC_REF(/obj, deconstruct)
 	hanging_wall_turf = target_wall
 	on_drop = on_drop_callback
 
@@ -50,8 +48,16 @@
 /datum/component/wall_mounted/proc/drop_wallmount()
 	SIGNAL_HANDLER
 	var/obj/hanging_parent = parent
-	hanging_parent.visible_message(message = span_warning("\The [hanging_parent] falls off the wall!"), vision_distance = 5)
-	on_drop?.Invoke(hanging_parent)
+
+	var/msg
+	if(on_drop)
+		msg = "\The [hanging_parent] falls off the wall!"
+		on_drop.Invoke(hanging_parent)
+	else
+		msg = "\The [hanging_parent] falls apart!"
+		hanging_parent.deconstruct()
+	hanging_parent.visible_message(message = span_warning(msg), vision_distance = 5)
+
 	if(!QDELING(src))
 		qdel(src) //Well, we fell off the wall, so we're done here.
 /**

--- a/code/datums/components/wall_mounted.dm
+++ b/code/datums/components/wall_mounted.dm
@@ -51,12 +51,11 @@
 
 	var/msg
 	if(on_drop)
-		msg = "\The [hanging_parent] falls off the wall!"
+		hanging_parent.visible_message(message = span_warning("\The [hanging_parent] falls off the wall!"), vision_distance = 5)
 		on_drop.Invoke(hanging_parent)
 	else
-		msg = "\The [hanging_parent] falls apart!"
+		hanging_parent.visible_message(message = span_warning("\The [hanging_parent] falls apart!"), vision_distance = 5)
 		hanging_parent.deconstruct()
-	hanging_parent.visible_message(message = span_warning(msg), vision_distance = 5)
 
 	if(!QDELING(src))
 		qdel(src) //Well, we fell off the wall, so we're done here.

--- a/code/game/objects/items/wall_mounted.dm
+++ b/code/game/objects/items/wall_mounted.dm
@@ -42,8 +42,6 @@
 
 		var/obj/hanging_object = new result_path(get_turf(user), floor_to_wall, TRUE)
 		hanging_object.setDir(floor_to_wall)
-		on_wall.AddComponent(/datum/component/wall_mounted, hanging_object)
-
 		if(pixel_shift)
 			switch(floor_to_wall)
 				if(NORTH)
@@ -55,7 +53,7 @@
 				if(WEST)
 					hanging_object.pixel_x = -pixel_shift
 		after_attach(hanging_object)
-		hanging_object.find_and_hang_on_wall()
+
 	qdel(src)
 
 /obj/item/wallframe/proc/after_attach(obj/attached_to)


### PR DESCRIPTION
## About The Pull Request
This component added in #77417 never actually worked. It has 2 problems

**1. Nothing even gets dismounted**

https://github.com/tgstation/tgstation/assets/110812394/8859794c-e2da-4bf2-bf2e-cd44fb240872

This is because a ton of objects in game don't actually pass a callback when the object is getting dismounted i.e. they pass no params to the `find_and_hang_on_wall()` proc for e.g.

https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/game/objects/items/wall_mounted.dm#L58

and because the callback is null the action 

https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/datums/components/wall_mounted.dm#L54

never gets executed. Now to combat this in the `Initialize()` proc a null check is done to ensure the callback is not null
https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/datums/components/wall_mounted.dm#L15-L18

But this code itself is broken for 2 reasons
1. We create a callback using the `CALLBACK` macro they are not the same as `TYPE_PROC_REF` also we never specify which object this proc ref should even be called on
2. `on_drop` ends up null anyway because we first check if the param is null and set its value here
https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/datums/components/wall_mounted.dm#L15-L16
But then we again overwrite `on_drop` with the param passed(which is null) so it ends up becoming null again
https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/datums/components/wall_mounted.dm#L18

So this never did it's job. Also we simply can't create a callback on `obj/deconstruct` because this proc accepts a boolean as it's param
https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/game/objects/obj_defense.dm#L150
But we pass the `hanging_param` as its param when invoking the callback
https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/datums/components/wall_mounted.dm#L54

Which would cause undefined behaviour so we have to manually do a null check for this param and call the `deconstruct` proc explicitly to ensure correct behaviour


**2. Wall mounts created in round would runtime**

**Reproduction**
1. Use some iron sheets to construct an air alarm wall frame(or any wallmount of your choice)
4. Put on wall
5. Get stack trace

![Error](https://github.com/tgstation/tgstation/assets/110812394/2f802dc2-faaa-4ee3-aacf-38b83adef17d)

This occurred because the component received an invalid parent when mounting was attempted.
![Cause](https://github.com/tgstation/tgstation/assets/110812394/aed12757-edf6-4f79-8763-00f4a86251ca)

Which was caused by
https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/game/objects/items/wall_mounted.dm#L45

We should be doing this the other way around i.e. 

`hanging_object.AddComponent(/datum/component/wall_mounted, on_wall)`

But the truth is even this is not required nor is this

https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/game/objects/items/wall_mounted.dm#L58

These 2 lines of code are not necessary because a lot of objects call `find_and_hang_on_wall()` proc by themselves in their `Initialization()` proc for e.g.

https://github.com/tgstation/tgstation/blob/11ec431834d384b9a813d8e2a9a28758d942ad7c/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm#L127

So the work is already done for us. we were just adding the component 2 more times for no reason and causing problems.

## Changelog
:cl:
fix: wall mounted objects air alarms, fire alarms etc now actually falls off/gets destroyed when their attached wall is deconstructed
fix: wall mounts crafted in game also properly falls off/gets destroyed when their attached wall is deconstructed
/:cl: