### PR TITLE
RCD construction effects no longer fall into chasms

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -29,6 +29,7 @@
 		/obj/effect/wisp,
 		/obj/effect/ebeam,
 		/obj/effect/fishing_lure,
+		/obj/effect/constructing_effect,
 	))
 
 /datum/component/chasm/Initialize(turf/target, mapload)


### PR DESCRIPTION

## About The Pull Request

Adds the construction effect to the chasm blacklist.

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/44811257/76a9cb90-19d9-447b-85d2-56916d8cd8ca)
Fixes #78440 

## Changelog
:cl:
fix: RCD Construction effects will no longer fall into chasms.
/:cl:
