### PR TITLE
Move the DreamChecker annotator into a new module

### DIFF
--- a/tools/ci/annotate_dm.sh
+++ b/tools/ci/annotate_dm.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 set -euo pipefail
-tools/bootstrap/python tools/ci/annotate_dm.py "$@"
+tools/bootstrap/python -m dm_annotator "$@"

--- a/tools/dm_annotator/__main__.py
+++ b/tools/dm_annotator/__main__.py
@@ -2,7 +2,7 @@ import sys
 import re
 import os.path as path
 
-# Usage: python3 annotate_dm.py [filename]
+# Usage: tools/bootstrap/python -m dm_annotator [filename]
 # If filename is not provided, stdin is checked instead
 
 def red(text):
@@ -44,7 +44,7 @@ def main():
         annotate(sys.stdin.read())
     else:
         print(red("Error: No input provided"))
-        print("Usage: tools/ci/annotate_dm.sh [filename]")
+        print("Usage: tools/bootstrap/python -m dm_annotator [filename]")
         sys.exit(1)
 
 if __name__ == '__main__':


### PR DESCRIPTION

## About The Pull Request

just moving the dm annotator script out of the CI folder, into a new module which can be executed

if this breaks stuff again then i am going to cry

## Why It's Good For The Game

less clutter inside of `./tools/ci`
## Changelog
nothing playerfacing
