### PR TITLE
Converts slapcrafting into a component

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -30972,7 +30972,7 @@
 "jRB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
-/obj/item/wirerod,
+/obj/item/melee/baton/security/cattleprod,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -13152,7 +13152,7 @@
 /area/station/maintenance/floor3/port/fore)
 "dss" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/item/wirerod,
+/obj/item/melee/baton/security/cattleprod,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
 "dsv" = (

--- a/code/datums/components/crafting/_recipes.dm
+++ b/code/datums/components/crafting/_recipes.dm
@@ -17,7 +17,7 @@
 	var/list/tool_paths
 	///time in seconds. Remember to use the SECONDS define!
 	var/time = 3 SECONDS
-	///type paths of items that will be placed in the result
+	///type paths of items that will be forceMoved() into the result, or added to the reagents of it
 	var/list/parts = list()
 	///like tool_behaviors but for reagents
 	var/list/chem_catalysts = list()

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -16,8 +16,11 @@
 	icon_state = "receiver"
 
 /obj/item/weaponcrafting/receiver/create_slapcraft_component()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/pipegun)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/pipegun)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/weaponcrafting/stock
@@ -29,8 +32,11 @@
 	icon_state = "riflestock"
 
 /obj/item/weaponcrafting/stock/create_slapcraft_component()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/smoothbore_disabler, /datum/crafting_recipe/laser_musket)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/smoothbore_disabler, /datum/crafting_recipe/laser_musket)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/weaponcrafting/giant_wrench
@@ -40,8 +46,11 @@
 	icon_state = "weaponkit_gw"
 
 /obj/item/weaponcrafting/giant_wrench/create_slapcraft_component() // slappycraft
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/giant_wrench)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/giant_wrench)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 ///These gun kits are printed from the security protolathe to then be used in making new weapons

--- a/code/datums/components/crafting/guncrafting.dm
+++ b/code/datums/components/crafting/guncrafting.dm
@@ -2,11 +2,23 @@
 
 // PARTS //
 
+/obj/item/weaponcrafting/Initialize(mapload)
+	. = ..()
+	create_slapcraft_component()
+
+/obj/item/weaponcrafting/proc/create_slapcraft_component()
+	return
+
 /obj/item/weaponcrafting/receiver
 	name = "modular receiver"
 	desc = "A prototype modular receiver and trigger assembly for a firearm."
 	icon = 'icons/obj/weapons/improvised.dmi'
 	icon_state = "receiver"
+
+/obj/item/weaponcrafting/receiver/create_slapcraft_component()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/pipegun)\
+	)
 
 /obj/item/weaponcrafting/stock
 	name = "rifle stock"
@@ -16,17 +28,27 @@
 	icon = 'icons/obj/weapons/improvised.dmi'
 	icon_state = "riflestock"
 
+/obj/item/weaponcrafting/stock/create_slapcraft_component()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/smoothbore_disabler, /datum/crafting_recipe/laser_musket)\
+	)
+
 /obj/item/weaponcrafting/giant_wrench
 	name = "Big Slappy parts kit"
 	desc = "Illegal parts to make a giant like wrench commonly known as a Big Slappy."
 	icon = 'icons/obj/weapons/improvised.dmi'
 	icon_state = "weaponkit_gw"
 
+/obj/item/weaponcrafting/giant_wrench/create_slapcraft_component() // slappycraft
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/giant_wrench)\
+	)
+
 ///These gun kits are printed from the security protolathe to then be used in making new weapons
 
 // GUN PART KIT //
 
-/obj/item/weaponcrafting/gunkit
+/obj/item/weaponcrafting/gunkit // These don't get a slapcraft component, it's added to the gun - more intuitive player-facing to slap the kit onto the gun.
 	name = "generic gun parts kit"
 	desc = "It's an empty gun parts container! Why do you have this?"
 	icon = 'icons/obj/weapons/improvised.dmi'

--- a/code/datums/components/crafting/slapcrafting.dm
+++ b/code/datums/components/crafting/slapcrafting.dm
@@ -107,8 +107,12 @@
 
 	var/atom/final_result = initial(actual_recipe.result)
 
+	to_chat(user, span_notice("You start crafting \a [initial(final_result.name)]..."))
+
 	var/error_string = craft_sheet.construct_item(user, actual_recipe)
-	to_chat(user, istext(error_string) ? span_danger("Crafting failed" + error_string) : span_notice("You start crafting \a [initial(final_result.name)]..."))
+
+	if(error_string)
+		to_chat(user, span_warning("crafting failed" + error_string))
 
 /// Alerts any examiners to the recipe, if they wish to know more.
 /datum/component/slapcrafting/proc/get_examine_info(atom/source, mob/user, list/examine_list)

--- a/code/datums/components/crafting/slapcrafting.dm
+++ b/code/datums/components/crafting/slapcrafting.dm
@@ -71,7 +71,7 @@
 		return
 
 	// We might use radials so we need to split the proc chain
-	INVOKE_ASYNC(src, PROC_REF(slapcraft_async), valid_recipes, user, craftsheet)
+	INVOKE_ASYNC(src, PROC_REF(slapcraft_async), valid_recipes, user, craft_sheet)
 
 /datum/component/slapcrafting/proc/slapcraft_async(list/valid_recipes, mob/user, datum/component/personal_crafting/craft_sheet)
 

--- a/code/datums/components/crafting/slapcrafting.dm
+++ b/code/datums/components/crafting/slapcrafting.dm
@@ -47,6 +47,10 @@
 	if(isnull(slapcraft_recipes))
 		CRASH("NULL SLAPCRAFT RECIPES?")
 
+	var/datum/component/personal_crafting/craft_sheet = user.GetComponent(/datum/component/personal_crafting)
+	if(!craft_sheet)
+		CRASH("No craft sheet on user ??")
+
 	var/list/valid_recipes
 	for(var/datum/crafting_recipe/recipe as anything in slapcraft_recipes)
 		// Gotta instance it to copy the list over.
@@ -67,9 +71,9 @@
 		return
 
 	// We might use radials so we need to split the proc chain
-	INVOKE_ASYNC(src, PROC_REF(slapcraft_async), valid_recipes, user)
+	INVOKE_ASYNC(src, PROC_REF(slapcraft_async), valid_recipes, user, craftsheet)
 
-/datum/component/slapcrafting/proc/slapcraft_async(list/valid_recipes, mob/user)
+/datum/component/slapcrafting/proc/slapcraft_async(list/valid_recipes, mob/user, datum/component/personal_crafting/craft_sheet)
 
 	var/list/recipe_choices = list()
 
@@ -93,9 +97,6 @@
 	if(string_chosen_recipe)
 		final_recipe = result_to_recipe[string_chosen_recipe]
 
-	var/datum/component/personal_crafting/craft_sheet = user.GetComponent(/datum/component/personal_crafting)
-	if(!craft_sheet)
-		CRASH("No craft sheet on user ??")
 
 	var/datum/crafting_recipe/actual_recipe = final_recipe
 

--- a/code/datums/components/crafting/slapcrafting.dm
+++ b/code/datums/components/crafting/slapcrafting.dm
@@ -1,0 +1,146 @@
+/// Slapcrafting component!
+/datum/component/slapcrafting
+	var/list/slapcraft_recipes = list()
+
+/**
+ * Slapcraft component
+ *
+ * Slap it onto a item to be able to slapcraft with it
+ *
+ * args:
+ * * item_to_slap_with (required) = When the item is slapped by this, it will attempt the slapcraft
+ * * slapcraft_recipe (required) = The recipe to attempt crafting. It will check the area near the user for the rest of the ingredients.
+ * *
+**/
+/datum/component/slapcrafting/Initialize(
+		slapcraft_recipes = null,
+	)
+
+	if(!isitem(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(attempt_slapcraft))
+	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(get_examine_info))
+	RegisterSignal(parent, COMSIG_ATOM_EXAMINE_MORE, PROC_REF(get_examine_more_info))
+
+	src.slapcraft_recipes = slapcraft_recipes
+
+/datum/component/slapcrafting/Destroy(force, silent)
+	UnregisterSignal(parent, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_EXAMINE, COMSIG_ATOM_EXAMINE_MORE))
+	return ..()
+
+/datum/component/slapcrafting/proc/attempt_slapcraft(obj/item/parent_item, obj/item/slapper, mob/user)
+
+	if(isnull(slapcraft_recipes))
+		CRASH("NULL SLAPCRAFT RECIPES?")
+
+	var/list/valid_recipes
+	for(var/datum/crafting_recipe/recipe in slapcraft_recipes)
+		// For our purposes, they're the same thing in the end
+		var/list/type_ingredient_list = initial(recipe.parts) + initial(recipe.reqs)
+		if(is_type_in_list(slapper, type_ingredient_list))
+			LAZYADD(valid_recipes, recipe)
+
+	if(!valid_recipes)
+		return
+
+	// We might use radials so we need to split the proc chain
+	INVOKE_ASYNC(src, PROC_REF(slapcraft_async), valid_recipes, user)
+
+/datum/component/slapcrafting/proc/slapcraft_async(list/valid_recipes, mob/user)
+
+	var/list/recipe_choices
+
+	var/final_recipe = valid_recipes[1]
+	if(valid_recipes > 1)
+		for(var/datum/crafting_recipe/recipe as anything in valid_recipes)
+			var/atom/recipe_result = initial(recipe.result)
+			var/image/option_image = image(icon = initial(recipe_result.icon), icon_state = initial(recipe_result.icon_state))
+			recipe_choices += list(recipe_result = option_image)
+
+		if(!recipe_choices)
+			CRASH("No recipe choices despite validating in earlier proc")
+
+		final_recipe = show_radial_menu(user, parent, recipe_choices, require_near = TRUE)
+
+	var/datum/component/personal_crafting/craft_sheet = user.GetComponent(/datum/component/personal_crafting)
+	if(!craft_sheet)
+		CRASH("No craft sheet on user ??")
+
+	var/actual_recipe
+
+	if(istype(actual_recipe, /datum/crafting_recipe/food))
+		actual_recipe = locate(slapcraft_recipe) in GLOB.cooking_recipes
+	else
+		actual_recipe = locate(slapcraft_recipe) in GLOB.crafting_recipes
+
+	craft_sheet.construct_item(user, actual_recipe)
+
+/// Alerts any examiners to the recipe, if they wish to know more.
+/datum/component/slapcrafting/proc/get_examine_info(atom/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	var/string_results
+	for(var/datum/crafting_recipe/recipe as anything in slapcraft_recipes)
+		var/atom/result = initial(recipe.result)
+		string_results += isnull(result) ? "a [initial(result.name)]" : ", or a [initial(result.name)]"
+
+	examine_list += span_notice("You think [parent] could be used to make [string_results]! Examine again to look at the details...")
+
+/// Alerts any examiners to the details of the recipe.
+/datum/component/slapcrafting/proc/get_examine_more_info(atom/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	var/atom/result = initial(slapcraft_recipe.result)
+
+	for(var/datum/crafting_recipe/recipe as anything in slapcraft_recipes)
+		var/atom/result = initial(recipe.result)
+		examine_list += "<a href='?src=[REF(src)];check_recipe=[recipe]'>See Recipe For [initial(result.name)]</a>"
+
+/datum/element/weapon_description/proc/topic_handler(atom/source, user, href_list)
+	SIGNAL_HANDLER
+
+	if(href_list["check_recipe"])
+		switch(href_list["member_action"])
+			if("remove")
+				remove_member(user,ckey,team)
+		to_chat(user, span_notice(examine_block("[build_label_text(source)]")))
+
+	examine_list += span_notice("You could craft a [initial(result.name)] by applying a [item_to_slap_with] to it!")
+
+	// For our purposes, they're the same thing in the end
+	var/list/type_ingredient_list = initial(slapcraft_recipe.parts)
+	type_ingredient_list += initial(slapcraft_recipe.reqs)
+
+	// Final return string list!
+	var/list/string_ingredient_list
+
+	for(var/valid_type in type_ingredient_list)
+		if(isdatum(valid_type))
+			var/datum/reagent/reagent_ingredient = valid_type
+			if(!istype(reagent_ingredient))
+				stack_trace("Ingredient is datum but not reagent? [reagent_ingredient]")
+			var/amount = initial(slapcraft_recipe.parts[reagent_ingredient])
+			string_ingredient_list += "[amount] unit[amount > 1 ? "s" : ""] of [initial(reagent_ingredient.name)]"
+
+		var/atom/ingredient = valid_type
+		if(!istype(ingredient, item_to_slap_with)) // redundant
+			var/amount = initial(slapcraft_recipe.parts[ingredient])
+			string_ingredient_list += "[amount > 1 ? (amount + "of") : "a"] [initial(ingredient.name)]"
+
+	if(length(string_ingredient_list))
+		examine_list += span_boldnotice("Additional Ingredients:")
+		examine_list += span_notice(string_ingredient_list)
+
+	var/tool_list = ""
+
+	for(var/valid_type in initial(slapcraft_recipe.tool_paths))
+		var/atom/tool = valid_type
+		tool_list += "\a [initial(tool.name)]"
+
+	for(var/string in initial(slapcraft_recipe.tool_behaviors))
+		tool_list += "\a [string]"
+
+	if(length(tool_list))
+		examine_list += span_boldnotice("Required Tools:")
+		examine_list += span_notice(tool_list)

--- a/code/datums/components/crafting/slapcrafting.dm
+++ b/code/datums/components/crafting/slapcrafting.dm
@@ -87,6 +87,8 @@
 			CRASH("No recipe choices despite validating in earlier proc")
 
 		string_chosen_recipe = show_radial_menu(user, parent, recipe_choices, require_near = TRUE)
+		if(isnull(string_chosen_recipe))
+			return // they closed the thing
 
 	if(string_chosen_recipe)
 		final_recipe = result_to_recipe[string_chosen_recipe]
@@ -111,7 +113,7 @@
 
 	var/error_string = craft_sheet.construct_item(user, actual_recipe)
 
-	if(error_string)
+	if(!isatom(error_string))
 		to_chat(user, span_warning("crafting failed" + error_string))
 
 /// Alerts any examiners to the recipe, if they wish to know more.

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -60,6 +60,17 @@
 /obj/item/clothing/gloves/boxing
 	var/datum/martial_art/boxing/style = new
 
+/obj/item/clothing/gloves/boxing/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/bodypart/arm/left/robot,\
+			slapcraft_recipe = /datum/crafting_recipe/extendohand_l,\
+	)
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/bodypart/arm/right/robot,\
+			slapcraft_recipe = /datum/crafting_recipe/extendohand_r,\
+	)
+
 /obj/item/clothing/gloves/boxing/equipped(mob/user, slot)
 	..()
 	// boxing requires human

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -62,8 +62,11 @@
 
 /obj/item/clothing/gloves/boxing/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/extendohand_l, /datum/crafting_recipe/extendohand_r)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/extendohand_l, /datum/crafting_recipe/extendohand_r)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/clothing/gloves/boxing/equipped(mob/user, slot)

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -63,12 +63,7 @@
 /obj/item/clothing/gloves/boxing/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/bodypart/arm/left/robot,\
-			slapcraft_recipe = /datum/crafting_recipe/extendohand_l,\
-	)
-	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/bodypart/arm/right/robot,\
-			slapcraft_recipe = /datum/crafting_recipe/extendohand_r,\
+			slapcraft_recipes = list(/datum/crafting_recipe/extendohand_l, /datum/crafting_recipe/extendohand_r)\
 	)
 
 /obj/item/clothing/gloves/boxing/equipped(mob/user, slot)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -749,8 +749,11 @@
 
 /obj/item/toy/crayon/spraycan/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/improvised_coolant)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/improvised_coolant)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/toy/crayon/spraycan/isValidSurface(surface)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -747,6 +747,12 @@
 	pre_noise = TRUE
 	post_noise = FALSE
 
+/obj/item/toy/crayon/spraycan/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/improvised_coolant)\
+	)
+
 /obj/item/toy/crayon/spraycan/isValidSurface(surface)
 	return (isfloorturf(surface) || iswallturf(surface))
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -39,8 +39,11 @@
 	update_brightness()
 	register_context()
 
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/flashlight_eyes)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/flashlight_eyes)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/flashlight/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -39,6 +39,10 @@
 	update_brightness()
 	register_context()
 
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/flashlight_eyes)\
+	)
+
 /obj/item/flashlight/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
 	// single use lights can be toggled on once
 	if(isnull(held_item) && (toggle_context || !on))

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -112,6 +112,13 @@
 
 	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
 
+	// No subtypes
+	if(type != /obj/item/radio)
+		return
+	AddComponent(/datum/component/slapcrafting,\
+		slapcraft_recipes = list(/datum/crafting_recipe/improv_explosive)\
+	)
+
 /obj/item/radio/Destroy()
 	remove_radio_all(src) //Just to be sure
 	QDEL_NULL(wires)

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -26,6 +26,12 @@
 	. = ..()
 	RegisterSignal(src, COMSIG_TOOL_ATOM_ACTED_PRIMARY(tool_behaviour), PROC_REF(on_analyze))
 
+	if(type != /obj/item/analyzer)
+		return
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/material_sniffer)\
+	)
+
 /obj/item/analyzer/equipped(mob/user, slot, initial)
 	. = ..()
 	ADD_TRAIT(user, TRAIT_DETECT_STORM, CLOTHING_TRAIT)

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -28,8 +28,11 @@
 
 	if(type != /obj/item/analyzer)
 		return
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/material_sniffer)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/material_sniffer)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/analyzer/equipped(mob/user, slot, initial)

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -45,8 +45,11 @@
 
 /obj/item/extinguisher/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/ghettojetpack)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/ghettojetpack)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/extinguisher/empty

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -43,6 +43,12 @@
 	/// Icon state when inside a tank holder.
 	var/tank_holder_icon_state = "holder_extinguisher"
 
+/obj/item/extinguisher/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/ghettojetpack)\
+	)
+
 /obj/item/extinguisher/empty
 	starting_water = FALSE
 

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -34,6 +34,9 @@
 /obj/item/flamethrower/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/flamethrower)\
+	)
 
 /obj/item/flamethrower/Destroy()
 	if(weldtool)

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -34,8 +34,11 @@
 /obj/item/flamethrower/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/flamethrower)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/flamethrower)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/flamethrower/Destroy()

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -175,10 +175,6 @@
 	. = ..()
 
 	var/static/list/hovering_item_typechecks = list(
-		/obj/item/stack/rods = list(
-			SCREENTIP_CONTEXT_LMB = "Craft wired rod",
-		),
-
 		/obj/item/stack/sheet/iron = list(
 			SCREENTIP_CONTEXT_LMB = "Craft bola",
 		),
@@ -189,6 +185,13 @@
 
 	if(new_color)
 		set_cable_color(new_color)
+
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/bola, /datum/crafting_recipe/gonbola)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+	)
 
 /obj/item/restraints/handcuffs/cable/proc/set_cable_color(new_color)
 	color = GLOB.cable_colors[new_color]
@@ -288,36 +291,6 @@
 	color = CABLE_HEX_COLOR_WHITE
 	cable_color = CABLE_COLOR_WHITE
 	inhand_icon_state = "coil_white"
-
-/obj/item/restraints/handcuffs/cable/attackby(obj/item/I, mob/user, params) //Slapcrafting
-	if(istype(I, /obj/item/stack/rods))
-		var/obj/item/stack/rods/R = I
-		if (R.use(1))
-			var/obj/item/wirerod/W = new /obj/item/wirerod
-			remove_item_from_storage(user)
-			user.put_in_hands(W)
-			to_chat(user, span_notice("You wrap [src] around the top of [I]."))
-			qdel(src)
-		else
-			to_chat(user, span_warning("You need one rod to make a wired rod!"))
-			return
-	else if(istype(I, /obj/item/stack/sheet/iron))
-		var/obj/item/stack/sheet/iron/M = I
-		if(M.get_amount() < 6)
-			to_chat(user, span_warning("You need at least six iron sheets to make good enough weights!"))
-			return
-		to_chat(user, span_notice("You begin to apply [I] to [src]..."))
-		if(do_after(user, 35, target = src))
-			if(M.get_amount() < 6 || !M)
-				return
-			var/obj/item/restraints/legcuffs/bola/S = new /obj/item/restraints/legcuffs/bola
-			M.use(6)
-			user.put_in_hands(S)
-			to_chat(user, span_notice("You make some weights out of [I] and tie them to [src]."))
-			remove_item_from_storage(user)
-			qdel(src)
-	else
-		return ..()
 
 /**
  * # Zipties

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -113,8 +113,11 @@
 
 /obj/item/shield/riot/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/strobeshield)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/strobeshield)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/shield/riot/attackby(obj/item/attackby_item, mob/user, params)

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -111,6 +111,12 @@
 	shield_break_sound = 'sound/effects/glassbr3.ogg'
 	shield_break_leftover = /obj/item/shard
 
+/obj/item/shield/riot/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/strobeshield)\
+	)
+
 /obj/item/shield/riot/attackby(obj/item/attackby_item, mob/user, params)
 	if(istype(attackby_item, /obj/item/melee/baton))
 		if(!COOLDOWN_FINISHED(src, baton_bash))

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -59,8 +59,11 @@
 
 // I dunno man
 /obj/item/spear/proc/add_headpike_component()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/headpike)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/headpike)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/spear/update_icon_state()
@@ -231,8 +234,11 @@
 	force_wielded = 20
 
 /obj/item/spear/bonespear/add_headpike_component()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/headpikebone)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/headpikebone)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /*
@@ -252,6 +258,9 @@
 
 
 /obj/item/spear/bamboospear/add_headpike_component()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/headpikebamboo)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/headpikebamboo)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -54,7 +54,15 @@
 		force_wielded = force_wielded, \
 		icon_wielded = "[icon_prefix]1", \
 	)
+	add_headpike_component()
 	update_appearance()
+
+// I dunno man
+/obj/item/spear/proc/add_headpike_component()
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/bodypart/head,\
+			slapcraft_recipe = /datum/crafting_recipe/headpike,\
+	)
 
 /obj/item/spear/update_icon_state()
 	icon_state = "[icon_prefix]0"
@@ -223,6 +231,12 @@
 	force_unwielded = 12
 	force_wielded = 20
 
+/obj/item/spear/bonespear/add_headpike_component()
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/bodypart/head,\
+			slapcraft_recipe = /datum/crafting_recipe/headpikebone,\
+	)
+
 /*
  * Bamboo Spear
  */
@@ -237,3 +251,10 @@
 	custom_materials = list(/datum/material/bamboo = SHEET_MATERIAL_AMOUNT * 20)
 	force_unwielded = 10
 	force_wielded = 18
+
+
+/obj/item/spear/bamboospear/add_headpike_component()
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/bodypart/head,\
+			slapcraft_recipe = /datum/crafting_recipe/headpikebamboo,\
+	)

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -60,8 +60,7 @@
 // I dunno man
 /obj/item/spear/proc/add_headpike_component()
 	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/bodypart/head,\
-			slapcraft_recipe = /datum/crafting_recipe/headpike,\
+			slapcraft_recipes = list(/datum/crafting_recipe/headpike)\
 	)
 
 /obj/item/spear/update_icon_state()
@@ -233,8 +232,7 @@
 
 /obj/item/spear/bonespear/add_headpike_component()
 	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/bodypart/head,\
-			slapcraft_recipe = /datum/crafting_recipe/headpikebone,\
+			slapcraft_recipes = list(/datum/crafting_recipe/headpikebone)\
 	)
 
 /*
@@ -255,6 +253,5 @@
 
 /obj/item/spear/bamboospear/add_headpike_component()
 	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/bodypart/head,\
-			slapcraft_recipe = /datum/crafting_recipe/headpikebamboo,\
+			slapcraft_recipes = list(/datum/crafting_recipe/headpikebamboo)\
 	)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -55,6 +55,13 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	)
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
 
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/spear, /datum/crafting_recipe/stunprod, /datum/crafting_recipe/teleprod) // snatcher prod isn't here as a spoopy secret
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
+	)
+
 /obj/item/stack/rods/handle_openspace_click(turf/target, mob/user, proximity_flag, click_parameters)
 	if(proximity_flag)
 		target.attackby(src, user, click_parameters)

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -503,8 +503,11 @@ GLOBAL_LIST_INIT(durathread_recipes, list ( \
 
 /obj/item/stack/sheet/durathread/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/durathread_helmet, /datum/crafting_recipe/durathread_vest)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/durathread_helmet, /datum/crafting_recipe/durathread_vest)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/stack/sheet/durathread/get_main_recipes()
@@ -625,8 +628,11 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 
 /obj/item/stack/sheet/cardboard/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/cardboard_id)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/cardboard_id)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/stack/sheet/cardboard/get_main_recipes()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -501,6 +501,12 @@ GLOBAL_LIST_INIT(durathread_recipes, list ( \
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'
 
+/obj/item/stack/sheet/durathread/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/durathread_helmet, /datum/crafting_recipe/durathread_vest)\
+	)
+
 /obj/item/stack/sheet/durathread/get_main_recipes()
 	. = ..()
 	. += GLOB.durathread_recipes
@@ -616,6 +622,12 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/cardboard
 	grind_results = list(/datum/reagent/cellulose = 10)
 	material_type = /datum/material/cardboard
+
+/obj/item/stack/sheet/cardboard/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/cardboard_id)\
+	)
 
 /obj/item/stack/sheet/cardboard/get_main_recipes()
 	. = ..()

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -49,6 +49,12 @@
 	resistance_flags = FIRE_PROOF
 	item_flags = NO_MAT_REDEMPTION
 
+/obj/item/bag_of_holding_inert/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+		slapcraft_recipes = list(/datum/crafting_recipe/boh)\
+	)
+
 /obj/item/storage/backpack/holding
 	name = "bag of holding"
 	desc = "A backpack that opens into a localized pocket of bluespace."

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -302,68 +302,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/katana/cursed //used by wizard events, see the tendril_loot.dm file for the miner one
 	slot_flags = null
 
-/obj/item/wirerod
-	name = "wired rod"
-	desc = "A rod with some wire wrapped around the top. It'd be easy to attach something to the top bit."
-	icon = 'icons/obj/weapons/spear.dmi'
-	icon_state = "wiredrod"
-	inhand_icon_state = "rods"
-	flags_1 = CONDUCT_1
-	force = 9
-	throwforce = 10
-	w_class = WEIGHT_CLASS_BULKY
-	custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT + SMALL_MATERIAL_AMOUNT * 1.5, /datum/material/glass= SMALL_MATERIAL_AMOUNT * 0.75)
-	attack_verb_continuous = list("hits", "bludgeons", "whacks", "bonks")
-	attack_verb_simple = list("hit", "bludgeon", "whack", "bonk")
-
-/obj/item/wirerod/Initialize(mapload)
-	. = ..()
-
-	var/static/list/hovering_item_typechecks = list(
-		/obj/item/shard = list(
-			SCREENTIP_CONTEXT_LMB = "Craft spear",
-		),
-
-		/obj/item/assembly/igniter = list(
-			SCREENTIP_CONTEXT_LMB = "Craft stunprod",
-		),
-	)
-	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
-
-/obj/item/wirerod/attackby(obj/item/attacking_item, mob/user, params)
-	if(istype(attacking_item, /obj/item/shard))
-		var/datum/crafting_recipe/recipe_to_use = /datum/crafting_recipe/spear
-		user.balloon_alert(user, "crafting spear...")
-		if(do_after(user, initial(recipe_to_use.time), src)) // we do initial work here to get the correct timer
-			var/obj/item/spear/crafted_spear = new /obj/item/spear()
-
-			remove_item_from_storage(user)
-			if (!user.transferItemToLoc(attacking_item, crafted_spear))
-				return
-			crafted_spear.CheckParts(list(attacking_item))
-			qdel(src)
-
-			user.put_in_hands(crafted_spear)
-			user.balloon_alert(user, "crafted spear")
-		return
-
-	if(isigniter(attacking_item) && !(HAS_TRAIT(attacking_item, TRAIT_NODROP)))
-		var/datum/crafting_recipe/recipe_to_use = /datum/crafting_recipe/stunprod
-		user.balloon_alert(user, "crafting cattleprod...")
-		if(do_after(user, initial(recipe_to_use.time), src))
-			var/obj/item/melee/baton/security/cattleprod/prod = new
-
-			remove_item_from_storage(user)
-
-			qdel(attacking_item)
-			qdel(src)
-
-			user.put_in_hands(prod)
-			user.balloon_alert(user, "crafted cattleprod")
-		return
-	return ..()
-
-
 /obj/item/throwing_star
 	name = "throwing star"
 	desc = "An ancient weapon still used to this day, due to its ease of lodging itself into its victim's body parts."

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -328,7 +328,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 			SCREENTIP_CONTEXT_LMB = "Craft stunprod",
 		),
 	)
-
 	AddElement(/datum/element/contextual_screentip_item_typechecks, hovering_item_typechecks)
 
 /obj/item/wirerod/attackby(obj/item/attacking_item, mob/user, params)

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -355,8 +355,11 @@
 	add_glasses_slapcraft_component()
 
 /obj/item/clothing/glasses/sunglasses/proc/add_glasses_slapcraft_component()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/hudsunsec, /datum/crafting_recipe/hudsunmed, /datum/crafting_recipe/hudsundiag, /datum/crafting_recipe/scienceglasses)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/hudsunsec, /datum/crafting_recipe/hudsunmed, /datum/crafting_recipe/hudsundiag, /datum/crafting_recipe/scienceglasses)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/clothing/glasses/sunglasses/reagent
@@ -372,8 +375,11 @@
 	clothing_traits = list(TRAIT_REAGENT_SCANNER, TRAIT_RESEARCH_SCANNER)
 
 /obj/item/clothing/glasses/sunglasses/chemical/add_glasses_slapcraft_component()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/scienceglassesremoval)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/scienceglassesremoval)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/clothing/glasses/sunglasses/gar

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -350,6 +350,26 @@
 	glass_colour_type = /datum/client_colour/glass_colour/gray
 	dog_fashion = /datum/dog_fashion/head
 
+/obj/item/clothing/glasses/sunglasses/Initialize(mapload)
+	. = ..()
+	// Yeah okay we need to refacor tihs
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/clothing/glasses/hud/security,\
+			slapcraft_recipe = /datum/crafting_recipe/hudsunsec,\
+	)
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/clothing/glasses/hud/health,\
+			slapcraft_recipe = /datum/crafting_recipe/hudsunhealth,\
+	)
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/clothing/glasses/hud/security,\
+			slapcraft_recipe = /datum/crafting_recipe/hudsunsec,\
+	)
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/clothing/glasses/hud/security,\
+			slapcraft_recipe = /datum/crafting_recipe/hudsunsec,\
+	)
+
 /obj/item/clothing/glasses/sunglasses/reagent
 	name = "beer goggles"
 	icon_state = "sunhudbeer"

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -352,22 +352,11 @@
 
 /obj/item/clothing/glasses/sunglasses/Initialize(mapload)
 	. = ..()
-	// Yeah okay we need to refacor tihs
+	add_glasses_slapcraft_component()
+
+/obj/item/clothing/glasses/sunglasses/proc/add_glasses_slapcraft_component()
 	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/clothing/glasses/hud/security,\
-			slapcraft_recipe = /datum/crafting_recipe/hudsunsec,\
-	)
-	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/clothing/glasses/hud/health,\
-			slapcraft_recipe = /datum/crafting_recipe/hudsunhealth,\
-	)
-	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/clothing/glasses/hud/security,\
-			slapcraft_recipe = /datum/crafting_recipe/hudsunsec,\
-	)
-	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/clothing/glasses/hud/security,\
-			slapcraft_recipe = /datum/crafting_recipe/hudsunsec,\
+			slapcraft_recipes = list(/datum/crafting_recipe/hudsunsec, /datum/crafting_recipe/hudsunmed, /datum/crafting_recipe/hudsundiag, /datum/crafting_recipe/scienceglasses)\
 	)
 
 /obj/item/clothing/glasses/sunglasses/reagent
@@ -381,6 +370,11 @@
 	icon_state = "sunhudsci"
 	desc = "A pair of tacky purple sunglasses that allow the wearer to recognize various chemical compounds with only a glance."
 	clothing_traits = list(TRAIT_REAGENT_SCANNER, TRAIT_RESEARCH_SCANNER)
+
+/obj/item/clothing/glasses/sunglasses/chemical/add_glasses_slapcraft_component()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/scienceglassesremoval)\
+	)
 
 /obj/item/clothing/glasses/sunglasses/gar
 	name = "black gar glasses"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -95,8 +95,11 @@
 
 /obj/item/clothing/glasses/hud/health/sunglasses/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/hudsunmedremoval)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/hudsunmedremoval)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/clothing/glasses/hud/diagnostic
@@ -127,8 +130,11 @@
 
 /obj/item/clothing/glasses/hud/diagnostic/sunglasses/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/hudsundiagremoval)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/hudsundiagremoval)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/clothing/glasses/hud/security
@@ -167,8 +173,11 @@
 
 /obj/item/clothing/glasses/hud/security/sunglasses/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/hudsunsecremoval)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/hudsunsecremoval)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/clothing/glasses/hud/security/night

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -93,6 +93,12 @@
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/blue
 
+/obj/item/clothing/glasses/hud/health/sunglasses/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/hudsunmedremoval)\
+	)
+
 /obj/item/clothing/glasses/hud/diagnostic
 	name = "diagnostic HUD"
 	desc = "A heads-up display capable of analyzing the integrity and status of robotics and exosuits."
@@ -118,6 +124,12 @@
 	inhand_icon_state = "glasses"
 	flash_protect = FLASH_PROTECTION_FLASH
 	tint = 1
+
+/obj/item/clothing/glasses/hud/diagnostic/sunglasses/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/hudsundiagremoval)\
+	)
 
 /obj/item/clothing/glasses/hud/security
 	name = "security HUD"
@@ -152,6 +164,12 @@
 	flash_protect = FLASH_PROTECTION_FLASH
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/darkred
+
+/obj/item/clothing/glasses/hud/security/sunglasses/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/hudsunsecremoval)\
+	)
 
 /obj/item/clothing/glasses/hud/security/night
 	name = "night vision security HUD"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -12,8 +12,11 @@
 
 /obj/item/clothing/gloves/color/black/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/radiogloves)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/radiogloves)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/clothing/gloves/fingerless
@@ -31,8 +34,11 @@
 
 /obj/item/clothing/gloves/color/fingerless/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/gripperoffbrand)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/gripperoffbrand)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/clothing/gloves/color/orange

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -10,6 +10,12 @@
 	resistance_flags = NONE
 	cut_type = /obj/item/clothing/gloves/fingerless
 
+/obj/item/clothing/gloves/color/black/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/radiogloves)\
+	)
+
 /obj/item/clothing/gloves/fingerless
 	name = "fingerless gloves"
 	desc = "Plain black gloves without fingertips for the hard-working."
@@ -22,6 +28,12 @@
 	custom_price = PAYCHECK_CREW * 1.5
 	undyeable = TRUE
 	clothing_traits = list(TRAIT_FINGERPRINT_PASSTHROUGH)
+
+/obj/item/clothing/gloves/color/fingerless/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/gripperoffbrand)\
+	)
 
 /obj/item/clothing/gloves/color/orange
 	name = "orange gloves"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -14,8 +14,11 @@
 	// Only actual eguns can be converted
 	if(type != /obj/item/gun/energy/e_gun)
 		return
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/advancedegun, /datum/crafting_recipe/tempgun, /datum/crafting_recipe/beam_rifle)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/advancedegun, /datum/crafting_recipe/tempgun, /datum/crafting_recipe/beam_rifle)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/gun/energy/e_gun/add_seclight_point()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -9,6 +9,15 @@
 	ammo_x_offset = 3
 	dual_wield_spread = 60
 
+/obj/item/gun/energy/e_gun/Initialize(mapload)
+	. = ..()
+	// Only actual eguns can be converted
+	if(type != /obj/item/gun/energy/e_gun)
+		return
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/advancedegun, /datum/crafting_recipe/tempgun, /datum/crafting_recipe/beam_rifle)\
+	)
+
 /obj/item/gun/energy/e_gun/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
 		light_overlay_icon = 'icons/obj/weapons/guns/flashlights.dmi', \

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -22,8 +22,11 @@
 	// Only actual KAs can be converted
 	if(type != /obj/item/gun/energy/recharge/kinetic_accelerator)
 		return
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/ebow)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/ebow)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/gun/energy/recharge/kinetic_accelerator/apply_fantasy_bonuses(bonus)

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -16,6 +16,16 @@
 	var/list/modkits = list()
 	gun_flags = NOT_A_REAL_GUN
 
+
+/obj/item/gun/energy/recharge/kinetic_accelerator/Initialize(mapload)
+	. = ..()
+	// Only actual KAs can be converted
+	if(type != /obj/item/gun/energy/recharge/kinetic_accelerator)
+		return
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/ebow)\
+	)
+
 /obj/item/gun/energy/recharge/kinetic_accelerator/apply_fantasy_bonuses(bonus)
 	. = ..()
 	max_mod_capacity = modify_fantasy_variable("max_mod_capacity", max_mod_capacity, bonus * 10)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -14,8 +14,11 @@
 	// Only actual lasguns can be converted
 	if(type != /obj/item/gun/energy/laser)
 		return
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/xraylaser, /datum/crafting_recipe/hellgun, /datum/crafting_recipe/ioncarbine, /datum/crafting_recipe/decloner)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/xraylaser, /datum/crafting_recipe/hellgun, /datum/crafting_recipe/ioncarbine, /datum/crafting_recipe/decloner)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/gun/energy/laser/practice

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -9,6 +9,15 @@
 	ammo_x_offset = 1
 	shaded_charge = 1
 
+/obj/item/gun/energy/laser/Initialize(mapload)
+	. = ..()
+	// Only actual lasguns can be converted
+	if(type != /obj/item/gun/energy/laser)
+		return
+	AddComponent(/datum/component/slapcrafting,\
+			slapcraft_recipes = list(/datum/crafting_recipe/xraylaser, /datum/crafting_recipe/hellgun, /datum/crafting_recipe/ioncarbine, /datum/crafting_recipe/decloner)\
+	)
+
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"
 	desc = "A modified version of the basic laser gun, this one fires less concentrated energy bolts designed for target practice."

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -40,6 +40,12 @@
 	tool_behaviour = TOOL_ROLLINGPIN // Used to knock out the Chef.
 	toolspeed = 1.3 //it's a little awkward to use, but it's a cylinder alright.
 
+/obj/item/reagent_containers/cup/glass/bottle/Initialize(mapload, vol)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+		slapcraft_recipes = list(/datum/crafting_recipe/molotov)\
+	)
+
 /obj/item/reagent_containers/cup/glass/bottle/small
 	name = "small glass bottle"
 	desc = "This blank bottle is unyieldingly anonymous, offering no clues to its contents."

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -21,6 +21,12 @@
 	/// If the can hasn't been opened yet, this is the measure of how fizzed up it is from being shaken or thrown around. When opened, this is rolled as a percentage chance to burst
 	var/fizziness = 0
 
+/obj/item/reagent_containers/cup/soda_cans/Initialize(mapload, vol)
+	. = ..()
+	AddComponent(/datum/component/slapcrafting,\
+		slapcraft_recipes = list(/datum/crafting_recipe/improv_explosive)\
+	)
+
 /obj/item/reagent_containers/cup/soda_cans/random/Initialize(mapload)
 	..()
 	var/T = pick(subtypesof(/obj/item/reagent_containers/cup/soda_cans) - /obj/item/reagent_containers/cup/soda_cans/random)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -258,6 +258,10 @@
 	butcher_sound = 'sound/weapons/circsawhit.ogg', \
 	)
 	//saws are very accurate and fast at butchering
+	AddComponent(/datum/component/slapcrafting,\
+			item_to_slap_with = /obj/item/stack/sheet/plasteel,\
+			slapcraft_recipe = /datum/crafting_recipe/chainsaw,\
+	)
 
 /obj/item/circular_saw/get_surgery_tool_overlay(tray_extended)
 	return surgical_tray_overlay

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -259,8 +259,7 @@
 	)
 	//saws are very accurate and fast at butchering
 	AddComponent(/datum/component/slapcrafting,\
-			item_to_slap_with = /obj/item/stack/sheet/plasteel,\
-			slapcraft_recipe = /datum/crafting_recipe/chainsaw,\
+			slapcraft_recipes = list(/datum/crafting_recipe/chainsaw)\
 	)
 
 /obj/item/circular_saw/get_surgery_tool_overlay(tray_extended)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -258,8 +258,11 @@
 	butcher_sound = 'sound/weapons/circsawhit.ogg', \
 	)
 	//saws are very accurate and fast at butchering
-	AddComponent(/datum/component/slapcrafting,\
-			slapcraft_recipes = list(/datum/crafting_recipe/chainsaw)\
+	var/static/list/slapcraft_recipe_list = list(/datum/crafting_recipe/chainsaw)
+
+	AddComponent(
+		/datum/component/slapcrafting,\
+		slapcraft_recipes = slapcraft_recipe_list,\
 	)
 
 /obj/item/circular_saw/get_surgery_tool_overlay(tray_extended)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1123,6 +1123,7 @@
 #include "code\datums\components\crafting\misc.dm"
 #include "code\datums\components\crafting\ranged_weapon.dm"
 #include "code\datums\components\crafting\robot.dm"
+#include "code\datums\components\crafting\slapcrafting.dm"
 #include "code\datums\components\crafting\structures.dm"
 #include "code\datums\components\crafting\tailoring.dm"
 #include "code\datums\components\crafting\tiles.dm"


### PR DESCRIPTION

## About The Pull Request

Converts slapcrafting into a component!

The component is added on to an ingredient (presumably the main ingredient) with a list of recipes attached. If you interact an ingredient (if no ignredients, a tool) with it, you will start crafting the recipe. If there's multiple, pick between them with a radial menu.

Opening on draft as there's just a liiiiil bit left to do. The actual wired rod was left for last.

## Why It's Good For The Game

Slapcrafting is simply better and more accessible and less laggy than menu crafting. By making it a component we can attach it to things in which it'd make sense to while stopping unintended weirdness that might arise from this being global.

Additionally the way examine lets you see crafting recipes opens up visibility for those, which allows new players to learn about them in a intuitive manner.

## Changelog

:cl:
refactor: Turned slapcrafting into a component! You can examine compatible items to see what recipes they can be used in, and what the ingredients for them are. For example, spears and the head-on-spear crafting recipe.
/:cl:

