### PR TITLE
basic mobs ranged attacks can check for friendly fire

### DIFF
--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -90,7 +90,9 @@
 		controller.clear_blackboard_key(target_key)
 
 /datum/ai_behavior/basic_ranged_attack/proc/check_friendly_in_path(mob/living/source, atom/target, datum/targetting_datum/targetting_datum)
-	var/list/turfs_list = get_line(source, target) - get_turf(source)
+	var/list/turfs_list = get_line(source, target)
+	turfs_list -= get_turf(source)
+	turfs_list -= get_turf(target)
 	for(var/turf/possible_turf in turfs_list)
 
 		for(var/mob/living/potential_friend in possible_turf)

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -109,13 +109,12 @@
 		var/turf/target_turf = get_step(our_turf, direction)
 		if(isnull(target_turf))
 			continue
-		if(target_turf.is_blocked_turf() || get_dist(target_turf, target) > required_distance)
+		if(target_turf.is_blocked_turf() || get_dist(target_turf, target) > get_dist(living_pawn, target))
 			continue
 		possible_turfs += target_turf
 
 	if(!length(possible_turfs))
 		return
-
 	var/turf/picked_turf = get_closest_atom(/turf, possible_turfs, target)
 	step(living_pawn, get_dir(living_pawn, picked_turf))
 

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -117,6 +117,5 @@
 	var/turf/picked_turf = get_closest_atom(/turf, possible_turfs, target)
 	step(living_pawn, get_dir(living_pawn, picked_turf))
 
-
 /datum/ai_behavior/basic_ranged_attack/avoid_friendly_fire
 	avoid_friendly_fire = TRUE

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -100,11 +100,10 @@
 	return FALSE
 
 /datum/ai_behavior/basic_ranged_attack/proc/adjust_position(mob/living/living_pawn, atom/target)
-	var/list/possible_directions = GLOB.alldirs.Copy()
 	var/turf/our_turf = get_turf(living_pawn)
 	var/list/possible_turfs = list()
 
-	for(var/direction in possible_directions)
+	for(var/direction in GLOB.alldirs)
 		var/turf/target_turf = get_step(our_turf, direction)
 		if(isnull(target_turf))
 			continue

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -91,7 +91,7 @@
 
 /datum/ai_behavior/basic_ranged_attack/proc/check_friendly_in_path(mob/living/source, atom/target, datum/targetting_datum/targetting_datum)
 	var/list/turfs_list = calculate_trajectory(source, target)
-	for(var/turf/possible_turf in turfs_list)
+	for(var/turf/possible_turf as anything in turfs_list)
 
 		for(var/mob/living/potential_friend in possible_turf)
 			if(!targetting_datum.can_attack(source, potential_friend))

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -116,3 +116,7 @@
 
 	var/turf/picked_turf = get_closest_atom(/turf, possible_turfs, target)
 	step(living_pawn, get_dir(living_pawn, picked_turf))
+
+
+/datum/ai_behavior/basic_ranged_attack/avoid_friendly_fire
+	avoid_friendly_fire = TRUE

--- a/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
+++ b/code/datums/ai/basic_mobs/basic_ai_behaviors/basic_attacking.dm
@@ -90,9 +90,7 @@
 		controller.clear_blackboard_key(target_key)
 
 /datum/ai_behavior/basic_ranged_attack/proc/check_friendly_in_path(mob/living/source, atom/target, datum/targetting_datum/targetting_datum)
-	var/list/turfs_list = get_line(source, target)
-	turfs_list -= get_turf(source)
-	turfs_list -= get_turf(target)
+	var/list/turfs_list = calculate_trajectory(source, target)
 	for(var/turf/possible_turf in turfs_list)
 
 		for(var/mob/living/potential_friend in possible_turf)
@@ -117,6 +115,25 @@
 		return
 	var/turf/picked_turf = get_closest_atom(/turf, possible_turfs, target)
 	step(living_pawn, get_dir(living_pawn, picked_turf))
+
+/datum/ai_behavior/basic_ranged_attack/proc/calculate_trajectory(mob/living/source , atom/target)
+	var/list/turf_list = get_line(source, target)
+	var/list_length = length(turf_list) - 1
+	for(var/i in 1 to list_length)
+		var/turf/current_turf = turf_list[i]
+		var/turf/next_turf = turf_list[i+1]
+		var/direction_to_turf = get_dir(current_turf, next_turf)
+		if(!ISDIAGONALDIR(direction_to_turf))
+			continue
+
+		for(var/cardinal_direction in GLOB.cardinals)
+			if(cardinal_direction & direction_to_turf)
+				turf_list += get_step(current_turf, cardinal_direction)
+
+	turf_list -= get_turf(source)
+	turf_list -= get_turf(target)
+
+	return turf_list
 
 /datum/ai_behavior/basic_ranged_attack/avoid_friendly_fire
 	avoid_friendly_fire = TRUE

--- a/code/modules/mob/living/basic/minebots/minebot_ai.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_ai.dm
@@ -64,6 +64,7 @@
 
 /datum/ai_behavior/basic_ranged_attack/minebot
 	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
+	avoid_friendly_fire = TRUE
 
 /datum/ai_planning_subtree/basic_ranged_attack_subtree/minebot/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	var/mob/living/living_pawn = controller.pawn

--- a/code/modules/mob/living/basic/minebots/minebot_ai.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_ai.dm
@@ -63,7 +63,6 @@
 	ranged_attack_behavior = /datum/ai_behavior/basic_ranged_attack/minebot
 
 /datum/ai_behavior/basic_ranged_attack/minebot
-	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
 	avoid_friendly_fire = TRUE
 
 /datum/ai_planning_subtree/basic_ranged_attack_subtree/minebot/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)

--- a/code/modules/mob/living/basic/minebots/minebot_ai.dm
+++ b/code/modules/mob/living/basic/minebots/minebot_ai.dm
@@ -63,7 +63,7 @@
 	ranged_attack_behavior = /datum/ai_behavior/basic_ranged_attack/minebot
 
 /datum/ai_behavior/basic_ranged_attack/minebot
-	avoid_friendly_fire = TRUE
+	behavior_flags = AI_BEHAVIOR_REQUIRE_MOVEMENT
 
 /datum/ai_planning_subtree/basic_ranged_attack_subtree/minebot/SelectBehaviors(datum/ai_controller/controller, seconds_per_tick)
 	var/mob/living/living_pawn = controller.pawn

--- a/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_behavior.dm
+++ b/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_behavior.dm
@@ -64,6 +64,8 @@
 
 /datum/ai_behavior/basic_ranged_attack/hivebot
 	action_cooldown = 3 SECONDS
+	avoid_friendly_fire = TRUE
 
 /datum/ai_behavior/basic_ranged_attack/hivebot_rapid
 	action_cooldown = 1.5 SECONDS
+	avoid_friendly_fire = TRUE

--- a/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_subtree.dm
+++ b/code/modules/mob/living/basic/space_fauna/hivebot/hivebot_subtree.dm
@@ -32,7 +32,7 @@
 /datum/ai_controller/basic_controller/hivebot/ranged/rapid
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/simple_find_target,
-		/datum/ai_planning_subtree/basic_ranged_attack_subtree,
+		/datum/ai_planning_subtree/basic_ranged_attack_subtree/hivebot_rapid,
 		/datum/ai_planning_subtree/attack_obstacle_in_path,
 		/datum/ai_planning_subtree/hive_communicate,
 	)


### PR DESCRIPTION
## About The Pull Request
basic mobs can check for friends in the way before firing a attack. if they find someone in the way they will try to adjust their position so their friends dont get hit by the projectiles


## Why It's Good For The Game
nice optional feature people can put on the monsters they create

## Changelog
:cl:
add: added ranged attack friendly fire checks for basic mobs. minebots and hivebots will now try to avoid shooting their friends
/:cl:
