### PR TITLE
Fix butchered and gibbed mobs to transfer reagents and diseases to meat

### DIFF
--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -167,7 +167,7 @@
 	butcher_callback?.Invoke(butcher, target)
 	target.harvest(butcher)
 	target.log_message("has been butchered by [key_name(butcher)]", LOG_ATTACK)
-	target.gib(FALSE, FALSE, TRUE)
+	target.gib(no_bodyparts = TRUE)
 
 ///Enables the butchering mechanic for the mob who has equipped us.
 /datum/component/butchering/proc/enable_butchering(datum/source)

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -106,35 +106,41 @@
 	var/turf/location = target.drop_location()
 	var/final_effectiveness = effectiveness - target.butcher_difficulty
 	var/bonus_chance = max(0, (final_effectiveness - 100) + bonus_modifier) //so 125 total effectiveness = 25% extra chance
-	for(var/V in target.butcher_results)
-		var/obj/bones = V
-		var/amount = target.butcher_results[bones]
+
+	for(var/obj/remains in target.butcher_results)
+		var/amount = target.butcher_results[remains]
 		for(var/_i in 1 to amount)
 			if(!prob(final_effectiveness))
 				if(butcher)
-					to_chat(butcher, span_warning("You fail to harvest some of the [initial(bones.name)] from [target]."))
+					to_chat(butcher, span_warning("You fail to harvest some of the [initial(remains.name)] from [target]."))
 				continue
 
 			if(prob(bonus_chance))
 				if(butcher)
-					to_chat(butcher, span_info("You harvest some extra [initial(bones.name)] from [target]!"))
-				results += new bones (location)
-			results += new bones (location)
+					to_chat(butcher, span_info("You harvest some extra [initial(remains.name)] from [target]!"))
+				results += new remains (location)
+			results += new remains (location)
 
-		target.butcher_results.Remove(bones) //in case you want to, say, have it drop its results on gib
+		target.butcher_results.Remove(remains) //in case you want to, say, have it drop its results on gib
 
-	for(var/V in target.guaranteed_butcher_results)
-		var/obj/sinew = V
-		var/amount = target.guaranteed_butcher_results[sinew]
+	for(var/obj/guarnteed_remains in target.guaranteed_butcher_results)
+		var/amount = target.guaranteed_butcher_results[guarnteed_remains]
 		for(var/i in 1 to amount)
-			results += new sinew (location)
-		target.guaranteed_butcher_results.Remove(sinew)
+			results += new guarnteed_remains (location)
+		target.guaranteed_butcher_results.Remove(guarnteed_remains)
 
 	for(var/obj/item/carrion in results)
 		var/list/meat_mats = carrion.has_material_type(/datum/material/meat)
 		if(!length(meat_mats))
 			continue
 		carrion.set_custom_materials((carrion.custom_materials - meat_mats) + list(GET_MATERIAL_REF(/datum/material/meat/mob_meat, target) = counterlist_sum(meat_mats)))
+
+	if(target.reagents)
+		var/meat_produced = 0
+		for(var/obj/item/food/meat/slab/target_meat in results)
+			meat_produced += 1
+		for(var/obj/item/food/meat/slab/target_meat in results)
+			target.reagents.trans_to(target_meat, target.reagents.total_volume / meat_produced, remove_blacklisted = TRUE)
 
 	if(butcher)
 		butcher.visible_message(span_notice("[butcher] butchers [target]."), \

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -99,50 +99,50 @@
  *
  * Arguments:
  * - [butcher][/mob/living]: The mob doing the butchering
- * - [meat][/mob/living]: The mob being butchered
+ * - [target][/mob/living]: The mob being butchered
  */
-/datum/component/butchering/proc/on_butchering(atom/butcher, mob/living/meat)
+/datum/component/butchering/proc/on_butchering(atom/butcher, mob/living/target)
 	var/list/results = list()
-	var/turf/T = meat.drop_location()
-	var/final_effectiveness = effectiveness - meat.butcher_difficulty
+	var/turf/location = target.drop_location()
+	var/final_effectiveness = effectiveness - target.butcher_difficulty
 	var/bonus_chance = max(0, (final_effectiveness - 100) + bonus_modifier) //so 125 total effectiveness = 25% extra chance
-	for(var/V in meat.butcher_results)
+	for(var/V in target.butcher_results)
 		var/obj/bones = V
-		var/amount = meat.butcher_results[bones]
+		var/amount = target.butcher_results[bones]
 		for(var/_i in 1 to amount)
 			if(!prob(final_effectiveness))
 				if(butcher)
-					to_chat(butcher, span_warning("You fail to harvest some of the [initial(bones.name)] from [meat]."))
+					to_chat(butcher, span_warning("You fail to harvest some of the [initial(bones.name)] from [target]."))
 				continue
 
 			if(prob(bonus_chance))
 				if(butcher)
-					to_chat(butcher, span_info("You harvest some extra [initial(bones.name)] from [meat]!"))
-				results += new bones (T)
-			results += new bones (T)
+					to_chat(butcher, span_info("You harvest some extra [initial(bones.name)] from [target]!"))
+				results += new bones (location)
+			results += new bones (location)
 
-		meat.butcher_results.Remove(bones) //in case you want to, say, have it drop its results on gib
+		target.butcher_results.Remove(bones) //in case you want to, say, have it drop its results on gib
 
-	for(var/V in meat.guaranteed_butcher_results)
+	for(var/V in target.guaranteed_butcher_results)
 		var/obj/sinew = V
-		var/amount = meat.guaranteed_butcher_results[sinew]
+		var/amount = target.guaranteed_butcher_results[sinew]
 		for(var/i in 1 to amount)
-			results += new sinew (T)
-		meat.guaranteed_butcher_results.Remove(sinew)
+			results += new sinew (location)
+		target.guaranteed_butcher_results.Remove(sinew)
 
 	for(var/obj/item/carrion in results)
 		var/list/meat_mats = carrion.has_material_type(/datum/material/meat)
 		if(!length(meat_mats))
 			continue
-		carrion.set_custom_materials((carrion.custom_materials - meat_mats) + list(GET_MATERIAL_REF(/datum/material/meat/mob_meat, meat) = counterlist_sum(meat_mats)))
+		carrion.set_custom_materials((carrion.custom_materials - meat_mats) + list(GET_MATERIAL_REF(/datum/material/meat/mob_meat, target) = counterlist_sum(meat_mats)))
 
 	if(butcher)
-		butcher.visible_message(span_notice("[butcher] butchers [meat]."), \
-								span_notice("You butcher [meat]."))
-	butcher_callback?.Invoke(butcher, meat)
-	meat.harvest(butcher)
-	meat.log_message("has been butchered by [key_name(butcher)]", LOG_ATTACK)
-	meat.gib(FALSE, FALSE, TRUE)
+		butcher.visible_message(span_notice("[butcher] butchers [target]."), \
+								span_notice("You butcher [target]."))
+	butcher_callback?.Invoke(butcher, target)
+	target.harvest(butcher)
+	target.log_message("has been butchered by [key_name(butcher)]", LOG_ATTACK)
+	target.gib(FALSE, FALSE, TRUE)
 
 ///Enables the butchering mechanic for the mob who has equipped us.
 /datum/component/butchering/proc/enable_butchering(datum/source)
@@ -207,9 +207,9 @@
 	))
 
 ///When we are ready to drill through a mob
-/datum/component/butchering/mecha/proc/on_drill(datum/source, obj/vehicle/sealed/mecha/chassis, mob/living/meat)
+/datum/component/butchering/mecha/proc/on_drill(datum/source, obj/vehicle/sealed/mecha/chassis, mob/living/target)
 	SIGNAL_HANDLER
-	INVOKE_ASYNC(src, PROC_REF(on_butchering), chassis, meat)
+	INVOKE_ASYNC(src, PROC_REF(on_butchering), chassis, target)
 
 /datum/component/butchering/wearable
 

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -163,7 +163,7 @@
 
 	if(butcher)
 		butcher.visible_message(span_notice("[butcher] butchers [target]."), \
-								span_notice("You butcher [target]."))
+			span_notice("You butcher [target]."))
 	butcher_callback?.Invoke(butcher, target)
 	target.harvest(butcher)
 	target.log_message("has been butchered by [key_name(butcher)]", LOG_ATTACK)

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -107,7 +107,8 @@
 	var/final_effectiveness = effectiveness - target.butcher_difficulty
 	var/bonus_chance = max(0, (final_effectiveness - 100) + bonus_modifier) //so 125 total effectiveness = 25% extra chance
 
-	for(var/obj/remains in target.butcher_results)
+	for(var/result_typepath in target.butcher_results)
+		var/obj/remains = result_typepath
 		var/amount = target.butcher_results[remains]
 		for(var/_i in 1 to amount)
 			if(!prob(final_effectiveness))
@@ -123,7 +124,8 @@
 
 		target.butcher_results.Remove(remains) //in case you want to, say, have it drop its results on gib
 
-	for(var/obj/guarnteed_remains in target.guaranteed_butcher_results)
+	for(var/guaranteed_result_typepath in target.guaranteed_butcher_results)
+		var/obj/guaranteed_remains = guaranteed_result_typepath
 		var/amount = target.guaranteed_butcher_results[guarnteed_remains]
 		for(var/i in 1 to amount)
 			results += new guarnteed_remains (location)

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -137,12 +137,29 @@
 			continue
 		carrion.set_custom_materials((carrion.custom_materials - meat_mats) + list(GET_MATERIAL_REF(/datum/material/meat/mob_meat, target) = counterlist_sum(meat_mats)))
 
+	// transfer delicious reagents to meat
 	if(target.reagents)
 		var/meat_produced = 0
 		for(var/obj/item/food/meat/slab/target_meat in results)
 			meat_produced += 1
 		for(var/obj/item/food/meat/slab/target_meat in results)
 			target.reagents.trans_to(target_meat, target.reagents.total_volume / meat_produced, remove_blacklisted = TRUE)
+
+	// dont forget yummy diseases either!
+	if(iscarbon(target))
+		var/mob/living/carbon/host_target = target
+		var/list/diseases = host_target.get_static_viruses()
+		if(LAZYLEN(diseases))
+			var/list/datum/disease/diseases_to_add = list()
+			for(var/datum/disease/disease as anything in diseases)
+				// admin or special viruses that should not be reproduced
+				if(disease.spread_flags & (DISEASE_SPREAD_SPECIAL | DISEASE_SPREAD_NON_CONTAGIOUS))
+					continue
+
+				diseases_to_add += disease
+			if(LAZYLEN(diseases_to_add))
+				for(var/obj/diseased_remains in results)
+					diseased_remains.AddComponent(/datum/component/infective, diseases_to_add)
 
 	if(butcher)
 		butcher.visible_message(span_notice("[butcher] butchers [target]."), \

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -167,7 +167,7 @@
 	butcher_callback?.Invoke(butcher, target)
 	target.harvest(butcher)
 	target.log_message("has been butchered by [key_name(butcher)]", LOG_ATTACK)
-	target.gib(no_bodyparts = TRUE)
+	target.gib(FALSE, FALSE, TRUE)
 
 ///Enables the butchering mechanic for the mob who has equipped us.
 /datum/component/butchering/proc/enable_butchering(datum/source)

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -126,10 +126,10 @@
 
 	for(var/guaranteed_result_typepath in target.guaranteed_butcher_results)
 		var/obj/guaranteed_remains = guaranteed_result_typepath
-		var/amount = target.guaranteed_butcher_results[guarnteed_remains]
+		var/amount = target.guaranteed_butcher_results[guaranteed_remains]
 		for(var/i in 1 to amount)
-			results += new guarnteed_remains (location)
-		target.guaranteed_butcher_results.Remove(guarnteed_remains)
+			results += new guaranteed_remains (location)
+		target.guaranteed_butcher_results.Remove(guaranteed_remains)
 
 	for(var/obj/item/carrion in results)
 		var/list/meat_mats = carrion.has_material_type(/datum/material/meat)

--- a/code/modules/food_and_drinks/machinery/gibber.dm
+++ b/code/modules/food_and_drinks/machinery/gibber.dm
@@ -199,20 +199,6 @@
 			if(sourcejob)
 				newmeat.subjectjob = sourcejob
 
-			if(iscarbon(occupant))
-				var/mob/living/carbon/host_target = occupant
-				var/list/diseases = host_target.get_static_viruses()
-				if(LAZYLEN(diseases))
-					var/list/datum/disease/diseases_to_add = list()
-					for(var/datum/disease/disease as anything in diseases)
-						// admin or special viruses that should not be reproduced
-						if(disease.spread_flags & (DISEASE_SPREAD_SPECIAL | DISEASE_SPREAD_NON_CONTAGIOUS))
-							continue
-
-						diseases_to_add += disease
-					if(LAZYLEN(diseases_to_add))
-						newmeat.AddComponent(/datum/component/infective, diseases_to_add)
-
 		allmeat[i] = newmeat
 
 	if(typeofskin)
@@ -236,12 +222,24 @@
 		skin.throw_at(pick(nearby_turfs),meat_produced,3)
 	for (var/i=1 to meat_produced)
 		var/obj/item/meatslab = allmeat[i]
+
+		if(LAZYLEN(diseases))
+			var/list/datum/disease/diseases_to_add = list()
+			for(var/datum/disease/disease as anything in diseases)
+				// admin or special viruses that should not be reproduced
+				if(disease.spread_flags & (DISEASE_SPREAD_SPECIAL | DISEASE_SPREAD_NON_CONTAGIOUS))
+					continue
+
+				diseases_to_add += disease
+			if(LAZYLEN(diseases_to_add))
+				meatslab.AddComponent(/datum/component/infective, diseases_to_add)
+
 		meatslab.forceMove(loc)
 		meatslab.throw_at(pick(nearby_turfs),i,3)
 		for (var/turfs=1 to meat_produced)
 			var/turf/gibturf = pick(nearby_turfs)
 			if (!gibturf.density && (src in view(gibturf)))
-				new gibtype(gibturf,i,diseases)
+				new gibtype(gibturf, i, diseases)
 
 	pixel_x = base_pixel_x //return to its spot after shaking
 	operating = FALSE

--- a/code/modules/food_and_drinks/machinery/gibber.dm
+++ b/code/modules/food_and_drinks/machinery/gibber.dm
@@ -198,6 +198,21 @@
 				occupant.reagents.trans_to(newmeat, occupant_volume / meat_produced, remove_blacklisted = TRUE)
 			if(sourcejob)
 				newmeat.subjectjob = sourcejob
+
+			if(iscarbon(occupant))
+				var/mob/living/carbon/host_target = occupant
+				var/list/diseases = host_target.get_static_viruses()
+				if(LAZYLEN(diseases))
+					var/list/datum/disease/diseases_to_add = list()
+					for(var/datum/disease/disease as anything in diseases)
+						// admin or special viruses that should not be reproduced
+						if(disease.spread_flags & (DISEASE_SPREAD_SPECIAL | DISEASE_SPREAD_NON_CONTAGIOUS))
+							continue
+
+						diseases_to_add += disease
+					if(LAZYLEN(diseases_to_add))
+						newmeat.AddComponent(/datum/component/infective, diseases_to_add)
+
 		allmeat[i] = newmeat
 
 	if(typeofskin)


### PR DESCRIPTION

## About The Pull Request
Fixes #78386
Fixes #60352

Butchering monkey meat or gibbing mobs will now properly transfer all reagents and diseases to the byproducts.

## Why It's Good For The Game
More realism is nice.

## Changelog
:cl:
fix: Fix butchered monkeys to transfer reagents and diseases to meat
/:cl:
