### PR TITLE
clown bomb payload is now properly named and somewhat better summon payload dispersion

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -395,7 +395,7 @@ GLOBAL_LIST_EMPTY(species_list)
 				step_count = rand(1, max_walk)
 
 			for(var/i in 1 to step_count)
-				step(X, cardinals_only ? pick(NORTH, SOUTH, EAST, WEST) : pick(NORTH, SOUTH, EAST, WEST, NORTHWEST, NORTHEAST, SOUTHEAST, SOUTHWEST))
+				step(X, cardinals_only ? pick(GLOB.cardinals) : pick(GLOB.alldirs))
 
 	return spawned_mobs
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -366,7 +366,7 @@ GLOBAL_LIST_EMPTY(species_list)
 			X.flags_1 |= ADMIN_SPAWNED_1
 	return X //return the last mob spawned
 
-/proc/spawn_and_random_walk(spawn_type, target, amount, walk_chance=100, max_walk=3, always_max_walk=FALSE, admin_spawn=FALSE)
+/proc/spawn_and_random_walk(spawn_type, target, amount, walk_chance=100, max_walk=3, always_max_walk=FALSE, admin_spawn=FALSE, cardinals_only = TRUE)
 	var/turf/T = get_turf(target)
 	var/step_count = 0
 	if(!T)
@@ -395,7 +395,7 @@ GLOBAL_LIST_EMPTY(species_list)
 				step_count = rand(1, max_walk)
 
 			for(var/i in 1 to step_count)
-				step(X, pick(NORTH, SOUTH, EAST, WEST))
+				step(X, cardinals_only ? pick(NORTH, SOUTH, EAST, WEST) : pick(NORTH, SOUTH, EAST, WEST, NORTHWEST, NORTHEAST, SOUTHEAST, SOUTHWEST))
 
 	return spawned_mobs
 

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -409,11 +409,13 @@
 
 /obj/item/bombcore/badmin/summon/detonate()
 	var/obj/machinery/syndicatebomb/B = loc
-	spawn_and_random_walk(summon_path, src, amt_summon, walk_chance=50, admin_spawn=TRUE)
+	spawn_and_random_walk(summon_path, src, amt_summon, walk_chance=50, admin_spawn=TRUE, cardinals_only = FALSE)
 	qdel(B)
 	qdel(src)
 
 /obj/item/bombcore/badmin/summon/clown
+	name = "bananium payload"
+	desc = "Clowns delivered fast and cheap!"
 	summon_path = /mob/living/simple_animal/hostile/retaliate/clown
 	amt_summon = 50
 


### PR DESCRIPTION

## About The Pull Request

renamed clown bomb payloads and gave them a description so they arent just "badmin payload"

also spawn_and_random_walk now has an option to walk in diagonals too

## Why It's Good For The Game

![2023-09-20 06_54_12-Window](https://github.com/tgstation/tgstation/assets/70376633/077497c5-9f32-4e5f-af1b-51a2ade890f8)


## Changelog
:cl:
fix: clown bomb payload is no longer named badmin payload and no longer disperses clowns in cardinal directions only
/:cl:
