### PR TITLE
LINDA runtime fix

### DIFF
--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -955,8 +955,8 @@ GLOBAL_LIST_EMPTY(map_model_default)
 			instance = create_atom(members[index], crds)//first preloader pass
 		else
 			instance = crds.ChangeTurf(members[index], null, CHANGETURF_DEFER_CHANGE)
-			var/turf/instanced_turf = instance
-			instanced_turf.immediate_calculate_adjacent_turfs()
+		var/turf/instanced_turf = instance
+		instanced_turf.immediate_calculate_adjacent_turfs()
 		if(GLOB.use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 			world.preloader_load(instance)
 	// If this isn't template work, we didn't change our turf and we changed area, then we've gotta handle area lighting transfer

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -955,7 +955,8 @@ GLOBAL_LIST_EMPTY(map_model_default)
 			instance = create_atom(members[index], crds)//first preloader pass
 		else
 			instance = crds.ChangeTurf(members[index], null, CHANGETURF_DEFER_CHANGE)
-
+			var/turf/instanced_turf = instance
+        	instanced_turf.immediate_calculate_adjacent_turfs()
 		if(GLOB.use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 			world.preloader_load(instance)
 	// If this isn't template work, we didn't change our turf and we changed area, then we've gotta handle area lighting transfer

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -956,7 +956,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 		else
 			instance = crds.ChangeTurf(members[index], null, CHANGETURF_DEFER_CHANGE)
 			var/turf/instanced_turf = instance
-        	instanced_turf.immediate_calculate_adjacent_turfs()
+			instanced_turf.immediate_calculate_adjacent_turfs()
 		if(GLOB.use_preloader && instance)//second preloader pass, for those atoms that don't ..() in New()
 			world.preloader_load(instance)
 	// If this isn't template work, we didn't change our turf and we changed area, then we've gotta handle area lighting transfer


### PR DESCRIPTION

## About The Pull Request
Encountered an issue with unit tests where LINDA was throwing the following runtime error:
```
    FAILURE #1: [20:11:50] Runtime in LINDA_turf_tile.dm,281: Cannot execute null.archive().
    proc name: process cell (/turf/open/process_cell)
    src: space (67,25,12) (/turf/open/space)
```

@ZephyrTFA said this was related to atmos processing on maps that are still loading in,
and this was the fix
## Why It's Good For The Game
Bug fixes
## Changelog
N/A Not player facing
