### PR TITLE
Tweak greyscale JSON test error message

### DIFF
--- a/code/modules/unit_tests/greyscale_config.dm
+++ b/code/modules/unit_tests/greyscale_config.dm
@@ -38,4 +38,4 @@
 			continue
 		var/number_of_colors = length(colors) - 1
 		if(config.expected_colors != number_of_colors)
-			TEST_FAIL("[thing] has the wrong amount of colors configured for [config.DebugName()]. Expected [config.expected_colors] but only found [number_of_colors].")
+			TEST_FAIL("[thing] has the wrong amount of colors configured for [config.DebugName()]. Expected [config.expected_colors] colors but found [number_of_colors].")


### PR DESCRIPTION
## About The Pull Request

Slightly changes the wording of the greyscale JSON check error.

The previous creates messages such as "Expected 1 but only found 3." which implies it isn't finding enough, which isn't always the case.

## Changelog

:cl: LT3
spellcheck: Improved wording in greyscale JSON error message
/:cl: