### PR TITLE
Fixes a runtime in seed extractor when seeds do not have a product

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -37,7 +37,7 @@
 	plant_icon_offset = 2
 	species = "replicapod"
 	plantname = "Replica Pod"
-	product = /mob/living/carbon/human //verrry special -- Urist
+	product = null // the human mob is spawned in harvest()
 	lifespan = 50
 	endurance = 8
 	maturation = 10

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -179,9 +179,9 @@
 /obj/machinery/seed_extractor/proc/add_seed(obj/item/seeds/to_add, atom/taking_from)
 	var/seed_id = generate_seed_hash(to_add)
 	var/list/seed_data
-	var/add_ref // so we remember to do this last, in case for some reason we fail to take the seeds into the machine
+	var/has_seed_data // so we remember to add a seed obj weakref to piles[seed_id] at the end of the proc. That way if some reason we runtime in this proc it won't incorrectly add data to the list
 	if(piles[seed_id])
-		add_ref = TRUE
+		has_seed_data = TRUE
 	else
 		seed_data = list()
 		seed_data["icon"] = sanitize_css_class_name("[initial(to_add.icon)][initial(to_add.icon_state)]")
@@ -231,7 +231,7 @@
 		to_add.forceMove(src)
 
 	// do this at the end, in case any of the previous steps failed
-	if(add_ref)
+	if(has_seed_data)
 		piles[seed_id]["refs"] += WEAKREF(to_add)
 	else
 		piles[seed_id] = seed_data

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -207,9 +207,8 @@
 		seed_data["mutatelist"] = list()
 		for(var/obj/item/seeds/mutant as anything in to_add.mutatelist)
 			seed_data["mutatelist"] += initial(mutant.plantname)
-		var/obj/item/food/grown/product_path = to_add.product
-		if(product_path)
-			var/obj/item/food/grown/product = new product_path
+		if(to_add.product)
+			var/obj/item/food/grown/product = new to_add.product
 			var/datum/reagent/product_distill_reagent = product.distill_reagent
 			seed_data["distill_reagent"] = initial(product_distill_reagent.name)
 			var/datum/reagent/product_juice_typepath = product.juice_typepath

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -185,8 +185,6 @@
 
 		else if(!taking_from.atom_storage?.attempt_remove(to_add, src, silent = TRUE))
 			return FALSE
-	else
-		to_add.forceMove(src)
 
 	var/seed_id = generate_seed_hash(to_add)
 	if(piles[seed_id])
@@ -216,8 +214,9 @@
 		seed_data["mutatelist"] = list()
 		for(var/obj/item/seeds/mutant as anything in to_add.mutatelist)
 			seed_data["mutatelist"] += initial(mutant.plantname)
-		var/obj/item/food/grown/product = new to_add.product
-		if(product)
+		var/obj/item/food/grown/product_path = to_add.product
+		if(product_path)
+			var/obj/item/food/grown/product = new product_path
 			var/datum/reagent/product_distill_reagent = product.distill_reagent
 			seed_data["distill_reagent"] = initial(product_distill_reagent.name)
 			var/datum/reagent/product_juice_typepath = product.juice_typepath
@@ -225,8 +224,11 @@
 			seed_data["grind_results"] = list()
 			for(var/datum/reagent/reagent as anything in product.grind_results)
 				seed_data["grind_results"] += initial(reagent.name)
-		qdel(product)
+			qdel(product)
 		piles[seed_id] = seed_data
+
+	to_add.forceMove(src)
+
 	return TRUE
 
 /obj/machinery/seed_extractor/ui_state(mob/user)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Skyrat-SS13/Skyrat-tg/issues/23819

I don't know whether or not this started before or after the foodening but there were some logic errors in the seed extractor code.

1) Moved the logic around so that seeds will no longer get eaten by the seed extractor if the `add_seed` proc returned false or null. It shouldn't have been doing this to begin with.

2) Fixed a runtime that would cause `add_seed` to return null with a runtime every time you tried to insert a seed without a `product`. (ex: starthistle). This would in turn cause the seeds to be snatched from the user's hand and put into the machine, making them essentially deleted.

## Why It's Good For The Game

Fixes more botany bugs. Yay...

Makes the seed extractor code a bit more robust as well.

<details><summary>Starthistle can be added</summary>

![image](https://github.com/tgstation/tgstation/assets/13398309/56e9b78a-08ca-4c67-8220-27974e242320)

</details>

<details><summary>Now let's try to get it to runtime and see what happens</summary>

![dreamseeker_39LhTUCtWg](https://github.com/tgstation/tgstation/assets/13398309/83b20964-c2d4-4376-8ab5-86a8e430dafe)

![dreamseeker_eInEB47vPU](https://github.com/tgstation/tgstation/assets/13398309/384eab51-ef3a-4ae1-9cc7-c418e2aaf56b)

Yep. Still holding the seeds.

</details>

## Changelog

:cl:
fix: Seeds will no longer be removed from existence after receiving the "You can't seem to add [seed type] to the seed extractor" message
fix: Some seeds that were previously not able to be added to the seed extractor may now be added (starthistle for example)
fix: fixes replica pod seeds spawning humans in nullspace
/:cl:

edit: Includes the replica pod seed fix from https://github.com/tgstation/tgstation/pull/78628 at the request of Timothymtorres
