### PR TITLE
Fixes Intellicards in computers being deleted when the computer is destroyed

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -150,6 +150,7 @@
 	close_all_programs()
 	//Some components will actually try and interact with this, so let's do it later
 	QDEL_NULL(soundloop)
+	looping_sound = FALSE // Necessary to stop a possible runtime trying to call soundloop.stop() when soundloop has been qdel'd
 	QDEL_LIST(stored_files)
 
 	if(istype(inserted_disk))
@@ -802,14 +803,8 @@
 /obj/item/modular_computer/wrench_act_secondary(mob/living/user, obj/item/tool)
 	. = ..()
 	tool.play_tool_sound(src, user, 20, volume=20)
-	internal_cell?.forceMove(drop_location())
-	computer_id_slot?.forceMove(drop_location())
-	inserted_disk?.forceMove(drop_location())
-	remove_pai()
-	new /obj/item/stack/sheet/iron(get_turf(loc), steel_sheet_cost)
+	deconstruct(TRUE)
 	user.balloon_alert(user, "disassembled")
-	relay_qdel()
-	qdel(src)
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/modular_computer/welder_act(mob/living/user, obj/item/tool)
@@ -830,15 +825,26 @@
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/modular_computer/deconstruct(disassembled = TRUE)
-	break_apart()
+	remove_pai()
+	eject_aicard()
+	if(!(flags_1 & NODECONSTRUCT_1))
+		if (disassembled)
+			internal_cell?.forceMove(drop_location())
+			computer_id_slot?.forceMove(drop_location())
+			inserted_disk?.forceMove(drop_location())
+			new /obj/item/stack/sheet/iron(drop_location(), steel_sheet_cost)
+		else
+			physical.visible_message(span_notice("\The [src] breaks apart!"))
+			new /obj/item/stack/sheet/iron(drop_location(), round(steel_sheet_cost / 2))
+	relay_qdel()
 	return ..()
 
-/obj/item/modular_computer/proc/break_apart()
-	if(!(flags_1 & NODECONSTRUCT_1))
-		physical.visible_message(span_notice("\The [src] breaks apart!"))
-		var/turf/newloc = get_turf(src)
-		new /obj/item/stack/sheet/iron(newloc, round(steel_sheet_cost / 2))
-	relay_qdel()
+// Ejects the inserted intellicard, if one exists. Used when the computer is deconstructed.
+/obj/item/modular_computer/proc/eject_aicard()
+	var/datum/computer_file/program/ai_restorer/program = locate() in stored_files
+	if (program)
+		return program.try_eject(forced = TRUE)
+	return FALSE
 
 // Used by processor to relay qdel() to machinery type.
 /obj/item/modular_computer/proc/relay_qdel()

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -835,7 +835,7 @@
 			new /obj/item/stack/sheet/iron(drop_location(), steel_sheet_cost)
 		else
 			physical.visible_message(span_notice("\The [src] breaks apart!"))
-			new /obj/item/stack/sheet/iron(drop_location(), round(steel_sheet_cost / 2))
+			new /obj/item/stack/sheet/iron(drop_location(), round(steel_sheet_cost * 0.5))
 	relay_qdel()
 	return ..()
 

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -125,9 +125,9 @@
 		return cpu.screwdriver_act(user, tool)
 	return ..()
 
-/obj/machinery/modular_computer/wrench_act(mob/user, obj/item/tool)
+/obj/machinery/modular_computer/wrench_act_secondary(mob/user, obj/item/tool)
 	if(cpu)
-		return cpu.wrench_act(user, tool)
+		return cpu.wrench_act_secondary(user, tool)
 	return ..()
 
 /obj/machinery/modular_computer/welder_act(mob/user, obj/item/tool)

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -30,10 +30,6 @@
 	examine_text += span_info("Alt-click to eject the intelliCard.")
 	return examine_text
 
-/datum/computer_file/program/ai_restorer/Destroy(force)
-	if (stored_card) // The linter yells at me if I try to call try_eject here, so we have to do this instead
-		stored_card.forceMove(computer.drop_location())
-	return ..()
 
 /datum/computer_file/program/ai_restorer/kill_program(mob/user)
 	try_eject(forced = TRUE)

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -30,6 +30,11 @@
 	examine_text += span_info("Alt-click to eject the intelliCard.")
 	return examine_text
 
+/datum/computer_file/program/ai_restorer/Destroy(force)
+	if (stored_card) // The linter yells at me if I try to call try_eject here, so we have to do this instead
+		stored_card.forceMove(computer.drop_location())
+	return ..()
+
 /datum/computer_file/program/ai_restorer/kill_program(mob/user)
 	try_eject(forced = TRUE)
 	return ..()

--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -30,7 +30,6 @@
 	examine_text += span_info("Alt-click to eject the intelliCard.")
 	return examine_text
 
-
 /datum/computer_file/program/ai_restorer/kill_program(mob/user)
 	try_eject(forced = TRUE)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

As described in #78467, if an Intellicard is inserted into a laptop or stationary modular computer, and said computer is destroyed, then the Intellicard (as well as any AI on it) is instantly deleted. This PR makes the Intellicard get dropped instead. Closes #78467.
## Why It's Good For The Game

Bugs are bad.
## Changelog
:cl:
fix: Intellicards in computers are no longer deleted when the computer is destroyed.
fix: Modular consoles can now be deconstructed by right clicking with a wrench.
/:cl:
