### PR TITLE
[NO GBP] Fixes conveyor belt runtimes from screentips

### DIFF
--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -58,10 +58,10 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	if(istype(held_item, /obj/item/stack/conveyor))
 		context[SCREENTIP_CONTEXT_LMB] = "Extend current conveyor belt"
 		return CONTEXTUAL_SCREENTIP_SET
-	if(held_item.tool_behaviour == TOOL_WRENCH)
+	if(held_item?.tool_behaviour == TOOL_WRENCH)
 		context[SCREENTIP_CONTEXT_LMB] = "Rotate conveyor belt"
 		return CONTEXTUAL_SCREENTIP_SET
-	if(held_item.tool_behaviour == TOOL_SCREWDRIVER)
+	if(held_item?.tool_behaviour == TOOL_SCREWDRIVER)
 		context[SCREENTIP_CONTEXT_LMB] = "Invert conveyor belt"
 		context[SCREENTIP_CONTEXT_RMB] = "Flip conveyor belt"
 		return CONTEXTUAL_SCREENTIP_SET


### PR DESCRIPTION

## About The Pull Request

In #78278 it looks like I missed confirming for `tool_behavior` when mousing over on screentips, causing them to throw runtimes when not holding the correct tool. Oops. This corrects that, now properly providing screentips based on wrench and screwdriver mouseover.

## Why It's Good For The Game

Runtimes bad. 🐛 💥 

## Changelog

:cl:
fix: Conveyor belts now properly show their new screentips on mouseover with tools.
/:cl:
