### PR TITLE
Fixed several Foodening taste issues.

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -160,9 +160,10 @@ GLOBAL_LIST_INIT(food_buffs, list(
 ))
 
 /// Food quality change according to species diet
-#define TOXIC_FOOD_QUALITY_CHANGE -4
 #define DISLIKED_FOOD_QUALITY_CHANGE -2
 #define LIKED_FOOD_QUALITY_CHANGE 2
+/// Threshold for food to give a toxic reaction
+#define TOXIC_FOOD_QUALITY_THRESHOLD -4
 
 /// Food is "in a container", not in a code sense, but in a literal sense (canned foods)
 #define FOOD_IN_CONTAINER (1<<0)

--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -163,7 +163,7 @@ GLOBAL_LIST_INIT(food_buffs, list(
 #define DISLIKED_FOOD_QUALITY_CHANGE -2
 #define LIKED_FOOD_QUALITY_CHANGE 2
 /// Threshold for food to give a toxic reaction
-#define TOXIC_FOOD_QUALITY_THRESHOLD -4
+#define TOXIC_FOOD_QUALITY_THRESHOLD -8
 
 /// Food is "in a container", not in a code sense, but in a literal sense (canned foods)
 #define FOOD_IN_CONTAINER (1<<0)

--- a/code/game/objects/items/food/donuts.dm
+++ b/code/game/objects/items/food/donuts.dm
@@ -44,7 +44,7 @@
 	return "[icon_state]_inbox"
 
 ///Override for checkliked in edible component, because all cops LOVE donuts
-/obj/item/food/donut/proc/check_liked(fraction, mob/living/carbon/human/consumer)
+/obj/item/food/donut/proc/check_liked(mob/living/carbon/human/consumer)
 	var/obj/item/organ/internal/liver/liver = consumer.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(!HAS_TRAIT(consumer, TRAIT_AGEUSIA) && liver && HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		return FOOD_LIKED

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -491,7 +491,7 @@
 	. = ..()
 	AddComponent(/datum/component/edible, check_liked = CALLBACK(src, PROC_REF(check_liked)))
 
-/obj/item/food/pickle/proc/check_liked(fraction, mob/living/carbon/human/consumer)
+/obj/item/food/pickle/proc/check_liked(mob/living/carbon/human/consumer)
 	var/obj/item/organ/internal/liver/liver = consumer.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(!HAS_TRAIT(consumer, TRAIT_AGEUSIA) && liver && HAS_TRAIT(liver, TRAIT_CORONER_METABOLISM))
 		return FOOD_LIKED

--- a/code/game/objects/items/food/packaged.dm
+++ b/code/game/objects/items/food/packaged.dm
@@ -315,5 +315,5 @@
 	. = ..()
 	AddComponent(/datum/component/edible, check_liked = CALLBACK(src, PROC_REF(check_liked)))
 
-/obj/item/food/rationpack/proc/check_liked(fraction, mob/mob) //Nobody likes rationpacks. Nobody.
+/obj/item/food/rationpack/proc/check_liked(mob/mob) //Nobody likes rationpacks. Nobody.
 	return FOOD_DISLIKED

--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -265,7 +265,7 @@
 	AddComponent(/datum/component/edible, check_liked = CALLBACK(src, PROC_REF(check_liked)))
 
 ///Eat it right, or you die.
-/obj/item/food/sandwich/death/proc/check_liked(fraction, mob/living/carbon/human/consumer)
+/obj/item/food/sandwich/death/proc/check_liked(mob/living/carbon/human/consumer)
 	/// Closest thing to a mullet we have
 	if(consumer.hairstyle == "Gelled Back" && istype(consumer.get_item_by_slot(ITEM_SLOT_ICLOTHING), /obj/item/clothing/under/rank/civilian/cookjorts))
 		return FOOD_LIKED

--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -264,7 +264,11 @@
 	. = ..()
 	AddComponent(/datum/component/edible, check_liked = CALLBACK(src, PROC_REF(check_liked)))
 
-///Eat it right, or you die.
+/**
+* Callback to be used with the edible component.
+* If you eat the sandwich with the right clothes and hairstyle, you like it.
+* If you don't, you contract a deadly disease.
+*/
 /obj/item/food/sandwich/death/proc/check_liked(mob/living/carbon/human/consumer)
 	/// Closest thing to a mullet we have
 	if(consumer.hairstyle == "Gelled Back" && istype(consumer.get_item_by_slot(ITEM_SLOT_ICLOTHING), /obj/item/clothing/under/rank/civilian/cookjorts))

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -39,7 +39,7 @@
 		desc += " The curve on this one looks particularly acute."
 
 ///Clowns will always like bananas.
-/obj/item/food/grown/banana/proc/check_liked(fraction, mob/living/carbon/human/consumer)
+/obj/item/food/grown/banana/proc/check_liked(mob/living/carbon/human/consumer)
 	var/obj/item/organ/internal/liver/liver = consumer.get_organ_slot(ORGAN_SLOT_LIVER)
 	if (!HAS_TRAIT(consumer, TRAIT_AGEUSIA) && liver && HAS_TRAIT(liver, TRAIT_COMEDY_METABOLISM))
 		return FOOD_LIKED

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -78,7 +78,7 @@
  * Checks whether or not the person eating the holymelon
  * is a holy_role (chaplain), as chaplains love holymelons.
  */
-/obj/item/food/grown/holymelon/proc/check_holyness(fraction, mob/mob_eating)
+/obj/item/food/grown/holymelon/proc/check_holyness(mob/mob_eating)
 	if(!ishuman(mob_eating))
 		return
 	var/mob/living/carbon/human/holy_person = mob_eating


### PR DESCRIPTION

## About The Pull Request

Fixes a number of issues with taste that arose from the Foodening:
- Foods with special `check_liked` callbacks were having these thrown out without effect. This made food with special "liked" conditions get ignored - for example, security lizards didn't like donuts anymore.
- Ageusia was completely ignored when determining taste reactions (the entire point of the quirk!).
- Foods with a toxic ingredient still gave the normal toxic reaction, but would not always show up as inedible on examine if they were very complex or had several liked foodtypes.

These issues have been fixed through a rewrite of the `get_perceived_food_quality()` proc - all relevant checks are now made within this proc rather than some coming before (and being partly discarded). 

Food quality checks take on the following hierarchy:
`silver slime toxicity > check_liked > toxic foodtypes > ageusia > liked + disliked foodtypes`

- **Silver slime toxicity** is about the same as before, except it will return a toxic result early if the eater is not a jellyperson, or increase the perceived quality by 2 if they are. 
- **check_liked** will return early with a value based on the result of the callback: -8 (toxic) if toxic, -2 (disliked) if disliked, and 2 (a nice meal) if liked. As before, these ignore all further foodtype calculations.
- **Toxic foodtypes** will return the toxic threshold if present.
- **Ageusia** will always return 0 - you can't taste anything, so if it doesn't poison you it tastes completely neutral.
- **Liked + disliked foodtypes** are how things already work - save for toxic foodtypes no longer being needlessly factored into the math.

As part of unifying two disparate sets of checks, perceived food quality of -8 or lower now gives the toxic reaction rather than the disliked one. This threshold would be incredibly difficult to reach via disliked food alone, requiring four different disliked foodtypes at once in a non-handcrafted food. This could potentially be set to a less extreme value, like -4, if you wanted disliked-enough food to act as toxic - but, as this would be a minor balance change, I haven't done that here.

Finally, as a miscellaneous change, a vestigial "fraction" field has been removed from the invocation of check_liked - this was not used, and was inconvenient for the rewritten code.
## Why It's Good For The Game

Restores several features that were lost or muddled in the Foodening, and should not have been. 

Note that, while this change generally preserves old behavior, it diverges somewhat from the _intended_ design of the Foodening. Namely, toxic foodtypes will _always_ give the toxic disgust/moodlet (unless superseded by the above hierarchy), rather than being weighed against the other foodtypes. I personally think this is fine, as I disagree with the notion that wrapping poison in nice ingredients will make them edible.
## Changelog
:cl:
fix: Foods that have special conditions for liking/disliking them (such as donuts for sec officers) have these conditions again.
fix: Characters with ageusia properly ignore non-toxic food types that they eat.
fix: If you examine toxic food, it can no longer appear to you as edible.
/:cl:
