### PR TITLE
Condenses map lint yml files just a bit

### DIFF
--- a/tools/maplint/lints/banned_neighbors.yml
+++ b/tools/maplint/lints/banned_neighbors.yml
@@ -1,0 +1,37 @@
+help: There are things stacked on one another. Please check and remove them.
+/obj/structure/chair:
+  banned_neighbors:
+  - /obj/structure/chair
+/obj/machinery/door/airlock:
+  banned_neighbors:
+  - /obj/machinery/door/airlock
+/area:
+  banned_neighbors:
+  - /area
+=/obj/structure/cable:
+  banned_neighbors:
+  - =/obj/structure/cable
+/obj/structure/closet:
+  banned_neighbors:
+  - /obj/structure/closet
+=/obj/machinery/door/firedoor:
+  banned_neighbors:
+    - =/obj/machinery/door/firedoor
+/obj/structure/girder:
+  banned_neighbors:
+  - /obj/structure/girder
+/obj/structure/grille:
+  banned_neighbors:
+  - /obj/structure/grille
+/obj/structure/lattice:
+  banned_neighbors:
+  - /obj/structure/lattice
+/obj/structure/stairs:
+  banned_neighbors:
+  - /obj/structure/stairs
+/obj/structure/table:
+  banned_neighbors:
+  - /obj/structure/table
+/turf:
+  banned_neighbors:
+  - /turf

--- a/tools/maplint/lints/directionals.yml
+++ b/tools/maplint/lints/directionals.yml
@@ -5,3 +5,11 @@ help: "Use the directional variants when possible."
       allow: [25, -25]
     pixel_y:
       allow: [25, -25]
+/obj/structure/sign/poster:
+  banned_variables:
+    pixel_x:
+    pixel_y:
+/obj/structure/window:
+  banned_variables:
+    dir:
+      deny: [1, 2, 4, 8]

--- a/tools/maplint/lints/multiple_airlocks.yml
+++ b/tools/maplint/lints/multiple_airlocks.yml
@@ -1,3 +1,0 @@
-/obj/machinery/door/airlock:
-  banned_neighbors:
-  - /obj/machinery/door/airlock

--- a/tools/maplint/lints/multiple_area.yml
+++ b/tools/maplint/lints/multiple_area.yml
@@ -1,3 +1,0 @@
-/area:
-  banned_neighbors:
-  - /area

--- a/tools/maplint/lints/multiple_cables.yml
+++ b/tools/maplint/lints/multiple_cables.yml
@@ -1,3 +1,0 @@
-=/obj/structure/cable:
-  banned_neighbors:
-  - =/obj/structure/cable

--- a/tools/maplint/lints/multiple_chairs.yml
+++ b/tools/maplint/lints/multiple_chairs.yml
@@ -1,3 +1,0 @@
-/obj/structure/chair:
-  banned_neighbors:
-  - /obj/structure/chair

--- a/tools/maplint/lints/multiple_closets.yml
+++ b/tools/maplint/lints/multiple_closets.yml
@@ -1,3 +1,0 @@
-/obj/structure/closet:
-  banned_neighbors:
-  - /obj/structure/closet

--- a/tools/maplint/lints/multiple_firelocks.yml
+++ b/tools/maplint/lints/multiple_firelocks.yml
@@ -1,3 +1,0 @@
-=/obj/machinery/door/firedoor:
-  banned_neighbors:
-    - =/obj/machinery/door/firedoor

--- a/tools/maplint/lints/multiple_girders.yml
+++ b/tools/maplint/lints/multiple_girders.yml
@@ -1,3 +1,0 @@
-/obj/structure/girder:
-  banned_neighbors:
-  - /obj/structure/girder

--- a/tools/maplint/lints/multiple_grilles.yml
+++ b/tools/maplint/lints/multiple_grilles.yml
@@ -1,3 +1,0 @@
-/obj/structure/grille:
-  banned_neighbors:
-  - /obj/structure/grille

--- a/tools/maplint/lints/multiple_lattice.yml
+++ b/tools/maplint/lints/multiple_lattice.yml
@@ -1,3 +1,0 @@
-/obj/structure/lattice:
-  banned_neighbors:
-  - /obj/structure/lattice

--- a/tools/maplint/lints/multiple_stairs.yml
+++ b/tools/maplint/lints/multiple_stairs.yml
@@ -1,3 +1,0 @@
-/obj/structure/stairs:
-  banned_neighbors:
-  - /obj/structure/stairs

--- a/tools/maplint/lints/multiple_tables.yml
+++ b/tools/maplint/lints/multiple_tables.yml
@@ -1,3 +1,0 @@
-/obj/structure/table:
-  banned_neighbors:
-  - /obj/structure/table

--- a/tools/maplint/lints/multiple_turf.yml
+++ b/tools/maplint/lints/multiple_turf.yml
@@ -1,3 +1,0 @@
-/turf:
-  banned_neighbors:
-  - /turf

--- a/tools/maplint/lints/posters_directionals.yml
+++ b/tools/maplint/lints/posters_directionals.yml
@@ -1,5 +1,0 @@
-help: "Use the directional variants when possible."
-/obj/structure/sign/poster:
-  banned_variables:
-    pixel_x:
-    pixel_y:

--- a/tools/maplint/lints/window_pane_varedits.yml
+++ b/tools/maplint/lints/window_pane_varedits.yml
@@ -1,5 +1,0 @@
-help: "Use the directional variants when possible."
-/obj/structure/window:
-  banned_variables:
-    dir:
-      deny: [1, 2, 4, 8]


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
I want to add more map lints against certain things (forcing mappers to use /directional variants where applicable), but Mothblocks is against adding misc lints that would otherwise bloat the folder.

I ran a test to see if cramming them in one files works, and it does.
The only thing thats lost is the help message, which can't be customized per item outside of what the error is.

By doing this, I hope me and Mothblocks can reach a happy medium, I get to add more lints and Mothblocks doesn't have to put up with multiple misc maplints.

## Changelog

Not player facing.