### PR TITLE
Adds tiny fan to Tramstation Mass Driver.

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -34430,6 +34430,7 @@
 /area/station/cargo/sorting)
 "lnh" = (
 /obj/machinery/door/poddoor/massdriver_chapel,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/service/chapel/monastery)
 "lnk" = (


### PR DESCRIPTION

## About The Pull Request
Adds tiny fan to mass driver, so you don't cause air alarms when you try to throw someone with it.
## Why It's Good For The Game
Consistency.
## Changelog
:cl:
fix: [Tramstation] Mass Driver in chapel now has tiny fan so you don't space yourself.
/:cl:
