### PR TITLE
Freedom Implant Feedback and Facelift

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -365,3 +365,5 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define BATON_CUFF 2
 #define BATON_PROBE 3
 #define BATON_MODES 4
+
+#define FREEDOM_IMPLANT_CHARGES 4

--- a/code/game/objects/items/implants/implant_freedom.dm
+++ b/code/game/objects/items/implants/implant_freedom.dm
@@ -5,11 +5,17 @@
 	implant_color = "r"
 	uses = 4
 
+/obj/item/implant/freedom/implant(mob/living/target, mob/user, silent, force)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(!iscarbon(target)) //This is pretty much useless for anyone else since they can't be cuffed
+		balloon_alert(user, "that would be a waste!")
+		return FALSE
+	return TRUE
+
 /obj/item/implant/freedom/activate()
 	. = ..()
-	if(!iscarbon(imp_in)) //Maybe make it not implantable on these guys?
-		return
-
 	var/mob/living/carbon/carbon_imp_in = imp_in
 	if(!carbon_imp_in.handcuffed && !carbon_imp_in.legcuffed)
 		balloon_alert(carbon_imp_in, "no restraints!")
@@ -20,7 +26,7 @@
 	balloon_alert(carbon_imp_in, "bindings released!")
 	carbon_imp_in.uncuff()
 	if(!uses)
-		balloon_alert(carbon_imp_in, "implant degraded!")
+		addtimer(CALLBACK(carbon_imp_in, TYPE_PROC_REF(/atom, balloon_alert), carbon_imp_in, "implant degraded!"), 1 SECONDS)
 		qdel(src)
 
 /obj/item/implant/freedom/get_data()
@@ -32,7 +38,9 @@
 <HR>
 <b>Implant Details:</b> <BR>
 <b>Function:</b> Transmits a specialized cluster of signals to override handcuff locking
-mechanisms. These signals will release any bindings on both the arms and legs.<BR>"}
+mechanisms. These signals will release any bindings on both the arms and legs.<BR>
+<b>Disclaimer:</b> Heavy-duty restraints such as straightjackets are deemed "too complex" to release from.
+"}
 	return dat
 
 /obj/item/implanter/freedom

--- a/code/game/objects/items/implants/implant_freedom.dm
+++ b/code/game/objects/items/implants/implant_freedom.dm
@@ -5,34 +5,35 @@
 	implant_color = "r"
 	uses = 4
 
-
 /obj/item/implant/freedom/activate()
 	. = ..()
-	uses--
-	to_chat(imp_in, span_hear("You feel a faint click."))
-	if(iscarbon(imp_in))
-		var/mob/living/carbon/C_imp_in = imp_in
-		C_imp_in.uncuff()
-	if(!uses)
-		qdel(src)
+	if(!iscarbon(imp_in)) //Maybe make it not implantable on these guys?
+		return
 
+	var/mob/living/carbon/carbon_imp_in = imp_in
+	if(!carbon_imp_in.handcuffed && !carbon_imp_in.legcuffed)
+		balloon_alert(carbon_imp_in, "no restraints!")
+		return
+
+	uses--
+
+	balloon_alert(carbon_imp_in, "bindings released!")
+	carbon_imp_in.uncuff()
+	if(!uses)
+		balloon_alert(carbon_imp_in, "implant degraded!")
+		qdel(src)
 
 /obj/item/implant/freedom/get_data()
 	var/dat = {"
 <b>Implant Specifications:</b><BR>
 <b>Name:</b> Freedom Beacon<BR>
-<b>Life:</b> optimum 5 uses<BR>
+<b>Life:</b> Optimum 4 uses<BR>
 <b>Important Notes:</b> <font color='red'>Illegal</font><BR>
 <HR>
 <b>Implant Details:</b> <BR>
 <b>Function:</b> Transmits a specialized cluster of signals to override handcuff locking
-mechanisms<BR>
-<b>Special Features:</b><BR>
-<i>Neuro-Scan</i>- Analyzes certain shadow signals in the nervous system<BR>
-<HR>
-No Implant Specifics"}
+mechanisms. These signals will release any bindings on both the arms and legs.<BR>"}
 	return dat
-
 
 /obj/item/implanter/freedom
 	name = "implanter (freedom)"

--- a/code/game/objects/items/implants/implant_freedom.dm
+++ b/code/game/objects/items/implants/implant_freedom.dm
@@ -3,7 +3,7 @@
 	desc = "Use this to escape from those evil Red Shirts."
 	icon_state = "freedom"
 	implant_color = "r"
-	uses = 4
+	uses = FREEDOM_IMPLANT_CHARGES
 
 /obj/item/implant/freedom/implant(mob/living/target, mob/user, silent, force)
 	. = ..()

--- a/code/game/objects/items/implants/implant_freedom.dm
+++ b/code/game/objects/items/implants/implant_freedom.dm
@@ -23,7 +23,6 @@
 
 	uses--
 
-	balloon_alert(carbon_imp_in, "bindings released!")
 	carbon_imp_in.uncuff()
 	if(!uses)
 		addtimer(CALLBACK(carbon_imp_in, TYPE_PROC_REF(/atom, balloon_alert), carbon_imp_in, "implant degraded!"), 1 SECONDS)
@@ -31,16 +30,16 @@
 
 /obj/item/implant/freedom/get_data()
 	var/dat = {"
-<b>Implant Specifications:</b><BR>
-<b>Name:</b> Freedom Beacon<BR>
-<b>Life:</b> Optimum 4 uses<BR>
-<b>Important Notes:</b> <font color='red'>Illegal</font><BR>
-<HR>
-<b>Implant Details:</b> <BR>
-<b>Function:</b> Transmits a specialized cluster of signals to override handcuff locking
-mechanisms. These signals will release any bindings on both the arms and legs.<BR>
-<b>Disclaimer:</b> Heavy-duty restraints such as straightjackets are deemed "too complex" to release from.
-"}
+		<b>Implant Specifications:</b><BR>
+		<b>Name:</b> Freedom Beacon<BR>
+		<b>Life:</b> Optimum [initial(uses)] uses<BR>
+		<b>Important Notes:</b> <font color='red'>Illegal</font><BR>
+		<HR>
+		<b>Implant Details:</b> <BR>
+		<b>Function:</b> Transmits a specialized cluster of signals to override handcuff locking
+		mechanisms. These signals will release any bindings on both the arms and legs.<BR>
+		<b>Disclaimer:</b> Heavy-duty restraints such as straightjackets are deemed "too complex" to release from.
+	"}
 	return dat
 
 /obj/item/implanter/freedom

--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -9,10 +9,13 @@
 
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
-	desc = "Can be activated to release common restraints such as handcuffs, legcuffs, and even bolas tethered around the legs. \
-			Implant has enough energy for [FREEDOM_IMPLANT_CHARGES] uses before it becomes inert and harmlessly self-destructs."
+	desc = "Can be activated to release common restraints such as handcuffs, legcuffs, and even bolas tethered around the legs."
 	item = /obj/item/storage/box/syndie_kit/imp_freedom
 	cost = 5
+
+/datum/uplink_item/implants/freedom/New()
+	. = ..()
+	desc += " Implant has enough energy for [FREEDOM_IMPLANT_CHARGES] uses before it becomes inert and harmlessly self-destructs."
 
 /datum/uplink_item/implants/radio
 	name = "Internal Syndicate Radio Implant"

--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -10,7 +10,7 @@
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
 	desc = "An implant injected into the body and later activated at the user's will. It will attempt to free the \
-			user from common restraints such as handcuffs. Four uses."
+			user from common restraints such as handcuffs. Implant has enough energy for 4 uses before it becomes inert and self-destructs."
 	item = /obj/item/storage/box/syndie_kit/imp_freedom
 	cost = 5
 

--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -10,7 +10,7 @@
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
 	desc = "An implant injected into the body and later activated at the user's will. It will attempt to free the \
-			user from common restraints such as handcuffs."
+			user from common restraints such as handcuffs. Four uses."
 	item = /obj/item/storage/box/syndie_kit/imp_freedom
 	cost = 5
 

--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -9,8 +9,8 @@
 
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
-	desc = "An implant injected into the body and later activated at the user's will. It will attempt to free the \
-			user from common restraints such as handcuffs. Implant has enough energy for 4 uses before it becomes inert and harmlessly self-destructs."
+	desc = "Can be activated to release common restraints such as handcuffs, legcuffs, and even bolas tethered around the legs. \
+			Implant has enough energy for 4 uses before it becomes inert and harmlessly self-destructs."
 	item = /obj/item/storage/box/syndie_kit/imp_freedom
 	cost = 5
 

--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -10,7 +10,7 @@
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
 	desc = "An implant injected into the body and later activated at the user's will. It will attempt to free the \
-			user from common restraints such as handcuffs. Implant has enough energy for 4 uses before it becomes inert and self-destructs."
+			user from common restraints such as handcuffs. Implant has enough energy for 4 uses before it becomes inert and harmlessly self-destructs."
 	item = /obj/item/storage/box/syndie_kit/imp_freedom
 	cost = 5
 

--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -10,7 +10,7 @@
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
 	desc = "Can be activated to release common restraints such as handcuffs, legcuffs, and even bolas tethered around the legs. \
-			Implant has enough energy for 4 uses before it becomes inert and harmlessly self-destructs."
+			Implant has enough energy for [FREEDOM_IMPLANT_CHARGES] uses before it becomes inert and harmlessly self-destructs."
 	item = /obj/item/storage/box/syndie_kit/imp_freedom
 	cost = 5
 


### PR DESCRIPTION

## About The Pull Request

This aims to make the freedom implant a bit less clunky, and a bit more responsive. No fundamental changes or buffs or anything, just some more feedback and player-facing clarity on what this thing actually does.

Changes include:
- Freedom implants can no longer be implanted into non-carbon (uncuffable) mobs.
- The freedom implant will no longer expend charges when used without active restraints.
- The to_chat has been replaced with a balloon alert (displayed to the user only, of course).
- The implant throws a balloon alert shortly after it runs out of charges, notifying the user that it has degraded and is gone.
- The implant pad readout has been changed to provide a bit more useful information, and provide a bit less incorrect information.
- No, seriously, what did _"Analyzes certain shadow signals in the nervous system"_ even mean? Shadowlings??
- The uplink listing now lists the number of uses, and explains that the implant is useful for more than just handcuffs.
## Why It's Good For The Game

I used this thing once on a nukie round and thought "oh god this needs a facelift immediately".

Players should be able to know the basic functions of their toys without having to consult the wiki.
## Changelog
:cl: Rhials
qol: The freedom implant has received minor feedback and other minor usage improvements. 
/:cl:
