### PR TITLE
Makes some better use of passtable_on / off

### DIFF
--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -12,6 +12,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slowdown = 1
 	item_flags = SLOWS_WHILE_IN_HAND
+	pass_flags = NONE
 
 	/// If true we're currently portable
 	var/is_portable = TRUE

--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -117,11 +117,11 @@
 
 	if(is_portable)
 		interaction_flags_item |= INTERACT_ITEM_ATTACK_HAND_PICKUP
-		pass_flags |= PASSTABLE
+		passtable_on(src, type)
 		RemoveElement(/datum/element/noisy_movement)
 	else
 		interaction_flags_item &= ~INTERACT_ITEM_ATTACK_HAND_PICKUP
-		pass_flags &= ~PASSTABLE
+		passtable_off(src, type)
 		AddElement(/datum/element/noisy_movement)
 
 	update_appearance()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -165,16 +165,13 @@
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, span_danger("Throwing [pushed_mob] onto the table might hurt them!"))
 		return
-	var/added_passtable = FALSE
-	if(!(pushed_mob.pass_flags & PASSTABLE))
-		added_passtable = TRUE
-		pushed_mob.pass_flags |= PASSTABLE
+	var/passtable_key = REF(user)
+	passtable_on(pushed_mob, passtable_key)
 	for (var/obj/obj in user.loc.contents)
 		if(!obj.CanAllowThrough(pushed_mob))
 			return
 	pushed_mob.Move(src.loc)
-	if(added_passtable)
-		pushed_mob.pass_flags &= ~PASSTABLE
+	passtable_off(pushed_mob, passtable_key)
 	if(pushed_mob.loc != loc) //Something prevented the tabling
 		return
 	pushed_mob.Knockdown(30)
@@ -901,4 +898,3 @@
 		R.add_fingerprint(user)
 		qdel(src)
 	building = FALSE
-

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -49,13 +49,13 @@
 
 /datum/species/monkey/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	. = ..()
-	H.pass_flags |= PASSTABLE
+	passtable_on(H, SPECIES_TRAIT)
 	H.dna.add_mutation(/datum/mutation/human/race, MUT_NORMAL)
 	H.dna.activate_mutation(/datum/mutation/human/race)
 
 /datum/species/monkey/on_species_loss(mob/living/carbon/C)
 	. = ..()
-	C.pass_flags = initial(C.pass_flags)
+	passtable_off(C, SPECIES_TRAIT)
 	C.dna.remove_mutation(/datum/mutation/human/race)
 
 /datum/species/monkey/spec_unarmedattack(mob/living/carbon/human/user, atom/target, modifiers)

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -102,12 +102,12 @@
 	if(!HAS_TRAIT_FROM(human, TRAIT_MOVE_FLYING, SPECIES_FLIGHT_TRAIT))
 		human.physiology.stun_mod *= 2
 		human.add_traits(list(TRAIT_NO_FLOATING_ANIM, TRAIT_MOVE_FLYING), SPECIES_FLIGHT_TRAIT)
-		passtable_on(human, SPECIES_TRAIT)
+		passtable_on(human, SPECIES_FLIGHT_TRAIT)
 		open_wings()
 	else
 		human.physiology.stun_mod *= 0.5
 		human.remove_traits(list(TRAIT_NO_FLOATING_ANIM, TRAIT_MOVE_FLYING), SPECIES_FLIGHT_TRAIT)
-		passtable_off(human, SPECIES_TRAIT)
+		passtable_off(human, SPECIES_FLIGHT_TRAIT)
 		close_wings()
 	human.update_body_parts()
 

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -359,10 +359,10 @@
 	animate(vehicle, pixel_y = -6, time = 3)
 	playsound(vehicle, 'sound/vehicles/skateboard_ollie.ogg', 50, TRUE)
 	passtable_on(rider, VEHICLE_TRAIT)
-	vehicle.pass_flags |= PASSTABLE
+	passtable_on(vehicle, VEHICLE_TRAIT)
 	rider.Move(landing_turf, vehicle_target.dir)
 	passtable_off(rider, VEHICLE_TRAIT)
-	vehicle.pass_flags &= ~PASSTABLE
+	passtable_off(vehicle, VEHICLE_TRAIT)
 
 /datum/action/vehicle/ridden/scooter/skateboard/kickflip
 	name = "Kickflip"


### PR DESCRIPTION
## About The Pull Request

Flicking the passtable flag has a helper to avoid accidentally overriding passtable from another source. A few places don't use it, which makes it plausible you're removing the flag when you shouldn't be. 

So I just went through a few places I noticed setting it directly and made it use the helper. 

## Changelog

:cl: Melbert
fix: Maybe fixes some weird occurrences where you lose the ability to pass over tables when you shouldn't, and visa versa
/:cl:
