### PR TITLE
Fix supermatter surge randomness [NO GBP]

### DIFF
--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -2,6 +2,7 @@
 #define SURGE_DURATION_MAX 270 EVENT_SECONDS
 #define SURGE_SEVERITY_MIN 1
 #define SURGE_SEVERITY_MAX 4
+#define SURGE_SEVERITY_RANDOM 5
 /// The amount of bullet energy we add for the duration of the SM surge
 #define SURGE_BULLET_ENERGY_ADDITION 5
 /// The amount of powerloss inhibition (energy retention) we add for the duration of the SM surge
@@ -46,7 +47,7 @@
 	announce_when = 4
 	end_when = SURGE_DURATION_MIN
 	/// How powerful is the supermatter surge going to be?
-	var/surge_class =  SURGE_SEVERITY_MIN
+	var/surge_class = SURGE_SEVERITY_RANDOM
 	/// Typecasted reference to the supermatter chosen at event start
 	var/obj/machinery/power/supermatter_crystal/engine
 	/// Typecasted reference to the nitrogen properies in the SM chamber
@@ -54,11 +55,11 @@
 
 /datum/event_admin_setup/input_number/surge_spiciness
 	input_text = "Set surge intensity. (Higher is more severe.)"
-	min_value = 1
-	max_value = 4
+	min_value = SURGE_SEVERITY_MIN
+	max_value = SURGE_SEVERITY_MAX
 
 /datum/event_admin_setup/input_number/surge_spiciness/prompt_admins()
-	default_value = rand(1, 4)
+	default_value = rand(SURGE_SEVERITY_MIN, SURGE_SEVERITY_MAX)
 	return ..()
 
 /datum/event_admin_setup/input_number/surge_spiciness/apply_to_event(datum/round_event/supermatter_surge/event)
@@ -75,8 +76,17 @@
 		stack_trace("SM surge event failed to find gas properties for [engine].")
 		return
 
-	if(isnull(surge_class))
-		surge_class = rand(SURGE_SEVERITY_MIN, SURGE_SEVERITY_MAX)
+	if(surge_class == SURGE_SEVERITY_RANDOM)
+		var/severity_weight = rand(1, 100)
+		switch(severity_weight)
+			if(1 to 14)
+				surge_class = 1
+			if(15 to 34)
+				surge_class = 2
+			if(35 to 69)
+				surge_class = 3
+			if(70 to 100)
+				surge_class = 4
 
 	end_when = rand(SURGE_DURATION_MIN, SURGE_DURATION_MAX)
 
@@ -103,6 +113,7 @@
 #undef SURGE_DURATION_MAX
 #undef SURGE_SEVERITY_MIN
 #undef SURGE_SEVERITY_MAX
+#undef SURGE_SEVERITY_RANDOM
 #undef SURGE_BULLET_ENERGY_ADDITION
 #undef SURGE_BASE_POWERLOSS_INHIBITION
 #undef SURGE_POWERLOSS_INHIBITION_MODIFIER


### PR DESCRIPTION
## About The Pull Request

Fixes the event introduced in https://github.com/tgstation/tgstation/pull/78244 not properly picking a severity as expected.

## Changelog

:cl: LT3
fix: Fixed supermatter surges always being the lowest severity
/:cl: