### PR TITLE
Fix ghosts/godmode mobs causing supermatter resonance

### DIFF
--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -69,10 +69,10 @@
 
 /datum/component/supermatter_crystal/proc/animal_hit(datum/source, mob/living/simple_animal/user, list/modifiers)
 	SIGNAL_HANDLER
-	if(user.incorporeal_move || user.status_flags & GODMODE)
-		return
 	var/atom/atom_source = source
 	var/murder
+	if(user.incorporeal_move || user.status_flags & GODMODE)
+		return
 	if(!user.melee_damage_upper && !user.melee_damage_lower)
 		murder = user.friendly_verb_continuous
 	else

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -58,8 +58,10 @@
 			span_hear("You hear a loud crack as you are washed with a wave of heat."))
 		consume(atom_source, blob)
 
-/datum/component/supermatter_crystal/proc/paw_hit(datum/source, mob/user, list/modifiers)
+/datum/component/supermatter_crystal/proc/paw_hit(datum/source, mob/living/user, list/modifiers)
 	SIGNAL_HANDLER
+	if(user.incorporeal_move || user.status_flags & GODMODE)
+		return
 	if(isalien(user))
 		dust_mob(source, user, cause = "alien attack")
 		return
@@ -67,6 +69,8 @@
 
 /datum/component/supermatter_crystal/proc/animal_hit(datum/source, mob/living/simple_animal/user, list/modifiers)
 	SIGNAL_HANDLER
+	if(user.incorporeal_move || user.status_flags & GODMODE)
+		return
 	var/atom/atom_source = source
 	var/murder
 	if(!user.melee_damage_upper && !user.melee_damage_lower)
@@ -82,9 +86,11 @@
 	SIGNAL_HANDLER
 	dust_mob(source, user, cause = "hulk attack")
 
-/datum/component/supermatter_crystal/proc/unarmed_hit(datum/source, mob/user, list/modifiers)
+/datum/component/supermatter_crystal/proc/unarmed_hit(datum/source, mob/living/user, list/modifiers)
 	SIGNAL_HANDLER
 	var/atom/atom_source = source
+	if(user.incorporeal_move || user.status_flags & GODMODE)
+		return
 	if(iscyborg(user) && atom_source.Adjacent(user))
 		dust_mob(source, user, cause = "cyborg attack")
 		return
@@ -185,6 +191,8 @@
 		return
 
 	if(atom_source.Adjacent(user)) //if the item is stuck to the person, kill the person too instead of eating just the item.
+		if(user.incorporeal_move || user.status_flags & GODMODE)
+			return
 		var/vis_msg = span_danger("[user] reaches out and touches [atom_source] with [item], inducing a resonance... [item] starts to glow briefly before the light continues up to [user]'s body. [user.p_They()] burst[user.p_s()] into flames before flashing into dust!")
 		var/mob_msg = span_userdanger("You reach out and touch [atom_source] with [item]. Everything starts burning and all you can hear is ringing. Your last thought is \"That was not a wise decision.\"")
 		dust_mob(source, user, vis_msg, mob_msg)
@@ -200,6 +208,10 @@
 	SIGNAL_HANDLER
 	var/atom/atom_source = source
 	var/obj/machinery/power/supermatter_crystal/our_supermatter = parent // Why is this a component?
+	if(isliving(hit_object))
+		var/mob/living/hit_mob = hit_object
+		if(hit_mob.incorporeal_move || hit_mob.status_flags & GODMODE)
+			return
 	if(istype(our_supermatter))
 		our_supermatter.log_activation(who = hit_object)
 	if(isliving(hit_object))

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -58,10 +58,12 @@
 			span_hear("You hear a loud crack as you are washed with a wave of heat."))
 		consume(atom_source, blob)
 
-/datum/component/supermatter_crystal/proc/paw_hit(datum/source, mob/living/user, list/modifiers)
+/datum/component/supermatter_crystal/proc/paw_hit(datum/source, mob/user, list/modifiers)
 	SIGNAL_HANDLER
-	if(user.incorporeal_move || user.status_flags & GODMODE)
-		return
+	if(isliving(user))
+		var/mob/living/living_mob = user
+		if(living_mob.incorporeal_move || living_mob.status_flags & GODMODE)
+			return
 	if(isalien(user))
 		dust_mob(source, user, cause = "alien attack")
 		return
@@ -86,11 +88,13 @@
 	SIGNAL_HANDLER
 	dust_mob(source, user, cause = "hulk attack")
 
-/datum/component/supermatter_crystal/proc/unarmed_hit(datum/source, mob/living/user, list/modifiers)
+/datum/component/supermatter_crystal/proc/unarmed_hit(datum/source, mob/user, list/modifiers)
 	SIGNAL_HANDLER
 	var/atom/atom_source = source
-	if(user.incorporeal_move || user.status_flags & GODMODE)
-		return
+	if(isliving(user))
+		var/mob/living/living_mob = user
+		if(living_mob.incorporeal_move || living_mob.status_flags & GODMODE)
+			return
 	if(iscyborg(user) && atom_source.Adjacent(user))
 		dust_mob(source, user, cause = "cyborg attack")
 		return

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -71,10 +71,10 @@
 
 /datum/component/supermatter_crystal/proc/animal_hit(datum/source, mob/living/simple_animal/user, list/modifiers)
 	SIGNAL_HANDLER
-	var/atom/atom_source = source
-	var/murder
 	if(user.incorporeal_move || user.status_flags & GODMODE)
 		return
+	var/atom/atom_source = source
+	var/murder
 	if(!user.melee_damage_upper && !user.melee_damage_lower)
 		murder = user.friendly_verb_continuous
 	else
@@ -90,11 +90,11 @@
 
 /datum/component/supermatter_crystal/proc/unarmed_hit(datum/source, mob/user, list/modifiers)
 	SIGNAL_HANDLER
-	var/atom/atom_source = source
 	if(isliving(user))
 		var/mob/living/living_mob = user
 		if(living_mob.incorporeal_move || living_mob.status_flags & GODMODE)
 			return
+	var/atom/atom_source = source
 	if(iscyborg(user) && atom_source.Adjacent(user))
 		dust_mob(source, user, cause = "cyborg attack")
 		return
@@ -106,14 +106,12 @@
 
 /datum/component/supermatter_crystal/proc/hand_hit(datum/source, mob/living/user, list/modifiers)
 	SIGNAL_HANDLER
-	var/atom/atom_source = source
 	if(user.incorporeal_move || user.status_flags & GODMODE)
 		return
-
 	if(user.zone_selected != BODY_ZONE_PRECISE_MOUTH)
 		dust_mob(source, user, cause = "hand")
 		return
-
+	var/atom/atom_source = source
 	if(!user.is_mouth_covered())
 		if(user.combat_mode)
 			dust_mob(source, user,
@@ -210,12 +208,12 @@
 
 /datum/component/supermatter_crystal/proc/bumped_hit(datum/source, atom/movable/hit_object)
 	SIGNAL_HANDLER
-	var/atom/atom_source = source
-	var/obj/machinery/power/supermatter_crystal/our_supermatter = parent // Why is this a component?
 	if(isliving(hit_object))
 		var/mob/living/hit_mob = hit_object
 		if(hit_mob.incorporeal_move || hit_mob.status_flags & GODMODE)
 			return
+	var/atom/atom_source = source
+	var/obj/machinery/power/supermatter_crystal/our_supermatter = parent // Why is this a component?
 	if(istype(our_supermatter))
 		our_supermatter.log_activation(who = hit_object)
 	if(isliving(hit_object))
@@ -240,9 +238,9 @@
 	return FALL_INTERCEPTED | FALL_NO_MESSAGE
 
 /datum/component/supermatter_crystal/proc/dust_mob(datum/source, mob/living/nom, vis_msg, mob_msg, cause)
-	var/atom/atom_source = source
 	if(nom.incorporeal_move || nom.status_flags & GODMODE) //try to keep supermatter sliver's + hemostat's dust conditions in sync with this too
 		return
+	var/atom/atom_source = source
 	if(!vis_msg)
 		vis_msg = span_danger("[nom] reaches out and touches [atom_source], inducing a resonance... [nom.p_their()] body starts to glow and burst into flames before flashing into dust!")
 	if(!mob_msg)


### PR DESCRIPTION
## About The Pull Request

Adds the incorporeal/godmode check to living mob interactions with the supermatter. Already in hand_hit() but there are other procs that can be triggered as well.

## Why It's Good For The Game

Ghost animals, revenants, mobs with godmode enabled should not cause supermatter resonance messages when interacting with it.

Fixes https://github.com/tgstation/tgstation/issues/78490

## Changelog

:cl: LT3
fix: Ghosts and godmode mobs will no longer create resonance when touching the supermatter crystal
/:cl: