### PR TITLE
Dusting Poly causes a power surge

### DIFF
--- a/code/__DEFINES/events.dm
+++ b/code/__DEFINES/events.dm
@@ -36,6 +36,8 @@
 /// Return from admin setup to stop the event from triggering entirely.
 #define ADMIN_CANCEL_EVENT "cancel event"
 
+/// Event can never be triggered by wizards
+#define NEVER_TRIGGERED_BY_WIZARDS -1
 /// Event can only run on a map set in space
 #define EVENT_SPACE_ONLY (1 << 0)
 /// Event can only run on a map which is a planet

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -254,6 +254,7 @@
 		consumed_mob.investigate_log("has been dusted by [atom_source].", INVESTIGATE_DEATHS)
 		if(istype(consumed_mob, /mob/living/simple_animal/parrot/poly)) // Dusting Poly creates a power surge
 			force_event(/datum/round_event_control/supermatter_surge/poly, "Poly's revenge")
+			notify_ghosts("[consumed_mob] has been dusted by [atom_source]!", source = atom_source, action = NOTIFY_JUMP, header = "Polytechnical Difficulties")
 		consumed_mob.dust(force = TRUE)
 		matter_increase += 100 * object_size
 		if(is_clown_job(consumed_mob.mind?.assigned_role))

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -206,6 +206,9 @@
 		hit_object.visible_message(span_danger("\The [hit_object] slams into \the [atom_source] inducing a resonance... [hit_object.p_their()] body starts to glow and burst into flames before flashing into dust!"),
 			span_userdanger("You slam into \the [atom_source] as your ears are filled with unearthly ringing. Your last thought is \"Oh, fuck.\""),
 			span_hear("You hear an unearthly noise as a wave of heat washes over you."))
+		if(istype(hit_object, /mob/living/simple_animal/parrot/poly)) // Dusting Poly creates a power surge
+			our_supermatter.visible_message(span_userdanger("\The [atom_source] glows intensely, the ground starting to shake as \the [hit_object] causes an unusually strong resonance!"))
+			force_event(/datum/round_event_control/supermatter_surge/poly, "Poly's revenge")
 	else if(isobj(hit_object) && !iseffect(hit_object))
 		hit_object.visible_message(span_danger("\The [hit_object] smacks into \the [atom_source] and rapidly flashes to ash."), null,
 			span_hear("You hear a loud crack as you are washed with a wave of heat."))

--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -206,9 +206,6 @@
 		hit_object.visible_message(span_danger("\The [hit_object] slams into \the [atom_source] inducing a resonance... [hit_object.p_their()] body starts to glow and burst into flames before flashing into dust!"),
 			span_userdanger("You slam into \the [atom_source] as your ears are filled with unearthly ringing. Your last thought is \"Oh, fuck.\""),
 			span_hear("You hear an unearthly noise as a wave of heat washes over you."))
-		if(istype(hit_object, /mob/living/simple_animal/parrot/poly)) // Dusting Poly creates a power surge
-			our_supermatter.visible_message(span_userdanger("\The [atom_source] glows intensely, the ground starting to shake as \the [hit_object] causes an unusually strong resonance!"))
-			force_event(/datum/round_event_control/supermatter_surge/poly, "Poly's revenge")
 	else if(isobj(hit_object) && !iseffect(hit_object))
 		hit_object.visible_message(span_danger("\The [hit_object] smacks into \the [atom_source] and rapidly flashes to ash."), null,
 			span_hear("You hear a loud crack as you are washed with a wave of heat."))
@@ -255,6 +252,8 @@
 		message_admins("[atom_source] has consumed [key_name_admin(consumed_mob)] [ADMIN_JMP(atom_source)].")
 		atom_source.investigate_log("has consumed [key_name(consumed_mob)].", INVESTIGATE_ENGINE)
 		consumed_mob.investigate_log("has been dusted by [atom_source].", INVESTIGATE_DEATHS)
+		if(istype(consumed_mob, /mob/living/simple_animal/parrot/poly)) // Dusting Poly creates a power surge
+			force_event(/datum/round_event_control/supermatter_surge/poly, "Poly's revenge")
 		consumed_mob.dust(force = TRUE)
 		matter_increase += 100 * object_size
 		if(is_clown_job(consumed_mob.mind?.assigned_role))

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -1,5 +1,4 @@
 #define RANDOM_EVENT_ADMIN_INTERVENTION_TIME (10 SECONDS)
-#define NEVER_TRIGGERED_BY_WIZARDS -1
 
 //this singleton datum is used by the events controller to dictate how it selects events
 /datum/round_event_control
@@ -312,4 +311,3 @@ Runs the event
 	return ..()
 
 #undef RANDOM_EVENT_ADMIN_INTERVENTION_TIME
-#undef NEVER_TRIGGERED_BY_WIZARDS

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -80,8 +80,8 @@
 
 	end_when = rand(SURGE_DURATION_MIN, SURGE_DURATION_MAX)
 
-/datum/round_event/supermatter_surge/announce()
-	priority_announce("The Crystal Integrity Monitoring System has detected unusual atmospheric properties in the supermatter chamber and energy output from the supermatter crystal has increased significantly. Engineering intervention is required to stabilize the engine.", "Class [surge_class] Supermatter Surge Alert", 'sound/machines/engine_alert3.ogg')
+/datum/round_event/supermatter_surge/announce(fake)
+	priority_announce("The Crystal Integrity Monitoring System has detected unusual atmospheric properties in the supermatter chamber, energy output from the supermatter crystal has increased significantly. Engineering intervention is required to stabilize the engine.", "Class [surge_class] Supermatter Surge Alert", 'sound/machines/engine_alert3.ogg')
 
 /datum/round_event/supermatter_surge/start()
 	engine.bullet_energy = surge_class + SURGE_BULLET_ENERGY_ADDITION
@@ -98,6 +98,24 @@
 	priority_announce("The supermatter surge has dissipated, crystal output readings have normalized.", "Anomaly Cleared")
 	engine = null
 	sm_gas = null
+
+/datum/round_event_control/supermatter_surge/poly
+	name = "Supermatter Surge: Poly's Revenge"
+	typepath = /datum/round_event/supermatter_surge/poly
+	category = EVENT_CATEGORY_ENGINEERING
+	weight = 0
+	description = "For when Poly is sacrificed to the SM. Not really useful to run manually."
+	min_wizard_trigger_potency = NEVER_TRIGGERED_BY_WIZARDS
+	max_wizard_trigger_potency = NEVER_TRIGGERED_BY_WIZARDS
+	admin_setup = null
+
+/datum/round_event/supermatter_surge/poly
+	announce_when = 4
+	surge_class =  4
+	fakeable = FALSE
+
+/datum/round_event/supermatter_surge/poly/announce(fake)
+	priority_announce("The Crystal Integrity Monitoring System has detected unusual parrot type resonance in the supermatter chamber, energy output from the supermatter crystal has increased significantly. Engineering intervention is required to stabilize the engine.", "Class P Supermatter Surge Alert", 'sound/machines/engine_alert3.ogg')
 
 #undef SURGE_DURATION_MIN
 #undef SURGE_DURATION_MAX

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -104,6 +104,7 @@
 	typepath = /datum/round_event/supermatter_surge/poly
 	category = EVENT_CATEGORY_ENGINEERING
 	weight = 0
+	max_occurrences = 0
 	description = "For when Poly is sacrificed to the SM. Not really useful to run manually."
 	min_wizard_trigger_potency = NEVER_TRIGGERED_BY_WIZARDS
 	max_wizard_trigger_potency = NEVER_TRIGGERED_BY_WIZARDS


### PR DESCRIPTION
## About The Pull Request

With surges now added, causes a power surge event when Poly is dusted on the supermatter crystal.

Requires https://github.com/tgstation/tgstation/pull/78492

## Why It's Good For The Game

Adds some flavor to killing the engineering department's pet.

## Changelog

:cl: LT3
add: Poly now causes a power surge when dusted by the supermatter crystal
/:cl:
