### PR TITLE
Adds an Admin Tool for the DNA Infuser

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -149,6 +149,7 @@
 #define VV_HK_MOD_QUIRKS "quirkmod"
 #define VV_HK_SET_SPECIES "setspecies"
 #define VV_HK_PURRBATION "purrbation"
+#define VV_HK_APPLY_DNA_INFUSION "apply_dna_infusion"
 
 // misc
 #define VV_HK_SPACEVINE_PURGE "spacevine_purge"

--- a/code/modules/admin/verbs/grant_dna_infusion.dm
+++ b/code/modules/admin/verbs/grant_dna_infusion.dm
@@ -1,0 +1,32 @@
+/*
+ * Attempts to grant the target all organs from a given DNA infuser entry.area
+ * Returns the entry if all organs were successfully replaced.
+ * If no infusion was picked, the infusion had no organs, or if one or more organs could not be granted, returns FALSE
+*/
+/client/proc/grant_dna_infusion(mob/living/carbon/human/target in world)
+	set name = "Apply DNA Infusion"
+	set category = "Debug"
+
+	var/list/infusions = list()
+	for(var/path in subtypesof(/datum/infuser_entry))
+		infusions += path
+
+	var/datum/infuser_entry/picked_infusion = tgui_input_list(usr, "Select infusion", "Apply DNA Infusion", infusions)
+	// This is necessary because list propererties are not defined until initialization
+	picked_infusion = new picked_infusion()
+
+	if(isnull(picked_infusion))
+		return FALSE
+	if(!length(picked_infusion.output_organs))
+		return FALSE
+
+	. = picked_infusion
+	for(var/obj/item/organ/infusion_organ as anything in picked_infusion.output_organs)
+		var/obj/item/organ/new_organ = new infusion_organ()
+		if(!new_organ.replace_into(target))
+			to_chat(usr, span_notice("[target] is unable to carry [new_organ]!"))
+			qdel(new_organ)
+			. = FALSE
+			continue
+		log_admin("[key_name(usr)] has added organ [new_organ.type] to [key_name(target)]")
+		message_admins("[key_name_admin(usr)] has added organ [new_organ.type] to [ADMIN_LOOKUPFLW(target)]")

--- a/code/modules/admin/verbs/grant_dna_infusion.dm
+++ b/code/modules/admin/verbs/grant_dna_infusion.dm
@@ -8,15 +8,19 @@
 	set category = "Debug"
 
 	var/list/infusions = list()
-	for(var/path in subtypesof(/datum/infuser_entry))
-		infusions += path
+	for(var/datum/infuser_entry/path as anything in subtypesof(/datum/infuser_entry))
+		var/str = "[initial(path.name)] ([path])"
+		infusions[str] = path
 
 	var/datum/infuser_entry/picked_infusion = tgui_input_list(usr, "Select infusion", "Apply DNA Infusion", infusions)
-	// This is necessary because list propererties are not defined until initialization
-	picked_infusion = new picked_infusion()
 
 	if(isnull(picked_infusion))
 		return FALSE
+
+	// This is necessary because list propererties are not defined until initialization
+	picked_infusion = infusions[picked_infusion]
+	picked_infusion = new picked_infusion
+
 	if(!length(picked_infusion.output_organs))
 		return FALSE
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -543,4 +543,4 @@
 	var/obj/item/organ/internal/brain/old_brain = new_owner.get_organ_slot(ORGAN_SLOT_BRAIN)
 	old_brain.Remove(new_owner, special = TRUE, no_id_transfer = TRUE)
 	qdel(old_brain)
-	Insert(new_owner, special = TRUE, drop_if_replaced = FALSE, no_id_transfer = TRUE)
+	return Insert(new_owner, special = TRUE, drop_if_replaced = FALSE, no_id_transfer = TRUE)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -742,6 +742,7 @@
 	VV_DROPDOWN_OPTION(VV_HK_MOD_QUIRKS, "Add/Remove Quirks")
 	VV_DROPDOWN_OPTION(VV_HK_SET_SPECIES, "Set Species")
 	VV_DROPDOWN_OPTION(VV_HK_PURRBATION, "Toggle Purrbation")
+	VV_DROPDOWN_OPTION(VV_HK_APPLY_DNA_INFUSION, "Apply DNA Infusion")
 
 /mob/living/carbon/human/vv_do_topic(list/href_list)
 	. = ..()
@@ -822,6 +823,19 @@
 			var/msg = span_notice("[key_name_admin(usr)] has removed [key_name(src)] from purrbation.")
 			message_admins(msg)
 			admin_ticket_log(src, msg)
+	if(href_list[VV_HK_APPLY_DNA_INFUSION])
+		if(!check_rights(R_SPAWN))
+			return
+		if(!ishuman(src))
+			to_chat(usr, "This can only be done to human species.")
+			return
+		var/result = usr.client.grant_dna_infusion(src)
+		if(result)
+			to_chat(usr, "Successfully applied DNA Infusion [result] to [src].")
+			log_admin("[key_name(usr)] has applied DNA Infusion [result] to [key_name(src)].")
+		else
+			to_chat(usr, "Failed to apply DNA Infusion to [src].")
+			log_admin("[key_name(usr)] failed to apply a DNA Infusion to [key_name(src)].")
 
 /mob/living/carbon/human/limb_attack_self()
 	var/obj/item/bodypart/arm = hand_bodyparts[active_hand_index]

--- a/code/modules/surgery/organs/_organ.dm
+++ b/code/modules/surgery/organs/_organ.dm
@@ -424,4 +424,4 @@ INITIALIZE_IMMEDIATE(/obj/item/organ)
 
 /// Tries to replace the existing organ on the passed mob with this one, with special handling for replacing a brain without ghosting target
 /obj/item/organ/proc/replace_into(mob/living/carbon/new_owner)
-	Insert(new_owner, special = TRUE, drop_if_replaced = FALSE)
+	return Insert(new_owner, special = TRUE, drop_if_replaced = FALSE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2664,6 +2664,7 @@
 #include "code\modules\admin\verbs\fps.dm"
 #include "code\modules\admin\verbs\getlogs.dm"
 #include "code\modules\admin\verbs\ghost_pool_protection.dm"
+#include "code\modules\admin\verbs\grant_dna_infusion.dm"
 #include "code\modules\admin\verbs\hiddenprints.dm"
 #include "code\modules\admin\verbs\highlander_datum.dm"
 #include "code\modules\admin\verbs\individual_logging.dm"


### PR DESCRIPTION
## About The Pull Request

Adds some an vv admin tool for DNA Infusions. The tool will automatically grant all of the relevant organs to the target.

![pic1](https://github.com/tgstation/tgstation/assets/21979502/e34548af-9648-4842-a089-02cffc9989cf)
![pic4](https://github.com/tgstation/tgstation/assets/21979502/1c0aa855-e284-4891-800e-717383425b76)
![pic3](https://github.com/tgstation/tgstation/assets/21979502/c955a35f-5835-4271-88cb-f1ab198cb8df)
## Why It's Good For The Game

It was already possible to do this with the organ manipulation tool, but that's a lot slower and probably has issues when replacing brains. This new tool will hopefully streamline the testing of new DNA infuser entries.
## Changelog
:cl:
admin: There is now a tool to apply a DNA Infuser entry to any human.
/:cl:
