### PR TITLE
Makes the Food/Slime Processor more consistent and understandable

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1239,7 +1239,7 @@
 
 /obj/item/circuitboard/machine/processor
 	name = "Food Processor"
-	desc = "A food or slime processor. Multitool the circuit board to select between them."
+	desc = "A food or slime processor. Use a multitool on the circuit board to select between them."
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/processor
 	req_components = list(

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1239,6 +1239,7 @@
 
 /obj/item/circuitboard/machine/processor
 	name = "Food Processor"
+	desc = "A food or slime processor. Multitool the circuit board to select between them."
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	build_path = /obj/machinery/processor
 	req_components = list(
@@ -1246,15 +1247,15 @@
 		/datum/stock_part/servo = 1)
 	needs_anchored = FALSE
 
-/obj/item/circuitboard/machine/processor/screwdriver_act(mob/living/user, obj/item/tool)
+/obj/item/circuitboard/machine/processor/multitool_act(mob/living/user, obj/item/tool)
 	if(build_path == /obj/machinery/processor)
 		name = "Slime Processor"
 		build_path = /obj/machinery/processor/slime
-		to_chat(user, span_notice("Name protocols successfully updated."))
+		to_chat(user, span_notice("You set the processor to 'Slime Time'."))
 	else
 		name = "Food Processor"
 		build_path = /obj/machinery/processor
-		to_chat(user, span_notice("Defaulting name protocols."))
+		to_chat(user, span_notice("You set the processor to 'Meat Grinder'."))
 	return TRUE
 
 /obj/item/circuitboard/machine/protolathe/department/service

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -57,9 +57,9 @@
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Outputting <b>[rating_amount]</b> item(s) at <b>[rating_speed*100]%</b> speed.")
 		if(slime_time)
-			. += span_notice("It is currently set to 'Slime Time'. To turn it into a Food Procesor, multitool the circuit board.")
+			. += span_notice("It is currently set to 'Slime Time'. To turn it into a Food Processor, use a multitool on the circuit board.")
 		else
-			. += span_notice("It is currently set to 'Meat Grinder'. To turn it into a Slime Procesor, multitool the circuit board.")
+			. += span_notice("It is currently set to 'Meat Grinder'. To turn it into a Slime Processor, use a multitool on the circuit board.")
 
 /obj/machinery/processor/Exited(atom/movable/gone, direction)
 	..()

--- a/code/modules/food_and_drinks/machinery/processor.dm
+++ b/code/modules/food_and_drinks/machinery/processor.dm
@@ -24,6 +24,8 @@
 	 * This allows for different types of processor to produce different outputs from same input as long as the recipes require different processors.
 	 */
 	var/static/list/processor_inputs
+	/// Awkward variable for examining
+	var/slime_time = FALSE
 
 /obj/machinery/processor/Initialize(mapload)
 	. = ..()
@@ -54,6 +56,10 @@
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Outputting <b>[rating_amount]</b> item(s) at <b>[rating_speed*100]%</b> speed.")
+		if(slime_time)
+			. += span_notice("It is currently set to 'Slime Time'. To turn it into a Food Procesor, multitool the circuit board.")
+		else
+			. += span_notice("It is currently set to 'Meat Grinder'. To turn it into a Slime Procesor, multitool the circuit board.")
 
 /obj/machinery/processor/Exited(atom/movable/gone, direction)
 	..()
@@ -187,8 +193,9 @@
 
 /obj/machinery/processor/slime
 	name = "slime processor"
-	desc = "An industrial grinder with a sticker saying appropriated for science department. Keep hands clear of intake area while operating."
+	desc = "An industrial grinder appropriated for the science department. Keep hands clear of intake area while operating."
 	circuit = /obj/item/circuitboard/machine/processor/slime
+	slime_time = TRUE
 
 /obj/machinery/processor/slime/adjust_item_drop_location(atom/movable/atom_to_drop)
 	var/static/list/slimecores = subtypesof(/obj/item/slime_extract)

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -574,7 +574,7 @@
 
 /datum/design/board/processor
 	name = "Food/Slime Processor Board"
-	desc = "The circuit board for a processing unit. Multitool the circuit to switch between food (default) or slime processing."
+	desc = "The circuit board for a processing unit. Use a multitool on the circuit to switch between food (default) or slime processing."
 	id = "processor"
 	build_path = /obj/item/circuitboard/machine/processor
 	category = list(

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -574,7 +574,7 @@
 
 /datum/design/board/processor
 	name = "Food/Slime Processor Board"
-	desc = "The circuit board for a processing unit. Screwdriver the circuit to switch between food (default) or slime processing."
+	desc = "The circuit board for a processing unit. Multitool the circuit to switch between food (default) or slime processing."
 	id = "processor"
 	build_path = /obj/item/circuitboard/machine/processor
 	category = list(


### PR DESCRIPTION

## About The Pull Request

You multitool the Food/Slime Processor to change between its modes now.

Added clarifying descriptors to the circuitboard and built machine to ease this.

## Why It's Good For The Game

I got confused by being unable to grind up slimes, turns out that the food processor no longer sucks up slimes? I'm 90% sure that it used to. Either way, I didn't know why it wasn't working for me so I decided to make this PR to clarify it.

I changed it to multitooling because that's more consistent with the cargo console's board.

## Changelog

:cl:
qol: You multitool the Food/Slime Processor to change between its modes now.
qol: Added clarifying descriptors to the circuitboard and built machine on examine that indicate how to do the above.
/:cl:

