### PR TITLE
Fixes map votes of only one choice

### DIFF
--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -20,7 +20,7 @@
 /datum/vote/map_vote/create_vote()
 	. = ..()
 	check_population(should_key_choices = FALSE)
-	if((length(choices) == 1) && EMERGENCY_ESCAPED_OR_ENDGAMED) // Only one choice, no need to vote. Let's just auto-rotate it to the only remaining map because it would just happen anyways.
+	if(length(choices) == 1) // Only one choice, no need to vote. Let's just auto-rotate it to the only remaining map because it would just happen anyways.
 		var/de_facto_winner = choices[1]
 		var/datum/map_config/change_me_out = global.config.maplist[de_facto_winner]
 		SSmapping.changemap(change_me_out)


### PR DESCRIPTION

## About The Pull Request

Unfortunately, back in #70340 (4085e792ab5716485d379ce5f3dcbbae1c3d0522) which was declared to fix the issue of having only one map to vote for, I cocked up a part of it. For some reason, the part where it states that only one map could be voted for would only play on the emergency shuttle leaving. I think I did this because of the fact that the mapvote would auto-call, and this didn't really respect the fact that people would also call their own votes with only one map to vote for. Thus, the vote would fire with one map to choose for and there wouldn't be the message on there being only one map to vote for that I added in the aforementioned PR. This brings it back to the intended working condition.

## Why It's Good For The Game

I over-specified the code I wrote last year when I really should not have.

## Changelog
:cl:
fix: The custom error message for when there is only one map to vote for should pop up in all cases rather than just a select few.
/:cl:
