### PR TITLE
Prevents players from getting antagonist if they can't qualify for any role beforehand.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -671,9 +671,9 @@ SUBSYSTEM_DEF(job)
 	if(PopcapReached())
 		JobDebug("Popcap overflow Check observer located, Player: [player]")
 	JobDebug("Player rejected :[player]")
-	to_chat(player, "<span class='infoplain'><b>You have failed to qualify for any job you desired.</b></span>")
 	unassigned -= player
 	if(!run_divide_occupation_pure)
+		to_chat(player, "<span class='infoplain'><b>You have failed to qualify for any job you desired.</b></span>")
 		player.ready = PLAYER_NOT_READY
 
 

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -227,8 +227,7 @@ SUBSYSTEM_DEF(job)
 	JobDebug("Player: [player] is now Rank: [job.title], JCP:[job.current_positions], JPL:[latejoin ? job.total_positions : job.spawn_positions]")
 	player.mind.set_assigned_role(job)
 	unassigned -= player
-	if(!run_divide_occupation_pure)
-		job.current_positions++
+	job.current_positions++
 	return TRUE
 
 /datum/controller/subsystem/job/proc/FindOccupationCandidates(datum/job/job, level)
@@ -371,7 +370,7 @@ SUBSYSTEM_DEF(job)
 	//Setup new player list and get the jobs list
 	JobDebug("Running DO, allow_all = [allow_all], pure = [pure]")
 	run_divide_occupation_pure = pure
-	SEND_SIGNAL(src, COMSIG_OCCUPATIONS_DIVIDED)
+	SEND_SIGNAL(src, COMSIG_OCCUPATIONS_DIVIDED, pure, allow_all)
 
 	//Get the players who are ready
 	for(var/i in GLOB.new_player_list)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -363,9 +363,9 @@ SUBSYSTEM_DEF(job)
  *  fills var "assigned_role" for all ready players.
  *  This proc must not have any side effect besides of modifying "assigned_role".
  **/
-/datum/controller/subsystem/job/proc/DivideOccupations()
+/datum/controller/subsystem/job/proc/DivideOccupations(allow_all = FALSE)
 	//Setup new player list and get the jobs list
-	JobDebug("Running DO")
+	JobDebug("Running DO, allow_all = [allow_all]")
 
 	SEND_SIGNAL(src, COMSIG_OCCUPATIONS_DIVIDED)
 
@@ -435,8 +435,9 @@ SUBSYSTEM_DEF(job)
 
 		// Loop through all unassigned players
 		for(var/mob/dead/new_player/player in unassigned)
-			if(PopcapReached())
-				RejectPlayer(player)
+			if(!allow_all)
+				if(PopcapReached())
+					RejectPlayer(player)
 
 			// Loop through all jobs
 			for(var/datum/job/job in shuffledoccupations) // SHUFFLE ME BABY
@@ -474,7 +475,7 @@ SUBSYSTEM_DEF(job)
 	// Hand out random jobs to the people who didn't get any in the last check
 	// Also makes sure that they got their preference correct
 	for(var/mob/dead/new_player/player in unassigned)
-		HandleUnassigned(player)
+		HandleUnassigned(player, allow_all)
 	JobDebug("DO, Ending handle unassigned.")
 
 	JobDebug("DO, Handle unrejectable unassigned")
@@ -493,12 +494,13 @@ SUBSYSTEM_DEF(job)
 	return TRUE
 
 //We couldn't find a job from prefs for this guy.
-/datum/controller/subsystem/job/proc/HandleUnassigned(mob/dead/new_player/player)
+/datum/controller/subsystem/job/proc/HandleUnassigned(mob/dead/new_player/player, allow_all = FALSE)
 	var/jobless_role = player.client.prefs.read_preference(/datum/preference/choiced/jobless_role)
 
-	if(PopcapReached())
-		RejectPlayer(player)
-		return
+	if(!allow_all)
+		if(PopcapReached())
+			RejectPlayer(player)
+			return
 
 	switch (jobless_role)
 		if (BEOVERFLOW)

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -458,12 +458,16 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 	//To new_player and such, and we want the datums to just free when the roundstart work is done
 	var/list/roundstart_rules = init_rulesets(/datum/dynamic_ruleset/roundstart)
 
-	SSjob.DivideOccupations()
+	SSjob.DivideOccupations(allow_all = TRUE)
 	for(var/i in GLOB.new_player_list)
 		var/mob/dead/new_player/player = i
-		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && !is_unassigned_job(player.mind.assigned_role) && player.check_preferences())
-			roundstart_pop_ready++
-			candidates.Add(player)
+		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && player.check_preferences())
+			if(is_unassigned_job(player.mind.assigned_role))
+				log_admin("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any antagonist role.")
+				message_admins("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. This is an old antag rolling technique. They will be unable to qualify for any antagonist role.")
+			else
+				roundstart_pop_ready++
+				candidates.Add(player)
 	SSjob.ResetOccupations()
 	log_dynamic("Listing [roundstart_rules.len] round start rulesets, and [candidates.len] players ready.")
 	if (candidates.len <= 0)

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -458,7 +458,7 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 	//To new_player and such, and we want the datums to just free when the roundstart work is done
 	var/list/roundstart_rules = init_rulesets(/datum/dynamic_ruleset/roundstart)
 
-	SSjob.DivideOccupations(allow_all = TRUE)
+	SSjob.DivideOccupations(pure = TRUE, allow_all = TRUE)
 	for(var/i in GLOB.new_player_list)
 		var/mob/dead/new_player/player = i
 		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && player.check_preferences())

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -463,8 +463,8 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 		var/mob/dead/new_player/player = i
 		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && player.check_preferences())
 			if(is_unassigned_job(player.mind.assigned_role))
-				log_admin("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any antagonist role.")
-				message_admins("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. This is an old antag rolling technique. They will be unable to qualify for any antagonist role.")
+				log_admin("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any roundstart antagonist role.")
+				message_admins("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. This is an old antag rolling technique. They will be unable to qualify for any roundstart antagonist role.")
 			else
 				roundstart_pop_ready++
 				candidates.Add(player)

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -458,11 +458,13 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 	//To new_player and such, and we want the datums to just free when the roundstart work is done
 	var/list/roundstart_rules = init_rulesets(/datum/dynamic_ruleset/roundstart)
 
+	SSjob.DivideOccupations()
 	for(var/i in GLOB.new_player_list)
 		var/mob/dead/new_player/player = i
-		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && player.check_preferences())
+		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && !is_unassigned_job(player.mind.assigned_role) && player.check_preferences())
 			roundstart_pop_ready++
 			candidates.Add(player)
+	SSjob.ResetOccupations()
 	log_dynamic("Listing [roundstart_rules.len] round start rulesets, and [candidates.len] players ready.")
 	if (candidates.len <= 0)
 		log_dynamic("[candidates.len] candidates.")

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -463,8 +463,13 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 		var/mob/dead/new_player/player = i
 		if(player.ready == PLAYER_READY_TO_PLAY && player.mind && player.check_preferences())
 			if(is_unassigned_job(player.mind.assigned_role))
-				log_admin("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any roundstart antagonist role.")
-				message_admins("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. This is an old antag rolling technique. They will be unable to qualify for any roundstart antagonist role.")
+				var/list/job_data = list()
+				var/job_prefs = player.client.prefs.job_preferences
+				for(var/job in job_prefs)
+					var/priority = job_prefs[job]
+					job_data += "[job]: [SSjob.job_priority_level_to_string(priority)]"
+				to_chat(player, span_danger("You were unable to qualify for any roundstart antagonist role because you could not qualify for any of the roundstart jobs you were trying to qualify for, along with 'return to lobby if job is unavailable' enabled."))
+				log_admin("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any roundstart antagonist role. These are their job preferences - [job_data.Join(" | ")]")
 			else
 				roundstart_pop_ready++
 				candidates.Add(player)

--- a/code/modules/admin/verbs/ai_triumvirate.dm
+++ b/code/modules/admin/verbs/ai_triumvirate.dm
@@ -13,14 +13,15 @@ GLOBAL_DATUM(triple_ai_controller, /datum/triple_ai_controller)
 	. = ..()
 	RegisterSignal(SSjob, COMSIG_OCCUPATIONS_DIVIDED, PROC_REF(on_occupations_divided))
 
-/datum/triple_ai_controller/proc/on_occupations_divided(datum/source)
+/datum/triple_ai_controller/proc/on_occupations_divided(datum/source, pure, allow_all)
 	SIGNAL_HANDLER
 
 	for(var/datum/job/ai/ai_datum in SSjob.joinable_occupations)
 		ai_datum.spawn_positions = 3
-	for(var/obj/effect/landmark/start/ai/secondary/secondary_ai_spawn in GLOB.start_landmarks_list)
-		secondary_ai_spawn.latejoin_active = TRUE
-	qdel(src)
+	if(!pure)
+		for(var/obj/effect/landmark/start/ai/secondary/secondary_ai_spawn in GLOB.start_landmarks_list)
+			secondary_ai_spawn.latejoin_active = TRUE
+		qdel(src)
 
 /datum/triple_ai_controller/Destroy(force)
 	UnregisterSignal(SSjob, COMSIG_OCCUPATIONS_DIVIDED)


### PR DESCRIPTION
## About The Pull Request
As the title says, you can no longer become an antagonist if you can't qualify for a role beforehand. How this works is that it runs job assignment before antagonist roles are handed out to see which players can qualify for a job role. It then undoes job assignments and then runs antagonist assignment.
This is to prevent players from setting a highly contested role to low priority so that they have a 0% chance of ever getting it, whilst still being eligible for every antag role.

It's not completely foolproof as it's not really possible to account for the fact that some players may become antagonists, thereby freeing up some job slots. Since it's an approximation, it means that players who put themselves at a high chance of returning back to lobby due to their preference choices have an overall lower chance of becoming an antagonist as they can be excluded from the antagonist roll due to the random nature of job selection.
If players want to prevent this from happening, simply set a lot of jobs to low/medium priority or adjust the "Return back to lobby" preference to any other preference.

## Why It's Good For The Game
Prevents players from rolling antag without ever intending to play the game as a non-antagonist.

## Changelog
:cl:
fix: Fixed players being able to roll antagonist without ever being eligible to play any role. Players who have their preferences set up so that they're likely to return to lobby when the round starts have a lowered chance of becoming antagonist.
/:cl:
