### PR TITLE
Nerfs flash stun to need the target confused.

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -169,17 +169,18 @@
 			flashed.set_confusion_if_lower(confusion_duration * CONFUSION_STACK_MAX_MULTIPLIER)
 			visible_message(span_danger("[user] blinds [flashed] with the flash!"), span_userdanger("[user] blinds you with the flash!"))
 			//easy way to make sure that you can only long stun someone who is facing in your direction
-			flashed.adjustStaminaLoss(rand(80, 120) * (1 - (deviation * 0.5)))
-			flashed.Paralyze(rand(25, 50) * (1 - (deviation * 0.5)))
+			flashed.adjustStaminaLoss(rand(60, 100) * (1 - (deviation * 0.5)))
+			//making it so that the paralyze requires initially having confused the target with a flash or something else
+			if(flashed.get_timed_status_effect_duration(/datum/status_effect/confusion) > 0)
+				flashed.Paralyze(rand(25, 50) * (1 - (deviation * 0.5)))
 			SEND_SIGNAL(user, COMSIG_MOB_SUCCESSFUL_FLASHED_CARBON, flashed, src, deviation)
 
 		else if(user)
 			visible_message(span_warning("[user] fails to blind [flashed] with the flash!"), span_danger("[user] fails to blind you with the flash!"))
 		else
 			to_chat(flashed, span_danger("[src] fails to blind you!"))
-	else
-		if(flashed.flash_act())
-			flashed.set_confusion_if_lower(confusion_duration * CONFUSION_STACK_MAX_MULTIPLIER)
+	if(flashed.flash_act())
+		flashed.set_confusion_if_lower(confusion_duration * CONFUSION_STACK_MAX_MULTIPLIER)
 
 /**
  * Handles the directionality of the attack


### PR DESCRIPTION
## About The Pull Request

Makes flashes' stun effect require that the target first be confused to kick in (either by flashing them, which the targeted flash does now as well, or by any other means of confusion.) 

Reduces the stamina damage done by flashes to almost never be an immediate one-tap stamcrit.

## Why It's Good For The Game

Flashes are weird. Flash protection is precious and strangely scarce without a tradeoff (blinding or otherwise reducing your vision.) They're hard-countered by any EMP (unlike batons since they were changed) but prior to this change were probably one of the safest ways to one-tap somebody if you had flash protection. They were also great for ambushes even though one of their only putative counters without flash protection was to be running/facing away from the attacker. 

Also, they used to be a hard counter to borgs prior to #75819 - they're not now, but pretty much all borgs still have flashes. 

It's time carbons stopped playing by the rocket-tag rules for flashes too.

(this is actually a secret peacekeeper borg buff since now their funny confuse/pacify alarm can be used to synergize with flashes) 

(rev flashes still work as before, converting and muting on the flash, but my concern that this might be turned into a way of antag testing for revheads is limited given that it's usually done with a loyalty implant.) 

## Changelog

:cl:
balance: Flashes no longer instantly stun carbons, confuse on a targeted attack, and do slightly less stamina damage than before. Flashes only stun carbons which are first confused, though they can still be used to put people into stamina crit if susceptible.
/:cl:
