### PR TITLE
Fix secret documents steal objective failing while inside folder

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -353,6 +353,7 @@
 
 /datum/objective_item/steal/documents
 	name = "any set of secret documents of any organization"
+	valid_containers = list(/obj/item/folder)
 	targetitem = /obj/item/documents
 	exists_on_map = TRUE
 


### PR DESCRIPTION

## About The Pull Request
Fixes #67318

Secret documents inserted into a folder would result in failure. This was frustrating for people who kept the original folder it was spawned in.  It has now been fixed properly.

## Why It's Good For The Game
Greentext is good.

## Changelog
:cl:
fix: Fix secret documents steal objective failing while inside folder.
/:cl:
