### PR TITLE
Removes `CANPUSH` status flag from lavaland basic mobs

### DIFF
--- a/code/modules/mob/living/basic/lavaland/mining.dm
+++ b/code/modules/mob/living/basic/lavaland/mining.dm
@@ -2,6 +2,7 @@
 /mob/living/basic/mining
 	icon = 'icons/mob/simple/lavaland/lavaland_monsters.dmi'
 	combat_mode = TRUE
+	status_flags = NONE //don't inherit standard basicmob flags
 	mob_size = MOB_SIZE_LARGE
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	faction = list(FACTION_MINING)


### PR DESCRIPTION
## About The Pull Request

Title. This makes it so every lavaland mob is now unable to be pushed by moving into them while on combat mode. Namely this helps with watchers, as they have gained this vulnerability when they've got the basic bitch treatment — it caused their _look away_ ability to be easily cancellable by just pushing them. ~~you can still just fuckin' grab them to do that and i think it's fair game~~
 
Lobsters and brimdemons are also affected, which i'm not sure how exactly this affects their gameplay... but it is what it is.

## Why It's Good For The Game

Previous behavior restored, mobs stop being bullied by literally running into them.

## Changelog

:cl:
fix: you can no longer push watchers (and any other lavaland basic mob) around by running into them
/:cl: