### PR TITLE
Stops metalgen destructing indestructible turfs

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -8,9 +8,9 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 			.[ckey(initial(R.name))] = t
 
 GLOBAL_LIST_INIT(blacklisted_metalgen_types, typecacheof(list(
-		/turf/closed/indestructible, //indestructible turfs should be indestructible, metalgen transmutation to plasma allows them to be destroyed
-		/turf/open/indestructible
-	)))
+	/turf/closed/indestructible, //indestructible turfs should be indestructible, metalgen transmutation to plasma allows them to be destroyed
+	/turf/open/indestructible
+)))
 
 //Various reagents
 //Toxin & acid reagents

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -7,6 +7,10 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 		if (length(initial(R.name)))
 			.[ckey(initial(R.name))] = t
 
+GLOBAL_LIST_INIT(blacklisted_metalgen_types, typecacheof(list(
+		/turf/closed/indestructible, //indestructible turfs should be indestructible, metalgen transmutation to plasma allows them to be destroyed
+		/turf/open/indestructible
+	)))
 
 //Various reagents
 //Toxin & acid reagents

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2665,13 +2665,16 @@
 	metal_morph(exposed_turf)
 
 ///turn an object into a special material
-/datum/reagent/metalgen/proc/metal_morph(atom/A)
+/datum/reagent/metalgen/proc/metal_morph(atom/target)
 	var/metal_ref = data["material"]
 	if(!metal_ref)
 		return
 
+	if(is_type_in_typecache(target, GLOB.blacklisted_metalgen_types)) //some stuff can lead to exploits if transmuted
+		return
+
 	var/metal_amount = 0
-	var/list/materials_to_transmute = A.get_material_composition(BREAKDOWN_INCLUDE_ALCHEMY)
+	var/list/materials_to_transmute = target.get_material_composition(BREAKDOWN_INCLUDE_ALCHEMY)
 	for(var/metal_key in materials_to_transmute) //list with what they're made of
 		metal_amount += materials_to_transmute[metal_key]
 
@@ -2679,9 +2682,9 @@
 		metal_amount = default_material_amount //some stuff doesn't have materials at all. To still give them properties, we give them a material. Basically doesn't exist
 
 	var/list/metal_dat = list((metal_ref) = metal_amount)
-	A.material_flags = applied_material_flags
-	A.set_custom_materials(metal_dat)
-	ADD_TRAIT(A, TRAIT_MAT_TRANSMUTED, type)
+	target.material_flags = applied_material_flags
+	target.set_custom_materials(metal_dat)
+	ADD_TRAIT(target, TRAIT_MAT_TRANSMUTED, type)
 
 /datum/reagent/gravitum
 	name = "Gravitum"


### PR DESCRIPTION

## About The Pull Request

Adds a check to metalgen transmutation to allow for blacklisting of types. Adds indestructible open and closed turfs to the blacklist to prevent an exploit where they are transmuted to plasma and burned to remove them.

## Why It's Good For The Game

Exploits are bad.

## Changelog
:cl:
fix: Metalgen can no longer be used to transmute indestructible turfs.
/:cl:
