### PR TITLE
Fulton beacons can be renamed and redeployed

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	icon_state = "folded_extraction"
 
 /obj/item/fulton_core/attack_self(mob/user)
-	if(do_after(user,15,target = user) && !QDELETED(src))
+	if(do_after(user, 1.5 SECONDS, target = user) && !QDELETED(src))
 		new /obj/structure/extraction_point(get_turf(user))
 		playsound(src, 'sound/items/deconstruct.ogg', vol = 50, vary = TRUE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE)
 		qdel(src)
@@ -156,6 +156,7 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	icon_state = "extraction_point"
 	anchored = TRUE
 	density = FALSE
+	obj_flags = CAN_BE_HIT | UNIQUE_RENAME
 	var/beacon_network = "station"
 
 /obj/structure/extraction_point/Initialize(mapload)
@@ -167,6 +168,15 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 /obj/structure/extraction_point/Destroy()
 	GLOB.total_extraction_beacons -= src
 	return ..()
+
+/obj/structure/extraction_point/attack_hand(mob/living/user, list/modifiers)
+	. = ..()
+	balloon_alert_to_viewers("undeploying...")
+	if(!do_after(user, 1.5 SECONDS, src))
+		return
+	new /obj/item/fulton_core(drop_location())
+	playsound(src, 'sound/items/deconstruct.ogg', vol = 50, vary = TRUE, extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE)
+	qdel(src)
 
 /obj/structure/extraction_point/update_overlays()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Lets players rename a deployed fulton beacon with a pen, changing its name/decription. Also lets players click said beacon with an empty hand to undeploy it after a short delay, which leaves a ready-to-use fulton core kit.

## Why It's Good For The Game

Good QoL to let players move their beacons around. Renaming them also allows players to shorten the name of the beacon, removing guesswork like _where the fuck is **fulton beacon (666) (Cargo Bay)**_.

## Changelog

:cl:
qol: you can undeploy fulton beacons by clicking them with an empty hand
qol: you can rename fulton beacons with a pen
/:cl: