### PR TITLE
Patches some cargo shuttle Centcom exploits.

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -67,10 +67,54 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 					return FALSE
 	return TRUE
 
+/// Returns anything on the cargo blacklist found within areas_to_check back to the turf of the home docking port via Centcom branded supply pod.
+/obj/docking_port/mobile/supply/proc/return_blacklisted_things_home(list/area/areas_to_check, obj/docking_port/stationary/home)
+	var/list/stuff_to_send_home = list()
+	for(var/area/shuttle_area as anything in areas_to_check)
+		for(var/turf/shuttle_turf in shuttle_area)
+			for(var/atom/passenger in shuttle_turf.get_all_contents())
+				if((is_type_in_typecache(passenger, GLOB.blacklisted_cargo_types) || HAS_TRAIT(passenger, TRAIT_BANNED_FROM_CARGO_SHUTTLE)) && !istype(passenger, /obj/docking_port))
+					stuff_to_send_home += passenger
+
+	if(!length(stuff_to_send_home))
+		return FALSE
+
+	var/obj/structure/closet/supplypod/centcompod/et_go_home = new()
+
+	for(var/atom/movable/et as anything in stuff_to_send_home)
+		et.forceMove(et_go_home)
+
+	new /obj/effect/pod_landingzone(get_turf(home), et_go_home)
+
+	return stuff_to_send_home
+
 /obj/docking_port/mobile/supply/request(obj/docking_port/stationary/S)
 	if(mode != SHUTTLE_IDLE)
 		return 2
 	return ..()
+
+/obj/docking_port/mobile/supply/check_dock(obj/docking_port/stationary/S, silent)
+	. = ..()
+
+	if(!.)
+		return
+
+	// If we're not trying to dock at Centcom, we don't care.
+	if(S.shuttle_id != "cargo_away")
+		return
+
+	// Else we are docking at Centcom, check the blacklist to make sure no contraband was put onto the shuttle mid-transit.
+	// This is a sort of catch-all exploit check.
+	var/list/stuff_sent_home = return_blacklisted_things_home(shuttle_areas, previous)
+	if(!length(stuff_sent_home))
+		return
+
+	for(var/atom/thing_sent_home in stuff_sent_home)
+		investigate_log("Blacklisted item found on in-transit Cargo Shuttle: [thing_sent_home] ([thing_sent_home.type])", INVESTIGATE_CARGO)
+
+	message_admins("Blacklisted item found on in-transit Cargo Shuttle. See cargo logs for more details.")
+	SSshuttle.centcom_message = "Contraband found on Cargo Shuttle. This has been returned via drop pod."
+	return FALSE
 
 /obj/docking_port/mobile/supply/initiate_docking()
 	if(getDockedId() == "cargo_away") // Buy when we leave home.

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 /obj/docking_port/mobile/supply/proc/check_blacklist(areaInstances)
 	for(var/place in areaInstances)
 		var/area/shuttle/shuttle_area = place
-		for(var/turf/shuttle_turf in shuttle_area)
+		for(var/turf/shuttle_turf in shuttle_area.get_contained_turfs())
 			for(var/atom/passenger in shuttle_turf.get_all_contents())
 				if((is_type_in_typecache(passenger, GLOB.blacklisted_cargo_types) || HAS_TRAIT(passenger, TRAIT_BANNED_FROM_CARGO_SHUTTLE)) && !istype(passenger, /obj/docking_port))
 					return FALSE
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 /obj/docking_port/mobile/supply/proc/return_blacklisted_things_home(list/area/areas_to_check, obj/docking_port/stationary/home)
 	var/list/stuff_to_send_home = list()
 	for(var/area/shuttle_area as anything in areas_to_check)
-		for(var/turf/shuttle_turf in shuttle_area)
+		for(var/turf/shuttle_turf in shuttle_area.get_contained_turfs())
 			for(var/atom/passenger in shuttle_turf.get_all_contents())
 				if((is_type_in_typecache(passenger, GLOB.blacklisted_cargo_types) || HAS_TRAIT(passenger, TRAIT_BANNED_FROM_CARGO_SHUTTLE)) && !istype(passenger, /obj/docking_port))
 					stuff_to_send_home += passenger
@@ -104,17 +104,17 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		return
 
 	// Else we are docking at Centcom, check the blacklist to make sure no contraband was put onto the shuttle mid-transit.
-	// This is a sort of catch-all exploit check.
+	// If there's anything contrabandy, send these items back to the origin docking port.
+	// This is a sort of catch-all Centcom exploit check.
 	var/list/stuff_sent_home = return_blacklisted_things_home(shuttle_areas, previous)
 	if(!length(stuff_sent_home))
 		return
 
-	for(var/atom/thing_sent_home in stuff_sent_home)
+	for(var/atom/thing_sent_home as anything in stuff_sent_home)
 		investigate_log("Blacklisted item found on in-transit Cargo Shuttle: [thing_sent_home] ([thing_sent_home.type])", INVESTIGATE_CARGO)
 
 	message_admins("Blacklisted item found on in-transit Cargo Shuttle. See cargo logs for more details.")
 	SSshuttle.centcom_message = "Contraband found on Cargo Shuttle. This has been returned via drop pod."
-	return FALSE
 
 /obj/docking_port/mobile/supply/initiate_docking()
 	if(getDockedId() == "cargo_away") // Buy when we leave home.


### PR DESCRIPTION

## About The Pull Request

Globally prevents anything blacklisted from actually getting to the Centcom z-level by shipping blacklisted items back to their location of origin just before the shuttle docks at Centcom.

Everything rejected in this way is logged and admins are given an alert to let them know something funky went on.

![image](https://github.com/tgstation/tgstation/assets/24975989/09717f16-1115-45f2-8f8b-85b316ed4bc6)
![image](https://github.com/tgstation/tgstation/assets/24975989/af149939-1cf1-49f1-b458-7d5d4ff6ae89)
## Why It's Good For The Game

Hopefully universally patches all current methods of getting to the Centcom Z-level via getting on the cargo shuttle mid-transit. 

Individual methods to accomplish this can still be patched individually, but this tries to blanket prevent such exploits from working on a more fundamental level.
## Changelog
:cl:
fix: Centcom now rejects contraband that somehow makes it way onto the cargo shuttle mid-transit and returns it.
/:cl:
