### PR TITLE
Removes debug species from magic mirror

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/abominations.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abominations.dm
@@ -3,6 +3,7 @@
 	name = "\improper Tall Boy"
 	id = SPECIES_TALLBOY
 	examine_limb_id = SPECIES_HUMAN
+	changesource_flags = NONE
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right,
@@ -13,8 +14,10 @@
 	)
 
 /datum/species/monkey/human_legged
+	name = "human-legged monkey"
 	id = SPECIES_MONKEY_HUMAN_LEGGED
 	examine_limb_id = SPECIES_MONKEY
+	changesource_flags = NONE
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/monkey,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/monkey,
@@ -25,8 +28,10 @@
 	)
 
 /datum/species/monkey/monkey_freak
+	name = "human-armed monkey"
 	id = SPECIES_MONKEY_FREAK
 	examine_limb_id = SPECIES_MONKEY
+	changesource_flags = NONE
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right,

--- a/code/modules/mob/living/carbon/human/species_types/abominations.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abominations.dm
@@ -3,7 +3,7 @@
 	name = "\improper Tall Boy"
 	id = SPECIES_TALLBOY
 	examine_limb_id = SPECIES_HUMAN
-	changesource_flags = NONE
+	changesource_flags = MIRROR_BADMIN | WABBAJACK
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right,
@@ -17,7 +17,7 @@
 	name = "human-legged monkey"
 	id = SPECIES_MONKEY_HUMAN_LEGGED
 	examine_limb_id = SPECIES_MONKEY
-	changesource_flags = NONE
+	changesource_flags = MIRROR_BADMIN | WABBAJACK
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/monkey,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/monkey,
@@ -31,7 +31,7 @@
 	name = "human-armed monkey"
 	id = SPECIES_MONKEY_FREAK
 	examine_limb_id = SPECIES_MONKEY
-	changesource_flags = NONE
+	changesource_flags = MIRROR_BADMIN | WABBAJACK
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right,

--- a/code/modules/surgery/organs/external/_external_organ.dm
+++ b/code/modules/surgery/organs/external/_external_organ.dm
@@ -78,8 +78,10 @@
 		return
 
 	if(bodypart_overlay.imprint_on_next_insertion) //We only want this set *once*
-
-		bodypart_overlay.set_appearance_from_name(receiver.dna.features[bodypart_overlay.feature_key])
+		var/feature_name = receiver.dna.features[bodypart_overlay.feature_key]
+		if (isnull(feature_name))
+			feature_name = receiver.dna.species.external_organs[type]
+		bodypart_overlay.set_appearance_from_name(feature_name)
 		bodypart_overlay.imprint_on_next_insertion = FALSE
 
 	ownerlimb = limb


### PR DESCRIPTION
## About The Pull Request

Tallboys strike again
Fixes #78538
Removes "Tall Boys" from the magic mirror, again.
Also gives the two fucked up monkey species names and removes _them_ from the magic mirror.
When the magic mirror was looping through available species it was finding these monkey subtypes with fucked up limbs, noting that they were not forbidden, then adding them to the assoc list.
Because all of them were called "monkey" it would overwrite "monkey" with "monkey who has human arms and torso" which is... not what you wanted to turn into.

Additionally I made external organ feature name fall back to the species default if not provided because I kept getting a runtime on monkey tail insertion (nobody has a monkey tail feature in their prefs or DNA) which I originally thought was the cause of this bug, until I fixed it and learned that actually it was something much stupider.

## Changelog

:cl:
fix: Selecting "Monkey" on a magic mirror will now once again turn you into a Monkey rather than a disgusting freak of nature.
fix: Tall Boys have once again been barred from joining the Wizard Federation.
/:cl:
