### PR TITLE
Fixes halloween spooky meteors

### DIFF
--- a/code/modules/meteors/meteor_waves.dm
+++ b/code/modules/meteors/meteor_waves.dm
@@ -26,4 +26,4 @@ GLOBAL_LIST_INIT(meteors_stray, list(/obj/effect/meteor/medium=15, /obj/effect/m
 
 GLOBAL_LIST_INIT(meteors_sandstorm, list(/obj/effect/meteor/sand=45, /obj/effect/meteor/dust=5)) //for sandstorm event
 
-GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin))
+GLOBAL_LIST_INIT(meteorsSPOOKY, list(/obj/effect/meteor/pumpkin=1))


### PR DESCRIPTION

## About The Pull Request

This fixes the "spooky" meteors that get summoned during catastrophic meteor waves during the Halloween event.

By adding a weight value to the SPOOKY meteor list, the meteor wave spawning event process will properly pick_weight the path it's looking for.
## Why It's Good For The Game

Fixes a runtime case I hypothesized might happen.
## Changelog
:cl: Rhials
fix: "Spooky" meteors will now properly spawn during halloween.
/:cl:
