### PR TITLE
Fixes cigarettes smoking on any slot

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -346,6 +346,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(!istype(smoker) || smoker.get_item_by_slot(ITEM_SLOT_MASK) != loc)
 			reagents.remove_any(to_smoke)
 			return
+	else
+		if(src != smoker.wear_mask)
+			reagents.remove_any(to_smoke)
+			return
 
 	reagents.expose(smoker, INGEST, min(to_smoke / reagents.total_volume, 1))
 	var/obj/item/organ/internal/lungs/lungs = smoker.get_organ_slot(ORGAN_SLOT_LUNGS)


### PR DESCRIPTION
## About The Pull Request

#76881 allowed you to put cigarettes in a gas mask but removed the check for, if the thing was a cigarette, making sure it was in your mask slot. 

What this meant was that standing around with a cigarette in your hand would still make you passively smoke it - although this is somewhat more immersive to me as a former smoker, it also gets obnoxious having to set the cigarette on a table or put it in my bag to avoid racking up the ridiculously easy-to-accumulate nicotine addiction points you otherwise get from even one cigarette in-game.

This just readds that check after the checks for gas masks/non-smoker locations (which may also be broken but are beyond me right now - trying to put a cigarette into a gas mask's filter* slot returns 'mask's mouth is covered.')

## Why It's Good For The Game

fix good, let me do my nicotine slave rp 

## Changelog

:cl:
fix: cigarettes no longer smoke themselves from inside your pockets or on your hands.
/:cl: