### PR TITLE
Fixes Strong Stone ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_strong_rock.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_strong_rock.dmm
@@ -4,7 +4,7 @@
 /area/template_noop)
 "b" = (
 /turf/closed/mineral/strong,
-/area/template_noop)
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
 a


### PR DESCRIPTION
## About The Pull Request

It was spawning all this time but it was overridden by mapgen!
just places the rock in a lavaland/surface/outdoors area

### look at how snug he looks in there

![confy](https://github.com/tgstation/tgstation/assets/75863639/3f6e32d3-a031-4348-b004-22d49c3b2f6c)


## Changelog

:cl:
fix: fixed Strong Stone ruin generation
/:cl: