### PR TITLE
Fixed overflow role not actually being overflow anymore after ResetOccupation is called

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -299,6 +299,8 @@ SUBSYSTEM_DEF(job)
 		player.mind.special_role = null
 	SetupOccupations()
 	unassigned = list()
+	if(overflow_role)
+		set_overflow_role(overflow_role)
 	return
 
 


### PR DESCRIPTION

## About The Pull Request
See title. Calling ResetOccupation doesn't re-apply the overflow role correctly so it has reduced slots when it shouldn't.

## Why It's Good For The Game
Bugfix

## Changelog
:cl:
fix: Fixed the overflow role having less slots than it actually should.
/:cl:
