### PR TITLE
Removes all spawn locations of the awakened plush except the bus ruin

### DIFF
--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -151,4 +151,4 @@
 
 /datum/wires/explosive/gibtonite/explode()
 	var/obj/item/gibtonite/P = holder
-	P.GibtoniteReaction(null, 2)
+	P.GibtoniteReaction(null, "A wire signal has primed a")

--- a/code/game/objects/effects/spawners/random/entertainment.dm
+++ b/code/game/objects/effects/spawners/random/entertainment.dm
@@ -271,7 +271,6 @@
 		/obj/item/toy/plush/carpplushie = 3,
 		/obj/item/toy/plush/lizard_plushie/green = 3,
 		/obj/item/toy/plush/lizard_plushie/space/green = 3,
-		/obj/item/toy/plush/awakenedplushie = 3,
 		/obj/item/toy/plush/goatplushie = 3,
 		/obj/item/toy/plush/rouny = 3,
 		/obj/item/toy/plush/abductor = 3,

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -584,6 +584,7 @@
 	squeak_override = list('sound/effects/blobattack.ogg' = 1)
 	gender = FEMALE //given all the jokes and drawings, I'm not sure the xenobiologists would make a slimeboy
 
+// This is supposed to be only in the bus ruin, don't spawn it elsewhere
 /obj/item/toy/plush/awakenedplushie
 	name = "awakened plushie"
 	desc = "An ancient plushie that has grown enlightened to the true nature of reality."

--- a/code/game/objects/items/stacks/golem_food/golem_hand_actions.dm
+++ b/code/game/objects/items/stacks/golem_food/golem_hand_actions.dm
@@ -35,7 +35,7 @@
 	playsound(src, 'sound/weapons/sonic_jackhammer.ogg', 50, TRUE)
 	held_gibtonite.forceMove(get_turf(src))
 	held_gibtonite.det_time = 2 SECONDS
-	held_gibtonite.GibtoniteReaction(user)
+	held_gibtonite.GibtoniteReaction(user, "A [src] has targeted [target] with a thrown and primed")
 	held_gibtonite.throw_at(target, range = 10, speed = 3, thrower = user)
 	held_gibtonite = null
 	qdel(src)
@@ -44,7 +44,7 @@
 /// Called when you can't hold it in any longer and just drop it on the ground
 /obj/item/gibtonite_hand/proc/release_gibtonite()
 	held_gibtonite.forceMove(get_turf(src))
-	held_gibtonite.GibtoniteReaction(isliving(loc) ? loc : null)
+	held_gibtonite.GibtoniteReaction(isliving(loc) ? loc : null, "A [src] has dropped and primed a")
 	held_gibtonite = null
 	qdel(src)
 

--- a/code/modules/jobs/job_types/chaplain/chaplain.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain.dm
@@ -25,7 +25,6 @@
 
 	mail_goodies = list(
 		/obj/item/reagent_containers/cup/glass/bottle/holywater = 30,
-		/obj/item/toy/plush/awakenedplushie = 10,
 		/obj/item/grenade/chem_grenade/holy = 5,
 		/obj/item/toy/plush/narplush = 2,
 		/obj/item/toy/plush/ratplush = 1

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -190,7 +190,7 @@
 		if(67 to 68)
 			var/obj/item/gibtonite/free_bomb = new /obj/item/gibtonite(src)
 			free_bomb.quality = rand(1, 3)
-			free_bomb.GibtoniteReaction(null, 3)
+			free_bomb.GibtoniteReaction(null, "A secure loot closet has spawned a live")
 		if(69 to 70)
 			new /obj/item/stack/ore/bluespace_crystal(src, 5)
 		if(71 to 72)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -189,7 +189,7 @@
 			new /obj/item/clothing/suit/hooded/ian_costume(src)
 		if(67 to 68)
 			var/obj/item/gibtonite/free_bomb = new /obj/item/gibtonite(src)
-			free_bomb.quality = GIBTONITE_QUALITY_HIGH
+			free_bomb.quality = rand(1, 3)
 			free_bomb.GibtoniteReaction(null, 3)
 		if(69 to 70)
 			new /obj/item/stack/ore/bluespace_crystal(src, 5)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -188,7 +188,9 @@
 			new /obj/item/clothing/suit/costume/wellworn_shirt/graphic/ian(src)
 			new /obj/item/clothing/suit/hooded/ian_costume(src)
 		if(67 to 68)
-			new /obj/item/toy/plush/awakenedplushie(src)
+			var/obj/item/gibtonite/free_bomb = new /obj/item/gibtonite(src)
+			free_bomb.quality = GIBTONITE_QUALITY_HIGH
+			free_bomb.GibtoniteReaction(null, 3)
 		if(69 to 70)
 			new /obj/item/stack/ore/bluespace_crystal(src, 5)
 		if(71 to 72)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -311,18 +311,21 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	if(!is_mining_level(z))//Only annoy the admins ingame if we're triggered off the mining zlevel
 		notify_admins = TRUE
 
-	if(triggered_by == 1)
-		log_bomber(null, "An explosion has primed a", src, "for detonation", notify_admins)
-	else if(triggered_by == 2)
-		var/turf/bombturf = get_turf(src)
-		if(notify_admins)
-			message_admins("A signal has triggered a [name] to detonate at [ADMIN_VERBOSEJMP(bombturf)]. Igniter attacher: [ADMIN_LOOKUPFLW(attacher)]")
-		var/bomb_message = "A signal has primed a [name] for detonation at [AREACOORD(bombturf)]. Igniter attacher: [key_name(attacher)]."
-		log_game(bomb_message)
-		GLOB.bombers += bomb_message
-	else
-		user.visible_message(span_warning("[user] strikes \the [src], causing a chain reaction!"), span_danger("You strike \the [src], causing a chain reaction."))
-		log_bomber(user, "has primed a", src, "for detonation", notify_admins)
+	switch(triggered_by)
+		if(1)
+			log_bomber(null, "An explosion has primed a", src, "for detonation", notify_admins)
+		if(2)
+			var/turf/bombturf = get_turf(src)
+			if(notify_admins)
+				message_admins("A signal has triggered a [name] to detonate at [ADMIN_VERBOSEJMP(bombturf)]. Igniter attacher: [ADMIN_LOOKUPFLW(attacher)]")
+			var/bomb_message = "A signal has primed a [name] for detonation at [AREACOORD(bombturf)]. Igniter attacher: [key_name(attacher)]."
+			log_game(bomb_message)
+			GLOB.bombers += bomb_message
+		if(3)
+			log_bomber(null, "A secure loot closet has spawned a live", src, message_admins=notify_admins)
+		else
+			user.visible_message(span_warning("[user] strikes \the [src], causing a chain reaction!"), span_danger("You strike \the [src], causing a chain reaction."))
+			log_bomber(user, "has primed a", src, "for detonation", notify_admins)
 	det_timer = addtimer(CALLBACK(src, PROC_REF(detonate), notify_admins), det_time, TIMER_STOPPABLE)
 
 /obj/item/gibtonite/proc/detonate(notify_admins)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -267,7 +267,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 			return
 
 	if(I.tool_behaviour == TOOL_MINING || istype(I, /obj/item/resonator) || I.force >= 10)
-		GibtoniteReaction(user)
+		GibtoniteReaction(user, "A resonator has primed for detonation a")
 		return
 
 	if(istype(I, /obj/item/mining_scanner) || istype(I, /obj/item/t_scanner/adv_mining_scanner) || I.tool_behaviour == TOOL_MULTITOOL)
@@ -294,14 +294,14 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		return ..()
 
 /obj/item/gibtonite/bullet_act(obj/projectile/P)
-	GibtoniteReaction(P.firer)
+	GibtoniteReaction(P.firer, "A projectile has primed for detonation a")
 	return ..()
 
 /obj/item/gibtonite/ex_act()
-	GibtoniteReaction(null, 1)
+	GibtoniteReaction(null, "An explosion has primed for detonation a")
 	return TRUE
 
-/obj/item/gibtonite/proc/GibtoniteReaction(mob/user, triggered_by = 0)
+/obj/item/gibtonite/proc/GibtoniteReaction(mob/user, triggered_by)
 	if(primed)
 		return
 	primed = TRUE
@@ -311,21 +311,16 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	if(!is_mining_level(z))//Only annoy the admins ingame if we're triggered off the mining zlevel
 		notify_admins = TRUE
 
-	switch(triggered_by)
-		if(1)
-			log_bomber(null, "An explosion has primed a", src, "for detonation", notify_admins)
-		if(2)
-			var/turf/bombturf = get_turf(src)
-			if(notify_admins)
-				message_admins("A signal has triggered a [name] to detonate at [ADMIN_VERBOSEJMP(bombturf)]. Igniter attacher: [ADMIN_LOOKUPFLW(attacher)]")
-			var/bomb_message = "A signal has primed a [name] for detonation at [AREACOORD(bombturf)]. Igniter attacher: [key_name(attacher)]."
-			log_game(bomb_message)
-			GLOB.bombers += bomb_message
-		if(3)
-			log_bomber(null, "A secure loot closet has spawned a live", src, message_admins=notify_admins)
-		else
-			user.visible_message(span_warning("[user] strikes \the [src], causing a chain reaction!"), span_danger("You strike \the [src], causing a chain reaction."))
-			log_bomber(user, "has primed a", src, "for detonation", notify_admins)
+	if(user)
+		user.visible_message(span_warning("[user] strikes \the [src], causing a chain reaction!"), span_danger("You strike \the [src], causing a chain reaction."))
+
+	var/attacher_text = attacher ? "Igniter attacher: [ADMIN_LOOKUPFLW(attacher)]" : null
+
+	if(triggered_by)
+		log_bomber(user, triggered_by, src, attacher_text, notify_admins)
+	else
+		log_bomber(user, "Something has primed a", src, "for detonation.[attacher_text ? " " : ""][attacher_text]", notify_admins)
+
 	det_timer = addtimer(CALLBACK(src, PROC_REF(detonate), notify_admins), det_time, TIMER_STOPPABLE)
 
 /obj/item/gibtonite/proc/detonate(notify_admins)


### PR DESCRIPTION
It's supposed to be a coderbus easter egg, stop putting it elsewhere. I want it to stay rare enough that it confuses people when it makes it to the station.

The secure closet had it on the loot table and due to how that's coded it has to have something replace the slot (or rework the loot spawning code there) so I put a live bomb in the slot instead.

:cl: ninjanomnom
del: An easter egg plushie that was spawning where it shouldn't has been brought back home.
add: The secure closet can now spawn live gibtonite, enjoy your free bomb.
/:cl:
