### PR TITLE
Tweaks the BEPIS category of the bitrunning order console

### DIFF
--- a/code/modules/bitrunning/orders/tech.dm
+++ b/code/modules/bitrunning/orders/tech.dm
@@ -1,9 +1,22 @@
 /datum/orderable_item/bepis
 	category_index = CATEGORY_BEPIS
 
-/datum/orderable_item/bepis/random
-	item_path = /obj/item/disk/design_disk/bepis
-	cost_per_order = 500
+/datum/orderable_item/bepis/survival_pen
+	item_path = /obj/item/pen/survival
+	cost_per_order = 90
+
+/datum/orderable_item/bepis/party_sleeper
+	item_path = /obj/item/circuitboard/machine/sleeper/party
+	cost_per_order = 150
+	desc = "An old decommissioned sleeper circuitboard, repurposed for recreational purposes."
+
+/datum/orderable_item/bepis/sprayoncan
+	item_path = /obj/item/toy/sprayoncan
+	cost_per_order = 200
+
+/datum/orderable_item/bepis/circuit_stack
+	item_path = /obj/item/stack/circuit_stack/full
+	cost_per_order = 280
 
 /datum/orderable_item/bepis/pristine
 	item_path = /obj/item/disk/design_disk/bepis/remove_tech

--- a/code/modules/bitrunning/orders/tech.dm
+++ b/code/modules/bitrunning/orders/tech.dm
@@ -1,22 +1,22 @@
 /datum/orderable_item/bepis
 	category_index = CATEGORY_BEPIS
 
+/datum/orderable_item/bepis/circuit_stack
+	item_path = /obj/item/stack/circuit_stack/full
+	cost_per_order = 150
+
 /datum/orderable_item/bepis/survival_pen
 	item_path = /obj/item/pen/survival
-	cost_per_order = 90
+	cost_per_order = 150
 
 /datum/orderable_item/bepis/party_sleeper
 	item_path = /obj/item/circuitboard/machine/sleeper/party
-	cost_per_order = 150
-	desc = "An old decommissioned sleeper circuitboard, repurposed for recreational purposes."
+	cost_per_order = 750
+	desc = "A decommissioned sleeper circuitboard, repurposed for recreational purposes."
 
 /datum/orderable_item/bepis/sprayoncan
 	item_path = /obj/item/toy/sprayoncan
-	cost_per_order = 200
-
-/datum/orderable_item/bepis/circuit_stack
-	item_path = /obj/item/stack/circuit_stack/full
-	cost_per_order = 280
+	cost_per_order = 750
 
 /datum/orderable_item/bepis/pristine
 	item_path = /obj/item/disk/design_disk/bepis/remove_tech


### PR DESCRIPTION
## About The Pull Request

The bitrunner PR has removed the BEPIS machine, but kept two BEPIS disks as a possible reward. However, the base BEPIS disks may contain duplicate data. Originally, the BEPIS dispensed a Reformatted version of the disks, which on spawn remove their tech from the spawn list, ensuring that any future BEPIS disks would not contain duplicates of this purchased data. Therefore, I have removed the cheaper version, after discussing this with jlsnow301.

Of course, your expensive disk can still contain data that was in a base disk found in space, or worse, mailed to a scientist, and eventually, you will run out of techs to purchase, but these are separate issue.

I have also added the orphaned minor rewards to the same console, with prices suggested by @ArcaneMusic, who has also suggested that I should set all prices to be derived from the crew paycheck define, however, none of the product vendors use this, so I think I would like to do all of those in one go in a separate PR.

The reasoning behind the prices:

- Survival Pen: Not too disruptive, it just lets you dig. 150, lets round it up. Worth 100, or 1 star when not express ordered. 
- Spray on gloves: prevents shocks 10 times, cleaning also uses up charges, uses up glove slots. Potentially disruptive item. 750 or 500 when not express ordered.
- Party pod:  Mainly drugs, beer and recolouring chems, with potential of poisoning. 750 or 500 when not express ordered as while it is something silly you can do during downtime, you should do a bit of hunting for crates before you get this.
- Polycircuit: Actually very good item for engineers, so they have to carry less stuff around. They would still get bleed from using it, if someone interrupts them, but that doesn't matter much. 8 uses of circuits, adds up to little more than half sheet of materials, which is vastly smaller than the mineral amounts you get from the crates. 150, or 100 when not expressed ordered, just because of the versatility, and taking up only one slot in the inventories. Much cheaper than the original proposed one.

Still thinking about how to reintroduce the "Make Buck" Doe, I will try to reintroduce them in a different PR.

## Why It's Good For The Game

Its bad when a bitrunner buys an expensive disk, only to realize its contents are the same as the cheaper disk they bought due to RNG.

The silly items from the BEPIS shouldn't be lost. The prices are fair because you are giving up your precious domain loot points that you could use to give a gun to your avatar to buy a silly spray-on glove. 

## Changelog

:cl:
add: Added the BEPIS' minor rewards as purchasable products to the bitrunning order console.
del: Removed the base BEPIS disk from the bitrunner console
/:cl:
