### PR TITLE
Borgs will slow down when stuff is thrown at them

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -1,4 +1,4 @@
-/** AI defines */
+// AI defines
 
 #define DEFAULT_AI_LAWID "default"
 #define LAW_ZEROTH "zeroth"
@@ -27,7 +27,10 @@
 ///Malfunctioning AI hijacking mecha
 #define AI_MECH_HACK 3
 
-/** Cyborg defines */
+// Cyborg defines
+
+/// If an item does this or more throwing damage it will slow a borg down on hit
+#define CYBORG_THROW_SLOWDOWN_THRESHOLD 10
 
 /// Special value to reset cyborg's lamp_cooldown
 #define BORG_LAMP_CD_RESET -1

--- a/code/datums/status_effects/debuffs/cyborg.dm
+++ b/code/datums/status_effects/debuffs/cyborg.dm
@@ -2,7 +2,7 @@
 /datum/status_effect/borg_throw_slow
 	id = "borg_throw_slowdown"
 	alert_type = /atom/movable/screen/alert/status_effect/borg_throw_slow
-	duration = 5 SECONDS
+	duration = 3 SECONDS
 	status_type = STATUS_EFFECT_REPLACE
 
 /datum/status_effect/borg_throw_slow/on_apply()

--- a/code/datums/status_effects/debuffs/cyborg.dm
+++ b/code/datums/status_effects/debuffs/cyborg.dm
@@ -1,0 +1,22 @@
+/// Reduce a cyborg's speed when you throw things at it
+/datum/status_effect/borg_throw_slow
+	id = "borg_throw_slowdown"
+	alert_type = /atom/movable/screen/alert/status_effect/borg_throw_slow
+	duration = 5 SECONDS
+	status_type = STATUS_EFFECT_REPLACE
+
+/datum/status_effect/borg_throw_slow/on_apply()
+	. = ..()
+	owner.add_movespeed_modifier(/datum/movespeed_modifier/borg_throw, update = TRUE)
+
+/datum/status_effect/borg_throw_slow/on_remove()
+	. = ..()
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/borg_throw, update = TRUE)
+
+/atom/movable/screen/alert/status_effect/borg_throw_slow
+	name = "Percussive Maintenance"
+	desc = "A sudden impact has triggered your collision avoidance routines, reducing movement speed."
+	icon_state = "weaken"
+
+/datum/movespeed_modifier/borg_throw
+	multiplicative_slowdown = 0.9

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -439,11 +439,8 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 	if(prob(75) && Proj.damage > 0)
 		spark_system.start()
 
-/mob/living/silicon/on_hit(obj/projectile/P)
-	if(!has_movespeed_modifier(/datum/movespeed_modifier/borg_throw))
-		add_movespeed_modifier(/datum/movespeed_modifier/borg_throw)
-		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/silicon, clear_throw_slowdown)), (P.throwforce / 10) SECONDS)
-	return ..()
-
-/mob/living/silicon/proc/clear_throw_slowdown()
-	src.remove_movespeed_modifier(/datum/movespeed_modifier/borg_throw)
+/mob/living/silicon/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	. = ..()
+	if (. || AM.throwforce < CYBORG_THROW_SLOWDOWN_THRESHOLD)
+		return
+	apply_status_effect(/datum/status_effect/borg_throw_slow)

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -84,9 +84,6 @@
 /datum/movespeed_modifier/shove
 	multiplicative_slowdown = SHOVE_SLOWDOWN_STRENGTH
 
-/datum/movespeed_modifier/borg_throw
-	multiplicative_slowdown = 0.9
-
 /datum/movespeed_modifier/human_carry
 	multiplicative_slowdown = HUMAN_CARRY_SLOWDOWN
 	blacklisted_movetypes = FLOATING

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1641,6 +1641,7 @@
 #include "code\datums\status_effects\debuffs\choke.dm"
 #include "code\datums\status_effects\debuffs\confusion.dm"
 #include "code\datums\status_effects\debuffs\cursed.dm"
+#include "code\datums\status_effects\debuffs\cyborg.dm"
 #include "code\datums\status_effects\debuffs\debuffs.dm"
 #include "code\datums\status_effects\debuffs\decloning.dm"
 #include "code\datums\status_effects\debuffs\dizziness.dm"


### PR DESCRIPTION
## About The Pull Request

This feature was added in #75819 but didn't work, for two reasons.
Reason one: it was checking for throwing impact on the "I got shot by a bullet" proc and then checking the throwforce of a bullet (generally 0, because you don't throw those).
Reason two: the duration was throwforce / 10 seconds. This would apply a slowdown which was usually one or fewer seconds, which might as well not exist.

The solution to this is to assign it to the correct proc and give it a flat duration for anything over a threshold of damage.
Currently this is 3 seconds for anything with 10 or more force (such as the humble iron rod). You can reapply it by just throwing more stuff.

## Why It's Good For The Game

Cyborgs don't suffer health-based slowdown like humans.
This is good because cyborg combat should be similar to humans, but bad because our move speed config is so ludicrously high that it makes fighting anyone at full speed a real pain in the ass.
Since flashes have been nerfed to require two clicks in order to stun a cyborg, you have to be able to catch them to apply the second click. Throwing something at them should make this more likely.

## Changelog

:cl:
fix: Throwing things at cyborgs will now slow them down, as intended
balance: Adjusted the calculation of throwforce -> slowdown for cyborgs such that it is simply a flat duration for anything above a certain damage threshold (the value of throwing iron rods)
/:cl: