### PR TITLE
Tweaks the message that players get when not qualifying for an antagonist role.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -468,7 +468,7 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 				for(var/job in job_prefs)
 					var/priority = job_prefs[job]
 					job_data += "[job]: [SSjob.job_priority_level_to_string(priority)]"
-				to_chat(player, span_danger("You were unable to qualify for any roundstart antagonist role this round as your job preferences presented a high chance of all of your selected jobs being unavailable, along with 'return to lobby if job is unavailable' enabled. Increase the number of roles set to medium or low priority to reduce the chances of this happening."))
+				to_chat(player, span_danger("You were unable to qualify for any roundstart antagonist role this round because your job preferences presented a high chance of all of your selected jobs being unavailable, along with 'return to lobby if job is unavailable' enabled. Increase the number of roles set to medium or low priority to reduce the chances of this happening."))
 				log_admin("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any roundstart antagonist role. These are their job preferences - [job_data.Join(" | ")]")
 			else
 				roundstart_pop_ready++

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -469,7 +469,7 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 					var/priority = job_prefs[job]
 					job_data += "[job]: [SSjob.job_priority_level_to_string(priority)]"
 				to_chat(player, span_danger("You were unable to qualify for any roundstart antagonist role this round because your job preferences presented a high chance of all of your selected jobs being unavailable, along with 'return to lobby if job is unavailable' enabled. Increase the number of roles set to medium or low priority to reduce the chances of this happening."))
-				log_admin("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any roundstart antagonist role. These are their job preferences - [job_data.Join(" | ")]")
+				log_admin("[player.ckey] failed to qualify for any roundstart antagonist role because their job preferences presented a high chance of all of their selected jobs being unavailable, along with 'return to lobby if job is unavailable' enabled and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any roundstart antagonist role. These are their job preferences - [job_data.Join(" | ")]")
 			else
 				roundstart_pop_ready++
 				candidates.Add(player)

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -468,7 +468,7 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 				for(var/job in job_prefs)
 					var/priority = job_prefs[job]
 					job_data += "[job]: [SSjob.job_priority_level_to_string(priority)]"
-				to_chat(player, span_danger("You were unable to qualify for any roundstart antagonist role because you could not qualify for any of the roundstart jobs you were trying to qualify for, along with 'return to lobby if job is unavailable' enabled."))
+				to_chat(player, span_danger("You were unable to qualify for any roundstart antagonist role this round because of how you've set up your job preferences, along with 'return to lobby if job is unavailable' enabled. Increase the number of roles set to medium or low priority to reduce the chances of this happening."))
 				log_admin("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any roundstart antagonist role. These are their job preferences - [job_data.Join(" | ")]")
 			else
 				roundstart_pop_ready++

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -468,7 +468,7 @@ GLOBAL_LIST_EMPTY(dynamic_station_traits)
 				for(var/job in job_prefs)
 					var/priority = job_prefs[job]
 					job_data += "[job]: [SSjob.job_priority_level_to_string(priority)]"
-				to_chat(player, span_danger("You were unable to qualify for any roundstart antagonist role this round because of how you've set up your job preferences, along with 'return to lobby if job is unavailable' enabled. Increase the number of roles set to medium or low priority to reduce the chances of this happening."))
+				to_chat(player, span_danger("You were unable to qualify for any roundstart antagonist role this round as your job preferences presented a high chance of all of your selected jobs being unavailable, along with 'return to lobby if job is unavailable' enabled. Increase the number of roles set to medium or low priority to reduce the chances of this happening."))
 				log_admin("[player.ckey] failed to qualify for any job and has [player.client.prefs.be_special.len] antag preferences enabled. They will be unable to qualify for any roundstart antagonist role. These are their job preferences - [job_data.Join(" | ")]")
 			else
 				roundstart_pop_ready++


### PR DESCRIPTION

## About The Pull Request
See title

## Why It's Good For The Game
You can still end up qualifying for a role if you get lucky. The message is primarily there to tell players they weren't able to become an antagonist because their preferences are set up in a way that they're likely to return back to lobby.

## Changelog
:cl:
spellcheck: Tweaks the message that players get when not being able to qualify for roundstart antag to be more accurate as to what's happening.
/:cl:
