### PR TITLE
Refsearch Info Injection

### DIFF
--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -92,6 +92,7 @@
 			return
 
 		datum_container.last_find_references = search_time
+		var/container_print = datum_container.ref_search_details()
 		var/list/vars_list = datum_container.vars
 
 		for(var/varname in vars_list)
@@ -108,11 +109,11 @@
 					found_refs[varname] = TRUE
 					continue //End early, don't want these logging
 				#endif
-				log_reftracker("Found [type] [text_ref(src)] in [datum_container.type]'s [text_ref(datum_container)] [varname] var. [container_name]")
+				log_reftracker("Found [type] [text_ref(src)] in [datum_container.type]'s [container_print] [varname] var. [container_name]")
 				continue
 
 			if(islist(variable))
-				DoSearchVar(variable, "[container_name] [text_ref(datum_container)] -> [varname] (list)", recursive_limit - 1, search_time)
+				DoSearchVar(variable, "[container_name] [container_print] -> [varname] (list)", recursive_limit - 1, search_time)
 
 	else if(islist(potential_container))
 		var/normal = IS_NORMAL_LIST(potential_container)
@@ -159,3 +160,11 @@
 	qdel(src, force)
 
 #endif
+
+/// Return info about us for reference searching purposes
+/// Will be logged as a representation of this datum if it's a part of a search chain
+/datum/proc/ref_search_details()
+	return text_ref(src)
+
+/datum/callback/ref_search_details()
+	return "[text_ref(src)] (obj: [object] proc: [delegate] args: [json_encode(arguments)] user: [user?.resolve() || "null"])"

--- a/code/modules/admin/view_variables/reference_tracking.dm
+++ b/code/modules/admin/view_variables/reference_tracking.dm
@@ -161,6 +161,8 @@
 
 #endif
 
+// Kept outside the ifdef so overrides are easy to implement
+
 /// Return info about us for reference searching purposes
 /// Will be logged as a representation of this datum if it's a part of a search chain
 /datum/proc/ref_search_details()


### PR DESCRIPTION

## About The Pull Request

Adds a proc that types can override to inject extra information into the refsearch
This'll allow us to more easily track and deal with refs held by general datums, like callbacks.
I've implemented a template example FOR callbacks, to provide an example and assist in solving future issues

Done to help lumipharon from TGMC, they were having trouble with this case.

This isn't perfectly optimized, but this proc has a LOT of issues just in general. Need to rework it to cut down on string churn someday