### PR TITLE
Fixes a speech_subtree.dm code error that causes runtimes when trying to call initial() on a list.

### DIFF
--- a/code/datums/ai/basic_mobs/basic_subtrees/speech_subtree.dm
+++ b/code/datums/ai/basic_mobs/basic_subtrees/speech_subtree.dm
@@ -208,10 +208,10 @@
 	if(isnull(speech_lines))
 		return ..()
 	
-	speak = speech_lines[BB_EMOTE_SAY] ? speech_lines[BB_EMOTE_SAY] : initial(speak)
-	emote_see = speech_lines[BB_EMOTE_SEE] ? speech_lines[BB_EMOTE_SEE] : initial(emote_see)
-	emote_hear = speech_lines[BB_EMOTE_HEAR] ? speech_lines[BB_EMOTE_HEAR] : initial(emote_hear)
-	sound = speech_lines[BB_EMOTE_SOUND] ? speech_lines[BB_EMOTE_SOUND] : initial(sound)
+	speak = speech_lines[BB_EMOTE_SAY] ? speech_lines[BB_EMOTE_SAY] : list()
+	emote_see = speech_lines[BB_EMOTE_SEE] ? speech_lines[BB_EMOTE_SEE] : list()
+	emote_hear = speech_lines[BB_EMOTE_HEAR] ? speech_lines[BB_EMOTE_HEAR] : list()
+	sound = speech_lines[BB_EMOTE_SOUND] ? speech_lines[BB_EMOTE_SOUND] : list()
 	speech_chance = speech_lines[BB_EMOTE_CHANCE] ? speech_lines[BB_EMOTE_CHANCE] : initial(speech_chance)
 
 	return ..()


### PR DESCRIPTION

## About The Pull Request

Fixes a speech_subtree.dm code error that causes runtimes when trying to call initial() on a list.

## Why It's Good For The Game

Runtimes are bad.

## Changelog

:cl: BurgerBB
fix: Fixes a speech_subtree.dm code error that causes runtimes when trying to call initial() on a list.
/:cl:
