### PR TITLE
Fixes full advanced surgery trays spawning with 'nothing'

### DIFF
--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -207,7 +207,7 @@
 	name = "autopsy tray"
 	desc = "A Deforest brand surgery tray, made for use in morgues. It is a folding model, \
 		meaning the wheels on the bottom can be extended outwards, making it a cart."
-	
+
 /obj/item/surgery_tray/full/morgue/populate_contents()
 	new /obj/item/blood_filter(src)
 	new /obj/item/bonesetter(src)
@@ -227,13 +227,13 @@
 /obj/item/surgery_tray/full/advanced
 
 /obj/item/surgery_tray/full/advanced/populate_contents()
-	new /obj/item/scalpel/advanced
-	new /obj/item/retractor/advanced
-	new /obj/item/cautery/advanced
-	new /obj/item/surgical_drapes
-	new /obj/item/reagent_containers/medigel/sterilizine
-	new /obj/item/bonesetter
-	new /obj/item/blood_filter
-	new /obj/item/stack/medical/bone_gel
-	new /obj/item/stack/sticky_tape/surgical
-	new /obj/item/clothing/mask/surgical
+	new /obj/item/scalpel/advanced(src)
+	new /obj/item/retractor/advanced(src)
+	new /obj/item/cautery/advanced(src)
+	new /obj/item/surgical_drapes(src)
+	new /obj/item/reagent_containers/medigel/sterilizine(src)
+	new /obj/item/bonesetter(src)
+	new /obj/item/blood_filter(src)
+	new /obj/item/stack/medical/bone_gel(src)
+	new /obj/item/stack/sticky_tape/surgical(src)
+	new /obj/item/clothing/mask/surgical(src)


### PR DESCRIPTION

## About The Pull Request

Fixes full advanced surgery trays spawning with 'nothing'

They were spawning into null space

## Why It's Good For The Game

I dont know

## Changelog

Zepyhyr, Carlarc, Not Jacquerel
:cl:
fix: Fixes full advanced surgery trays spawning with 'nothing'
/:cl:

