### PR TITLE
Move felinid brain shrinkage from the species to the brain

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -39,6 +39,18 @@
 	/// Maximum skillchip slots available. Do not reference this var directly and instead call get_max_skillchip_slots()
 	var/max_skillchip_slots = 5
 
+	/// Size modifier for the sprite
+	var/brain_size = 1
+
+/obj/item/organ/internal/brain/Initialize(mapload)
+	. = ..()
+	// Brain size logic
+	transform = transform.Scale(brain_size)
+	if(brain_size < 1)
+		desc += "\nIt is a bit on the smaller side"
+	if(brain_size > 1)
+		desc += "\nIt is bigger than average"
+
 /obj/item/organ/internal/brain/Insert(mob/living/carbon/brain_owner, special = FALSE, drop_if_replaced = TRUE, no_id_transfer = FALSE)
 	. = ..()
 	if(!.)
@@ -405,6 +417,9 @@
 /obj/item/organ/internal/brain/lustrous/on_insert(mob/living/carbon/organ_owner, special)
 	. = ..()
 	organ_owner.gain_trauma(/datum/brain_trauma/special/bluespace_prophet, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/obj/item/organ/internal/brain/felinid //A bit smaller than average
+	brain_size = 0.8
 
 ////////////////////////////////////TRAUMAS////////////////////////////////////////
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -46,10 +46,13 @@
 	. = ..()
 	// Brain size logic
 	transform = transform.Scale(brain_size)
+
+/obj/item/organ/internal/brain/examine()
+	. = ..()
 	if(brain_size < 1)
-		desc += "\nIt is a bit on the smaller side"
+		. += span_notice("It is a bit on the smaller side...")
 	if(brain_size > 1)
-		desc += "\nIt is bigger than average"
+		. += span_notice("It is bigger than average...")
 
 /obj/item/organ/internal/brain/Insert(mob/living/carbon/brain_owner, special = FALSE, drop_if_replaced = TRUE, no_id_transfer = FALSE)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -4,6 +4,7 @@
 	id = SPECIES_FELINE
 	examine_limb_id = SPECIES_HUMAN
 	mutant_bodyparts = list("ears" = "Cat", "wings" = "None")
+	mutantbrain = /obj/item/organ/internal/brain/felinid
 	mutanttongue = /obj/item/organ/internal/tongue/cat
 	mutantears = /obj/item/organ/internal/ears/cat
 	external_organs = list(
@@ -21,8 +22,6 @@
 	family_heirlooms = list(/obj/item/toy/cattoy)
 	/// When false, this is a felinid created by mass-purrbation
 	var/original_felinid = TRUE
-	/// Brain size for scaling
-	var/brain_size = 0.8
 
 // Prevents felinids from taking toxin damage from carpotoxin
 /datum/species/human/felinid/handle_chemical(datum/reagent/chem, mob/living/carbon/human/affected, seconds_per_tick, times_fired)
@@ -45,16 +44,6 @@
 			ears.Insert(target_human, drop_if_replaced = FALSE)
 		else
 			mutantears = /obj/item/organ/internal/ears
-		var/obj/item/organ/internal/brain/current_brain = target_human.get_organ_by_type(/obj/item/organ/internal/brain)
-		if(current_brain)
-			current_brain.transform = current_brain.transform.Scale(brain_size) //smaller brain
-	return ..()
-
-/datum/species/human/felinid/on_species_loss(mob/living/carbon/former_feline, datum/species/old_species, pref_load)
-	if(iscarbon(former_feline))
-		var/obj/item/organ/internal/brain/current_brain = former_feline.get_organ_by_type(/obj/item/organ/internal/brain)
-		if(current_brain)
-			current_brain.transform = current_brain.transform.Scale(1 / brain_size) //bigger brain
 	return ..()
 
 /datum/species/human/felinid/randomize_features(mob/living/carbon/human/human_mob)


### PR DESCRIPTION

## About The Pull Request
Brain size is now a var on brains, and felinids have their own brains. This makes the feature implemented here: #77879 more modular and in line with our species goals. 
## Why It's Good For The Game
I didn't spend all that time moving species specific traits to bodyparts and organs for this bullshit.
## Changelog
pls add code improvement tag
