### PR TITLE
Valentines and ERTs will no longer get mood boosts from traitor moodener items

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -333,7 +333,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 
 
 // If this flag is enabled the antagonist datum allows the antagonist to be inducted into a nuclear operative team.
-#define FLAG_ANTAG_CAN_BE_INDUCTED (1 << 0)
+#define FLAG_FAKE_ANTAG (1 << 0)
 
 #define HUNTER_PACK_COPS "Spacepol Fugitive Hunters"
 #define HUNTER_PACK_RUSSIAN "Russian Fugitive Hunters"

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -332,7 +332,7 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define ANTAG_GROUP_PARADOX "Spacetime Aberrations"
 
 
-// If this flag is enabled the antagonist datum allows the antagonist to be inducted into a nuclear operative team.
+// This flag disables certain checks that presume antagonist datums mean 'baddie'.
 #define FLAG_FAKE_ANTAG (1 << 0)
 
 #define HUNTER_PACK_COPS "Spacepol Fugitive Hunters"

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -747,13 +747,13 @@
 			human_target.reagents.add_reagent(/datum/reagent/toxin, 2)
 			return FALSE
 
-	/// If no antag datums which allow induction are there, disallow induction! No self-antagging.
-	var/allowed = FALSE
+	/// If all the antag datums are 'fake', disallow induction! No self-antagging.
+	var/faker
 	for(var/datum/antagonist/antag_datum as anything in human_target.mind.antag_datums)
-		if((antag_datum.antag_flags & FLAG_ANTAG_CAN_BE_INDUCTED))
-			allowed = TRUE
+		if((antag_datum.antag_flags & FLAG_FAKE_ANTAG))
+			faker = TRUE
 
-	if(!allowed) // GTFO. Technically not foolproof but making a heartbreaker or a paradox clone a nuke op sounds hilarious
+	if(faker) // GTFO. Technically not foolproof but making a heartbreaker or a paradox clone a nuke op sounds hilarious
 		to_chat(human_target, span_notice("Huh? Nothing happened? But you're starting to feel a little ill..."))
 		human_target.reagents.add_reagent(/datum/reagent/toxin, 15)
 		return FALSE

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -224,7 +224,7 @@
 			var/color = "#e6e6e6"
 			if(i%2 == 0)
 				color = "#f2f2f2"
-			var/is_antagonist = is_special_character(M)
+			var/is_antagonist = is_special_character(M, allow_fake_antags = TRUE)
 
 			var/M_job = ""
 

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	/// The typepath for the outfit to show in the preview for the preferences menu.
 	var/preview_outfit
 	/// Flags for antags to turn on or off and check!
-	var/antag_flags = FLAG_ANTAG_CAN_BE_INDUCTED
+	var/antag_flags = FLAG_FAKE_ANTAG
 	/// If true, this antagonist can assign themself a new objective
 	var/can_assign_self_objectives = FALSE
 	/// Default to fill in when entering a custom objective.

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -12,8 +12,8 @@
 	antagpanel_category = ANTAG_GROUP_ERT
 	suicide_cry = "FOR NANOTRASEN!!"
 	count_against_dynamic_roll_chance = FALSE
-	// Not 'true' antags, cannot induct to prevent issues
-	antag_flags = NONE
+	// Not 'true' antags, this disables certain interactions that assume the owner is a baddie
+	antag_flags = FLAG_FAKE_ANTAG
 	var/datum/team/ert/ert_team
 	var/leader = FALSE
 	var/datum/outfit/outfit = /datum/outfit/centcom/ert/security

--- a/code/modules/antagonists/valentines/valentine.dm
+++ b/code/modules/antagonists/valentines/valentine.dm
@@ -4,8 +4,8 @@
 	show_in_antagpanel = FALSE
 	prevent_roundtype_conversion = FALSE
 	suicide_cry = "FOR MY LOVE!!"
-	// Not 'true' antags, cannot induct
-	antag_flags = NONE
+	// Not 'true' antags, this disables certain interactions that assume the owner is a baddie
+	antag_flags = FLAG_FAKE_ANTAG
 	var/datum/mind/date
 	count_against_dynamic_roll_chance = FALSE
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -211,7 +211,7 @@
  * Returns TRUE if the game has started and we're either an AI with a 0th law, or we're someone with a special role/antag datum
  * If allow_fake_antags is set to FALSE, Valentines, ERTs, and any such roles with FLAG_FAKE_ANTAG won't pass.
 */
-/proc/is_special_character(mob/M, var/allow_fake_antags = FALSE)
+/proc/is_special_character(mob/M, allow_fake_antags = FALSE)
 	if(!SSticker.HasRoundStarted())
 		return FALSE
 	if(!istype(M))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -207,20 +207,38 @@
 	return ""
 
 // moved out of admins.dm because things other than admin procs were calling this.
-/// Returns TRUE if the game has started and we're either an AI with a 0th law, or we're someone with a special role/antag datum
-/proc/is_special_character(mob/M)
+/**
+ * Returns TRUE if the game has started and we're either an AI with a 0th law, or we're someone with a special role/antag datum
+ * If allow_fake_antags is set to FALSE, Valentines, ERTs, and any such roles with FLAG_FAKE_ANTAG won't pass.
+*/
+/proc/is_special_character(mob/M, var/allow_fake_antags = FALSE)
 	if(!SSticker.HasRoundStarted())
 		return FALSE
 	if(!istype(M))
 		return FALSE
 	if(iscyborg(M)) //as a borg you're now beholden to your laws rather than greentext
 		return FALSE
+
+
+	// Returns TRUE if AI has a zeroth law *and* either has a special role *or* an antag datum.
 	if(isAI(M))
 		var/mob/living/silicon/ai/A = M
 		return (A.laws?.zeroth && (A.mind?.special_role || !isnull(M.mind?.antag_datums)))
-	if(M.mind?.special_role || !isnull(M.mind?.antag_datums)) //they have an antag datum!
+
+	if(M.mind?.special_role)
 		return TRUE
-	return FALSE
+
+	// Turns 'faker' to TRUE if the antag datum is fake. If it's not fake, returns TRUE directly.
+	var/faker = FALSE
+	for(var/datum/antagonist/antag_datum as anything in M.mind?.antag_datums)
+		if((antag_datum.antag_flags & FLAG_FAKE_ANTAG))
+			faker = TRUE
+		else
+			return TRUE
+
+	// If 'faker' was assigned TRUE in the above loop and the argument 'allow_fake_antags' is set to TRUE, this passes.
+	// Else, return FALSE.
+	return (faker && allow_fake_antags)
 
 /**
  * Fancy notifications for ghosts


### PR DESCRIPTION

## About The Pull Request

Valentines and ERTs will no longer get mood boosts from traitor moodener items

Closes #73432

## Why It's Good For The Game

bugge

## Changelog

:cl:
fix: Valentines and ERTs will no longer get mood boosts from traitor moodener items
/:cl:

