### PR TITLE
Increases codeside roundstart Cyborg slots to 3.

### DIFF
--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -4,7 +4,7 @@
 	auto_deadmin_role_flags = DEADMIN_POSITION_SILICON
 	faction = FACTION_STATION
 	total_positions = 0
-	spawn_positions = 1
+	spawn_positions = 3
 	supervisors = "your laws and the AI" //Nodrak
 	spawn_type = /mob/living/silicon/robot
 	minimal_player_age = 21


### PR DESCRIPTION

## About The Pull Request

This PR ups the codebase defaults to three roundstart Cyborg slots.
## Why It's Good For The Game

I got a bit of GBP banked. Might as well spend a little.

[Codebase has configed in two borgs since I made the changes for Spookuni during their last term.](https://tgstation13.org/phpBB/viewtopic.php?p=668042#p668042) This adds one extra codebase-side default over the server status quo.

With new Silicon Policy in play, I think it's time to open up the roundstart cyborgs to be a full and complete faction alongside their master AI. This could potentially allow for a fully staffed silicon """department""" roundstart. This makes the silicon team more impactful right from the get-go and opens up more scope for dedicated silicon mains to actually get silicon roles in a unique and often contested jobspace.

That is definitely a buff to Malf AI and may cause fewer roundstart borgings in Robotics, so it may take away a minor bit of job content from them. However, Robos already have modsuits, circuits and mechs - plus giving them more roundstart borgs to eventually upgrade and subvert and generally play alongside could still contribute to job content overall.

It's also a buff to individual borg players, in the sense that their module selection now has less overall impact roundstart and thus they may be able to pick their module of choices more often without gimping their master AI's ability to interact with the shift.
## Changelog
:cl:
balance: There are now 3 roundstart cyborg job slots open by default.
/:cl:
