### PR TITLE
Public PDA (Weapons) chargers

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -2487,6 +2487,9 @@
 	},
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/entry)
 "aZL" = (
@@ -7717,8 +7720,8 @@
 /obj/structure/sink/kitchen/directional/east,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/button/door/directional/west{
-	pixel_y = 8;
-	id = "custodialshutters"
+	id = "custodialshutters";
+	pixel_y = 8
 	},
 /turf/open/floor/iron/white/small,
 /area/station/service/janitor)
@@ -18750,8 +18753,8 @@
 	},
 /obj/structure/industrial_lift/tram,
 /obj/machinery/door/window/tram/right/directional/north{
-	pixel_y = -25;
-	associated_lift = "maint_tram"
+	associated_lift = "maint_tram";
+	pixel_y = -25
 	},
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
@@ -19741,8 +19744,8 @@
 	pixel_y = 11
 	},
 /obj/item/mod/module/signlang_radio{
-	pixel_y = 2;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/small,
 /area/station/security/office)
@@ -22135,9 +22138,9 @@
 	},
 /obj/structure/industrial_lift/tram,
 /obj/machinery/door/window/tram/left/directional/north{
+	associated_lift = "maint_tram";
 	pixel_x = -32;
-	pixel_y = -25;
-	associated_lift = "maint_tram"
+	pixel_y = -25
 	},
 /turf/open/floor/noslip/tram_platform,
 /area/station/maintenance/port/aft)
@@ -40788,6 +40791,9 @@
 /area/station/bitrunning/den)
 "oIk" = (
 /obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons)
 "oIP" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -7555,6 +7555,12 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "bPj" = (
@@ -38421,16 +38427,9 @@
 	},
 /area/station/service/chapel)
 "jAi" = (
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "jAk" = (
@@ -61241,6 +61240,7 @@
 /obj/structure/table,
 /obj/item/storage/crayons,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/toy/cards/deck,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "puW" = (
@@ -62235,14 +62235,17 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "pFF" = (
-/obj/item/kirbyplants/random,
 /obj/machinery/camera/directional/north{
 	c_tag = "Arrivals - Starboard Entrance";
 	dir = 9;
 	name = "arrivals camera"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/bot,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "pFO" = (
@@ -91139,8 +91142,10 @@
 /area/station/hallway/primary/central/fore)
 "wKt" = (
 /obj/structure/table,
-/obj/item/toy/cards/deck,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "wKu" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1391,8 +1391,8 @@
 /area/station/security/courtroom)
 "awR" = (
 /obj/machinery/conveyor{
-	id = "garbage";
-	dir = 1
+	dir = 1;
+	id = "garbage"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -2828,8 +2828,8 @@
 "aUi" = (
 /obj/structure/table,
 /obj/item/storage/briefcase{
-	pixel_y = 3;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/storage/wallet,
@@ -2935,6 +2935,9 @@
 /obj/effect/landmark/start/hangover,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -3186,8 +3189,8 @@
 	pixel_x = 7
 	},
 /obj/item/reagent_containers/cup/soda_cans/sol_dry{
-	pixel_y = 4;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
@@ -5334,8 +5337,8 @@
 	dir = 8;
 	id = "garbage";
 	name = "disposal conveyor";
-	pixel_y = 5;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 5
 	},
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/box/corners{
@@ -7118,8 +7121,8 @@
 	name = "Disposal Exit Vent"
 	},
 /obj/machinery/conveyor{
-	id = "garbage";
-	dir = 1
+	dir = 1;
+	id = "garbage"
 	},
 /obj/effect/turf_decal/stripes/red/box,
 /turf/open/floor/plating,
@@ -7818,8 +7821,8 @@
 /obj/structure/table,
 /obj/item/storage/wallet,
 /obj/item/storage/wallet{
-	pixel_y = 3;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 3
 	},
 /turf/open/floor/plastic,
 /area/station/commons/dorms/laundry)
@@ -13237,6 +13240,7 @@
 /obj/structure/table,
 /obj/item/toy/cards/deck,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/spawner/random/entertainment/dice,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "dVq" = (
@@ -16877,8 +16881,8 @@
 /area/icemoon/underground/explored)
 "fdX" = (
 /obj/item/toy/cards/deck{
-	pixel_y = 13;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 13
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/generic,
@@ -20999,8 +21003,8 @@
 /area/station/security/prison/workout)
 "gvp" = (
 /obj/item/chair/stool{
-	pixel_y = -3;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = -3
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/dim/directional/west,
@@ -22547,13 +22551,13 @@
 /area/station/science/breakroom)
 "gVm" = (
 /obj/item/coin/silver{
-	pixel_y = -3;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = -3
 	},
 /obj/item/toy/plush/moth{
-	pixel_y = 5;
+	name = "Marcellus";
 	pixel_x = 5;
-	name = "Marcellus"
+	pixel_y = 5
 	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/laundry)
@@ -24568,17 +24572,17 @@
 "hCY" = (
 /obj/structure/table/wood,
 /obj/item/folder/yellow{
-	pixel_y = 8;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 8
 	},
 /obj/item/folder/white{
-	pixel_y = 12;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 12
 	},
 /obj/structure/sign/poster/contraband/random/directional/south,
 /obj/item/folder/blue{
-	pixel_y = 3;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /obj/item/folder/red{
 	pixel_x = 5;
@@ -27364,8 +27368,8 @@
 "ixb" = (
 /obj/machinery/button/door/directional/south{
 	id = "vacantofficemaintshutter";
-	pixel_x = 4;
 	name = "Privacy Shutters";
+	pixel_x = 4;
 	pixel_y = -28
 	},
 /turf/open/floor/iron/grimy,
@@ -31076,8 +31080,8 @@
 /area/station/engineering/atmos)
 "jHV" = (
 /obj/machinery/mineral/stacking_machine{
-	stack_amt = 10;
-	output_dir = 2
+	output_dir = 2;
+	stack_amt = 10
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -32353,8 +32357,8 @@
 /area/icemoon/surface/outdoors/nospawn)
 "kbq" = (
 /obj/machinery/conveyor{
-	id = "garbage";
-	dir = 1
+	dir = 1;
+	id = "garbage"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -34402,8 +34406,8 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/suit/hooded/wintercoat/eva{
-	pixel_y = 5;
-	pixel_x = 1
+	pixel_x = 1;
+	pixel_y = 5
 	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/mining_weather_monitor/directional/north,
@@ -43640,8 +43644,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Arrivals Dock";
-	dir = 4
+	dir = 4;
+	name = "Arrivals Dock"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
@@ -46481,8 +46485,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Arrivals Dock";
-	dir = 4
+	dir = 4;
+	name = "Arrivals Dock"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
@@ -49133,12 +49137,12 @@
 /area/station/medical/medbay/central)
 "pcc" = (
 /obj/item/stack/spacecash/c10{
-	pixel_y = 4;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /obj/item/toy/plush/beeplushie{
-	pixel_y = -6;
-	name = "Coolidge"
+	name = "Coolidge";
+	pixel_y = -6
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -56635,8 +56639,8 @@
 	pixel_y = 3
 	},
 /obj/item/assembly/flash/handheld{
-	pixel_y = 3;
-	pixel_x = -19
+	pixel_x = -19;
+	pixel_y = 3
 	},
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -59776,13 +59780,13 @@
 	pixel_y = -5
 	},
 /obj/item/coin/plasma{
-	pixel_y = -2;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = -2
 	},
 /obj/item/toy/plush/lizard_plushie{
+	name = "Cassius";
 	pixel_x = 11;
-	pixel_y = -4;
-	name = "Cassius"
+	pixel_y = -4
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -61278,8 +61282,8 @@
 /area/station/medical/chemistry)
 "sLR" = (
 /obj/machinery/conveyor{
-	id = "garbage";
-	dir = 1
+	dir = 1;
+	id = "garbage"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -62279,9 +62283,9 @@
 "teE" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters{
+	dir = 8;
 	id = "vacantofficemaintshutter";
-	name = "Privacy Shutters";
-	dir = 8
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/office)
@@ -62630,8 +62634,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/multi_tile/public/glass{
-	name = "Auxiliary Dock";
-	dir = 4
+	dir = 4;
+	name = "Auxiliary Dock"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
@@ -71250,7 +71254,9 @@
 "vZg" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table,
-/obj/effect/spawner/random/entertainment/dice,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "vZp" = (
@@ -75282,8 +75288,8 @@
 "xgX" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/deck{
-	pixel_y = 15;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 15
 	},
 /obj/effect/spawner/random/food_or_drink/snack{
 	pixel_x = 5;

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15825,6 +15825,7 @@
 /obj/structure/table,
 /obj/item/storage/crayons,
 /obj/effect/landmark/start/hangover,
+/obj/effect/spawner/random/entertainment/deck,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "fRr" = (
@@ -23534,7 +23535,9 @@
 /area/station/hallway/primary/aft)
 "iEE" = (
 /obj/structure/table,
-/obj/effect/spawner/random/entertainment/deck,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "iEK" = (
@@ -53664,7 +53667,10 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "tiD" = (
-/obj/item/kirbyplants/random,
+/obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "tjf" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -56748,15 +56748,6 @@
 /obj/structure/beebox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
-"oLI" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/floor4/aft)
 "oLL" = (
 /obj/structure/toilet{
 	dir = 4
@@ -58542,6 +58533,8 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/sign/poster/official/random/directional/north,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "pmw" = (
@@ -85729,9 +85722,10 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "wtt" = (
 /obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/fore)
 "wtu" = (
@@ -319205,7 +319199,7 @@ vRO
 qbg
 nWW
 tEh
-oLI
+bVy
 vVu
 vOE
 tDs

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -1599,9 +1599,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	volume_rate = 200;
 	dir = 8;
-	initialize_directions = 8
+	initialize_directions = 8;
+	volume_rate = 200
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
@@ -13834,6 +13834,10 @@
 /area/station/engineering/atmos)
 "dAN" = (
 /obj/machinery/light_switch/directional/west,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "dAU" = (
@@ -42143,6 +42147,9 @@
 /area/station/engineering/atmos)
 "laC" = (
 /obj/structure/table/wood,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/carpet/green,
 /area/station/commons/dorms/apartment1)
 "laJ" = (
@@ -46851,6 +46858,13 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor1/aft)
+"mkP" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "mkZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -56734,6 +56748,15 @@
 /obj/structure/beebox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"oLI" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/floor4/aft)
 "oLL" = (
 /obj/structure/toilet{
 	dir = 4
@@ -79202,9 +79225,9 @@
 /area/station/maintenance/floor2/port/aft)
 "uLB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	volume_rate = 200;
 	dir = 8;
-	initialize_directions = 8
+	initialize_directions = 8;
+	volume_rate = 200
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold/layer2{
 	dir = 8
@@ -108430,7 +108453,7 @@ nrx
 bag
 mdB
 mMr
-mdB
+mkP
 pgo
 rqM
 wyp
@@ -319182,7 +319205,7 @@ vRO
 qbg
 nWW
 tEh
-bVy
+oLI
 vVu
 vOE
 tDs

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -16622,6 +16622,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "eOw" = (
@@ -28660,8 +28663,8 @@
 /area/station/security/checkpoint/supply)
 "jnL" = (
 /obj/structure/railing{
-	layer = 3.1;
-	dir = 4
+	dir = 4;
+	layer = 3.1
 	},
 /obj/machinery/netpod,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -35306,6 +35309,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/escapepodbay)
+"lzN" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "lAm" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -186651,7 +186664,7 @@ pEx
 aGr
 fmy
 sWq
-akS
+lzN
 gXH
 fmy
 fmy


### PR DESCRIPTION
## About The Pull Request
Companion PR for #78580. Adds two (or four) public-accessible weapons chargers, for charging PDAs *and nothing else*. These have been placed with the intention of being spread out and fairly accessible. In all cases, one exists in the dorms/locker room area.

- Birdshot has been given one charger in the arrivals lounge, and one in the main dorms area.

- For Delta I have added an extra table to the arrivals statue area for the charger. It's also now symmetrical with the opposite side, which has a coffee vendor in the same spot. A second charger is in the dorms locker room.

- Ice Box unfortunately has dorms in the arrivals hallway. Putting both public chargers so close wouldn't be ideal, so one has been placed in dorms, and the second in departures instead.

- Meta has been given a new table in arrivals hallway, just after the public shuttle, for the arrivals charger. A singular plant has been lost. The second is in dorms, as normal.

- North Star, being our designated big boi map, has four chargers. One per floor. Floor one has the charger just next to the holodeck. Floor two's charger is in the locker room. Floor three, in Dorms 1A (but not in Dorms 1B). The floor four charger is just outside the mid-ship stairwell door, making it fairly accessible but also within view of security.

- Finally, Tram, which also has dorms sitting close to arrivals. The first has been placed in the Fitness Room (lower floor), while the second is in Departures (upper floor).

@Zytolg for Birdshot considerations
@Cheshify for North Star considerations
## Why It's Good For The Game
Gives the crew public charging options for their PDAs, with the secondary use of charging weaponry for those of ill-intent.
## Changelog
:cl:
balance: All maps now have two public "PDA" (weapon) chargers (except one particular map with four). You'll find one in the dorms or locker room area.
/:cl:
