### PR TITLE
Allow name to start with number if AI/Borg

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -191,7 +191,7 @@
 
 			// 0  .. 9
 			if(48 to 57) //Numbers
-				if(last_char_group == NO_CHARS_DETECTED || !allow_numbers) //suppress at start of string
+				if(!allow_numbers) //allow name to start with number if AI/Borg
 					if(strict)
 						return
 					continue


### PR DESCRIPTION
## About The Pull Request

Allows names to start with a number if the player is an AI/Borg or otherwise allows numbers in their name.

## Why It's Good For The Game

Serial number roleplay.

## Changelog
:cl:
qol: allowed names to start with a number if AI/Borg
/:cl:
