### PR TITLE
Planetary atmos fix

### DIFF
--- a/code/datums/atmosphere/_atmosphere.dm
+++ b/code/datums/atmosphere/_atmosphere.dm
@@ -59,7 +59,6 @@
 	while(gasmix.return_pressure() > target_pressure)
 		gaslist[gastype][MOLES] -= gaslist[gastype][MOLES] * 0.1
 	gaslist[gastype][MOLES] = FLOOR(gaslist[gastype][MOLES], 0.1)
-	var/current_pressure = gasmix.return_pressure()
 	gasmix.garbage_collect()
 
 	// Now finally lets make that string
@@ -70,13 +69,3 @@
 	gas_string_builder += "TEMP=[gasmix.temperature]"
 	gas_string = gas_string_builder.Join(";")
 	return current_pressure
-
-/datum/atmosphere/proc/validate_minimum_pressure()
-	var/fail_count = 0
-	var/i
-	var/test_pressure
-	for(i = 1, i <= 100, i++)
-		test_pressure = generate_gas_string()
-		if (test_pressure < minimum_pressure)
-			fail_count++
-	return "Pressure validation failed [fail_count] times"

--- a/code/datums/atmosphere/_atmosphere.dm
+++ b/code/datums/atmosphere/_atmosphere.dm
@@ -52,10 +52,14 @@
 		ASSERT_GAS_IN_LIST(gastype, gaslist)
 		gaslist[gastype][MOLES] += amount
 
+	// Ensure that minimum_pressure is actually a hard lower limit
+	target_pressure = clamp(target_pressure, minimum_pressure + (gaslist[gastype][MOLES] * 0.1), maximum_pressure)
+
 	// That last one put us over the limit, remove some of it
 	while(gasmix.return_pressure() > target_pressure)
 		gaslist[gastype][MOLES] -= gaslist[gastype][MOLES] * 0.1
 	gaslist[gastype][MOLES] = FLOOR(gaslist[gastype][MOLES], 0.1)
+	var/current_pressure = gasmix.return_pressure()
 	gasmix.garbage_collect()
 
 	// Now finally lets make that string
@@ -65,3 +69,14 @@
 		gas_string_builder += "[gas[GAS_META][META_GAS_ID]]=[gas[MOLES]]"
 	gas_string_builder += "TEMP=[gasmix.temperature]"
 	gas_string = gas_string_builder.Join(";")
+	return current_pressure
+
+/datum/atmosphere/proc/validate_minimum_pressure()
+	var/fail_count = 0
+	var/i
+	var/test_pressure
+	for(i = 1, i <= 100, i++)
+		test_pressure = generate_gas_string()
+		if (test_pressure < minimum_pressure)
+			fail_count++
+	return "Pressure validation failed [fail_count] times"

--- a/code/datums/atmosphere/_atmosphere.dm
+++ b/code/datums/atmosphere/_atmosphere.dm
@@ -68,4 +68,3 @@
 		gas_string_builder += "[gas[GAS_META][META_GAS_ID]]=[gas[MOLES]]"
 	gas_string_builder += "TEMP=[gasmix.temperature]"
 	gas_string = gas_string_builder.Join(";")
-	return current_pressure


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The code for generating random atmospheres for lavaland and icemoon has variables that define the minimum and maximum pressure that the atmosphere can be. However, due to an oversight, it was possible for the actual pressure to be below this minimum. This caused problems for the flight potion wings, as the wings will not work if the pressure is lower than the minimum lavaland/icemoon pressure.

I tested this by making a quick test proc that would generate lavaland atmos 100 times, and count how often the final pressure was lower than the minimum pressure. I ran it a few times after making my changes, and it returned 0 failures every time, so I'm confident that my code works.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I think its good practice for minimums and maximums variables like this to actually be hard limits. Furthermore, if there's _one_ place that mining loot should actually be useful, then its outside where you mine.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The flight potion wings will no longer fail to work on lavaland/icemoon on rare occasions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
