### PR TITLE
TGUI panel font setting overrides applies to all text

### DIFF
--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -50,7 +50,7 @@ export const SettingsPanel = (props, context) => {
 };
 
 export const SettingsGeneral = (props, context) => {
-  const { theme, fontFamily, fontSize, lineHeight } = useSelector(
+  const { theme, fontFamily, fontSize, freeFontSize, lineHeight } = useSelector(
     context,
     selectSettings
   );
@@ -114,19 +114,34 @@ export const SettingsGeneral = (props, context) => {
           </Stack>
         </LabeledList.Item>
         <LabeledList.Item label="Font size">
-          <NumberInput
-            width="4em"
-            step={1}
-            stepPixelSize={10}
-            minValue={8}
-            maxValue={32}
-            value={fontSize}
-            unit="px"
-            format={(value) => toFixed(value)}
-            onChange={(e, value) =>
+          {freeFontSize && (
+            <NumberInput
+              width="4em"
+              step={1}
+              stepPixelSize={10}
+              minValue={8}
+              maxValue={32}
+              value={fontSize}
+              unit="px"
+              format={(value) => toFixed(value)}
+              onChange={(e, value) =>
+                dispatch(
+                  updateSettings({
+                    fontSize: value,
+                  })
+                )
+              }
+            />
+          )}
+          <Button
+            content="Override font size"
+            icon={freeFontSize ? 'lock-open' : 'lock'}
+            color={freeFontSize ? 'good' : 'bad'}
+            ml={freeFontSize ? 1 : 0}
+            onClick={() =>
               dispatch(
                 updateSettings({
-                  fontSize: value,
+                  freeFontSize: !freeFontSize,
                 })
               )
             }

--- a/tgui/packages/tgui-panel/settings/middleware.js
+++ b/tgui/packages/tgui-panel/settings/middleware.js
@@ -10,16 +10,43 @@ import { loadSettings, updateSettings, addHighlightSetting, removeHighlightSetti
 import { selectSettings } from './selectors';
 import { FONTS_DISABLED } from './constants';
 
+let overrideRule = null;
+let overrideFontFamily = null;
+let overrideFontSize = null;
+
+const updateGlobalOverrideRule = () => {
+  let fontFamily = '';
+  let fontSize = '';
+
+  if (overrideFontFamily !== null) {
+    fontFamily = `font-family: ${overrideFontFamily} !important;`;
+  }
+
+  if (overrideFontSize !== null) {
+    fontSize = `font-size: ${overrideFontSize} !important;`;
+  }
+
+  const constructedRule = `body * :not(.Icon) {
+    ${fontFamily}
+    ${fontSize}
+  }`;
+
+  if (overrideRule === null) {
+    overrideRule = document.createElement('style');
+    document.querySelector('head').append(overrideRule);
+  }
+
+  // no other way to force a CSS refresh other than to update its innerText
+  overrideRule.innerText = constructedRule;
+};
+
 const setGlobalFontSize = (fontSize) => {
-  document.documentElement.style.setProperty('font-size', fontSize + 'px');
-  document.body.style.setProperty('font-size', fontSize + 'px');
+  overrideFontSize = `${fontSize}px`;
 };
 
 const setGlobalFontFamily = (fontFamily) => {
   if (fontFamily === FONTS_DISABLED) fontFamily = null;
-
-  document.documentElement.style.setProperty('font-family', fontFamily);
-  document.body.style.setProperty('font-family', fontFamily);
+  overrideFontFamily = fontFamily;
 };
 
 export const settingsMiddleware = (store) => {
@@ -48,8 +75,9 @@ export const settingsMiddleware = (store) => {
       next(action);
       const settings = selectSettings(store.getState());
       // Update global UI font size
-      setGlobalFontSize(settings.fontSize);
+      setGlobalFontSize(settings.freeFontSize ? settings.fontSize : null);
       setGlobalFontFamily(settings.fontFamily);
+      updateGlobalOverrideRule();
       // Save settings to the web storage
       storage.set('panel-settings', settings);
       return;

--- a/tgui/packages/tgui-panel/settings/middleware.js
+++ b/tgui/packages/tgui-panel/settings/middleware.js
@@ -41,7 +41,7 @@ const updateGlobalOverrideRule = () => {
 };
 
 const setGlobalFontSize = (fontSize) => {
-  overrideFontSize = `${fontSize}px`;
+  overrideFontSize = fontSize ? `${fontSize}px` : null;
 };
 
 const setGlobalFontFamily = (fontFamily) => {

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -13,6 +13,7 @@ const defaultHighlightSetting = createDefaultHighlightSetting();
 const initialState = {
   version: 1,
   fontSize: 13,
+  freeFontSize: false,
   fontFamily: FONTS[0],
   lineHeight: 1.2,
   theme: 'light',


### PR DESCRIPTION

## About The Pull Request

Fixes #65747

Title summarizes all. Achieved by injecting a new style sheet with a pretty aggressive rule that overrides all text. Please let me know if what I am doing is valid and legal, tbh I have no idea what I was reading most of the time and what I did feels very cursed
## Why It's Good For The Game

Accessibility, being able to consistently use your chosen font is important.
## Changelog
:cl:
qol: Font settings in the chat panel applies to all text now.
/:cl:
