### PR TITLE
Fixes Lazy Templates fucking over cables, pipes , and shuttles at random

### DIFF
--- a/code/datums/lazy_template.dm
+++ b/code/datums/lazy_template.dm
@@ -97,9 +97,7 @@
 					loaded_atmospherics += thing
 				loaded_atom_movables |= thing
 
-	SSatoms.InitializeAtoms(loaded_areas)
-	SSatoms.InitializeAtoms(loaded_atom_movables)
-	SSatoms.InitializeAtoms(loaded_turfs)
+	SSatoms.InitializeAtoms(loaded_areas + loaded_atom_movables + loaded_turfs)
 	SSmachines.setup_template_powernets(loaded_cables)
 	SSair.setup_template_machinery(loaded_atmospherics)
 

--- a/code/datums/lazy_template.dm
+++ b/code/datums/lazy_template.dm
@@ -87,8 +87,8 @@
 		for(var/turf/open/open_turf in target_turfs)
 			for(var/turf/open/adjacent_turf as anything in open_turf.atmos_adjacent_turfs)
 				adjacent_turf.atmos_adjacent_turfs -= open_turf
-			open_turf.atmos_adjacent_turfs.Cut()
 			SSair.remove_from_active(open_turf)
+			open_turf.atmos_adjacent_turfs = null
 		SSair.can_fire = TRUE
 
 		load_map(

--- a/code/datums/lazy_template.dm
+++ b/code/datums/lazy_template.dm
@@ -64,9 +64,18 @@
 	if(!reservation)
 		CRASH("Failed to reserve a block for lazy template: '[key]'")
 
+	// lists kept for overall loading
 	var/list/loaded_atom_movables = list()
 	var/list/loaded_turfs = list()
 	var/list/loaded_areas = list()
+
+	// list which matches a type to a list of things for that type
+	var/list/type_to_list = list(
+		/obj/structure/cable = list(),
+		/obj/machinery/atmospherics = list(),
+		/obj/docking_port/stationary = list(),
+	)
+
 	for(var/z_idx in parsed_template.parsed_bounds[MAP_MAXZ] to 1 step -1)
 		var/turf/bottom_left = reservation.bottom_left_turfs[z_idx]
 		var/turf/top_right = reservation.top_right_turfs[z_idx]
@@ -81,12 +90,26 @@
 		for(var/turf/turf as anything in block(bottom_left, top_right))
 			loaded_turfs += turf
 			loaded_areas |= get_area(turf)
-			for(var/thing in turf.get_all_contents())
-				// atoms can actually be in the contents of two or more turfs based on its icon/bound size
-				// see https://www.byond.com/docs/ref/index.html#/atom/var/contents
+
+			// atoms can actually be in the contents of two or more turfs based on its icon/bound size
+			// see https://www.byond.com/docs/ref/index.html#/atom/var/contents
+			for(var/thing in (turf.get_all_contents() - turf))
+				// check for specific type handling
+				for(var/load_type in type_to_list)
+					if(!istype(thing, load_type))
+						continue
+					type_to_list[load_type] += thing
+					break
+
 				loaded_atom_movables |= thing
 
-	SSatoms.InitializeAtoms(loaded_atom_movables + loaded_turfs + loaded_areas)
+	SSatoms.InitializeAtoms(loaded_areas)
+	SSatoms.InitializeAtoms(loaded_atom_movables)
+	SSatoms.InitializeAtoms(loaded_turfs)
+	SSmachines.setup_template_powernets(type_to_list[/obj/structure/cable])
+	SSair.setup_template_machinery(type_to_list[/obj/machinery/atmospherics])
+	SSshuttle.setup_shuttles(type_to_list[/obj/docking_port/stationary])
+
 	SEND_SIGNAL(src, COMSIG_LAZY_TEMPLATE_LOADED, loaded_atom_movables, loaded_turfs, loaded_areas)
 	reservations += reservation
 	return reservation

--- a/code/datums/lazy_template.dm
+++ b/code/datums/lazy_template.dm
@@ -80,17 +80,6 @@
 		var/turf/bottom_left = reservation.bottom_left_turfs[z_idx]
 		var/turf/top_right = reservation.top_right_turfs[z_idx]
 
-		var/list/target_turfs = block(bottom_left, top_right)
-		// we're going to interrupt SSair for just a moment to ensure cleanup on the turfs we're about to replace
-		SSair.can_fire = FALSE
-		UNTIL(!length(SSair.currentrun))
-		for(var/turf/open/open_turf in target_turfs)
-			for(var/turf/open/adjacent_turf as anything in open_turf.atmos_adjacent_turfs)
-				adjacent_turf.atmos_adjacent_turfs -= open_turf
-			SSair.remove_from_active(open_turf)
-			open_turf.atmos_adjacent_turfs = null
-		SSair.can_fire = TRUE
-
 		load_map(
 			file(load_path),
 			bottom_left.x,
@@ -99,7 +88,7 @@
 			z_upper = z_idx,
 			z_lower = z_idx,
 		)
-		for(var/turf/turf as anything in target_turfs)
+		for(var/turf/turf as anything in block(bottom_left, top_right))
 			loaded_turfs += turf
 			loaded_areas |= get_area(turf)
 

--- a/code/datums/lazy_template.dm
+++ b/code/datums/lazy_template.dm
@@ -79,6 +79,14 @@
 	for(var/z_idx in parsed_template.parsed_bounds[MAP_MAXZ] to 1 step -1)
 		var/turf/bottom_left = reservation.bottom_left_turfs[z_idx]
 		var/turf/top_right = reservation.top_right_turfs[z_idx]
+
+		var/list/target_turfs = block(bottom_left, top_right)
+		// we're going to interrupt SSair for just a moment to ensure cleanup on the turfs we're about to replace
+		SSair.can_fire = FALSE
+		UNTIL(!length(SSair.currentrun))
+		SSair.active_turfs -= target_turfs
+		SSair.can_fire = TRUE
+
 		load_map(
 			file(load_path),
 			bottom_left.x,
@@ -87,7 +95,7 @@
 			z_upper = z_idx,
 			z_lower = z_idx,
 		)
-		for(var/turf/turf as anything in block(bottom_left, top_right))
+		for(var/turf/turf as anything in target_turfs)
 			loaded_turfs += turf
 			loaded_areas |= get_area(turf)
 

--- a/code/datums/lazy_template.dm
+++ b/code/datums/lazy_template.dm
@@ -69,11 +69,8 @@
 	var/list/loaded_turfs = list()
 	var/list/loaded_areas = list()
 
-	// list which matches a type to a list of things for that type
-	var/list/type_to_list = list(
-		/obj/structure/cable = list(),
-		/obj/machinery/atmospherics = list(),
-	)
+	var/list/obj/structure/cable/loaded_cables = list()
+	var/list/obj/machinery/atmospherics/loaded_atmospherics = list()
 
 	for(var/z_idx in parsed_template.parsed_bounds[MAP_MAXZ] to 1 step -1)
 		var/turf/bottom_left = reservation.bottom_left_turfs[z_idx]
@@ -94,20 +91,17 @@
 			// atoms can actually be in the contents of two or more turfs based on its icon/bound size
 			// see https://www.byond.com/docs/ref/index.html#/atom/var/contents
 			for(var/thing in (turf.get_all_contents() - turf))
-				// check for specific type handling
-				for(var/load_type in type_to_list)
-					if(!istype(thing, load_type))
-						continue
-					type_to_list[load_type] += thing
-					break
-
+				if(istype(thing, /obj/structure/cable))
+					loaded_cables += thing
+				else if(istype(thing, /obj/machinery/atmospherics))
+					loaded_atmospherics += thing
 				loaded_atom_movables |= thing
 
 	SSatoms.InitializeAtoms(loaded_areas)
 	SSatoms.InitializeAtoms(loaded_atom_movables)
 	SSatoms.InitializeAtoms(loaded_turfs)
-	SSmachines.setup_template_powernets(type_to_list[/obj/structure/cable])
-	SSair.setup_template_machinery(type_to_list[/obj/machinery/atmospherics])
+	SSmachines.setup_template_powernets(loaded_cables)
+	SSair.setup_template_machinery(loaded_atmospherics)
 
 	SEND_SIGNAL(src, COMSIG_LAZY_TEMPLATE_LOADED, loaded_atom_movables, loaded_turfs, loaded_areas)
 	reservations += reservation

--- a/code/datums/lazy_template.dm
+++ b/code/datums/lazy_template.dm
@@ -84,7 +84,11 @@
 		// we're going to interrupt SSair for just a moment to ensure cleanup on the turfs we're about to replace
 		SSair.can_fire = FALSE
 		UNTIL(!length(SSair.currentrun))
-		SSair.active_turfs -= target_turfs
+		for(var/turf/open/open_turf in target_turfs)
+			for(var/turf/open/adjacent_turf as anything in open_turf.atmos_adjacent_turfs)
+				adjacent_turf.atmos_adjacent_turfs -= open_turf
+			open_turf.atmos_adjacent_turfs.Cut()
+			SSair.remove_from_active(open_turf)
 		SSair.can_fire = TRUE
 
 		load_map(

--- a/code/datums/lazy_template.dm
+++ b/code/datums/lazy_template.dm
@@ -73,7 +73,6 @@
 	var/list/type_to_list = list(
 		/obj/structure/cable = list(),
 		/obj/machinery/atmospherics = list(),
-		/obj/docking_port/stationary = list(),
 	)
 
 	for(var/z_idx in parsed_template.parsed_bounds[MAP_MAXZ] to 1 step -1)
@@ -109,7 +108,6 @@
 	SSatoms.InitializeAtoms(loaded_turfs)
 	SSmachines.setup_template_powernets(type_to_list[/obj/structure/cable])
 	SSair.setup_template_machinery(type_to_list[/obj/machinery/atmospherics])
-	SSshuttle.setup_shuttles(type_to_list[/obj/docking_port/stationary])
 
 	SEND_SIGNAL(src, COMSIG_LAZY_TEMPLATE_LOADED, loaded_atom_movables, loaded_turfs, loaded_areas)
 	reservations += reservation

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -211,9 +211,12 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			if(stashed_group.should_display || SSair.display_all_groups)
 				stashed_group.display_turf(new_turf)
 	else
+		for(var/turf/open/adjacent_turf as anything in atmos_adjacent_turfs)
+			adjacent_turf.atmos_adjacent_turfs -= src
+		atmos_adjacent_turfs = null
 		if(excited || excited_group)
 			SSair.remove_from_active(src) //Clean up wall excitement, and refresh excited groups
-		if(ispath(path,/turf/closed) || ispath(path,/turf/cordon))
+		if(ispath(path, /turf/closed) || ispath(path, /turf/cordon))
 			flags |= CHANGETURF_RECALC_ADJACENT
 		return ..()
 

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -211,9 +211,6 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 			if(stashed_group.should_display || SSair.display_all_groups)
 				stashed_group.display_turf(new_turf)
 	else
-		for(var/turf/open/adjacent_turf as anything in atmos_adjacent_turfs)
-			adjacent_turf.atmos_adjacent_turfs -= src
-		atmos_adjacent_turfs = null
 		if(excited || excited_group)
 			SSair.remove_from_active(src) //Clean up wall excitement, and refresh excited groups
 		if(ispath(path, /turf/closed) || ispath(path, /turf/cordon))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -110,6 +110,12 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		return FALSE
 	. = ..()
 
+/turf/New(...)
+	// This is done to prevent atmos from processing on turfs that have just been created, for example during mapload
+	SSair.currentrun -= src
+	SSair.active_turfs -= src
+	return ..()
+
 /**
  * Turf Initialize
  *

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -110,12 +110,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 		return FALSE
 	. = ..()
 
-/turf/New(...)
-	// This is done to prevent atmos from processing on turfs that have just been created, for example during mapload
-	SSair.currentrun -= src
-	SSair.active_turfs -= src
-	return ..()
-
 /**
  * Turf Initialize
  *

--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -109,7 +109,6 @@
 	// need these two below?
 	SSmachines.setup_template_powernets(cables)
 	SSair.setup_template_machinery(atmos_machines)
-	SSshuttle.setup_shuttles(ports)
 
 	//calculate all turfs inside the border
 	var/list/template_and_bordering_turfs = block(

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -240,7 +240,8 @@
 			T.turf_flags |= NO_RUINS
 
 	if(SSshuttle.initialized)
-		SSshuttle.setup_shuttles(list(src))
+		ASYNC
+			SSshuttle.setup_shuttles(list(src))
 
 	#ifdef DOCKING_PORT_HIGHLIGHT
 	highlight("#f00")

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -240,8 +240,7 @@
 			T.turf_flags |= NO_RUINS
 
 	if(SSshuttle.initialized)
-		ASYNC
-			SSshuttle.setup_shuttles(list(src))
+		INVOKE_ASYNC(SSshuttle, TYPE_PROC_REF(/datum/controller/subsystem/shuttle, setup_shuttles), list(src))
 
 	#ifdef DOCKING_PORT_HIGHLIGHT
 	highlight("#f00")

--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -239,6 +239,9 @@
 		for(var/turf/T in return_turfs())
 			T.turf_flags |= NO_RUINS
 
+	if(SSshuttle.initialized)
+		SSshuttle.setup_shuttles(list(src))
+
 	#ifdef DOCKING_PORT_HIGHLIGHT
 	highlight("#f00")
 	#endif


### PR DESCRIPTION

## About The Pull Request

See title.
## Why It's Good For The Game

If a lazy template is loaded AFTER roundstart it doesn't get included into the global init procs, because that work is offloaded into a subsystem
LINDA runtimes are bad, null.archive() runtime be gone.
## Changelog
:cl:
fix: The Syndicate have fired their previous construction company after poor results in recent outposts.
/:cl:
