### PR TITLE
Fixes a runtime with the polymorph belt

### DIFF
--- a/code/modules/clothing/belts/polymorph_belt.dm
+++ b/code/modules/clothing/belts/polymorph_belt.dm
@@ -35,8 +35,8 @@
 	return slot & ITEM_SLOT_BELT
 
 /obj/item/polymorph_belt/update_icon_state()
-	icon_state = base_icon_state + (active) ? "" : "_inactive"
-	worn_icon_state = base_icon_state + (active) ? "" : "_inactive"
+	icon_state = base_icon_state + (active ? "" : "_inactive")
+	worn_icon_state = base_icon_state + (active ? "" : "_inactive")
 	return ..()
 
 /obj/item/polymorph_belt/attackby(obj/item/weapon, mob/user, params)


### PR DESCRIPTION

## About The Pull Request

The Polymorph Belt no longer runtimes when trying to update its icon state.

The parenthesis around a conditional statement in update_icon_state() did not cover the entire statement. As a result, the "active" value was added to the icon state, which would cause a mismatch and runtime.
## Why It's Good For The Game

This bugfix was brought to you by https://runtimes.moth.fans/
## Changelog
:cl: Rhials
fix: The Polymorph Belt should now update its sprite when active.
/:cl:
