### PR TITLE
Fix mood runtimes with error handling

### DIFF
--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -113,6 +113,11 @@
 
 /// Handles mood given by nutrition
 /datum/mood/proc/handle_nutrition()
+	if(!mob_parent)
+		stack_trace("Mood is processing without a mob parent!")
+		qdel(src)
+		return
+
 	if (HAS_TRAIT(mob_parent, TRAIT_NOHUNGER))
 		clear_mood_event(MOOD_CATEGORY_NUTRITION)  // if you happen to switch species while hungry youre no longer hungy
 		return FALSE // no moods for nutrition
@@ -410,6 +415,11 @@
 
 /// Sets sanity to the specified amount and applies effects.
 /datum/mood/proc/set_sanity(amount, minimum = SANITY_INSANE, maximum = SANITY_GREAT, override = FALSE)
+	if(!mob_parent)
+		stack_trace("Mood is processing without a mob parent!")
+		qdel(src)
+		return
+
 	// If we're out of the acceptable minimum-maximum range move back towards it in steps of 0.7
 	// If the new amount would move towards the acceptable range faster then use it instead
 	if(amount < minimum)

--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -73,6 +73,11 @@
 	return ..()
 
 /datum/mood/process(seconds_per_tick)
+	if(!mob_parent)
+		stack_trace("Mood is processing without a mob parent!")
+		qdel(src)
+		return
+
 	switch(mood_level)
 		if(MOOD_LEVEL_SAD4)
 			set_sanity(sanity - 0.3 * seconds_per_tick, SANITY_INSANE)
@@ -113,11 +118,6 @@
 
 /// Handles mood given by nutrition
 /datum/mood/proc/handle_nutrition()
-	if(!mob_parent)
-		stack_trace("Mood is processing without a mob parent!")
-		qdel(src)
-		return
-
 	if (HAS_TRAIT(mob_parent, TRAIT_NOHUNGER))
 		clear_mood_event(MOOD_CATEGORY_NUTRITION)  // if you happen to switch species while hungry youre no longer hungy
 		return FALSE // no moods for nutrition
@@ -415,11 +415,6 @@
 
 /// Sets sanity to the specified amount and applies effects.
 /datum/mood/proc/set_sanity(amount, minimum = SANITY_INSANE, maximum = SANITY_GREAT, override = FALSE)
-	if(!mob_parent)
-		stack_trace("Mood is processing without a mob parent!")
-		qdel(src)
-		return
-
 	// If we're out of the acceptable minimum-maximum range move back towards it in steps of 0.7
 	// If the new amount would move towards the acceptable range faster then use it instead
 	if(amount < minimum)


### PR DESCRIPTION

## About The Pull Request
The runtime log:

```
[2023-09-26 04:34:40.230] RUNTIME: runtime error: Cannot read null._status_traits
 - proc name: set sanity (/datum/mood/proc/set_sanity)
 -   source file: code/datums/mood.dm,417
 -   usr: null
 -   src: /datum/mood (/datum/mood)
 -   call stack:
 - /datum/mood (/datum/mood): set sanity(48.5, 50, 125, 0)
 - /datum/mood (/datum/mood): process(1)
 - Mood (/datum/controller/subsystem/processing/mood): fire(0)
 - Mood (/datum/controller/subsystem/processing/mood): fire(0)
 - Mood (/datum/controller/subsystem/processing/mood): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 
[2023-09-26 04:34:40.231] RUNTIME: runtime error: Cannot read null._status_traits
 - proc name: handle nutrition (/datum/mood/proc/handle_nutrition)
 -   source file: code/datums/mood.dm,116
 -   usr: null
 -   src: /datum/mood (/datum/mood)
 -   call stack:
 - /datum/mood (/datum/mood): handle nutrition()
 - /datum/mood (/datum/mood): process(1)
 - Mood (/datum/controller/subsystem/processing/mood): fire(0)
 - Mood (/datum/controller/subsystem/processing/mood): fire(0)
 - Mood (/datum/controller/subsystem/processing/mood): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 
[2023-09-26 04:34:40.232] RUNTIME: runtime error: Cannot read null._status_traits
 - proc name: process (/datum/mood/process)
 -   source file: code/datums/mood.dm,99
 -   usr: null
 -   src: /datum/mood (/datum/mood)
 -   call stack:
 - /datum/mood (/datum/mood): process(1)
 - Mood (/datum/controller/subsystem/processing/mood): fire(0)
 - Mood (/datum/controller/subsystem/processing/mood): fire(0)
 - Mood (/datum/controller/subsystem/processing/mood): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 ```

From looking at the [runtime logs for the round](https://tgstation13.download/parsed-logs/manuel/data/logs/2023/09/26/round-215371/runtime.txt), it looks like someone spawned a replica pod mob in null space. (via harvesting seeds with a plant bag)  Then I guess this mob somehow had mood events triggered later on from some method without   Not really sure what happened as the only proc that handles making the `mob_parent` null is when the signal for `COMSIG_QDELETING` is called.  

Regardless, I added an error handling check in `process()` to make sure `mob_parent` exists and if it doesn't to `qdel` and throw a stack trace.

## Why It's Good For The Game
No more runtime mood spam.

## Changelog
:cl:
fix: Fix mood events to not process without a mob assigned to it
/:cl:
