### PR TITLE
Fix water puddle runtime when washing items

### DIFF
--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -591,6 +591,12 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink/kitchen, (-16))
 	var/busy = FALSE //Something's being washed at the moment
 	var/dispensedreagent = /datum/reagent/water // for whenever plumbing happens
 
+/obj/structure/water_source/Initialize(mapload)
+	. = ..()
+
+	create_reagents(INFINITY, NO_REACT)
+	reagents.add_reagent(dispensedreagent, INFINITY)
+
 /obj/structure/water_source/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(.)


### PR DESCRIPTION

## About The Pull Request
Runtime log:

```
[2023-09-26 03:06:01.741] RUNTIME: runtime error: Cannot read null.total_volume
 - proc name: attackby (/obj/structure/water_source/attackby)
 -   source file: code/game/objects/structures/watercloset.dm,697
 -   usr: Seed-Xil (/mob/living/carbon/human)
 -   src: the puddle (/obj/structure/water_source/puddle)
 -   usr.loc: the volcanic floor (143,199,3) (/turf/open/misc/asteroid/basalt/lava_land_surface)
 -   src.loc: the volcanic floor (144,199,3) (/turf/open/misc/asteroid/basalt/lava_land_surface)
 -   call stack:
 - the puddle (/obj/structure/water_source/puddle): attackby(the hairless hide (/obj/item/stack/sheet/hairlesshide), Seed-Xil (/mob/living/carbon/human), "icon-x=18;icon-y=12;left=1;but...")
 - the puddle (/obj/structure/water_source/puddle): attackby(the hairless hide (/obj/item/stack/sheet/hairlesshide), Seed-Xil (/mob/living/carbon/human), "icon-x=18;icon-y=12;left=1;but...")
 - the hairless hide (/obj/item/stack/sheet/hairlesshide): melee attack chain(Seed-Xil (/mob/living/carbon/human), the puddle (/obj/structure/water_source/puddle), "icon-x=18;icon-y=12;left=1;but...")
 - Seed-Xil (/mob/living/carbon/human): ClickOn(the puddle (/obj/structure/water_source/puddle), "icon-x=18;icon-y=12;left=1;but...")
 - the puddle (/obj/structure/water_source/puddle): Click(the volcanic floor (144,199,3) (/turf/open/misc/asteroid/basalt/lava_land_surface), "mapwindow.map", "icon-x=18;icon-y=12;left=1;but...")
 ```

The water puddle would runtime due to not having initialized the water reagents and volume.  The error would popup whenever someone attempted to wash an item in the puddle.  

## Why It's Good For The Game
One less runtime for the codebase to worry about.

## Changelog
:cl:
fix: Fix water puddle runtime when washing items
/:cl:
