### PR TITLE
Fix seed extractor runtime

### DIFF
--- a/code/modules/hydroponics/grown/replicapod.dm
+++ b/code/modules/hydroponics/grown/replicapod.dm
@@ -37,7 +37,7 @@
 	plant_icon_offset = 2
 	species = "replicapod"
 	plantname = "Replica Pod"
-	product = /mob/living/carbon/human //verrry special -- Urist
+	product = null // the human mob is spawned in harvest()
 	lifespan = 50
 	endurance = 8
 	maturation = 10

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -216,8 +216,9 @@
 		seed_data["mutatelist"] = list()
 		for(var/obj/item/seeds/mutant as anything in to_add.mutatelist)
 			seed_data["mutatelist"] += initial(mutant.plantname)
-		var/obj/item/food/grown/product = new to_add.product
-		if(product)
+
+		if(to_add.product)
+			var/obj/item/food/grown/product = new to_add.product
 			var/datum/reagent/product_distill_reagent = product.distill_reagent
 			seed_data["distill_reagent"] = initial(product_distill_reagent.name)
 			var/datum/reagent/product_juice_typepath = product.juice_typepath
@@ -225,7 +226,8 @@
 			seed_data["grind_results"] = list()
 			for(var/datum/reagent/reagent as anything in product.grind_results)
 				seed_data["grind_results"] += initial(reagent.name)
-		qdel(product)
+			qdel(product)
+
 		piles[seed_id] = seed_data
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
The runtime log:

```
[2023-09-26 03:24:26.314] RUNTIME: runtime error: Cannot create objects of type null.
 - proc name: add seed (/obj/machinery/seed_extractor/proc/add_seed)
 -   source file: code/modules/hydroponics/seed_extractor.dm,219
 -   usr: Airi Ixo (/mob/living/carbon/human)
 -   src: the seed extractor (/obj/machinery/seed_extractor)
 -   usr.loc: the floor (123,178,2) (/turf/open/floor/iron)
 -   src.loc: the floor (123,177,2) (/turf/open/floor/iron/dark)
 -   call stack:
 - the seed extractor (/obj/machinery/seed_extractor): add seed(the pack of starthistle seeds (/obj/item/seeds/starthistle), the portable seed extractor (/obj/item/storage/bag/plants/portaseeder))
 - the seed extractor (/obj/machinery/seed_extractor): attackby(the portable seed extractor (/obj/item/storage/bag/plants/portaseeder), Airi Ixo (/mob/living/carbon/human), "icon-x=19;icon-y=16;left=1;but...")
 - the portable seed extractor (/obj/item/storage/bag/plants/portaseeder): melee attack chain(Airi Ixo (/mob/living/carbon/human), the seed extractor (/obj/machinery/seed_extractor), "icon-x=19;icon-y=16;left=1;but...")
 - Airi Ixo (/mob/living/carbon/human): ClickOn(the seed extractor (/obj/machinery/seed_extractor), "icon-x=19;icon-y=16;left=1;but...")
 - the seed extractor (/obj/machinery/seed_extractor): Click(the floor (123,177,2) (/turf/open/floor/iron/dark), "mapwindow.map", "icon-x=19;icon-y=16;left=1;but...")
 - the seed extractor (/obj/machinery/seed_extractor):  Click(the floor (123,177,2) (/turf/open/floor/iron/dark), "mapwindow.map", "icon-x=19;icon-y=16;left=1;but...")
 - /datum/callback/verb_callback (/datum/callback/verb_callback): Invoke()
 - world: push usr(Airi Ixo (/mob/living/carbon/human), /datum/callback/verb_callback (/datum/callback/verb_callback))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - Input (/datum/controller/subsystem/verb_manager/input): run verb queue()
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 ```

Not every seed has a product that is created.  So when weeds are added to the seed data, it would try to initialize a null product.  Just needed to add a simple check to resolve it.

Also it appears that replicapods had a human typepath as a product.  This caused mobs to spawn in nullspace.

Runtime log for that:

```
[2023-09-26 03:56:33.016] RUNTIME: runtime error: undefined variable /mob/living/carbon/human/var/distill_reagent
 - proc name: add seed (/obj/machinery/seed_extractor/proc/add_seed)
 -   source file: code/modules/hydroponics/seed_extractor.dm,221
 -   usr: Airi Ixo (/mob/living/carbon/human)
 -   src: the seed extractor (/obj/machinery/seed_extractor)
 -   usr.loc: the floor (123,176,2) (/turf/open/floor/iron/dark/smooth_large)
 -   src.loc: the floor (123,177,2) (/turf/open/floor/iron/dark)
 -   call stack:
 - the seed extractor (/obj/machinery/seed_extractor): add seed(the pack of replica pod seeds (/obj/item/seeds/replicapod), the plant bag (/obj/item/storage/bag/plants))
 - the seed extractor (/obj/machinery/seed_extractor): attackby(the plant bag (/obj/item/storage/bag/plants), Airi Ixo (/mob/living/carbon/human), "icon-x=19;icon-y=20;left=1;but...")
 - the plant bag (/obj/item/storage/bag/plants): melee attack chain(Airi Ixo (/mob/living/carbon/human), the seed extractor (/obj/machinery/seed_extractor), "icon-x=19;icon-y=20;left=1;but...")
 - Airi Ixo (/mob/living/carbon/human): ClickOn(the seed extractor (/obj/machinery/seed_extractor), "icon-x=19;icon-y=20;left=1;but...")
 - the seed extractor (/obj/machinery/seed_extractor): Click(the floor (123,177,2) (/turf/open/floor/iron/dark), "mapwindow.map", "icon-x=19;icon-y=20;left=1;but...")
 - the seed extractor (/obj/machinery/seed_extractor):  Click(the floor (123,177,2) (/turf/open/floor/iron/dark), "mapwindow.map", "icon-x=19;icon-y=20;left=1;but...")
 - /datum/callback/verb_callback (/datum/callback/verb_callback): Invoke()
 - world: push usr(Airi Ixo (/mob/living/carbon/human), /datum/callback/verb_callback (/datum/callback/verb_callback))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - Input (/datum/controller/subsystem/verb_manager/input): run verb queue()
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 - 
[2023-09-26 03:56:33.054] RUNTIME: runtime error: Basic mob being instantiated in nullspace (code/modules/mob/living/basic/basic.dm:113)
 - proc name:  stack trace (/proc/_stack_trace)
 -   source file: code/__HELPERS/stack_trace.dm,4
 -   usr: the seedling (/mob/living/basic/seedling)
 -   src: null
 -   usr.loc: null
 -   call stack:
 -  stack trace("Basic mob being instantiated i...", "code/modules/mob/living/basic/...", 113)
 - the seedling (/mob/living/basic/seedling): Initialize(0)
 - the seedling (/mob/living/basic/seedling): Initialize(0)
 - Atoms (/datum/controller/subsystem/atoms): InitAtom(the seedling (/mob/living/basic/seedling), 0, /list (/list))
 - the seedling (/mob/living/basic/seedling): New(0)
 - the seedling (/mob/living/basic/seedling): New()
 - the seed extractor (/obj/machinery/seed_extractor): add seed(the pack of seedling seeds (/obj/item/seeds/seedling), the plant bag (/obj/item/storage/bag/plants))
 - the seed extractor (/obj/machinery/seed_extractor): attackby(the plant bag (/obj/item/storage/bag/plants), Airi Ixo (/mob/living/carbon/human), "icon-x=19;icon-y=20;left=1;but...")
 - the plant bag (/obj/item/storage/bag/plants): melee attack chain(Airi Ixo (/mob/living/carbon/human), the seed extractor (/obj/machinery/seed_extractor), "icon-x=19;icon-y=20;left=1;but...")
 - Airi Ixo (/mob/living/carbon/human): ClickOn(the seed extractor (/obj/machinery/seed_extractor), "icon-x=19;icon-y=20;left=1;but...")
 - ...
 - /datum/callback/verb_callback (/datum/callback/verb_callback): Invoke()
 - world: push usr(Airi Ixo (/mob/living/carbon/human), /datum/callback/verb_callback (/datum/callback/verb_callback))
 - /datum/callback/verb_callback (/datum/callback/verb_callback): InvokeAsync()
 - Input (/datum/controller/subsystem/verb_manager/input): run verb queue()
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): fire(0)
 - Input (/datum/controller/subsystem/verb_manager/input): ignite(0)
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
 ```

## Why It's Good For The Game
Multiple runtimes fixed.

## Changelog
:cl:
fix: Fix hydro seed extractor having runtimes when a seed has no harvestable product. It would also spawn replicapod mobs into nullspace.
fix: Fix seed extractor deleting replicapod, starthistle, corpse flower, and galaxythistle seeds when inserted.
/:cl:
