### PR TITLE
Fix: Make death sandwich safe to examine

### DIFF
--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -262,14 +262,13 @@
 // Makes you feel disgusted if you look at it wrong.
 /obj/item/food/sandwich/death/examine(mob/user)
 	. = ..()
+	// Only human mobs, not animals or silicons, can like/dislike by this.
+	if(!ishuman(user))
+		return
 	if(check_liked(user) == FOOD_LIKED)
 		return
-	// Only human mobs, not animals or silicons, can be disgusted by this.
-	if(!istype(user, /mob/living/carbon/human))
-		return
-	balloon_alert(user, "looked at it wrong!")
 	to_chat(user, span_warning("You imagine yourself eating [src]. You feel a sudden sour taste in your mouth, and a horrible feeling that you've done something wrong."))
-	user.adjust_disgust(33);
+	user.adjust_disgust(33)
 
 ///Override for after_eat and check_liked callbacks.
 /obj/item/food/sandwich/death/make_edible()
@@ -285,8 +284,7 @@
 	/// Closest thing to a mullet we have
 	if(consumer.hairstyle == "Gelled Back" && istype(consumer.get_item_by_slot(ITEM_SLOT_ICLOTHING), /obj/item/clothing/under/rank/civilian/cookjorts))
 		return FOOD_LIKED
-	else
-		return FOOD_DISLIKED
+	return FOOD_DISLIKED
 
 /**
 * Callback to be used with the edible component.
@@ -294,7 +292,7 @@
 * If you don't, you contract a deadly disease.
 */
 /obj/item/food/sandwich/death/proc/after_eat(mob/living/carbon/human/consumer)
-	/// If you're eating it right, you like it.
+	/// If you like it, you're eating it right.
 	if(check_liked(consumer) == FOOD_LIKED)
 		return
 	// I thought it didn't make sense for it to instantly kill you, so instead enjoy shitloads of toxin damage per bite.

--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -259,10 +259,34 @@
 	. = ..()
 	obj_flags &= ~UNIQUE_RENAME // You shouldn't be able to disguise this on account of how it kills you
 
-///Override for checkliked callback
+// Makes you feel disgusted if you look at it wrong.
+/obj/item/food/sandwich/death/examine(mob/user)
+	. = ..()
+	if(check_liked(user) == FOOD_LIKED)
+		return
+	// Only human mobs, not animals or silicons, can be disgusted by this.
+	if(!istype(user, /mob/living/carbon/human))
+		return
+	balloon_alert(user, "looked at it wrong!")
+	to_chat(user, span_warning("You imagine yourself eating [src]. You feel a sudden sour taste in your mouth, and a horrible feeling that you've done something wrong."))
+	user.adjust_disgust(33);
+
+///Override for after_eat and check_liked callbacks.
 /obj/item/food/sandwich/death/make_edible()
 	. = ..()
-	AddComponent(/datum/component/edible, after_eat = CALLBACK(src, PROC_REF(after_eat)))
+	AddComponent(/datum/component/edible, after_eat = CALLBACK(src, PROC_REF(after_eat)), check_liked = CALLBACK(src, PROC_REF(check_liked)))
+
+/**
+* Callback to be used with the edible component.
+* If you have the right clothes and hairstyle, you like it.
+* If you don't, you don't like it.
+*/
+/obj/item/food/sandwich/death/proc/check_liked(mob/living/carbon/human/consumer)
+	/// Closest thing to a mullet we have
+	if(consumer.hairstyle == "Gelled Back" && istype(consumer.get_item_by_slot(ITEM_SLOT_ICLOTHING), /obj/item/clothing/under/rank/civilian/cookjorts))
+		return FOOD_LIKED
+	else
+		return FOOD_DISLIKED
 
 /**
 * Callback to be used with the edible component.
@@ -270,12 +294,12 @@
 * If you don't, you contract a deadly disease.
 */
 /obj/item/food/sandwich/death/proc/after_eat(mob/living/carbon/human/consumer)
-	/// Closest thing to a mullet we have
-	if(consumer.hairstyle == "Gelled Back" && istype(consumer.get_item_by_slot(ITEM_SLOT_ICLOTHING), /obj/item/clothing/under/rank/civilian/cookjorts))
-		return FOOD_LIKED
+	/// If you're eating it right, you like it.
+	if(check_liked(consumer) == FOOD_LIKED)
+		return
 	// I thought it didn't make sense for it to instantly kill you, so instead enjoy shitloads of toxin damage per bite.
 	balloon_alert(consumer, "ate it wrong!")
-	consumer.ForceContractDisease(new/datum/disease/death_sandwich_poisoning())
+	consumer.ForceContractDisease(new /datum/disease/death_sandwich_poisoning())
 
 /obj/item/food/sandwich/death/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] starts to shove [src] down [user.p_their()] throat the wrong way. It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -270,7 +270,7 @@
 	to_chat(user, span_warning("You imagine yourself eating [src]. You feel a sudden sour taste in your mouth, and a horrible feeling that you've done something wrong."))
 	user.adjust_disgust(33)
 
-///Override for after_eat and check_liked callbacks.
+// Override for after_eat and check_liked callbacks.
 /obj/item/food/sandwich/death/make_edible()
 	. = ..()
 	AddComponent(/datum/component/edible, after_eat = CALLBACK(src, PROC_REF(after_eat)), check_liked = CALLBACK(src, PROC_REF(check_liked)))
@@ -281,7 +281,7 @@
 * If you don't, you don't like it.
 */
 /obj/item/food/sandwich/death/proc/check_liked(mob/living/carbon/human/consumer)
-	/// Closest thing to a mullet we have
+	// Closest thing to a mullet we have
 	if(consumer.hairstyle == "Gelled Back" && istype(consumer.get_item_by_slot(ITEM_SLOT_ICLOTHING), /obj/item/clothing/under/rank/civilian/cookjorts))
 		return FOOD_LIKED
 	return FOOD_DISLIKED
@@ -292,7 +292,7 @@
 * If you don't, you contract a deadly disease.
 */
 /obj/item/food/sandwich/death/proc/after_eat(mob/living/carbon/human/consumer)
-	/// If you like it, you're eating it right.
+	// If you like it, you're eating it right.
 	if(check_liked(consumer) == FOOD_LIKED)
 		return
 	// I thought it didn't make sense for it to instantly kill you, so instead enjoy shitloads of toxin damage per bite.

--- a/code/game/objects/items/food/sandwichtoast.dm
+++ b/code/game/objects/items/food/sandwichtoast.dm
@@ -262,14 +262,14 @@
 ///Override for checkliked callback
 /obj/item/food/sandwich/death/make_edible()
 	. = ..()
-	AddComponent(/datum/component/edible, check_liked = CALLBACK(src, PROC_REF(check_liked)))
+	AddComponent(/datum/component/edible, after_eat = CALLBACK(src, PROC_REF(after_eat)))
 
 /**
 * Callback to be used with the edible component.
-* If you eat the sandwich with the right clothes and hairstyle, you like it.
+* If you take a bite of the sandwich with the right clothes and hairstyle, you like it.
 * If you don't, you contract a deadly disease.
 */
-/obj/item/food/sandwich/death/proc/check_liked(mob/living/carbon/human/consumer)
+/obj/item/food/sandwich/death/proc/after_eat(mob/living/carbon/human/consumer)
 	/// Closest thing to a mullet we have
 	if(consumer.hairstyle == "Gelled Back" && istype(consumer.get_item_by_slot(ITEM_SLOT_ICLOTHING), /obj/item/clothing/under/rank/civilian/cookjorts))
 		return FOOD_LIKED


### PR DESCRIPTION
## About The Pull Request

The death sandwich currently has a humorous bug which causes the "death sandwich poisoning" disease to be applied upon examining the item. The bug is caused by the usage of the `check_liked` callback, which is part of the edible component, and is called when a player examines the food. Flavor text such as "You find this meal edible" is expected, but side effects are applied instead.

To fix the bug, I swapped over to the `after_eat` callback which is called for each bite of food taken.

In addition to fixing the bug, I also added a new override for the death sandwich `examine` proc which causes the examiner to become disgusted/nauseated if they "look at it wrong".

## Why It's Good For The Game

I had the pleasure of watching this bug happen live on Skyrat, it was hilarious! Someone dumped a pile of death sandwiches on the evac shuttle for everyone to look at.

Testing the fix in-game was successful and I was able to examine the sandwich without getting the disease. I was able to eat it "wrong" and get the message/disease as expected. I also tested eating it "right" with the gelled back hair and cooking jorts.

## Changelog

:cl: A.C.M.O.
fix: Fixes the death sandwich, making it safe to examine.
/:cl:
