### PR TITLE
Fixes missing grinder in Birdshot's Virology department

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -49479,6 +49479,7 @@
 /obj/structure/table/glass,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "ruD" = (


### PR DESCRIPTION

## About The Pull Request
See, it's right there.

![image](https://github.com/tgstation/tgstation/assets/7019927/6696f699-cba4-48d8-8ebf-840b17e1427e)

Someone had intended to remap all of Virology but it went stale and they haven't seemed to pick it back up yet, so I might as well fix this while we wait on it.

## Why It's Good For The Game
Virologists need this for their job and were getting annoyed that they had to co-opt Chemistry's grinder.

## Changelog
:cl: Vekter
fix: Fixes the missing grinder in Birdshot's Virology department
/:cl:
