### PR TITLE
Human sounds now depend on body type

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -18,7 +18,7 @@
 	human_mob.skin_tone = random_skin_tone()
 
 /datum/species/human/get_scream_sound(mob/living/carbon/human/human)
-	if(human.gender == MALE)
+	if(human.physique == MALE)
 		if(prob(1))
 			return 'sound/voice/human/wilhelm_scream.ogg'
 		return pick(

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -189,7 +189,7 @@
 		return
 	var/mob/living/carbon/human/human_user = user
 	if(human_user.dna.species.id == SPECIES_HUMAN && !HAS_MIND_TRAIT(human_user, TRAIT_MIMING))
-		if(human_user.gender == FEMALE)
+		if(human_user.physique == FEMALE)
 			return pick('sound/voice/human/gasp_female1.ogg', 'sound/voice/human/gasp_female2.ogg', 'sound/voice/human/gasp_female3.ogg')
 		else
 			return pick('sound/voice/human/gasp_male1.ogg', 'sound/voice/human/gasp_male2.ogg')

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -56,9 +56,9 @@
 
 /obj/item/photo/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is taking one last look at \the [src]! It looks like [user.p_theyre()] giving in to death!"))//when you wanna look at photo of waifu one last time before you die...
-	if (user.gender == MALE)
+	if (user.physique == MALE)
 		playsound(user, 'sound/voice/human/manlaugh1.ogg', 50, TRUE)//EVERY TIME I DO IT MAKES ME LAUGH
-	else if (user.gender == FEMALE)
+	else
 		playsound(user, 'sound/voice/human/womanlaugh.ogg', 50, TRUE)
 	return OXYLOSS
 

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -56,7 +56,7 @@
 
 /obj/item/photo/suicide_act(mob/living/carbon/human/user)
 	user.visible_message(span_suicide("[user] is taking one last look at \the [src]! It looks like [user.p_theyre()] giving in to death!"))//when you wanna look at photo of waifu one last time before you die...
-	if (user.physique == MALE)
+	if (!ishuman(user) || user.physique == MALE)
 		playsound(user, 'sound/voice/human/manlaugh1.ogg', 50, TRUE)//EVERY TIME I DO IT MAKES ME LAUGH
 	else
 		playsound(user, 'sound/voice/human/womanlaugh.ogg', 50, TRUE)

--- a/code/modules/photography/photos/photo.dm
+++ b/code/modules/photography/photos/photo.dm
@@ -54,7 +54,7 @@
 		icon = I
 	return ..()
 
-/obj/item/photo/suicide_act(mob/living/carbon/user)
+/obj/item/photo/suicide_act(mob/living/carbon/human/user)
 	user.visible_message(span_suicide("[user] is taking one last look at \the [src]! It looks like [user.p_theyre()] giving in to death!"))//when you wanna look at photo of waifu one last time before you die...
 	if (user.physique == MALE)
 		playsound(user, 'sound/voice/human/manlaugh1.ogg', 50, TRUE)//EVERY TIME I DO IT MAKES ME LAUGH


### PR DESCRIPTION
## About The Pull Request

So there's currently a problem where our human sounds are dependent on whether you are a male or female, however we have 4 genders in-game.
This leads to scream sounds being female if you're anything but a Male, and gasp shock sounds being male if you're anything but a Female. This is very inconsistent, and I think as a better way of handling this, it should all be handled by Bodytype, since we only have 2 and is a separate choice from gender. This means regardless of gender, you can still choose what sounds your character will make.

## Why It's Good For The Game

Mostly explained in the about section, this lets people who play as they/them & it/its to decide what they should sound like.
I guess as a bonus, it means men now appear more like women if they choose the female bodytype, and vice versa. Or at least I think it's a bonus? I'm not really knowledgeable in this sort of stuff.

I kinda have the same argument as why I think TTS should be accurate. You should be able to customize your character to how you want it, and I think that choosing the non-male/female ones shouldn't give you inconsistent voices.

## Changelog

I actually don't know what to label this.

:cl:
code: Your bodytype now decides what gendered sounds you make.
/:cl: