### PR TITLE
[NO GBP] fixes crab walking

### DIFF
--- a/code/datums/elements/sideway_movement.dm
+++ b/code/datums/elements/sideway_movement.dm
@@ -23,5 +23,5 @@
 		return
 	var/new_dir = old_dir
 	if(direction == old_dir || direction == REVERSE_DIR(old_dir))
-		new_dir = angle2dir(dir2angle(direction) + pick(90, -90))
+		new_dir = turn(source.dir, pick(90, -90))
 	source.setDir(new_dir)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -132,7 +132,7 @@
 	//Basically an optional override for our glide size
 	//Sometimes you want to look like you're moving with a delay you don't actually have yet
 	visual_delay = 0
-	var/old_dir = dir
+	var/old_dir = mob.dir
 
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
the sideway movement element isn't working as intended, because apparently the client dir and not the mob's (which is always SOUTH) was being sent with the signal, and the existence of the `turn(dir, angle)` proc hadn't crossed my mind while I coded the element.

## Why It's Good For The Game
This fixes the above.

## Changelog

:cl:
fix: Fixed crabs not correctly (kinda) walking sideway.
/:cl:
