### PR TITLE
[no gbp] Restores player blob mob attack speeds

### DIFF
--- a/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
@@ -14,6 +14,7 @@
 	verb_yell = "bellows"
 	melee_damage_lower = 10
 	melee_damage_upper = 15
+	melee_attack_cooldown = CLICK_CD_MELEE
 	obj_damage = 20
 	attack_verb_continuous = "punches"
 	attack_verb_simple = "punch"

--- a/code/modules/mob/living/basic/blob_minions/blobbernaut.dm
+++ b/code/modules/mob/living/basic/blob_minions/blobbernaut.dm
@@ -13,6 +13,7 @@
 	damage_coeff = list(BRUTE = 0.5, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	melee_damage_lower = BLOBMOB_BLOBBERNAUT_DMG_SOLO_LOWER
 	melee_damage_upper = BLOBMOB_BLOBBERNAUT_DMG_SOLO_UPPER
+	melee_attack_cooldown = CLICK_CD_MELEE
 	obj_damage = BLOBMOB_BLOBBERNAUT_DMG_OBJ
 	attack_verb_continuous = "slams"
 	attack_verb_simple = "slam"


### PR DESCRIPTION
## About The Pull Request

when i said "report any unexpected behaviour" i didnt mean in the manuel discord round end channel, i dont read that shit
excepting that I did this time

anyway some asshole (me) added a new var to basic mobs that you need to keep track of when converting them and I forgot 
these guys are essentially exclusively player-controlled so previously just had the normal click CD
I gave them that again

## Changelog

:cl:
fix: Blob Zombies and Blobbernauts have had their attack speed restored to its original value
/:cl:
