### PR TITLE
Adds add/remove mob ability to VV dropdown menu

### DIFF
--- a/code/__DEFINES/vv.dm
+++ b/code/__DEFINES/vv.dm
@@ -114,6 +114,8 @@
 
 // /mob
 #define VV_HK_GIB "gib"
+#define VV_HK_GIVE_MOB_ACTION "give_mob_action"
+#define VV_HK_REMOVE_MOB_ACTION "remove_mob_action"
 #define VV_HK_GIVE_SPELL "give_spell"
 #define VV_HK_REMOVE_SPELL "remove_spell"
 #define VV_HK_GIVE_DISEASE "give_disease"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -730,7 +730,7 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	qdel(to_remove)
 	log_admin("[key_name(usr)] removed the spell [chosen_ability] from [key_name(removal_target)].")
 	message_admins("[key_name_admin(usr)] removed the spell [chosen_ability] from [key_name_admin(removal_target)].")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Remove Spell") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Remove Mob Ability From VV") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
 
 /client/proc/give_spell(mob/spell_recipient in GLOB.mob_list)
 	set category = "Admin.Fun"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -105,7 +105,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/datum/admins/proc/station_traits_panel,
 // Client procs
 	/client/proc/admin_away,
-	/client/proc/add_mob_ability,
+	/client/proc/add_marked_mob_ability,
 	/client/proc/admin_change_sec_level,
 	/client/proc/cinematic,
 	/client/proc/cmd_admin_add_freeform_ai_law,
@@ -120,7 +120,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/mass_zombie_infection,
 	/client/proc/object_say,
 	/client/proc/polymorph_all,
-	/client/proc/remove_mob_ability,
+	/client/proc/remove_marked_mob_ability,
 	/client/proc/reset_ooc,
 	/client/proc/run_weather,
 	/client/proc/set_dynex_scale,
@@ -693,20 +693,44 @@ GLOBAL_PROTECT(admin_verbs_poll)
 		for (var/datum/action/cooldown/mob_cooldown as anything in all_mob_actions)
 			actions_by_name["[initial(mob_cooldown.name)] ([mob_cooldown])"] = mob_cooldown
 
-	var/ability = tgui_input_list(usr, "Choose an ability", "Ability Selection", actions_by_name)
+	var/ability = tgui_input_list(usr, "Choose an ability", "Ability", actions_by_name)
 	if(isnull(ability))
-		return
-	if(QDELETED(ability_recipient))
-		to_chat(usr, span_warning("The intended ability recipient no longer exists."))
 		return
 
 	var/ability_type = actions_by_name[ability]
-	var/datum/action/cooldown/mob_cooldown/add_ability = new ability_type(ability_recipient)
+	var/datum/action/cooldown/mob_cooldown/add_ability
+
+	var/make_sequence = tgui_alert(usr, "Would you like this action to be a sequence of multiple abilities?", "Sequence Ability", list("Yes", "No"))
+	if(make_sequence == "Yes")
+		add_ability = new /datum/action/cooldown/mob_cooldown(ability_recipient)
+		add_ability.sequence_actions = list()
+		while(!isnull(ability_type))
+			var/ability_delay = tgui_input_number(usr, "Enter the delay in seconds before the next ability in the sequence is used", "Ability Delay", 2)
+			if(isnull(ability_delay) || ability_delay < 0)
+				ability_delay = 0
+			add_ability.sequence_actions[ability_type] = ability_delay * 1 SECONDS
+			ability = tgui_input_list(usr, "Choose a new sequence ability", "Sequence Ability", actions_by_name)
+			ability_type = actions_by_name[ability]
+		var/ability_cooldown = tgui_input_number(usr, "Enter the sequence abilities cooldown in seconds", "Ability Cooldown", 2)
+		if(isnull(ability_cooldown) || ability_cooldown < 0)
+			ability_cooldown = 2
+		add_ability.cooldown_time = ability_cooldown * 1 SECONDS
+		var/ability_melee_cooldown = tgui_input_number(usr, "Enter the abilities melee cooldown in seconds", "Melee Cooldown", 2)
+		if(isnull(ability_melee_cooldown) || ability_melee_cooldown < 0)
+			ability_melee_cooldown = 2
+		add_ability.melee_cooldown_time = ability_melee_cooldown * 1 SECONDS
+		add_ability.name = tgui_input_text(usr, "Choose ability name", "Ability name", "Generic Ability")
+		add_ability.create_sequence_actions()
+	else
+		add_ability = new ability_type(ability_recipient)
+
+	if(isnull(ability_recipient))
+		return
 	add_ability.Grant(ability_recipient)
 
 	message_admins("[key_name_admin(usr)] added mob ability [ability_type] to mob [ability_recipient].")
 	log_admin("[key_name(usr)] added mob ability [ability_type] to mob [ability_recipient].")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Add Mob Ability From VV") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Add Mob Ability") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
 
 /client/proc/remove_mob_action(mob/removal_target in GLOB.mob_list)
 	set category = "Admin.Fun"
@@ -728,9 +752,9 @@ GLOBAL_PROTECT(admin_verbs_poll)
 		return
 
 	qdel(to_remove)
-	log_admin("[key_name(usr)] removed the spell [chosen_ability] from [key_name(removal_target)].")
-	message_admins("[key_name_admin(usr)] removed the spell [chosen_ability] from [key_name_admin(removal_target)].")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Remove Mob Ability From VV") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
+	log_admin("[key_name(usr)] removed the ability [chosen_ability] from [key_name(removal_target)].")
+	message_admins("[key_name_admin(usr)] removed the ability [chosen_ability] from [key_name_admin(removal_target)].")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Remove Mob Ability") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
 
 /client/proc/give_spell(mob/spell_recipient in GLOB.mob_list)
 	set category = "Admin.Fun"

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -338,9 +338,9 @@
 	log_admin("[key_name(usr)] started weather of type [weather_type] on the z-level [z_level].")
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Run Weather")
 
-/client/proc/add_mob_ability()
+/client/proc/add_marked_mob_ability()
 	set category = "Admin.Events"
-	set name = "Add Marked Mob Ability"
+	set name = "Add Mob Ability (Marked Mob)"
 	set desc = "Adds an ability to a marked mob."
 
 	if(!holder)
@@ -349,56 +349,11 @@
 	if(!isliving(holder.marked_datum))
 		to_chat(usr, span_warning("Error: Please mark a mob to add actions to it."))
 		return
+	give_mob_action(holder.marked_datum)
 
-	var/mob/living/marked_mob = holder.marked_datum
-
-	var/static/list/all_mob_actions = sort_list(subtypesof(/datum/action/cooldown/mob_cooldown), GLOBAL_PROC_REF(cmp_typepaths_asc))
-	var/static/list/actions_by_name = list()
-	if (!length(actions_by_name))
-		for (var/datum/action/cooldown/mob_cooldown as anything in all_mob_actions)
-			actions_by_name["[initial(mob_cooldown.name)] ([mob_cooldown])"] = mob_cooldown
-
-	var/ability = tgui_input_list(usr, "Choose an ability", "Ability", actions_by_name)
-	if(isnull(ability))
-		return
-
-	var/ability_type = actions_by_name[ability]
-	var/datum/action/cooldown/mob_cooldown/add_ability
-
-	var/make_sequence = tgui_alert(usr, "Would you like this action to be a sequence of multiple abilities?", "Sequence Ability", list("Yes", "No"))
-	if(make_sequence == "Yes")
-		add_ability = new /datum/action/cooldown/mob_cooldown(marked_mob)
-		add_ability.sequence_actions = list()
-		while(!isnull(ability_type))
-			var/ability_delay = tgui_input_number(usr, "Enter the delay in seconds before the next ability in the sequence is used", "Ability Delay", 2)
-			if(isnull(ability_delay) || ability_delay < 0)
-				ability_delay = 0
-			add_ability.sequence_actions[ability_type] = ability_delay * 1 SECONDS
-			ability_type = tgui_input_list(usr, "Choose a new sequence ability", "Sequence Ability", all_mob_actions)
-		var/ability_cooldown = tgui_input_number(usr, "Enter the sequence abilities cooldown in seconds", "Ability Cooldown", 2)
-		if(isnull(ability_cooldown) || ability_cooldown < 0)
-			ability_cooldown = 2
-		add_ability.cooldown_time = ability_cooldown * 1 SECONDS
-		var/ability_melee_cooldown = tgui_input_number(usr, "Enter the abilities melee cooldown in seconds", "Melee Cooldown", 2)
-		if(isnull(ability_melee_cooldown) || ability_melee_cooldown < 0)
-			ability_melee_cooldown = 2
-		add_ability.melee_cooldown_time = ability_melee_cooldown * 1 SECONDS
-		add_ability.name = tgui_input_text(usr, "Choose ability name", "Ability name", "Generic Ability")
-		add_ability.create_sequence_actions()
-	else
-		add_ability = new ability_type(marked_mob)
-
-	if(isnull(marked_mob))
-		return
-	add_ability.Grant(marked_mob)
-
-	message_admins("[key_name_admin(usr)] added mob ability [ability_type] to mob [marked_mob].")
-	log_admin("[key_name(usr)] added mob ability [ability_type] to mob [marked_mob].")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Add Mob Ability") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
-
-/client/proc/remove_mob_ability()
+/client/proc/remove_marked_mob_ability()
 	set category = "Admin.Events"
-	set name = "Remove Marked Mob Ability"
+	set name = "Remove Mob Ability (Marked Mob)"
 	set desc = "Removes an ability from marked mob."
 
 	if(!holder)
@@ -407,24 +362,7 @@
 	if(!isliving(holder.marked_datum))
 		to_chat(usr, span_warning("Error: Please mark a mob to remove actions from it."))
 		return
-
-	var/mob/living/marked_mob = holder.marked_datum
-
-	var/list/all_mob_actions = list()
-	for(var/datum/action/cooldown/mob_cooldown/ability in marked_mob.actions)
-		all_mob_actions.Add(ability)
-
-	var/datum/action/cooldown/mob_cooldown/ability = tgui_input_list(usr, "Remove an ability", "Ability", all_mob_actions)
-
-	if(!ability)
-		return
-
-	var/ability_name = ability.name
-	QDEL_NULL(ability)
-
-	message_admins("[key_name_admin(usr)] removed ability [ability_name] from mob [marked_mob].")
-	log_admin("[key_name(usr)] removed mob ability [ability_name] from mob [marked_mob].")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Remove Mob Ability") // If you are copy-pasting this, ensure the 4th parameter is unique to the new proc!
+	remove_mob_action(holder.marked_datum)
 
 /client/proc/command_report_footnote()
 	set category = "Admin.Events"

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -340,7 +340,7 @@
 
 /client/proc/add_mob_ability()
 	set category = "Admin.Events"
-	set name = "Add Mob Ability"
+	set name = "Add Marked Mob Ability"
 	set desc = "Adds an ability to a marked mob."
 
 	if(!holder)
@@ -398,7 +398,7 @@
 
 /client/proc/remove_mob_ability()
 	set category = "Admin.Events"
-	set name = "Remove Mob Ability"
+	set name = "Remove Marked Mob Ability"
 	set desc = "Removes an ability from marked mob."
 
 	if(!holder)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1365,8 +1365,11 @@
 	. = ..()
 	VV_DROPDOWN_OPTION("", "---------")
 	VV_DROPDOWN_OPTION(VV_HK_GIB, "Gib")
+	VV_DROPDOWN_OPTION(VV_HK_REMOVE_SPELL, "Remove Spell")
 	VV_DROPDOWN_OPTION(VV_HK_GIVE_SPELL, "Give Spell")
 	VV_DROPDOWN_OPTION(VV_HK_REMOVE_SPELL, "Remove Spell")
+	VV_DROPDOWN_OPTION(VV_HK_GIVE_MOB_ACTION, "Give Mob Ability")
+	VV_DROPDOWN_OPTION(VV_HK_REMOVE_MOB_ACTION, "Remove Mob Ability")
 	VV_DROPDOWN_OPTION(VV_HK_GIVE_DISEASE, "Give Disease")
 	VV_DROPDOWN_OPTION(VV_HK_GODMODE, "Toggle Godmode")
 	VV_DROPDOWN_OPTION(VV_HK_DROP_ALL, "Drop Everything")
@@ -1392,6 +1395,14 @@
 		if(!check_rights(R_ADMIN))
 			return
 		usr.client.cmd_admin_godmode(src)
+	if(href_list[VV_HK_GIVE_MOB_ACTION])
+		if(!check_rights(NONE))
+			return
+		usr.client.give_mob_action(src)
+	if(href_list[VV_HK_REMOVE_MOB_ACTION])
+		if(!check_rights(NONE))
+			return
+		usr.client.remove_mob_action(src)
 	if(href_list[VV_HK_GIVE_SPELL])
 		if(!check_rights(NONE))
 			return


### PR DESCRIPTION
## About The Pull Request

You add spells to mobs via a dropdown in VV but mob abilities via marking the mob and pressing a button in the admin status panel.
I like opening the VV menu more than I like marking mobs (I am usually going to need to open it anyway) so I added an alternate route in the VV dropdown. 

## Why It's Good For The Game

It's better for my personal workflow.

## Changelog

:cl:
admin: Mob abilities can be granted to arbitrary mobs via the VV menu in a similar way to spells.
/:cl:
