### PR TITLE
Bitrunning "Clown Planet" Mission Fix

### DIFF
--- a/_maps/virtual_domains/clown_planet.dmm
+++ b/_maps/virtual_domains/clown_planet.dmm
@@ -127,6 +127,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/baseturf_helper/virtual_domain,
 /turf/open/floor/plating,
 /area/virtual_domain/powered)
 "gH" = (
@@ -346,7 +347,7 @@
 /area/virtual_domain/powered)
 "uX" = (
 /obj/effect/mapping_helpers/no_lava,
-/mob/living/simple_animal/hostile/retaliate/clown,
+/mob/living/basic/clown,
 /turf/open/floor/noslip,
 /area/virtual_domain/powered)
 "uY" = (
@@ -365,7 +366,7 @@
 "wz" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/mapping_helpers/no_lava,
-/mob/living/simple_animal/hostile/retaliate/clown,
+/mob/living/basic/clown,
 /turf/open/floor/noslip,
 /area/virtual_domain/powered)
 "xt" = (


### PR DESCRIPTION
## About The Pull Request
I hate this ruin with passion. HOW ARE YOU SUPPOSED TO DO IT WITHOUT A CROWBAR?!? but I digress. this fixes runtimes when the code tried to spawn pre-/basic/ clown typepath and missing baseturf. you can't space the VDOM with mining bananium anymore
## Why It's Good For The Game
less bugs good, gbp good.
## Changelog
:cl:
fix: Fixes missing baseturfs and clowns in mining planet VDOM..
/:cl:
