### PR TITLE
Makes the reverse revolver better hidden.

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -276,6 +276,7 @@
 
 /obj/item/gun/ballistic/revolver/reverse //Fires directly at its user... unless the user is a clown, of course.
 	name = "\improper Syndicate Revolver"
+	desc = "A modernized 7 round revolver manufactured by Waffle Co. Uses .357 ammo."
 	clumsy_check = FALSE
 	icon_state = "revolversyndie"
 

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -275,10 +275,14 @@
 	user.visible_message(span_danger("[user.name]'s soul is captured by \the [src]!"), span_userdanger("You've lost the gamble! Your soul is forfeit!"))
 
 /obj/item/gun/ballistic/revolver/reverse //Fires directly at its user... unless the user is a clown, of course.
-	name = "\improper Syndicate Revolver"
-	desc = "A modernized 7 round revolver manufactured by Waffle Co. Uses .357 ammo."
 	clumsy_check = FALSE
 	icon_state = "revolversyndie"
+
+/obj/item/gun/ballistic/revolver/reverse/Initialize(mapload)
+	. = ..()
+	var/obj/item/gun/ballistic/revolver/syndicate/syndie_revolver = /obj/item/gun/ballistic/revolver/syndicate
+	name = initial(syndie_revolver.name)
+	desc = initial(syndie_revolver.desc)
 
 /obj/item/gun/ballistic/revolver/reverse/can_trigger_gun(mob/living/user, akimbo_usage)
 	if(akimbo_usage)


### PR DESCRIPTION
## About The Pull Request

Fixes #78639

Makes the name and description of the reverse revolver always equal those of the Syndicate revolver.
## Why It's Good For The Game

The reverse revolver is supposed to look like a normal Syndicate revolver until you shoot yourself in the face with it. Having an obvious tell is bad.
## Changelog
:cl:
fix: The reverse revolver now looks like a normal Syndicate revolver on inspection.
/:cl:
