### PR TITLE
Small clean up code for Airlocks

### DIFF
--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -6,10 +6,6 @@
 	var/airlock_state
 	var/frequency
 
-/obj/machinery/door/airlock/Initialize(mapload)
-	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_GREY_TIDE, PROC_REF(grey_tide))
-
 /// Forces the airlock to unbolt and open
 /obj/machinery/door/airlock/proc/secure_open()
 	locked = FALSE
@@ -34,17 +30,6 @@
 	// Airlocks should unlock themselves when knock is casted, THEN open up.
 	locked = FALSE
 	return ..()
-
-/obj/machinery/door/airlock/proc/grey_tide(datum/source, list/grey_tide_areas)
-	SIGNAL_HANDLER
-
-	if(!is_station_level(z) || critical_machine)
-		return //Skip doors in critical positions, such as the SM chamber.
-
-	for(var/area_type in grey_tide_areas)
-		if(!istype(get_area(src), area_type))
-			continue
-		INVOKE_ASYNC(src, PROC_REF(prison_open)) //Sleep gets called further down in open(), so we have to invoke async
 
 /obj/machinery/airlock_sensor
 	icon = 'icons/obj/machines/wallmounts.dmi'

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -163,6 +163,7 @@
 
 /obj/machinery/door/airlock/Initialize(mapload)
 	. = ..()
+
 	set_wires(get_wires())
 	if(glass)
 		airlock_material = "glass"
@@ -181,12 +182,23 @@
 
 	diag_hud_set_electrified()
 
-	RegisterSignal(src, COMSIG_MACHINERY_BROKEN, PROC_REF(on_break))
-
 	// Click on the floor to close airlocks
 	AddComponent(/datum/component/redirect_attack_hand_from_turf)
 
-	return INITIALIZE_HINT_LATELOAD
+	RegisterSignal(src, COMSIG_MACHINERY_BROKEN, PROC_REF(on_break))
+
+	RegisterSignal(SSdcs, COMSIG_GLOB_GREY_TIDE, PROC_REF(grey_tide))
+
+/obj/machinery/door/airlock/proc/grey_tide(datum/source, list/grey_tide_areas)
+	SIGNAL_HANDLER
+
+	if(!is_station_level(z) || critical_machine)
+		return //Skip doors in critical positions, such as the SM chamber.
+
+	for(var/area_type in grey_tide_areas)
+		if(!istype(get_area(src), area_type))
+			continue
+		INVOKE_ASYNC(src, PROC_REF(prison_open)) //Sleep gets called further down in open(), so we have to invoke async
 
 /obj/machinery/door/airlock/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	if(id_tag)


### PR DESCRIPTION
## About The Pull Request
So like Byond for the longest time has been complaining about a duplicate `Initialize()` proc defined for airlocks
![Screenshot (312)](https://github.com/tgstation/tgstation/assets/110812394/72a850db-5c83-46eb-b9a7-6ed5656f6ee2)

So i did something about it and moved the `grey_tide()` proc back inside the original airlocks file

Also there is no need to explicity return `INITIALIZE_HINT_LOAD` because the parent `obj/machinery/Initialize()` proc already returns this value and the parent type for airlocks that is `obj/machinery/door` does not change it in any way

## Changelog
:cl:
code: removed some redundant code for airlocks
/:cl: