### PR TITLE
Moves the Metastation CMO's stamp onto the table

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4532,7 +4532,6 @@
 "bDS" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable,
-/obj/item/stamp/head/cmo,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bDW" = (
@@ -11004,6 +11003,9 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/cmo,
 /obj/structure/cable,
+/obj/item/stamp/head/cmo{
+	pixel_x = -9
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "edq" = (


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/tgstation/tgstation/assets/20053168/894354be-3079-42bf-9f4b-2ec2fea8fac7)
I moved it down one tile, as shown by my horrible drawing.
## Why It's Good For The Game
A stamp isn't being thrown on the floor for no reason
## Changelog
:cl:
fix: fixed the stamp in the metastation CMO office always spawning on the floor
/:cl:
