### PR TITLE
Makes the Regal Condor realistically simulate being shot dead with a high caliber hand cannon by making it HITSCAN

### DIFF
--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -222,18 +222,19 @@
 	time = 30 SECONDS //contemplate for a bit
 	category = CAT_WEAPON_RANGED
 
-/datum/crafting_recipe/deagle_prime //When you factor in the makarov (7 tc), the toolbox (1 tc), and the emag (3 tc), this comes to a total of 17 TC or thereabouts. Igorning the 20k pricetag, obviously.
+/datum/crafting_recipe/deagle_prime //When you factor in the makarov (7 tc), the toolbox (1 tc), and the emag (3 tc), this comes to a total of 18 TC or thereabouts. Igorning the 20k pricetag, obviously.
 	name = "Regal Condor"
 	always_available = FALSE
-	result = /obj/item/gun/ballistic/automatic/pistol/deagle/regal/no_mag
+	result = /obj/item/gun/ballistic/automatic/pistol/deagle/regal
 	reqs = list(
 		/obj/item/gun/ballistic/automatic/pistol = 1,
 		/obj/item/stack/sheet/mineral/gold = 25,
 		/obj/item/stack/sheet/mineral/silver = 25,
 		/obj/item/food/donkpocket = 1,
-		/obj/item/stack/telecrystal = 3,
+		/obj/item/stack/telecrystal = 4,
 		/obj/item/clothing/head/costume/crown/fancy = 1, //the captain's crown
 		/obj/item/storage/toolbox/syndicate = 1,
+		/obj/item/stack/sheet/iron = 10,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	tool_paths = list(
@@ -249,18 +250,22 @@
 	blacklist += subtypesof(/obj/item/gun/ballistic/automatic/pistol)
 
 /datum/crafting_recipe/deagle_prime_mag
-	name = "Regal Condor Magazine (10mm)"
+	name = "Regal Condor Magazine (10mm Reaper)"
 	always_available = FALSE
-	result = /obj/item/ammo_box/magazine/r10mm/empty
+	result = /obj/item/ammo_box/magazine/r10mm
 	reqs = list(
 		/obj/item/stack/sheet/iron = 10,
-		/obj/item/stack/telecrystal = 2,
+		/obj/item/stack/sheet/mineral/gold = 10,
+		/obj/item/stack/sheet/mineral/silver = 10,
+		/obj/item/stack/sheet/mineral/plasma = 10,
+		/obj/item/food/donkpocket = 1, //Station mass murder, as sponsored by Donk Co.
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_WELDER)
 	tool_paths = list(
 		/obj/item/clothing/under/syndicate,
 		/obj/item/clothing/mask/gas/syndicate,
-		/obj/item/card/emag
+		/obj/item/card/emag,
+		/obj/item/gun/ballistic/automatic/pistol/deagle/regal
 	)
 	time = 5 SECONDS
 	category = CAT_WEAPON_RANGED

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -21,6 +21,11 @@
 	desc = "A 10mm incendiary bullet casing."
 	projectile_type = /obj/projectile/bullet/incendiary/c10mm
 
+/obj/item/ammo_casing/c10mm/reaper
+	name = "10mm reaper bullet casing"
+	desc = "A 10mm reaper bullet casing."
+	projectile_type = /obj/projectile/bullet/c10mm/reaper
+
 // 9mm (Makarov, Stechkin APS, PP-95)
 
 /obj/item/ammo_casing/c9mm

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -107,15 +107,11 @@
 	multiple_sprites = AMMO_BOX_PER_BULLET
 
 /obj/item/ammo_box/magazine/r10mm
-	name = "regal condor magazine (10mm)"
+	name = "regal condor magazine (10mm Reaper)"
 	icon_state = "r10mm-8"
 	base_icon_state = "r10mm"
-	ammo_type = /obj/item/ammo_casing/c10mm
+	ammo_type = /obj/item/ammo_casing/c10mm/reaper
 	caliber = CALIBER_10MM
 	max_ammo = 8
 	multiple_sprites = AMMO_BOX_PER_BULLET
 	multiple_sprite_use_base = TRUE
-
-/obj/item/ammo_box/magazine/r10mm/empty
-	icon_state = "r10mm-0"
-	start_empty = TRUE

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -95,9 +95,6 @@
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	obj_flags = UNIQUE_RENAME // if you did the sidequest, you get the customization
 
-/obj/item/gun/ballistic/automatic/pistol/deagle/regal/no_mag
-	spawnwithmagazine = FALSE
-
 /obj/item/gun/ballistic/automatic/pistol/aps
 	name = "\improper Stechkin APS machine pistol"
 	desc = "An old Soviet machine pistol. It fires quickly, but kicks like a mule. Uses 9mm ammo. Has a threaded barrel for suppressors."

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -42,3 +42,22 @@
 	name = "10mm incendiary bullet"
 	damage = 20
 	fire_stacks = 3
+
+/obj/projectile/bullet/c10mm/reaper
+	name = "10mm reaper pellet"
+	damage = 50
+	armour_penetration = 40
+	tracer_type = /obj/effect/projectile/tracer/sniper
+	impact_type = /obj/effect/projectile/impact/sniper
+	muzzle_type = /obj/effect/projectile/muzzle/sniper
+	hitscan = TRUE
+	impact_effect_type = null
+	hitscan_light_intensity = 3
+	hitscan_light_range = 0.75
+	hitscan_light_color_override = LIGHT_COLOR_DIM_YELLOW
+	muzzle_flash_intensity = 5
+	muzzle_flash_range = 1
+	muzzle_flash_color_override = LIGHT_COLOR_DIM_YELLOW
+	impact_light_intensity = 5
+	impact_light_range = 1
+	impact_light_color_override = LIGHT_COLOR_DIM_YELLOW


### PR DESCRIPTION

## About The Pull Request

The Regal Condor come with a magazine and ammo already inside.

The recipe for the magazine now no longer needs TC, but does need donk pockets (sponsored murder gear, you see) and a hell of a lot more materials per magazine (you're looking at like 40 sheets of various materials all up). It also needs you to make the Condor first. But it comes preloaded with ammo.

The Condor is 1 whole TC more expensive. Also needs some metal. The old recipe is there in spirit.

The Regal Condor and the magazines come with 10mm Reaper bullets. They're high damage. They're high AP. They are also hitscan. 

## Why It's Good For The Game

Apparently people don't like the Condor. Too much effort for not enough reward. After all, revolvers exist. 'It must be a joke' they say! 'It's joke content! I went to all that effort to make it for nothing! That slut Anne tricked us!'

**Wrong, bitch.**

If you want the Condor to make you shit yourself the moment someone with it appears on the screen, then fine!

### **You get what you fucking deserve.**

## Changelog
:cl:
balance: Despite earlier reports suggesting that the famous lethality of the Regal Condor was largely a myth, there has been rumors that the gun has once again started to display its true killing potential on any station that it 'manifests'.
/:cl:
