### PR TITLE
Fixes runtime when baking foods that don't have reagents.

### DIFF
--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -69,7 +69,7 @@
 	var/atom/baked_result = new bake_result(used_tray)
 	if(baked_result.reagents) //make space and tranfer reagents if it has any
 		baked_result.reagents.clear_reagents()
-		original_object.reagents?.trans_to(baked_result, original_object.reagents.total_volume)
+		original_object.reagents.trans_to(baked_result, original_object.reagents.total_volume)
 
 	if(who_baked_us)
 		ADD_TRAIT(baked_result, TRAIT_FOOD_CHEF_MADE, who_baked_us)

--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -67,8 +67,9 @@
 	var/atom/original_object = parent
 	var/obj/item/plate/oven_tray/used_tray = original_object.loc
 	var/atom/baked_result = new bake_result(used_tray)
-	baked_result.reagents.clear_reagents()
-	original_object.reagents?.trans_to(baked_result, original_object.reagents.total_volume)
+	if(baked_result.reagents) //make space and tranfer reagents if it has any
+		baked_result.reagents.clear_reagents()
+		original_object.reagents?.trans_to(baked_result, original_object.reagents.total_volume)
 
 	if(who_baked_us)
 		ADD_TRAIT(baked_result, TRAIT_FOOD_CHEF_MADE, who_baked_us)


### PR DESCRIPTION
## About The Pull Request
Fixes #78672

Not all baked foods have reagents
![Screenshot (313)](https://github.com/tgstation/tgstation/assets/110812394/c2b2440a-f94e-42c7-9524-7316714aef2e)

 but when it does then we can clear them and transfer reagents from the original object to the final baked product

## Changelog
:cl:
fix: Aloe and other baked foods that don't have reagents can be baked again without turning to ash
/:cl:
