### PR TITLE
Security Officers can now Download the Plexagon Crew Manifest PDA App

### DIFF
--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -4,7 +4,7 @@
 	category = PROGRAM_CATEGORY_CREW
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and printing the current crew manifest"
-	transfer_access = list(ACCESS_COMMAND)
+	transfer_access = list(ACCESS_SECURITY, ACCESS_COMMAND)
 	requires_ntnet = TRUE
 	size = 4
 	tgui_id = "NtosCrewManifest"


### PR DESCRIPTION

## About The Pull Request

Despite starting with the Plexagon app, security officers did not have sufficient access to actually download the app onto new machines. Now they do.
## Why It's Good For The Game

Its weird and unintuitive to start with an app but not be able to download it if you have to get a new PDA.
## Changelog
:cl:
fix: Security officers can now download the crew manifest PDA app that they start with.
/:cl:
