### PR TITLE
Fixes Listening Post Door

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -234,7 +234,6 @@
 	anchored = 1
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	req_access = list("syndicate");
 	name = "Self Destruct Option"
 	},
@@ -305,9 +304,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "rr" = (
-/obj/machinery/door/airlock{
-	name = "Emergency Backup"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -392,7 +388,6 @@
 /area/ruin/space/has_grav/listeningstation)
 "xh" = (
 /obj/machinery/computer/records/medical/syndie{
-	dir = 2;
 	req_access = list("syndicate")
 	},
 /obj/machinery/light/small/directional/north,
@@ -813,6 +808,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/door/airlock{
+	name = "Emergency Backup"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
 "RK" = (


### PR DESCRIPTION

## About The Pull Request
Moves the door on the listening post where the comms agent spawns to the doorway, and puts an access helper on the door.

![image](https://github.com/tgstation/tgstation/assets/86125936/b8a136c4-ce2f-4e19-a124-13c488091b81)
## Why It's Good For The Game
Puts the door where the door needs to be, and gives it proper access requirements.
## Changelog
:cl:
fix: fixed misplaced door on syndicate listening post
/:cl:
