### PR TITLE
[no gbp] Reduces click cooldown of more primarily player-controlled mobs

### DIFF
--- a/code/modules/mob/living/basic/heretic/heretic_summon.dm
+++ b/code/modules/mob/living/basic/heretic/heretic_summon.dm
@@ -13,6 +13,7 @@
 	unsuitable_heat_damage = 0
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	speed = 0
+	melee_attack_cooldown = CLICK_CD_MELEE
 
 	attack_sound = 'sound/weapons/punch1.ogg'
 	response_help_continuous = "thinks better of touching"

--- a/code/modules/mob/living/basic/space_fauna/morph.dm
+++ b/code/modules/mob/living/basic/space_fauna/morph.dm
@@ -21,6 +21,7 @@
 	obj_damage = 50
 	melee_damage_lower = 20
 	melee_damage_upper = 20
+	melee_attack_cooldown = CLICK_CD_MELEE
 
 	// Oh you KNOW it's gonna be real green
 	lighting_cutoff_red = 10

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
@@ -24,6 +24,7 @@
 	obj_damage = 10
 	melee_damage_lower = 13
 	melee_damage_upper = 15
+	melee_attack_cooldown = CLICK_CD_MELEE
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	attack_sound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/basic/space_fauna/spider/spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider.dm
@@ -13,6 +13,7 @@
 	response_disarm_continuous = "gently pushes aside"
 	response_disarm_simple = "gently push aside"
 	initial_language_holder = /datum/language_holder/spider
+	melee_attack_cooldown = CLICK_CD_MELEE
 	damage_coeff = list(BRUTE = 1, BURN = 1.25, TOX = 1, CLONE = 1, STAMINA = 1, OXY = 1)
 	basic_mob_flags = FLAMMABLE_MOB
 	status_flags = NONE


### PR DESCRIPTION
## About The Pull Request

Fixes #78679
We made a change to synchronise mob attack speed when controlled by players and when controlled by AI but this ended up reducing the attack speed of a few mobs which are primarily controlled by players. This wasn't meant to be a balance change, so we should revert it for those mobs. 
People can use it as a balance lever later if they want (preferably after Swing Combat is merged).

## Changelog

:cl:
fix: Spiders, Morphs, Fire Sharks, and Regal Rats no longer have a reduced click speed.
/:cl:
