### PR TITLE
Ashwalkers team stores players_spawned via ckeys rather than keys now

### DIFF
--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -59,7 +59,7 @@
 			if(H.mind?.has_antag_datum(/datum/antagonist/ashwalker) && (H.ckey || H.get_ghost(FALSE, TRUE))) //special interactions for dead lava lizards with ghosts attached
 				visible_message(span_warning("Serrated tendrils carefully pull [H] to [src], absorbing the body and creating it anew."))
 				var/datum/mind/deadmind
-				if(H.key)
+				if(H.ckey)
 					deadmind = H
 				else
 					deadmind = H.get_ghost(FALSE, TRUE)
@@ -76,8 +76,8 @@
 				meat_counter++
 			visible_message(span_warning("Serrated tendrils eagerly pull [H] to [src], tearing the body apart as its blood seeps over the eggs."))
 			playsound(get_turf(src),'sound/magic/demon_consume.ogg', 100, TRUE)
-			var/deliverykey = H.fingerprintslast //key of whoever brought the body
-			var/mob/living/deliverymob = get_mob_by_key(deliverykey) //mob of said key
+			var/deliverykey = H.fingerprintslast //ckey of whoever brought the body
+			var/mob/living/deliverymob = get_mob_by_key(deliverykey) //mob of said ckey
 			//there is a 40% chance that the Lava Lizard unlocks their respawn with each sacrifice
 			if(deliverymob && (deliverymob.mind?.has_antag_datum(/datum/antagonist/ashwalker)) && (deliverykey in ashies.players_spawned) && (prob(40)))
 				to_chat(deliverymob, span_warning("<b>The Necropolis is pleased with your sacrifice. You feel confident your existence after death is secure.</b>"))

--- a/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm
@@ -56,7 +56,7 @@
 				visible_message(span_notice("Serrated tendrils eagerly pull [H] apart, but find nothing of interest."))
 				return
 
-			if(H.mind?.has_antag_datum(/datum/antagonist/ashwalker) && (H.key || H.get_ghost(FALSE, TRUE))) //special interactions for dead lava lizards with ghosts attached
+			if(H.mind?.has_antag_datum(/datum/antagonist/ashwalker) && (H.ckey || H.get_ghost(FALSE, TRUE))) //special interactions for dead lava lizards with ghosts attached
 				visible_message(span_warning("Serrated tendrils carefully pull [H] to [src], absorbing the body and creating it anew."))
 				var/datum/mind/deadmind
 				if(H.key)

--- a/code/modules/mob_spawn/ghost_roles/mining_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/mining_roles.dm
@@ -227,7 +227,7 @@
 	return ..()
 
 /obj/effect/mob_spawn/ghost_role/human/ash_walker/allow_spawn(mob/user, silent = FALSE)
-	if(!(user.key in team.players_spawned))//one per person unless you get a bonus spawn
+	if(!(user.ckey in team.players_spawned))//one per person unless you get a bonus spawn
 		return TRUE
 	if(!silent)
 		to_chat(user, span_warning("You have exhausted your usefulness to the Necropolis."))
@@ -241,7 +241,7 @@
 	spawned_human.mind.add_antag_datum(/datum/antagonist/ashwalker, team)
 
 	spawned_human.remove_language(/datum/language/common)
-	team.players_spawned += (spawned_human.key)
+	team.players_spawned += (spawned_human.ckey)
 	eggshell.egg = null
 	QDEL_NULL(eggshell)
 


### PR DESCRIPTION
## About The Pull Request

So this just changes some instances of `key` to `ckey`. There is a reason for it I swear!

So when ashwalkers get spawned their mob gets added to the `team.players_spawned` list via their `key` var.

---

However, we have this as part of sacrifice code:

Here the `deliverykey` var is set to `fingerprintslast`, which is a ckey.

https://github.com/tgstation/tgstation/blob/f6f6ebc276bacd33e0f88e6454783209c1b28d57/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm#L79

https://github.com/tgstation/tgstation/blob/f6f6ebc276bacd33e0f88e6454783209c1b28d57/code/modules/forensics/_forensics.dm#L218

---

That `deliverykey` is then used to remove a ckey from the list here 

https://github.com/tgstation/tgstation/blob/f6f6ebc276bacd33e0f88e6454783209c1b28d57/code/modules/mapfluff/ruins/objects_and_mobs/ash_walker_den.dm#L84

Since `deliverkey` is a `ckey`, which is not always the same thing as the `key`, this can cause a mob to not get removed from the list properly if the two mismatch.

```(From DM Reference on `ckey`: "The key in canonical form. To do this, it strips all punctuation and space from the key and converts to lowercase. The result is still unique for each different key. ")```

I just think it's a bit confusing to switch back and forth, and it's unclear if it causes errors or not. This could be considered a code improvement I guess? Or a fix, depending.

## Why It's Good For The Game

Less confusing, more consistent code. Less bugs. Much good.

## Changelog

Nothing anyone shall ever notice besides the coders
