### PR TITLE
Kudzu is destroyed by storms

### DIFF
--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -144,7 +144,7 @@
 			break //only capture one mob at a time
 
 /obj/structure/spacevine/proc/entangle(mob/living/victim)
-	if(!victim || isvineimmune(victim))
+	if(isnull(victim) || isvineimmune(victim))
 		return
 	for(var/datum/spacevine_mutation/mutation in mutations)
 		mutation.on_buckle(src, victim)
@@ -154,7 +154,7 @@
 
 /// Finds a target tile to spread to. If checks pass it will spread to it and also proc on_spread on target.
 /obj/structure/spacevine/proc/spread()
-	if(!master) //If we've lost our controller, something has gone terribly wrong.
+	if(isnull(master)) //If we've lost our controller, something has gone terribly wrong.
 		return
 
 	var/direction = pick(GLOB.cardinals)
@@ -168,17 +168,17 @@
 		return
 	if(islava(stepturf) && !HAS_TRAIT(stepturf, TRAIT_LAVA_STOPPED))
 		return
-	var/obj/structure/spacevine/spot_taken = locate() in stepturf //Locates any vine on target turf. Calls that vine "spot_taken".
-	var/datum/spacevine_mutation/vine_eating/eating = locate() in mutations //Locates the vine eating trait in our own seed and calls it E.
-	if(!isnull(spot_taken)) //Proceed if there isn't a vine on the target turf, OR we have vine eater AND target vine is from our seed and doesn't. Vines from other seeds are eaten regardless.
+	var/obj/structure/spacevine/spot_taken = locate() in stepturf
+	var/datum/spacevine_mutation/vine_eating/eating = locate() in mutations
+	if(!isnull(spot_taken)) //Proceed if there isn't a vine on the target turf, OR we have vine eater AND target vine is from our seed and doesn't.
 		if (isnull(eating))
 			return
 		if (spot_taken.mutations?.Find(eating))
 			return
 	for(var/datum/spacevine_mutation/mutation in mutations)
-		mutation.on_spread(src, stepturf) //Only do the on_spread proc if it actually spreads.
-		stepturf = get_step(src,direction) //in case turf changes, to make sure no runtimes happen
-	var/obj/structure/spacevine/spawning_vine = master.spawn_spacevine_piece(stepturf, src) //Let's do a cool little animate
+		mutation.on_spread(src, stepturf)
+		stepturf = get_step(src, direction)
+	var/obj/structure/spacevine/spawning_vine = master.spawn_spacevine_piece(stepturf, src)
 	if(NSCOMPONENT(direction))
 		spawning_vine.pixel_y = direction == NORTH ? -32 : 32
 		animate(spawning_vine, pixel_y = 0, time = 1 SECONDS)

--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -162,7 +162,7 @@
 	if(!istype(stepturf))
 		return
 
-	if(isspaceturf(stepturf) || !stepturf.Enter(src))
+	if(isspaceturf(stepturf) || isopenspaceturf(stepturf) || !stepturf.Enter(src))
 		return
 	if(ischasm(stepturf) && !HAS_TRAIT(stepturf, TRAIT_CHASM_STOPPED))
 		return


### PR DESCRIPTION
## About The Pull Request

Kudzu is destroyed if it's in a turf affected by an active ash, snow, or void storm.
Additionally it won't attempt to spread onto open chasms or lava, just to save us some time on creating atoms which will be destroyed seconds later.

_**Additionally**_ it won't attempt to spread over open space. This prevents orphaned "levitating" kudzu which is a really unecessary pain in the ass to deal with, especially over large gaps like the tram interstitial tunnels.

If the Kudzu infestation gets too bad indoors, simply hire a trained shrub management technician (void heretic) to fumigate your entire station.

## Why It's Good For The Game

Kudzu growing on lavaland can be a massive pain in the ass to remove, creates hundreds of processing structures, and doesn't really benefit the game at all. Now it is unlikely to survive there for extended periods of time.
Same for the surface of Icebox. This doesn't do anything about kudzu on the lower levels of icebox, but you can't win them all.

## Changelog

:cl:
balance: Kudzu will now be destroyed by adverse weather.
balance: Kudzu will no longer spread over holes.
/:cl:
