### PR TITLE
Bladists can now use silver *or* titanium while creating their blades

### DIFF
--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -177,9 +177,11 @@
 			var/obj/item/stack/sac_stack = sacrificed
 			var/how_much_to_use = 0
 			for(var/requirement in required_atoms)
-				if(islist(requirement) && !is_type_in_list(sacrificed, requirement))
+				// If it's not requirement type and type is not a list, skip over this check
+				if(!istype(sacrificed, requirement) && !islist(requirement))
 					continue
-				if(!istype(sacrificed, requirement))
+				// If requirement *is* a list and the stack *is* in the list, skip over this check
+				if(islist(requirement) && !is_type_in_list(sacrificed, requirement))
 					continue
 				how_much_to_use = min(required_atoms[requirement], sac_stack.amount)
 				break

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -29,13 +29,13 @@
 /datum/heretic_knowledge/limited_amount/starting/base_blade
 	name = "The Cutting Edge"
 	desc = "Opens up the Path of Blades to you. \
-		Allows you to transmute a knife with two bars of silver to create a Sundered Blade. \
+		Allows you to transmute a knife with two bars of silver or titanium to create a Sundered Blade. \
 		You can create up to five at a time."
 	gain_text = "Our great ancestors forged swords and practiced sparring on the eve of great battles."
 	next_knowledge = list(/datum/heretic_knowledge/blade_grasp)
 	required_atoms = list(
 		/obj/item/knife = 1,
-		/obj/item/stack/sheet/mineral/silver = 2,
+		list(/obj/item/stack/sheet/mineral/silver, /obj/item/stack/sheet/mineral/titanium) = 2,
 	)
 	result_atoms = list(/obj/item/melee/sickly_blade/dark)
 	limit = 5 // It's the blade path, it's a given


### PR DESCRIPTION

## About The Pull Request

Blade Heretics can now use silver *or* titanium while creating their blades.

## Why It's Good For The Game

Silver quite literally *only* exists on surgery tables. Being a blade heretic with shit miners/roundstart means one of several things.

1. Wait for miners to come back with enough silver (They might never come back or they might have not gotten any silver)

2. Go to lavaland to dig your own silver (Extremely time-consuming on the antagonist role that has most downtime, death knell for latejoin heretics)

All that is not even to mention that for some reason it takes two sheets rather than one, and surgery tables give one silver when scavenged.

 This all combined makes obtaining blades super annoying as the BLADE path.

Now we can farm titanium off shuttles if the miners are jacking off or dead, or if we joined 9 minutes to roundend.

## Changelog

:cl:
qol: Bladists can now use silver *or* titanium while creating their blades
/:cl:

