### PR TITLE
Paper bins behave properly when dumping their contents.

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -54,12 +54,26 @@
 		droppoint = drop_location()
 	if(collapse)
 		visible_message(span_warning("The stack of paper collapses!"))
-	for(var/atom/movable/movable_atom in contents)
-		movable_atom.forceMove(droppoint)
-		if(!movable_atom.pixel_y)
-			movable_atom.pixel_y = rand(-3,3)
-		if(!movable_atom.pixel_x)
-			movable_atom.pixel_x = rand(-3,3)
+	for(var/obj/item/paper/stacked_paper in paper_stack) //first, dump all of the paper that already exists
+		stacked_paper.forceMove(droppoint)
+		if(!stacked_paper.pixel_y)
+			stacked_paper.pixel_y = rand(-3,3)
+		if(!stacked_paper.pixel_x)
+			stacked_paper.pixel_x = rand(-3,3)
+		paper_stack -= stacked_paper
+		total_paper -= 1
+	for(var/i in 1 to total_paper) //second, generate new paper for the remainder
+		var/obj/item/paper/new_paper = generate_paper()
+		new_paper.forceMove(droppoint)
+		if(!new_paper.pixel_y)
+			new_paper.pixel_y = rand(-3,3)
+		if(!new_paper.pixel_x)
+			new_paper.pixel_x = rand(-3,3)
+	if(bin_pen)
+		var/obj/item/pen/pen = bin_pen
+		pen.forceMove(droppoint)
+		bin_pen = null
+	total_paper = 0
 	update_appearance()
 
 /obj/item/paper_bin/fire_act(exposed_temperature, exposed_volume)
@@ -212,6 +226,8 @@
 
 /obj/item/paper_bin/bundlenatural/dump_contents(atom/droppoint)
 	. = ..()
+	binding_cable.forceMove(droppoint)
+	binding_cable = null
 	qdel(src)
 
 /obj/item/paper_bin/bundlenatural/update_overlays()
@@ -225,7 +241,7 @@
 		deconstruct(FALSE)
 
 /obj/item/paper_bin/bundlenatural/deconstruct(disassembled)
-	dump_contents()
+	dump_contents(drop_location())
 	return ..()
 
 /obj/item/paper_bin/bundlenatural/fire_act(exposed_temperature, exposed_volume)


### PR DESCRIPTION

## About The Pull Request

Fixes #78696

`dump_contents()` for paper bins was never updated to match the refactor in #69586. This meant that it didn't work at all, dumping only initialized sheets of paper and not removing references to them from the bin itself. Most tangibly, this means that cutting open a natural bundle of paper deletes all of the paper along with the object.

The paper bundle problem is now fixed. I don't know if there's actually any way for a regular paper bin to dump its contents, but it works properly regardless.
## Why It's Good For The Game

Dumping the contents out of something should dump the contents out of that thing.
## Changelog
:cl:
fix: Cutting open a hand-pressed paper bundle no longer deletes all of the paper.
/:cl:
