### PR TITLE
Revert font scaling in TGUI chat back to its prior implementation

### DIFF
--- a/tgui/packages/tgui-panel/settings/SettingsPanel.js
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.js
@@ -50,7 +50,7 @@ export const SettingsPanel = (props, context) => {
 };
 
 export const SettingsGeneral = (props, context) => {
-  const { theme, fontFamily, fontSize, freeFontSize, lineHeight } = useSelector(
+  const { theme, fontFamily, fontSize, lineHeight } = useSelector(
     context,
     selectSettings
   );
@@ -114,34 +114,19 @@ export const SettingsGeneral = (props, context) => {
           </Stack>
         </LabeledList.Item>
         <LabeledList.Item label="Font size">
-          {freeFontSize && (
-            <NumberInput
-              width="4em"
-              step={1}
-              stepPixelSize={10}
-              minValue={8}
-              maxValue={32}
-              value={fontSize}
-              unit="px"
-              format={(value) => toFixed(value)}
-              onChange={(e, value) =>
-                dispatch(
-                  updateSettings({
-                    fontSize: value,
-                  })
-                )
-              }
-            />
-          )}
-          <Button
-            content="Override font size"
-            icon={freeFontSize ? 'lock-open' : 'lock'}
-            color={freeFontSize ? 'good' : 'bad'}
-            ml={freeFontSize ? 1 : 0}
-            onClick={() =>
+          <NumberInput
+            width="4em"
+            step={1}
+            stepPixelSize={10}
+            minValue={8}
+            maxValue={32}
+            value={fontSize}
+            unit="px"
+            format={(value) => toFixed(value)}
+            onChange={(e, value) =>
               dispatch(
                 updateSettings({
-                  freeFontSize: !freeFontSize,
+                  fontSize: value,
                 })
               )
             }

--- a/tgui/packages/tgui-panel/settings/middleware.js
+++ b/tgui/packages/tgui-panel/settings/middleware.js
@@ -16,23 +16,14 @@ let overrideFontSize = null;
 
 const updateGlobalOverrideRule = () => {
   let fontFamily = '';
-  let fontSize = '';
 
   if (overrideFontFamily !== null) {
     fontFamily = `font-family: ${overrideFontFamily} !important;`;
   }
 
-  if (overrideFontSize !== null) {
-    fontSize = `font-size: ${overrideFontSize} !important;`;
-  }
-
   const constructedRule = `body * :not(.Icon) {
     ${fontFamily}
-  }
-  body {
-    ${fontSize}
-  }
-  `;
+  }`;
 
   if (overrideRule === null) {
     overrideRule = document.createElement('style');
@@ -41,10 +32,12 @@ const updateGlobalOverrideRule = () => {
 
   // no other way to force a CSS refresh other than to update its innerText
   overrideRule.innerText = constructedRule;
+
+  document.body.style.setProperty('font-size', overrideFontSize);
 };
 
 const setGlobalFontSize = (fontSize) => {
-  overrideFontSize = fontSize ? `${fontSize}px` : null;
+  overrideFontSize = `${fontSize}px`;
 };
 
 const setGlobalFontFamily = (fontFamily) => {
@@ -78,7 +71,7 @@ export const settingsMiddleware = (store) => {
       next(action);
       const settings = selectSettings(store.getState());
       // Update global UI font size
-      setGlobalFontSize(settings.freeFontSize ? settings.fontSize : null);
+      setGlobalFontSize(settings.fontSize);
       setGlobalFontFamily(settings.fontFamily);
       updateGlobalOverrideRule();
       // Save settings to the web storage

--- a/tgui/packages/tgui-panel/settings/middleware.js
+++ b/tgui/packages/tgui-panel/settings/middleware.js
@@ -28,8 +28,11 @@ const updateGlobalOverrideRule = () => {
 
   const constructedRule = `body * :not(.Icon) {
     ${fontFamily}
+  }
+  body {
     ${fontSize}
-  }`;
+  }
+  `;
 
   if (overrideRule === null) {
     overrideRule = document.createElement('style');

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -13,7 +13,6 @@ const defaultHighlightSetting = createDefaultHighlightSetting();
 const initialState = {
   version: 1,
   fontSize: 13,
-  freeFontSize: false,
   fontFamily: FONTS[0],
   lineHeight: 1.2,
   theme: 'light',


### PR DESCRIPTION

## About The Pull Request

I tried to fix an issue that wasn't even an issue, and then I made it worse. That's pretty much a classic for me.

Implementation for font sizes should be the same as before https://github.com/tgstation/tgstation/pull/78621
## Why It's Good For The Game

Fixes #78692
## Changelog
:cl: distributivgesetz
fix: Font scaling in TGUI chat has been reverted to its original implementation.
/:cl:
