### PR TITLE
Fixed spritesheet images for sprite accessories with no icon_state

### DIFF
--- a/code/modules/client/preferences/species_features/basic.dm
+++ b/code/modules/client/preferences/species_features/basic.dm
@@ -4,16 +4,13 @@
 		head_icon = icon('icons/mob/human/bodyparts_greyscale.dmi', "human_head_m")
 		head_icon.Blend(skintone2hex("caucasian1"), ICON_MULTIPLY)
 
-	if (isnull(sprite_accessory))
-		return head_icon
-
-	ASSERT(istype(sprite_accessory))
-
 	var/icon/final_icon = new(head_icon)
+	if (!isnull(sprite_accessory))
+		ASSERT(istype(sprite_accessory))
 
-	var/icon/head_accessory_icon = icon(sprite_accessory.icon, sprite_accessory.icon_state)
-	head_accessory_icon.Blend(COLOR_DARK_BROWN, ICON_MULTIPLY)
-	final_icon.Blend(head_accessory_icon, ICON_OVERLAY)
+		var/icon/head_accessory_icon = icon(sprite_accessory.icon, sprite_accessory.icon_state)
+		head_accessory_icon.Blend(COLOR_DARK_BROWN, ICON_MULTIPLY)
+		final_icon.Blend(head_accessory_icon, ICON_OVERLAY)
 
 	final_icon.Crop(10, 19, 22, 31)
 	final_icon.Scale(32, 32)


### PR DESCRIPTION
## About The Pull Request

Some sprite accessories (such as bald and shaved) do not have icon states, and these are stored as nulls in the GLOB lists. When generating sprite sheets, nulls were simply returning the basic head icon without scaling it in the same manner as the other sprites were scaled.

Old:
![Before](https://github.com/tgstation/tgstation/assets/16478175/e095dd8b-2fc2-4f7b-a176-7f0684629428)

New:
![after](https://github.com/tgstation/tgstation/assets/16478175/ea5b4583-58c5-42de-b5ea-367661ebb9e9)

## Why It's Good For The Game

Having some hairstyles be scaled differently in the spritesheets looks bad.

## Changelog

:cl:
fix: Some icons for selecting character preferences are no longer scaled incorrectly.
/:cl:

