### PR TITLE
Attacking simple animals/basic mobs with a stun baton M1 will now automatically harmbaton.

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -140,7 +140,7 @@
 			balloon_alert(potential_chunky_finger_human, "fingers are too big!")
 			return BATON_ATTACK_DONE
 
-	if(!active || LAZYACCESS(modifiers, RIGHT_CLICK))
+	if(!active || LAZYACCESS(modifiers, RIGHT_CLICK) || isanimal_or_basicmob(target)) 
 		return BATON_DO_NORMAL_ATTACK
 
 	if(cooldown_check > world.time)


### PR DESCRIPTION
## About The Pull Request

Attacking simple animals/basic mobs with a stun baton M1 will now automatically harmbaton.

## Why It's Good For The Game

New players will often try to stun baton simple animals or basic mobs like Space Carp only to find out the hard way that you cannot stun them and are in fact doing nearly absolutely nothing to them. Given that we want stun batons to be new player friendly, this improves the experience.

## Changelog

:cl:
fix: Attacking simple animals/basic mobs with a stun baton M1 will now automatically harmbaton.
/:cl: