### PR TITLE
Fixes modified MA overlays potentially causing duplicate overlays

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -733,7 +733,6 @@
 
 /// Updates the icon of the atom
 /atom/proc/update_icon(updates=ALL)
-	SIGNAL_HANDLER
 	SHOULD_CALL_PARENT(TRUE)
 
 	. = NONE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -756,7 +756,6 @@
 				continue
 			new_overlays[i] = maybe_not_an_atom.appearance
 		if(nulls)
-			stack_trace("Nulls should not be returned by update_overlays()")
 			for(var/i in 1 to nulls)
 				new_overlays -= null
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -751,7 +751,7 @@
 		for(var/atom/maybe_not_an_atom as anything in unknown_new_overlays)
 			if(isnull(maybe_not_an_atom))
 				continue
-			if(istext(maybe_not_an_atom))
+			if(istext(maybe_not_an_atom) || isicon(maybe_not_an_atom))
 				new_overlays += maybe_not_an_atom
 				continue
 			new_overlays += maybe_not_an_atom.appearance

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -484,9 +484,9 @@
 	. = ..()
 	if(unscrewed)
 		return
-	if(broadcasting)
+	if(broadcasting && overlay_mic_idle)
 		. += overlay_mic_idle
-	if(listening)
+	if(listening && overlay_speaker_idle)
 		. += overlay_speaker_idle
 
 /obj/item/radio/screwdriver_act(mob/living/user, obj/item/tool)

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -227,8 +227,8 @@
 	custom_price = PAYCHECK_LOWER * 0.8
 
 /obj/item/reagent_containers/cup/glass/waterbottle/Initialize(mapload)
-	. = ..()
 	cap_overlay = mutable_appearance(cap_icon, cap_icon_state)
+	. = ..()
 	if(cap_on)
 		spillable = FALSE
 		update_appearance()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -145,7 +145,9 @@
 
 /obj/item/reagent_containers/syringe/update_overlays()
 	. = ..()
-	. += update_reagent_overlay()
+	var/list/reagent_overlays = update_reagent_overlay()
+	if(reagent_overlays)
+		. += reagent_overlays
 
 /// Returns a list of overlays to add that relate to the reagents inside the syringe
 /obj/item/reagent_containers/syringe/proc/update_reagent_overlay()


### PR DESCRIPTION
Also optimizes the update_icon proc a little bit, especially as a round goes on, since everything is stored as an appearance (or text, gross) this allows us to only call on overlay update code if the managed overlays change.

![dreamseeker_2023-10-01_18-45-55](https://github.com/tgstation/tgstation/assets/1234602/722a183a-dc19-4e7c-93ba-8a19cde9da5a)

This also fixes some sources of null overlays but it ended up being more things than I should shove into this pr if I were to fix all of them.

Should probably be testmerged for a little bit to make sure nothing weird comes from assuming everything being passed in has an appearance var.