### PR TITLE
adds directional helpers for empty fire axe and mech removal crowbar cabinets

### DIFF
--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -36,6 +36,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet, 32)
 	if(populate_contents)
 		held_item = new item_path(src)
 	update_appearance()
+	find_and_hang_on_wall()
 
 /obj/structure/fireaxecabinet/Destroy()
 	if(held_item)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -36,7 +36,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet, 32)
 	if(populate_contents)
 		held_item = new item_path(src)
 	update_appearance()
-	find_and_hang_on_wall()
 
 /obj/structure/fireaxecabinet/Destroy()
 	if(held_item)
@@ -211,6 +210,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet, 32)
 /obj/structure/fireaxecabinet/empty
 	populate_contents = FALSE
 
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet/empty, 32)
+
 /obj/item/wallframe/fireaxecabinet
 	name = "fire axe cabinet"
 	desc = "Home to a window's greatest nightmare. Apply to wall to use."
@@ -237,6 +238,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet/mechremoval, 32)
 
 /obj/structure/fireaxecabinet/mechremoval/empty
 	populate_contents = FALSE
+
+MAPPING_DIRECTIONAL_HELPERS(/obj/structure/fireaxecabinet/mechremoval/empty, 32)
 
 /obj/item/wallframe/fireaxecabinet/mechremoval
 	name = "mech removal tool cabinet"

--- a/tools/UpdatePaths/Scripts/78722_empty_fireaxe_cabinet_directionals.txt
+++ b/tools/UpdatePaths/Scripts/78722_empty_fireaxe_cabinet_directionals.txt
@@ -1,0 +1,11 @@
+/obj/structure/fireaxecabinet/empty{dir = @UNSET} : /obj/structure/fireaxecabinet/empty/directional/south
+/obj/structure/fireaxecabinet/empty{dir = 1} : /obj/structure/fireaxecabinet/empty/directional/north
+/obj/structure/fireaxecabinet/empty{dir = 2} : /obj/structure/fireaxecabinet/empty/directional/south
+/obj/structure/fireaxecabinet/empty{dir = 4} : /obj/structure/fireaxecabinet/empty/directional/east
+/obj/structure/fireaxecabinet/empty{dir = 8} : /obj/structure/fireaxecabinet/empty/directional/west
+
+/obj/structure/fireaxecabinet/mechremoval/empty{dir = @UNSET} : /obj/structure/fireaxecabinet/mechremoval/empty/directional/south
+/obj/structure/fireaxecabinet/mechremoval/empty{dir = 1} : /obj/structure/fireaxecabinet/mechremoval/empty/directional/north
+/obj/structure/fireaxecabinet/mechremoval/empty{dir = 2} : /obj/structure/fireaxecabinet/mechremoval/empty/directional/south
+/obj/structure/fireaxecabinet/mechremoval/empty{dir = 4} : /obj/structure/fireaxecabinet/mechremoval/empty/directional/east
+/obj/structure/fireaxecabinet/mechremoval/empty{dir = 8} : /obj/structure/fireaxecabinet/mechremoval/empty/directional/west


### PR DESCRIPTION

## About The Pull Request
title. it's mostly so they can be used conveniently in areas you don't want to put fireaxes, but do want an empty cabinet for reasons.
## Why It's Good For The Game
more flexible options for mappers, more convenient than making directional variants yourself. it's what the helper is for
## Changelog
:cl:
qol: gives empty fireaxe and mech removal crowbars cabinets directional helpers
/:cl:
