### PR TITLE
Rule Of Cool: Nukie Hallway Mosiac

### DIFF
--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -210,6 +210,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "cT" = (
@@ -696,6 +699,16 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/centcom/syndicate_mothership/control)
+"hX" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/syndicate_mothership/control)
 "ia" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -937,6 +950,7 @@
 	dir = 9
 	},
 /obj/structure/sign/poster/contraband/gorlex_recruitment/directional/north,
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "kU" = (
@@ -1157,10 +1171,6 @@
 /area/centcom/syndicate_mothership/control)
 "nF" = (
 /obj/effect/turf_decal/syndicateemblem/top/middle,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/control)
 "nH" = (
@@ -1748,6 +1758,9 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/sign/poster/contraband/gorlex_recruitment/directional/south,
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "um" = (
@@ -1788,10 +1801,6 @@
 /area/centcom/syndicate_mothership/control)
 "ve" = (
 /obj/effect/turf_decal/syndicateemblem/top/middle{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -2060,6 +2069,9 @@
 /obj/machinery/camera/autoname/directional/south{
 	network = list("nukie")
 	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "zi" = (
@@ -2151,6 +2163,13 @@
 	dir = 1
 	},
 /turf/open/misc/ice/icemoon,
+/area/centcom/syndicate_mothership/control)
+"zZ" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "Ab" = (
 /obj/effect/turf_decal/siding/thinplating_new/light{
@@ -2400,6 +2419,9 @@
 	dir = 10
 	},
 /obj/structure/sign/poster/contraband/energy_swords/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "CX" = (
@@ -2442,6 +2464,16 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
 /turf/open/floor/plating/snowed/icemoon,
+/area/centcom/syndicate_mothership/control)
+"DM" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "DY" = (
 /obj/structure/table/wood/poker,
@@ -2759,19 +2791,17 @@
 /obj/effect/turf_decal/syndicateemblem/top/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/control)
 "Hc" = (
 /turf/open/floor/plating/icemoon,
 /area/centcom/syndicate_mothership/control)
 "Hm" = (
-/obj/effect/turf_decal/syndicateemblem/top/right,
+/obj/effect/turf_decal/syndicateemblem/bottom/middle{
+	dir = 8
+	},
 /obj/effect/turf_decal/syndicateemblem/top/left,
-/obj/effect/turf_decal/siding/thinplating_new/dark/end{
+/obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -3011,6 +3041,9 @@
 "JL" = (
 /obj/machinery/light/cold/directional/south,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "JR" = (
@@ -3038,10 +3071,6 @@
 "JX" = (
 /obj/effect/turf_decal/syndicateemblem/top/right,
 /obj/effect/turf_decal/syndicateemblem/top/left,
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/control)
 "Ka" = (
@@ -3456,6 +3485,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "Ox" = (
@@ -3485,6 +3517,16 @@
 	dir = 1
 	},
 /turf/open/misc/asteroid/snow/icemoon,
+/area/centcom/syndicate_mothership/control)
+"OM" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "OO" = (
 /obj/item/gun/energy/ionrifle,
@@ -3881,6 +3923,14 @@
 "To" = (
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
+"Ts" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/syndicate_mothership/control)
 "Tw" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Gangway"
@@ -3960,13 +4010,13 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "TY" = (
-/obj/effect/turf_decal/syndicateemblem/top/right{
-	dir = 1
+/obj/effect/turf_decal/syndicateemblem/bottom/middle{
+	dir = 4
 	},
 /obj/effect/turf_decal/syndicateemblem/top/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/thinplating_new/dark/end{
+/obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
@@ -4008,10 +4058,7 @@
 /obj/effect/turf_decal/syndicateemblem/middle/left{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/thinplating_new/dark,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 1
-	},
+/obj/effect/turf_decal/trimline/dark,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/control)
 "Vm" = (
@@ -4021,6 +4068,9 @@
 "Vr" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark/corner{
+	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
@@ -4409,6 +4459,13 @@
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
+/area/centcom/syndicate_mothership/control)
+"ZI" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "ZL" = (
 /obj/structure/flora/grass/both/style_random,
@@ -5322,9 +5379,9 @@ yf
 yf
 na
 PD
-zE
+OM
 Hm
-lt
+DM
 ws
 Wz
 KL
@@ -5424,9 +5481,9 @@ Ge
 Ge
 Ge
 xf
-zE
+ZI
 nF
-lt
+zZ
 ZO
 JJ
 mb
@@ -5526,7 +5583,7 @@ Jf
 eu
 hN
 PD
-zE
+ZI
 JX
 yP
 RD
@@ -5628,7 +5685,7 @@ nQ
 nQ
 nQ
 nQ
-zE
+ZI
 Va
 JL
 RD
@@ -5730,9 +5787,9 @@ yK
 Ht
 In
 VK
-zE
+ZI
 GU
-lt
+zZ
 FM
 wM
 ee
@@ -5832,9 +5889,9 @@ Zg
 pU
 lt
 XQ
-zE
+ZI
 ve
-lt
+zZ
 Lu
 ae
 ae
@@ -5934,9 +5991,9 @@ rS
 iH
 Bn
 VK
-zE
+Ts
 TY
-lt
+hX
 FM
 iL
 mB

--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -1155,6 +1155,14 @@
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/mineral/titanium/yellow,
 /area/centcom/syndicate_mothership/control)
+"nF" = (
+/obj/effect/turf_decal/syndicateemblem/top/middle,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_mothership/control)
 "nH" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/structure/closet/syndicate/personal,
@@ -1777,6 +1785,16 @@
 "uX" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
+/area/centcom/syndicate_mothership/control)
+"ve" = (
+/obj/effect/turf_decal/syndicateemblem/top/middle{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/control)
 "vv" = (
 /obj/structure/table/reinforced,
@@ -2734,8 +2752,29 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/centcom/syndicate_mothership/control)
+"GU" = (
+/obj/effect/turf_decal/syndicateemblem/top/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/syndicateemblem/top/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_mothership/control)
 "Hc" = (
 /turf/open/floor/plating/icemoon,
+/area/centcom/syndicate_mothership/control)
+"Hm" = (
+/obj/effect/turf_decal/syndicateemblem/top/right,
+/obj/effect/turf_decal/syndicateemblem/top/left,
+/obj/effect/turf_decal/siding/thinplating_new/dark/end{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/control)
 "Ho" = (
 /obj/effect/light_emitter{
@@ -2996,6 +3035,15 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
+"JX" = (
+/obj/effect/turf_decal/syndicateemblem/top/right,
+/obj/effect/turf_decal/syndicateemblem/top/left,
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_mothership/control)
 "Ka" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -3912,6 +3960,15 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "TY" = (
+/obj/effect/turf_decal/syndicateemblem/top/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/syndicateemblem/top/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark/end{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/control)
 "Un" = (
@@ -3943,6 +4000,19 @@
 "UE" = (
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/plating,
+/area/centcom/syndicate_mothership/control)
+"Va" = (
+/obj/effect/turf_decal/syndicateemblem/middle/left{
+	dir = 8
+	},
+/obj/effect/turf_decal/syndicateemblem/middle/left{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/control)
 "Vm" = (
 /obj/structure/flora/rock/pile/style_random,
@@ -5253,7 +5323,7 @@ yf
 na
 PD
 zE
-TY
+Hm
 lt
 ws
 Wz
@@ -5355,7 +5425,7 @@ Ge
 Ge
 xf
 zE
-TY
+nF
 lt
 ZO
 JJ
@@ -5457,7 +5527,7 @@ eu
 hN
 PD
 zE
-TY
+JX
 yP
 RD
 RD
@@ -5559,7 +5629,7 @@ nQ
 nQ
 nQ
 zE
-TY
+Va
 JL
 RD
 SD
@@ -5661,7 +5731,7 @@ Ht
 In
 VK
 zE
-TY
+GU
 lt
 FM
 wM
@@ -5763,7 +5833,7 @@ pU
 lt
 XQ
 zE
-TY
+ve
 lt
 Lu
 ae


### PR DESCRIPTION
## About The Pull Request
Quick history lesson, yes, seriously, this is backstory for this goofy PR that affects a *single line of tiles*: near the start of this year I was asked to help work on a project for here that, to my knowledge, is all but canned now(?) - more specifically, I was asked to [remap the nukie base](https://cdn.discordapp.com/attachments/927814428882251776/1070593334269190175/image.png), a project I didn't get too particularly far into before things went quiet. Up at the top-right there you can see I was starting to experiment with some, quote, "sick-ass designs" using the syndicate emblem turf decal, which later became [this.](https://cdn.discordapp.com/attachments/1040395260922183700/1158248386537996350/image.png)

Not anything all too impressive, but it was still fun to work on (special shoutout to putting the assault pod into a implied slinglauncher, that was cool as fuck) - that all said, I recently *remembered* that exercise... which's led to this PR.
### So what does this PR **actually** do?

Simple. Edits this single line of tiles to have a neat, snaking design on 'em. Yyyyep. That's it.
![image](https://github.com/tgstation/tgstation/assets/50649185/4d00fd35-0bb5-4d44-9efa-56db302dc1e1)

## Why It's Good For The Game
Honestly it's just pretty neat looking. On a related note from my experimentation, if we ever get diagonal trimline turf decals, you could pretty easily repurpose the `syndicateemblem/top/left` decal to make a little Interdyne Pharmaceuticals logo following the design on the shipping containers.
## Changelog
:cl:
add: The funds the syndicate have been saving by restricting galley access has been suddenly funneled into a singular mosaic pattern in the experiments wing.
/:cl:
