### PR TITLE
The Galactic Materials Market no longer runtimes on opening or ordering.

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -161,4 +161,4 @@
 	var/sale_value = sold_block.export_value
 	SSstock_market.materials_quantity[sold_block.export_mat] += sold_block.quantity
 	SSstock_market.materials_prices[sold_block.export_mat] -= round((sale_value) * (sold_block.quantity / (sold_block.quantity + SSstock_market.materials_quantity[sold_block.export_mat])))
-	SSstock_market.materials_prices[sold_block.export_mat] = round(clamp(SSstock_market.materials_prices[sold_block.export_mat], initial(sold_block.export_mat.value_per_unit * SHEET_MATERIAL_AMOUNT * 0.5) , initial(sold_block.export_mat.value_per_unit * SHEET_MATERIAL_AMOUNT * 3)))
+	SSstock_market.materials_prices[sold_block.export_mat] = round(clamp(SSstock_market.materials_prices[sold_block.export_mat], initial(sold_block.export_mat.value_per_unit) * SHEET_MATERIAL_AMOUNT * 0.5 , initial(sold_block.export_mat.value_per_unit) * SHEET_MATERIAL_AMOUNT * 3))

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -161,4 +161,4 @@
 	var/sale_value = sold_block.export_value
 	SSstock_market.materials_quantity[sold_block.export_mat] += sold_block.quantity
 	SSstock_market.materials_prices[sold_block.export_mat] -= round((sale_value) * (sold_block.quantity / (sold_block.quantity + SSstock_market.materials_quantity[sold_block.export_mat])))
-	SSstock_market.materials_prices[sold_block.export_mat] = round(clamp(SSstock_market.materials_prices[sold_block.export_mat], sold_block.export_mat.value_per_unit * SHEET_MATERIAL_AMOUNT * 0.5 , sold_block.export_mat.value_per_unit * SHEET_MATERIAL_AMOUNT * 3))
+	SSstock_market.materials_prices[sold_block.export_mat] = round(clamp(SSstock_market.materials_prices[sold_block.export_mat], initial(sold_block.export_mat.value_per_unit * SHEET_MATERIAL_AMOUNT * 0.5) , initial(sold_block.export_mat.value_per_unit * SHEET_MATERIAL_AMOUNT * 3)))

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -92,12 +92,12 @@
 		else if(SSstock_market.materials_trends[traded_mat] == -1)
 			trend_string = "down"
 		var/color_string = ""
-		if(traded_mat.color)
-			color_string = traded_mat.color
-		else if (traded_mat.greyscale_colors)
-			color_string = splicetext(traded_mat.greyscale_colors, 6, length(traded_mat.greyscale_colors), "") //slice it to a standard 6 char hex
+		if (initial(traded_mat.greyscale_colors))
+			color_string = splicetext(initial(traded_mat.greyscale_colors), 7, length(initial(traded_mat.greyscale_colors)), "") //slice it to a standard 6 char hex
+		else if(initial(traded_mat.color))
+			color_string = initial(traded_mat.color)
 		material_data += list(list(
-			"name" = traded_mat.name,
+			"name" = initial(traded_mat.name),
 			"price" = SSstock_market.materials_prices[traded_mat],
 			"quantity" = SSstock_market.materials_quantity[traded_mat],
 			"trend" = trend_string,
@@ -144,7 +144,7 @@
 			var/datum/material/material_bought
 			var/obj/item/stack/sheet/sheet_to_buy
 			for(var/datum/material/mat as anything in SSstock_market.materials_prices)
-				if(mat.name == material_str)
+				if(initial(mat.name) == material_str)
 					material_bought = mat
 					break
 			if(!material_bought)
@@ -159,7 +159,7 @@
 
 			var/cost = SSstock_market.materials_prices[material_bought] * quantity
 
-			sheet_to_buy = material_bought.sheet_type
+			sheet_to_buy = initial(material_bought.sheet_type)
 			if(!sheet_to_buy)
 				CRASH("Material with no sheet type being sold on materials market!")
 			if(!account_payable)

--- a/code/modules/cargo/materials_market.dm
+++ b/code/modules/cargo/materials_market.dm
@@ -231,7 +231,7 @@
 
 /obj/item/stock_block/examine(mob/user)
 	. = ..()
-	. += span_notice("\The [src] is worth [export_value] cr, from selling [quantity] sheets of [export_mat?.name].")
+	. += span_notice("\The [src] is worth [export_value] cr, from selling [quantity] sheets of [initial(export_mat?.name)].")
 	if(fluid)
 		. += span_warning("\The [src] is currently liquid! It's value is based on the market price.")
 	else


### PR DESCRIPTION

## About The Pull Request

The Galactic Materials Market, currently, runtimes while attempting to open the UI. This is due to attempting to load various fields from un-initialized material datums. Through liberal application of `initial()`, these runtimes have been removed, and it is now possible to use the market at all (though it has some other issues that I'll make bug reports for...).

Also gives priority to `greyscale_colors` over `color` when choosing colors for the UI, to make the correct colors appear.
## Why It's Good For The Game

The Materials Market is rather important as the only source of minerals on rounds without any miners. So... it's good if it actually loads.
## Changelog
:cl:
fix: The Galactic Materials Market now offers things for sale as it should.
/:cl:
