### PR TITLE
Tendril Tagging - scanning necropolis tendrils with a mining analyzer updates its GPS tag

### DIFF
--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -20,6 +20,9 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/wolf)
 	move_resist = INFINITY
 	anchored = TRUE
+	scanner_taggable = TRUE
+	mob_gps_id = "WF" // wolf
+	spawner_gps_id = "Animal Den"
 
 /obj/structure/spawner/ice_moon/Initialize(mapload)
 	. = ..()
@@ -65,6 +68,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	max_mobs = 1
 	spawn_time = 60 SECONDS
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/polarbear)
+	mob_gps_id = "BR" // bear
 
 /obj/structure/spawner/ice_moon/polarbear/clear_rock()
 	for(var/turf/potential in RANGE_TURFS(1, src))
@@ -79,6 +83,8 @@ GLOBAL_LIST_INIT(ore_probability, list(
 	mob_types = list(/mob/living/simple_animal/hostile/asteroid/ice_demon)
 	light_range = 1
 	light_color = COLOR_SOFT_RED
+	mob_gps_id = "WT|B" // watcher | bluespace
+	spawner_gps_id = "Netheric Distortion"
 
 /obj/structure/spawner/ice_moon/demonic_portal/Initialize(mapload)
 	. = ..()
@@ -100,9 +106,11 @@ GLOBAL_LIST_INIT(ore_probability, list(
 
 /obj/structure/spawner/ice_moon/demonic_portal/ice_whelp
 	mob_types = list(/mob/living/basic/mining/ice_whelp)
+	mob_gps_id = "ID|W" // ice drake | whelp
 
 /obj/structure/spawner/ice_moon/demonic_portal/snowlegion
 	mob_types = list(/mob/living/basic/mining/legion/snow/spawner_made)
+	mob_gps_id = "LG|S" // legion | snow
 
 /obj/effect/collapsing_demonic_portal
 	name = "collapsing demonic portal"

--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -15,23 +15,21 @@
 	anchored = TRUE
 	resistance_flags = FIRE_PROOF | LAVA_PROOF
 	var/obj/effect/light_emitter/tendril/emitted_light
-	/// has this tendril been tagged/analyzed by a mining scanner?
-	var/gps_tagged = FALSE
-	/// what tag does this tendril use?
-	var/tagged_id = "WT"
-
+	scanner_taggable = TRUE
+	mob_gps_id = "WT"
+	spawner_gps_id = "Necropolis Tendril"
 
 /obj/structure/spawner/lavaland/goliath
 	mob_types = list(/mob/living/basic/mining/goliath)
-	tagged_id = "GL"
+	mob_gps_id = "GL"
 
 /obj/structure/spawner/lavaland/legion
 	mob_types = list(/mob/living/basic/mining/legion/spawner_made)
-	tagged_id = "LG"
+	mob_gps_id = "LG"
 
 /obj/structure/spawner/lavaland/icewatcher
 	mob_types = list(/mob/living/basic/mining/watcher/icewing)
-	tagged_id = "IW"
+	mob_gps_id = "WT|I" // icewing
 
 GLOBAL_LIST_INIT(tendrils, list())
 /obj/structure/spawner/lavaland/Initialize(mapload)
@@ -53,23 +51,6 @@ GLOBAL_LIST_INIT(tendrils, list())
 	examine_messages += span_notice("Once this thing gets hurts enough, it triggers a violent final retaliation.")
 	examine_messages += span_notice("You'll only have a few moments to run up, grab some loot with an open hand, and get out with it.")
 	return examine_messages
-
-/obj/structure/spawner/lavaland/attackby(obj/item/item, mob/user, params)
-	if(!istype(item, /obj/item/mining_scanner) && !istype(item, /obj/item/t_scanner/adv_mining_scanner))
-		return ..()
-	gps_tag(user)
-
-/// Tag the necropolis tendril, appending a mob-based tag and randomized numeric identifier.
-/obj/structure/spawner/lavaland/proc/gps_tag(mob/user)
-	if(gps_tagged)
-		balloon_alert(user, "already tagged!")
-		return
-
-	balloon_alert(user, "tagged on GPS!")
-
-	gps_tagged = TRUE
-	var/datum/component/gps/our_gps = GetComponent(/datum/component/gps)
-	our_gps.gpstag = "\[[tagged_id]-[rand(100,999)]\] " + our_gps.gpstag
 
 /obj/structure/spawner/lavaland/Destroy()
 	var/last_tendril = TRUE

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -14,14 +14,24 @@
 	var/spawn_text = "emerges from"
 	var/faction = list(FACTION_HOSTILE)
 	var/spawner_type = /datum/component/spawner
-	/// is this spawner taggable with a mining scanner?
+	/// Is this spawner taggable with a mining scanner?
 	var/scanner_taggable = FALSE
-	/// has this tendril been tagged/analyzed by a mining scanner?
+	/// Has this spawner been tagged/analyzed by a mining scanner?
 	var/gps_tagged = FALSE
-	/// short identifier for the mob it spawns. probably stick around 3 characters or less?
+	/// A short identifier for the mob it spawns. Keep around 3 characters or less?
 	var/mob_gps_id = "???"
-	/// short identifier for what kind of spawner it is.
+	/// A short identifier for what kind of spawner it is, for use in putting together its GPS tag.
 	var/spawner_gps_id = "Creature Nest"
+	/// A complete identifier. Generated on tag (if tagged), used for its examine.
+	var/assigned_tag
+
+/obj/structure/spawner/examine(mob/user)
+	. = ..()
+	if(scanner_taggable)
+		if(!gps_tagged)
+			. += span_notice("It looks like you could probably scan and tag it with a <b>mining analyzer</b>.")
+		else
+			. += span_notice("A holotag's been attached, projecting \"<b>[assigned_tag]</b>\".")
 
 /obj/structure/spawner/attackby(obj/item/item, mob/user, params)
 	if(scanner_taggable)
@@ -36,12 +46,12 @@
 		return
 	balloon_alert(user, "tagged on GPS!")
 	gps_tagged = TRUE
-	var/new_tag = "\[[mob_gps_id]-[rand(100,999)]\] " + spawner_gps_id
+	assigned_tag = "\[[mob_gps_id]-[rand(100,999)]\] " + spawner_gps_id
 	var/datum/component/gps/our_gps = GetComponent(/datum/component/gps)
 	if(our_gps)
-		our_gps.gpstag = new_tag
+		our_gps.gpstag = assigned_tag
 		return
-	AddComponent(/datum/component/gps, new_tag)
+	AddComponent(/datum/component/gps, assigned_tag)
 
 /obj/structure/spawner/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/structures/spawner.dm
+++ b/code/game/objects/structures/spawner.dm
@@ -14,6 +14,34 @@
 	var/spawn_text = "emerges from"
 	var/faction = list(FACTION_HOSTILE)
 	var/spawner_type = /datum/component/spawner
+	/// is this spawner taggable with a mining scanner?
+	var/scanner_taggable = FALSE
+	/// has this tendril been tagged/analyzed by a mining scanner?
+	var/gps_tagged = FALSE
+	/// short identifier for the mob it spawns. probably stick around 3 characters or less?
+	var/mob_gps_id = "???"
+	/// short identifier for what kind of spawner it is.
+	var/spawner_gps_id = "Creature Nest"
+
+/obj/structure/spawner/attackby(obj/item/item, mob/user, params)
+	if(scanner_taggable)
+		if(!istype(item, /obj/item/mining_scanner) && !istype(item, /obj/item/t_scanner/adv_mining_scanner))
+			return ..()
+		gps_tag(user)
+
+/// Tag the spawner, prefixing its GPS entry with an identifier - or giving it one, if nonexistent.
+/obj/structure/spawner/proc/gps_tag(mob/user)
+	if(gps_tagged)
+		balloon_alert(user, "already tagged!")
+		return
+	balloon_alert(user, "tagged on GPS!")
+	gps_tagged = TRUE
+	var/new_tag = "\[[mob_gps_id]-[rand(100,999)]\] " + spawner_gps_id
+	var/datum/component/gps/our_gps = GetComponent(/datum/component/gps)
+	if(our_gps)
+		our_gps.gpstag = new_tag
+		return
+	AddComponent(/datum/component/gps, new_tag)
 
 /obj/structure/spawner/Initialize(mapload)
 	. = ..()
@@ -32,6 +60,8 @@
 	spawn_text = "warps in from"
 	mob_types = list(/mob/living/basic/syndicate/ranged)
 	faction = list(ROLE_SYNDICATE)
+	mob_gps_id = "SYN" // syndicate
+	spawner_gps_id = "Hostile Warp Beacon"
 
 /obj/structure/spawner/skeleton
 	name = "bone pit"
@@ -44,6 +74,8 @@
 	mob_types = list(/mob/living/simple_animal/hostile/skeleton)
 	spawn_text = "climbs out of"
 	faction = list(FACTION_SKELETON)
+	mob_gps_id = "SKL" // skeletons
+	spawner_gps_id = "Bone Pit"
 
 /obj/structure/spawner/clown
 	name = "Laughing Larry"
@@ -67,6 +99,8 @@
 	)
 	spawn_text = "climbs out of"
 	faction = list(FACTION_CLOWN)
+	mob_gps_id = "???" // clowns
+	spawner_gps_id = "Clown Planet Distortion"
 
 /obj/structure/spawner/mining
 	name = "monster den"
@@ -80,7 +114,7 @@
 		/mob/living/basic/mining/basilisk,
 		/mob/living/basic/mining/goldgrub,
 		/mob/living/basic/mining/goliath/ancient,
-		/mob/living/basic/mining/legion,
+		/mob/living/basic/mining/hivelord,
 		/mob/living/basic/wumborian_fugu,
 	)
 	faction = list(FACTION_MINING)
@@ -89,26 +123,31 @@
 	name = "goldgrub den"
 	desc = "A den housing a nest of goldgrubs, annoying but arguably much better than anything else you'll find in a nest."
 	mob_types = list(/mob/living/basic/mining/goldgrub)
+	mob_gps_id = "GG"
 
 /obj/structure/spawner/mining/goliath
 	name = "goliath den"
 	desc = "A den housing a nest of goliaths, oh god why?"
 	mob_types = list(/mob/living/basic/mining/goliath/ancient)
+	mob_gps_id = "GL|A"
 
 /obj/structure/spawner/mining/hivelord
 	name = "hivelord den"
 	desc = "A den housing a nest of hivelords."
 	mob_types = list(/mob/living/basic/mining/hivelord)
+	mob_gps_id = "HL"
 
 /obj/structure/spawner/mining/basilisk
 	name = "basilisk den"
 	desc = "A den housing a nest of basilisks, bring a coat."
 	mob_types = list(/mob/living/basic/mining/basilisk)
+	mob_gps_id = "BK"
 
 /obj/structure/spawner/mining/wumborian
 	name = "wumborian fugu den"
 	desc = "A den housing a nest of wumborian fugus, how do they all even fit in there?"
 	mob_types = list(/mob/living/basic/wumborian_fugu)
+	mob_gps_id = "WF"
 
 /obj/structure/spawner/nether
 	name = "netherworld link"
@@ -125,6 +164,9 @@
 		/mob/living/basic/migo,
 	)
 	faction = list(FACTION_NETHER)
+	scanner_taggable = TRUE
+	mob_gps_id = "?!?"
+	spawner_gps_id = "Netheric Distortion"
 
 /obj/structure/spawner/nether/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Makes it so that if you wave a mining analyzer over a necropolis tendril (kinda like a geyser), its GPS tag is updated with a code for what it spawns and a numerical designation. Unlike geyser scanning, this awards no points, and is solely for figuring out what tendril spawns what fauna.
<details>
<summary>Screenshots in the dropdown:</summary>

![image](https://github.com/tgstation/tgstation/assets/31829017/888f19f9-2291-4349-995a-2821e99da375)
![image](https://github.com/tgstation/tgstation/assets/31829017/d847e88e-a8ae-4a18-ae57-aed248343457)
![image](https://github.com/tgstation/tgstation/assets/31829017/d9646dad-70b6-4e92-8b5d-ce5eed873869)

Updated: now on the `structure/spawner` level, allowing it to cover icemoon spawners.
![image](https://github.com/tgstation/tgstation/assets/31829017/73cc2972-1c34-485d-8b70-a04f44a92bcd)

Updated again: now it has an associated examine thing.
![image](https://github.com/tgstation/tgstation/assets/31829017/44027082-3672-4033-b603-de1a0c3d2af2)
</details>

Also removes the redundant `gps` variable because it got componentalized.
## Why It's Good For The Game

I think being able to know what one of fifteen eerie signals is spawning without having to memorize which one is spawning which thing at what coordinate, or just vaguely going "oh so that's where the legion tendril was today".

## Changelog

:cl:
qol: Miners can now tag monster spawners (necropolis tendrils, animal dens, demonic portals, and netherworld links) by using their mining scanner on it, which updates their GPS tag (and/or gives them one) to give it a numerical designation and a short identifier for what it's spawning.
/:cl:
